### PR TITLE
Move SHAMap hash computations from dirtyUp to walkSubTree

### DIFF
--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -270,13 +270,6 @@ SHAMap::setLedgerSeq (std::uint32_t lseq)
 }
 
 inline
-uint256
-SHAMap::getHash () const
-{
-    return root_->getNodeHash ();
-}
-
-inline
 void
 SHAMap::setImmutable ()
 {

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -77,8 +77,7 @@ public:
     uint256 const& getNodeHash () const;
 
 public:  // public only to SHAMap
-    bool setChild (int m, uint256 const& hash,
-                   std::shared_ptr<SHAMapTreeNode> const& child);
+    void setChild (int m, std::shared_ptr<SHAMapTreeNode> const& child);
     void shareChild (int m, std::shared_ptr<SHAMapTreeNode> const& child);
 
     // node functions
@@ -118,12 +117,13 @@ public:  // public only to SHAMap
     void dump (SHAMapNodeID const&, beast::Journal journal);
 #endif
     std::string getString (SHAMapNodeID const&) const;
+    bool updateHash ();
+    void updateHashDeep();
 
 private:
     bool isTransaction () const;
     bool hasMetaData () const;
     bool isAccountState () const;
-    bool updateHash ();
 };
 
 inline


### PR DESCRIPTION
in order to reduce the total number of hash computations.

Addresses https://ripplelabs.atlassian.net/browse/RIPD-730

The shamap unittest run about 19% faster with this patch.  It passes unittest, npm, syncs and stops on OS X.

@JoelKatz @mtrippled 