### PR TITLE
Report autobridge test failures more usefully

### DIFF
--- a/test/autobridge-test.coffee
+++ b/test/autobridge-test.coffee
@@ -100,7 +100,8 @@ make_offer_create_test = (get_context, test_name, test_decl) ->
 
     submit_for_final tx, (m) ->
       'assert transaction was successful'
-      assert.equal m.metadata.TransactionResult, 'tesSUCCESS'
+      assert m.metadata?.TransactionResult == 'tesSUCCESS',
+             "txn failed: " + ledger_state.pretty_json m
 
       context.ledger.verifier(test_decl.post_ledger).do_verify (errors) ->
         this_done = ->


### PR DESCRIPTION
When a transaction fails, show the full message from the server, with addresses substituted with readable aliases. Without this patch, tests with transactions that process without metadata will fail with a useless error along the lines of "can't read TransactionResult from undefined"

@nbougalis 
@JoelKatz 
