### PR TITLE
Adjust SSL context generation for Server:

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -712,8 +712,11 @@ public:
         //
         //----------------------------------------------------------------------
 
-        serverHandler_->setup (setup_ServerHandler(getConfig(), std::cerr),
-            m_journal);
+        {
+            auto setup = setup_ServerHandler(getConfig(), std::cerr);
+            setup.makeContexts();
+            serverHandler_->setup (setup, m_journal);
+        }
 
         // VFALCO NOTE Unfortunately, in stand-alone mode some code still
         //             foolishly calls overlay(). When this is fixed we can

--- a/src/ripple/server/Port.h
+++ b/src/ripple/server/Port.h
@@ -54,6 +54,11 @@ struct Port
     bool
     websockets() const;
 
+    // Returns `true` if any secure protocols are specified
+    template <class = void>
+    bool
+    secure() const;
+
     // Returns a string containing the list of protocols
     template <class = void>
     std::string
@@ -67,6 +72,14 @@ bool
 Port::websockets() const
 {
     return protocol.count("ws") > 0 || protocol.count("wss") > 0;
+}
+
+template <class>
+bool
+Port::secure() const
+{
+    return protocol.count("peer") > 0 ||
+        protocol.count("https") > 0 || protocol.count("wss") > 0;
 }
 
 template <class>

--- a/src/ripple/server/ServerHandler.h
+++ b/src/ripple/server/ServerHandler.h
@@ -66,6 +66,9 @@ public:
         };
 
         overlay_t overlay;
+
+        void
+        makeContexts();
     };
 
     virtual

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -427,6 +427,29 @@ adminRole (HTTP::Port const& port,
 
 //------------------------------------------------------------------------------
 
+void
+ServerHandler::Setup::makeContexts()
+{
+    for(auto& p : ports)
+    {
+        if (p.secure())
+        {
+            if (p.ssl_key.empty() && p.ssl_cert.empty() &&
+                    p.ssl_chain.empty())
+                p.context = make_SSLContext();
+            else
+                p.context = make_SSLContextAuthed (
+                    p.ssl_key, p.ssl_cert, p.ssl_chain);
+        }
+        else
+        {
+            p.context = std::make_shared<
+                boost::asio::ssl::context>(
+                    boost::asio::ssl::context::sslv23);
+        }
+    }
+}
+
 namespace detail {
 
 // Parse a comma-delimited list of values.
@@ -615,13 +638,6 @@ to_Port(ParsedPort const& parsed, std::ostream& log)
     p.ssl_key = parsed.ssl_key;
     p.ssl_cert = parsed.ssl_cert;
     p.ssl_chain = parsed.ssl_chain;
-
-    if (p.ssl_key.empty() && p.ssl_cert.empty() &&
-            p.ssl_chain.empty())
-        p.context = make_SSLContext();
-    else
-        p.context = make_SSLContextAuthed (
-            p.ssl_key, p.ssl_cert, p.ssl_chain);
 
     return p;
 }


### PR DESCRIPTION
The creation of self-signed certificates slows down the command
line client when launched repeatedly during unit test.
- Contexts are no longer generated for the command line client
- A port with no secure protocols generates an empty context

Reviewers: @donovanhide @josh-ripple
