### PR TITLE
Proposed 0.28.0-b22

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -4509,6 +4509,8 @@
     </ClCompile>
     <ClInclude Include="..\..\src\soci\src\core\values.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\soci\src\core\version.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\sqlite\sqlite.h">
     </ClInclude>
     <ClCompile Include="..\..\src\sqlite\sqlite.unity.c">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -5280,6 +5280,9 @@
     <ClInclude Include="..\..\src\soci\src\core\values.h">
       <Filter>soci\src\core</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\soci\src\core\version.h">
+      <Filter>soci\src\core</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\sqlite\sqlite.h">
       <Filter>sqlite</Filter>
     </ClInclude>

--- a/Builds/rpm/rippled.spec
+++ b/Builds/rpm/rippled.spec
@@ -1,5 +1,5 @@
 Name:           rippled
-Version:        0.28.0-b21
+Version:        0.28.0-b22
 Release:        1%{?dist}
 Summary:        Ripple peer-to-peer network daemon
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -567,16 +567,16 @@ int Config::getSize (SizedItemName item) const
         { siValidationsSize,    {   256,    256,    512,    1024,       1024    } },
         { siValidationsAge,     {   500,    500,    500,    500,        500     } },
 
-        { siNodeCacheSize,      {   16384,  32768,  131072, 262144,     0       } },
-        { siNodeCacheAge,       {   60,     90,     120,    900,        0       } },
+        { siNodeCacheSize,      {   16384,  32768,  131072, 262144,     524288  } },
+        { siNodeCacheAge,       {   60,     90,     120,    900,        1800    } },
 
-        { siTreeCacheSize,      {   128000, 256000, 512000, 768000,     0       } },
+        { siTreeCacheSize,      {   128000, 256000, 512000, 768000,     2048000 } },
         { siTreeCacheAge,       {   30,     60,     90,     120,        900     } },
 
-        { siSLECacheSize,       {   4096,   8192,   16384,  65536,      0       } },
+        { siSLECacheSize,       {   4096,   8192,   16384,  65536,      131072  } },
         { siSLECacheAge,        {   30,     60,     90,     120,        300     } },
 
-        { siLedgerSize,         {   32,     128,    256,    384,        0       } },
+        { siLedgerSize,         {   32,     128,    256,    384,        768     } },
         { siLedgerAge,          {   30,     90,     180,    240,        900     } },
 
         { siHashNodeDBCache,    {   4,      12,     24,     64,         128      } },

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -35,7 +35,7 @@ char const* getRawVersionString ()
     //
     //  The build version number (edit this for each release)
     //
-        "0.28.0-b21"
+        "0.28.0-b22"
     //
     //  Must follow the format described here:
     //

--- a/src/soci/src/core/connection-pool.cpp
+++ b/src/soci/src/core/connection-pool.cpp
@@ -99,6 +99,7 @@ std::size_t connection_pool::lease()
 
     // no timeout
     bool const success = try_lease(pos, -1);
+    (void)success;
     assert(success);
 
     return pos;


### PR DESCRIPTION
Fixes a leak when "huge" node size is configured - does not require a restart of the testing process.
