### PR TITLE
Reword tesSUCCESS description to reduce confusion

### DIFF
--- a/src/ripple/data/protocol/TER.cpp
+++ b/src/ripple/data/protocol/TER.cpp
@@ -123,7 +123,7 @@ bool transResultInfo (TER terCode, std::string& strToken, std::string& strHuman)
         {   terPRE_SEQ,             "terPRE_SEQ",               "Missing/inapplicable prior transaction."               },
         {   terOWNERS,              "terOWNERS",                "Non-zero owner count."                                 },
 
-        {   tesSUCCESS,             "tesSUCCESS",               "The transaction was applied."                          },
+        {   tesSUCCESS,             "tesSUCCESS",               "The transaction was applied. Only final in a validated ledger."        },
     };
 
     int iIndex = RIPPLE_ARRAYSIZE (transResultInfoA);


### PR DESCRIPTION
One of the biggest sources of confusion for people integrating against the Ripple protocol is that the response to submit has this somewhat misleading description. I've reworded it to be a little more cautionary without being too specific or wordy.
