### PR TITLE
Add "deferred" flag to transaction relay message

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1278,7 +1278,13 @@ PeerImp::on_message (std::shared_ptr <protocol::TMTransaction> const& m)
 
         if (clusterNode_)
         {
-            flags |= SF_TRUSTED;
+            if (! m->has_deferred () || ! m->deferred ())
+            {
+                // Skip local checks if a server we trust
+                // put the transaction in its open ledger
+                flags |= SF_TRUSTED;
+            }
+
             if (! getConfig().VALIDATION_PRIV.isSet())
             {
                 // For now, be paranoid and have each validator

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -127,7 +127,7 @@ message TMTransaction
     required bytes rawTransaction           = 1;
     required TransactionStatus status       = 2;
     optional uint64 receiveTimestamp        = 3;
-    optional bool checkedSignature          = 4;    // no vouches for signature being correct
+    optional bool deferred                  = 4;    // not applied to open ledger
 }
 
 


### PR DESCRIPTION
This code currently has no effect, but it is needed to facilitate the transaction to new fee logic. Without this change, servers in a cluster would erroneously accept into their open ledgers transactions that did not meet the fee requirements.

The "checkedSignature" flag was part of an older implementation plan and never used. No existing code ever sets it to any value.
