### PR TITLE
Add online_delete reminder to ledger_history in example cfg

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -477,6 +477,8 @@
 #   need to serve clients can set this to "none".  Servers that want complete
 #   history can set this to "full".
 #
+#   This must be less than or equal to online_delete (if online_delete is used)
+#
 #   The default is: 256
 #
 #


### PR DESCRIPTION
Bryce and Bob discovered that breaking this rule (ledger_history <= online_delete) can cause rippled not to start, and the error is not always obvious. There is already a comment about this in the description for online_delete, but I added the reverse warning to the description of ledger_history to make it harder to miss.