### PR TITLE
Combine history_ledger_index and online_delete (RIPD-774)

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -481,13 +481,6 @@
 #
 #
 #
-# [ledger_history_index]
-#
-#   If set to greater than 0, the index number of the earliest ledger to
-#   acquire.
-#
-#
-#
 # [fetch_depth]
 #
 #   The number of past ledgers to serve to other peers that request historical

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -1552,7 +1552,7 @@ bool LedgerMaster::shouldAcquire (std::uint32_t const currentLedger,
 {
     bool ret (candidateLedger >= currentLedger ||
         candidateLedger > ledgerHistoryIndex ||
-            (currentLedger - candidateLedger) <= ledgerHistory);
+        (currentLedger - candidateLedger) <= ledgerHistory);
 
     WriteLog (lsTRACE, LedgerMaster)
         << "Missing ledger "

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -1551,9 +1551,8 @@ bool LedgerMaster::shouldAcquire (std::uint32_t const currentLedger,
     std::uint32_t const candidateLedger)
 {
     bool ret (candidateLedger >= currentLedger ||
-        (ledgerHistoryIndex != std::numeric_limits <LedgerIndex>::max () &&
-            candidateLedger > ledgerHistoryIndex) ||
-        (currentLedger - candidateLedger) <= ledgerHistory);
+        candidateLedger > ledgerHistoryIndex ||
+            (currentLedger - candidateLedger) <= ledgerHistory);
 
     WriteLog (lsTRACE, LedgerMaster)
         << "Missing ledger "

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -150,9 +150,9 @@ public:
 
     virtual beast::PropertyStream::Source& getPropertySource () = 0;
 
-    static bool shouldAcquire (std::uint32_t const currentLedgerID, 
-        std::uint32_t const ledgerHistory, std::uint32_t const ledgerHistoryIndex,
-        std::uint32_t const targetLedger);
+    static bool shouldAcquire (std::uint32_t currentLedgerID, 
+        std::uint32_t ledgerHistory, std::uint32_t ledgerHistoryIndex,
+        std::uint32_t targetLedger);
 
     virtual void clearPriorLedgers (LedgerIndex seq) = 0;
 

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -150,9 +150,9 @@ public:
 
     virtual beast::PropertyStream::Source& getPropertySource () = 0;
 
-    static bool shouldAcquire (std::uint32_t currentLedgerID, 
-        std::uint32_t ledgerHistory, std::uint32_t ledgerHistoryIndex,
-        std::uint32_t targetLedger);
+    static bool shouldAcquire (std::uint32_t const currentLedgerID, 
+        std::uint32_t const ledgerHistory, std::uint32_t const ledgerHistoryIndex,
+        std::uint32_t const targetLedger);
 
     virtual void clearPriorLedgers (LedgerIndex seq) = 0;
 

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -344,7 +344,6 @@ int run (int argc, char** argv)
         {
             getConfig ().RUN_STANDALONE = true;
             getConfig ().LEDGER_HISTORY = 0;
-            getConfig ().LEDGER_HISTORY_INDEX = 0;
         }
     }
 

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -205,7 +205,7 @@ SHAMapStoreImp::SHAMapStoreImp (Setup const& setup,
     , journal_ (journal)
     , nodeStoreJournal_ (nodeStoreJournal)
     , transactionMaster_ (transactionMaster)
-    , canDelete_ (0)
+    , canDelete_ (std::numeric_limits <LedgerIndex>::max())
 {
     if (setup_.deleteInterval)
     {
@@ -326,7 +326,6 @@ SHAMapStoreImp::run()
             lastRotated = validatedSeq;
             state_db_.setLastRotated (lastRotated);
         }
-        canDelete_ = std::numeric_limits <LedgerIndex>::max();
         if (setup_.advisoryDelete)
             canDelete_ = state_db_.getCanDelete();
 

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -326,8 +326,6 @@ SHAMapStoreImp::run()
             lastRotated = validatedSeq;
             state_db_.setLastRotated (lastRotated);
         }
-        if (setup_.advisoryDelete)
-            canDelete_ = state_db_.getCanDelete();
 
         // will delete up to (not including) lastRotated)
         if (validatedSeq >= lastRotated + setup_.deleteInterval

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -302,6 +302,9 @@ SHAMapStoreImp::run()
     transactionDb_ = &getApp().getTxnDB();
     ledgerDb_ = &getApp().getLedgerDB();
 
+    if (setup_.advisoryDelete)
+        canDelete_ = state_db_.getCanDelete ();
+
     while (1)
     {
         healthy_ = true;

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -204,8 +204,8 @@ SHAMapStoreImp::SHAMapStoreImp (Setup const& setup,
     , scheduler_ (scheduler)
     , journal_ (journal)
     , nodeStoreJournal_ (nodeStoreJournal)
-    , database_ (nullptr)
     , transactionMaster_ (transactionMaster)
+    , canDelete_ (0)
 {
     if (setup_.deleteInterval)
     {
@@ -326,17 +326,17 @@ SHAMapStoreImp::run()
             lastRotated = validatedSeq;
             state_db_.setLastRotated (lastRotated);
         }
-        LedgerIndex canDelete = std::numeric_limits <LedgerIndex>::max();
+        canDelete_ = std::numeric_limits <LedgerIndex>::max();
         if (setup_.advisoryDelete)
-            canDelete = state_db_.getCanDelete();
+            canDelete_ = state_db_.getCanDelete();
 
         // will delete up to (not including) lastRotated)
         if (validatedSeq >= lastRotated + setup_.deleteInterval
-                && canDelete >= lastRotated - 1)
+                && canDelete_ >= lastRotated - 1)
         {
             journal_.debug << "rotating  validatedSeq " << validatedSeq
                     << " lastRotated " << lastRotated << " deleteInterval "
-                    << setup_.deleteInterval << " canDelete " << canDelete;
+                    << setup_.deleteInterval << " canDelete_ " << canDelete_;
 
             switch (health())
             {

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -85,7 +85,7 @@ private:
     NodeStore::Scheduler& scheduler_;
     beast::Journal journal_;
     beast::Journal nodeStoreJournal_;
-    NodeStore::DatabaseRotating* database_;
+    NodeStore::DatabaseRotating* database_ = nullptr;
     SavedStateDB state_db_;
     std::thread thread_;
     bool stop_ = false;
@@ -95,6 +95,7 @@ private:
     Ledger::pointer newLedger_;
     Ledger::pointer validatedLedger_;
     TransactionMaster& transactionMaster_;
+    std::atomic <LedgerIndex> canDelete_;
     // these do not exist upon SHAMapStore creation, but do exist
     // as of onPrepare() or before
     NetworkOPs* netOPs_ = nullptr;
@@ -131,6 +132,7 @@ public:
     LedgerIndex
     setCanDelete (LedgerIndex seq) override
     {
+        canDelete_ = seq;
         return state_db_.setCanDelete (seq);
     }
 
@@ -149,7 +151,7 @@ public:
     LedgerIndex
     getCanDelete() override
     {
-        return state_db_.getCanDelete();
+        return canDelete_;
     }
 
     void onLedgerClosed (Ledger::pointer validatedLedger) override;

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -132,7 +132,8 @@ public:
     LedgerIndex
     setCanDelete (LedgerIndex seq) override
     {
-        canDelete_ = seq;
+        if (setup_.advisoryDelete)
+            canDelete_ = seq;
         return state_db_.setCanDelete (seq);
     }
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -291,7 +291,6 @@ public:
 
     // Node storage configuration
     std::uint32_t                      LEDGER_HISTORY;
-    std::uint32_t                      LEDGER_HISTORY_INDEX;
     std::uint32_t                      FETCH_DEPTH;
     int                         NODE_SIZE;
 

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -43,7 +43,6 @@ struct ConfigSection
 #define SECTION_FEE_OWNER_RESERVE       "fee_owner_reserve"
 #define SECTION_FETCH_DEPTH             "fetch_depth"
 #define SECTION_LEDGER_HISTORY          "ledger_history"
-#define SECTION_LEDGER_HISTORY_INDEX    "ledger_history_index"
 #define SECTION_INSIGHT                 "insight"
 #define SECTION_IPS                     "ips"
 #define SECTION_IPS_FIXED               "ips_fixed"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -249,7 +249,6 @@ Config::Config ()
     FEE_CONTRACT_OPERATION  = DEFAULT_FEE_OPERATION;
 
     LEDGER_HISTORY          = 256;
-    LEDGER_HISTORY_INDEX    = 0;
     FETCH_DEPTH             = 1000000000;
 
     // An explanation of these magical values would be nice.
@@ -584,10 +583,6 @@ void Config::load ()
                     LEDGER_HISTORY = 0;
                 else
                     LEDGER_HISTORY = beast::lexicalCastThrow <std::uint32_t> (strTemp);
-            }
-            if (getSingleSection(secConfig, SECTION_LEDGER_HISTORY_INDEX, strTemp))
-            {
-                LEDGER_HISTORY_INDEX = beast::lexicalCastThrow <std::uint32_t>(strTemp);
             }
 
             if (getSingleSection (secConfig, SECTION_FETCH_DEPTH, strTemp))


### PR DESCRIPTION
Combine the history_ledger_index functionality into online_delete. The 'history_ledger_index' label no loner exists in the rippled config file. A ledger index can be specified in the 'can_delete' RPC command. This index represents up to which ledger will be deleted. Ledger greater than this index will be retrieved.

Reviewers: @mtrippled @HowardHinnant 