### PR TITLE
[Performance] Change several uses of std::list to alternative containers:

### DIFF
--- a/src/beast/beast/container/tests/aged_associative_container.test.cpp
+++ b/src/beast/beast/container/tests/aged_associative_container.test.cpp
@@ -387,10 +387,10 @@ public:
 
     template <class Cont>
     static
-    std::list <typename Cont::value_type>
+    std::vector <typename Cont::value_type>
     make_list (Cont const& c)
     {
-        return std::list <typename Cont::value_type> (
+        return std::vector <typename Cont::value_type> (
             c.begin(), c.end());
     }
 

--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -1720,10 +1720,10 @@ private:
     */
     void playbackProposals ()
     {
-        for (auto it: getApp().getOPs ().peekStoredProposals ())
+        for (auto const& it: getApp().getOPs ().peekStoredProposals ())
         {
             bool relay = false;
-            for (auto proposal : it.second)
+            for (auto const& proposal : it.second)
             {
                 if (proposal->hasSignature ())
                 {

--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -821,8 +821,8 @@ bool InboundLedger::takeHeader (std::string const& data)
 /** Process TX data received from a peer
     Call with a lock
 */
-bool InboundLedger::takeTxNode (const std::list<SHAMapNodeID>& nodeIDs,
-    const std::list< Blob >& data, SHAMapAddNode& san)
+bool InboundLedger::takeTxNode (const std::vector<SHAMapNodeID>& nodeIDs,
+    const std::vector< Blob >& data, SHAMapAddNode& san)
 {
     if (!mHaveHeader)
     {
@@ -838,11 +838,11 @@ bool InboundLedger::takeTxNode (const std::list<SHAMapNodeID>& nodeIDs,
         return true;
     }
 
-    std::list<SHAMapNodeID>::const_iterator nodeIDit = nodeIDs.begin ();
-    std::list< Blob >::const_iterator nodeDatait = data.begin ();
+    auto nodeIDit = nodeIDs.cbegin ();
+    auto nodeDatait = data.begin ();
     TransactionStateSF tFilter;
 
-    while (nodeIDit != nodeIDs.end ())
+    while (nodeIDit != nodeIDs.cend ())
     {
         if (nodeIDit->isRoot ())
         {
@@ -881,8 +881,8 @@ bool InboundLedger::takeTxNode (const std::list<SHAMapNodeID>& nodeIDs,
 /** Process AS data received from a peer
     Call with a lock
 */
-bool InboundLedger::takeAsNode (const std::list<SHAMapNodeID>& nodeIDs,
-    const std::list< Blob >& data, SHAMapAddNode& san)
+bool InboundLedger::takeAsNode (const std::vector<SHAMapNodeID>& nodeIDs,
+    const std::vector< Blob >& data, SHAMapAddNode& san)
 {
     if (m_journal.trace) m_journal.trace <<
         "got ASdata (" << nodeIDs.size () << ") acquiring ledger " << mHash;
@@ -905,11 +905,11 @@ bool InboundLedger::takeAsNode (const std::list<SHAMapNodeID>& nodeIDs,
         return true;
     }
 
-    std::list<SHAMapNodeID>::const_iterator nodeIDit = nodeIDs.begin ();
-    std::list< Blob >::const_iterator nodeDatait = data.begin ();
+    auto nodeIDit = nodeIDs.cbegin ();
+    auto nodeDatait = data.begin ();
     AccountStateSF tFilter;
 
-    while (nodeIDit != nodeIDs.end ())
+    while (nodeIDit != nodeIDs.cend ())
     {
         if (nodeIDit->isRoot ())
         {
@@ -1120,9 +1120,6 @@ int InboundLedger::processData (std::shared_ptr<Peer> peer,
     if ((packet.type () == protocol::liTX_NODE) || (
         packet.type () == protocol::liAS_NODE))
     {
-        std::list<SHAMapNodeID> nodeIDs;
-        std::list< Blob > nodeData;
-
         if (packet.nodes ().size () == 0)
         {
             if (m_journal.info) m_journal.info <<
@@ -1130,6 +1127,11 @@ int InboundLedger::processData (std::shared_ptr<Peer> peer,
             peer->charge (Resource::feeInvalidRequest);
             return -1;
         }
+
+        std::vector<SHAMapNodeID> nodeIDs;
+        nodeIDs.reserve(packet.nodes().size());
+        std::vector< Blob > nodeData;
+        nodeData.reserve(packet.nodes().size());
 
         for (int i = 0; i < packet.nodes ().size (); ++i)
         {

--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -125,7 +125,7 @@ private:
     int processData (std::shared_ptr<Peer> peer, protocol::TMLedgerData& data);
 
     bool takeHeader (std::string const& data);
-    bool takeTxNode (const std::list<SHAMapNodeID>& IDs, const std::list<Blob >& data,
+    bool takeTxNode (const std::vector<SHAMapNodeID>& IDs, const std::vector<Blob>& data,
                      SHAMapAddNode&);
     bool takeTxRootNode (Blob const& data, SHAMapAddNode&);
 
@@ -133,7 +133,7 @@ private:
     //             Don't use acronyms, but if we are going to use them at least
     //             capitalize them correctly.
     //
-    bool takeAsNode (const std::list<SHAMapNodeID>& IDs, const std::list<Blob >& data,
+    bool takeAsNode (const std::vector<SHAMapNodeID>& IDs, const std::vector<Blob>& data,
                      SHAMapAddNode&);
     bool takeAsRootNode (Blob const& data, SHAMapAddNode&);
 

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -931,7 +931,7 @@ public:
             mAdvanceWork = false; // If there's work to do, we'll make progress
             bool progress = false;
 
-            std::list<Ledger::pointer> pubLedgers = findNewLedgersToPublish ();
+            auto const pubLedgers = findNewLedgersToPublish ();
             if (pubLedgers.empty())
             {
                 if (!standalone_ && !getApp().getFeeTrack().isLoadedLocal() &&
@@ -1068,9 +1068,9 @@ public:
         } while (mAdvanceWork);
     }
 
-    std::list<Ledger::pointer> findNewLedgersToPublish ()
+    std::vector<Ledger::pointer> findNewLedgersToPublish ()
     {
-        std::list<Ledger::pointer> ret;
+        std::vector<Ledger::pointer> ret;
 
         WriteLog (lsTRACE, LedgerMaster) << "findNewLedgersToPublish<";
         if (mValidLedger.empty ())

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -28,6 +28,7 @@
 #include <beast/cxx14/memory.h> // <memory>
 #include <beast/threads/Stoppable.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <deque>
 #include <tuple>
 
 #include "ripple.pb.h"
@@ -267,7 +268,7 @@ public:
     virtual Json::Value getLedgerFetchInfo () = 0;
     virtual std::uint32_t acceptLedger () = 0;
 
-    typedef hash_map <NodeID, std::list<LedgerProposal::pointer>> Proposals;
+    typedef hash_map <NodeID, std::deque<LedgerProposal::pointer>> Proposals;
     virtual Proposals& peekStoredProposals () = 0;
 
     virtual void storeProposal (LedgerProposal::ref proposal,

--- a/src/ripple/net/impl/SNTPClient.cpp
+++ b/src/ripple/net/impl/SNTPClient.cpp
@@ -24,6 +24,7 @@
 #include <beast/asio/placeholders.h>
 #include <beast/threads/Thread.h>
 #include <boost/asio.hpp>
+#include <deque>
 #include <mutex>
 
 namespace ripple {
@@ -316,14 +317,10 @@ public:
         mLastOffsetUpdate = now;
 
         // select median time
-        std::list<int> offsetList = mOffsetList;
-        offsetList.sort ();
-        int j = offsetList.size ();
-        std::list<int>::iterator it = offsetList.begin ();
-
-        for (int i = 0; i < (j / 2); ++i)
-            ++it;
-
+        auto offsetList = mOffsetList;
+        std::sort(offsetList.begin(), offsetList.end());
+        auto j = offsetList.size ();
+        auto it = std::next(offsetList.begin (), j/2);
         mOffset = *it;
 
         if ((j % 2) == 0)
@@ -361,7 +358,7 @@ private:
 
     int                                             mOffset;
     time_t                                          mLastOffsetUpdate;
-    std::list<int>                                  mOffsetList;
+    std::deque<int>                                 mOffsetList;
 
     std::vector<uint8_t>                mReceiveBuffer;
     boost::asio::ip::udp::endpoint      mReceiveEndpoint;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1891,7 +1891,7 @@ PeerImp::getLedger (std::shared_ptr<protocol::TMGetLedger> const& m)
         }
 
         std::vector<SHAMapNodeID> nodeIDs;
-        std::list< Blob > rawNodes;
+        std::vector< Blob > rawNodes;
 
         try
         {
@@ -1901,7 +1901,7 @@ PeerImp::getLedger (std::shared_ptr<protocol::TMGetLedger> const& m)
                 p_journal_.trace <<
                     "GetLedger: getNodeFat got " << rawNodes.size () << " nodes";
                 std::vector<SHAMapNodeID>::iterator nodeIDIterator;
-                std::list< Blob >::iterator rawNodeIterator;
+                std::vector< Blob >::iterator rawNodeIterator;
 
                 for (nodeIDIterator = nodeIDs.begin (),
                         rawNodeIterator = rawNodes.begin ();

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -43,6 +43,7 @@
 #include <beast/http/parser.h>
 #include <beast/utility/WrappedSink.h>
 #include <cstdint>
+#include <deque>
 #include <queue>
 
 namespace ripple {
@@ -127,8 +128,8 @@ private:
     LedgerIndex maxLedger_ = 0;
     uint256 closedLedgerHash_;
     uint256 previousLedgerHash_;
-    std::list<uint256> recentLedgers_;
-    std::list<uint256> recentTxSets_;
+    std::deque<uint256> recentLedgers_;
+    std::deque<uint256> recentTxSets_;
     mutable std::mutex recentLock_;
     protocol::TMStatusChange last_status_;
     protocol::TMHello hello_;

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -147,7 +147,7 @@ public:
     void getMissingNodes (std::vector<SHAMapNodeID>& nodeIDs, std::vector<uint256>& hashes, int max,
                           SHAMapSyncFilter * filter);
     bool getNodeFat (SHAMapNodeID node, std::vector<SHAMapNodeID>& nodeIDs,
-                     std::list<Blob >& rawNode, bool fatRoot, bool fatLeaves) const;
+                     std::vector<Blob >& rawNode, bool fatRoot, bool fatLeaves) const;
     bool getRootNode (Serializer & s, SHANodeFormat format) const;
     std::vector<uint256> getNeededHashes (int max, SHAMapSyncFilter * filter);
     SHAMapAddNode addRootNode (uint256 const& hash, Blob const& rootNode, SHANodeFormat format,

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -303,7 +303,7 @@ std::vector<uint256> SHAMap::getNeededHashes (int max, SHAMapSyncFilter* filter)
 }
 
 bool SHAMap::getNodeFat (SHAMapNodeID wanted, std::vector<SHAMapNodeID>& nodeIDs,
-                         std::list<Blob >& rawNodes, bool fatRoot, bool fatLeaves) const
+                         std::vector<Blob >& rawNodes, bool fatRoot, bool fatLeaves) const
 {
     // Gets a node and some of its children
 

--- a/src/ripple/shamap/tests/SHAMapSync.test.cpp
+++ b/src/ripple/shamap/tests/SHAMapSync.test.cpp
@@ -113,11 +113,11 @@ public:
         source.setImmutable ();
 
         std::vector<SHAMapNodeID> nodeIDs, gotNodeIDs;
-        std::list< Blob > gotNodes;
+        std::vector< Blob > gotNodes;
         std::vector<uint256> hashes;
 
         std::vector<SHAMapNodeID>::iterator nodeIDIterator;
-        std::list< Blob >::iterator rawNodeIterator;
+        std::vector< Blob >::iterator rawNodeIterator;
 
         int passes = 0;
         int nodes = 0;


### PR DESCRIPTION
This addresses 99% of https://ripplelabs.atlassian.net/browse/RIPD-284

During a survey which looked at where we call `std::list::size()`, I found the following uses of `std::list` which should be changed to either `std::deque` or `std::vector` for performance reasons.  As a side effect, their calls to `size()` are no longer problematic ( `std::list::size()` is O(N) on gcc-4.8).  But these changes are a performance win even neglecting the calls to the O(N) `size`.

`deque` was chosen for the use cases that were only inserting and erasing at the front or back.
`vector` was chosen for the use cases that were only inserting and erasing at the back.

Simulations were run on wandbox -O2 gcc-4.8 to confirm the performance win.

Furthermore, there was one for-loop where we were copying an entire container per iteration of the loop -- fixed.

After this PR, there is still one place in rippled where we call `std::list::size()`.  In that use case we erase from the middle.  That use case is not addressed herein.

@rec @scottschurr  (or whoever has the time to volunteer)