### PR TITLE
Support a "--noserver" command line option in tests.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -22,6 +22,10 @@ This ensures that each test is run against the known
 To use a running `rippled`, particularly one running in a debugger, follow
 these steps:
 
+#### Setup
+
+##### Using configuration files
+
 1. Make a copy of the example configuration file: `cp -i test/config-example.js test/config.js`
 
 2. Edit `test/config.js` to select the "debug" server configuration.
@@ -33,36 +37,47 @@ these steps:
   2. Copy and/or rename the `tmp/server/debug/rippled.cfg` file to somewhere
   convenient.
 
-4. Start `rippled` (in a debugger) with command line options
+##### Using the command line
+
+1. Create a `rippled.cfg` file for the tests.
+  1. Run `npm test --noserver`. The tests will fail. **This failure is expected.**
+  2. Copy and/or rename the `tmp/server/alpha/rippled.cfg` file to somewhere
+  convenient.
+
+#### Running the tests.
+
+1. Start `rippled` (in a debugger) with command line options
 `-av --conf <rippled-created-above.cfg>`.
 
-5. Set any desired breakpoints in the `rippled` source.
+2. Set any desired breakpoints in the `rippled` source.
 
-6. Running one test per [_genesis ledger_][genesis_ledger] is highly recommended.
+3. Running one test per [_genesis ledger_][genesis_ledger] is highly recommended.
 If the relevant `.js` file contains more than one test, change `test(` to
 `test.only(` for the single desired test.
   * To run multiple tests, change `test(` to `test.skip(` for any undesired tests
   in the .js file.
 
-7. Start test(s) in the [_node-inspector_][node_inspector] debugger.
-(Note that the tests can be run without the debugger, but there will probably
+4. Start test(s) in the [_node-inspector_][node_inspector] debugger.
+(The tests can be run without the debugger, but there will probably
 be problems with timeouts or reused ledgers).
   1. `node_modules/node-inspector/bin/inspector.js &`
   2. `node node_modules/.bin/mocha --debug --debug-brk test/<testfile.js>`
   3. Browse to http://127.0.0.1:8080/debug?port=5858 in a browser supported
   by [_node-inspector_][node_inspector] (i.e. Chrome or Safari).
 
-8. To run multiple tests, put a breakpoint in the following function:
+5. To run multiple tests (not recommended), put a breakpoint in the following function:
   * File `testutils.js` -> function `build_teardown()` -> nested function
   `teardown()` -> nested series function `stop_server()`.
     * When this breakpoint is hit, stop and restart `rippled`.
 
-9. Use the [_node-inspector UI_][node_inspector_ui] to step through and run
+6. Use the [_node-inspector UI_][node_inspector_ui] to step through and run
 the test(s) until control is handed off to `rippled`. When the request is
 finished control will be handed back to node-inspector, which may or may not
 stop depending on which breakpoints are set.
 
-### After debugging
+### After debugging using configuration files.
+
+With the command line `--noserver` flag, this step is unnecessary.
 
 1. To return to the default behavior, edit `test/config.js` and change the
 default server back to its original value: `exports.server_default = "alpha";`.

--- a/test/server.js
+++ b/test/server.js
@@ -88,19 +88,6 @@ Server.prototype._serverSpawnSync = function() {
   var self  = this;
 
   var rippledpath = this.config.rippled_path;
-  // Override the config with command line if provided
-  if (process.env["npm_config_rippled"]) {
-    rippledpath = path.resolve(process.cwd(),
-        process.env["npm_config_rippled"]);
-  } else {
-    for (var i = process.argv.length-1; i >= 0; --i) {
-      arg = process.argv[i].split("=", 2);
-      if (arg.length === 2 && arg[0] === "--rippled") {
-        rippledpath = path.resolve(process.cwd(), arg[1]);
-        break;
-      }
-    };
-  }
   assert(rippledpath, "rippled_path not provided");
 
   var args  = [

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -28,7 +28,19 @@ get_server_config =
 function(config, host) {
   config = config || init_config();
   host = host || config.server_default;
-  return extend({}, config.default_server_config, config.servers[host]);
+  // Override the config with the command line if provided.
+  local = {};
+  if (process.env["npm_config_noserver"]) {
+    local["no_server"] = true;
+  } else {
+    for (var i = 0; i < process.argv.length; ++i) {
+      if (process.argv[i] === "--noserver") {
+        local["no_server"] = true;
+        break;
+      }
+    }
+  }
+  return extend(local, config.default_server_config, config.servers[host]);
 }
 
 function prepare_tests(tests, fn) {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -30,33 +30,34 @@ function(config, host) {
   config = config || init_config();
   host = host || config.server_default;
   // Override the config with the command line if provided.
-  var local = {};
+  var override = {};
   // --noserver -> no_server
   if (process.env["npm_config_noserver"]) {
-    local["no_server"] = true;
+    override["no_server"] = true;
   } else {
-    local["no_server"] = process.argv.indexOf("--noserver") > -1;
+    override["no_server"] = process.argv.indexOf("--noserver") > -1;
   }
   // --rippled -> rippled_path
   var index = -1;
   if (process.env["npm_config_rippled"]) {
-    local["rippled_path"] = path.resolve(process.cwd(),
+    override["rippled_path"] = path.resolve(process.cwd(),
         process.env["npm_config_rippled"]);
   } else if ((index = process.argv.indexOf("--rippled")) > -1) {
     if (index < process.argv.length) {
-      local["rippled_path"] = path.resolve(process.cwd(),
+      override["rippled_path"] = path.resolve(process.cwd(),
         process.argv[index + 1]);
     }
   } else {
     for (var i = process.argv.length-1; i >= 0; --i) {
       arg = process.argv[i].split("=", 2);
       if (arg.length === 2 && arg[0] === "--rippled") {
-        local["rippled_path"] = path.resolve(process.cwd(), arg[1]);
+        override["rippled_path"] = path.resolve(process.cwd(), arg[1]);
         break;
       }
     };
   }
-  return extend({}, config.default_server_config, config.servers[host], local);
+  return extend({}, config.default_server_config, config.servers[host],
+      override);
 }
 
 function prepare_tests(tests, fn) {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -49,12 +49,12 @@ function(config, host) {
     }
   } else {
     for (var i = process.argv.length-1; i >= 0; --i) {
-      arg = process.argv[i].split("=", 2);
+      var arg = process.argv[i].split("=", 2);
       if (arg.length === 2 && arg[0] === "--rippled") {
         override["rippled_path"] = path.resolve(process.cwd(), arg[1]);
         break;
       }
-    };
+    }
   }
   return extend({}, config.default_server_config, config.servers[host],
       override);

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -56,7 +56,7 @@ function(config, host) {
       }
     };
   }
-  return extend(local, config.default_server_config, config.servers[host]);
+  return extend({}, config.default_server_config, config.servers[host], local);
 }
 
 function prepare_tests(tests, fn) {


### PR DESCRIPTION
* Run npm/integration tests without launching rippled, using a running instance of rippled (possibly in a debugger) instead.
* Works for "npm test" and "mocha"

Scratching an itch that's been bothering me since the "no_server" config option was added. Rendered README is at https://github.com/ximinez/rippled/blob/noserver-cli/test/README.md. 

Reviewers: @rec, @sublimator 