### PR TITLE
New serialized object, public key, and private key interfaces: 

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1780,6 +1780,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\Blob.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\basics\Buffer.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\ByteOrder.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\CheckLibraryVersions.h">
@@ -1851,6 +1853,8 @@
     <ClInclude Include="..\..\src\ripple\basics\ResolverAsio.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\seconds_clock.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\basics\Slice.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\strHex.h">
     </ClInclude>
@@ -2302,6 +2306,10 @@
     <ClCompile Include="..\..\src\ripple\peerfinder\tests\PeerFinder_test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\protocol\AnyPublicKey.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\protocol\AnySecretKey.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\Book.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\BuildInfo.h">
@@ -2310,6 +2318,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\HashPrefix.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\protocol\impl\AnyPublicKey.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\protocol\impl\AnySecretKey.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\protocol\impl\BuildInfo.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
@@ -2425,6 +2439,8 @@
     <ClInclude Include="..\..\src\ripple\protocol\STBitString.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\STBlob.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\protocol\STExchange.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\STInteger.h">
     </ClInclude>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2667,6 +2667,9 @@
     <ClInclude Include="..\..\src\ripple\basics\Blob.h">
       <Filter>ripple\basics</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\basics\Buffer.h">
+      <Filter>ripple\basics</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\ByteOrder.h">
       <Filter>ripple\basics</Filter>
     </ClInclude>
@@ -2752,6 +2755,9 @@
       <Filter>ripple\basics</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\seconds_clock.h">
+      <Filter>ripple\basics</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\basics\Slice.h">
       <Filter>ripple\basics</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\strHex.h">
@@ -3315,6 +3321,12 @@
     <ClCompile Include="..\..\src\ripple\peerfinder\tests\PeerFinder_test.cpp">
       <Filter>ripple\peerfinder\tests</Filter>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\protocol\AnyPublicKey.h">
+      <Filter>ripple\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\protocol\AnySecretKey.h">
+      <Filter>ripple\protocol</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\Book.h">
       <Filter>ripple\protocol</Filter>
     </ClInclude>
@@ -3327,6 +3339,12 @@
     <ClInclude Include="..\..\src\ripple\protocol\HashPrefix.h">
       <Filter>ripple\protocol</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\protocol\impl\AnyPublicKey.cpp">
+      <Filter>ripple\protocol\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\protocol\impl\AnySecretKey.cpp">
+      <Filter>ripple\protocol\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\protocol\impl\BuildInfo.cpp">
       <Filter>ripple\protocol\impl</Filter>
     </ClCompile>
@@ -3460,6 +3478,9 @@
       <Filter>ripple\protocol</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\STBlob.h">
+      <Filter>ripple\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\protocol\STExchange.h">
       <Filter>ripple\protocol</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\protocol\STInteger.h">

--- a/src/ripple/basics/Buffer.h
+++ b/src/ripple/basics/Buffer.h
@@ -1,0 +1,149 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_BASICS_BUFFER_H_INCLUDED
+#define RIPPLE_BASICS_BUFFER_H_INCLUDED
+
+#include <beast/utility/noexcept.h>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <utility>
+
+namespace ripple {
+
+/** Like std::vector<char> but better.
+    Meets the requirements of BufferFactory.
+*/
+class Buffer
+{
+private:
+    std::unique_ptr<
+        std::uint8_t[]> p_;
+    std::size_t size_ = 0;
+
+public:
+    Buffer() = default;
+    Buffer (Buffer const&) = delete;
+    Buffer& operator= (Buffer const&) = delete;
+
+    /** Move-construct.
+        The other buffer is reset.
+    */
+    Buffer (Buffer&& other)
+        : p_ (std::move(other.p_))
+        , size_ (other.size_)
+    {
+        other.size_ = 0;
+    }
+
+    /** Move-assign.
+        The other buffer is reset.
+    */
+    Buffer& operator= (Buffer&& other)
+    {
+        p_ = std::move(other.p_);
+        size_ = other.size_;
+        other.size_ = 0;
+        return *this;
+    }
+
+    /** Create an uninitialized buffer with the given size. */
+    explicit
+    Buffer (std::size_t size)
+        : p_ (size ?
+            new std::uint8_t[size] : nullptr)
+        , size_ (size)
+    {
+    }
+
+    /** Create a buffer as a copy of existing memory. */
+    Buffer (void const* data, std::size_t size)
+        : p_ (size ?
+            new std::uint8_t[size] : nullptr)
+        , size_ (size)
+    {
+        std::memcpy(p_.get(), data, size);
+    }
+
+    /** Returns the number of bytes in the buffer. */
+    std::size_t
+    size() const noexcept
+    {
+        return size_;
+    }
+
+    /** Return a pointer to beginning of the storage.
+        @note The return type is guaranteed to be a pointer
+              to a single byte, to facilitate pointer arithmetic.
+    */
+    /** @{ */
+    std::uint8_t const*
+    data() const noexcept
+    {
+        return p_.get();
+    }
+
+    std::uint8_t*
+    data() noexcept
+    {
+        return p_.get();
+    }
+    /** @} */
+
+    /** Reset the buffer.
+        All memory is deallocated. The resulting size is 0.
+    */
+    void
+    clear() noexcept
+    {
+        p_.reset();
+        size_ = 0;
+    }
+
+    /** Reallocate the storage.
+        Existing data, if any, is discarded.
+    */
+    std::uint8_t*
+    alloc (std::size_t n)
+    {
+        if (n == 0)
+        {
+            clear();
+            return nullptr;
+        }
+        if (n != size_)
+        {
+            p_.reset(new std::uint8_t[n]);
+            size_ = n;
+        }
+        return p_.get();
+    }
+
+    // Meet the requirements of BufferFactory
+    void*
+    operator()(std::size_t n)
+    {
+        return alloc(n);
+    }
+};
+
+} // ripple
+
+#endif

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_BASICS_SLICE_H_INCLUDED
+#define RIPPLE_BASICS_SLICE_H_INCLUDED
+
+#include <beast/utility/noexcept.h>
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+
+namespace ripple {
+
+/** An immutable linear range of bytes.
+
+    A fully constructed Slice is guaranteed to be in a valid state.
+    Default construction, construction from nullptr, and zero-byte
+    ranges are disallowed. A Slice is lightweight and copyable, it
+    retains no ownership of the underlying memory.
+*/
+class Slice
+{
+private:
+    std::uint8_t const* data_;
+    std::size_t size_;
+
+public:
+    // Disallowed
+    Slice() = delete;
+
+    Slice (Slice const&) = default;
+    
+    Slice& operator= (Slice const&) = default;
+
+    /** Create a slice pointing to existing memory. */
+    Slice (void const* data, std::size_t size)
+        : data_ (reinterpret_cast<
+            std::uint8_t const*>(data))
+        , size_ (size)
+    {
+        assert(data_ != nullptr);
+        assert(size_ > 0);
+    }
+
+    /** Returns the number of bytes in the storage.
+
+        This will never be zero.
+    */
+    std::size_t
+    size() const noexcept
+    {
+        return size_;
+    }
+
+    /** Return a pointer to beginning of the storage.
+        @note The return type is guaranteed to be a pointer
+              to a single byte, to facilitate pointer arithmetic.
+    */
+    std::uint8_t const*
+    data() const noexcept
+    {
+        return data_;
+    }
+};
+
+template <class Hasher>
+inline
+void
+hash_append (Hasher& h, Slice const& v)
+{
+    h.append(v.data(), v.size());
+}
+
+inline
+bool
+operator== (Slice const& lhs, Slice const& rhs) noexcept
+{
+    return lhs.size() == rhs.size() &&
+        std::memcmp(
+            lhs.data(), rhs.data(), lhs.size()) == 0;
+}
+
+inline
+bool
+operator< (Slice const& lhs, Slice const& rhs) noexcept
+{
+    return std::lexicographical_compare(
+        lhs.data(), lhs.data() + lhs.size(),
+            rhs.data(), rhs.data() + rhs.size());
+}
+
+} // ripple
+
+#endif

--- a/src/ripple/protocol/AnyPublicKey.h
+++ b/src/ripple/protocol/AnyPublicKey.h
@@ -1,0 +1,185 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_ANYPUBLICKEY_H_INCLUDED
+#define RIPPLE_PROTOCOL_ANYPUBLICKEY_H_INCLUDED
+
+#include <ripple/basics/Buffer.h>
+#include <ripple/protocol/HashPrefix.h>
+#include <ripple/protocol/STExchange.h>
+#include <ripple/protocol/STObject.h>
+#include <beast/hash/hash_append.h>
+#include <beast/utility/noexcept.h>
+#include <boost/utility/base_from_member.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace ripple {
+
+enum class KeyType
+{
+    unknown,
+    secp256k1,
+    ed25519
+};
+
+//------------------------------------------------------------------------------
+
+/** Variant container for all public keys. */
+class AnyPublicKeySlice
+    : public Slice
+{
+public:
+#ifdef _MSC_VER
+    AnyPublicKeySlice (
+            void const* data, std::size_t size)
+        : Slice (data, size)
+    {
+    }
+#else
+    using Slice::Slice;
+#endif
+
+    AnyPublicKeySlice() = delete;
+
+    AnyPublicKeySlice (
+        AnyPublicKeySlice const&) = default;
+
+    AnyPublicKeySlice& operator= (
+        AnyPublicKeySlice const&) = default;
+
+    /** Returns the type of key stored. */
+    KeyType
+    type() const noexcept;
+
+    /** Verify a signature using this public key. */
+    bool
+    verify (void const* msg, std::size_t msg_size,
+        void const* sig, std::size_t sig_size) const;
+};
+
+template <>
+struct STExchange<STBlob, AnyPublicKeySlice>
+{
+    using value_type = AnyPublicKeySlice;
+
+    static
+    void
+    get (boost::optional<value_type>& t,
+        STBlob const& u)
+    {
+        t = boost::in_place(u.data(), u.size());
+    }
+
+    static
+    std::unique_ptr<STBlob>
+    set (SField const& f, AnyPublicKeySlice const& t)
+    {
+        return std::make_unique<STBlob>(
+            f, t.data(), t.size());
+    }
+};
+
+//------------------------------------------------------------------------------
+
+/** Variant container for all public keys, with ownership. */
+class AnyPublicKey
+    : private boost::base_from_member<Buffer>
+    , public AnyPublicKeySlice
+{
+private:
+    using buffer_type = boost::base_from_member<Buffer>;
+
+public:
+    AnyPublicKey() = delete;
+    AnyPublicKey (AnyPublicKey const&) = delete;
+    AnyPublicKey& operator= (AnyPublicKey const&) = delete;
+
+#ifdef _MSC_VER
+    AnyPublicKey (AnyPublicKey&& other)
+        : buffer_type(std::move(other.buffer_type::member))
+        , AnyPublicKeySlice (buffer_type::member.data(),
+            buffer_type::member.size())
+    {
+    }
+
+    AnyPublicKey& operator= (AnyPublicKey&& other)
+    {
+        buffer_type::member =
+            std::move(other.buffer_type::member);
+        return *this;
+    }
+#else
+    AnyPublicKey (AnyPublicKey&&) = default;
+    AnyPublicKey& operator= (AnyPublicKey&&) = default;
+#endif
+
+    AnyPublicKey (void const* data_, std::size_t size_)
+        : buffer_type (data_, size_)
+        , AnyPublicKeySlice (
+            member.data(), member.size())
+    {
+    }
+
+    /** Returns ownership of the underlying Buffer.
+        After calling this function, only the destructor
+        or the move assignment operator may be called.
+    */
+    Buffer
+    releaseBuffer() noexcept
+    {
+        return std::move(buffer_type::member);
+    }
+};
+
+template <>
+struct STExchange<STBlob, AnyPublicKey>
+{
+    using value_type = AnyPublicKey;
+
+    static
+    void
+    get (boost::optional<value_type>& t,
+        STBlob const& u)
+    {
+        t = boost::in_place(u.data(), u.size());
+    }
+
+    static
+    std::unique_ptr<STBlob>
+    set (SField const& f, AnyPublicKey const& t)
+    {
+        return std::make_unique<STBlob>(
+            f, t.data(), t.size());
+    }
+
+    static
+    std::unique_ptr<STBlob>
+    set (SField const& f, AnyPublicKey&& t)
+    {
+        return std::make_unique<STBlob>(
+            f, t.releaseBuffer());
+    }
+};
+
+} // ripple
+
+#endif

--- a/src/ripple/protocol/AnySecretKey.h
+++ b/src/ripple/protocol/AnySecretKey.h
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_ANYSECRETKEY_H_INCLUDED
+#define RIPPLE_PROTOCOL_ANYSECRETKEY_H_INCLUDED
+
+#include <ripple/basics/Buffer.h>
+#include <ripple/protocol/AnyPublicKey.h>
+#include <ripple/protocol/HashPrefix.h>
+#include <boost/utility/base_from_member.hpp>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+namespace ripple {
+
+/** Variant container for secret key, with ownership. */
+class AnySecretKey
+{
+private:
+    Buffer p_;
+    KeyType type_;
+
+public:
+    AnySecretKey() = delete;
+    AnySecretKey (AnySecretKey const&) = delete;
+    AnySecretKey& operator= (AnySecretKey const&) = delete;
+
+    /** Destroy the key.
+        The memory area is secure erased.
+    */
+    ~AnySecretKey();
+
+    AnySecretKey (AnySecretKey&& other);
+
+    AnySecretKey& operator= (AnySecretKey&& other);
+
+    AnySecretKey (KeyType type,
+        void const* data, std::size_t size);
+
+    /** Returns the type of secret key. */
+    KeyType
+    type() const noexcept
+    {
+        return type_;
+    }
+
+    /** Returns the corresponding public key. */
+    AnyPublicKey
+    publicKey() const;
+
+    /** Create a signature for the given message. */
+    Buffer
+    sign (void const* msg, std::size_t msg_len) const;
+
+    /** Securely generate a new ed25519 secret key. */
+    static
+    AnySecretKey
+    make_ed25519();
+
+    /** Securely generate a new secp256k1 key pair. */
+    static
+    std::pair<AnySecretKey, AnyPublicKey>
+    make_secp256k1_pair();
+};
+
+} // ripple
+
+#endif

--- a/src/ripple/protocol/RippleAddress.h
+++ b/src/ripple/protocol/RippleAddress.h
@@ -25,6 +25,7 @@
 #include <ripple/protocol/RipplePublicKey.h>
 #include <ripple/protocol/UInt160.h>
 #include <ripple/protocol/UintTypes.h>
+#include <beast/utility/noexcept.h>
 
 namespace ripple {
 
@@ -52,6 +53,18 @@ private:
 
 public:
     RippleAddress ();
+
+    void const*
+    data() const noexcept
+    {
+        return vchData.data();
+    }
+
+    std::size_t
+    size() const noexcept
+    {
+        return vchData.size();
+    }
 
     // For public and private key, checks if they are legal.
     bool isValid () const

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -22,8 +22,15 @@
 
 #include <ripple/basics/BasicTypes.h>
 #include <ripple/json/json_value.h>
+#include <cstdint>
+#include <utility>
 
 namespace ripple {
+
+// Forwards
+class STBlob;
+template <class>
+class STInteger;
 
 enum SerializedTypeID
 {
@@ -139,7 +146,7 @@ public:
     {}
 #endif
 
-private:
+protected:
     // These constructors can only be called from FieldNames.cpp
     SField (SerializedTypeID tid, int fv, const char* fn,
             int meta = sMD_Default, bool signing = true);
@@ -253,6 +260,25 @@ private:
     static int num;
 };
 
+/** A field with a type known at compile time. */
+template <class T>
+struct TypedField : SField
+{
+    using type = T;
+
+    template <class... Args>
+    explicit
+    TypedField (Args&&... args)
+        : SField(std::forward<Args>(args)...)
+    {
+    }
+
+    TypedField (TypedField&& u)
+        : SField(std::move(u))
+    {
+    }
+};
+
 extern SField const sfInvalid;
 extern SField const sfGeneric;
 extern SField const sfLedgerEntry;
@@ -272,7 +298,7 @@ extern SField const sfTransactionType;
 // 32-bit integers (common)
 extern SField const sfFlags;
 extern SField const sfSourceTag;
-extern SField const sfSequence;
+extern TypedField<STInteger<std::uint32_t>> const sfSequence;
 extern SField const sfPreviousTxnLgrSeq;
 extern SField const sfLedgerSequence;
 extern SField const sfCloseTime;
@@ -359,12 +385,12 @@ extern SField const sfRippleEscrow;
 extern SField const sfDeliveredAmount;
 
 // variable length
-extern SField const sfPublicKey;
+extern TypedField<STBlob> const sfPublicKey;
 extern SField const sfMessageKey;
-extern SField const sfSigningPubKey;
+extern TypedField<STBlob> const sfSigningPubKey;
 extern SField const sfTxnSignature;
 extern SField const sfGenerator;
-extern SField const sfSignature;
+extern TypedField<STBlob> const sfSignature;
 extern SField const sfDomain;
 extern SField const sfFundCode;
 extern SField const sfRemoveCode;
@@ -412,6 +438,8 @@ extern SField const sfNecessary;
 extern SField const sfSufficient;
 extern SField const sfAffectedNodes;
 extern SField const sfMemos;
+
+//------------------------------------------------------------------------------
 
 } // ripple
 

--- a/src/ripple/protocol/STExchange.h
+++ b/src/ripple/protocol/STExchange.h
@@ -1,0 +1,202 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_STEXCHANGE_H_INCLUDED
+#define RIPPLE_PROTOCOL_STEXCHANGE_H_INCLUDED
+
+#include <ripple/basics/Buffer.h>
+#include <ripple/basics/Slice.h>
+#include <ripple/protocol/SField.h>
+#include <ripple/protocol/STBlob.h>
+#include <ripple/protocol/STInteger.h>
+#include <ripple/protocol/STObject.h>
+#include <ripple/basics/Blob.h>
+#include <boost/optional.hpp>
+#include <beast/cxx14/memory.h> // <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+namespace ripple {
+
+/** Convert between serialized type U and C++ type T. */
+template <class U, class T>
+struct STExchange;
+
+
+template <class U, class T>
+struct STExchange<STInteger<U>, T>
+{
+    using value_type = U;
+
+    static
+    void
+    get (boost::optional<T>& t,
+        STInteger<U> const& u)
+    {
+        t = u.getValue();
+    }
+
+    static
+    std::unique_ptr<STInteger<U>>
+    set (SField const& f, T const& t)
+    {
+        return std::make_unique<
+            STInteger<U>>(f, t);
+    }
+};
+
+template <>
+struct STExchange<STBlob, Slice>
+{
+    using value_type = Slice;
+
+    static
+    void
+    get (boost::optional<value_type>& t,
+        STBlob const& u)
+    {
+        t = boost::in_place(u.data(), u.size());
+    }
+
+    static
+    std::unique_ptr<STBlob>
+    set (TypedField<STBlob> const& f,
+        Slice const& t)
+    {
+        return std::make_unique<STBlob>(
+            f, t.data(), t.size());
+    }
+};
+
+template <>
+struct STExchange<STBlob, Buffer>
+{
+    using value_type = Buffer;
+
+    static
+    void
+    get (boost::optional<Buffer>& t,
+        STBlob const& u)
+    {
+        t = boost::in_place(
+            u.data(), u.size());
+    }
+
+    static
+    std::unique_ptr<STBlob>
+    set (TypedField<STBlob> const& f,
+        Buffer const& t)
+    {
+        return std::make_unique<STBlob>(
+            f, t.data(), t.size());
+    }
+
+    static
+    std::unique_ptr<STBlob>
+    set (TypedField<STBlob> const& f,
+        Buffer&& t)
+    {
+        return std::make_unique<STBlob>(
+            f, std::move(t));
+    }
+};
+
+//------------------------------------------------------------------------------
+
+/** Return the value of a field in an STObject as a given type. */
+/** @{ */
+template <class T, class U>
+boost::optional<T>
+get (STObject const& st,
+    TypedField<U> const& f)
+{
+    boost::optional<T> t;
+    STBase const* const b =
+        st.peekAtPField(f);
+    if (! b)
+        return t;
+    auto const id = b->getSType();
+    if (id == STI_NOTPRESENT)
+        return t;
+    auto const u =
+        dynamic_cast<U const*>(b);
+    // This should never happen
+    if (! u)
+        throw std::runtime_error (
+            "Wrong field type");
+    STExchange<U, T>::get(t, *u);
+    return t;
+}
+
+template <class U>
+boost::optional<typename STExchange<
+    U, typename U::value_type>::value_type>
+get (STObject const& st,
+    TypedField<U> const& f)
+{
+    return get<typename U::value_type>(st, f);
+}
+/** @} */
+
+/** Set a field value in an STObject. */
+template <class U, class T>
+void
+set (STObject& st,
+    TypedField<U> const& f, T&& t)
+{
+    st.set(STExchange<U,
+        typename std::decay<T>::type>::set(
+            f, std::forward<T>(t)));
+}
+
+/** Set a blob field using an init function. */
+template <class Init>
+void
+set (STObject& st,
+    TypedField<STBlob> const& f,
+        std::size_t size, Init&& init)
+{
+    st.set(std::make_unique<STBlob>(
+        f, size, init));
+}
+
+/** Set a blob field from data. */
+template <class = void>
+void
+set (STObject& st,
+    TypedField<STBlob> const& f,
+        void const* data, std::size_t size)
+{
+    st.set(std::make_unique<STBlob>(
+        f, data, size));
+}
+
+/** Remove a field in an STObject. */
+template <class U>
+void
+erase (STObject& st,
+    TypedField<U> const& f)
+{
+    st.makeFieldAbsent(f);
+}
+
+} // ripple
+
+#endif

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -29,6 +29,8 @@ class STInteger
     : public STBase
 {
 public:
+    using value_type = Integer;
+
     explicit
     STInteger (Integer v) 
         : value_ (v)

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -221,6 +221,12 @@ public:
     const STVector256& getFieldV256 (SField::ref field) const;
     const STArray& getFieldArray (SField::ref field) const;
 
+    /** Set a field.
+        if the field already exists, it is replaced.
+    */
+    void
+    set (std::unique_ptr<STBase> v);
+
     void setFieldU8 (SField::ref field, unsigned char);
     void setFieldU16 (SField::ref field, std::uint16_t);
     void setFieldU32 (SField::ref field, std::uint32_t);
@@ -419,8 +425,8 @@ private:
     }
 
 private:
-    boost::ptr_vector<STBase>   mData;
-    const SOTemplate*                   mType;
+    boost::ptr_vector<STBase> mData;
+    const SOTemplate* mType;
 };
 
 } // ripple

--- a/src/ripple/protocol/Serializer.h
+++ b/src/ripple/protocol/Serializer.h
@@ -63,6 +63,18 @@ public:
         ;
     }
 
+    std::size_t
+    size() const noexcept
+    {
+        return mData.size();
+    }
+
+    void const*
+    data() const noexcept
+    {
+        return mData.data();
+    }
+
     // assemble functions
     int add8 (unsigned char byte);
     int add16 (std::uint16_t);
@@ -238,10 +250,6 @@ public:
     Blob ::const_iterator end () const
     {
         return mData.end ();
-    }
-    Blob ::size_type size () const
-    {
-        return mData.size ();
     }
     void reserve (size_t n)
     {

--- a/src/ripple/protocol/Sign.h
+++ b/src/ripple/protocol/Sign.h
@@ -1,0 +1,50 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_SIGN_H_INCLUDED
+#define RIPPLE_PROTOCOL_SIGN_H_INCLUDED
+
+#include <ripple/protocol/AnyPublicKey.h>
+#include <ripple/protocol/AnySecretKey.h>
+#include <ripple/protocol/HashPrefix.h>
+#include <ripple/protocol/STObject.h>
+#include <utility>
+
+namespace ripple {
+
+/** Sign a STObject using any secret key.
+    The signature is placed in sfSignature. If
+    a signature already exists, it is overwritten.
+*/
+void
+sign (STObject& st,
+    HashPrefix const& prefix,
+        AnySecretKey const& sk);
+
+/** Verify the signature on a STObject.
+    The signature must be contained in sfSignature.
+*/
+bool
+verify (STObject const& st,
+    HashPrefix const& prefix,
+        AnyPublicKeySlice const& pk);
+
+} // ripple
+
+#endif

--- a/src/ripple/protocol/impl/AnyPublicKey.cpp
+++ b/src/ripple/protocol/impl/AnyPublicKey.cpp
@@ -1,0 +1,93 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/AnyPublicKey.h>
+#include <ripple/protocol/Serializer.h>
+#include <ripple/protocol/STExchange.h>
+#include <ed25519-donna/ed25519.h>
+#include <cassert>
+
+namespace ripple {
+
+/** Verify a secp256k1 signature. */
+bool
+verify_secp256k1 (void const* pk,
+    void const* msg, std::size_t msg_size,
+    void const* sig, std::size_t sig_size)
+{
+    return false;
+}
+
+bool
+verify_ed25519 (void const* pk,
+    void const* msg, std::size_t msg_size,
+    void const* sig, std::size_t sig_size)
+{
+    if (sig_size != 64)
+        return false;
+    ed25519_public_key epk;
+    ed25519_signature es;
+    std::memcpy(epk, pk, 32);
+    std::memcpy(es, sig, sig_size);
+    return ed25519_sign_open(
+        reinterpret_cast<unsigned char const*>(msg),
+            msg_size, epk, es) == 0;
+}
+
+//------------------------------------------------------------------------------
+
+KeyType
+AnyPublicKeySlice::type() const noexcept
+{
+    auto const pk = data();
+    auto const pk_size = size();
+
+    if (pk_size < 1)
+        return KeyType::unknown;
+    auto const len = pk_size - 1;
+    if (len == 32 &&
+            pk[0] == 0xED)
+        return KeyType::ed25519;
+    if (len == 33 &&
+            (pk[0] == 0x02 || pk[0] == 0x03))
+        return KeyType::secp256k1;
+    return KeyType::unknown;
+}
+
+bool
+AnyPublicKeySlice::verify (
+    void const* msg, std::size_t msg_size,
+    void const* sig, std::size_t sig_size) const
+{
+    switch(type())
+    {
+    case KeyType::ed25519:
+        return verify_ed25519(data() + 1,
+            msg, msg_size, sig, sig_size);
+    case KeyType::secp256k1:
+        return verify_secp256k1(data() + 1,
+            msg, msg_size, sig, sig_size);
+    default:
+        break;
+    }
+    // throw?
+    return false;
+}
+
+} // ripple

--- a/src/ripple/protocol/impl/AnySecretKey.cpp
+++ b/src/ripple/protocol/impl/AnySecretKey.cpp
@@ -1,0 +1,143 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/AnySecretKey.h>
+#include <ripple/protocol/RippleAddress.h>
+#include <ripple/protocol/Serializer.h>
+#include <ripple/crypto/RandomNumbers.h>
+#include <ed25519-donna/ed25519.h>
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+namespace ripple {
+
+AnySecretKey::~AnySecretKey()
+{
+    // secure erase
+    std::fill(p_.data(), p_.data() + p_.size(), 0);
+}
+
+AnySecretKey::AnySecretKey (AnySecretKey&& other)
+    : p_ (std::move(other.p_))
+    , type_ (other.type_)
+{
+    other.type_ = KeyType::unknown;
+}
+
+AnySecretKey&
+AnySecretKey::operator= (AnySecretKey&& other)
+{
+    p_ = std::move(other.p_);
+    type_ = other.type_;
+    other.type_ = KeyType::unknown;
+    return *this;
+}
+
+AnySecretKey::AnySecretKey (KeyType type,
+        void const* data, std::size_t size)
+    : p_ (data, size)
+    , type_ (type)
+{
+    if (type_ == KeyType::unknown)
+        throw std::runtime_error(
+            "AnySecretKey: unknown type");
+    if (type_ == KeyType::ed25519 &&
+            size != 32)
+        throw std::runtime_error(
+            "AnySecretKey: wrong ed25519 size");
+    if (type_ == KeyType::secp256k1 &&
+            size != 32)
+        throw std::runtime_error(
+            "AnySecretKey: wrong secp256k1 size");
+}
+
+AnyPublicKey
+AnySecretKey::publicKey() const
+{
+    switch (type())
+    {
+    case KeyType::ed25519:
+    {
+        unsigned char buf[33];
+        buf[0] = 0xED;
+        ed25519_publickey(p_.data() + 1, &buf[1]);
+        return AnyPublicKey(buf, sizeof(buf));
+    }
+    default:
+        throw std::runtime_error(
+            "AnySecretKey: unknown type");
+    };
+}
+
+Buffer
+AnySecretKey::sign (
+    void const* msg, std::size_t msg_len) const
+{
+    switch(type_)
+    {
+        case KeyType::ed25519:
+        {
+            auto const sk = p_.data() + 1;
+            ed25519_public_key pk;
+            ed25519_publickey(sk, pk);
+            Buffer b(64);
+            ed25519_sign(reinterpret_cast<
+                unsigned char const*>(msg), msg_len,
+                    sk, pk, b.data());
+            return b;
+        }
+        default:
+            break;
+    }
+    throw std::runtime_error(
+        "AnySecretKey: unknown type");
+}
+
+AnySecretKey
+AnySecretKey::make_ed25519()
+{
+    std::uint8_t buf[32];
+    random_fill(&buf[0], sizeof(buf));
+    AnySecretKey ask(KeyType::ed25519,
+        buf, sizeof(buf));
+    // secure erase
+    std::fill(buf, buf + sizeof(buf), 0);
+    return ask;
+}
+
+std::pair<AnySecretKey, AnyPublicKey>
+AnySecretKey::make_secp256k1_pair()
+{
+    // VFALCO What a pile
+    RippleAddress s;
+    s.setSeedRandom();
+    RippleAddress const g =
+        RippleAddress::createGeneratorPublic(s);
+    RippleAddress sk;
+    sk.setAccountPrivate (g, s, 0);
+    RippleAddress pk;
+    pk.setAccountPublic (g, 0);
+    return std::pair<AnySecretKey, AnyPublicKey>(
+        std::piecewise_construct, std::make_tuple(
+            KeyType::secp256k1, sk.data(), sk.size()),
+                std::make_tuple(pk.data(), pk.size()));
+}
+
+} // ripple

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -762,6 +762,24 @@ const STVector256& STObject::getFieldV256 (SField::ref field) const
     return getFieldByConstRef <STVector256> (field, empty);
 }
 
+void
+STObject::set (std::unique_ptr<STBase> v)
+{
+    auto const i =
+        getFieldIndex(v->getFName());
+    if (i != -1)
+    {
+        mData.replace(i, v.release());
+    }
+    else
+    {
+        if (! isFree())
+            throw std::runtime_error(
+                "missing field in templated STObject");
+        mData.push_back(v.release());
+    }
+}
+
 void STObject::setFieldU8 (SField::ref field, unsigned char v)
 {
     setFieldUsingSetValue <STUInt8> (field, v);

--- a/src/ripple/protocol/impl/Sign.cpp
+++ b/src/ripple/protocol/impl/Sign.cpp
@@ -1,0 +1,51 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/Sign.h>
+
+namespace ripple {
+
+void
+sign (STObject& st, HashPrefix const& prefix,
+    AnySecretKey const& sk)
+{
+    Serializer ss;
+    ss.add32(prefix);
+    st.add(ss, false);
+    set(st, sfSignature,
+        sk.sign(ss.data(), ss.size()));
+}
+
+bool
+verify (STObject const& st,
+    HashPrefix const& prefix,
+        AnyPublicKeySlice const& pk)
+{
+    auto const sig = get(st, sfSignature);
+    if (! sig)
+        return false;
+    Serializer ss;
+    ss.add32(prefix);
+    st.add(ss, false);
+    return pk.verify(
+        ss.data(), ss.size(),
+            sig->data(), sig->size());
+}
+
+} // ripple

--- a/src/ripple/unity/protocol.cpp
+++ b/src/ripple/unity/protocol.cpp
@@ -19,6 +19,8 @@
 
 #include <BeastConfig.h>
 
+#include <ripple/protocol/impl/AnyPublicKey.cpp>
+#include <ripple/protocol/impl/AnySecretKey.cpp>
 #include <ripple/protocol/impl/BuildInfo.cpp>
 #include <ripple/protocol/impl/ByteOrder.cpp>
 #include <ripple/protocol/impl/ErrorCodes.cpp>


### PR DESCRIPTION
This introduces functions get and set, and a family of specialized structs called `STExchange`. These interfaces allow efficient and seamless interchange between serialized object fields and user defined types, especially variable length objects. 

A new base class template `TypedField` is mixed into existing `SField` declarations to encode information on the field, allowing template metaprograms to both customize interchange based on the type and detect misuse at compile-time.

New types `AnyPublicKey` and `AnySecretKey` are introduced. These are intended to replace the corresponding functionality in the deprecated class `RippleAddress`. Specializations of `STExchange` for these types are provided to allow interchange. New free functions verify and sign allow signature verification and signature generation for serialized objects.

* Add `Buffer` and `Slice` primitives
* Add `TypedField` and modify some `SField`
* Add `STExchange` and specializations for `STBlob` and `STInteger`
* Improve `STBlob` and `STInteger` to support `STExchange`
* Expose raw data in `RippleAddress` and `Serializer`
