### PR TITLE
Update default SSL cipher spec (RIPD-108)

### DIFF
--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -257,7 +257,7 @@ Config::Config ()
     RPC_ADMIN_ALLOW.push_back (beast::IP::Endpoint::from_string("127.0.0.1"));
 
     // By default, allow anonymous DH.
-    PEER_SSL_CIPHER_LIST    = "ALL:!LOW:!EXP:!MD5:@STRENGTH";
+    PEER_SSL_CIPHER_LIST    = "HIGH:!DSS:!SSLv3:!MD5:!3DES:@STRENGTH";
 
     PEER_PRIVATE            = false;
     PEERS_MAX               = 0;    // indicates "use default"


### PR DESCRIPTION
This changes the default list of ciphers we accept. It should be fine and not cause interoperability problems, but it should be validated nonetheless.
