### PR TITLE
STVar: optimized storage for STObject (RIPD-825): 

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2940,6 +2940,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\protocol\impl\STVar.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\protocol\impl\STVar.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\protocol\impl\STVector256.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3471,6 +3471,12 @@
     <ClCompile Include="..\..\src\ripple\protocol\impl\STValidation.cpp">
       <Filter>ripple\protocol\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\protocol\impl\STVar.cpp">
+      <Filter>ripple\protocol\impl</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\protocol\impl\STVar.h">
+      <Filter>ripple\protocol\impl</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\protocol\impl\STVector256.cpp">
       <Filter>ripple\protocol\impl</Filter>
     </ClCompile>

--- a/src/ripple/app/ledger/LedgerEntrySet.cpp
+++ b/src/ripple/app/ledger/LedgerEntrySet.cpp
@@ -513,22 +513,22 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
             {
                 // go through the original node for modified fields saved on modification
                 if (obj.getFName ().shouldMeta (SField::sMD_ChangeOrig) && !curNode->hasMatchingEntry (obj))
-                    prevs.addObject (obj);
+                    prevs.emplace_back (obj);
             }
 
             if (!prevs.empty ())
-                mSet.getAffectedNode (it.first).addObject (prevs);
+                mSet.getAffectedNode (it.first).emplace_back (std::move(prevs));
 
             STObject finals (sfFinalFields);
             for (auto const& obj : *curNode)
             {
                 // go through the final node for final fields
                 if (obj.getFName ().shouldMeta (SField::sMD_Always | SField::sMD_DeleteFinal))
-                    finals.addObject (obj);
+                    finals.emplace_back (obj);
             }
 
             if (!finals.empty ())
-                mSet.getAffectedNode (it.first).addObject (finals);
+                mSet.getAffectedNode (it.first).emplace_back (std::move(finals));
         }
         else if (type == &sfModifiedNode)
         {
@@ -542,22 +542,22 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
             {
                 // search the original node for values saved on modify
                 if (obj.getFName ().shouldMeta (SField::sMD_ChangeOrig) && !curNode->hasMatchingEntry (obj))
-                    prevs.addObject (obj);
+                    prevs.emplace_back (obj);
             }
 
             if (!prevs.empty ())
-                mSet.getAffectedNode (it.first).addObject (prevs);
+                mSet.getAffectedNode (it.first).emplace_back (std::move(prevs));
 
             STObject finals (sfFinalFields);
             for (auto const& obj : *curNode)
             {
                 // search the final node for values saved always
                 if (obj.getFName ().shouldMeta (SField::sMD_Always | SField::sMD_ChangeNew))
-                    finals.addObject (obj);
+                    finals.emplace_back (obj);
             }
 
             if (!finals.empty ())
-                mSet.getAffectedNode (it.first).addObject (finals);
+                mSet.getAffectedNode (it.first).emplace_back (std::move(finals));
         }
         else if (type == &sfCreatedNode) // if created, thread to owner(s)
         {
@@ -572,11 +572,11 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
             {
                 // save non-default values
                 if (!obj.isDefault () && obj.getFName ().shouldMeta (SField::sMD_Create | SField::sMD_Always))
-                    news.addObject (obj);
+                    news.emplace_back (obj);
             }
 
             if (!news.empty ())
-                mSet.getAffectedNode (it.first).addObject (news);
+                mSet.getAffectedNode (it.first).emplace_back (std::move(news));
         }
         else assert (false);
     }

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -44,9 +44,19 @@ public:
     {
         ;
     }
-    static std::unique_ptr<STBase> deserialize (SerialIter& sit, SField::ref name)
+
+    STAccount (SerialIter& sit, SField::ref name);
+
+    STBase*
+    copy (std::size_t n, void* buf) const override
     {
-        return std::unique_ptr<STBase> (construct (sit, name));
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
     }
 
     SerializedTypeID getSType () const override
@@ -75,12 +85,6 @@ public:
     }
 
     bool isValueH160 () const;
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STAccount>(*this);
-    }
 
 private:
     static STAccount* construct (SerialIter&, SField::ref);

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -38,7 +38,7 @@ namespace ripple {
 // Wire form:
 // High 8 bits are (offset+142), legal range is, 80 to 22 inclusive
 // Low 56 bits are value, legal range is 10^15 to (10^16 - 1) inclusive
-class STAmount final
+class STAmount
     : public STBase
 {
 public:
@@ -73,6 +73,8 @@ public:
 
     struct unchecked { };
 
+    STAmount(SerialIter& sit, SField::ref name);
+
     // Calls canonicalize
     STAmount (SField::ref name, Issue const& issue,
         mantissa_type mantissa, exponent_type exponent,
@@ -104,6 +106,18 @@ public:
 
     STAmount (Issue const& issue, int mantissa, int exponent = 0);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
+    }
+
     //--------------------------------------------------------------------------
 
 private:
@@ -118,18 +132,6 @@ public:
     static
     STAmount
     createFromInt64 (SField::ref n, std::int64_t v);
-
-    static
-    std::unique_ptr <STBase>
-    deserialize (
-        SerialIter& sit, SField::ref name)
-    {
-        return construct (sit, name);
-    }
-
-    static
-    STAmount
-    deserialize (SerialIter&);
 
     //--------------------------------------------------------------------------
     //
@@ -287,12 +289,6 @@ public:
     isDefault() const override
     {
         return (mValue == 0) && mIsNative;
-    }
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STAmount>(*this);
     }
 
     void canonicalize();

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -57,11 +57,21 @@ public:
         bitString_.SetHex (v);
     }
 
-    static
-    std::unique_ptr<STBase>
-    deserialize (SerialIter& sit, SField::ref name)
+    STBitString (SerialIter& sit, SField::ref name)
+        : STBitString(name, sit.getBitString<Bits>())
     {
-        return std::make_unique<STBitString> (name, sit.getBitString<Bits> ());
+    }
+
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
     }
 
     SerializedTypeID
@@ -109,12 +119,6 @@ public:
     isDefault () const override
     {
         return bitString_ == zero;
-    }
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STBitString>(*this);
     }
 
 private:

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -72,11 +72,16 @@ public:
 
     STBlob (SerialIter&, SField::ref name = sfGeneric);
 
-    static
-    std::unique_ptr<STBase>
-    deserialize (SerialIter& sit, SField::ref name)
+    STBase*
+    copy (std::size_t n, void* buf) const override
     {
-        return std::make_unique<STBlob> (name, sit.getVLBuffer ());
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
     }
 
     std::size_t
@@ -148,12 +153,6 @@ public:
     isDefault () const override
     {
         return value_.empty ();
-    }
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STBlob>(*this);
     }
 
 private:

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -40,9 +40,19 @@ public:
         : STBase (n), value_ (v)
     { }
 
-    static
-    std::unique_ptr<STBase>
-    deserialize (SerialIter& sit, SField::ref name);
+    STInteger(SerialIter& sit, SField::ref name);
+
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
+    }
 
     SerializedTypeID
     getSType () const override;
@@ -90,12 +100,6 @@ public:
     {
         const STInteger* v = dynamic_cast<const STInteger*> (&t);
         return v && (value_ == v->value_);
-    }
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STInteger>(*this);
     }
 
 private:

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -41,6 +41,18 @@ public:
     STLedgerEntry (LedgerEntryType type, uint256 const& index);
     STLedgerEntry (const STObject & object, uint256 const& index);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
+    }
+
     SerializedTypeID getSType () const override
     {
         return STI_LEDGERENTRY;
@@ -93,12 +105,6 @@ public:
     bool thread (uint256 const& txID, std::uint32_t ledgerSeq, uint256 & prevTxID,
                  std::uint32_t & prevLedgerID);
     std::vector<uint256> getOwners ();  // nodes notified if this node is deleted
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STLedgerEntry>(*this);
-    }
 
 private:
     /** Make STObject comply with the template for this SLE type

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -237,14 +237,18 @@ public:
         : STBase (n)
     { }
 
-    static
-    std::unique_ptr<STBase>
-    deserialize (SerialIter& sit, SField::ref name);
+    STPathSet (SerialIter& sit, SField::ref name);
 
-    std::unique_ptr<STBase>
-    duplicate () const override
+    STBase*
+    copy (std::size_t n, void* buf) const override
     {
-        return std::make_unique<STPathSet>(*this);
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
     }
 
     void

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -56,6 +56,18 @@ public:
     // Only called from ripple::RPC::transactionSign - can we eliminate this?
     explicit STTx (STObject const& object);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
+    }
+
     // STObject functions
     SerializedTypeID getSType () const override
     {
@@ -142,12 +154,6 @@ public:
         std::uint32_t inLedger,
         char status,
         std::string const& escapedMetaData) const;
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STTx>(*this);
-    }
 
 private:
     TxType tx_type_;

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -52,6 +52,18 @@ public:
     STValidation (uint256 const& ledgerHash, std::uint32_t signTime,
                           const RippleAddress & raPub, bool isFull);
 
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
+    }
+
     uint256         getLedgerHash ()     const;
     std::uint32_t   getSignTime ()       const;
     std::uint32_t   getFlags ()          const;

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -27,7 +27,7 @@
 
 namespace ripple {
 
-class STVector256 final
+class STVector256
     : public STBase
 {
 public:
@@ -41,6 +41,20 @@ public:
         : mValue (vector)
     { }
 
+    STVector256 (SerialIter& sit, SField::ref name);
+
+    STBase*
+    copy (std::size_t n, void* buf) const override
+    {
+        return emplace(n, buf, *this);
+    }
+
+    STBase*
+    move (std::size_t n, void* buf) override
+    {
+        return emplace(n, buf, std::move(*this));
+    }
+
     SerializedTypeID
     getSType () const override
     {
@@ -49,10 +63,6 @@ public:
     
     void
     add (Serializer& s) const override;
-
-    static
-    std::unique_ptr<STBase>
-    deserialize (SerialIter& sit, SField::ref name);
 
     Json::Value
     getJson (int) const override;
@@ -70,12 +80,6 @@ public:
     setValue (const STVector256& v)
     {
         mValue = v.mValue;
-    }
-
-    std::unique_ptr<STBase>
-    duplicate () const override
-    {
-        return std::make_unique<STVector256>(*this);
     }
 
     /** Retrieve a copy of the vector we contain */

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -22,6 +22,11 @@
 
 namespace ripple {
 
+STAccount::STAccount (SerialIter& sit, SField::ref name)
+    : STAccount(name, sit.getVLBuffer())
+{
+}
+
 std::string STAccount::getText () const
 {
     Account u;

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -145,27 +145,7 @@ STBase::addFieldID (Serializer& s) const
     s.addFieldID (fName->fieldType, fName->fieldValue);
 }
 
-std::unique_ptr <STBase>
-STBase::deserialize (SField::ref name)
-{
-    return std::make_unique<STBase>(name);
-}
-
 //------------------------------------------------------------------------------
-
-STBase*
-new_clone (const STBase& s)
-{
-    STBase* const copy (s.duplicate ().release ());
-    assert (typeid (*copy) == typeid (s));
-    return copy;
-}
-
-void
-delete_clone (const STBase* s)
-{
-    boost::checked_delete (s);
-}
 
 std::ostream&
 operator<< (std::ostream& out, const STBase& t)

--- a/src/ripple/protocol/impl/STInteger.cpp
+++ b/src/ripple/protocol/impl/STInteger.cpp
@@ -28,18 +28,17 @@
 
 namespace ripple {
 
+template<>
+STInteger<unsigned char>::STInteger(SerialIter& sit, SField::ref name)
+    : STInteger(name, sit.get8())
+{
+}
+
 template <>
 SerializedTypeID
 STUInt8::getSType () const
 {
     return STI_UINT8;
-}
-
-template <>
-std::unique_ptr<STBase>
-STUInt8::deserialize (SerialIter& sit, SField::ref name)
-{
-    return std::make_unique <STUInt8> (name, sit.get8 ());
 }
 
 template <>
@@ -77,18 +76,17 @@ STUInt8::getJson (int) const
 
 //------------------------------------------------------------------------------
 
+template<>
+STInteger<std::uint16_t>::STInteger(SerialIter& sit, SField::ref name)
+    : STInteger(name, sit.get16())
+{
+}
+
 template <>
 SerializedTypeID
 STUInt16::getSType () const
 {
     return STI_UINT16;
-}
-
-template <>
-std::unique_ptr<STBase>
-STUInt16::deserialize (SerialIter& sit, SField::ref name)
-{
-    return std::make_unique <STUInt16> (name, sit.get16 ());
 }
 
 template <>
@@ -143,18 +141,17 @@ STUInt16::getJson (int) const
 
 //------------------------------------------------------------------------------
 
+template<>
+STInteger<std::uint32_t>::STInteger(SerialIter& sit, SField::ref name)
+    : STInteger(name, sit.get32())
+{
+}
+
 template <>
 SerializedTypeID
 STUInt32::getSType () const
 {
     return STI_UINT32;
-}
-
-template <>
-std::unique_ptr<STBase>
-STUInt32::deserialize (SerialIter& sit, SField::ref name)
-{
-    return std::make_unique <STUInt32> (name, sit.get32 ());
 }
 
 template <>
@@ -173,18 +170,17 @@ STUInt32::getJson (int) const
 
 //------------------------------------------------------------------------------
 
+template<>
+STInteger<std::uint64_t>::STInteger(SerialIter& sit, SField::ref name)
+    : STInteger(name, sit.get64())
+{
+}
+
 template <>
 SerializedTypeID
 STUInt64::getSType () const
 {
     return STI_UINT64;
-}
-
-template <>
-std::unique_ptr<STBase>
-STUInt64::deserialize (SerialIter& sit, SField::ref name)
-{
-    return std::make_unique <STUInt64> (name, sit.get64 ());
 }
 
 template <>

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -50,14 +50,11 @@ STPathElement::get_hash (STPathElement const& element)
     return (hash_account ^ hash_currency ^ hash_issuer);
 }
 
-std::unique_ptr<STBase>
-STPathSet::deserialize (SerialIter& sit, SField::ref name)
+STPathSet::STPathSet (SerialIter& sit, SField::ref name)
+    : STBase(name)
 {
     std::vector<STPathElement> path;
-
-    auto pathset = std::make_unique <STPathSet> (name);
-
-    do
+    for(;;)
     {
         int iType = sit.get8 ();
 
@@ -71,13 +68,11 @@ STPathSet::deserialize (SerialIter& sit, SField::ref name)
                 throw std::runtime_error ("empty path");
             }
 
-            pathset->push_back (path);
+            push_back (path);
             path.clear ();
 
             if (iType == STPathElement::typeNone)
-            {
-                return std::move (pathset);
-            }
+                return;
         }
         else if (iType & ~STPathElement::typeAll)
         {
@@ -108,7 +103,6 @@ STPathSet::deserialize (SerialIter& sit, SField::ref name)
             path.emplace_back (account, currency, issuer, hasCurrency);
         }
     }
-    while (1);
 }
 
 bool

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -127,7 +127,7 @@ STTx::getMentionedAccounts () const
 {
     std::vector<RippleAddress> accounts;
 
-    for (auto const& it : peekData ())
+    for (auto const& it : *this)
     {
         if (auto sa = dynamic_cast<STAccount const*> (&it))
         {

--- a/src/ripple/protocol/impl/STVar.cpp
+++ b/src/ripple/protocol/impl/STVar.cpp
@@ -1,0 +1,183 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/STAccount.h>
+#include <ripple/protocol/STAmount.h>
+#include <ripple/protocol/STArray.h>
+#include <ripple/protocol/STBase.h>
+#include <ripple/protocol/STBitString.h>
+#include <ripple/protocol/STBlob.h>
+#include <ripple/protocol/STInteger.h>
+#include <ripple/protocol/STObject.h>
+#include <ripple/protocol/STPathSet.h>
+#include <ripple/protocol/STVector256.h>
+#include <ripple/protocol/impl/STVar.h>
+
+namespace ripple {
+namespace detail {
+
+defaultObject_t defaultObject;
+nonPresentObject_t nonPresentObject;
+
+//------------------------------------------------------------------------------
+
+STVar::Log::~Log()
+{
+    beast::debug_ostream os;
+    for(auto const& e : map_)
+        os << e.first << "," << e.second;
+}
+
+void
+STVar::Log::operator() (std::size_t n)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto const result = map_.emplace(n, 1);
+    if (! result.second)
+        ++result.first->second;
+}
+
+//------------------------------------------------------------------------------
+
+STVar::~STVar()
+{
+    destroy();
+}
+
+STVar::STVar (STVar const& other)
+    : p_(nullptr)
+{
+    if (other.p_ != nullptr)
+        p_ = other.p_->copy(
+            sizeof(d_), &d_);
+}
+
+STVar::STVar (STVar&& other)
+{
+    if (other.on_heap())
+    {
+        p_ = other.p_;
+        other.p_ = nullptr;
+    }
+    else
+    {
+        p_ = other.p_->move(
+            sizeof(d_), &d_);
+    }
+}
+
+STVar&
+STVar::operator= (STVar const& rhs)
+{
+    destroy();
+    p_ = nullptr;
+    if (rhs.p_)
+        p_ = rhs.p_->copy(
+            sizeof(d_), &d_);
+    return *this;
+}
+
+STVar&
+STVar::operator= (STVar&& rhs)
+{
+    destroy();
+    if (rhs.on_heap())
+    {
+        p_ = rhs.p_;
+        rhs.p_ = nullptr;
+    }
+    else
+    {
+        p_ = nullptr;
+        p_ = rhs.p_->move(
+            sizeof(d_), &d_);
+    }
+    return *this;
+}
+
+STVar::STVar (defaultObject_t, SField::ref name)
+    : STVar(name.fieldType, name)
+{
+}
+
+STVar::STVar (nonPresentObject_t, SField::ref name)
+    : STVar(STI_NOTPRESENT, name)
+{
+}
+
+STVar::STVar (SerialIter& sit, SField::ref name)
+{
+    switch (name.fieldType)
+    {
+    case STI_NOTPRESENT:    construct<STBase>(name); return;
+    case STI_UINT8:         construct<STUInt8>(sit, name); return;
+    case STI_UINT16:        construct<STUInt16>(sit, name); return;
+    case STI_UINT32:        construct<STUInt32>(sit, name); return;
+    case STI_UINT64:        construct<STUInt64>(sit, name); return;
+    case STI_AMOUNT:        construct<STAmount>(sit, name); return;
+    case STI_HASH128:       construct<STHash128>(sit, name); return;
+    case STI_HASH160:       construct<STHash160>(sit, name); return;
+    case STI_HASH256:       construct<STHash256>(sit, name); return;
+    case STI_VECTOR256:     construct<STVector256>(sit, name); return;
+    case STI_VL:            construct<STBlob>(sit, name); return;
+    case STI_ACCOUNT:       construct<STAccount>(sit, name); return;
+    case STI_PATHSET:       construct<STPathSet>(sit, name); return;
+    case STI_OBJECT:        construct<STObject>(sit, name); return;
+    case STI_ARRAY:         construct<STArray>(sit, name); return;
+    default:
+        throw std::runtime_error ("Unknown object type");
+    }
+}
+
+STVar::STVar (SerializedTypeID id, SField::ref name)
+{
+    assert ((id == STI_NOTPRESENT) || (id == name.fieldType));
+    switch (id)
+    {
+    case STI_NOTPRESENT:    construct<STBase>(name); return;
+    case STI_UINT8:         construct<STUInt8>(name); return;
+    case STI_UINT16:        construct<STUInt16>(name); return;
+    case STI_UINT32:        construct<STUInt32>(name); return;
+    case STI_UINT64:        construct<STUInt64>(name); return;
+    case STI_AMOUNT:        construct<STAmount>(name); return;
+    case STI_HASH128:       construct<STHash128>(name); return;
+    case STI_HASH160:       construct<STHash160>(name); return;
+    case STI_HASH256:       construct<STHash256>(name); return;
+    case STI_VECTOR256:     construct<STVector256>(name); return;
+    case STI_VL:            construct<STBlob>(name); return;
+    case STI_ACCOUNT:       construct<STAccount>(name); return;
+    case STI_PATHSET:       construct<STPathSet>(name); return;
+    case STI_OBJECT:        construct<STObject>(name); return;
+    case STI_ARRAY:         construct<STArray>(name); return;
+    default:
+        throw std::runtime_error ("Unknown object type");
+    }
+}
+
+void
+STVar::destroy()
+{
+    if (on_heap())
+        delete p_;
+    else
+        p_->~STBase();
+}
+
+} // detail
+} // ripple

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -1,0 +1,133 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PROTOCOL_STVAR_H_INCLUDED
+#define RIPPLE_PROTOCOL_STVAR_H_INCLUDED
+
+#include <ripple/protocol/Serializer.h>
+#include <ripple/protocol/SField.h>
+#include <ripple/protocol/STBase.h>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <typeinfo>
+
+#include <beast/streams/debug_ostream.h>
+#include <beast/utility/static_initializer.h>
+#include <mutex>
+#include <unordered_map>
+
+namespace ripple {
+namespace detail {
+
+struct defaultObject_t { };
+struct nonPresentObject_t { };
+
+extern defaultObject_t defaultObject;
+extern nonPresentObject_t nonPresentObject;
+
+// "variant" that can hold any type of serialized object
+// and includes a small-object allocation optimization.
+class STVar
+{
+private:
+    std::aligned_storage<72>::type d_;
+    STBase* p_ = nullptr;
+
+    struct Log
+    {
+        std::mutex mutex_;
+        std::unordered_map<
+            std::size_t, std::size_t> map_;
+
+        ~Log();
+        void operator() (std::size_t n);
+    };
+
+public:
+    ~STVar();
+    STVar (STVar const& other);
+    STVar (STVar&& other);
+    STVar& operator= (STVar const& rhs);
+    STVar& operator= (STVar&& rhs);
+
+    STVar (STBase&& t)
+    {
+        p_ = t.move(sizeof(d_), &d_);
+    }
+
+    STVar (STBase const& t)
+    {
+        p_ = t.copy(sizeof(d_), &d_);
+    }
+
+    STVar (defaultObject_t, SField::ref name);
+    STVar (nonPresentObject_t, SField::ref name);
+    STVar (SerialIter& sit, SField::ref name);
+
+    STBase& get() { return *p_; }
+    STBase& operator*() { return get(); }
+    STBase* operator->() { return &get(); }
+    STBase const& get() const { return *p_; }
+    STBase const& operator*() const { return get(); }
+    STBase const* operator->() const { return &get(); }
+
+private:
+    STVar (SerializedTypeID id, SField::ref name);
+
+    void destroy();
+
+    template <class T, class... Args>
+    void
+    construct(Args&&... args)
+    {
+        if(sizeof(T) > sizeof(d_))
+            p_ = new T(
+                std::forward<Args>(args)...);
+        else
+            p_ = new(&d_) T(
+                std::forward<Args>(args)...);
+    }
+
+    bool
+    on_heap() const
+    {
+        return static_cast<void const*>(p_) !=
+            static_cast<void const*>(&d_);
+    }
+};
+
+inline
+bool
+operator== (STVar const& lhs, STVar const& rhs)
+{
+    return lhs.get().isEquivalent(rhs.get());
+}
+
+inline
+bool
+operator!= (STVar const& lhs, STVar const& rhs)
+{
+    return ! (lhs == rhs);
+}
+
+} // detail
+} // ripple
+
+#endif

--- a/src/ripple/protocol/impl/STVector256.cpp
+++ b/src/ripple/protocol/impl/STVector256.cpp
@@ -25,31 +25,22 @@
 
 namespace ripple {
 
-std::unique_ptr<STBase>
-STVector256::deserialize (SerialIter& sit, SField::ref name)
+STVector256::STVector256(SerialIter& sit, SField::ref name)
+    : STBase(name)
 {
-    auto vec = std::make_unique<STVector256> (name);
-
     Blob data = sit.getVL ();
-
     auto const count = data.size () / (256 / 8);
-
-    vec->mValue.reserve (count);
-
+    mValue.reserve (count);
     Blob::iterator begin = data.begin ();
     unsigned int uStart  = 0;
-
     for (unsigned int i = 0; i != count; i++)
     {
-        unsigned int    uEnd    = uStart + (256 / 8);
-
-        // This next line could be optimized to construct a default uint256
-        // in the vector and then copy into it
-        vec->mValue.push_back (uint256 (Blob (begin + uStart, begin + uEnd)));
+        unsigned int uEnd = uStart + (256 / 8);
+        // This next line could be optimized to construct a default
+        // uint256 in the vector and then copy into it
+        mValue.push_back (uint256 (Blob (begin + uStart, begin + uEnd)));
         uStart  = uEnd;
     }
-
-    return std::move (vec);
 }
 
 void

--- a/src/ripple/protocol/tests/STAmount.test.cpp
+++ b/src/ripple/protocol/tests/STAmount.test.cpp
@@ -34,7 +34,7 @@ public:
         s.add (ser);
 
         SerialIter sit (ser);
-        return STAmount::deserialize (sit);
+        return STAmount(sit, sfGeneric);
     }
 
     //--------------------------------------------------------------------------

--- a/src/ripple/unity/protocol.cpp
+++ b/src/ripple/unity/protocol.cpp
@@ -47,6 +47,7 @@
 #include <ripple/protocol/impl/STPathSet.cpp>
 #include <ripple/protocol/impl/STTx.cpp>
 #include <ripple/protocol/impl/STValidation.cpp>
+#include <ripple/protocol/impl/STVar.cpp>
 #include <ripple/protocol/impl/STVector256.cpp>
 
 #include <ripple/protocol/tests/BuildInfo.test.cpp>


### PR DESCRIPTION
This introduces the STVar container, capable of holding any STBase-derived class and implementing a "small string" optimization. STObject is changed to store std::vector<STVar> instead of boost::ptr_vector<STBase>. This eliminates a significant number of needless dynamic memory allocations and deallocations during transaction processing when ledger entries are deserialized. It comes at the expense of larger overall storage requirements for STObject.