### PR TITLE
Changes to Universal Port

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "async": "~0.2.9",
     "deep-equal": "0.0.0",
     "extend": "~1.2.0",
+    "request": "^2.47.0",
     "ripple-lib": "0.10.0",
     "simple-jsonrpc": "~0.0.2"
   },

--- a/src/ripple/app/websocket/WSConnection.cpp
+++ b/src/ripple/app/websocket/WSConnection.cpp
@@ -24,6 +24,7 @@
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/resource/Fees.h>
 #include <ripple/server/Role.h>
+#include <ripple/rpc/RPCHandler.h>
 
 namespace ripple {
 
@@ -163,8 +164,11 @@ Json::Value WSConnection::invokeCommand (Json::Value& jvRequest)
     Resource::Charge loadType = Resource::feeReferenceRPC;
     Json::Value jvResult (Json::objectValue);
 
-    Role const role = port_.allow_admin ? adminRole (port_, jvRequest,
-        m_remoteAddress, getConfig().RPC_ADMIN_ALLOW) : Role::GUEST;
+    Role const required = RPC::roleRequired (
+                                jvRequest[jss::command].asString());
+
+    Role const role = requestRole (required, port_, jvRequest, m_remoteAddress,
+                                 getConfig().RPC_ADMIN_ALLOW);
 
     if (Role::FORBID == role)
     {

--- a/src/ripple/rpc/RPCHandler.h
+++ b/src/ripple/rpc/RPCHandler.h
@@ -37,8 +37,7 @@ Status doCommand (RPC::Context&, Json::Value&, YieldStrategy const& s = {});
 /** Execute an RPC command and store the results in an std::string. */
 void executeRPC (RPC::Context&, std::string&, YieldStrategy const& s = {});
 
-/** Temporary flag to enable RPCs. */
-auto const streamingRPC = false;
+Role roleRequired (std::string const& method );
 
 } // RPC
 } // ripple

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -254,5 +254,15 @@ void executeRPC (
     }
 }
 
+Role roleRequired (std::string const& method)
+{
+    auto handler = RPC::getHandler(method);
+
+    if (!handler)
+        return Role::FORBID;
+
+    return handler->role_;
+}
+
 } // RPC
 } // ripple

--- a/src/ripple/server/Role.h
+++ b/src/ripple/server/Role.h
@@ -44,8 +44,8 @@ enum class Role
     validate the credentials.
 */
 Role
-adminRole (HTTP::Port const& port, Json::Value const& jsonRPC,
-    beast::IP::Endpoint const& remoteIp,
+requestRole (Role const& required, HTTP::Port const& port,
+    Json::Value const& jsonRPC, beast::IP::Endpoint const& remoteIp,
         std::vector<beast::IP::Endpoint> const& admin_allow);
 
 } // ripple

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -33,7 +33,7 @@
 #include <ripple/resource/Fees.h>
 #include <ripple/rpc/Coroutine.h>
 #include <beast/crypto/base64.h>
-#include <ripple/rpc/RPCHandler.h> 
+#include <ripple/rpc/RPCHandler.h>
 #include <beast/cxx14/algorithm.h> // <algorithm>
 #include <beast/http/rfc2616.h>
 #include <boost/algorithm/string.hpp>
@@ -274,16 +274,41 @@ ServerHandlerImp::processRequest (
         }
     }
 
+    // Parse id now so errors from here on will have the id
+    //
+    // VFALCO NOTE Except that "id" isn't included in the following errors.
+    //
+    Json::Value const& id = jsonRPC ["id"];
+
+    Json::Value const& method = jsonRPC ["method"];
+
+    if (method.isNull ()) {
+        HTTPReply (400, "Null method", output);
+        return;
+    }
+
+    if (!method.isString ()) {
+        HTTPReply (400, "method is not string", output);
+        return;
+    }
+
+    /* ---------------------------------------------------------------------- */
     auto const& admin_allow = getConfig().RPC_ADMIN_ALLOW;
     auto role = Role::FORBID;
+    auto required = RPC::roleRequired(id.asString());
+
     if (jsonRPC.isObject() && jsonRPC.isMember("params") &&
             jsonRPC["params"].isArray() && jsonRPC["params"].size() > 0 &&
                 jsonRPC["params"][Json::UInt(0)].isObject())
-        role = adminRole(port, jsonRPC["params"][Json::UInt(0)],
+    {
+        role = requestRole(required, port, jsonRPC["params"][Json::UInt(0)],
             remoteIPAddress, admin_allow);
+    }
     else
-        role = adminRole(port, Json::objectValue,
+    {
+        role = requestRole(required, port, Json::objectValue,
             remoteIPAddress, admin_allow);
+    }
 
     Resource::Consumer usage;
 
@@ -295,25 +320,6 @@ ServerHandlerImp::processRequest (
     if (usage.disconnect ())
     {
         HTTPReply (503, "Server is overloaded", output);
-        return;
-    }
-
-    // Parse id now so errors from here on will have the id
-    //
-    // VFALCO NOTE Except that "id" isn't included in the following errors.
-    //
-    Json::Value const id = jsonRPC ["id"];
-    Json::Value const method = jsonRPC ["method"];
-
-    if (method.isNull ())
-    {
-        HTTPReply (400, "Null method", output);
-        return;
-    }
-
-    if (! method.isString ())
-    {
-        HTTPReply (400, "method is not string", output);
         return;
     }
 
@@ -410,7 +416,7 @@ ServerHandlerImp::processRequest (
         context.metrics.fetches));
     rpc_size_.notify (static_cast <beast::insight::Event::value_type> (
         response.size ()));
-    
+
     response += '\n';
     usage.charge (loadType);
 
@@ -466,76 +472,6 @@ void
 ServerHandlerImp::onWrite (beast::PropertyStream::Map& map)
 {
     m_server->onWrite (map);
-}
-
-//------------------------------------------------------------------------------
-
-// Copied from Config::getAdminRole and modified to use the Port
-Role
-adminRole (HTTP::Port const& port,
-    Json::Value const& params, beast::IP::Endpoint const& remoteIp)
-{
-    Role role (Role::FORBID);
-
-    bool const bPasswordSupplied =
-        params.isMember ("admin_user") ||
-        params.isMember ("admin_password");
-
-    bool const bPasswordRequired =
-        ! port.admin_user.empty() || ! port.admin_password.empty();
-
-    bool bPasswordWrong;
-
-    if (bPasswordSupplied)
-    {
-        if (bPasswordRequired)
-        {
-            // Required, and supplied, check match
-            bPasswordWrong =
-                (port.admin_user !=
-                    (params.isMember ("admin_user") ? params["admin_user"].asString () : ""))
-                ||
-                (port.admin_password !=
-                    (params.isMember ("admin_user") ? params["admin_password"].asString () : ""));
-        }
-        else
-        {
-            // Not required, but supplied
-            bPasswordWrong = false;
-        }
-    }
-    else
-    {
-        // Required but not supplied,
-        bPasswordWrong = bPasswordRequired;
-    }
-
-    // Meets IP restriction for admin.
-    beast::IP::Endpoint const remote_addr (remoteIp.at_port (0));
-    bool bAdminIP = false;
-
-    for (auto const& allow_addr : getConfig().RPC_ADMIN_ALLOW)
-    {
-        if (allow_addr == remote_addr)
-        {
-            bAdminIP = true;
-            break;
-        }
-    }
-
-    if (bPasswordWrong                          // Wrong
-            || (bPasswordSupplied && !bAdminIP))    // Supplied and doesn't meet IP filter.
-    {
-        role   = Role::FORBID;
-    }
-    // If supplied, password is correct.
-    else
-    {
-        // Allow admin, if from admin IP and no password is required or it was supplied and correct.
-        role = bAdminIP && (!bPasswordRequired || bPasswordSupplied) ? Role::ADMIN : Role::GUEST;
-    }
-
-    return role;
 }
 
 //------------------------------------------------------------------------------
@@ -832,7 +768,7 @@ setup_ServerHandler (BasicConfig const& config, std::ostream& log)
 
 std::unique_ptr <ServerHandler>
 make_ServerHandler (beast::Stoppable& parent,
-    boost::asio::io_service& io_service, JobQueue& jobQueue, 
+    boost::asio::io_service& io_service, JobQueue& jobQueue,
         NetworkOPs& networkOPs, Resource::Manager& resourceManager,
             CollectorManager& cm)
 {

--- a/src/ripple/unity/server.cpp
+++ b/src/ripple/unity/server.cpp
@@ -16,7 +16,6 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
-
 #if DOXYGEN
 #include <ripple/server/README.md>
 #endif

--- a/test/config-example.js
+++ b/test/config-example.js
@@ -2,9 +2,26 @@
 // Configuration for unit tests: to be locally customized as needed.
 //
 
+var extend      = require('extend');
 var path        = require("path");
 var extend      = require('extend');
 var testconfig  = require("./testconfig.js");
+
+//
+// Helpers
+//
+
+function lines () {
+  return Array.prototype.slice.call(arguments).join('\n');
+};
+
+function for_each_item (o, f) {
+  for (var k in o) {
+    if (o.hasOwnProperty(k)) {
+      f(k, o[k], o);
+    }
+  }
+};
 
 exports.accounts = testconfig.accounts;
 
@@ -20,8 +37,6 @@ exports.default_server_config = {
 //
 // For testing, you might choose to target a persistent server at alternate ports.
 //
-
-var lines = function() {return Array.prototype.slice.call(arguments).join('\n')}
 
 exports.servers = {
   // A local test server.
@@ -58,6 +73,20 @@ exports.servers = {
 
     'node_db': lines('type=memory',
                      'path=integration')
+  },
+
+  'uniport_tests' : {
+    // rippled.cfg
+    'node_db': lines('type=memory', 'path=integration'),
+
+    // We let testutils.build_setup connect normally, and use the Remote to
+    // determine when the server is ready, so we must configure it, even though
+    // we don't otherwise use it in the test.
+    'websocket_ip': "127.0.0.1",
+    'websocket_port': 6432,
+    'websocket_ssl': false,
+    'trusted' : true,
+
   }
 };
 
@@ -65,6 +94,71 @@ exports.servers.debug = extend({
   no_server: true,
   debug_logfile: "debug.log"
 }, exports.servers.alpha);
+
+exports.uniport_test_ports = {
+    'port_admin_http':
+        {'admin': 'allow', 'port': 6434, 'protocol': 'http'},
+    'port_admin_http_and_https':
+        {'admin': 'allow', 'port': 6437, 'protocol': 'http,https'},
+    'port_admin_https':
+        {'admin': 'allow', 'port': 6435, 'protocol': 'https'},
+    'port_admin_ws':
+        {'admin': 'allow', 'port': 6432, 'protocol': 'ws'},
+    'port_admin_ws_and_wss':
+        {'admin': 'allow', 'port': 6436, 'protocol': 'ws,wss'},
+    'port_admin_wss':
+        {'admin': 'allow', 'port': 6433, 'protocol': 'wss'},
+
+    'port_http':
+        {'admin': 'no', 'port': 6440, 'protocol': 'http'},
+    'port_http_and_https':
+        {'admin': 'no', 'port': 6443, 'protocol': 'http,https'},
+    'port_https':
+        {'admin': 'no', 'port': 6441, 'protocol': 'https'},
+    'port_https_and_http_and_peer':
+        {'admin': 'no', 'port': 6450, 'protocol': 'https,peer,http'},
+
+    'port_passworded_admin_http':
+        {'admin': 'allow', 'admin_password': 'p', 'admin_user': 'u',
+         'port': 6446, 'protocol': 'http'},
+    'port_passworded_admin_http_and_https':
+        {'admin': 'allow', 'admin_password': 'p', 'admin_user': 'u',
+         'port': 6449, 'protocol': 'http,https'},
+    'port_passworded_admin_https':
+        {'admin': 'allow', 'admin_password': 'p', 'admin_user': 'u',
+         'port': 6447, 'protocol': 'https'},
+    'port_passworded_admin_ws':
+        {'admin': 'allow', 'admin_password': 'p', 'admin_user': 'u',
+         'port': 6444, 'protocol': 'ws'},
+    'port_passworded_admin_ws_and_wss':
+        {'admin': 'allow', 'admin_password': 'p', 'admin_user': 'u',
+         'port': 6448, 'protocol': 'ws,wss'},
+    'port_passworded_admin_wss':
+        {'admin': 'allow', 'admin_password': 'p', 'admin_user': 'u',
+         'port': 6445, 'protocol': 'wss'},
+
+    'port_ws':
+        {'admin': 'no', 'port': 6438, 'protocol': 'ws'},
+    'port_ws_and_wss':
+        {'admin': 'no', 'port': 6442, 'protocol': 'ws,wss'},
+    'port_wss':
+        {'admin': 'no', 'port': 6439, 'protocol': 'wss'}
+};
+
+(function() {
+  var server_config = exports.servers.uniport_tests;
+  var test_ports = exports.uniport_test_ports;
+
+  // [server]
+  server_config.server = Object.keys(test_ports).join('\n');
+
+  // [port_*]
+  for_each_item(test_ports, function(port_name, options) {
+    var opt_line = ['ip=127.0.0.1'];
+    for_each_item(options, function(k, v) {opt_line.push(k+'='+v);});
+    server_config[port_name] = opt_line.join('\n');
+  });
+}());
 
 exports.http_servers = {
   // A local test server

--- a/test/uniport-tests.js
+++ b/test/uniport-tests.js
@@ -1,0 +1,511 @@
+/* -------------------------------- REQUIRES -------------------------------- */
+
+var async       = require("async");
+var assert      = require('assert');
+var assert      = require('assert');
+var UInt160     = require("ripple-lib").UInt160;
+var Remote      = require('ripple-lib').Remote;
+var Server      = require('ripple-lib').Server;
+var Request     = require('ripple-lib').Request;
+var testutils   = require("./testutils");
+var config      = testutils.init_config();
+var http        = require('http');
+var request     = require('request');
+
+/* --------------------------------- CONFIG --------------------------------- */
+
+// So we can connect to the ports with self signed certificates.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+var uniport_test_config = {
+  // We have one main WebSocket connection that we inherit from
+  // `testutils.build_setup`. We use that, configured on a non admin, non ssl
+  // port, to determine readiness for tests on the other ports. This Remote's
+  // trace is configured in the normal way, however we can set trace for each of
+  // the test connections on the various ports.
+  remote_trace : false,
+
+  // There's a bug where we can't subscribe to the admin ports requiring
+  // credentials, even though subscribe has Role::USER. `Remote` always issues a
+  // subscribe command after connect(). Setting this flag adds the credentials
+  // to let the tests go further to test that admin requests without credentials
+  // are not honored.
+  add_credentials_to_ws_subscribe: false,
+
+  // WebSocket connections honor admin=no regardless of ip address, yet admin
+  // commands issued via http will be executed for any client with an ip in the
+  // [rpc_admin_allow] whitelist. 127.0.0.1 is hardcoded in cpp code.
+  expect_http_to_honour_admin_no: true,
+
+  // We can be a bit more exhaustive, but it will cost us 2 seconds, unless
+  // we use `skip_tests_matching` to `test.skip` them.
+  define_redundant_tests : false,
+
+  skip_tests_matching : [
+    // /redundant/
+
+    // /can not issue/,
+    // /http/
+  ],
+
+  skip_tests_not_matching : [
+    // /wrong password/,
+    // /ws/
+  ],
+
+  skip_ports_not_matching : [
+    // /admin/,
+    // /password/,
+    // /http/
+  ],
+
+  skip_ports_matching : [
+    // /admin/,
+    // /password/,
+    // /http/
+  ]
+};
+
+/* --------------------------------- HELPERS -------------------------------- */
+
+function for_each_item (o, f) {
+  for (var k in o) {
+    if (o.hasOwnProperty(k)) {
+      f(k, o[k], o);
+    }
+  }
+};
+
+function pretty_json (o) {
+  return JSON.stringify(o, undefined, 2);
+};
+
+function client_protocols (conf) {
+  return conf.protocol.split(',').filter(function (p) {return p !== 'peer';});
+};
+
+function same_protocol_opposite_security (protocol) {
+  switch(protocol)
+  {
+    case 'ws':
+      return 'wss';
+    case 'http':
+      return 'https';
+    case 'wss':
+      return 'ws';
+    case 'https':
+      return 'http';
+    default:
+      throw new Error('unknown protocol '+ protocol);
+  }
+};
+
+function one_invocation_function (f) {
+  var already_done = false;
+  return function done_once() {
+    try {
+      if (!already_done) {
+        f();
+      }
+    } finally {
+      already_done = true;
+    }
+  };
+};
+
+function mark_redundant_tests (normalizer) {
+  var tested = [];
+
+  return function (test_name, func) {
+    var normed = normalizer ? normalizer(test_name) : test_name;
+    var redundant = ~tested.indexOf(normed);
+
+    if (redundant)
+      test_name += ' (redundant)';
+    else
+      tested.push(normed);
+
+    if (!redundant || uniport_test_config.define_redundant_tests) {
+      define_test(test_name, func);
+    }
+  };
+};
+
+function add_credentials_to_request (message, credentials, wrong_pass,
+                                                                wrong_user)
+{
+  message.admin_user = credentials.admin_user;
+  message.admin_password = credentials.admin_password;
+
+  if (wrong_pass) {
+    if (wrong_pass === 'send_object_instead_of_string') {
+      message.admin_password = {admin_password: message.admin_password};
+    } else {
+       message.admin_password += '_';
+    }
+  }
+
+  if (wrong_user) {
+    message.admin_user += '_';
+  }
+};
+
+var define_test = testutils.definer_matching(
+    {
+      skip_if_not_match:uniport_test_config.skip_tests_not_matching,
+      skip_if_match:uniport_test_config.skip_tests_matching
+    },
+    global.test );
+
+var define_suite = testutils.definer_matching(
+    {
+      skip_if_not_match:uniport_test_config.skip_ports_not_matching,
+      skip_if_match:uniport_test_config.skip_ports_matching
+    },
+    global.suite );
+
+/* ---------------------------------- TESTS --------------------------------- */
+
+
+function test_websocket_admin_command (test_declaration,
+                                             protocol,
+                                             port_conf, done)
+{
+  var expect_success = test_declaration.expect_success;
+  var expect_failure = !expect_success;
+  var require_pass = Boolean(port_conf.admin_password);
+  var send_credentials = test_declaration.send_credentials;
+  var wrong_pass = test_declaration.wrong_pass;
+  var wrong_user = test_declaration.wrong_user;
+
+  var config = {
+    'websocket_ip':  "127.0.0.1",
+    'websocket_port': port_conf.port,
+    'websocket_ssl': protocol === 'wss',
+    'trace' : uniport_test_config.remote_trace
+  };
+
+  var remote = Remote.from_config(config);
+
+  if (require_pass) {
+    remote.on('prepare_subscribe', function (request){
+      if (require_pass && uniport_test_config.add_credentials_to_ws_subscribe) {
+        add_credentials_to_request(request.message, port_conf);
+      }
+      request.once('error', function (e, m){
+        if (!uniport_test_config.add_credentials_to_ws_subscribe) {
+          assert.notEqual(e.remote.error,
+                          'forbidden',
+                          'Need credentials for non admin request (subscribe)');
+        }
+      });
+    });
+  }
+
+  remote.once('connected', function () {
+    var before_accept = remote._ledger_current_index;
+    var request = new Request(remote, 'ledger_accept');
+
+    if (send_credentials) {
+      add_credentials_to_request( request.message, port_conf,
+                                  wrong_pass, wrong_user);
+    }
+
+    request.request(function (error, response){
+      // Disconnect
+      remote.connect(false);
+
+      function create_error (message) {
+        var struct = {port_conf: port_conf,
+                      request: request.message,
+                      error: error,
+                      response: response,
+                      test_failure: message};
+        return pretty_json(struct);
+      };
+
+      if (error) {
+        assert(expect_failure,
+              create_error('unexpect failure to issue admin command'));
+
+        if (expect_failure) {
+          if (require_pass && (!send_credentials || wrong_pass || wrong_user)) {
+            assert.equal(error.remote.error,
+                         'forbidden',
+                         create_error('should be forbidden'));
+
+          } else if (!require_pass) {
+            assert.equal(error.remote.error,
+                        'forbidden',
+                         create_error('should be forbidden'));
+          }
+        }
+      }
+
+      if (response) {
+        if (expect_success) {
+          assert.equal((before_accept + 1), response.ledger_current_index,
+                       create_error('admin command should work but did not'));
+        } else {
+          assert.equal(before_accept, response.ledger_current_index,
+                       create_error('admin command worked but should not have'));
+        }
+      }
+      done();
+    });
+  });
+  remote.connect();
+};
+
+function test_http_admin_command (test_declaration, protocol, conf, done)
+{
+  var expect_success = test_declaration.expect_success;
+  var expect_failure = !expect_success;
+  var require_pass = Boolean(conf.admin_password);
+  var send_credentials = test_declaration.send_credentials;
+  var wrong_pass = test_declaration.wrong_pass;
+  var wrong_user = test_declaration.wrong_user;
+
+  var url = protocol+'://localhost:'+conf.port + '/';
+
+  var post_options = {
+    url: url,
+    json: true,
+    body: {
+      method: 'ledger_accept',
+    }
+  };
+
+  if (send_credentials) {
+    var credentials = {};
+    post_options.body.params = [credentials];
+    add_credentials_to_request(credentials, conf, wrong_pass, wrong_user);
+  }
+
+  request.post(post_options, function (err, response, body) {
+    function create_error (message) {
+      var struct = {port_conf: conf,
+                    request: post_options,
+                    error: err,
+                    response: body,
+                    statusCode: response.statusCode,
+                    test_failure: message};
+      return pretty_json(struct);
+    };
+
+    if (err) {
+      assert(!err, String(err));
+    }
+
+    if (expect_failure)
+    {
+      if (!body) {
+        assert.equal(response.statusCode, 403);
+        assert (false, create_error("we expect some kind of response body"));
+      }
+      else if (typeof body == 'string') {
+        assert.equal(response.statusCode, 403);
+        assert.equal(body.trim(), 'Forbidden');
+      }
+      else {
+        if (uniport_test_config.expect_http_to_honour_admin_no) {
+          assert(body.result.status != 'success',
+                create_error("succeded when shouldn't have"));
+        }
+      }
+      done();
+    }
+    else {
+      var msg = "expected 200 got " + response.statusCode+'\n'+pretty_json(body);
+      assert.equal(response.statusCode, 200, msg);
+
+      if (body && body.result) {
+        assert.equal(body.result.status, 'success', pretty_json(body));
+      }
+      done();
+    }
+  });
+};
+
+function test_admin_command (test_declaration, protocol,
+                                   port_conf, done) {
+
+  var type = protocol.slice(0, 2);
+  if (type == 'ws') {
+    test_websocket_admin_command(test_declaration, protocol, port_conf, done);
+  }
+  else if (type == 'ht') {
+    test_http_admin_command(test_declaration, protocol, port_conf, done);
+  }
+  else {
+    throw new Error('unknown protocol: ' + protocol);
+  }
+};
+
+function test_cant_connect (port_conf, protocol, done) {
+  var type = protocol.slice(0, 2);
+
+  if (type == 'ws') {
+    done_once = one_invocation_function (done);
+
+    var WebSocket = Server.websocketConstructor();
+    var ws_url = protocol+'://localhost:'+port_conf.port + '/';
+    var ws = new WebSocket(ws_url);
+
+    ws.onopen = function () {
+      assert(false);
+    };
+
+    if (protocol == 'wss') {
+      setTimeout(function () {
+        assert.equal(ws.readyState, 0);
+        done_once();
+      }, 20);
+    }
+
+    ws.onerror = ws.onclose = function (m) {
+      assert(true);
+      done_once();
+    };
+  } else if (type == 'ht') {
+    var url = protocol+'://localhost:'+port_conf.port + '/';
+
+    var post_options = {
+      url: url,
+      json: true,
+      body: {
+        method: 'server_info',
+      }
+    };
+
+    request.post(post_options, function (err, response, body) {
+      assert(!body);
+      assert(!response);
+      assert(err);
+      done();
+    });
+
+  } else {
+    throw new Error('unknown protocol: ' + protocol);
+  }
+};
+
+suite("Uniport tests", function () {
+  var $ = { };
+
+  suiteSetup(function (done) {
+    testutils.build_setup({}, 'uniport_tests').call($, function () {
+      done();
+    });
+  });
+
+  suiteTeardown(function (done) {
+    testutils.build_teardown('uniport_tests').call($, done);
+  });
+
+  suite('connection', function () {
+    var define_test = mark_redundant_tests();
+
+    for_each_item(config.uniport_test_ports, function (name, conf) {
+      var protocols = client_protocols(conf);
+
+      define_suite(name, function () {
+        ['http', 'https', 'ws', 'wss'].forEach(function (p) {
+          var op = same_protocol_opposite_security(p);
+          if (!(~protocols.indexOf(p)) &&
+               ~(protocols.indexOf(op))) {
+
+            var test_name = "can't connect using " + p +
+                            " with only " + op + " set";
+
+            define_test( test_name,
+              function (done){
+                test_cant_connect(conf, p, done);
+            });
+          }
+        });
+      });
+    });
+  });
+
+  suite('admin commands', function () {
+    var define_test = mark_redundant_tests(function (test_name) {
+      // The password checking should be the same regardless of protocol,
+      // so we normalize the test name (used to determine test redundancy).
+      return test_name.replace('wss', 'ws')
+                      .replace('https', 'http');
+    });
+
+    for_each_item(config.uniport_test_ports, function (name, conf) {
+      define_suite(name, function () {
+        var protocols = client_protocols(conf);
+
+        var allow_admin = conf.admin == 'allow';
+        var require_pass = Boolean(conf.admin_password);
+
+        function test_for (protocol, params) {
+          return function (done) {
+            test_admin_command(params, protocol, conf, done);
+          };
+        };
+
+        if (allow_admin && require_pass) {
+          protocols.forEach(function (protocol) {
+            var can_not_issue_admin_commands =
+                  'can not issue admin commands on '+ protocol + ' ';
+
+            define_test(
+              ('can issue admin commands on '+protocol+
+                ' with correct credentials'),
+               test_for(protocol,
+                        {expect_success: true, send_credentials: true})
+            );
+            define_test(
+              can_not_issue_admin_commands + 'with wrong password',
+              test_for(protocol, {expect_success: false,
+                                  send_credentials: true,
+                                  wrong_pass: true})
+            );
+            define_test(
+              can_not_issue_admin_commands + 'with garbage password',
+              test_for(protocol, {expect_success: false,
+                                  send_credentials: true,
+                                  wrong_pass: 'send_object_instead_of_string'})
+            );
+            define_test(
+              can_not_issue_admin_commands + ' with wrong user',
+              test_for(protocol, {expect_success: false,
+                                  send_credentials: true,
+                                  wrong_user: true})
+            );
+            define_test(
+              can_not_issue_admin_commands + 'without credentials',
+              test_for(protocol, {expect_success: false,
+                                  send_credentials: false})
+            );
+          });
+        }
+        else if (allow_admin)
+        {
+          protocols.forEach(function (protocol) {
+            define_test(
+              'can issue admin commands on ' + protocol,
+              test_for(protocol, {expect_success: true,
+                                  send_credentials: false})
+            );
+          });
+        }
+        else if (!allow_admin)
+        {
+          protocols.forEach(function (protocol) {
+            define_test(
+              'can not issue admin commands on ' + protocol,
+              test_for(protocol, {expect_success: false,
+                                  send_credentials: false})
+            );
+          });
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Started on these a few months back, but then progress stalled. I'm not happy with the state of the current javascript tests, however they did help uncover some weird inconsistencies. 

I've talked with integration people, and they agree, that if a port is specified as `admin=no` that that setting should be honoured, regardless of any ip white list. 

This patch includes some C++ code, and different logic, that requires some C++ devs to audit. 

@JoelKatz 
@vinniefalco 