### PR TITLE
Add RPC metrics (RIPD-705)

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -305,7 +305,7 @@ public:
 
         , serverHandler_ (make_ServerHandler (*m_networkOPs,
             get_io_service(), *m_jobQueue, *m_networkOPs,
-                *m_resourceManager))
+                *m_resourceManager, m_collectorManager.get ()))
 
         , m_nodeStore (m_nodeStoreManager->make_Database ("NodeStore.main",
             m_nodeStoreScheduler, m_logs.journal("NodeObject"),
@@ -727,7 +727,8 @@ public:
         {
             if (! port.websockets())
                 continue;
-            auto door = make_WSDoor(port, *m_resourceManager, getOPs());
+            auto door (make_WSDoor (port, *m_resourceManager, getOPs (),
+                m_collectorManager.get ()));
             if (door == nullptr)
             {
                 m_journal.fatal << "Could not create Websocket for [" <<

--- a/src/ripple/app/main/CollectorManager.cpp
+++ b/src/ripple/app/main/CollectorManager.cpp
@@ -49,6 +49,10 @@ public:
         }
 
         m_groups = beast::insight::make_Groups (m_collector);
+        rpc_requests_ = m_collector->make_counter ("rpc", "requests");
+        rpc_io_ = m_collector->make_event ("rpc", "io");
+        rpc_size_ = m_collector->make_event ("rpc", "size");
+        rpc_time_ = m_collector->make_event ("rpc", "time");
     }
 
     ~CollectorManagerImp ()

--- a/src/ripple/app/main/CollectorManager.h
+++ b/src/ripple/app/main/CollectorManager.h
@@ -34,6 +34,11 @@ public:
     virtual ~CollectorManager () = 0;
     virtual beast::insight::Collector::ptr const& collector () = 0;
     virtual beast::insight::Group::ptr const& group (std::string const& name) = 0;
+
+    beast::insight::Counter rpc_requests_;
+    beast::insight::Event rpc_io_;
+    beast::insight::Event rpc_size_;
+    beast::insight::Event rpc_time_;
 };
 
 }

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -68,7 +68,7 @@ void startServer ()
             if (!getConfig ().QUIET)
                 std::cerr << "Startup RPC: " << jvCommand << std::endl;
 
-            RPCHandler  rhHandler (getApp().getOPs ());
+            RPCHandler  rhHandler (nullptr, getApp ().getOPs ());
 
             Resource::Charge loadType = Resource::feeReferenceRPC;
             Json::Value jvResult    = rhHandler.doCommand (jvCommand, Role::ADMIN, loadType);
@@ -78,7 +78,7 @@ void startServer ()
         }
     }
 
-    getApp().run ();                 // Blocks till we get a stop RPC.
+    getApp ().run ();                 // Blocks till we get a stop RPC.
 }
 
 void printHelp (const po::options_description& desc)

--- a/src/ripple/app/websocket/WSConnection.cpp
+++ b/src/ripple/app/websocket/WSConnection.cpp
@@ -28,7 +28,8 @@ namespace ripple {
 WSConnection::WSConnection (HTTP::Port const& port,
     Resource::Manager& resourceManager, Resource::Consumer usage,
         InfoSub::Source& source, bool isPublic,
-            beast::IP::Endpoint const& remoteAddress, boost::asio::io_service& io_service)
+            beast::IP::Endpoint const& remoteAddress,
+                boost::asio::io_service& io_service, CollectorManager* cm)
     : InfoSub (source, usage)
     , port_(port)
     , m_resourceManager (resourceManager)
@@ -40,6 +41,7 @@ WSConnection::WSConnection (HTTP::Port const& port,
     , m_receiveQueueRunning (false)
     , m_isDead (false)
     , m_io_service (io_service)
+    , collectorManager_ (cm)
 {
     WriteLog (lsDEBUG, WSConnection) <<
         "Websocket connection from " << remoteAddress;
@@ -156,7 +158,8 @@ Json::Value WSConnection::invokeCommand (Json::Value& jvRequest)
     }
 
     Resource::Charge loadType = Resource::feeReferenceRPC;
-    RPCHandler  mRPCHandler (m_netOPs, std::dynamic_pointer_cast<InfoSub> (this->shared_from_this ()));
+    RPCHandler  mRPCHandler (collectorManager_, m_netOPs,
+        std::dynamic_pointer_cast<InfoSub> (this->shared_from_this ()));
     Json::Value jvResult (Json::objectValue);
 
     Role const role = port_.allow_admin ? adminRole (port_, jvRequest,

--- a/src/ripple/app/websocket/WSConnection.h
+++ b/src/ripple/app/websocket/WSConnection.h
@@ -42,10 +42,10 @@ public:
 protected:
     typedef websocketpp::message::data::ptr message_ptr;
 
-    WSConnection (HTTP::Port const& port,
-        Resource::Manager& resourceManager, Resource::Consumer usage,
-            InfoSub::Source& source, bool isPublic,
-                beast::IP::Endpoint const& remoteAddress, boost::asio::io_service& io_service);
+    WSConnection (HTTP::Port const& port, Resource::Manager& resourceManager,
+        Resource::Consumer usage, InfoSub::Source& source, bool isPublic,
+            beast::IP::Endpoint const& remoteAddress,
+                boost::asio::io_service& io_service, CollectorManager* cm);
 
     WSConnection(WSConnection const&) = delete;
     WSConnection& operator= (WSConnection const&) = delete;
@@ -77,6 +77,7 @@ protected:
     bool m_receiveQueueRunning;
     bool m_isDead;
     boost::asio::io_service& m_io_service;
+    CollectorManager* collectorManager_;
 };
 
 //------------------------------------------------------------------------------
@@ -102,7 +103,8 @@ private:
 
 public:
     WSConnectionType (Resource::Manager& resourceManager, InfoSub::Source& source,
-            server_type& serverHandler, connection_ptr const& cpConnection)
+            server_type& serverHandler, connection_ptr const& cpConnection,
+                CollectorManager* cm)
         : WSConnection (
             serverHandler.port(),
             resourceManager,
@@ -110,7 +112,8 @@ public:
             source,
             serverHandler.getPublic (),
             cpConnection->get_socket ().remote_endpoint (),
-            cpConnection->get_io_service ())
+            cpConnection->get_io_service (),
+            cm)
         , m_serverHandler (serverHandler)
         , m_connection (cpConnection)
     {

--- a/src/ripple/app/websocket/WSDoor.cpp
+++ b/src/ripple/app/websocket/WSDoor.cpp
@@ -52,15 +52,17 @@ private:
     InfoSub::Source& m_source;
     LockType m_endpointLock;
     std::shared_ptr<websocketpp::server_autotls> m_endpoint;
+    CollectorManager* collectorManager_;
 
 public:
     WSDoorImp (HTTP::Port const& port, Resource::Manager& resourceManager,
-        InfoSub::Source& source)
+        InfoSub::Source& source, CollectorManager* cm)
         : WSDoor (source)
         , Thread ("websocket")
-        , port_(std::make_shared<HTTP::Port>(port))
+        , port_(std::make_shared<HTTP::Port> (port))
         , m_resourceManager (resourceManager)
         , m_source (source)
+        , collectorManager_ (cm)
     {
         startThread ();
     }
@@ -80,7 +82,7 @@ private:
 
         websocketpp::server_autotls::handler::ptr handler (
             new WSServerHandler <websocketpp::server_autotls> (
-                port_, m_resourceManager, m_source));
+                port_, m_resourceManager, m_source, collectorManager_));
 
         {
             ScopedLockType lock (m_endpointLock);
@@ -153,13 +155,13 @@ WSDoor::WSDoor (Stoppable& parent)
 
 std::unique_ptr<WSDoor>
 make_WSDoor (HTTP::Port const& port, Resource::Manager& resourceManager,
-    InfoSub::Source& source)
+    InfoSub::Source& source, CollectorManager* cm)
 {
     std::unique_ptr<WSDoor> door;
 
     try
     {
-        door = std::make_unique <WSDoorImp> (port, resourceManager, source);
+        door = std::make_unique <WSDoorImp> (port, resourceManager, source, cm);
     }
     catch (...)
     {

--- a/src/ripple/app/websocket/WSDoor.h
+++ b/src/ripple/app/websocket/WSDoor.h
@@ -39,7 +39,7 @@ public:
 
 std::unique_ptr<WSDoor>
 make_WSDoor (HTTP::Port const& port, Resource::Manager& resourceManager,
-    InfoSub::Source& source);
+    InfoSub::Source& source, CollectorManager* cm);
 
 }
 

--- a/src/ripple/app/websocket/WSServerHandler.h
+++ b/src/ripple/app/websocket/WSServerHandler.h
@@ -65,6 +65,7 @@ private:
     std::shared_ptr<HTTP::Port> port_;
     Resource::Manager& m_resourceManager;
     InfoSub::Source& m_source;
+    CollectorManager* collectorManager_;
 
 protected:
     // VFALCO TODO Make this private.
@@ -78,10 +79,12 @@ protected:
 
 public:
     WSServerHandler (std::shared_ptr<HTTP::Port> const& port,
-        Resource::Manager& resourceManager, InfoSub::Source& source)
+        Resource::Manager& resourceManager, InfoSub::Source& source,
+            CollectorManager* cm)
         : port_(port)
         , m_resourceManager (resourceManager)
         , m_source (source)
+        , collectorManager_ (cm)
     {
     }
 
@@ -199,7 +202,8 @@ public:
             std::pair <typename MapType::iterator, bool> const result (
                 mMap.emplace (cpClient,
                     std::make_shared < WSConnectionType <endpoint_type> > (std::ref(m_resourceManager),
-                    std::ref (m_source), std::ref(*this), std::cref(cpClient))));
+                    std::ref (m_source), std::ref (*this), std::cref (cpClient),
+                    collectorManager_)));
             assert (result.second);
             (void) result.second;
             WriteLog (lsDEBUG, WSServerHandlerLog) <<

--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -21,6 +21,7 @@
 #define RIPPLE_NODESTORE_DATABASE_H_INCLUDED
 
 #include <ripple/nodestore/NodeObject.h>
+#include <boost/thread/tss.hpp>
 
 namespace ripple {
 namespace NodeStore {
@@ -141,6 +142,13 @@ public:
     virtual std::uint32_t getFetchHitCount () const = 0;
     virtual std::uint32_t getStoreSize () const = 0;
     virtual std::uint32_t getFetchSize () const = 0;
+
+    struct DBmetrics
+    {
+        std::size_t fetches;
+    };
+
+    static boost::thread_specific_ptr<DBmetrics> dbMetrics_;
 };
 
 }

--- a/src/ripple/nodestore/impl/DatabaseImp.h
+++ b/src/ripple/nodestore/impl/DatabaseImp.h
@@ -31,6 +31,8 @@
 namespace ripple {
 namespace NodeStore {
 
+boost::thread_specific_ptr<Database::DBmetrics> Database::dbMetrics_;
+
 class DatabaseImp
     : public Database
     , public beast::LeakChecked <DatabaseImp>
@@ -146,6 +148,9 @@ public:
 
     NodeObject::Ptr fetch (uint256 const& hash) override
     {
+        if (dbMetrics_.get ())
+            ++dbMetrics_->fetches;
+
         return doTimedFetch (hash, false);
     }
 

--- a/src/ripple/rpc/RPCHandler.h
+++ b/src/ripple/rpc/RPCHandler.h
@@ -23,6 +23,7 @@
 #include <ripple/server/Role.h>
 #include <ripple/core/Config.h>
 #include <ripple/net/InfoSub.h>
+#include <ripple/app/main/CollectorManager.h>
 
 namespace ripple {
 
@@ -31,8 +32,8 @@ class NetworkOPs;
 class RPCHandler
 {
 public:
-    explicit RPCHandler (
-        NetworkOPs& netOps, InfoSub::pointer infoSub = nullptr);
+    explicit RPCHandler (CollectorManager* cm, NetworkOPs& netOps,
+        InfoSub::pointer infoSub = nullptr);
 
     Json::Value doCommand (
         Json::Value const& request,
@@ -46,6 +47,7 @@ public:
         Resource::Charge& loadType);
 
 private:
+    CollectorManager* collectorManager_;
     NetworkOPs& netOps_;
     InfoSub::pointer infoSub_;
 

--- a/src/ripple/server/impl/ServerHandlerImp.h
+++ b/src/ripple/server/impl/ServerHandlerImp.h
@@ -23,7 +23,6 @@
 #include <ripple/core/Job.h>
 #include <ripple/server/ServerHandler.h>
 #include <ripple/server/Session.h>
-#include <ripple/rpc/RPCHandler.h>
 
 namespace ripple {
 
@@ -40,11 +39,12 @@ private:
     NetworkOPs& m_networkOPs;
     std::unique_ptr<HTTP::Server> m_server;
     Setup setup_;
+    CollectorManager* collectorManager_;
 
 public:
     ServerHandlerImp (Stoppable& parent, boost::asio::io_service& io_service,
         JobQueue& jobQueue, NetworkOPs& networkOPs,
-            Resource::Manager& resourceManager);
+            Resource::Manager& resourceManager, CollectorManager* cm);
 
     ~ServerHandlerImp();
 

--- a/src/ripple/server/make_ServerHandler.h
+++ b/src/ripple/server/make_ServerHandler.h
@@ -34,7 +34,8 @@ namespace ripple {
 
 std::unique_ptr <ServerHandler>
 make_ServerHandler (beast::Stoppable& parent, boost::asio::io_service& io_service,
-    JobQueue& jobQueue, NetworkOPs& networkOPs, Resource::Manager& resourceManager);
+    JobQueue& jobQueue, NetworkOPs& networkOPs, Resource::Manager& resourceManager,
+        CollectorManager* cm);
 
 } // ripple
 


### PR DESCRIPTION
Add metrics to record the number of RPC requests received. Record the number of
node store fetches performed per request. Additionally record the byte size of
each request response and measure the response time of each request in
milliseconds.

A CollectorManager pointer param is used with dependency injection in the
ctors and factory functions so that the option of passing nullptr is
available when journaling nor metrics collection is desired.

Reviewers: @vinniefalco, @rec
