### PR TITLE
Decouple LedgerMaster from configuration

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -151,9 +151,9 @@ public:
 };
 
 std::unique_ptr <LedgerMaster>
-make_LedgerMaster (beast::Stoppable& parent,
-    beast::insight::Collector::ptr const& collector,
-        beast::Journal journal);
+make_LedgerMaster (bool standalone, std::uint32_t fetch_depth,
+    std::uint32_t ledger_history, int ledger_fetch_size, beast::Stoppable& parent,
+    beast::insight::Collector::ptr const& collector, beast::Journal journal);
 
 } // ripple
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -289,7 +289,9 @@ public:
         , m_pathRequests (new PathRequests (
             m_logs.journal("PathRequest"), m_collectorManager->collector ()))
 
-        , m_ledgerMaster (make_LedgerMaster (*m_jobQueue,
+        , m_ledgerMaster (make_LedgerMaster (getConfig ().RUN_STANDALONE,
+            getConfig ().FETCH_DEPTH, getConfig ().LEDGER_HISTORY, 
+            getConfig ().getSize (siLedgerFetch), *m_jobQueue,
             m_collectorManager->collector (), m_logs.journal("LedgerMaster")))
 
         // VFALCO NOTE must come before NetworkOPs to prevent a crash due


### PR DESCRIPTION
Pass necessary arguments into `LedgerMaster` to avoid coupling with the `Config` object. Reviews by @ximinez and @rec (welcome back!)
