### PR TITLE
Allow beast::lexicalCast to parse 'true' & 'false' into a bool

### DIFF
--- a/src/beast/beast/module/core/text/LexicalCast.h
+++ b/src/beast/beast/module/core/text/LexicalCast.h
@@ -185,13 +185,13 @@ struct LexicalCast <Out, std::string>
         // Convert the input to lowercase
         std::transform(in.begin (), in.end (), in.begin (), ::tolower);
 
-        if (in == "1" || in == "true" || in == "yes" || in == "on")
+        if (in == "1" || in == "true")
         {
             out = true;
             return true;
         }
 
-        if (in == "0" || in == "false" || in == "no" || in == "off")
+        if (in == "0" || in == "false")
         {
             out = false;
             return true;


### PR DESCRIPTION
Our config and RPC documentation specifies the use of keywords like `true` and `false` but `beast::lexicalCast` and the `boost` variants only support `0` or `1`. Add support for the following: `1`, `true`, `yes` and `on` for `true` and `0`, `false`, `no` and `off` for `false`. 

Reviews: @vinniefalco, @rec
