### PR TITLE
Move SHAMap hash computations from dirtyUp to walkSubTree

### DIFF
--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -183,14 +183,13 @@ public:
     void setUnbacked ();
 
     void dump (bool withHashes = false) const;
+    int unshare ();
 
 private:
     using SharedPtrNodeStack =
         std::stack<std::pair<std::shared_ptr<SHAMapTreeNode>, SHAMapNodeID>>;
     using DeltaRef = std::pair<std::shared_ptr<SHAMapItem> const&,
                                std::shared_ptr<SHAMapItem> const&> ;
-
-    int unshare ();
 
      // tree node cache operations
     std::shared_ptr<SHAMapTreeNode> getCache (uint256 const& hash) const;

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -78,7 +78,7 @@ public:
 
 public:  // public only to SHAMap
     bool setChild (int m, uint256 const& hash,
-                   std::shared_ptr<SHAMapTreeNode> const& child);
+                   std::shared_ptr<SHAMapTreeNode> const& child, bool computeHash = true);
     void shareChild (int m, std::shared_ptr<SHAMapTreeNode> const& child);
 
     // node functions
@@ -118,12 +118,13 @@ public:  // public only to SHAMap
     void dump (SHAMapNodeID const&, beast::Journal journal);
 #endif
     std::string getString (SHAMapNodeID const&) const;
+    bool updateHash ();
+    void updateHashDeep();
 
 private:
     bool isTransaction () const;
     bool hasMetaData () const;
     bool isAccountState () const;
-    bool updateHash ();
 };
 
 inline

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -78,6 +78,7 @@ public:
         sMap.addItem (i4, true, false);
         sMap.delItem (i2.getTag ());
         sMap.addItem (i3, true, false);
+        sMap.unshare();
         i = sMap.peekFirstItem ();
         unexpected (!i || (*i != i1), "bad traverse");
         i = sMap.peekNextItem (i->getTag ());

--- a/src/ripple/shamap/tests/SHAMapSync.test.cpp
+++ b/src/ripple/shamap/tests/SHAMapSync.test.cpp
@@ -50,6 +50,7 @@ public:
     {
         // add a bunch of random states to a map, then remove them
         // map should be the same
+        map.unshare();
         uint256 beforeHash = map.getHash ();
 
         std::list<uint256> items;
@@ -78,7 +79,7 @@ public:
                 return false;
             }
         }
-
+        map.unshare();
         if (beforeHash != map.getHash ())
         {
             log <<


### PR DESCRIPTION
in order to reduce the total number of hash computations.

Addresses https://ripplelabs.atlassian.net/browse/RIPD-730

I have mixed feelings about this pull request.  It is not without risk.  However I have measured benefit.  The shamap unit tests are doing about 40% fewer hash computations and running about 8% faster.  I'm measuring approximately 20% fewer hash computations between rippled launch and sync.

Some of the tests had to be modified in order to pass.  That worries me.  But it is not necessarily a deal breaker.

I've been running a validator for over an hour without problems.

@JoelKatz is a must reviewer on this one.  @mtrippled 
I'm open to suggestions on how to reduce the risk or increase the benefit.  I'm also open to the team making a decision that this change isn't worth the benefit.