### PR TITLE
Pathfinding dispatch improvements

### DIFF
--- a/src/ripple_app/paths/PathRequest.h
+++ b/src/ripple_app/paths/PathRequest.h
@@ -57,6 +57,7 @@ public:
     bool        isValid ();
     bool        isNew ();
     bool        needsUpdate (bool newOnly, LedgerIndex index);
+    void        updateComplete ();
     Json::Value getStatus ();
 
     Json::Value doCreate (const boost::shared_ptr<Ledger>&, const RippleLineCache::pointer&,
@@ -93,7 +94,9 @@ private:
 
     bool                            bValid;
 
-    std::atomic<LedgerIndex>        iLastIndex;
+    LockType                        mIndexLock;
+    LedgerIndex                     mLastIndex;
+    bool                            mInProgress;
 
     int                             iLastLevel;
     bool                            bLastSuccess;

--- a/src/ripple_app/paths/PathRequests.cpp
+++ b/src/ripple_app/paths/PathRequests.cpp
@@ -90,6 +90,7 @@ void PathRequests::updateAll (Ledger::ref inLedger, CancelCallback shouldCancel)
                         if (!ipSub->getConsumer ().warn ())
                         {
                             Json::Value update = pRequest->doUpdate (cache, false);
+                            pRequest->updateComplete ();
                             update["type"] = "path_find";
                             ipSub->send (update, false);
                             remove = false;


### PR DESCRIPTION
This simplifies the logic that decides whether to update a particular pathfinding request by replacing complex atomic operations with a simple lock. The primary change is to prevent both pathfinding threads from trying to update the same pathfinding request at the same time.
