### PR TITLE
Patches for Yosemite

### DIFF
--- a/src/beast/site_scons/Beast.py
+++ b/src/beast/site_scons/Beast.py
@@ -59,9 +59,10 @@ class __System(object):
             self.__display = '%s %s (%s)' % (self.distro, self.version, self.name)
 
         elif self.osx:
-            ten, major, minor = platform.mac_ver()[0].split('.')
-            self.__display = '%s %s.%s.%s' % (self.name, ten, major, minor)
-
+            parts = platform.mac_ver()[0].split('.')
+            while len(parts) < 3:
+                parts.append('0')
+            self.__display = '%s %s' % (self.name, '.'.join(parts))
         elif self.windows:
             release, version, csd, ptype = platform.win32_ver()
             self.__display = '%s %s %s (%s)' % (self.name, release, version, ptype)

--- a/src/websocket/src/network_utilities.hpp
+++ b/src/websocket/src/network_utilities.hpp
@@ -41,6 +41,9 @@ namespace zsutil {
 #define TYP_SMLE 1 
 #define TYP_BIGE 2 
 
+#undef htonll
+#undef ntohll
+
 uint64_t htonll(uint64_t src);
 uint64_t ntohll(uint64_t src);
 


### PR DESCRIPTION
This gets rippled going on Yosemite.

After upgrading you have to re-install command-line tools prior to building:
$ xcode-select --install

Tested on both Mavericks and Yosemite.  Passes Travis.
@josh-ripple @niq
