### PR TITLE
Improvements to aged_containers (RIPD-363)

### DIFF
--- a/src/beast/beast/container/detail/aged_ordered_container.h
+++ b/src/beast/beast/container/detail/aged_ordered_container.h
@@ -42,6 +42,18 @@
 namespace beast {
 namespace detail {
 
+// Traits templates used to discern reverse_iterators, which are disallowed
+// for mutating operations.
+template <class It>
+struct is_boost_reverse_iterator
+    : std::false_type
+{};
+
+template <class It>
+struct is_boost_reverse_iterator<boost::intrusive::detail::reverse_iterator<It>>
+    : std::true_type
+{};
+
 /** Associative container where each element is also indexed by time.
 
     This container mirrors the interface of the standard library ordered
@@ -203,7 +215,7 @@ private:
         {
             return this->member() (k, extract (e.value));
         }
-        
+
         template <class K>
         bool operator() (element const& e, K const& k) const
         {
@@ -215,7 +227,7 @@ private:
         {
             return this->member() (k, extract (e.value));
         }
-        
+
         bool operator() (element const& e, Key const& k) const
         {
             return this->member() (extract (e.value), k);
@@ -384,13 +396,14 @@ private:
         return p;
     }
 
-    void delete_element (element* p)
+    void delete_element (element const* p)
     {
         ElementAllocatorTraits::destroy (m_config.alloc(), p);
-        ElementAllocatorTraits::deallocate (m_config.alloc(), p, 1);
+        ElementAllocatorTraits::deallocate (
+            m_config.alloc(), const_cast<element*>(p), 1);
     }
 
-    void unlink_and_delete_element (element* p)
+    void unlink_and_delete_element (element const* p)
     {
         chronological.list.erase (
             chronological.list.iterator_to (*p));
@@ -412,11 +425,13 @@ public:
     typedef typename std::allocator_traits <
         Allocator>::const_pointer const_pointer;
 
-    typedef detail::aged_container_iterator <false,
+    // A set (that is, !IsMap) iterator is aways const because the elements
+    // of a set are immutable.
+    typedef detail::aged_container_iterator <!IsMap,
         typename cont_type::iterator> iterator;
     typedef detail::aged_container_iterator <true,
         typename cont_type::iterator> const_iterator;
-    typedef detail::aged_container_iterator <false,
+    typedef detail::aged_container_iterator <!IsMap,
         typename cont_type::reverse_iterator> reverse_iterator;
     typedef detail::aged_container_iterator <true,
         typename cont_type::reverse_iterator> const_reverse_iterator;
@@ -433,11 +448,13 @@ public:
     class chronological_t
     {
     public:
-        typedef detail::aged_container_iterator <false,
+        // A set (that is, !IsMap) iterator is aways const because the elements
+        // of a set are immutable.
+        typedef detail::aged_container_iterator <!IsMap,
             typename list_type::iterator> iterator;
         typedef detail::aged_container_iterator <true,
             typename list_type::iterator> const_iterator;
-        typedef detail::aged_container_iterator <false,
+        typedef detail::aged_container_iterator <!IsMap,
             typename list_type::reverse_iterator> reverse_iterator;
         typedef detail::aged_container_iterator <true,
             typename list_type::reverse_iterator> const_reverse_iterator;
@@ -823,7 +840,7 @@ public:
     template <bool maybe_multi = IsMulti>
     typename std::enable_if <maybe_multi,
         iterator>::type
-    insert (const_iterator const& /*hint*/, value_type const& value)
+    insert (const_iterator /*hint*/, value_type const& value)
     {
         // VFALCO TODO Figure out how to utilize 'hint'
         return insert (value);
@@ -840,7 +857,7 @@ public:
     template <bool maybe_multi = IsMulti>
     typename std::enable_if <maybe_multi,
         iterator>::type
-    insert (const_iterator const& /*hint*/, value_type&& value)
+    insert (const_iterator /*hint*/, value_type&& value)
     {
         // VFALCO TODO Figure out how to utilize 'hint'
         return insert (std::move (value));
@@ -882,7 +899,7 @@ public:
 
     template <class InputIt>
     void
-    insert (InputIt first, InputIt const& last)
+    insert (InputIt first, InputIt last)
     {
         for (; first != last; ++first)
             insert (cend(), *first);
@@ -911,7 +928,7 @@ public:
     // map, set
     template <bool maybe_multi = IsMulti, class... Args>
     auto
-    emplace_hint (const_iterator const& hint, Args&&... args) ->
+    emplace_hint (const_iterator hint, Args&&... args) ->
         typename std::enable_if <! maybe_multi,
             std::pair <iterator, bool>>::type;
 
@@ -919,24 +936,26 @@ public:
     template <bool maybe_multi = IsMulti, class... Args>
     typename std::enable_if <maybe_multi,
         iterator>::type
-    emplace_hint (const_iterator const& /*hint*/, Args&&... args)
+    emplace_hint (const_iterator /*hint*/, Args&&... args)
     {
         // VFALCO TODO Figure out how to utilize 'hint'
         return emplace <maybe_multi> (
             std::forward <Args> (args)...);
     }
 
-    template <bool is_const, class Iterator, class Base>
+    // enable_if prevents erase (reverse_iterator pos) from compiling
+    template <bool is_const, class Iterator, class Base,
+         class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
     detail::aged_container_iterator <false, Iterator, Base>
-    erase (detail::aged_container_iterator <
-        is_const, Iterator, Base> const& pos);
+    erase (detail::aged_container_iterator <is_const, Iterator, Base> pos);
 
-    template <bool is_const, class Iterator, class Base>
+    // enable_if prevents erase (reverse_iterator first, reverse_iterator last)
+    // from compiling
+    template <bool is_const, class Iterator, class Base,
+        class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
     detail::aged_container_iterator <false, Iterator, Base>
-    erase (detail::aged_container_iterator <
-        is_const, Iterator, Base> first,
-            detail::aged_container_iterator <
-                is_const, Iterator, Base> const& last);
+    erase (detail::aged_container_iterator <is_const, Iterator, Base> first,
+           detail::aged_container_iterator <is_const, Iterator, Base> last);
 
     template <class K>
     auto
@@ -948,10 +967,11 @@ public:
 
     //--------------------------------------------------------------------------
 
-    template <bool is_const, class Iterator, class Base>
+    // enable_if prevents touch (reverse_iterator pos) from compiling
+    template <bool is_const, class Iterator, class Base,
+        class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
     void
-    touch (detail::aged_container_iterator <
-        is_const, Iterator, Base> const& pos)
+    touch (detail::aged_container_iterator <is_const, Iterator, Base> pos)
     {
         touch (pos, clock().now());
     }
@@ -1047,7 +1067,7 @@ public:
     const_iterator
     upper_bound (K const& k) const
     {
-        return const_iterator (m_cont.upper_bound (k, 
+        return const_iterator (m_cont.upper_bound (k,
             std::cref (m_config.key_compare())));
     }
 
@@ -1176,10 +1196,12 @@ public:
     }
 
 private:
-    template <bool is_const, class Iterator, class Base>
+    // enable_if prevents erase (reverse_iterator pos, now) from compiling
+    template <bool is_const, class Iterator, class Base,
+        class = std::enable_if_t<!is_boost_reverse_iterator<Iterator>::value>>
     void
     touch (detail::aged_container_iterator <
-        is_const, Iterator, Base> const& pos,
+        is_const, Iterator, Base> pos,
             typename clock_type::time_point const& now);
 
     template <bool maybe_propagate = std::allocator_traits <
@@ -1693,7 +1715,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
 template <bool maybe_multi, class... Args>
 auto
 aged_ordered_container <IsMulti, IsMap, Key, T, Duration, Compare, Allocator>::
-emplace_hint (const_iterator const& hint, Args&&... args) ->
+emplace_hint (const_iterator hint, Args&&... args) ->
     typename std::enable_if <! maybe_multi,
         std::pair <iterator, bool>>::type
 {
@@ -1716,36 +1738,27 @@ emplace_hint (const_iterator const& hint, Args&&... args) ->
 
 template <bool IsMulti, bool IsMap, class Key, class T,
     class Duration, class Compare, class Allocator>
-template <bool is_const, class Iterator, class Base>
-auto
+template <bool is_const, class Iterator, class Base, class>
+detail::aged_container_iterator <false, Iterator, Base>
 aged_ordered_container <IsMulti, IsMap, Key, T, Duration, Compare, Allocator>::
-erase (detail::aged_container_iterator <
-    is_const, Iterator, Base> const& pos) ->
-    detail::aged_container_iterator <false, Iterator, Base>
+erase (detail::aged_container_iterator <is_const, Iterator, Base> pos)
 {
-    auto iter (pos.iterator());
-    auto p (&*iter++);
-    unlink_and_delete_element (p);
+    unlink_and_delete_element(&*((pos++).iterator()));
     return detail::aged_container_iterator <
-        false, Iterator, Base> (iter);
+        false, Iterator, Base> (pos.iterator());
 }
 
 template <bool IsMulti, bool IsMap, class Key, class T,
     class Duration, class Compare, class Allocator>
-template <bool is_const, class Iterator, class Base>
-auto
+template <bool is_const, class Iterator, class Base, class>
+detail::aged_container_iterator <false, Iterator, Base>
 aged_ordered_container <IsMulti, IsMap, Key, T, Duration, Compare, Allocator>::
-erase (detail::aged_container_iterator <
-    is_const, Iterator, Base> first,
-        detail::aged_container_iterator <
-            is_const, Iterator, Base> const& last) ->
-    detail::aged_container_iterator <false, Iterator, Base>
+erase (detail::aged_container_iterator <is_const, Iterator, Base> first,
+       detail::aged_container_iterator <is_const, Iterator, Base> last)
 {
     for (; first != last;)
-    {
-        auto p (&*first++);
-        unlink_and_delete_element (p);
-    }
+        unlink_and_delete_element(&*((first++).iterator()));
+
     return detail::aged_container_iterator <
         false, Iterator, Base> (first.iterator());
 }
@@ -1839,11 +1852,11 @@ operator== (
 
 template <bool IsMulti, bool IsMap, class Key, class T,
     class Duration, class Compare, class Allocator>
-template <bool is_const, class Iterator, class Base>
+template <bool is_const, class Iterator, class Base, class>
 void
 aged_ordered_container <IsMulti, IsMap, Key, T, Duration, Compare, Allocator>::
 touch (detail::aged_container_iterator <
-    is_const, Iterator, Base> const& pos,
+    is_const, Iterator, Base> pos,
         typename clock_type::time_point const& now)
 {
     auto& e (*pos.iterator());

--- a/src/beast/beast/container/detail/aged_unordered_container.h
+++ b/src/beast/beast/container/detail/aged_unordered_container.h
@@ -186,7 +186,7 @@ private:
         {
             return this->member() (extract (e.value));
         }
-  
+
         Hash& hash_function()
         {
             return this->member();
@@ -222,7 +222,7 @@ private:
         {
             return this->member() (k, extract (e.value));
         }
-        
+
         template <class K>
         bool operator() (element const& e, K const& k) const
         {
@@ -234,7 +234,7 @@ private:
         {
             return this->member() (k, extract (e.value));
         }
-  
+
         bool operator() (element const& e, Key const& k) const
         {
             return this->member() (extract (e.value), k);
@@ -584,13 +584,14 @@ private:
         return p;
     }
 
-    void delete_element (element* p)
+    void delete_element (element const* p)
     {
         ElementAllocatorTraits::destroy (m_config.alloc(), p);
-        ElementAllocatorTraits::deallocate (m_config.alloc(), p, 1);
+        ElementAllocatorTraits::deallocate (
+            m_config.alloc(), const_cast<element*>(p), 1);
     }
 
-    void unlink_and_delete_element (element* p)
+    void unlink_and_delete_element (element const* p)
     {
         chronological.list.erase (
             chronological.list.iterator_to (*p));
@@ -609,12 +610,14 @@ public:
     typedef typename std::allocator_traits <
         Allocator>::const_pointer const_pointer;
 
-    typedef detail::aged_container_iterator <false,
+    // A set (that is, !IsMap) iterator is aways const because the elements
+    // of a set are immutable.
+    typedef detail::aged_container_iterator <!IsMap,
         typename cont_type::iterator> iterator;
     typedef detail::aged_container_iterator <true,
         typename cont_type::iterator> const_iterator;
 
-    typedef detail::aged_container_iterator <false,
+    typedef detail::aged_container_iterator <!IsMap,
         typename cont_type::local_iterator> local_iterator;
     typedef detail::aged_container_iterator <true,
         typename cont_type::local_iterator> const_local_iterator;
@@ -631,11 +634,13 @@ public:
     class chronological_t
     {
     public:
-        typedef detail::aged_container_iterator <false,
+        // A set (that is, !IsMap) iterator is aways const because the elements
+        // of a set are immutable.
+        typedef detail::aged_container_iterator <!IsMap,
             typename list_type::iterator> iterator;
         typedef detail::aged_container_iterator <true,
             typename list_type::iterator> const_iterator;
-        typedef detail::aged_container_iterator <false,
+        typedef detail::aged_container_iterator <!IsMap,
             typename list_type::reverse_iterator> reverse_iterator;
         typedef detail::aged_container_iterator <true,
             typename list_type::reverse_iterator> const_reverse_iterator;
@@ -1021,7 +1026,7 @@ public:
     template <bool maybe_multi = IsMulti>
     typename std::enable_if <maybe_multi,
         iterator>::type
-    insert (const_iterator const& /*hint*/, value_type const& value)
+    insert (const_iterator /*hint*/, value_type const& value)
     {
         // VFALCO TODO The hint could be used to let
         //             the client order equal ranges
@@ -1043,7 +1048,7 @@ public:
     template <bool maybe_multi = IsMulti>
     typename std::enable_if <maybe_multi,
         iterator>::type
-    insert (const_iterator const& /*hint*/, value_type&& value)
+    insert (const_iterator /*hint*/, value_type&& value)
     {
         // VFALCO TODO The hint could be used to let
         //             the client order equal ranges
@@ -1083,7 +1088,7 @@ public:
     }
 
     template <class InputIt>
-    void insert (InputIt first, InputIt const& last)
+    void insert (InputIt first, InputIt last)
     {
         insert (first, last,
             typename std::iterator_traits <
@@ -1113,7 +1118,7 @@ public:
     // set, map
     template <bool maybe_multi = IsMulti, class... Args>
     auto
-    emplace_hint (const_iterator const& /*hint*/, Args&&... args) ->
+    emplace_hint (const_iterator /*hint*/, Args&&... args) ->
         typename std::enable_if <! maybe_multi,
             std::pair <iterator, bool>>::type;
 
@@ -1121,7 +1126,7 @@ public:
     template <bool maybe_multi = IsMulti, class... Args>
     typename std::enable_if <maybe_multi,
         iterator>::type
-    emplace_hint (const_iterator const& /*hint*/, Args&&... args)
+    emplace_hint (const_iterator /*hint*/, Args&&... args)
     {
         // VFALCO TODO The hint could be used for multi, to let
         //             the client order equal ranges
@@ -1132,14 +1137,14 @@ public:
     template <bool is_const, class Iterator, class Base>
     detail::aged_container_iterator <false, Iterator, Base>
     erase (detail::aged_container_iterator <
-        is_const, Iterator, Base> const& pos);
+        is_const, Iterator, Base> pos);
 
     template <bool is_const, class Iterator, class Base>
     detail::aged_container_iterator <false, Iterator, Base>
     erase (detail::aged_container_iterator <
         is_const, Iterator, Base> first,
             detail::aged_container_iterator <
-                is_const, Iterator, Base> const& last);
+                is_const, Iterator, Base> last);
 
     template <class K>
     auto
@@ -1152,7 +1157,7 @@ public:
     template <bool is_const, class Iterator, class Base>
     void
     touch (detail::aged_container_iterator <
-        is_const, Iterator, Base> const& pos)
+        is_const, Iterator, Base> pos)
     {
         touch (pos, clock().now());
     }
@@ -1349,24 +1354,11 @@ public:
         class OtherAllocator,
         bool maybe_multi = IsMulti
     >
-    typename std::enable_if <! maybe_multi,
-        bool>::type
+    typename std::enable_if <! maybe_multi, bool>::type
     operator== (
         aged_unordered_container <false, OtherIsMap,
             OtherKey, OtherT, OtherDuration, OtherHash, KeyEqual,
-                OtherAllocator> const& other) const
-    {
-        if (size() != other.size())
-            return false;
-        for (auto iter (cbegin()), last (cend()), olast (other.cend());
-            iter != last; ++iter)
-        {
-            auto oiter (other.find (extract (*iter)));
-            if (oiter == olast)
-                return false;
-        }
-        return true;
-    }
+                OtherAllocator> const& other) const;
 
     template <
         bool OtherIsMap,
@@ -1377,35 +1369,11 @@ public:
         class OtherAllocator,
         bool maybe_multi = IsMulti
     >
-    typename std::enable_if <maybe_multi,
-        bool>::type
+    typename std::enable_if <maybe_multi, bool>::type
     operator== (
         aged_unordered_container <true, OtherIsMap,
             OtherKey, OtherT, OtherDuration, OtherHash, KeyEqual,
-                OtherAllocator> const& other) const
-    {
-        if (size() != other.size())
-            return false;
-        typedef std::pair <const_iterator, const_iterator> EqRng;
-        for (auto iter (cbegin()), last (cend()); iter != last;)
-        {
-            auto const& k (extract (*iter));
-            auto const eq (equal_range (k));
-            auto const oeq (other.equal_range (k));
-#if BEAST_NO_CXX14_IS_PERMUTATION
-            if (std::distance (eq.first, eq.second) !=
-                std::distance (oeq.first, oeq.second) ||
-                ! std::is_permutation (eq.first, eq.second, oeq.first))
-                return false;
-#else
-            if (! std::is_permutation (eq.first,
-                eq.second, oeq.first, oeq.second))
-                return false;
-#endif
-            iter = eq.second;
-        }
-        return true;
-    }
+                OtherAllocator> const& other) const;
 
     template <
         bool OtherIsMulti,
@@ -1456,7 +1424,7 @@ private:
 
     template <class InputIt>
     void
-    insert_unchecked (InputIt first, InputIt const& last)
+    insert_unchecked (InputIt first, InputIt last)
     {
         for (; first != last; ++first)
             insert_unchecked (*first);
@@ -1464,7 +1432,7 @@ private:
 
     template <class InputIt>
     void
-    insert (InputIt first, InputIt const& last,
+    insert (InputIt first, InputIt last,
         std::input_iterator_tag)
     {
         for (; first != last; ++first)
@@ -1473,7 +1441,7 @@ private:
 
     template <class InputIt>
     void
-    insert (InputIt first, InputIt const& last,
+    insert (InputIt first, InputIt last,
         std::random_access_iterator_tag)
     {
         auto const n (std::distance (first, last));
@@ -1484,7 +1452,7 @@ private:
     template <bool is_const, class Iterator, class Base>
     void
     touch (detail::aged_container_iterator <
-        is_const, Iterator, Base> const& pos,
+        is_const, Iterator, Base> pos,
             typename clock_type::time_point const& now)
     {
         auto& e (*pos.iterator());
@@ -2268,7 +2236,7 @@ template <bool maybe_multi, class... Args>
 auto
 aged_unordered_container <IsMulti, IsMap, Key, T, Duration,
     Hash, KeyEqual, Allocator>::
-emplace_hint (const_iterator const& /*hint*/, Args&&... args) ->
+emplace_hint (const_iterator /*hint*/, Args&&... args) ->
     typename std::enable_if <! maybe_multi,
         std::pair <iterator, bool>>::type
 {
@@ -2298,13 +2266,11 @@ detail::aged_container_iterator <false, Iterator, Base>
 aged_unordered_container <IsMulti, IsMap, Key, T, Duration,
     Hash, KeyEqual, Allocator>::
 erase (detail::aged_container_iterator <
-    is_const, Iterator, Base> const& pos)
+    is_const, Iterator, Base> pos)
 {
-    auto iter (pos.iterator());
-    auto p (&*iter++);
-    unlink_and_delete_element (p);
+    unlink_and_delete_element(&*((pos++).iterator()));
     return detail::aged_container_iterator <
-        false, Iterator, Base> (iter);
+        false, Iterator, Base> (pos.iterator());
 }
 
 template <bool IsMulti, bool IsMap, class Key, class T,
@@ -2316,14 +2282,11 @@ aged_unordered_container <IsMulti, IsMap, Key, T, Duration,
 erase (detail::aged_container_iterator <
     is_const, Iterator, Base> first,
         detail::aged_container_iterator <
-            is_const, Iterator, Base> const& last)
+            is_const, Iterator, Base> last)
 {
-    size_type n (0);
-    for (; first != last; ++n)
-    {
-        auto p (&*first++);
-        unlink_and_delete_element (p);
-    }
+    for (; first != last;)
+        unlink_and_delete_element(&*((first++).iterator()));
+
     return detail::aged_container_iterator <
         false, Iterator, Base> (first.iterator());
 }
@@ -2385,6 +2348,79 @@ touch (K const& k) ->
         ++n;
     }
     return n;
+}
+
+template <bool IsMulti, bool IsMap, class Key, class T,
+    class Duration, class Hash, class KeyEqual, class Allocator>
+template <
+    bool OtherIsMap,
+    class OtherKey,
+    class OtherT,
+    class OtherDuration,
+    class OtherHash,
+    class OtherAllocator,
+    bool maybe_multi
+>
+typename std::enable_if <! maybe_multi, bool>::type
+aged_unordered_container <
+    IsMulti, IsMap, Key, T, Duration, Hash, KeyEqual, Allocator>::
+operator== (
+    aged_unordered_container <false, OtherIsMap,
+        OtherKey, OtherT, OtherDuration, OtherHash, KeyEqual,
+            OtherAllocator> const& other) const
+{
+    if (size() != other.size())
+        return false;
+    for (auto iter (cbegin()), last (cend()), olast (other.cend());
+        iter != last; ++iter)
+    {
+        auto oiter (other.find (extract (*iter)));
+        if (oiter == olast)
+            return false;
+    }
+    return true;
+}
+
+template <bool IsMulti, bool IsMap, class Key, class T,
+    class Duration, class Hash, class KeyEqual, class Allocator>
+template <
+    bool OtherIsMap,
+    class OtherKey,
+    class OtherT,
+    class OtherDuration,
+    class OtherHash,
+    class OtherAllocator,
+    bool maybe_multi
+>
+typename std::enable_if <maybe_multi, bool>::type
+aged_unordered_container <
+    IsMulti, IsMap, Key, T, Duration, Hash, KeyEqual, Allocator>::
+operator== (
+    aged_unordered_container <true, OtherIsMap,
+        OtherKey, OtherT, OtherDuration, OtherHash, KeyEqual,
+            OtherAllocator> const& other) const
+{
+    if (size() != other.size())
+        return false;
+    typedef std::pair <const_iterator, const_iterator> EqRng;
+    for (auto iter (cbegin()), last (cend()); iter != last;)
+    {
+        auto const& k (extract (*iter));
+        auto const eq (equal_range (k));
+        auto const oeq (other.equal_range (k));
+#if BEAST_NO_CXX14_IS_PERMUTATION
+        if (std::distance (eq.first, eq.second) !=
+            std::distance (oeq.first, oeq.second) ||
+            ! std::is_permutation (eq.first, eq.second, oeq.first))
+            return false;
+#else
+        if (! std::is_permutation (eq.first,
+            eq.second, oeq.first, oeq.second))
+            return false;
+#endif
+        iter = eq.second;
+    }
+    return true;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Added unit tests for element erase
- Added unit tests for range erase
- Extended unit tests for touch
- Added unit tests for iterators and reverse_iterators
- Un-inlined operator== for unordered containers
- Fixed minor problems with ordered_container erase()
- Made ordered_container...
  - erase (reverse_iterator pos) not compile
  - erase (reverse_iterator first, reverse_iterator last) not compile
  - touch (reverse iterator pos) not compile
- Verified that ordered container...
  - insert() already rejects reverse_iterator
  - emplace_hint() already rejects reverse_iterator
- Made set/multiset iterators const

Regarding the set/multiset iterators, see section 5.1 of
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2009/n2913.pdf
as pointed out by Vinnie.
