### PR TITLE
Remove nested types SField::ref and SField::ptr...

### DIFF
--- a/src/ripple/app/ledger/LedgerEntrySet.cpp
+++ b/src/ripple/app/ledger/LedgerEntrySet.cpp
@@ -459,7 +459,7 @@ void LedgerEntrySet::calcRawMeta (Serializer& s, TER result, std::uint32_t index
 
     for (auto& it : mEntries)
     {
-        SField::ptr type = &sfGeneric;
+        auto type = &sfGeneric;
 
         switch (it.second.mAction)
         {

--- a/src/ripple/app/paths/cursor/RippleLiquidity.cpp
+++ b/src/ripple/app/paths/cursor/RippleLiquidity.cpp
@@ -207,8 +207,8 @@ rippleQuality (
     Account const& destination,
     Account const& source,
     Currency const& currency,
-    SField::ref sfLow,
-    SField::ref sfHigh)
+    SField const& sfLow,
+    SField const& sfHigh)
 {
     std::uint32_t uQuality (QUALITY_ONE);
 
@@ -221,7 +221,7 @@ rippleQuality (
 
         if (sleRippleState)
         {
-            SField::ref sfField = destination < source ? sfLow : sfHigh;
+            auto const& sfField = destination < source ? sfLow : sfHigh;
 
             uQuality = sleRippleState->isFieldPresent (sfField)
                 ? sleRippleState->getFieldU32 (sfField)

--- a/src/ripple/app/tx/TransactionMeta.cpp
+++ b/src/ripple/app/tx/TransactionMeta.cpp
@@ -72,7 +72,7 @@ bool TransactionMetaSet::isNodeAffected (uint256 const& node) const
     return false;
 }
 
-void TransactionMetaSet::setAffectedNode (uint256 const& node, SField::ref type,
+void TransactionMetaSet::setAffectedNode (uint256 const& node, SField const& type,
                                           std::uint16_t nodeType)
 {
     // make sure the node exists and force its type
@@ -158,7 +158,7 @@ std::vector<RippleAddress> TransactionMetaSet::getAffectedAccounts ()
     return accounts;
 }
 
-STObject& TransactionMetaSet::getAffectedNode (SLE::ref node, SField::ref type)
+STObject& TransactionMetaSet::getAffectedNode (SLE::ref node, SField const& type)
 {
     assert (&type);
     uint256 index = node->getIndex ();

--- a/src/ripple/app/tx/TransactionMeta.h
+++ b/src/ripple/app/tx/TransactionMeta.h
@@ -86,8 +86,9 @@ public:
     }
 
     bool isNodeAffected (uint256 const& ) const;
-    void setAffectedNode (uint256 const& , SField::ref type, std::uint16_t nodeType);
-    STObject& getAffectedNode (SLE::ref node, SField::ref type); // create if needed
+    void setAffectedNode (uint256 const& , SField const& type,
+                          std::uint16_t nodeType);
+    STObject& getAffectedNode (SLE::ref node, SField const& type); // create if needed
     STObject& getAffectedNode (uint256 const& );
     const STObject& peekAffectedNode (uint256 const& ) const;
     std::vector<RippleAddress> getAffectedAccounts ();

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -104,9 +104,6 @@ field_code(int id, int index)
 class SField
 {
 public:
-    typedef const SField&   ref;
-    typedef SField const*   ptr;
-
     enum
     {
         sMD_Never          = 0x00,
@@ -155,13 +152,13 @@ protected:
 
 public:
     // getField will dynamically construct a new SField if necessary
-    static SField::ref getField (int fieldCode);
-    static SField::ref getField (std::string const& fieldName);
-    static SField::ref getField (int type, int value)
+    static const SField& getField (int fieldCode);
+    static const SField& getField (std::string const& fieldName);
+    static const SField& getField (int type, int value)
     {
         return getField (field_code (type, value));
     }
-    static SField::ref getField (SerializedTypeID type, int value)
+    static const SField& getField (SerializedTypeID type, int value)
     {
         return getField (field_code (type, value));
     }
@@ -252,7 +249,7 @@ public:
         return fieldCode != f.fieldCode;
     }
 
-    static int compare (SField::ref f1, SField::ref f2);
+    static int compare (const SField& f1, const SField& f2);
 
     struct make;  // public, but still an implementation detail
 

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -41,10 +41,10 @@ enum SOE_Flags
 class SOElement
 {
 public:
-    SField::ref       e_field;
+    SField const&     e_field;
     SOE_Flags const   flags;
 
-    SOElement (SField::ref fieldName, SOE_Flags flags)
+    SOElement (SField const& fieldName, SOE_Flags flags)
         : e_field (fieldName)
         , flags (flags)
     {
@@ -82,7 +82,7 @@ public:
     void push_back (SOElement const& r);
 
     /** Retrieve the position of a named field. */
-    int getIndex (SField::ref) const;
+    int getIndex (SField const&) const;
 
 private:
     list_type mTypes;

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -30,13 +30,13 @@ class STAccount final
     : public STBlob
 {
 public:
-    STAccount (SField::ref n, Buffer&& v)
+    STAccount (SField const& n, Buffer&& v)
             : STBlob (n, std::move(v))
     {
         ;
     }
-    STAccount (SField::ref n, Account const& v);
-    STAccount (SField::ref n) : STBlob (n)
+    STAccount (SField const& n, Account const& v);
+    STAccount (SField const& n) : STBlob (n)
     {
         ;
     }
@@ -45,7 +45,7 @@ public:
         ;
     }
 
-    STAccount (SerialIter& sit, SField::ref name);
+    STAccount (SerialIter& sit, SField const& name);
 
     STBase*
     copy (std::size_t n, void* buf) const override
@@ -87,7 +87,7 @@ public:
     bool isValueH160 () const;
 
 private:
-    static STAccount* construct (SerialIter&, SField::ref);
+    static STAccount* construct (SerialIter&, SField const&);
 };
 
 } // ripple

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -73,24 +73,24 @@ public:
 
     struct unchecked { };
 
-    STAmount(SerialIter& sit, SField::ref name);
+    STAmount(SerialIter& sit, SField const& name);
 
     // Calls canonicalize
-    STAmount (SField::ref name, Issue const& issue,
+    STAmount (SField const& name, Issue const& issue,
         mantissa_type mantissa, exponent_type exponent,
             bool native, bool negative);
 
     // Does not call canonicalize
-    STAmount (SField::ref name, Issue const& issue,
+    STAmount (SField const& name, Issue const& issue,
         mantissa_type mantissa, exponent_type exponent,
             bool native, bool negative, unchecked);
 
-    STAmount (SField::ref name, std::int64_t mantissa);
+    STAmount (SField const& name, std::int64_t mantissa);
 
-    STAmount (SField::ref name,
+    STAmount (SField const& name,
         std::uint64_t mantissa = 0, bool negative = false);
 
-    STAmount (SField::ref name, Issue const& issue,
+    STAmount (SField const& name, Issue const& issue,
         std::uint64_t mantissa = 0, int exponent = 0, bool negative = false);
 
     STAmount (std::uint64_t mantissa = 0, bool negative = false);
@@ -123,7 +123,7 @@ public:
 private:
     static
     std::unique_ptr<STAmount>
-    construct (SerialIter&, SField::ref name);
+    construct (SerialIter&, SField const& name);
 
     void
     setSNValue (std::int64_t);
@@ -131,7 +131,7 @@ private:
 public:
     static
     STAmount
-    createFromInt64 (SField::ref n, std::int64_t v);
+    createFromInt64 (SField const& n, std::int64_t v);
 
     //--------------------------------------------------------------------------
     //
@@ -306,7 +306,7 @@ STAmount
 amountFromQuality (std::uint64_t rate);
 
 STAmount
-amountFromJson (SField::ref name, Json::Value const& v);
+amountFromJson (SField const& name, Json::Value const& v);
 
 STAmount
 amountFromRate (std::uint64_t uRate);

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -52,10 +52,10 @@ public:
     STArray();
     STArray (STArray&&);
     STArray (STArray const&) = default;
-    STArray (SField::ref f, int n);
-    STArray (SerialIter& sit, SField::ref f);
+    STArray (SField const& f, int n);
+    STArray (SerialIter& sit, SField const& f);
     explicit STArray (int n);
-    explicit STArray (SField::ref f);
+    explicit STArray (SField const& f);
     STArray& operator= (STArray const&) = default;
     STArray& operator= (STArray&&);
 

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -62,7 +62,7 @@ public:
     STBase();
 
     explicit
-    STBase (SField::ref n);
+    STBase (SField const& n);
 
     virtual ~STBase() = default;
 
@@ -137,16 +137,16 @@ public:
         This sets the name.
     */
     void
-    setFName (SField::ref n);
+    setFName (SField const& n);
 
-    SField::ref
+    SField const&
     getFName() const;
 
     void
     addFieldID (Serializer& s) const;
 
 protected:
-    SField::ptr fName;
+    SField const* fName;
 
     template <class T>
     static

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -33,7 +33,7 @@ public:
 
     STBitString () = default;
 
-    STBitString (SField::ref n)
+    STBitString (SField const& n)
         : STBase (n)
     { }
 
@@ -41,23 +41,23 @@ public:
         : bitString_ (v)
     { }
 
-    STBitString (SField::ref n, const BitString& v)
+    STBitString (SField const& n, const BitString& v)
         : STBase (n), bitString_ (v)
     { }
 
-    STBitString (SField::ref n, const char* v)
+    STBitString (SField const& n, const char* v)
         : STBase (n)
     {
         bitString_.SetHex (v);
     }
 
-    STBitString (SField::ref n, std::string const& v)
+    STBitString (SField const& n, std::string const& v)
         : STBase (n)
     {
         bitString_.SetHex (v);
     }
 
-    STBitString (SerialIter& sit, SField::ref name)
+    STBitString (SerialIter& sit, SField const& name)
         : STBitString(name, sit.getBitString<Bits>())
     {
     }

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -47,14 +47,14 @@ public:
             void(void* data, std::size_t size)
     */
     template <class Init>
-    STBlob (SField::ref f, std::size_t size,
+    STBlob (SField const& f, std::size_t size,
             Init&& init)
         : STBase(f), value_ (size)
     {
         init(value_.data(), value_.size());
     }
 
-    STBlob (SField::ref f,
+    STBlob (SField const& f,
             void const* data, std::size_t size)
         : STBase(f), value_ (data, size)
     {
@@ -65,12 +65,12 @@ public:
     {
     }
 
-    STBlob (SField::ref n)
+    STBlob (SField const& n)
         : STBase (n)
     {
     }
 
-    STBlob (SerialIter&, SField::ref name = sfGeneric);
+    STBlob (SerialIter&, SField const& name = sfGeneric);
 
     STBase*
     copy (std::size_t n, void* buf) const override

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -36,11 +36,11 @@ public:
         : value_ (v)
     { }
 
-    STInteger (SField::ref n, Integer v = 0)
+    STInteger (SField const& n, Integer v = 0)
         : STBase (n), value_ (v)
     { }
 
-    STInteger(SerialIter& sit, SField::ref name);
+    STInteger(SerialIter& sit, SField const& name);
 
     STBase*
     copy (std::size_t n, void* buf) const override

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -97,14 +97,14 @@ public:
 
     STObject(STObject&&);
     STObject(STObject const&) = default;
-    STObject (const SOTemplate & type, SField::ref name);
-    STObject (const SOTemplate & type, SerialIter & sit, SField::ref name);
-    STObject (SField::ref name, boost::ptr_vector<STBase>& data);
-    STObject (SerialIter& sit, SField::ref name);
+    STObject (const SOTemplate & type, SField const& name);
+    STObject (const SOTemplate & type, SerialIter & sit, SField const& name);
+    STObject (SField const& name, boost::ptr_vector<STBase>& data);
+    STObject (SerialIter& sit, SField const& name);
     STObject& operator= (STObject const&) = default;
     STObject& operator= (STObject&& other);
 
-    explicit STObject (SField::ref name);
+    explicit STObject (SField const& name);
 
     virtual ~STObject();
 
@@ -137,7 +137,7 @@ public:
 
     bool setType (const SOTemplate & type);
     bool isValidForType ();
-    bool isFieldAllowed (SField::ref);
+    bool isFieldAllowed (SField const&);
     bool isFree () const
     {
         return mType == nullptr;
@@ -217,33 +217,33 @@ public:
         return &v_[offset].get();
     }
 
-    int getFieldIndex (SField::ref field) const;
-    SField::ref getFieldSType (int index) const;
+    int getFieldIndex (SField const& field) const;
+    SField const& getFieldSType (int index) const;
 
-    const STBase& peekAtField (SField::ref field) const;
-    STBase& getField (SField::ref field);
-    const STBase* peekAtPField (SField::ref field) const;
-    STBase* getPField (SField::ref field, bool createOkay = false);
+    const STBase& peekAtField (SField const& field) const;
+    STBase& getField (SField const& field);
+    const STBase* peekAtPField (SField const& field) const;
+    STBase* getPField (SField const& field, bool createOkay = false);
 
     // these throw if the field type doesn't match, or return default values
     // if the field is optional but not present
-    std::string getFieldString (SField::ref field) const;
-    unsigned char getFieldU8 (SField::ref field) const;
-    std::uint16_t getFieldU16 (SField::ref field) const;
-    std::uint32_t getFieldU32 (SField::ref field) const;
-    std::uint64_t getFieldU64 (SField::ref field) const;
-    uint128 getFieldH128 (SField::ref field) const;
+    std::string getFieldString (SField const& field) const;
+    unsigned char getFieldU8 (SField const& field) const;
+    std::uint16_t getFieldU16 (SField const& field) const;
+    std::uint32_t getFieldU32 (SField const& field) const;
+    std::uint64_t getFieldU64 (SField const& field) const;
+    uint128 getFieldH128 (SField const& field) const;
 
-    uint160 getFieldH160 (SField::ref field) const;
-    uint256 getFieldH256 (SField::ref field) const;
-    RippleAddress getFieldAccount (SField::ref field) const;
-    Account getFieldAccount160 (SField::ref field) const;
+    uint160 getFieldH160 (SField const& field) const;
+    uint256 getFieldH256 (SField const& field) const;
+    RippleAddress getFieldAccount (SField const& field) const;
+    Account getFieldAccount160 (SField const& field) const;
 
-    Blob getFieldVL (SField::ref field) const;
-    STAmount const& getFieldAmount (SField::ref field) const;
-    STPathSet const& getFieldPathSet (SField::ref field) const;
-    const STVector256& getFieldV256 (SField::ref field) const;
-    const STArray& getFieldArray (SField::ref field) const;
+    Blob getFieldVL (SField const& field) const;
+    STAmount const& getFieldAmount (SField const& field) const;
+    STPathSet const& getFieldPathSet (SField const& field) const;
+    const STVector256& getFieldV256 (SField const& field) const;
+    const STArray& getFieldArray (SField const& field) const;
 
     /** Set a field.
         if the field already exists, it is replaced.
@@ -251,25 +251,25 @@ public:
     void
     set (std::unique_ptr<STBase> v);
 
-    void setFieldU8 (SField::ref field, unsigned char);
-    void setFieldU16 (SField::ref field, std::uint16_t);
-    void setFieldU32 (SField::ref field, std::uint32_t);
-    void setFieldU64 (SField::ref field, std::uint64_t);
-    void setFieldH128 (SField::ref field, uint128 const&);
-    void setFieldH256 (SField::ref field, uint256 const& );
-    void setFieldVL (SField::ref field, Blob const&);
-    void setFieldAccount (SField::ref field, Account const&);
-    void setFieldAccount (SField::ref field, RippleAddress const& addr)
+    void setFieldU8 (SField const& field, unsigned char);
+    void setFieldU16 (SField const& field, std::uint16_t);
+    void setFieldU32 (SField const& field, std::uint32_t);
+    void setFieldU64 (SField const& field, std::uint64_t);
+    void setFieldH128 (SField const& field, uint128 const&);
+    void setFieldH256 (SField const& field, uint256 const& );
+    void setFieldVL (SField const& field, Blob const&);
+    void setFieldAccount (SField const& field, Account const&);
+    void setFieldAccount (SField const& field, RippleAddress const& addr)
     {
         setFieldAccount (field, addr.getAccountID ());
     }
-    void setFieldAmount (SField::ref field, STAmount const&);
-    void setFieldPathSet (SField::ref field, STPathSet const&);
-    void setFieldV256 (SField::ref field, STVector256 const& v);
-    void setFieldArray (SField::ref field, STArray const& v);
+    void setFieldAmount (SField const& field, STAmount const&);
+    void setFieldPathSet (SField const& field, STPathSet const&);
+    void setFieldV256 (SField const& field, STVector256 const& v);
+    void setFieldArray (SField const& field, STArray const& v);
 
     template <class Tag>
-    void setFieldH160 (SField::ref field, base_uint<160, Tag> const& v)
+    void setFieldH160 (SField const& field, base_uint<160, Tag> const& v)
     {
         STBase* rf = getPField (field, true);
 
@@ -286,12 +286,12 @@ public:
             throw std::runtime_error ("Wrong field type");
     }
 
-    STObject& peekFieldObject (SField::ref field);
+    STObject& peekFieldObject (SField const& field);
 
-    bool isFieldPresent (SField::ref field) const;
-    STBase* makeFieldPresent (SField::ref field);
-    void makeFieldAbsent (SField::ref field);
-    bool delField (SField::ref field);
+    bool isFieldPresent (SField const& field) const;
+    STBase* makeFieldPresent (SField const& field);
+    void makeFieldAbsent (SField const& field);
+    bool delField (SField const& field);
     void delField (int index);
 
     bool hasMatchingEntry (const STBase&);
@@ -311,7 +311,7 @@ private:
     template <typename T, typename V =
         typename std::remove_cv < typename std::remove_reference <
             decltype (std::declval <T> ().getValue ())>::type >::type >
-    V getFieldByValue (SField::ref field) const
+    V getFieldByValue (SField const& field) const
     {
         const STBase* rf = peekAtPField (field);
 
@@ -337,7 +337,7 @@ private:
     // obvious to return.  So we insist on having the call provide an
     // 'empty' value we return in that circumstance.
     template <typename T, typename V>
-    V const& getFieldByConstRef (SField::ref field, V const& empty) const
+    V const& getFieldByConstRef (SField const& field, V const& empty) const
     {
         const STBase* rf = peekAtPField (field);
 
@@ -359,7 +359,7 @@ private:
 
     // Implementation for setting most fields with a setValue() method.
     template <typename T, typename V>
-    void setFieldUsingSetValue (SField::ref field, V value)
+    void setFieldUsingSetValue (SField const& field, V value)
     {
         static_assert(!std::is_lvalue_reference<V>::value, "");
 
@@ -381,7 +381,7 @@ private:
 
     // Implementation for setting fields using assignment
     template <typename T>
-    void setFieldUsingAssignment (SField::ref field, T const& value)
+    void setFieldUsingAssignment (SField const& field, T const& value)
     {
         STBase* rf = getPField (field, true);
 

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -233,11 +233,11 @@ class STPathSet final
 public:
     STPathSet () = default;
 
-    STPathSet (SField::ref n)
+    STPathSet (SField const& n)
         : STBase (n)
     { }
 
-    STPathSet (SerialIter& sit, SField::ref name);
+    STPathSet (SerialIter& sit, SField const& name);
 
     STBase*
     copy (std::size_t n, void* buf) const override

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -33,7 +33,7 @@ class STVector256
 public:
     STVector256 () = default;
 
-    explicit STVector256 (SField::ref n)
+    explicit STVector256 (SField const& n)
         : STBase (n)
     { }
 
@@ -41,7 +41,7 @@ public:
         : mValue (vector)
     { }
 
-    STVector256 (SerialIter& sit, SField::ref name);
+    STVector256 (SerialIter& sit, SField const& name);
 
     STBase*
     copy (std::size_t n, void* buf) const override

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -31,7 +31,7 @@ namespace ripple {
 // file-scope.  The following 3 objects must have scope prior to
 // the file-scope SFields.
 static std::mutex SField_mutex;
-static std::map<int, SField::ptr> knownCodeToField;
+static std::map<int, SField const*> knownCodeToField;
 static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
 
 int SField::num = 0;
@@ -267,7 +267,8 @@ SField::SField (SerializedTypeID tid, int fv)
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
 }
 
-SField::ref SField::getField (int code)
+SField const&
+SField::getField (int code)
 {
     auto it = knownCodeToField.find (code);
 
@@ -323,7 +324,7 @@ SField::ref SField::getField (int code)
     }
 }
 
-int SField::compare (SField::ref f1, SField::ref f2)
+int SField::compare (SField const& f1, SField const& f2)
 {
     // -1 = f1 comes before f2, 0 = illegal combination, 1 = f1 comes after f2
     if ((f1.fieldCode <= 0) || (f2.fieldCode <= 0))
@@ -350,7 +351,8 @@ std::string SField::getName () const
             std::to_string(fieldValue);
 }
 
-SField::ref SField::getField (std::string const& fieldName)
+SField const&
+SField::getField (std::string const& fieldName)
 {
     for (auto const & fieldPair : knownCodeToField)
     {

--- a/src/ripple/protocol/impl/SOTemplate.cpp
+++ b/src/ripple/protocol/impl/SOTemplate.cpp
@@ -55,7 +55,7 @@ void SOTemplate::push_back (SOElement const& r)
     mTypes.push_back (value_type (new SOElement (r)));
 }
 
-int SOTemplate::getIndex (SField::ref f) const
+int SOTemplate::getIndex (SField const& f) const
 {
     // The mapping table should be large enough for any possible field
     //

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -22,7 +22,7 @@
 
 namespace ripple {
 
-STAccount::STAccount (SerialIter& sit, SField::ref name)
+STAccount::STAccount (SerialIter& sit, SField const& name)
     : STAccount(name, sit.getVLBuffer())
 {
 }
@@ -40,12 +40,12 @@ std::string STAccount::getText () const
 }
 
 STAccount*
-STAccount::construct (SerialIter& u, SField::ref name)
+STAccount::construct (SerialIter& u, SField const& name)
 {
     return new STAccount (name, u.getVLBuffer ());
 }
 
-STAccount::STAccount (SField::ref n, Account const& v)
+STAccount::STAccount (SField const& n, Account const& v)
         : STBlob (n, v.data (), v.size ())
 {
 }

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -42,7 +42,7 @@ STAmount const saOne (noIssue(), 1u);
 
 //------------------------------------------------------------------------------
 
-STAmount::STAmount(SerialIter& sit, SField::ref name)
+STAmount::STAmount(SerialIter& sit, SField const& name)
     : STBase(name)
 {
     std::uint64_t value = sit.get64 ();
@@ -118,7 +118,7 @@ STAmount::STAmount(SerialIter& sit, SField::ref name)
     canonicalize();
 }
 
-STAmount::STAmount (SField::ref name, Issue const& issue,
+STAmount::STAmount (SField const& name, Issue const& issue,
         mantissa_type mantissa, exponent_type exponent,
             bool native, bool negative)
     : STBase (name)
@@ -131,7 +131,7 @@ STAmount::STAmount (SField::ref name, Issue const& issue,
     canonicalize();
 }
 
-STAmount::STAmount (SField::ref name, Issue const& issue,
+STAmount::STAmount (SField const& name, Issue const& issue,
         mantissa_type mantissa, exponent_type exponent,
             bool native, bool negative, unchecked)
     : STBase (name)
@@ -143,7 +143,7 @@ STAmount::STAmount (SField::ref name, Issue const& issue,
 {
 }
 
-STAmount::STAmount (SField::ref name, std::int64_t mantissa)
+STAmount::STAmount (SField const& name, std::int64_t mantissa)
     : STBase (name)
     , mOffset (0)
     , mIsNative (true)
@@ -151,7 +151,7 @@ STAmount::STAmount (SField::ref name, std::int64_t mantissa)
     set (mantissa);
 }
 
-STAmount::STAmount (SField::ref name,
+STAmount::STAmount (SField const& name,
         std::uint64_t mantissa, bool negative)
     : STBase (name)
     , mValue (mantissa)
@@ -161,7 +161,7 @@ STAmount::STAmount (SField::ref name,
 {
 }
 
-STAmount::STAmount (SField::ref name, Issue const& issue,
+STAmount::STAmount (SField const& name, Issue const& issue,
         std::uint64_t mantissa, int exponent, bool negative)
     : STBase (name)
     , mIssue (issue)
@@ -214,13 +214,13 @@ STAmount::STAmount (Issue const& issue,
 }
 
 std::unique_ptr<STAmount>
-STAmount::construct (SerialIter& sit, SField::ref name)
+STAmount::construct (SerialIter& sit, SField const& name)
 {
     return std::make_unique<STAmount>(sit, name);
 }
 
 STAmount
-STAmount::createFromInt64 (SField::ref name, std::int64_t value)
+STAmount::createFromInt64 (SField const& name, std::int64_t value)
 {
     return value >= 0
            ? STAmount (name, static_cast<std::uint64_t> (value), false)
@@ -877,7 +877,7 @@ amountFromQuality (std::uint64_t rate)
 }
 
 STAmount
-amountFromJson (SField::ref name, Json::Value const& v)
+amountFromJson (SField const& name, Json::Value const& v)
 {
     STAmount::mantissa_type mantissa = 0;
     STAmount::exponent_type exponent = 0;

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -50,19 +50,19 @@ STArray::STArray (int n)
     v_.reserve(n);
 }
 
-STArray::STArray (SField::ref f)
+STArray::STArray (SField const& f)
     : STBase (f)
 {
     v_.reserve(reserveSize);
 }
 
-STArray::STArray (SField::ref f, int n)
+STArray::STArray (SField const& f, int n)
     : STBase (f)
 {
     v_.reserve(n);
 }
 
-STArray::STArray (SerialIter& sit, SField::ref f)
+STArray::STArray (SerialIter& sit, SField const& f)
     : STBase(f)
 {
     while (!sit.empty ())
@@ -80,7 +80,7 @@ STArray::STArray (SerialIter& sit, SField::ref f)
             throw std::runtime_error ("Illegal terminator in array");
         }
 
-        SField::ref const fn = SField::getField (type, field);
+        auto const& fn = SField::getField (type, field);
 
         if (fn.isInvalid ())
         {

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -30,7 +30,7 @@ STBase::STBase()
 {
 }
 
-STBase::STBase (SField::ref n)
+STBase::STBase (SField const& n)
     : fName(&n)
 {
     assert(fName);
@@ -126,13 +126,13 @@ STBase::isDefault() const
 }
 
 void
-STBase::setFName (SField::ref n)
+STBase::setFName (SField const& n)
 {
     fName = &n;
     assert (fName);
 }
 
-SField::ref
+SField const&
 STBase::getFName() const
 {
     return *fName;

--- a/src/ripple/protocol/impl/STBlob.cpp
+++ b/src/ripple/protocol/impl/STBlob.cpp
@@ -23,7 +23,7 @@
 
 namespace ripple {
 
-STBlob::STBlob (SerialIter& st, SField::ref name)
+STBlob::STBlob (SerialIter& st, SField const& name)
     : STBase (name)
     , value_ (st.getVLBuffer ())
 {

--- a/src/ripple/protocol/impl/STInteger.cpp
+++ b/src/ripple/protocol/impl/STInteger.cpp
@@ -29,7 +29,7 @@
 namespace ripple {
 
 template<>
-STInteger<unsigned char>::STInteger(SerialIter& sit, SField::ref name)
+STInteger<unsigned char>::STInteger(SerialIter& sit, SField const& name)
     : STInteger(name, sit.get8())
 {
 }
@@ -77,7 +77,7 @@ STUInt8::getJson (int) const
 //------------------------------------------------------------------------------
 
 template<>
-STInteger<std::uint16_t>::STInteger(SerialIter& sit, SField::ref name)
+STInteger<std::uint16_t>::STInteger(SerialIter& sit, SField const& name)
     : STInteger(name, sit.get16())
 {
 }
@@ -142,7 +142,7 @@ STUInt16::getJson (int) const
 //------------------------------------------------------------------------------
 
 template<>
-STInteger<std::uint32_t>::STInteger(SerialIter& sit, SField::ref name)
+STInteger<std::uint32_t>::STInteger(SerialIter& sit, SField const& name)
     : STInteger(name, sit.get32())
 {
 }
@@ -171,7 +171,7 @@ STUInt32::getJson (int) const
 //------------------------------------------------------------------------------
 
 template<>
-STInteger<std::uint64_t>::STInteger(SerialIter& sit, SField::ref name)
+STInteger<std::uint64_t>::STInteger(SerialIter& sit, SField const& name)
     : STInteger(name, sit.get64())
 {
 }

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -47,7 +47,7 @@ STObject::STObject(STObject&& other)
 {
 }
 
-STObject::STObject (SField::ref name)
+STObject::STObject (SField const& name)
     : STBase (name)
     , mType (nullptr)
 {
@@ -56,14 +56,14 @@ STObject::STObject (SField::ref name)
 }
 
 STObject::STObject (SOTemplate const& type,
-        SField::ref name)
+        SField const& name)
     : STBase (name)
 {
     set (type);
 }
 
 STObject::STObject (SOTemplate const& type,
-        SerialIter & sit, SField::ref name)
+        SerialIter & sit, SField const& name)
     : STBase (name)
 {
     v_.reserve(type.peek().size());
@@ -71,7 +71,7 @@ STObject::STObject (SOTemplate const& type,
     setType (type);
 }
 
-STObject::STObject (SField::ref name,
+STObject::STObject (SField const& name,
         boost::ptr_vector<STBase>& data)
     : STBase (name)
     , mType (nullptr)
@@ -81,7 +81,7 @@ STObject::STObject (SField::ref name,
         v_.emplace_back(b);
 }
 
-STObject::STObject (SerialIter& sit, SField::ref name)
+STObject::STObject (SerialIter& sit, SField const& name)
     : STBase(name)
     , mType(nullptr)
 {
@@ -178,7 +178,7 @@ bool STObject::isValidForType ()
     return true;
 }
 
-bool STObject::isFieldAllowed (SField::ref field)
+bool STObject::isFieldAllowed (SField const& field)
 {
     if (mType == nullptr)
         return true;
@@ -217,7 +217,7 @@ bool STObject::set (SerialIter& sit, int depth)
         {
             // Figure out the field
             //
-            SField::ref fn = SField::getField (type, field);
+            auto const& fn = SField::getField (type, field);
 
             if (fn.isInvalid ())
             {
@@ -380,7 +380,7 @@ uint256 STObject::getSigningHash (std::uint32_t prefix) const
     return s.getSHA512Half ();
 }
 
-int STObject::getFieldIndex (SField::ref field) const
+int STObject::getFieldIndex (SField const& field) const
 {
     if (mType != nullptr)
         return mType->getIndex (field);
@@ -395,7 +395,7 @@ int STObject::getFieldIndex (SField::ref field) const
     return -1;
 }
 
-const STBase& STObject::peekAtField (SField::ref field) const
+const STBase& STObject::peekAtField (SField const& field) const
 {
     int index = getFieldIndex (field);
 
@@ -405,7 +405,7 @@ const STBase& STObject::peekAtField (SField::ref field) const
     return peekAtIndex (index);
 }
 
-STBase& STObject::getField (SField::ref field)
+STBase& STObject::getField (SField const& field)
 {
     int index = getFieldIndex (field);
 
@@ -415,12 +415,13 @@ STBase& STObject::getField (SField::ref field)
     return getIndex (index);
 }
 
-SField::ref STObject::getFieldSType (int index) const
+SField const&
+STObject::getFieldSType (int index) const
 {
     return v_[index]->getFName ();
 }
 
-const STBase* STObject::peekAtPField (SField::ref field) const
+const STBase* STObject::peekAtPField (SField const& field) const
 {
     int index = getFieldIndex (field);
 
@@ -430,7 +431,7 @@ const STBase* STObject::peekAtPField (SField::ref field) const
     return peekAtPIndex (index);
 }
 
-STBase* STObject::getPField (SField::ref field, bool createOkay)
+STBase* STObject::getPField (SField const& field, bool createOkay)
 {
     int index = getFieldIndex (field);
 
@@ -445,7 +446,7 @@ STBase* STObject::getPField (SField::ref field, bool createOkay)
     return getPIndex (index);
 }
 
-bool STObject::isFieldPresent (SField::ref field) const
+bool STObject::isFieldPresent (SField const& field) const
 {
     int index = getFieldIndex (field);
 
@@ -455,7 +456,7 @@ bool STObject::isFieldPresent (SField::ref field) const
     return peekAtIndex (index).getSType () != STI_NOTPRESENT;
 }
 
-STObject& STObject::peekFieldObject (SField::ref field)
+STObject& STObject::peekFieldObject (SField const& field)
 {
     STBase* rf = getPField (field, true);
 
@@ -510,7 +511,7 @@ std::uint32_t STObject::getFlags (void) const
     return t->getValue ();
 }
 
-STBase* STObject::makeFieldPresent (SField::ref field)
+STBase* STObject::makeFieldPresent (SField const& field)
 {
     int index = getFieldIndex (field);
 
@@ -532,7 +533,7 @@ STBase* STObject::makeFieldPresent (SField::ref field)
     return getPIndex (index);
 }
 
-void STObject::makeFieldAbsent (SField::ref field)
+void STObject::makeFieldAbsent (SField const& field)
 {
     int index = getFieldIndex (field);
 
@@ -547,7 +548,7 @@ void STObject::makeFieldAbsent (SField::ref field)
         detail::nonPresentObject, f.getFName());
 }
 
-bool STObject::delField (SField::ref field)
+bool STObject::delField (SField const& field)
 {
     int index = getFieldIndex (field);
 
@@ -563,7 +564,7 @@ void STObject::delField (int index)
     v_.erase (v_.begin () + index);
 }
 
-std::string STObject::getFieldString (SField::ref field) const
+std::string STObject::getFieldString (SField const& field) const
 {
     const STBase* rf = peekAtPField (field);
 
@@ -572,42 +573,42 @@ std::string STObject::getFieldString (SField::ref field) const
     return rf->getText ();
 }
 
-unsigned char STObject::getFieldU8 (SField::ref field) const
+unsigned char STObject::getFieldU8 (SField const& field) const
 {
     return getFieldByValue <STUInt8> (field);
 }
 
-std::uint16_t STObject::getFieldU16 (SField::ref field) const
+std::uint16_t STObject::getFieldU16 (SField const& field) const
 {
     return getFieldByValue <STUInt16> (field);
 }
 
-std::uint32_t STObject::getFieldU32 (SField::ref field) const
+std::uint32_t STObject::getFieldU32 (SField const& field) const
 {
     return getFieldByValue <STUInt32> (field);
 }
 
-std::uint64_t STObject::getFieldU64 (SField::ref field) const
+std::uint64_t STObject::getFieldU64 (SField const& field) const
 {
     return getFieldByValue <STUInt64> (field);
 }
 
-uint128 STObject::getFieldH128 (SField::ref field) const
+uint128 STObject::getFieldH128 (SField const& field) const
 {
     return getFieldByValue <STHash128> (field);
 }
 
-uint160 STObject::getFieldH160 (SField::ref field) const
+uint160 STObject::getFieldH160 (SField const& field) const
 {
     return getFieldByValue <STHash160> (field);
 }
 
-uint256 STObject::getFieldH256 (SField::ref field) const
+uint256 STObject::getFieldH256 (SField const& field) const
 {
     return getFieldByValue <STHash256> (field);
 }
 
-RippleAddress STObject::getFieldAccount (SField::ref field) const
+RippleAddress STObject::getFieldAccount (SField const& field) const
 {
     const STBase* rf = peekAtPField (field);
 
@@ -626,7 +627,7 @@ RippleAddress STObject::getFieldAccount (SField::ref field) const
     return cf->getValueNCA ();
 }
 
-Account STObject::getFieldAccount160 (SField::ref field) const
+Account STObject::getFieldAccount160 (SField const& field) const
 {
     auto rf = peekAtPField (field);
     if (!rf)
@@ -646,32 +647,32 @@ Account STObject::getFieldAccount160 (SField::ref field) const
     return account;
 }
 
-Blob STObject::getFieldVL (SField::ref field) const
+Blob STObject::getFieldVL (SField const& field) const
 {
     STBlob empty;
     STBlob const& b = getFieldByConstRef <STBlob> (field, empty);
     return Blob (b.data (), b.data () + b.size ());
 }
 
-STAmount const& STObject::getFieldAmount (SField::ref field) const
+STAmount const& STObject::getFieldAmount (SField const& field) const
 {
     static STAmount const empty{};
     return getFieldByConstRef <STAmount> (field, empty);
 }
 
-const STArray& STObject::getFieldArray (SField::ref field) const
+const STArray& STObject::getFieldArray (SField const& field) const
 {
     static STArray const empty{};
     return getFieldByConstRef <STArray> (field, empty);
 }
 
-STPathSet const& STObject::getFieldPathSet (SField::ref field) const
+STPathSet const& STObject::getFieldPathSet (SField const& field) const
 {
     static STPathSet const empty{};
     return getFieldByConstRef <STPathSet> (field, empty);
 }
 
-const STVector256& STObject::getFieldV256 (SField::ref field) const
+const STVector256& STObject::getFieldV256 (SField const& field) const
 {
     static STVector256 const empty{};
     return getFieldByConstRef <STVector256> (field, empty);
@@ -695,42 +696,42 @@ STObject::set (std::unique_ptr<STBase> v)
     }
 }
 
-void STObject::setFieldU8 (SField::ref field, unsigned char v)
+void STObject::setFieldU8 (SField const& field, unsigned char v)
 {
     setFieldUsingSetValue <STUInt8> (field, v);
 }
 
-void STObject::setFieldU16 (SField::ref field, std::uint16_t v)
+void STObject::setFieldU16 (SField const& field, std::uint16_t v)
 {
     setFieldUsingSetValue <STUInt16> (field, v);
 }
 
-void STObject::setFieldU32 (SField::ref field, std::uint32_t v)
+void STObject::setFieldU32 (SField const& field, std::uint32_t v)
 {
     setFieldUsingSetValue <STUInt32> (field, v);
 }
 
-void STObject::setFieldU64 (SField::ref field, std::uint64_t v)
+void STObject::setFieldU64 (SField const& field, std::uint64_t v)
 {
     setFieldUsingSetValue <STUInt64> (field, v);
 }
 
-void STObject::setFieldH128 (SField::ref field, uint128 const& v)
+void STObject::setFieldH128 (SField const& field, uint128 const& v)
 {
     setFieldUsingSetValue <STHash128> (field, v);
 }
 
-void STObject::setFieldH256 (SField::ref field, uint256 const& v)
+void STObject::setFieldH256 (SField const& field, uint256 const& v)
 {
     setFieldUsingSetValue <STHash256> (field, v);
 }
 
-void STObject::setFieldV256 (SField::ref field, STVector256 const& v)
+void STObject::setFieldV256 (SField const& field, STVector256 const& v)
 {
     setFieldUsingSetValue <STVector256> (field, v);
 }
 
-void STObject::setFieldAccount (SField::ref field, Account const& v)
+void STObject::setFieldAccount (SField const& field, Account const& v)
 {
     STBase* rf = getPField (field, true);
 
@@ -748,23 +749,23 @@ void STObject::setFieldAccount (SField::ref field, Account const& v)
     cf->setValueH160 (v);
 }
 
-void STObject::setFieldVL (SField::ref field, Blob const& v)
+void STObject::setFieldVL (SField const& field, Blob const& v)
 {
     setFieldUsingSetValue <STBlob>
             (field, Buffer(v.data (), v.size ()));
 }
 
-void STObject::setFieldAmount (SField::ref field, STAmount const& v)
+void STObject::setFieldAmount (SField const& field, STAmount const& v)
 {
     setFieldUsingAssignment (field, v);
 }
 
-void STObject::setFieldPathSet (SField::ref field, STPathSet const& v)
+void STObject::setFieldPathSet (SField const& field, STPathSet const& v)
 {
     setFieldUsingAssignment (field, v);
 }
 
-void STObject::setFieldArray (SField::ref field, STArray const& v)
+void STObject::setFieldArray (SField const& field, STArray const& v)
 {
     setFieldUsingAssignment (field, v);
 }

--- a/src/ripple/protocol/impl/STParsedJSON.cpp
+++ b/src/ripple/protocol/impl/STParsedJSON.cpp
@@ -143,13 +143,13 @@ static Json::Value singleton_expected (std::string const& object,
 static std::unique_ptr <STBase> parseLeaf (
     std::string const& json_name,
     std::string const& fieldName,
-    SField::ptr name,
+    SField const* name,
     Json::Value const& value,
     Json::Value& error)
 {
     std::unique_ptr <STBase> ret;
 
-    SField::ref field = SField::getField (fieldName);
+    auto const& field = SField::getField (fieldName);
 
     if (field == sfInvalid)
     {
@@ -664,7 +664,7 @@ static const int maxDepth = 64;
 static bool parseArray (
     std::string const& json_name,
     Json::Value const& json,
-    SField::ref inName,
+    SField const& inName,
     int depth,
     std::unique_ptr <STArray>& sub_array,
     Json::Value& error);
@@ -674,7 +674,7 @@ static bool parseArray (
 static bool parseObject (
     std::string const& json_name,
     Json::Value const& json,
-    SField::ref inName,
+    SField const& inName,
     int depth,
     std::unique_ptr <STObject>& sub_object,
     Json::Value& error)
@@ -691,7 +691,7 @@ static bool parseObject (
         return false;
     }
 
-    SField::ptr name (&inName);
+    auto name (&inName);
 
     boost::ptr_vector<STBase> data;
     Json::Value::Members members (json.getMemberNames ());
@@ -700,7 +700,7 @@ static bool parseObject (
     {
         Json::Value const& value = json [fieldName];
 
-        SField::ref field = SField::getField (fieldName);
+        auto const& field = SField::getField (fieldName);
 
         if (field == sfInvalid)
         {
@@ -781,7 +781,7 @@ static bool parseObject (
 static bool parseArray (
     std::string const& json_name,
     Json::Value const& json,
-    SField::ref inName,
+    SField const& inName,
     int depth,
     std::unique_ptr <STArray>& sub_array,
     Json::Value& error)
@@ -817,7 +817,7 @@ static bool parseArray (
             // first/only key in an object without copying all keys into
             // a vector
             std::string const objectName (json[i].getMemberNames()[0]);;
-            SField::ref       nameField (SField::getField(objectName));
+            auto const&       nameField (SField::getField(objectName));
 
             if (nameField == sfInvalid)
             {

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -50,7 +50,7 @@ STPathElement::get_hash (STPathElement const& element)
     return (hash_account ^ hash_currency ^ hash_issuer);
 }
 
-STPathSet::STPathSet (SerialIter& sit, SField::ref name)
+STPathSet::STPathSet (SerialIter& sit, SField const& name)
     : STBase(name)
 {
     std::vector<STPathElement> path;

--- a/src/ripple/protocol/impl/STVar.cpp
+++ b/src/ripple/protocol/impl/STVar.cpp
@@ -111,17 +111,17 @@ STVar::operator= (STVar&& rhs)
     return *this;
 }
 
-STVar::STVar (defaultObject_t, SField::ref name)
+STVar::STVar (defaultObject_t, SField const& name)
     : STVar(name.fieldType, name)
 {
 }
 
-STVar::STVar (nonPresentObject_t, SField::ref name)
+STVar::STVar (nonPresentObject_t, SField const& name)
     : STVar(STI_NOTPRESENT, name)
 {
 }
 
-STVar::STVar (SerialIter& sit, SField::ref name)
+STVar::STVar (SerialIter& sit, SField const& name)
 {
     switch (name.fieldType)
     {
@@ -145,7 +145,7 @@ STVar::STVar (SerialIter& sit, SField::ref name)
     }
 }
 
-STVar::STVar (SerializedTypeID id, SField::ref name)
+STVar::STVar (SerializedTypeID id, SField const& name)
 {
     assert ((id == STI_NOTPRESENT) || (id == name.fieldType));
     switch (id)

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -77,9 +77,9 @@ public:
         p_ = t.copy(sizeof(d_), &d_);
     }
 
-    STVar (defaultObject_t, SField::ref name);
-    STVar (nonPresentObject_t, SField::ref name);
-    STVar (SerialIter& sit, SField::ref name);
+    STVar (defaultObject_t, SField const& name);
+    STVar (nonPresentObject_t, SField const& name);
+    STVar (SerialIter& sit, SField const& name);
 
     STBase& get() { return *p_; }
     STBase& operator*() { return get(); }
@@ -89,7 +89,7 @@ public:
     STBase const* operator->() const { return &get(); }
 
 private:
-    STVar (SerializedTypeID id, SField::ref name);
+    STVar (SerializedTypeID id, SField const& name);
 
     void destroy();
 

--- a/src/ripple/protocol/impl/STVector256.cpp
+++ b/src/ripple/protocol/impl/STVector256.cpp
@@ -25,7 +25,7 @@
 
 namespace ripple {
 
-STVector256::STVector256(SerialIter& sit, SField::ref name)
+STVector256::STVector256(SerialIter& sit, SField const& name)
     : STBase(name)
 {
     Blob data = sit.getVL ();


### PR DESCRIPTION
* This silences a warning about a redundant cv-qualifier.
* This makes future coding mistakes about redundant
  cv-qualifiers much less likely.
* This makes the code easier to read.

@vinniefalco @nbougalis 