### PR TITLE
fixed RIPD-293 - return error when checking status of missing pathfinding request

### DIFF
--- a/src/ripple/module/rpc/handlers/PathFind.cpp
+++ b/src/ripple/module/rpc/handlers/PathFind.cpp
@@ -56,7 +56,7 @@ Json::Value RPCHandler::doPathFind (Json::Value params, Resource::Charge& loadTy
         PathRequest::pointer request = mInfoSub->getPathRequest ();
 
         if (!request)
-            return rpcNO_PF_REQUEST;
+            return rpcError (rpcNO_PF_REQUEST);
 
         return request->doStatus (params);
     }


### PR DESCRIPTION
https://ripplelabs.atlassian.net/browse/RIPD-293

I'm pretty sure this fixes the error where `path_find status` gets a weird "success" response when checking on a nonexistent pathfinding request, even though `path_find close` does return a reasonable error message. Looks like a simple typo in the original source.
