### PR TITLE
Improvements to protocol serialization:

### DIFF
--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -81,7 +81,7 @@ bool ConsensusTransSetSF::haveNode (const SHAMapNodeID& id, uint256 const& nodeH
         WriteLog (lsDEBUG, TransactionAcquire) << "Node in our acquiring TX set is TXN we have";
         Serializer s;
         s.add32 (HashPrefix::transactionID);
-        txn->getSTransaction ()->add (s, true);
+        txn->getSTransaction ()->add (s);
         assert (s.getSHA512Half () == nodeHash);
         nodeData = s.peekData ();
         return true;

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -564,7 +564,7 @@ AmendmentTableImpl<AppApiFacade>::doVoting (Ledger::ref lastClosedLedger,
 
         // Inject the transaction into our initial proposal
         Serializer s;
-        trans.add (s, true);
+        trans.add (s);
 #if RIPPLE_PROPOSE_AMENDMENTS
         SHAMapItem::pointer tItem = std::make_shared<SHAMapItem> (txID, s.peekData ());
         if (!initialPosition->addGiveItem (tItem, true, false))

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -226,7 +226,7 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
             journal_.warning << "Vote: " << txID;
 
         Serializer s;
-        trans.add (s, true);
+        trans.add (s);
 
         SHAMapItem::pointer tItem = std::make_shared<SHAMapItem> (
             txID, s.peekData ());

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -111,13 +111,20 @@ public:
         sMD_Default        = sMD_ChangeOrig | sMD_ChangeNew | sMD_DeleteFinal | sMD_Create
     };
 
-    const int               fieldCode;      // (type<<16)|index
-    const SerializedTypeID  fieldType;      // STI_*
-    const int               fieldValue;     // Code number for protocol
+    enum class IsSigning : unsigned char
+    {
+        no,
+        yes
+    };
+    static IsSigning const notSigning = IsSigning::no;
+
+    int const               fieldCode;      // (type<<16)|index
+    SerializedTypeID const  fieldType;      // STI_*
+    int const               fieldValue;     // Code number for protocol
     std::string             fieldName;
     int                     fieldMeta;
     int                     fieldNum;
-    bool                    signingField;
+    IsSigning               signingField;
     std::string             rawJsonName;
     Json::StaticString      jsonName;
 
@@ -142,7 +149,7 @@ public:
 private:
     // These constructors can only be called from FieldNames.cpp
     SField (SerializedTypeID tid, int fv, const char* fn,
-            int meta = sMD_Default, bool signing = true);
+            int meta = sMD_Default, IsSigning signing = IsSigning::yes);
     explicit SField (int fc);
     SField (SerializedTypeID id, int val);
 
@@ -215,11 +222,11 @@ public:
 
     bool isSigningField () const
     {
-        return signingField;
+        return signingField == IsSigning::yes;
     }
     void notSigningField ()
     {
-        signingField = false;
+        signingField = IsSigning::no;
     }
     bool shouldMeta (int c) const
     {
@@ -232,7 +239,8 @@ public:
 
     bool shouldInclude (bool withSigningField) const
     {
-        return (fieldValue < 256) && (withSigningField || signingField);
+        return (fieldValue < 256) &&
+            (withSigningField || (signingField == IsSigning::yes));
     }
 
     bool operator== (const SField& f) const

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -124,7 +124,7 @@ public:
     std::string             fieldName;
     int                     fieldMeta;
     int                     fieldNum;
-    IsSigning               signingField;
+    IsSigning const         signingField;
     std::string             rawJsonName;
     Json::StaticString      jsonName;
 
@@ -223,10 +223,6 @@ public:
     bool isSigningField () const
     {
         return signingField == IsSigning::yes;
-    }
-    void notSigningField ()
-    {
-        signingField = IsSigning::no;
     }
     bool shouldMeta (int c) const
     {

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -35,6 +35,13 @@ class STObject
     : public STBase
     , public CountedObject <STObject>
 {
+private:
+    enum class IncludeSigningFields : unsigned char
+    {
+        no,
+        yes,
+    };
+
 public:
     static char const* getCountedObjectName () { return "STObject"; }
 
@@ -50,14 +57,14 @@ public:
     }
 
     STObject (const SOTemplate & type, SField::ref name)
-        : STBase (name)
+        : STBase (name), mType (nullptr)
     {
         set (type);
     }
 
     STObject (
         const SOTemplate & type, SerialIter & sit, SField::ref name)
-        : STBase (name)
+        : STBase (name), mType (nullptr)
     {
         set (sit);
         setType (type);
@@ -102,10 +109,8 @@ public:
 
     virtual void add (Serializer & s) const override
     {
-        add (s, true);    // just inner elements
+        add (s, IncludeSigningFields::yes);
     }
-
-    void add (Serializer & s, bool withSignature) const;
 
     // VFALCO NOTE does this return an expensive copy of an object with a
     //             dynamic buffer?
@@ -113,7 +118,7 @@ public:
     Serializer getSerializer () const
     {
         Serializer s;
-        add (s);
+        add (s, IncludeSigningFields::yes);
         return s;
     }
 
@@ -126,16 +131,6 @@ public:
     int addObject (const STBase & t)
     {
         mData.push_back (t.duplicate ().release ());
-        return mData.size () - 1;
-    }
-    int giveObject (std::unique_ptr<STBase> t)
-    {
-        mData.push_back (t.release ());
-        return mData.size () - 1;
-    }
-    int giveObject (STBase * t)
-    {
-        mData.push_back (t);
         return mData.size () - 1;
     }
     const boost::ptr_vector<STBase>& peekData () const
@@ -220,6 +215,7 @@ public:
     STPathSet const& getFieldPathSet (SField::ref field) const;
     const STVector256& getFieldV256 (SField::ref field) const;
     const STArray& getFieldArray (SField::ref field) const;
+    const STObject& getFieldObject (SField::ref field) const;
 
     void setFieldU8 (SField::ref field, unsigned char);
     void setFieldU16 (SField::ref field, std::uint16_t);
@@ -237,6 +233,7 @@ public:
     void setFieldPathSet (SField::ref field, STPathSet const&);
     void setFieldV256 (SField::ref field, STVector256 const& v);
     void setFieldArray (SField::ref field, STArray const& v);
+    void setFieldObject (SField::ref field, STObject const& v);
 
     template <class Tag>
     void setFieldH160 (SField::ref field, base_uint<160, Tag> const& v)
@@ -257,6 +254,7 @@ public:
     }
 
     STObject& peekFieldObject (SField::ref field);
+    STArray& peekFieldArray (SField::ref field);
 
     bool isFieldPresent (SField::ref field) const;
     STBase* makeFieldPresent (SField::ref field);
@@ -317,13 +315,61 @@ public:
         return ! (*this == o);
     }
 
-    std::unique_ptr<STBase>
-    duplicate () const override
+private:
+    // This signature for giveObject () initially seems a little misleading,
+    // but it is correct.
+    //
+    // This call expects to receive a temporary (an rvalue reference to a)
+    // unique_ptr.  The unique_ptr move constructor moves the innards of that
+    // temporary into this unique_ptr, t.
+    //
+    // Given that description it seems like the signature would be better with
+    //   std::unique_ptr<STBase>&& t
+    // That's not quite right because giveObject unconditionally takes
+    // ownership of the contents of the unique_ptr, even in the face of an
+    // exception.  Once giveObject is called you can never get the contents
+    // of the unique_ptr back.  The current signature matches that reality.
+    int giveObject (std::unique_ptr<STBase> t)
+    {
+        // Howard and I initially thought that transferring pointer ownership
+        // in this form would leak if the push_back throws.  Howard dug in
+        // further and discovered that the ptr_vector takes ownership of the
+        // pointer even in the case where the push_back throws.  So this *is*
+        // the right form for the call to push_back.
+        mData.push_back (t.release ());
+        return mData.size () - 1;
+    }
+    int giveObject (STBase * t)
+    {
+        mData.push_back (t);
+        return mData.size () - 1;
+    }
+
+    void add (Serializer & s, IncludeSigningFields signingFieldsChoice) const;
+
+    std::unique_ptr<STBase> duplicate () const override
     {
         return std::make_unique<STObject>(*this);
     }
 
-private:
+    // Sort the entries in an STObject into the order that they will be
+    // serialized.  Note: they are not sorted into pointer value order, they
+    // are sorted by SField::fieldCode.
+    static
+    std::vector<STBase const*>
+    getSortedFields (
+        STObject const& objToSort, IncludeSigningFields signingFieldsChoice);
+
+    // Two different ways to compare STObjects.
+    //
+    // This one works only if the SOTemplates are the same.  Presumably it
+    // runs faster since there's no sorting.
+    static bool equivalentSTObjectSameTemplate (
+        STObject const& obj1, STObject const& obj2);
+
+    // This way of comparing STObjects always works, but is slower.
+    static bool equivalentSTObject (STObject const& obj1, STObject const& obj2);
+
     // Implementation for getting (most) fields that return by value.
     //
     // The remove_cv and remove_reference are necessitated by the STBitString
@@ -416,6 +462,26 @@ private:
             throw std::runtime_error ("Wrong field type");
 
         (*cf) = value;
+    }
+
+    // Implementation for peeking STObjects and STArrays
+    template <typename T>
+    T& peekField (SField::ref field)
+    {
+        STBase* rf = getPField (field, true);
+
+        if (!rf)
+            throw std::runtime_error ("Field not found");
+
+        if (rf->getSType () == STI_NOTPRESENT)
+            rf = makeFieldPresent (field);
+
+        T* cf = dynamic_cast<T*> (rf);
+
+        if (!cf)
+            throw std::runtime_error ("Wrong field type");
+
+        return *cf;
     }
 
 private:

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -97,19 +97,24 @@ public:
     void set (const SOTemplate&);
     bool set (SerialIter& u, int depth = 0);
 
-    virtual SerializedTypeID getSType () const override
+    SerializedTypeID getSType () const override
     {
         return STI_OBJECT;
     }
-    virtual bool isEquivalent (const STBase & t) const override;
-    virtual bool isDefault () const override
+    bool isEquivalent (const STBase & t) const override;
+    bool isDefault () const override
     {
         return mData.empty ();
     }
 
-    virtual void add (Serializer & s) const override
+    void add (Serializer & s) const override
     {
         add (s, IncludeSigningFields::yes);
+    }
+
+    void addWithoutSigningFields (Serializer & s)
+    {
+        add (s, IncludeSigningFields::no);
     }
 
     // VFALCO NOTE does this return an expensive copy of an object with a
@@ -122,11 +127,11 @@ public:
         return s;
     }
 
-    virtual std::string getFullText () const override;
-    virtual std::string getText () const override;
+    std::string getFullText () const override;
+    std::string getText () const override;
 
     // TODO(tom): options should be an enum.
-    virtual Json::Value getJson (int options) const override;
+    Json::Value getJson (int options) const override;
 
     int addObject (const STBase & t)
     {

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -321,6 +321,12 @@ public:
     }
 
 private:
+    int giveObject (STBase * t)
+    {
+        mData.push_back (t);
+        return mData.size () - 1;
+    }
+
     // This signature for giveObject () initially seems a little misleading,
     // but it is correct.
     //
@@ -336,18 +342,11 @@ private:
     // of the unique_ptr back.  The current signature matches that reality.
     int giveObject (std::unique_ptr<STBase> t)
     {
-        // Howard and I initially thought that transferring pointer ownership
-        // in this form would leak if the push_back throws.  Howard dug in
-        // further and discovered that the ptr_vector takes ownership of the
-        // pointer even in the case where the push_back throws.  So this *is*
-        // the right form for the call to push_back.
-        mData.push_back (t.release ());
-        return mData.size () - 1;
-    }
-    int giveObject (STBase * t)
-    {
-        mData.push_back (t);
-        return mData.size () - 1;
+        // Because mData is a ptr_vector, mData.push_back() takes ownership of
+        // the pointer even if the push_back() throws.  So calling t.release()
+        // here (which will go straight into an mData.push_back()) does not
+        // present the opportunity for a leak.
+        return giveObject (t.release ());
     }
 
     void add (Serializer & s, IncludeSigningFields signingFieldsChoice) const;

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -34,6 +34,9 @@ static std::mutex SField_mutex;
 static std::map<int, SField::ptr> knownCodeToField;
 static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
 
+// Storage for static const member.
+SField::IsSigning const SField::notSigning;
+
 int SField::num = 0;
 
 typedef std::lock_guard <std::mutex> StaticScopedLockType;
@@ -206,9 +209,9 @@ SField const sfDeliveredAmount = make::one(&sfDeliveredAmount, STI_AMOUNT, 18, "
 SField const sfPublicKey     = make::one(&sfPublicKey,     STI_VL,  1, "PublicKey");
 SField const sfMessageKey    = make::one(&sfMessageKey,    STI_VL,  2, "MessageKey");
 SField const sfSigningPubKey = make::one(&sfSigningPubKey, STI_VL,  3, "SigningPubKey");
-SField const sfTxnSignature  = make::one(&sfTxnSignature,  STI_VL,  4, "TxnSignature", SField::sMD_Default, false);
+SField const sfTxnSignature  = make::one(&sfTxnSignature,  STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
 SField const sfGenerator     = make::one(&sfGenerator,     STI_VL,  5, "Generator");
-SField const sfSignature     = make::one(&sfSignature,     STI_VL,  6, "Signature", SField::sMD_Default, false);
+SField const sfSignature     = make::one(&sfSignature,     STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
 SField const sfDomain        = make::one(&sfDomain,        STI_VL,  7, "Domain");
 SField const sfFundCode      = make::one(&sfFundCode,      STI_VL,  8, "FundCode");
 SField const sfRemoveCode    = make::one(&sfRemoveCode,    STI_VL,  9, "RemoveCode");
@@ -249,7 +252,7 @@ SField const sfMemo                = make::one(&sfMemo,                STI_OBJEC
 // array of objects
 // ARRAY/1 is reserved for end of array
 SField const sfSigningAccounts = make::one(&sfSigningAccounts, STI_ARRAY, 2, "SigningAccounts");
-SField const sfTxnSignatures   = make::one(&sfTxnSignatures,   STI_ARRAY, 3, "TxnSignatures", SField::sMD_Default, false);
+SField const sfTxnSignatures   = make::one(&sfTxnSignatures,   STI_ARRAY, 3, "TxnSignatures", SField::sMD_Default, SField::notSigning);
 SField const sfSignatures      = make::one(&sfSignatures,      STI_ARRAY, 4, "Signatures");
 SField const sfTemplate        = make::one(&sfTemplate,        STI_ARRAY, 5, "Template");
 SField const sfNecessary       = make::one(&sfNecessary,       STI_ARRAY, 6, "Necessary");
@@ -258,7 +261,7 @@ SField const sfAffectedNodes   = make::one(&sfAffectedNodes,   STI_ARRAY, 8, "Af
 SField const sfMemos           = make::one(&sfMemos,           STI_ARRAY, 9, "Memos");
 
 SField::SField (SerializedTypeID tid, int fv, const char* fn,
-                int meta, bool signing)
+                int meta, IsSigning signing)
     : fieldCode (field_code (tid, fv))
     , fieldType (tid)
     , fieldValue (fv)
@@ -277,7 +280,7 @@ SField::SField (int fc)
     , fieldValue (0)
     , fieldMeta (sMD_Never)
     , fieldNum (++num)
-    , signingField (true)
+    , signingField (IsSigning::yes)
     , rawJsonName (getName ())
     , jsonName (rawJsonName.c_str ())
 {
@@ -290,7 +293,7 @@ SField::SField (SerializedTypeID tid, int fv)
         : fieldCode (field_code (tid, fv)), fieldType (tid), fieldValue (fv),
           fieldMeta (sMD_Default),
           fieldNum (++num),
-          signingField (true),
+          signingField (IsSigning::yes),
           jsonName (nullptr)
 {
     fieldName = std::to_string (tid) + '/' + std::to_string (fv);


### PR DESCRIPTION
A few serialization changes coming from m-of-n development:

 o Improve readability of SField.cpp.
 o Better initialization of STObject.
 o Trimming a few STObject public methods.
 o Add STObject::getFieldObject and STObject::setFieldObject.
 o Make STObject::isEquivalent more robust.

@JoelKatz @nbougalis