### PR TITLE
Attempt to fix spurious travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,11 @@ before_install:
   # What versions are we ACTUALLY running?
   - g++ -v
   - clang -v
+  # Avoid `spurious errors` caused by ~/.npm permission issues
+  # Does it already exist? Who owns? What permissions?
+  - ls -lah ~/.npm || mkdir ~/.npm
+  # Make sure we own it
+  - sudo chown -R $USER ~/.npm
 
 script:
   # Set so any failing command will abort the build


### PR DESCRIPTION
See:  https://github.com/travis-ci/travis-ci/issues/2244

Apparently this annoying problem happens now and then for lots of people, and people have had success in avoiding the issue by a simple chown. It's hard to see how this would fix things, but I guess on some boxes, somehow the .npm folder permissions get messed up?
