### PR TITLE
Change output range names of ledger_cleaner

### DIFF
--- a/src/ripple/app/ledger/LedgerCleaner.cpp
+++ b/src/ripple/app/ledger/LedgerCleaner.cpp
@@ -118,8 +118,8 @@ public:
         else
         {
             map["status"] = "running";
-            map["ledger_min"] = state->minRange;
-            map["ledger_max"] = state->maxRange;
+            map["min_ledger"] = state->minRange;
+            map["max_ledger"] = state->maxRange;
             map["check_nodes"] = state->checkNodes ? "true" : "false";
             map["fix_txns"] = state->fixTxns ? "true" : "false";
             if (state->failures > 0)


### PR DESCRIPTION
The input parameters are called "min_ledger" and "max_ledger", they are also called "minRange" and "maxRange" in the code BUT "ledger_min" and ledger_max" if printed. This is inconsistent and should be changed, as it might lead to confusion on how to call this module via RPC.
