### PR TITLE
Only HashPrefix can create prefixes.

### DIFF
--- a/src/ripple/data/protocol/HashPrefix.h
+++ b/src/ripple/data/protocol/HashPrefix.h
@@ -52,7 +52,7 @@ private:
     }
 
 public:
-    HashPrefix(HashPrefix const&) = default;
+    HashPrefix(HashPrefix const&) = delete;
     HashPrefix& operator=(HashPrefix const&) = delete;
 
     /** Returns the hash prefix associated with this object */


### PR DESCRIPTION
Have compiler enforce that we have our complete list of prefixes in HashPrefix.cpp by disallowing the rest of rippled to construct or modify them.
- Make constructor private.
- Disallow assignment.

@scottschurr, @ximinez
