### PR TITLE
Always initialize LedgerHolder options

### DIFF
--- a/src/ripple/rpc/handlers/Ledger.h
+++ b/src/ripple/rpc/handlers/Ledger.h
@@ -64,7 +64,7 @@ private:
     Context& context_;
     Ledger::pointer ledger_;
     Json::Value result_;
-    int options_;
+    int options_ = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `options_` field is initialized inside `LedgerHolder::check` but only in certain code paths. Ensure that it always has a sane default value of 0.

Reviews @rec and @josh-ripple
