### PR TITLE
Add +DEBUG to the raw version string for DEBUG builds.

### DIFF
--- a/src/ripple/data/protocol/BuildInfo.cpp
+++ b/src/ripple/data/protocol/BuildInfo.cpp
@@ -37,6 +37,9 @@ char const* BuildInfo::getRawVersionString ()
     //
     //  http://semver.org/
     //
+#ifdef DEBUG
+        "+DEBUG"
+#endif
     //--------------------------------------------------------------------------
     ;
 


### PR DESCRIPTION
This will show up in the rpc server_info command.
There is no impact on the version string for release builds.
@torrie @vinniefalco 
