### PR TITLE
NuDB: limit size of mempool (RIPD-787):

### DIFF
--- a/src/beast/beast/module/core/containers/ElementComparator.h
+++ b/src/beast/beast/module/core/containers/ElementComparator.h
@@ -24,8 +24,9 @@
 #ifndef BEAST_ELEMENTCOMPARATOR_H_INCLUDED
 #define BEAST_ELEMENTCOMPARATOR_H_INCLUDED
 
-namespace beast
-{
+#include <algorithm>
+
+namespace beast {
 
 #ifndef DOXYGEN
 

--- a/src/beast/beast/nudb/detail/win32_file.h
+++ b/src/beast/beast/nudb/detail/win32_file.h
@@ -394,7 +394,6 @@ template <class _>
 std::pair<DWORD, DWORD>
 win32_file<_>::flags (file_mode mode)
 {
-mode = file_mode::write;
     std::pair<DWORD, DWORD> result(0, 0);
     switch (mode)
     {


### PR DESCRIPTION
nudb::store::insert now blocks when the size of the memory pool exceeds a predefined threshold. This solves the problem where sustained insertions cause the memory pool to grow without bound.
