### PR TITLE
[Performance] Remove unnecessary allocation / deallocation from Application::masterLock

### DIFF
--- a/src/beast/beast/utility/make_lock.h
+++ b/src/beast/beast/utility/make_lock.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
-    This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012-2014 Ripple Labs Inc.
+    This file is part of Beast: https://github.com/vinniefalco/Beast
+    Copyright 2015, Howard Hinnant <howard.hinnant@gmail.com>
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -17,18 +17,22 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
-#include <beast/utility/make_lock.h>
+#ifndef BEAST_UTILITY_MAKE_LOCK_H_INCLUDED
+#define BEAST_UTILITY_MAKE_LOCK_H_INCLUDED
 
-namespace ripple {
+#include <mutex>
+#include <utility>
 
-// unl_score
-Json::Value doUnlScore (RPC::Context& context)
+namespace beast {
+
+template <class Mutex, class ...Args>
+inline
+std::unique_lock<Mutex>
+make_lock(Mutex& mutex, Args&&... args)
 {
-    auto lock = beast::make_lock(getApp().getMasterMutex());
-    getApp().getUNL ().nodeScore ();
-
-    return RPC::makeObjectValue ("scoring requested");
+    return std::unique_lock<Mutex>(mutex, std::forward<Args>(args)...);
 }
 
-} // ripple
+} // beast
+
+#endif

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -248,7 +248,7 @@ private:
 public:
     Logs& m_logs;
     beast::Journal m_journal;
-    Application::LockType m_masterMutex;
+    Application::MutexType m_masterMutex;
 
     // Required by the SHAMapStore
     TransactionMaster m_txMaster;
@@ -524,7 +524,7 @@ public:
         return *m_nodeStore;
     }
 
-    Application::LockType& getMasterLock ()
+    Application::MutexType& getMasterMutex ()
     {
         return m_masterMutex;
     }

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -70,7 +70,7 @@ class Application : public beast::PropertyStream::Source
 public:
     /* VFALCO NOTE
 
-        The master lock protects:
+        The master mutex protects:
 
         - The open ledger
         - Server global state
@@ -79,16 +79,8 @@ public:
 
         other things
     */
-    typedef std::recursive_mutex LockType;
-    typedef std::unique_lock <LockType> ScopedLockType;
-    typedef std::unique_ptr <ScopedLockType> ScopedLock;
-
-    virtual LockType& getMasterLock () = 0;
-
-    ScopedLock masterLock()
-    {
-        return std::make_unique<ScopedLockType> (getMasterLock());
-    }
+    using MutexType = std::recursive_mutex;
+    virtual MutexType& getMasterMutex () = 0;
 
 public:
     Application ();

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -60,6 +60,7 @@
 #include <beast/module/core/thread/DeadlineTimer.h>
 #include <beast/module/core/system/SystemStats.h>
 #include <beast/cxx14/memory.h> // <memory>
+#include <beast/utility/make_lock.h>
 #include <boost/optional.hpp>
 #include <tuple>
 
@@ -652,7 +653,7 @@ void NetworkOPsImp::onDeadlineTimer (beast::DeadlineTimer& timer)
 void NetworkOPsImp::processHeartbeatTimer ()
 {
     {
-        auto lock = getApp().masterLock();
+        auto lock = beast::make_lock(getApp().getMasterMutex());
 
         // VFALCO NOTE This is for diagnosing a crash on exit
         Application& app (getApp ());
@@ -1004,7 +1005,7 @@ Transaction::pointer NetworkOPsImp::processTransactionCb (
     }
 
     {
-        auto lock = getApp().masterLock();
+        auto lock = beast::make_lock(getApp().getMasterMutex());
 
         bool didApply;
         TER r = m_ledgerMaster.doTransaction (
@@ -1600,7 +1601,7 @@ void NetworkOPsImp::processTrustedProposal (
     uint256 checkLedger, bool sigGood)
 {
     {
-        auto lock = getApp().masterLock();
+        auto lock = beast::make_lock(getApp().getMasterMutex());
 
         bool relay = true;
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1478,7 +1478,7 @@ PeerImp::checkPropose (Job& job,
     uint256 consensusLCL;
     if (! set.has_previousledger() || ! isTrusted)
     {
-        Application::ScopedLockType lock (getApp ().getMasterLock ());
+        std::lock_guard<Application::MutexType> lock(getApp().getMasterMutex());
         consensusLCL = getApp().getOPs ().getConsensusLCL ();
     }
 
@@ -1614,7 +1614,7 @@ PeerImp::getLedger (std::shared_ptr<protocol::TMGetLedger> const& m)
         memcpy (txHash.begin (), packet.ledgerhash ().data (), 32);
 
         {
-            Application::ScopedLockType lock (getApp ().getMasterLock ());
+            std::lock_guard<Application::MutexType> lock(getApp().getMasterMutex());
             map = getApp().getOPs ().getTXMap (txHash);
         }
 
@@ -1976,7 +1976,7 @@ PeerImp::peerTXData (Job&, uint256 const& hash,
 
     SHAMapAddNode san;
     {
-        Application::ScopedLockType lock (getApp ().getMasterLock ());
+        std::lock_guard<Application::MutexType> lock(getApp().getMasterMutex());
 
         san =  getApp().getOPs().gotTXData (shared_from_this(),
             hash, nodeIDs, nodeData);

--- a/src/ripple/rpc/handlers/Connect.cpp
+++ b/src/ripple/rpc/handlers/Connect.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/overlay/Overlay.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
@@ -29,7 +30,7 @@ namespace ripple {
 // XXX Might allow domain for manual connections.
 Json::Value doConnect (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     if (getConfig ().RUN_STANDALONE)
         return "cannot connect in standalone mode";
 

--- a/src/ripple/rpc/handlers/ConsensusInfo.cpp
+++ b/src/ripple/rpc/handlers/ConsensusInfo.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
@@ -26,7 +27,7 @@ Json::Value doConsensusInfo (RPC::Context& context)
     Json::Value ret (Json::objectValue);
 
     {
-        auto lock = getApp().masterLock();
+        auto lock = beast::make_lock(getApp().getMasterMutex());
         ret[jss::info] = context.netOps.getConsensusInfo ();
     }
 

--- a/src/ripple/rpc/handlers/LedgerAccept.cpp
+++ b/src/ripple/rpc/handlers/LedgerAccept.cpp
@@ -18,12 +18,13 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
 Json::Value doLedgerAccept (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     Json::Value jvResult;
 
     if (!getConfig ().RUN_STANDALONE)

--- a/src/ripple/rpc/handlers/Peers.cpp
+++ b/src/ripple/rpc/handlers/Peers.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/peers/UniqueNodeList.h>
 #include <ripple/overlay/Overlay.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
@@ -29,7 +30,7 @@ Json::Value doPeers (RPC::Context& context)
     Json::Value jvResult (Json::objectValue);
 
     {
-        auto lock = getApp().masterLock();
+        auto lock = beast::make_lock(getApp().getMasterMutex());
 
         jvResult[jss::peers] = getApp().overlay ().json ();
         getApp().getUNL().addClusterStatus(jvResult);

--- a/src/ripple/rpc/handlers/Stop.cpp
+++ b/src/ripple/rpc/handlers/Stop.cpp
@@ -18,12 +18,13 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
 Json::Value doStop (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     getApp().signalStop ();
 
     return RPC::makeObjectValue (systemName () + " server stopping");

--- a/src/ripple/rpc/handlers/UnlAdd.cpp
+++ b/src/ripple/rpc/handlers/UnlAdd.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/peers/UniqueNodeList.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
@@ -28,7 +29,7 @@ namespace ripple {
 // }
 Json::Value doUnlAdd (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
 
     std::string strNode = context.params.isMember (jss::node)
             ? context.params[jss::node].asString () : "";

--- a/src/ripple/rpc/handlers/UnlDelete.cpp
+++ b/src/ripple/rpc/handlers/UnlDelete.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
@@ -26,7 +27,7 @@ namespace ripple {
 // }
 Json::Value doUnlDelete (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
 
     if (!context.params.isMember (jss::node))
         return rpcError (rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/UnlList.cpp
+++ b/src/ripple/rpc/handlers/UnlList.cpp
@@ -18,12 +18,13 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
 Json::Value doUnlList (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     Json::Value obj (Json::objectValue);
 
     obj[jss::unl] = getApp().getUNL ().getUnlJson ();

--- a/src/ripple/rpc/handlers/UnlLoad.cpp
+++ b/src/ripple/rpc/handlers/UnlLoad.cpp
@@ -18,13 +18,14 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
 // Populate the UNL from a local validators.txt file.
 Json::Value doUnlLoad (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
 
     if (getConfig ().VALIDATORS_FILE.empty ()
         || !getApp().getUNL ().nodeLoad (getConfig ().VALIDATORS_FILE))

--- a/src/ripple/rpc/handlers/UnlNetwork.cpp
+++ b/src/ripple/rpc/handlers/UnlNetwork.cpp
@@ -18,13 +18,14 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
 // Populate the UNL from ripple.com's validators.txt file.
 Json::Value doUnlNetwork (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     getApp().getUNL ().nodeNetwork ();
 
     return RPC::makeObjectValue ("fetching");

--- a/src/ripple/rpc/handlers/UnlReset.cpp
+++ b/src/ripple/rpc/handlers/UnlReset.cpp
@@ -18,12 +18,13 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
 Json::Value doUnlReset (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     getApp().getUNL ().nodeReset ();
 
     return RPC::makeObjectValue ("removing nodes");

--- a/src/ripple/rpc/handlers/ValidationSeed.cpp
+++ b/src/ripple/rpc/handlers/ValidationSeed.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <beast/utility/make_lock.h>
 
 namespace ripple {
 
@@ -26,7 +27,7 @@ namespace ripple {
 // }
 Json::Value doValidationSeed (RPC::Context& context)
 {
-    auto lock = getApp().masterLock();
+    auto lock = beast::make_lock(getApp().getMasterMutex());
     Json::Value obj (Json::objectValue);
 
     if (!context.params.isMember (jss::secret))


### PR DESCRIPTION
Every time we call getApp().getMasterLock() we are doing a new for the lock, and a delete for the unlock.  This is ridiculously expensive.  And part of the reason that nobody noticed we are doing this is because the code is over encapsulated.

This PR gets rid of the extra (hidden) new/delete, and also de-complicates the code:  The `Application` is now only responsible for providing the mutex.  The client that needs to lock the mutex is responsible for providing the lock, and deciding how to lock the mutex.  This makes it much clearer that there is nothing (like memory allocation) behind the curtain, because there is no more curtain.

To this end a new utility `make_lock` is introduced which deduces the correct lock type, based on the type of mutex passed to it.  This is only a convenience, and the client does not have to use it.  It is anticipated that this pattern will be followed in other places as well, and so `make_lock` may be reused in more places.  However `Application::masterLock` is the only place where there is currently a known performance penalty that needs fixing.

Also in one place a potential deadlock is fixed.  There currently is no deadlock.  But the code is very hard to read and prove to one's self that it can't deadlock.  The rewritten version proposed here is trivial to read and know there is no deadlock.

This PR is subdivided into 5 simple steps for ease in reviewing (from top to bottom).  These can be folded if desired.

@josh-ripple @seelabs  (or whoever has time to volunteer)