### PR TITLE
Updated example configuration file to match what we use internally.

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -782,10 +782,17 @@
 [node_size]
 medium
 
-# Note that HyperLevelDB is unavailable on Windows platforms
+# This is primary persistent datastore for rippled.  This includes transaction
+# metadata, account states, and ledger headers.  Helpful information can be
+# found here: https://ripple.com/wiki/NodeBackEnd
 [node_db]
-type=HyperLevelDB
-path=/var/lib/ripple/db/hyperldb
+type=RocksDB
+path=/var/lib/rippled/db/rocksdb
+open_files=2000
+filter_bits=12
+cache_mb=256
+file_size_mb=8
+file_size_mult=2
 
 [database_path]
 /var/lib/ripple/db
@@ -825,7 +832,15 @@ n9KF6RpvktjNs2MDBkmxpJbup4BKrKeMKDXPhaXkq7cKTwLmWkFr    RIP5
 [validation_quorum]
 3
 
-# Configure SSL for WebSockets.  Not enabled by default yet.
+# Turn down default logging to save disk space in the long run.
+# Valid values here are trace, debug, info, warning, error, and fatal
+[rpc_startup]
+{ "command": "log_level", "severity": "warning" }
+
+# Configure SSL for WebSockets.  Not enabled by default because not everybody
+# has an SSL cert on their server, but if you uncomment the following lines and
+# set the path to the SSL certificate and private key the WebSockets protocol
+# will be protected by SSL/TLS.
 #[websocket_secure]
 #1
 
@@ -835,6 +850,9 @@ n9KF6RpvktjNs2MDBkmxpJbup4BKrKeMKDXPhaXkq7cKTwLmWkFr    RIP5
 #[websocket_ssl_key]
 #/etc/ssl/private/server.key
 
+# Defaults to 0 ("no") so that you can use self-signed SSL certificates for
+# development, or internally.
 #[ssl_verify]
 #0
+
 


### PR DESCRIPTION
I've updated the example configuration file to match the default that we use internally.  This includes using RocksDB instead of HyperLevelDB and default log levels.  Some of the later comments are a little more helpful, too.
