### PR TITLE
Reduce the number of copies needed when we unshare

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -394,8 +394,9 @@ public:
         }
         if (didApply)
         {
-           mCurrentLedger.set (ledger);
-           getApp().getOPs ().pubProposedTransaction (ledger, txn, result);
+            ledger->setImmutable (); // So the next line doesn't have to copy
+            mCurrentLedger.set (ledger);
+            getApp().getOPs ().pubProposedTransaction (ledger, txn, result);
         }
         return result;
     }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1062,6 +1062,7 @@ void ApplicationImp::startNewLedger ()
         firstLedger->updateHash ();
         firstLedger->setClosed ();
         firstLedger->setAccepted ();
+        firstLedger->setImmutable();
         m_ledgerMaster->pushLedger (firstLedger);
 
         Ledger::pointer secondLedger = std::make_shared<Ledger> (true, std::ref (*firstLedger));

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -274,6 +274,7 @@ void
 SHAMap::setImmutable ()
 {
     assert (state_ != SHAMapState::Invalid);
+    unshare ();
     state_ = SHAMapState::Immutable;
 }
 

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -75,7 +75,7 @@ SHAMap::snapShot (bool isMutable) const
     newMap.seq_ = seq_ + 1;
     newMap.root_ = root_;
 
-    if ((state_ != SHAMapState::Immutable) || !isMutable)
+    if ((state_ != SHAMapState::Immutable) || isMutable)
     {
         // If either map may change, they cannot share nodes
         newMap.unshare ();


### PR DESCRIPTION
In some code paths, we bump the SHAMap sequence number before we unshare. This forces SHAMapTreeNode copies. Setting the ledger immutable causes the unshare to occur earlier, eliminating the copies.

There was also a small bug in the decision whether to call unshare in SHAMap::snapShot.