### PR TITLE
Delete or devirtualize member functions

### DIFF
--- a/src/ripple/shamap/SHAMapNodeID.h
+++ b/src/ripple/shamap/SHAMapNodeID.h
@@ -30,7 +30,7 @@
 namespace ripple {
 
 // Identifies a node in a SHA256 hash map
-class SHAMapNodeID
+class SHAMapNodeID final
 {
 private:
     uint256 mNodeID;
@@ -108,7 +108,7 @@ public:
     }
     bool operator!= (uint256 const& n) const {return !(*this == n);}
 
-    virtual std::string getString () const;
+    std::string getString () const;
 
     static uint256 getNodeID (int depth, uint256 const& hash);
 

--- a/src/ripple/shamap/SHAMapNodeID.h
+++ b/src/ripple/shamap/SHAMapNodeID.h
@@ -109,7 +109,6 @@ public:
     bool operator!= (uint256 const& n) const {return !(*this == n);}
 
     virtual std::string getString () const;
-    void dump (beast::Journal journal) const;
 
     static uint256 getNodeID (int depth, uint256 const& hash);
 

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -175,8 +175,6 @@ public:
         mFullBelowGen = gen;
     }
 
-    // VFALCO Why is this virtual?
-    virtual void dump (SHAMapNodeID const&, beast::Journal journal);
     virtual std::string getString (SHAMapNodeID const&) const;
 
     SHAMapTreeNode* getChildPointer (int branch);

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -38,7 +38,7 @@ enum SHANodeFormat
     snfHASH     = 3, // just the hash
 };
 
-class SHAMapTreeNode
+class SHAMapTreeNode final
     : public CountedObject <SHAMapTreeNode>
 {
 public:
@@ -175,7 +175,7 @@ public:
         mFullBelowGen = gen;
     }
 
-    virtual std::string getString (SHAMapNodeID const&) const;
+    std::string getString (SHAMapNodeID const&) const;
 
     SHAMapTreeNode* getChildPointer (int branch);
     SHAMapTreeNode::pointer getChild (int branch);

--- a/src/ripple/shamap/impl/SHAMapNodeID.cpp
+++ b/src/ripple/shamap/impl/SHAMapNodeID.cpp
@@ -177,10 +177,4 @@ int SHAMapNodeID::selectBranch (uint256 const& hash) const
     return branch;
 }
 
-void SHAMapNodeID::dump (beast::Journal journal) const
-{
-    if (journal.debug) journal.debug <<
-        getString ();
-}
-
 } // ripple

--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -437,12 +437,6 @@ void SHAMapTreeNode::makeInner ()
     mHash.zero ();
 }
 
-void SHAMapTreeNode::dump (const SHAMapNodeID & id, beast::Journal journal)
-{
-    if (journal.debug) journal.debug <<
-        "SHAMapTreeNode(" << id.getNodeID () << ")";
-}
-
 std::string SHAMapTreeNode::getString (const SHAMapNodeID & id) const
 {
     std::string ret = "NodeID(";


### PR DESCRIPTION
Remove unused dump() members.
Devirtualize getString().