### PR TITLE
Add more unit tests to rpc/impl/TransactionSign [RIPD-480]

### DIFF
--- a/src/ripple/rpc/impl/TransactionSign.h
+++ b/src/ripple/rpc/impl/TransactionSign.h
@@ -25,10 +25,10 @@
 namespace ripple {
 namespace RPC {
 
-namespace RPCDetail {
+namespace detail {
 // A class that allows these methods to be called with or without a
 // real NetworkOPs instance.  This allows for unit testing.
-class LedgerFacade
+class TxSignApiFacade
 {
 private:
     NetworkOPs* const netOPs_;
@@ -42,21 +42,21 @@ public:
         noNetOPs
     };
 
-    LedgerFacade () = delete;
-    LedgerFacade (LedgerFacade const&) = delete;
-    LedgerFacade& operator= (LedgerFacade const&) = delete;
+    TxSignApiFacade () = delete;
+    TxSignApiFacade (TxSignApiFacade const&) = delete;
+    TxSignApiFacade& operator= (TxSignApiFacade const&) = delete;
 
     // For use in non unit testing circumstances.
-    explicit LedgerFacade (NetworkOPs& netOPs)
+    explicit TxSignApiFacade (NetworkOPs& netOPs)
     : netOPs_ (&netOPs)
     { }
 
     // For testTransactionRPC unit tests.
-    explicit LedgerFacade (NoNetworkOPs noOPs)
+    explicit TxSignApiFacade (NoNetworkOPs noOPs)
     : netOPs_ (nullptr) { }
 
     // For testAutoFillFees unit tests.
-    LedgerFacade (NoNetworkOPs noOPs, Ledger::pointer ledger)
+    TxSignApiFacade (NoNetworkOPs noOPs, Ledger::pointer ledger)
     : netOPs_ (nullptr)
     , ledger_ (ledger)
     { }
@@ -101,21 +101,21 @@ public:
 } // namespace RPCDetail
 
 Json::Value transactionSign (
-    Json::Value params,
+    Json::Value params, // Passed by value so the local copy can be changed.
     bool bSubmit,
     bool bFailHard,
-    RPCDetail::LedgerFacade& ledgerFacade,
+    detail::TxSignApiFacade& apiFacade,
     Role role);
 
 inline Json::Value transactionSign (
-    Json::Value params,
+    Json::Value const& params,
     bool bSubmit,
     bool bFailHard,
     NetworkOPs& netOPs,
     Role role)
 {
-    RPCDetail::LedgerFacade ledgerFacade (netOPs);
-    return transactionSign (params, bSubmit, bFailHard, ledgerFacade, role);
+    detail::TxSignApiFacade apiFacade (netOPs);
+    return transactionSign (params, bSubmit, bFailHard, apiFacade, role);
 }
 
 } // RPC


### PR DESCRIPTION
By adding a mock it is possible to test the transactionSign
function without interacting with the ledger.  This is the
smallest change I could come up with that allows transactionSign
to be unit tested.

The unit tests are white boxed.  Each test case is a result
of examining the code and identifying behavior associated with
different JSON fields.  That means the tests are not based on
requirements, they are based on observed behavior.

The point of adding unit tests is to increase confidence in the 
face of expected future refactors of this code.  If the refactors
continue to pass these unit tests then they are less likely to
have changed important behavior.

@vinniefalco because he has strong opinions on unit tests.
@nbougalis because he's been in this part of the code.
@JoelKatz (optional) I know David is buried in code reviews,
but it would be great if he has time to look at this.
