### PR TITLE
Pathfinding unit tests:

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1873,6 +1873,10 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\tests\common_ledger.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\app\tests\Path_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\transactors\CancelOffer.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -3168,6 +3172,8 @@
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\impl\ParseAccountIds.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\rpc\impl\RipplePathFind.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\impl\RPCHandler.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2625,6 +2625,9 @@
     <ClInclude Include="..\..\src\ripple\app\tests\common_ledger.h">
       <Filter>ripple\app\tests</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\app\tests\Path_test.cpp">
+      <Filter>ripple\app\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\transactors\CancelOffer.cpp">
       <Filter>ripple\app\transactors</Filter>
     </ClCompile>
@@ -3925,6 +3928,9 @@
       <Filter>ripple\rpc\impl</Filter>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\impl\ParseAccountIds.h">
+      <Filter>ripple\rpc\impl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\rpc\impl\RipplePathFind.h">
       <Filter>ripple\rpc\impl</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\impl\RPCHandler.cpp">

--- a/src/ripple/app/ledger/tests/Ledger_test.cpp
+++ b/src/ripple/app/ledger/tests/Ledger_test.cpp
@@ -29,10 +29,10 @@ class Ledger_test : public beast::unit_test::suite
         std::uint64_t const xrp = std::mega::num;
 
         auto master = createAccount ("masterpassphrase", keyType);
-
-        Ledger::pointer LCL = createGenesisLedger(100000*xrp, master);
-
-        Ledger::pointer ledger = std::make_shared<Ledger>(false, *LCL);
+        
+        Ledger::pointer LCL;
+        Ledger::pointer ledger;
+        std::tie(LCL, ledger) = createGenesisLedger(100000*xrp, master);
 
         // User accounts
         auto gw1 = createAccount ("gw1", keyType);
@@ -50,8 +50,7 @@ class Ledger_test : public beast::unit_test::suite
         makeAndApplyPayment(master, alice, 2000 * xrp, ledger, sign);
         makeAndApplyPayment(master, mark, 1000 * xrp, ledger, sign);
 
-        LCL = close_and_advance(ledger, LCL);
-        ledger = std::make_shared<Ledger>(false, *LCL);
+        close_and_advance(ledger, LCL);
 
         // alice trusts FOO/gw1
         makeTrustSet (alice, gw1, "FOO", 1, ledger, sign);
@@ -63,33 +62,30 @@ class Ledger_test : public beast::unit_test::suite
         makeTrustSet (mark, gw3, "FOO", 1, ledger, sign);
 
         // gw2 pays mark with FOO
-        makeAndApplyPayment(gw2, mark, "FOO", ".1", ledger, sign);
+        makeAndApplyPayment(gw2, mark, "FOO", "0.1", ledger, sign);
 
         // gw3 pays mark with FOO
-        makeAndApplyPayment(gw3, mark, "FOO", ".2", ledger, sign);
+        makeAndApplyPayment(gw3, mark, "FOO", "0.2", ledger, sign);
 
         // gw1 pays alice with FOO
-        makeAndApplyPayment(gw1, alice, "FOO", ".3", ledger, sign);
+        makeAndApplyPayment(gw1, alice, "FOO", "0.3", ledger, sign);
 
-        verifyBalance(ledger, mark, Amount(.1, "FOO", gw2));
-        verifyBalance(ledger, mark, Amount(.2, "FOO", gw3));
-        verifyBalance(ledger, alice, Amount(.3, "FOO", gw1));
+        verifyBalance(ledger, mark, Amount(0.1, "FOO", gw2));
+        verifyBalance(ledger, mark, Amount(0.2, "FOO", gw3));
+        verifyBalance(ledger, alice, Amount(0.3, "FOO", gw1));
 
-        LCL = close_and_advance(ledger, LCL);
-        ledger = std::make_shared<Ledger>(false, *LCL);
+        close_and_advance(ledger, LCL);
 
         createOffer (mark, Amount (1, "FOO", gw1), Amount (1, "FOO", gw2), ledger, sign);
         createOffer (mark, Amount (1, "FOO", gw2), Amount (1, "FOO", gw3), ledger, sign);
         cancelOffer (mark, ledger, sign);
         freezeAccount (alice, ledger, sign);
 
-        LCL = close_and_advance(ledger, LCL);
-        ledger = std::make_shared<Ledger>(false, *LCL);
+        close_and_advance(ledger, LCL);
 
         makeAndApplyPayment(alice, mark, 1 * xrp, ledger, sign);
 
-        LCL = close_and_advance(ledger, LCL);
-        ledger = std::make_shared<Ledger>(false, *LCL);
+        close_and_advance(ledger, LCL);
 
         pass ();
     }
@@ -100,9 +96,9 @@ class Ledger_test : public beast::unit_test::suite
 
         auto master = createAccount ("masterpassphrase", keyType);
 
-        Ledger::pointer LCL = createGenesisLedger (100000 * xrp, master);
-
-        Ledger::pointer ledger = std::make_shared<Ledger> (false, *LCL);
+        Ledger::pointer LCL;
+        Ledger::pointer ledger;
+        std::tie(LCL, ledger) = createGenesisLedger (100000 * xrp, master);
 
         auto gw1 = createAccount ("gw1", keyType);
 

--- a/src/ripple/app/ledger/tests/Ledger_test.cpp
+++ b/src/ripple/app/ledger/tests/Ledger_test.cpp
@@ -71,6 +71,10 @@ class Ledger_test : public beast::unit_test::suite
         // gw1 pays alice with FOO
         makeAndApplyPayment(gw1, alice, "FOO", ".3", ledger, sign);
 
+        verifyBalance(ledger, mark, Amount(.1, "FOO", gw2));
+        verifyBalance(ledger, mark, Amount(.2, "FOO", gw3));
+        verifyBalance(ledger, alice, Amount(.3, "FOO", gw1));
+
         LCL = close_and_advance(ledger, LCL);
         ledger = std::make_shared<Ledger>(false, *LCL);
 

--- a/src/ripple/app/tests/Path_test.cpp
+++ b/src/ripple/app/tests/Path_test.cpp
@@ -43,8 +43,8 @@ class Path_test : public TestSuite
 
         auto accounts = createAndFundAccounts(master, { "alice", "bob" }, 
             KeyType::ed25519, 10000 * xrp, ledger);
-        auto alice = accounts["alice"];
-        auto bob = accounts["bob"];
+        auto& alice = accounts["alice"];
+        auto& bob = accounts["bob"];
         expectNotEquals(alice.pk.humanAccountID(), master.pk.humanAccountID());
         
         auto alternatives = findPath(ledger, alice, bob, { Currency("USD") },
@@ -69,8 +69,8 @@ class Path_test : public TestSuite
         // Create accounts
         auto accounts = createAndFundAccounts(master, { "alice", "bob" },
             KeyType::ed25519, 10000 * xrp, ledger);
-        auto alice = accounts["alice"];
-        auto bob = accounts["bob"];
+        auto& alice = accounts["alice"];
+        auto& bob = accounts["bob"];
         expectNotEquals(alice.pk.humanAccountID(), master.pk.humanAccountID());
 
         // Set credit limit
@@ -107,9 +107,9 @@ class Path_test : public TestSuite
         // Create accounts
         auto accounts = createAndFundAccounts(master, { "alice", "bob", "mtgox" },
             KeyType::ed25519, 10000 * xrp, ledger);
-        auto alice = accounts["alice"];
-        auto bob = accounts["bob"];
-        auto mtgox = accounts["mtgox"];
+        auto& alice = accounts["alice"];
+        auto& bob = accounts["bob"];
+        auto& mtgox = accounts["mtgox"];
         expectNotEquals(alice.pk.humanAccountID(), master.pk.humanAccountID());
 
         // Set credit limits
@@ -147,9 +147,9 @@ class Path_test : public TestSuite
         // Create accounts
         auto accounts = createAndFundAccounts(master, { "alice", "bob", "mtgox" },
             KeyType::ed25519, 10000 * xrp, ledger);
-        auto alice = accounts["alice"];
-        auto bob = accounts["bob"];
-        auto mtgox = accounts["mtgox"];
+        auto& alice = accounts["alice"];
+        auto& bob = accounts["bob"];
+        auto& mtgox = accounts["mtgox"];
         expectNotEquals(alice.pk.humanAccountID(), master.pk.humanAccountID());
 
         // Set credit limits

--- a/src/ripple/app/tests/Path_test.cpp
+++ b/src/ripple/app/tests/Path_test.cpp
@@ -1,0 +1,198 @@
+//------------------------------------------------------------------------------
+/*
+This file is part of rippled: https://github.com/ripple/rippled
+Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose  with  or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/tests/common_ledger.h>
+#include <ripple/crypto/KeyType.h>
+#include <ripple/json/json_writer.h>
+
+// probably going to be moved to common_ledger.h
+
+namespace ripple {
+namespace test {
+
+class Path_test : public beast::unit_test::suite
+{
+    void
+    test_no_direct_path_no_intermediary_no_alternatives()
+    {
+        testcase("no direct path no intermediary no alternatives");
+        std::uint64_t const xrp = std::mega::num;
+
+        auto master = createAccount("masterpassphrase", KeyType::ed25519);
+
+        Ledger::pointer LCL = createGenesisLedger(100000 * xrp, master);
+
+        Ledger::pointer ledger = std::make_shared<Ledger>(false, *LCL);
+
+        auto accounts = createAndFundAccounts(master, { "alice", "bob" }, 
+            KeyType::ed25519, 10000 * xrp, ledger);
+        auto alice = accounts["alice"];
+        auto bob = accounts["bob"];
+        expect(alice.pk != master.pk);
+        
+        auto alternatives = findPath(ledger, alice, bob, { Currency("USD") }, Amount(5, "USD", alice), log.stream());
+        log << "ripplePathFind alternatives: " << alternatives;
+
+        expect(alternatives.size() == 0, "alternatives.size() == 0");
+    }
+
+    void
+    test_direct_path_no_intermediary()
+    {
+        testcase("direct path no intermediary");
+        std::uint64_t const xrp = std::mega::num;
+
+        auto master = createAccount("masterpassphrase", KeyType::ed25519);
+
+        Ledger::pointer LCL = createGenesisLedger(100000 * xrp, master);
+
+        Ledger::pointer ledger = std::make_shared<Ledger>(false, *LCL);
+
+        // Create accounts
+        auto accounts = createAndFundAccounts(master, { "alice", "bob" },
+            KeyType::ed25519, 10000 * xrp, ledger);
+        auto alice = accounts["alice"];
+        auto bob = accounts["bob"];
+        expect(alice.pk != master.pk);
+
+        // Set credit limit
+        makeTrustSet(bob, alice, "USD", 700, ledger);
+
+        // Find path from alice to bob
+        auto alternatives = findPath(ledger, alice, bob, { Currency("USD") }, Amount(5, "USD", bob), log.stream());
+        log << "ripplePathFind alternatives: " << alternatives;
+
+        expect(alternatives.size() == 1, "result.second.size() == 1");
+        auto alt = alternatives[0u];
+        expect(alt[jss::paths_canonical].size() == 0, "alt[jss::paths_canonical].size() == 0");
+        expect(alt[jss::paths_computed].size() == 0, "alt[jss::paths_computed].size() == 0");
+        auto srcAmount = alt[jss::source_amount];
+        expect(srcAmount[jss::currency] == "USD", "srcAmount[jss::currency] == USD");
+        expect(srcAmount[jss::value] == "5", "srcAmount[jss::value] == 5");
+        expect(srcAmount[jss::issuer] == alice.pk.humanAccountID(), "srcAmount[jss::value] == 5");
+    }
+
+    void
+    test_payment_auto_path_find_using_build_path()
+    {
+        testcase("payment auto path find (using build_path)");
+
+        std::uint64_t const xrp = std::mega::num;
+
+        auto master = createAccount("masterpassphrase", KeyType::ed25519);
+
+        Ledger::pointer LCL = createGenesisLedger(100000 * xrp, master);
+
+        Ledger::pointer ledger = std::make_shared<Ledger>(false, *LCL);
+
+        // Create accounts
+        auto accounts = createAndFundAccounts(master, { "alice", "bob", "mtgox" },
+            KeyType::ed25519, 10000 * xrp, ledger);
+        auto alice = accounts["alice"];
+        auto bob = accounts["bob"];
+        auto mtgox = accounts["mtgox"];
+        expect(alice.pk != master.pk);
+
+        // Set credit limits
+        makeTrustSet(alice, mtgox, "USD", 600, ledger);
+        makeTrustSet(bob, mtgox, "USD", 700, ledger);
+
+        // Distribute funds.
+        makeAndApplyPayment(mtgox, alice, "USD", "70", ledger);
+
+        verifyBalance(ledger, alice, Amount(70, "USD", mtgox));
+
+        // Payment with path.
+        makeAndApplyPayment(alice, bob, "USD", "24", ledger, build_path);
+
+        // Verify balances
+        verifyBalance(ledger, alice, Amount(46, "USD", mtgox));
+        verifyBalance(ledger, mtgox, Amount(-46, "USD", alice));
+        verifyBalance(ledger, mtgox, Amount(-24, "USD", bob));
+        verifyBalance(ledger, bob, Amount(24, "USD", mtgox));
+    }
+
+    void
+    test_path_find()
+    {
+        testcase("path find");
+
+        std::uint64_t const xrp = std::mega::num;
+
+        auto master = createAccount("masterpassphrase", KeyType::ed25519);
+
+        Ledger::pointer LCL = createGenesisLedger(100000 * xrp, master);
+
+        Ledger::pointer ledger = std::make_shared<Ledger>(false, *LCL);
+
+        // Create accounts
+        auto accounts = createAndFundAccounts(master, { "alice", "bob", "mtgox" },
+            KeyType::ed25519, 10000 * xrp, ledger);
+        auto alice = accounts["alice"];
+        auto bob = accounts["bob"];
+        auto mtgox = accounts["mtgox"];
+        expect(alice.pk != master.pk);
+
+        // Set credit limits
+        makeTrustSet(alice, mtgox, "USD", 600, ledger);
+        makeTrustSet(bob, mtgox, "USD", 700, ledger);
+
+        // Distribute funds.
+        makeAndApplyPayment(mtgox, alice, "USD", "70", ledger);
+        makeAndApplyPayment(mtgox, bob, "USD", "50", ledger);
+
+        verifyBalance(ledger, alice, Amount(70, "USD", mtgox));
+        verifyBalance(ledger, bob, Amount(50, "USD", mtgox));
+
+        // Find path from alice to mtgox
+        auto alternatives = findPath(ledger, alice, bob, { Currency("USD") }, Amount(5, "USD", mtgox), log.stream());
+        log << "Path find alternatives: " << alternatives;
+        expect(alternatives.size() == 1, "alternatives.size() == 1");
+        auto alt = alternatives[0u];
+        expect(alt["paths_canonical"].size() == 0, "alt[\"paths_canonical\"].size() == 0");
+        expect(alt["paths_computed"].size() == 1, "alt[\"paths_computed\"].size() == 0");
+        auto computedPaths = alt["paths_computed"];
+        expect(computedPaths.size() == 1, "computedPaths.size() == 1");
+        auto computedPath = computedPaths[0u];
+        expect(computedPath.size() == 1, "computedPath.size() == 1");
+        auto computedPathStep = computedPath[0u];
+        expect(computedPathStep[jss::account] == mtgox.pk.humanAccountID(), "computedPathStep[jss::account] == mtgox");
+        expect(computedPathStep[jss::type] == 1, "computedPathStep[jss::type] == 1");
+        expect(computedPathStep[jss::type_hex] == "0000000000000001", "computedPathStep[jss::type_hex] == 0000000000000001");
+        auto srcAmount = alt[jss::source_amount];
+        expect(srcAmount[jss::currency] == "USD", "srcAmount[jss::currency] == USD");
+        expect(srcAmount[jss::value] == "5", "srcAmount[jss::value] == 5");
+        expect(srcAmount[jss::issuer] == alice.pk.humanAccountID(), "srcAmount[jss::issuer] == alice");
+    }
+
+
+public:
+    void run()
+    {
+        test_no_direct_path_no_intermediary_no_alternatives();
+        test_direct_path_no_intermediary();
+        test_payment_auto_path_find_using_build_path();
+        test_path_find();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Path, ripple_app, ripple);
+
+} // test
+} // ripple

--- a/src/ripple/app/tests/common_ledger.h
+++ b/src/ripple/app/tests/common_ledger.h
@@ -129,7 +129,7 @@ applyTransaction(Ledger::pointer const& ledger, STTx const& tx, bool check = tru
 
 // Create genesis ledger from a start amount in drops, and the public
 // master RippleAddress
-Ledger::pointer
+std::pair<Ledger::pointer, Ledger::pointer>
 createGenesisLedger(std::uint64_t start_amount_drops, TestAccount const& master);
 
 // Create an account represented by public RippleAddress and private
@@ -197,8 +197,8 @@ makeTrustSet(TestAccount& from, TestAccount const& issuer,
                 std::string const& currency, double amount,
                 Ledger::pointer const& ledger, bool sign = true);
 
-Ledger::pointer
-close_and_advance(Ledger::pointer ledger, Ledger::pointer LCL);
+void
+close_and_advance(Ledger::pointer& ledger, Ledger::pointer& LCL);
 
 Json::Value findPath(Ledger::pointer ledger, TestAccount const& src, 
     TestAccount const& dest, std::vector<Currency> srcCurrencies, 
@@ -206,7 +206,9 @@ Json::Value findPath(Ledger::pointer ledger, TestAccount const& src,
     boost::optional<Json::Value> contextPaths = boost::none);
 
 SLE::pointer
-get_ledger_entry_ripple_state(Ledger::pointer ledger, RippleAddress account1, RippleAddress account2, Currency currency);
+get_ledger_entry_ripple_state(Ledger::pointer ledger,
+    RippleAddress account1, RippleAddress account2,
+    Currency currency);
 
 void
 verifyBalance(Ledger::pointer ledger, TestAccount const& account, Amount const& amount);

--- a/src/ripple/basics/TestSuite.h
+++ b/src/ripple/basics/TestSuite.h
@@ -46,6 +46,24 @@ public:
 
     }
 
+    template <class S, class T>
+    bool expectNotEquals(S actual, T expected, std::string const& message = "")
+    {
+        if (actual == expected)
+        {
+            std::stringstream ss;
+            if (!message.empty())
+                ss << message << "\n";
+            ss << "Actual: " << actual << "\n"
+                << "Expected anything but: " << expected;
+            fail(ss.str());
+            return false;
+        }
+        pass();
+        return true;
+
+    }
+
     template <class Collection>
     bool expectCollectionEquals (
         Collection const& actual, Collection const& expected,

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/rpc/impl/RipplePathFind.h>
 #include <ripple/app/paths/AccountCurrencies.h>
 #include <ripple/app/paths/FindPaths.h>
 #include <ripple/app/paths/RippleCalc.h>
@@ -126,15 +127,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
         }
         else
         {
-            auto currencies = accountSourceCurrencies (raSrc, cache, true);
-            jvSrcCurrencies = Json::Value (Json::arrayValue);
-
-            for (auto const& uCurrency: currencies)
-            {
-                Json::Value jvCurrency (Json::objectValue);
-                jvCurrency[jss::currency] = to_string(uCurrency);
-                jvSrcCurrencies.append (jvCurrency);
-            }
+            jvSrcCurrencies = buildSrcCurrencies(raSrc, cache);
         }
 
         // Fill in currencies destination will accept
@@ -148,8 +141,6 @@ Json::Value doRipplePathFind (RPC::Context& context)
 
         jvResult[jss::destination_currencies] = jvDestCur;
         jvResult[jss::destination_account] = raDst.humanAccountID ();
-
-        Json::Value jvArray (Json::arrayValue);
 
         int level = getConfig().PATH_SEARCH_OLD;
         if ((getConfig().PATH_SEARCH_MAX > level)
@@ -166,158 +157,13 @@ Json::Value doRipplePathFind (RPC::Context& context)
                 level = rLev;
         }
 
-        FindPaths fp (
-            cache,
-            raSrc.getAccountID(),
-            raDst.getAccountID(),
-            saDstAmount,
-            level,
-            4); // max paths
-
-        for (unsigned int i = 0; i != jvSrcCurrencies.size (); ++i)
-        {
-            Json::Value jvSource        = jvSrcCurrencies[i];
-
-            Currency uSrcCurrencyID;
-            Account uSrcIssuerID;
-
-            if (!jvSource.isObject ())
-                return rpcError (rpcINVALID_PARAMS);
-
-            // Parse mandatory currency.
-            if (!jvSource.isMember (jss::currency)
-                || !to_currency (
-                    uSrcCurrencyID, jvSource[jss::currency].asString ()))
-            {
-                WriteLog (lsINFO, RPCHandler) << "Bad currency.";
-
-                return rpcError (rpcSRC_CUR_MALFORMED);
-            }
-
-            if (uSrcCurrencyID.isNonZero ())
-                uSrcIssuerID = raSrc.getAccountID ();
-
-            // Parse optional issuer.
-            if (jvSource.isMember (jss::issuer) &&
-                ((!jvSource[jss::issuer].isString () ||
-                  !to_issuer (uSrcIssuerID, jvSource[jss::issuer].asString ())) ||
-                 (uSrcIssuerID.isZero () != uSrcCurrencyID.isZero ()) ||
-                 (noAccount() == uSrcIssuerID)))
-            {
-                WriteLog (lsINFO, RPCHandler) << "Bad issuer.";
-                return rpcError (rpcSRC_ISR_MALFORMED);
-            }
-
-            STPathSet spsComputed;
-            if (context.params.isMember(jss::paths))
-            {
-                Json::Value pathSet = Json::objectValue;
-                pathSet[jss::Paths] = context.params[jss::paths];
-                STParsedJSONObject paths ("pathSet", pathSet);
-                if (paths.object.get() == nullptr)
-                    return paths.error;
-                else
-                {
-                    spsComputed = paths.object.get()->getFieldPathSet (sfPaths);
-                    WriteLog (lsTRACE, RPCHandler) << "ripple_path_find: Paths: " << spsComputed.getJson (0);
-                }
-            }
-
-            STPath fullLiquidityPath;
-            auto valid = fp.findPathsForIssue (
-                {uSrcCurrencyID, uSrcIssuerID},
-                spsComputed,
-                fullLiquidityPath);
-            if (!valid)
-            {
-                WriteLog (lsWARNING, RPCHandler)
-                    << "ripple_path_find: No paths found.";
-            }
-            else
-            {
-                auto& issuer =
-                    isXRP (uSrcIssuerID) ?
-                        isXRP (uSrcCurrencyID) ? // Default to source account.
-                            xrpAccount() :
-                            Account (raSrc.getAccountID ())
-                        : uSrcIssuerID;            // Use specifed issuer.
-
-                STAmount saMaxAmount ({uSrcCurrencyID, issuer}, 1);
-                saMaxAmount.negate ();
-
-                LedgerEntrySet lesSandbox (lpLedger, tapNONE);
-
-                auto rc = path::RippleCalc::rippleCalculate (
-                    lesSandbox,
-                    saMaxAmount,            // --> Amount to send is unlimited
-                                            //     to get an estimate.
-                    saDstAmount,            // --> Amount to deliver.
-                    raDst.getAccountID (),  // --> Account to deliver to.
-                    raSrc.getAccountID (),  // --> Account sending from.
-                    spsComputed);           // --> Path set.
-
-                WriteLog (lsWARNING, RPCHandler)
-                    << "ripple_path_find:"
-                    << " saMaxAmount=" << saMaxAmount
-                    << " saDstAmount=" << saDstAmount
-                    << " saMaxAmountAct=" << rc.actualAmountIn
-                    << " saDstAmountAct=" << rc.actualAmountOut;
-
-                if (fullLiquidityPath.size() > 0 &&
-                    (rc.result() == terNO_LINE || rc.result() == tecPATH_PARTIAL))
-                {
-                    WriteLog (lsDEBUG, PathRequest)
-                        << "Trying with an extra path element";
-
-                    spsComputed.push_back (fullLiquidityPath);
-                    lesSandbox.clear ();
-                    rc = path::RippleCalc::rippleCalculate (
-                        lesSandbox,
-                        saMaxAmount,            // --> Amount to send is unlimited
-                        //     to get an estimate.
-                        saDstAmount,            // --> Amount to deliver.
-                        raDst.getAccountID (),  // --> Account to deliver to.
-                        raSrc.getAccountID (),  // --> Account sending from.
-                        spsComputed);         // --> Path set.
-                    WriteLog (lsDEBUG, PathRequest)
-                        << "Extra path element gives "
-                        << transHuman (rc.result ());
-                }
-
-                if (rc.result () == tesSUCCESS)
-                {
-                    Json::Value jvEntry (Json::objectValue);
-
-                    STPathSet   spsCanonical;
-
-                    // Reuse the expanded as it would need to be calcuated
-                    // anyway to produce the canonical.  (At least unless we
-                    // make a direct canonical.)
-
-                    jvEntry[jss::source_amount] = rc.actualAmountIn.getJson (0);
-                    jvEntry[jss::paths_canonical]  = Json::arrayValue;
-                    jvEntry[jss::paths_computed]   = spsComputed.getJson (0);
-
-                    jvArray.append (jvEntry);
-                }
-                else
-                {
-                    std::string strToken;
-                    std::string strHuman;
-
-                    transResultInfo (rc.result (), strToken, strHuman);
-
-                    WriteLog (lsDEBUG, RPCHandler)
-                        << "ripple_path_find: "
-                        << strToken << " "
-                        << strHuman << " "
-                        << spsComputed.getJson (0);
-                }
-            }
-        }
+        auto contextPaths = context.params.isMember(jss::paths) ? boost::optional<Json::Value>(context.params[jss::paths]) : boost::optional<Json::Value>(boost::none);
+        auto pathFindResult = ripplePathFind(cache, raSrc, raDst, saDstAmount, lpLedger, jvSrcCurrencies, contextPaths, level);
+        if (!pathFindResult.first)
+            return pathFindResult.second;
 
         // Each alternative differs by source currency.
-        jvResult[jss::alternatives] = jvArray;
+        jvResult[jss::alternatives] = pathFindResult.second;
     }
 
     WriteLog (lsDEBUG, RPCHandler)
@@ -325,6 +171,181 @@ Json::Value doRipplePathFind (RPC::Context& context)
                            % jvResult);
 
     return jvResult;
+}
+
+Json::Value
+buildSrcCurrencies(RippleAddress const& raSrc, RippleLineCache::pointer const& cache)
+{
+    auto currencies = accountSourceCurrencies(raSrc, cache, true);
+    auto jvSrcCurrencies = Json::Value(Json::arrayValue);
+
+    for (auto const& uCurrency : currencies)
+    {
+        Json::Value jvCurrency(Json::objectValue);
+        jvCurrency[jss::currency] = to_string(uCurrency);
+        jvSrcCurrencies.append(jvCurrency);
+    }
+
+    return jvSrcCurrencies;
+}
+
+std::pair<bool, Json::Value>
+ripplePathFind(RippleLineCache::pointer const& cache, RippleAddress const& raSrc, RippleAddress const& raDst,
+    STAmount const& saDstAmount, Ledger::pointer const& lpLedger, Json::Value const& jvSrcCurrencies, boost::optional<Json::Value> const& contextPaths, int const& level)
+{
+    FindPaths fp(
+        cache,
+        raSrc.getAccountID(),
+        raDst.getAccountID(),
+        saDstAmount,
+        level,
+        4); // max paths
+
+    Json::Value jvArray(Json::arrayValue);
+
+    for (unsigned int i = 0; i != jvSrcCurrencies.size(); ++i)
+    {
+        Json::Value jvSource = jvSrcCurrencies[i];
+
+        Currency uSrcCurrencyID;
+        Account uSrcIssuerID;
+
+        if (!jvSource.isObject())
+            return std::make_pair(false, rpcError(rpcINVALID_PARAMS));
+
+        // Parse mandatory currency.
+        if (!jvSource.isMember(jss::currency)
+            || !to_currency(
+            uSrcCurrencyID, jvSource[jss::currency].asString()))
+        {
+            WriteLog(lsINFO, RPCHandler) << "Bad currency.";
+
+            return std::make_pair(false, rpcError(rpcSRC_CUR_MALFORMED));
+        }
+
+        if (uSrcCurrencyID.isNonZero())
+            uSrcIssuerID = raSrc.getAccountID();
+
+        // Parse optional issuer.
+        if (jvSource.isMember(jss::issuer) &&
+            ((!jvSource[jss::issuer].isString() ||
+            !to_issuer(uSrcIssuerID, jvSource[jss::issuer].asString())) ||
+            (uSrcIssuerID.isZero() != uSrcCurrencyID.isZero()) ||
+            (noAccount() == uSrcIssuerID)))
+        {
+            WriteLog(lsINFO, RPCHandler) << "Bad issuer.";
+            return std::make_pair(false, rpcError(rpcSRC_ISR_MALFORMED));
+        }
+
+        STPathSet spsComputed;
+        if (contextPaths)
+        {
+            Json::Value pathSet = Json::objectValue;
+            pathSet[jss::Paths] = contextPaths.get();
+            STParsedJSONObject paths("pathSet", pathSet);
+            if (paths.object.get() == nullptr)
+                return std::make_pair(false, paths.error);
+            else
+            {
+                spsComputed = paths.object.get()->getFieldPathSet(sfPaths);
+                WriteLog(lsTRACE, RPCHandler) << "ripple_path_find: Paths: " << spsComputed.getJson(0);
+            }
+        }
+
+        STPath fullLiquidityPath;
+        auto valid = fp.findPathsForIssue(
+            { uSrcCurrencyID, uSrcIssuerID },
+            spsComputed,
+            fullLiquidityPath);
+        if (!valid)
+        {
+            WriteLog(lsWARNING, RPCHandler)
+                << "ripple_path_find: No paths found.";
+        }
+        else
+        {
+            auto& issuer =
+                isXRP(uSrcIssuerID) ?
+                isXRP(uSrcCurrencyID) ? // Default to source account.
+                xrpAccount() :
+                Account(raSrc.getAccountID())
+                : uSrcIssuerID;            // Use specifed issuer.
+
+            STAmount saMaxAmount({ uSrcCurrencyID, issuer }, 1);
+            saMaxAmount.negate();
+
+            LedgerEntrySet lesSandbox(lpLedger, tapNONE);
+
+            auto rc = path::RippleCalc::rippleCalculate(
+                lesSandbox,
+                saMaxAmount,            // --> Amount to send is unlimited
+                //     to get an estimate.
+                saDstAmount,            // --> Amount to deliver.
+                raDst.getAccountID(),  // --> Account to deliver to.
+                raSrc.getAccountID(),  // --> Account sending from.
+                spsComputed);           // --> Path set.
+
+            WriteLog(lsWARNING, RPCHandler)
+                << "ripple_path_find:"
+                << " saMaxAmount=" << saMaxAmount
+                << " saDstAmount=" << saDstAmount
+                << " saMaxAmountAct=" << rc.actualAmountIn
+                << " saDstAmountAct=" << rc.actualAmountOut;
+
+            if (fullLiquidityPath.size() > 0 &&
+                (rc.result() == terNO_LINE || rc.result() == tecPATH_PARTIAL))
+            {
+                WriteLog(lsDEBUG, PathRequest)
+                    << "Trying with an extra path element";
+
+                spsComputed.push_back(fullLiquidityPath);
+                lesSandbox.clear();
+                rc = path::RippleCalc::rippleCalculate(
+                    lesSandbox,
+                    saMaxAmount,            // --> Amount to send is unlimited
+                    //     to get an estimate.
+                    saDstAmount,            // --> Amount to deliver.
+                    raDst.getAccountID(),  // --> Account to deliver to.
+                    raSrc.getAccountID(),  // --> Account sending from.
+                    spsComputed);         // --> Path set.
+                WriteLog(lsDEBUG, PathRequest)
+                    << "Extra path element gives "
+                    << transHuman(rc.result());
+            }
+
+            if (rc.result() == tesSUCCESS)
+            {
+                Json::Value jvEntry(Json::objectValue);
+
+                STPathSet   spsCanonical;
+
+                // Reuse the expanded as it would need to be calcuated
+                // anyway to produce the canonical.  (At least unless we
+                // make a direct canonical.)
+
+                jvEntry[jss::source_amount] = rc.actualAmountIn.getJson(0);
+                jvEntry[jss::paths_canonical] = Json::arrayValue;
+                jvEntry[jss::paths_computed] = spsComputed.getJson(0);
+
+                jvArray.append(jvEntry);
+            }
+            else
+            {
+                std::string strToken;
+                std::string strHuman;
+
+                transResultInfo(rc.result(), strToken, strHuman);
+
+                WriteLog(lsDEBUG, RPCHandler)
+                    << "ripple_path_find: "
+                    << strToken << " "
+                    << strHuman << " "
+                    << spsComputed.getJson(0);
+            }
+        }
+    }
+
+    return std::make_pair(true, jvArray);
 }
 
 } // ripple

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -157,8 +157,11 @@ Json::Value doRipplePathFind (RPC::Context& context)
                 level = rLev;
         }
 
-        auto contextPaths = context.params.isMember(jss::paths) ? boost::optional<Json::Value>(context.params[jss::paths]) : boost::optional<Json::Value>(boost::none);
-        auto pathFindResult = ripplePathFind(cache, raSrc, raDst, saDstAmount, lpLedger, jvSrcCurrencies, contextPaths, level);
+        auto contextPaths = context.params.isMember(jss::paths) ?
+            boost::optional<Json::Value>(context.params[jss::paths]) :
+                boost::optional<Json::Value>(boost::none);
+        auto pathFindResult = ripplePathFind(cache, raSrc, raDst, saDstAmount, 
+            lpLedger, jvSrcCurrencies, contextPaths, level);
         if (!pathFindResult.first)
             return pathFindResult.second;
 
@@ -190,8 +193,11 @@ buildSrcCurrencies(RippleAddress const& raSrc, RippleLineCache::pointer const& c
 }
 
 std::pair<bool, Json::Value>
-ripplePathFind(RippleLineCache::pointer const& cache, RippleAddress const& raSrc, RippleAddress const& raDst,
-    STAmount const& saDstAmount, Ledger::pointer const& lpLedger, Json::Value const& jvSrcCurrencies, boost::optional<Json::Value> const& contextPaths, int const& level)
+ripplePathFind(RippleLineCache::pointer const& cache, 
+  RippleAddress const& raSrc, RippleAddress const& raDst,
+    STAmount const& saDstAmount, Ledger::pointer const& lpLedger, 
+      Json::Value const& jvSrcCurrencies, 
+        boost::optional<Json::Value> const& contextPaths, int const& level)
 {
     FindPaths fp(
         cache,
@@ -248,7 +254,8 @@ ripplePathFind(RippleLineCache::pointer const& cache, RippleAddress const& raSrc
             else
             {
                 spsComputed = paths.object.get()->getFieldPathSet(sfPaths);
-                WriteLog(lsTRACE, RPCHandler) << "ripple_path_find: Paths: " << spsComputed.getJson(0);
+                WriteLog(lsTRACE, RPCHandler) << "ripple_path_find: Paths: " <<
+                    spsComputed.getJson(0);
             }
         }
 

--- a/src/ripple/rpc/impl/RipplePathFind.h
+++ b/src/ripple/rpc/impl/RipplePathFind.h
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+/*
+This file is part of rippled: https://github.com/ripple/rippled
+Copyright (c) 2015 Ripple Labs Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose  with  or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_RPC_IMPL_RIPPLEPATHFIND_H_INCLUDED
+#define RIPPLE_RPC_IMPL_RIPPLEPATHFIND_H_INCLUDED
+
+#include <ripple/app/paths/RippleLineCache.h>
+#include <ripple/app/ledger/Ledger.h>
+
+namespace ripple {
+
+class RippleAddress;
+
+Json::Value
+buildSrcCurrencies(RippleAddress const& raSrc, RippleLineCache::pointer const& cache);
+
+std::pair<bool, Json::Value>
+ripplePathFind(RippleLineCache::pointer const& cache, RippleAddress const& raSrc, RippleAddress const& raDst,
+    STAmount const& saDstAmount, Ledger::pointer const& lpLedger, Json::Value const& jvSrcCurrencies, boost::optional<Json::Value> const& contextPaths, int const& level);
+
+}
+
+#endif

--- a/src/ripple/unity/app3.cpp
+++ b/src/ripple/unity/app3.cpp
@@ -24,3 +24,4 @@
 
 #include <ripple/app/tests/common_ledger.cpp>
 #include <ripple/app/ledger/tests/Ledger_test.cpp>
+#include <ripple/app/tests/Path_test.cpp>


### PR DESCRIPTION
* Refactor ripple path find to be more testable.
* Reimplements the first 4 tests from `tests\path-test.js`
* Verify balances in Ledger test.

Reviewers: @HowardHinnant, @scottschurr, @rec 

By way of background, my intention with these changes was to make debugging my changes for RIPD-655 easier. In the process of developing and validating the test functions, I started reimplementing the tests from `tests/path-test.js`. Even though it's not done, with RIPD-655 on hold for now, I figure the utility functions may be useful for other path-related tests. There are no RIPD-655-related changes in this PR. (Unsquashed changes are in https://github.com/ximinez/rippled/tree/x-path-unit.)