### PR TITLE
Added automatic conversion and comparisons for base_uint<Bits, Tags>.

### DIFF
--- a/src/ripple/types/api/base_uint.h
+++ b/src/ripple/types/api/base_uint.h
@@ -150,7 +150,7 @@ public:
         SetHex (str);
     }
 
-    base_uint (base_uint<Bits, Tag> const& other) = default;
+    base_uint (base_uint const& other) = default;
 
     template <
         class OtherTag,


### PR DESCRIPTION
- Automatic conversions and comparisons are enabled both ways between
  base_uint<Bits, Tags> and base_uint<Bits, void>.
- No coversions or comparisons are enabled between base_uint<Bits, Tags1>
  and base_uint<Bits, Tags2> if Tags1 is not Tags2 and neither is void.

This is already successfully in use on another branch, https://github.com/rec/rippled/tree/x-ripple-calc.
