### PR TITLE
Builds/test-only.sh will build and test by scons target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ My Amplifier XE Results - RippleD
 
 # Build Log
 rippled-build.log
+
+# Profiling data
+gmon.out


### PR DESCRIPTION
* test-all.sh simplified to call test-only.sh.
* Script fails if build or tests fail. Allows chaining and git bisect run.
* Add copyright notice
* Ignore gprof performance data created by testing the profile builds.

Followup to #889. "All" is useful, but takes too long for development and casual testing. Now you can get any level of granularity you want.

...And, yes, it's still `sh` for now.

Reviewers: @tdfischer @clark800 @rec 