### PR TITLE
Remove ineffective const qualifier.

### DIFF
--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -80,7 +80,7 @@ STArray::STArray (SerialIter& sit, SField::ref f)
             throw std::runtime_error ("Illegal terminator in array");
         }
 
-        SField::ref const fn = SField::getField (type, field);
+        SField::ref fn = SField::getField (type, field);
 
         if (fn.isInvalid ())
         {


### PR DESCRIPTION
Silence this warning:

src/ripple/protocol/impl/STArray.cpp:83:21: warning: 'const' qualifier on reference type 'SField::ref' (aka 'const ripple::SField &') has no effect
      [-Wignored-qualifiers]
        SField::ref const fn = SField::getField (type, field);
                    ^~~~~~

@vinniefalco @miguelportilla 