### PR TITLE
Add --quorum command line argument (RIPD-563)

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -1295,6 +1295,7 @@ public:
 
     void setMinValidations (int v)
     {
+        WriteLog (lsINFO, LedgerMaster) << "Validation quorum: " << v;
         mMinValidations = v;
     }
 

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -192,6 +192,7 @@ int run (int argc, char** argv)
     ("unittest-format", po::value <std::string> ()->implicit_value ("text"), "Format unit test output. Choices are 'text', 'junit'")
     ("parameters", po::value< vector<string> > (), "Specify comma separated parameters.")
     ("quiet,q", "Reduce diagnotics.")
+    ("quorum", po::value <int> (), "Set the validation quorum.")
     ("verbose,v", "Verbose logging.")
     ("load", "Load the current ledger from the local DB.")
     ("replay","Replay a ledger close.")
@@ -351,6 +352,14 @@ int run (int argc, char** argv)
         {
             // VFALCO TODO This should be a short.
             getConfig ().setRpcPort (vm ["rpc_port"].as <int> ());
+        }
+
+        if (vm.count ("quorum"))
+        {
+            getConfig ().VALIDATION_QUORUM = vm["quorum"].as <int> ();
+
+            if (getConfig ().VALIDATION_QUORUM < 0)
+                iResult = 1;
         }
     }
 


### PR DESCRIPTION
The `--quorum` command line argument accepts an integer and can be used to temporarily change the `validation_quorum` value without requiring editing of the configuration file. The value persists until execution is terminated.

Negative values are not allowed and using them will generate an error. An upper bound is not placed and any positive value will be accepted (up to `numeric_limits<int>::max()`). One open question is whether a value of `0` should be allowed.

@JoelKatz
