### PR TITLE
Revert RocksDB backend settings:

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{26B7D9AC-1A80-8EF8-6703-D061F1BECB75}</ProjectGuid>
@@ -2675,6 +2675,8 @@
     <ClCompile Include="..\..\src\ripple\rpc\handlers\ValidationSeed.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\rpc\handlers\Version.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\WalletAccounts.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
@@ -2740,6 +2742,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\impl\RPCHandler.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\impl\RPCVersion.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\impl\Status.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
@@ -2770,6 +2775,8 @@
     <ClInclude Include="..\..\src\ripple\rpc\Request.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\rpc\RPCHandler.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\rpc\RPCVersion.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\rpc\Status.h">
     </ClInclude>

--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2081,6 +2081,9 @@
     <ClCompile Include="..\..\src\ripple\nodestore\backend\RocksDBFactory.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\nodestore\backend\RocksDBQuickFactory.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\nodestore\Database.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\nodestore\DatabaseRotating.h">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3723,6 +3723,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\handlers\ValidationSeed.cpp">
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\rpc\handlers\Version.h">
+      <Filter>ripple\rpc\handlers</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\WalletAccounts.cpp">
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>
@@ -3798,6 +3801,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\impl\RPCHandler.cpp">
       <Filter>ripple\rpc\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\impl\RPCVersion.cpp">
+      <Filter>ripple\rpc\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\impl\Status.cpp">
       <Filter>ripple\rpc\impl</Filter>
     </ClCompile>
@@ -3835,6 +3841,9 @@
       <Filter>ripple\rpc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\rpc\RPCHandler.h">
+      <Filter>ripple\rpc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\rpc\RPCVersion.h">
       <Filter>ripple\rpc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\rpc\Status.h">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3027,6 +3027,9 @@
     <ClCompile Include="..\..\src\ripple\nodestore\backend\RocksDBFactory.cpp">
       <Filter>ripple\nodestore\backend</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\nodestore\backend\RocksDBQuickFactory.cpp">
+      <Filter>ripple\nodestore\backend</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\nodestore\Database.h">
       <Filter>ripple\nodestore</Filter>
     </ClInclude>

--- a/Builds/rpm/rippled.spec
+++ b/Builds/rpm/rippled.spec
@@ -1,5 +1,5 @@
 Name:           rippled
-Version:        0.28.0-b3
+Version:        0.28.0-b4
 Release:        1%{?dist}
 Summary:        Ripple peer-to-peer network daemon
 

--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -688,9 +688,7 @@
 #       The 'temp_db' configures a look-aside cache for high volume storage
 #           which doesn't necessarily persist between server launches. This
 #           is an optional configuration parameter. If it is left out then
-#           no look-aside database is created or used. Use of temp_db may
-#           improve performance in some environments, but should be tested
-#           with and without to determine if beneficial.
+#           no look-aside database is created or used.
 #
 #       The 'import_db' is used with the '--import' command line option to
 #           migrate the specified database into the current database given

--- a/src/beast/beast/nudb/detail/posix_file.h
+++ b/src/beast/beast/nudb/detail/posix_file.h
@@ -23,8 +23,9 @@
 #include <beast/nudb/error.h>
 #include <beast/nudb/mode.h>
 #include <beast/nudb/detail/config.h>
-#include <string.h>
 #include <cassert>
+#include <cerrno>
+#include <cstring>
 #include <string>
 #include <utility>
 
@@ -75,7 +76,7 @@ private:
     std::string
     text (int errnum)
     {
-        return ::strerror(errnum);
+        return std::strerror(errnum);
     }
 };
 

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -190,6 +190,11 @@ public:
     };
 
     //--------------------------------------------------------------------------
+    //
+    //  Version 1 Database
+    //
+    //      Uncompressed
+    //
 
     Status
     fetch1 (void const* key,
@@ -221,6 +226,11 @@ public:
     }
 
     //--------------------------------------------------------------------------
+    //
+    //  Version 2 Database
+    //
+    //      Snappy compression
+    //
 
     Status
     fetch2 (void const* key,
@@ -270,10 +280,6 @@ public:
     Status
     fetch (void const* key, NodeObject::Ptr* pno)
     {
-        Buffer b1;
-        if (! db_.fetch (key, b1))
-            return notFound;
-
         switch (db_.appnum())
         {
         case typeOne:   return fetch1 (key, pno);

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -26,7 +26,6 @@
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
-#include <ripple/nodestore/impl/BatchWriter.h>
 #include <ripple/nodestore/impl/DecodedBlob.h>
 #include <ripple/nodestore/impl/EncodedBlob.h>
 #include <beast/threads/Thread.h>
@@ -36,10 +35,10 @@
 namespace ripple {
 namespace NodeStore {
 
-class RocksDBEnv : public rocksdb::EnvWrapper
+class RocksDBQuickEnv : public rocksdb::EnvWrapper
 {
 public:
-    RocksDBEnv ()
+    RocksDBQuickEnv ()
         : EnvWrapper (rocksdb::Env::Default())
     {
     }
@@ -78,15 +77,14 @@ public:
     StartThread (void (*f)(void*), void* a)
     {
         ThreadParams* const p (new ThreadParams (f, a));
-        EnvWrapper::StartThread (&RocksDBEnv::thread_entry, p);
+        EnvWrapper::StartThread (&RocksDBQuickEnv::thread_entry, p);
     }
 };
 
 //------------------------------------------------------------------------------
 
-class RocksDBBackend
+class RocksDBQuickBackend
     : public Backend
-    , public BatchWriter::Callback
 {
 private:
     std::atomic <bool> m_deletePath;
@@ -94,82 +92,83 @@ private:
 public:
     beast::Journal m_journal;
     size_t const m_keyBytes;
-    Scheduler& m_scheduler;
-    BatchWriter m_batch;
     std::string m_name;
     std::unique_ptr <rocksdb::DB> m_db;
 
-    RocksDBBackend (int keyBytes, Parameters const& keyValues,
-        Scheduler& scheduler, beast::Journal journal, RocksDBEnv* env)
+    RocksDBQuickBackend (int keyBytes, Parameters const& keyValues,
+        Scheduler& scheduler, beast::Journal journal, RocksDBQuickEnv* env)
         : m_deletePath (false)
         , m_journal (journal)
         , m_keyBytes (keyBytes)
-        , m_scheduler (scheduler)
-        , m_batch (*this, scheduler)
         , m_name (keyValues ["path"].toStdString ())
     {
         if (m_name.empty())
-            throw std::runtime_error ("Missing path in RocksDBFactory backend");
+            throw std::runtime_error ("Missing path in RocksDBQuickFactory backend");
 
+        // Defaults
+        std::uint64_t budget = 512 * 1024 * 1024;  // 512MB
+        std::string style("level");
+        std::uint64_t threads=4;
+
+        if (!keyValues["budget"].isEmpty())
+            budget = keyValues["budget"].getIntValue();
+
+        if (!keyValues["style"].isEmpty())
+            style = keyValues["style"].toStdString();
+
+        if (!keyValues["threads"].isEmpty())
+            threads = keyValues["threads"].getIntValue();
+
+
+        // Set options
         rocksdb::Options options;
-        rocksdb::BlockBasedTableOptions table_options;
         options.create_if_missing = true;
         options.env = env;
 
-        if (keyValues["cache_mb"].isEmpty())
-        {
-            table_options.block_cache = rocksdb::NewLRUCache (getConfig ().getSize (siHashNodeDBCache) * 1024 * 1024);
-        }
-        else
-        {
-            table_options.block_cache = rocksdb::NewLRUCache (keyValues["cache_mb"].getIntValue() * 1024L * 1024L);
-        }
+        if (style == "level")
+            options.OptimizeLevelStyleCompaction(budget);
 
-        if (keyValues["filter_bits"].isEmpty())
-        {
-            if (getConfig ().NODE_SIZE >= 2)
-                table_options.filter_policy.reset (rocksdb::NewBloomFilterPolicy (10));
-        }
-        else if (keyValues["filter_bits"].getIntValue() != 0)
-        {
-            table_options.filter_policy.reset (rocksdb::NewBloomFilterPolicy (keyValues["filter_bits"].getIntValue()));
-        }
+        if (style == "universal")
+            options.OptimizeUniversalStyleCompaction(budget);
+
+        if (style == "point")
+            options.OptimizeForPointLookup(budget / 1024 / 1024);  // In MB
+
+        options.IncreaseParallelism(threads);
+
+        // Allows hash indexes in blocks
+        options.prefix_extractor.reset(rocksdb::NewNoopTransform());
+
+        // overrride OptimizeLevelStyleCompaction
+        options.min_write_buffer_number_to_merge = 1;
+        
+        rocksdb::BlockBasedTableOptions table_options;
+        // Use hash index
+        table_options.index_type =
+            rocksdb::BlockBasedTableOptions::kHashSearch;
+        table_options.filter_policy.reset(
+            rocksdb::NewBloomFilterPolicy(10));
+        options.table_factory.reset(
+            NewBlockBasedTableFactory(table_options));
+        
+        // Higher values make reads slower
+        // table_options.block_size = 4096;
+
+        // No point when DatabaseImp has a cache
+        // table_options.block_cache =
+        //     rocksdb::NewLRUCache(64 * 1024 * 1024);
+
+        options.memtable_factory.reset(rocksdb::NewHashSkipListRepFactory());
+        // Alternative:
+        // options.memtable_factory.reset(
+        //     rocksdb::NewHashCuckooRepFactory(options.write_buffer_size));
 
         if (! keyValues["open_files"].isEmpty())
         {
             options.max_open_files = keyValues["open_files"].getIntValue();
         }
-
-        if (! keyValues["file_size_mb"].isEmpty())
-        {
-            options.target_file_size_base = 1024 * 1024 * keyValues["file_size_mb"].getIntValue();
-            options.max_bytes_for_level_base = 5 * options.target_file_size_base;
-            options.write_buffer_size = 2 * options.target_file_size_base;
-        }
-
-        if (! keyValues["file_size_mult"].isEmpty())
-        {
-            options.target_file_size_multiplier = keyValues["file_size_mult"].getIntValue();
-        }
-
-        if (! keyValues["bg_threads"].isEmpty())
-        {
-            options.env->SetBackgroundThreads
-                (keyValues["bg_threads"].getIntValue(), rocksdb::Env::LOW);
-        }
-
-        if (! keyValues["high_threads"].isEmpty())
-        {
-            auto const highThreads = keyValues["high_threads"].getIntValue();
-            options.env->SetBackgroundThreads (highThreads, rocksdb::Env::HIGH);
-
-            // If we have high-priority threads, presumably we want to
-            // use them for background flushes
-            if (highThreads > 0)
-                options.max_background_flushes = highThreads;
-        }
-
-        if (! keyValues["compression"].isEmpty ())
+ 
+        if (! keyValues["compression"].isEmpty ())  
         {
             if (keyValues["compression"].getIntValue () == 0)
             {
@@ -177,35 +176,24 @@ public:
             }
         }
 
-        if (! keyValues["block_size"].isEmpty ())
-        {
-            table_options.block_size = keyValues["block_size"].getIntValue ();
-        }
-
-        if (! keyValues["universal_compaction"].isEmpty ())
-        {
-            if (keyValues["universal_compaction"].getIntValue () != 0)
-            {
-                options.compaction_style = rocksdb:: kCompactionStyleUniversal;
-                options.min_write_buffer_number_to_merge = 2;
-                options.max_write_buffer_number = 6;
-                options.write_buffer_size = 6 * options.target_file_size_base;
-            }
-        }
-
-        options.table_factory.reset(NewBlockBasedTableFactory(table_options));
-
         rocksdb::DB* db = nullptr;
+
         rocksdb::Status status = rocksdb::DB::Open (options, m_name, &db);
         if (!status.ok () || !db)
-            throw std::runtime_error (std::string("Unable to open/create RocksDB: ") + status.ToString());
+            throw std::runtime_error (std::string("Unable to open/create RocksDBQuick: ") + status.ToString());
 
         m_db.reset (db);
     }
 
-    ~RocksDBBackend ()
+    ~RocksDBQuickBackend ()
     {
         close();
+    }
+
+    std::string
+    getName()
+    {
+        return m_name;
     }
 
     void
@@ -220,12 +208,6 @@ public:
                 boost::filesystem::remove_all (dir);
             }
         }
-    }
-
-    std::string
-    getName()
-    {
-        return m_name;
     }
 
     //--------------------------------------------------------------------------
@@ -283,29 +265,32 @@ public:
     void
     store (NodeObject::ref object)
     {
-        m_batch.store (object);
+        storeBatch(Batch{object});
     }
 
     void
     storeBatch (Batch const& batch)
     {
         rocksdb::WriteBatch wb;
-
+ 
         EncodedBlob encoded;
 
         for (auto const& e : batch)
         {
             encoded.prepare (e);
 
-            wb.Put (
-                rocksdb::Slice (reinterpret_cast <char const*> (
-                    encoded.getKey ()), m_keyBytes),
-                rocksdb::Slice (reinterpret_cast <char const*> (
-                    encoded.getData ()), encoded.getSize ()));
+            wb.Put(
+                rocksdb::Slice(reinterpret_cast<char const*>(encoded.getKey()),
+                               m_keyBytes),
+                rocksdb::Slice(reinterpret_cast<char const*>(encoded.getData()),
+                               encoded.getSize()));
         }
 
-        rocksdb::WriteOptions const options;
+        rocksdb::WriteOptions options;
 
+        // Crucial to ensure good write speed and non-blocking writes to memtable
+        options.disableWAL = true;
+        
         auto ret = m_db->Write (options, &wb);
 
         if (!ret.ok ())
@@ -351,7 +336,7 @@ public:
     int
     getWriteLoad ()
     {
-        return m_batch.getWriteLoad ();
+        return 0;
     }
 
     void
@@ -376,17 +361,17 @@ public:
 
 //------------------------------------------------------------------------------
 
-class RocksDBFactory : public Factory
+class RocksDBQuickFactory : public Factory
 {
 public:
-    RocksDBEnv m_env;
+    RocksDBQuickEnv m_env;
 
-    RocksDBFactory ()
+    RocksDBQuickFactory()
     {
         Manager::instance().insert(*this);
     }
 
-    ~RocksDBFactory ()
+    ~RocksDBQuickFactory()
     {
         Manager::instance().erase(*this);
     }
@@ -394,7 +379,7 @@ public:
     std::string
     getName () const
     {
-        return "RocksDB";
+        return "RocksDBQuick";
     }
 
     std::unique_ptr <Backend>
@@ -404,12 +389,12 @@ public:
         Scheduler& scheduler,
         beast::Journal journal)
     {
-        return std::make_unique <RocksDBBackend> (
+        return std::make_unique <RocksDBQuickBackend> (
             keyBytes, keyValues, scheduler, journal, &m_env);
     }
 };
 
-static RocksDBFactory rocksDBFactory;
+static RocksDBQuickFactory rocksDBQuickFactory;
 
 }
 }

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_OVERLAY_OVERLAY_H_INCLUDED
 #define RIPPLE_OVERLAY_OVERLAY_H_INCLUDED
 
+#include <ripple/json/json_value.h>
 #include <ripple/overlay/Peer.h>
 #include <ripple/server/Handoff.h>
 #include <beast/asio/ssl_bundle.h>
@@ -100,6 +101,11 @@ public:
     virtual
     std::size_t
     size () = 0;
+
+    /** Returns information reported to the crawl cgi command. */
+    virtual
+    Json::Value
+    crawl() = 0;
 
     /** Return diagnostics on the status of all peers.
         @deprecated This is superceded by PropertyStream

--- a/src/ripple/overlay/README.md
+++ b/src/ripple/overlay/README.md
@@ -51,9 +51,6 @@ operating in the Client Handler role accepts incoming connections from clients
 and services them through the JSON-RPC interface. A peer can operate in either
 the leaf or superpeer roles while also operating as a client handler.
 
-
-
-
 ## Handshake
 
 To establish a protocol connection, a peer makes an outgoing TLS encrypted
@@ -69,8 +66,8 @@ Upgrade: RTXP/1.2, RTXP/1.3
 Connection: Upgrade
 Connect-As: Leaf, Peer
 Accept-Encoding: identity, zlib, snappy
-Protocol-Public-Key: aBRoQibi2jpDofohooFuzZi9nEzKw9Zdfc4ExVNmuXHaJpSPh8uJ
-Protocol-Session-Cookie: 71ED064155FFADFA38782C5E0158CB26
+Public-Key: aBRoQibi2jpDofohooFuzZi9nEzKw9Zdfc4ExVNmuXHaJpSPh8uJ
+Session-Signature: 71ED064155FFADFA38782C5E0158CB26
 ```
 
 Upon receipt of a well-formed HTTP request the remote peer will send back a
@@ -84,8 +81,8 @@ Upgrade: RTXP/1.2
 Connection: Upgrade
 Connect-As: Leaf
 Transfer-Encoding: snappy
-Protocol-Public-Key: aBRoQibi2jpDofohooFuzZi9nEzKw9Zdfc4ExVNmuXHaJpSPh8uJ
-Protocol-Session-Cookie: 71ED064155FFADFA38782C5E0158CB26
+Public-Key: aBRoQibi2jpDofohooFuzZi9nEzKw9Zdfc4ExVNmuXHaJpSPh8uJ
+Session-Signature: 71ED064155FFADFA38782C5E0158CB26
 ```
 
 If the remote peer has no available slots, the HTTP status code 503 (Service
@@ -163,21 +160,28 @@ Content-Type: application/json
     of elements specified in the request. If a server does not recognize any
     of the connection types it must return a HTTP error response.
 
-* `Protocol-Public-Key`
+* `Public-Key`
 
-    This field value must be present, and contain a Base58 encoded value used
+    This field value must be present, and contain a base 64 encoded value used
     as a server public key identifier.
 
-* `Protocol-Session-Proof`
+* `Session-Signature`
 
-    This field must be present (TODO)
+    This field must be present. It contains a cryptographic token formed
+    from the SHA512 hash of the shared data exchanged during SSL handshaking.
+    For more details see the corresponding source code.
 
-* _User Defined_
+* `Crawl` (optional)
+
+    If present, and the value is "public" then neighbors will report the IP
+    address to crawler requests. If absent, neighbor's default behavior is to
+    not report IP addresses.
+
+* _User Defined_ (Unimplemented)
 
     The rippled operator may specify additional, optional fields and values
     through the configuration. These headers will be transmitted in the
     corresponding request or response messages.
-
 
 ---
 

--- a/src/ripple/overlay/impl/ConnectAttempt.cpp
+++ b/src/ripple/overlay/impl/ConnectAttempt.cpp
@@ -218,7 +218,8 @@ ConnectAttempt::onHandshake (error_code ec)
         return close(); // makeSharedValue logs
 
     beast::http::message req = makeRequest(
-        remote_endpoint_.address());
+        ! overlay_.peerFinder().config().peerPrivate,
+            remote_endpoint_.address());
     auto const hello = buildHello (sharedValue, getApp());
     appendHello (req, hello);
 
@@ -509,7 +510,7 @@ ConnectAttempt::onReadBody (error_code ec,
 //--------------------------------------------------------------------------
 
 beast::http::message
-ConnectAttempt::makeRequest (
+ConnectAttempt::makeRequest (bool crawl,
     boost::asio::ip::address const& remote_address)
 {
     beast::http::message m;
@@ -521,13 +522,7 @@ ConnectAttempt::makeRequest (
         //std::string("RTXP/") + to_string (BuildInfo::getCurrentProtocol()));
     m.headers.append ("Connection", "Upgrade");
     m.headers.append ("Connect-As", "Peer");
-    //m.headers.append ("Connect-As", "Leaf, Peer");
-    //m.headers.append ("Accept-Encoding", "identity");
-    //m.headers.append ("Local-Address", stream_.
-    //m.headers.append ("X-Try-IPs", "192.168.0.1:51234");
-    //m.headers.append ("X-Try-IPs", "208.239.114.74:51234");
-    //m.headers.append ("A", "BC");
-    //m.headers.append ("Content-Length", "0");
+    m.headers.append ("Crawl", crawl ? "public" : "private");
     return m;
 }
 

--- a/src/ripple/overlay/impl/ConnectAttempt.h
+++ b/src/ripple/overlay/impl/ConnectAttempt.h
@@ -106,7 +106,8 @@ private:
 
     static
     beast::http::message
-    makeRequest (boost::asio::ip::address const& remote_address);
+    makeRequest (bool crawl,
+        boost::asio::ip::address const& remote_address);
 
     template <class Streambuf>
     void processResponse (beast::http::message const& m,

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -208,7 +208,14 @@ private:
     size() override;
 
     Json::Value
+    crawl() override;
+
+    Json::Value
     json() override;
+
+    bool
+    processRequest (beast::http::message const& req,
+        Handoff& handoff);
 
     //--------------------------------------------------------------------------
 

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -109,49 +109,37 @@ private:
     // the current conditions as closely as possible.
     beast::IP::Endpoint remote_address_;
 
-    // These is up here to prevent warnings about order of initializations
+    // These are up here to prevent warnings about order of initializations
     //
     OverlayImpl& overlay_;
     bool m_inbound;
-
     State state_;          // Current state
     bool detaching_ = false;
-
     // Node public key of peer.
     RippleAddress publicKey_;
-
     std::string name_;
-
     uint256 sharedValue_;
 
     // The indices of the smallest and largest ledgers this peer has available
     //
     LedgerIndex minLedger_ = 0;
     LedgerIndex maxLedger_ = 0;
-
     uint256 closedLedgerHash_;
     uint256 previousLedgerHash_;
-
     std::list<uint256> recentLedgers_;
     std::list<uint256> recentTxSets_;
     mutable std::mutex recentLock_;
-
     protocol::TMStatusChange last_status_;
     protocol::TMHello hello_;
-
     Resource::Consumer usage_;
     PeerFinder::Slot::ptr slot_;
-
     beast::asio::streambuf read_buffer_;
     beast::http::message http_message_;
-    boost::optional <beast::http::parser> http_parser_;
     beast::http::body http_body_;
     beast::asio::streambuf write_buffer_;
     std::queue<Message::pointer> send_queue_;
     bool gracefulClose_ = false;
-
     std::unique_ptr <LoadEvent> load_event_;
-
     std::unique_ptr<Validators::Connection> validatorsConnection_;
 
     //--------------------------------------------------------------------------
@@ -235,6 +223,9 @@ public:
     }
 
     bool
+    crawl() const;
+
+    bool
     cluster() const override
     {
         return slot_->cluster();
@@ -300,10 +291,6 @@ private:
     std::string
     makePrefix(id_t id);
 
-    static
-    beast::http::message
-    makeRequest (boost::asio::ip::address const& remote_address);
-
     // Called when the timer wait completes
     void
     onTimer (boost::system::error_code const& ec);
@@ -320,7 +307,7 @@ private:
 
     static
     beast::http::message
-    makeResponse (beast::http::message const& req,
+    makeResponse (bool crawl, beast::http::message const& req,
         uint256 const& sharedValue);
 
     void

--- a/src/ripple/peerfinder/Manager.h
+++ b/src/ripple/peerfinder/Manager.h
@@ -58,6 +58,9 @@ struct Config
     */
     double outPeers;
 
+    /** `true` if we want our IP address kept private. */
+    bool peerPrivate = true;
+
     /** `true` if we want to accept incoming connections. */
     bool wantIncoming;
 
@@ -135,6 +138,11 @@ public:
             Can be called from any threads at any time.
     */
     virtual void setConfig (Config const& config) = 0;
+
+    /** Returns the configuration for the manager. */
+    virtual
+    Config
+    config() = 0;
 
     /** Add a peer that should always be connected.
         This is useful for maintaining a private cluster of peers.

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -180,6 +180,13 @@ public:
         state->counts.onConfig (state->config);
     }
 
+    Config
+    config()
+    {
+        typename SharedState::Access state (m_state);
+        return state->config;
+    }
+
     void
     addFixedPeer (std::string const& name,
         beast::IP::Endpoint const& ep)

--- a/src/ripple/peerfinder/impl/Manager.cpp
+++ b/src/ripple/peerfinder/impl/Manager.cpp
@@ -94,6 +94,12 @@ public:
         m_logic.config (config);
     }
 
+    Config
+    config() override
+    {
+        return m_logic.config();
+    }
+
     void addFixedPeer (std::string const& name,
         std::vector <beast::IP::Endpoint> const& addresses) override
     {

--- a/src/ripple/peerfinder/impl/PeerfinderConfig.cpp
+++ b/src/ripple/peerfinder/impl/PeerfinderConfig.cpp
@@ -24,7 +24,7 @@
 namespace ripple {
 namespace PeerFinder {
 
-Config::Config ()
+Config::Config()
     : maxPeers (Tuning::defaultMaxPeers)
     , outPeers (calcOutPeers ())
     , wantIncoming (true)

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -35,7 +35,7 @@ char const* getRawVersionString ()
     //
     //  The build version number (edit this for each release)
     //
-        "0.28.0-b3"
+        "0.28.0-b4"
     //
     //  Must follow the format described here:
     //

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/json/json_reader.h>
+#include <ripple/server/JsonWriter.h>
 #include <ripple/server/make_ServerHandler.h>
 #include <ripple/server/impl/JSONRPCUtil.h>
 #include <ripple/server/impl/ServerHandlerImp.h>

--- a/src/ripple/unity/nodestore.cpp
+++ b/src/ripple/unity/nodestore.cpp
@@ -25,6 +25,7 @@
 #include <ripple/nodestore/backend/NuDBFactory.cpp>
 #include <ripple/nodestore/backend/NullFactory.cpp>
 #include <ripple/nodestore/backend/RocksDBFactory.cpp>
+#include <ripple/nodestore/backend/RocksDBQuickFactory.cpp>
 
 #include <ripple/nodestore/impl/BatchWriter.cpp>
 #include <ripple/nodestore/impl/DatabaseImp.h>


### PR DESCRIPTION
This reverts the change that makes RocksDBQuick the default settings for
node_db "type=rocksdb". The quick settings can be obtained by setting
"type=rocksdbquick".

RocksDBQuick settings are implicated in memory over-utilization problems
seen recently.