### PR TITLE
Fix incorrect address in connectvity check report:

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2911,6 +2911,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\peerfinder\Manager.h">
     </ClInclude>
+    <None Include="..\..\src\ripple\peerfinder\README.md">
+    </None>
     <ClInclude Include="..\..\src\ripple\peerfinder\sim\FunctionQueue.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\peerfinder\sim\GraphAlgorithms.h">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -4080,6 +4080,9 @@
     <ClInclude Include="..\..\src\ripple\peerfinder\Manager.h">
       <Filter>ripple\peerfinder</Filter>
     </ClInclude>
+    <None Include="..\..\src\ripple\peerfinder\README.md">
+      <Filter>ripple\peerfinder</Filter>
+    </None>
     <ClInclude Include="..\..\src\ripple\peerfinder\sim\FunctionQueue.h">
       <Filter>ripple\peerfinder\sim</Filter>
     </ClInclude>

--- a/src/ripple/peerfinder/README.md
+++ b/src/ripple/peerfinder/README.md
@@ -161,11 +161,6 @@ Endpoint messages are received from the overlay over time.
 
 The `Bootcache` stores IP addresses useful for gaining initial connections.
 Each address is associated with the following metadata:
-
-* **Uptime**
-
-  The number of seconds that the address has maintained an active
-  peer connection, cumulative, without a connection attempt failure.
  
 * **Valence**
 
@@ -173,17 +168,16 @@ Each address is associated with the following metadata:
   consecutive connection attempts when positive, and the number of
   failed consecutive connection attempts when negative. If an outgoing
   connection attempt to the corresponding IP address fails to complete the
-  handshake, the valence is reset to negative one, and all accrued uptime is
-  reset to zero. This harsh penalty is intended to prevent popular servers
-  from forever remaining top ranked in all peer databases.
+  handshake the valence is reset to negative one. This harsh penalty is
+  intended to prevent popular servers from forever remaining top ranked in
+  all peer databases.
 
 When choosing addresses from the boot cache for the purpose of
-establishing outgoing connections, addresses are ranked in decreasing
-order of high uptime, with valence as the tie breaker. The Bootcache is
-persistent. Entries are periodically inserted and updated in the corresponding
-SQLite database during program operation. When **rippled** is launched, the
-existing Bootcache database data is accessed and loaded to accelerate the
-bootstrap process.
+establishing outgoing connections, addresses are ranked in decreasing order of
+valence. The Bootcache is persistent. Entries are periodically inserted and
+updated in the corresponding SQLite database during program operation. When
+**rippled** is launched, the existing Bootcache database data is accessed and
+loaded to accelerate the bootstrap process.
 
 Desirable entries in the Bootcache are addresses for servers which are known to
 have high uptimes, and for which connection attempts usually succeed. However,
@@ -341,12 +335,12 @@ desired. The stage remains active while:
 
 * There are addresses in the cache that have not been tried recently.
 
-Entries in the Bootcache are ranked, with high uptime and highly connectible
-addresses preferred over others. Connection attempts to Bootcache addresses
-are very likely to succeed but unlikely to produce an active connection since
-the peers likely do not have open slots. Before the remote peer closes the
-connection it will send a handful of addresses from its Livecache to help the
-new peer coming online obtain connections.
+Entries in the Bootcache are ranked, with highly connectible addresses preferred
+over others. Connection attempts to Bootcache addresses are very likely to
+succeed but unlikely to produce an active connection since the peers likely do
+not have open slots. Before the remote peer closes the connection it will send
+a handful of addresses from its Livecache to help the new peer coming online
+obtain connections.
 
 --------------------------------------------------------------------------------
 

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -214,21 +214,22 @@ public:
     //--------------------------------------------------------------------------
 
     // Called when the Checker completes a connectivity test
-    void checkComplete (beast::IP::Endpoint const& address,
-        beast::IP::Endpoint const & checkedAddress, Checker::Result const& result)
+    void checkComplete (beast::IP::Endpoint const& remoteAddress,
+        beast::IP::Endpoint const& checkedAddress,
+            Checker::Result const& result)
     {
         if (result.error == boost::asio::error::operation_aborted)
             return;
 
         SharedState::Access state (m_state);
-        Slots::iterator const iter (state->slots.find (address));
+        Slots::iterator const iter (state->slots.find (remoteAddress));
         SlotImp& slot (*iter->second);
 
         if (iter == state->slots.end())
         {
             // The slot disconnected before we finished the check
             if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
-                "Logic tested " << address <<
+                "Logic tested " << checkedAddress <<
                 " but the connection was closed";
             return;
         }
@@ -244,12 +245,12 @@ public:
             if (slot.canAccept)
             {
                 if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
-                    "Logic testing " << address << " succeeded";
+                    "Logic testing " << checkedAddress << " succeeded";
             }
             else
             {
                 if (m_journal.info) m_journal.info << beast::leftw (18) <<
-                    "Logic testing " << address << " failed";
+                    "Logic testing " << checkedAddress << " failed";
             }
         }
         else
@@ -264,7 +265,7 @@ public:
         }
 
         if (! slot.canAccept)
-            state->bootcache.on_failure (address);
+            state->bootcache.on_failure (checkedAddress);
     }
 
     //--------------------------------------------------------------------------

--- a/src/ripple/peerfinder/impl/Manager.cpp
+++ b/src/ripple/peerfinder/impl/Manager.cpp
@@ -17,16 +17,16 @@
 */
 //==============================================================================
 
-#if DOXYGEN
-#include <ripple/overlay/README.md>
-#endif
-
 #include <ripple/peerfinder/Manager.h>
 #include <ripple/peerfinder/impl/CheckerAdapter.h>
 #include <ripple/peerfinder/impl/Logic.h>
 #include <ripple/peerfinder/impl/SourceStrings.h>
 #include <ripple/peerfinder/impl/StoreSqdb.h>
 #include <beast/module/core/thread/DeadlineTimer.h>
+
+#if DOXYGEN
+#include <ripple/peerfinder/README.md>
+#endif
 
 namespace ripple {
 namespace PeerFinder {


### PR DESCRIPTION
The remoteAddress is the address as seen on the socket, which for
incoming connections has a random port chosen by the remote implementation
that is different from the port number used to accept connections by the
remote listening socket. The checkedAddress is the remote address as seen
on the socket, combined with the port advertised in the TMEndpoints message.
This fixes the reporting and metadata associated with addresses tested
for connectivity.
@nbougalis @jjuran
