### PR TITLE
Trivial: Get rid of compilation warning.

### DIFF
--- a/src/ripple/crypto/impl/openssl.cpp
+++ b/src/ripple/crypto/impl/openssl.cpp
@@ -148,6 +148,7 @@ void serialize_ec_point (ec_point const& point, std::uint8_t* ptr)
     int const size = i2o_ECPublicKey ((EC_KEY*) key.get(), &ptr);
 
     assert (size <= 33);
+    (void) size;
 }
 
 } // openssl


### PR DESCRIPTION
Replaces https://github.com/ripple/rippled/pull/892

Reviewers: @josh-ripple @HowardHinnant

You already passed exactly this commit ID.  :-) So I'm premarking it approved. 