### PR TITLE
Don't log StatsD messages to the console by default

### DIFF
--- a/src/beast/beast/insight/impl/StatsDCollector.cpp
+++ b/src/beast/beast/insight/impl/StatsDCollector.cpp
@@ -413,8 +413,6 @@ public:
 
     void run ()
     {
-        m_journal.sink().console (true);
-
         boost::system::error_code ec;
 
         if (m_socket.connect (to_endpoint (m_address), ec))


### PR DESCRIPTION
Suppress verbose reporting of insight module to the console.
