### PR TITLE
Perform Transactor checks early:

### DIFF
--- a/src/ripple/app/transactors/Change.cpp
+++ b/src/ripple/app/transactors/Change.cpp
@@ -100,7 +100,6 @@ public:
         if (mTxnAccountID.isNonZero ())
         {
             m_journal.warning << "Bad source id";
-
             return temBAD_SRC_ACCOUNT;
         }
 

--- a/src/ripple/app/transactors/SetRegularKey.cpp
+++ b/src/ripple/app/transactors/SetRegularKey.cpp
@@ -54,27 +54,30 @@ public:
 
     }
 
-    TER doApply () override
+    TER preCheck () override
     {
         std::uint32_t const uTxFlags = mTxn.getFlags ();
 
         if (uTxFlags & tfUniversalMask)
         {
-            m_journal.trace <<
+            if (m_journal.trace) m_journal.trace <<
                 "Malformed transaction: Invalid flags set.";
 
             return temINVALID_FLAG;
         }
 
+        return Transactor::preCheck ();
+    }
+
+    TER doApply () override
+    {
         if (mFeeDue == zero)
-        {
             mTxnAccount->setFlag (lsfPasswordSpent);
-        }
 
         if (mTxn.isFieldPresent (sfRegularKey))
         {
-            Account uAuthKeyID = mTxn.getFieldAccount160 (sfRegularKey);
-            mTxnAccount->setFieldAccount (sfRegularKey, uAuthKeyID);
+            mTxnAccount->setFieldAccount (sfRegularKey,
+                mTxn.getFieldAccount160 (sfRegularKey));
         }
         else
         {

--- a/src/ripple/app/transactors/Transactor.cpp
+++ b/src/ripple/app/transactors/Transactor.cpp
@@ -257,16 +257,16 @@ TER Transactor::apply ()
     TER terResult (preCheck ());
 
     if (terResult != tesSUCCESS)
-        return (terResult);
-
-    mTxnAccount = mEngine->entryCache (ltACCOUNT_ROOT,
-        getAccountRootIndex (mTxnAccountID));
-    calculateFee ();
+        return terResult;
 
     // Find source account
+    mTxnAccount = mEngine->entryCache (ltACCOUNT_ROOT,
+        getAccountRootIndex (mTxnAccountID));
+
+    calculateFee ();
+
     // If are only forwarding, due to resource limitations, we might verifying
     // only some transactions, this would be probabilistic.
-
     if (!mTxnAccount)
     {
         if (mustHaveValidAccount ())

--- a/src/ripple/app/tx/Transaction.cpp
+++ b/src/ripple/app/tx/Transaction.cpp
@@ -189,18 +189,4 @@ Json::Value Transaction::getJson (int options, bool binary) const
     return ret;
 }
 
-bool Transaction::isHexTxID (std::string const& txid)
-{
-    if (txid.size () != 64)
-        return false;
-
-    auto const ret = std::find_if (txid.begin (), txid.end (),
-        [](std::string::value_type c)
-        {
-            return !std::isxdigit (c);
-        });
-
-    return (ret == txid.end ());
-}
-
 } // ripple

--- a/src/ripple/app/tx/Transaction.h
+++ b/src/ripple/app/tx/Transaction.h
@@ -119,8 +119,6 @@ public:
 
     static Transaction::pointer load (uint256 const& id);
 
-    static bool isHexTxID (std::string const&);
-
 private:
     uint256         mTransactionID;
     RippleAddress   mAccountFrom;

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -25,6 +25,23 @@ namespace ripple {
 // {
 //   transaction: <hex>
 // }
+
+static
+bool
+isHexTxID (std::string const& txid)
+{
+    if (txid.size () != 64)
+        return false;
+
+    auto const ret = std::find_if (txid.begin (), txid.end (),
+        [](std::string::value_type c)
+        {
+            return !std::isxdigit (c);
+        });
+
+    return (ret == txid.end ());
+}
+
 Json::Value doTx (RPC::Context& context)
 {
     if (!context.params.isMember (jss::transaction))
@@ -35,7 +52,7 @@ Json::Value doTx (RPC::Context& context)
 
     auto const txid  = context.params[jss::transaction].asString ();
 
-    if (!Transaction::isHexTxID (txid))
+    if (!isHexTxID (txid))
         return rpcError (rpcNOT_IMPL);
 
     auto txn = getApp().getMasterTransaction ().fetch (uint256 (txid), true);


### PR DESCRIPTION
Certain checks that determine if a transaction is malformed can be performed
without needing to look up accounts or access the ledger.

Whenever possible, perform those checks as early as possible to help optimize
transaction processing.

Reviews: @scottschurr, @JoelKatz