### PR TITLE
Stop rippled on SIGTERM in addition to SIGINT

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -412,7 +412,7 @@ public:
 
         , m_entropyTimer (this)
 
-        , m_signals(get_io_service(), SIGINT)
+        , m_signals(get_io_service(), SIGINT, SIGTERM)
 
         , m_resolver (ResolverAsio::New (get_io_service(), m_logs.journal("Resolver")))
 
@@ -668,9 +668,9 @@ public:
             m_journal.error << "Received signal: " << signal_number
                             << " with error: " << ec.message();
         }
-        else
+        else if (signal_number == SIGTERM || signal_number == SIGINT)
         {
-            m_journal.debug << "Received signal: " << signal_number;
+            m_journal.debug << "Received killing signal: " << signal_number;
             signalStop();
         }
     }


### PR DESCRIPTION
This causes sending SIGTERM to a rippled process to execute the same shutdown code as sending the ``stop`` RPC command. Additionally, it improves the signal handler to only shut down the server on SIGINT and SIGTERM to prevent accidental modifications to the m_signals initializer from inadvertently stopping the server.

With this change, rippled no longer requires calling the ``stop`` RPC command prior to exiting the process as one can continue to use the existing POSIX semantics. If the RPC server is not running or otherwise unable to respond to requests, the server still has a chance of exiting cleanly with this mechanism.

Sysadmins everywhere rejoice.