### PR TITLE
Fix missing break on mtCLUSTER handler

### DIFF
--- a/src/ripple_overlay/impl/PeerImp.h
+++ b/src/ripple_overlay/impl/PeerImp.h
@@ -871,6 +871,7 @@ private:
                 else
                     m_journal.warning << "parse error: " << type;
             }
+                break;
 
             case protocol::mtERROR_MSG:
             {


### PR DESCRIPTION
The mtCLUSTER handler is missing a break and falls through to the mtERROR_MSG handler. Add the break.
