### PR TITLE
Trivial: Require boost 1.57

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -465,8 +465,8 @@ int main (int argc, char** argv)
         "GCC version 4.8.1 or later is required to compile rippled.");
 #endif
 
-    static_assert (BOOST_VERSION >= 105500,
-        "Boost version 1.55 or later is required to compile rippled");
+    static_assert (BOOST_VERSION >= 105700,
+        "Boost version 1.57 or later is required to compile rippled");
 
     //
     // These debug heap calls do nothing in release or non Visual Studio builds.


### PR DESCRIPTION
Update assert in main.cpp to require boost version 1.57

Reviewers: @HowardHinnant @nbougalis 