### PR TITLE
Protocol cleanups:

### DIFF
--- a/src/ripple/data/protocol/BuildInfo.cpp
+++ b/src/ripple/data/protocol/BuildInfo.cpp
@@ -133,12 +133,6 @@ char const* BuildInfo::getFullVersionString ()
 
 //------------------------------------------------------------------------------
 
-BuildInfo::Protocol::Protocol ()
-    : vmajor (0)
-    , vminor (0)
-{
-}
-
 BuildInfo::Protocol::Protocol (unsigned short major_, unsigned short minor_)
     : vmajor (major_)
     , vminor (minor_)

--- a/src/ripple/data/protocol/BuildInfo.h
+++ b/src/ripple/data/protocol/BuildInfo.h
@@ -22,9 +22,14 @@
 
 namespace ripple {
 
+class BuildInfo_test;
+
 /** Versioning information for this build. */
 struct BuildInfo
 {
+    BuildInfo(BuildInfo const&) = delete;
+    BuildInfo& operator=(BuildInfo const&) = delete;
+
     /** Server version.
 
         Follows the Semantic Versioning Specification:
@@ -49,20 +54,24 @@ struct BuildInfo
     */
     struct Protocol
     {
+    private:
         unsigned short vmajor;
         unsigned short vminor;
 
         //----
 
+        Protocol(Protocol const&) = delete;
+        Protocol& operator=(Protocol const&) = delete;
+
         /** The serialized format of the protocol version. */
         typedef std::uint32_t PackedFormat;
 
-        Protocol ();
         Protocol (unsigned short vmajor, unsigned short vminor);
+
+    public:
         explicit Protocol (PackedFormat packedVersion);
 
         PackedFormat toPacked () const noexcept;
-
         std::string toStdString () const noexcept;
 
         bool operator== (Protocol const& other) const noexcept { return toPacked () == other.toPacked (); }
@@ -71,6 +80,9 @@ struct BuildInfo
         bool operator<= (Protocol const& other) const noexcept { return toPacked () <= other.toPacked (); }
         bool operator>  (Protocol const& other) const noexcept { return toPacked () >  other.toPacked (); }
         bool operator<  (Protocol const& other) const noexcept { return toPacked () <  other.toPacked (); }
+
+        friend struct BuildInfo;
+        friend class BuildInfo_test;
     };
 
     /** The protocol version we speak and prefer. */
@@ -79,7 +91,10 @@ struct BuildInfo
     /** The oldest protocol version we will accept. */
     static Protocol const& getMinimumProtocol ();
 
+private:
     static char const* getRawVersionString ();
+
+    friend class BuildInfo_test;
 };
 
 } // ripple

--- a/src/ripple/data/protocol/SField.h
+++ b/src/ripple/data/protocol/SField.h
@@ -84,7 +84,7 @@ field_code(int id, int index)
     1.  Those that are created at compile time.
     2.  Those that are created at run time.
 
-    Both are always const.  Category 1 can only be created in FieldNames.cpp.
+    Both are always const.  Category 1 can only be created in SField.cpp.
     This is enforced at compile time.  Category 2 can only be created by
     calling getField with an as yet unused fieldType and fieldValue (or the
     equivalent fieldCode).
@@ -139,7 +139,7 @@ public:
 #endif
 
 private:
-    // These constructors can only be called from FieldNames.cpp
+    // These constructors can only be called from SField.cpp
     SField (SerializedTypeID tid, int fv, const char* fn,
             int meta = sMD_Default, bool signing = true);
     explicit SField (int fc);

--- a/src/ripple/data/protocol/TxFormats.h
+++ b/src/ripple/data/protocol/TxFormats.h
@@ -58,12 +58,12 @@ class TxFormats : public KnownFormats <TxType>
 private:
     void addCommonFields (Item& item);
 
-public:
     /** Create the object.
         This will load the object will all the known transaction formats.
     */
     TxFormats ();
 
+public:
     static TxFormats* getInstance ();
 };
 


### PR DESCRIPTION
- Reduce the exposed API of BuildInfo and BuildInfo::Protocol
  This includes enforcing non-copyablility for both classes,
  removing an unneeded Protocol default constructor, and making
  implementation details private.
- Make The TxFormats default constructor private.  This class
  is a singleton, and should only be default constructed in
  TxFormats::getInstance().
- Rename FieldNames.cpp to SField.cpp in comments.
