### PR TITLE
Update example config

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -136,10 +136,10 @@
 #
 #
 #
-# [max_peers]
+# [peers_max]
 #
-#	The largest number of desired peer connections (incoming or outgoing).
-#	Cluster and fixed peers do not count towards this total. There are
+#   The largest number of desired peer connections (incoming or outgoing).
+#   Cluster and fixed peers do not count towards this total. There are
 #   implementation-defined lower limits imposed on this value for security
 #   purposes.
 #


### PR DESCRIPTION
This trivial change corrects our default configuration file, which documents an option using the wrong name. This is in response to https://ripplelabs.atlassian.net/browse/RIPD-255
