### PR TITLE
Fix specified destination issuer in pathfinding (RIPD-812)

### DIFF
--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -176,6 +176,7 @@ private:
 
     Account mSrcAccount;
     Account mDstAccount;
+    Account mEffectiveDst; // The account the paths need to end at
     STAmount mDstAmount;
     Currency mSrcCurrency;
     boost::optional<Account> mSrcIssuer;


### PR DESCRIPTION
* Compute the effective recipient.
* Make sure the effective recipient exists.
* Prohibit paths to the recipient, if not the effective recipient.
* Treat paths to the effective recipient as complete.
* Don't find looped paths.
* Use the effective recipient for getPathsOut weight.