### PR TITLE
Clean, expand and document JsonFields.

### DIFF
--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -195,19 +195,19 @@ public:
         switch (mState)
         {
         case lcsPRE_CLOSE:
-            ret["state"] = "open";
+            ret[jss::state] = "open";
             break;
 
         case lcsESTABLISH:
-            ret["state"] = "consensus";
+            ret[jss::state] = "consensus";
             break;
 
         case lcsFINISHED:
-            ret["state"] = "finished";
+            ret[jss::state] = "finished";
             break;
 
         case lcsACCEPTED:
-            ret["state"] = "accepted";
+            ret[jss::state] = "accepted";
             break;
         }
 

--- a/src/ripple/app/ledger/DirectoryEntryIterator.cpp
+++ b/src/ripple/app/ledger/DirectoryEntryIterator.cpp
@@ -86,11 +86,11 @@ bool DirectoryEntryIterator::addJson (Json::Value& j) const
 {
     if (mDirNode && (mEntry != 0))
     {
-        j["dir_root"] = to_string (mRootIndex);
-        j["dir_entry"] = static_cast<Json::UInt> (mEntry);
+        j[jss::dir_root] = to_string (mRootIndex);
+        j[jss::dir_entry] = static_cast<Json::UInt> (mEntry);
 
         if (mDirNode)
-            j["dir_index"] = to_string (mDirIndex);
+            j[jss::dir_index] = to_string (mDirIndex);
 
         return true;
     }
@@ -99,18 +99,18 @@ bool DirectoryEntryIterator::addJson (Json::Value& j) const
 
 bool DirectoryEntryIterator::setJson (Json::Value const& j, LedgerEntrySet& les)
 {
-    if (!j.isMember("dir_root") || !j.isMember("dir_index") || !j.isMember("dir_entry"))
+    if (!j.isMember(jss::dir_root) || !j.isMember(jss::dir_index) || !j.isMember(jss::dir_entry))
         return false;
 #if 0 // WRITEME
-    Json::Value const& dirRoot = j["dir_root"];
-    Json::Value const& dirIndex = j["dir_index"];
-    Json::Value const& dirEntry = j["dir_entry"];
+    Json::Value const& dirRoot = j[jss::dir_root];
+    Json::Value const& dirIndex = j[jss::dir_index];
+    Json::Value const& dirEntry = j[jss::dir_entry];
 
     assert(false); // CAUTION: This function is incomplete
 
-    mEntry = j["dir_entry"].asUInt ();
+    mEntry = j[jss::dir_entry].asUInt ();
 
-    if (!mDirIndex.SetHex(j["dir_index"].asString()))
+    if (!mDirIndex.SetHex(j[jss::dir_index].asString()))
         return false;
 #endif
 

--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -31,6 +31,7 @@
 #include <ripple/overlay/Overlay.h>
 #include <ripple/resource/Fees.h>
 #include <ripple/protocol/HashPrefix.h>
+#include <ripple/protocol/JsonFields.h>
 #include <ripple/nodestore/Database.h>
 
 namespace ripple {
@@ -1228,29 +1229,29 @@ Json::Value InboundLedger::getJson (int)
 
     ScopedLockType sl (mLock);
 
-    ret["hash"] = to_string (mHash);
+    ret[jss::hash] = to_string (mHash);
 
     if (mComplete)
-        ret["complete"] = true;
+        ret[jss::complete] = true;
 
     if (mFailed)
-        ret["failed"] = true;
+        ret[jss::failed] = true;
 
     if (!mComplete && !mFailed)
-        ret["peers"] = static_cast<int>(mPeers.size());
+        ret[jss::peers] = static_cast<int>(mPeers.size());
 
-    ret["have_header"] = mHaveHeader;
+    ret[jss::have_header] = mHaveHeader;
 
     if (mHaveHeader)
     {
-        ret["have_state"] = mHaveState;
-        ret["have_transactions"] = mHaveTransactions;
+        ret[jss::have_state] = mHaveState;
+        ret[jss::have_transactions] = mHaveTransactions;
     }
 
     if (mAborted)
-        ret["aborted"] = true;
+        ret[jss::aborted] = true;
 
-    ret["timeouts"] = getTimeouts ();
+    ret[jss::timeouts] = getTimeouts ();
 
     if (mHaveHeader && !mHaveState)
     {
@@ -1262,7 +1263,7 @@ Json::Value InboundLedger::getJson (int)
         {
             hv.append (to_string (h));
         }
-        ret["needed_state_hashes"] = hv;
+        ret[jss::needed_state_hashes] = hv;
     }
 
     if (mHaveHeader && !mHaveTransactions)
@@ -1274,7 +1275,7 @@ Json::Value InboundLedger::getJson (int)
         {
             hv.append (to_string (h));
         }
-        ret["needed_transaction_hashes"] = hv;
+        ret[jss::needed_transaction_hashes] = hv;
     }
 
     return ret;

--- a/src/ripple/app/ledger/Ledger.test.cpp
+++ b/src/ripple/app/ledger/Ledger.test.cpp
@@ -52,9 +52,9 @@ class Ledger_test : public beast::unit_test::suite
         getJson() const
         {
             Json::Value tx_json;
-            tx_json["currency"] = currency;
-            tx_json["issuer"] = issuer.first.humanAccountID();
-            tx_json["value"] = std::to_string(value);
+            tx_json[jss::currency] = currency;
+            tx_json[jss::issuer] = issuer.first.humanAccountID();
+            tx_json[jss::value] = std::to_string(value);
             return tx_json;
         }
     };
@@ -64,7 +64,7 @@ class Ledger_test : public beast::unit_test::suite
     STTx
     parseTransaction(TestAccount& account, Json::Value const& tx_json)
     {
-        STParsedJSONObject parsed("tx_json", tx_json);
+        STParsedJSONObject parsed (std::string (jss::tx_json), tx_json);
         std::unique_ptr<STObject> sopTrans = std::move(parsed.object);
         expect(sopTrans != nullptr);
         sopTrans->setFieldVL(sfSigningPubKey, account.first.getAccountPublic());
@@ -115,11 +115,11 @@ class Ledger_test : public beast::unit_test::suite
     freezeAccount(TestAccount& account, Ledger::pointer const& ledger)
     {
         Json::Value tx_json;
-        tx_json["TransactionType"] = "AccountSet";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Account"] = account.first.humanAccountID();
-        tx_json["SetFlag"] = asfGlobalFreeze;
-        tx_json["Sequence"] = ++account.second;
+        tx_json[jss::TransactionType] = "AccountSet";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Account] = account.first.humanAccountID();
+        tx_json[jss::SetFlag] = asfGlobalFreeze;
+        tx_json[jss::Sequence] = ++account.second;
         STTx tx = parseTransaction(account, tx_json);
         applyTransaction(ledger, tx);
     }
@@ -128,11 +128,11 @@ class Ledger_test : public beast::unit_test::suite
     unfreezeAccount(TestAccount& account, Ledger::pointer const& ledger)
     {
         Json::Value tx_json;
-        tx_json["TransactionType"] = "AccountSet";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Account"] = account.first.humanAccountID();
-        tx_json["ClearFlag"] = asfGlobalFreeze;
-        tx_json["Sequence"] = ++account.second;
+        tx_json[jss::TransactionType] = "AccountSet";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Account] = account.first.humanAccountID();
+        tx_json[jss::ClearFlag] = asfGlobalFreeze;
+        tx_json[jss::Sequence] = ++account.second;
         STTx tx = parseTransaction(account, tx_json);
         applyTransaction(ledger, tx);
     }
@@ -143,13 +143,13 @@ class Ledger_test : public beast::unit_test::suite
                 Ledger::pointer const& ledger)
     {
         Json::Value tx_json;
-        tx_json["Account"] = from.first.humanAccountID();
-        tx_json["Amount"] = std::to_string(amountDrops);
-        tx_json["Destination"] = to.first.humanAccountID();
-        tx_json["TransactionType"] = "Payment";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Sequence"] = ++from.second;
-        tx_json["Flags"] = tfUniversal;
+        tx_json[jss::Account] = from.first.humanAccountID();
+        tx_json[jss::Amount] = std::to_string(amountDrops);
+        tx_json[jss::Destination] = to.first.humanAccountID();
+        tx_json[jss::TransactionType] = "Payment";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Sequence] = ++from.second;
+        tx_json[jss::Flags] = tfUniversal;
         STTx tx = parseTransaction(from, tx_json);
         applyTransaction(ledger, tx);
     }
@@ -160,13 +160,13 @@ class Ledger_test : public beast::unit_test::suite
                 Ledger::pointer const& ledger)
     {
         Json::Value tx_json;
-        tx_json["Account"] = from.first.humanAccountID();
-        tx_json["Amount"] = Amount(std::stod(amount), currency, to).getJson();
-        tx_json["Destination"] = to.first.humanAccountID();
-        tx_json["TransactionType"] = "Payment";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Sequence"] = ++from.second;
-        tx_json["Flags"] = tfUniversal;
+        tx_json[jss::Account] = from.first.humanAccountID();
+        tx_json[jss::Amount] = Amount(std::stod(amount), currency, to).getJson();
+        tx_json[jss::Destination] = to.first.humanAccountID();
+        tx_json[jss::TransactionType] = "Payment";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Sequence] = ++from.second;
+        tx_json[jss::Flags] = tfUniversal;
         STTx tx = parseTransaction(from, tx_json);
         applyTransaction(ledger, tx);
     }
@@ -176,12 +176,12 @@ class Ledger_test : public beast::unit_test::suite
                 Ledger::pointer ledger)
     {
         Json::Value tx_json;
-        tx_json["TransactionType"] = "OfferCreate";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Account"] = from.first.humanAccountID();
-        tx_json["TakerPays"] = in.getJson();
-        tx_json["TakerGets"] = out.getJson();
-        tx_json["Sequence"] = ++from.second;
+        tx_json[jss::TransactionType] = "OfferCreate";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Account] = from.first.humanAccountID();
+        tx_json[jss::TakerPays] = in.getJson();
+        tx_json[jss::TakerGets] = out.getJson();
+        tx_json[jss::Sequence] = ++from.second;
         STTx tx = parseTransaction(from, tx_json);
         applyTransaction(ledger, tx);
     }
@@ -192,11 +192,11 @@ class Ledger_test : public beast::unit_test::suite
     cancelOffer(TestAccount& from, Ledger::pointer ledger)
     {
         Json::Value tx_json;
-        tx_json["TransactionType"] = "OfferCancel";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Account"] = from.first.humanAccountID();
-        tx_json["OfferSequence"] = from.second;
-        tx_json["Sequence"] = ++from.second;
+        tx_json[jss::TransactionType] = "OfferCancel";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Account] = from.first.humanAccountID();
+        tx_json[jss::OfferSequence] = from.second;
+        tx_json[jss::Sequence] = ++from.second;
         STTx tx = parseTransaction(from, tx_json);
         applyTransaction(ledger, tx);
     }
@@ -207,15 +207,15 @@ class Ledger_test : public beast::unit_test::suite
                  Ledger::pointer const& ledger)
     {
         Json::Value tx_json;
-        tx_json["Account"] = from.first.humanAccountID();
-        Json::Value& limitAmount = tx_json["LimitAmount"];
-        limitAmount["currency"] = currency;
-        limitAmount["issuer"] = issuer.first.humanAccountID();
-        limitAmount["value"] = std::to_string(amount);
-        tx_json["TransactionType"] = "TrustSet";
-        tx_json["Fee"] = std::to_string(10);
-        tx_json["Sequence"] = ++from.second;
-        tx_json["Flags"] = tfClearNoRipple;
+        tx_json[jss::Account] = from.first.humanAccountID();
+        Json::Value& limitAmount = tx_json[jss::LimitAmount];
+        limitAmount[jss::currency] = currency;
+        limitAmount[jss::issuer] = issuer.first.humanAccountID();
+        limitAmount[jss::value] = std::to_string(amount);
+        tx_json[jss::TransactionType] = "TrustSet";
+        tx_json[jss::Fee] = std::to_string(10);
+        tx_json[jss::Sequence] = ++from.second;
+        tx_json[jss::Flags] = tfClearNoRipple;
         STTx tx = parseTransaction(from, tx_json);
         applyTransaction(ledger, tx);
     }

--- a/src/ripple/app/ledger/LedgerCleaner.cpp
+++ b/src/ripple/app/ledger/LedgerCleaner.cpp
@@ -188,30 +188,30 @@ public:
             */
 
             // Quick way to fix a single ledger
-            if (params.isMember("ledger"))
+            if (params.isMember(jss::ledger))
             {
-                state->maxRange = params["ledger"].asUInt();
-                state->minRange = params["ledger"].asUInt();
+                state->maxRange = params[jss::ledger].asUInt();
+                state->minRange = params[jss::ledger].asUInt();
                 state->fixTxns = true;
                 state->checkNodes = true;
             }
 
-            if (params.isMember("max_ledger"))
-                 state->maxRange = params["max_ledger"].asUInt();
+            if (params.isMember(jss::max_ledger))
+                 state->maxRange = params[jss::max_ledger].asUInt();
 
-            if (params.isMember("min_ledger"))
-                state->minRange = params["min_ledger"].asUInt();
+            if (params.isMember(jss::min_ledger))
+                state->minRange = params[jss::min_ledger].asUInt();
 
-            if (params.isMember("full"))
-                state->fixTxns = state->checkNodes = params["full"].asBool();
+            if (params.isMember(jss::full))
+                state->fixTxns = state->checkNodes = params[jss::full].asBool();
 
-            if (params.isMember("fix_txns"))
-                state->fixTxns = params["fix_txns"].asBool();
+            if (params.isMember(jss::fix_txns))
+                state->fixTxns = params[jss::fix_txns].asBool();
 
-            if (params.isMember("check_nodes"))
-                state->checkNodes = params["check_nodes"].asBool();
+            if (params.isMember(jss::check_nodes))
+                state->checkNodes = params[jss::check_nodes].asBool();
 
-            if (params.isMember("stop") && params["stop"].asBool())
+            if (params.isMember(jss::stop) && params[jss::stop].asBool())
                 state->minRange = state->maxRange = 0;
         }
 

--- a/src/ripple/app/ledger/LedgerEntrySet.cpp
+++ b/src/ripple/app/ledger/LedgerEntrySet.cpp
@@ -23,6 +23,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/json/to_string.h>
+#include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/Indexes.h>
 
 namespace ripple {
@@ -275,36 +276,36 @@ Json::Value LedgerEntrySet::getJson (int) const
     for (auto it = mEntries.begin (), end = mEntries.end (); it != end; ++it)
     {
         Json::Value entry (Json::objectValue);
-        entry["node"] = to_string (it->first);
+        entry[jss::node] = to_string (it->first);
 
         switch (it->second.mEntry->getType ())
         {
         case ltINVALID:
-            entry["type"] = "invalid";
+            entry[jss::type] = "invalid";
             break;
 
         case ltACCOUNT_ROOT:
-            entry["type"] = "acccount_root";
+            entry[jss::type] = "acccount_root";
             break;
 
         case ltDIR_NODE:
-            entry["type"] = "dir_node";
+            entry[jss::type] = "dir_node";
             break;
 
         case ltGENERATOR_MAP:
-            entry["type"] = "generator_map";
+            entry[jss::type] = "generator_map";
             break;
 
         case ltRIPPLE_STATE:
-            entry["type"] = "ripple_state";
+            entry[jss::type] = "ripple_state";
             break;
 
         case ltNICKNAME:
-            entry["type"] = "nickname";
+            entry[jss::type] = "nickname";
             break;
 
         case ltOFFER:
-            entry["type"] = "offer";
+            entry[jss::type] = "offer";
             break;
 
         default:
@@ -314,19 +315,19 @@ Json::Value LedgerEntrySet::getJson (int) const
         switch (it->second.mAction)
         {
         case taaCACHED:
-            entry["action"] = "cache";
+            entry[jss::action] = "cache";
             break;
 
         case taaMODIFY:
-            entry["action"] = "modify";
+            entry[jss::action] = "modify";
             break;
 
         case taaDELETE:
-            entry["action"] = "delete";
+            entry[jss::action] = "delete";
             break;
 
         case taaCREATE:
-            entry["action"] = "create";
+            entry[jss::action] = "create";
             break;
 
         default:
@@ -336,9 +337,9 @@ Json::Value LedgerEntrySet::getJson (int) const
         nodes.append (entry);
     }
 
-    ret["nodes" ] = nodes;
+    ret[jss::nodes] = nodes;
 
-    ret["metaData"] = mSet.getJson (0);
+    ret[jss::metaData] = mSet.getJson (0);
 
     return ret;
 }
@@ -775,14 +776,14 @@ TER LedgerEntrySet::dirDelete (
             WriteLog (lsWARNING, LedgerEntrySet) << "dirDelete: no such entry";
             return tefBAD_LEDGER;
         }
-        
+
         if (uNodeDir < 20)
         {
             // Go the extra mile. Even if entry not in node, try the next node.
             return dirDelete (bKeepRoot, uNodeDir + 1, uRootIndex, uLedgerIndex,
                 bStable, true);
         }
-        
+
         return tefBAD_LEDGER;
     }
 
@@ -1569,7 +1570,7 @@ TER LedgerEntrySet::rippleSend (
 
         return result;
     }
-    
+
     assert (uSenderID != issue.account && uReceiverID != issue.account);
 
     // Sending IOUs to a third party: we must calculate the transit fee, by
@@ -1872,7 +1873,7 @@ TER LedgerEntrySet::redeem_iou (
             bSenderHigh ? issue.account : account,
             bSenderHigh ? account : issue.account);
     }
-    
+
     entryModify (state);
     return tesSUCCESS;
 }
@@ -1912,7 +1913,7 @@ TER LedgerEntrySet::transfer_xrp (
     receiver->setFieldAmount (sfBalance,
         receiver->getFieldAmount (sfBalance) + amount);
     entryModify (receiver);
-    
+
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/ledger/LedgerProposal.cpp
+++ b/src/ripple/app/ledger/LedgerProposal.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/ledger/LedgerProposal.h>
 #include <ripple/core/Config.h>
+#include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/HashPrefix.h>
 #include <ripple/protocol/Serializer.h>
 
@@ -131,18 +132,18 @@ Blob LedgerProposal::sign (void)
 Json::Value LedgerProposal::getJson () const
 {
     Json::Value ret = Json::objectValue;
-    ret["previous_ledger"] = to_string (mPreviousLedger);
+    ret[jss::previous_ledger] = to_string (mPreviousLedger);
 
     if (mProposeSeq != seqLeave)
     {
-        ret["transaction_hash"] = to_string (mCurrentHash);
-        ret["propose_seq"] = mProposeSeq;
+        ret[jss::transaction_hash] = to_string (mCurrentHash);
+        ret[jss::propose_seq] = mProposeSeq;
     }
 
-    ret["close_time"] = mCloseTime;
+    ret[jss::close_time] = mCloseTime;
 
     if (mPublicKey.isValid ())
-        ret["peer_id"] = mPublicKey.humanNodePublic ();
+        ret[jss::peer_id] = mPublicKey.humanNodePublic ();
 
     return ret;
 }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1095,9 +1095,9 @@ bool ApplicationImp::loadOldLedger (
 
                      if (ledger.get().isMember ("accountState"))
                      {
-                          if (ledger.get().isMember ("ledger_index"))
+                          if (ledger.get().isMember (jss::ledger_index))
                           {
-                              seq = ledger.get()["ledger_index"].asUInt();
+                              seq = ledger.get()[jss::ledger_index].asUInt();
                           }
                           if (ledger.get().isMember ("close_time"))
                           {
@@ -1135,8 +1135,8 @@ bool ApplicationImp::loadOldLedger (
                              Json::Value& entry = ledger.get()[index];
 
                              uint256 uIndex;
-                             uIndex.SetHex (entry["index"].asString());
-                             entry.removeMember ("index");
+                             uIndex.SetHex (entry[jss::index].asString());
+                             entry.removeMember (jss::index);
 
                              STParsedJSONObject stp ("sle", ledger.get()[index]);
                              // m_journal.info << "json: " << stp.object->getJson(0);

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -392,7 +392,7 @@ int run (int argc, char** argv)
         {
             // VFALCO TODO This is currently broken
             //getConfig ().setRpcIpAndOptionalPort (vm ["rpc_ip"].as <std::string> ());
-            //getConfig().overwrite("rpc", "ip", vm["rpc_ip"].as<std::string>());
+            //getConfig().overwrite("rpc", jss::ip, vm["rpc_ip"].as<std::string>());
         }
 
         // Override the RPC destination port number
@@ -402,7 +402,7 @@ int run (int argc, char** argv)
             // VFALCO TODO This should be a short.
             // VFALCO TODO This is currently broken
             //getConfig ().setRpcPort (vm ["rpc_port"].as <int> ());
-            //getConfig().overwrite("rpc", "port", vm["rpc_port"].as<std::string>());
+            //getConfig().overwrite("rpc", jss::port, vm["rpc_port"].as<std::string>());
         }
 
         if (vm.count ("quorum"))

--- a/src/ripple/app/misc/AccountState.cpp
+++ b/src/ripple/app/misc/AccountState.cpp
@@ -75,11 +75,11 @@ void AccountState::addJson (Json::Value& val)
     if (mValid)
     {
         if (mLedgerEntry->isFieldPresent (sfEmailHash))
-            val["urlgravatar"]  = createGravatarUrl (mLedgerEntry->getFieldH128 (sfEmailHash));
+            val[jss::urlgravatar]  = createGravatarUrl (mLedgerEntry->getFieldH128 (sfEmailHash));
     }
     else
     {
-        val["Invalid"] = true;
+        val[jss::Invalid] = true;
     }
 }
 

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -596,16 +596,16 @@ void
 AmendmentTableImpl<AppApiFacade>::setJson (Json::Value& v, const AmendmentState& fs)
 {
     if (!fs.mFriendlyName.empty())
-        v["name"] = fs.mFriendlyName;
+        v[jss::name] = fs.mFriendlyName;
 
-    v["supported"] = fs.mSupported;
-    v["vetoed"] = fs.mVetoed;
+    v[jss::supported] = fs.mSupported;
+    v[jss::vetoed] = fs.mVetoed;
 
     if (fs.mEnabled)
-        v["enabled"] = true;
+        v[jss::enabled] = true;
     else
     {
-        v["enabled"] = false;
+        v[jss::enabled] = false;
 
         if (m_lastReport != 0)
         {

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2313,11 +2313,11 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
     info [jss::server_state] = strOperatingMode ();
 
     if (mNeedNetworkLedger)
-        info[jss::network_ledger] = jss::waiting;
+        info[jss::network_ledger] = "waiting";
 
     info[jss::validation_quorum] = m_ledgerMaster.getMinValidations ();
 
-    info["io_latency_ms"] = static_cast<Json::UInt> (
+    info[jss::io_latency_ms] = static_cast<Json::UInt> (
         getApp().getIOLatency().count());
 
     if (admin)
@@ -2329,7 +2329,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
         }
         else
         {
-            info[jss::pubkey_validator] = jss::none;
+            info[jss::pubkey_validator] = "none";
         }
     }
 
@@ -2463,7 +2463,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
         Ledger::pointer lpPublished = getPublishedLedger ();
         if (!lpPublished)
-            info[jss::published_ledger] = jss::none;
+            info[jss::published_ledger] = "none";
         else if (lpPublished->getLedgerSeq() != lpClosed->getLedgerSeq())
             info[jss::published_ledger] = lpPublished->getLedgerSeq();
     }
@@ -2490,12 +2490,12 @@ Json::Value NetworkOPsImp::pubBootstrapAccountInfo (
 {
     Json::Value         jvObj (Json::objectValue);
 
-    jvObj["type"]           = "accountInfoBootstrap";
-    jvObj["account"]        = naAccountID.humanAccountID ();
-    jvObj["owner"]          = getOwnerInfo (lpAccepted, naAccountID);
-    jvObj["ledger_index"]   = lpAccepted->getLedgerSeq ();
-    jvObj["ledger_hash"]    = to_string (lpAccepted->getHash ());
-    jvObj["ledger_time"]
+    jvObj[jss::type]           = "accountInfoBootstrap";
+    jvObj[jss::account]        = naAccountID.humanAccountID ();
+    jvObj[jss::owner]          = getOwnerInfo (lpAccepted, naAccountID);
+    jvObj[jss::ledger_index]   = lpAccepted->getLedgerSeq ();
+    jvObj[jss::ledger_hash]    = to_string (lpAccepted->getHash ());
+    jvObj[jss::ledger_time]
             = Json::Value::UInt (utFromSeconds (lpAccepted->getCloseTimeNC ()));
 
     return jvObj;
@@ -2545,7 +2545,7 @@ void NetworkOPsImp::pubLedger (Ledger::ref accepted)
         {
             Json::Value jvObj (Json::objectValue);
 
-            jvObj[jss::type] = jss::ledgerClosed;
+            jvObj[jss::type] = "ledgerClosed";
             jvObj[jss::ledger_index] = lpAccepted->getLedgerSeq ();
             jvObj[jss::ledger_hash] = to_string (lpAccepted->getHash ());
             jvObj[jss::ledger_time]
@@ -2611,7 +2611,7 @@ Json::Value NetworkOPsImp::transJson(
 
     transResultInfo (terResult, sToken, sHuman);
 
-    jvObj[jss::type]           = jss::transaction;
+    jvObj[jss::type]           = "transaction";
     jvObj[jss::transaction]    = stTxn.getJson (0);
 
     if (bValidated)
@@ -2630,7 +2630,7 @@ Json::Value NetworkOPsImp::transJson(
         jvObj[jss::ledger_current_index]   = lpCurrent->getLedgerSeq ();
     }
 
-    jvObj[jss::status]                 = bValidated ? jss::closed : jss::proposed;
+    jvObj[jss::status]                 = bValidated ? "closed" : "proposed";
     jvObj[jss::engine_result]          = sToken;
     jvObj[jss::engine_result_code]     = terResult;
     jvObj[jss::engine_result_message]  = sHuman;
@@ -3233,8 +3233,8 @@ void NetworkOPsImp::getBookPage (
         }
     }
 
-    //  jvResult["marker"]  = Json::Value(Json::arrayValue);
-    //  jvResult["nodes"]   = Json::Value(Json::arrayValue);
+    //  jvResult[jss::marker]  = Json::Value(Json::arrayValue);
+    //  jvResult[jss::nodes]   = Json::Value(Json::arrayValue);
 }
 
 
@@ -3384,8 +3384,8 @@ void NetworkOPsImp::getBookPage (
         }
     }
 
-    //  jvResult["marker"]  = Json::Value(Json::arrayValue);
-    //  jvResult["nodes"]   = Json::Value(Json::arrayValue);
+    //  jvResult[jss::marker]  = Json::Value(Json::arrayValue);
+    //  jvResult[jss::nodes]   = Json::Value(Json::arrayValue);
 }
 
 #endif

--- a/src/ripple/app/paths/Node.cpp
+++ b/src/ripple/app/paths/Node.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/paths/Node.h>
 #include <ripple/app/paths/PathState.h>
+#include <ripple/protocol/JsonFields.h>
 
 namespace ripple {
 namespace path {
@@ -39,7 +40,7 @@ Json::Value Node::getJson () const
     Json::Value jvNode (Json::objectValue);
     Json::Value jvFlags (Json::arrayValue);
 
-    jvNode["type"]  = uFlags;
+    jvNode[jss::type]  = uFlags;
 
     bool const hasCurrency = !isXRP (issue_.currency);
     bool const hasAccount = !isXRP (account_);
@@ -65,13 +66,13 @@ Json::Value Node::getJson () const
     jvNode["flags"] = jvFlags;
 
     if (!isXRP (account_))
-        jvNode["account"] = to_string (account_);
+        jvNode[jss::account] = to_string (account_);
 
     if (!isXRP (issue_.currency))
-        jvNode["currency"] = to_string (issue_.currency);
+        jvNode[jss::currency] = to_string (issue_.currency);
 
     if (!isXRP (issue_.account))
-        jvNode["issuer"] = to_string (issue_.account);
+        jvNode[jss::issuer] = to_string (issue_.account);
 
     if (saRevRedeem)
         jvNode["rev_redeem"] = saRevRedeem.getFullText ();

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -163,7 +163,7 @@ bool PathRequest::isValid (RippleLineCache::ref crCache)
                 lrLedger, raDstAccount);
 
             Json::Value& jvDestCur =
-                    (jvStatus["destination_currencies"] = Json::arrayValue);
+                    (jvStatus[jss::destination_currencies] = Json::arrayValue);
 
             if (!asDst)
             {
@@ -203,8 +203,8 @@ bool PathRequest::isValid (RippleLineCache::ref crCache)
 
     if (bValid)
     {
-        jvStatus["ledger_hash"] = to_string (lrLedger->getHash ());
-        jvStatus["ledger_index"] = lrLedger->getLedgerSeq ();
+        jvStatus[jss::ledger_hash] = to_string (lrLedger->getHash ());
+        jvStatus[jss::ledger_index] = lrLedger->getLedgerSeq ();
     }
     return bValid;
 }
@@ -256,9 +256,9 @@ int PathRequest::parseJson (Json::Value const& jvParams, bool complete)
 {
     int ret = PFR_PJ_NOCHANGE;
 
-    if (jvParams.isMember ("source_account"))
+    if (jvParams.isMember (jss::source_account))
     {
-        if (!raSrcAccount.setAccountID (jvParams["source_account"].asString ()))
+        if (!raSrcAccount.setAccountID (jvParams[jss::source_account].asString ()))
         {
             jvStatus = rpcError (rpcSRC_ACT_MALFORMED);
             return PFR_PJ_INVALID;
@@ -270,9 +270,9 @@ int PathRequest::parseJson (Json::Value const& jvParams, bool complete)
         return PFR_PJ_INVALID;
     }
 
-    if (jvParams.isMember ("destination_account"))
+    if (jvParams.isMember (jss::destination_account))
     {
-        if (!raDstAccount.setAccountID (jvParams["destination_account"].asString ()))
+        if (!raDstAccount.setAccountID (jvParams[jss::destination_account].asString ()))
         {
             jvStatus = rpcError (rpcDST_ACT_MALFORMED);
             return PFR_PJ_INVALID;
@@ -284,10 +284,10 @@ int PathRequest::parseJson (Json::Value const& jvParams, bool complete)
         return PFR_PJ_INVALID;
     }
 
-    if (jvParams.isMember ("destination_amount"))
+    if (jvParams.isMember (jss::destination_amount))
     {
         if (! amountFromJsonNoThrow (
-                saDstAmount, jvParams["destination_amount"]) ||
+                saDstAmount, jvParams[jss::destination_amount]) ||
             (saDstAmount.getCurrency ().isZero () &&
              saDstAmount.getIssuer ().isNonZero ()) ||
             (saDstAmount.getCurrency () == badCurrency ()) ||
@@ -303,9 +303,9 @@ int PathRequest::parseJson (Json::Value const& jvParams, bool complete)
         return PFR_PJ_INVALID;
     }
 
-    if (jvParams.isMember ("source_currencies"))
+    if (jvParams.isMember (jss::source_currencies))
     {
-        Json::Value const& jvSrcCur = jvParams["source_currencies"];
+        Json::Value const& jvSrcCur = jvParams[jss::source_currencies];
 
         if (!jvSrcCur.isArray ())
         {
@@ -321,15 +321,15 @@ int PathRequest::parseJson (Json::Value const& jvParams, bool complete)
             Currency uCur;
             Account uIss;
 
-            if (!jvCur.isObject() || !jvCur.isMember ("currency") ||
-                !to_currency (uCur, jvCur["currency"].asString ()))
+            if (!jvCur.isObject() || !jvCur.isMember (jss::currency) ||
+                !to_currency (uCur, jvCur[jss::currency].asString ()))
             {
                 jvStatus = rpcError (rpcSRC_CUR_MALFORMED);
                 return PFR_PJ_INVALID;
             }
 
-            if (jvCur.isMember ("issuer") &&
-                !to_issuer (uIss, jvCur["issuer"].asString ()))
+            if (jvCur.isMember (jss::issuer) &&
+                !to_issuer (uIss, jvCur[jss::issuer].asString ()))
             {
                 jvStatus = rpcError (rpcSRC_ISR_MALFORMED);
             }
@@ -402,9 +402,9 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
         }
     }
 
-    jvStatus["source_account"] = raSrcAccount.humanAccountID ();
-    jvStatus["destination_account"] = raDstAccount.humanAccountID ();
-    jvStatus["destination_amount"] = saDstAmount.getJson (0);
+    jvStatus[jss::source_account] = raSrcAccount.humanAccountID ();
+    jvStatus[jss::destination_account] = raDstAccount.humanAccountID ();
+    jvStatus[jss::destination_amount] = saDstAmount.getJson (0);
 
     if (!jvId.isNull ())
         jvStatus["id"] = jvId;
@@ -526,8 +526,8 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
                 Json::Value jvEntry (Json::objectValue);
                 rc.actualAmountIn.setIssuer (sourceAccount);
 
-                jvEntry["source_amount"] = rc.actualAmountIn.getJson (0);
-                jvEntry["paths_computed"] = spsPaths.getJson (0);
+                jvEntry[jss::source_amount] = rc.actualAmountIn.getJson (0);
+                jvEntry[jss::paths_computed] = spsPaths.getJson (0);
                 found  = true;
                 jvArray.append (jvEntry);
             }
@@ -557,7 +557,7 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
         mOwner.reportFull ((ptFullReply-ptCreated).total_milliseconds());
     }
 
-    jvStatus["alternatives"] = jvArray;
+    jvStatus[jss::alternatives] = jvArray;
     return jvStatus;
 }
 

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -98,7 +98,7 @@ void PathRequests::updateAll (Ledger::ref inLedger,
                         {
                             Json::Value update = pRequest->doUpdate (cache, false);
                             pRequest->updateComplete ();
-                            update["type"] = "path_find";
+                            update[jss::type] = "path_find";
                             ipSub->send (update, false);
                             remove = false;
                             ++processed;

--- a/src/ripple/app/paths/PathState.cpp
+++ b/src/ripple/app/paths/PathState.cpp
@@ -824,9 +824,9 @@ Json::Value PathState::getJson () const
     for (auto const &pnNode: nodes_)
         jvNodes.append (pnNode.getJson ());
 
-    jvPathState["status"]   = terStatus;
-    jvPathState["index"]    = mIndex;
-    jvPathState["nodes"]    = jvNodes;
+    jvPathState[jss::status]   = terStatus;
+    jvPathState[jss::index]    = mIndex;
+    jvPathState[jss::nodes]    = jvNodes;
 
     if (saInReq)
         jvPathState["in_req"]   = saInReq.getJson (0);

--- a/src/ripple/app/paths/PathState.h
+++ b/src/ripple/app/paths/PathState.h
@@ -81,8 +81,6 @@ class PathState : public CountedObject <PathState>
         umReverse.insert({ai, i});
     }
 
-    Json::Value getJson () const;
-
     static char const* getCountedObjectName () { return "PathState"; }
     OfferIndexList& unfundedOffers() { return unfundedOffers_; }
 
@@ -160,6 +158,8 @@ class PathState : public CountedObject <PathState>
         Account const& account,
         Currency const& currency,
         Account const& issuer);
+    
+    Json::Value getJson () const;
 };
 
 } // ripple

--- a/src/ripple/app/peers/UniqueNodeList.cpp
+++ b/src/ripple/app/peers/UniqueNodeList.cpp
@@ -436,7 +436,7 @@ public:
         {
             int          now   = getApp().getOPs().getNetworkTimeNC();
             std::uint32_t ref   = getApp().getFeeTrack().getLoadBase();
-            Json::Value& nodes = (obj["cluster"] = Json::objectValue);
+            Json::Value& nodes = (obj[jss::cluster] = Json::objectValue);
 
             for (std::map<RippleAddress, ClusterNodeStatus>::iterator it = m_clusterNodes.begin(),
                 end = m_clusterNodes.end(); it != end; ++it)

--- a/src/ripple/app/tx/Transaction.cpp
+++ b/src/ripple/app/tx/Transaction.cpp
@@ -23,6 +23,7 @@
 #include <ripple/app/data/DatabaseCon.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/protocol/JsonFields.h>
 
 namespace ripple {
 
@@ -240,15 +241,15 @@ Json::Value Transaction::getJson (int options, bool binary) const
 
     if (mInLedger)
     {
-        ret["inLedger"] = mInLedger;        // Deprecated.
-        ret["ledger_index"] = mInLedger;
+        ret[jss::inLedger] = mInLedger;        // Deprecated.
+        ret[jss::ledger_index] = mInLedger;
 
         if (options == 1)
         {
             auto ledger = getApp().getLedgerMaster ().
                     getLedgerBySeq (mInLedger);
             if (ledger)
-                ret["date"] = ledger->getCloseTimeNC ();
+                ret[jss::date] = ledger->getCloseTimeNC ();
         }
     }
 

--- a/src/ripple/app/websocket/WSConnection.cpp
+++ b/src/ripple/app/websocket/WSConnection.cpp
@@ -145,7 +145,7 @@ Json::Value WSConnection::invokeCommand (Json::Value& jvRequest)
     {
         Json::Value jvResult (Json::objectValue);
 
-        jvResult[jss::type]    = jss::response;
+        jvResult[jss::type]    = "response";
         jvResult[jss::status]  = jss::error;
         jvResult[jss::error]   = jss::missingCommand;
         jvResult[jss::request] = jvRequest;
@@ -207,7 +207,7 @@ Json::Value WSConnection::invokeCommand (Json::Value& jvRequest)
         jvResult[jss::id] = jvRequest[jss::id];
     }
 
-    jvResult[jss::type] = jss::response;
+    jvResult[jss::type] = "response";
 
     return jvResult;
 }

--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -95,6 +95,26 @@ private:
     const char* str_;
 };
 
+inline bool operator== (std::string const& x, StaticString y)
+{
+    return x == y.c_str();
+}
+
+inline bool operator!= (std::string const& x, StaticString y)
+{
+    return x != y.c_str();
+}
+
+inline bool operator== (StaticString x, std::string const& y)
+{
+    return y == x;
+}
+
+inline bool operator!= (StaticString x, std::string const& y)
+{
+    return y != x;
+}
+
 /** \brief Represents a <a HREF="http://www.json.org">JSON</a> value.
  *
  * This class is a discriminated union wrapper that can represents a:

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -92,16 +92,16 @@ private:
     {
         if (strLedger == "current" || strLedger == "closed" || strLedger == "validated")
         {
-            jvRequest["ledger_index"]   = strLedger;
+            jvRequest[jss::ledger_index]   = strLedger;
         }
         else if (strLedger.length () == 64)
         {
             // YYY Could confirm this is a uint256.
-            jvRequest["ledger_hash"]    = strLedger;
+            jvRequest[jss::ledger_hash]    = strLedger;
         }
         else
         {
-            jvRequest["ledger_index"]   = beast::lexicalCast <std::uint32_t> (strLedger);
+            jvRequest[jss::ledger_index]   = beast::lexicalCast <std::uint32_t> (strLedger);
         }
 
         return true;
@@ -120,12 +120,12 @@ private:
             std::string strCurrency = smMatch[1];
             std::string strIssuer   = smMatch[2];
 
-            jvResult["currency"]    = strCurrency;
+            jvResult[jss::currency]    = strCurrency;
 
             if (strIssuer.length ())
             {
                 // Could confirm issuer is a valid Ripple address.
-                jvResult["issuer"]      = strIssuer;
+                jvResult[jss::issuer]      = strIssuer;
             }
 
             return jvResult;
@@ -145,7 +145,7 @@ private:
         Json::Value v (Json::objectValue);
 
         if (jvParams.isArray () && (jvParams.size () > 0))
-            v["params"] = jvParams;
+            v[jss::params] = jvParams;
 
         return v;
     }
@@ -153,14 +153,14 @@ private:
     Json::Value parseInternal (Json::Value const& jvParams)
     {
         Json::Value v (Json::objectValue);
-        v["internal_command"] = jvParams[0u];
+        v[jss::internal_command] = jvParams[0u];
 
         Json::Value params (Json::arrayValue);
 
         for (unsigned i = 1; i < jvParams.size (); ++i)
             params.append (jvParams[i]);
 
-        v["params"] = params;
+        v[jss::params] = params;
 
         return v;
     }
@@ -187,25 +187,25 @@ private:
         if (!raAccount.setAccountID (jvParams[0u].asString ()))
             return rpcError (rpcACT_MALFORMED);
 
-        jvRequest["account"]    = raAccount.humanAccountID ();
+        jvRequest[jss::account]    = raAccount.humanAccountID ();
 
         bool            bDone   = false;
 
         while (!bDone && iParams >= 2)
         {
-            if (jvParams[iParams - 1].asString () == "binary")
+            if (jvParams[iParams - 1].asString () == jss::binary)
             {
-                jvRequest["binary"]     = true;
+                jvRequest[jss::binary]     = true;
                 --iParams;
             }
-            else if (jvParams[iParams - 1].asString () == "count")
+            else if (jvParams[iParams - 1].asString () == jss::count)
             {
-                jvRequest["count"]      = true;
+                jvRequest[jss::count]      = true;
                 --iParams;
             }
-            else if (jvParams[iParams - 1].asString () == "descending")
+            else if (jvParams[iParams - 1].asString () == jss::descending)
             {
-                jvRequest["descending"] = true;
+                jvRequest[jss::descending] = true;
                 --iParams;
             }
             else
@@ -232,14 +232,14 @@ private:
                 return rpcError (rpcLGR_IDXS_INVALID);
             }
 
-            jvRequest["ledger_index_min"]   = jvParams[1u].asInt ();
-            jvRequest["ledger_index_max"]   = jvParams[2u].asInt ();
+            jvRequest[jss::ledger_index_min]   = jvParams[1u].asInt ();
+            jvRequest[jss::ledger_index_max]   = jvParams[2u].asInt ();
 
             if (iParams >= 4)
-                jvRequest["limit"]  = jvParams[3u].asInt ();
+                jvRequest[jss::limit]  = jvParams[3u].asInt ();
 
             if (iParams >= 5)
-                jvRequest["offset"] = jvParams[4u].asInt ();
+                jvRequest[jss::offset] = jvParams[4u].asInt ();
         }
 
         return jvRequest;
@@ -255,25 +255,25 @@ private:
         if (!raAccount.setAccountID (jvParams[0u].asString ()))
             return rpcError (rpcACT_MALFORMED);
 
-        jvRequest["account"]    = raAccount.humanAccountID ();
+        jvRequest[jss::account]    = raAccount.humanAccountID ();
 
         bool            bDone   = false;
 
         while (!bDone && iParams >= 2)
         {
-            if (jvParams[iParams - 1].asString () == "binary")
+            if (jvParams[iParams - 1].asString () == jss::binary)
             {
-                jvRequest["binary"]     = true;
+                jvRequest[jss::binary]     = true;
                 --iParams;
             }
-            else if (jvParams[iParams - 1].asString () == "count")
+            else if (jvParams[iParams - 1].asString () == jss::count)
             {
-                jvRequest["count"]      = true;
+                jvRequest[jss::count]      = true;
                 --iParams;
             }
-            else if (jvParams[iParams - 1].asString () == "forward")
+            else if (jvParams[iParams - 1].asString () == jss::forward)
             {
-                jvRequest["forward"] = true;
+                jvRequest[jss::forward] = true;
                 --iParams;
             }
             else
@@ -300,11 +300,11 @@ private:
                 return rpcError (rpcLGR_IDXS_INVALID);
             }
 
-            jvRequest["ledger_index_min"]   = jvParams[1u].asInt ();
-            jvRequest["ledger_index_max"]   = jvParams[2u].asInt ();
+            jvRequest[jss::ledger_index_min]   = jvParams[1u].asInt ();
+            jvRequest[jss::ledger_index_max]   = jvParams[2u].asInt ();
 
             if (iParams >= 4)
-                jvRequest["limit"]  = jvParams[3u].asInt ();
+                jvRequest[jss::limit]  = jvParams[3u].asInt ();
         }
 
         return jvRequest;
@@ -328,7 +328,7 @@ private:
         }
         else
         {
-            jvRequest["taker_pays"] = jvTakerPays;
+            jvRequest[jss::taker_pays] = jvTakerPays;
         }
 
         if (isRpcError (jvTakerGets))
@@ -337,12 +337,12 @@ private:
         }
         else
         {
-            jvRequest["taker_gets"] = jvTakerGets;
+            jvRequest[jss::taker_gets] = jvTakerGets;
         }
 
         if (jvParams.size () >= 3)
         {
-            jvRequest["issuer"] = jvParams[2u].asString ();
+            jvRequest[jss::issuer] = jvParams[2u].asString ();
         }
 
         if (jvParams.size () >= 4 && !jvParseLedger (jvRequest, jvParams[3u].asString ()))
@@ -353,16 +353,16 @@ private:
             int     iLimit  = jvParams[5u].asInt ();
 
             if (iLimit > 0)
-                jvRequest["limit"]  = iLimit;
+                jvRequest[jss::limit]  = iLimit;
         }
 
         if (jvParams.size () >= 6 && jvParams[5u].asInt ())
         {
-            jvRequest["proof"]  = true;
+            jvRequest[jss::proof]  = true;
         }
 
         if (jvParams.size () == 7)
-            jvRequest["marker"] = jvParams[6u];
+            jvRequest[jss::marker] = jvParams[6u];
 
         return jvRequest;
     }
@@ -390,10 +390,10 @@ private:
     {
         Json::Value     jvRequest (Json::objectValue);
 
-        jvRequest["ip"] = jvParams[0u].asString ();
+        jvRequest[jss::ip] = jvParams[0u].asString ();
 
         if (jvParams.size () == 2)
-            jvRequest["port"]   = jvParams[1u].asUInt ();
+            jvRequest[jss::port]   = jvParams[1u].asUInt ();
 
         return jvRequest;
     }
@@ -410,10 +410,10 @@ private:
         Json::Value     jvRequest (Json::objectValue);
 
         if (jvParams.size () > 0)
-            jvRequest["feature"]    = jvParams[0u].asString ();
+            jvRequest[jss::feature]    = jvParams[0u].asString ();
 
         if (jvParams.size () > 1)
-            jvRequest["vote"]       = beast::lexicalCastThrow <bool> (jvParams[1u].asString ());
+            jvRequest[jss::vote]       = beast::lexicalCastThrow <bool> (jvParams[1u].asString ());
 
         return jvRequest;
     }
@@ -424,7 +424,7 @@ private:
         Json::Value     jvRequest (Json::objectValue);
 
         if (jvParams.size ())
-            jvRequest["min_count"]  = jvParams[0u].asUInt ();
+            jvRequest[jss::min_count]  = jvParams[0u].asUInt ();
 
         return jvRequest;
     }
@@ -465,7 +465,7 @@ private:
 
         if (2 == jvParams.size () && jvParams[1u].asString () == "full")
         {
-            jvRequest["full"]   = bool (1);
+            jvRequest[jss::full]   = bool (1);
         }
 
         return jvRequest;
@@ -480,11 +480,11 @@ private:
 
         if (strLedger.length () == 32)
         {
-            jvRequest["ledger_hash"]    = strLedger;
+            jvRequest[jss::ledger_hash]    = strLedger;
         }
         else
         {
-            jvRequest["ledger_index"]   = beast::lexicalCast <std::uint32_t> (strLedger);
+            jvRequest[jss::ledger_index]   = beast::lexicalCast <std::uint32_t> (strLedger);
         }
 
         return jvRequest;
@@ -499,12 +499,12 @@ private:
 
         if (jvParams.size () == 1)
         {
-            jvRequest["severity"] = jvParams[0u].asString ();
+            jvRequest[jss::severity] = jvParams[0u].asString ();
         }
         else if (jvParams.size () == 2)
         {
-            jvRequest["partition"] = jvParams[0u].asString ();
-            jvRequest["severity"] = jvParams[1u].asString ();
+            jvRequest[jss::partition] = jvParams[0u].asString ();
+            jvRequest[jss::severity] = jvParams[1u].asString ();
         }
 
         return jvRequest;
@@ -539,7 +539,7 @@ private:
         bool            bStrict     = false;
         std::string     strPeer;
 
-        if (!bPeer && iCursor >= 2 && jvParams[iCursor - 1] == "strict")
+        if (!bPeer && iCursor >= 2 && jvParams[iCursor - 1] == jss::strict)
         {
             bStrict = true;
             --iCursor;
@@ -559,13 +559,13 @@ private:
         // Get info on account.
         Json::Value jvRequest (Json::objectValue);
 
-        jvRequest["account"]    = strIdent;
+        jvRequest[jss::account]    = strIdent;
 
         if (bStrict)
-            jvRequest["strict"]     = 1;
+            jvRequest[jss::strict]     = 1;
 
         if (iIndex)
-            jvRequest["account_index"]  = iIndex;
+            jvRequest[jss::account_index]  = iIndex;
 
         if (!strPeer.empty ())
         {
@@ -592,7 +592,7 @@ private:
             jvRequest["difficulty"] = jvParams[0u].asInt ();
 
         if (jvParams.size () >= 2)
-            jvRequest["secret"] = jvParams[1u].asString ();
+            jvRequest[jss::secret] = jvParams[1u].asString ();
 
         return jvRequest;
     }
@@ -619,7 +619,7 @@ private:
             jvRequest["difficulty"] = jvParams[2u].asInt ();
 
         if (jvParams.size () >= 4)
-            jvRequest["secret"] = jvParams[3u].asString ();
+            jvRequest[jss::secret] = jvParams[3u].asString ();
 
         return jvRequest;
     }
@@ -663,7 +663,7 @@ private:
 
             Json::Value jvRequest;
 
-            jvRequest["tx_blob"]    = jvParams[0u].asString ();
+            jvRequest[jss::tx_blob]    = jvParams[0u].asString ();
 
             return jvRequest;
         }
@@ -673,11 +673,11 @@ private:
             // Signing or submitting tx_json.
             Json::Value jvRequest;
 
-            jvRequest["secret"]     = jvParams[0u].asString ();
-            jvRequest["tx_json"]    = txJSON;
+            jvRequest[jss::secret]     = jvParams[0u].asString ();
+            jvRequest[jss::tx_json]    = txJSON;
 
             if (bOffline)
-                jvRequest["offline"]    = true;
+                jvRequest[jss::offline]    = true;
 
             return jvRequest;
         }
@@ -690,7 +690,7 @@ private:
     {
         Json::Value     jvRequest;
 
-        jvRequest["text"]   = jvParams[0u].asString ();
+        jvRequest[jss::text]   = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -702,8 +702,8 @@ private:
 
         if (jvParams.size () > 1)
         {
-            if (jvParams[1u].asString () == "binary")
-                jvRequest["binary"] = true;
+            if (jvParams[1u].asString () == jss::binary)
+                jvRequest[jss::binary] = true;
         }
 
         jvRequest["transaction"]    = jvParams[0u].asString ();
@@ -715,7 +715,7 @@ private:
     {
         Json::Value jvRequest;
 
-        jvRequest["start"]  = jvParams[0u].asUInt ();
+        jvRequest[jss::start]  = jvParams[0u].asUInt ();
 
         return jvRequest;
     }
@@ -732,10 +732,10 @@ private:
         {
             Json::Value jvRequest;
 
-            jvRequest["node"]       = strNode;
+            jvRequest[jss::node]       = strNode;
 
             if (strComment.length ())
-                jvRequest["comment"]    = strComment;
+                jvRequest[jss::comment]    = strComment;
 
             return jvRequest;
         }
@@ -748,7 +748,7 @@ private:
     {
         Json::Value jvRequest;
 
-        jvRequest["node"]       = jvParams[0u].asString ();
+        jvRequest[jss::node]       = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -762,7 +762,7 @@ private:
         Json::Value jvRequest;
 
         if (jvParams.size ())
-            jvRequest["secret"]     = jvParams[0u].asString ();
+            jvRequest[jss::secret]     = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -776,7 +776,7 @@ private:
         Json::Value jvRequest;
 
         if (jvParams.size ())
-            jvRequest["secret"]     = jvParams[0u].asString ();
+            jvRequest[jss::secret]     = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -786,7 +786,7 @@ private:
     {
         Json::Value jvRequest;
 
-        jvRequest["seed"]       = jvParams[0u].asString ();
+        jvRequest[jss::seed]       = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -798,7 +798,7 @@ private:
         Json::Value jvRequest;
 
         if (jvParams.size ())
-            jvRequest["passphrase"]     = jvParams[0u].asString ();
+            jvRequest[jss::passphrase]     = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -809,7 +809,7 @@ private:
         Json::Value jvRequest;
 
         if (jvParams.size ())
-            jvRequest["secret"]     = jvParams[0u].asString ();
+            jvRequest[jss::secret]     = jvParams[0u].asString ();
 
         return jvRequest;
     }
@@ -1069,13 +1069,13 @@ int RPCCall::fromCommandLine (const std::vector<std::string>& vCmd)
         Json::Value jvRpc   = Json::Value (Json::objectValue);
 
         jvRpc["method"] = vCmd[0];
-        jvRpc["params"] = jvRpcParams;
+        jvRpc[jss::params] = jvRpcParams;
 
         jvRequest   = rpParser.parseCommand (vCmd[0], jvRpcParams, true);
 
         WriteLog (lsTRACE, RPCParser) << "RPC Request: " << jvRequest << std::endl;
 
-        if (jvRequest.isMember ("error"))
+        if (jvRequest.isMember (jss::error))
         {
             jvOutput            = jvRequest;
             jvOutput["rpc"]     = jvRpc;
@@ -1130,19 +1130,19 @@ int RPCCall::fromCommandLine (const std::vector<std::string>& vCmd)
             }
 
             // If had an error, supply invokation in result.
-            if (jvOutput.isMember ("error"))
+            if (jvOutput.isMember (jss::error))
             {
                 jvOutput["rpc"]             = jvRpc;            // How the command was seen as method + params.
                 jvOutput["request_sent"]    = jvRequest;        // How the command was translated.
             }
         }
 
-        if (jvOutput.isMember ("error"))
+        if (jvOutput.isMember (jss::error))
         {
-            jvOutput["status"]  = "error";
+            jvOutput[jss::status]  = "error";
 
-            nRet    = jvOutput.isMember ("error_code")
-                      ? beast::lexicalCast <int> (jvOutput["error_code"].asString ())
+            nRet    = jvOutput.isMember (jss::error_code)
+                      ? beast::lexicalCast <int> (jvOutput[jss::error_code].asString ())
                       : 1;
         }
 

--- a/src/ripple/net/impl/RPCErr.cpp
+++ b/src/ripple/net/impl/RPCErr.cpp
@@ -35,7 +35,7 @@ Json::Value rpcError (int iError, Json::Value jvResult)
 // VFALCO NOTE Deprecated function
 bool isRpcError (Json::Value jvResult)
 {
-    return jvResult.isObject () && jvResult.isMember ("error");
+    return jvResult.isObject () && jvResult.isMember (jss::error);
 }
 
 } // ripple

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/make_SSLContext.h>
+#include <ripple/protocol/JsonFields.h>
 #include <ripple/server/JsonWriter.h>
 #include <ripple/overlay/impl/ConnectAttempt.h>
 #include <ripple/overlay/impl/OverlayImpl.h>
@@ -620,16 +621,16 @@ OverlayImpl::crawl()
         if (sp)
         {
             auto& pv = av.append(Json::Value(Json::objectValue));
-            pv["type"] = "peer";
-            pv["public_key"] = beast::base64_encode(
+            pv[jss::type] = "peer";
+            pv[jss::public_key] = beast::base64_encode(
                 sp->getNodePublic().getNodePublic().data(),
                     sp->getNodePublic().getNodePublic().size());
             if (sp->crawl())
             {
                 if (sp->slot()->inbound())
-                    pv["ip"] = sp->getRemoteAddress().address().to_string();
+                    pv[jss::ip] = sp->getRemoteAddress().address().to_string();
                 else
-                    pv["ip"] = sp->getRemoteAddress().to_string();
+                    pv[jss::ip] = sp->getRemoteAddress().to_string();
             }
         }
     }

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -201,63 +201,63 @@ PeerImp::json()
 {
     Json::Value ret (Json::objectValue);
 
-    ret["public_key"]   = publicKey_.ToString ();
-    ret["address"]      = remote_address_.to_string();
+    ret[jss::public_key]   = publicKey_.ToString ();
+    ret[jss::address]      = remote_address_.to_string();
 
     if (m_inbound)
-        ret["inbound"] = true;
+        ret[jss::inbound] = true;
 
     if (cluster())
     {
-        ret["cluster"] = true;
+        ret[jss::cluster] = true;
 
         if (!name_.empty ())
-            ret["name"] = name_;
+            ret[jss::name] = name_;
     }
 
     if (hello_.has_fullversion ())
-        ret["version"] = hello_.fullversion ();
+        ret[jss::version] = hello_.fullversion ();
 
     if (hello_.has_protoversion ())
     {
         auto protocol = BuildInfo::make_protocol (hello_.protoversion ());
 
         if (protocol != BuildInfo::getCurrentProtocol())
-            ret["protocol"] = to_string (protocol);
+            ret[jss::protocol] = to_string (protocol);
     }
 
     std::uint32_t minSeq, maxSeq;
     ledgerRange(minSeq, maxSeq);
 
     if ((minSeq != 0) || (maxSeq != 0))
-        ret["complete_ledgers"] = boost::lexical_cast<std::string>(minSeq) +
+        ret[jss::complete_ledgers] = boost::lexical_cast<std::string>(minSeq) +
             " - " + boost::lexical_cast<std::string>(maxSeq);
 
     if (closedLedgerHash_ != zero)
-        ret["ledger"] = to_string (closedLedgerHash_);
+        ret[jss::ledger] = to_string (closedLedgerHash_);
 
     if (last_status_.has_newstatus ())
     {
         switch (last_status_.newstatus ())
         {
         case protocol::nsCONNECTING:
-            ret["status"] = "connecting";
+            ret[jss::status] = "connecting";
             break;
 
         case protocol::nsCONNECTED:
-            ret["status"] = "connected";
+            ret[jss::status] = "connected";
             break;
 
         case protocol::nsMONITORING:
-            ret["status"] = "monitoring";
+            ret[jss::status] = "monitoring";
             break;
 
         case protocol::nsVALIDATING:
-            ret["status"] = "validating";
+            ret[jss::status] = "validating";
             break;
 
         case protocol::nsSHUTTING:
-            ret["status"] = "shutting";
+            ret[jss::status] = "shutting";
             break;
 
         default:

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -192,6 +192,11 @@ inline Json::Value missing_field_error (std::string const& name)
     return make_param_error (missing_field_message (name));
 }
 
+inline Json::Value missing_field_error (Json::StaticString name)
+{
+    return missing_field_error (std::string (name));
+}
+
 inline std::string object_field_message (std::string const& name)
 {
     return "Invalid field '" + name + "', not object.";
@@ -202,14 +207,29 @@ inline Json::Value object_field_error (std::string const& name)
     return make_param_error (object_field_message (name));
 }
 
+inline Json::Value object_field_error (Json::StaticString name)
+{
+    return object_field_error (std::string (name));
+}
+
 inline std::string invalid_field_message (std::string const& name)
 {
     return "Invalid field '" + name + "'.";
 }
 
+inline std::string invalid_field_message (Json::StaticString name)
+{
+    return invalid_field_message (std::string(name));
+}
+
 inline Json::Value invalid_field_error (std::string const& name)
 {
     return make_param_error (invalid_field_message (name));
+}
+
+inline Json::Value invalid_field_error (Json::StaticString name)
+{
+    return invalid_field_error (std::string (name));
 }
 
 inline std::string expected_field_message (
@@ -218,10 +238,22 @@ inline std::string expected_field_message (
     return "Invalid field '" + name + "', not " + type + ".";
 }
 
+inline std::string expected_field_message (
+    Json::StaticString name, std::string const& type)
+{
+    return expected_field_message (std::string (name), type);
+}
+
 inline Json::Value expected_field_error (
     std::string const& name, std::string const& type)
 {
     return make_param_error (expected_field_message (name, type));
+}
+
+inline Json::Value expected_field_error (
+    Json::StaticString name, std::string const& type)
+{
+    return expected_field_error (std::string (name), type);
 }
 
 /** @} */

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -32,155 +32,345 @@ namespace jss {
 /* The "StaticString" field names are used instead of string literals to
    optimize the performance of accessing members of Json::Value objects.
 */
-// VFALCO NOTE Some of these are part of the JSON-RPC API and some aren't
-//        TODO Move the string not part of the JSON-RPC API into another file
-JSS ( accepted );
-JSS ( account );
-JSS ( account_hash );
-JSS ( account_index );
-JSS ( accounts );
-JSS ( accountState );
-JSS ( accountTreeHash );
-JSS ( affected );
-JSS ( age );
-JSS ( amendment_blocked );
-JSS ( asks );
-JSS ( authorized );
-JSS ( balance );
-JSS ( base_fee );
-JSS ( base_fee_xrp );
-JSS ( bids );
-JSS ( binary );
-JSS ( build_version );
-JSS ( can_delete );
-JSS ( closed );
-JSS ( closed_ledger );
-JSS ( close_time );
-JSS ( close_time_estimated );
-JSS ( close_time_human );
-JSS ( close_time_offset );
-JSS ( close_time_resolution );
-JSS ( code );
-JSS ( command );
-JSS ( complete_ledgers );
-JSS ( consensus );
-JSS ( converge_time );
-JSS ( converge_time_s );
-JSS ( currency );
-JSS ( data );
-JSS ( date );
-JSS ( delivered_amount );
-JSS ( engine_result );
-JSS ( engine_result_code );
-JSS ( engine_result_message );
-JSS ( error );
-JSS ( error_code );
-JSS ( error_exception );
-JSS ( error_message );
-JSS ( expand );
-JSS ( fee_base );
-JSS ( fee_ref );
-JSS ( fetch_pack );
-JSS ( first );
-JSS ( flags );
-JSS ( freeze );
-JSS ( freeze_peer );
-JSS ( full );
-JSS ( good );
-JSS ( hash );
-JSS ( hostid );
-JSS ( id );
-JSS ( issuer );
-JSS ( last );
-JSS ( last_close );
-JSS ( ledger );
-JSS ( ledgerClosed );
-JSS ( ledger_current_index );
-JSS ( ledger_hash );
-JSS ( ledger_index );
-JSS ( ledger_index_max );
-JSS ( ledger_index_min );
-JSS ( ledger_time );
-JSS ( limit );
-JSS ( limit_peer );
-JSS ( lines );
-JSS ( load );
-JSS ( load_base );
-JSS ( load_factor );
-JSS ( load_factor_cluster );
-JSS ( load_factor_local );
-JSS ( load_factor_net );
-JSS ( load_fee );
-JSS ( marker );
-JSS ( message );
-JSS ( meta );
-JSS ( metaData );
-JSS ( method );
-JSS ( missingCommand );
-JSS ( name );
-JSS ( network_ledger );
-JSS ( none );
-JSS ( no_ripple );
-JSS ( no_ripple_peer );
-JSS ( offers );
-JSS ( open );
-JSS ( owner_funds );
-JSS ( params );
-JSS ( parent_hash );
-JSS ( peer );
-JSS ( peer_authorized );
-JSS ( peer_index );
-JSS ( peers );
-JSS ( proposed );
-JSS ( proposers );
-JSS ( pubkey_node );
-JSS ( pubkey_validator );
-JSS ( published_ledger );
-JSS ( quality );
-JSS ( quality_in );
-JSS ( quality_out );
-JSS ( random );
-JSS ( raw_meta );
-JSS ( request );
-JSS ( reserve_base );
-JSS ( reserve_base_xrp );
-JSS ( reserve_inc );
-JSS ( reserve_inc_xrp );
-JSS ( response );
-JSS ( result );
-JSS ( ripple_lines );
-JSS ( seq );
-JSS ( seqNum );
-JSS ( server_state );
-JSS ( server_status );
-JSS ( stand_alone );
-JSS ( status );
-JSS ( success );
-JSS ( system_time_offset );
-JSS ( taker_gets );
-JSS ( taker_gets_funded );
-JSS ( taker_pays );
-JSS ( taker_pays_funded );
-JSS ( total_coins );
-JSS ( totalCoins );
-JSS ( transaction );
-JSS ( transaction_hash );
-JSS ( transactions );
-JSS ( transTreeHash );
-JSS ( tx );
-JSS ( tx_blob );
-JSS ( tx_json );
-JSS ( txn_count );
-JSS ( type );
-JSS ( type_hex );
-JSS ( validated );
-JSS ( validated_ledger );
-JSS ( validated_ledgers );
-JSS ( validation_quorum );
-JSS ( value );
-JSS ( version );
-JSS ( waiting );
-JSS ( warning );
+JSS ( AL_hit_rate );                // out: GetCounts
+JSS ( Account );                    // in: TransactionSign; field.
+JSS ( Amount );                     // in: TransactionSign; field.
+JSS ( ClearFlag );                  // field.
+JSS ( Destination );                // in: TransactionSign; field.
+JSS ( Fee );                        // in/out: TransactionSign; field.
+JSS ( Flags );                      // in/out: TransactionSign; field.
+JSS ( Invalid );                    // out: app/misc/AccountState
+JSS ( LimitAmount );                // field.
+JSS ( OfferSequence );              // field.
+JSS ( Paths );                      // in/out: TransactionSign
+JSS ( SLE_hit_rate );               // out: GetCounts
+JSS ( SendMax );                    // in: TransactionSign
+JSS ( Sequence );                   // in/out: TransactionSign; field.
+JSS ( SetFlag );                    // field.
+JSS ( TakerGets );                  // field.
+JSS ( TakerPays );                  // field.
+JSS ( TransactionType );            // in: TransactionSign
+JSS ( aborted );                    // out: InboundLedger
+JSS ( accepted );                   // out: LedgerToJson, OwnerInfo
+JSS ( account );                    // in/out: many
+JSS ( accountState );               // out: LedgerToJson
+JSS ( accountTreeHash );            // out: ledger/Ledger.cpp
+JSS ( account_data );               // out: AccountInfo
+JSS ( account_hash );               // out: LedgerToJson
+JSS ( account_id );                 // out: WalletPropose
+JSS ( account_index );              // in: AccountCurrencies, AccountOffers,
+                                    //     AccountInfo, AccountLines, OwnerInfo
+                                    // out: AccountOffers
+JSS ( account_root );               // in: LedgerEntry
+JSS ( accounts );                   // in: LedgerEntry, Subscribe,
+                                    //     handlers/Ledger, Unsubscribe
+                                    // out: WalletAccounts
+JSS ( accounts_proposed );          // in: Subscribe, Unsubscribe
+JSS ( action );                     // out: LedgerEntrySet
+JSS ( address );                    // out: PeerImp
+JSS ( affected );                   // out: AcceptedLedgerTx
+JSS ( age );                        // out: UniqueNodeList, NetworkOPs
+JSS ( alternatives );               // out: PathRequest, RipplePathFind
+JSS ( amendment_blocked );          // out: NetworkOPs
+JSS ( asks );                       // out: Subscribe
+JSS ( authorized );                 // out: AccountLines
+JSS ( balance );                    // out: AccountLines
+JSS ( base );                       // out: LogLevel
+JSS ( base_fee );                   // out: NetworkOPs
+JSS ( base_fee_xrp );               // out: NetworkOPs
+JSS ( bids );                       // out: Subscribe
+JSS ( binary );                     // in: AccountTX, LedgerEntry,
+                                    //     AccountTxOld, Tx LedgerData
+JSS ( books );                      // in: Subscribe, Unsubscribe
+JSS ( both );                       // in: Subscribe, Unsubscribe
+JSS ( both_sides );                 // in: Subscribe, Unsubscribe
+JSS ( build_path );                 // in: TransactionSign
+JSS ( build_version );              // out: NetworkOPs
+JSS ( can_delete );                 // out: CanDelete
+JSS ( check_nodes );                // in: LedgerCleaner
+JSS ( clear );                      // in/out: FetchInfo
+JSS ( close_time );                 // in: Application, out: NetworkOPs,
+                                    //      LedgerProposal, LedgerToJson
+JSS ( close_time_estimated );       // in: Application, out: LedgerToJson
+JSS ( close_time_human );           // out: LedgerToJson
+JSS ( close_time_offset );          // out: NetworkOPs
+JSS ( close_time_resolution );      // in: Application; out: LedgerToJson
+JSS ( closed );                     // out: NetworkOPs, LedgerToJson,
+                                    //      handlers/Ledger
+JSS ( closed_ledger );              // out: NetworkOPs
+JSS ( cluster );                    // out: UniqueNodeList, PeerImp
+JSS ( code );                       // out: errors
+JSS ( command );                    // in: RPCHandler
+JSS ( comment );                    // in: UnlAdd
+JSS ( complete );                   // out: NetworkOPs, InboundLedger
+JSS ( complete_ledgers );           // out: NetworkOPs, PeerImp
+JSS ( consensus );                  // out: NetworkOPs, LedgerConsensus
+JSS ( converge_time );              // out: NetworkOPs
+JSS ( converge_time_s );            // out: NetworkOPs
+JSS ( count );                      // in: AccountTx*
+JSS ( currency );                   // in: paths/PathRequest, STAmount
+                                    // out: paths/Node, STPathSet, STAmount
+JSS ( current );                    // out: OwnerInfo
+JSS ( data );                       // out: LedgerData
+JSS ( date );                       // out: tx/Transaction, NetworkOPs
+JSS ( dbKBLedger );                 // out: getCounts
+JSS ( dbKBTotal );                  // out: getCounts
+JSS ( dbKBTransaction );            // out: getCounts
+JSS ( debug_signing );              // in: TransactionSign
+JSS ( delivered_amount );           // out: addPaymentDeliveredAmount
+JSS ( deprecated );                 // out: WalletSeed
+JSS ( descending );                 // in: AccountTx*
+JSS ( destination_account );        // in: PathRequest, RipplePathFind
+JSS ( destination_amount );         // in: PathRequest, RipplePathFind
+JSS ( destination_currencies );     // in: PathRequest, RipplePathFind
+JSS ( dir_entry );                  // out: DirectoryEntryIterator
+JSS ( dir_index );                  // out: DirectoryEntryIterator
+JSS ( dir_root );                   // out: DirectoryEntryIterator
+JSS ( directory );                  // in: LedgerEntry
+JSS ( enabled );                    // out: AmendmentTable
+JSS ( engine_result );              // out: NetworkOPs, TransactionSign, Submit
+JSS ( engine_result_code );         // out: NetworkOPs, TransactionSign, Submit
+JSS ( engine_result_message );      // out: NetworkOPs, TransactionSign, Submit
+JSS ( error );                      // out: error
+JSS ( error_code );                 // out: error
+JSS ( error_exception );            // out: Submit
+JSS ( error_message );              // out: error
+JSS ( expand );                     // in: handler/Ledger
+JSS ( fail_hard );                  // in: Sign, Submit
+JSS ( failed );                     // out: InboundLedger
+JSS ( feature );                    // in: Feature
+JSS ( features );                   // out: Feature
+JSS ( fee_base );                   // out: NetworkOPs
+JSS ( fee_mult_max );               // in: TransactionSign
+JSS ( fee_ref );                    // out: NetworkOPs
+JSS ( fetch_pack );                 // out: NetworkOPs
+JSS ( first );                      // out: rpc/Version
+JSS ( fix_txns );                   // in: LedgerCleaner
+JSS ( flags );                      // out: paths/Node, AccountOffers
+JSS ( forward );                    // in: AccountTx
+JSS ( freeze );                     // out: AccountLines
+JSS ( freeze_peer );                // out: AccountLines
+JSS ( full );                       // in: LedgerClearer, handlers/Ledger
+JSS ( fullbelow_size );             // in: GetCounts
+JSS ( generator );                  // in: LedgerEntry
+JSS ( good );                       // out: RPCVersion
+JSS ( hash );                       // out: NetworkOPs, InboundLedger,
+                                    //      LedgerToJson, STTx; field
+JSS ( have_header );                // out: InboundLedger
+JSS ( have_state );                 // out: InboundLedger
+JSS ( have_transactions );          // out: InboundLedger
+JSS ( hostid );                     // out: NetworkOPs
+JSS ( id );                         // websocket.
+JSS ( ident );                      // in: AccountCurrencies, AccountInfo,
+                                    //     OwnerInfo
+JSS ( inLedger );                   // out: tx/Transaction
+JSS ( inbound );                    // out: PeerImp
+JSS ( index );                      // in: LedgerEntry; out: PathState,
+                                    //     STLedgerEntry, LedgerEntry,
+                                    //     TxHistory, LedgerData;
+                                    // field
+JSS ( info );                       // out: ServerInfo, ConsensusInfo, FetchInfo
+JSS ( internal_command );           // in: Internal
+JSS ( io_latency_ms );              // out: NetworkOPs
+JSS ( ip );                         // in: Connect, out: OverlayImpl
+JSS ( issuer );                     // in: RipplePathFind, Subscribe,
+                                    //     Unsubscribe, BookOffers
+                                    // out: paths/Node, STPathSet, STAmount
+JSS ( key );                        // out: WalletSeed
+JSS ( last );                       // out: RPCVersion
+JSS ( last_close );                 // out: NetworkOPs
+JSS ( ledger );                     // in: NetworkOPs, LedgerCleaner,
+                                    //     LookupLedger
+                                    // out: NetworkOPs, PeerImp
+JSS ( ledger_current_index );       // out: NetworkOPs, LookupLedger,
+                                    //      LedgerCurrent, LedgerAccept
+JSS ( ledger_data );                // out: LedgerHeader
+JSS ( ledger_hash );                // in: LookupLedger, LedgerRequest,
+                                    //     RipplePathFind, TransactionEntry,
+                                    //     handlers/Ledger
+                                    // out: NetworkOPs, LookupLedger,
+                                    //      LedgerClosed, LedgerData
+JSS ( ledger_hit_rate );            // out: GetCounts
+JSS ( ledger_index );               // in/out: many
+JSS ( ledger_index_max );           // in, out: AccountTx*
+JSS ( ledger_index_min );           // in, out: AccountTx*
+JSS ( ledger_max );                 // in, out: AccountTx*
+JSS ( ledger_min );                 // in, out: AccountTx*
+JSS ( ledger_time );                // out: NetworkOPs
+JSS ( levels );                     // LogLevels
+JSS ( limit );                      // in/out: AccountTx*, AccountOffers,
+                                    //         AccountLines;
+                                    // in: LedgerData, BookOffers
+JSS ( limit_peer );                 // out: AccountLines
+JSS ( lines );                      // out: AccountLines
+JSS ( load );                       // out: NetworkOPs
+JSS ( load_base );                  // out: NetworkOPs
+JSS ( load_factor );                // out: NetworkOPs
+JSS ( load_factor_cluster );        // out: NetworkOPs
+JSS ( load_factor_local );          // out: NetworkOPs
+JSS ( load_factor_net );            // out: NetworkOPs
+JSS ( load_fee );                   // out: LoadFeeTrackImp
+JSS ( local );                      // out: resource/Logic.h
+JSS ( local_txs );                  // out: GetCounts
+JSS ( marker );                     // in/out: AccountTx, AccountOffers,
+                                    //         AccountLines, LedgerData
+                                    // in: BookOffers
+JSS ( master_key );                 // out: WalletPropose
+JSS ( master_seed );                // out: WalletPropose
+JSS ( master_seed_hex );            // out: WalletPropose
+JSS ( max_ledger );                 // in/out: LedgerCleaner
+JSS ( message );                    // error.
+JSS ( meta );                       // out: NetworkOPs, AccountTx*, Tx
+JSS ( metaData );                   // out: LedgerEntrySet, LedgerToJson
+JSS ( metadata );                   // out: TransactionEntry
+JSS ( method );                     // RPC
+JSS ( min_count );                  // in: GetCounts
+JSS ( min_ledger );                 // in: LedgerCleaner
+JSS ( missingCommand );             // error
+JSS ( name );                       // out: AmendmentTableImpl, PeerImp
+JSS ( needed_state_hashes );        // out: InboundLedger
+JSS ( needed_transaction_hashes );  // out: InboundLedger
+JSS ( network_ledger );             // out: NetworkOPs
+JSS ( no_ripple );                  // out: AccountLines
+JSS ( no_ripple_peer );             // out: AccountLines
+JSS ( node );                       // in: UnlAdd, UnlDelete
+                                    // out: LedgerEntrySet, LedgerEntry
+JSS ( node_binary );                // out: LedgerEntry
+JSS ( node_hit_rate );              // out: GetCounts
+JSS ( node_read_bytes );            // out: GetCounts
+JSS ( node_reads_hit );             // out: GetCounts
+JSS ( node_reads_total );           // out: GetCounts
+JSS ( node_writes );                // out: GetCounts
+JSS ( node_written_bytes );         // out: GetCounts
+JSS ( nodes );                      // out: LedgerEntrySet, PathState
+JSS ( offer );                      // in: LedgerEntry
+JSS ( offers );                     // out: NetworkOPs, AccountOffers, Subscribe
+JSS ( offline );                    // in: TransactionSign
+JSS ( offset );                     // in/out: AccountTxOld
+JSS ( open );                       // out: handlers/Ledger
+JSS ( owner );                      // in: LedgerEntry, out: NetworkOPs
+JSS ( owner_funds );                // out: NetworkOPs, AcceptedLedgerTx
+JSS ( params );                     // RPC
+JSS ( parent_hash );                // out: LedgerToJson
+JSS ( partition );                  // in: LogLevel
+JSS ( passphrase );                 // in: WalletPropose
+JSS ( password );                   // in: Subscribe
+JSS ( paths );                      // in: RipplePathFind
+JSS ( paths_canonical );            // out: RipplePathFind
+JSS ( paths_computed );             // out: PathRequest, RipplePathFind
+JSS ( peer );                       // in: AccountLines
+JSS ( peer_authorized );            // out: AccountLines
+JSS ( peer_id );                    // out: LedgerProposal
+JSS ( peer_index );                 // in/out: AccountLines
+JSS ( peers );                      // out: InboundLedger, handlers/Peers
+JSS ( port );                       // in: Connect
+JSS ( previous_ledger );            // out: LedgerPropose
+JSS ( proof );                      // in: BookOffers
+JSS ( propose_seq );                // out: LedgerPropose
+JSS ( proposers );                  // out: NetworkOPs, LedgerConsensus
+JSS ( protocol );                   // out: PeerImp
+JSS ( pubkey_node );                // out: NetworkOPs
+JSS ( pubkey_validator );           // out: NetworkOPs
+JSS ( public_key );                 // out: OverlayImpl, PeerImp, WalletPropose
+JSS ( public_key_hex );             // out: WalletPropose
+JSS ( published_ledger );           // out: NetworkOPs
+JSS ( quality );                    // out: NetworkOPs
+JSS ( quality_in );                 // out: AccountLines
+JSS ( quality_out );                // out: AccountLines
+JSS ( random );                     // out: Random
+JSS ( raw_meta );                   // out: AcceptedLedgerTx
+JSS ( receive_currencies );         // out: AccountCurrencies
+JSS ( regular_seed );               // in/out: LedgerEntry
+JSS ( remote );                     // out: Logic.h
+JSS ( request );                    // RPC
+JSS ( reserve_base );               // out: NetworkOPs
+JSS ( reserve_base_xrp );           // out: NetworkOPs
+JSS ( reserve_inc );                // out: NetworkOPs
+JSS ( reserve_inc_xrp );            // out: NetworkOPs
+JSS ( result );                     // RPC
+JSS ( ripple_lines );               // out: NetworkOPs
+JSS ( ripple_state );               // in: LedgerEntr
+JSS ( rt_accounts );                // in: Subscribe, Unsubscribe
+JSS ( search_depth );               // in: RipplePathFind
+JSS ( secret );                     // in: TransactionSign, WalletSeed,
+                                    //     ValidationCreate, ValidationSeed
+JSS ( seed );                       // in: WalletAccounts, out: WalletSeed
+JSS ( send_currencies );            // out: AccountCurrencies
+JSS ( seq );                        // in: LedgerEntry;
+                                    // out: NetworkOPs, RPCSub, AccountOffers
+JSS ( seqNum );                     // out: LedgerToJson
+JSS ( server_state );               // out: NetworkOPs
+JSS ( server_status );              // out: NetworkOPs
+JSS ( severity );                   // in: LogLevel
+JSS ( snapshot );                   // in: Subscribe
+JSS ( source_account );             // in: PathRequest, RipplePathFind
+JSS ( source_amount );              // in: PathRequest, RipplePathFind
+JSS ( source_currencies );          // in: PathRequest, RipplePathFind
+JSS ( stand_alone );                // out: NetworkOPs
+JSS ( start );                      // in: TxHistory
+JSS ( state );                      // out: Logic.h, ServerState, LedgerData
+JSS ( state_now );                  // in: Subscribe
+JSS ( status );                     // error
+JSS ( stop );                       // in: LedgerCleaner
+JSS ( streams );                    // in: Subscribe, Unsubscribe
+JSS ( strict );                     // in: AccountCurrencies, AccountInfo
+JSS ( sub_index );                  // in: LedgerEntry
+JSS ( subcommand );                 // in: PathFind
+JSS ( success );                    // rpc
+JSS ( supported );                  // out: AmendmentTableImpl
+JSS ( system_time_offset );         // out: NetworkOPs
+JSS ( taker );                      // in: Subscribe, BookOffers
+JSS ( taker_gets );                 // in: Subscribe, Unsubscribe, BookOffers
+JSS ( taker_gets_funded );          // out: NetworkOPs
+JSS ( taker_pays );                 // in: Subscribe, Unsubscribe, BookOffers
+JSS ( taker_pays_funded );          // out: NetworkOPs
+JSS ( text );                       // in: SMS
+JSS ( threshold );                  // in: Blacklist
+JSS ( timeouts );                   // out: InboundLedger
+JSS ( totalCoins );                 // out: LedgerToJson
+JSS ( total_coins );                // out: LedgerToJson
+JSS ( transTreeHash );              // out: ledger/Ledger.cpp
+JSS ( transaction );                // in: Tx
+                                    // out: NetworkOPs, AcceptedLedgerTx,
+JSS ( transaction_hash );           // out: LedgerProposal, LedgerToJson
+JSS ( transactions );               // out: LedgerToJson,
+                                    // in: AccountTx*, Unsubscribe
+JSS ( treenode_cache_size );        // out: GetCounts
+JSS ( treenode_track_size );        // out: GetCounts
+JSS ( tx );                         // out: STTx, AccountTx*
+JSS ( tx_blob );                    // in/out: Submit,
+                                    // in: TransactionSign, AccountTx*
+JSS ( tx_hash );                    // in: TransactionEntry
+JSS ( tx_json );                    // in/out: TransactionSign
+                                    // out: TransactionEntry
+JSS ( tx_signing_hash );            // out: TransactionSign
+JSS ( tx_unsigned );                // out: TransactionSign
+JSS ( txn_count );                  // out: NetworkOPs
+JSS ( txs );                        // out: TxHistory
+JSS ( type );                       // rpc; out: NetworkOPs, LedgerEntrySet
+                                    //      paths/Node.cpp, OverlayImpl, Logic
+JSS ( type_hex );                   // out: STPathSet
+JSS ( unl );                        // out: UnlList
+JSS ( uptime );                     // out: GetCounts
+JSS ( url );                        // in/out: Subscribe, Unsubscribe
+JSS ( url_password );               // in: Subscribe
+JSS ( url_username );               // in: Subscribe
+JSS ( urlgravatar );                // out: AccountState
+JSS ( username );                   // in: Subscribe
+JSS ( validated );                  // out: NetworkOPs, LookupLedger, AccountTx*
+                                    //      Tx
+JSS ( validated_ledger );           // out: NetworkOPs
+JSS ( validated_ledgers );          // out: NetworkOPs
+JSS ( validation_key );             // out: ValidationCreate, ValidationSeed
+JSS ( validation_public_key );      // out: ValidationCreate, ValidationSeed
+JSS ( validation_quorum );          // out: NetworkOPs
+JSS ( validation_seed );            // out: ValidationCreate, ValidationSeed
+JSS ( value );                      // out: STAmount
+JSS ( version );                    // out: RPCVersion
+JSS ( vetoed );                     // out: AmendmentTableImpl
+JSS ( vote );                       // in: Feature
+JSS ( warning );                    // rpc:
+JSS ( write_load );                 // out: GetCounts
 
 #undef JSS
 

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -166,7 +166,7 @@ Json::Value make_error (error_code_i code, std::string const& message)
 
 bool contains_error (Json::Value const& json)
 {
-    if (json.isObject() && json.isMember ("error"))
+    if (json.isObject() && json.isMember (jss::error))
         return true;
     return false;
 }

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -876,7 +876,7 @@ amountFromJson (SField::ref name, Json::Value const& v)
     if (v.isObject ())
     {
         WriteLog (lsTRACE, STAmount) <<
-            "value='" << v["value"].asString () <<
+            "value='" << v[jss::value].asString () <<
             "', currency='" << v["currency"].asString () <<
             "', issuer='" << v["issuer"].asString () <<
             "')";

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -113,7 +113,7 @@ Json::Value STLedgerEntry::getJson (int options) const
 {
     Json::Value ret (STObject::getJson (options));
 
-    ret["index"] = to_string (mIndex);
+    ret[jss::index] = to_string (mIndex);
 
     return ret;
 }

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -221,7 +221,7 @@ void STTx::setSourceAccount (RippleAddress const& naSource)
 Json::Value STTx::getJson (int) const
 {
     Json::Value ret = STObject::getJson (0);
-    ret["hash"] = to_string (getTransactionID ());
+    ret[jss::hash] = to_string (getTransactionID ());
     return ret;
 }
 
@@ -231,8 +231,8 @@ Json::Value STTx::getJson (int options, bool binary) const
     {
         Json::Value ret;
         Serializer s = STObject::getSerializer ();
-        ret["tx"] = strHex (s.peekData ());
-        ret["hash"] = to_string (getTransactionID ());
+        ret[jss::tx] = strHex (s.peekData ());
+        ret[jss::hash] = to_string (getTransactionID ());
         return ret;
     }
     return getJson(options);

--- a/src/ripple/resource/impl/Logic.h
+++ b/src/ripple/resource/impl/Logic.h
@@ -25,6 +25,7 @@
 #include <ripple/resource/impl/Import.h>
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/json/json_value.h>
+#include <ripple/protocol/JsonFields.h>
 #include <beast/chrono/abstract_clock.h>
 #include <beast/Insight.h>
 #include <beast/threads/SharedData.h>
@@ -253,9 +254,9 @@ public:
             if ((localBalance + inboundEntry.remote_balance) >= threshold)
             {
                 Json::Value& entry = (ret[inboundEntry.to_string()] = Json::objectValue);
-                entry["local"] = localBalance;
-                entry["remote"] = inboundEntry.remote_balance;
-                entry["type"] = "outbound";
+                entry[jss::local] = localBalance;
+                entry[jss::remote] = inboundEntry.remote_balance;
+                entry[jss::type] = "outbound";
             }
 
         }
@@ -265,9 +266,9 @@ public:
             if ((localBalance + outboundEntry.remote_balance) >= threshold)
             {
                 Json::Value& entry = (ret[outboundEntry.to_string()] = Json::objectValue);
-                entry["local"] = localBalance;
-                entry["remote"] = outboundEntry.remote_balance;
-                entry["type"] = "outbound";
+                entry[jss::local] = localBalance;
+                entry[jss::remote] = outboundEntry.remote_balance;
+                entry[jss::type] = "outbound";
             }
 
         }
@@ -277,9 +278,9 @@ public:
             if ((localBalance + adminEntry.remote_balance) >= threshold)
             {
                 Json::Value& entry = (ret[adminEntry.to_string()] = Json::objectValue);
-                entry["local"] = localBalance;
-                entry["remote"] = adminEntry.remote_balance;
-                entry["type"] = "admin";
+                entry[jss::local] = localBalance;
+                entry[jss::remote] = adminEntry.remote_balance;
+                entry[jss::type] = "admin";
             }
 
         }

--- a/src/ripple/rpc/handlers/AccountCurrencies.cpp
+++ b/src/ripple/rpc/handlers/AccountCurrencies.cpp
@@ -35,18 +35,18 @@ Json::Value doAccountCurrencies (RPC::Context& context)
     if (!ledger)
         return result;
 
-    if (!(params.isMember ("account") || params.isMember ("ident")))
-        return RPC::missing_field_error ("account");
+    if (!(params.isMember (jss::account) || params.isMember (jss::ident)))
+        return RPC::missing_field_error (jss::account);
 
-    std::string const strIdent (params.isMember ("account")
-        ? params["account"].asString ()
-        : params["ident"].asString ());
+    std::string const strIdent (params.isMember (jss::account)
+        ? params[jss::account].asString ()
+        : params[jss::ident].asString ());
 
-    int const iIndex (params.isMember ("account_index")
-        ? params["account_index"].asUInt ()
+    int const iIndex (params.isMember (jss::account_index)
+        ? params[jss::account_index].asUInt ()
         : 0);
-    bool const bStrict = params.isMember ("strict") &&
-            params["strict"].asBool ();
+    bool const bStrict = params.isMember (jss::strict) &&
+            params[jss::strict].asBool ();
 
     // Get info on account.
     bool bIndex; // out param
@@ -73,12 +73,12 @@ Json::Value doAccountCurrencies (RPC::Context& context)
     receive.erase (badCurrency());
 
     Json::Value& sendCurrencies =
-            (result["send_currencies"] = Json::arrayValue);
+            (result[jss::send_currencies] = Json::arrayValue);
     for (auto const& c: send)
         sendCurrencies.append (to_string (c));
 
     Json::Value& recvCurrencies =
-            (result["receive_currencies"] = Json::arrayValue);
+            (result[jss::receive_currencies] = Json::arrayValue);
     for (auto const& c: receive)
         recvCurrencies.append (to_string (c));
 

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -41,15 +41,15 @@ Json::Value doAccountInfo (RPC::Context& context)
     if (!ledger)
         return result;
 
-    if (!params.isMember ("account") && !params.isMember ("ident"))
-        return RPC::missing_field_error ("account");
+    if (!params.isMember (jss::account) && !params.isMember (jss::ident))
+        return RPC::missing_field_error (jss::account);
 
-    std::string strIdent = params.isMember ("account")
-            ? params["account"].asString () : params["ident"].asString ();
+    std::string strIdent = params.isMember (jss::account)
+            ? params[jss::account].asString () : params[jss::ident].asString ();
     bool bIndex;
-    int iIndex = params.isMember ("account_index")
-            ? params["account_index"].asUInt () : 0;
-    bool bStrict = params.isMember ("strict") && params["strict"].asBool ();
+    int iIndex = params.isMember (jss::account_index)
+            ? params[jss::account_index].asUInt () : 0;
+    bool bStrict = params.isMember (jss::strict) && params[jss::strict].asBool ();
     RippleAddress naAccount;
 
     // Get info on account.
@@ -65,11 +65,11 @@ Json::Value doAccountInfo (RPC::Context& context)
     if (asAccepted)
     {
         asAccepted->addJson (jvAccepted);
-        result["account_data"]    = jvAccepted;
+        result[jss::account_data]    = jvAccepted;
     }
     else
     {
-        result["account"] = naAccount.humanAccountID ();
+        result[jss::account] = naAccount.humanAccountID ();
         RPC::inject_error (rpcACT_NOT_FOUND, result);
     }
 

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -78,7 +78,7 @@ Json::Value doAccountLines (RPC::Context& context)
 {
     auto const& params (context.params);
     if (! params.isMember (jss::account))
-        return RPC::missing_field_error ("account");
+        return RPC::missing_field_error (jss::account);
 
     Ledger::pointer ledger;
     Json::Value result (RPC::lookupLedger (params, ledger, context.netOps));
@@ -133,7 +133,7 @@ Json::Value doAccountLines (RPC::Context& context)
     {
         auto const& jvLimit (params[jss::limit]);
         if (! jvLimit.isIntegral ())
-            return RPC::expected_field_error ("limit", "unsigned integer");
+            return RPC::expected_field_error (jss::limit, "unsigned integer");
 
         limit = jvLimit.isUInt () ? jvLimit.asUInt () :
             std::max (0, jvLimit.asInt ());
@@ -163,7 +163,7 @@ Json::Value doAccountLines (RPC::Context& context)
         Json::Value const& marker (params[jss::marker]);
 
         if (! marker.isString ())
-            return RPC::expected_field_error ("marker", "string");
+            return RPC::expected_field_error (jss::marker, "string");
 
         startAfter.SetHex (marker.asString ());
         SLE::pointer sleLine (ledger->getSLEi (startAfter));

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -34,7 +34,7 @@ Json::Value doAccountOffers (RPC::Context& context)
 {
     auto const& params (context.params);
     if (! params.isMember (jss::account))
-        return RPC::missing_field_error ("account");
+        return RPC::missing_field_error (jss::account);
 
     Ledger::pointer ledger;
     Json::Value result (RPC::lookupLedger (params, ledger, context.netOps));
@@ -70,7 +70,7 @@ Json::Value doAccountOffers (RPC::Context& context)
     {
         auto const& jvLimit (params[jss::limit]);
         if (! jvLimit.isIntegral ())
-            return RPC::expected_field_error ("limit", "unsigned integer");
+            return RPC::expected_field_error (jss::limit, "unsigned integer");
 
         limit = jvLimit.isUInt () ? jvLimit.asUInt () :
             std::max (0, jvLimit.asInt ());
@@ -100,7 +100,7 @@ Json::Value doAccountOffers (RPC::Context& context)
         Json::Value const& marker (params[jss::marker]);
 
         if (! marker.isString ())
-            return RPC::expected_field_error ("marker", "string");
+            return RPC::expected_field_error (jss::marker, "string");
 
         startAfter.SetHex (marker.asString ());
         SLE::pointer sleOffer (ledger->getSLEi (startAfter));

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -38,8 +38,8 @@ Json::Value doAccountTx (RPC::Context& context)
     RippleAddress   raAccount;
     int limit = params.isMember (jss::limit) ?
             params[jss::limit].asUInt () : -1;
-    bool bBinary = params.isMember ("binary") && params["binary"].asBool ();
-    bool bForward = params.isMember ("forward") && params["forward"].asBool ();
+    bool bBinary = params.isMember (jss::binary) && params[jss::binary].asBool ();
+    bool bForward = params.isMember (jss::forward) && params[jss::forward].asBool ();
     std::uint32_t   uLedgerMin;
     std::uint32_t   uLedgerMax;
     std::uint32_t   uValidatedMin;
@@ -53,21 +53,21 @@ Json::Value doAccountTx (RPC::Context& context)
         return rpcError (rpcLGR_IDXS_INVALID);
     }
 
-    if (!params.isMember ("account"))
+    if (!params.isMember (jss::account))
         return rpcError (rpcINVALID_PARAMS);
 
-    if (!raAccount.setAccountID (params["account"].asString ()))
+    if (!raAccount.setAccountID (params[jss::account].asString ()))
         return rpcError (rpcACT_MALFORMED);
 
     context.loadType = Resource::feeMediumBurdenRPC;
 
-    if (params.isMember ("ledger_index_min") ||
-        params.isMember ("ledger_index_max"))
+    if (params.isMember (jss::ledger_index_min) ||
+        params.isMember (jss::ledger_index_max))
     {
-        std::int64_t iLedgerMin  = params.isMember ("ledger_index_min")
-                ? params["ledger_index_min"].asInt () : -1;
-        std::int64_t iLedgerMax  = params.isMember ("ledger_index_max")
-                ? params["ledger_index_max"].asInt () : -1;
+        std::int64_t iLedgerMin  = params.isMember (jss::ledger_index_min)
+                ? params[jss::ledger_index_min].asInt () : -1;
+        std::int64_t iLedgerMax  = params.isMember (jss::ledger_index_max)
+                ? params[jss::ledger_index_max].asInt () : -1;
 
         uLedgerMin  = iLedgerMin == -1 ? uValidatedMin :
             ((iLedgerMin >= uValidatedMin) ? iLedgerMin : uValidatedMin);
@@ -100,8 +100,8 @@ Json::Value doAccountTx (RPC::Context& context)
 #endif
         Json::Value ret (Json::objectValue);
 
-        ret["account"] = raAccount.humanAccountID ();
-        Json::Value& jvTxns = (ret["transactions"] = Json::arrayValue);
+        ret[jss::account] = raAccount.humanAccountID ();
+        Json::Value& jvTxns = (ret[jss::transactions] = Json::arrayValue);
 
         if (bBinary)
         {
@@ -113,12 +113,12 @@ Json::Value doAccountTx (RPC::Context& context)
             {
                 Json::Value& jvObj = jvTxns.append (Json::objectValue);
 
-                jvObj["tx_blob"] = std::get<0> (it);
-                jvObj["meta"] = std::get<1> (it);
+                jvObj[jss::tx_blob] = std::get<0> (it);
+                jvObj[jss::meta] = std::get<1> (it);
 
                 std::uint32_t uLedgerIndex = std::get<2> (it);
 
-                jvObj["ledger_index"] = uLedgerIndex;
+                jvObj[jss::ledger_index] = uLedgerIndex;
                 jvObj[jss::validated] = bValidated &&
                     uValidatedMin <= uLedgerIndex &&
                     uValidatedMax >= uLedgerIndex;

--- a/src/ripple/rpc/handlers/AccountTxSwitch.cpp
+++ b/src/ripple/rpc/handlers/AccountTxSwitch.cpp
@@ -24,11 +24,11 @@ namespace ripple {
 // Temporary switching code until the old account_tx is removed
 Json::Value doAccountTxSwitch (RPC::Context& context)
 {
-    if (context.params.isMember("offset") ||
-        context.params.isMember("count") ||
-        context.params.isMember("descending") ||
-        context.params.isMember("ledger_max") ||
-        context.params.isMember("ledger_min"))
+    if (context.params.isMember(jss::offset) ||
+        context.params.isMember(jss::count) ||
+        context.params.isMember(jss::descending) ||
+        context.params.isMember(jss::ledger_max) ||
+        context.params.isMember(jss::ledger_min))
     {
         return doAccountTxOld(context);
     }

--- a/src/ripple/rpc/handlers/BlackList.cpp
+++ b/src/ripple/rpc/handlers/BlackList.cpp
@@ -25,8 +25,8 @@ namespace ripple {
 Json::Value doBlackList (RPC::Context& context)
 {
     auto& rm = getApp().getResourceManager();
-    if (context.params.isMember("threshold"))
-        return rm.getJson(context.params["threshold"].asInt());
+    if (context.params.isMember(jss::threshold))
+        return rm.getJson(context.params[jss::threshold].asInt());
     else
         return rm.getJson();
 }

--- a/src/ripple/rpc/handlers/BookOffers.cpp
+++ b/src/ripple/rpc/handlers/BookOffers.cpp
@@ -36,37 +36,37 @@ Json::Value doBookOffers (RPC::Context& context)
     if (!lpLedger)
         return jvResult;
 
-    if (!context.params.isMember ("taker_pays"))
-        return RPC::missing_field_error ("taker_pays");
+    if (!context.params.isMember (jss::taker_pays))
+        return RPC::missing_field_error (jss::taker_pays);
 
-    if (!context.params.isMember ("taker_gets"))
-        return RPC::missing_field_error ("taker_gets");
+    if (!context.params.isMember (jss::taker_gets))
+        return RPC::missing_field_error (jss::taker_gets);
 
-    if (!context.params["taker_pays"].isObject ())
-        return RPC::object_field_error ("taker_pays");
+    if (!context.params[jss::taker_pays].isObject ())
+        return RPC::object_field_error (jss::taker_pays);
 
-    if (!context.params["taker_gets"].isObject ())
-        return RPC::object_field_error ("taker_gets");
+    if (!context.params[jss::taker_gets].isObject ())
+        return RPC::object_field_error (jss::taker_gets);
 
-    Json::Value const& taker_pays (context.params["taker_pays"]);
+    Json::Value const& taker_pays (context.params[jss::taker_pays]);
 
-    if (!taker_pays.isMember ("currency"))
+    if (!taker_pays.isMember (jss::currency))
         return RPC::missing_field_error ("taker_pays.currency");
 
-    if (! taker_pays ["currency"].isString ())
+    if (! taker_pays [jss::currency].isString ())
         return RPC::expected_field_error ("taker_pays.currency", "string");
 
-    Json::Value const& taker_gets = context.params["taker_gets"];
+    Json::Value const& taker_gets = context.params[jss::taker_gets];
 
-    if (! taker_gets.isMember ("currency"))
+    if (! taker_gets.isMember (jss::currency))
         return RPC::missing_field_error ("taker_gets.currency");
 
-    if (! taker_gets ["currency"].isString ())
+    if (! taker_gets [jss::currency].isString ())
         return RPC::expected_field_error ("taker_gets.currency", "string");
 
     Currency pay_currency;
 
-    if (!to_currency (pay_currency, taker_pays ["currency"].asString ()))
+    if (!to_currency (pay_currency, taker_pays [jss::currency].asString ()))
     {
         WriteLog (lsINFO, RPCHandler) << "Bad taker_pays currency.";
         return RPC::make_error (rpcSRC_CUR_MALFORMED,
@@ -75,7 +75,7 @@ Json::Value doBookOffers (RPC::Context& context)
 
     Currency get_currency;
 
-    if (!to_currency (get_currency, taker_gets ["currency"].asString ()))
+    if (!to_currency (get_currency, taker_gets [jss::currency].asString ()))
     {
         WriteLog (lsINFO, RPCHandler) << "Bad taker_gets currency.";
         return RPC::make_error (rpcDST_AMT_MALFORMED,
@@ -84,13 +84,13 @@ Json::Value doBookOffers (RPC::Context& context)
 
     Account pay_issuer;
 
-    if (taker_pays.isMember ("issuer"))
+    if (taker_pays.isMember (jss::issuer))
     {
-        if (! taker_pays ["issuer"].isString())
+        if (! taker_pays [jss::issuer].isString())
             return RPC::expected_field_error ("taker_pays.issuer", "string");
 
         if (!to_issuer(
-            pay_issuer, taker_pays ["issuer"].asString ()))
+            pay_issuer, taker_pays [jss::issuer].asString ()))
             return RPC::make_error (rpcSRC_ISR_MALFORMED,
                 "Invalid field 'taker_pays.issuer', bad issuer.");
 
@@ -114,13 +114,13 @@ Json::Value doBookOffers (RPC::Context& context)
 
     Account get_issuer;
 
-    if (taker_gets.isMember ("issuer"))
+    if (taker_gets.isMember (jss::issuer))
     {
-        if (! taker_gets ["issuer"].isString())
+        if (! taker_gets [jss::issuer].isString())
             return RPC::expected_field_error ("taker_gets.issuer", "string");
 
         if (! to_issuer (
-            get_issuer, taker_gets ["issuer"].asString ()))
+            get_issuer, taker_gets [jss::issuer].asString ()))
             return RPC::make_error (rpcDST_ISR_MALFORMED,
                 "Invalid field 'taker_gets.issuer', bad issuer.");
 
@@ -145,13 +145,13 @@ Json::Value doBookOffers (RPC::Context& context)
 
     RippleAddress raTakerID;
 
-    if (context.params.isMember ("taker"))
+    if (context.params.isMember (jss::taker))
     {
-        if (! context.params ["taker"].isString ())
-            return RPC::expected_field_error ("taker", "string");
+        if (! context.params [jss::taker].isString ())
+            return RPC::expected_field_error (jss::taker, "string");
 
-        if (! raTakerID.setAccountID (context.params ["taker"].asString ()))
-            return RPC::invalid_field_error ("taker");
+        if (! raTakerID.setAccountID (context.params [jss::taker].asString ()))
+            return RPC::invalid_field_error (jss::taker);
     }
     else
     {
@@ -170,7 +170,7 @@ Json::Value doBookOffers (RPC::Context& context)
         auto const& jvLimit (context.params[jss::limit]);
 
         if (! jvLimit.isIntegral ())
-            return RPC::expected_field_error ("limit", "unsigned integer");
+            return RPC::expected_field_error (jss::limit, "unsigned integer");
 
         iLimit = jvLimit.isUInt () ? jvLimit.asUInt () :
             std::max (0, jvLimit.asInt ());
@@ -180,10 +180,10 @@ Json::Value doBookOffers (RPC::Context& context)
         iLimit = 0;
     }
 
-    bool const bProof (context.params.isMember ("proof"));
+    bool const bProof (context.params.isMember (jss::proof));
 
-    Json::Value const jvMarker (context.params.isMember ("marker")
-        ? context.params["marker"]
+    Json::Value const jvMarker (context.params.isMember (jss::marker)
+        ? context.params[jss::marker]
         : Json::Value (Json::nullValue));
 
     context.netOps.getBookPage (

--- a/src/ripple/rpc/handlers/CanDelete.cpp
+++ b/src/ripple/rpc/handlers/CanDelete.cpp
@@ -32,7 +32,7 @@ Json::Value doCanDelete (RPC::Context& context)
 
     Json::Value ret (Json::objectValue);
 
-    if (context.params.isMember("can_delete"))
+    if (context.params.isMember(jss::can_delete))
     {
         Json::Value canDelete  = context.params.get(jss::can_delete, 0);
         std::uint32_t canDeleteSeq = 0;
@@ -83,12 +83,12 @@ Json::Value doCanDelete (RPC::Context& context)
             }
         }
 
-        ret["can_delete"] =
+        ret[jss::can_delete] =
                 getApp().getSHAMapStore().setCanDelete (canDeleteSeq);
     }
     else
     {
-        ret["can_delete"] = getApp().getSHAMapStore().getCanDelete();
+        ret[jss::can_delete] = getApp().getSHAMapStore().getCanDelete();
     }
 
     return ret;

--- a/src/ripple/rpc/handlers/Connect.cpp
+++ b/src/ripple/rpc/handlers/Connect.cpp
@@ -33,24 +33,24 @@ Json::Value doConnect (RPC::Context& context)
     if (getConfig ().RUN_STANDALONE)
         return "cannot connect in standalone mode";
 
-    if (!context.params.isMember ("ip"))
-        return RPC::missing_field_error ("ip");
+    if (!context.params.isMember (jss::ip))
+        return RPC::missing_field_error (jss::ip);
 
-    if (context.params.isMember ("port") &&
-        !context.params["port"].isConvertibleTo (Json::intValue))
+    if (context.params.isMember (jss::port) &&
+        !context.params[jss::port].isConvertibleTo (Json::intValue))
     {
         return rpcError (rpcINVALID_PARAMS);
     }
 
     int iPort;
 
-    if(context.params.isMember ("port"))
-        iPort = context.params["port"].asInt ();
+    if(context.params.isMember (jss::port))
+        iPort = context.params[jss::port].asInt ();
     else
         iPort = 6561;
 
     auto ip = beast::IP::Endpoint::from_string(
-        context.params["ip"].asString ());
+        context.params[jss::ip].asString ());
 
     if (! is_unspecified (ip))
         getApp().overlay ().connect (ip.at_port(iPort));

--- a/src/ripple/rpc/handlers/ConsensusInfo.cpp
+++ b/src/ripple/rpc/handlers/ConsensusInfo.cpp
@@ -27,7 +27,7 @@ Json::Value doConsensusInfo (RPC::Context& context)
 
     {
         auto lock = getApp().masterLock();
-        ret["info"] = context.netOps.getConsensusInfo ();
+        ret[jss::info] = context.netOps.getConsensusInfo ();
     }
 
     return ret;

--- a/src/ripple/rpc/handlers/Feature.cpp
+++ b/src/ripple/rpc/handlers/Feature.cpp
@@ -45,26 +45,26 @@ static void textTime (
 
 Json::Value doFeature (RPC::Context& context)
 {
-    if (!context.params.isMember ("feature"))
+    if (!context.params.isMember (jss::feature))
     {
         Json::Value jvReply = Json::objectValue;
-        jvReply["features"] = getApp().getAmendmentTable ().getJson(0);
+        jvReply[jss::features] = getApp().getAmendmentTable ().getJson(0);
         return jvReply;
     }
 
     uint256 uFeature
             = getApp().getAmendmentTable ().get(
-                context.params["feature"].asString());
+                context.params[jss::feature].asString());
 
     if (uFeature.isZero ())
     {
-        uFeature.SetHex (context.params["feature"].asString ());
+        uFeature.SetHex (context.params[jss::feature].asString ());
 
         if (uFeature.isZero ())
             return rpcError (rpcBAD_FEATURE);
     }
 
-    if (!context.params.isMember ("vote"))
+    if (!context.params.isMember (jss::vote))
         return getApp().getAmendmentTable ().getJson(uFeature);
 
     // WRITEME

--- a/src/ripple/rpc/handlers/FetchInfo.cpp
+++ b/src/ripple/rpc/handlers/FetchInfo.cpp
@@ -25,13 +25,13 @@ Json::Value doFetchInfo (RPC::Context& context)
 {
     Json::Value ret (Json::objectValue);
 
-    if (context.params.isMember("clear") && context.params["clear"].asBool())
+    if (context.params.isMember(jss::clear) && context.params[jss::clear].asBool())
     {
         context.netOps.clearLedgerFetch();
-        ret["clear"] = true;
+        ret[jss::clear] = true;
     }
 
-    ret["info"] = context.netOps.getLedgerFetchInfo();
+    ret[jss::info] = context.netOps.getLedgerFetchInfo();
 
     return ret;
 }

--- a/src/ripple/rpc/handlers/GetCounts.cpp
+++ b/src/ripple/rpc/handlers/GetCounts.cpp
@@ -35,8 +35,8 @@ Json::Value doGetCounts (RPC::Context& context)
 
     int minCount = 10;
 
-    if (context.params.isMember ("min_count"))
-        minCount = context.params["min_count"].asUInt ();
+    if (context.params.isMember (jss::min_count))
+        minCount = context.params[jss::min_count].asUInt ();
 
     auto objectCounts = CountedObjects::getInstance ().getCounts (minCount);
 
@@ -52,34 +52,34 @@ Json::Value doGetCounts (RPC::Context& context)
     int dbKB = app.getLedgerDB ().getDB ()->getKBUsedAll ();
 
     if (dbKB > 0)
-        ret["dbKBTotal"] = dbKB;
+        ret[jss::dbKBTotal] = dbKB;
 
     dbKB = app.getLedgerDB ().getDB ()->getKBUsedDB ();
 
     if (dbKB > 0)
-        ret["dbKBLedger"] = dbKB;
+        ret[jss::dbKBLedger] = dbKB;
 
     dbKB = app.getTxnDB ().getDB ()->getKBUsedDB ();
 
     if (dbKB > 0)
-        ret["dbKBTransaction"] = dbKB;
+        ret[jss::dbKBTransaction] = dbKB;
 
     {
         std::size_t c = app.getOPs().getLocalTxCount ();
         if (c > 0)
-            ret["local_txs"] = static_cast<Json::UInt> (c);
+            ret[jss::local_txs] = static_cast<Json::UInt> (c);
     }
 
-    ret["write_load"] = app.getNodeStore ().getWriteLoad ();
+    ret[jss::write_load] = app.getNodeStore ().getWriteLoad ();
 
-    ret["SLE_hit_rate"] = app.getSLECache ().getHitRate ();
-    ret["node_hit_rate"] = app.getNodeStore ().getCacheHitRate ();
-    ret["ledger_hit_rate"] = app.getLedgerMaster ().getCacheHitRate ();
-    ret["AL_hit_rate"] = AcceptedLedger::getCacheHitRate ();
+    ret[jss::SLE_hit_rate] = app.getSLECache ().getHitRate ();
+    ret[jss::node_hit_rate] = app.getNodeStore ().getCacheHitRate ();
+    ret[jss::ledger_hit_rate] = app.getLedgerMaster ().getCacheHitRate ();
+    ret[jss::AL_hit_rate] = AcceptedLedger::getCacheHitRate ();
 
-    ret["fullbelow_size"] = static_cast<int>(app.getFullBelowCache().size());
-    ret["treenode_cache_size"] = app.getTreeNodeCache().getCacheSize();
-    ret["treenode_track_size"] = app.getTreeNodeCache().getTrackSize();
+    ret[jss::fullbelow_size] = static_cast<int>(app.getFullBelowCache().size());
+    ret[jss::treenode_cache_size] = app.getTreeNodeCache().getCacheSize();
+    ret[jss::treenode_track_size] = app.getTreeNodeCache().getTrackSize();
 
     std::string uptime;
     int s = UptimeTimer::getInstance ().getElapsedSeconds ();
@@ -88,13 +88,13 @@ Json::Value doGetCounts (RPC::Context& context)
     textTime (uptime, s, "hour", 60 * 60);
     textTime (uptime, s, "minute", 60);
     textTime (uptime, s, "second", 1);
-    ret["uptime"] = uptime;
+    ret[jss::uptime] = uptime;
 
-    ret["node_writes"] = app.getNodeStore().getStoreCount();
-    ret["node_reads_total"] = app.getNodeStore().getFetchTotalCount();
-    ret["node_reads_hit"] = app.getNodeStore().getFetchHitCount();
-    ret["node_written_bytes"] = app.getNodeStore().getStoreSize();
-    ret["node_read_bytes"] = app.getNodeStore().getFetchSize();
+    ret[jss::node_writes] = app.getNodeStore().getStoreCount();
+    ret[jss::node_reads_total] = app.getNodeStore().getFetchTotalCount();
+    ret[jss::node_reads_hit] = app.getNodeStore().getFetchHitCount();
+    ret[jss::node_written_bytes] = app.getNodeStore().getStoreSize();
+    ret[jss::node_read_bytes] = app.getNodeStore().getFetchSize();
 
     return ret;
 }

--- a/src/ripple/rpc/handlers/Internal.cpp
+++ b/src/ripple/rpc/handlers/Internal.cpp
@@ -27,11 +27,11 @@ RPC::InternalHandler* RPC::InternalHandler::headHandler = nullptr;
 Json::Value doInternal (RPC::Context& context)
 {
     // Used for debug or special-purpose RPC commands
-    if (!context.params.isMember ("internal_command"))
+    if (!context.params.isMember (jss::internal_command))
         return rpcError (rpcINVALID_PARAMS);
 
-    auto name = context.params["internal_command"].asString ();
-    auto params = context.params["params"];
+    auto name = context.params[jss::internal_command].asString ();
+    auto params = context.params[jss::params];
 
     for (auto* h = RPC::InternalHandler::headHandler; h; )
     {

--- a/src/ripple/rpc/handlers/LedgerAccept.cpp
+++ b/src/ripple/rpc/handlers/LedgerAccept.cpp
@@ -28,13 +28,13 @@ Json::Value doLedgerAccept (RPC::Context& context)
 
     if (!getConfig ().RUN_STANDALONE)
     {
-        jvResult["error"] = "notStandAlone";
+        jvResult[jss::error] = "notStandAlone";
     }
     else
     {
         context.netOps.acceptLedger ();
 
-        jvResult["ledger_current_index"]
+        jvResult[jss::ledger_current_index]
                 = context.netOps.getCurrentLedgerID ();
     }
 

--- a/src/ripple/rpc/handlers/LedgerClosed.cpp
+++ b/src/ripple/rpc/handlers/LedgerClosed.cpp
@@ -26,8 +26,8 @@ Json::Value doLedgerClosed (RPC::Context& context)
     uint256 uLedger = context.netOps.getClosedLedgerHash ();
 
     Json::Value jvResult;
-    jvResult["ledger_index"] = context.netOps.getLedgerID (uLedger);
-    jvResult["ledger_hash"] = to_string (uLedger);
+    jvResult[jss::ledger_index] = context.netOps.getLedgerID (uLedger);
+    jvResult[jss::ledger_hash] = to_string (uLedger);
 
     return jvResult;
 }

--- a/src/ripple/rpc/handlers/LedgerCurrent.cpp
+++ b/src/ripple/rpc/handlers/LedgerCurrent.cpp
@@ -24,7 +24,7 @@ namespace ripple {
 Json::Value doLedgerCurrent (RPC::Context& context)
 {
     Json::Value jvResult;
-    jvResult["ledger_current_index"] = context.netOps.getCurrentLedgerID ();
+    jvResult[jss::ledger_current_index] = context.netOps.getCurrentLedgerID ();
     return jvResult;
 }
 

--- a/src/ripple/rpc/handlers/LedgerData.cpp
+++ b/src/ripple/rpc/handlers/LedgerData.cpp
@@ -45,25 +45,25 @@ Json::Value doLedgerData (RPC::Context& context)
         return jvResult;
 
     uint256 resumePoint;
-    if (params.isMember ("marker"))
+    if (params.isMember (jss::marker))
     {
-        Json::Value const& jMarker = params["marker"];
+        Json::Value const& jMarker = params[jss::marker];
         if (!jMarker.isString ())
-            return RPC::expected_field_error ("marker", "valid");
+            return RPC::expected_field_error (jss::marker, "valid");
         if (!resumePoint.SetHex (jMarker.asString ()))
-            return RPC::expected_field_error ("marker", "valid");
+            return RPC::expected_field_error (jss::marker, "valid");
     }
 
-    bool isBinary = params["binary"].asBool();
+    bool isBinary = params[jss::binary].asBool();
 
     int limit = -1;
     int maxLimit = isBinary ? BINARY_PAGE_LENGTH : JSON_PAGE_LENGTH;
 
-    if (params.isMember ("limit"))
+    if (params.isMember (jss::limit))
     {
-        Json::Value const& jLimit = params["limit"];
+        Json::Value const& jLimit = params[jss::limit];
         if (!jLimit.isIntegral ())
-            return RPC::expected_field_error ("limit", "integer");
+            return RPC::expected_field_error (jss::limit, "integer");
 
         limit = jLimit.asInt ();
     }
@@ -71,10 +71,10 @@ Json::Value doLedgerData (RPC::Context& context)
     if ((limit < 0) || ((limit > maxLimit) && (context.role != Role::ADMIN)))
         limit = maxLimit;
 
-    jvResult["ledger_hash"] = to_string (lpLedger->getHash());
-    jvResult["ledger_index"] = std::to_string( lpLedger->getLedgerSeq ());
+    jvResult[jss::ledger_hash] = to_string (lpLedger->getHash());
+    jvResult[jss::ledger_index] = std::to_string( lpLedger->getLedgerSeq ());
 
-    Json::Value& nodes = (jvResult["state"] = Json::arrayValue);
+    Json::Value& nodes = (jvResult[jss::state] = Json::arrayValue);
     SHAMap& map = *(lpLedger->peekAccountStateMap ());
 
     for (;;)
@@ -87,22 +87,22 @@ Json::Value doLedgerData (RPC::Context& context)
        if (limit-- <= 0)
        {
            --resumePoint;
-           jvResult["marker"] = to_string (resumePoint);
+           jvResult[jss::marker] = to_string (resumePoint);
            break;
        }
 
        if (isBinary)
        {
            Json::Value& entry = nodes.append (Json::objectValue);
-           entry["data"] = strHex (
+           entry[jss::data] = strHex (
                item->peekData().begin(), item->peekData().size());
-           entry["index"] = to_string (item->getTag ());
+           entry[jss::index] = to_string (item->getTag ());
        }
        else
        {
            SLE sle (item->peekSerializer(), item->getTag ());
            Json::Value& entry = nodes.append (sle.getJson (0));
-           entry["index"] = to_string (item->getTag ());
+           entry[jss::index] = to_string (item->getTag ());
        }
     }
 

--- a/src/ripple/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/rpc/handlers/LedgerEntry.cpp
@@ -39,21 +39,21 @@ Json::Value doLedgerEntry (RPC::Context& context)
     uint256     uNodeIndex;
     bool        bNodeBinary = false;
 
-    if (context.params.isMember ("index"))
+    if (context.params.isMember (jss::index))
     {
         // XXX Needs to provide proof.
-        uNodeIndex.SetHex (context.params["index"].asString ());
+        uNodeIndex.SetHex (context.params[jss::index].asString ());
         bNodeBinary = true;
     }
-    else if (context.params.isMember ("account_root"))
+    else if (context.params.isMember (jss::account_root))
     {
         RippleAddress   naAccount;
 
         if (!naAccount.setAccountID (
-                context.params["account_root"].asString ())
+                context.params[jss::account_root].asString ())
             || !naAccount.getAccountID ())
         {
-            jvResult["error"]   = "malformedAddress";
+            jvResult[jss::error]   = "malformedAddress";
         }
         else
         {
@@ -61,39 +61,39 @@ Json::Value doLedgerEntry (RPC::Context& context)
                     = getAccountRootIndex (naAccount.getAccountID ());
         }
     }
-    else if (context.params.isMember ("directory"))
+    else if (context.params.isMember (jss::directory))
     {
-        if (!context.params["directory"].isObject ())
+        if (!context.params[jss::directory].isObject ())
         {
-            uNodeIndex.SetHex (context.params["directory"].asString ());
+            uNodeIndex.SetHex (context.params[jss::directory].asString ());
         }
-        else if (context.params["directory"].isMember ("sub_index")
-                 && !context.params["directory"]["sub_index"].isIntegral ())
+        else if (context.params[jss::directory].isMember (jss::sub_index)
+                 && !context.params[jss::directory][jss::sub_index].isIntegral ())
         {
-            jvResult["error"]   = "malformedRequest";
+            jvResult[jss::error]   = "malformedRequest";
         }
         else
         {
             std::uint64_t  uSubIndex
-                    = context.params["directory"].isMember ("sub_index")
-                    ? context.params["directory"]["sub_index"].asUInt () : 0;
+                    = context.params[jss::directory].isMember (jss::sub_index)
+                    ? context.params[jss::directory][jss::sub_index].asUInt () : 0;
 
-            if (context.params["directory"].isMember ("dir_root"))
+            if (context.params[jss::directory].isMember (jss::dir_root))
             {
                 uint256 uDirRoot;
 
-                uDirRoot.SetHex (context.params["dir_root"].asString ());
+                uDirRoot.SetHex (context.params[jss::dir_root].asString ());
 
                 uNodeIndex  = getDirNodeIndex (uDirRoot, uSubIndex);
             }
-            else if (context.params["directory"].isMember ("owner"))
+            else if (context.params[jss::directory].isMember (jss::owner))
             {
                 RippleAddress   naOwnerID;
 
                 if (!naOwnerID.setAccountID (
-                        context.params["directory"]["owner"].asString ()))
+                        context.params[jss::directory][jss::owner].asString ()))
                 {
-                    jvResult["error"]   = "malformedAddress";
+                    jvResult[jss::error]   = "malformedAddress";
                 }
                 else
                 {
@@ -105,26 +105,26 @@ Json::Value doLedgerEntry (RPC::Context& context)
             }
             else
             {
-                jvResult["error"]   = "malformedRequest";
+                jvResult[jss::error]   = "malformedRequest";
             }
         }
     }
-    else if (context.params.isMember ("generator"))
+    else if (context.params.isMember (jss::generator))
     {
         RippleAddress   naGeneratorID;
 
-        if (!context.params["generator"].isObject ())
+        if (!context.params[jss::generator].isObject ())
         {
-            uNodeIndex.SetHex (context.params["generator"].asString ());
+            uNodeIndex.SetHex (context.params[jss::generator].asString ());
         }
-        else if (!context.params["generator"].isMember ("regular_seed"))
+        else if (!context.params[jss::generator].isMember (jss::regular_seed))
         {
-            jvResult["error"]   = "malformedRequest";
+            jvResult[jss::error]   = "malformedRequest";
         }
         else if (!naGeneratorID.setSeedGeneric (
-            context.params["generator"]["regular_seed"].asString ()))
+            context.params[jss::generator][jss::regular_seed].asString ()))
         {
-            jvResult["error"]   = "malformedAddress";
+            jvResult[jss::error]   = "malformedAddress";
         }
         else
         {
@@ -137,62 +137,62 @@ Json::Value doLedgerEntry (RPC::Context& context)
             uNodeIndex  = getGeneratorIndex (na0Public.getAccountID ());
         }
     }
-    else if (context.params.isMember ("offer"))
+    else if (context.params.isMember (jss::offer))
     {
         RippleAddress   naAccountID;
 
-        if (!context.params["offer"].isObject ())
+        if (!context.params[jss::offer].isObject ())
         {
-            uNodeIndex.SetHex (context.params["offer"].asString ());
+            uNodeIndex.SetHex (context.params[jss::offer].asString ());
         }
-        else if (!context.params["offer"].isMember ("account")
-                 || !context.params["offer"].isMember ("seq")
-                 || !context.params["offer"]["seq"].isIntegral ())
+        else if (!context.params[jss::offer].isMember (jss::account)
+                 || !context.params[jss::offer].isMember (jss::seq)
+                 || !context.params[jss::offer][jss::seq].isIntegral ())
         {
-            jvResult["error"]   = "malformedRequest";
+            jvResult[jss::error]   = "malformedRequest";
         }
         else if (!naAccountID.setAccountID (
-            context.params["offer"]["account"].asString ()))
+            context.params[jss::offer][jss::account].asString ()))
         {
-            jvResult["error"]   = "malformedAddress";
+            jvResult[jss::error]   = "malformedAddress";
         }
         else
         {
             uNodeIndex  = getOfferIndex (naAccountID.getAccountID (),
-                context.params["offer"]["seq"].asUInt ());
+                context.params[jss::offer][jss::seq].asUInt ());
         }
     }
-    else if (context.params.isMember ("ripple_state"))
+    else if (context.params.isMember (jss::ripple_state))
     {
         RippleAddress   naA;
         RippleAddress   naB;
         Currency         uCurrency;
-        Json::Value     jvRippleState   = context.params["ripple_state"];
+        Json::Value     jvRippleState   = context.params[jss::ripple_state];
 
         if (!jvRippleState.isObject ()
-            || !jvRippleState.isMember ("currency")
-            || !jvRippleState.isMember ("accounts")
-            || !jvRippleState["accounts"].isArray ()
-            || 2 != jvRippleState["accounts"].size ()
-            || !jvRippleState["accounts"][0u].isString ()
-            || !jvRippleState["accounts"][1u].isString ()
-            || (jvRippleState["accounts"][0u].asString ()
-                == jvRippleState["accounts"][1u].asString ())
+            || !jvRippleState.isMember (jss::currency)
+            || !jvRippleState.isMember (jss::accounts)
+            || !jvRippleState[jss::accounts].isArray ()
+            || 2 != jvRippleState[jss::accounts].size ()
+            || !jvRippleState[jss::accounts][0u].isString ()
+            || !jvRippleState[jss::accounts][1u].isString ()
+            || (jvRippleState[jss::accounts][0u].asString ()
+                == jvRippleState[jss::accounts][1u].asString ())
            )
         {
-            jvResult["error"]   = "malformedRequest";
+            jvResult[jss::error]   = "malformedRequest";
         }
         else if (!naA.setAccountID (
-                     jvRippleState["accounts"][0u].asString ())
+                     jvRippleState[jss::accounts][0u].asString ())
                  || !naB.setAccountID (
-                     jvRippleState["accounts"][1u].asString ()))
+                     jvRippleState[jss::accounts][1u].asString ()))
         {
-            jvResult["error"]   = "malformedAddress";
+            jvResult[jss::error]   = "malformedAddress";
         }
         else if (!to_currency (
-            uCurrency, jvRippleState["currency"].asString ()))
+            uCurrency, jvRippleState[jss::currency].asString ()))
         {
-            jvResult["error"]   = "malformedCurrency";
+            jvResult[jss::error]   = "malformedCurrency";
         }
         else
         {
@@ -202,21 +202,21 @@ Json::Value doLedgerEntry (RPC::Context& context)
     }
     else
     {
-        jvResult["error"]   = "unknownOption";
+        jvResult[jss::error]   = "unknownOption";
     }
 
     if (uNodeIndex.isNonZero ())
     {
         auto sleNode = context.netOps.getSLEi (lpLedger, uNodeIndex);
 
-        if (context.params.isMember("binary"))
-            bNodeBinary = context.params["binary"].asBool();
+        if (context.params.isMember(jss::binary))
+            bNodeBinary = context.params[jss::binary].asBool();
 
         if (!sleNode)
         {
             // Not found.
             // XXX Should also provide proof.
-            jvResult["error"]       = "entryNotFound";
+            jvResult[jss::error]       = "entryNotFound";
         }
         else if (bNodeBinary)
         {
@@ -225,13 +225,13 @@ Json::Value doLedgerEntry (RPC::Context& context)
 
             sleNode->add (s);
 
-            jvResult["node_binary"] = strHex (s.peekData ());
-            jvResult["index"]       = to_string (uNodeIndex);
+            jvResult[jss::node_binary] = strHex (s.peekData ());
+            jvResult[jss::index]       = to_string (uNodeIndex);
         }
         else
         {
-            jvResult["node"]        = sleNode->getJson (0);
-            jvResult["index"]       = to_string (uNodeIndex);
+            jvResult[jss::node]        = sleNode->getJson (0);
+            jvResult[jss::index]       = to_string (uNodeIndex);
         }
     }
 

--- a/src/ripple/rpc/handlers/LedgerHeader.cpp
+++ b/src/ripple/rpc/handlers/LedgerHeader.cpp
@@ -39,7 +39,7 @@ Json::Value doLedgerHeader (RPC::Context& context)
 
     lpLedger->addRaw (s);
 
-    jvResult["ledger_data"] = strHex (s.peekData ());
+    jvResult[jss::ledger_data] = strHex (s.peekData ());
 
     // This information isn't verified: they should only use it if they trust
     // us.

--- a/src/ripple/rpc/handlers/LedgerRequest.cpp
+++ b/src/ripple/rpc/handlers/LedgerRequest.cpp
@@ -45,11 +45,11 @@ Json::Value doLedgerRequest (RPC::Context& context)
     {
         auto const& jsonHash = context.params[jss::ledger_hash];
         if (!jsonHash.isString() || !ledgerHash.SetHex (jsonHash.asString ()))
-            return RPC::invalid_field_message ("ledger_hash");
+            return RPC::invalid_field_message (jss::ledger_hash);
     } else {
         auto const& jsonIndex = context.params[jss::ledger_index];
         if (!jsonIndex.isNumeric ())
-            return RPC::invalid_field_message ("ledger_index");
+            return RPC::invalid_field_message (jss::ledger_index);
 
         // We need a validated ledger to get the hash from the sequence
         if (ledgerMaster.getValidatedLedgerAge() > 120)

--- a/src/ripple/rpc/handlers/LogLevel.cpp
+++ b/src/ripple/rpc/handlers/LogLevel.cpp
@@ -25,13 +25,13 @@ namespace ripple {
 Json::Value doLogLevel (RPC::Context& context)
 {
     // log_level
-    if (!context.params.isMember ("severity"))
+    if (!context.params.isMember (jss::severity))
     {
         // get log severities
         Json::Value ret (Json::objectValue);
         Json::Value lev (Json::objectValue);
 
-        lev["base"] =
+        lev[jss::base] =
                 Logs::toString(Logs::fromSeverity(deprecatedLogs().severity()));
         std::vector< std::pair<std::string, std::string> > logTable (
             deprecatedLogs().partition_severities());
@@ -39,19 +39,19 @@ Json::Value doLogLevel (RPC::Context& context)
         for (auto const& it : logTable)
             lev[it.first] = it.second;
 
-        ret["levels"] = lev;
+        ret[jss::levels] = lev;
         return ret;
     }
 
     LogSeverity const sv (
-        Logs::fromString (context.params["severity"].asString ()));
+        Logs::fromString (context.params[jss::severity].asString ()));
 
     if (sv == lsINVALID)
         return rpcError (rpcINVALID_PARAMS);
 
     auto severity = Logs::toSeverity(sv);
     // log_level severity
-    if (!context.params.isMember ("partition"))
+    if (!context.params.isMember (jss::partition))
     {
         // set base log severity
         deprecatedLogs().severity(severity);
@@ -59,10 +59,10 @@ Json::Value doLogLevel (RPC::Context& context)
     }
 
     // log_level partition severity base?
-    if (context.params.isMember ("partition"))
+    if (context.params.isMember (jss::partition))
     {
         // set partition severity
-        std::string partition (context.params["partition"].asString ());
+        std::string partition (context.params[jss::partition].asString ());
 
         if (boost::iequals (partition, "base"))
             deprecatedLogs().severity (severity);

--- a/src/ripple/rpc/handlers/OwnerInfo.cpp
+++ b/src/ripple/rpc/handlers/OwnerInfo.cpp
@@ -28,18 +28,18 @@ namespace ripple {
 Json::Value doOwnerInfo (RPC::Context& context)
 {
     auto lock = getApp().masterLock();
-    if (!context.params.isMember ("account") &&
-        !context.params.isMember ("ident"))
+    if (!context.params.isMember (jss::account) &&
+        !context.params.isMember (jss::ident))
     {
-        return RPC::missing_field_error ("account");
+        return RPC::missing_field_error (jss::account);
     }
 
-    std::string strIdent = context.params.isMember ("account")
-            ? context.params["account"].asString ()
-            : context.params["ident"].asString ();
+    std::string strIdent = context.params.isMember (jss::account)
+            ? context.params[jss::account].asString ()
+            : context.params[jss::ident].asString ();
     bool bIndex;
-    int iIndex = context.params.isMember ("account_index")
-            ? context.params["account_index"].asUInt () : 0;
+    int iIndex = context.params.isMember (jss::account_index)
+            ? context.params[jss::account_index].asUInt () : 0;
     RippleAddress raAccount;
     Json::Value ret;
 
@@ -55,7 +55,7 @@ Json::Value doOwnerInfo (RPC::Context& context)
         false,
         context.netOps);
 
-    ret["accepted"] = jAccepted.empty () ? context.netOps.getOwnerInfo (
+    ret[jss::accepted] = jAccepted.empty () ? context.netOps.getOwnerInfo (
         closedLedger, raAccount) : jAccepted;
 
     auto const& currentLedger = context.netOps.getCurrentLedger ();
@@ -68,7 +68,7 @@ Json::Value doOwnerInfo (RPC::Context& context)
         false,
         context.netOps);
 
-    ret["current"] = jCurrent.empty () ? context.netOps.getOwnerInfo (
+    ret[jss::current] = jCurrent.empty () ? context.netOps.getOwnerInfo (
         currentLedger, raAccount) : jCurrent;
 
     return ret;

--- a/src/ripple/rpc/handlers/PathFind.cpp
+++ b/src/ripple/rpc/handlers/PathFind.cpp
@@ -26,8 +26,8 @@ Json::Value doPathFind (RPC::Context& context)
 {
     Ledger::pointer lpLedger = context.netOps.getClosedLedger();
 
-    if (!context.params.isMember ("subcommand") ||
-        !context.params["subcommand"].isString ())
+    if (!context.params.isMember (jss::subcommand) ||
+        !context.params[jss::subcommand].isString ())
     {
         return rpcError (rpcINVALID_PARAMS);
     }
@@ -35,7 +35,7 @@ Json::Value doPathFind (RPC::Context& context)
     if (!context.infoSub)
         return rpcError (rpcNO_EVENTS);
 
-    std::string sSubCommand = context.params["subcommand"].asString ();
+    std::string sSubCommand = context.params[jss::subcommand].asString ();
 
     if (sSubCommand == "create")
     {

--- a/src/ripple/rpc/handlers/Peers.cpp
+++ b/src/ripple/rpc/handlers/Peers.cpp
@@ -31,7 +31,7 @@ Json::Value doPeers (RPC::Context& context)
     {
         auto lock = getApp().masterLock();
 
-        jvResult["peers"] = getApp().overlay ().json ();
+        jvResult[jss::peers] = getApp().overlay ().json ();
         getApp().getUNL().addClusterStatus(jvResult);
     }
 

--- a/src/ripple/rpc/handlers/Print.cpp
+++ b/src/ripple/rpc/handlers/Print.cpp
@@ -25,10 +25,10 @@ Json::Value doPrint (RPC::Context& context)
 {
     JsonPropertyStream stream;
     if (context.params.isObject()
-        && context.params["params"].isArray()
-        && context.params["params"][0u].isString ())
+        && context.params[jss::params].isArray()
+        && context.params[jss::params][0u].isString ())
     {
-        getApp().write (stream, context.params["params"][0u].asString());
+        getApp().write (stream, context.params[jss::params][0u].asString());
     }
     else
     {

--- a/src/ripple/rpc/handlers/Random.cpp
+++ b/src/ripple/rpc/handlers/Random.cpp
@@ -37,7 +37,7 @@ Json::Value doRandom (RPC::Context& context)
         random_fill (rand.begin (), rand.size ());
 
         Json::Value jvResult;
-        jvResult["random"]  = to_string (rand);
+        jvResult[jss::random]  = to_string (rand);
         return jvResult;
     }
     catch (...)

--- a/src/ripple/rpc/handlers/SMS.cpp
+++ b/src/ripple/rpc/handlers/SMS.cpp
@@ -24,11 +24,11 @@ namespace ripple {
 
 Json::Value doSMS (RPC::Context& context)
 {
-    if (!context.params.isMember ("text"))
+    if (!context.params.isMember (jss::text))
         return rpcError (rpcINVALID_PARAMS);
 
     HTTPClient::sendSMS (
-        getApp().getIOService (), context.params["text"].asString ());
+        getApp().getIOService (), context.params[jss::text].asString ());
 
     return RPC::makeObjectValue ("sms dispatched");
 }

--- a/src/ripple/rpc/handlers/ServerInfo.cpp
+++ b/src/ripple/rpc/handlers/ServerInfo.cpp
@@ -27,7 +27,7 @@ Json::Value doServerInfo (RPC::Context& context)
     auto lock = getApp().masterLock();
     Json::Value ret (Json::objectValue);
 
-    ret["info"] = context.netOps.getServerInfo (
+    ret[jss::info] = context.netOps.getServerInfo (
         true, context.role == Role::ADMIN);
 
     return ret;

--- a/src/ripple/rpc/handlers/ServerState.cpp
+++ b/src/ripple/rpc/handlers/ServerState.cpp
@@ -27,7 +27,7 @@ Json::Value doServerState (RPC::Context& context)
     auto lock = getApp().masterLock();
     Json::Value ret (Json::objectValue);
 
-    ret["state"] = context.netOps.getServerInfo (
+    ret[jss::state] = context.netOps.getServerInfo (
         false, context.role == Role::ADMIN);
 
     return ret;

--- a/src/ripple/rpc/handlers/Sign.cpp
+++ b/src/ripple/rpc/handlers/Sign.cpp
@@ -29,8 +29,8 @@ namespace ripple {
 Json::Value doSign (RPC::Context& context)
 {
     context.loadType = Resource::feeHighBurdenRPC;
-    bool bFailHard = context.params.isMember ("fail_hard")
-            && context.params["fail_hard"].asBool ();
+    bool bFailHard = context.params.isMember (jss::fail_hard)
+            && context.params[jss::fail_hard].asBool ();
     return RPC::transactionSign (
         context.params, false, bFailHard, context.netOps, context.role);
 }

--- a/src/ripple/rpc/handlers/Submit.cpp
+++ b/src/ripple/rpc/handlers/Submit.cpp
@@ -31,17 +31,17 @@ Json::Value doSubmit (RPC::Context& context)
 {
     context.loadType = Resource::feeMediumBurdenRPC;
 
-    if (!context.params.isMember ("tx_blob"))
+    if (!context.params.isMember (jss::tx_blob))
     {
-        bool bFailHard = context.params.isMember ("fail_hard")
-                && context.params["fail_hard"].asBool ();
+        bool bFailHard = context.params.isMember (jss::fail_hard)
+                && context.params[jss::fail_hard].asBool ();
         return RPC::transactionSign (
             context.params, true, bFailHard, context.netOps, context.role);
     }
 
     Json::Value jvResult;
 
-    std::pair<Blob, bool> ret(strUnHex (context.params["tx_blob"].asString ()));
+    std::pair<Blob, bool> ret(strUnHex (context.params[jss::tx_blob].asString ()));
 
     if (!ret.second || !ret.first.size ())
         return rpcError (rpcINVALID_PARAMS);
@@ -58,7 +58,7 @@ Json::Value doSubmit (RPC::Context& context)
     catch (std::exception& e)
     {
         jvResult[jss::error]           = "invalidTransaction";
-        jvResult["error_exception"] = e.what ();
+        jvResult[jss::error_exception] = e.what ();
 
         return jvResult;
     }
@@ -72,7 +72,7 @@ Json::Value doSubmit (RPC::Context& context)
     catch (std::exception& e)
     {
         jvResult[jss::error]           = "internalTransaction";
-        jvResult["error_exception"] = e.what ();
+        jvResult[jss::error_exception] = e.what ();
 
         return jvResult;
     }
@@ -80,7 +80,7 @@ Json::Value doSubmit (RPC::Context& context)
     if (tpTrans->getStatus() != NEW)
     {
         jvResult[jss::error]            = "invalidTransactions";
-        jvResult["error_exception"] = "fails local checks";
+        jvResult[jss::error_exception] = "fails local checks";
 
         return jvResult;
     }
@@ -89,8 +89,8 @@ Json::Value doSubmit (RPC::Context& context)
     {
         (void) context.netOps.processTransaction (
             tpTrans, context.role == Role::ADMIN, true,
-            context.params.isMember ("fail_hard")
-            && context.params["fail_hard"].asBool ());
+            context.params.isMember (jss::fail_hard)
+            && context.params[jss::fail_hard].asBool ());
     }
     catch (std::exception& e)
     {

--- a/src/ripple/rpc/handlers/TransactionEntry.cpp
+++ b/src/ripple/rpc/handlers/TransactionEntry.cpp
@@ -39,28 +39,28 @@ Json::Value doTransactionEntry (RPC::Context& context)
     if (!lpLedger)
         return jvResult;
 
-    if (!context.params.isMember ("tx_hash"))
+    if (!context.params.isMember (jss::tx_hash))
     {
-        jvResult["error"]   = "fieldNotFoundTransaction";
+        jvResult[jss::error]   = "fieldNotFoundTransaction";
     }
-    else if (!context.params.isMember ("ledger_hash")
-             && !context.params.isMember ("ledger_index"))
+    else if (!context.params.isMember (jss::ledger_hash)
+             && !context.params.isMember (jss::ledger_index))
     {
         // We don't work on ledger current.
 
         // XXX We don't support any transaction yet.
-        jvResult["error"]   = "notYetImplemented";
+        jvResult[jss::error]   = "notYetImplemented";
     }
     else
     {
         uint256 uTransID;
         // XXX Relying on trusted WSS client. Would be better to have a strict
         // routine, returning success or failure.
-        uTransID.SetHex (context.params["tx_hash"].asString ());
+        uTransID.SetHex (context.params[jss::tx_hash].asString ());
 
         if (!lpLedger)
         {
-            jvResult["error"]   = "ledgerNotFound";
+            jvResult[jss::error]   = "ledgerNotFound";
         }
         else
         {
@@ -69,13 +69,13 @@ Json::Value doTransactionEntry (RPC::Context& context)
 
             if (!lpLedger->getTransaction (uTransID, tpTrans, tmTrans))
             {
-                jvResult["error"]   = "transactionNotFound";
+                jvResult[jss::error]   = "transactionNotFound";
             }
             else
             {
-                jvResult["tx_json"]     = tpTrans->getJson (0);
+                jvResult[jss::tx_json]     = tpTrans->getJson (0);
                 if (tmTrans)
-                    jvResult["metadata"]    = tmTrans->getJson (0);
+                    jvResult[jss::metadata]    = tmTrans->getJson (0);
                 // 'accounts'
                 // 'engine_...'
                 // 'ledger_...'

--- a/src/ripple/rpc/handlers/TxHistory.cpp
+++ b/src/ripple/rpc/handlers/TxHistory.cpp
@@ -29,10 +29,10 @@ Json::Value doTxHistory (RPC::Context& context)
 {
     context.loadType = Resource::feeMediumBurdenRPC;
 
-    if (!context.params.isMember ("start"))
+    if (!context.params.isMember (jss::start))
         return rpcError (rpcINVALID_PARAMS);
 
-    unsigned int startIndex = context.params["start"].asUInt ();
+    unsigned int startIndex = context.params[jss::start].asUInt ();
 
     if ((startIndex > 10000) &&  (context.role != Role::ADMIN))
         return rpcError (rpcNO_PERMISSION);
@@ -40,7 +40,7 @@ Json::Value doTxHistory (RPC::Context& context)
     Json::Value obj;
     Json::Value txs;
 
-    obj["index"] = startIndex;
+    obj[jss::index] = startIndex;
 
     std::string sql =
         boost::str (boost::format (
@@ -58,7 +58,7 @@ Json::Value doTxHistory (RPC::Context& context)
         }
     }
 
-    obj["txs"] = txs;
+    obj[jss::txs] = txs;
 
     return obj;
 }

--- a/src/ripple/rpc/handlers/UnlAdd.cpp
+++ b/src/ripple/rpc/handlers/UnlAdd.cpp
@@ -30,10 +30,10 @@ Json::Value doUnlAdd (RPC::Context& context)
 {
     auto lock = getApp().masterLock();
 
-    std::string strNode = context.params.isMember ("node")
-            ? context.params["node"].asString () : "";
-    std::string strComment = context.params.isMember ("comment")
-            ? context.params["comment"].asString () : "";
+    std::string strNode = context.params.isMember (jss::node)
+            ? context.params[jss::node].asString () : "";
+    std::string strComment = context.params.isMember (jss::comment)
+            ? context.params[jss::comment].asString () : "";
 
     RippleAddress raNodePublic;
 

--- a/src/ripple/rpc/handlers/UnlDelete.cpp
+++ b/src/ripple/rpc/handlers/UnlDelete.cpp
@@ -28,10 +28,10 @@ Json::Value doUnlDelete (RPC::Context& context)
 {
     auto lock = getApp().masterLock();
 
-    if (!context.params.isMember ("node"))
+    if (!context.params.isMember (jss::node))
         return rpcError (rpcINVALID_PARAMS);
 
-    auto strNode = context.params["node"].asString ();
+    auto strNode = context.params[jss::node].asString ();
     RippleAddress raNodePublic;
 
     if (raNodePublic.setNodePublic (strNode))

--- a/src/ripple/rpc/handlers/UnlList.cpp
+++ b/src/ripple/rpc/handlers/UnlList.cpp
@@ -26,7 +26,7 @@ Json::Value doUnlList (RPC::Context& context)
     auto lock = getApp().masterLock();
     Json::Value obj (Json::objectValue);
 
-    obj["unl"] = getApp().getUNL ().getUnlJson ();
+    obj[jss::unl] = getApp().getUNL ().getUnlJson ();
 
     return obj;
 }

--- a/src/ripple/rpc/handlers/ValidationCreate.cpp
+++ b/src/ripple/rpc/handlers/ValidationCreate.cpp
@@ -32,21 +32,21 @@ Json::Value doValidationCreate (RPC::Context& context)
     RippleAddress   raSeed;
     Json::Value     obj (Json::objectValue);
 
-    if (!context.params.isMember ("secret"))
+    if (!context.params.isMember (jss::secret))
     {
         WriteLog (lsDEBUG, RPCHandler) << "Creating random validation seed.";
 
         raSeed.setSeedRandom ();                // Get a random seed.
     }
-    else if (!raSeed.setSeedGeneric (context.params["secret"].asString ()))
+    else if (!raSeed.setSeedGeneric (context.params[jss::secret].asString ()))
     {
         return rpcError (rpcBAD_SEED);
     }
 
-    obj["validation_public_key"]
+    obj[jss::validation_public_key]
             = RippleAddress::createNodePublic (raSeed).humanNodePublic ();
-    obj["validation_seed"] = raSeed.humanSeed ();
-    obj["validation_key"] = raSeed.humanSeed1751 ();
+    obj[jss::validation_seed] = raSeed.humanSeed ();
+    obj[jss::validation_key] = raSeed.humanSeed1751 ();
 
     return obj;
 }

--- a/src/ripple/rpc/handlers/ValidationSeed.cpp
+++ b/src/ripple/rpc/handlers/ValidationSeed.cpp
@@ -29,7 +29,7 @@ Json::Value doValidationSeed (RPC::Context& context)
     auto lock = getApp().masterLock();
     Json::Value obj (Json::objectValue);
 
-    if (!context.params.isMember ("secret"))
+    if (!context.params.isMember (jss::secret))
     {
         std::cerr << "Unset validation seed." << std::endl;
 
@@ -38,7 +38,7 @@ Json::Value doValidationSeed (RPC::Context& context)
         getConfig ().VALIDATION_PRIV.clear ();
     }
     else if (!getConfig ().VALIDATION_SEED.setSeedGeneric (
-        context.params["secret"].asString ()))
+        context.params[jss::secret].asString ()))
     {
         getConfig ().VALIDATION_PUB.clear ();
         getConfig ().VALIDATION_PRIV.clear ();
@@ -53,9 +53,9 @@ Json::Value doValidationSeed (RPC::Context& context)
         pub = RippleAddress::createNodePublic (seed);
         getConfig ().VALIDATION_PRIV = RippleAddress::createNodePrivate (seed);
 
-        obj["validation_public_key"] = pub.humanNodePublic ();
-        obj["validation_seed"] = seed.humanSeed ();
-        obj["validation_key"] = seed.humanSeed1751 ();
+        obj[jss::validation_public_key] = pub.humanNodePublic ();
+        obj[jss::validation_seed] = seed.humanSeed ();
+        obj[jss::validation_key] = seed.humanSeed1751 ();
     }
 
     return obj;

--- a/src/ripple/rpc/handlers/WalletAccounts.cpp
+++ b/src/ripple/rpc/handlers/WalletAccounts.cpp
@@ -39,8 +39,8 @@ Json::Value doWalletAccounts (RPC::Context& context)
 
     RippleAddress   naSeed;
 
-    if (!context.params.isMember ("seed")
-        || !naSeed.setSeedGeneric (context.params["seed"].asString ()))
+    if (!context.params.isMember (jss::seed)
+        || !naSeed.setSeedGeneric (context.params[jss::seed].asString ()))
     {
         return rpcError (rpcBAD_SEED);
     }

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -29,10 +29,10 @@ Json::Value doWalletPropose (RPC::Context& context)
     RippleAddress   naSeed;
     RippleAddress   naAccount;
 
-    if (!context.params.isMember ("passphrase"))
+    if (!context.params.isMember (jss::passphrase))
         naSeed.setSeedRandom ();
 
-    else if (!naSeed.setSeedGeneric (context.params["passphrase"].asString ()))
+    else if (!naSeed.setSeedGeneric (context.params[jss::passphrase].asString ()))
         return rpcError(rpcBAD_SEED);
 
     RippleAddress naGenerator = RippleAddress::createGeneratorPublic (naSeed);
@@ -40,14 +40,14 @@ Json::Value doWalletPropose (RPC::Context& context)
 
     Json::Value obj (Json::objectValue);
 
-    obj["master_seed"]      = naSeed.humanSeed ();
-    obj["master_seed_hex"]  = to_string (naSeed.getSeed ());
-    obj["master_key"]     = naSeed.humanSeed1751();
-    obj["account_id"]       = naAccount.humanAccountID ();
-    obj["public_key"] = naAccount.humanAccountPublic();
+    obj[jss::master_seed]      = naSeed.humanSeed ();
+    obj[jss::master_seed_hex]  = to_string (naSeed.getSeed ());
+    obj[jss::master_key]     = naSeed.humanSeed1751();
+    obj[jss::account_id]       = naAccount.humanAccountID ();
+    obj[jss::public_key] = naAccount.humanAccountPublic();
 
     auto acct = naAccount.getAccountPublic();
-    obj["public_key_hex"] = strHex(acct.begin(), acct.size());
+    obj[jss::public_key_hex] = strHex(acct.begin(), acct.size());
 
     return obj;
 }

--- a/src/ripple/rpc/handlers/WalletSeed.cpp
+++ b/src/ripple/rpc/handlers/WalletSeed.cpp
@@ -27,9 +27,9 @@ namespace ripple {
 Json::Value doWalletSeed (RPC::Context& context)
 {
     RippleAddress   seed;
-    bool bSecret = context.params.isMember ("secret");
+    bool bSecret = context.params.isMember (jss::secret);
 
-    if (bSecret && !seed.setSeedGeneric (context.params["secret"].asString ()))
+    if (bSecret && !seed.setSeedGeneric (context.params[jss::secret].asString ()))
     {
         return rpcError (rpcBAD_SEED);
     }
@@ -48,9 +48,9 @@ Json::Value doWalletSeed (RPC::Context& context)
 
         Json::Value obj (Json::objectValue);
 
-        obj["seed"]     = seed.humanSeed ();
-        obj["key"]      = seed.humanSeed1751 ();
-        obj["deprecated"] = "Use wallet_propose instead";
+        obj[jss::seed]     = seed.humanSeed ();
+        obj[jss::key]      = seed.humanSeed1751 ();
+        obj[jss::deprecated] = "Use wallet_propose instead";
 
         return obj;
     }

--- a/src/ripple/rpc/impl/DoPrint.h
+++ b/src/ripple/rpc/impl/DoPrint.h
@@ -34,10 +34,10 @@ public:
         JsonPropertyStream stream;
 
         if (req.params.isObject() &&
-            req.params["params"].isArray() &&
-            req.params["params"][0u].isString ())
+            req.params[jss::params].isArray() &&
+            req.params[jss::params][0u].isString ())
         {
-            req.app.write (stream, req.params["params"][0u].asString());
+            req.app.write (stream, req.params[jss::params][0u].asString());
         }
         else
         {

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -285,10 +285,10 @@ ServerHandlerImp::processRequest (
 
     auto const& admin_allow = getConfig().RPC_ADMIN_ALLOW;
     auto role = Role::FORBID;
-    if (jsonRPC.isObject() && jsonRPC.isMember("params") &&
-            jsonRPC["params"].isArray() && jsonRPC["params"].size() > 0 &&
-                jsonRPC["params"][Json::UInt(0)].isObject())
-        role = adminRole(port, jsonRPC["params"][Json::UInt(0)],
+    if (jsonRPC.isObject() && jsonRPC.isMember(jss::params) &&
+            jsonRPC[jss::params].isArray() && jsonRPC[jss::params].size() > 0 &&
+                jsonRPC[jss::params][Json::UInt(0)].isObject())
+        role = adminRole(port, jsonRPC[jss::params][Json::UInt(0)],
             remoteIPAddress, admin_allow);
     else
         role = adminRole(port, Json::objectValue,
@@ -339,7 +339,7 @@ ServerHandlerImp::processRequest (
     //
     // Otherwise, that field must be an array of length 1 (why?)
     // and we take that first entry and validate that it's an object.
-    Json::Value params = jsonRPC ["params"];
+    Json::Value params = jsonRPC [jss::params];
 
     if (params.isNull () || params.empty())
         params = Json::Value (Json::objectValue);
@@ -393,13 +393,13 @@ ServerHandlerImp::processRequest (
         RPC::doCommand (context, result, setup_.yieldStrategy);
 
         // Always report "status".  On an error report the request as received.
-        if (result.isMember ("error"))
+        if (result.isMember (jss::error))
         {
             result[jss::status] = jss::error;
             result[jss::request] = params;
             WriteLog (lsDEBUG, RPCErr) <<
-                "rpcError: " << result ["error"] <<
-                ": " << result ["error_message"];
+                "rpcError: " << result [jss::error] <<
+                ": " << result [jss::error_message];
         }
         else
         {


### PR DESCRIPTION
As part of my grand survey of existing RPC commands, I need to isolate all the data members of JSON input and output to rippled.

This is a pretty huge task, and I imagine there are still a few missing, but I scoured the code and am reasonably confident of having found nearly all of them.

Reviewers: @nbougalis @josh-ripple 