### PR TITLE
Don't call std::exit on clean exit

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -866,11 +866,14 @@ public:
         m_journal.info << "Received shutdown request";
         stop (m_journal);
         m_journal.info << "Done.";
-        exitWithCode(0);
+        StopSustain();
     }
 
-    void exitWithCode(int code){
+    void exitWithCode(int code)
+    {
         StopSustain();
+        // VFALCO This breaks invariants: automatic objects
+        //        will not have destructors called.
         std::exit(code);
     }
 


### PR DESCRIPTION
Reviewers: @donovanhide, @rec 
