### PR TITLE
Add needed #include <istream>

### DIFF
--- a/src/ripple/net/impl/HTTPRequest.cpp
+++ b/src/ripple/net/impl/HTTPRequest.cpp
@@ -21,6 +21,7 @@
 #include <beast/module/core/text/LexicalCast.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <istream>
 #include <string>
 
 namespace ripple {


### PR DESCRIPTION
This is needed for the combination of boost 1.56 and libc++
