### PR TITLE
Avoid copying and improve optimization opportunities

### DIFF
--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -43,6 +43,7 @@
 #include <ripple/protocol/UintTypes.h>
 #include <beast/module/core/text/LexicalCast.h>
 #include <beast/utility/make_lock.h>
+#include <type_traits>
 
 namespace ripple {
 
@@ -1433,10 +1434,10 @@ private:
 
         s.set_ledgerseq (ledger.getLedgerSeq ());
         s.set_networktime (getApp().getOPs ().getNetworkTimeNC ());
-        uint256 hash = ledger.getParentHash ();
-        s.set_ledgerhashprevious (hash.begin (), hash.size ());
-        hash = ledger.getHash ();
-        s.set_ledgerhash (hash.begin (), hash.size ());
+        s.set_ledgerhashprevious(ledger.getParentHash ().begin (),
+            std::decay_t<decltype(ledger.getParentHash ())>::bytes);
+        s.set_ledgerhash (ledger.getHash ().begin (),
+            std::decay_t<decltype(ledger.getHash ())>::bytes);
 
         std::uint32_t uMin, uMax;
         if (!getApp().getOPs ().getFullValidatedRange (uMin, uMax))

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -616,7 +616,8 @@ bool Ledger::getMetaHex (uint256 const& transID, std::string& hex) const
     return true;
 }
 
-uint256 Ledger::getHash ()
+uint256 const&
+Ledger::getHash ()
 {
     if (!mValidHash)
         updateHash ();

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -187,7 +187,7 @@ public:
     void addRaw (Serializer & s) const;
     void setRaw (Serializer & s, bool hasPrefix);
 
-    uint256 getHash ();
+    uint256 const& getHash ();
     uint256 const& getParentHash () const
     {
         return mParentHash;

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -261,12 +261,10 @@ public:
     NodeCache m_tempNodeCache;
     std::unique_ptr <CollectorManager> m_collectorManager;
     detail::AppFamily family_;
-    TreeNodeCache m_treeNodeCache;
     SLECache m_sleCache;
     LocalCredentials m_localCredentials;
 
     std::unique_ptr <Resource::Manager> m_resourceManager;
-    std::unique_ptr <FullBelowCache> m_fullBelowCache;
 
     // These are Stoppable-related
     std::unique_ptr <JobQueue> m_jobQueue;
@@ -341,18 +339,11 @@ public:
 
         , family_ (*m_nodeStore, *m_collectorManager)
 
-        , m_treeNodeCache ("TreeNodeCache", 65536, 60, get_seconds_clock (),
-            deprecatedLogs().journal("TaggedCache"))
-
         , m_sleCache ("LedgerEntryCache", 4096, 120, get_seconds_clock (),
             m_logs.journal("TaggedCache"))
 
         , m_resourceManager (Resource::make_Manager (
             m_collectorManager->collector(), m_logs.journal("Resource")))
-
-        , m_fullBelowCache (std::make_unique <FullBelowCache> (
-            "full_below", get_seconds_clock (), m_collectorManager->collector (),
-                fullBelowTargetSize, fullBelowExpirationSeconds))
 
         // The JobQueue has to come pretty early since
         // almost everything is a Stoppable child of the JobQueue.
@@ -457,11 +448,6 @@ public:
         return family_;
     }
 
-    FullBelowCache& getFullBelowCache ()
-    {
-        return *m_fullBelowCache;
-    }
-
     JobQueue& getJobQueue ()
     {
         return *m_jobQueue;
@@ -512,11 +498,6 @@ public:
     NodeCache& getTempNodeCache ()
     {
         return m_tempNodeCache;
-    }
-
-    TreeNodeCache&  getTreeNodeCache ()
-    {
-        return m_treeNodeCache;
     }
 
     NodeStore::Database& getNodeStore ()
@@ -785,8 +766,8 @@ public:
         m_ledgerMaster->tune (getConfig ().getSize (siLedgerSize), getConfig ().getSize (siLedgerAge));
         m_sleCache.setTargetSize (getConfig ().getSize (siSLECacheSize));
         m_sleCache.setTargetAge (getConfig ().getSize (siSLECacheAge));
-        m_treeNodeCache.setTargetSize (getConfig ().getSize (siTreeCacheSize));
-        m_treeNodeCache.setTargetAge (getConfig ().getSize (siTreeCacheAge));
+        family().treecache().setTargetSize (getConfig ().getSize (siTreeCacheSize));
+        family().treecache().setTargetAge (getConfig ().getSize (siTreeCacheAge));
 
         //----------------------------------------------------------------------
         //
@@ -995,7 +976,7 @@ public:
         //         have listeners register for "onSweep ()" notification.
         //
 
-        m_fullBelowCache->sweep ();
+        family_.fullbelow().sweep ();
 
         logTimedCall (m_journal.warning, "TransactionMaster::sweep", __FILE__, __LINE__, std::bind (
             &TransactionMaster::sweep, &m_txMaster));
@@ -1022,7 +1003,7 @@ public:
             &AcceptedLedger::sweep);
 
         logTimedCall (m_journal.warning, "SHAMap::sweep", __FILE__, __LINE__,std::bind (
-            &TreeNodeCache::sweep, &m_treeNodeCache));
+            &TreeNodeCache::sweep, &family().treecache()));
 
         logTimedCall (m_journal.warning, "NetworkOPs::sweepFetchPack", __FILE__, __LINE__, std::bind (
             &NetworkOPs::sweepFetchPack, m_networkOPs.get ()));

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -90,11 +90,9 @@ public:
     virtual boost::asio::io_service& getIOService () = 0;
     virtual CollectorManager&       getCollectorManager () = 0;
     virtual shamap::Family&         family() = 0;
-    virtual FullBelowCache&         getFullBelowCache () = 0;
     virtual JobQueue&               getJobQueue () = 0;
     virtual RPC::Manager&           getRPCManager () = 0;
     virtual NodeCache&              getTempNodeCache () = 0;
-    virtual TreeNodeCache&          getTreeNodeCache () = 0;
     virtual SLECache&               getSLECache () = 0;
     virtual Validators::Manager&    getValidators () = 0;
     virtual AmendmentTable&         getAmendmentTable() = 0;

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -265,8 +265,8 @@ SHAMapStoreImp::run()
     LedgerIndex lastRotated = state_db_.getState().lastRotated;
     netOPs_ = &getApp().getOPs();
     ledgerMaster_ = &getApp().getLedgerMaster();
-    fullBelowCache_ = &getApp().getFullBelowCache();
-    treeNodeCache_ = &getApp().getTreeNodeCache();
+    fullBelowCache_ = &getApp().family().fullbelow();
+    treeNodeCache_ = &getApp().family().treecache();
     transactionDb_ = &getApp().getTxnDB();
     ledgerDb_ = &getApp().getLedgerDB();
 

--- a/src/ripple/basics/impl/strHex.cpp
+++ b/src/ripple/basics/impl/strHex.cpp
@@ -19,21 +19,8 @@
 
 #include <BeastConfig.h>
 #include <algorithm>
-    
+
 namespace ripple {
-
-char charHex (int iDigit)
-{
-    if (iDigit >= 0)
-    {
-        if(iDigit < 10)
-            return '0' + iDigit;
-        if(iDigit < 16)
-            return 'A' - 10 + iDigit;
-    }
-
-    return 0;
-}
 
 int charUnHex (unsigned char c)
 {

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -26,14 +26,24 @@
 #define RIPPLE_BASICS_STRHEX_H_INCLUDED
 
 #include <string>
-    
+
 namespace ripple {
 
 /** Converts an integer to the corresponding hex digit
     @param iDigit 0-15 inclusive
-    @return a character from '0'-'9' or 'A'-'F' on success; 0 on failure.
+    @return a character from '0'-'9' or 'A'-'F'.
 */
-char charHex (int iDigit);
+inline
+char
+charHex (unsigned int digit)
+{
+    static
+    char const xtab[] = "0123456789ABCDEF";
+
+    assert (digit < 16);
+
+    return xtab[digit];
+}
 
 /** @{ */
 /** Converts a hex digit to the corresponding integer

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -110,11 +110,10 @@ Json::Value STArray::getJson (int p) const
     {
         if (object.getSType () != STI_NOTPRESENT)
         {
-            Json::Value inner = Json::objectValue;
+            Json::Value& inner = v.append (Json::objectValue);
             auto const& fname = object.getFName ();
             auto k = fname.hasName () ? fname.fieldName : std::to_string(index);
             inner[k] = object.getJson (p);
-            v.append (inner);
             index++;
         }
     }

--- a/src/ripple/rpc/handlers/GetCounts.cpp
+++ b/src/ripple/rpc/handlers/GetCounts.cpp
@@ -75,9 +75,9 @@ Json::Value doGetCounts (RPC::Context& context)
     ret[jss::ledger_hit_rate] = app.getLedgerMaster ().getCacheHitRate ();
     ret[jss::AL_hit_rate] = AcceptedLedger::getCacheHitRate ();
 
-    ret[jss::fullbelow_size] = static_cast<int>(app.getFullBelowCache().size());
-    ret[jss::treenode_cache_size] = app.getTreeNodeCache().getCacheSize();
-    ret[jss::treenode_track_size] = app.getTreeNodeCache().getTrackSize();
+    ret[jss::fullbelow_size] = static_cast<int>(app.family().fullbelow().size());
+    ret[jss::treenode_cache_size] = app.family().treecache().getCacheSize();
+    ret[jss::treenode_track_size] = app.family().treecache().getTrackSize();
 
     std::string uptime;
     int s = UptimeTimer::getInstance ().getElapsedSeconds ();


### PR DESCRIPTION
Two small optimizations: 

* Returning a reference to a `uint256` instead of a copy when getting the hash of a ledger. This should be trivially safe: callers who previously saved the result in an explicitly or `auto` declared `uint256` will still get the same semantics as before, as will callers who directly pass the result to a function.

* Reduce the complexity of the `charHex` function and alllow the compiler to inline it. This is also trivially safe, despite the removal of the `if` that checks to make sure that the input is not out-of-bounds. The code that calls this function always correctly provides a value between 0 and 15.

@HowardHinnant, @josh-ripple