### PR TITLE
Add counters to track nodestore read and write activities.

### DIFF
--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -132,6 +132,15 @@ public:
 
     /** Remove expired entries from the positive and negative caches. */
     virtual void sweep () = 0;
+
+    /** Gather statistics pertaining to read and write activities.
+        Return the reads and writes, and total read and written bytes.
+     */
+    virtual std::uint32_t getStoreCount () const = 0;
+    virtual std::uint32_t getFetchTotalCount () const = 0;
+    virtual std::uint32_t getFetchHitCount () const = 0;
+    virtual std::uint32_t getStoreSize () const = 0;
+    virtual std::uint32_t getFetchSize () const = 0;
 };
 
 }

--- a/src/ripple/nodestore/impl/DatabaseImp.h
+++ b/src/ripple/nodestore/impl/DatabaseImp.h
@@ -74,6 +74,11 @@ public:
             cacheTargetSize, cacheTargetSeconds)
         , m_readShut (false)
         , m_readGen (0)
+        , m_storeCount (0)
+        , m_fetchTotalCount (0)
+        , m_fetchHitCount (0)
+        , m_storeSize (0)
+        , m_fetchSize (0)
     {
         for (int i = 0; i < readThreads; ++i)
             m_readThreads.push_back (std::thread (&DatabaseImp::threadEntry, this));
@@ -221,7 +226,12 @@ public:
                 // If we have a fast back end, store it there for later.
                 //
                 if (m_fastBackend != nullptr)
+                {
                     m_fastBackend->store (obj);
+                    ++m_storeCount;
+                    if (obj.get())
+                        m_storeSize += obj->getData().size();
+                }
 
                 // Since this was a 'hard' fetch, we will log it.
                 //
@@ -239,10 +249,14 @@ public:
         NodeObject::Ptr object;
 
         Status const status = backend.fetch (hash.begin (), &object);
+        ++m_fetchTotalCount;
 
         switch (status)
         {
         case ok:
+            ++m_fetchHitCount;
+            if (object.get())
+                m_fetchSize += object->getData().size();
         case notFound:
             break;
 
@@ -278,11 +292,19 @@ public:
         m_cache.canonicalize (hash, object, true);
 
         m_backend->store (object);
+        ++m_storeCount;
+        if (object.get())
+            m_storeSize += object->getData().size();
 
         m_negCache.erase (hash);
 
         if (m_fastBackend)
+        {
             m_fastBackend->store (object);
+            ++m_storeCount;
+            if (object.get())
+                m_storeSize += object->getData().size();
+        }
     }
 
     //------------------------------------------------------------------------------
@@ -377,11 +399,46 @@ public:
             }
 
             b.push_back (object);
+            ++m_storeCount;
+            if (object.get())
+                m_storeSize += object->getData().size();
         });
 
         if (! b.empty ())
             m_backend->storeBatch (b);
     }
+
+    std::uint32_t getStoreCount () const override
+    {
+        return m_storeCount;
+    }
+
+    std::uint32_t getFetchTotalCount () const override
+    {
+        return m_fetchTotalCount;
+    }
+
+    std::uint32_t getFetchHitCount () const override
+    {
+        return m_fetchHitCount;
+    }
+
+    std::uint32_t getStoreSize () const override
+    {
+        return m_storeSize;
+    }
+
+    std::uint32_t getFetchSize () const override
+    {
+        return m_fetchSize;
+    }
+
+private:
+    std::atomic <std::uint32_t> m_storeCount;
+    std::atomic <std::uint32_t> m_fetchTotalCount;
+    std::atomic <std::uint32_t> m_fetchHitCount;
+    std::atomic <std::uint32_t> m_storeSize;
+    std::atomic <std::uint32_t> m_fetchSize;
 };
 
 }

--- a/src/ripple/rpc/handlers/GetCounts.cpp
+++ b/src/ripple/rpc/handlers/GetCounts.cpp
@@ -85,6 +85,12 @@ Json::Value doGetCounts (RPC::Context& context)
     textTime (uptime, s, "minute", 60);
     textTime (uptime, s, "second", 1);
     ret["uptime"] = uptime;
+    
+    ret["node_writes"] = app.getNodeStore().getStoreCount();
+    ret["node_reads_total"] = app.getNodeStore().getFetchTotalCount();
+    ret["node_reads_hit"] = app.getNodeStore().getFetchHitCount();
+    ret["node_written_bytes"] = app.getNodeStore().getStoreSize();
+    ret["node_read_bytes"] = app.getNodeStore().getFetchSize();
 
     return ret;
 }


### PR DESCRIPTION
@vinniefalco @HowardHinnant please review.

This adds read and write counters, as well as total data sizes (not including hash key) read and written, for each activity to the nodestore. Results are currently emitted via get_counts. This format can plug easily into any stats display system by measuring differences over time to derive throughput.

The goal is to be able to measure nodestore activity in general as well as to measure affect of rotate-delete on the nodestore. We can also see the effectiveness of key-value store caching behavior by comparing these numbers to system physical I/O statistics.

Overhead should be minimal here. Up to two additions to atomic unsigned ints for every store and every fetch.
