### PR TITLE
Add missing header needed for boost 1.57 compatibility.

### DIFF
--- a/src/beast/beast/http/message.h
+++ b/src/beast/beast/http/message.h
@@ -30,6 +30,7 @@
 #include <cctype>
 #include <ostream>
 #include <string>
+#include <sstream>
 #include <utility>
 
 namespace beast {


### PR DESCRIPTION
With this one change, boost 1.57 seems to work perfectly well.
