### PR TITLE
Decipher ASIO SSL error codes to be human readable

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -135,6 +135,11 @@
     </ClCompile>
     <ClInclude Include="..\..\src\beast\beast\asio\bind_handler.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\beast\beast\asio\error.h">
+    </ClInclude>
+    <ClCompile Include="..\..\src\beast\beast\asio\impl\error.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\beast\beast\asio\impl\IPAddressConversion.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
@@ -144,13 +149,14 @@
     </ClInclude>
     <ClInclude Include="..\..\src\beast\beast\asio\placeholders.h">
     </ClInclude>
-    <ClInclude Include="..\..\src\beast\beast\asio\ssl.h">
-    </ClInclude>
     <ClInclude Include="..\..\src\beast\beast\asio\ssl_bundle.h">
     </ClInclude>
     <ClInclude Include="..\..\src\beast\beast\asio\streambuf.h">
     </ClInclude>
     <ClCompile Include="..\..\src\beast\beast\asio\tests\bind_handler.test.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\beast\beast\asio\tests\error_test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\beast\beast\asio\tests\streambuf.test.cpp">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -591,6 +591,12 @@
     <ClInclude Include="..\..\src\beast\beast\asio\bind_handler.h">
       <Filter>beast\asio</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\beast\beast\asio\error.h">
+      <Filter>beast\asio</Filter>
+    </ClInclude>
+    <ClCompile Include="..\..\src\beast\beast\asio\impl\error.cpp">
+      <Filter>beast\asio\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\beast\beast\asio\impl\IPAddressConversion.cpp">
       <Filter>beast\asio\impl</Filter>
     </ClCompile>
@@ -603,9 +609,6 @@
     <ClInclude Include="..\..\src\beast\beast\asio\placeholders.h">
       <Filter>beast\asio</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\beast\beast\asio\ssl.h">
-      <Filter>beast\asio</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\beast\beast\asio\ssl_bundle.h">
       <Filter>beast\asio</Filter>
     </ClInclude>
@@ -613,6 +616,9 @@
       <Filter>beast\asio</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\beast\beast\asio\tests\bind_handler.test.cpp">
+      <Filter>beast\asio\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\beast\beast\asio\tests\error_test.cpp">
       <Filter>beast\asio\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\beast\beast\asio\tests\streambuf.test.cpp">

--- a/src/beast/beast/asio/error.h
+++ b/src/beast/beast/asio/error.h
@@ -17,11 +17,11 @@
 */
 //==============================================================================
 
-#ifndef BEAST_ASIO_SSL_H_INCLUDED
-#define BEAST_ASIO_SSL_H_INCLUDED
+#ifndef BEAST_ASIO_ERROR_H_INCLUDED
+#define BEAST_ASIO_ERROR_H_INCLUDED
 
+#include <boost/asio.hpp>
 #include <boost/asio/ssl/error.hpp>
-#include <boost/system/error_code.hpp>
 
 namespace beast {
 namespace asio {
@@ -32,8 +32,12 @@ bool
 is_short_read (boost::system::error_code const& ec)
 {
     return (ec.category() == boost::asio::error::get_ssl_category())
-         && (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ);
+        && (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ);
 }
+    
+/** Returns a human readable message if the error code is SSL related. */
+std::string
+asio_message(boost::system::error_code const& ec);
 
 }
 }

--- a/src/beast/beast/asio/tests/error_test.cpp
+++ b/src/beast/beast/asio/tests/error_test.cpp
@@ -17,13 +17,28 @@
 */
 //==============================================================================
 
-#if BEAST_INCLUDE_BEASTCONFIG
-#include <BeastConfig.h>
-#endif
+#include <beast/asio/error.h>
+#include <beast/unit_test/suite.h>
+#include <string>
 
-#include <beast/asio/impl/IPAddressConversion.cpp>
-#include <beast/asio/impl/error.cpp>
-#include <beast/asio/tests/bind_handler.test.cpp>
-#include <beast/asio/tests/streambuf.test.cpp>
-#include <beast/asio/tests/error_test.cpp>
+namespace beast {
+namespace asio {
 
+class error_test : public unit_test::suite
+{
+public:
+    void run ()
+    {        
+        {
+            boost::system::error_code ec = boost::system::error_code (335544539,
+                boost::asio::error::get_ssl_category ());
+            std::string const s = beast::asio::asio_message (ec);
+            expect(s == " (20,0,219) error:140000DB:SSL routines:SSL routines:short read");
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(error,asio,beast);
+
+}
+}

--- a/src/ripple/server/impl/Peer.h
+++ b/src/ripple/server/impl/Peer.h
@@ -25,7 +25,7 @@
 #include <ripple/server/impl/ServerImpl.h>
 #include <beast/asio/IPAddressConversion.h>
 #include <beast/asio/placeholders.h>
-#include <beast/asio/ssl.h> // for is_short_read?
+#include <beast/asio/error.h> // for is_short_read?
 #include <beast/http/message.h>
 #include <beast/http/parser.h>
 #include <beast/module/core/time/Time.h>


### PR DESCRIPTION
* Renamed beast::asio::ssl.h to beast::asio:error.h
* Added a new function, that returns a human readable message from an SSL error code
* Created a unit test for the short read (335544539) SSL error

Reviewers: @rec @vinniefalco 