### PR TITLE
Eliminate temREDUNDANT_SEND_MAX (RIPD-690):

### DIFF
--- a/src/ripple/app/transactors/Payment.cpp
+++ b/src/ripple/app/transactors/Payment.cpp
@@ -126,15 +126,6 @@ public:
 
             return temREDUNDANT;
         }
-        else if (bMax && maxSourceAmount == saDstAmount &&
-                 maxSourceAmount.getCurrency () == saDstAmount.getCurrency ())
-        {
-            // Consistent but redundant transaction.
-            m_journal.trace <<
-                "Malformed transaction: Redundant SendMax.";
-
-            return temREDUNDANT_SEND_MAX;
-        }
         else if (bXRPDirect && bMax)
         {
             // Consistent but redundant transaction.

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -79,7 +79,6 @@ enum TER    // aka TransactionEngineResult
     temINVALID,
     temINVALID_FLAG,
     temREDUNDANT,
-    temREDUNDANT_SEND_MAX,
     temRIPPLE_EMPTY,
 
     // An intermediate result used internally, should never be returned.

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -108,7 +108,6 @@ bool transResultInfo (TER terCode, std::string& strToken, std::string& strHuman)
         {   temINVALID,             "temINVALID",               "The transaction is ill-formed."                        },
         {   temINVALID_FLAG,        "temINVALID_FLAG",          "The transaction has an invalid flag."                  },
         {   temREDUNDANT,           "temREDUNDANT",             "Sends same currency to self."                          },
-        {   temREDUNDANT_SEND_MAX,  "temREDUNDANT_SEND_MAX",    "Send max is redundant."                                },
         {   temRIPPLE_EMPTY,        "temRIPPLE_EMPTY",          "PathSet with no paths."                                },
         {   temUNCERTAIN,           "temUNCERTAIN",             "In process of determining result. Never returned."     },
         {   temUNKNOWN,             "temUNKNOWN",               "The transactions requires logic not implemented yet."  },


### PR DESCRIPTION
The rules for when a SendMax is redundant are complicated. It is easier to always allow a SendMax and eliminate temREDUNDANT_SEND_MAX.

Reviewers: @JoelKatz, @scottschurr 