### PR TITLE
Remove support for deprecated PreviousTxnID field (RIPD-710):

### DIFF
--- a/src/ripple/app/transactors/Transactor.cpp
+++ b/src/ripple/app/transactors/Transactor.cpp
@@ -207,11 +207,6 @@ TER Transactor::checkSeq ()
         return tefPAST_SEQ;
     }
 
-    // Deprecated: Do not use
-    if (mTxn.isFieldPresent (sfPreviousTxnID) &&
-            (mTxnAccount->getFieldH256 (sfPreviousTxnID) != mTxn.getFieldH256 (sfPreviousTxnID)))
-        return tefWRONG_PRIOR;
-
     if (mTxn.isFieldPresent (sfAccountTxnID) &&
             (mTxnAccount->getFieldH256 (sfAccountTxnID) != mTxn.getFieldH256 (sfAccountTxnID)))
         return tefWRONG_PRIOR;
@@ -231,7 +226,7 @@ TER Transactor::checkSeq ()
 // check stuff before you bother to lock the ledger
 TER Transactor::preCheck ()
 {
-    mTxnAccountID   = mTxn.getSourceAccount ().getAccountID ();
+    mTxnAccountID = mTxn.getSourceAccount ().getAccountID ();
 
     if (!mTxnAccountID)
     {

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -93,7 +93,6 @@ void TxFormats::addCommonFields (Item& item)
         << SOElement(sfSourceTag,           SOE_OPTIONAL)
         << SOElement(sfAccount,             SOE_REQUIRED)
         << SOElement(sfSequence,            SOE_REQUIRED)
-        << SOElement(sfPreviousTxnID,       SOE_OPTIONAL) // Deprecated: Do not use
         << SOElement(sfLastLedgerSequence,  SOE_OPTIONAL)
         << SOElement(sfAccountTxnID,        SOE_OPTIONAL)
         << SOElement(sfFee,                 SOE_REQUIRED)


### PR DESCRIPTION
The PreviousTxnID field has been deprecated and should not be used for
transactions that use the field will now be rejected.

The AccountTxnID feature should be used instead by enabling transaction
tracking and specifying a transaction ID at submission. More details
are available at: https://ripple.com/build/transactions/#accounttxnid

Reviews: @JoelKatz, @rec