### PR TITLE
Reduce scope of global lock during RPC calls.

### DIFF
--- a/src/ripple/module/app/main/Application.h
+++ b/src/ripple/module/app/main/Application.h
@@ -72,8 +72,14 @@ public:
     */
     typedef RippleRecursiveMutex LockType;
     typedef std::unique_lock <LockType> ScopedLockType;
+    typedef std::unique_ptr <ScopedLockType> ScopedLock;
 
     virtual LockType& getMasterLock () = 0;
+
+    ScopedLock masterLock()
+    {
+        return std::make_unique<ScopedLockType> (getMasterLock());
+    }
 
 public:
     Application ();

--- a/src/ripple/module/app/misc/NetworkOPs.h
+++ b/src/ripple/module/app/misc/NetworkOPs.h
@@ -285,20 +285,17 @@ public:
             bool count, bool bAdmin) = 0;
 
     // client information retrieval functions
-    typedef std::vector<
-        std::pair<Transaction::pointer, TransactionMetaSet::pointer> >
-    AccountTxs;
+    typedef std::pair<Transaction::pointer, TransactionMetaSet::pointer>
+    AccountTx;
+
+    typedef std::vector<AccountTx> AccountTxs;
 
     virtual AccountTxs getAccountTxs (
         const RippleAddress& account,
         std::int32_t minLedger, std::int32_t maxLedger,  bool descending,
         std::uint32_t offset, int limit, bool bAdmin) = 0;
 
-    typedef std::vector<
-        std::pair<Transaction::pointer, TransactionMetaSet::pointer> >
-    TxsAccount;
-
-    virtual TxsAccount getTxsAccount (
+    virtual AccountTxs getTxsAccount (
         const RippleAddress& account,
         std::int32_t minLedger, std::int32_t maxLedger, bool forward,
         Json::Value& token, int limit, bool bAdmin) = 0;

--- a/src/ripple/module/app/misc/ProofOfWorkFactory.cpp
+++ b/src/ripple/module/app/misc/ProofOfWorkFactory.cpp
@@ -157,7 +157,7 @@ public:
 
         ScopedLockType sl (mLock);
 
-        std::string s = boost::str (boost::format (f) % to_string (challenge) % 
+        std::string s = boost::str (boost::format (f) % to_string (challenge) %
             to_string (mTarget) % mIterations % now);
         std::string c = to_string (mSecret) + s;
         s += "-" + to_string (Serializer::getSHA512Half (c));
@@ -183,7 +183,7 @@ public:
             return powCORRUPT;
         }
 
-        std::string v = to_string (mSecret) + fields[0] + "-" + 
+        std::string v = to_string (mSecret) + fields[0] + "-" +
                         fields[1] + "-" + fields[2] + "-" + fields[3];
 
         if (fields[4] != to_string (Serializer::getSHA512Half (v)))
@@ -354,9 +354,9 @@ private:
 
 //------------------------------------------------------------------------------
 
-ProofOfWorkFactory* ProofOfWorkFactory::New ()
+std::unique_ptr<ProofOfWorkFactory> ProofOfWorkFactory::New ()
 {
-    return new ProofOfWorkFactoryImp;
+    return std::make_unique<ProofOfWorkFactoryImp>();
 }
 
 //------------------------------------------------------------------------------
@@ -372,7 +372,7 @@ public:
         ProofOfWork pow = gen.getProof ();
 
         beast::String s;
-        
+
         s << "solve difficulty " << beast::String (pow.getDifficulty ());
 
         uint256 solution = pow.solve (16777216);

--- a/src/ripple/module/app/misc/ProofOfWorkFactory.h
+++ b/src/ripple/module/app/misc/ProofOfWorkFactory.h
@@ -33,7 +33,7 @@ public:
         kMaxDifficulty = 30,
     };
 
-    static ProofOfWorkFactory* New ();
+    static std::unique_ptr<ProofOfWorkFactory> New ();
 
     virtual ~ProofOfWorkFactory () { }
 

--- a/src/ripple/module/app/tx/TransactionAcquire.cpp
+++ b/src/ripple/module/app/tx/TransactionAcquire.cpp
@@ -82,7 +82,7 @@ void TransactionAcquire::onTimer (bool progress, ScopedLockType& psl)
         WriteLog (lsWARNING, TransactionAcquire) << "Ten timeouts on TX set " << getHash ();
         psl.unlock();
         {
-            Application::ScopedLockType lock (getApp().getMasterLock ());
+            auto lock = getApp().masterLock();
 
             if (getApp().getOPs ().stillNeedTXSet (mHash))
             {

--- a/src/ripple/module/rpc/RPCHandler.h
+++ b/src/ripple/module/rpc/RPCHandler.h
@@ -66,7 +66,8 @@ public:
 
 public:
     RPCInternalHandler (const std::string& name, handler_t handler);
-    static Json::Value runHandler (const std::string& name, const Json::Value& params);
+    static Json::Value runHandler (
+        const std::string& name, const Json::Value& params);
 
 private:
     // VFALCO TODO Replace with a singleton with a well defined interface and

--- a/src/ripple/module/rpc/Tuning.h
+++ b/src/ripple/module/rpc/Tuning.h
@@ -26,6 +26,8 @@ namespace RPC {
 const int DEFAULT_AUTO_FILL_FEE_MULTIPLIER = 10;
 const int MAX_PATHFINDS_IN_PROGRESS = 2;
 const int MAX_PATHFIND_JOB_COUNT = 50;
+const int MAX_JOB_QUEUE_CLIENTS = 500;
+const int MAX_VALIDATED_LEDGER_AGE = 120;
 
 // TODO(tom): Shouldn't DEFAULT_AUTO_FILL_FEE_MULTIPLIER be floating point?
 

--- a/src/ripple/module/rpc/handlers/AccountCurrencies.cpp
+++ b/src/ripple/module/rpc/handlers/AccountCurrencies.cpp
@@ -21,37 +21,40 @@ namespace ripple {
 
 Json::Value doAccountCurrencies (RPC::Context& context)
 {
-    context.lock_.unlock ();
-    // Get the current ledger
-    Ledger::pointer lpLedger;
-    Json::Value jvResult (RPC::lookupLedger (context.params_, lpLedger, context.netOps_));
-    if (!lpLedger)
-        return jvResult;
+    auto& params = context.params_;
 
-    if (! context.params_.isMember ("account") && ! context.params_.isMember ("ident"))
+    // Get the current ledger
+    Ledger::pointer ledger;
+    Json::Value result (RPC::lookupLedger (params, ledger, context.netOps_));
+
+    if (!ledger)
+        return result;
+
+    if (!(params.isMember ("account") || params.isMember ("ident")))
         return RPC::missing_field_error ("account");
 
-    std::string const strIdent (context.params_.isMember ("account")
-        ? context.params_["account"].asString ()
-        : context.params_["ident"].asString ());
+    std::string const strIdent (params.isMember ("account")
+        ? params["account"].asString ()
+        : params["ident"].asString ());
 
-    int const iIndex (context.params_.isMember ("account_index")
-        ? context.params_["account_index"].asUInt ()
+    int const iIndex (params.isMember ("account_index")
+        ? params["account_index"].asUInt ()
         : 0);
-    bool const bStrict (context.params_.isMember ("strict") && context.params_["strict"].asBool ());
+    bool const bStrict = params.isMember ("strict") &&
+            params["strict"].asBool ();
 
     // Get info on account.
     bool bIndex; // out param
     RippleAddress naAccount; // out param
     Json::Value jvAccepted (RPC::accountFromString (
-        lpLedger, naAccount, bIndex, strIdent, iIndex, bStrict, context.netOps_));
+        ledger, naAccount, bIndex, strIdent, iIndex, bStrict, context.netOps_));
 
     if (!jvAccepted.empty ())
         return jvAccepted;
 
     std::set<Currency> send, receive;
     AccountItems rippleLines (
-        naAccount.getAccountID (), lpLedger,
+        naAccount.getAccountID (), ledger,
         AccountItem::pointer (new RippleState ()));
     for (auto item: rippleLines.getItems ())
     {
@@ -64,22 +67,20 @@ Json::Value doAccountCurrencies (RPC::Context& context)
             send.insert (saBalance.getCurrency ());
     }
 
-
     send.erase (badCurrency());
     receive.erase (badCurrency());
 
     Json::Value& sendCurrencies =
-            (jvResult["send_currencies"] = Json::arrayValue);
+            (result["send_currencies"] = Json::arrayValue);
     for (auto const& c: send)
         sendCurrencies.append (to_string (c));
 
     Json::Value& recvCurrencies =
-            (jvResult["receive_currencies"] = Json::arrayValue);
+            (result["receive_currencies"] = Json::arrayValue);
     for (auto const& c: receive)
         recvCurrencies.append (to_string (c));
 
-
-    return jvResult;
+    return result;
 }
 
 } // ripple

--- a/src/ripple/module/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/module/rpc/handlers/AccountLines.cpp
@@ -28,60 +28,66 @@ namespace ripple {
 // }
 Json::Value doAccountLines (RPC::Context& context)
 {
-    context.lock_.unlock ();
+    auto& params = context.params_;
 
-    Ledger::pointer     lpLedger;
-    Json::Value         jvResult    = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Ledger::pointer ledger;
+    Json::Value result = RPC::lookupLedger (params, ledger, context.netOps_);
 
-    if (!lpLedger)
-        return jvResult;
+    if (!ledger)
+        return result;
 
-    if (!context.params_.isMember (jss::account))
+    if (!params.isMember (jss::account))
         return RPC::missing_field_error ("account");
 
-    std::string     strIdent    = context.params_[jss::account].asString ();
-    bool            bIndex      = context.params_.isMember (jss::account_index);
-    int             iIndex      = bIndex ? context.params_[jss::account_index].asUInt () : 0;
+    std::string strIdent = params[jss::account].asString ();
+    bool bIndex = params.isMember (jss::account_index);
+    int iIndex = bIndex ? params[jss::account_index].asUInt () : 0;
 
     RippleAddress   raAccount;
 
-    jvResult    = RPC::accountFromString (lpLedger, raAccount, bIndex, strIdent, iIndex, false, context.netOps_);
+    result = RPC::accountFromString (
+        ledger, raAccount, bIndex, strIdent, iIndex, false, context.netOps_);
 
-    if (!jvResult.empty ())
-        return jvResult;
+    if (!result.empty ())
+        return result;
 
-    std::string     strPeer     = context.params_.isMember (jss::peer) ? context.params_[jss::peer].asString () : "";
-    bool            bPeerIndex      = context.params_.isMember (jss::peer_index);
-    int             iPeerIndex      = bIndex ? context.params_[jss::peer_index].asUInt () : 0;
+    std::string strPeer = params.isMember (jss::peer)
+            ? params[jss::peer].asString () : "";
+    bool bPeerIndex = params.isMember (jss::peer_index);
+    int iPeerIndex = bIndex ? params[jss::peer_index].asUInt () : 0;
 
     RippleAddress   raPeer;
 
     if (!strPeer.empty ())
     {
-        jvResult[jss::peer]    = raAccount.humanAccountID ();
+        result[jss::peer]    = raAccount.humanAccountID ();
 
         if (bPeerIndex)
-            jvResult[jss::peer_index]  = iPeerIndex;
+            result[jss::peer_index]  = iPeerIndex;
 
-        jvResult    = RPC::accountFromString (lpLedger, raPeer, bPeerIndex, strPeer, iPeerIndex, false, context.netOps_);
+        result = RPC::accountFromString (
+            ledger, raPeer, bPeerIndex, strPeer, iPeerIndex, false,
+            context.netOps_);
 
-        if (!jvResult.empty ())
-            return jvResult;
+        if (!result.empty ())
+            return result;
     }
 
-    if (lpLedger->hasAccount (raAccount))
+    if (ledger->hasAccount (raAccount))
     {
-        AccountItems rippleLines (raAccount.getAccountID (), lpLedger, AccountItem::pointer (new RippleState ()));
+        AccountItems rippleLines (raAccount.getAccountID (), ledger,
+                                  AccountItem::pointer (new RippleState ()));
 
-        jvResult[jss::account] = raAccount.humanAccountID ();
-        Json::Value& jsonLines = (jvResult[jss::lines] = Json::arrayValue);
+        result[jss::account] = raAccount.humanAccountID ();
+        Json::Value& jsonLines = (result[jss::lines] = Json::arrayValue);
 
 
-        BOOST_FOREACH (AccountItem::ref item, rippleLines.getItems ())
+        for (auto& item: rippleLines.getItems ())
         {
             RippleState* line = (RippleState*)item.get ();
 
-            if (!raPeer.isValid () || raPeer.getAccountID () == line->getAccountIDPeer ())
+            if (!raPeer.isValid () ||
+                raPeer.getAccountID () == line->getAccountIDPeer ())
             {
                 const STAmount&     saBalance   = line->getBalance ();
                 const STAmount&     saLimit     = line->getLimit ();
@@ -90,14 +96,19 @@ Json::Value doAccountLines (RPC::Context& context)
                 Json::Value&    jPeer   = jsonLines.append (Json::objectValue);
 
                 jPeer[jss::account]       = to_string (line->getAccountIDPeer ());
-                // Amount reported is positive if current account holds other account's IOUs.
-                // Amount reported is negative if other account holds current account's IOUs.
+                // Amount reported is positive if current account holds other
+                // account's IOUs.
+                //
+                // Amount reported is negative if other account holds current
+                // account's IOUs.
                 jPeer[jss::balance]       = saBalance.getText ();
                 jPeer[jss::currency]      = saBalance.getHumanCurrency ();
                 jPeer[jss::limit]         = saLimit.getText ();
                 jPeer[jss::limit_peer]     = saLimitPeer.getText ();
-                jPeer[jss::quality_in]     = static_cast<Json::UInt> (line->getQualityIn ());
-                jPeer[jss::quality_out]    = static_cast<Json::UInt> (line->getQualityOut ());
+                jPeer[jss::quality_in]
+                        = static_cast<Json::UInt> (line->getQualityIn ());
+                jPeer[jss::quality_out]
+                        = static_cast<Json::UInt> (line->getQualityOut ());
                 if (line->getAuth())
                     jPeer[jss::authorized] = true;
                 if (line->getAuthPeer())
@@ -117,10 +128,10 @@ Json::Value doAccountLines (RPC::Context& context)
     }
     else
     {
-        jvResult    = rpcError (rpcACT_NOT_FOUND);
+        result    = rpcError (rpcACT_NOT_FOUND);
     }
 
-    return jvResult;
+    return result;
 }
 
 } // ripple

--- a/src/ripple/module/rpc/handlers/AccountTxOld.cpp
+++ b/src/ripple/module/rpc/handlers/AccountTxOld.cpp
@@ -32,19 +32,24 @@ namespace ripple {
 // }
 Json::Value doAccountTxOld (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     RippleAddress   raAccount;
-    std::uint32_t   offset      = context.params_.isMember ("offset") ? context.params_["offset"].asUInt () : 0;
-    int             limit       = context.params_.isMember ("limit") ? context.params_["limit"].asUInt () : -1;
-    bool            bBinary     = context.params_.isMember ("binary") && context.params_["binary"].asBool ();
-    bool            bDescending = context.params_.isMember ("descending") && context.params_["descending"].asBool ();
-    bool            bCount      = context.params_.isMember ("count") && context.params_["count"].asBool ();
+    std::uint32_t offset
+            = context.params_.isMember ("offset")
+            ? context.params_["offset"].asUInt () : 0;
+    int limit = context.params_.isMember ("limit")
+            ? context.params_["limit"].asUInt () : -1;
+    bool bBinary = context.params_.isMember ("binary")
+            && context.params_["binary"].asBool ();
+    bool bDescending = context.params_.isMember ("descending")
+            && context.params_["descending"].asBool ();
+    bool bCount = context.params_.isMember ("count")
+            && context.params_["count"].asBool ();
     std::uint32_t   uLedgerMin;
     std::uint32_t   uLedgerMax;
     std::uint32_t   uValidatedMin;
     std::uint32_t   uValidatedMax;
-    bool            bValidated  = context.netOps_.getValidatedRange (uValidatedMin, uValidatedMax);
+    bool bValidated  = context.netOps_.getValidatedRange (
+        uValidatedMin, uValidatedMax);
 
     if (!context.params_.isMember ("account"))
         return rpcError (rpcINVALID_PARAMS);
@@ -71,10 +76,13 @@ Json::Value doAccountTxOld (RPC::Context& context)
         bDescending = true;
     }
 
-    if (context.params_.isMember ("ledger_index_min") || context.params_.isMember ("ledger_index_max"))
+    if (context.params_.isMember ("ledger_index_min")
+        || context.params_.isMember ("ledger_index_max"))
     {
-        std::int64_t iLedgerMin  = context.params_.isMember ("ledger_index_min") ? context.params_["ledger_index_min"].asInt () : -1;
-        std::int64_t iLedgerMax  = context.params_.isMember ("ledger_index_max") ? context.params_["ledger_index_max"].asInt () : -1;
+        std::int64_t iLedgerMin  = context.params_.isMember ("ledger_index_min")
+                ? context.params_["ledger_index_min"].asInt () : -1;
+        std::int64_t iLedgerMax  = context.params_.isMember ("ledger_index_max")
+                ? context.params_["ledger_index_max"].asInt () : -1;
 
         if (!bValidated && (iLedgerMin == -1 || iLedgerMax == -1))
         {
@@ -116,11 +124,11 @@ Json::Value doAccountTxOld (RPC::Context& context)
 
         if (bBinary)
         {
-            std::vector<NetworkOPs::txnMetaLedgerType> txns =
-                context.netOps_.getAccountTxsB (raAccount, uLedgerMin, uLedgerMax, bDescending, offset, limit, context.role_ == Config::ADMIN);
+            auto txns = context.netOps_.getAccountTxsB (
+                raAccount, uLedgerMin, uLedgerMax, bDescending, offset, limit,
+                context.role_ == Config::ADMIN);
 
-            for (std::vector<NetworkOPs::txnMetaLedgerType>::const_iterator it = txns.begin (), end = txns.end ();
-                    it != end; ++it)
+            for (auto it = txns.begin (), end = txns.end (); it != end; ++it)
             {
                 ++count;
                 Json::Value& jvObj = jvTxns.append (Json::objectValue);
@@ -129,15 +137,20 @@ Json::Value doAccountTxOld (RPC::Context& context)
                 jvObj["tx_blob"]            = std::get<0> (*it);
                 jvObj["meta"]               = std::get<1> (*it);
                 jvObj["ledger_index"]       = uLedgerIndex;
-                jvObj["validated"]          = bValidated && uValidatedMin <= uLedgerIndex && uValidatedMax >= uLedgerIndex;
+                jvObj["validated"]
+                        = bValidated
+                        && uValidatedMin <= uLedgerIndex
+                        && uValidatedMax >= uLedgerIndex;
 
             }
         }
         else
         {
-            std::vector< std::pair<Transaction::pointer, TransactionMetaSet::pointer> > txns = context.netOps_.getAccountTxs (raAccount, uLedgerMin, uLedgerMax, bDescending, offset, limit, context.role_ == Config::ADMIN);
+            auto txns = context.netOps_.getAccountTxs (
+                raAccount, uLedgerMin, uLedgerMax, bDescending, offset, limit,
+                context.role_ == Config::ADMIN);
 
-            for (std::vector< std::pair<Transaction::pointer, TransactionMetaSet::pointer> >::iterator it = txns.begin (), end = txns.end (); it != end; ++it)
+            for (auto it = txns.begin (), end = txns.end (); it != end; ++it)
             {
                 ++count;
                 Json::Value&    jvObj = jvTxns.append (Json::objectValue);
@@ -150,7 +163,10 @@ Json::Value doAccountTxOld (RPC::Context& context)
                     std::uint32_t uLedgerIndex = it->second->getLgrSeq ();
 
                     jvObj["meta"]           = it->second->getJson (0);
-                    jvObj["validated"]      = bValidated && uValidatedMin <= uLedgerIndex && uValidatedMax >= uLedgerIndex;
+                    jvObj["validated"]
+                            = bValidated
+                            && uValidatedMin <= uLedgerIndex
+                            && uValidatedMax >= uLedgerIndex;
                 }
 
             }
@@ -159,11 +175,15 @@ Json::Value doAccountTxOld (RPC::Context& context)
         //Add information about the original query
         ret["ledger_index_min"] = uLedgerMin;
         ret["ledger_index_max"] = uLedgerMax;
-        ret["validated"]        = bValidated && uValidatedMin <= uLedgerMin && uValidatedMax >= uLedgerMax;
+        ret["validated"]
+                = bValidated
+                && uValidatedMin <= uLedgerMin
+                && uValidatedMax >= uLedgerMax;
         ret["offset"]           = offset;
 
-        // We no longer return the full count but only the count of returned transactions
-        // Computing this count was two expensive and this API is deprecated anyway
+        // We no longer return the full count but only the count of returned
+        // transactions. Computing this count was two expensive and this API is
+        // deprecated anyway.
         if (bCount)
             ret["count"]        = count;
 

--- a/src/ripple/module/rpc/handlers/BlackList.cpp
+++ b/src/ripple/module/rpc/handlers/BlackList.cpp
@@ -22,11 +22,11 @@ namespace ripple {
 
 Json::Value doBlackList (RPC::Context& context)
 {
-    context.lock_.unlock();
+    auto& rm = getApp().getResourceManager();
     if (context.params_.isMember("threshold"))
-        return getApp().getResourceManager().getJson(context.params_["threshold"].asInt());
+        return rm.getJson(context.params_["threshold"].asInt());
     else
-        return getApp().getResourceManager().getJson();
+        return rm.getJson();
 }
 
 } // ripple

--- a/src/ripple/module/rpc/handlers/BookOffers.cpp
+++ b/src/ripple/module/rpc/handlers/BookOffers.cpp
@@ -21,8 +21,6 @@ namespace ripple {
 
 Json::Value doBookOffers (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     // VFALCO TODO Here is a terrible place for this kind of business
     //             logic. It needs to be moved elsewhere and documented,
     //             and encapsulated into a function.
@@ -30,7 +28,8 @@ Json::Value doBookOffers (RPC::Context& context)
         return rpcError (rpcTOO_BUSY);
 
     Ledger::pointer lpLedger;
-    Json::Value jvResult (RPC::lookupLedger (context.params_, lpLedger, context.netOps_));
+    Json::Value jvResult (
+        RPC::lookupLedger (context.params_, lpLedger, context.netOps_));
 
     if (!lpLedger)
         return jvResult;
@@ -103,8 +102,9 @@ Json::Value doBookOffers (RPC::Context& context)
     }
 
     if (isXRP (pay_currency) && ! isXRP (pay_issuer))
-        return RPC::make_error (rpcSRC_ISR_MALFORMED,
-            "Unneeded field 'taker_pays.issuer' for XRP currency specification.");
+        return RPC::make_error (
+            rpcSRC_ISR_MALFORMED, "Unneeded field 'taker_pays.issuer' for "
+            "XRP currency specification.");
 
     if (!isXRP (pay_currency) && isXRP (pay_issuer))
         return RPC::make_error (rpcSRC_ISR_MALFORMED,
@@ -134,7 +134,8 @@ Json::Value doBookOffers (RPC::Context& context)
 
     if (isXRP (get_currency) && ! isXRP (get_issuer))
         return RPC::make_error (rpcDST_ISR_MALFORMED,
-            "Unneeded field 'taker_gets.issuer' for XRP currency specification.");
+            "Unneeded field 'taker_gets.issuer' for "
+                               "XRP currency specification.");
 
     if (!isXRP (get_currency) && isXRP (get_issuer))
         return RPC::make_error (rpcDST_ISR_MALFORMED,

--- a/src/ripple/module/rpc/handlers/Connect.cpp
+++ b/src/ripple/module/rpc/handlers/Connect.cpp
@@ -28,14 +28,18 @@ namespace ripple {
 // XXX Might allow domain for manual connections.
 Json::Value doConnect (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     if (getConfig ().RUN_STANDALONE)
         return "cannot connect in standalone mode";
 
     if (!context.params_.isMember ("ip"))
         return RPC::missing_field_error ("ip");
 
-    if (context.params_.isMember ("port") && !context.params_["port"].isConvertibleTo (Json::intValue))
+    if (context.params_.isMember ("port") &&
+        !context.params_["port"].isConvertibleTo (Json::intValue))
+    {
         return rpcError (rpcINVALID_PARAMS);
+    }
 
     int iPort;
 
@@ -44,7 +48,8 @@ Json::Value doConnect (RPC::Context& context)
     else
         iPort = SYSTEM_PEER_PORT;
 
-    beast::IP::Endpoint ip (beast::IP::Endpoint::from_string(context.params_["ip"].asString ()));
+    auto ip = beast::IP::Endpoint::from_string(
+        context.params_["ip"].asString ());
 
     if (! is_unspecified (ip))
         getApp().overlay ().connect (ip.at_port(iPort));

--- a/src/ripple/module/rpc/handlers/ConsensusInfo.cpp
+++ b/src/ripple/module/rpc/handlers/ConsensusInfo.cpp
@@ -23,7 +23,10 @@ Json::Value doConsensusInfo (RPC::Context& context)
 {
     Json::Value ret (Json::objectValue);
 
-    ret["info"] = context.netOps_.getConsensusInfo ();
+    {
+        auto lock = getApp().masterLock();
+        ret["info"] = context.netOps_.getConsensusInfo ();
+    }
 
     return ret;
 }

--- a/src/ripple/module/rpc/handlers/Feature.cpp
+++ b/src/ripple/module/rpc/handlers/Feature.cpp
@@ -20,7 +20,8 @@
 
 namespace ripple {
 
-static void textTime (std::string& text, int& seconds, const char* unitName, int unitVal)
+static void textTime (
+    std::string& text, int& seconds, const char* unitName, int unitVal)
 {
     int i = seconds / unitVal;
 
@@ -49,7 +50,9 @@ Json::Value doFeature (RPC::Context& context)
         return jvReply;
     }
 
-    uint256 uFeature = getApp().getAmendmentTable ().get(context.params_["feature"].asString());
+    uint256 uFeature
+            = getApp().getAmendmentTable ().get(
+                context.params_["feature"].asString());
 
     if (uFeature.isZero ())
     {

--- a/src/ripple/module/rpc/handlers/FetchInfo.cpp
+++ b/src/ripple/module/rpc/handlers/FetchInfo.cpp
@@ -22,8 +22,6 @@ namespace ripple {
 
 Json::Value doFetchInfo (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     Json::Value ret (Json::objectValue);
 
     if (context.params_.isMember("clear") && context.params_["clear"].asBool())

--- a/src/ripple/module/rpc/handlers/GetCounts.cpp
+++ b/src/ripple/module/rpc/handlers/GetCounts.cpp
@@ -26,12 +26,14 @@ namespace ripple {
 // }
 Json::Value doGetCounts (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
+
     int minCount = 10;
 
     if (context.params_.isMember ("min_count"))
         minCount = context.params_["min_count"].asUInt ();
 
-    CountedObjects::List objectCounts = CountedObjects::getInstance ().getCounts (minCount);
+    auto objectCounts = CountedObjects::getInstance ().getCounts (minCount);
 
     Json::Value ret (Json::objectValue);
 

--- a/src/ripple/module/rpc/handlers/Ledger.cpp
+++ b/src/ripple/module/rpc/handlers/Ledger.cpp
@@ -27,10 +27,12 @@ namespace ripple {
 // }
 Json::Value doLedger (RPC::Context& context)
 {
-    context.lock_.unlock ();
-    if (!context.params_.isMember ("ledger") && !context.params_.isMember ("ledger_hash") && !context.params_.isMember ("ledger_index"))
+    if (!context.params_.isMember ("ledger")
+        && !context.params_.isMember ("ledger_hash")
+        && !context.params_.isMember ("ledger_index"))
     {
-        Json::Value ret (Json::objectValue), current (Json::objectValue), closed (Json::objectValue);
+        Json::Value ret (Json::objectValue), current (Json::objectValue),
+                closed (Json::objectValue);
 
         getApp().getLedgerMaster ().getCurrentLedger ()->addJson (current, 0);
         getApp().getLedgerMaster ().getClosedLedger ()->addJson (closed, 0);
@@ -42,15 +44,20 @@ Json::Value doLedger (RPC::Context& context)
     }
 
     Ledger::pointer     lpLedger;
-    Json::Value         jvResult    = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Json::Value jvResult = RPC::lookupLedger (
+        context.params_, lpLedger, context.netOps_);
 
     if (!lpLedger)
         return jvResult;
 
-    bool    bFull           = context.params_.isMember ("full") && context.params_["full"].asBool ();
-    bool    bTransactions   = context.params_.isMember ("transactions") && context.params_["transactions"].asBool ();
-    bool    bAccounts       = context.params_.isMember ("accounts") && context.params_["accounts"].asBool ();
-    bool    bExpand         = context.params_.isMember ("expand") && context.params_["expand"].asBool ();
+    bool bFull = context.params_.isMember ("full")
+            && context.params_["full"].asBool ();
+    bool bTransactions = context.params_.isMember ("transactions")
+            && context.params_["transactions"].asBool ();
+    bool bAccounts = context.params_.isMember ("accounts")
+            && context.params_["accounts"].asBool ();
+    bool bExpand = context.params_.isMember ("expand")
+            && context.params_["expand"].asBool ();
     int     iOptions        = (bFull ? LEDGER_JSON_FULL : 0)
                               | (bExpand ? LEDGER_JSON_EXPAND : 0)
                               | (bTransactions ? LEDGER_JSON_DUMP_TXRP : 0)
@@ -61,12 +68,13 @@ Json::Value doLedger (RPC::Context& context)
 
         if (context.role_ != Config::ADMIN)
         {
-            // Until some sane way to get full ledgers has been implemented, disallow
-            // retrieving all state nodes
+            // Until some sane way to get full ledgers has been implemented,
+            // disallow retrieving all state nodes.
             return rpcError (rpcNO_PERMISSION);
         }
 
-        if (getApp().getFeeTrack().isLoadedLocal() && (context.role_ != Config::ADMIN))
+        if (getApp().getFeeTrack().isLoadedLocal() &&
+            context.role_ != Config::ADMIN)
         {
             WriteLog (lsDEBUG, Peer) << "Too busy to give full ledger";
             return rpcError(rpcTOO_BUSY);

--- a/src/ripple/module/rpc/handlers/LedgerAccept.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerAccept.cpp
@@ -22,6 +22,7 @@ namespace ripple {
 
 Json::Value doLedgerAccept (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     Json::Value jvResult;
 
     if (!getConfig ().RUN_STANDALONE)
@@ -32,7 +33,8 @@ Json::Value doLedgerAccept (RPC::Context& context)
     {
         context.netOps_.acceptLedger ();
 
-        jvResult["ledger_current_index"]    = context.netOps_.getCurrentLedgerID ();
+        jvResult["ledger_current_index"]
+                = context.netOps_.getCurrentLedgerID ();
     }
 
     return jvResult;

--- a/src/ripple/module/rpc/handlers/LedgerCleaner.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerCleaner.cpp
@@ -22,7 +22,6 @@ namespace ripple {
 
 Json::Value doLedgerCleaner (RPC::Context& context)
 {
-    context.lock_.unlock();
     getApp().getLedgerMaster().doLedgerCleaner (context.params_);
     return "Cleaner configured";
 }

--- a/src/ripple/module/rpc/handlers/LedgerClosed.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerClosed.cpp
@@ -22,7 +22,6 @@ namespace ripple {
 
 Json::Value doLedgerClosed (RPC::Context& context)
 {
-    context.lock_.unlock ();
     Json::Value jvResult;
 
     uint256 uLedger = context.netOps_.getClosedLedgerHash ();

--- a/src/ripple/module/rpc/handlers/LedgerCurrent.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerCurrent.cpp
@@ -22,7 +22,6 @@ namespace ripple {
 
 Json::Value doLedgerCurrent (RPC::Context& context)
 {
-    context.lock_.unlock ();
     Json::Value jvResult;
 
     jvResult["ledger_current_index"]    = context.netOps_.getCurrentLedgerID ();

--- a/src/ripple/module/rpc/handlers/LedgerData.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerData.cpp
@@ -32,14 +32,13 @@ namespace ripple {
 //     marker:       resume point, if any
 Json::Value doLedgerData (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     int const BINARY_PAGE_LENGTH = 256;
     int const JSON_PAGE_LENGTH = 2048;
 
     Ledger::pointer lpLedger;
 
-    Json::Value jvResult = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Json::Value jvResult = RPC::lookupLedger (
+        context.params_, lpLedger, context.netOps_);
     if (!lpLedger)
         return jvResult;
 
@@ -80,7 +79,7 @@ Json::Value doLedgerData (RPC::Context& context)
     Json::Value jvReply = Json::objectValue;
 
     jvReply["ledger_hash"] = to_string (lpLedger->getHash());
-    jvReply["ledger_index"] = beast::lexicalCastThrow <std::string> (lpLedger->getLedgerSeq ());
+    jvReply["ledger_index"] = std::to_string( lpLedger->getLedgerSeq ());
 
     Json::Value& nodes = (jvReply["state"] = Json::arrayValue);
     SHAMap& map = *(lpLedger->peekAccountStateMap ());
@@ -102,7 +101,8 @@ Json::Value doLedgerData (RPC::Context& context)
        if (isBinary)
        {
            Json::Value& entry = nodes.append (Json::objectValue);
-           entry["data"] = strHex (item->peekData().begin(), item->peekData().size());
+           entry["data"] = strHex (
+               item->peekData().begin(), item->peekData().size());
            entry["index"] = to_string (item->getTag ());
        }
        else

--- a/src/ripple/module/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerEntry.cpp
@@ -27,10 +27,9 @@ namespace ripple {
 // }
 Json::Value doLedgerEntry (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
-    Ledger::pointer     lpLedger;
-    Json::Value         jvResult    = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Ledger::pointer lpLedger;
+    Json::Value jvResult = RPC::lookupLedger (
+        context.params_, lpLedger, context.netOps_);
 
     if (!lpLedger)
         return jvResult;
@@ -48,14 +47,16 @@ Json::Value doLedgerEntry (RPC::Context& context)
     {
         RippleAddress   naAccount;
 
-        if (!naAccount.setAccountID (context.params_["account_root"].asString ())
-                || !naAccount.getAccountID ())
+        if (!naAccount.setAccountID (
+                context.params_["account_root"].asString ())
+            || !naAccount.getAccountID ())
         {
             jvResult["error"]   = "malformedAddress";
         }
         else
         {
-            uNodeIndex = Ledger::getAccountRootIndex (naAccount.getAccountID ());
+            uNodeIndex
+                    = Ledger::getAccountRootIndex (naAccount.getAccountID ());
         }
     }
     else if (context.params_.isMember ("directory"))
@@ -71,9 +72,9 @@ Json::Value doLedgerEntry (RPC::Context& context)
         }
         else
         {
-            std::uint64_t  uSubIndex = context.params_["directory"].isMember ("sub_index")
-                                ? context.params_["directory"]["sub_index"].asUInt ()
-                                : 0;
+            std::uint64_t  uSubIndex
+                    = context.params_["directory"].isMember ("sub_index")
+                    ? context.params_["directory"]["sub_index"].asUInt () : 0;
 
             if (context.params_["directory"].isMember ("dir_root"))
             {
@@ -87,14 +88,16 @@ Json::Value doLedgerEntry (RPC::Context& context)
             {
                 RippleAddress   naOwnerID;
 
-                if (!naOwnerID.setAccountID (context.params_["directory"]["owner"].asString ()))
+                if (!naOwnerID.setAccountID (
+                        context.params_["directory"]["owner"].asString ()))
                 {
                     jvResult["error"]   = "malformedAddress";
                 }
                 else
                 {
-                    uint256 uDirRoot    = Ledger::getOwnerDirIndex (naOwnerID.getAccountID ());
-
+                    uint256 uDirRoot
+                            = Ledger::getOwnerDirIndex (
+                                naOwnerID.getAccountID ());
                     uNodeIndex  = Ledger::getDirNodeIndex (uDirRoot, uSubIndex);
                 }
             }
@@ -116,14 +119,16 @@ Json::Value doLedgerEntry (RPC::Context& context)
         {
             jvResult["error"]   = "malformedRequest";
         }
-        else if (!naGeneratorID.setSeedGeneric (context.params_["generator"]["regular_seed"].asString ()))
+        else if (!naGeneratorID.setSeedGeneric (
+            context.params_["generator"]["regular_seed"].asString ()))
         {
             jvResult["error"]   = "malformedAddress";
         }
         else
         {
-            RippleAddress       na0Public;      // To find the generator's index.
-            RippleAddress       naGenerator = RippleAddress::createGeneratorPublic (naGeneratorID);
+            RippleAddress na0Public;      // To find the generator's index.
+            RippleAddress naGenerator
+                    = RippleAddress::createGeneratorPublic (naGeneratorID);
 
             na0Public.setAccountPublic (naGenerator, 0);
 
@@ -144,15 +149,16 @@ Json::Value doLedgerEntry (RPC::Context& context)
         {
             jvResult["error"]   = "malformedRequest";
         }
-        else if (!naAccountID.setAccountID (context.params_["offer"]["account"].asString ()))
+        else if (!naAccountID.setAccountID (
+            context.params_["offer"]["account"].asString ()))
         {
             jvResult["error"]   = "malformedAddress";
         }
         else
         {
-            std::uint32_t      uSequence   = context.params_["offer"]["seq"].asUInt ();
-
-            uNodeIndex  = Ledger::getOfferIndex (naAccountID.getAccountID (), uSequence);
+            auto uSequence = context.params_["offer"]["seq"].asUInt ();
+            uNodeIndex  = Ledger::getOfferIndex (
+                naAccountID.getAccountID (), uSequence);
         }
     }
     else if (context.params_.isMember ("ripple_state"))
@@ -163,19 +169,22 @@ Json::Value doLedgerEntry (RPC::Context& context)
         Json::Value     jvRippleState   = context.params_["ripple_state"];
 
         if (!jvRippleState.isObject ()
-                || !jvRippleState.isMember ("currency")
-                || !jvRippleState.isMember ("accounts")
-                || !jvRippleState["accounts"].isArray ()
-                || 2 != jvRippleState["accounts"].size ()
-                || !jvRippleState["accounts"][0u].isString ()
-                || !jvRippleState["accounts"][1u].isString ()
-                || jvRippleState["accounts"][0u].asString () == jvRippleState["accounts"][1u].asString ()
+            || !jvRippleState.isMember ("currency")
+            || !jvRippleState.isMember ("accounts")
+            || !jvRippleState["accounts"].isArray ()
+            || 2 != jvRippleState["accounts"].size ()
+            || !jvRippleState["accounts"][0u].isString ()
+            || !jvRippleState["accounts"][1u].isString ()
+            || (jvRippleState["accounts"][0u].asString ()
+                == jvRippleState["accounts"][1u].asString ())
            )
         {
             jvResult["error"]   = "malformedRequest";
         }
-        else if (!naA.setAccountID (jvRippleState["accounts"][0u].asString ())
-                 || !naB.setAccountID (jvRippleState["accounts"][1u].asString ()))
+        else if (!naA.setAccountID (
+                     jvRippleState["accounts"][0u].asString ())
+                 || !naB.setAccountID (
+                     jvRippleState["accounts"][1u].asString ()))
         {
             jvResult["error"]   = "malformedAddress";
         }
@@ -196,7 +205,7 @@ Json::Value doLedgerEntry (RPC::Context& context)
 
     if (uNodeIndex.isNonZero ())
     {
-        SLE::pointer    sleNode = context.netOps_.getSLEi (lpLedger, uNodeIndex);
+        auto sleNode = context.netOps_.getSLEi (lpLedger, uNodeIndex);
 
         if (context.params_.isMember("binary"))
             bNodeBinary = context.params_["binary"].asBool();

--- a/src/ripple/module/rpc/handlers/LedgerHeader.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerHeader.cpp
@@ -26,10 +26,9 @@ namespace ripple {
 // }
 Json::Value doLedgerHeader (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
-    Ledger::pointer     lpLedger;
-    Json::Value         jvResult    = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Ledger::pointer lpLedger;
+    Json::Value jvResult = RPC::lookupLedger (
+        context.params_, lpLedger, context.netOps_);
 
     if (!lpLedger)
         return jvResult;
@@ -40,7 +39,8 @@ Json::Value doLedgerHeader (RPC::Context& context)
 
     jvResult["ledger_data"] = strHex (s.peekData ());
 
-    // This information isn't verified, they should only use it if they trust us.
+    // This information isn't verified: they should only use it if they trust
+    // us.
     lpLedger->addJson (jvResult, 0);
 
     return jvResult;

--- a/src/ripple/module/rpc/handlers/LedgerRequest.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerRequest.cpp
@@ -26,8 +26,6 @@ namespace ripple {
 // }
 Json::Value doLedgerRequest (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     auto const hasHash = context.params_.isMember (jss::ledger_hash);
     auto const hasIndex = context.params_.isMember (jss::ledger_index);
 
@@ -75,8 +73,10 @@ Json::Value doLedgerRequest (RPC::Context& context)
             {
                 // We don't have the ledger we need to figure out which ledger
                 // they want. Try to get it.
-                Json::Value jvResult =  getApp().getInboundLedgers().findCreate (
-                    refHash, refIndex, InboundLedger::fcGENERIC)->getJson (0);
+                Json::Value jvResult
+                        =  getApp().getInboundLedgers().findCreate (
+                            refHash, refIndex, InboundLedger::fcGENERIC)
+                        ->getJson (0);
 
                 jvResult[jss::error] = "ledgerNotFound";
                 return jvResult;

--- a/src/ripple/module/rpc/handlers/LogLevel.cpp
+++ b/src/ripple/module/rpc/handlers/LogLevel.cpp
@@ -29,7 +29,8 @@ Json::Value doLogLevel (RPC::Context& context)
         Json::Value ret (Json::objectValue);
         Json::Value lev (Json::objectValue);
 
-        lev["base"] = Logs::toString(Logs::fromSeverity(deprecatedLogs().severity()));
+        lev["base"] =
+                Logs::toString(Logs::fromSeverity(deprecatedLogs().severity()));
         std::vector< std::pair<std::string, std::string> > logTable (
             deprecatedLogs().partition_severities());
         typedef std::map<std::string, std::string>::value_type stringPair;
@@ -40,16 +41,18 @@ Json::Value doLogLevel (RPC::Context& context)
         return ret;
     }
 
-    LogSeverity const sv (Logs::fromString (context.params_["severity"].asString ()));
+    LogSeverity const sv (
+        Logs::fromString (context.params_["severity"].asString ()));
 
     if (sv == lsINVALID)
         return rpcError (rpcINVALID_PARAMS);
 
+    auto severity = Logs::toSeverity(sv);
     // log_level severity
     if (!context.params_.isMember ("partition"))
     {
         // set base log severity
-        deprecatedLogs().severity(Logs::toSeverity(sv));
+        deprecatedLogs().severity(severity);
         return Json::objectValue;
     }
 
@@ -60,9 +63,9 @@ Json::Value doLogLevel (RPC::Context& context)
         std::string partition (context.params_["partition"].asString ());
 
         if (boost::iequals (partition, "base"))
-            deprecatedLogs().severity (Logs::toSeverity(sv));
+            deprecatedLogs().severity (severity);
         else
-            deprecatedLogs().get(partition).severity(Logs::toSeverity(sv));
+            deprecatedLogs().get(partition).severity(severity);
 
         return Json::objectValue;
     }

--- a/src/ripple/module/rpc/handlers/LogRotate.cpp
+++ b/src/ripple/module/rpc/handlers/LogRotate.cpp
@@ -22,7 +22,6 @@ namespace ripple {
 
 Json::Value doLogRotate (RPC::Context& context)
 {
-    context.lock_.unlock ();
     return deprecatedLogs().rotate();
 }
 

--- a/src/ripple/module/rpc/handlers/NicknameInfo.cpp
+++ b/src/ripple/module/rpc/handlers/NicknameInfo.cpp
@@ -21,9 +21,9 @@
 namespace ripple {
 
 #if 0
-// XXX Needs to be revised for new paradigm
-// nickname_info <nickname>
-// Note: Nicknames are not automatically looked up by commands as they are advisory and can be changed.
+// XXX Needs to be revised for new paradigm nickname_info <nickname> Note:
+// Nicknames are not automatically looked up by commands as they are advisory
+// and can be changed.
 Json::Value doNicknameInfo (Json::Value params)
 {
     std::string strNickname = context.params_[0u].asString ();
@@ -34,7 +34,7 @@ Json::Value doNicknameInfo (Json::Value params)
         return rpcError (rpcNICKNAME_MALFORMED);
     }
 
-    NicknameState::pointer  nsSrc   = context.netOps_.getNicknameState (uint256 (0), strNickname);
+    auto nsSrc = context.netOps_.getNicknameState (uint256 (0), strNickname);
 
     if (!nsSrc)
     {

--- a/src/ripple/module/rpc/handlers/OwnerInfo.cpp
+++ b/src/ripple/module/rpc/handlers/OwnerInfo.cpp
@@ -27,25 +27,36 @@ namespace ripple {
 // XXX This would be better if it took the ledger.
 Json::Value doOwnerInfo (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     if (!context.params_.isMember ("account") && !context.params_.isMember ("ident"))
         return RPC::missing_field_error ("account");
 
-    std::string     strIdent    = context.params_.isMember ("account") ? context.params_["account"].asString () : context.params_["ident"].asString ();
-    bool            bIndex;
-    int             iIndex      = context.params_.isMember ("account_index") ? context.params_["account_index"].asUInt () : 0;
-    RippleAddress   raAccount;
+    std::string strIdent = context.params_.isMember ("account")
+            ? context.params_["account"].asString ()
+            : context.params_["ident"].asString ();
+    bool bIndex;
+    int iIndex = context.params_.isMember ("account_index")
+            ? context.params_["account_index"].asUInt () : 0;
+    RippleAddress raAccount;
 
-    Json::Value     ret;
+    Json::Value ret;
 
     // Get info on account.
 
-    Json::Value     jAccepted   = RPC::accountFromString (context.netOps_.getClosedLedger (), raAccount, bIndex, strIdent, iIndex, false, context.netOps_);
+    Json::Value jAccepted = RPC::accountFromString (
+        context.netOps_.getClosedLedger (), raAccount, bIndex, strIdent, iIndex,
+        false, context.netOps_);
 
-    ret["accepted"] = jAccepted.empty () ? context.netOps_.getOwnerInfo (context.netOps_.getClosedLedger (), raAccount) : jAccepted;
+    ret["accepted"] = jAccepted.empty ()
+            ? context.netOps_.getOwnerInfo (
+                context.netOps_.getClosedLedger (), raAccount) : jAccepted;
 
-    Json::Value     jCurrent    = RPC::accountFromString (context.netOps_.getCurrentLedger (), raAccount, bIndex, strIdent, iIndex, false, context.netOps_);
+    Json::Value jCurrent = RPC::accountFromString (
+        context.netOps_.getCurrentLedger (), raAccount, bIndex, strIdent, iIndex,
+        false, context.netOps_);
 
-    ret["current"]  = jCurrent.empty () ? context.netOps_.getOwnerInfo (context.netOps_.getCurrentLedger (), raAccount) : jCurrent;
+    ret["current"] = jCurrent.empty () ? context.netOps_.getOwnerInfo (
+        context.netOps_.getCurrentLedger (), raAccount) : jCurrent;
 
     return ret;
 }

--- a/src/ripple/module/rpc/handlers/PathFind.cpp
+++ b/src/ripple/module/rpc/handlers/PathFind.cpp
@@ -23,10 +23,12 @@ namespace ripple {
 Json::Value doPathFind (RPC::Context& context)
 {
     Ledger::pointer lpLedger = context.netOps_.getClosedLedger();
-    context.lock_.unlock();
 
-    if (!context.params_.isMember ("subcommand") || !context.params_["subcommand"].isString ())
+    if (!context.params_.isMember ("subcommand") ||
+        !context.params_["subcommand"].isString ())
+    {
         return rpcError (rpcINVALID_PARAMS);
+    }
 
     if (!context.infoSub_)
         return rpcError (rpcNO_EVENTS);
@@ -37,7 +39,8 @@ Json::Value doPathFind (RPC::Context& context)
     {
         context.loadType_ = Resource::feeHighBurdenRPC;
         context.infoSub_->clearPathRequest ();
-        return getApp().getPathRequests().makePathRequest (context.infoSub_, lpLedger, context.params_);
+        return getApp().getPathRequests().makePathRequest (
+            context.infoSub_, lpLedger, context.params_);
     }
 
     if (sSubCommand == "close")

--- a/src/ripple/module/rpc/handlers/Peers.cpp
+++ b/src/ripple/module/rpc/handlers/Peers.cpp
@@ -23,11 +23,15 @@ namespace ripple {
 
 Json::Value doPeers (RPC::Context& context)
 {
+
     Json::Value jvResult (Json::objectValue);
 
-    jvResult["peers"]   = getApp().overlay ().json ();
+    {
+        auto lock = getApp().masterLock();
 
-    getApp().getUNL().addClusterStatus(jvResult);
+        jvResult["peers"]   = getApp().overlay ().json ();
+        getApp().getUNL().addClusterStatus(jvResult);
+    }
 
     return jvResult;
 }

--- a/src/ripple/module/rpc/handlers/Print.cpp
+++ b/src/ripple/module/rpc/handlers/Print.cpp
@@ -22,13 +22,17 @@ namespace ripple {
 
 Json::Value doPrint (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     JsonPropertyStream stream;
-    if (context.params_.isObject() && context.params_["params"].isArray() && context.params_["params"][0u].isString ())
+    if (context.params_.isObject()
+        && context.params_["params"].isArray()
+        && context.params_["params"][0u].isString ())
+    {
         getApp().write (stream, context.params_["params"][0u].asString());
+    }
     else
+    {
         getApp().write (stream);
+    }
 
     return stream.top();
 }

--- a/src/ripple/module/rpc/handlers/Profile.cpp
+++ b/src/ripple/module/rpc/handlers/Profile.cpp
@@ -20,11 +20,18 @@
 
 namespace ripple {
 
-// profile offers <pass_a> <account_a> <currency_offer_a> <account_b> <currency_offer_b> <count> [submit]
-// profile 0:offers 1:pass_a 2:account_a 3:currency_offer_a 4:account_b 5:currency_offer_b 6:<count> 7:[submit]
+// profile offers <pass_a> <account_a> <currency_offer_a> <account_b>
+// <currency_offer_b> <count> [submit]
+//
+// profile 0:offers 1:pass_a 2:account_a 3:currency_offer_a 4:account_b
+// 5:currency_offer_b 6:<count> 7:[submit]
+//
 // issuer is the offering account
+//
 // --> submit: 'submit|true|false': defaults to false
-// Prior to running allow each to have a credit line of what they will be getting from the other account.
+//
+// Prior to running allow each to have a credit line of what they will be
+// getting from the other account.
 Json::Value doProfile (RPC::Context& context)
 {
     /* need to fix now that sharedOfferCreate is gone

--- a/src/ripple/module/rpc/handlers/ProofCreate.cpp
+++ b/src/ripple/module/rpc/handlers/ProofCreate.cpp
@@ -28,15 +28,14 @@ namespace ripple {
 // }
 Json::Value doProofCreate (RPC::Context& context)
 {
-    context.lock_.unlock ();
     // XXX: Add ability to create proof with arbitrary time
-
     Json::Value     jvResult (Json::objectValue);
 
-    if (context.params_.isMember ("difficulty") || context.params_.isMember ("secret"))
+    if (context.params_.isMember ("difficulty") ||
+        context.params_.isMember ("secret"))
     {
         // VFALCO TODO why aren't we using the app's factory?
-        std::unique_ptr <ProofOfWorkFactory> pgGen (ProofOfWorkFactory::New ());
+        auto pgGen = ProofOfWorkFactory::New ();
 
         if (context.params_.isMember ("difficulty"))
         {
@@ -45,8 +44,11 @@ Json::Value doProofCreate (RPC::Context& context)
 
             int const iDifficulty (context.params_["difficulty"].asInt ());
 
-            if (iDifficulty < 0 || iDifficulty > ProofOfWorkFactory::kMaxDifficulty)
+            if (iDifficulty < 0 ||
+                iDifficulty > ProofOfWorkFactory::kMaxDifficulty)
+            {
                 return RPC::invalid_field_error ("difficulty");
+            }
 
             pgGen->setDifficulty (iDifficulty);
         }
@@ -62,7 +64,8 @@ Json::Value doProofCreate (RPC::Context& context)
     }
     else
     {
-        jvResult["token"]   = getApp().getProofOfWorkFactory ().getProof ().getToken ();
+        jvResult["token"]
+                = getApp().getProofOfWorkFactory ().getProof ().getToken ();
     }
 
     return jvResult;

--- a/src/ripple/module/rpc/handlers/ProofSolve.cpp
+++ b/src/ripple/module/rpc/handlers/ProofSolve.cpp
@@ -25,22 +25,20 @@ namespace ripple {
 // }
 Json::Value doProofSolve (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
-    Json::Value         jvResult;
+    Json::Value jvResult;
 
     if (!context.params_.isMember ("token"))
         return RPC::missing_field_error ("token");
 
-    std::string         strToken        = context.params_["token"].asString ();
+    std::string strToken = context.params_["token"].asString ();
 
     if (!ProofOfWork::validateToken (strToken))
         return RPC::invalid_field_error ("token");
 
-    ProofOfWork         powProof (strToken);
-    uint256             uSolution       = powProof.solve ();
+    ProofOfWork powProof (strToken);
+    uint256 uSolution = powProof.solve ();
 
-    jvResult["solution"]                = to_string (uSolution);
+    jvResult["solution"] = to_string (uSolution);
 
     return jvResult;
 }

--- a/src/ripple/module/rpc/handlers/Random.cpp
+++ b/src/ripple/module/rpc/handlers/Random.cpp
@@ -26,17 +26,14 @@ namespace ripple {
 // }
 Json::Value doRandom (RPC::Context& context)
 {
-    context.lock_.unlock ();
-    uint256         uRandom;
+    uint256 rand;
 
     try
     {
-        RandomNumbers::getInstance ().fillBytes (uRandom.begin (), uRandom.size ());
+        RandomNumbers::getInstance ().fillBytes (rand.begin (), rand.size ());
 
         Json::Value jvResult;
-
-        jvResult["random"]  = to_string (uRandom);
-
+        jvResult["random"]  = to_string (rand);
         return jvResult;
     }
     catch (...)

--- a/src/ripple/module/rpc/handlers/SMS.cpp
+++ b/src/ripple/module/rpc/handlers/SMS.cpp
@@ -22,11 +22,11 @@ namespace ripple {
 
 Json::Value doSMS (RPC::Context& context)
 {
-    context.lock_.unlock ();
     if (!context.params_.isMember ("text"))
         return rpcError (rpcINVALID_PARAMS);
 
-    HTTPClient::sendSMS (getApp().getIOService (), context.params_["text"].asString ());
+    HTTPClient::sendSMS (
+        getApp().getIOService (), context.params_["text"].asString ());
 
     return "sms dispatched";
 }

--- a/src/ripple/module/rpc/handlers/ServerInfo.cpp
+++ b/src/ripple/module/rpc/handlers/ServerInfo.cpp
@@ -22,9 +22,11 @@ namespace ripple {
 
 Json::Value doServerInfo (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     Json::Value ret (Json::objectValue);
 
-    ret["info"] = context.netOps_.getServerInfo (true, context.role_ == Config::ADMIN);
+    ret["info"] = context.netOps_.getServerInfo (
+        true, context.role_ == Config::ADMIN);
 
     return ret;
 }

--- a/src/ripple/module/rpc/handlers/ServerState.cpp
+++ b/src/ripple/module/rpc/handlers/ServerState.cpp
@@ -22,9 +22,11 @@ namespace ripple {
 
 Json::Value doServerState (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     Json::Value ret (Json::objectValue);
 
-    ret["state"]    = context.netOps_.getServerInfo (false, context.role_ == Config::ADMIN);
+    ret["state"] = context.netOps_.getServerInfo (
+        false, context.role_ == Config::ADMIN);
 
     return ret;
 }

--- a/src/ripple/module/rpc/handlers/Sign.cpp
+++ b/src/ripple/module/rpc/handlers/Sign.cpp
@@ -26,11 +26,11 @@ namespace ripple {
 // }
 Json::Value doSign (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     context.loadType_ = Resource::feeHighBurdenRPC;
-    bool bFailHard = context.params_.isMember ("fail_hard") && context.params_["fail_hard"].asBool ();
-    return RPC::transactionSign (context.params_, false, bFailHard, context.lock_, context.netOps_, context.role_);
+    bool bFailHard = context.params_.isMember ("fail_hard")
+            && context.params_["fail_hard"].asBool ();
+    return RPC::transactionSign (
+        context.params_, false, bFailHard, context.netOps_, context.role_);
 }
 
 } // ripple

--- a/src/ripple/module/rpc/handlers/Stop.cpp
+++ b/src/ripple/module/rpc/handlers/Stop.cpp
@@ -22,6 +22,7 @@ namespace ripple {
 
 Json::Value doStop (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     getApp().signalStop ();
 
     return SYSTEM_NAME " server stopping";

--- a/src/ripple/module/rpc/handlers/Submit.cpp
+++ b/src/ripple/module/rpc/handlers/Submit.cpp
@@ -26,14 +26,14 @@ namespace ripple {
 // }
 Json::Value doSubmit (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     context.loadType_ = Resource::feeMediumBurdenRPC;
 
     if (!context.params_.isMember ("tx_blob"))
     {
-        bool bFailHard = context.params_.isMember ("fail_hard") && context.params_["fail_hard"].asBool ();
-        return RPC::transactionSign (context.params_, true, bFailHard, context.lock_, context.netOps_, context.role_);
+        bool bFailHard = context.params_.isMember ("fail_hard")
+                && context.params_["fail_hard"].asBool ();
+        return RPC::transactionSign (
+            context.params_, true, bFailHard, context.netOps_, context.role_);
     }
 
     Json::Value                 jvResult;
@@ -76,8 +76,10 @@ Json::Value doSubmit (RPC::Context& context)
 
     try
     {
-        (void) context.netOps_.processTransaction (tpTrans, context.role_ == Config::ADMIN, true,
-            context.params_.isMember ("fail_hard") && context.params_["fail_hard"].asBool ());
+        (void) context.netOps_.processTransaction (
+            tpTrans, context.role_ == Config::ADMIN, true,
+            context.params_.isMember ("fail_hard")
+            && context.params_["fail_hard"].asBool ());
     }
     catch (std::exception& e)
     {
@@ -90,8 +92,9 @@ Json::Value doSubmit (RPC::Context& context)
 
     try
     {
-        jvResult[jss::tx_json]     = tpTrans->getJson (0);
-        jvResult[jss::tx_blob]     = strHex (tpTrans->getSTransaction ()->getSerializer ().peekData ());
+        jvResult[jss::tx_json] = tpTrans->getJson (0);
+        jvResult[jss::tx_blob] = strHex (
+            tpTrans->getSTransaction ()->getSerializer ().peekData ());
 
         if (temUNCERTAIN != tpTrans->getResult ())
         {

--- a/src/ripple/module/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/module/rpc/handlers/Subscribe.cpp
@@ -22,6 +22,8 @@ namespace ripple {
 
 Json::Value doSubscribe (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
+
     // FIXME: This needs to release the master lock immediately
     // Subscriptions need to be protected by their own lock
 
@@ -262,8 +264,8 @@ Json::Value doSubscribe (RPC::Context& context)
             if (book.in.currency == book.out.currency
                     && book.in.account == book.out.account)
             {
-                WriteLog (lsINFO, RPCHandler) << "taker_gets same as taker_pays.";
-
+                WriteLog (lsINFO, RPCHandler)
+                    << "taker_gets same as taker_pays.";
                 return rpcError (rpcBAD_MARKET);
             }
 
@@ -289,7 +291,7 @@ Json::Value doSubscribe (RPC::Context& context)
             {
                 if (bHaveMasterLock)
                 {
-                    context.lock_.unlock ();
+                    lock->unlock ();
                     bHaveMasterLock = false;
                 }
 

--- a/src/ripple/module/rpc/handlers/TransactionEntry.cpp
+++ b/src/ripple/module/rpc/handlers/TransactionEntry.cpp
@@ -24,13 +24,14 @@ namespace ripple {
 //   ledger_hash : <ledger>,
 //   ledger_index : <ledger_index>
 // }
-// XXX In this case, not specify either ledger does not mean ledger current. It means any ledger.
+//
+// XXX In this case, not specify either ledger does not mean ledger current. It
+// means any ledger.
 Json::Value doTransactionEntry (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     Ledger::pointer     lpLedger;
-    Json::Value         jvResult    = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Json::Value jvResult
+            = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
 
     if (!lpLedger)
         return jvResult;
@@ -39,16 +40,19 @@ Json::Value doTransactionEntry (RPC::Context& context)
     {
         jvResult["error"]   = "fieldNotFoundTransaction";
     }
-    else if (!context.params_.isMember ("ledger_hash") && !context.params_.isMember ("ledger_index"))
+    else if (!context.params_.isMember ("ledger_hash")
+             && !context.params_.isMember ("ledger_index"))
     {
         // We don't work on ledger current.
 
-        jvResult["error"]   = "notYetImplemented";  // XXX We don't support any transaction yet.
+        // XXX We don't support any transaction yet.
+        jvResult["error"]   = "notYetImplemented";
     }
     else
     {
-        uint256                     uTransID;
-        // XXX Relying on trusted WSS client. Would be better to have a strict routine, returning success or failure.
+        uint256 uTransID;
+        // XXX Relying on trusted WSS client. Would be better to have a strict
+        // routine, returning success or failure.
         uTransID.SetHex (context.params_["tx_hash"].asString ());
 
         if (!lpLedger)

--- a/src/ripple/module/rpc/handlers/Tx.cpp
+++ b/src/ripple/module/rpc/handlers/Tx.cpp
@@ -25,12 +25,11 @@ namespace ripple {
 // }
 Json::Value doTx (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     if (!context.params_.isMember (jss::transaction))
         return rpcError (rpcINVALID_PARAMS);
 
-    bool binary = context.params_.isMember (jss::binary) && context.params_[jss::binary].asBool ();
+    bool binary = context.params_.isMember (jss::binary)
+            && context.params_[jss::binary].asBool ();
 
     std::string strTransaction  = context.params_[jss::transaction].asString ();
 
@@ -39,7 +38,7 @@ Json::Value doTx (RPC::Context& context)
         // transaction by ID
         uint256 txid (strTransaction);
 
-        Transaction::pointer txn = getApp().getMasterTransaction ().fetch (txid, true);
+        auto txn = getApp().getMasterTransaction ().fetch (txid, true);
 
         if (!txn)
             return rpcError (rpcTXN_NOT_FOUND);
@@ -53,7 +52,7 @@ Json::Value doTx (RPC::Context& context)
 
         if (txn->getLedger () != 0)
         {
-            Ledger::pointer lgr = context.netOps_.getLedgerBySeq (txn->getLedger ());
+            auto lgr = context.netOps_.getLedgerBySeq (txn->getLedger ());
 
             if (lgr)
             {

--- a/src/ripple/module/rpc/handlers/TxHistory.cpp
+++ b/src/ripple/module/rpc/handlers/TxHistory.cpp
@@ -25,7 +25,6 @@ namespace ripple {
 // }
 Json::Value doTxHistory (RPC::Context& context)
 {
-    context.lock_.unlock ();
     context.loadType_ = Resource::feeMediumBurdenRPC;
 
     if (!context.params_.isMember ("start"))
@@ -42,7 +41,8 @@ Json::Value doTxHistory (RPC::Context& context)
     obj["index"] = startIndex;
 
     std::string sql =
-        boost::str (boost::format ("SELECT * FROM Transactions ORDER BY LedgerSeq desc LIMIT %u,20")
+        boost::str (boost::format (
+            "SELECT * FROM Transactions ORDER BY LedgerSeq desc LIMIT %u,20")
                     % startIndex);
 
     {
@@ -51,9 +51,8 @@ Json::Value doTxHistory (RPC::Context& context)
 
         SQL_FOREACH (db, sql)
         {
-            Transaction::pointer trans = Transaction::transactionFromSQL (db, false);
-
-            if (trans) txs.append (trans->getJson (0));
+            if (auto trans = Transaction::transactionFromSQL (db, false))
+                txs.append (trans->getJson (0));
         }
     }
 

--- a/src/ripple/module/rpc/handlers/UnlAdd.cpp
+++ b/src/ripple/module/rpc/handlers/UnlAdd.cpp
@@ -26,20 +26,26 @@ namespace ripple {
 // }
 Json::Value doUnlAdd (RPC::Context& context)
 {
-    std::string strNode     = context.params_.isMember ("node") ? context.params_["node"].asString () : "";
-    std::string strComment  = context.params_.isMember ("comment") ? context.params_["comment"].asString () : "";
+    auto lock = getApp().masterLock();
+
+    std::string strNode = context.params_.isMember ("node")
+            ? context.params_["node"].asString () : "";
+    std::string strComment = context.params_.isMember ("comment")
+            ? context.params_["comment"].asString () : "";
 
     RippleAddress   raNodePublic;
 
     if (raNodePublic.setNodePublic (strNode))
     {
-        getApp().getUNL ().nodeAddPublic (raNodePublic, UniqueNodeList::vsManual, strComment);
+        getApp().getUNL ().nodeAddPublic (
+            raNodePublic, UniqueNodeList::vsManual, strComment);
 
         return "adding node by public key";
     }
     else
     {
-        getApp().getUNL ().nodeAddDomain (strNode, UniqueNodeList::vsManual, strComment);
+        getApp().getUNL ().nodeAddDomain (
+            strNode, UniqueNodeList::vsManual, strComment);
 
         return "adding node by domain";
     }

--- a/src/ripple/module/rpc/handlers/UnlDelete.cpp
+++ b/src/ripple/module/rpc/handlers/UnlDelete.cpp
@@ -25,6 +25,8 @@ namespace ripple {
 // }
 Json::Value doUnlDelete (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
+
     if (!context.params_.isMember ("node"))
         return rpcError (rpcINVALID_PARAMS);
 

--- a/src/ripple/module/rpc/handlers/UnlList.cpp
+++ b/src/ripple/module/rpc/handlers/UnlList.cpp
@@ -22,6 +22,7 @@ namespace ripple {
 
 Json::Value doUnlList (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     Json::Value obj (Json::objectValue);
 
     obj["unl"] = getApp().getUNL ().getUnlJson ();

--- a/src/ripple/module/rpc/handlers/UnlLoad.cpp
+++ b/src/ripple/module/rpc/handlers/UnlLoad.cpp
@@ -23,7 +23,10 @@ namespace ripple {
 // Populate the UNL from a local validators.txt file.
 Json::Value doUnlLoad (RPC::Context& context)
 {
-    if (getConfig ().VALIDATORS_FILE.empty () || !getApp().getUNL ().nodeLoad (getConfig ().VALIDATORS_FILE))
+    auto lock = getApp().masterLock();
+
+    if (getConfig ().VALIDATORS_FILE.empty ()
+        || !getApp().getUNL ().nodeLoad (getConfig ().VALIDATORS_FILE))
     {
         return rpcError (rpcLOAD_FAILED);
     }

--- a/src/ripple/module/rpc/handlers/UnlNetwork.cpp
+++ b/src/ripple/module/rpc/handlers/UnlNetwork.cpp
@@ -23,6 +23,7 @@ namespace ripple {
 // Populate the UNL from ripple.com's validators.txt file.
 Json::Value doUnlNetwork (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     getApp().getUNL ().nodeNetwork ();
 
     return "fetching";

--- a/src/ripple/module/rpc/handlers/UnlReset.cpp
+++ b/src/ripple/module/rpc/handlers/UnlReset.cpp
@@ -22,6 +22,7 @@ namespace ripple {
 
 Json::Value doUnlReset (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     getApp().getUNL ().nodeReset ();
 
     return "removing nodes";

--- a/src/ripple/module/rpc/handlers/UnlScore.cpp
+++ b/src/ripple/module/rpc/handlers/UnlScore.cpp
@@ -23,6 +23,7 @@ namespace ripple {
 // unl_score
 Json::Value doUnlScore (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
     getApp().getUNL ().nodeScore ();
 
     return "scoring requested";

--- a/src/ripple/module/rpc/handlers/Unsubscribe.cpp
+++ b/src/ripple/module/rpc/handlers/Unsubscribe.cpp
@@ -20,9 +20,12 @@
 
 namespace ripple {
 
-// FIXME: This leaks RPCSub objects for JSON-RPC.  Shouldn't matter for anyone sane.
+// FIXME: This leaks RPCSub objects for JSON-RPC.  Shouldn't matter for anyone
+// sane.
 Json::Value doUnsubscribe (RPC::Context& context)
 {
+    auto lock = getApp().masterLock();
+
     InfoSub::pointer ispSub;
     Json::Value jvResult (Json::objectValue);
 
@@ -51,33 +54,27 @@ Json::Value doUnsubscribe (RPC::Context& context)
 
     if (context.params_.isMember ("streams"))
     {
-        for (Json::Value::iterator it = context.params_["streams"].begin (); it != context.params_["streams"].end (); it++)
+        for (auto& it: context.params_["streams"])
         {
-            if ((*it).isString ())
+            if (it.isString ())
             {
-                std::string streamName = (*it).asString ();
+                std::string streamName = it.asString ();
 
                 if (streamName == "server")
-                {
                     context.netOps_.unsubServer (ispSub->getSeq ());
-                }
+
                 else if (streamName == "ledger")
-                {
                     context.netOps_.unsubLedger (ispSub->getSeq ());
-                }
+
                 else if (streamName == "transactions")
-                {
                     context.netOps_.unsubTransactions (ispSub->getSeq ());
-                }
+
                 else if (streamName == "transactions_proposed"
                          || streamName == "rt_transactions")         // DEPRECATED
-                {
                     context.netOps_.unsubRTTransactions (ispSub->getSeq ());
-                }
+
                 else
-                {
-                    jvResult["error"]   = str (boost::format ("Unknown stream: %s") % streamName);
-                }
+                    jvResult["error"] = "Unknown stream: " + streamName;
             }
             else
             {
@@ -86,35 +83,28 @@ Json::Value doUnsubscribe (RPC::Context& context)
         }
     }
 
-    if (context.params_.isMember ("accounts_proposed") || context.params_.isMember ("rt_accounts"))
+    if (context.params_.isMember ("accounts_proposed")
+        || context.params_.isMember ("rt_accounts"))
     {
-        hash_set<RippleAddress> usnaAccoundIds  = RPC::parseAccountIds (
+        auto accounts  = RPC::parseAccountIds (
                     context.params_.isMember ("accounts_proposed")
                     ? context.params_["accounts_proposed"]
-                    : context.params_["rt_accounts"]);                    // DEPRECATED
+                    : context.params_["rt_accounts"]); // DEPRECATED
 
-        if (usnaAccoundIds.empty ())
-        {
+        if (accounts.empty ())
             jvResult["error"]   = "malformedAccount";
-        }
         else
-        {
-            context.netOps_.unsubAccount (ispSub->getSeq (), usnaAccoundIds, true);
-        }
+            context.netOps_.unsubAccount (ispSub->getSeq (), accounts, true);
     }
 
     if (context.params_.isMember ("accounts"))
     {
-        hash_set<RippleAddress> usnaAccoundIds  = RPC::parseAccountIds (context.params_["accounts"]);
+        auto accounts  = RPC::parseAccountIds (context.params_["accounts"]);
 
-        if (usnaAccoundIds.empty ())
-        {
+        if (accounts.empty ())
             jvResult["error"]   = "malformedAccount";
-        }
         else
-        {
-            context.netOps_.unsubAccount (ispSub->getSeq (), usnaAccoundIds, false);
-        }
+            context.netOps_.unsubAccount (ispSub->getSeq (), accounts, false);
     }
 
     if (!context.params_.isMember ("books"))
@@ -126,10 +116,8 @@ Json::Value doUnsubscribe (RPC::Context& context)
     }
     else
     {
-        for (Json::Value::iterator it = context.params_["books"].begin (); it != context.params_["books"].end (); it++)
+        for (auto& jvSubRequest: context.params_["books"])
         {
-            Json::Value&    jvSubRequest    = *it;
-
             if (!jvSubRequest.isObject ()
                     || !jvSubRequest.isMember ("taker_pays")
                     || !jvSubRequest.isMember ("taker_gets")

--- a/src/ripple/module/rpc/handlers/ValidationCreate.cpp
+++ b/src/ripple/module/rpc/handlers/ValidationCreate.cpp
@@ -24,7 +24,8 @@ namespace ripple {
 //   secret: <string>   // optional
 // }
 //
-// This command requires Config::ADMIN access because it makes no sense to ask an untrusted server for this.
+// This command requires Config::ADMIN access because it makes no sense to ask
+// an untrusted server for this.
 Json::Value doValidationCreate (RPC::Context& context)
 {
     RippleAddress   raSeed;
@@ -41,9 +42,10 @@ Json::Value doValidationCreate (RPC::Context& context)
         return rpcError (rpcBAD_SEED);
     }
 
-    obj["validation_public_key"]    = RippleAddress::createNodePublic (raSeed).humanNodePublic ();
-    obj["validation_seed"]          = raSeed.humanSeed ();
-    obj["validation_key"]           = raSeed.humanSeed1751 ();
+    obj["validation_public_key"]
+            = RippleAddress::createNodePublic (raSeed).humanNodePublic ();
+    obj["validation_seed"] = raSeed.humanSeed ();
+    obj["validation_key"] = raSeed.humanSeed1751 ();
 
     return obj;
 }

--- a/src/ripple/module/rpc/handlers/WalletAccounts.cpp
+++ b/src/ripple/module/rpc/handlers/WalletAccounts.cpp
@@ -27,34 +27,39 @@ namespace ripple {
 // }
 Json::Value doWalletAccounts (RPC::Context& context)
 {
-    Ledger::pointer     lpLedger;
-    Json::Value         jvResult    = RPC::lookupLedger (context.params_, lpLedger, context.netOps_);
+    Ledger::pointer ledger;
+    Json::Value jvResult
+            = RPC::lookupLedger (context.params_, ledger, context.netOps_);
 
-    if (!lpLedger)
+    if (!ledger)
         return jvResult;
 
     RippleAddress   naSeed;
 
-    if (!context.params_.isMember ("seed") || !naSeed.setSeedGeneric (context.params_["seed"].asString ()))
+    if (!context.params_.isMember ("seed")
+        || !naSeed.setSeedGeneric (context.params_["seed"].asString ()))
     {
         return rpcError (rpcBAD_SEED);
     }
 
     // Try the seed as a master seed.
-    RippleAddress   naMasterGenerator   = RippleAddress::createGeneratorPublic (naSeed);
+    RippleAddress naMasterGenerator
+            = RippleAddress::createGeneratorPublic (naSeed);
 
-    Json::Value jsonAccounts    = RPC::accounts (lpLedger, naMasterGenerator, context.netOps_);
+    Json::Value jsonAccounts
+            = RPC::accounts (ledger, naMasterGenerator, context.netOps_);
 
     if (jsonAccounts.empty ())
     {
         // No account via seed as master, try seed a regular.
-        Json::Value ret = RPC::getMasterGenerator (lpLedger, naSeed, naMasterGenerator, context.netOps_);
+        Json::Value ret = RPC::getMasterGenerator (
+            ledger, naSeed, naMasterGenerator, context.netOps_);
 
         if (!ret.empty ())
             return ret;
 
-        ret["accounts"] = RPC::accounts (lpLedger, naMasterGenerator, context.netOps_);
-
+        ret["accounts"]
+                = RPC::accounts (ledger, naMasterGenerator, context.netOps_);
         return ret;
     }
     else

--- a/src/ripple/module/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/module/rpc/handlers/WalletPropose.cpp
@@ -25,8 +25,6 @@ namespace ripple {
 // }
 Json::Value doWalletPropose (RPC::Context& context)
 {
-    context.lock_.unlock ();
-
     RippleAddress   naSeed;
     RippleAddress   naAccount;
 

--- a/src/ripple/module/rpc/handlers/WalletSeed.cpp
+++ b/src/ripple/module/rpc/handlers/WalletSeed.cpp
@@ -24,10 +24,10 @@ namespace ripple {
 // }
 Json::Value doWalletSeed (RPC::Context& context)
 {
-    RippleAddress   raSeed;
-    bool            bSecret = context.params_.isMember ("secret");
+    RippleAddress   seed;
+    bool bSecret = context.params_.isMember ("secret");
 
-    if (bSecret && !raSeed.setSeedGeneric (context.params_["secret"].asString ()))
+    if (bSecret && !seed.setSeedGeneric (context.params_["secret"].asString ()))
     {
         return rpcError (rpcBAD_SEED);
     }
@@ -37,17 +37,17 @@ Json::Value doWalletSeed (RPC::Context& context)
 
         if (!bSecret)
         {
-            raSeed.setSeedRandom ();
+            seed.setSeedRandom ();
         }
 
-        RippleAddress   raGenerator = RippleAddress::createGeneratorPublic (raSeed);
+        RippleAddress raGenerator = RippleAddress::createGeneratorPublic (seed);
 
         raAccount.setAccountPublic (raGenerator, 0);
 
         Json::Value obj (Json::objectValue);
 
-        obj["seed"]     = raSeed.humanSeed ();
-        obj["key"]      = raSeed.humanSeed1751 ();
+        obj["seed"]     = seed.humanSeed ();
+        obj["key"]      = seed.humanSeed1751 ();
         obj["deprecated"] = "Use wallet_propose instead";
 
         return obj;

--- a/src/ripple/module/rpc/impl/Context.h
+++ b/src/ripple/module/rpc/impl/Context.h
@@ -27,7 +27,6 @@ namespace RPC {
 struct Context {
     Json::Value params_;
     Resource::Charge& loadType_;
-    Application::ScopedLockType& lock_;
     NetworkOPs& netOps_;
     InfoSub::pointer infoSub_;
     Config::Role role_;

--- a/src/ripple/module/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/module/rpc/impl/TransactionSign.cpp
@@ -179,8 +179,8 @@ static Json::Value signPayment(
 //             submit the tranaction
 //
 Json::Value transactionSign (
-    Json::Value params, bool bSubmit, bool bFailHard,
-    Application::ScopedLockType& mlh, NetworkOPs& netOps, int role)
+    Json::Value params, bool bSubmit, bool bFailHard, NetworkOPs& netOps,
+    int role)
 {
     Json::Value jvResult;
 

--- a/src/ripple/module/rpc/impl/TransactionSign.h
+++ b/src/ripple/module/rpc/impl/TransactionSign.h
@@ -27,7 +27,6 @@ Json::Value transactionSign (
     Json::Value jvRequest,
     bool bSubmit,
     bool bFailHard,
-    Application::ScopedLockType& mlh,
     NetworkOPs& netOps,
     int role);
 


### PR DESCRIPTION
The first change is pure cleaning - the second one changes the business logic.
