### PR TITLE
Bump ripple-lib subversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
 
   "dependencies": {
-    "ripple-lib": "0.7.21",
+    "ripple-lib": "0.7.22",
     "async": "~0.2.9",
     "extend": "~1.2.0",
     "simple-jsonrpc": "~0.0.2"


### PR DESCRIPTION
The previous version of ripple-lib had a deprecation warning that was logged by default. This patch will yield proper xunit output so that the CI server can do its thing.
