### PR TITLE
Ensure account_tx queries over and returns correct range

### DIFF
--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -69,8 +69,10 @@ Json::Value doAccountTx (RPC::Context& context)
         std::int64_t iLedgerMax  = params.isMember ("ledger_index_max")
                 ? params["ledger_index_max"].asInt () : -1;
 
-        uLedgerMin  = iLedgerMin == -1 ? uValidatedMin : iLedgerMin;
-        uLedgerMax  = iLedgerMax == -1 ? uValidatedMax : iLedgerMax;
+        uLedgerMin  = iLedgerMin == -1 ? uValidatedMin :
+            ((iLedgerMin >= uValidatedMin) ? iLedgerMin : uValidatedMin);
+        uLedgerMax  = iLedgerMax == -1 ? uValidatedMax :
+            ((iLedgerMax <= uValidatedMax) ? iLedgerMax : uValidatedMax);
 
         if (uLedgerMax < uLedgerMin)
             return rpcError (rpcLGR_IDXS_INVALID);


### PR DESCRIPTION
Don't allow a query to cover ledgers that might be in process. Make sure the returned ledger_index_min/ledger_index_max indicate the range actually covered.

Reviewers requested