### PR TITLE
Remove calls to SHAMapNode::getID

### DIFF
--- a/src/ripple/module/app/shamap/SHAMap.h
+++ b/src/ripple/module/app/shamap/SHAMap.h
@@ -188,7 +188,7 @@ public:
     // comparison/sync functions
     void getMissingNodes (std::vector<SHAMapNodeID>& nodeIDs, std::vector<uint256>& hashes, int max,
                           SHAMapSyncFilter * filter);
-    bool getNodeFat (SHAMapNodeID const& node, std::vector<SHAMapNodeID>& nodeIDs,
+    bool getNodeFat (SHAMapNodeID node, std::vector<SHAMapNodeID>& nodeIDs,
                      std::list<Blob >& rawNode, bool fatRoot, bool fatLeaves);
     bool getRootNode (Serializer & s, SHANodeFormat format);
     std::vector<uint256> getNeededHashes (int max, SHAMapSyncFilter * filter);
@@ -260,13 +260,16 @@ private:
     SHAMapTreeNode::pointer getCache (uint256 const& hash, SHAMapNodeID const& id);
     void canonicalize (uint256 const& hash, SHAMapTreeNode::pointer&);
 
-    void dirtyUp (std::stack<SHAMapTreeNode::pointer>& stack, uint256 const & target, uint256 prevHash);
-    std::stack<SHAMapTreeNode::pointer> getStack (uint256 const & id, bool include_nonmatching_leaf);
+    void dirtyUp (std::stack<std::pair<SHAMapTreeNode::pointer, SHAMapNodeID>>& stack,
+                  uint256 const & target, uint256 prevHash);
+    std::stack<std::pair<SHAMapTreeNode::pointer, SHAMapNodeID>>
+        getStack (uint256 const & id, bool include_nonmatching_leaf);
     SHAMapTreeNode::pointer walkTo (uint256 const & id, bool modify);
     SHAMapTreeNode* walkToPointer (uint256 const & id);
     SHAMapTreeNode::pointer checkCacheNode (const SHAMapNodeID&);
-    void returnNode (SHAMapTreeNode::pointer&, bool modify);
-    void trackNewNode (SHAMapTreeNode::pointer&);
+    void returnNode (SHAMapTreeNode::pointer&, SHAMapNodeID const& nodeID,
+                                                                   bool modify);
+    void trackNewNode (SHAMapTreeNode::pointer&, SHAMapNodeID const&);
 
     SHAMapTreeNode::pointer getNode (const SHAMapNodeID & id);
     SHAMapTreeNode::pointer getNode (const SHAMapNodeID & id, uint256 const & hash, bool modify);
@@ -275,20 +278,21 @@ private:
     SHAMapTreeNode* getNodePointerNT (const SHAMapNodeID & id, uint256 const & hash);
     SHAMapTreeNode* getNodePointer (const SHAMapNodeID & id, uint256 const & hash, SHAMapSyncFilter * filter);
     SHAMapTreeNode* getNodePointerNT (const SHAMapNodeID & id, uint256 const & hash, SHAMapSyncFilter * filter);
-    SHAMapTreeNode* firstBelow (SHAMapTreeNode*);
-    SHAMapTreeNode* lastBelow (SHAMapTreeNode*);
+    SHAMapTreeNode* firstBelow (SHAMapTreeNode*, SHAMapNodeID);
+    SHAMapTreeNode* lastBelow (SHAMapTreeNode*, SHAMapNodeID);
 
     // Non-blocking version of getNodePointerNT
     SHAMapTreeNode* getNodeAsync (
         const SHAMapNodeID & id, uint256 const & hash, SHAMapSyncFilter * filter, bool& pending);
 
-    SHAMapItem::pointer onlyBelow (SHAMapTreeNode*);
-    void eraseChildren (SHAMapTreeNode::pointer);
-    void dropBelow (SHAMapTreeNode*);
+    SHAMapItem::pointer onlyBelow (SHAMapTreeNode*, SHAMapNodeID);
+    void eraseChildren (SHAMapTreeNode::pointer, SHAMapNodeID);
+    void dropBelow (SHAMapTreeNode*, SHAMapNodeID);
     bool hasInnerNode (const SHAMapNodeID & nodeID, uint256 const & hash);
     bool hasLeafNode (uint256 const & tag, uint256 const & hash);
 
-    bool walkBranch (SHAMapTreeNode * node, SHAMapItem::ref otherMapItem, bool isFirstMap,
+    bool walkBranch (SHAMapTreeNode* node, SHAMapNodeID nodeID,
+                     SHAMapItem::ref otherMapItem, bool isFirstMap,
                      Delta & differences, int & maxCount);
 
     void visitLeavesInternal (std::function<void (SHAMapItem::ref item)>& function);

--- a/src/ripple/module/app/shamap/SHAMapNodeID.h
+++ b/src/ripple/module/app/shamap/SHAMapNodeID.h
@@ -31,7 +31,6 @@ namespace ripple {
 class SHAMapNodeID
 {
 private:
-    static uint256 smMasks[65]; // AND with hash to get node id
 
     uint256 mNodeID;
     int     mDepth;
@@ -115,7 +114,6 @@ public:
     virtual std::string getString () const;
     void dump () const;
 
-    static bool ClassInit ();
     static uint256 getNodeID (int depth, uint256 const& hash);
 
     // Convert to/from wire format (256-bit nodeID, 1-byte depth)

--- a/src/ripple/module/app/shamap/SHAMapTreeNode.cpp
+++ b/src/ripple/module/app/shamap/SHAMapTreeNode.cpp
@@ -31,7 +31,7 @@ SHAMapTreeNode::SHAMapTreeNode (std::uint32_t seq, const SHAMapNodeID& nodeID)
 }
 
 SHAMapTreeNode::SHAMapTreeNode (const SHAMapTreeNode& node, std::uint32_t seq)
-    : mID (node.getID())
+    : mID (node.mID)
     , mHash (node.mHash)
     , mSeq (seq)
     , mType (node.mType)
@@ -490,6 +490,25 @@ bool SHAMapTreeNode::setChildHash (int m, uint256 const& hash)
         mIsBranch &= ~ (1 << m);
 
     return updateHash ();
+}
+
+// Descends along the specified branch
+// On invocation, nodeID must be the ID of this node
+// Returns false if there is no node down that branch
+// Otherwise, returns true and fills in the node's ID and hash
+
+bool
+SHAMapTreeNode::descend (int branch, SHAMapNodeID& nodeID, uint256& nodeHash)
+{
+    assert (isInnerNode ());
+
+    if (isEmptyBranch (branch))
+        return false;
+
+    nodeID = nodeID.getChildNodeID (branch);
+    nodeHash = mHashes [branch];
+
+    return true;
 }
 
 } // ripple

--- a/src/ripple/module/app/shamap/SHAMapTreeNode.h
+++ b/src/ripple/module/app/shamap/SHAMapTreeNode.h
@@ -52,6 +52,9 @@ public:
     };
 
 public:
+    SHAMapTreeNode (const SHAMapTreeNode&) = delete;
+    SHAMapTreeNode& operator= (const SHAMapTreeNode&) = delete;
+
     SHAMapTreeNode (std::uint32_t seq, const SHAMapNodeID & nodeID); // empty node
     SHAMapTreeNode (const SHAMapTreeNode & node, std::uint32_t seq); // copy node from older tree
     SHAMapTreeNode (const SHAMapNodeID & nodeID, SHAMapItem::ref item, TNType type,
@@ -176,10 +179,19 @@ public:
     SHAMapNodeID const& getID() const {return mID;}
     void setID(SHAMapNodeID const& id) {mID = id;}
 
+    /** Descends along the specified branch
+    * On invocation, nodeID must be the ID of this node
+    * Returns false if there is no node down that branch
+    * Otherwise, returns true and fills in the node's ID and hash
+    *
+    * @param branch   the branch to descend [0, 15]
+    * @param nodeID   on entry the ID of the parent. On exit the ID of the child
+    * @param nodeHash on exit the hash of the child node.
+    * @return true if nodeID and nodeHash are altered.
+    */
+    bool descend (int branch, SHAMapNodeID& nodeID, uint256& nodeHash);
+
 private:
-    // VFALCO TODO derive from Uncopyable
-    SHAMapTreeNode (const SHAMapTreeNode&); // no implementation
-    SHAMapTreeNode& operator= (const SHAMapTreeNode&); // no implementation
 
     // VFALCO TODO remove the use of friend
     friend class SHAMap;

--- a/src/ripple/unity/app.cpp
+++ b/src/ripple/unity/app.cpp
@@ -73,6 +73,11 @@ int main (int argc, char** argv)
 #ifdef _MSC_VER
     static_assert (_MSC_VER >= 1800,
         "Visual Studio 2013 or later is required to compile rippled.");
+    // Warm up a function-local static under SHAMapNodeID to workaround
+    //   vc++ lack of support for thread safe function-local statics
+    {
+        SHAMapNodeID node{0, uint256{}};
+    }
 #endif
 
     static_assert (BOOST_VERSION >= 105500,


### PR DESCRIPTION
This addresses RIPD-347
Calls in SHAMap::getCache and SHAMap::canonicalize are
purposefully left in place at this time (to be removed
later).
