### PR TITLE
Reduce Ledger public members and avoid copying during RippleState lookups

### DIFF
--- a/src/ripple/module/app/ledger/Ledger.cpp
+++ b/src/ripple/module/app/ledger/Ledger.cpp
@@ -1775,18 +1775,16 @@ uint256 Ledger::getOwnerDirIndex (Account const& account)
 }
 
 uint256 Ledger::getRippleStateIndex (
-    RippleAddress const& naA, RippleAddress const& naB,
-    Currency const& currency)
+    Account const& a, Account const& b, Currency const& currency)
 {
-    auto uAID = naA.getAccountID ();
-    auto uBID = naB.getAccountID ();
-    bool        bAltB   = uAID < uBID;
     Serializer  s (62);
 
+    bool const bAltB = a < b;
+
     s.add16 (spaceRipple);          //  2
-    s.add160 (bAltB ? uAID : uBID); // 20
-    s.add160 (bAltB ? uBID : uAID); // 20
-    s.add160 (currency);           // 20
+    s.add160 (bAltB ? a : b);       // 20
+    s.add160 (bAltB ? b : a);       // 20
+    s.add160 (currency);            // 20
 
     return s.getSHA512Half ();
 }
@@ -1797,8 +1795,8 @@ uint256 Ledger::getTicketIndex (
     Serializer  s (26);
 
     s.add16 (spaceTicket);       //  2
-    s.add160 (account);         // 20
-    s.add32 (uSequence);        //  4
+    s.add160 (account);          // 20
+    s.add32 (uSequence);         //  4
 
     return s.getSHA512Half ();
 }

--- a/src/ripple/module/app/ledger/Ledger.h
+++ b/src/ripple/module/app/ledger/Ledger.h
@@ -432,30 +432,19 @@ public:
     //             don't access global variables. e.g.
     //             "calculateKeyFromRippleStateAndAddress"
     static uint256 getRippleStateIndex (
-        RippleAddress const&, RippleAddress const&, Currency const&);
+        Account const& a, Account const& b, Currency const& currency);
     static uint256 getRippleStateIndex (
-        Account const& a, Account const& b, Currency const& uCurrency)
+        Account const& a, Issue const& issue)
     {
-        return getRippleStateIndex (
-            RippleAddress::createAccountID (a),
-            RippleAddress::createAccountID (b), uCurrency);
+        return getRippleStateIndex (a, issue.account, issue.currency);
     }
 
     SLE::pointer getRippleState (uint256 const& uNode);
 
     SLE::pointer getRippleState (
-        RippleAddress const& a, RippleAddress const& b,
-        Currency const& currency)
-    {
-        return getRippleState (getRippleStateIndex (a, b, currency));
-    }
-
-    SLE::pointer getRippleState (
         Account const& a, Account const& b, Currency const& currency)
     {
-        return getRippleState (getRippleStateIndex (
-            RippleAddress::createAccountID (a),
-            RippleAddress::createAccountID (b), currency));
+        return getRippleState (getRippleStateIndex (a, b, currency));
     }
 
     std::uint32_t getReferenceFeeUnits ()

--- a/src/ripple/module/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/module/rpc/handlers/LedgerEntry.cpp
@@ -195,7 +195,8 @@ Json::Value doLedgerEntry (RPC::Context& context)
         }
         else
         {
-            uNodeIndex  = Ledger::getRippleStateIndex (naA, naB, uCurrency);
+            uNodeIndex  = Ledger::getRippleStateIndex (
+                naA.getAccountID (), naB.getAccountID (), uCurrency);
         }
     }
     else


### PR DESCRIPTION
While doing autobridging work, I stumbled on this and wanted to get it into develop sooner rather than later, so here we go:

Two `Ledger::getRippleStateIndex` overloads exist: one which accepts two `RippleAddress` objects and one which accepts two `Account` (a.k.a. `base_uint<160, AccountTag>`) objects.

The `Account` version converts the `Account` objects to `RippleAddress` and calls the other version. 

Meanwhile, the `RippleAddress` version calls `getAccountID` which returns an `Account` object (with the _same_ value as the `Account` object you constructed the `RippleAddress` with) and then uses it directly. 

Considering that all calls to `getRippleStateIndex` but one actually pass `Account` objects directly, this seems like overkill. So this PR removes the `RippleAccount` overload and modifies the single call that used it to use the `Account` variant.
