### PR TITLE
[TRIVIAL] Reduce warning level of offer cancel logging

### DIFF
--- a/src/ripple/app/transactors/CreateOffer.cpp
+++ b/src/ripple/app/transactors/CreateOffer.cpp
@@ -486,14 +486,14 @@ public:
         }
 
         bool const bHaveExpiration (mTxn.isFieldPresent (sfExpiration));
-        
+
         if (bHaveExpiration && (mTxn.getFieldU32 (sfExpiration) == 0))
         {
             if (m_journal.debug) m_journal.warning <<
                 "Malformed offer: bad expiration";
             return temBAD_EXPIRATION;
         }
-        
+
         bool const bHaveCancel (mTxn.isFieldPresent (sfOfferSequence));
 
         if (bHaveCancel && (mTxn.getFieldU32 (sfOfferSequence) == 0))
@@ -609,7 +609,7 @@ public:
 
         if (view.isGlobalFrozen (uPaysIssuerID) || view.isGlobalFrozen (uGetsIssuerID))
         {
-            m_journal.warning <<
+            if (m_journal.warning) m_journal.warning <<
                 "Offer involves frozen asset";
 
             result = tecFROZEN;
@@ -617,7 +617,7 @@ public:
         else if (view.accountFunds (
             mTxnAccountID, saTakerGets, fhZERO_IF_FROZEN) <= zero)
         {
-            m_journal.warning <<
+            if (m_journal.debug) m_journal.debug <<
                 "delay: Offers must be at least partially funded.";
 
             result = tecUNFUNDED_OFFER;

--- a/src/ripple/legacy/0.27/CreateOffer27.cpp
+++ b/src/ripple/legacy/0.27/CreateOffer27.cpp
@@ -299,7 +299,7 @@ CreateOffer::doApply()
     }
     else if (view.isGlobalFrozen (uPaysIssuerID) || view.isGlobalFrozen (uGetsIssuerID))
     {
-        m_journal.warning <<
+        if (m_journal.debug) m_journal.debug <<
             "Offer involves frozen asset";
 
         terResult = tecFROZEN;
@@ -307,7 +307,7 @@ CreateOffer::doApply()
     else if (view.accountFunds (
         mTxnAccountID, saTakerGets, fhZERO_IF_FROZEN) <= zero)
     {
-        m_journal.warning <<
+        if (m_journal.debug) m_journal.debug <<
             "delay: Offers must be at least partially funded.";
 
         terResult = tecUNFUNDED_OFFER;
@@ -342,7 +342,7 @@ CreateOffer::doApply()
         // been consumed or removed as we are processing.
         if (sleCancel)
         {
-            m_journal.warning <<
+            if (m_journal.debug) m_journal.debug <<
                 "Cancelling order with sequence " << uCancelSequence;
 
             terResult = view.offerDelete (sleCancel);


### PR DESCRIPTION
The legacy OfferCreate transactor generates a log at warning level when trying to cancel a previous offer, which is allowed and non-exceptional.

Reviews: @vinniefalco 