### PR TITLE
Implement Ed25519 key generation and signatures

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2213,6 +2213,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\crypto\impl\KeyType.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\crypto\impl\openssl.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -2227,6 +2231,8 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\crypto\KeyType.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\crypto\RandomNumbers.h">
     </ClInclude>
     <None Include="..\..\src\ripple\crypto\README.md">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2970,6 +2970,9 @@
     <ClCompile Include="..\..\src\ripple\crypto\impl\GenerateDeterministicKey.cpp">
       <Filter>ripple\crypto\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\crypto\impl\KeyType.cpp">
+      <Filter>ripple\crypto\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\crypto\impl\openssl.cpp">
       <Filter>ripple\crypto\impl</Filter>
     </ClCompile>
@@ -2982,6 +2985,9 @@
     <ClCompile Include="..\..\src\ripple\crypto\impl\RFC1751.cpp">
       <Filter>ripple\crypto\impl</Filter>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\crypto\KeyType.h">
+      <Filter>ripple\crypto</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\crypto\RandomNumbers.h">
       <Filter>ripple\crypto</Filter>
     </ClInclude>

--- a/src/ripple/app/ledger/tests/Ledger_test.cpp
+++ b/src/ripple/app/ledger/tests/Ledger_test.cpp
@@ -24,24 +24,24 @@ namespace test {
 
 class Ledger_test : public beast::unit_test::suite
 {
-    void test_genesisLedger (bool sign)
+    void test_genesisLedger (bool sign, KeyType keyType)
     {
         std::uint64_t const xrp = std::mega::num;
 
-        auto master = createAccount ("masterpassphrase");
+        auto master = createAccount ("masterpassphrase", keyType);
 
         Ledger::pointer LCL = createGenesisLedger(100000*xrp, master);
 
         Ledger::pointer ledger = std::make_shared<Ledger>(false, *LCL);
 
         // User accounts
-        auto gw1 = createAccount ("gw1");
+        auto gw1 = createAccount ("gw1", keyType);
         expect (gw1.pk != master.pk, "gw1.pk != master.pk");
         expect (gw1.sk != master.sk, "gw1.sk != master.sk");
-        auto gw2 = createAccount ("gw2");
-        auto gw3 = createAccount ("gw3");
-        auto alice = createAccount ("alice");
-        auto mark = createAccount ("mark");
+        auto gw2 = createAccount ("gw2", keyType);
+        auto gw3 = createAccount ("gw3", keyType);
+        auto alice = createAccount ("alice", keyType);
+        auto mark = createAccount ("mark", keyType);
 
         // Fund gw1, gw2, gw3, alice, mark from master
         makeAndApplyPayment(master, gw1, 5000 * xrp, ledger, sign);
@@ -90,17 +90,17 @@ class Ledger_test : public beast::unit_test::suite
         pass ();
     }
 
-    void test_unsigned_fails ()
+    void test_unsigned_fails (KeyType keyType)
     {
         std::uint64_t const xrp = std::mega::num;
 
-        auto master = createAccount ("masterpassphrase");
+        auto master = createAccount ("masterpassphrase", keyType);
 
         Ledger::pointer LCL = createGenesisLedger (100000 * xrp, master);
 
         Ledger::pointer ledger = std::make_shared<Ledger> (false, *LCL);
 
-        auto gw1 = createAccount ("gw1");
+        auto gw1 = createAccount ("gw1", keyType);
 
         auto tx = getPaymentTx(master, gw1, 5000 * xrp, false);
 
@@ -129,16 +129,15 @@ class Ledger_test : public beast::unit_test::suite
 public:
     void run ()
     {
-        testcase ("genesisLedger signed transactions");
-        test_genesisLedger (true);
+        test_genesisLedger (true, KeyType::secp256k1);
+        test_genesisLedger (true, KeyType::ed25519);
 
-        testcase ("genesisLedger unsigned transactions");
-        test_genesisLedger (false);
+        test_genesisLedger (false, KeyType::secp256k1);
+        test_genesisLedger (false, KeyType::ed25519);
 
-        testcase ("unsigned invalid");
-        test_unsigned_fails ();
+        test_unsigned_fails (KeyType::secp256k1);
+        test_unsigned_fails (KeyType::ed25519);
 
-        testcase ("getQuality");
         test_getQuality ();
     }
 };

--- a/src/ripple/app/tests/common_ledger.cpp
+++ b/src/ripple/app/tests/common_ledger.cpp
@@ -18,6 +18,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //==============================================================================
 
 #include <ripple/app/tests/common_ledger.h>
+#include <ripple/protocol/RippleAddress.h>
 
 namespace ripple {
 namespace test {
@@ -90,16 +91,16 @@ createGenesisLedger(std::uint64_t start_amount_drops, TestAccount const& master)
 // Create an account represented by public RippleAddress and private
 // RippleAddress
 TestAccount
-createAccount(std::string const& passphrase)
+createAccount(std::string const& passphrase, KeyType keyType)
 {
     RippleAddress const seed
         = RippleAddress::createSeedGeneric(passphrase);
-    RippleAddress const generator
-        = RippleAddress::createGeneratorPublic(seed);
+
+    auto keyPair = generateKeysFromSeed(keyType, seed);
 
     return {
-        std::move(RippleAddress::createAccountPublic(generator, 0)),
-        std::move(RippleAddress::createAccountPrivate(generator, seed, 0)),
+        std::move(keyPair.publicKey),
+        std::move(keyPair.secretKey),
         std::uint64_t(0)
     };
 }

--- a/src/ripple/app/tests/common_ledger.h
+++ b/src/ripple/app/tests/common_ledger.h
@@ -26,6 +26,7 @@
 #include <ripple/app/misc/CanonicalTXSet.h>
 #include <ripple/app/transactors/Transactor.h>
 #include <ripple/basics/seconds_clock.h>
+#include <ripple/crypto/KeyType.h>
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/RippleAddress.h>
@@ -75,7 +76,7 @@ createGenesisLedger(std::uint64_t start_amount_drops, TestAccount const& master)
 // Create an account represented by public RippleAddress and private
 // RippleAddress
 TestAccount
-createAccount(std::string const& passphrase);
+createAccount(std::string const& passphrase, KeyType keyType);
 
 void
 freezeAccount(TestAccount& account, Ledger::pointer const& ledger, bool sign = true);

--- a/src/ripple/crypto/KeyType.h
+++ b/src/ripple/crypto/KeyType.h
@@ -17,18 +17,26 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_RPC_SIGNATUREKEYPAIR_H_INCLUDED
-#define RIPPLE_RPC_SIGNATUREKEYPAIR_H_INCLUDED
+#ifndef RIPPLE_CRYPTO_KEYTYPE_H_INCLUDED
+#define RIPPLE_CRYPTO_KEYTYPE_H_INCLUDED
 
-#include <ripple/json/json_reader.h>
-#include <ripple/protocol/RippleAddress.h>
+#include <string>
 
 namespace ripple {
-namespace RPC {
 
-KeyPair keypairForSignature (Json::Value const& params, Json::Value& error);
+enum class KeyType
+{
+    invalid = -1,
+    unknown = invalid,
 
-} // RPC
-} // ripple
+    secp256k1 = 0,
+    ed25519   = 1,
+};
+
+KeyType keyTypeFromString (std::string const& s);
+
+const char* to_string (KeyType type);
+
+}
 
 #endif

--- a/src/ripple/crypto/impl/KeyType.cpp
+++ b/src/ripple/crypto/impl/KeyType.cpp
@@ -17,18 +17,24 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_RPC_SIGNATUREKEYPAIR_H_INCLUDED
-#define RIPPLE_RPC_SIGNATUREKEYPAIR_H_INCLUDED
-
-#include <ripple/json/json_reader.h>
-#include <ripple/protocol/RippleAddress.h>
+#include <BeastConfig.h>
+#include <ripple/crypto/KeyType.h>
 
 namespace ripple {
-namespace RPC {
 
-KeyPair keypairForSignature (Json::Value const& params, Json::Value& error);
+KeyType keyTypeFromString (std::string const& s)
+{
+    if (s == "secp256k1")  return KeyType::secp256k1;
+    if (s == "ed25519"  )  return KeyType::ed25519;
 
-} // RPC
-} // ripple
+    return KeyType::invalid;
+}
 
-#endif
+const char* to_string (KeyType type)
+{
+    return   type == KeyType::secp256k1 ? "secp256k1"
+           : type == KeyType::ed25519   ? "ed25519"
+           :                              "INVALID";
+}
+
+}

--- a/src/ripple/protocol/AnyPublicKey.h
+++ b/src/ripple/protocol/AnyPublicKey.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_ANYPUBLICKEY_H_INCLUDED
 
 #include <ripple/basics/Buffer.h>
+#include <ripple/crypto/KeyType.h>
 #include <ripple/protocol/HashPrefix.h>
 #include <ripple/protocol/STExchange.h>
 #include <ripple/protocol/STObject.h>
@@ -33,15 +34,6 @@
 #include <utility>
 
 namespace ripple {
-
-enum class KeyType
-{
-    unknown,
-    secp256k1,
-    ed25519
-};
-
-//------------------------------------------------------------------------------
 
 /** Variant container for all public keys. */
 class AnyPublicKeySlice

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -177,6 +177,7 @@ JSS ( issuer );                     // in: RipplePathFind, Subscribe,
                                     //     Unsubscribe, BookOffers
                                     // out: paths/Node, STPathSet, STAmount
 JSS ( key );                        // out: WalletSeed
+JSS ( key_type );                   // in/out: WalletPropose, TransactionSign
 JSS ( last );                       // out: RPCVersion
 JSS ( last_close );                 // out: NetworkOPs
 JSS ( ledger );                     // in: NetworkOPs, LedgerCleaner,
@@ -296,6 +297,7 @@ JSS ( search_depth );               // in: RipplePathFind
 JSS ( secret );                     // in: TransactionSign, WalletSeed,
                                     //     ValidationCreate, ValidationSeed
 JSS ( seed );                       // in: WalletAccounts, out: WalletSeed
+JSS ( seed_hex );                   // in: WalletPropose, TransactionSign
 JSS ( send_currencies );            // out: AccountCurrencies
 JSS ( seq );                        // in: LedgerEntry;
                                     // out: NetworkOPs, RPCSub, AccountOffers

--- a/src/ripple/protocol/RippleAddress.h
+++ b/src/ripple/protocol/RippleAddress.h
@@ -20,8 +20,11 @@
 #ifndef RIPPLE_PROTOCOL_RIPPLEADDRESS_H_INCLUDED
 #define RIPPLE_PROTOCOL_RIPPLEADDRESS_H_INCLUDED
 
+#include <ripple/basics/base_uint.h>
 #include <ripple/crypto/Base58Data.h>
 #include <ripple/crypto/ECDSACanonical.h>
+#include <ripple/crypto/KeyType.h>
+#include <ripple/json/json_value.h>
 #include <ripple/protocol/RipplePublicKey.h>
 #include <ripple/protocol/UInt160.h>
 #include <ripple/protocol/UintTypes.h>
@@ -142,7 +145,7 @@ public:
     void setAccountPublic (Blob const& vPublic);
     void setAccountPublic (RippleAddress const& generator, int seq);
 
-    bool accountPublicVerify (uint256 const& uHash, Blob const& vucSig,
+    bool accountPublicVerify (Blob const& message, Blob const& vucSig,
                               ECDSA mustBeFullyCanonical) const;
 
     static RippleAddress createAccountPublic (Blob const& vPublic)
@@ -172,7 +175,7 @@ public:
     void setAccountPrivate (RippleAddress const& naGenerator,
                             RippleAddress const& naSeed, int seq);
 
-    bool accountPrivateSign (uint256 const& uHash, Blob& vucSig) const;
+    Blob accountPrivateSign (Blob const& message) const;
 
     // Encrypt a message.
     Blob accountPrivateEncrypt (
@@ -284,6 +287,18 @@ operator>=(RippleAddress const& lhs, RippleAddress const& rhs)
 {
     return !(lhs < rhs);
 }
+
+struct KeyPair
+{
+    RippleAddress secretKey;
+    RippleAddress publicKey;
+};
+
+uint256 keyFromSeed (uint128 const& seed);
+
+RippleAddress getSeedFromRPC (Json::Value const& params);
+
+KeyPair generateKeysFromSeed (KeyType keyType, RippleAddress const& seed);
 
 } // ripple
 

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -18,7 +18,10 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/crypto/KeyType.h>
+#include <ripple/protocol/RippleAddress.h>
 #include <ripple/rpc/handlers/WalletPropose.h>
+#include <ed25519-donna/ed25519.h>
 
 namespace ripple {
 
@@ -35,14 +38,58 @@ Json::Value walletPropose (Json::Value const& params)
     RippleAddress   naSeed;
     RippleAddress   naAccount;
 
-    if (!params.isMember (jss::passphrase))
-        naSeed.setSeedRandom ();
+    KeyType type = KeyType::secp256k1;
 
-    else if (!naSeed.setSeedGeneric (params[jss::passphrase].asString ()))
+    bool const has_key_type   = params.isMember (jss::key_type);
+    bool const has_passphrase = params.isMember (jss::passphrase);
+
+    if (has_key_type)
+    {
+        // `key_type` must be valid if present.
+
+        type = keyTypeFromString (params[jss::key_type].asString());
+
+        if (type == KeyType::invalid)
+        {
+            return rpcError (rpcBAD_SEED);
+        }
+
+        naSeed = getSeedFromRPC (params);
+    }
+    else if (has_passphrase)
+    {
+        naSeed.setSeedGeneric (params[jss::passphrase].asString());
+    }
+    else
+    {
+        naSeed.setSeedRandom();
+    }
+
+    if (!naSeed.isSet())
+    {
         return rpcError(rpcBAD_SEED);
+    }
 
-    RippleAddress naGenerator = RippleAddress::createGeneratorPublic (naSeed);
-    naAccount.setAccountPublic (naGenerator, 0);
+    if (type == KeyType::secp256k1)
+    {
+        RippleAddress naGenerator = RippleAddress::createGeneratorPublic (naSeed);
+        naAccount.setAccountPublic (naGenerator, 0);
+    }
+    else if (type == KeyType::ed25519)
+    {
+        uint256 secretkey = keyFromSeed (naSeed.getSeed());
+
+        Blob publickey (33);
+        publickey[0] = 0xED;
+        ed25519_publickey (secretkey.data(), &publickey[1]);
+        secretkey.zero();  // security erase
+
+        naAccount.setAccountPublic (publickey);
+    }
+    else
+    {
+        assert (false);  // not reached
+    }
 
     Json::Value obj (Json::objectValue);
 
@@ -51,6 +98,7 @@ Json::Value walletPropose (Json::Value const& params)
     obj[jss::master_key] = naSeed.humanSeed1751();
     obj[jss::account_id] = naAccount.humanAccountID ();
     obj[jss::public_key] = naAccount.humanAccountPublic();
+    obj[jss::key_type] = to_string (type);
 
     auto acct = naAccount.getAccountPublic();
     obj[jss::public_key_hex] = strHex(acct.begin(), acct.size());

--- a/src/ripple/rpc/impl/KeypairForSignature.cpp
+++ b/src/ripple/rpc/impl/KeypairForSignature.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/protocol/RippleAddress.h>
 #include <ripple/rpc/impl/KeypairForSignature.h>
 
 namespace ripple {
@@ -25,30 +26,60 @@ namespace RPC {
 
 KeyPair keypairForSignature (Json::Value const& params, Json::Value& error)
 {
-    if (! params.isMember ("secret"))
-    {
-        error = RPC::missing_field_error ("secret");
+    bool const has_key_type   = params.isMember (jss::key_type);
+    bool const has_passphrase = params.isMember (jss::passphrase);
+    bool const has_secret     = params.isMember (jss::secret);
+    bool const has_seed       = params.isMember (jss::seed);
+    bool const has_seed_hex   = params.isMember (jss::seed_hex);
 
+    int const n_secrets = has_passphrase + has_secret + has_seed + has_seed_hex;
+
+    if (n_secrets == 0)
+    {
+        error = RPC::missing_field_error (jss::secret);
         return KeyPair();
     }
+
+    if (n_secrets > 1)
+    {
+        // `passphrase`, `secret`, `seed`, and `seed_hex` are mutually exclusive.
+        error = rpcError (rpcBAD_SECRET);
+        return KeyPair();
+    }
+
+    if (has_key_type  &&  has_secret)
+    {
+        // `secret` is deprecated.
+        error = rpcError (rpcBAD_SECRET);
+        return KeyPair();
+    }
+
+    KeyType type = KeyType::secp256k1;
 
     RippleAddress seed;
 
-    if (! seed.setSeedGeneric (params["secret"].asString ()))
+    if (has_key_type)
+    {
+        // `key_type` must be valid if present.
+
+        type = keyTypeFromString (params[jss::key_type].asString());
+
+        if (type == KeyType::invalid)
+        {
+            error = rpcError (rpcBAD_SEED);
+            return KeyPair();
+        }
+
+        seed = getSeedFromRPC (params);
+    }
+    else
+    if (! seed.setSeedGeneric (params[jss::secret].asString ()))
     {
         error = RPC::make_error (rpcBAD_SEED,
-            RPC::invalid_field_message ("secret"));
-
-        return KeyPair();
+            RPC::invalid_field_message (jss::secret));
     }
 
-    KeyPair result;
-
-    RippleAddress generator = RippleAddress::createGeneratorPublic (seed);
-    result.secretKey.setAccountPrivate (generator, seed, 0);
-    result.publicKey.setAccountPublic (generator, 0);
-
-    return result;
+    return generateKeysFromSeed (type, seed);
 }
 
 } // RPC

--- a/src/ripple/unity/crypto.cpp
+++ b/src/ripple/unity/crypto.cpp
@@ -29,6 +29,7 @@
 #include <ripple/crypto/impl/ECDSAKey.cpp>
 #include <ripple/crypto/impl/ECIES.cpp>
 #include <ripple/crypto/impl/GenerateDeterministicKey.cpp>
+#include <ripple/crypto/impl/KeyType.cpp>
 #include <ripple/crypto/impl/openssl.cpp>
 #include <ripple/crypto/impl/RandomNumbers.cpp>
 #include <ripple/crypto/impl/RFC1751.cpp>


### PR DESCRIPTION
* Support Ed25519 in RippleAddress
* Add `key_type` parameter to `wallet_propose` and `sign`/`submit`
* Add unit tests