### PR TITLE
Don't VACUUM SQLite databases on startup with online delete enabled.

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -564,20 +564,6 @@ public:
         mWalletDB = std::make_unique <DatabaseCon> (setup, "wallet.db",
                 WalletDBInit, WalletDBCount);
 
-        if (setup.onlineDelete && mTxnDB && mLedgerDB)
-        {
-            {
-                std::lock_guard <std::recursive_mutex> lock (
-                        mTxnDB->peekMutex());
-                mTxnDB->getDB()->executeSQL ("VACUUM;");
-            }
-            {
-                std::lock_guard <std::recursive_mutex> lock (
-                        mLedgerDB->peekMutex());
-                mLedgerDB->getDB()->executeSQL ("VACUUM;");
-            }
-        }
-
         return
             mRpcDB.get() != nullptr &&
             mTxnDB.get () != nullptr &&


### PR DESCRIPTION
Online delete does not reduce the size of ledger.db and transaction.db SQLite
databases. Having rippled VACUUM these on process startup was intended to
compact these databases so that space would be reclaimed. However, this
causes a delay in startup time. The larger the databases, the longer the delay.

What should happen instead is that the user should be provided with a shell
script that does a VACUUM on these databases that the user specifically
calls when they want to shrink these files. That could be in a startup script,
or as simple as giving them a couple of command-line arguments to call.

@BobWay Please comment on this if you have questions, I think this issue will be
noticeable to partners as they restart rippled for upgrades and such.
