### PR TITLE
Re-introduce linking to boost::thread.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -297,6 +297,7 @@ def config_env(toolchain, variant, env):
             'boost_program_options',
             'boost_regex',
             'boost_system',
+            'boost_thread'
         ]
         # We prefer static libraries for boost
         if env.get('BOOST_ROOT'):


### PR DESCRIPTION
The asio library needs to link to boost::thread, at least on OS X.

@scottschurr, @josh
