### PR TITLE
Support 'cancel or fail' semantics in OfferCreate (RIPD-562):

### DIFF
--- a/src/ripple/data/protocol/TxFlags.h
+++ b/src/ripple/data/protocol/TxFlags.h
@@ -71,7 +71,8 @@ const std::uint32_t tfPassive              = 0x00010000;
 const std::uint32_t tfImmediateOrCancel    = 0x00020000;
 const std::uint32_t tfFillOrKill           = 0x00040000;
 const std::uint32_t tfSell                 = 0x00080000;
-const std::uint32_t tfOfferCreateMask      = ~ (tfUniversal | tfPassive | tfImmediateOrCancel | tfFillOrKill | tfSell);
+const std::uint32_t tfMustCancel           = 0x00100000;
+const std::uint32_t tfOfferCreateMask      = ~ (tfUniversal | tfPassive | tfImmediateOrCancel | tfFillOrKill | tfSell | tfMustCancel);
 
 // Payment flags:
 const std::uint32_t tfNoRippleDirect       = 0x00010000;


### PR DESCRIPTION
Currently, if you specify a cancel sequence in OfferCreate, the
offer may or may not be canceled.

This makes it difficult to implement client-facing interfaces
that implement "modify existing order" functionality which are
implemented by doing a cancel for the old order along with a
create with the new parameters.

The new `tfMustCancel` flag that can be specified in OfferCreate
can be used to ensure that the new offer will only be placed if
the cancel request is successful.
