### PR TITLE
Fix unit_test suite matching with full names

### DIFF
--- a/src/beast/beast/unit_test/match.h
+++ b/src/beast/beast/unit_test/match.h
@@ -51,9 +51,9 @@ public:
     };
 
 private:
-    mode_t m_mode;
-    std::string m_pat;
-    std::string m_library;
+    mode_t mode_;
+    std::string pat_;
+    std::string library_;
 
 public:
     template <class = void>
@@ -69,52 +69,52 @@ public:
 
 template <class>
 selector::selector (mode_t mode, std::string const& pattern)
-    : m_mode (mode)
-    , m_pat (pattern)
+    : mode_ (mode)
+    , pat_ (pattern)
 {
-    if (m_mode == automatch && pattern.empty())
-        m_mode = all;
+    if (mode_ == automatch && pattern.empty())
+        mode_ = all;
 }
 
 template <class>
 bool
 selector::operator() (suite_info const& s)
 {
-    switch (m_mode)
+    switch (mode_)
     {
     case automatch:
-        // check suite
-        if (m_pat == s.name())
+        // suite or full name
+        if (s.name() == pat_ || s.full_name() == pat_)
         {
-            m_mode = none;
+            mode_ = none;
             return true;
         }
 
         // check module
-        if (m_pat == s.module())
+        if (pat_ == s.module())
         {
-            m_mode = module;
-            m_library = s.library();
+            mode_ = module;
+            library_ = s.library();
             return ! s.manual();
         }
 
         // check library
-        if (m_pat == s.library())
+        if (pat_ == s.library())
         {
-            m_mode = library;
+            mode_ = library;
             return ! s.manual();
         }
 
         return false;
 
     case suite:
-        return m_pat == s.name();
+        return pat_ == s.name();
 
     case module:
-        return m_pat == s.module() && ! s.manual();
+        return pat_ == s.module() && ! s.manual();
 
     case library:
-        return m_pat == s.library() && ! s.manual();
+        return pat_ == s.library() && ! s.manual();
 
     case none:
         return false;

--- a/src/beast/beast/unit_test/suite_info.h
+++ b/src/beast/beast/unit_test/suite_info.h
@@ -33,35 +33,35 @@ class runner;
 class suite_info
 {
 private:
-    typedef std::function <void (runner&)> run_type;
+    using run_type = std::function <void (runner&)>;
 
-    char const* m_name;
-    char const* m_module;
-    char const* m_library;
+    std::string name_;
+    std::string module_;
+    std::string library_;
     bool m_manual;
     run_type m_run;
 
 public:
     template <class = void>
-    suite_info (char const* name, char const* module, char const* library,
-        bool manual, run_type run);
+    suite_info (std::string const& name, std::string const& module,
+        std::string const& library, bool manual, run_type run);
 
-    char const*
+    std::string const&
     name() const
     {
-        return m_name;
+        return name_;
     }
 
-    char const*
+    std::string const&
     module() const
     {
-        return m_module;
+        return module_;
     }
 
-    char const*
+    std::string const&
     library() const
     {
-        return m_library;
+        return library_;
     }
 
     /** Returns `true` if this suite only runs manually. */
@@ -87,15 +87,11 @@ public:
 //------------------------------------------------------------------------------
 
 template <class>
-suite_info::suite_info (
-    char const* name,
-    char const* module,
-    char const* library,
-    bool manual,
-    run_type run)
-    : m_name (name)
-    , m_module (module)
-    , m_library (library)
+suite_info::suite_info (std::string const& name, std::string const& module,
+        std::string const& library, bool manual, run_type run)
+    : name_ (name)
+    , module_ (module)
+    , library_ (library)
     , m_manual (manual)
     , m_run (std::move (run))
 {
@@ -105,10 +101,7 @@ template <class>
 std::string
 suite_info::full_name() const
 {
-    return 
-        std::string (m_library) + "." +
-        std::string (m_module) + "." +
-        std::string (m_name);
+    return library_ + "." + module_ + "." + name_;
 }
 
 inline
@@ -121,15 +114,11 @@ operator< (suite_info const& lhs, suite_info const& rhs)
 /** Convenience for producing suite_info for a given test type. */
 template <class Suite>
 suite_info
-make_suite_info (char const* name, char const* module, char const* library,
-    bool manual)
+make_suite_info (std::string const& name, std::string const& module,
+    std::string const& library, bool manual)
 {
-    return suite_info (name, module, library, manual,
-        [](runner& r)
-        {
-            Suite test;
-            return test (r);
-        });
+    return suite_info(name, module, library, manual,
+        [](runner& r) { return Suite{}(r); });
 }
 
 } // unit_test


### PR DESCRIPTION
This fixes `--unittest=ripple.ripple_core.NodeStoreBasic`
Reviewers: @JoelKatz 
