### PR TITLE
Improve hex-to-dec conversion routines

### DIFF
--- a/src/ripple/types/impl/strHex.cpp
+++ b/src/ripple/types/impl/strHex.cpp
@@ -32,7 +32,7 @@ char charHex (int iDigit)
     return 0;
 }
 
-int charUnHex (char cDigit)
+int charUnHex (unsigned char c)
 {
     struct HexTab
     {
@@ -49,15 +49,15 @@ int charUnHex (char cDigit)
                 hex ['a'+i] = 10 + i;
             }
         }
-        int operator[] (int i) const
+        int operator[] (unsigned char c) const
         {
-           return hex[i];
+            return hex[c];
         }
     };
 
     static HexTab xtab;
 
-    return xtab[cDigit];
+    return xtab[c];
 }
 
 }

--- a/src/ripple/types/strHex.h
+++ b/src/ripple/types/strHex.h
@@ -33,11 +33,21 @@ namespace ripple {
 */
 char charHex (int iDigit);
 
+/** @{ */
 /** Converts a hex digit to the corresponding integer
     @param cDigit one of '0'-'9', 'A'-'F' or 'a'-'f'
     @return an integer from 0 to 15 on success; -1 on failure.
 */
-int charUnHex (char cDigit);
+int
+charUnHex (unsigned char c);
+
+inline
+int
+charUnHex (char c)
+{
+    return charUnHex (static_cast<unsigned char>(c));
+}
+/** @} */
 
 // NIKB TODO cleanup this function and reduce the need for the many overloads
 //           it has in various places.


### PR DESCRIPTION
Explicitly handle both `char` and `unsigned char` in `charUnHex` by casting `char` to `unsigned char` to ensure that the range of inputs is always `[0,255]`.

Reviews: @vinniefalco, @HowardHinnant
