### PR TITLE
Move an auto variable back into a scoped lock.

### DIFF
--- a/src/ripple/module/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/module/app/ledger/OrderBookDB.cpp
@@ -33,9 +33,9 @@ void OrderBookDB::invalidate ()
 
 void OrderBookDB::setup (Ledger::ref ledger)
 {
-    auto seq = ledger->getLedgerSeq ();
     {
         ScopedLockType sl (mLock);
+        auto seq = ledger->getLedgerSeq ();
 
         // Do a full update every 256 ledgers
         if (mSeq != 0)


### PR DESCRIPTION
Fix for conceivable race condition revealed by nikb.

Even if the problem is not possible now, the lock should surround that access.
