### PR TITLE
Add config "ledger_history_index" functionality (RIPD-559)

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -481,6 +481,13 @@
 #
 #
 #
+# [ledger_history_index]
+#
+#   If set to greater than 0, the index number of the earliest ledger to
+#   acquire.
+#
+#
+#
 # [fetch_depth]
 #
 #   The number of past ledgers to serve to other peers that request historical

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -23,6 +23,7 @@
 #include <ripple/app/ledger/LedgerEntrySet.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/RippleLedgerHash.h>
+#include <ripple/core/Config.h>
 #include <beast/insight/Collector.h>
 #include <beast/threads/Stoppable.h>
 #include <beast/threads/UnlockGuard.h>
@@ -149,8 +150,9 @@ public:
 
     virtual beast::PropertyStream::Source& getPropertySource () = 0;
 
-    static bool shouldAcquire (std::uint32_t currentLedgerID,
-                               std::uint32_t ledgerHistory, std::uint32_t targetLedger);
+    static bool shouldAcquire (std::uint32_t currentLedgerID, 
+        std::uint32_t ledgerHistory, std::uint32_t ledgerHistoryIndex,
+        std::uint32_t targetLedger);
 
     virtual void clearPriorLedgers (LedgerIndex seq) = 0;
 
@@ -158,8 +160,7 @@ public:
 };
 
 std::unique_ptr <LedgerMaster>
-make_LedgerMaster (bool standalone, std::uint32_t fetch_depth,
-    std::uint32_t ledger_history, int ledger_fetch_size, beast::Stoppable& parent,
+make_LedgerMaster (Config const& config, beast::Stoppable& parent,
     beast::insight::Collector::ptr const& collector, beast::Journal journal);
 
 } // ripple

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -291,9 +291,7 @@ public:
         , m_pathRequests (new PathRequests (
             m_logs.journal("PathRequest"), m_collectorManager->collector ()))
 
-        , m_ledgerMaster (make_LedgerMaster (getConfig ().RUN_STANDALONE,
-            getConfig ().FETCH_DEPTH, getConfig ().LEDGER_HISTORY,
-            getConfig ().getSize (siLedgerFetch), *m_jobQueue,
+        , m_ledgerMaster (make_LedgerMaster (getConfig (), *m_jobQueue,
             m_collectorManager->collector (), m_logs.journal("LedgerMaster")))
 
         // VFALCO NOTE must come before NetworkOPs to prevent a crash due

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -315,6 +315,7 @@ int run (int argc, char** argv)
         {
             getConfig ().RUN_STANDALONE = true;
             getConfig ().LEDGER_HISTORY = 0;
+            getConfig ().LEDGER_HISTORY_INDEX = 0;
         }
     }
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -291,6 +291,7 @@ public:
 
     // Node storage configuration
     std::uint32_t                      LEDGER_HISTORY;
+    std::uint32_t                      LEDGER_HISTORY_INDEX;
     std::uint32_t                      FETCH_DEPTH;
     int                         NODE_SIZE;
 
@@ -310,7 +311,7 @@ public:
 public:
     Config ();
 
-    int getSize (SizedItemName);
+    int getSize (SizedItemName) const;
     void setup (std::string const& strConf, bool bQuiet);
     void load ();
 };

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -43,6 +43,7 @@ struct ConfigSection
 #define SECTION_FEE_OWNER_RESERVE       "fee_owner_reserve"
 #define SECTION_FETCH_DEPTH             "fetch_depth"
 #define SECTION_LEDGER_HISTORY          "ledger_history"
+#define SECTION_LEDGER_HISTORY_INDEX    "ledger_history_index"
 #define SECTION_INSIGHT                 "insight"
 #define SECTION_IPS                     "ips"
 #define SECTION_IPS_FIXED               "ips_fixed"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -249,6 +249,7 @@ Config::Config ()
     FEE_CONTRACT_OPERATION  = DEFAULT_FEE_OPERATION;
 
     LEDGER_HISTORY          = 256;
+    LEDGER_HISTORY_INDEX    = 0;
     FETCH_DEPTH             = 1000000000;
 
     // An explanation of these magical values would be nice.
@@ -584,6 +585,11 @@ void Config::load ()
                 else
                     LEDGER_HISTORY = beast::lexicalCastThrow <std::uint32_t> (strTemp);
             }
+            if (getSingleSection(secConfig, SECTION_LEDGER_HISTORY_INDEX, strTemp))
+            {
+                LEDGER_HISTORY_INDEX = beast::lexicalCastThrow <std::uint32_t>(strTemp);
+            }
+
             if (getSingleSection (secConfig, SECTION_FETCH_DEPTH, strTemp))
             {
                 boost::to_lower (strTemp);
@@ -628,7 +634,7 @@ void Config::load ()
     }
 }
 
-int Config::getSize (SizedItemName item)
+int Config::getSize (SizedItemName item) const
 {
     SizedItem sizeTable[] =   //    tiny    small   medium  large       huge
     {


### PR DESCRIPTION
A [ledger_history_index] section can be specified in the config file. The value specified would indicate a ledger sequence to acquire past ledgers up to.

Reviewers: @JoelKatz  @mtrippled