### PR TITLE
Allows scons vcxproj to work on all systems

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -399,7 +399,7 @@ def config_env(toolchain, variant, env):
             '/MACHINE:X64',
             '/MANIFEST',
             #'''/MANIFESTUAC:"level='asInvoker' uiAccess='false'"''',
-            #'/NOLOGO',
+            '/NOLOGO',
             '/NXCOMPAT',
             '/SUBSYSTEM:CONSOLE',
             '/TLBID:1',

--- a/src/beast/site_scons/site_tools/VSProject.py
+++ b/src/beast/site_scons/site_tools/VSProject.py
@@ -134,6 +134,7 @@ class SwitchConverter(object):
     def getXml(self, switches, prefix = ''):
         if type(switches) != list:
             switches = list(switches)
+        switches = list(set(switches))      # Filter dupes because on windows platforms, /nologo is added automatically to the environment.
         xml = []
         unknown = []
         for switch in switches:
@@ -281,10 +282,6 @@ class LinkSwitchConverter(SwitchConverter):
         # Based on code in Generate Your Project
         booltable = {
             '/DEBUG'                : ['GenerateDebugInformation'],
-            '/DYNAMICBASE'          : ['RandomizedBaseAddress'],
-            '/DYNAMICBASE'          : ['RandomizedBaseAddress'],
-            '/DYNAMICBASE'          : ['RandomizedBaseAddress'],
-            '/DYNAMICBASE'          : ['RandomizedBaseAddress'],
             '/DYNAMICBASE'          : ['RandomizedBaseAddress'],
             '/NOLOGO'               : ['SuppressStartupBanner'],
         }


### PR DESCRIPTION
This changes the way toolchains is looped over, always looping over
only gcc, clang, and msvc, but only aliasing if the toolchain is in
toolchains.

Changes along the way:
- Ensures the visual studio file is always described
- Makes the toolchain loop more straightforward
- Removes an old variable
- Prevents checking nonexistant enviro vars
- Prevents pkg-config protobuf env vars if not clang/gcc
- Removes tabs
- Doesn't use any pkg-config enviro vars unless clang/gcc
- Makes all directories windows-style
