### PR TITLE
Remove one-arg SerializedTransaction::checkSign()

### DIFF
--- a/src/ripple/app/misc/SerializedTransaction.h
+++ b/src/ripple/app/misc/SerializedTransaction.h
@@ -111,7 +111,6 @@ public:
     void sign (RippleAddress const& private_key);
 
     bool checkSign () const;
-    bool checkSign (RippleAddress const& public_key) const;
 
     bool isKnownGood () const
     {

--- a/src/ripple/app/transactors/Transactor.cpp
+++ b/src/ripple/app/transactors/Transactor.cpp
@@ -251,7 +251,7 @@ TER Transactor::preCheck ()
     if (!mTxn.isKnownGood ())
     {
         if (mTxn.isKnownBad () ||
-            (!(mParams & tapNO_CHECK_SIGN) && !mTxn.checkSign (mSigningPubKey)))
+            (!(mParams & tapNO_CHECK_SIGN) && !mTxn.checkSign()))
         {
             mTxn.setBad ();
             m_journal.warning << "apply: Invalid transaction (bad signature)";

--- a/src/ripple/app/tx/Transaction.cpp
+++ b/src/ripple/app/tx/Transaction.cpp
@@ -69,7 +69,7 @@ Transaction::pointer Transaction::sharedTransaction (
 bool Transaction::checkSign () const
 {
     if (mFromPubKey.isValid ())
-        return mTransaction->checkSign (mFromPubKey);
+        return mTransaction->checkSign();
 
     WriteLog (lsWARNING, Ledger) << "Transaction has bad source public key";
     return false;


### PR DESCRIPTION
Callers don't need this.  Insulating them from RippleAddress details will make it easier to migrate away from RippleAddress in the future.

This simplifies Ed25519 implementation.
