### PR TITLE
Zero out base_uint on destruction.

### DIFF
--- a/src/ripple/types/base_uint.h
+++ b/src/ripple/types/base_uint.h
@@ -154,6 +154,11 @@ public:
 
     base_uint (base_uint<Bits, Tag> const& other) = default;
 
+    ~base_uint()
+    {
+        std::fill_n((unsigned volatile*)pn, static_cast<std::size_t>(WIDTH), 0);
+    }
+
     template <class OtherTag>
     void copyFrom (base_uint<Bits, OtherTag> const& other)
     {


### PR DESCRIPTION
We discussed this a few days ago. 

I did some profiling with this code and when I used callgrind, `base_uint::~base_uint()` didn't show up before _or_ after this change at all - so at least it's not in the top 753 call sites.
