### PR TITLE
Fix paths in the example config file

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -796,10 +796,10 @@ medium
 # Note that HyperLevelDB is unavailable on Windows platforms
 [node_db]
 type=HyperLevelDB
-path=/var/lib/ripple/db/hyperldb
+path=/var/lib/rippled/db/hyperldb
 
 [database_path]
-/var/lib/ripple/db
+/var/lib/rippled/db
 
 # This needs to be an absolute directory reference, not a relative one.
 # Modify this value as required.
@@ -818,7 +818,7 @@ pool.ntp.org
 r.ripple.com 51235
 
 # These validators are taken from the v0.16 release notes on the wiki:
-# https://ripple.com/wiki/Latest_rippled_release_notes
+# https://ripple.com/wiki/Rippled-0.16
 [validators]
 n9KPnVLn7ewVzHvn218DcEYsnWLzKerTDwhpofhk4Ym1RUq4TeGw    RIP1
 n9LFzWuhKNvXStHAuemfRKFVECLApowncMAM5chSCL9R5ECHGN4V    RIP2


### PR DESCRIPTION
DB should be in /var/lib/rippled, not /var/lib/ripple
