### PR TITLE
Fix out-of-order initialization

### DIFF
--- a/src/ripple_app/misc/NetworkOPs.cpp
+++ b/src/ripple_app/misc/NetworkOPs.cpp
@@ -51,9 +51,9 @@ public:
         : NetworkOPs (parent)
         , m_clock (clock)
         , m_journal (journal)
+        , m_localTX (LocalTxs::New ())
         , m_feeVote (make_FeeVote(10, 20 * SYSTEM_CURRENCY_PARTS,
             5 * SYSTEM_CURRENCY_PARTS, LogPartition::getJournal <FeeVoteLog>()))
-        , m_localTX (LocalTxs::New ())
         , mMode (omDISCONNECTED)
         , mNeedNetworkLedger (false)
         , mProposing (false)


### PR DESCRIPTION
Order of initialization in constructor initializer lists must match order of declaration.
