### PR TITLE
Update path tests:

### DIFF
--- a/test/declarative-path-test.coffee
+++ b/test/declarative-path-test.coffee
@@ -297,6 +297,20 @@ test_alternatives_factory = (realias_pp, realias_text) ->
                         error_context()
     return
 
+expand_source_currencies = (via) ->
+  expand_ = (via) ->
+    [currency, issuer] = via.split('/')
+    ret = {currency: currency}
+    if currency != 'XRP' and issuer?
+        ret.issuer = issuer
+    return ret
+
+  if via?
+    via = [via] unless Array.isArray via
+    source_currencies = (expand_(v) for v in via)
+  else
+    source_currencies = []
+
 ################################################################################
 
 create_path_test = (pth) ->
@@ -307,20 +321,12 @@ create_path_test = (pth) ->
     test_alternatives = test_alternatives_factory ledger.pretty_json.bind(ledger),
                                                   ledger.realias_issuer
 
-
     WHAT "#{pth.title}: #{pth.src} sending #{pth.dst}, "+
          "#{pth.send}, via #{pth.via}"
-
-    one_message = (f) ->
-      self.remote._servers[0].once 'before_send_message_for_non_mutators', f
-
-    sent = "TODO: need to patch ripple-lib"
-    one_message (m) -> sent = m
 
     error_info = (m, more) ->
       info =
         path_expected:     pth,
-        path_find_request: sent,
         path_find_updates: messages
 
       extend(info, more) if more?
@@ -333,8 +339,8 @@ create_path_test = (pth) ->
     _dst = UInt160.json_rewrite(pth.dst)
     _amt = Amount.from_json(pth.send)
 
-    # self.server.clear_logs() "TODO: need to patch ripple-lib"
-    pf = self.remote.path_find(_src, _dst, _amt, [{currency: pth.via}])
+    source_currencies = expand_source_currencies(pth.via)
+    pf = self.remote.path_find(_src, _dst, _amt, source_currencies)
 
     updates  = 0
     max_seen = 0
@@ -347,13 +353,19 @@ create_path_test = (pth) ->
       done()
 
     pf.on "update", propagates (m) ->                                      # <--
-      # TODO:hack:
-      expand_alternative alt for alt in m.alternatives
+      # TODO:hack:STILL:TODO
 
+      # ND: The story was I developed a shorthand notation as it helped to see
+      # the possible paths, seeing everything in a condensed form, with aliases
+      # instead of rBigZfkunAdresZeseck2aaaa0aapl, and the like. It turned out
+      # that rippled was over-specifying a lot of the information in the paths
+      # returned by the path finding commands, but by the time that was
+      # discovered a lot of the tests were written, so I wrote a routine to fill
+      # in the implied information.
+      expand_alternative alt for alt in m.alternatives
 
       messages[if updates then "update-#{updates}" else 'initial-response'] = m
       updates++
-      # console.log updates
 
       assert m.alternatives.length >= max_seen,
              "Subsequent path_find update' should never have less " +
@@ -361,16 +373,7 @@ create_path_test = (pth) ->
 
       max_seen = m.alternatives.length
 
-      # if updates == 2
-      #   testutils.ledger_close(self.remote, -> )
-
       if updates == 2
-        # "TODO: need to patch ripple-lib"
-        # self.log_pre(self.server.get_logs(), "Server Logs")
-
-        if pth.do_send?
-          do_send( (ledger.pretty_json.bind ledger), WHAT, self.remote, pth,
-                   messages['update-2'], done )
 
         if pth.debug
           console.log ledger.pretty_json(messages)
@@ -394,7 +397,7 @@ create_path_test = (pth) ->
           assert pth.n_alternatives ==  m.alternatives.length,
                  "fail (wrong n_alternatives): #{error_info(m)}"
 
-        done() if not pth.do_send?
+        done()
 
 ################################ SUITE CREATION ################################
 
@@ -430,7 +433,7 @@ suite_factory = (declaration) ->
       context = @
       @log_what = ->
 
-      testutils.build_setup().call @, ->
+      testutils.build_setup({no_server: declaration.no_server}).call @, ->
         context.ledger = new LedgerState(declaration.ledger,
                                          assert,
                                          context.remote,
@@ -462,355 +465,6 @@ catch e
 
 # You need two gateways, same currency. A market maker. A source that trusts one
 # gateway and holds its currency, and a destination that trusts the other.
-
-extend path_finding_cases,
-  "CNY test":
-    paths_expected:
-      BS:
-        P101: src: "SRC", dst: "GATEWAY_DST", send: "10.1/CNY/GATEWAY_DST", via: "XRP", n_alternatives: 1
-
-    ledger:
-      accounts:
-        SRC:
-          balance: ["4999.999898"]
-          trusts: []
-          offers: []
-
-        GATEWAY_DST:
-          balance: ["10846.168060"]
-          trusts: []
-          offers: []
-
-        MONEY_MAKER_1:
-          balance: ["4291.430036"]
-          trusts: []
-          offers: []
-
-        MONEY_MAKER_2:
-          balance: [
-            "106839375770"
-            "0.0000000003599/CNY/MONEY_MAKER_1"
-            "137.6852546843001/CNY/GATEWAY_DST"
-          ]
-          trusts: [
-            "1001/CNY/MONEY_MAKER_1"
-            "1001/CNY/GATEWAY_DST"
-          ]
-          offers: [
-            [
-              "1000000"
-              "1/CNY/GATEWAY_DST"
-              # []
-            ]
-            [
-              "1/CNY/GATEWAY_DST"
-              "1000000"
-              # []
-            ]
-            [
-              "318000/CNY/GATEWAY_DST"
-              "53000000000"
-              # ["Sell"]
-            ]
-            [
-              "209000000"
-              "4.18/CNY/MONEY_MAKER_2"
-              # []
-            ]
-            [
-              "990000/CNY/MONEY_MAKER_1"
-              "10000000000"
-              # ["Sell"]
-            ]
-            [
-              "9990000/CNY/MONEY_MAKER_1"
-              "10000000000"
-              # ["Sell"]
-            ]
-            [
-              "8870000/CNY/GATEWAY_DST"
-              "10000000000"
-              # ["Sell"]
-            ]
-            [
-              "232000000"
-              "5.568/CNY/MONEY_MAKER_2"
-              # []
-            ]
-          ]
-
-        A1:
-          balance: [
-            # "240.997150"
-            "1240.997150"
-            "0.0000000119761/CNY/MONEY_MAKER_1"
-            "33.047994/CNY/GATEWAY_DST"
-          ]
-          trusts: [
-            "1000000/CNY/MONEY_MAKER_1"
-            "100000/USD/MONEY_MAKER_1"
-            "10000/BTC/MONEY_MAKER_1"
-            "1000/USD/GATEWAY_DST"
-            "1000/CNY/GATEWAY_DST"
-          ]
-          offers: []
-
-        A2:
-          balance: [
-            "14115.046893"
-            "209.3081873019994/CNY/MONEY_MAKER_1"
-            "694.6251706504019/CNY/GATEWAY_DST"
-          ]
-          trusts: [
-            "3000/CNY/MONEY_MAKER_1"
-            "3000/CNY/GATEWAY_DST"
-          ]
-          offers: [
-            [
-              "2000000000"
-              "66.8/CNY/MONEY_MAKER_1"
-              # []
-            ]
-            [
-              "1200000000"
-              "42/CNY/GATEWAY_DST"
-              # []
-            ]
-            [
-              "43.2/CNY/MONEY_MAKER_1"
-              "900000000"
-              # ["Sell"]
-            ]
-          ]
-
-        A3:
-          balance: [
-            "512087.883181"
-            "23.617050013581/CNY/MONEY_MAKER_1"
-            "70.999614649799/CNY/GATEWAY_DST"
-          ]
-          trusts: [
-            "10000/CNY/MONEY_MAKER_1"
-            "10000/CNY/GATEWAY_DST"
-          ]
-          offers: [[
-            "2240/CNY/MONEY_MAKER_1"
-            "50000000000"
-            # ["Sell"]
-          ]]
-
-
-  "Path Tests (Bitstamp + SnapSwap account holders | liquidity provider with no offers)":
-    ledger:
-      accounts:
-        G1BS:
-          balance: ["1000.0"]
-        G2SW:
-          balance: ["1000.0"]
-        A1:
-          balance: ["1000.0", "1000/HKD/G1BS"]
-          trusts: ["2000/HKD/G1BS"]
-        A2:
-          balance: ["1000.0", "1000/HKD/G2SW"]
-          trusts: ["2000/HKD/G2SW"]
-        M1:
-          # SnapSwap wants to be able to set trust line quality settings so they
-          # can charge a fee when transactions ripple across. Liquitidy
-          # provider, via trusting/holding both accounts
-          balance: ["11000.0",
-                   "1200/HKD/G1BS",
-                   "5000/HKD/G2SW"
-          ]
-          trusts: ["100000/HKD/G1BS", "100000/HKD/G2SW"]
-          # We haven't got ANY offers
-
-    paths_expected: {
-      BS:
-        P1:
-          debug: false
-          src: "A1", dst: "A2", send: "10/HKD/A2", via: "HKD"
-          n_alternatives: 1
-        P2:
-          debug: false
-          src: "A2", dst: "A1", send: "10/HKD/A1", via: "HKD"
-          n_alternatives: 1
-        P3:
-          debug: false
-          src: "G1BS", dst: "A2", send: "10/HKD/A2", via: "HKD"
-          alternatives: [
-            amount: "10/HKD/G1BS",
-            paths: [["HKD/M1|M1", "HKD/G2SW|G2SW"]]
-          ]
-        P5:
-          debug: false
-          src: "M1",
-          send: "10/HKD/M1",
-          dst: "G1BS",
-          via: "HKD"
-        P4:
-          debug: false
-          src: "G2SW", send: "10/HKD/A1", dst: "A1", via: "HKD"
-          alternatives: [
-            amount: "10/HKD/G2SW",
-            paths: [["HKD/M1|M1", "HKD/G1BS|G1BS"]]
-          ]
-    }
-  "Path Tests #4 (non-XRP to non-XRP, same currency)": {
-    ledger:
-      accounts:
-        G1: balance: ["1000.0"]
-        G2: balance: ["1000.0"]
-        G3: balance: ["1000.0"]
-        G4: balance: ["1000.0"]
-        A1:
-          balance: ["1000.0", "1000/HKD/G1"]
-          trusts:  ["2000/HKD/G1"]
-        A2:
-          balance: ["1000.0", "1000/HKD/G2"]
-          trusts:  ["2000/HKD/G2"]
-        A3:
-          balance: ["1000.0", "1000/HKD/G1"]
-          trusts:  ["2000/HKD/G1"]
-        A4:
-          balance: ["10000.0"]
-        M1:
-          balance: ["11000.0", "1200/HKD/G1", "5000/HKD/G2"]
-          trusts:  ["100000/HKD/G1", "100000/HKD/G2"]
-          offers:  [
-            ["1000/HKD/G1", "1000/HKD/G2"]
-          ]
-        M2:
-          balance: ["11000.0", "1200/HKD/G1", "5000/HKD/G2"]
-          trusts:  ["100000/HKD/G1", "100000/HKD/G2"]
-          offers:  [
-            ["10000.0", "1000/HKD/G2"]
-            ["1000/HKD/G1", "10000.0"]
-          ]
-
-    paths_expected: {
-      T4:
-        "A) Borrow or repay":
-          comment: 'Source -> Destination (repay source issuer)'
-          src: "A1", send: "10/HKD/G1", dst: "G1", via: "HKD"
-          alternatives: [amount: "10/HKD/A1", paths: []]
-
-        "A2) Borrow or repay":
-          comment: 'Source -> Destination (repay destination issuer)'
-          src: "A1", send: "10/HKD/A1", dst: "G1", via: "HKD"
-          alternatives: [amount: "10/HKD/A1", paths: []]
-
-        "B) Common gateway":
-          comment: 'Source -> AC -> Destination'
-          src: "A1", send: "10/HKD/A3", dst: "A3", via: "HKD"
-          alternatives: [amount: "10/HKD/A1", paths: [["HKD/G1|G1"]]]
-
-        "C) Gateway to gateway":
-          comment: 'Source -> OB -> Destination'
-          src: "G1", send: "10/HKD/G2", dst: "G2", via: "HKD"
-          debug: false
-          alternatives: [
-            amount: "10/HKD/G1"
-            paths: [["HKD/M2|M2"],
-                    ["HKD/M1|M1"],
-                    ["HKD/G2|$"]
-                    ["XRP|$", "HKD/G2|$"]
-                  ]
-          ]
-
-        "D) User to unlinked gateway via order book":
-          comment: 'Source -> AC -> OB -> Destination'
-          src: "A1", send: "10/HKD/G2", dst: "G2", via: "HKD"
-          debug: false
-          alternatives: [
-            amount: "10/HKD/A1"
-            paths: [
-              ["HKD/G1|G1", "HKD/G2|$"],                                   # <--
-              ["HKD/G1|G1", "HKD/M2|M2"],
-              ["HKD/G1|G1", "HKD/M1|M1"],
-              ["HKD/G1|G1", "XRP|$", "HKD/G2|$"]
-            ]
-          ]
-
-        "I4) XRP bridge":
-          comment: 'Source -> AC -> OB to XRP -> OB from XRP -> AC -> Destination'
-          src: "A1", send: "10/HKD/A2", dst: "A2", via: "HKD"
-          debug: false
-          alternatives: [
-            amount: "10/HKD/A1",
-            paths: [
-              # Focus
-              ["HKD/G1|G1", "HKD/G2|$", "HKD/G2|G2"            ],
-              ["HKD/G1|G1", "XRP|$",    "HKD/G2|$", "HKD/G2|G2"],          # <--
-              # Incidental
-              ["HKD/G1|G1", "HKD/M1|M1", "HKD/G2|G2"],
-              ["HKD/G1|G1", "HKD/M2|M2", "HKD/G2|G2"]
-            ]
-          ]
-
-    }
-  },
-  "Path Tests #2 (non-XRP to non-XRP, same currency)": {
-    ledger:
-      accounts:
-        G1: balance: ["1000.0"]
-        G2: balance: ["1000.0"]
-        A1:
-          balance: ["1000.0", "1000/HKD/G1"]
-          trusts:  ["2000/HKD/G1"]
-        A2:
-          balance: ["1000.0", "1000/HKD/G2"]
-          trusts:  ["2000/HKD/G2"]
-        A3:
-          balance: ["1000.0"]
-          trusts:  ["2000/HKD/A2"]
-        M1:
-          balance: ["11000.0", "5000/HKD/G1", "5000/HKD/G2"]
-          trusts:  ["100000/HKD/G1", "100000/HKD/G2"]
-          offers:  [
-            ["1000/HKD/G1",    "1000/HKD/G2"]
-            # ["2000/HKD/G2",  "2000/HKD/G1"]
-            # ["2000/HKD/M1",  "2000/HKD/G1"]
-            # ["100.0",        "1000/HKD/G1"]
-            # ["1000/HKD/G1",        "100.0"]
-          ]
-
-    paths_expected: {
-      T4:
-        "E) Gateway to user":
-          ledger: false
-          comment: 'Source -> OB -> AC -> Destination'
-          # comment: 'Gateway -> OB -> Gateway 2 -> User'
-          src: "G1", send: "10/HKD/A2", dst: "A2", via: "HKD"
-          debug: false
-          alternatives: [
-            amount: "10/HKD/G1"
-            paths: [
-              ["HKD/G2|$", "HKD/G2|G2"],
-              ["HKD/M1|M1", "HKD/G2|G2"]
-            ]
-          ]
-
-        "F) Different gateways, ripple  _skip":
-          comment: 'Source -> AC -> AC -> Destination'
-
-        "G) Different users of different gateways, ripple  _skip":
-          comment: 'Source -> AC -> AC -> AC -> Destination'
-
-        "H) Different gateways, order book  _skip":
-          comment: 'Source -> AC -> OB -> AC -> Destination'
-
-        "I1) XRP bridge  _skip":
-          comment: 'Source -> OB to XRP -> OB from XRP -> Destination'
-          src: "A4", send: "10/HKD/G2", dst: "G2", via: "XRP"
-          debug: true
-
-        "I2) XRP bridge  _skip":
-          comment: 'Source -> AC -> OB to XRP -> OB from XRP -> Destination'
-
-        "I3) XRP bridge  _skip":
-          comment: 'Source -> OB to XRP -> OB from XRP -> AC -> Destination'
-    }
-  }
 
 ################################# DEFINE SUITES ################################
 

--- a/test/ledger-state.coffee
+++ b/test/ledger-state.coffee
@@ -1,6 +1,9 @@
 ################################### REQUIRES ###################################
 
 # This gives coffee-script proper file/lines in the exceptions
+{
+  writeFileSync
+}           = require 'fs'
 
 async       = require 'async'
 assert      = require 'assert'
@@ -27,9 +30,7 @@ exports.TestAccount = class TestAccount
     seed = Seed.from_json(passphrase)
     master_seed = seed.to_json()
     key_pair = seed.get_key()
-    pubKey = sjcl.codec.hex.toBits key_pair.to_hex_pub()
-    address = Base.encode_check(0,
-              sjcl.codec.bytes.fromBits(@SHA256_RIPEMD160 pubKey))
+    address = key_pair.get_address().to_json()
     [address, master_seed, key_pair]
 
   constructor: (passphrase) ->
@@ -197,6 +198,7 @@ class AliasManager
     "#{currency}/#{issuer}"
 
   create_issuer_realiaser: ->
+
     users = @config.accounts
     lookup = {}
     accounts = []
@@ -206,7 +208,9 @@ class AliasManager
       lookup[user.account] = name
 
     realias = new RegExp(accounts.join("|"), "g")
-    (str) -> str.replace(realias, (match) ->lookup[match])
+    (str, f) ->
+      f ?= (a) -> a
+      str.replace(realias, (match) -> f(lookup[match]))
 
 ############################# LEDGER STATE COMPILER ############################
 
@@ -412,6 +416,8 @@ exports.LedgerState = class LedgerState
     @am = new AliasManager(@config, @remote, Object.keys(@declaration.accounts))
     @realias_issuer = @am.realias_issuer
 
+  # bound to `this` via => so we can pass it around without having to bind every
+  # time
   pretty_json: (v) =>
     @realias_issuer pretty_json(v)
 
@@ -438,6 +444,8 @@ exports.LedgerState = class LedgerState
     @add_transaction_fees()
 
   compile_to_rpc_commands: ->
+    lines = ['#!/bin/bash']
+
     passphrase = (src) ->
       if src == 'root'
         'masterpassphrase'
@@ -447,47 +455,66 @@ exports.LedgerState = class LedgerState
     make_tx_json = (src, tt) ->
       {"Account": UInt160.json_rewrite(src), "TransactionType": tt}
 
-    submit_line = (src, tx_json) ->
-      "build/rippled submit #{passphrase(src)} '#{JSON.stringify tx_json}'"
+    submit_line = (src, tx_json) =>
+      # prefix any aliases with $ for later use as an environment variable
+      f = (a) -> "$#{a}"
+      "submit #{passphrase(src)} '#{@realias_issuer(pretty_json(tx_json), f)}'"
 
-    lines = []
-    ledger_accept = -> lines.push('build/rippled ledger_accept')
+    L = (l) -> lines.push l
+    separator = -> L('')
+    ledger_accept = ->
+      separator()
+      L('$RIPPLED ledger_accept')
+      separator()
 
+    separator()
+    L("export RIPPLED='build/gcc.debug/rippled'")
+    separator()
+
+    L("function submit ()")
+    L("{")
+    L('    txn="$(echo $2 | sed \'s/"/\\\\"/g\')"')
+    L('    ${RIPPLED} submit $1 "`eval echo -e $txn`" ')
+    L("}")
+    separator()
+
+    L('# All the accounts used')
+    Object.keys(@accounts).concat('root').forEach (a) ->
+      L("export #{a}='#{UInt160.json_rewrite a}'")
+
+    separator()
+    L('# Funding the accounts via XRP Payment from root')
     for [src, dst, amount] in @xrp_payments
       tx_json = make_tx_json(src, 'Payment')
       tx_json.Destination =  UInt160.json_rewrite dst
       tx_json.Amount = amount.to_json()
-      lines.push submit_line(src, tx_json)
+      L submit_line(src, tx_json)
 
     ledger_accept()
 
+    L('# Setting up trusts')
     for [src, limit] in @trusts
       tx_json = make_tx_json(src, 'TrustSet')
       tx_json.LimitAmount = limit.to_json()
-      lines.push submit_line(src, tx_json)
+      L submit_line(src, tx_json)
 
     ledger_accept()
 
+    L('# Issuing credit')
     for [src, dst, amount] in @iou_payments
       tx_json = make_tx_json(src, 'Payment')
       tx_json.Destination = UInt160.json_rewrite dst
       tx_json.Amount = amount.to_json()
-      lines.push submit_line(src, tx_json)
+      L submit_line(src, tx_json)
 
     ledger_accept()
 
+    L('# Setting up the books')
     for [src, pays, gets, flags] in @offers
       tx = new Transaction({secrets: {}})
       tx.offer_create(src, pays, gets)
-      tx.set_flags(flags)
-
-      # console.log tx.tx_json
-      # process.exit()
-
-      # tx_json = make_tx_json(src, 'OfferCreate')
-      # tx_json.TakerPays = pays.to_json()
-      # tx_json.TakerGets = gets.to_json()
-      lines.push submit_line(src, tx.tx_json)
+      tx.set_flags(flags ? ['Passive'])
+      L submit_line(src, tx.tx_json)
 
     ledger_accept()
     lines.join('\n')
@@ -568,6 +595,29 @@ exports.LedgerState = class LedgerState
             cb)
       (cb) ->
         testutils.ledger_close self.remote, cb
+
+      (cb) =>
+        to = @declaration.dump_ledger
+        if to?
+          req = @remote.request_ledger {full: true}
+          req.message.ledger_index = 'validated'
+          req.request (e, m) =>
+            m.ledger.accountStateRealiased = JSON.parse(@pretty_json(
+                                                        m.ledger.accountState))
+            m.ledger.declaration = @declaration
+            ledger_dump = pretty_json m.ledger
+            writeFileSync(to, ledger_dump)
+            cb()
+        else
+          cb()
+
+      (cb) =>
+        to = @declaration.dump_setup_script
+        if to?
+          writeFileSync(to, @compile_to_rpc_commands())
+
+        cb()
+
     ], (error) ->
       assert !error,
              "There was an error @ #{self.what}"

--- a/test/path-tests-json.js
+++ b/test/path-tests-json.js
@@ -1,88 +1,406 @@
 module.exports = {
+
+  // Suffixing this suite name with _only will run ONLY this test
+  // "Path Tests #6: Two orderbooks _only": {
+
+  // Suffixing this suite name with _skip will skip the test
+  // "Path Tests #6: Two orderbooks _skip": {
+
+  "Path Tests #6: Two orderbooks (RIPD-639)": {
+    // Maybe don't want to spawn the server, as we want to run the server under
+    // gdb or some other debugger.
+    // We can run `build/rippled -a --conf tmp/server/alpha/rippled.cfg`
+    no_server: false,
+    // warning: console.warn("This test is up the wazoo"),
+
+    ledger: {
+      // Set path to dump a full ledger after setup via `ledger` rpc request
+      // Includes this structure plus a realiased accountState (as well as
+      // unmodified).
+      // dump_ledger: "/some/path/ledger-dump.json",
+
+      // This will dump an equivalent rpc script, which will do the setting up.
+      // dump_setup_script: "/some/path/some-script.sh",
+
+      accounts: {
+        Alice: {
+          balance: ["1000.0", "1/FOO/GW1"],
+          // We only need to specify the trust if we need a trust greater
+          // than the balance.
+          // trusts: ["1/FOO/GW1"]
+        },
+
+        Mark: {
+          balance: ["1000.0", "1/FOO/GW2", "1/FOO/GW3"],
+          // We only need to specify the trust if we need a trust greater
+          // than the balance.
+          // trusts: ["1/FOO/GW2", "1/FOO/GW3"],
+
+                  // Pays          Gets
+          offers: [["1/FOO/GW1", "1/FOO/GW2"],
+                   ["1/FOO/GW2", "1/FOO/GW3"]]
+        },
+
+        GW1: {balance: ["1000.0"]},
+        GW2: {balance: ["1000.0"]},
+        GW3: {balance: ["1000.0"]}
+      }
+    },
+    paths_expected: {
+      A1: {
+        "E) user to gateway to gateyway to user (works) _skip": {
+          comment: 'Source -> OB -> OB -> Destination',
+          src: "Alice",
+          // destination_amount
+          send: "1/FOO/GW3",
+          // destination account
+          dst: "GW3",
+          // specify as source currency (non optional)
+          via: "FOO",
+          // will dump more information
+          debug: false,
+          alternatives: [
+            {
+              // source_amount
+              amount: "1/FOO/Alice",
+              paths: [
+                [
+                // Through GW1
+                "FOO/GW1|GW1",
+                // Through Orderbook
+                "FOO/GW2|$",
+                // Through Orderbook
+                "FOO/GW3|$"
+                ]
+              ]
+            }
+            ]
+        },
+        "E) user to gateway to gateyway to user (is broken)": {
+          src: "Alice",
+          send: "1/FOO/GW3",
+          dst: "GW3",
+          via: "FOO",
+          debug: false,
+          alternatives: []
+        },
+      }
+    }
+  },
+
   "Path Tests #1 (XRP -> XRP) and #2 (XRP -> IOU)": {
 
-    "ledger": {"accounts": {"A1": {"balance": ["100000.0",
-                                               "3500/XYZ/G1",
-                                               "1200/ABC/G3"],
-                                   "trusts": ["5000/XYZ/G1",
-                                              "5000/ABC/G3"]},
-                            "A2": {"balance": ["10000.0"],
-                                   "trusts": ["5000/XYZ/G2",
-                                              "5000/ABC/G3"]},
-                            "A3": {"balance": ["1000.0"],
-                                   "trusts": ["1000/ABC/A2"]},
-                            "G1": {"balance": ["1000.0"]},
-                            "G2": {"balance": ["1000.0"]},
-                            "G3": {"balance": ["1000.0"]},
-                            "M1": {"balance": ["1000.0",
-                                               "25000/XYZ/G2",
-                                               "25000/ABC/G3"],
-                                   "offers": [["1000/XYZ/G1",
-                                               "1000/XYZ/G2"],
-                                              ["10000.0",
-                                               "1000/ABC/G3"]],
-                                   "trusts": ["100000/XYZ/G1",
-                                              "100000/ABC/G3",
-                                              "100000/XYZ/G2"]}}},
+    "ledger": {
+      "accounts":
+        {"A1": {"balance": ["100000.0", "3500/XYZ/G1", "1200/ABC/G3"],
+                "trusts": ["5000/XYZ/G1", "5000/ABC/G3"]},
+         "A2": {"balance": ["10000.0"], "trusts": ["5000/XYZ/G2", "5000/ABC/G3"]},
+         "A3": {"balance": ["1000.0"], "trusts": ["1000/ABC/A2"]},
+         "G1": {"balance": ["1000.0"]},
+         "G2": {"balance": ["1000.0"]},
+         "G3": {"balance": ["1000.0"]},
+         "M1": {"balance": ["1000.0", "25000/XYZ/G2", "25000/ABC/G3"],
+                "offers": [["1000/XYZ/G1", "1000/XYZ/G2"],
+                           ["10000.0", "1000/ABC/G3"]],
+                "trusts": ["100000/XYZ/G1", "100000/ABC/G3", "100000/XYZ/G2"]}}},
 
-    "paths_expected": {"T1": {"A1": {"n_alternatives": 0,
-                                     "src": "A1",
-                                     "send": "10.0",
-                                     "dst": "A2",
-                                     "via": "XRP"},
-                              "A2": {"comment": "Send to non existing account",
-                                     "src": "A1",
-                                     "send_comment": "malformed error not great for 10.0 amount",
-                                     "send": "200.0",
-                                     "dst": "rBmhuVAvi372AerwzwERGjhLjqkMmAwxX",
-                                     "via": "XRP",
-                                     "n_alternatives": 0}},
-                       "T2": {"A": {"alternatives": [{"amount": "100.0",
-                                                           "paths": [
-                                                            ["ABC/G3|$"]
-                                                           ]}],
-                                    "src": "A2",
-                                    "send": "10/ABC/G3",
-                                    "dst": "G3",
-                                    "via": "XRP",
-                                    "debug": 0,
-                                    "n_alternatives": 1},
-                              "B": {"alternatives": [{"amount": "10.0",
-                                                      "paths": [["ABC/G3|$",
-                                                                 "ABC/G3|G3"]]}],
-                                    "src": "A1",
-                                    "send": "1/ABC/A2",
-                                    "dst": "A2",
-                                    "via": "XRP",
-                                    "n_alternatives": 1},
-                              "C": {"alternatives": [{"amount": "10.0",
-                                                      "paths": [["ABC/G3|$",
-                                                                 "ABC/G3|G3",
-                                                                 "ABC/A2|A2"]]}],
-                                    "src": "A1",
-                                    "send": "1/ABC/A3",
-                                    "dst": "A3",
-                                    "via": "XRP",
-                                    "n_alternatives": 1}}}},
+    "paths_expected": {
+      "T1": {"A1": {"dst": "A2",
+                     "n_alternatives": 0,
+                     "send": "10.0",
+                     "src": "A1",
+                     "via": "XRP"},
+              "A2": {"comment": "Send to non existing account",
+                     "dst": "rBmhuVAvi372AerwzwERGjhLjqkMmAwxX",
+                     "n_alternatives": 0,
+                     "send": "200.0",
+                     "send_comment": "malformed error not great for 10.0 amount",
+                     "src": "A1",
+                     "via": "XRP"}},
+       "T2": {"A": {"alternatives": [{"amount": "100.0", "paths": [["ABC/G3|$"]]}],
+                    "debug": 0,
+                    "dst": "G3",
+                    "n_alternatives": 1,
+                    "send": "10/ABC/G3",
+                    "src": "A2",
+                    "via": "XRP"},
+              "B": {"alternatives": [{"amount": "10.0",
+                                      "paths": [["ABC/G3|$", "ABC/G3|G3"]]}],
+                    "dst": "A2",
+                    "n_alternatives": 1,
+                    "send": "1/ABC/A2",
+                    "src": "A1",
+                    "via": "XRP"},
+              "C": {"alternatives": [{"amount": "10.0",
+                                      "paths": [["ABC/G3|$",
+                                                 "ABC/G3|G3",
+                                                 "ABC/A2|A2"]]}],
+                    "dst": "A3",
+                    "n_alternatives": 1,
+                    "send": "1/ABC/A3",
+                    "src": "A1",
+                    "via": "XRP"}}}},
+
  "Path Tests #3 (non-XRP to XRP)": {
 
-    "ledger": {"accounts": {"A1": {"balance": ["1000.0",
-                                               "1000/ABC/G3"]},
-                            "A2": {"balance": ["1000.0",
-                                               "1000/ABC/G3"]},
-                            "G3": {"balance": ["1000.0"]},
-                            "M1": {"balance": ["11000.0",
-                                               "1200/ABC/G3"],
-                                   "offers": [["1000/ABC/G3",
-                                               "10000.0"]],
-                                   "trusts": ["100000/ABC/G3"]}}},
+    "ledger": {
+       "accounts": {"A1": {"balance": ["1000.0", "1000/ABC/G3"]},
+                    "A2": {"balance": ["1000.0", "1000/ABC/G3"]},
+                    "G3": {"balance": ["1000.0"]},
+                    "M1": {"balance": ["11000.0", "1200/ABC/G3"],
+                           "offers": [["1000/ABC/G3", "10000.0"]],
+                           "trusts": ["100000/ABC/G3"]}}},
 
-    "paths_expected": {"T3": {"A": {"alternatives": [{"amount": "1/ABC/A1",
-                                                      "paths": [["ABC/G3|G3",
-                                                                 "XRP|$"]]}],
-                                    "src": "A1",
-                                    "dst": "A2",
-                                    "debug":false,
-                                    "send": "10.0",
-                                    "via": "ABC"}}}}
+    "paths_expected": {
+      "T3": {
+        "A": {"alternatives": [{"amount": "1/ABC/G3", "paths": []}],
+               "debug": false,
+               "dst": "A2",
+               "send": "10.0",
+               "src": "A1",
+               "via": ["ABC/G3"]},
+
+         "B": {"alternatives": [{"amount": "1/ABC/G3", "paths": []},
+                                {"amount": "1/ABC/A1",
+                                 "paths": [["ABC/G3|G3", "XRP|$"]]}],
+               "debug": false,
+               "dst": "A2",
+               "send": "10.0",
+               "src": "A1",
+               "via": ["ABC/G3", "ABC/A1"]}}},
+  },
+
+  "CNY test":{
+    "ledger": {
+      "accounts": {
+        "A1": {"balance": ["1240.997150",
+                            "0.0000000119761/CNY/MONEY_MAKER_1",
+                            "33.047994/CNY/GATEWAY_DST"],
+                "offers": [],
+                "trusts": ["1000000/CNY/MONEY_MAKER_1",
+                           "100000/USD/MONEY_MAKER_1",
+                           "10000/BTC/MONEY_MAKER_1",
+                           "1000/USD/GATEWAY_DST",
+                           "1000/CNY/GATEWAY_DST"]},
+
+         "A2": {"balance": ["14115.046893",
+                            "209.3081873019994/CNY/MONEY_MAKER_1",
+                            "694.6251706504019/CNY/GATEWAY_DST"],
+                "offers": [["2000000000", "66.8/CNY/MONEY_MAKER_1"],
+                           ["1200000000", "42/CNY/GATEWAY_DST"],
+                           ["43.2/CNY/MONEY_MAKER_1", "900000000"]],
+                "trusts": ["3000/CNY/MONEY_MAKER_1", "3000/CNY/GATEWAY_DST"]},
+
+         "A3": {"balance": ["512087.883181",
+                            "23.617050013581/CNY/MONEY_MAKER_1",
+                            "70.999614649799/CNY/GATEWAY_DST"],
+                "offers": [["2240/CNY/MONEY_MAKER_1", "50000000000"]],
+                "trusts": ["10000/CNY/MONEY_MAKER_1", "10000/CNY/GATEWAY_DST"]},
+
+         "GATEWAY_DST": {"balance": ["10846.168060"], "offers": [], "trusts": []},
+
+         "MONEY_MAKER_1": {"balance": ["4291.430036"], "offers": [], "trusts": []},
+
+         "MONEY_MAKER_2": {"balance": ["106839375770",
+                                       "0.0000000003599/CNY/MONEY_MAKER_1",
+                                       "137.6852546843001/CNY/GATEWAY_DST"],
+                           "offers": [["1000000", "1/CNY/GATEWAY_DST"],
+                                      ["1/CNY/GATEWAY_DST", "1000000"],
+                                      ["318000/CNY/GATEWAY_DST", "53000000000"],
+                                      ["209000000", "4.18/CNY/MONEY_MAKER_2"],
+                                      ["990000/CNY/MONEY_MAKER_1", "10000000000"],
+                                      ["9990000/CNY/MONEY_MAKER_1", "10000000000"],
+                                      ["8870000/CNY/GATEWAY_DST", "10000000000"],
+                                      ["232000000", "5.568/CNY/MONEY_MAKER_2"]],
+                           "trusts": ["1001/CNY/MONEY_MAKER_1",
+                                      "1001/CNY/GATEWAY_DST"]},
+
+         "SRC": {"balance": ["4999.999898"], "offers": [], "trusts": []}}},
+
+    "paths_expected": {
+      "BS": {"P101": {"dst": "GATEWAY_DST",
+                       "n_alternatives": 1,
+                       "send": "10.1/CNY/GATEWAY_DST",
+                       "src": "SRC",
+                       "via": "XRP"}}}},
+
+  "Path Tests (Bitstamp + SnapSwap account holders | liquidity provider with no offers)": {
+    "ledger": {
+      "accounts": {"A1": {"balance": ["1000.0", "1000/HKD/G1BS"],
+                           "trusts": ["2000/HKD/G1BS"]},
+                    "A2": {"balance": ["1000.0", "1000/HKD/G2SW"],
+                           "trusts": ["2000/HKD/G2SW"]},
+                    "G1BS": {"balance": ["1000.0"]},
+                    "G2SW": {"balance": ["1000.0"]},
+                    "M1": {"balance": ["11000.0",
+                                       "1200/HKD/G1BS",
+                                       "5000/HKD/G2SW"],
+                           "trusts": ["100000/HKD/G1BS", "100000/HKD/G2SW"]}}},
+    "paths_expected": {
+      "BS": {
+        "P1": {"debug": false,
+               "dst": "A2",
+               "n_alternatives": 1,
+               "send": "10/HKD/A2",
+               "src": "A1",
+               "via": "HKD"},
+        "P2": {"debug": false,
+               "dst": "A1",
+               "n_alternatives": 1,
+               "send": "10/HKD/A1",
+               "src": "A2",
+               "via": "HKD"},
+        "P3": {"alternatives": [{"amount": "10/HKD/G1BS",
+                                 "paths": [["HKD/M1|M1", "HKD/G2SW|G2SW"]]}],
+               "debug": false,
+               "dst": "A2",
+               "send": "10/HKD/A2",
+               "src": "G1BS",
+               "via": "HKD"},
+        "P4": {"alternatives": [{"amount": "10/HKD/G2SW",
+                                 "paths": [["HKD/M1|M1", "HKD/G1BS|G1BS"]]}],
+               "debug": false,
+               "dst": "A1",
+               "send": "10/HKD/A1",
+               "src": "G2SW",
+               "via": "HKD"},
+        "P5": {"debug": false,
+               "dst": "G1BS",
+               "send": "10/HKD/M1",
+               "src": "M1",
+               "via": "HKD"}}}},
+
+  "Path Tests #4 (non-XRP to non-XRP, same currency)": {
+    "ledger": {
+      "accounts": {
+        "A1": {"balance": ["1000.0", "1000/HKD/G1"], "trusts": ["2000/HKD/G1"]},
+         "A2": {"balance": ["1000.0", "1000/HKD/G2"], "trusts": ["2000/HKD/G2"]},
+         "A3": {"balance": ["1000.0", "1000/HKD/G1"], "trusts": ["2000/HKD/G1"]},
+         "A4": {"balance": ["10000.0"]},
+         "G1": {"balance": ["1000.0"]},
+         "G2": {"balance": ["1000.0"]},
+         "G3": {"balance": ["1000.0"]},
+         "G4": {"balance": ["1000.0"]},
+         "M1": {"balance": ["11000.0", "1200/HKD/G1", "5000/HKD/G2"],
+                "offers": [["1000/HKD/G1", "1000/HKD/G2"]],
+                "trusts": ["100000/HKD/G1", "100000/HKD/G2"]},
+         "M2": {"balance": ["11000.0", "1200/HKD/G1", "5000/HKD/G2"],
+                "offers": [["10000.0", "1000/HKD/G2"], ["1000/HKD/G1", "10000.0"]],
+                "trusts": ["100000/HKD/G1", "100000/HKD/G2"]}}},
+
+    "paths_expected": {
+      "T4": {
+        "A) Borrow or repay": {
+          "alternatives": [{"amount": "10/HKD/A1", "paths": []}],
+          "comment": "Source -> Destination (repay source issuer)",
+          "dst": "G1",
+          "send": "10/HKD/G1",
+          "src": "A1",
+          "via": "HKD"},
+
+        "A2) Borrow or repay": {
+          "alternatives": [{"amount": "10/HKD/A1", "paths": []}],
+          "comment": "Source -> Destination (repay destination issuer)",
+          "dst": "G1",
+          "send": "10/HKD/A1",
+          "src": "A1",
+          "via": "HKD"},
+
+        "B) Common gateway": {
+          "alternatives": [{"amount": "10/HKD/A1", "paths": [["HKD/G1|G1"]]}],
+          "comment": "Source -> AC -> Destination",
+          "dst": "A3",
+          "send": "10/HKD/A3",
+          "src": "A1",
+          "via": "HKD"},
+
+        "C) Gateway to gateway": {
+           "alternatives": [{"amount": "10/HKD/G1",
+                             "paths": [["HKD/M2|M2"],
+                                       ["HKD/M1|M1"],
+                                       ["HKD/G2|$"],
+                                       ["XRP|$", "HKD/G2|$"]]}],
+           "comment": "Source -> OB -> Destination",
+           "debug": false,
+           "dst": "G2",
+           "send": "10/HKD/G2",
+           "src": "G1",
+           "via": "HKD"},
+
+        "D) User to unlinked gateway via order book": {
+          "alternatives": [{"amount": "10/HKD/A1",
+                            "paths": [["HKD/G1|G1", "HKD/G2|$"],
+                                      ["HKD/G1|G1", "HKD/M2|M2"],
+                                      ["HKD/G1|G1", "HKD/M1|M1"],
+                                      ["HKD/G1|G1", "XRP|$", "HKD/G2|$"]]}],
+          "comment": "Source -> AC -> OB -> Destination",
+          "debug": false,
+          "dst": "G2",
+          "send": "10/HKD/G2",
+          "src": "A1",
+          "via": "HKD"},
+
+        "I4) XRP bridge": {
+          "alternatives": [{"amount": "10/HKD/A1",
+                            "paths": [["HKD/G1|G1", "HKD/G2|$", "HKD/G2|G2"],
+                                      ["HKD/G1|G1",
+                                       "XRP|$",
+                                       "HKD/G2|$",
+                                       "HKD/G2|G2"],
+                                      ["HKD/G1|G1", "HKD/M1|M1", "HKD/G2|G2"],
+                                      ["HKD/G1|G1", "HKD/M2|M2", "HKD/G2|G2"]]}],
+          "comment": "Source -> AC -> OB to XRP -> OB from XRP -> AC -> Destination",
+          "debug": false,
+          "dst": "A2",
+          "send": "10/HKD/A2",
+          "src": "A1",
+          "via": "HKD"}}}},
+
+  "Path Tests #2 (non-XRP to non-XRP, same currency)": {
+    "ledger": {
+      "accounts": {
+        "A1": {"balance": ["1000.0", "1000/HKD/G1"], "trusts": ["2000/HKD/G1"]},
+        "A2": {"balance": ["1000.0", "1000/HKD/G2"], "trusts": ["2000/HKD/G2"]},
+        "A3": {"balance": ["1000.0"], "trusts": ["2000/HKD/A2"]},
+        "G1": {"balance": ["1000.0"]},
+        "G2": {"balance": ["1000.0"]},
+        "M1": {"balance": ["11000.0", "5000/HKD/G1", "5000/HKD/G2"],
+               "offers": [["1000/HKD/G1", "1000/HKD/G2"]],
+               "trusts": ["100000/HKD/G1", "100000/HKD/G2"]}}},
+
+    "paths_expected": {
+      "T4": {
+        "E) Gateway to user": {
+            "alternatives": [{"amount": "10/HKD/G1",
+                             "paths": [["HKD/G2|$", "HKD/G2|G2"],
+                                       ["HKD/M1|M1", "HKD/G2|G2"]]}],
+           "comment": "Source -> OB -> AC -> Destination",
+           "debug": false,
+           "dst": "A2",
+           "ledger": false,
+           "send": "10/HKD/A2",
+           "src": "G1",
+           "via": "HKD"},
+
+        "F) Different gateways, ripple  _skip": {
+          "comment": "Source -> AC -> AC -> Destination"},
+
+        "G) Different users of different gateways, ripple  _skip": {
+          "comment": "Source -> AC -> AC -> AC -> Destination"},
+
+        "H) Different gateways, order book  _skip": {
+          "comment": "Source -> AC -> OB -> AC -> Destination"},
+
+        "I1) XRP bridge  _skip": {
+            "comment": "Source -> OB to XRP -> OB from XRP -> Destination",
+           "debug": true,
+           "dst": "G2",
+           "send": "10/HKD/G2",
+           "src": "A4",
+           "via": "XRP"},
+
+        "I2) XRP bridge  _skip": {
+          "comment": "Source -> AC -> OB to XRP -> OB from XRP -> Destination"},
+        "I3) XRP bridge  _skip": {
+          "comment": "Source -> OB to XRP -> OB from XRP -> AC -> Destination"}}}}
 }


### PR DESCRIPTION
- Add test for RIPD-639
- Add ability to specify `no_server`
- Add ability to dump ledger setup to rpc script
- Add ability to dump the ledger after setup for inspection
- Add ability to declare multiple currencies with via
- Move all path test declarations into the js file
- Use new ripple-lib features in TestAccount
