### PR TITLE
Make callers of InboundLedgers::findCreate handle a nullptr return.

### DIFF
--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -1185,8 +1185,9 @@ void fillPaths (Pathfinder::PaymentType type, PathCostList const& costs)
 void Pathfinder::initPathTable ()
 {
     // CAUTION: Do not include rules that build default paths
-    fillPaths(
-        pt_XRP_to_XRP, {});
+
+    mPathTable.clear();
+    fillPaths (pt_XRP_to_XRP, {});
 
     fillPaths(
         pt_XRP_to_nonXRP, {

--- a/src/ripple/rpc/handlers/LedgerRequest.cpp
+++ b/src/ripple/rpc/handlers/LedgerRequest.cpp
@@ -76,13 +76,18 @@ Json::Value doLedgerRequest (RPC::Context& context)
             {
                 // We don't have the ledger we need to figure out which ledger
                 // they want. Try to get it.
-                Json::Value jvResult
-                        =  getApp().getInboundLedgers().findCreate (
-                            refHash, refIndex, InboundLedger::fcGENERIC)
-                        ->getJson (0);
 
-                jvResult[jss::error] = "ledgerNotFound";
-                return jvResult;
+                if (auto il = getApp().getInboundLedgers().findCreate (
+                        refHash, refIndex, InboundLedger::fcGENERIC))
+                {
+                    Json::Value jvResult = il->getJson (0);
+
+                    jvResult[jss::error] = "ledgerNotFound";
+                    return jvResult;
+                }
+
+                // findCreate failed to return an inbound ledger. App is likely shutting down
+                return Json::Value();
             }
 
             ledgerHash = ledger->getLedgerHash (ledgerIndex);
@@ -102,9 +107,13 @@ Json::Value doLedgerRequest (RPC::Context& context)
     else
     {
         // Try to get the desired ledger
-        auto il = getApp().getInboundLedgers().findCreate (
-            ledgerHash, 0, InboundLedger::fcGENERIC);
-        return il->getJson (0);
+        if (auto il = getApp ().getInboundLedgers ().findCreate (
+                ledgerHash, 0, InboundLedger::fcGENERIC))
+        {
+            return il->getJson (0);
+        }
+        return RPC::make_error (
+            rpcNOT_READY, "findCreate failed to return an inbound ledger");
     }
 }
 


### PR DESCRIPTION
In normal operation, InboundLedgers::findCreate never returns null, but
during system shutdown, it will return null.

Since this only happens in system shutdown, when findCreate returns null
the calling function stops what it was doing and returns.

During testing, I found an issue where destroying the application object
and creating a new one caused problems with a static PathTable. This table
is now cleared when re-initialized.