### PR TITLE
Reduce overhead of HTTP/RPC replies

### DIFF
--- a/src/ripple_net/rpc/RPCUtil.cpp
+++ b/src/ripple_net/rpc/RPCUtil.cpp
@@ -160,7 +160,7 @@ std::string HTTPReply (int nStatus, const std::string& strMsg)
         ret.append ("Access-Control-Allow-Origin: *\r\n");
     
     ret.append ("Content-Length: ");
-    ret.append (boost::lexical_cast<std::string>(strMsg.size () + 2));
+    ret.append (std::to_string(strMsg.size () + 2));
     ret.append ("\r\n");
 
     ret.append ("Content-Type: application/json; charset=UTF-8\r\n");


### PR DESCRIPTION
This refactor eliminates the need for the expensive `strprintf` calls to format HTTP replies, especially when very large objects are being returned. 
Additionally, it identifies a couple of instances where we return inconsistent values for the "Server: " header - this may not be a big deal, but we should be consistent, and a potential (micro-)optimization in the construction of HTTP header timestamps.
