### PR TITLE
Improve pool seeding during startup:

### DIFF
--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -124,6 +124,9 @@ public:
     /** Returns the full path and filename of the debug log file. */
     boost::filesystem::path getDebugLogFile () const;
 
+    /** Returns the full path and filename of the entropy seed file. */
+    boost::filesystem::path getEntropyFile () const;
+
     // DEPRECATED
     boost::filesystem::path CONFIG_FILE; // used by UniqueNodeList
 private:

--- a/src/ripple/crypto/RandomNumbers.h
+++ b/src/ripple/crypto/RandomNumbers.h
@@ -20,9 +20,20 @@
 #ifndef RIPPLE_CRYPTO_RANDOMNUMBERS_H_INCLUDED
 #define RIPPLE_CRYPTO_RANDOMNUMBERS_H_INCLUDED
 
+#include <string>
 #include <beast/cxx14/type_traits.h> // <type_traits>
 
 namespace ripple {
+
+/** Stir the RNG using entropy from stable storage.
+
+    @param file the file from which state is loaded and into
+           which it is saved.
+
+    @return true if the pool has sufficient entropy; false
+            otherwise.
+*/
+bool stir_entropy (std::string file);
 
 /** Adds entropy to the RNG pool.
 

--- a/src/ripple/crypto/impl/RandomNumbers.cpp
+++ b/src/ripple/crypto/impl/RandomNumbers.cpp
@@ -26,6 +26,18 @@
 
 namespace ripple {
 
+bool stir_entropy (std::string file)
+{
+    // First, we attempt to stir any existing saved entropy
+    // into the pool: no use letting it go to waste.
+    RAND_load_file (file.c_str (), 1024);
+
+    // And now, we extract some entropy out, and save it for
+    // the future. If the quality of the entropy isn't great
+    // then we let the user know.
+    return RAND_write_file (file.c_str ()) != -1;
+}
+
 void add_entropy (void* buffer, int count)
 {
     assert (buffer == nullptr || count != 0);
@@ -35,7 +47,7 @@ void add_entropy (void* buffer, int count)
     if (buffer != nullptr && count != 0)
         RAND_add (buffer, count, count / 4.0);
 
-    // Try to add a bit more entropy from the system
+    // And try to add some entropy from the system
     unsigned int rdbuf[32];
 
     std::random_device rd;


### PR DESCRIPTION
* When starting up, we no longer rely just on the standard
  system RNG to generate entropy: we attempt to squeeze some
  from the execution state, and to recover any entropy that
  we had previously stored.

* When shutting down, if sufficient entropy has been accumulated
  attempt to store it for future use.

Reviews: @JoelKatz, @vinniefalco