### PR TITLE
Compare current seq vs validated seq (RIPD-669)

### DIFF
--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -149,7 +149,9 @@ error_code_i fillHandler (Context& context,
     if (!getConfig ().RUN_STANDALONE
         && (handler->condition_ & NEEDS_CURRENT_LEDGER)
         && (getApp().getLedgerMaster().getValidatedLedgerAge() >
-            Tuning::maxValidatedLedgerAge))
+            Tuning::maxValidatedLedgerAge
+            || context.netOps.getCurrentLedgerID() <=
+                context.netOps.getValidatedLedger ()->getLedgerSeq ()))
     {
         return rpcNO_CURRENT;
     }


### PR DESCRIPTION
This compares the current ledger sequence against the validated ledger sequence on RPC commands that require a current ledger. The current ledger sequence should always be greater than the validated ledger sequence.