### PR TITLE
Improve ledger fetching behavior

### DIFF
--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -100,11 +100,6 @@ void InboundLedger::init (ScopedLockType& collectionLock)
     {
         addPeers ();
         setTimer ();
-
-        // For historical nodes, wait a bit since a
-        // fetch pack is probably coming
-        if (mReason != fcHISTORY)
-            trigger (Peer::ptr ());
     }
     else if (!isFailed ())
     {
@@ -272,9 +267,16 @@ void InboundLedger::onTimer (bool wasProgress, ScopedLockType&)
             "No progress(" << pc <<
             ") for ledger " << mHash;
 
-        trigger (Peer::ptr ());
+        // addPeers triggers if the reason is not fcHISTORY
+        // So if the reason IS fcHISTORY, need to trigger after we add
+        // otherwise, we need to trigger before we add
+        // so each peer gets triggered once
+        if (mReason != fcHISTORY)
+            trigger (Peer::ptr ());
         if (pc < 4)
             addPeers ();
+        if (mReason == fcHISTORY)
+            trigger (Peer::ptr ());
     }
 }
 

--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -114,7 +114,10 @@ private:
 
     void newPeer (Peer::ptr const& peer)
     {
-        trigger (peer);
+        // For historical nodes, do not trigger too soon
+        // since a fetch pack is probably coming
+        if (mReason != fcHISTORY)
+            trigger (peer);
     }
 
     std::weak_ptr <PeerSet> pmDowncast ();

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -576,9 +576,7 @@ public:
         {
             if (peer->hasRange (nextLedger->getLedgerSeq() - 1, nextLedger->getLedgerSeq()))
             {
-                if (count++ == 0)
-                    target = peer;
-                else if ((rand () % ++count) == 0)
+                if ((count++ == 0) || ((rand() % count) == 0))
                     target = peer;
             }
         }


### PR DESCRIPTION
getMissingNode changes:
* Log getMissingNode behavior and performance
* If we pend an async fetch, process the results of that fetch even if we find all the missing nodes we're looking for.
* Don't try to descend to nodes we've already deemed missing

Fix a double increment that resulted in unfair distribution of fetch pack requests.

When fetching ledgers for other than historical purposes, don't trigger each initial peer twice. Otherwise, if we're really fast we can get a version of sorcerer's apprentice syndrome where we have two nearly-identical requests in flight and each one triggers a nearly-identical follow up request. Node filtering unjams this until the filters clear and it repeats once per clear interval.