### PR TITLE
Refactor Job tracking code: introduce a JobType object

### DIFF
--- a/src/ripple_app/rpc/RPCHandler.cpp
+++ b/src/ripple_app/rpc/RPCHandler.cpp
@@ -46,9 +46,10 @@ public:
             ++inProgress;
         else
         {
-            if ((getApp().getJobQueue ().getJobCountGE (jtCLIENT) > 50) ||
-                    getApp().getFeeTrack().isLoadedLocal ())
-            return;
+            int count = getApp().getJobQueue ().getJobCountGE (jtCLIENT);
+
+            if ((count > 50) || getApp().getFeeTrack().isLoadedLocal ())
+                return;
 
             do
             {

--- a/src/ripple_core/functional/Job.cpp
+++ b/src/ripple_core/functional/Job.cpp
@@ -17,57 +17,40 @@
 */
 //==============================================================================
 
-Job::Job ()
-    : mType (jtINVALID)
-    , mJobIndex (0)
-{
-}
-
-Job::Job (JobType type, uint64 index)
-    : mType (type)
-    , mJobIndex (index)
+Job::Job (JobType& type, uint64 index)
+    : m_type (type)
+    , m_index (index)
 {
 }
 
 Job::Job (Job const& other)
     : m_cancelCallback (other.m_cancelCallback)
-    , mType (other.mType)
-    , mJobIndex (other.mJobIndex)
-    , mJob (other.mJob)
+    , m_type (other.m_type)
+    , m_index (other.m_index)
+    , m_work (other.m_work)
     , m_loadEvent (other.m_loadEvent)
-    , mName (other.mName)
+    , m_name (other.m_name)
 {
 }
 
-Job::Job (JobType type,
+Job::Job (JobType& type,
           std::string const& name,
           uint64 index,
-          LoadMonitor& lm,
-          std::function <void (Job&)> const& job,
+          std::function <void (Job&)> const& work,
           CancelCallback cancelCallback)
     : m_cancelCallback (cancelCallback)
-    , mType (type)
-    , mJobIndex (index)
-    , mJob (job)
-    , mName (name)
+    , m_type (type)
+    , m_index (index)
+    , m_work (work)
+    , m_name (name)
 {
-    m_loadEvent = boost::make_shared <LoadEvent> (boost::ref (lm), name, false);
+    m_loadEvent = boost::make_shared <LoadEvent> (
+        boost::ref (m_type.get ().load), name, false);
 }
 
-Job& Job::operator= (Job const& other)
+JobType& Job::getType () const
 {
-    mType = other.mType;
-    mJobIndex = other.mJobIndex;
-    mJob = other.mJob;
-    m_loadEvent = other.m_loadEvent;
-    mName = other.mName;
-    m_cancelCallback = other.m_cancelCallback;
-    return *this;
-}
-
-JobType Job::getType () const
-{
-    return mType;
+    return m_type;
 }
 
 CancelCallback Job::getCancelCallback () const
@@ -83,105 +66,59 @@ bool Job::shouldCancel () const
     return false;
 }
 
-void Job::doJob ()
+void Job::work ()
 {
     m_loadEvent->start ();
-    m_loadEvent->reName (mName);
+    m_loadEvent->reName (m_name);
 
-    mJob (*this);
+    m_work (*this);
 }
 
 void Job::rename (std::string const& newName)
 {
-    mName = newName;
+    m_name = newName;
 }
 
-const char* Job::toString (JobType t)
+bool Job::operator> (Job const& j) const
 {
-    switch (t)
-    {
-    case jtINVALID:         return "invalid";
-    case jtPACK:            return "peerLedgerReq";
-    case jtPUBOLDLEDGER:    return "publishAcqLedger";
-    case jtVALIDATION_ut:   return "untrustedValidation";
-    case jtPROOFWORK:       return "proofOfWork";
-    case jtTRANSACTION_l:   return "localTransaction";
-    case jtPROPOSAL_ut:     return "untrustedProposal";
-    case jtLEDGER_DATA:     return "ledgerData";
-    case jtUPDATE_PF:       return "updatePaths";
-    case jtCLIENT:          return "clientCommand";
-    case jtRPC:             return "RPC";
-    case jtTRANSACTION:     return "transaction";
-    case jtUNL:             return "unl";
-    case jtADVANCE:         return "advanceLedger";
-    case jtPUBLEDGER:       return "publishNewLedger";
-    case jtTXN_DATA:        return "fetchTxnData";
-    case jtWAL:             return "writeAhead";
-    case jtVALIDATION_t:    return "trustedValidation";
-    case jtWRITE:           return "writeObjects";
-    case jtACCEPT:          return "acceptLedger";
-    case jtPROPOSAL_t:      return "trustedProposal";
-    case jtSWEEP:           return "sweep";
-    case jtNETOP_CLUSTER:   return "clusterReport";
-    case jtNETOP_TIMER:     return "heartbeat";
-
-    case jtADMIN:           return "administration";
-
-    // special types not dispatched by the job pool
-    case jtPEER:            return "peerCommand";
-    case jtDISK:            return "diskAccess";
-    case jtTXN_PROC:        return "processTransaction";
-    case jtOB_SETUP:        return "orderBookSetup";
-    case jtPATH_FIND:       return "pathFind";
-    case jtHO_READ:         return "nodeRead";
-    case jtHO_WRITE:        return "nodeWrite";
-    case jtGENERIC:         return "generic";
-    default:
-        assert (false);
-        return "unknown";
-    }
-}
-
-bool Job::operator> (const Job& j) const
-{
-    if (mType < j.mType)
+    if (m_type < j.m_type)
         return true;
 
-    if (mType > j.mType)
+    if (m_type > j.m_type)
         return false;
 
-    return mJobIndex > j.mJobIndex;
+    return m_index > j.m_index;
 }
 
-bool Job::operator>= (const Job& j) const
+bool Job::operator>= (Job const& j) const
 {
-    if (mType < j.mType)
+    if (m_type < j.m_type)
         return true;
 
-    if (mType > j.mType)
+    if (m_type > j.m_type)
         return false;
 
-    return mJobIndex >= j.mJobIndex;
+    return m_index >= j.m_index;
 }
 
-bool Job::operator< (const Job& j) const
+bool Job::operator< (Job const& j) const
 {
-    if (mType < j.mType)
+    if (m_type < j.m_type)
         return false;
 
-    if (mType > j.mType)
+    if (m_type > j.m_type)
         return true;
 
-    return mJobIndex < j.mJobIndex;
+    return m_index < j.m_index;
 }
 
-bool Job::operator<= (const Job& j) const
+bool Job::operator<= (Job const& j) const
 {
-    if (mType < j.mType)
+    if (m_type < j.m_type)
         return false;
 
-    if (mType > j.mType)
+    if (m_type > j.m_type)
         return true;
 
-    return mJobIndex <= j.mJobIndex;
+    return m_index <= j.m_index;
 }

--- a/src/ripple_core/functional/Job.h
+++ b/src/ripple_core/functional/Job.h
@@ -20,107 +20,47 @@
 #ifndef RIPPLE_JOB_H
 #define RIPPLE_JOB_H
 
-// Note that this queue should only be used for CPU-bound jobs
-// It is primarily intended for signature checking
-enum JobType
-{
-    // must be in priority order, low to high
-    jtINVALID       = -1,
-    jtPACK          = 1,    // Make a fetch pack for a peer
-    jtPUBOLDLEDGER  = 2,    // An old ledger has been accepted
-    jtVALIDATION_ut = 3,    // A validation from an untrusted source
-    jtPROOFWORK     = 4,    // A proof of work demand from another server
-    jtTRANSACTION_l = 5,    // A local transaction
-    jtPROPOSAL_ut   = 6,    // A proposal from an untrusted source
-    jtLEDGER_DATA   = 7,    // Received data for a ledger we're acquiring
-    jtUPDATE_PF     = 8,    // Update pathfinding requests
-    jtCLIENT        = 9,    // A websocket command from the client
-    jtRPC           = 10,    // A websocket command from the client
-    jtTRANSACTION   = 11,   // A transaction received from the network
-    jtUNL           = 12,   // A Score or Fetch of the UNL (DEPRECATED)
-    jtADVANCE       = 13,   // Advance validated/acquired ledgers
-    jtPUBLEDGER     = 14,   // Publish a fully-accepted ledger
-    jtTXN_DATA      = 15,   // Fetch a proposed set
-    jtWAL           = 16,   // Write-ahead logging
-    jtVALIDATION_t  = 17,   // A validation from a trusted source
-    jtWRITE         = 18,   // Write out hashed objects
-    jtACCEPT        = 19,   // Accept a consensus ledger
-    jtPROPOSAL_t    = 20,   // A proposal from a trusted source
-    jtSWEEP         = 21,   // Sweep for stale structures
-    jtNETOP_CLUSTER = 22,   // NetworkOPs cluster peer report
-    jtNETOP_TIMER   = 23,   // NetworkOPs net timer processing
-    jtADMIN         = 24,   // An administrative operation
-
-    // special types not dispatched by the job pool
-    jtPEER          = 30,
-    jtDISK          = 31,
-    jtTXN_PROC      = 32,
-    jtOB_SETUP      = 33,
-    jtPATH_FIND     = 34,
-    jtHO_READ       = 35,
-    jtHO_WRITE      = 36,
-    jtGENERIC       = 37,   // Used just to measure time
-}; // CAUTION: If you add new types, add them to Job.cpp too
-
-// VFALCO TODO move this into the enum so it calculates itself?
-#define NUM_JOB_TYPES 48 // why 48 and not 38?
-
 class Job
 {
 public:
-    /** Default constructor.
-
-        Allows Job to be used as a container type.
-
-        This is used to allow things like jobMap [key] = value.
-    */
-    // VFALCO NOTE I'd prefer not to have a default constructed object.
-    //             What is the semantic meaning of a Job with no associated
-    //             function? Having the invariant "all Job objects refer to
-    //             a job" would reduce the number of states.
-    //
-    Job ();
+    // Jobs are not default-constructible or assignable.
+    Job& operator= (Job const& other) = delete;
+    Job () = delete;
 
     Job (Job const& other);
 
-    Job (JobType type, uint64 index);
+    Job (JobType& type, uint64 index);
 
-    // VFALCO TODO try to remove the dependency on LoadMonitor.
-    Job (JobType type,
+    Job (JobType& type,
          std::string const& name,
          uint64 index,
-         LoadMonitor& lm,
-         std::function <void (Job&)> const& job,
+         std::function <void (Job&)> const& work,
          CancelCallback cancelCallback);
 
-    Job& operator= (Job const& other);
-
-    JobType getType () const;
+    JobType& getType () const;
 
     CancelCallback getCancelCallback () const;
 
     /** Returns `true` if the running job should make a best-effort cancel. */
     bool shouldCancel () const;
 
-    void doJob ();
+    void work ();
 
     void rename (const std::string& n);
 
     // These comparison operators make the jobs sort in priority order in the job set
-    bool operator< (const Job& j) const;
-    bool operator> (const Job& j) const;
-    bool operator<= (const Job& j) const;
-    bool operator>= (const Job& j) const;
-
-    static const char* toString (JobType);
+    bool operator< (Job const& j) const;
+    bool operator> (Job const& j) const;
+    bool operator<= (Job const& j) const;
+    bool operator>= (Job const& j) const;
 
 private:
     CancelCallback m_cancelCallback;
-    JobType                     mType;
-    uint64                      mJobIndex;
-    std::function <void (Job&)> mJob;
-    LoadEvent::pointer          m_loadEvent;
-    std::string                 mName;
+    std::reference_wrapper<JobType> m_type;
+    uint64 m_index;
+    std::function <void (Job&)> m_work;
+    LoadEvent::pointer m_loadEvent;
+    std::string m_name;
 };
 
 #endif

--- a/src/ripple_core/functional/JobQueue.h
+++ b/src/ripple_core/functional/JobQueue.h
@@ -36,20 +36,17 @@ public:
     //
     //        TODO Replace with std::function
     //
-    virtual void addJob (JobType type,
-        std::string const& name, boost::function <void (Job&)> const& job) = 0;
+    virtual void addJob (JobType& type, const std::string& name,
+        boost::function<void (Job&)> const& job) = 0;
 
-    // Jobs waiting at this priority
-    virtual int getJobCount (JobType t) = 0;
+    // Number of jobs waiting at the specified priority
+    virtual int getJobCount (JobType const& t) = 0;
 
-    // Jobs waiting plus running at this priority
-    virtual int getJobCountTotal (JobType t) = 0;
+    // Number of jobs waiting as selected by the specified predicate
+    virtual int getJobCountGE (JobType const& t) = 0;
 
-    // All waiting jobs at or greater than this priority
-    virtual int getJobCountGE (JobType t) = 0;
-
-    // jobs waiting, threads doing
-    virtual std::vector< std::pair<JobType, std::pair<int, int> > > getJobCounts () = 0;
+    // Jobs waiting plus running at the specified priority
+    virtual int getJobCountTotal (JobType const& t) = 0;
 
     virtual void shutdown () = 0;
 
@@ -58,14 +55,14 @@ public:
     // VFALCO TODO Rename these to newLoadEventMeasurement or something similar
     //             since they create the object.
     //
-    virtual LoadEvent::pointer getLoadEvent (JobType t, const std::string& name) = 0;
+    virtual LoadEvent::pointer getLoadEvent (JobType& t, const std::string& name) = 0;
 
     // VFALCO TODO Why do we need two versions, one which returns a shared
     //             pointer and the other which returns an autoptr?
     //          
-    virtual LoadEvent::autoptr getLoadEventAP (JobType t, const std::string& name) = 0;
+    virtual LoadEvent::autoptr getLoadEventAP (JobType& t, const std::string& name) = 0;
 
-    virtual bool isOverloaded () = 0;
+    virtual bool isOverloaded () const = 0;
 
     virtual Json::Value getJson (int c = 0) = 0;
 };

--- a/src/ripple_core/functional/JobType.cpp
+++ b/src/ripple_core/functional/JobType.cpp
@@ -1,0 +1,184 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+//==============================================================================
+// Tracks every JobType that has been defined.
+JobType::Map JobType::Jobs;
+
+//==============================================================================
+std::atomic <int> JobType::s_nextPriority (0);
+
+//==============================================================================
+JobType::JobType (char const* name_, int limit_, bool skip_)
+    : priority (++s_nextPriority)
+    , limit (limit_)
+    , name (name_)
+    , skip (skip_)
+    , waiting (0)
+    , running (0)
+    , deferred (0)
+{
+    Jobs.insert (std::make_pair (
+        limit, std::reference_wrapper<JobType> (*this)));
+}
+
+bool JobType::addTask ()
+{
+    ++waiting;
+
+    if (waiting + running <= limit)
+        return true;
+
+    // We are over the limit so this task should be deferred until we go below
+    ++deferred;
+
+    return false;
+}
+
+//==============================================================================
+bool operator< (JobType const& rhs, JobType const& lhs)
+{
+    return (rhs.priority < lhs.priority);
+}
+
+bool operator<= (JobType const& rhs, JobType const& lhs)
+{
+    return (rhs.priority <= lhs.priority);
+}
+
+bool operator> (JobType const& rhs, JobType const& lhs)
+{
+    return (rhs.priority > lhs.priority);
+}
+
+bool operator>= (JobType const& rhs, JobType const& lhs)
+{
+    return (rhs.priority >= lhs.priority);
+}
+
+bool operator== (JobType const& rhs, JobType const& lhs)
+{
+    return (rhs.priority == lhs.priority);
+}
+
+bool operator!= (JobType const& rhs, JobType const& lhs)
+{
+    return (rhs.priority != lhs.priority);
+}
+
+//==============================================================================
+// These are all the job types that the server understands.
+
+// NOTICE: It is *IMPORTANT* that jobs be declared in order of priority, from
+//         low to high. Each will get assigned a strictly monotonically
+//         increasing numerical priority.
+
+// Make a fetch pack for a peer
+JobType jtPACK ("makeFetchPack", 1, true);
+
+// An old ledger has been accepted
+JobType jtPUBOLDLEDGER ("publishAcqLedger", 2, true);
+
+// A validation from an untrusted source
+JobType jtVALIDATION_ut ("untrustedValidation", JobType::maxLimit, true);
+
+// A proof of work demand from another server
+JobType jtPROOFWORK ("proofOfWork", JobType::maxLimit, true);
+
+// A local transaction
+JobType jtTRANSACTION_l ("localTransaction", JobType::maxLimit, true);
+
+// A proposal from an untrusted source
+JobType jtPROPOSAL_ut ("untrustedProposal", JobType::maxLimit, true);
+
+// Received data for a ledger we're acquiring
+JobType jtLEDGER_DATA ("ledgerData", 2, true);
+
+// Update pathfinding requests
+JobType jtUPDATE_PF ("updatePaths", JobType::maxLimit, true);
+
+// A websocket command from the client
+JobType jtCLIENT ("clientCommand", JobType::maxLimit, true);
+
+// A websocket command from the client
+// don't skip (assert)
+JobType jtRPC ("RPC", JobType::maxLimit, false);
+
+// A transaction received from the network
+JobType jtTRANSACTION ("transaction", JobType::maxLimit, true);
+
+// A Score or Fetch of the UNL (DEPRECATED)
+JobType jtUNL ("unl", 1, true);
+
+// Advance validated/acquired ledgers
+JobType jtADVANCE ("advanceLedger", JobType::maxLimit, true);
+
+// Publish a fully-accepted ledger
+JobType jtPUBLEDGER ("publishNewLedger", JobType::maxLimit, true);
+
+// Fetch a proposed set
+JobType jtTXN_DATA ("fetchTxnData", 1, true);
+
+// Write-ahead logging
+// don't skip
+JobType jtWAL ("writeAhead", JobType::maxLimit, false);
+
+// A validation from a trusted source
+JobType jtVALIDATION_t ("trustedValidation", JobType::maxLimit, true);
+
+// Write out hashed objects
+// don't skip
+JobType jtWRITE ("writeObjects", JobType::maxLimit, false);
+
+// Accept a consensus ledger
+// don't skip (assert)
+JobType jtACCEPT ("acceptLedger", JobType::maxLimit, false);
+
+// A proposal from a trusted source
+JobType jtPROPOSAL_t ("trustedProposal", JobType::maxLimit, false);
+
+// Sweep for stale structures
+JobType jtSWEEP ("sweep", JobType::maxLimit, true);
+
+// NetworkOPs cluster peer report
+JobType jtNETOP_CLUSTER ("clusterReport", 1, true);
+
+// NetworkOPs net timer processing
+JobType jtNETOP_TIMER ("heartbeat", 1, true);
+
+// An administrative operation
+JobType jtADMIN ("administration", JobType::maxLimit, true);
+
+// The rest are special job types that are not dispatched
+// by the job pool. The "limit" and "skip" attributes are
+// not applicable to these types of jobs.
+JobType jtPEER ("peerCommand", 0, false);
+
+JobType jtDISK ("diskAccess", 0, false);
+
+JobType jtTXN_PROC ("processTransaction", 0, false);
+
+JobType jtOB_SETUP ("orderBookSetup", 0, false);
+
+JobType jtPATH_FIND ("pathFind", 0, false);
+
+JobType jtHO_READ ("nodeRead", 0, false);
+
+JobType jtHO_WRITE ("nodeWrite", 0, false);
+
+JobType jtGENERIC ("generic", 0, false);

--- a/src/ripple_core/functional/JobType.h
+++ b/src/ripple_core/functional/JobType.h
@@ -1,0 +1,108 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_JOBTYPE_H
+#define RIPPLE_JOBTYPE_H
+
+struct JobType
+{
+private:
+    static std::atomic <int> s_nextPriority;
+
+public:
+    typedef std::map <int, std::reference_wrapper <JobType>> Map;
+
+    static Map Jobs;
+
+    int const priority;
+    int const limit;
+    std::string const name;
+
+    // Indicates that jobs of this type should be skipped
+    // when the job queue is stopping. Jobs that aren't
+    // skipped will be called and the job must call
+    // Job::shouldCancel to determine if a long-running or
+    // non-mandatory operation should be cancelled.
+    bool const skip;
+
+    LoadMonitor load;
+
+    // How many are waiting
+    int waiting;
+
+    // How many are running
+    int running;
+
+    // How many we didn't signal due to limits
+    int deferred;
+
+public:
+    static int const maxLimit = std::numeric_limits <int>::max ();
+
+    JobType (char const* name_, int limit_, bool skip_);
+
+    bool addTask ();
+
+    static int getMaxPriority ();
+};
+
+bool operator< (JobType const& rhs, JobType const& lhs);
+bool operator<= (JobType const& rhs, JobType const& lhs);
+
+bool operator> (JobType const& rhs, JobType const& lhs);
+bool operator>= (JobType const& rhs, JobType const& lhs);
+
+bool operator== (JobType const& rhs, JobType const& lhs);
+bool operator!= (JobType const& rhs, JobType const& lhs);
+
+//==============================================================================
+extern JobType jtPACK;
+extern JobType jtPUBOLDLEDGER;
+extern JobType jtVALIDATION_ut;
+extern JobType jtPROOFWORK;
+extern JobType jtTRANSACTION_l;
+extern JobType jtPROPOSAL_ut;
+extern JobType jtLEDGER_DATA;
+extern JobType jtUPDATE_PF;
+extern JobType jtCLIENT;
+extern JobType jtRPC;
+extern JobType jtTRANSACTION;
+extern JobType jtUNL;
+extern JobType jtADVANCE;
+extern JobType jtPUBLEDGER;
+extern JobType jtTXN_DATA;
+extern JobType jtWAL;
+extern JobType jtVALIDATION_t;
+extern JobType jtWRITE;
+extern JobType jtACCEPT;
+extern JobType jtPROPOSAL_t;
+extern JobType jtSWEEP;
+extern JobType jtNETOP_CLUSTER;
+extern JobType jtNETOP_TIMER;
+extern JobType jtADMIN;
+extern JobType jtPEER;
+extern JobType jtDISK;
+extern JobType jtTXN_PROC;
+extern JobType jtOB_SETUP;
+extern JobType jtPATH_FIND;
+extern JobType jtHO_READ;
+extern JobType jtHO_WRITE;
+extern JobType jtGENERIC;
+
+#endif

--- a/src/ripple_core/ripple_core.cpp
+++ b/src/ripple_core/ripple_core.cpp
@@ -40,6 +40,7 @@ namespace ripple
 # include "functional/LoadFeeTrackImp.h" // private
 #include "functional/LoadFeeTrackImp.cpp"
 #include "functional/Job.cpp"
+#include "functional/JobType.cpp"
 #include "functional/JobQueue.cpp"
 #include "functional/LoadEvent.cpp"
 #include "functional/LoadMonitor.cpp"

--- a/src/ripple_core/ripple_core.h
+++ b/src/ripple_core/ripple_core.h
@@ -40,6 +40,7 @@ namespace ripple
 #include "functional/LoadFeeTrack.h"
 #  include "functional/LoadEvent.h"
 #  include "functional/LoadMonitor.h"
+#include "functional/JobType.h"
 # include "functional/Job.h"
 #include "functional/JobQueue.h"
 


### PR DESCRIPTION
This pull request addresses issue #250 by eliminating the `JobType` enum in favor of a class that represents a job type and encapsulates multiple fields.

This is the first step of a refactor of the job tracking code.
