### PR TITLE
Improve RPCUtils by removing string copies and DecodeBase64.

### DIFF
--- a/src/ripple/net/RPCUtil.h
+++ b/src/ripple/net/RPCUtil.h
@@ -22,7 +22,7 @@
 
 namespace ripple {
 
-using HTTPHeaders = std::map<std::string, std::string>;
+using HeaderMap = std::map<std::string, std::string>;
 
 // VFALCO TODO Wrap these up into a class. It looks like they just do some
 //             convenience packaging of JSON data from the pieces. It looks
@@ -36,14 +36,14 @@ std::string JSONRPCReply (
 
 std::string HTTPReply (int nStatus, std::string const& strMsg);
 
-// VFALCO TODO Create a HTTPHeaders class with a nice interface.
-bool HTTPAuthorized (HTTPHeaders const& mapHeaders);
+// VFALCO TODO Create a HeaderMap class with a nice interface.
+bool HTTPAuthorized (HeaderMap const& mapHeaders);
 
 std::string createHTTPPost (
     std::string const& host,
     std::string const& path,
     std::string const& msg,
-    HTTPHeaders const& requestHeaders);
+    HeaderMap const& requestHeaders);
 
 } // ripple
 

--- a/src/ripple/net/impl/RPCUtil.cpp
+++ b/src/ripple/net/impl/RPCUtil.cpp
@@ -58,7 +58,7 @@ std::string createHTTPPost (
     std::string const& strHost,
     std::string const& strPath,
     std::string const& strMsg,
-    HTTPHeaders const& mapRequestHeaders)
+    HeaderMap const& mapRequestHeaders)
 {
     std::string s;
 
@@ -69,17 +69,17 @@ std::string createHTTPPost (
     s += "POST ";
     s += strPath.empty () ? "/" : strPath;
     s += " HTTP/1.0\r\n"
-            "User-Agent: " SYSTEM_NAME "-json-rpc/";
+         "User-Agent: " SYSTEM_NAME "-json-rpc/";
     s += versionNumber;
     s += "\r\n"
-            "Host: ";
+         "Host: ";
     s += strHost;
     s += "\r\n"
-            "Content-Type: application/json\r\n"
-            "Content-Length: ";
+         "Content-Type: application/json\r\n"
+         "Content-Length: ";
     s += std::to_string (strMsg.size ());
     s += "\r\n"
-            "Accept: application/json\r\n";
+         "Accept: application/json\r\n";
 
     for (auto const& item : mapRequestHeaders)
         (((s += item.first) += ": ") += item.second) += "\r\n";
@@ -133,7 +133,6 @@ std::string HTTPReply (int nStatus, std::string const& strMsg)
     }
     else
     {
-
         ret.reserve(256 + strMsg.length());
 
         switch (nStatus)
@@ -167,7 +166,7 @@ std::string HTTPReply (int nStatus, std::string const& strMsg)
     return ret;
 }
 
-bool HTTPAuthorized (HTTPHeaders const& mapHeaders)
+bool HTTPAuthorized (HeaderMap const& mapHeaders)
 {
     bool const credentialsRequired (! getConfig().RPC_USER.empty() &&
         ! getConfig().RPC_PASSWORD.empty());


### PR DESCRIPTION
The first commit is a clean - it just removes unused code and restricts columns to 80.

The second one gets rid of redundant string copies.

The third commit replaces our own supposedly-suboptimal base64 conversion with a seemingly-better one.

Reviewers: @HowardHinnant @nbougalis 
