### PR TITLE
Constrain valid inputs for MemoFormat and MemoType fields (RIPD-712)

### DIFF
--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -30,7 +30,6 @@
 #include <ripple/json/to_string.h>
 #include <beast/unit_test/suite.h>
 #include <boost/format.hpp>
-#include <cctype>
 
 namespace ripple {
 
@@ -334,15 +333,30 @@ isMemoOkay (STObject const& st, std::string& reason)
 
             // The only allowed characters for MemoType and MemoFormat are the
             // characters allowed in URLs per RFC 3986: alphanumerics and the
-            // following symbols:
-            static std::string const allowed_symbols ("-._~:/?#[]@!$&'()*+,;=%");
+            // following symbols: -._~:/?#[]@!$&'()*+,;=%
+            static int const allowed_symbols[] =
+            {
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1,
+                0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            };
 
             for (auto c : data.first)
             {
-                if (isalnum (c))
-                    continue;
-
-                if (allowed_symbols.find (c) == std::string::npos)
+                if (!allowed_symbols[c])
                 {
                     reason = "The MemoType and MemoFormat fields may only "
                              "contain characters that are allowed in URLs "

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -30,6 +30,7 @@
 #include <ripple/json/to_string.h>
 #include <beast/unit_test/suite.h>
 #include <boost/format.hpp>
+#include <array>
 
 namespace ripple {
 
@@ -334,29 +335,25 @@ isMemoOkay (STObject const& st, std::string& reason)
             // The only allowed characters for MemoType and MemoFormat are the
             // characters allowed in URLs per RFC 3986: alphanumerics and the
             // following symbols: -._~:/?#[]@!$&'()*+,;=%
-            static int const allowed_symbols[] =
+            static std::array<char, 256> const allowedSymbols = []
             {
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1,
-                0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            };
+                std::array<char, 256> a;
+                a.fill(0);
+
+                std::string symbols (
+                    "0123456789"
+                    "-._~:/?#[]@!$&'()*+,;=%"
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                    "abcdefghijklmnopqrstuvwxyz");
+
+                for(char c : symbols)
+                    a[c] = 1;
+                return a;
+            }();
 
             for (auto c : data.first)
             {
-                if (!allowed_symbols[c])
+                if (!allowedSymbols[c])
                 {
                     reason = "The MemoType and MemoFormat fields may only "
                              "contain characters that are allowed in URLs "


### PR DESCRIPTION
Currently, all possible ASCII characters are allowed inside the `MemoType`, `MemoData` and `MemoFormat` fields. This patch will reject any memos that contain ASCII control characters (`0x00,...,0x1F`, and `0x7F`) and will additionally prevent `MemoType` and `MemoFormat` from containing the space character.

@justmoon is this fine, or would you prefer to more robustly validate the contents of the `MemoType` field against the MIME RFCs? If so, please update https://ripplelabs.atlassian.net/browse/RIPD-712 accordingly.

Reviews: @josh-ripple, @seelabs 