### PR TITLE
Compile git tags now include name and branch (RIPD-493)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -336,9 +336,8 @@ def config_env(toolchain, variant, env):
         if toolchain != 'msvc':
             git = Beast.Git(env)
             if git.exists:
-                env.Append(CPPDEFINES={
-                    'GIT_COMMIT_ID' : '\'"%s"\'' % git.commit_id
-                    })
+                id = '%s+%s.%s' % (git.tags, git.user, git.branch)
+                env.Append(CPPDEFINES={'GIT_COMMIT_ID' : '\'"%s"\'' % id })
 
         if toolchain == 'clang':
             if Beast.system.osx:

--- a/src/beast/site_scons/Beast.py
+++ b/src/beast/site_scons/Beast.py
@@ -77,14 +77,16 @@ class __System(object):
 class Git(object):
     """Provides information about git and the repository we are called from"""
     def __init__(self, env):
+        self.tags = self.branch = self.user = ''
         self.exists = env.Detect('git')
         if self.exists:
             try:
-                self.commit_id = _execute('git describe --tags')
+                self.tags = _execute('git describe --tags')
+                self.branch = _execute('git rev-parse --abbrev-ref HEAD')
+                remote = _execute('git config remote.origin.url')
+                self.user = remote.split(':')[1].split('/')[0]
             except:
                 self.exists = False
-        else:
-            self.commit_id = None
 
 system = __System()
 


### PR DESCRIPTION
Realized how to do this in a few lines when I was doing other Python stuff.

With this change, the git id looks like:  

 -DGIT_COMMIT_ID='"0.26.0-66-g8368798:rec:git-tag"'
