### PR TITLE
Improve RPC command wallet_propose and deprecate wallet_seed.

### DIFF
--- a/src/ripple_rpc/handlers/WalletPropose.cpp
+++ b/src/ripple_rpc/handlers/WalletPropose.cpp
@@ -30,24 +30,25 @@ Json::Value RPCHandler::doWalletPropose (Json::Value params, Resource::Charge& l
     RippleAddress   naSeed;
     RippleAddress   naAccount;
 
-    if (params.isMember ("passphrase"))
-    {
-        naSeed  = RippleAddress::createSeedGeneric (params["passphrase"].asString ());
-    }
-    else
-    {
+    if (!params.isMember ("passphrase"))
         naSeed.setSeedRandom ();
-    }
 
-    RippleAddress   naGenerator = RippleAddress::createGeneratorPublic (naSeed);
+    else if (!naSeed.setSeedGeneric (params["passphrase"].asString ()))
+        return rpcError(rpcBAD_SEED);
+
+    RippleAddress naGenerator = RippleAddress::createGeneratorPublic (naSeed);
     naAccount.setAccountPublic (naGenerator, 0);
 
     Json::Value obj (Json::objectValue);
 
     obj["master_seed"]      = naSeed.humanSeed ();
     obj["master_seed_hex"]  = naSeed.getSeed ().ToString ();
-    //obj["master_key"]     = naSeed.humanSeed1751();
+    obj["master_key"]     = naSeed.humanSeed1751();
     obj["account_id"]       = naAccount.humanAccountID ();
+    obj["public_key"] = naAccount.humanAccountPublic();
+
+    auto acct = naAccount.getAccountPublic();
+    obj["public_key_hex"] = strHex(acct.begin(), acct.size());
 
     return obj;
 }

--- a/src/ripple_rpc/handlers/WalletSeed.cpp
+++ b/src/ripple_rpc/handlers/WalletSeed.cpp
@@ -48,6 +48,7 @@ Json::Value RPCHandler::doWalletSeed (Json::Value params, Resource::Charge& load
 
         obj["seed"]     = raSeed.humanSeed ();
         obj["key"]      = raSeed.humanSeed1751 ();
+        obj["deprecated"] = "Use wallet_propose instead";
 
         return obj;
     }


### PR DESCRIPTION
- Add master_key, public_key and public_key_hex to wallet_propose's
  JSON response.
- Report an error if we can't understand wallet_propose's passphrase.
- Deprecate wallet_seed by adding a "deprecated" parameter directing
  the user to wallet_propose.
