### PR TITLE
Arch Linux PKGBUILD

### DIFF
--- a/Builds/ArchLinux/PKGBUILD
+++ b/Builds/ArchLinux/PKGBUILD
@@ -10,7 +10,8 @@ license=('custom:ISC')
 depends=('protobuf' 'openssl' 'boost-libs')
 makedepends=('git' 'scons' 'boost')
 checkdepends=('nodejs')
-source=("git://github.com/ripple/rippled.git")
+backup=("etc/$pkgname/rippled.cfg")
+source=("git://github.com/ripple/rippled.git#branch=master")
 sha512sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
This is an Arch Linux PKGBUILD, which I also uploaded on the [AUR](https://aur.archlinux.org/packages/rippled/)
The example rippled configuration file was installed in /etc.
Since the data directory in that file is /etc/ripple/db, the package creates this empty directory.
This is a compromise between the "no patches" arch policy and a working initial configuration
The user is assumed to run the server in this way:

```
# rippled --conf=/etc/rippled/rippled.cfg
```

or can write a systemd service file similar to [this one](http://pastebin.com/FyMQV1Rq). At the moment such a file is not present in the rippled repository.

The ideal solution (according to the Arch standards) would be to put the database in /var instead of /etc,

I would also like to claim the bounty offered in (this forum thread)[https://ripple.com/forum/viewtopic.php?f=2&t=6151]:
rJDfM2S6uPaNwbcpHhvCz1WY7pSsfJALMC
