### PR TITLE
In consensus, get relative times from a steady clock (RIPD-859)

### DIFF
--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -103,7 +103,7 @@ public:
         , mClosePercent (0)
         , mHaveCloseTimeConsensus (false)
         , mConsensusStartTime
-            (boost::posix_time::microsec_clock::universal_time ())
+            (std::chrono::steady_clock::now ())
     {
         WriteLog (lsDEBUG, LedgerConsensus) << "Creating consensus object";
         WriteLog (lsTRACE, LedgerConsensus)
@@ -594,9 +594,8 @@ public:
         if ((mState != lcsFINISHED) && (mState != lcsACCEPTED))
             checkLCL ();
 
-        mCurrentMSeconds =
-            (boost::posix_time::microsec_clock::universal_time ()
-            - mConsensusStartTime).total_milliseconds ();
+        mCurrentMSeconds = std::chrono::duration_cast <std::chrono::milliseconds>
+            (std::chrono::steady_clock::now() - mConsensusStartTime).count ();
         mClosePercent = mCurrentMSeconds * 100 / mPreviousMSeconds;
 
         switch (mState)
@@ -1425,11 +1424,11 @@ private:
     void updateOurPositions ()
     {
         // Compute a cutoff time
-        boost::posix_time::ptime peerCutoff
-            = boost::posix_time::second_clock::universal_time ();
-        boost::posix_time::ptime ourCutoff
-            = peerCutoff - boost::posix_time::seconds (PROPOSE_INTERVAL);
-        peerCutoff -= boost::posix_time::seconds (PROPOSE_FRESHNESS);
+        auto peerCutoff
+            = std::chrono::steady_clock::now ();
+        auto ourCutoff
+            = peerCutoff - std::chrono::seconds (PROPOSE_INTERVAL);
+        peerCutoff -= std::chrono::seconds (PROPOSE_FRESHNESS);
 
         bool changes = false;
         std::shared_ptr<SHAMap> ourPosition;
@@ -1654,7 +1653,7 @@ private:
         checkOurValidation ();
         mState = lcsESTABLISH;
         mConsensusStartTime
-            = boost::posix_time::microsec_clock::universal_time ();
+            = std::chrono::steady_clock::now ();
         mCloseTime = getApp().getOPs ().getCloseTimeNC ();
         getApp().getOPs ().setLastCloseTime (mCloseTime);
         statusChange (protocol::neCLOSING_LEDGER, *mPreviousLedger);
@@ -1782,7 +1781,7 @@ private:
     int mCurrentMSeconds, mClosePercent, mCloseResolution;
     bool mHaveCloseTimeConsensus;
 
-    boost::posix_time::ptime        mConsensusStartTime;
+    std::chrono::steady_clock::time_point   mConsensusStartTime;
     int                             mPreviousProposers;
     int                             mPreviousMSeconds;
 

--- a/src/ripple/app/ledger/LedgerProposal.cpp
+++ b/src/ripple/app/ledger/LedgerProposal.cpp
@@ -37,7 +37,7 @@ LedgerProposal::LedgerProposal (uint256 const& pLgr, std::uint32_t seq,
     // throw std::runtime_error("Invalid public key in proposal");
 
     mPeerID         = mPublicKey.getNodeID ();
-    mTime           = boost::posix_time::second_clock::universal_time ();
+    mTime           = std::chrono::steady_clock::now ();
 }
 
 LedgerProposal::LedgerProposal (RippleAddress const& naPub, RippleAddress const& naPriv,
@@ -47,14 +47,14 @@ LedgerProposal::LedgerProposal (RippleAddress const& naPub, RippleAddress const&
     mPublicKey (naPub), mPrivateKey (naPriv)
 {
     mPeerID      = mPublicKey.getNodeID ();
-    mTime        = boost::posix_time::second_clock::universal_time ();
+    mTime        = std::chrono::steady_clock::now ();
 }
 
 LedgerProposal::LedgerProposal (uint256 const& prevLgr, uint256 const& position,
                                 std::uint32_t closeTime) :
     mPreviousLedger (prevLgr), mCurrentHash (position), mCloseTime (closeTime), mProposeSeq (0)
 {
-    mTime       = boost::posix_time::second_clock::universal_time ();
+    mTime       = std::chrono::steady_clock::now ();
 }
 
 uint256 LedgerProposal::getSigningHash () const
@@ -103,14 +103,14 @@ bool LedgerProposal::changePosition (uint256 const& newPosition, std::uint32_t c
 
     mCurrentHash    = newPosition;
     mCloseTime      = closeTime;
-    mTime           = boost::posix_time::second_clock::universal_time ();
+    mTime           = std::chrono::steady_clock::now ();
     ++mProposeSeq;
     return true;
 }
 
 void LedgerProposal::bowOut ()
 {
-    mTime           = boost::posix_time::second_clock::universal_time ();
+    mTime           = std::chrono::steady_clock::now ();
     mProposeSeq     = seqLeave;
 }
 

--- a/src/ripple/app/ledger/LedgerProposal.h
+++ b/src/ripple/app/ledger/LedgerProposal.h
@@ -118,11 +118,11 @@ public:
         return mProposeSeq == seqLeave;
     }
 
-    const boost::posix_time::ptime getCreateTime ()
+    std::chrono::steady_clock::time_point getCreateTime ()
     {
         return mTime;
     }
-    bool isStale (boost::posix_time::ptime cutoff)
+    bool isStale (std::chrono::steady_clock::time_point cutoff)
     {
         return mTime <= cutoff;
     }
@@ -143,12 +143,12 @@ private:
     uint256 mPreviousLedger, mCurrentHash, mSuppression;
     std::uint32_t mCloseTime, mProposeSeq;
 
-    NodeID         mPeerID;
+    NodeID          mPeerID;
     RippleAddress   mPublicKey;
     RippleAddress   mPrivateKey;    // If ours
 
-    std::string                 mSignature; // set only if needed
-    boost::posix_time::ptime    mTime;
+    std::string     mSignature; // set only if needed
+    std::chrono::steady_clock::time_point mTime;
 };
 
 } // ripple


### PR DESCRIPTION
Using the system clock to get relative times for consensus timing can result in performance issues if the system time changes frequently.

This was observed to cause a stability problem on a machine with a fast clock and poor man's time synchronization (running ntpdate periodically).