### PR TITLE
Finalize autobridging implementation (RIPD-179):

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1652,6 +1652,9 @@
     <ClCompile Include="..\..\src\ripple\app\book\tests\Quality.test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\book\tests\Taker.test.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\book\Types.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\consensus\DisputedTx.cpp">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2499,6 +2499,9 @@
     <ClCompile Include="..\..\src\ripple\app\book\tests\Quality.test.cpp">
       <Filter>ripple\app\book\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\book\tests\Taker.test.cpp">
+      <Filter>ripple\app\book\tests</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\book\Types.h">
       <Filter>ripple\app\book</Filter>
     </ClInclude>

--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -197,7 +197,7 @@
     This determines whether ripple implements offer autobridging via XRP.
 */
 #ifndef RIPPLE_ENABLE_AUTOBRIDGING
-#define RIPPLE_ENABLE_AUTOBRIDGING 0
+#define RIPPLE_ENABLE_AUTOBRIDGING 1
 #endif
 
 /** Config: RIPPLE_SINGLE_IO_SERVICE_THREAD

--- a/src/ripple/app/book/OfferStream.h
+++ b/src/ripple/app/book/OfferStream.h
@@ -104,17 +104,6 @@ public:
     */
     bool
     step ();
-
-    /** Advance to the next valid offer that is not from the specified account.
-        This automatically removes:
-            - Offers with missing ledger entries
-            - Offers found unfunded
-            - Offers from the same account
-            - Expired offers
-        @return `true` if there is a valid offer.
-    */
-    bool
-    step_account (Account const& account);
 };
 
 }

--- a/src/ripple/app/book/Taker.h
+++ b/src/ripple/app/book/Taker.h
@@ -25,6 +25,7 @@
 #include <ripple/app/book/Offer.h>
 #include <ripple/app/book/Types.h>
 #include <ripple/protocol/TxFlags.h>
+
 #include <beast/utility/noexcept.h>
 #include <functional>
 
@@ -32,85 +33,167 @@ namespace ripple {
 namespace core {
 
 /** State for the active party during order book or payment operations. */
-class Taker
+class BasicTaker
 {
-public:
-    struct Options
+private:
+    class Rate
     {
-        Options() = delete;
+    private:
+        std::uint32_t quality_;
+        Amount rate_;
 
-        explicit
-        Options (std::uint32_t tx_flags)
-            : sell (tx_flags & tfSell)
-            , passive (tx_flags & tfPassive)
-            , fill_or_kill (tx_flags & tfFillOrKill)
-            , immediate_or_cancel (tx_flags & tfImmediateOrCancel)
+    public:
+        Rate (std::uint32_t quality)
+            : quality_ (quality)
         {
+            assert (quality_ != 0);
+            rate_ = Amount::saFromRate (quality_);
         }
 
-        bool const sell;
-        bool const passive;
-        bool const fill_or_kill;
-        bool const immediate_or_cancel;
+        Amount
+        divide (Amount const& amount) const;
+
+        Amount
+        multiply (Amount const& amount) const;
     };
 
 private:
-    std::reference_wrapper <LedgerView> m_view;
-    Account m_account;
-    Options m_options;
-    Quality m_quality;
-    Quality m_threshold;
+    Account account_;
+    Quality quality_;
+    Quality threshold_;
+
+    bool sell_;
 
     // The original in and out quantities.
-    Amounts const m_amount;
+    Amounts const original_;
 
     // The amounts still left over for us to try and take.
-    Amounts m_remain;
+    Amounts remaining_;
 
-    Amounts
-    flow (Amounts amount, Offer const& offer, Account const& taker);
+    // The issuers for the input and output
+    Issue const& issue_in_;
+    Issue const& issue_out_;
 
-    TER
-    fill (Offer const& offer, Amounts const& amount);
+    // The rates that will be paid when the input and output currencies are
+    // transfer when the currency issuer isn't involved:
+    std::uint32_t const m_rate_in;
+    std::uint32_t const m_rate_out;
 
-    TER
-    fill (Offer const& leg1, Amounts const& amount1,
-        Offer const& leg2, Amounts const& amount2);
+    // The type of crossing that we are performing
+    CrossType cross_type_;
 
-    void
-    consume (Offer const& offer, Amounts const& consumed) const;
+protected:
+    struct Flow
+    {
+        Amounts order;
+        Amounts issuers;
+
+        bool sanity_check () const
+        {
+            if (isXRP (order.in) && isXRP (order.out))
+                return false;
+
+            return order.in >= zero &&
+                order.out >= zero &&
+                issuers.in >= zero &&
+                issuers.out >= zero;
+        }
+    };
+
+private:
+    Flow
+    flow_xrp_to_iou (Amounts const& offer, Quality quality,
+        Amount const& owner_funds, Amount const& taker_funds,
+        Rate const& rate_out);
+
+    Flow
+    flow_iou_to_xrp (Amounts const& offer, Quality quality,
+        Amount const& owner_funds, Amount const& taker_funds,
+        Rate const& rate_in);
+
+    Flow
+    flow_iou_to_iou (Amounts const& offer, Quality quality,
+        Amount const& owner_funds, Amount const& taker_funds,
+        Rate const& rate_in, Rate const& rate_out);
+
+    // Calculates the transfer rate that we should use when calculating
+    // flows for a particular issue between two accounts.
+    static
+    Rate
+    effective_rate (std::uint32_t rate, Issue const &issue,
+        Account const& from, Account const& to);
+
+    // The transfer rate for the input currency between the given accounts
+    Rate
+    in_rate (Account const& from, Account const& to) const
+    {
+        return effective_rate (m_rate_in, original_.in.issue (), from, to);
+    }
+
+    // The transfer rate for the output currency between the given accounts
+    Rate
+    out_rate (Account const& from, Account const& to) const
+    {
+        return effective_rate (m_rate_out, original_.out.issue (), from, to);
+    }
 
 public:
-    Taker (LedgerView& view, Account const& account,
-        Amounts const& amount, Options const& options);
+    BasicTaker () = delete;
+    BasicTaker (BasicTaker const&) = delete;
 
-    LedgerView&
-    view () const noexcept
-    {
-        return m_view;
-    }
+    BasicTaker (
+        CrossType cross_type, Account const& account, Amounts const& amount,
+        Quality const& quality, std::uint32_t flags, std::uint32_t rate_in,
+        std::uint32_t rate_out);
+
+    virtual ~BasicTaker () = default;
 
     /** Returns the amount remaining on the offer.
         This is the amount at which the offer should be placed. It may either
         be for the full amount when there were no crossing offers, or for zero
         when the offer fully crossed, or any amount in between.
-        It is always at the original offer quality (m_quality)
+        It is always at the original offer quality (quality_)
     */
     Amounts
     remaining_offer () const;
+
+    /** Returns the amount that the offer was originally placed at. */
+    Amounts const&
+    original_offer () const;
 
     /** Returns the account identifier of the taker. */
     Account const&
     account () const noexcept
     {
-        return m_account;
+        return account_;
     }
 
     /** Returns `true` if the quality does not meet the taker's requirements. */
     bool
     reject (Quality const& quality) const noexcept
     {
-        return quality < m_threshold;
+        return quality < threshold_;
+    }
+
+    /** Returns the type of crossing that is being performed */
+    CrossType
+    cross_type () const
+    {
+        return cross_type_;
+    }
+
+    /** Returns the Issue associated with the input of the offer */
+    Issue const&
+    issue_in () const
+    {
+        return issue_in_;
+    }
+
+    /** Returns the Issue associated with the output of the offer */
+    Issue const&
+    issue_out () const
+    {
+        return issue_out_;
     }
 
     /** Returns `true` if order crossing should not continue.
@@ -121,24 +204,105 @@ public:
     done () const;
 
     /** Perform direct crossing through given offer.
-        @return tesSUCCESS on success, error code otherwise.
+        @return an `Amounts` describing the flow achieved during cross
     */
+    BasicTaker::Flow
+    do_cross (Amounts offer, Quality quality, Account const& owner);
+
+    /** Perform bridged crossing through given offers.
+        @return a pair of `Amounts` describing the flow achieved during cross
+    */
+    std::pair<BasicTaker::Flow, BasicTaker::Flow>
+    do_cross (
+        Amounts offer1, Quality quality1, Account const& owner1,
+        Amounts offer2, Quality quality2, Account const& owner2);
+
+    virtual
+    Amount
+    get_funds (Account const& account, Amount const& funds) const = 0;
+};
+
+class Taker
+    : public BasicTaker
+{
+private:
+    static
+    std::uint32_t
+    calculateRate (LedgerView& view, Account const& issuer, Account const& account);
+
+    // The underlying ledger entry we are dealing with
+    LedgerView& m_view;
+
+    // The amount of XRP that flowed if we were autobridging
+    STAmount xrp_flow_;
+
+    // The number direct crossings that we performed
+    std::uint32_t direct_crossings_;
+
+    // The number autobridged crossings that we performed
+    std::uint32_t bridge_crossings_;
+
+    TER
+    fill (BasicTaker::Flow const& flow, Offer const& offer);
+
+    TER
+    fill (
+        BasicTaker::Flow const& flow1, Offer const& leg1,
+        BasicTaker::Flow const& flow2, Offer const& leg2);
+
+    TER
+    transfer_xrp (Account const& from, Account const& to, Amount const& amount);
+
+    TER
+    redeem_iou (Account const& account, Amount const& amount, Issue const& issue);
+
+    TER
+    issue_iou (Account const& account, Amount const& amount, Issue const& issue);
+
+public:
+    Taker () = delete;
+    Taker (Taker const&) = delete;
+
+    Taker (CrossType cross_type, LedgerView& view, Account const& account,
+        Amounts const& offer, std::uint32_t flags);
+    ~Taker () = default;
+
+    void
+    consume_offer (Offer const& offer, Amounts const& order);
+
+    Amount
+    get_funds (Account const& account, Amount const& funds) const;
+
+    STAmount const&
+    get_xrp_flow () const
+    {
+        return xrp_flow_;
+    }
+
+    std::uint32_t
+    get_direct_crossings () const
+    {
+        return direct_crossings_;
+    }
+
+    std::uint32_t
+    get_bridge_crossings () const
+    {
+        return bridge_crossings_;
+    }
+
+    /** Perform a direct or bridged offer crossing as appropriate.
+        Funds will be transferred accordingly, and offers will be adjusted.
+        @return tesSUCCESS if successful, or an error code otherwise.
+    */
+    /** @{ */
     TER
     cross (Offer const& offer);
 
-    /** Perform bridged crossing through given offers.
-        @return tesSUCCESS on success, error code otherwise.
-    */
     TER
     cross (Offer const& leg1, Offer const& leg2);
+    /** @} */
 };
-
-inline
-std::ostream&
-operator<< (std::ostream& os, Taker const& taker)
-{
-    return os << taker.account();
-}
 
 }
 }

--- a/src/ripple/app/book/Types.h
+++ b/src/ripple/app/book/Types.h
@@ -29,6 +29,14 @@
 namespace ripple {
 namespace core {
 
+/** The flavor of an offer crossing */
+enum class CrossType
+{
+    XrpToIou,
+    IouToXrp,
+    IouToIou
+};
+
 /** A mutable view that overlays an immutable ledger to track changes. */
 typedef LedgerEntrySet LedgerView;
 

--- a/src/ripple/app/book/impl/OfferStream.cpp
+++ b/src/ripple/app/book/impl/OfferStream.cpp
@@ -124,7 +124,7 @@ OfferStream::step ()
         // NIKB NOTE The calling code also checks the funds, how expensive is
         //           looking up the funds twice?
         Amount const owner_funds (view().accountFunds (
-            m_offer.account(), m_offer.amount().out, fhZERO_IF_FROZEN));
+            m_offer.owner(), amount.out, fhZERO_IF_FROZEN));
 
         // Check for unfunded offer
         if (owner_funds <= zero)
@@ -132,8 +132,10 @@ OfferStream::step ()
             // If the owner's balance in the pristine view is the same,
             // we haven't modified the balance and therefore the
             // offer is "found unfunded" versus "became unfunded"
-            if (view_cancel().accountFunds (m_offer.account(),
-                m_offer.amount().out, fhZERO_IF_FROZEN) == owner_funds)
+            auto const original_funds = view_cancel().accountFunds (
+                m_offer.owner(), amount.out, fhZERO_IF_FROZEN);
+
+            if (original_funds == owner_funds)
             {
                 view_cancel().offerDelete (entry->getIndex());
                 if (m_journal.trace) m_journal.trace <<
@@ -152,18 +154,6 @@ OfferStream::step ()
     }
 
     return true;
-}
-
-bool
-OfferStream::step_account (Account const& account)
-{
-    while (step ())
-    {
-        if (tip ().account () != account)
-            return true;
-    }
-
-    return false;
 }
 
 }

--- a/src/ripple/app/book/impl/Taker.cpp
+++ b/src/ripple/app/book/impl/Taker.cpp
@@ -22,261 +22,625 @@
 namespace ripple {
 namespace core {
 
-Taker::Taker (LedgerView& view, Account const& account,
-    Amounts const& amount, Options const& options)
-    : m_view (view)
-    , m_account (account)
-    , m_options (options)
-    , m_quality (amount)
-    , m_threshold (m_quality)
-    , m_amount (amount)
-    , m_remain (amount)
+Amount
+BasicTaker::Rate::divide (Amount const& amount) const
 {
-    assert (m_remain.in > zero);
-    assert (m_remain.out > zero);
+    if (quality_ == QUALITY_ONE)
+        return amount;
 
-    // If this is a passive order (tfPassive), this prevents
-    // offers at the same quality level from being consumed.
-    if (m_options.passive)
-        ++m_threshold;
+    return ripple::divide (amount, rate_, amount.issue ());
+}
+
+Amount
+BasicTaker::Rate::multiply (Amount const& amount) const
+{
+    if (quality_ == QUALITY_ONE)
+        return amount;
+
+    return ripple::multiply (amount, rate_, amount.issue ());
+}
+
+BasicTaker::BasicTaker (
+        CrossType cross_type, Account const& account, Amounts const& amount,
+        Quality const& quality, std::uint32_t flags, std::uint32_t rate_in,
+        std::uint32_t rate_out)
+    : account_ (account)
+    , quality_ (quality)
+    , threshold_ (quality_)
+    , sell_ (flags & tfSell)
+    , original_ (amount)
+    , remaining_ (amount)
+    , issue_in_ (remaining_.in.issue ())
+    , issue_out_ (remaining_.out.issue ())
+    , m_rate_in (rate_in)
+    , m_rate_out (rate_out)
+    , cross_type_ (cross_type)
+{
+    assert (remaining_.in > zero);
+    assert (remaining_.out > zero);
+
+    assert (m_rate_in != 0);
+    assert (m_rate_out != 0);
+
+    // If we are dealing with a particular flavor, make sure that it's the
+    // flavor we expect:
+    assert (cross_type != CrossType::XrpToIou ||
+        (isXRP (issue_in ()) && !isXRP (issue_out ())));
+
+    assert (cross_type != CrossType::IouToXrp ||
+        (!isXRP (issue_in ()) && isXRP (issue_out ())));
+
+    // And make sure we're not crossing XRP for XRP
+    assert (!isXRP (issue_in ()) || !isXRP (issue_out ()));
+
+    // If this is a passive order, we adjust the quality so as to prevent offers
+    // at the same quality level from being consumed.
+    if (flags & tfPassive)
+        ++threshold_;
+}
+
+BasicTaker::Rate
+BasicTaker::effective_rate (
+    std::uint32_t rate, Issue const &issue,
+    Account const& from, Account const& to)
+{
+    assert (rate != 0);
+
+    if (rate != QUALITY_ONE)
+    {
+        // We ignore the transfer if the sender is also the recipient since no
+        // actual transfer takes place in that case. We also ignore if either
+        // the sender or the receiver is the issuer.
+
+        if (from != to && from != issue.account && to != issue.account)
+            return Rate (rate);
+    }
+
+    return Rate (QUALITY_ONE);
 }
 
 Amounts
-Taker::remaining_offer () const
+BasicTaker::remaining_offer () const
 {
     // If the taker is done, then there's no offer to place.
     if (done ())
-        return Amounts (m_amount.in.zeroed(), m_amount.out.zeroed());
+        return Amounts (remaining_.in.zeroed(), remaining_.out.zeroed());
 
     // Avoid math altogether if we didn't cross.
-   if (m_amount == m_remain)
-       return m_amount;
+   if (original_ == remaining_)
+       return original_;
 
-    if (m_options.sell)
+    if (sell_)
     {
-        assert (m_remain.in > zero);
+        assert (remaining_.in > zero);
 
         // We scale the output based on the remaining input:
-        return Amounts (m_remain.in, divRound (
-            m_remain.in, m_quality.rate (), m_remain.out, true));
+        return Amounts (remaining_.in, divRound (
+            remaining_.in, quality_.rate (), remaining_.out, true));
     }
 
-    assert (m_remain.out > zero);
+    assert (remaining_.out > zero);
 
     // We scale the input based on the remaining output:
     return Amounts (mulRound (
-        m_remain.out, m_quality.rate (), m_remain.in, true), m_remain.out);
+        remaining_.out, quality_.rate (), remaining_.in, true), remaining_.out);
 }
 
-/** Calculate the amount particular user could get through an offer.
-    @param amount the maximum flow that is available to the taker.
-    @param offer the offer to flow through.
-    @param taker the person taking the offer.
-    @return the maximum amount that can flow through this offer.
-*/
-Amounts
-Taker::flow (Amounts amount, Offer const& offer, Account const& taker)
+Amounts const&
+BasicTaker::original_offer () const
 {
-    // Limit taker's input by available funds less fees
-    Amount const taker_funds (view ().accountFunds (
-        taker, amount.in, fhZERO_IF_FROZEN));
-
-    // Get fee rate paid by taker
-    std::uint32_t const taker_charge_rate (rippleTransferRate (view (),
-        taker, offer.account (), amount.in.getIssuer()));
-
-    // Skip some math when there's no fee
-    if (taker_charge_rate == QUALITY_ONE)
-    {
-        amount = offer.quality ().ceil_in (amount, taker_funds);
-    }
-    else
-    {
-        Amount const taker_charge (Amount::saFromRate (taker_charge_rate));
-        amount = offer.quality ().ceil_in (amount,
-            divide (taker_funds, taker_charge));
-    }
-
-    // Best flow the owner can get.
-    // Start out assuming entire offer will flow.
-    Amounts owner_amount (amount);
-
-    // Limit owner's output by available funds less fees
-    Amount const owner_funds (view ().accountFunds (
-        offer.account (), owner_amount.out, fhZERO_IF_FROZEN));
-
-    // Get fee rate paid by owner
-    std::uint32_t const owner_charge_rate (rippleTransferRate (view (),
-        offer.account (), taker, amount.out.getIssuer()));
-
-    if (owner_charge_rate == QUALITY_ONE)
-    {
-        // Skip some math when there's no fee
-        owner_amount = offer.quality ().ceil_out (owner_amount, owner_funds);
-    }
-    else
-    {
-        Amount const owner_charge (Amount::saFromRate (owner_charge_rate));
-        owner_amount = offer.quality ().ceil_out (owner_amount,
-            divide (owner_funds, owner_charge));
-    }
-
-    // Calculate the amount that will flow through the offer
-    // This does not include the fees.
-    return (owner_amount.in < amount.in)
-        ? owner_amount
-        : amount;
+    return original_;
 }
 
-// Adjust an offer to indicate that we are consuming some (or all) of it.
-void
-Taker::consume (Offer const& offer, Amounts const& consumed) const
+// TODO: the presence of 'output' is an artifact caused by the fact that
+// Amounts carry issue information which should be decoupled.
+static
+Amount
+qual_div (Amount const& amount, Quality const& quality, Amount const& output)
 {
-    Amounts const& remaining (offer.amount ());
-
-    assert (remaining.in > zero && remaining.out > zero);
-    assert (remaining.in >= consumed.in && remaining.out >= consumed.out);
-
-    offer.entry ()->setFieldAmount (sfTakerPays, remaining.in - consumed.in);
-    offer.entry ()->setFieldAmount (sfTakerGets, remaining.out - consumed.out);
-
-    view ().entryModify (offer.entry());
-
-    assert (offer.entry ()->getFieldAmount (sfTakerPays) >= zero);
-    assert (offer.entry ()->getFieldAmount (sfTakerGets) >= zero);
+    auto result = divide (amount, quality.rate (), output.issue ());
+    return std::min (result, output);
 }
 
-// Fill a direct offer.
-//   @param offer the offer we are going to use.
-//   @param amount the amount to flow through the offer.
-//   @returns: tesSUCCESS if successful, or an error code otherwise.
-TER
-Taker::fill (Offer const& offer, Amounts const& amount)
+static
+Amount
+qual_mul (Amount const& amount, Quality const& quality, Amount const& output)
 {
-    consume (offer, amount);
-
-    // Pay the taker, then the owner
-    TER result = view ().accountSend (offer.account(), account(), amount.out);
-
-    if (result == tesSUCCESS)
-        result = view ().accountSend (account(), offer.account(), amount.in);
-
-    return result;
+    auto result = multiply (amount, quality.rate (), output.issue ());
+    return std::min (result, output);
 }
 
-// Fill a bridged offer.
-//   @param leg1 the first leg we are going to use.
-//   @param amount1 the amount to flow through the first leg of the offer.
-//   @param leg2 the second leg we are going to use.
-//   @param amount2 the amount to flow through the second leg of the offer.
-//   @return tesSUCCESS if successful, or an error code otherwise.
-TER
-Taker::fill (
-    Offer const& leg1, Amounts const& amount1,
-    Offer const& leg2, Amounts const& amount2)
+BasicTaker::Flow
+BasicTaker::flow_xrp_to_iou (
+    Amounts const& order, Quality quality,
+    Amount const& owner_funds, Amount const& taker_funds,
+    Rate const& rate_out)
 {
-    assert (amount1.out == amount2.in);
+    Flow f;
+    f.order = order;
+    f.issuers.out = rate_out.multiply (f.order.out);
 
-    consume (leg1, amount1);
-    consume (leg2, amount2);
+    // Clamp on owner balance
+    if (owner_funds < f.issuers.out)
+    {
+        f.issuers.out = owner_funds;
+        f.order.out = rate_out.divide (f.issuers.out);
+        f.order.in = qual_mul (f.order.out, quality, f.order.in);
+    }
 
-    /* It is possible that m_account is the same as leg1.account, leg2.account
-     * or both. This could happen when bridging over one's own offer. In that
-     * case, accountSend won't actually do a send, which is what we want.
-     */
-    TER result = view ().accountSend (m_account, leg1.account (), amount1.in);
+    // Clamp if taker wants to limit the output
+    if (!sell_ && remaining_.out < f.order.out)
+    {
+        f.order.out = remaining_.out;
+        f.order.in = qual_mul (f.order.out, quality, f.order.in);
+        f.issuers.out = rate_out.multiply (f.order.out);
+    }
 
-    if (result == tesSUCCESS)
-        result = view ().accountSend (leg1.account (), leg2.account (), amount1.out);
+    // Clamp on the taker's funds
+    if (taker_funds < f.order.in)
+    {
+        f.order.in = taker_funds;
+        f.order.out = qual_div (f.order.in, quality, f.order.out);
+        f.issuers.out = rate_out.multiply (f.order.out);
+    }
 
-    if (result == tesSUCCESS)
-        result = view ().accountSend (leg2.account (), m_account, amount2.out);
+    // Clamp on remaining offer if we are not handling the second leg
+    // of an autobridge.
+    if (cross_type_ == CrossType::XrpToIou && (remaining_.in < f.order.in))
+    {
+        f.order.in = remaining_.in;
+        f.order.out = qual_div (f.order.in, quality, f.order.out);
+        f.issuers.out = rate_out.multiply (f.order.out);
+    }
 
-    return result;
+    return f;
+}
+
+BasicTaker::Flow
+BasicTaker::flow_iou_to_xrp (
+    Amounts const& order, Quality quality,
+    Amount const& owner_funds, Amount const& taker_funds,
+    Rate const& rate_in)
+{
+    Flow f;
+    f.order = order;
+    f.issuers.in = rate_in.multiply (f.order.in);
+
+    // Clamp on owner's funds
+    if (owner_funds < f.order.out)
+    {
+        f.order.out = owner_funds;
+        f.order.in = qual_mul (f.order.out, quality, f.order.in);
+        f.issuers.in = rate_in.multiply (f.order.in);
+    }
+
+    // Clamp if taker wants to limit the output and we are not the
+    // first leg of an autobridge.
+    if (!sell_ && cross_type_ == CrossType::IouToXrp)
+    {
+        if (remaining_.out < f.order.out)
+        {
+            f.order.out = remaining_.out;
+            f.order.in = qual_mul (f.order.out, quality, f.order.in);
+            f.issuers.in = rate_in.multiply (f.order.in);
+        }
+    }
+
+    // Clamp on the taker's input offer
+    if (remaining_.in < f.order.in)
+    {
+        f.order.in = remaining_.in;
+        f.issuers.in = rate_in.multiply (f.order.in);
+        f.order.out = qual_div (f.order.in, quality, f.order.out);
+    }
+
+    // Clamp on the taker's input balance
+    if (taker_funds < f.issuers.in)
+    {
+        f.issuers.in = taker_funds;
+        f.order.in = rate_in.divide (f.issuers.in);
+        f.order.out = qual_div (f.order.in, quality, f.order.out);
+    }
+
+    return f;
+}
+
+BasicTaker::Flow
+BasicTaker::flow_iou_to_iou (
+    Amounts const& order, Quality quality,
+    Amount const& owner_funds, Amount const& taker_funds,
+    Rate const& rate_in, Rate const& rate_out)
+{
+    Flow f;
+    f.order = order;
+    f.issuers.in = rate_in.multiply (f.order.in);
+    f.issuers.out = rate_out.multiply (f.order.out);
+
+    // Clamp on owner balance
+    if (owner_funds < f.issuers.out)
+    {
+        f.issuers.out = owner_funds;
+        f.order.out = rate_out.divide (f.issuers.out);
+        f.order.in = qual_mul (f.order.out, quality, f.order.in);
+        f.issuers.in = rate_in.multiply (f.order.in);
+    }
+
+    // Clamp on taker's offer
+    if (!sell_ && remaining_.out < f.order.out)
+    {
+        f.order.out = remaining_.out;
+        f.order.in = qual_mul (f.order.out, quality, f.order.in);
+        f.issuers.out = rate_out.multiply (f.order.out);
+        f.issuers.in = rate_in.multiply (f.order.in);
+    }
+
+    // Clamp on the taker's input balance and input offer
+    if (remaining_.in < f.order.in)
+    {
+        f.order.in = remaining_.in;
+        f.issuers.in = rate_in.multiply (f.order.in);
+        f.order.out = qual_div (f.order.in, quality, f.order.out);
+        f.issuers.out = rate_out.multiply (f.order.out);
+    }
+
+    if (taker_funds < f.order.in)
+    {
+        f.issuers.in = taker_funds;
+        f.order.in = rate_in.divide (f.issuers.in);
+        f.order.out = qual_div (f.order.in, quality, f.order.out);
+        f.issuers.out = rate_out.multiply (f.order.out);
+    }
+
+    return f;
 }
 
 bool
-Taker::done () const
+BasicTaker::done () const
 {
-    if (m_options.sell && (m_remain.in <= zero))
-    {
-        // Sell semantics: we consumed all the input currency
+    // Sell semantics: we consumed all the input currency
+    if (sell_ && (remaining_.in <= zero))
         return true;
-    }
 
-    if (!m_options.sell && (m_remain.out <= zero))
-    {
-        // Buy semantics: we received the desired amount of output currency
+    // Buy semantics: we received the desired amount of output currency
+    if (!sell_ && (remaining_.out <= zero))
         return true;
-    }
 
     // We are finished if the taker is out of funds
-    return view().accountFunds (
-        account(), m_remain.in, fhZERO_IF_FROZEN) <= zero;
+    if (get_funds (account(), remaining_.in) <= zero)
+        return true;
+
+    return false;
+}
+
+// Calculates the direct flow through the specified offer
+BasicTaker::Flow
+BasicTaker::do_cross (Amounts offer, Quality quality, Account const& owner)
+{
+    assert (!done ());
+
+    auto const owner_funds = get_funds (owner, offer.out);
+    auto const taker_funds = get_funds (account (), offer.in);
+
+    Flow result;
+
+    if (cross_type_ == CrossType::XrpToIou)
+    {
+        result = flow_xrp_to_iou (offer, quality, owner_funds, taker_funds, 
+            out_rate (owner, account ()));
+    }
+    else if (cross_type_ == CrossType::IouToXrp)
+    {
+        result = flow_iou_to_xrp (offer, quality, owner_funds, taker_funds,
+            in_rate (owner, account ()));
+    }
+    else
+    {
+        result = flow_iou_to_iou (offer, quality, owner_funds, taker_funds,
+            in_rate (owner, account ()), out_rate (owner, account ()));
+    }
+
+    if (!result.sanity_check ())
+        throw std::logic_error ("Computed flow fails sanity check.");
+
+    remaining_.out -= result.order.out;
+    remaining_.in -= result.order.in;
+
+    assert (remaining_.in >= zero);
+
+    return result;
+}
+
+// Calculates the bridged flow through the specified offers
+std::pair<BasicTaker::Flow, BasicTaker::Flow>
+BasicTaker::do_cross (
+    Amounts offer1, Quality quality1, Account const& owner1,
+    Amounts offer2, Quality quality2, Account const& owner2)
+{
+    assert (!done ());
+
+    assert (!offer1.in.isNative ());
+    assert (offer1.out.isNative ());
+    assert (offer2.in.isNative ());
+    assert (!offer2.out.isNative ());
+
+    // If the taker owns the first leg of the offer, then the taker's available
+    // funds aren't the limiting factor for the input - the offer itself is.
+    auto leg1_in_funds = get_funds (account (), offer1.in);
+
+    if (account () == owner1)
+        leg1_in_funds = std::max (leg1_in_funds, offer1.in);
+
+    // If the taker owns the second leg of the offer, then the taker's available
+    // funds are not the limiting factor for the output - the offer itself is.
+    auto leg2_out_funds = get_funds (owner2, offer2.out);
+
+    if (account () == owner2)
+        leg2_out_funds = std::max (leg2_out_funds, offer2.out);
+
+    // The amount available to flow via XRP is the amount that the owner of the
+    // first leg of the bridge has, up to the first leg's output.
+    //
+    // But, when both legs of a bridge are owned by the same person, the amount
+    // of XRP that can flow between the two legs is, essentially, infinite
+    // since all the owner is doing is taking out XRP of his left pocket
+    // and putting it in his right pocket. In that case, we set the available
+    // XRP to the largest of the two offers.
+    auto xrp_funds = get_funds (owner1, offer1.out);
+
+    if (owner1 == owner2)
+        xrp_funds = std::max (offer1.out, offer2.in);
+
+    auto const leg1_rate = in_rate (owner1, account ());
+    auto const leg2_rate = out_rate (owner2, account ());
+
+    // Attempt to determine the maximal flow that can be achieved across each
+    // leg independent of the other.
+    auto flow1 = flow_iou_to_xrp (offer1, quality1, xrp_funds, leg1_in_funds, leg1_rate);
+
+    if (!flow1.sanity_check ())
+        throw std::logic_error ("Computed flow1 fails sanity check.");
+
+    auto flow2 = flow_xrp_to_iou (offer2, quality2, leg2_out_funds, xrp_funds, leg2_rate);
+
+    if (!flow2.sanity_check ())
+        throw std::logic_error ("Computed flow2 fails sanity check.");
+
+    // We now have the maximal flows across each leg individually. We need to
+    // equalize them, so that the amount of XRP that flows out of the first leg
+    // is the same as the amount of XRP that flows into the second leg. We take
+    // the side which is the limiting factor (if any) and adjust the other.
+    if (flow1.order.out < flow2.order.in)
+    {
+        // Adjust the second leg of the offer down:
+        flow2.order.in = flow1.order.out;
+        flow2.order.out = qual_div (flow2.order.in, quality2, flow2.order.out);
+        flow2.issuers.out = leg2_rate.multiply (flow2.order.out);
+    }
+    else if (flow1.order.out > flow2.order.in)
+    {
+        // Adjust the first leg of the offer down:
+        flow1.order.out = flow2.order.in;
+        flow1.order.in = qual_mul (flow1.order.out, quality1, flow1.order.in);
+        flow1.issuers.in = leg1_rate.multiply (flow1.order.in);
+    }
+
+    if (flow1.order.out != flow2.order.in)
+        throw std::logic_error ("Bridged flow is out of balance.");
+
+    remaining_.out -= flow2.order.out;
+    remaining_.in -= flow1.order.in;
+
+    return std::make_pair (flow1, flow2);
+}
+
+//==============================================================================
+
+std::uint32_t
+Taker::calculateRate (
+    LedgerView& view, Account const& issuer, Account const& account)
+{
+    return isXRP (issuer) || (account == issuer)
+        ? QUALITY_ONE
+        : rippleTransferRate (view, issuer);
+}
+
+Taker::Taker (CrossType cross_type, LedgerView& view, Account const& account,
+        Amounts const& offer, std::uint32_t flags)
+    : BasicTaker (cross_type, account, offer, Quality(offer), flags,
+        calculateRate(view, offer.in.getIssuer(), account),
+        calculateRate(view, offer.out.getIssuer(), account))
+    , m_view (view)
+    , xrp_flow_ (0)
+    , direct_crossings_ (0)
+    , bridge_crossings_ (0)
+{
+    assert (issue_in () == offer.in.issue ());
+    assert (issue_out () == offer.out.issue ());
+}
+
+void
+Taker::consume_offer (Offer const& offer, Amounts const& order)
+{
+    if (order.in < zero)
+        throw std::logic_error ("flow with negative input.");
+
+    if (order.out < zero)
+        throw std::logic_error ("flow with negative output.");
+
+    return offer.consume (m_view, order);
+}
+
+Amount
+Taker::get_funds (Account const& account, Amount const& funds) const
+{
+    return m_view.accountFunds (account, funds, fhZERO_IF_FROZEN);
+}
+
+TER Taker::transfer_xrp (
+    Account const& from,
+    Account const& to,
+    Amount const& amount)
+{
+    if (!isXRP (amount))
+        throw std::logic_error ("Using transfer_xrp with IOU");
+
+    if (from == to)
+        return tesSUCCESS;
+
+    return m_view.transfer_xrp (from, to, amount);
+}
+
+TER Taker::redeem_iou (
+    Account const& account,
+    Amount const& amount,
+    Issue const& issue)
+{
+    if (isXRP (amount))
+        throw std::logic_error ("Using redeem_iou with XRP");
+
+    if (account == issue.account)
+        return tesSUCCESS;
+
+    return m_view.redeem_iou (account, amount, issue);
+}
+
+TER Taker::issue_iou (
+    Account const& account,
+    Amount const& amount,
+    Issue const& issue)
+{
+    if (isXRP (amount))
+        throw std::logic_error ("Using issue_iou with XRP");
+
+    if (account == issue.account)
+        return tesSUCCESS;
+
+    return m_view.issue_iou (account, amount, issue);
+}
+
+// Performs funds transfers to fill the given offer and adjusts offer.
+TER
+Taker::fill (BasicTaker::Flow const& flow, Offer const& offer)
+{
+    // adjust offer
+    consume_offer (offer, flow.order);
+
+    TER result = tesSUCCESS;
+
+    if (cross_type () != CrossType::XrpToIou)
+    {
+        assert (!isXRP (flow.order.in));
+
+        if(result == tesSUCCESS)
+            result = redeem_iou (account (), flow.issuers.in, flow.issuers.in.issue ());
+
+        if (result == tesSUCCESS)
+            result = issue_iou (offer.owner (), flow.order.in, flow.order.in.issue ());
+    }
+    else
+    {
+        assert (isXRP (flow.order.in));
+
+        if (result == tesSUCCESS)
+            result = transfer_xrp (account (), offer.owner (), flow.order.in);
+    }
+
+    // Now send funds from the account whose offer we're taking
+    if (cross_type () != CrossType::IouToXrp)
+    {
+        assert (!isXRP (flow.order.out));
+
+        if(result == tesSUCCESS)
+            result = redeem_iou (offer.owner (), flow.issuers.out, flow.issuers.out.issue ());
+
+        if (result == tesSUCCESS)
+            result = issue_iou (account (), flow.order.out, flow.order.out.issue ());
+    }
+    else
+    {
+        assert (isXRP (flow.order.out));
+
+        if (result == tesSUCCESS)
+            result = transfer_xrp (offer.owner (), account (), flow.order.out);
+    }
+
+    if (result == tesSUCCESS)
+        direct_crossings_++;
+
+    return result;
+}
+
+// Performs bridged funds transfers to fill the given offers and adjusts offers.
+TER
+Taker::fill (
+    BasicTaker::Flow const& flow1, Offer const& leg1,
+    BasicTaker::Flow const& flow2, Offer const& leg2)
+{
+    // Adjust offers accordingly
+    consume_offer (leg1, flow1.order);
+    consume_offer (leg2, flow2.order);
+
+    TER result = tesSUCCESS;
+
+    // Taker to leg1: IOU
+    if (leg1.owner () != account ())
+    {
+        if (result == tesSUCCESS)
+            result = redeem_iou (account (), flow1.issuers.in, flow1.issuers.in.issue ());
+
+        if (result == tesSUCCESS)
+            result = issue_iou (leg1.owner (), flow1.order.in, flow1.order.in.issue ());
+    }
+
+    // leg1 to leg2: bridging over XRP
+    if (result == tesSUCCESS)
+        result = transfer_xrp (leg1.owner (), leg2.owner (), flow1.order.out);
+
+    // leg2 to Taker: IOU
+    if (leg2.owner () != account ())
+    {
+        if (result == tesSUCCESS)
+            result = redeem_iou (leg2.owner (), flow2.issuers.out, flow2.issuers.out.issue ());
+
+        if (result == tesSUCCESS)
+            result = issue_iou (account (), flow2.order.out, flow2.order.out.issue ());
+    }
+
+    if (result == tesSUCCESS)
+    {
+        bridge_crossings_++;
+        xrp_flow_ += flow1.order.out;
+    }
+
+    return result;
 }
 
 TER
 Taker::cross (Offer const& offer)
 {
-    assert (!done ());
+    // In direct crossings, at least one leg must not be XRP.
+    if (isXRP (offer.amount ().in) && isXRP (offer.amount ().out))
+        return tefINTERNAL;
 
-    /* Before we call flow we must set the limit right; for buy semantics we
-       need to clamp the output. And we always want to clamp the input.
-     */
-    Amounts limit (offer.amount());
+    auto const amount = do_cross (
+        offer.amount (), offer.quality (), offer.owner ());
 
-    if (! m_options.sell)
-        limit = offer.quality ().ceil_out (limit, m_remain.out);
-    limit = offer.quality().ceil_in (limit, m_remain.in);
-
-    assert (limit.in <= offer.amount().in);
-    assert (limit.out <= offer.amount().out);
-    assert (limit.in <= m_remain.in);
-
-    Amounts const amount (flow (limit, offer, account ()));
-
-    m_remain.out -= amount.out;
-    m_remain.in -= amount.in;
-
-    assert (m_remain.in >= zero);
-    return fill (offer, amount);
+    return fill (amount, offer);
 }
 
 TER
 Taker::cross (Offer const& leg1, Offer const& leg2)
 {
-    assert (!done ());
+    // In bridged crossings, XRP must can't be the input to the first leg
+    // or the output of the second leg.
+    if (isXRP (leg1.amount ().in) || isXRP (leg2.amount ().out))
+        return tefINTERNAL;
 
-    assert (leg1.amount ().out.isNative ());
-    assert (leg2.amount ().in.isNative ());
+    auto ret = do_cross (
+        leg1.amount (), leg1.quality (), leg1.owner (),
+        leg2.amount (), leg2.quality (), leg2.owner ());
 
-    Amounts amount1 (leg1.amount());
-    Amounts amount2 (leg2.amount());
-
-    if (m_options.sell)
-        amount1 = leg1.quality().ceil_in (amount1, m_remain.in);
-    else
-        amount2 = leg2.quality().ceil_out (amount2, m_remain.out);
-
-    if (amount1.out <= amount2.in)
-        amount2 = leg2.quality().ceil_in (amount2, amount1.out);
-    else
-        amount1 = leg1.quality().ceil_out (amount1, amount2.in);
-
-    assert (amount1.out == amount2.in);
-
-    // As written, flow can't handle a 3-party transfer, but this works for
-    // us because the output of leg1 and the input leg2 are XRP.
-    Amounts flow1 (flow (amount1, leg1, m_account));
-
-    amount2 = leg2.quality().ceil_in (amount2, flow1.out);
-
-    Amounts flow2 (flow (amount2, leg2, m_account));
-
-    m_remain.out -= amount2.out;
-    m_remain.in -= amount1.in;
-
-    return fill (leg1, flow1, leg2, flow2);
+    return fill (ret.first, leg1, ret.second, leg2);
 }
 
 }

--- a/src/ripple/app/book/tests/Taker.test.cpp
+++ b/src/ripple/app/book/tests/Taker.test.cpp
@@ -1,0 +1,373 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/book/Taker.h>
+#include <ripple/app/book/Types.h>
+
+#include <beast/unit_test/suite.h>
+#include <beast/module/core/text/LexicalCast.h>
+
+#include <beast/cxx14/type_traits.h>
+
+
+namespace ripple {
+namespace core {
+
+class Taker_test : public beast::unit_test::suite
+{
+    static bool const Buy = false;
+    static bool const Sell = true;
+
+    class TestTaker
+        : public BasicTaker
+    {
+        Amount funds_;
+        Amount cross_funds;
+
+    public:
+        TestTaker (
+                CrossType cross_type, Amounts const& amount, Quality const& quality,
+                Amount const& funds, std::uint32_t flags, std::uint32_t rate_in,
+                std::uint32_t rate_out)
+            : BasicTaker (cross_type, Account(0x4701), amount, quality, flags, rate_in, rate_out)
+            , funds_ (funds)
+        {
+        }
+
+        void
+        set_funds (Amount const& funds)
+        {
+            cross_funds = funds;
+        }
+
+        Amount
+        get_funds (Account const& owner, Amount const& funds) const
+        {
+            if (owner == account ())
+                return funds_;
+
+            return cross_funds;
+        }
+
+        Amounts
+        cross (Amounts offer, Quality quality)
+        {
+            if (reject (quality))
+                return Amounts (offer.in.zeroed (), offer.out.zeroed ());
+
+            // we need to emulate "unfunded offers" behavior
+            if (get_funds (Account (0x4702), offer.out) == zero)
+                return Amounts (offer.in.zeroed (), offer.out.zeroed ());
+
+            if (done ())
+                return Amounts (offer.in.zeroed (), offer.out.zeroed ());
+
+            auto result = do_cross (offer, quality, Account (0x4702));
+
+            funds_ -= result.order.in;
+
+            return result.order;
+        }
+
+        std::pair<Amounts, Amounts>
+        cross (Amounts offer1, Quality quality1, Amounts offer2, Quality quality2)
+        {
+            /* check if composed quality should be rejected */
+            Quality const quality (core::composed_quality (quality1, quality2));
+
+            if (reject (quality))
+                return std::make_pair(
+                    Amounts { offer1.in.zeroed (), offer1.out.zeroed () },
+                    Amounts { offer2.in.zeroed (), offer2.out.zeroed () });
+
+            if (done ())
+                return std::make_pair(
+                    Amounts { offer1.in.zeroed (), offer1.out.zeroed () },
+                    Amounts { offer2.in.zeroed (), offer2.out.zeroed () });
+
+            auto result = do_cross (
+                offer1, quality1, Account (0x4703),
+                offer2, quality2, Account (0x4704));
+
+            return std::make_pair (result.first.order, result.second.order);
+        }
+    };
+
+private:
+    Issue const& usd () const
+    {
+        static Issue const issue (
+            Currency (0x5553440000000000), Account (0x4985601));
+        return issue;
+    }
+
+    Issue const& eur () const
+    {
+        static Issue const issue (
+            Currency (0x4555520000000000), Account (0x4985602));
+        return issue;
+    }
+
+    Issue const& xrp () const
+    {
+        static Issue const issue (
+            xrpCurrency (), xrpAccount ());
+        return issue;
+    }
+
+    Amount parse_amount (std::string const& amount, Issue const& issue)
+    {
+        Amount result (issue);
+        expect (result.setValue (amount), amount);
+        return result;
+    }
+
+    Amounts parse_amounts (
+        std::string const& amount_in, Issue const& issue_in,
+        std::string const& amount_out, Issue const& issue_out)
+    {
+        Amount const in (parse_amount (amount_in, issue_in));
+        Amount const out (parse_amount (amount_out, issue_out));
+
+        return { in, out };
+    }
+
+    struct cross_attempt_offer
+    {
+        cross_attempt_offer (std::string const& in_,
+            std::string const &out_)
+            : in (in_)
+            , out (out_)
+        {
+        }
+
+        std::string in;
+        std::string out;
+    };
+
+private:
+    std::string
+    format_amount (STAmount const& amount)
+    {
+        std::string txt = amount.getText ();
+        txt += "/";
+        txt += amount.getHumanCurrency ();
+        return txt;
+    }
+
+    void
+    attempt (
+        bool sell,
+        std::string name,
+        Quality taker_quality,
+        cross_attempt_offer const offer,
+        std::string const funds,
+        Quality cross_quality,
+        cross_attempt_offer const cross,
+        std::string const cross_funds,
+        cross_attempt_offer const flow,
+        Issue const& issue_in,
+        Issue const& issue_out,
+        std::uint32_t rate_in = QUALITY_ONE,
+        std::uint32_t rate_out = QUALITY_ONE)
+    {
+        Amounts taker_offer (parse_amounts (
+            offer.in, issue_in,
+            offer.out, issue_out));
+
+        Amounts cross_offer (parse_amounts (
+            cross.in, issue_in,
+            cross.out, issue_out));
+
+        CrossType cross_type;
+
+        if (isXRP (issue_out))
+            cross_type = core::CrossType::IouToXrp;
+        else if (isXRP (issue_in))
+            cross_type = core::CrossType::XrpToIou;
+        else
+            cross_type = CrossType::IouToIou;
+
+        // FIXME: We are always invoking the IOU-to-IOU taker. We should select
+        // the correct type dynamically.
+        TestTaker taker (cross_type, taker_offer, taker_quality,
+            parse_amount (funds, issue_in), sell ? tfSell : 0,
+            rate_in, rate_out);
+
+        taker.set_funds (parse_amount (cross_funds, issue_out));
+
+        auto result = taker.cross (cross_offer, cross_quality);
+
+        Amounts const expected (parse_amounts (
+            flow.in, issue_in,
+            flow.out, issue_out));
+        
+        expect (expected == result, name + (sell ? " (s)" : " (b)"));
+
+        if (expected != result)
+        {
+            log <<
+                "Expected: " << format_amount (expected.in) <<
+                " : " << format_amount (expected.out);
+            log <<
+                "  Actual: " << format_amount (result.in) <<
+                " : " << format_amount (result.out);
+        }
+
+        assert (expected == result);
+    }
+
+    Quality get_quality(std::string in, std::string out)
+    {
+        return Quality (parse_amounts (in, xrp(), out, xrp ()));
+    }
+
+public:
+    Taker_test ()
+    {
+    }
+
+    // Notation for clamp scenario descriptions:
+    // 
+    // IN:OUT (with the last in the list being limiting factor)
+    //  N  = Nothing
+    //  T  = Taker Offer Balance
+    //  A  = Taker Account Balance
+    //  B  = Owner Account Balance
+    //
+    // (s) = sell semantics: taker wants unlimited output
+    // (b) = buy semantics: taker wants a limited amount out
+
+    // NIKB TODO: Augment TestTaker so currencies and rates can be specified
+    //            once without need for repetition.
+    void
+    test_xrp_to_iou ()
+    {
+        testcase ("XRP Quantization: input");
+
+        Quality q1 = get_quality ("1", "1");
+
+        //                             TAKER                    OWNER
+        //                     QUAL    OFFER     FUNDS  QUAL    OFFER     FUNDS     EXPECTED
+        //                                        XRP                      USD
+        attempt (Sell, "N:N",   q1, { "2", "2" },  "2",  q1, { "2", "2" }, "2",   { "2", "2" },   xrp(), usd());
+        attempt (Sell, "N:B",   q1, { "2", "2" },  "2",  q1, { "2", "2" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "N:T",   q1, { "1", "1" },  "2",  q1, { "2", "2" }, "2",   { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "N:BT",  q1, { "1", "1" },  "2",  q1, { "2", "2" }, "1.8", { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "N:TB",  q1, { "1", "1" },  "2",  q1, { "2", "2" }, "0.8", { "0", "0.8" }, xrp(), usd());
+
+        attempt (Sell, "T:N",   q1, { "1", "1" },  "2",  q1, { "2", "2" }, "2",   { "1", "1" },   xrp(), usd());
+        attempt (Sell, "T:B",   q1, { "1", "1" },  "2",  q1, { "2", "2" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "T:T",   q1, { "1", "1" },  "2",  q1, { "2", "2" }, "2",   { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "T:BT",  q1, { "1", "1" },  "2",  q1, { "2", "2" }, "1.8", { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "T:TB",  q1, { "1", "1" },  "2",  q1, { "2", "2" }, "0.8", { "0", "0.8" }, xrp(), usd());
+
+        attempt (Sell, "A:N",   q1, { "2", "2" },  "1",  q1, { "2", "2" }, "2",   { "1", "1" },   xrp(), usd());
+        attempt (Sell, "A:B",   q1, { "2", "2" },  "1",  q1, { "2", "2" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "A:T",   q1, { "2", "2" },  "1",  q1, { "3", "3" }, "3",   { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "A:BT",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "2.4", { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "A:TB",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "0.8", { "0", "0.8" }, xrp(), usd());
+
+        attempt (Sell, "TA:N",  q1, { "2", "2" },  "1",  q1, { "2", "2" }, "2",   { "1", "1" },   xrp(), usd());
+        attempt (Sell, "TA:B",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "TA:T",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "3",   { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "TA:BT", q1, { "2", "2" },  "1",  q1, { "3", "3" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "TA:TB", q1, { "2", "2" },  "1",  q1, { "3", "3" }, "1.8", { "1", "1.8" }, xrp(), usd());
+
+        attempt (Sell, "AT:N",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "3",   { "1", "1" },   xrp(), usd());
+        attempt (Sell, "AT:B",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "AT:T",  q1, { "2", "2" },  "1",  q1, { "3", "3" }, "3",   { "1", "1" },   xrp(), usd());
+        attempt (Buy,  "AT:BT", q1, { "2", "2" },  "1",  q1, { "3", "3" }, "1.8", { "1", "1.8" }, xrp(), usd());
+        attempt (Buy,  "AT:TB", q1, { "2", "2" },  "1",  q1, { "3", "3" }, "0.8", { "0", "0.8" }, xrp(), usd());
+    }
+
+    void
+    test_iou_to_xrp ()
+    {
+        testcase ("XRP Quantization: output");
+
+        Quality q1 = get_quality ("1", "1");
+
+        //                             TAKER                     OWNER
+        //                     QUAL    OFFER     FUNDS   QUAL    OFFER     FUNDS    EXPECTED
+        //                                        USD                       XRP
+        attempt (Sell, "N:N",   q1, { "3", "3" }, "3",   q1, { "3", "3" }, "3",  { "3",   "3" }, usd(), xrp());
+        attempt (Sell, "N:B",   q1, { "3", "3" }, "3",   q1, { "3", "3" }, "2",  { "2",   "2" }, usd(), xrp());
+        attempt (Buy,  "N:T",   q1, { "3", "3" }, "2.5", q1, { "5", "5" }, "5",  { "2.5", "2" }, usd(), xrp());
+        attempt (Buy,  "N:BT",  q1, { "3", "3" }, "1.5", q1, { "5", "5" }, "4",  { "1.5", "1" }, usd(), xrp());
+        attempt (Buy,  "N:TB",  q1, { "3", "3" }, "2.2", q1, { "5", "5" }, "1",  { "1",   "1" }, usd(), xrp());
+
+        attempt (Sell, "T:N",   q1, { "1", "1" }, "2",   q1, { "2", "2" }, "2",  { "1",   "1" }, usd(), xrp());
+        attempt (Sell, "T:B",   q1, { "2", "2" }, "2",   q1, { "3", "3" }, "1",  { "1",   "1" }, usd(), xrp());
+        attempt (Buy,  "T:T",   q1, { "1", "1" }, "2",   q1, { "2", "2" }, "2",  { "1",   "1" }, usd(), xrp());
+        attempt (Buy,  "T:BT",  q1, { "1", "1" }, "2",   q1, { "3", "3" }, "2",  { "1",   "1" }, usd(), xrp());
+        attempt (Buy,  "T:TB",  q1, { "2", "2" }, "2",   q1, { "3", "3" }, "1",  { "1",   "1" }, usd(), xrp());
+
+        attempt (Sell, "A:N",   q1, { "2", "2" }, "1.5", q1, { "2", "2" }, "2",  { "1.5", "1" }, usd(), xrp());
+        attempt (Sell, "A:B",   q1, { "2", "2" }, "1.8", q1, { "3", "3" }, "2",  { "1.8", "1" }, usd(), xrp());
+        attempt (Buy,  "A:T",   q1, { "2", "2" }, "1.2", q1, { "3", "3" }, "3",  { "1.2", "1" }, usd(), xrp());
+        attempt (Buy,  "A:BT",  q1, { "2", "2" }, "1.5", q1, { "4", "4" }, "3",  { "1.5", "1" }, usd(), xrp());
+        attempt (Buy,  "A:TB",  q1, { "2", "2" }, "1.5", q1, { "4", "4" }, "1",  { "1",   "1" }, usd(), xrp());
+
+        attempt (Sell, "TA:N",  q1, { "2", "2" }, "1.5", q1, { "2", "2" }, "2",  { "1.5", "1" }, usd(), xrp());
+        attempt (Sell, "TA:B",  q1, { "2", "2" }, "1.5", q1, { "3", "3" }, "1",  { "1",   "1" }, usd(), xrp());
+        attempt (Buy,  "TA:T",  q1, { "2", "2" }, "1.5", q1, { "3", "3" }, "3",  { "1.5", "1" }, usd(), xrp());
+        attempt (Buy,  "TA:BT", q1, { "2", "2" }, "1.8", q1, { "4", "4" }, "3",  { "1.8", "1" }, usd(), xrp());
+        attempt (Buy,  "TA:TB", q1, { "2", "2" }, "1.2", q1, { "3", "3" }, "1",  { "1",   "1" }, usd(), xrp());
+
+        attempt (Sell, "AT:N",  q1, { "2", "2" }, "2.5", q1, { "4", "4" }, "4",  { "2",   "2" }, usd(), xrp());
+        attempt (Sell, "AT:B",  q1, { "2", "2" }, "2.5", q1, { "3", "3" }, "1",  { "1",   "1" }, usd(), xrp());
+        attempt (Buy,  "AT:T",  q1, { "2", "2" }, "2.5", q1, { "3", "3" }, "3",  { "2",   "2" }, usd(), xrp());
+        attempt (Buy,  "AT:BT", q1, { "2", "2" }, "2.5", q1, { "4", "4" }, "3",  { "2",   "2" }, usd(), xrp());
+        attempt (Buy,  "AT:TB", q1, { "2", "2" }, "2.5", q1, { "3", "3" }, "1",  { "1",   "1" }, usd(), xrp());
+    }
+
+    void
+    test_iou_to_iou ()
+    {
+        testcase ("IOU to IOU");
+
+        Quality q1 = get_quality ("1", "1");
+
+        // Highly exaggerated 50% transfer rate for the input and output:
+        std::uint32_t rate = QUALITY_ONE + (QUALITY_ONE / 2);
+
+        //                             TAKER                    OWNER
+        //                     QUAL    OFFER     FUNDS  QUAL    OFFER     FUNDS     EXPECTED
+        //                                        EUR                      USD
+        attempt (Sell, "N:N",   q1, { "2", "2" },  "10",  q1, { "2", "2" }, "10",   { "2",                  "2" },                  eur(), usd(), rate, rate);
+        attempt (Sell, "N:B",   q1, { "4", "4" },  "10",  q1, { "4", "4" },  "4",   { "2.666666666666666",  "2.666666666666666" },  eur(), usd(), rate, rate);
+        attempt (Buy,  "N:T",   q1, { "1", "1" },  "10",  q1, { "2", "2" }, "10",   { "1",                  "1" },                  eur(), usd(), rate, rate);
+        attempt (Buy,  "N:BT",  q1, { "2", "2" },  "10",  q1, { "6", "6" },  "5",   { "2",                  "2" },                  eur(), usd(), rate, rate);
+        attempt (Buy,  "N:TB",  q1, { "2", "2" },   "2",  q1, { "6", "6" },  "1",   { "0.6666666666666667", "0.6666666666666667" }, eur(), usd(), rate, rate);
+    }
+
+    void
+    run()
+    {
+        test_xrp_to_iou ();
+        test_iou_to_xrp ();
+        test_iou_to_iou ();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Taker,core,ripple);
+
+}
+}

--- a/src/ripple/app/ledger/LedgerEntrySet.h
+++ b/src/ripple/app/ledger/LedgerEntrySet.h
@@ -207,10 +207,6 @@ public:
 
     bool isGlobalFrozen (Account const& issuer);
 
-    STAmount rippleTransferFee (
-        Account const& uSenderID, Account const& uReceiverID,
-        Account const& issuer, const STAmount & saAmount);
-
     TER rippleCredit (
         Account const& uSenderID, Account const& uReceiverID,
         const STAmount & saAmount, bool bCheckIssuer = true);
@@ -282,6 +278,14 @@ public:
         mSet.setDeliveredAmount (amt);
     }
 
+    TER issue_iou (Account const& account,
+        STAmount const& amount, Issue const& issue);
+
+    TER redeem_iou (Account const& account,
+        STAmount const& amount, Issue const& issue);
+
+    TER transfer_xrp (Account const& from, Account const& to, STAmount const& amount);
+
 private:
     Ledger::pointer mLedger;
     std::map<uint256, LedgerEntrySetEntry>  mEntries; // cannot be unordered!
@@ -321,6 +325,9 @@ private:
     STAmount rippleHolds (
         Account const& account, Currency const& currency,
         Account const& issuer, FreezeHandling zeroIfFrozen);
+
+    bool checkState (SLE::pointer state, bool bIssuerHigh, 
+        Account const& sender, STAmount const& before, STAmount const& after);
 };
 
 // NIKB FIXME: move these to the right place

--- a/src/ripple/app/transactors/Transactor.cpp
+++ b/src/ripple/app/transactors/Transactor.cpp
@@ -153,57 +153,52 @@ TER Transactor::payFee ()
 
 TER Transactor::checkSig ()
 {
-    // Consistency: Check signature
-    // Verify the transaction's signing public key is the key authorized for signing.
-    if (mSigningPubKey.getAccountID () == mTxnAccountID)
-    {
-        // Authorized to continue.
-        mSigMaster = true;
-        if (mTxnAccount->isFlag(lsfDisableMaster))
-        return tefMASTER_DISABLED;
-    }
-    else if (mHasAuthKey && mSigningPubKey.getAccountID () == mTxnAccount->getFieldAccount160 (sfRegularKey))
-    {
-        // Authorized to continue.
-    }
-    else if (mHasAuthKey)
-    {
-        m_journal.trace << "applyTransaction: Delay: Not authorized to use account.";
-        return tefBAD_AUTH;
-    }
-    else
-    {
-        m_journal.trace << "applyTransaction: Invalid: Not authorized to use account.";
+    // Consistency: Check signature and verify the transaction's signing public
+    // key is the key authorized for signing.
 
+    auto const signing_account = mSigningPubKey.getAccountID ();
+
+    if (signing_account == mTxnAccountID)
+    {
+        if (mTxnAccount->isFlag(lsfDisableMaster))
+            return tefMASTER_DISABLED;
+
+        mSigMaster = true;
+        return tesSUCCESS;
+    }
+
+    if (!mHasAuthKey)
+    {
+        m_journal.trace << "Invalid: Not authorized to use account.";
         return temBAD_AUTH_MASTER;
     }
 
-    return tesSUCCESS;
+    if (signing_account == mTxnAccount->getFieldAccount160 (sfRegularKey))
+        return tesSUCCESS;
+
+    m_journal.trace << "Delay: Not authorized to use account.";
+    return tefBAD_AUTH;
 }
 
 TER Transactor::checkSeq ()
 {
-    std::uint32_t t_seq = mTxn.getSequence ();
-    std::uint32_t a_seq = mTxnAccount->getFieldU32 (sfSequence);
-
-    m_journal.trace << "Aseq=" << a_seq << ", Tseq=" << t_seq;
+    std::uint32_t const t_seq = mTxn.getSequence ();
+    std::uint32_t const a_seq = mTxnAccount->getFieldU32 (sfSequence);
 
     if (t_seq != a_seq)
     {
         if (a_seq < t_seq)
         {
-            m_journal.trace << "apply: transaction has future sequence number";
-
+            m_journal.trace << "Transaction has future sequence number " <<
+                "a_seq=" << a_seq << " t_seq=" << t_seq;
             return terPRE_SEQ;
         }
-        else
-        {
-            if (mEngine->getLedger ()->hasTransaction (mTxn.getTransactionID ()))
-                return tefALREADY;
-        }
 
-        m_journal.warning << "apply: transaction has past sequence number";
+        if (mEngine->getLedger ()->hasTransaction (mTxn.getTransactionID ()))
+            return tefALREADY;
 
+        m_journal.trace << "Transaction has past sequence number " <<
+            "a_seq=" << a_seq << " t_seq=" << t_seq;
         return tefPAST_SEQ;
     }
 

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -56,6 +56,7 @@ public:
     static const int cMinOffset = -96;
     static const int cMaxOffset = 80;
 
+    // Maximum native value supported by the code
     static const std::uint64_t cMinValue   = 1000000000000000ull;
     static const std::uint64_t cMaxValue   = 9999999999999999ull;
     static const std::uint64_t cMaxNative  = 9000000000000000000ull;
@@ -124,7 +125,7 @@ public:
 
     static
     STAmount
-    saFromRate (std::uint64_t uRate = 0)
+    saFromRate (std::uint64_t uRate)
     {
         return STAmount (noIssue(), uRate, -9, false);
     }

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -191,6 +191,7 @@ enum TER    // aka TransactionEngineResult
     tecNO_PERMISSION            = 139,
     tecNO_ENTRY                 = 140,
     tecINSUFFICIENT_RESERVE     = 141,
+    tecINTERNAL                 = 142,
 };
 
 inline bool isTelLocal(TER x)

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -59,6 +59,7 @@ bool transResultInfo (TER terCode, std::string& strToken, std::string& strHuman)
         {   tecNO_PERMISSION,       "tecNO_PERMISSION",         "No permission to perform requested operation."         },
         {   tecNO_ENTRY,            "tecNO_ENTRY",              "No matching entry found."                              },
         {   tecINSUFFICIENT_RESERVE,"tecINSUFFICIENT_RESERVE",  "Insufficient reserve to complete requested operation." },
+        {   tecINTERNAL,            "tecINTERNAL",              "An internal error has occurred during processing."     },
 
         {   tefALREADY,             "tefALREADY",               "The exact transaction was already in this ledger."     },
         {   tefBAD_ADD_AUTH,        "tefBAD_ADD_AUTH",          "Not authorized to add account."                        },

--- a/src/ripple/types/Issue.h
+++ b/src/ripple/types/Issue.h
@@ -86,6 +86,9 @@ bool isConsistent(IssueType<ByValue> const& ac)
 template <bool ByValue>
 std::string to_string (IssueType<ByValue> const& ac)
 {
+    if (isXRP (ac.account))
+        return to_string (ac.currency);
+
     return to_string(ac.account) + "/" + to_string(ac.currency);
 }
 

--- a/src/ripple/unity/app4.cpp
+++ b/src/ripple/unity/app4.cpp
@@ -23,6 +23,7 @@
 
 #include <ripple/app/book/tests/OfferStream.test.cpp>
 #include <ripple/app/book/tests/Quality.test.cpp>
+#include <ripple/app/book/tests/Taker.test.cpp>
 #include <ripple/app/ledger/InboundLedger.cpp>
 #include <ripple/app/paths/RippleState.cpp>
 #include <ripple/app/peers/UniqueNodeList.cpp>


### PR DESCRIPTION
* RIPD-486: Refactoring the taker into a unit-testable architecture
* RIPD-659: Asset-aware offer crossing
* RIPD-491: Unit tests for IOU to XRP, XRP to IOU and IOU to IOU
* RIPD-441: Handle case when autobridging over same owner offers
* RIPD-665: Handle case when autobridging over own offers
* RIPD-273: Groom order books while crossing

Additionally, add support in LedgerEntrySet to allow transfer fees
to be specified by calling code instead of being calculated by the
transfer functions:

* Implement new "issue/redeem" model for IOU movements
* Implement new "transfer" model for IOU movements

Clean up signature verification logic in the main Transactor.

Reviews: @JoelKatz, @rec, @vinniefalco but everyone is welcome to get in on the game.