### PR TITLE
Fix marker being set for last result

### DIFF
--- a/src/ripple_app/misc/NetworkOPs.cpp
+++ b/src/ripple_app/misc/NetworkOPs.cpp
@@ -1883,6 +1883,10 @@ NetworkOPsImp::getTxsAccount (const RippleAddress& account, int32 minLedger, int
         }
     }
 
+    // ST NOTE We're using the token reference both for passing inputs and
+    //         outputs, so we need to clear it in between.
+    token = Json::nullValue;
+
     std::string sql = boost::str (boost::format
         ("SELECT AccountTransactions.LedgerSeq,AccountTransactions.TxnSeq,Status,RawTxn,TxnMeta "
          "FROM AccountTransactions INNER JOIN Transactions ON Transactions.TransID = AccountTransactions.TransID "


### PR DESCRIPTION
The API docs for the new account_tx API state that the last result will not return a continuation marker. In reality it returns the marker you passed in. This appears to be unintentional - the variable is simply used for both input and output and not cleared in between uses.
