### PR TITLE
Remove Jenkins CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 #Ripple - P2P Payment Network
 
 ##[![Build Status](https://travis-ci.org/ripple/rippled.png?branch=develop)](https://travis-ci.org/ripple/rippled)
-##[![Build Status](https://ci.ripple.com/jenkins/buildStatus/icon?job=rippled)](https://ci.ripple.com/jenkins/job/rippled/)
 
 This is the repository for Ripple's `rippled`, reference P2P network server.
 


### PR DESCRIPTION
This isn't used any more is it?
