### PR TITLE
Give ledger data requests their own job type

### DIFF
--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -40,8 +40,8 @@ enum JobType
     jtPACK,          // Make a fetch pack for a peer
     jtPUBOLDLEDGER,  // An old ledger has been accepted
     jtVALIDATION_ut, // A validation from an untrusted source
-    jtPROOFWORK,     // A proof of work demand from another server
     jtTRANSACTION_l, // A local transaction
+    jtLEDGER_REQ,    // Peer request ledger/txnset data
     jtPROPOSAL_ut,   // A proposal from an untrusted source
     jtLEDGER_DATA,   // Received data for a ledger we're acquiring
     jtCLIENT,        // A websocket command from the client

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -33,7 +33,6 @@ public:
     typedef std::map <JobType, JobTypeInfo> Map;
     typedef Map::const_iterator const_iterator;
 
-
     JobTypes ()
         : m_unknown (jtINVALID, "invalid", 0, true, true, 0, 0)
     {
@@ -51,13 +50,13 @@ public:
         add (jtVALIDATION_ut, "untrustedValidation",
             maxLimit, true,   false, 2000,  5000);
 
-        // A proof of work demand from another server
-        add (jtPROOFWORK,     "proofOfWork",
-            maxLimit, true,   false, 2000,  5000);
-
         // A local transaction
         add (jtTRANSACTION_l, "localTransaction",
             maxLimit, true,   false, 100,   500);
+
+        // A request for ledger/txnset data from another server
+        add (jtLEDGER_REQ,    "ledgerRequest",
+            2,        true,   false,    0,     0);
 
         // A proposal from an untrusted source
         add (jtPROPOSAL_ut,   "untrustedProposal",
@@ -67,10 +66,6 @@ public:
         add (jtLEDGER_DATA,   "ledgerData",
             2,        true,   false, 0,     0);
 
-        // Update pathfinding requests
-        add (jtUPDATE_PF,     "updatePaths",
-            maxLimit, true,   false, 0,     0);
-
         // A websocket command from the client
         add (jtCLIENT,        "clientCommand",
             maxLimit, true,   false, 2000,  5000);
@@ -78,6 +73,10 @@ public:
         // A websocket command from the client
         add (jtRPC,           "RPC",
             maxLimit, false,  false, 0,     0);
+
+        // Update pathfinding requests
+        add (jtUPDATE_PF,     "updatePaths",
+            maxLimit, true,   false, 0,     0);
 
         // A transaction received from the network
         add (jtTRANSACTION,   "transaction",

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -943,7 +943,7 @@ void
 PeerImp::onMessage (std::shared_ptr <protocol::TMGetLedger> const& m)
 {
     fee_ = Resource::feeMediumBurdenPeer;
-    getApp().getJobQueue().addJob (jtPACK, "recvGetLedger", std::bind(
+    getApp().getJobQueue().addJob (jtLEDGER_REQ, "recvGetLedger", std::bind(
         beast::weak_fn(&PeerImp::getLedger, shared_from_this()), m));
 }
 


### PR DESCRIPTION
This gives requests for ledger data (and transaction set data) from peers its own job type and prioritizes it appropriately. Previously, it was lumped in with fetch packs, which have a very low concurrency limit.