### PR TITLE
Fix missing 'else' when handling sfMessageKey

### DIFF
--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -24,8 +24,8 @@ namespace ripple {
 class SetAccount
     : public Transactor
 {
-    static int const DOMAIN_BYTES_MAX = 256;
-    static int const PUBLIC_BYTES_MAX = 33;
+    static std::size_t const DOMAIN_BYTES_MAX = 256;
+    static std::size_t const PUBLIC_BYTES_MAX = 33;
 
 public:
     SetAccount (
@@ -86,7 +86,6 @@ public:
             if (!mEngine->view().dirIsEmpty (Ledger::getOwnerDirIndex (mTxnAccountID)))
             {
                 m_journal.trace << "Retry: Owner directory not empty.";
-
                 return (mParams & tapRETRY) ? terOWNERS : tecOWNERS;
             }
 
@@ -256,22 +255,20 @@ public:
         {
             Blob    vucPublic   = mTxn.getFieldVL (sfMessageKey);
 
+            if (vucPublic.size () > PUBLIC_BYTES_MAX)
+            {
+                m_journal.trace << "message key too long";
+                return telBAD_PUBLIC_KEY;
+            }
+
             if (vucPublic.empty ())
             {
                 m_journal.debug << "set message key";
-
                 mTxnAccount->makeFieldAbsent (sfMessageKey);
-            }
-            else if (vucPublic.size () > PUBLIC_BYTES_MAX)
-            {
-                m_journal.trace << "message key too long";
-
-                return telBAD_PUBLIC_KEY;
             }
             else
             {
                 m_journal.debug << "set message key";
-
                 mTxnAccount->setFieldVL (sfMessageKey, vucPublic);
             }
         }
@@ -284,22 +281,20 @@ public:
         {
             Blob    vucDomain   = mTxn.getFieldVL (sfDomain);
 
+            if (vucDomain.size () > DOMAIN_BYTES_MAX)
+            {
+                m_journal.trace << "domain too long";
+                return telBAD_DOMAIN;
+            }
+
             if (vucDomain.empty ())
             {
                 m_journal.trace << "unset domain";
-
                 mTxnAccount->makeFieldAbsent (sfDomain);
-            }
-            else if (vucDomain.size () > DOMAIN_BYTES_MAX)
-            {
-                m_journal.trace << "domain too long";
-
-                return telBAD_DOMAIN;
             }
             else
             {
                 m_journal.trace << "set domain";
-
                 mTxnAccount->setFieldVL (sfDomain, vucDomain);
             }
         }

--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -147,12 +147,6 @@ public:
         // DisableMaster
         //
 
-        if ((uSetFlag == asfDisableMaster) && (uClearFlag == asfDisableMaster))
-        {
-            m_journal.trace << "Malformed transaction: Contradictory flags set.";
-            return temINVALID_FLAG;
-        }
-
         if ((uSetFlag == asfDisableMaster) && !(uFlagsIn & lsfDisableMaster))
         {
             if (!mTxnAccount->isFieldPresent (sfRegularKey))
@@ -168,14 +162,14 @@ public:
             uFlagsOut   &= ~lsfDisableMaster;
         }
 
-        if ((uSetFlag == asfNoFreeze) && (uClearFlag != asfNoFreeze))
+        if (uSetFlag == asfNoFreeze)
         {
             m_journal.trace << "Set NoFreeze flag";
             uFlagsOut   |= lsfNoFreeze;
         }
 
         // Anyone may set global freeze
-        if ((uSetFlag == asfGlobalFreeze) && (uClearFlag != asfGlobalFreeze))
+        if (uSetFlag == asfGlobalFreeze)
         {
             m_journal.trace << "Set GlobalFreeze flag";
             uFlagsOut   |= lsfGlobalFreeze;
@@ -195,13 +189,13 @@ public:
         // Track transaction IDs signed by this account in its root
         //
 
-        if ((uSetFlag == asfAccountTxnID) && (uClearFlag != asfAccountTxnID) && !mTxnAccount->isFieldPresent (sfAccountTxnID))
+        if ((uSetFlag == asfAccountTxnID) && !mTxnAccount->isFieldPresent (sfAccountTxnID))
         {
             m_journal.trace << "Set AccountTxnID";
             mTxnAccount->makeFieldPresent (sfAccountTxnID);
          }
 
-        if ((uClearFlag == asfAccountTxnID) && (uSetFlag != asfAccountTxnID) && mTxnAccount->isFieldPresent (sfAccountTxnID))
+        if ((uClearFlag == asfAccountTxnID) && mTxnAccount->isFieldPresent (sfAccountTxnID))
         {
             m_journal.trace << "Clear AccountTxnID";
             mTxnAccount->makeFieldAbsent (sfAccountTxnID);

--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -49,7 +49,7 @@ public:
         std::uint32_t uFlagsOut = uFlagsIn;
 
         std::uint32_t const uSetFlag = mTxn.getFieldU32 (sfSetFlag);
-        std::uint32_t const uClearFlag  = mTxn.getFieldU32 (sfClearFlag);
+        std::uint32_t const uClearFlag = mTxn.getFieldU32 (sfClearFlag);
 
         if ((uSetFlag != 0) && (uSetFlag == uClearFlag))
         {
@@ -90,7 +90,7 @@ public:
             }
 
             m_journal.trace << "Set RequireAuth.";
-            uFlagsOut   |= lsfRequireAuth;
+            uFlagsOut |= lsfRequireAuth;
         }
 
         if (bClearRequireAuth && (uFlagsIn & lsfRequireAuth))
@@ -112,13 +112,13 @@ public:
         if (bSetRequireDest && !(uFlagsIn & lsfRequireDestTag))
         {
             m_journal.trace << "Set lsfRequireDestTag.";
-            uFlagsOut   |= lsfRequireDestTag;
+            uFlagsOut |= lsfRequireDestTag;
         }
 
         if (bClearRequireDest && (uFlagsIn & lsfRequireDestTag))
         {
             m_journal.trace << "Clear lsfRequireDestTag.";
-            uFlagsOut   &= ~lsfRequireDestTag;
+            uFlagsOut &= ~lsfRequireDestTag;
         }
 
         //
@@ -134,13 +134,13 @@ public:
         if (bSetDisallowXRP && !(uFlagsIn & lsfDisallowXRP))
         {
             m_journal.trace << "Set lsfDisallowXRP.";
-            uFlagsOut   |= lsfDisallowXRP;
+            uFlagsOut |= lsfDisallowXRP;
         }
 
         if (bClearDisallowXRP && (uFlagsIn & lsfDisallowXRP))
         {
             m_journal.trace << "Clear lsfDisallowXRP.";
-            uFlagsOut   &= ~lsfDisallowXRP;
+            uFlagsOut &= ~lsfDisallowXRP;
         }
 
         //
@@ -153,26 +153,26 @@ public:
                 return tecNO_REGULAR_KEY;
 
             m_journal.trace << "Set lsfDisableMaster.";
-            uFlagsOut   |= lsfDisableMaster;
+            uFlagsOut |= lsfDisableMaster;
         }
 
         if ((uClearFlag == asfDisableMaster) && (uFlagsIn & lsfDisableMaster))
         {
             m_journal.trace << "Clear lsfDisableMaster.";
-            uFlagsOut   &= ~lsfDisableMaster;
+            uFlagsOut &= ~lsfDisableMaster;
         }
 
         if (uSetFlag == asfNoFreeze)
         {
             m_journal.trace << "Set NoFreeze flag";
-            uFlagsOut   |= lsfNoFreeze;
+            uFlagsOut |= lsfNoFreeze;
         }
 
         // Anyone may set global freeze
         if (uSetFlag == asfGlobalFreeze)
         {
             m_journal.trace << "Set GlobalFreeze flag";
-            uFlagsOut   |= lsfGlobalFreeze;
+            uFlagsOut |= lsfGlobalFreeze;
         }
 
         // If you have set NoFreeze, you may not clear GlobalFreeze
@@ -182,7 +182,7 @@ public:
             ((uFlagsOut & lsfNoFreeze) == 0))
         {
             m_journal.trace << "Clear GlobalFreeze flag";
-            uFlagsOut   &= ~lsfGlobalFreeze;
+            uFlagsOut &= ~lsfGlobalFreeze;
         }
 
         //
@@ -207,7 +207,7 @@ public:
 
         if (mTxn.isFieldPresent (sfEmailHash))
         {
-            uint128     uHash   = mTxn.getFieldH128 (sfEmailHash);
+            uint128 const uHash = mTxn.getFieldH128 (sfEmailHash);
 
             if (!uHash)
             {
@@ -227,7 +227,7 @@ public:
 
         if (mTxn.isFieldPresent (sfWalletLocator))
         {
-            uint256     uHash   = mTxn.getFieldH256 (sfWalletLocator);
+            uint256 const uHash = mTxn.getFieldH256 (sfWalletLocator);
 
             if (!uHash)
             {
@@ -247,15 +247,15 @@ public:
 
         if (mTxn.isFieldPresent (sfMessageKey))
         {
-            Blob    vucPublic   = mTxn.getFieldVL (sfMessageKey);
+            Blob const messageKey = mTxn.getFieldVL (sfMessageKey);
 
-            if (vucPublic.size () > PUBLIC_BYTES_MAX)
+            if (messageKey.size () > PUBLIC_BYTES_MAX)
             {
                 m_journal.trace << "message key too long";
                 return telBAD_PUBLIC_KEY;
             }
 
-            if (vucPublic.empty ())
+            if (messageKey.empty ())
             {
                 m_journal.debug << "set message key";
                 mTxnAccount->makeFieldAbsent (sfMessageKey);
@@ -263,7 +263,7 @@ public:
             else
             {
                 m_journal.debug << "set message key";
-                mTxnAccount->setFieldVL (sfMessageKey, vucPublic);
+                mTxnAccount->setFieldVL (sfMessageKey, messageKey);
             }
         }
 
@@ -273,15 +273,15 @@ public:
 
         if (mTxn.isFieldPresent (sfDomain))
         {
-            Blob    vucDomain   = mTxn.getFieldVL (sfDomain);
+            Blob const domain = mTxn.getFieldVL (sfDomain);
 
-            if (vucDomain.size () > DOMAIN_BYTES_MAX)
+            if (domain.size () > DOMAIN_BYTES_MAX)
             {
                 m_journal.trace << "domain too long";
                 return telBAD_DOMAIN;
             }
 
-            if (vucDomain.empty ())
+            if (domain.empty ())
             {
                 m_journal.trace << "unset domain";
                 mTxnAccount->makeFieldAbsent (sfDomain);
@@ -289,7 +289,7 @@ public:
             else
             {
                 m_journal.trace << "set domain";
-                mTxnAccount->setFieldVL (sfDomain, vucDomain);
+                mTxnAccount->setFieldVL (sfDomain, domain);
             }
         }
 
@@ -299,7 +299,7 @@ public:
 
         if (mTxn.isFieldPresent (sfTransferRate))
         {
-            std::uint32_t      uRate   = mTxn.getFieldU32 (sfTransferRate);
+            std::uint32_t uRate = mTxn.getFieldU32 (sfTransferRate);
 
             if (!uRate || uRate == QUALITY_ONE)
             {

--- a/src/ripple/app/transactors/SetAccount.cpp
+++ b/src/ripple/app/transactors/SetAccount.cpp
@@ -262,7 +262,7 @@ public:
 
                 mTxnAccount->makeFieldAbsent (sfMessageKey);
             }
-            if (vucPublic.size () > PUBLIC_BYTES_MAX)
+            else if (vucPublic.size () > PUBLIC_BYTES_MAX)
             {
                 m_journal.trace << "message key too long";
 


### PR DESCRIPTION
When clearing out a message key the transactor would incorrectly
create an empty `sfMessageKey` field instead of simply deleting
the field.

[**Transaction Processing Change**]

Reviews:  @JoelKatz, @ximinez