### PR TITLE
Properly standardize RFC1751 inputs

### DIFF
--- a/src/ripple_data/crypto/RFC1751.cpp
+++ b/src/ripple_data/crypto/RFC1751.cpp
@@ -338,17 +338,14 @@ void RFC1751::standard (std::string& strWord)
 {
     for (auto& letter : strWord)
     {
-        if (isascii (letter))
-        {
-            if (islower (letter))
-                letter = toupper (letter);
-            else if (letter == '1')
-                letter = 'L';
-            else if (letter == '0')
-                letter = 'O';
-            else if (letter == '5')
-                letter = 'S';
-        }
+        if (islower (letter))
+            letter = toupper (letter);
+        else if (letter == '1')
+            letter = 'L';
+        else if (letter == '0')
+            letter = 'O';
+        else if (letter == '5')
+            letter = 'S';
     }
 }
 


### PR DESCRIPTION
While spelunking through Ripple code (instead of sleeping) I stumbled across `RFC1751::standard`. The intention of the code seems to be to convert the input string to all uppercase ASCII characters and replace the numerals `0`, `1` and `5` with the similar-looking ASCII characters `'O'`, `'I'` and `'S'`.

Unfortunately, the function was a no-op: it modified the local copy of the variable `cLetter`, leaving the original string unchanged.

I believe this change properly reflects the intention of the code.
