### PR TITLE
Use trusted validators median fee

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/RangeSet.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/validators/Manager.h>
+#include <algorithm>
 #include <cassert>
 #include <beast/cxx14/memory.h> // <memory>
 
@@ -772,15 +773,25 @@ public:
             getApp().getOrderBookDB().setup(ledger);
         }
 
-        std::uint64_t fee, fee2, ref;
-        ref = getApp().getFeeTrack().getLoadBase();
-        int count = getApp().getValidations().getFeeAverage(ledger->getHash(), ref, fee);
-        int count2 = getApp().getValidations().getFeeAverage(ledger->getParentHash(), ref, fee2);
-
-        if ((count + count2) == 0)
-            getApp().getFeeTrack().setRemoteFee(ref);
+        std::uint64_t const base = getApp().getFeeTrack().getLoadBase();
+        auto fees = getApp().getValidations().fees (ledger->getHash(), base);
+        {
+            auto fees2 = getApp().getValidations().fees (ledger->getParentHash(), base);
+            fees.reserve (fees.size() + fees2.size());
+            std::copy (fees2.begin(), fees2.end(), std::back_inserter(fees));
+        }
+        std::uint64_t fee;
+        if (! fees.empty())
+        {
+            std::sort (fees.begin(), fees.end());
+            fee = fees[fees.size() / 2]; // median
+        }
         else
-            getApp().getFeeTrack().setRemoteFee(((fee * count) + (fee2 * count2)) / (count + count2));
+        {
+            fee = base;
+        }
+
+        getApp().getFeeTrack().setRemoteFee(fee);
 
         tryAdvance ();
     }

--- a/src/ripple/app/misc/Validations.h
+++ b/src/ripple/app/misc/Validations.h
@@ -51,8 +51,10 @@ public:
 
     virtual int getTrustedValidationCount (uint256 const& ledger) = 0;
 
-    virtual int getFeeAverage(
-        uint256 const& ledger, std::uint64_t ref, std::uint64_t& fee) = 0;
+    /** Returns fees reported by trusted validators in the given ledger. */
+    virtual
+    std::vector <std::uint64_t>
+    fees (uint256 const& ledger, std::uint64_t base) = 0;
 
     virtual int getNodesAfter (uint256 const& ledger) = 0;
     virtual int getLoadRatio (bool overLoaded) = 0;


### PR DESCRIPTION
This fixes the problem with people running validators that don't use the temporary new fee floor. Note that this has already been deployed:
https://github.com/ripple/rippled/commits/release

Reviewers: @JoelKatz @tdfischer
Approvers: @rec @nbougalis 
