### PR TITLE
Fix Travis Build

### DIFF
--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -50,10 +50,10 @@ function build_teardown() {
   return function (done) {
     var self  = this;
 
-    self.server.close(function () {
-      // console.log("server closed");
-
-      teardown.call(self, done);
+    teardown.call(self, function () {
+      self.server.close(function () {
+        done();
+      });
     });
   };
 };

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -140,9 +140,12 @@ function build_setup(opts, host) {
       },
 
       function create_ledger_interval(callback) {
+        if (opts.no_auto_ledger_close) {return callback(); };
+
         self.ledger_interval = setInterval(function() {
           self.remote.ledger_accept();
-        }, 200);
+        }, 200);  
+
         callback();
       }
 
@@ -170,7 +173,7 @@ function build_teardown(host) {
 
     var series = [
       function clear_ledger_interval(callback) {
-        clearInterval(self.ledger_interval);
+        if (self.ledger_interval != null) {clearInterval(self.ledger_interval)};
         callback();
       },
 


### PR DESCRIPTION
Shutdown rippled before http server in json rpc test to avoid http server potentially receiving messages due to automatic ledger close interval. 

I suspect there's a race to close down the http server cleanly before some kind of subscription message is received from rippled. The test that was causing the stall was subscribing to ledger events.

These tests already pass locally, yet Travis was failing, possibly due to local dev machines being faster than the challenged travis 1.5 cpu instances. 
