### PR TITLE
Enable Amendments from config file or static data

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1987,6 +1987,9 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\misc\SHAMapStoreImp.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\app\misc\tests\AmendmentTable.test.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\misc\Validations.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -325,6 +325,9 @@
     <Filter Include="ripple\app\misc">
       <UniqueIdentifier>{5A1509B2-871B-A7AC-1E60-544D3F398741}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ripple\app\misc\tests">
+      <UniqueIdentifier>{815DC1A2-E2EF-E6E3-D979-19AD1476A28B}</UniqueIdentifier>
+    </Filter>
     <Filter Include="ripple\app\node">
       <UniqueIdentifier>{0FCD3973-E9A6-7172-C8A3-C3401E1A03DD}</UniqueIdentifier>
     </Filter>
@@ -2961,6 +2964,9 @@
     <ClInclude Include="..\..\src\ripple\app\misc\SHAMapStoreImp.h">
       <Filter>ripple\app\misc</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\app\misc\tests\AmendmentTable.test.cpp">
+      <Filter>ripple\app\misc\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\misc\Validations.cpp">
       <Filter>ripple\app\misc</Filter>
     </ClCompile>

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -320,8 +320,7 @@ public:
 
         , m_amendmentTable (make_AmendmentTable
                             (weeks(2), MAJORITY_FRACTION,
-                             m_logs.journal("AmendmentTable"),
-                             make_AmendmentTableInjections()))
+                             m_logs.journal("AmendmentTable")))
 
         , mFeeTrack (LoadFeeTrack::New (m_logs.journal("LoadManager")))
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -50,6 +50,7 @@
 #include <ripple/json/json_reader.h>
 #include <ripple/json/to_string.h>
 #include <ripple/core/LoadFeeTrack.h>
+#include <ripple/core/ConfigSections.h>
 #include <ripple/net/SNTPClient.h>
 #include <ripple/nodestore/Database.h>
 #include <ripple/nodestore/DummyScheduler.h>
@@ -317,8 +318,10 @@ public:
         , m_validators (Validators::make_Manager(*this, get_io_service(),
             getConfig ().getModuleDatabasePath (), m_logs.journal("UVL")))
 
-        , m_amendmentTable (make_AmendmentTable (weeks(2), MAJORITY_FRACTION,
-            m_logs.journal("AmendmentTable")))
+        , m_amendmentTable (make_AmendmentTable
+                            (weeks(2), MAJORITY_FRACTION,
+                             m_logs.journal("AmendmentTable"),
+                             make_AmendmentTableInjections()))
 
         , mFeeTrack (LoadFeeTrack::New (m_logs.journal("LoadManager")))
 
@@ -650,7 +653,8 @@ public:
         if (!getConfig ().RUN_STANDALONE)
             updateTables ();
 
-        m_amendmentTable->addInitial();
+        m_amendmentTable->addInitial (
+            getConfig ().section (SECTION_AMENDMENTS));
         initializePathfinding ();
 
         m_ledgerMaster->setMinValidations (getConfig ().VALIDATION_QUORUM);

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -46,6 +46,48 @@ public:
     }
 };
 
+/** 256-bit Id and human friendly name of an amendment.
+*/
+class AmendmentName final
+{
+private:
+    uint256 mId;
+    // Keep the hex string around for error reporting
+    std::string mHexString;
+    std::string mFriendlyName;
+    bool mValid{false};
+
+public:
+    AmendmentName () = default;
+    AmendmentName (AmendmentName const& rhs) = default;
+    // AmendmentName (AmendmentName&& rhs) = default; // MSVS not supported
+    AmendmentName (uint256 const& id, std::string friendlyName)
+        : mId (id), mFriendlyName (friendlyName), mValid (true)
+    {
+    }
+    AmendmentName (std::string id, std::string friendlyName)
+        : mHexString (std::move (id)), mFriendlyName (std::move (friendlyName))
+    {
+        mValid = mId.SetHex (mHexString);
+    }
+    bool valid () const
+    {
+        return mValid;
+    }
+    uint256 const& id () const
+    {
+        return mId;
+    }
+    std::string const& hexString () const
+    {
+        return mHexString;
+    }
+    std::string const& friendlyName () const
+    {
+        return mFriendlyName;
+    }
+};
+
 /** Current state of an amendment.
     Tells if a amendment is supported, enabled or vetoed. A vetoed amendment
     means the node will never announce its support.
@@ -53,19 +95,25 @@ public:
 class AmendmentState
 {
 public:
-    bool mVetoed;   // We don't want this amendment enabled
+    bool mVetoed;  // We don't want this amendment enabled
     bool mEnabled;
     bool mSupported;
     bool mDefault;  // Include in genesis ledger
 
-    core::Clock::time_point m_firstMajority; // First time we saw a majority (close time)
-    core::Clock::time_point m_lastMajority;  // Most recent time we saw a majority (close time)
+    core::Clock::time_point
+        m_firstMajority;  // First time we saw a majority (close time)
+    core::Clock::time_point
+        m_lastMajority;  // Most recent time we saw a majority (close time)
 
     std::string mFriendlyName;
 
     AmendmentState ()
-        : mVetoed (false), mEnabled (false), mSupported (false), mDefault (false),
-          m_firstMajority (0), m_lastMajority (0)
+        : mVetoed (false)
+        , mEnabled (false)
+        , mSupported (false)
+        , mDefault (false)
+        , m_firstMajority (0)
+        , m_lastMajority (0)
     {
         ;
     }
@@ -133,9 +181,7 @@ public:
 
         @return true if the amendment was added to the table, otherwise false.
     */
-    virtual bool addKnown (uint256 const& amendmentID,
-                           std::string const& friendlyName,
-                           bool veto) = 0;
+    virtual bool addKnown (AmendmentName const& name) = 0;
 
     virtual uint256 get (std::string const& name) = 0;
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -187,9 +187,17 @@ public:
     virtual bool isEnabled (uint256 const& amendment) = 0;
     virtual bool isSupported (uint256 const& amendment) = 0;
 
+    /** Enable only the specified amendments.
+        Other amendments in the table will be set to disabled.
+    */
     virtual void setEnabled (const std::vector<uint256>& amendments) = 0;
+    /** Support only the specified amendments.
+        Other amendments in the table will be set to unsupported.
+    */
     virtual void setSupported (const std::vector<uint256>& amendments) = 0;
 
+    /** Update the walletDB with the majority times.
+     */
     virtual void reportValidations (const AmendmentSet&) = 0;
 
     virtual Json::Value getJson (int) = 0;

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -62,7 +62,7 @@ public:
     AmendmentName (AmendmentName const& rhs) = default;
     // AmendmentName (AmendmentName&& rhs) = default; // MSVS not supported
     AmendmentName (uint256 const& id, std::string friendlyName)
-        : mId (id), mFriendlyName (friendlyName), mValid (true)
+        : mId (id), mFriendlyName (std::move (friendlyName)), mValid (true)
     {
     }
     AmendmentName (std::string id, std::string friendlyName)

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -212,7 +212,7 @@ public:
 };
 
 /**
-   AmendmentTableInjections is used to insert moc objects into the amendment
+   AmendmentTableInjections is used to insert mock objects into the amendment
    table class while unit testing.
  */
 class AmendmentTableInjections
@@ -224,7 +224,7 @@ public:
     virtual void setMajorityTimesFromDBToState (
         AmendmentState& toUpdate,
         uint256 const& amendmentHash) const = 0;
-    /** For eash hash, get the first and last majority from the corresponding
+    /** For each hash, get the first and last majority from the corresponding
      * AmendmentState object and update the walletDB.
      */
     virtual void setMajorityTimesFromStateToDB (
@@ -236,7 +236,7 @@ public:
 // Use for regular system
 std::unique_ptr<AmendmentTableInjections> make_AmendmentTableInjections ();
 // Use for unit testing
-std::unique_ptr<AmendmentTableInjections> make_MOCAmendmentTableInjections ();
+std::unique_ptr<AmendmentTableInjections> make_MockAmendmentTableInjections ();
 
 std::unique_ptr<AmendmentTable> make_AmendmentTable (
     std::chrono::seconds majorityTime,

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -211,25 +211,11 @@ public:
     doVoting (Ledger::ref lastClosedLedger, SHAMap::ref initialPosition) = 0;
 };
 
-namespace AmendmentTableDetail
-{
-/**
-   AppApiFacade is used to insert mock objects into the amendment
-   table class while unit testing.
- */
-enum class AppApiFacade
-{
-    useApp,
-    useMock
-};
-}  // AmendmentTableDetail
-
 std::unique_ptr<AmendmentTable> make_AmendmentTable (
     std::chrono::seconds majorityTime,
     int majorityFraction,
     beast::Journal journal,
-    AmendmentTableDetail::AppApiFacade apiFacade =
-        AmendmentTableDetail::AppApiFacade::useApp);
+    bool useMockFacade = false);
 
 }  // ripple
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -217,36 +217,19 @@ namespace AmendmentTableDetail
    AppApiFacade is used to insert mock objects into the amendment
    table class while unit testing.
  */
-class AppApiFacade
+enum class AppApiFacade
 {
-public:
-    /** Get the first and last majority from the walletDB and update the
-     * AmendmentState object.
-     */
-    virtual void setMajorityTimesFromDBToState (
-        AmendmentState& toUpdate,
-        uint256 const& amendmentHash) const = 0;
-    /** For each hash, get the first and last majority from the corresponding
-     * AmendmentState object and update the walletDB.
-     */
-    virtual void setMajorityTimesFromStateToDB (
-        std::vector<uint256> const& changedAmendments,
-        hash_map<uint256, AmendmentState>& amendmentMap) const = 0;
-    virtual ValidationSet getValidations (uint256 const& hash) const = 0;
+    useApp,
+    useMock
 };
-
-// Use for regular system
-std::unique_ptr<AppApiFacade> make_AppApiFacade ();
-// Use for unit testing
-std::unique_ptr<AppApiFacade> make_MockAppApiFacade ();
 }  // AmendmentTableDetail
 
 std::unique_ptr<AmendmentTable> make_AmendmentTable (
     std::chrono::seconds majorityTime,
     int majorityFraction,
     beast::Journal journal,
-    std::unique_ptr<AmendmentTableDetail::AppApiFacade> facade =
-        AmendmentTableDetail::make_AppApiFacade ());
+    AmendmentTableDetail::AppApiFacade apiFacade =
+        AmendmentTableDetail::AppApiFacade::useApp);
 
 }  // ripple
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -125,6 +125,14 @@ public:
 
     virtual void addInitial () = 0;
 
+    /** Add an amendment to the AmendmentTable
+
+        @param amendmentId hash identifying the amendment to add.
+        @param friendlyName human readable name for the amendment.
+        @param veto set to true to veto this amendment.
+
+        @return true if the amendment was added to the table, otherwise false.
+    */
     virtual bool addKnown (uint256 const& amendmentID,
                            std::string const& friendlyName,
                            bool veto) = 0;

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -125,8 +125,10 @@ public:
 
     virtual void addInitial () = 0;
 
-    virtual AmendmentState* addKnown (const char* amendmentID,
-        const char* friendlyName, bool veto) = 0;
+    virtual AmendmentState* addKnown (uint256 const& amendmentID,
+                                      std::string const& friendlyName,
+                                      bool veto) = 0;
+
     virtual uint256 get (std::string const& name) = 0;
 
     virtual bool veto (uint256 const& amendment) = 0;

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -175,13 +175,9 @@ public:
 
     /** Add an amendment to the AmendmentTable
 
-        @param amendmentId hash identifying the amendment to add.
-        @param friendlyName human readable name for the amendment.
-        @param veto set to true to veto this amendment.
-
-        @return true if the amendment was added to the table, otherwise false.
+        @throw will throw if the name parameter is not valid
     */
-    virtual bool addKnown (AmendmentName const& name) = 0;
+    virtual void addKnown (AmendmentName const& name) = 0;
 
     virtual uint256 get (std::string const& name) = 0;
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -242,7 +242,8 @@ std::unique_ptr<AmendmentTable> make_AmendmentTable (
     std::chrono::seconds majorityTime,
     int majorityFraction,
     beast::Journal journal,
-    std::unique_ptr<AmendmentTableInjections> injections);
+    std::unique_ptr<AmendmentTableInjections> injections =
+        make_AmendmentTableInjections ());
 
 }  // ripple
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -211,11 +211,13 @@ public:
     doVoting (Ledger::ref lastClosedLedger, SHAMap::ref initialPosition) = 0;
 };
 
+namespace AmendmentTableDetail
+{
 /**
-   AmendmentTableInjections is used to insert mock objects into the amendment
+   AppApiFacade is used to insert mock objects into the amendment
    table class while unit testing.
  */
-class AmendmentTableInjections
+class AppApiFacade
 {
 public:
     /** Get the first and last majority from the walletDB and update the
@@ -234,16 +236,17 @@ public:
 };
 
 // Use for regular system
-std::unique_ptr<AmendmentTableInjections> make_AmendmentTableInjections ();
+std::unique_ptr<AppApiFacade> make_AppApiFacade ();
 // Use for unit testing
-std::unique_ptr<AmendmentTableInjections> make_MockAmendmentTableInjections ();
+std::unique_ptr<AppApiFacade> make_MockAppApiFacade ();
+}  // AmendmentTableDetail
 
 std::unique_ptr<AmendmentTable> make_AmendmentTable (
     std::chrono::seconds majorityTime,
     int majorityFraction,
     beast::Journal journal,
-    std::unique_ptr<AmendmentTableInjections> injections =
-        make_AmendmentTableInjections ());
+    std::unique_ptr<AmendmentTableDetail::AppApiFacade> facade =
+        AmendmentTableDetail::make_AppApiFacade ());
 
 }  // ripple
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -95,28 +95,19 @@ public:
 class AmendmentState
 {
 public:
-    bool mVetoed;  // We don't want this amendment enabled
-    bool mEnabled;
-    bool mSupported;
-    bool mDefault;  // Include in genesis ledger
+    bool mVetoed{false};  // We don't want this amendment enabled
+    bool mEnabled{false};
+    bool mSupported{false};
+    bool mDefault{false};  // Include in genesis ledger
 
     core::Clock::time_point
-        m_firstMajority;  // First time we saw a majority (close time)
+        m_firstMajority{0};  // First time we saw a majority (close time)
     core::Clock::time_point
-        m_lastMajority;  // Most recent time we saw a majority (close time)
+        m_lastMajority{0};  // Most recent time we saw a majority (close time)
 
     std::string mFriendlyName;
 
-    AmendmentState ()
-        : mVetoed (false)
-        , mEnabled (false)
-        , mSupported (false)
-        , mDefault (false)
-        , m_firstMajority (0)
-        , m_lastMajority (0)
-    {
-        ;
-    }
+    AmendmentState () = default;
 
     void setVeto ()
     {

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -125,9 +125,9 @@ public:
 
     virtual void addInitial () = 0;
 
-    virtual AmendmentState* addKnown (uint256 const& amendmentID,
-                                      std::string const& friendlyName,
-                                      bool veto) = 0;
+    virtual bool addKnown (uint256 const& amendmentID,
+                           std::string const& friendlyName,
+                           bool veto) = 0;
 
     virtual uint256 get (std::string const& name) = 0;
 

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -69,7 +69,7 @@ public:
 
     void addInitial () override;
 
-    bool addKnown (AmendmentName const& name) override;
+    void addKnown (AmendmentName const& name) override;
 
     uint256 get (std::string const& name) override;
 
@@ -227,13 +227,17 @@ AmendmentTableImpl::get (std::string const& name)
     return uint256 ();
 }
 
-bool
+void
 AmendmentTableImpl::addKnown (AmendmentName const& name)
 {
     if (!name.valid ())
     {
-        assert (false);
-        return false;
+        std::string const errorMsg =
+            (boost::format (
+                 "addKnown was given an invalid hash (expected a hex number). "
+                 "Value was: %1%") %
+             name.hexString ()).str ();
+        throw std::runtime_error (errorMsg);
     }
 
     ScopedLockType sl (mLock);
@@ -244,8 +248,6 @@ AmendmentTableImpl::addKnown (AmendmentName const& name)
 
     amendment.mVetoed = false;
     amendment.mSupported = true;
-
-    return true;
 }
 
 bool

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -114,8 +114,6 @@ PreEnabledAmendmentsCollection const preEnabledAmendments;
 void
 AmendmentTableImpl::addInitial ()
 {
-    detail::PreEnabledAmendmentsCollection toAdd (detail::preEnabledAmendments);
-
     for (auto const& a : detail::preEnabledAmendments)
     {
         if (!a.valid ())
@@ -128,6 +126,8 @@ AmendmentTableImpl::addInitial ()
             throw std::runtime_error (errorMsg);
         }
     }
+
+    detail::PreEnabledAmendmentsCollection toAdd (detail::preEnabledAmendments);
 
     {
         // add the amendments from the config file

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -652,7 +652,7 @@ public:
     virtual ValidationSet getValidations (uint256 const& hash) const override;
 };
 
-class AmendmentTableInjectionsMOC final : public AmendmentTableInjections
+class AmendmentTableInjectionsMock final : public AmendmentTableInjections
 {
 public:
     virtual void setMajorityTimesFromDBToState (
@@ -729,9 +729,9 @@ std::unique_ptr<AmendmentTableInjections> make_AmendmentTableInjections ()
 }
 
 // Use for unit testing
-std::unique_ptr<AmendmentTableInjections> make_MOCAmendmentTableInjections ()
+std::unique_ptr<AmendmentTableInjections> make_MockAmendmentTableInjections ()
 {
-    return std::make_unique<detail::AmendmentTableInjectionsMOC>();
+    return std::make_unique<detail::AmendmentTableInjectionsMock>();
 }
 
 }  // ripple

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -217,6 +217,8 @@ AmendmentTableImpl::getExisting (uint256 const& amendmentHash)
 uint256
 AmendmentTableImpl::get (std::string const& name)
 {
+    ScopedLockType sl (mLock);
+
     for (auto const& e : m_amendmentMap)
     {
         if (name == e.second.mFriendlyName)

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -115,9 +115,6 @@ public:
 void
 AmendmentTableImpl::addInitial ()
 {
-    // For each amendment this version supports, construct the AmendmentState
-    // object by calling addKnown. Set any vetoes or defaults.
-
     std::set<std::pair<uint256, std::string>> toAdd;
 
     for (auto const& _ : detail::PreEnabledAmendments)

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -80,9 +80,10 @@ public:
 
     void addInitial () override;
 
-    AmendmentState* addKnown (uint256 const& amendmentID,
-                              std::string const& friendlyName,
-                              bool veto) override;
+    bool addKnown (uint256 const& amendmentID,
+                   std::string const& friendlyName,
+                   bool veto) override;
+
     uint256 get (std::string const& name) override;
 
     bool veto (uint256 const& amendment) override;
@@ -115,8 +116,7 @@ void
 AmendmentTableImpl::addInitial ()
 {
     // For each amendment this version supports, construct the AmendmentState
-    // object by calling addKnown. Set any vetoes or defaults. A pointer to the
-    // AmendmentState can be stashed
+    // object by calling addKnown. Set any vetoes or defaults.
 
     std::set<std::pair<uint256, std::string>> toAdd;
 
@@ -146,7 +146,7 @@ AmendmentTableImpl::addInitial ()
             int numToks = 0;
             uint256 id;
             std::string friendlyName;
-            for(auto const& curTok : tokenizer)
+            for (auto const& curTok : tokenizer)
             {
                 ++numToks;
                 if (numToks > numExpectedToks)
@@ -157,13 +157,14 @@ AmendmentTableImpl::addInitial ()
 
                 if (numToks == 1)
                 {
-                    
                     if (!id.SetHex (curTok))
                     {
                         std::string const errorMsg =
-                                (boost::format (
-                                 "%1% is not a valid hash. Expected a hex number. In config setcion: %2%. Line was: %3%")
-                             % curTok % SECTION_AMENDMENTS % _).str();
+                            (boost::format (
+                                 "%1% is not a valid hash. Expected a hex "
+                                 "number. In config setcion: %2%. Line was: "
+                                 "%3%") %
+                             curTok % SECTION_AMENDMENTS % _).str ();
                         throw std::runtime_error (errorMsg);
                     }
                 }
@@ -238,14 +239,15 @@ AmendmentTableImpl::get (std::string const& name)
     return uint256 ();
 }
 
-AmendmentState* AmendmentTableImpl::addKnown (uint256 const& hash,
-                                              std::string const& friendlyName,
-                                              bool veto)
+bool
+AmendmentTableImpl::addKnown (uint256 const& hash,
+                              std::string const& friendlyName,
+                              bool veto)
 {
     if (hash.isZero ())
     {
         assert (false);
-        return nullptr;
+        return false;
     }
 
     ScopedLockType sl (mLock);
@@ -257,7 +259,7 @@ AmendmentState* AmendmentTableImpl::addKnown (uint256 const& hash,
     s->mVetoed = veto;
     s->mSupported = true;
 
-    return s;
+    return true;
 }
 
 bool

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -45,7 +45,7 @@ std::set<std::pair<std::string, std::string>> PreEnabledAmendments;
     rules that is identified by a 256-bit amendment identifier
     and adopted, or rejected, by the network.
 */
-class AmendmentTableImpl : public AmendmentTable
+class AmendmentTableImpl final : public AmendmentTable
 {
 protected:
     typedef hash_map<uint256, AmendmentState> amendmentMap_t;

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -37,7 +37,6 @@ class AmendmentTableImpl final : public AmendmentTable
 {
 protected:
     typedef hash_map<uint256, AmendmentState> amendmentMap_t;
-    typedef std::pair<const uint256, AmendmentState> amendmentIt_t;
     typedef hash_set<uint256> amendmentList_t;
 
     typedef RippleMutex LockType;

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -397,7 +397,7 @@ AmendmentTableImpl::reportValidations (const AmendmentSet& set)
         m_firstReport = set.mCloseTime;
 
     std::vector<uint256> changedAmendments;
-    changedAmendments.resize(set.mVotes.size());
+    changedAmendments.reserve (set.mVotes.size());
 
     for (auto const& e : set.mVotes)
     {
@@ -663,7 +663,7 @@ public:
         hash_map<uint256, AmendmentState>& amendmentMap) const override{};
     virtual ValidationSet getValidations (uint256 const& hash) const override
     {
-        return {};
+        return ValidationSet();
     };
 };
 

--- a/src/ripple/app/misc/tests/AmendmentTable.test.cpp
+++ b/src/ripple/app/misc/tests/AmendmentTable.test.cpp
@@ -99,7 +99,7 @@ private:
         return make_AmendmentTable (weeks (2),
                                     majorityFraction,
                                     journal,
-                                    make_MOCAmendmentTableInjections ());
+                                    make_MockAmendmentTableInjections ());
     };
 
     // Create the amendments by string pairs instead of AmendmentNames

--- a/src/ripple/app/misc/tests/AmendmentTable.test.cpp
+++ b/src/ripple/app/misc/tests/AmendmentTable.test.cpp
@@ -100,7 +100,7 @@ private:
             weeks (2),
             majorityFraction,
             journal,
-            AmendmentTableDetail::AppApiFacade::useMock);
+            /*useMock*/ true);
     };
 
     // Create the amendments by string pairs instead of AmendmentNames
@@ -151,7 +151,7 @@ public:
              {TablePopulationAlgo::addInitial, TablePopulationAlgo::addKnown})
         {
             {
-                // test that the amendmens we add are enabled and amendments we
+                // test that the amendments we add are enabled and amendments we
                 // didn't add are not enabled
 
                 auto table (makeTable ());

--- a/src/ripple/app/misc/tests/AmendmentTable.test.cpp
+++ b/src/ripple/app/misc/tests/AmendmentTable.test.cpp
@@ -1,0 +1,195 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+
+#include <ripple/app/misc/AmendmentTable.h>
+#include <ripple/core/ConfigSections.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple
+{
+class AmendmentTable_test : public beast::unit_test::suite
+{
+public:
+    using StringPairVec = std::vector<std::pair<std::string, std::string>>;
+
+private:
+    // 204/256 about 80%
+    static int const majorityFraction{204};
+
+    void populateTable (AmendmentTable& table,
+                        std::vector<std::string> const& configLines)
+    {
+        Section section (SECTION_AMENDMENTS);
+        section.append (configLines);
+        table.addInitial (section);
+    }
+
+    std::vector<AmendmentName> getAmendmentNames (
+        StringPairVec const& amendmentPairs)
+    {
+        std::vector<AmendmentName> amendmentNames;
+        amendmentNames.reserve (amendmentPairs.size ());
+        for (auto const& i : amendmentPairs)
+        {
+            amendmentNames.emplace_back (i.first, i.second);
+        }
+        return amendmentNames;
+    }
+
+    std::vector<AmendmentName> populateTable (
+        AmendmentTable& table,
+        StringPairVec const& amendmentPairs)
+    {
+        std::vector<AmendmentName> const amendmentNames (
+            getAmendmentNames (amendmentPairs));
+        std::vector<std::string> configLines;
+        configLines.reserve (amendmentPairs.size ());
+        for (auto const& i : amendmentPairs)
+        {
+            configLines.emplace_back (i.first + " " + i.second);
+        }
+        populateTable (table, configLines);
+        return amendmentNames;
+    }
+
+public:
+    void testAddInitial ()
+    {
+        testcase ("addInitial");
+
+        auto makeTable = []()
+        {
+            beast::Journal journal;
+            return make_AmendmentTable (weeks (2),
+                                        majorityFraction,
+                                        journal,
+                                        make_MOCAmendmentTableInjections ());
+        };
+
+        {
+            // test that the amendmens we add are enabled and amendments we
+            // didn't add are not enabled
+
+            // Create the amendments by string pairs instead of AmendmentNames
+            // as this helps test the AmendmentNames class
+            StringPairVec const amendmentPairs (
+                {{"a49f90e7cddbcadfed8fc89ec4d02011", "Added1"},
+                 {"ca956ccabf25151a16d773171c485423", "Added2"},
+                 {"60dcd528f057711c5d26b57be28e23df", "Added3"}});
+
+            StringPairVec const notAddedAmendmentPairs (
+                {{"a9f90e7cddbcadfed8fc89ec4d02011c", "NotAdded1"},
+                 {"c956ccabf25151a16d773171c485423b", "NotAdded2"},
+                 {"6dcd528f057711c5d26b57be28e23dfa", "NotAdded3"}});
+
+            auto table (makeTable ());
+            std::vector<AmendmentName> const amendmentNames (
+                populateTable (*table, amendmentPairs));
+            std::vector<AmendmentName> const notAddedAmendmentNames (
+                getAmendmentNames (notAddedAmendmentPairs));
+
+            for (auto const& i : amendmentNames)
+            {
+                expect (table->isEnabled (i.id ()));
+            }
+
+            for (auto const& i : notAddedAmendmentNames)
+            {
+                expect (!table->isEnabled (i.id ()));
+            }
+        }
+
+        {
+            // check that we throw an exception on bad hex pairs
+            StringPairVec const badHexPairs (
+                {{"a9f90e7cddbcadfedm8fc89ec4d02011c", "BadHex1"},
+                 {"c956ccabf25151a16d77T3171c485423b", "BadHex2"},
+                 {"6dcd528f057711c5d2Z6b57be28e23dfa", "BadHex3"}});
+
+            // make sure each element throws
+            for (auto const& i : badHexPairs)
+            {
+                StringPairVec v ({i});
+                auto table (makeTable ());
+                try
+                {
+                    populateTable (*table, v);
+                    // line above should throw
+                    expect (false);
+                }
+                catch (...)
+                {
+                }
+                try
+                {
+                    populateTable (*table, badHexPairs);
+                    // line above should throw
+                    expect (false);
+                }
+                catch (...)
+                {
+                }
+            }
+        }
+
+        {
+            // check that we thow on bad num tokens
+            std::vector<std::string> const badNumTokensConfigLines (
+                {"19f6d",
+                 "19fd6 bad friendly name"
+                 "9876 one two"});
+
+            // make sure each element throws
+            for (auto const& i : badNumTokensConfigLines)
+            {
+                std::vector<std::string> v ({i});
+                auto table (makeTable ());
+                try
+                {
+                    populateTable (*table, v);
+                    // line above should throw
+                    expect (false);
+                }
+                catch (...)
+                {
+                }
+                try
+                {
+                    populateTable (*table, badNumTokensConfigLines);
+                    // line above should throw
+                    expect (false);
+                }
+                catch (...)
+                {
+                }
+            }
+        }
+    }
+
+    void run ()
+    {
+        testAddInitial ();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE (AmendmentTable, ripple_app, ripple);
+
+}  // ripple

--- a/src/ripple/app/misc/tests/AmendmentTable.test.cpp
+++ b/src/ripple/app/misc/tests/AmendmentTable.test.cpp
@@ -100,7 +100,7 @@ private:
             weeks (2),
             majorityFraction,
             journal,
-            AmendmentTableDetail::make_MockAppApiFacade ());
+            AmendmentTableDetail::AppApiFacade::useMock);
     };
 
     // Create the amendments by string pairs instead of AmendmentNames

--- a/src/ripple/app/misc/tests/AmendmentTable.test.cpp
+++ b/src/ripple/app/misc/tests/AmendmentTable.test.cpp
@@ -96,10 +96,11 @@ private:
     static std::unique_ptr<AmendmentTable> makeTable ()
     {
         beast::Journal journal;
-        return make_AmendmentTable (weeks (2),
-                                    majorityFraction,
-                                    journal,
-                                    make_MockAmendmentTableInjections ());
+        return make_AmendmentTable (
+            weeks (2),
+            majorityFraction,
+            journal,
+            AmendmentTableDetail::make_MockAppApiFacade ());
     };
 
     // Create the amendments by string pairs instead of AmendmentNames

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -32,6 +32,7 @@ struct ConfigSection
 
 // VFALCO TODO Rename and replace these macros with variables.
 #define SECTION_ACCOUNT_PROBE_MAX       "account_probe_max"
+#define SECTION_AMENDMENTS              "amendments"
 #define SECTION_CLUSTER_NODES           "cluster_nodes"
 #define SECTION_DATABASE_PATH           "database_path"
 #define SECTION_DEBUG_LOGFILE           "debug_logfile"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -456,7 +456,7 @@ void Config::load ()
                     if (!jrReader.parse (strJson, jvCommand))
                         throw std::runtime_error (
                             boost::str (boost::format (
-                                "Couldn't parse [" + SECTION_RPC_STARTUP + "] command: %s") % strJson));
+                                "Couldn't parse [" SECTION_RPC_STARTUP "] command: %s") % strJson));
 
                     RPC_STARTUP.append (jvCommand);
                 }

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -456,7 +456,7 @@ void Config::load ()
                     if (!jrReader.parse (strJson, jvCommand))
                         throw std::runtime_error (
                             boost::str (boost::format (
-                                "Couldn't parse [" SECTION_RPC_STARTUP "] command: %s") % strJson));
+                                "Couldn't parse [" + SECTION_RPC_STARTUP + "] command: %s") % strJson));
 
                     RPC_STARTUP.append (jvCommand);
                 }

--- a/src/ripple/unity/app6.cpp
+++ b/src/ripple/unity/app6.cpp
@@ -30,3 +30,4 @@
 #include <ripple/app/paths/FindPaths.cpp>
 #include <ripple/app/paths/Pathfinder.cpp>
 #include <ripple/app/misc/AmendmentTableImpl.cpp>
+#include <ripple/app/misc/tests/AmendmentTable.test.cpp>


### PR DESCRIPTION
* The rippled.cfg file has a new section called "amendments"

* Each line in this section contains two white-space separated items
** The first item is the id of the amendment (a 256-bit hash)
** The second item is the friendly name

* Replaces config section name macros with variables

* Make addKnown arguments safer

* Added lock to addKnown

@scott @tomswirly