### PR TITLE
Return a validated ledger if there is one (RIPD-814)

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -1448,6 +1448,28 @@ public:
 
     Ledger::pointer getLedgerBySeq (std::uint32_t index)
     {
+        if (index <= mValidLedgerSeq)
+        {
+            // Always prefer a validated ledger
+            auto valid = mValidLedger.get ();
+            if (valid)
+            {
+                if (valid->getLedgerSeq() == index)
+                    return valid;
+
+                try
+                {
+                    uint256 const& hash = valid->getLedgerHash (index);
+                    if (hash.isNonZero())
+                        return mLedgerHistory.getLedgerByHash (hash);
+                }
+                catch (...)
+                {
+                    // Missing nodes are already handled
+                }
+            }
+        }
+
         Ledger::pointer ret = mLedgerHistory.getLedgerBySeq (index);
         if (ret)
             return ret;


### PR DESCRIPTION
LedgerMaster::getLedgerBySeq should return a validated ledger (rather than the the open or closed ledger) for a sequence number for which it has a fully-validated ledger. This avoids surprising results from lookupLedger. This will require a bit of testing as there could be other callers that expect to get the open or closed ledger. (I've audited them all, and it seems to me that they all prefer a validated ledger.)