### PR TITLE
Convert rvalue to an lvalue. (RIPD-494)

### DIFF
--- a/src/ripple/module/app/paths/Pathfinder.cpp
+++ b/src/ripple/module/app/paths/Pathfinder.cpp
@@ -270,13 +270,15 @@ STPathSet Pathfinder::filterPaths(int iMaxPaths, STPath& extraPath)
     try
     {
         LedgerEntrySet lesSandbox (mLedger, tapNONE);
+        // Need a lvalue here. An rvalue will be destructed as soon as the RippleCalc ctor ends.
+        STPathSet spsPaths;
         path::RippleCalc rc(
             lesSandbox,
             mSrcAmount,
             mDstAmount,
             mDstAccountID,
             mSrcAccountID,
-            STPathSet ());
+            spsPaths);
         rc.partialPaymentAllowed_ = true;
 
         TER result = rc.rippleCalculate ();


### PR DESCRIPTION
- The rvalue gets destructed as soon as rc is constructed.

Quick fix for the issue without any refactoring involved.
