### PR TITLE
Fix lexicographical compare during tfRequireAuth processing

### DIFF
--- a/src/ripple_app/transactors/OfferCreateTransactor.cpp
+++ b/src/ripple_app/transactors/OfferCreateTransactor.cpp
@@ -927,7 +927,7 @@ TER OfferCreateTransactor::doApply ()
                     ? terNO_LINE
                     : tecNO_LINE;
             }
-            else if (!is_bit_set (sleRippleState->getFieldU32 (sfFlags), (canonical_gt ? lsfHighAuth : lsfLowAuth)))
+            else if (!is_bit_set (sleRippleState->getFieldU32 (sfFlags), (canonical_gt ? lsfLowAuth : lsfHighAuth)))
             {
                 m_journal.debug <<
                     "delay: can't receive IOUs from issuer without auth.";


### PR DESCRIPTION
RippleState entries utilize lexicographical order, with one item being designated "low" while the other is designated "high". We use this distinction when checking flags (e.g. flags which indicate whether someone is authorized to hold an asset).

When checking trust lines against a currency whose issuer had specified `tfRequireAuth`, the comparison logic was reversed; as a result, users might find themselves unable to hold assets that they are authorized to hold.

Fix the check.
