### PR TITLE
A collection of small fixes

### DIFF
--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -385,7 +385,7 @@ public:
         {
             leaveConsensus();
             WriteLog (lsERROR, LedgerConsensus) <<
-                "Missind node processing complete map " << mn;
+                "Missing node processing complete map " << mn;
             throw;
         }
     }
@@ -393,7 +393,7 @@ public:
     void mapCompleteInternal (uint256 const& hash,
                               std::shared_ptr<SHAMap> const& map, bool acquired)
     {
-        CondLog (acquired, lsINFO, LedgerConsensus)
+        CondLog (acquired, lsDEBUG, LedgerConsensus)
             << "We have acquired TXS " << hash;
 
         if (!map)  // If the map was invalid
@@ -2090,7 +2090,7 @@ void applyTransactions (std::shared_ptr<SHAMap> const& set,
             if (!checkLedger->hasTransaction (item->getTag ()))
             {
                 // Then try to apply the transaction to applyLedger
-                WriteLog (lsINFO, LedgerConsensus) <<
+                WriteLog (lsDEBUG, LedgerConsensus) <<
                     "Processing candidate transaction: " << item->getTag ();
                 try
                 {

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -46,6 +46,7 @@ namespace ripple {
 
 #define MIN_VALIDATION_RATIO    150     // 150/256ths of validations of previous ledger
 #define MAX_LEDGER_GAP          100     // Don't catch up more than 100 ledgers  (cannot exceed 256)
+#define MAX_LEDGER_AGE_ACQUIRE  60      // Don't acquire history if ledger is too old
 
 class LedgerMasterImp
     : public LedgerMaster
@@ -936,7 +937,7 @@ public:
                 if (!standalone_ && !getApp().getFeeTrack().isLoadedLocal() &&
                     (getApp().getJobQueue().getJobCount(jtPUBOLDLEDGER) < 10) &&
                     (mValidLedgerSeq == mPubLedgerSeq) &&
-                    (getValidatedLedgerAge() < 60))
+                    (getValidatedLedgerAge() < MAX_LEDGER_AGE_ACQUIRE))
                 { // We are in sync, so can acquire
                     std::uint32_t missing;
                     {

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -935,7 +935,8 @@ public:
             {
                 if (!standalone_ && !getApp().getFeeTrack().isLoadedLocal() &&
                     (getApp().getJobQueue().getJobCount(jtPUBOLDLEDGER) < 10) &&
-                    (mValidLedgerSeq == mPubLedgerSeq))
+                    (mValidLedgerSeq == mPubLedgerSeq) &&
+                    (getValidatedLedgerAge() < 60))
                 { // We are in sync, so can acquire
                     std::uint32_t missing;
                     {
@@ -1071,7 +1072,11 @@ public:
         std::list<Ledger::pointer> ret;
 
         WriteLog (lsTRACE, LedgerMaster) << "findNewLedgersToPublish<";
-        if (!mPubLedger)
+        if (mValidLedger.empty ())
+        {
+            // No valid ledger, nothing to do
+        }
+        else if (! mPubLedger)
         {
             WriteLog (lsINFO, LedgerMaster) << "First published ledger will be " << mValidLedgerSeq;
             ret.push_back (mValidLedger.get ());

--- a/src/ripple/app/ledger/LedgerTiming.cpp
+++ b/src/ripple/app/ledger/LedgerTiming.cpp
@@ -130,7 +130,7 @@ bool ContinuousLedgerTiming::haveConsensus (
     // If 80% of current proposers (plus us) agree on a set, we have consensus
     if (((currentAgree * 100 + 100) / (currentProposers + 1)) > 80)
     {
-        CondLog (forReal, lsINFO, LedgerTiming) << "normal consensus";
+        CondLog (forReal, lsDEBUG, LedgerTiming) << "normal consensus";
         failed = false;
         return true;
     }

--- a/src/ripple/app/ledger/README.md
+++ b/src/ripple/app/ledger/README.md
@@ -397,6 +397,39 @@ are occupied by the exchange rate.
 
 ---
 
+# Ledger Publication #
+
+## Overview ##
+
+The Ripple server permits clients to subscribe to a continuous stream of
+fully-validated ledgers. The publication code maintains this stream.
+
+The server attempts to maintain this continuous stream unless it falls
+too far behind, in which case it jumps to the current fully-validated
+ledger and then attempts to resume a continuous stream.
+
+## Implementation ##
+
+LedgerMaster::doAdvance is invoked when work may need to be done to
+publish ledgers to clients. This code loops until it cannot make further
+progress.
+
+LedgerMaster::findNewLedgersToPublish is called first. If the last
+fully-valid ledger's sequence number is greater than the last published
+ledger's sequence number, it attempts to publish those ledgers, retrieving
+them if needed.
+
+If there are no new ledgers to publish, doAdvance determines if it can
+backfill history. If the publication is not caught up, bakfilling is not
+attempted to conserve resources.
+
+If history can be backfilled, the missing ledger with the highest
+sequence number is retrieved first. If a historical ledger is retrieved,
+and its predecessor is in the database, tryFill is invoked to update
+the list of resident ledgers.
+
+---
+
 # The Ledger Cleaner #
 
 ## Overview ##

--- a/src/ripple/app/ledger/README.md
+++ b/src/ripple/app/ledger/README.md
@@ -410,22 +410,22 @@ ledger and then attempts to resume a continuous stream.
 
 ## Implementation ##
 
-LedgerMaster::doAdvance is invoked when work may need to be done to
+`LedgerMaster::doAdvance` is invoked when work may need to be done to
 publish ledgers to clients. This code loops until it cannot make further
 progress.
 
-LedgerMaster::findNewLedgersToPublish is called first. If the last
+`LedgerMaster::findNewLedgersToPublish` is called first. If the last
 fully-valid ledger's sequence number is greater than the last published
 ledger's sequence number, it attempts to publish those ledgers, retrieving
 them if needed.
 
-If there are no new ledgers to publish, doAdvance determines if it can
+If there are no new ledgers to publish, `doAdvance` determines if it can
 backfill history. If the publication is not caught up, bakfilling is not
 attempted to conserve resources.
 
 If history can be backfilled, the missing ledger with the highest
 sequence number is retrieved first. If a historical ledger is retrieved,
-and its predecessor is in the database, tryFill is invoked to update
+and its predecessor is in the database, `tryFill` is invoked to update
 the list of resident ledgers.
 
 ---

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1039,7 +1039,7 @@ Transaction::pointer NetworkOPsImp::processTransactionCb (
 
         if (r == tesSUCCESS)
         {
-            m_journal.info << "Transaction is now included in open ledger";
+            m_journal.debug << "Transaction is now included in open ledger";
             trans->setStatus (INCLUDED);
 
             // VFALCO NOTE The value of trans can be changed here!
@@ -1701,7 +1701,7 @@ SHAMapAddNode NetworkOPsImp::gotTXData (
 
     if (!mConsensus)
     {
-        m_journal.warning << "Got TX data with no consensus object";
+        m_journal.debug << "Got TX data with no consensus object";
         return SHAMapAddNode ();
     }
 
@@ -2765,7 +2765,7 @@ void NetworkOPsImp::pubAccountTransaction (
             }
         }
     }
-    m_journal.info << "pubAccountTransaction:" <<
+    m_journal.trace << "pubAccountTransaction:" <<
         " iProposed=" << iProposed <<
         " iAccepted=" << iAccepted;
 

--- a/src/ripple/app/peers/PeerSet.cpp
+++ b/src/ripple/app/peers/PeerSet.cpp
@@ -90,7 +90,8 @@ void PeerSet::invokeOnTimer ()
     if (!isProgress())
     {
         ++mTimeouts;
-        WriteLog (lsWARNING, InboundLedger) << "Timeout(" << mTimeouts << ") pc=" << mPeers.size () << " acquiring " << mHash;
+        WriteLog (lsDEBUG, InboundLedger) << "Timeout(" << mTimeouts
+            << ") pc=" << mPeers.size () << " acquiring " << mHash;
         onTimer (false, sl);
     }
     else

--- a/src/ripple/app/tx/TransactionAcquire.cpp
+++ b/src/ripple/app/tx/TransactionAcquire.cpp
@@ -71,7 +71,7 @@ void TransactionAcquire::done ()
     }
     else
     {
-        WriteLog (lsINFO, TransactionAcquire) << "Acquired TX set " << mHash;
+        WriteLog (lsDEBUG, TransactionAcquire) << "Acquired TX set " << mHash;
         mMap->setImmutable ();
         map = mMap;
     }

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1654,7 +1654,7 @@ PeerImp::getLedger (std::shared_ptr<protocol::TMGetLedger> const& m)
                 return;
             }
 
-            p_journal_.error <<
+            p_journal_.debug <<
                 "GetLedger: Can't provide map ";
             charge (Resource::feeInvalidRequest);
             return;

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -66,10 +66,12 @@ TxFormats::TxFormats ()
         ;
 
     add ("EnableAmendment", ttAMENDMENT)
+        << SOElement (sfLedgerSequence,      SOE_OPTIONAL)
         << SOElement (sfAmendment,           SOE_REQUIRED)
         ;
 
     add ("SetFee", ttFEE)
+        << SOElement (sfLedgerSequence,      SOE_OPTIONAL)
         << SOElement (sfBaseFee,             SOE_REQUIRED)
         << SOElement (sfReferenceFeeUnits,   SOE_REQUIRED)
         << SOElement (sfReserveBase,         SOE_REQUIRED)

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -870,7 +870,7 @@ SHAMap::updateGiveItem (std::shared_ptr<SHAMapItem> const& item,
     if (!node->setItem (item, !isTransaction ? SHAMapTreeNode::tnACCOUNT_STATE :
                         (hasMeta ? SHAMapTreeNode::tnTRANSACTION_MD : SHAMapTreeNode::tnTRANSACTION_NM)))
     {
-        if (journal_.warning) journal_.warning <<
+        journal_.trace <<
             "SHAMap setItem, no change";
         return true;
     }


### PR DESCRIPTION
Document and cleanup ledger advance log. Don't acquire if validated ledger is too old and don't try to publish if we have no valid ledger.

Tolerate a ledger sequence number is pseudo-transactions. That will allow the server to parse the future pseudo-transaction change to avoid re-using transaction hashes

Reduce chattiness of some log outputs.

Reviewers needed. All changes are fairly trivial.