### PR TITLE
Remove Og from debug mode

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -369,6 +369,9 @@ def config_env(toolchain, variant, env):
                 env.Append(CPPDEFINES={
                     '_FORTIFY_SOURCE': 2
                     })
+                env.Append(CCFLAGS=[
+                    '-O0'
+                    ])
 
     elif toolchain == 'msvc':
         env.Append (CPPPATH=[


### PR DESCRIPTION
Last time I used gdb, iterating over a directory's `Indexes`, each uint256 printed as `<optimized out>`. 

Debug mode is for debugging ...
