### PR TITLE
Add RPC metrics (RIPD-705)

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2565,6 +2565,9 @@
     <ClCompile Include="..\..\src\ripple\nodestore\impl\NodeObject.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\nodestore\impl\ScopedMetrics.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\nodestore\impl\Tuning.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\nodestore\Manager.h">
@@ -2572,6 +2575,8 @@
     <ClInclude Include="..\..\src\ripple\nodestore\NodeObject.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\nodestore\Scheduler.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\nodestore\ScopedMetrics.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\nodestore\Task.h">
     </ClInclude>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3657,6 +3657,9 @@
     <ClCompile Include="..\..\src\ripple\nodestore\impl\NodeObject.cpp">
       <Filter>ripple\nodestore\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\nodestore\impl\ScopedMetrics.cpp">
+      <Filter>ripple\nodestore\impl</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\nodestore\impl\Tuning.h">
       <Filter>ripple\nodestore\impl</Filter>
     </ClInclude>
@@ -3667,6 +3670,9 @@
       <Filter>ripple\nodestore</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\nodestore\Scheduler.h">
+      <Filter>ripple\nodestore</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\nodestore\ScopedMetrics.h">
       <Filter>ripple\nodestore</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\nodestore\Task.h">

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -308,9 +308,8 @@ public:
         // VFALCO NOTE LocalCredentials starts the deprecated UNL service
         , m_deprecatedUNL (make_UniqueNodeList (*m_jobQueue))
 
-        , serverHandler_ (make_ServerHandler (*m_networkOPs,
-            get_io_service(), *m_jobQueue, *m_networkOPs,
-                *m_resourceManager))
+        , serverHandler_ (make_ServerHandler (*m_networkOPs, get_io_service (),
+            *m_jobQueue, *m_networkOPs, *m_resourceManager, *m_collectorManager))
 
         , m_sntpClient (SNTPClient::New (*this))
 
@@ -738,7 +737,8 @@ public:
         {
             if (! port.websockets())
                 continue;
-            auto door = make_WSDoor(port, *m_resourceManager, getOPs());
+            auto door (make_WSDoor (port, *m_resourceManager, getOPs (),
+                *m_collectorManager));
             if (door == nullptr)
             {
                 m_journal.fatal << "Could not create Websocket for [" <<

--- a/src/ripple/app/websocket/WSConnection.cpp
+++ b/src/ripple/app/websocket/WSConnection.cpp
@@ -23,7 +23,6 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/resource/Fees.h>
-#include <ripple/rpc/RPCHandler.h>
 #include <ripple/server/Role.h>
 
 namespace ripple {
@@ -177,6 +176,7 @@ Json::Value WSConnection::invokeCommand (Json::Value& jvRequest)
             jvRequest, loadType, m_netOPs, role,
             std::dynamic_pointer_cast<InfoSub> (this->shared_from_this ())};
         RPC::doCommand (context, jvResult[jss::result]);
+        recordMetrics (context);
     }
 
     getConsumer().charge (loadType);

--- a/src/ripple/app/websocket/WSConnection.h
+++ b/src/ripple/app/websocket/WSConnection.h
@@ -27,6 +27,7 @@
 #include <ripple/server/Port.h>
 #include <ripple/json/to_string.h>
 #include <ripple/unity/websocket.h>
+#include <ripple/rpc/RPCHandler.h>
 #include <beast/asio/placeholders.h>
 #include <memory>
 
@@ -59,6 +60,8 @@ protected:
 
     virtual void preDestroy () = 0;
     virtual void disconnect () = 0;
+    
+    virtual void recordMetrics (RPC::Context const&) const = 0;
 
 public:
     void onPong (std::string const&);
@@ -140,6 +143,11 @@ public:
     static void destroy (std::shared_ptr <WSConnectionType <endpoint_type> >)
     {
         // Just discards the reference
+    }
+
+    void recordMetrics (RPC::Context const& context) const override
+    {
+        m_serverHandler.recordMetrics (context);
     }
 
     // Implement overridden functions from base class:

--- a/src/ripple/app/websocket/WSDoor.cpp
+++ b/src/ripple/app/websocket/WSDoor.cpp
@@ -57,15 +57,17 @@ private:
     InfoSub::Source& m_source;
     LockType m_endpointLock;
     std::shared_ptr<websocketpp_02::server_autotls> m_endpoint;
+    CollectorManager& collectorManager_;
 
 public:
     WSDoorImp (HTTP::Port const& port, Resource::Manager& resourceManager,
-        InfoSub::Source& source)
+        InfoSub::Source& source, CollectorManager& cm)
         : WSDoor (source)
         , Thread ("websocket")
         , port_(std::make_shared<HTTP::Port>(port))
         , m_resourceManager (resourceManager)
         , m_source (source)
+        , collectorManager_ (cm)
     {
         startThread ();
     }
@@ -85,7 +87,7 @@ private:
 
         websocketpp_02::server_autotls::handler::ptr handler (
             new WSServerHandler <websocketpp_02::server_autotls> (
-                port_, m_resourceManager, m_source));
+                port_, m_resourceManager, m_source, collectorManager_));
 
         {
             ScopedLockType lock (m_endpointLock);
@@ -162,13 +164,13 @@ WSDoor::WSDoor (Stoppable& parent)
 
 std::unique_ptr<WSDoor>
 make_WSDoor (HTTP::Port const& port, Resource::Manager& resourceManager,
-    InfoSub::Source& source)
+    InfoSub::Source& source, CollectorManager& cm)
 {
     std::unique_ptr<WSDoor> door;
 
     try
     {
-        door = std::make_unique <WSDoorImp> (port, resourceManager, source);
+        door = std::make_unique <WSDoorImp> (port, resourceManager, source, cm);
     }
     catch (...)
     {

--- a/src/ripple/app/websocket/WSDoor.h
+++ b/src/ripple/app/websocket/WSDoor.h
@@ -42,7 +42,7 @@ public:
 
 std::unique_ptr<WSDoor>
 make_WSDoor (HTTP::Port const& port, Resource::Manager& resourceManager,
-    InfoSub::Source& source);
+    InfoSub::Source& source, CollectorManager& cm);
 
 }
 

--- a/src/ripple/nodestore/ScopedMetrics.h
+++ b/src/ripple/nodestore/ScopedMetrics.h
@@ -17,36 +17,36 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_RPC_CONTEXT
-#define RIPPLE_RPC_CONTEXT
+#ifndef RIPPLE_NODESTORE_SCOPEDMETRICS_H_INCLUDED
+#define RIPPLE_NODESTORE_SCOPEDMETRICS_H_INCLUDED
 
-#include <ripple/core/Config.h>
-#include <ripple/net/InfoSub.h>
-#include <ripple/rpc/Yield.h>
-#include <ripple/server/Role.h>
-#include <ripple/nodestore/ScopedMetrics.h>
+#include <cstddef>
 
 namespace ripple {
+namespace NodeStore {
 
-class NetworkOPs;
-
-namespace RPC {
-
-/** The context of information needed to call an RPC. */
-struct Context
+/** RAII observer to track NodeStore fetches made by the calling thread. */
+class ScopedMetrics
 {
-    Json::Value params;
-    Resource::Charge& loadType;
-    NetworkOPs& netOps;
-    Role role;
-    InfoSub::pointer infoSub;
-    RPC::Yield yield;
-    NodeStore::ScopedMetrics metrics;
+private:
+    ScopedMetrics* prev_;
+
+public:
+    ScopedMetrics ();
+    ~ScopedMetrics ();
+
+    static
+    ScopedMetrics*
+    get ();
+
+    static
+    void
+    incrementThreadFetches ();
+
+    std::size_t fetches = 0;
 };
 
-} // RPC
-} // ripple
-
-
+}
+}
 
 #endif

--- a/src/ripple/nodestore/impl/DatabaseImp.h
+++ b/src/ripple/nodestore/impl/DatabaseImp.h
@@ -28,6 +28,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/seconds_clock.h>
 #include <beast/threads/Thread.h>
+#include <ripple/nodestore/ScopedMetrics.h>
 #include <chrono>
 #include <condition_variable>
 #include <set>
@@ -167,6 +168,8 @@ public:
 
     NodeObject::Ptr fetch (uint256 const& hash) override
     {
+        ScopedMetrics::incrementThreadFetches ();
+
         return doTimedFetch (hash, false);
     }
 

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -33,7 +33,6 @@
 #include <ripple/net/InfoSub.h>
 #include <ripple/net/RPCErr.h>
 #include <ripple/protocol/JsonFields.h>
-#include <ripple/rpc/impl/Context.h>
 #include <ripple/server/Role.h>
 
 namespace ripple {

--- a/src/ripple/server/impl/ServerHandlerImp.h
+++ b/src/ripple/server/impl/ServerHandlerImp.h
@@ -25,6 +25,7 @@
 #include <ripple/server/Session.h>
 #include <ripple/rpc/Output.h>
 #include <ripple/rpc/RPCHandler.h>
+#include <ripple/app/main/CollectorManager.h>
 
 namespace ripple {
 
@@ -41,11 +42,15 @@ private:
     NetworkOPs& m_networkOPs;
     std::unique_ptr<HTTP::Server> m_server;
     Setup setup_;
+    beast::insight::Counter rpc_requests_;
+    beast::insight::Event rpc_io_;
+    beast::insight::Event rpc_size_;
+    beast::insight::Event rpc_time_;
 
 public:
     ServerHandlerImp (Stoppable& parent, boost::asio::io_service& io_service,
         JobQueue& jobQueue, NetworkOPs& networkOPs,
-            Resource::Manager& resourceManager);
+            Resource::Manager& resourceManager, CollectorManager& cm);
 
     ~ServerHandlerImp();
 

--- a/src/ripple/server/make_ServerHandler.h
+++ b/src/ripple/server/make_ServerHandler.h
@@ -33,7 +33,8 @@ class NetworkOPs;
 
 std::unique_ptr <ServerHandler>
 make_ServerHandler (beast::Stoppable& parent, boost::asio::io_service& io_service,
-    JobQueue& jobQueue, NetworkOPs& networkOPs, Resource::Manager& resourceManager);
+    JobQueue& jobQueue, NetworkOPs& networkOPs, Resource::Manager& resourceManager,
+        CollectorManager& cm);
 
 } // ripple
 

--- a/src/ripple/unity/nodestore.cpp
+++ b/src/ripple/unity/nodestore.cpp
@@ -36,6 +36,7 @@
 #include <ripple/nodestore/impl/EncodedBlob.cpp>
 #include <ripple/nodestore/impl/ManagerImp.cpp>
 #include <ripple/nodestore/impl/NodeObject.cpp>
+#include <ripple/nodestore/impl/ScopedMetrics.cpp>
 
 #include <ripple/nodestore/tests/Backend.test.cpp>
 #include <ripple/nodestore/tests/Basics.test.cpp>


### PR DESCRIPTION
Add metrics to record the number of RPC requests received. Record the number of
node store fetches performed per request. Additionally record the byte size of
each request response and measure the response time of each request in
milliseconds.

A new class, ScopedMetrics, uses the Boost Thead Local Storage mechanism to
efficiently record NodeStore metrics within the same thread.

Reviewers: @vinniefalco , @rec 