### PR TITLE
Handle whitespace separating an 'ip port' correctly

### DIFF
--- a/src/beast/beast/net/detail/Parse.h
+++ b/src/beast/beast/net/detail/Parse.h
@@ -42,6 +42,20 @@ bool expect (InputStream& is, char v)
     return false;
 }
 
+/** Require and consume whitespace from the input.
+    @return `true` if the character matched.
+*/
+template <typename InputStream>
+bool expect_whitespace (InputStream& is)
+{
+    char c;
+    if (is.get(c) && isspace(c))
+        return true;
+    is.unget();
+    is.setstate (std::ios_base::failbit);
+    return false;
+}
+
 /** Used to disambiguate 8-bit integers from characters. */
 template <typename IntType>
 struct integer_holder

--- a/src/beast/beast/net/impl/IPEndpoint.cpp
+++ b/src/beast/beast/net/impl/IPEndpoint.cpp
@@ -79,14 +79,14 @@ Endpoint Endpoint::from_string_altform (std::string const& s)
 
         if (is.rdbuf()->in_avail()>0)
         {
-            if (! IP::detail::expect (is, ' '))
+            if (! IP::detail::expect_whitespace (is))
                 return Endpoint();
 
             while (is.rdbuf()->in_avail()>0)
             {
                 char c;
                 is.get(c);
-                if (c != ' ')
+                if (!isspace (c))
                 {
                     is.unget();
                     break;


### PR DESCRIPTION
The `altform` parser for an `ip/port` pair accepted an arbitrary number of spaces between the `ip` and `port` components, but did not accept things like `tab`. Since such characters are often used in config files by admins to ensure that things like up properly, we should support them as well.
