### PR TITLE
Dockerize rippled

### DIFF
--- a/Builds/Docker/Dockerfile-testnet
+++ b/Builds/Docker/Dockerfile-testnet
@@ -1,0 +1,23 @@
+FROM ubuntu
+MAINTAINER Torrie Fischer <torrie@ripple.com>
+
+RUN apt-get update -qq &&\
+    apt-get install -qq software-properties-common &&\
+    apt-add-repository -y ppa:ubuntu-toolchain-r/test &&\
+    apt-add-repository -y ppa:afrank/boost &&\
+    apt-get update -qq
+
+RUN apt-get purge -qq libboost1.48-dev &&\
+    apt-get install -qq libprotobuf8 libboost1.57-all-dev
+
+RUN mkdir -p /srv/rippled/data
+
+VOLUME /srv/rippled/data/
+
+ENTRYPOINT ["/srv/rippled/bin/rippled"]
+CMD ["--conf", "/srv/rippled/data/rippled.cfg"]
+EXPOSE 51235/udp
+EXPOSE 5005/tcp
+
+ADD ./rippled.cfg /srv/rippled/data/rippled.cfg
+ADD ./rippled /srv/rippled/bin/

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,52 @@
+machine:
+  services:
+    - docker
+dependencies:
+  pre:
+    - sudo apt-add-repository -y 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.4 main'
+    - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo add-apt-repository -y ppa:afrank/boost
+    - wget -q -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+    - sudo apt-get update -qq
+    - sudo apt-get purge -qq libboost1.48-dev
+    - sudo apt-get install -qq libboost1.57-all-dev
+    - sudo apt-get install -qq clang-3.4 gcc-4.8 scons protobuf-compiler libprotobuf-dev libssl-dev exuberant-ctags
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 99 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+    - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.4 99 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.4
+    - gcc --version
+    - clang --version
+test:
+  pre:
+    - scons clang.debug
+  override:
+    - | # create gdb script
+      echo "set env MALLOC_CHECK_=3" > script.gdb 
+      echo "run" >> script.gdb
+      echo "backtrace full" >> script.gdb 
+      # gdb --help
+    - cat script.gdb | gdb --ex 'set print thread-events off' --return-child-result --args build/clang.debug/rippled --unittest
+    - npm install
+    # Use build/(gcc|clang).debug/rippled
+    - |
+      echo "exports.default_server_config = {\"rippled_path\" : \"$HOME/rippled/build/clang.debug/rippled\"};" > test/config.js
+
+    # Run integration tests
+    - npm test
+  post:
+    - mkdir -p build/docker/
+    - cp doc/rippled-example.cfg build/clang.debug/rippled build/docker/
+    - cp Builds/Docker/Dockerfile-testnet build/docker/Dockerfile
+    - mv build/docker/rippled-example.cfg build/docker/rippled.cfg
+    - strip build/docker/rippled
+    - docker build -t ripple/rippled:$CIRCLE_SHA1 build/docker/
+    - docker tag ripple/rippled:$CIRCLE_SHA1 ripple/rippled:latest
+    - docker tag ripple/rippled:$CIRCLE_SHA1 ripple/rippled:$CIRCLE_BRANCH
+    - docker images
+deployment:
+  docker:
+    branch: /.*/
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      - docker push ripple/rippled:$CIRCLE_SHA1
+      - docker push ripple/rippled:$CIRCLE_BRANCH
+      - docker push ripple/rippled:latest

--- a/doc/Docker.md
+++ b/doc/Docker.md
@@ -1,0 +1,16 @@
+# Rippled Docker Image
+
+Rippled has a continuous deployment pipeline that turns every git commit into a
+docker image for quick testing and deployment.
+
+To run the tip of the latest release via docker:
+
+```$ docker run -P -v /srv/rippled/ ripple/rippled:latest```
+
+To run the tip of active development:
+
+```$ docker run -P -v /srv/rippled/ ripple/rippled:develop```
+
+Where ```/srv/rippled``` points to a directory containing a rippled.cfg and
+database files. By default, port 5005/tcp maps to the RPC port and 51235/udp to
+the peer port.


### PR DESCRIPTION
This starts building docker images of rippled inside circleci, which is the first step towards automating testnet rollouts. Circleci is used instead of travis because travis doesn't provide support for building docker images as part of a build. The docker image that is built provides a hook for supplying a custom rippled.cfg, exposes the UDP peer port, and TCP RPC port, which should be the only user-serviceable entry points needed. This currently does not create docker images with version tags from git, or work for per-user forks.

The travis tests should continue to operate as expected and should continue to be used as the source of truth for the rippled team, though you might find that circleci builds finish faster since they don't stick in the build queue as long. A future PR might leverage circleci's parallelism to run multiple tests in parallel for even faster build turnaround, as documented here: https://circleci.com/docs/parallel-manual-setup

I'm taking on any responsibility for fixing circleci/docker builds as needed.

Reviewers who probably know sysadminy bits the most: @ximinez @rec @mtrippled 

After this is merged, I'll need to work with a repo admin to turn on the circleci commit hook integration.

Corresponding circleci test: https://circleci.com/gh/tdfischer/rippled/37
Successful test pre-squash: https://circleci.com/gh/tdfischer/rippled/36