### PR TITLE
Build and run tests on all available build types

### DIFF
--- a/Builds/test-all.sh
+++ b/Builds/test-all.sh
@@ -1,6 +1,6 @@
-#/bin/bash
+#/bin/sh
 
-# Invoke as "bash ./Builds/test-all.sh"
+# Invoke as "sh ./Builds/test-all.sh"
 # or first make it executable ("chmod a+rx ./Builds/test-all.sh)
 #   then invoke as "./Builds/test-all.sh"
 #

--- a/Builds/test-all.sh
+++ b/Builds/test-all.sh
@@ -1,0 +1,38 @@
+#/bin/bash
+
+# Invoke as "bash ./Builds/test-all.sh"
+# or first make it executable ("chmod a+rx ./Builds/test-all.sh)
+#   then invoke as "./Builds/test-all.sh"
+#
+# Build must succeed without shell aliases for this to work. 
+
+BUILD="debug release all" 
+success=""
+scons ${BUILD}  && \
+  for dir in ./build/*
+  do
+    if [ ! -x ${dir}/rippled ]
+    then
+      echo -e "\n\n\n${dir} is not a build dir\n\n\n"
+      continue
+    fi
+    RUN=$( basename ${dir} )
+    echo -e "\n\n\nTesting ${RUN}\n\n\n"
+    RIPPLED=./build/${RUN}/rippled 
+    LOG=unittest.${RUN}.log
+    ${RIPPLED} --unittest | tee ${LOG} && \
+      grep -q "0 failures" ${LOG} && \
+        npm test --rippled=${RIPPLED} \
+          || break
+    success="${success} ${RUN}"
+    RUN=
+  done
+
+if [ -n "${RUN}" ]
+then
+  echo "Failed on ${RUN}" 
+fi
+if [ -n "${success}" ]
+then
+  echo "Success on ${success}"
+fi


### PR DESCRIPTION
* Tests include unit and integration (npm)

Requests scons to build as many types as it can ("debug release all"), then iterates over the scons output folders, running tests on any `rippled`s it finds there. Aborts on the first failure.