### PR TITLE
Bump ripple-lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
 
   "dependencies": {
-    "ripple-lib": "0.7.22",
+    "ripple-lib": "0.7.25",
     "async": "~0.2.9",
     "extend": "~1.2.0",
     "simple-jsonrpc": "~0.0.2"


### PR DESCRIPTION
This version of ripple-lib includes some directories that were not whitelisted in previous versions, causing ripple-lib to crash. rippled CI tests expected to pass with this fix.
