### PR TITLE
Missing #include in LexicalCast.h

### DIFF
--- a/src/beast/beast/module/core/text/LexicalCast.h
+++ b/src/beast/beast/module/core/text/LexicalCast.h
@@ -28,7 +28,7 @@
 #include <limits>
 #include <string>
 #include <utility>
-
+#include <typeinfo>
 #include <iostream>
 
 namespace beast {


### PR DESCRIPTION
Make it compile.

@nbougalis  @vinniefalco 
