### PR TITLE
Build gcc.debug using -Og flag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -370,6 +370,11 @@ def config_env(toolchain, variant, env):
                 env.Append(CPPDEFINES={
                     '_FORTIFY_SOURCE': 2
                     })
+                # Build debuggable but still optimized executable
+                # via -Og switch introduced in GCC 4.8
+                env.Append(CCFLAGS=[
+                '-Og'
+                ])
 
     elif toolchain == 'msvc':
         env.Append (CPPPATH=[


### PR DESCRIPTION
Since gcc 4.8 is required anyways, it might be nice to use its features.

Intro to feature (second bullet point):
https://gcc.gnu.org/gcc-4.8/changes.html

-g (line 328) is still needed:
http://stackoverflow.com/questions/12970596/gcc-4-8-does-og-imply-g
