### PR TITLE
Separate beast::http::body from beast::http::message (RIPD-660):

### DIFF
--- a/src/beast/beast/http/message.h
+++ b/src/beast/beast/http/message.h
@@ -21,7 +21,6 @@
 #define BEAST_HTTP_MESSAGE_H_INCLUDED
 
 #include <beast/http/basic_parser.h>
-#include <beast/http/body.h>
 #include <beast/http/method.h>
 #include <beast/http/headers.h>
 #include <beast/utility/ci_char_traits.h>
@@ -72,9 +71,8 @@ public:
 
 #endif
 
-    // Memberspaces
+    // Memberspace
     beast::http::headers headers;
-    beast::http::body body;
 
     bool
     request() const
@@ -213,7 +211,6 @@ message::message (message&& other)
     , keep_alive_ (other.keep_alive_)
     , upgrade_ (other.upgrade_)
     , headers (std::move(other.headers))
-    , body (std::move(other.body))
 {
 }
 
@@ -230,33 +227,32 @@ message::operator= (message&& other)
     keep_alive_ = other.keep_alive_;
     upgrade_ = other.upgrade_;
     headers = std::move(other.headers);
-    body = std::move(other.body);
     return *this;    
 }
 #endif
 
 //------------------------------------------------------------------------------
 
-template <class AsioStreamBuf>
+template <class Streambuf>
 void
-write (AsioStreamBuf& stream, std::string const& s)
+write (Streambuf& stream, std::string const& s)
 {
     stream.commit (boost::asio::buffer_copy (
         stream.prepare (s.size()), boost::asio::buffer(s)));
 }
 
-template <class AsioStreamBuf>
+template <class Streambuf>
 void
-write (AsioStreamBuf& stream, char const* s)
+write (Streambuf& stream, char const* s)
 {
     auto const len (::strlen(s));
     stream.commit (boost::asio::buffer_copy (
         stream.prepare (len), boost::asio::buffer (s, len)));
 }
 
-template <class AsioStreamBuf>
+template <class Streambuf>
 void
-write (AsioStreamBuf& stream, message const& m)
+write (Streambuf& stream, message const& m)
 {
     if (m.request())
     {

--- a/src/beast/beast/http/tests/parser.test.cpp
+++ b/src/beast/beast/http/tests/parser.test.cpp
@@ -20,6 +20,7 @@
 #include <beast/http/message.h>
 #include <beast/http/parser.h>
 #include <beast/unit_test/suite.h>
+#include <utility>
 
 namespace beast {
 namespace http {
@@ -31,7 +32,8 @@ public:
     request (std::string const& text)
     {
         message m;
-        parser p (m, true);
+        body b;
+        parser p (m, b, true);
         auto result (p.write (boost::asio::buffer(text)));
         p.write_eof();
         return std::make_pair (std::move(m), result.first);
@@ -65,7 +67,8 @@ public:
                 "\r\n"
                 ;
             message m;
-            parser p (m, true);
+            body b;
+            parser p (m, b, true);
             auto result (p.write (boost::asio::buffer(text)));
             expect (! result.first);
             auto result2 (p.write_eof());
@@ -80,7 +83,8 @@ public:
                 "\r\n"
                 ;
             message m;
-            parser p (m, true);
+            body b;
+            parser p (m, b, true);
             auto result = p.write (boost::asio::buffer(text));
             if (expect (result.first))
                 expect (result.first.message() == "invalid HTTP method");

--- a/src/ripple/app/main/ServerHandlerImp.cpp
+++ b/src/ripple/app/main/ServerHandlerImp.cpp
@@ -113,7 +113,7 @@ void
 ServerHandlerImp::onRequest (HTTP::Session& session)
 {
     // Check user/password authorization
-    auto const headers (build_map (session.message().headers));
+    auto const headers = build_map (session.request().headers);
     if (! HTTPAuthorized (headers))
     {
         session.write (HTTPReply (403, "Forbidden"));
@@ -146,11 +146,10 @@ ServerHandlerImp::onStopped (HTTP::Server&)
 void
 ServerHandlerImp::processSession (Job& job, HTTP::Session& session)
 {
-    auto const s (to_string(session.message().body));
-    session.write (processRequest (to_string(session.message().body),
+    session.write (processRequest (to_string(session.body()),
         session.remoteAddress().at_port(0)));
 
-    if (session.message().keep_alive())
+    if (session.request().keep_alive())
     {
         session.complete();
     }

--- a/src/ripple/http/Session.h
+++ b/src/ripple/http/Session.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_HTTP_SESSION_H_INCLUDED
 #define RIPPLE_HTTP_SESSION_H_INCLUDED
 
+#include <beast/http/body.h>
 #include <beast/http/message.h>
 #include <beast/net/IPEndpoint.h>
 #include <beast/utility/Journal.h>
@@ -59,10 +60,15 @@ public:
     beast::IP::Endpoint
     remoteAddress() = 0;
 
-    /** Returns the currently known set of headers. */
+    /** Returns the current HTTP request. */
     virtual
     beast::http::message&
-    message() = 0;
+    request() = 0;
+
+    /** Returns the Content-Body of the current HTTP request. */
+    virtual
+    beast::http::body const&
+    body() = 0;
 
     /** Send a copy of data asynchronously. */
     /** @{ */

--- a/src/ripple/http/impl/Peer.h
+++ b/src/ripple/http/impl/Peer.h
@@ -103,6 +103,7 @@ protected:
 
     boost::asio::streambuf read_buf_;
     beast::http::message message_;
+    beast::http::body body_;
     std::list <buffer> write_queue_;
     std::mutex mutex_;
     bool graceful_ = false;
@@ -181,9 +182,15 @@ protected:
     }
 
     beast::http::message&
-    message() override
+    request() override
     {
         return message_;
+    }
+
+    beast::http::body const&
+    body() override
+    {
+        return body_;
     }
 
     void
@@ -481,7 +488,8 @@ Peer<Impl>::do_read (boost::asio::yield_context yield)
 
     error_code ec;
     bool eof = false;
-    beast::http::parser parser (message_, true);
+    body_.clear();
+    beast::http::parser parser (message_, body_, true);
     for(;;)
     {
         if (read_buf_.size() == 0)

--- a/src/ripple/http/tests/Server.test.cpp
+++ b/src/ripple/http/tests/Server.test.cpp
@@ -66,7 +66,7 @@ public:
         onRequest (Session& session) override
         {
             session.write (std::string ("Hello, world!\n"));
-            if (session.message().keep_alive())
+            if (session.request().keep_alive())
                 session.complete();
             else
                 session.close (true);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -413,7 +413,9 @@ PeerImp::on_write_http_request (error_code ec, std::size_t bytes_transferred)
     {
         // done sending request, now read the response
         http_message_ = boost::in_place ();
-        http_parser_ = boost::in_place (std::ref(*http_message_), false);
+        http_body_.clear();
+        http_parser_ = boost::in_place (std::ref(*http_message_),
+            std::ref(http_body_), false);
         on_read_http_response (error_code(), 0);
         return;
     }
@@ -559,7 +561,9 @@ PeerImp::on_read_http_detect (error_code ec, std::size_t bytes_transferred)
     else if (! is_peer_protocol)
     {
         http_message_ = boost::in_place ();
-        http_parser_ = boost::in_place (std::ref(*http_message_), true);
+        http_body_.clear();
+        http_parser_ = boost::in_place (std::ref(*http_message_),
+            std::ref(http_body_), true);
         on_read_http_request (error_code(), 0);
         return;
     }

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -172,6 +172,7 @@ private:
     boost::asio::streambuf read_buffer_;
     boost::optional <beast::http::message> http_message_;
     boost::optional <beast::http::parser> http_parser_;
+    beast::http::body http_body_;
     message_stream message_stream_;
 
     boost::asio::streambuf write_buffer_;


### PR DESCRIPTION
This changes the http::message object to no longer contain a body. It modifies
the parser to store the body in a separate object, or to pass the body data
to a functor. This allows the body to be stored in more flexible ways. For
example, in HTTP responses the body can be generated procedurally instead
of being required to exist entirely in memory at once.
Reviewers: @howardhinnant, @ximinez, @nbougalis 
