### PR TITLE
Adds missing include.

### DIFF
--- a/src/beast/beast/nudb/detail/posix_file.h
+++ b/src/beast/beast/nudb/detail/posix_file.h
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <string>
 #include <utility>
+#include <cerrno>
 
 #ifndef BEAST_NUDB_POSIX_FILE
 # ifdef _MSC_VER


### PR DESCRIPTION
* Compile failed on mac with clang without cerrno.

@HowardHinnant @scottschurr 