### PR TITLE
Handle changes to boost::optional in newly released 1.56.

### DIFF
--- a/src/ripple/module/app/tx/TransactionMeta.h
+++ b/src/ripple/module/app/tx/TransactionMeta.h
@@ -107,7 +107,7 @@ public:
 
     bool hasDeliveredAmount () const
     {
-         return mDelivered;
+        return bool(mDelivered);
     }
 
     static bool thread (STObject& node, uint256 const& prevTxID, std::uint32_t prevLgrID);


### PR DESCRIPTION
To improve compatibility with the proposed std::optional a number of changes were made,
one of which is the removal of the implicit conversion to bool.  As a result, returning
boost::optional as a bool value now fails.  Either explicit conversion to bool
or the use of operator! will work;  I chose the latter.
