### PR TITLE
Return descriptive error from account_currencies RPC (RIPD-806):

### DIFF
--- a/src/ripple/rpc/handlers/AccountCurrencies.cpp
+++ b/src/ripple/rpc/handlers/AccountCurrencies.cpp
@@ -42,9 +42,16 @@ Json::Value doAccountCurrencies (RPC::Context& context)
         ? params[jss::account].asString ()
         : params[jss::ident].asString ());
 
-    int const iIndex (params.isMember (jss::account_index)
-        ? params[jss::account_index].asUInt ()
-        : 0);
+    int iIndex = 0;
+
+    if (params.isMember (jss::account_index))
+    {
+        auto const& accountIndex = params[jss::account_index];
+        if (!accountIndex.isUInt() && !accountIndex.isInt ())
+            return RPC::invalid_field_message (jss::account_index);
+        iIndex = accountIndex.asUInt ();
+    }
+
     bool const bStrict = params.isMember (jss::strict) &&
             params[jss::strict].asBool ();
 


### PR DESCRIPTION
The 'account_index' field is expected to be an integer. If something
else is specified, the error message should clearly indicate which
field is at fault.

@rec, @HowardHinnant 