### PR TITLE
Require the use of the master key for some operations (RIPD-666)

### DIFF
--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -156,30 +156,36 @@ public:
 
         if ((uSetFlag == asfDisableMaster) && !(uFlagsIn & lsfDisableMaster))
         {
+            if (!mSigMaster)
+            {
+                m_journal.trace << "Can't use regular key to disable master key.";
+                return tecNEED_MASTER_KEY;
+            }
+
             if (!mTxnAccount->isFieldPresent (sfRegularKey))
                 return tecNO_REGULAR_KEY;
 
             m_journal.trace << "Set lsfDisableMaster.";
-            uFlagsOut   |= lsfDisableMaster;
+            uFlagsOut |= lsfDisableMaster;
         }
 
         if ((uClearFlag == asfDisableMaster) && (uFlagsIn & lsfDisableMaster))
         {
             m_journal.trace << "Clear lsfDisableMaster.";
-            uFlagsOut   &= ~lsfDisableMaster;
+            uFlagsOut &= ~lsfDisableMaster;
         }
 
         if ((uSetFlag == asfNoFreeze) && (uClearFlag != asfNoFreeze))
         {
             m_journal.trace << "Set NoFreeze flag";
-            uFlagsOut   |= lsfNoFreeze;
+            uFlagsOut |= lsfNoFreeze;
         }
 
         // Anyone may set global freeze
         if ((uSetFlag == asfGlobalFreeze) && (uClearFlag != asfGlobalFreeze))
         {
             m_journal.trace << "Set GlobalFreeze flag";
-            uFlagsOut   |= lsfGlobalFreeze;
+            uFlagsOut |= lsfGlobalFreeze;
         }
 
         // If you have set NoFreeze, you may not clear GlobalFreeze
@@ -189,7 +195,7 @@ public:
             ((uFlagsOut & lsfNoFreeze) == 0))
         {
             m_journal.trace << "Clear GlobalFreeze flag";
-            uFlagsOut   &= ~lsfGlobalFreeze;
+            uFlagsOut &= ~lsfGlobalFreeze;
         }
 
         //

--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -177,7 +177,7 @@ public:
 
         if ((uSetFlag == asfNoFreeze) && (uClearFlag != asfNoFreeze))
         {
-            if (!mSigMaster)
+            if (!mSigMaster && !(uFlagsIn & lsfDisableMaster))
             {
                 m_journal.trace << "Can't use regular key to set NoFreeze.";
                 return tecNEED_MASTER_KEY;

--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -177,6 +177,12 @@ public:
 
         if ((uSetFlag == asfNoFreeze) && (uClearFlag != asfNoFreeze))
         {
+            if (!mSigMaster)
+            {
+                m_journal.trace << "Can't use regular key to set NoFreeze.";
+                return tecNEED_MASTER_KEY;
+            }
+
             m_journal.trace << "Set NoFreeze flag";
             uFlagsOut |= lsfNoFreeze;
         }

--- a/src/ripple/data/protocol/TER.cpp
+++ b/src/ripple/data/protocol/TER.cpp
@@ -58,6 +58,7 @@ bool transResultInfo (TER terCode, std::string& strToken, std::string& strHuman)
         {   tecNO_PERMISSION,       "tecNO_PERMISSION",         "No permission to perform requested operation."         },
         {   tecNO_ENTRY,            "tecNO_ENTRY",              "No matching entry found."                              },
         {   tecINSUFFICIENT_RESERVE,"tecINSUFFICIENT_RESERVE",  "Insufficient reserve to complete requested operation." },
+        {   tecNEED_MASTER_KEY,     "tecNEED_MASTER_KEY",       "The operation requires the use of the Master Key."     },
 
         {   tefALREADY,             "tefALREADY",               "The exact transaction was already in this ledger."     },
         {   tefBAD_ADD_AUTH,        "tefBAD_ADD_AUTH",          "Not authorized to add account."                        },

--- a/src/ripple/data/protocol/TER.h
+++ b/src/ripple/data/protocol/TER.h
@@ -189,6 +189,7 @@ enum TER    // aka TransactionEngineResult
     tecNO_PERMISSION            = 139,
     tecNO_ENTRY                 = 140,
     tecINSUFFICIENT_RESERVE     = 141,
+    tecNEED_MASTER_KEY          = 142,
 };
 
 inline bool isTelLocal(TER x)


### PR DESCRIPTION
* When disabling the use of the master key; or
* When enabling 'no freeze'.

[**Transaction Processing Change**]

Reviews: @JoelKatz, @scottschurr