### PR TITLE
Disable Ticket transactions and tests

### DIFF
--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -204,4 +204,11 @@
 #define RIPPLE_HOOK_VALIDATORS 0
 #endif
 
+/** Config: RIPPLE_ENABLE_TICKETS
+    Enables processing of ticket transactions
+*/
+#ifndef RIPPLE_ENABLE_TICKETS
+#define RIPPLE_ENABLE_TICKETS 0
+#endif
+
 #endif

--- a/src/ripple/app/transactors/CancelTicket.cpp
+++ b/src/ripple/app/transactors/CancelTicket.cpp
@@ -85,7 +85,11 @@ transact_CancelTicket (
     TransactionEngineParams params,
     TransactionEngine* engine)
 {
+#if RIPPLE_ENABLE_TICKETS
     return CancelTicket (txn, params, engine).apply ();
+#else
+    return temDISABLED;
+#endif
 }
 
 

--- a/src/ripple/app/transactors/CreateTicket.cpp
+++ b/src/ripple/app/transactors/CreateTicket.cpp
@@ -127,7 +127,11 @@ transact_CreateTicket (
     TransactionEngineParams params,
     TransactionEngine* engine)
 {
+#if RIPPLE_ENABLE_TICKETS
     return CreateTicket (txn, params, engine).apply ();
+#else
+    return temDISABLED;
+#endif
 }
 
 }

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -81,6 +81,7 @@ enum TER    // aka TransactionEngineResult
     temREDUNDANT,
     temREDUNDANT_SEND_MAX,
     temRIPPLE_EMPTY,
+    temDISABLED,
 
     // An intermediate result used internally, should never be returned.
     temUNCERTAIN,

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -116,7 +116,8 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { temREDUNDANT_SEND_MAX,    "temREDUNDANT_SEND_MAX",    "Send max is redundant."                                        },
         { temRIPPLE_EMPTY,          "temRIPPLE_EMPTY",          "PathSet with no paths."                                        },
         { temUNCERTAIN,             "temUNCERTAIN",             "In process of determining result. Never returned."             },
-        { temUNKNOWN,               "temUNKNOWN",               "The transactions requires logic not implemented yet."          },
+        { temUNKNOWN,               "temUNKNOWN",               "The transaction requires logic that is not implemented yet."   },
+        { temDISABLED,              "temDISABLED",              "The transaction requires logic that is currently disabled."    },
 
         { terRETRY,                 "terRETRY",                 "Retry transaction."                                            },
         { terFUNDS_SPENT,           "terFUNDS_SPENT",           "Can't set password, password set funds already spent."         },

--- a/test/ticket-test.js
+++ b/test/ticket-test.js
@@ -33,7 +33,7 @@ var submit_transaction_factory = function(remote) {
 
 /* ---------------------------------- TESTS --------------------------------- */
 
-suite("Ticket tests", function() {
+suite.skip("Ticket tests", function() {
   var $ = { };
   var submit_tx;
 


### PR DESCRIPTION
Disable processing of ticket-related transactions -- attempting to use them will return the new `temDISABLED` error code.

Reviews: @JoelKatz, @vinniefalco