### PR TITLE
handle tuples in scons CPPDEFINES

### DIFF
--- a/src/beast/site_scons/site_tools/VSProject.py
+++ b/src/beast/site_scons/site_tools/VSProject.py
@@ -124,9 +124,12 @@ def itemList(items, sep):
         return items
     def gen():
         for item in xsorted(items):
-            if type(item) == dict:
+            if isinstance(item, dict):
                 for k, v in xsorted(item.items()):
                     yield k + '=' + v
+            elif isinstance(item, (tuple, list)):
+                assert len(item) == 2, "Item shoud have exactly two elements: " + str(item)
+                yield '%s=%s' % tuple(item)
             else:
                 yield item
             yield sep


### PR DESCRIPTION
SCons can handle a strings, dics, tuple in CPPDEFINES, but the VSProject
backend could only handle strings and dicts. This patch allows it handle
tuples.

Reviewers:
@vinniefalco @miguelportilla 