### PR TITLE
Fix default alphabet parameter to not pass null

### DIFF
--- a/modules/ripple_data/crypto/ripple_Base58.cpp
+++ b/modules/ripple_data/crypto/ripple_Base58.cpp
@@ -158,8 +158,8 @@ bool Base58::decode (const std::string& str, std::vector<unsigned char>& vchRet)
 
 bool Base58::decodeWithCheck (const char* psz, std::vector<unsigned char>& vchRet, const char* pAlphabet)
 {
-	if (pAlphabet == NULL)
-		pAlphabet = s_currentAlphabet;
+	assert (pAlphabet != NULL);
+
 	if (!decode (psz, vchRet, pAlphabet))
 		return false;
 	if (vchRet.size() < 4)

--- a/modules/ripple_data/types/ripple_RippleAddress.h
+++ b/modules/ripple_data/types/ripple_RippleAddress.h
@@ -71,7 +71,7 @@ public:
 
 	std::string humanAccountID() const;
 
-	bool setAccountID(const std::string& strAccountID, const char* pAlphabet=0);
+	bool setAccountID(const std::string& strAccountID, const char* pAlphabet=Base58::getCurrentAlphabet ());
 	void setAccountID(const uint160& hash160In);
 
 	static RippleAddress createAccountID(const std::string& strAccountID)


### PR DESCRIPTION
I introduced the Base58 alphabet because I did not recognize that pAlphabet was being passed as NULL in RippleAddress:setAccountID() to mean "use the current alphabet" (I only caught the null parameters in the Base58 member functions).

This pull request incorporates my preferred solution which is not to use null pointers at all and simply pass the return value of Base58::getCurrentAlphabet() as the default. As an additional precaution I've added an assert to make sure no unsavory characters are relying on NULL to get the default behavior.

My opinion is that there shouldn't be a default parameter at all; The alphabet should be explicit at every call site so that it is clear to the reader. This may be the subject of a future refactoring.
