### PR TITLE
Get rid of compilation warnings in Ledger.test.cpp

### DIFF
--- a/src/ripple/app/ledger/Ledger.test.cpp
+++ b/src/ripple/app/ledger/Ledger.test.cpp
@@ -219,10 +219,10 @@ class Ledger_test : public beast::unit_test::suite
         applyTransactions(set, newLCL, newLCL, retriableTransactions, false);
         newLCL->updateSkipList();
         newLCL->setClosed();
-        int asf = newLCL->peekAccountStateMap()->flushDirty(hotACCOUNT_NODE,
-                                                        newLCL->getLedgerSeq());
-        int tmf = newLCL->peekTransactionMap()->flushDirty(hotTRANSACTION_NODE,
-                                                        newLCL->getLedgerSeq());
+        newLCL->peekAccountStateMap()->flushDirty(
+            hotACCOUNT_NODE, newLCL->getLedgerSeq());
+        newLCL->peekTransactionMap()->flushDirty(
+            hotTRANSACTION_NODE, newLCL->getLedgerSeq());
         using namespace std::chrono;
         auto const epoch_offset = days{10957};  // 2000-01-01
         std::uint32_t closeTime = time_point_cast<seconds>  // now


### PR DESCRIPTION
Reviewers: @HowardHinnant @ximinez