### PR TITLE
Implement getFetchPack using visitDifferences

### DIFF
--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -231,7 +231,10 @@ public:
 
     typedef std::pair <uint256, Blob> fetchPackEntry_t;
 
-    void getFetchPack (SHAMap * have, bool includeLeaves, int max, std::function<void (uint256 const&, const Blob&)>);
+    void visitDifferences (SHAMap * have, std::function<bool (SHAMapTreeNode&)>);
+
+    void getFetchPack (SHAMap * have, bool includeLeaves, int max,
+        std::function<void (uint256 const&, const Blob&)>);
 
     void setUnbacked ()
     {


### PR DESCRIPTION
Turn the existing SHAMap::getFetchPack function into a cleaner visitDifferences, a function that visits every node in a SHAMap that's not in another SHAMap. Implement getFetchPack as a trivial wrapper around visitDifferences.