### PR TITLE
Simplify and improve performance of STAmount::createHumanCurrency

### DIFF
--- a/src/ripple_data/protocol/STAmount.cpp
+++ b/src/ripple_data/protocol/STAmount.cpp
@@ -233,9 +233,12 @@ std::string STAmount::createHumanCurrency (const uint160& uCurrency)
 
     if ((uCurrency & sIsoBits).isZero ())
     {
+        // The offset of the 3 character ISO code in the currency descriptor
+        int const isoOffset = 12;
+
         std::string const iso(
-            uCurrency.data () + (96 / 8),
-            uCurrency.data () + (96 / 8) + 3);
+            uCurrency.data () + isoOffset,
+            uCurrency.data () + isoOffset + 3);
 
         // Specifying the system currency code using ISO-style representation
         // is not allowed.


### PR DESCRIPTION
We call `STAmount::createHumanCurrency` to generate the human-readable name of a currency (e.g. "BTC", "USD", "XRP" or a very long hex string) from one of the various different formats.

The code was very inefficient, serializing the currency, only to then effectively deserialize it by copying parts of it into four different `Blob`s (aka `std::vector<unsigned char>`) and then iterating those vectors to check if they only contained zeros.

Leverage the capabilities of `uint160` and `base_uint` and eliminate the need for all the extra work.
