### PR TITLE
Ensure correct deleter is invoked

### DIFF
--- a/src/beast/beast/nudb/tests/common.h
+++ b/src/beast/beast/nudb/tests/common.h
@@ -51,7 +51,7 @@ class storage
 private:
     std::size_t size_ = 0;
     std::size_t capacity_ = 0;
-    std::unique_ptr<std::uint8_t> buf_;
+    std::unique_ptr<std::uint8_t[]> buf_;
 
 public:
     storage() = default;

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -257,7 +257,7 @@ public:
     insert2 (void const* key, void const* data,
         std::size_t size)
     {
-        std::unique_ptr<char> buf (
+        std::unique_ptr<char[]> buf (
             new char[snappy::MaxCompressedLength(size)]);
         std::size_t actual;
         snappy::RawCompress ((char const*)data, size,


### PR DESCRIPTION
In this instance `std::unique_ptr` can't deduce that it should use `delete[]` without some help.

Reviews: @vinniefalco, @HowardHinnant 