### PR TITLE
Add new memo restrictions

### DIFF
--- a/src/ripple/module/app/misc/SerializedTransaction.cpp
+++ b/src/ripple/module/app/misc/SerializedTransaction.cpp
@@ -318,13 +318,40 @@ bool isMemoOkay (STObject const& st)
 {
     if (!st.isFieldPresent (sfMemos))
         return true;
+
+    const STArray& memos = st.getFieldArray (sfMemos);
     // The number 2048 is a preallocation hint, not a hard limit
     // to avoid allocate/copy/free's
     Serializer s (2048);
-    st.getFieldArray (sfMemos).add (s);
+    memos.add (s);
     // FIXME move the memo limit into a config tunable
     if (s.getDataLength () > 1024)
         return false;
+
+    for (auto const& memo : memos)
+    {
+        auto memoObj = dynamic_cast <STObject const*> (&memo);
+
+        // Memos array must consist solely of Memo objects
+        if (!memoObj || (memoObj->getFName() != sfMemo))
+        {
+            return false;
+        }
+
+        // Memo objects may only contain
+        // MemoType, MemoData, and MemoFormat fields
+        for (auto const& memoElement : *memoObj)
+        {
+            if ((memoElement.getFName() != sfMemoType) &&
+                (memoElement.getFName() != sfMemoData) &&
+                (memoElement.getFName() != sfMemoFormat))
+            {
+                return false;
+            }
+        }
+
+    }
+
     return true;
 }
 

--- a/src/ripple/module/data/protocol/SerializeDeclarations.h
+++ b/src/ripple/module/data/protocol/SerializeDeclarations.h
@@ -162,6 +162,7 @@ FIELD (ExpireCode,           VL, 10)
 FIELD (CreateCode,           VL, 11)
 FIELD (MemoType,             VL, 12)
 FIELD (MemoData,             VL, 13)
+FIELD (MemoFormat,           VL, 14)
 
 // account
 FIELD (Account,              ACCOUNT, 1)


### PR DESCRIPTION
This tightens up the rules for memos. The "Memos" array can only consist of "Memo" objects. Memo objects can only contain "MemoData", "MemoFormat", and "MemoType" fields.

The distinction between the "type" and the "format" is that the "type" identifies a specific protocol for the netire memo data meaning. The "format" indicates whether it is JSON, text, X.609, MessagePack, raw binary, ripple serialization, or whatever. This permits a client that understands the format to provide some information about the memo even if it doesn't understand the entire protocol.
