### PR TITLE
Config improvements:

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -309,7 +309,8 @@ public:
         , m_deprecatedUNL (make_UniqueNodeList (*m_jobQueue))
 
         , m_rpcHTTPServer (make_RPCHTTPServer (*m_networkOPs,
-            *m_jobQueue, *m_networkOPs, *m_resourceManager))
+            *m_jobQueue, *m_networkOPs, *m_resourceManager,
+                setup_RPC(getConfig()["rpc"])))
 
         // passive object, not a Service
         , m_rpcServerHandler (*m_networkOPs, *m_resourceManager)

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -344,6 +344,7 @@ int run (int argc, char** argv)
         if (vm.count ("rpc_ip"))
         {
             getConfig ().setRpcIpAndOptionalPort (vm ["rpc_ip"].as <std::string> ());
+            getConfig().overwrite("rpc", "ip", vm["rpc_ip"].as<std::string>());
         }
 
         // Override the RPC destination port number
@@ -352,6 +353,7 @@ int run (int argc, char** argv)
         {
             // VFALCO TODO This should be a short.
             getConfig ().setRpcPort (vm ["rpc_port"].as <int> ());
+            getConfig().overwrite("rpc", "port", vm["rpc_port"].as<std::string>());
         }
 
         if (vm.count ("quorum"))

--- a/src/ripple/app/main/RPCHTTPServer.h
+++ b/src/ripple/app/main/RPCHTTPServer.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_APP_RPCHTTPSERVER_H_INCLUDED
 #define RIPPLE_APP_RPCHTTPSERVER_H_INCLUDED
 
+#include <ripple/core/Config.h>
 #include <beast/utility/Journal.h>
 #include <beast/utility/PropertyStream.h>
 #include <beast/cxx14/memory.h> // <memory>
@@ -48,7 +49,8 @@ public:
 
 std::unique_ptr <RPCHTTPServer>
 make_RPCHTTPServer (beast::Stoppable& parent, JobQueue& jobQueue,
-    NetworkOPs& networkOPs, Resource::Manager& resourceManager);
+    NetworkOPs& networkOPs, Resource::Manager& resourceManager,
+        RPC::Setup const& setup);
 
 } // ripple
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -93,9 +93,30 @@ public:
     }
     /** @} */
 
+    /** Overwrite a key/value pair with a command line argument
+        If the section does not exist it is created.
+        The previous value, if any, is overwritten.
+    */
+    void
+    overwrite (std::string const& section, std::string const& key,
+        std::string const& value);
+
+    friend
+    std::ostream&
+    operator<< (std::ostream& ss, BasicConfig const& c);
+
 protected:
     void
     build (IniFileSections const& ifs);
+
+    /** Insert a legacy single section as a key/value pair.
+        Does nothing if the section does not exist, or does not contain
+        a single line that is not a key/value pair.
+        @deprecated
+    */
+    void
+    remap (std::string const& legacy_section,
+        std::string const& key, std::string const& new_section);
 };
 
 //------------------------------------------------------------------------------
@@ -456,9 +477,36 @@ public:
     int getSize (SizedItemName);
     void setup (std::string const& strConf, bool bQuiet);
     void load ();
+
+private:
+    void build_legacy();
 };
 
 extern Config& getConfig ();
+
+//------------------------------------------------------------------------------
+
+namespace RPC {
+
+struct Setup
+{
+    bool allow_remote = false;
+    std::string admin_user;
+    std::string admin_password;
+    std::string ip;
+    int port = 5001;
+    std::string user;
+    std::string password;
+    bool secure = false;
+    std::string ssl_cert;
+    std::string ssl_chain;
+    std::string ssl_key;
+};
+
+}
+
+RPC::Setup
+setup_RPC (Section const& s);
 
 } // ripple
 

--- a/src/ripple/core/Section.h
+++ b/src/ripple/core/Section.h
@@ -23,6 +23,7 @@
 #include <beast/utility/ci_char_traits.h>
 #include <boost/lexical_cast.hpp>
 #include <map>
+#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -42,6 +43,32 @@ public:
     /** Create an empty section. */
     Section() = default;
 
+    /** Returns the number of key/value pairs. */
+    std::size_t
+    keys() const
+    {
+        return map_.size();
+    }
+
+    /** Returns all the lines in the section. */
+    std::vector <std::string> const&
+    lines() const
+    {
+        return lines_;
+    }
+
+    /** Set a key/value pair.
+        The previous value is discarded.
+    */
+    void
+    set (std::string const& key, std::string const& value);
+
+    /** Append a line to this section.
+        If the line can be parsed as a key/value pair it is added to the map.
+    */
+    void
+    append (std::string const& line);
+
     /** Append a set of lines to this section.
         Parsable key/value pairs are also added to the map.
     */
@@ -57,6 +84,10 @@ public:
     */
     std::pair <std::string, bool>
     find (std::string const& name) const;
+
+    friend
+    std::ostream&
+    operator<< (std::ostream&, Section const& section);
 };
 
 /** Set a value from a configuration Section


### PR DESCRIPTION
- More fine-grained Section mutators
- Add remap for mapping legacy single sections to key value pairs
- Add output stream operators for BasicConfig and Section
- Allow section values to be overwritten from command line
- Update rpc key/value configs from command line
- Add RPC::Setup with defaults and remap legacy rpc sections

@nbougalis @JoelKatz 
