### PR TITLE
Fix build warnings and .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.o
 build
 tags
+TAGS
 bin/rippled
 Debug/*.*
 Release/*.*

--- a/SConstruct
+++ b/SConstruct
@@ -241,7 +241,6 @@ def config_env(toolchain, variant, env):
         env.Append(CPPDEFINES=['NDEBUG'])
 
     if toolchain in Split('clang gcc'):
-
         if Beast.system.linux:
             env.ParseConfig('pkg-config --static --cflags --libs openssl')
             env.ParseConfig('pkg-config --static --cflags --libs protobuf')
@@ -253,8 +252,11 @@ def config_env(toolchain, variant, env):
             '-Wno-sign-compare',
             '-Wno-char-subscripts',
             '-Wno-format',
-            '-Wno-deprecated-register'
+            '-Wno-deprecated-register',
             ])
+
+        if toolchain == 'clang':
+            env.Append(CCFLAGS=['-Wno-redeclared-class-member'])
 
         env.Append(CXXFLAGS=[
             '-frtti',
@@ -329,7 +331,9 @@ def config_env(toolchain, variant, env):
             if Beast.system.osx:
                 env.Replace(CC='clang', CXX='clang++', LINK='clang++')
             elif 'CLANG_CC' in env and 'CLANG_CXX' in env and 'CLANG_LINK' in env:
-                env.Replace(CC=env['CLANG_CC'], CXX=env['CLANG_CXX'], LINK=env['CLANG_LINK'])
+                env.Replace(CC=env['CLANG_CC'],
+                            CXX=env['CLANG_CXX'],
+                            LINK=env['CLANG_LINK'])
             # C and C++
             # Add '-Wshorten-64-to-32'
             env.Append(CCFLAGS=[])
@@ -338,7 +342,9 @@ def config_env(toolchain, variant, env):
 
         elif toolchain == 'gcc':
             if 'GNU_CC' in env and 'GNU_CXX' in env and 'GNU_LINK' in env:
-                env.Replace(CC=env['GNU_CC'], CXX=env['GNU_CXX'], LINK=env['GNU_LINK'])
+                env.Replace(CC=env['GNU_CC'],
+                            CXX=env['GNU_CXX'],
+                            LINK=env['GNU_LINK'])
             # Why is this only for gcc?!
             env.Append(CCFLAGS=['-Wno-unused-local-typedefs'])
 
@@ -542,7 +548,7 @@ for toolchain in all_toolchains:
 
         objects.append(addSource('src/ripple/unity/nodestore.cpp', env, variant_dirs, [
             'src/leveldb/include',
-            #'src/hyperleveldb/include', # hyper 
+            #'src/hyperleveldb/include', # hyper
             'src/rocksdb/include',
             ]))
 

--- a/src/beast/beast/http/tests/client_session.test.cpp
+++ b/src/beast/beast/http/tests/client_session.test.cpp
@@ -42,7 +42,7 @@ namespace beast {
 namespace http {
 
 /** Allows thread-safe forward traversal of a sequence.
-    
+
     Each time the shared_iterator is dereferenced it provides an element in
     the sequence or the one-past-the-end iterator if there are no elements
     remaining in the sequence. Access to the shared iterator is thread safe:
@@ -285,7 +285,7 @@ public:
 
             Response resp;
             ec = session.get (req, resp);
-            
+
             if (ec)
             {
                 // hack
@@ -318,7 +318,7 @@ public:
             std::string const base (*cur);
             std::string url;
             url = "www." + base;
-            auto const ec (visit (session, url));
+            visit (session, url);
         }
     }
 
@@ -345,7 +345,7 @@ std::advance (last, 3000);
 #else
         std::size_t const hardware_concurrency (1);
 #endif
-        
+
         for (std::size_t n (hardware_concurrency); n--;)
             pool.emplace_back (std::bind (
                 &client_session_test::concurrent_get <Iterator>, this,

--- a/src/ripple/module/app/shamap/SHAMapSync.cpp
+++ b/src/ripple/module/app/shamap/SHAMapSync.cpp
@@ -629,10 +629,14 @@ bool SHAMap::hasLeafNode (uint256 const& tag, uint256 const& nodeHash)
     return false; // If this was a matching leaf, we would have caught it already
 }
 
-static void addFPtoList (std::list<SHAMap::fetchPackEntry_t>& list, const uint256& hash, const Blob& blob)
+#if 0
+static
+void addFPtoList (std::list<SHAMap::fetchPackEntry_t>& list,
+                  const uint256& hash, const Blob& blob)
 {
     list.push_back (SHAMap::fetchPackEntry_t (hash, blob));
 }
+#endif
 
 void SHAMap::getFetchPack (SHAMap* have, bool includeLeaves, int max,
                            std::function<void (const uint256&, const Blob&)> func)

--- a/src/ripple/overlay/impl/basic_message.h
+++ b/src/ripple/overlay/impl/basic_message.h
@@ -59,9 +59,8 @@ private:
     // request
     beast::http::method_t method_;
     std::string url_;
-    
+
     // response
-    int status_;
     std::string reason_;
 
     // message
@@ -102,7 +101,6 @@ public:
 
     basic_message()
         : method_ (beast::http::method_t::http_get)
-        , status_ (200)
         , version_ (1, 1)
     {
     }

--- a/src/ripple/unity/data.cpp
+++ b/src/ripple/unity/data.cpp
@@ -83,7 +83,6 @@
 static const std::uint64_t tenTo14 = 100000000000000ull;
 static const std::uint64_t tenTo14m1 = tenTo14 - 1;
 static const std::uint64_t tenTo17 = tenTo14 * 1000;
-static const std::uint64_t tenTo17m1 = tenTo17 - 1;
 #include <ripple/module/data/protocol/STAmount.cpp>
 #include <ripple/module/data/protocol/STAmountRound.cpp>
 


### PR DESCRIPTION
- Comment out unused local function for both clang and g++.
- Get rid of numerous Boost warnings for clang.
- Remove some unused local variables.
- Put TAGS into the .gitignore.
