### PR TITLE
Harden RippleCalc against dangling references (RIPD-500)

### DIFF
--- a/src/ripple/module/app/paths/PathRequest.cpp
+++ b/src/ripple/module/app/paths/PathRequest.cpp
@@ -459,7 +459,7 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
                 spsPaths);
 
             if (!extraPath.empty() &&
-                (rc.calculateResult_ == terNO_LINE || rc.calculateResult_ == tecPATH_PARTIAL))
+                (rc.result () == terNO_LINE || rc.result () == tecPATH_PARTIAL))
             {
                 m_journal.debug
                         << iIdentifier << " Trying with an extra path element";
@@ -470,20 +470,20 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
                     raDstAccount.getAccountID (),
                     raSrcAccount.getAccountID (),
                     spsPaths);
-                if (rc.calculateResult_ != tesSUCCESS)
+                if (rc.result () != tesSUCCESS)
                     m_journal.warning
                         << iIdentifier << " Failed with covering path "
-                        << transHuman (rc.calculateResult_);
+                        << transHuman (rc.result ());
                 else
                     m_journal.debug
                         << iIdentifier << " Extra path element gives "
-                        << transHuman (rc.calculateResult_);
+                        << transHuman (rc.result ());
             }
 
-            if (rc.calculateResult_ == tesSUCCESS)
+            if (rc.result () == tesSUCCESS)
             {
                 Json::Value jvEntry (Json::objectValue);
-                jvEntry["source_amount"]    = rc.actualAmountIn_.getJson (0);
+                jvEntry["source_amount"]    = rc.actualAmountIn.getJson (0);
                 jvEntry["paths_computed"]   = spsPaths.getJson (0);
                 found  = true;
                 jvArray.append (jvEntry);
@@ -491,7 +491,7 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
             else
             {
                 m_journal.debug << iIdentifier << " rippleCalc returns "
-                    << transHuman (rc.calculateResult_);
+                    << transHuman (rc.result ());
             }
         }
         else

--- a/src/ripple/module/app/paths/RippleCalc.h
+++ b/src/ripple/module/app/paths/RippleCalc.h
@@ -33,47 +33,44 @@ class RippleCalc
 public:
     struct Input
     {
-        Input (
-            bool partialPaymentAllowed = false,
-            bool defaultPathsAllowed = true,
-            bool limitQuality = false,
-            bool deleteUnfundedOffers = false,
-            bool isLedgerOpen = true
-            )
-            : partialPaymentAllowed_ (partialPaymentAllowed),
-            defaultPathsAllowed_ (defaultPathsAllowed),
-            limitQuality_ (limitQuality),
-            deleteUnfundedOffers_ (deleteUnfundedOffers),
-            isLedgerOpen_ (isLedgerOpen)
-        {
-        }
-
-        bool partialPaymentAllowed_ = false;
-        bool defaultPathsAllowed_ = true;
-        bool limitQuality_ = false;
-        bool deleteUnfundedOffers_ = false;
-        bool isLedgerOpen_ = true;
+        bool partialPaymentAllowed = false;
+        bool defaultPathsAllowed = true;
+        bool limitQuality = false;
+        bool deleteUnfundedOffers = false;
+        bool isLedgerOpen = true;
     };
     struct Output
     {
-        TER calculateResult_;
-
         // The computed input amount.
-        STAmount actualAmountIn_;
+        STAmount actualAmountIn;
 
         // The computed output amount.
-        STAmount actualAmountOut_;
+        STAmount actualAmountOut;
 
         // Expanded path with all the actual nodes in it.
         // A path starts with the source account, ends with the destination account
         // and goes through other acounts or order books.
-        PathState::List pathStateList_;
+        PathState::List pathStateList;
+
+    private:
+        TER calculationResult_;
+
+    public:
+        TER result () const
+        {
+            return calculationResult_;
+        }
+        void setResult (TER const value)
+        {
+            calculationResult_ = value;
+        }
+
     };
 
     static Output rippleCalculate (
         LedgerEntrySet& activeLedger,
 
-        // Compute paths vs this ledger entry set.  Up to caller to actually
+        // Compute paths using this ledger entry set.  Up to caller to actually
         // apply to ledger.
 
         // Issuer:
@@ -114,27 +111,11 @@ public:
 private:
     RippleCalc (
         LedgerEntrySet& activeLedger,
-
-        // Compute paths vs this ledger entry set.  Up to caller to actually
-        // apply to ledger.
-
-        // Issuer:
-        //      XRP: xrpAccount()
-        //  non-XRP: uSrcAccountID (for any issuer) or another account with
-        //           trust node.
         STAmount const& saMaxAmountReq,             // --> -1 = no limit.
-
-        // Issuer:
-        //      XRP: xrpAccount()
-        //  non-XRP: uDstAccountID (for any issuer) or another account with
-        //           trust node.
         STAmount const& saDstAmountReq,
 
         Account const& uDstAccountID,
         Account const& uSrcAccountID,
-
-        // A set of paths that are included in the transaction that we'll
-        // explore for liquidity.
         STPathSet const& spsPaths)
             : mActiveLedger (activeLedger),
               saDstAmountReq_(saDstAmountReq),
@@ -168,11 +149,7 @@ private:
     // and goes through other acounts or order books.
     PathState::List pathStateList_;
 
-    bool partialPaymentAllowed_ = false;
-    bool limitQuality_ = false;
-    bool defaultPathsAllowed_ = true;
-    bool deleteUnfundedOffers_ = false;
-    bool isLedgerOpen_ = true;
+    Input inputFlags;
 };
 
 } // path

--- a/src/ripple/module/app/paths/cursor/PathCursor.h
+++ b/src/ripple/module/app/paths/cursor/PathCursor.h
@@ -36,7 +36,7 @@ namespace path {
 class PathCursor
 {
 public:
-    PathCursor (
+    PathCursor(
         RippleCalc& rippleCalc,
         PathState& pathState,
         bool multiQuality,

--- a/src/ripple/module/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/module/rpc/handlers/RipplePathFind.cpp
@@ -228,21 +228,21 @@ Json::Value doRipplePathFind (RPC::Context& context)
                 auto rc = path::RippleCalc::rippleCalculate (
                     lesSandbox,
                     saMaxAmount,            // --> Amount to send is unlimited
-                    //     to get an estimate.
+                                            //     to get an estimate.
                     saDstAmount,            // --> Amount to deliver.
                     raDst.getAccountID (),  // --> Account to deliver to.
                     raSrc.getAccountID (),  // --> Account sending from.
-                    spsComputed);         // --> Path set.
+                    spsComputed);           // --> Path set.
 
                 WriteLog (lsWARNING, RPCHandler)
                     << "ripple_path_find:"
                     << " saMaxAmount=" << saMaxAmount
                     << " saDstAmount=" << saDstAmount
-                    << " saMaxAmountAct=" << rc.actualAmountIn_
-                    << " saDstAmountAct=" << rc.actualAmountOut_;
+                    << " saMaxAmountAct=" << rc.actualAmountIn
+                    << " saDstAmountAct=" << rc.actualAmountOut;
 
                 if (extraPath.size() > 0 &&
-                    (rc.calculateResult_ == terNO_LINE || rc.calculateResult_ == tecPATH_PARTIAL))
+                    (rc.result() == terNO_LINE || rc.result() == tecPATH_PARTIAL))
                 {
                     WriteLog (lsDEBUG, PathRequest)
                         << "Trying with an extra path element";
@@ -259,10 +259,10 @@ Json::Value doRipplePathFind (RPC::Context& context)
                         spsComputed);         // --> Path set.
                     WriteLog (lsDEBUG, PathRequest)
                         << "Extra path element gives "
-                        << transHuman (rc.calculateResult_);
+                        << transHuman (rc.result ());
                 }
 
-                if (rc.calculateResult_ == tesSUCCESS)
+                if (rc.result () == tesSUCCESS)
                 {
                     Json::Value jvEntry (Json::objectValue);
 
@@ -272,7 +272,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
                     // anyway to produce the canonical.  (At least unless we
                     // make a direct canonical.)
 
-                    jvEntry["source_amount"] = rc.actualAmountIn_.getJson (0);
+                    jvEntry["source_amount"] = rc.actualAmountIn.getJson (0);
                     jvEntry["paths_canonical"]  = Json::arrayValue;
                     jvEntry["paths_computed"]   = spsComputed.getJson (0);
 
@@ -283,7 +283,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
                     std::string strToken;
                     std::string strHuman;
 
-                    transResultInfo (rc.calculateResult_, strToken, strHuman);
+                    transResultInfo (rc.result (), strToken, strHuman);
 
                     WriteLog (lsDEBUG, RPCHandler)
                         << "ripple_path_find: "


### PR DESCRIPTION
Intentionally including 2 independent commits:
- Wrap RippleCalc into a single function.
- Add enable_if_lvalue to beast library

I ended up rewroting `RippleCalc` work to be called via a single function, eliminating the issues with passing rvalues to the constructor, so the `enable_if_lvalue` check is not necessary. (The `RippleCalc` class still exists, but with a private constructor, and no path finding logic was changed.) However, because `enable_if_lvalue` will be useful next time we encounter a similar issue (or have any doubts), it is still available in the beast library.
