### PR TITLE
Add PeerFinder Logic backoff unit test

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2714,6 +2714,9 @@
     <ClCompile Include="..\..\src\ripple\peerfinder\tests\Livecache.test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\peerfinder\tests\PeerFinder_test.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\protocol\Book.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\BuildInfo.h">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3852,6 +3852,9 @@
     <ClCompile Include="..\..\src\ripple\peerfinder\tests\Livecache.test.cpp">
       <Filter>ripple\peerfinder\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\peerfinder\tests\PeerFinder_test.cpp">
+      <Filter>ripple\peerfinder\tests</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\protocol\Book.h">
       <Filter>ripple\protocol</Filter>
     </ClInclude>

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -181,6 +181,15 @@ public:
 
     void
     addFixedPeer (std::string const& name,
+        beast::IP::Endpoint const& ep)
+    {
+        std::vector<beast::IP::Endpoint> v;
+        v.push_back(ep);
+        addFixedPeer (name, v);
+    }
+
+    void
+    addFixedPeer (std::string const& name,
         std::vector <beast::IP::Endpoint> const& addresses)
     {
         typename SharedState::Access state (m_state);

--- a/src/ripple/peerfinder/tests/PeerFinder_test.cpp
+++ b/src/ripple/peerfinder/tests/PeerFinder_test.cpp
@@ -1,0 +1,152 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/peerfinder/impl/Logic.h>
+#include <beast/unit_test/suite.h>
+#include <beast/chrono/manual_clock.h>
+
+namespace ripple {
+namespace PeerFinder {
+
+class Logic_test : public beast::unit_test::suite
+{
+public:
+    struct TestStore : Store
+    {
+        std::size_t
+        load (load_callback const& cb) override
+        {
+            return 0;
+        }
+
+        void
+        save (std::vector <Entry> const&) override
+        {
+        }
+    };
+
+    struct TestChecker
+    {
+        void
+        stop()
+        {
+        }
+
+        void wait()
+        {
+        }
+
+        template <class Handler>
+        void
+        async_connect (beast::IP::Endpoint const& ep,
+            Handler&& handler)
+        {
+            boost::system::error_code ec;
+            handler (ep, ep, ec);
+        }
+    };
+
+    void
+    test_backoff1()
+    {
+        auto const seconds = 10000;
+        testcase("backoff 1");
+        Config c;
+        TestStore store;
+        TestChecker checker;
+        beast::manual_clock <std::chrono::steady_clock> clock;
+        Logic<TestChecker> logic (clock, store, checker, beast::Journal{});
+        logic.addFixedPeer ("test",
+            beast::IP::Endpoint::from_string("65.0.0.1:5"));
+        c.autoConnect = false;
+        c.listeningPort = 1024;
+        logic.config(c);
+        std::size_t n = 0;
+        for (std::size_t i = 0; i < seconds; ++i)
+        {
+            auto const v = logic.autoconnect();
+            if (v.size() > 0)
+            {
+                auto const slot = logic.new_outbound_slot(v[0]);
+                expect (logic.onConnected(slot,
+                    beast::IP::Endpoint::from_string("65.0.0.2:5")));
+                logic.on_closed(slot);
+                ++n;
+            }
+            clock.advance(std::chrono::seconds(1));
+            logic.once_per_second();
+        }
+        expect (n < 20, "backoff");
+    }
+
+    // with activate
+    void
+    test_backoff2()
+    {
+        auto const seconds = 10000;
+        testcase("backoff 2");
+        Config c;
+        TestStore store;
+        TestChecker checker;
+        beast::manual_clock <std::chrono::steady_clock> clock;
+        Logic<TestChecker> logic (clock, store, checker, beast::Journal{});
+        logic.addFixedPeer ("test",
+            beast::IP::Endpoint::from_string("65.0.0.1:5"));
+        c.autoConnect = false;
+        c.listeningPort = 1024;
+        logic.config(c);
+        std::size_t n = 0;
+        std::array<std::uint8_t, 33> key;
+        key.fill(0);
+        for (std::size_t i = 0; i < seconds; ++i)
+        {
+            auto const v = logic.autoconnect();
+            if (v.size() > 0)
+            {
+                auto const slot = logic.new_outbound_slot(v[0]);
+                if (! expect (logic.onConnected(slot,
+                        beast::IP::Endpoint::from_string("65.0.0.2:5"))))
+                    return;
+                std::string s = ".";
+                RipplePublicKey pk (key.begin(), key.end());
+                if (! expect (logic.activate(slot, pk, false) ==
+                        PeerFinder::Result::success, "activate"))
+                    return;
+                logic.on_closed(slot);
+                ++n;
+            }
+            clock.advance(std::chrono::seconds(1));
+            logic.once_per_second();
+        }
+        // No more often than once per minute
+        expect (n <= (seconds+59)/60, "backoff");
+    }
+
+    void run ()
+    {
+        test_backoff1();
+        test_backoff2();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Logic,PeerFinder,ripple);
+
+}
+}

--- a/src/ripple/unity/peerfinder.cpp
+++ b/src/ripple/unity/peerfinder.cpp
@@ -42,6 +42,7 @@
 #include <ripple/peerfinder/sim/Tests.cpp>
 
 #include <ripple/peerfinder/tests/Livecache.test.cpp>
+#include <ripple/peerfinder/tests/PeerFinder_test.cpp>
 
 #if DOXYGEN
 #include <ripple/peerfinder/README.md>


### PR DESCRIPTION
This checks that the fixed connect logic backs off correctly, to prevent excessive outbound attempts to dead or full peers.
