### PR TITLE
Enable use of a JSON reviver function in response of "tx" RPC command

### DIFF
--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -49,6 +49,7 @@ Json::Value doTx (RPC::Context& context)
         ret[jss::transaction] = txn->getJson (1, binary);
 #else
         Json::Value ret = txn->getJson (1, binary);
+        ret[jss::transaction] = txn->getJson (1, binary);
 #endif
 
         if (txn->getLedger () != 0)


### PR DESCRIPTION
I created this issue at the ripple-rest project (because rippled does not allow me): ripple/ripple-rest#193 

The API supports the use of a JSON reviver very well overall, so I assume this is done intentionally. (A reviver allows the mapping of JSON objects to classes in a programming language. Revivers work by knowing what object type is followed by a specific JSON key. The [AffectedNode structure](https://gist.github.com/stevenroose/b94b53a201fb5a8e84f2) is a good example of how the API helps with this.)

Now, I've been implementing a library to use the Ripple API (the WebSocket API, but it uses the same response JSON as the REST API), and I didn't have any problems with my reviver, except for one message: the result message of the `tx` request.

The response to such a request looks like this: https://gist.github.com/stevenroose/eb87571dfbdb80c99a71

The object following `result` is a transaction object, but a JSON reviver cannot know that.

The way it should be in order to support revivers (and the way the Ripple API responses are usually structured: https://gist.github.com/stevenroose/e09c2cbdb6ba8867647b

The reviver then knows a transaction object follows and can correctly parse it to a Transaction class.

For backwards compatibility, it might be a good idea to include the transaction data both directly under `result`, and also under `result`->`transaction`, but on the long term, I think using `result`->`transaction` only is the correct way to go.

---

This PR just merges the old and new format. Response messages will almost double in size, but it's temporarily, until it's possible to stop supporting the old format.
