### PR TITLE
Update tests for latest ripple-lib

### DIFF
--- a/test/freeze-test.coffee
+++ b/test/freeze-test.coffee
@@ -188,7 +188,7 @@ config = testutils.init_config()
 #################################### HELPERS ###################################
 
 get_lines = (remote, acc, done) ->
-  remote.request_account_lines acc, null, 'validated', (err, lines) ->
+  remote.request_account_lines { account: acc, ledger: 'validated' }, (err, lines) ->
     done(lines)
 
 account_set_factory = (remote, ledger, alias_for) ->
@@ -636,7 +636,7 @@ execute_if_enabled (suite, skipped, enforced) ->
           test_if enforced, 'account_offers always shows their own offers', (done) ->
             {remote} = h = get_helpers()
 
-            remote.request_account_offers 'G1', null, 'validated', (err, res) ->
+            remote.request_account_offers { account: 'G1', ledger: 'validated' }, (err, res) ->
               assert.equal res.offers.length, 2
               done()
 
@@ -756,7 +756,7 @@ execute_if_enabled (suite, skipped, enforced) ->
             done()
 
         test 'offer was only partially consumed', (done) ->
-          remote.request_account_offers 'A3', null, 'validated', (err, res) ->
+          remote.request_account_offers { account: 'A3', ledger: 'validated' }, (err, res) ->
             assert res.offers.length == 1
             assert res.offers[0].taker_gets.value, '999'
             done()
@@ -794,7 +794,7 @@ execute_if_enabled (suite, skipped, enforced) ->
             done()
 
         test_if enforced, 'Partially consumed offer was removed by tes* payment', (done) ->
-          remote.request_account_offers 'A3', null, 'validated', (err, res) ->
+          remote.request_account_offers { account: 'A3', ledger: 'validated' }, (err, res) ->
             assert res.offers.length == 0
             done()
 
@@ -825,6 +825,6 @@ execute_if_enabled (suite, skipped, enforced) ->
             done()
 
         test_if enforced, 'offer was removed by offer_create', (done) ->
-          remote.request_account_offers 'A4', null, 'validated', (err, res) ->
+          remote.request_account_offers { account: 'A4', ledger: 'validated' }, (err, res) ->
             assert res.offers.length == 0
             done()

--- a/test/ledger-state.coffee
+++ b/test/ledger-state.coffee
@@ -125,7 +125,7 @@ class BulkRequests
     @assert callback?, "Must supply a callback"
 
     async.concatSeries(args_list, ((args, callback) =>
-      req = fn.apply @remote, args
+      req = fn.apply @remote, (args.map (arg) -> return { account: arg })
       on_each?(args..., req)
       req.on("success", (m) =>
         if m.status?

--- a/test/no-ripple-test.js
+++ b/test/no-ripple-test.js
@@ -61,7 +61,7 @@ suite('NoRipple', function() {
       function (callback) {
         self.what = 'Check no-ripple sender';
 
-        $.remote.requestAccountLines('root', void(0), 'CURRENT', function(err, m) {
+        $.remote.requestAccountLines({ account: 'root', ledger: 'validated' }, function(err, m) {
           if (err) return callback(err);
           assert(typeof m === 'object');
           assert(Array.isArray(m.lines));
@@ -73,7 +73,7 @@ suite('NoRipple', function() {
       function (callback) {
         self.what = 'Check no-ripple destination';
 
-        $.remote.requestAccountLines('alice', void(0), 'CURRENT', function(err, m) {
+        $.remote.requestAccountLines({ account: 'alice', ledger: 'validated' }, function(err, m) {
           if (err) return callback(err);
           assert(typeof m === 'object');
           assert(Array.isArray(m.lines));
@@ -104,7 +104,7 @@ suite('NoRipple', function() {
       function (callback) {
         self.what = 'Check no-ripple cleared sender';
 
-        $.remote.requestAccountLines('root', void(0), 'CURRENT', function(err, m) {
+        $.remote.requestAccountLines({ account: 'root', ledger: 'validated' }, function(err, m) {
           if (err) return callback(err);
           assert(typeof m === 'object');
           assert(Array.isArray(m.lines));
@@ -116,7 +116,7 @@ suite('NoRipple', function() {
       function (callback) {
         self.what = 'Check no-ripple cleared destination';
 
-        $.remote.requestAccountLines('alice', void(0), 'CURRENT', function(err, m) {
+        $.remote.requestAccountLines({ account: 'alice', ledger: 'validated' }, function(err, m) {
           if (err) return callback(err);
           assert(typeof m === 'object');
           assert(Array.isArray(m.lines));
@@ -217,7 +217,7 @@ suite('NoRipple', function() {
       },
 
       function (callback) {
-        $.remote.requestAccountLines('alice', function(err, res) {
+        $.remote.requestAccountLines({ account: 'alice' }, function(err, res) {
           assert.ifError(err);
           assert.strictEqual(typeof res, 'object');
           assert(Array.isArray(res.lines));


### PR DESCRIPTION
The method signature for account requests has changed. This commit will accommodate the latest ripple-lib. The ripple-lib version in package.json isn't bumped (yet), but this allows -lib developers to use the tests in the meanwhile.
