### PR TITLE
Simplification of basic_seconds_clock.

### DIFF
--- a/src/beast/beast/chrono/basic_seconds_clock.h
+++ b/src/beast/beast/chrono/basic_seconds_clock.h
@@ -22,125 +22,14 @@
 
 #include <beast/chrono/chrono_util.h>
 
-#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
-#include <vector>
+
+extern "C" int main(int argc, char** argv);
 
 namespace beast {
-
-namespace detail {
-
-class seconds_clock_worker
-{
-public:
-    virtual void sample () = 0;
-};
-
-//------------------------------------------------------------------------------
-
-// Updates the clocks
-class seconds_clock_thread
-{
-public:
-    typedef std::mutex mutex;
-    typedef std::condition_variable cond_var;
-    typedef std::lock_guard <mutex> lock_guard;
-    typedef std::unique_lock <mutex> unique_lock;
-    typedef std::chrono::steady_clock clock_type;
-    typedef std::chrono::seconds seconds;
-    typedef std::thread thread;
-    typedef std::vector <seconds_clock_worker*> workers;
-
-    bool m_stop;
-    mutex m_mutex;
-    cond_var m_cond;
-    workers m_workers;
-    thread m_thread;
-
-    seconds_clock_thread ()
-        : m_stop (false)
-    {
-        m_thread = thread (std::bind(
-            &seconds_clock_thread::run, this));
-    }
-
-    ~seconds_clock_thread ()
-    {
-        stop();
-    }
-
-    void add (seconds_clock_worker& w)
-    {
-        lock_guard lock (m_mutex);
-        m_workers.push_back (&w);
-    }
-
-    void remove (seconds_clock_worker& w)
-    {
-        lock_guard lock (m_mutex);
-        m_workers.erase (std::find (
-            m_workers.begin (), m_workers.end(), &w));
-    }
-
-    void stop()
-    {
-        if (m_thread.joinable())
-        {
-            {
-                lock_guard lock (m_mutex);
-                m_stop = true;
-            }
-            m_cond.notify_all();
-            m_thread.join();
-        }
-    }
-
-    void run()
-    {
-        unique_lock lock (m_mutex);;
-
-        for (;;)
-        {
-            for (auto iter : m_workers)
-                iter->sample();
-
-            clock_type::time_point const when (
-                floor <seconds> (
-                    clock_type::now().time_since_epoch()) +
-                        seconds (1));
-
-            if (m_cond.wait_until (lock, when, [this]{ return m_stop; }))
-                return;
-        }
-    }
-
-    static seconds_clock_thread& instance ()
-    {
-        static seconds_clock_thread singleton;
-        return singleton;
-    }
-};
-
-}
-
-//------------------------------------------------------------------------------
-
-/** Called before main exits to terminate the utility thread.
-    This is a workaround for Visual Studio 2013:
-    http://connect.microsoft.com/VisualStudio/feedback/details/786016/creating-a-global-c-object-that-used-thread-join-in-its-destructor-causes-a-lockup
-    http://stackoverflow.com/questions/10915233/stdthreadjoin-hangs-if-called-after-main-exits-when-using-vs2012-rc
-*/
-inline
-void
-basic_seconds_clock_main_hook()
-{
-#ifdef _MSC_VER
-    detail::seconds_clock_thread::instance().stop();
-#endif
-}
 
 /** A clock whose minimum resolution is one second.
     The purpose of this class is to optimize the performance of the now()
@@ -152,71 +41,124 @@ template <class TrivialClock>
 class basic_seconds_clock
 {
 public:
-    typedef std::chrono::seconds resolution;
-    typedef typename resolution::rep rep;
-    typedef typename resolution::period period;
-    typedef std::chrono::duration <rep, period> duration;
+    typedef std::chrono::seconds      duration;
+    typedef typename duration::period period;
+    typedef typename duration::rep    rep;
     typedef std::chrono::time_point <basic_seconds_clock> time_point;
 
     static bool const is_steady = TrivialClock::is_steady;
 
-    static time_point now ()
+    ~basic_seconds_clock() = delete;
+    basic_seconds_clock() = delete;
+    static time_point now();
+
+private:
+    static std::mutex& mut()
     {
-        // Make sure the thread is constructed before the
-        // worker otherwise we will crash during destruction
-        // of objects with static storage duration.
-        struct initializer
-        {
-            initializer ()
-            {
-                detail::seconds_clock_thread::instance();
-            }
-        };
-        static initializer init;
-
-        struct worker : detail::seconds_clock_worker
-        {
-            typedef std::mutex mutex;
-            typedef std::lock_guard <mutex> lock_guard;
-
-            time_point m_now;
-            mutex m_mutex;
-
-            static time_point get_now ()
-            {
-                return time_point (floor <resolution> (
-                    TrivialClock::now().time_since_epoch()));
-            }
-
-            worker ()
-                : m_now (get_now ())
-            {
-                detail::seconds_clock_thread::instance().add (*this);
-            }
-
-            ~worker ()
-            {
-                detail::seconds_clock_thread::instance().remove (*this);
-            }
-
-            time_point now()
-            {
-                lock_guard lock (m_mutex);
-                return m_now;
-            }
-
-            void sample ()
-            {
-                lock_guard lock (m_mutex);
-                m_now = get_now ();
-            }
-        };
-
-        static worker w;
-
-        return w.now ();
+        static std::mutex mut;
+        return mut;
     }
+
+    static std::condition_variable& cv()
+    {
+        static std::condition_variable cv;
+        return cv;
+    }
+
+    enum {uninitialized, started, stopping, stopped};
+
+    static unsigned& state()
+    {
+        static unsigned state = uninitialized;
+        return state;
+    }
+
+    static time_point& get_now()
+    {
+        static time_point now;
+        return now;
+    }
+
+    static void stop();
+    static void update_clock();
+    static unsigned init();
+
+    friend int ::main(int argc, char** argv);
 };
+
+/** 
+*  If uninitialized, set to stopped.
+*  If started, stop.
+*  If stopping, wait for stopped then return.
+*  If stopped, do nothing.
+*/
+template <class TrivialClock>
+void
+basic_seconds_clock<TrivialClock>::stop()
+{
+    std::unique_lock<std::mutex> lk(mut());
+    if (state() == uninitialized)
+    {
+        state() = stopped;
+    }
+    else if (state() != stopped)
+    {
+        if (state() == started)
+        {
+            state() = stopping;
+            cv().notify_all();
+        }
+        while (state() != stopped)
+            cv().wait(lk);
+    }
+}
+
+template <class TrivialClock>
+typename basic_seconds_clock<TrivialClock>::time_point
+basic_seconds_clock<TrivialClock>::now()
+{
+    struct initializer
+    {
+        ~initializer() { stop(); }
+        initializer()  { init(); }
+        initializer(initializer const&) = delete;
+        initializer& operator=(initializer const&) = delete;
+    };
+    static initializer start;
+    std::lock_guard<std::mutex> lk(mut());
+    return get_now();
+}
+
+template <class TrivialClock>
+void
+basic_seconds_clock<TrivialClock>::update_clock()
+{
+    using namespace std::chrono;
+    std::unique_lock<std::mutex> lk(mut());
+    while (state() == started)
+    {
+        get_now() = time_point
+                      (floor<duration>(TrivialClock::now().time_since_epoch()));
+        cv().wait_for(lk, seconds(1));
+    }
+    state() = stopped;
+    cv().notify_all();
+}
+
+template <class TrivialClock>
+unsigned
+basic_seconds_clock<TrivialClock>::init()
+{
+    using namespace std::chrono;
+    // Run these first to put them last in the atexit chain
+    cv();
+    mut();
+    get_now() = time_point
+                      (floor<duration>(TrivialClock::now().time_since_epoch()));
+    state() = started;
+    std::thread(&update_clock).detach();
+    return 0;
+}
 
 }
 

--- a/src/ripple/unity/app.cpp
+++ b/src/ripple/unity/app.cpp
@@ -98,7 +98,8 @@ int main (int argc, char** argv)
 
     auto const result (ripple::run (argc, argv));
 
-    beast::basic_seconds_clock_main_hook();
+    // This can probably be removed now.  Removal needs testing on VC++.
+    beast::basic_seconds_clock<std::chrono::steady_clock>::stop();
 
     return result;
 }


### PR DESCRIPTION
This eliminates an unnecessary vector of pointers from the basic_seconds_clock implementation.  This may allow us to remove the vc++ hack of stopping the clock at the end of main.
