### PR TITLE
Fix Subscribe RPC to correctly distinguish bids and asks.

### DIFF
--- a/src/ripple/protocol/Book.h
+++ b/src/ripple/protocol/Book.h
@@ -94,6 +94,12 @@ void hash_append (Hasher& h, BookType<ByValue> const& b)
     hash_append (h, b.in, b.out);
 }
 
+template <bool ByValue>
+BookType<ByValue> reversed (BookType<ByValue> const& book)
+{
+    return BookType<ByValue> (book.out, book.in);
+}
+
 /** Ordered comparison. */
 template <bool LhsByValue, bool RhsByValue>
 int compare (BookType <LhsByValue> const& lhs,

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -321,7 +321,7 @@ Json::Value doSubscribe (RPC::Context& context)
 
                         context.netOps.getBookPage (
                             context.role == Role::ADMIN,
-                            lpLedger, book, raTakerID.getAccountID (),
+                            lpLedger, reversed (book), raTakerID.getAccountID (),
                             false, 0, jvMarker, jvAsks);
 
                         if (jvAsks.isMember (jss::offers))


### PR DESCRIPTION
Found by Mickey!

See here:

https://github.com/ripple/rippled/commit/6014b132348bc51af658285cf2d385bc504deb6d#diff-e33c82fefe08b47268c75bbbd4bd054cL311

Note that there are apparently no tests for Subscribe - I filed a JIRA for this: https://ripplelabs.atlassian.net/browse/RIPD-740