### PR TITLE
Prefer language constants over macros and remove unused fee configurations

### DIFF
--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -238,7 +238,6 @@ public:
     std::uint64_t                      FEE_DEFAULT;            // Default fee.
     std::uint64_t                      FEE_ACCOUNT_RESERVE;    // Amount of units not allowed to send.
     std::uint64_t                      FEE_OWNER_RESERVE;      // Amount of units not allowed to send per owner entry.
-    int                                FEE_CONTRACT_OPERATION; // fee for each contract operation
 
     // Node storage configuration
     std::uint32_t                      LEDGER_HISTORY;

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -238,7 +238,6 @@ public:
     std::uint64_t                      FEE_DEFAULT;            // Default fee.
     std::uint64_t                      FEE_ACCOUNT_RESERVE;    // Amount of units not allowed to send.
     std::uint64_t                      FEE_OWNER_RESERVE;      // Amount of units not allowed to send per owner entry.
-    std::uint64_t                      FEE_OFFER;              // Rate per day.
     int                                FEE_CONTRACT_OPERATION; // fee for each contract operation
 
     // Node storage configuration

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -39,7 +39,6 @@ struct ConfigSection
 #define SECTION_DEBUG_LOGFILE           "debug_logfile"
 #define SECTION_ELB_SUPPORT             "elb_support"
 #define SECTION_FEE_DEFAULT             "fee_default"
-#define SECTION_FEE_OFFER               "fee_offer"
 #define SECTION_FEE_OPERATION           "fee_operation"
 #define SECTION_FEE_ACCOUNT_RESERVE     "fee_account_reserve"
 #define SECTION_FEE_OWNER_RESERVE       "fee_owner_reserve"

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -39,7 +39,6 @@ struct ConfigSection
 #define SECTION_DEBUG_LOGFILE           "debug_logfile"
 #define SECTION_ELB_SUPPORT             "elb_support"
 #define SECTION_FEE_DEFAULT             "fee_default"
-#define SECTION_FEE_OPERATION           "fee_operation"
 #define SECTION_FEE_ACCOUNT_RESERVE     "fee_account_reserve"
 #define SECTION_FEE_OWNER_RESERVE       "fee_owner_reserve"
 #define SECTION_FETCH_DEPTH             "fetch_depth"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -202,7 +202,6 @@ Config::Config ()
     FEE_ACCOUNT_RESERVE     = SYSTEM_FEE_ACCOUNT_RESERVE;
     FEE_OWNER_RESERVE       = SYSTEM_FEE_OWNER_RESERVE;
     FEE_DEFAULT             = SYSTEM_FEE_DEFAULT;
-    FEE_CONTRACT_OPERATION  = SYSTEM_FEE_CONTRACT_OPERATION;
 
     LEDGER_HISTORY          = 256;
     FETCH_DEPTH             = 1000000000;
@@ -489,9 +488,6 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_FEE_DEFAULT, strTemp))
         FEE_DEFAULT         = beast::lexicalCastThrow <int> (strTemp);
-
-    if (getSingleSection (secConfig, SECTION_FEE_OPERATION, strTemp))
-        FEE_CONTRACT_OPERATION  = beast::lexicalCastThrow <int> (strTemp);
 
     if (getSingleSection (secConfig, SECTION_LEDGER_HISTORY, strTemp))
     {

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -43,16 +43,6 @@ namespace ripple {
 // TODO: Check permissions on config file before using it.
 //
 
-// Fees are in XRP.
-#define DEFAULT_FEE_DEFAULT             10
-#define DEFAULT_FEE_ACCOUNT_RESERVE     200*SYSTEM_CURRENCY_PARTS
-#define DEFAULT_FEE_OWNER_RESERVE       50*SYSTEM_CURRENCY_PARTS
-#define DEFAULT_FEE_OFFER               DEFAULT_FEE_DEFAULT
-#define DEFAULT_FEE_OPERATION           1
-
-// Fee in fee units
-#define DEFAULT_TRANSACTION_FEE_BASE    10
-
 #define SECTION_DEFAULT_NAME    ""
 
 IniFileSections
@@ -204,16 +194,16 @@ Config::Config ()
     PEER_PRIVATE            = false;
     PEERS_MAX               = 0;    // indicates "use default"
 
-    TRANSACTION_FEE_BASE    = DEFAULT_TRANSACTION_FEE_BASE;
+    TRANSACTION_FEE_BASE    = SYSTEM_TRANSACTION_FEE_BASE;
 
     NETWORK_QUORUM          = 0;    // Don't need to see other nodes
     VALIDATION_QUORUM       = 1;    // Only need one node to vouch
 
-    FEE_ACCOUNT_RESERVE     = DEFAULT_FEE_ACCOUNT_RESERVE;
-    FEE_OWNER_RESERVE       = DEFAULT_FEE_OWNER_RESERVE;
-    FEE_OFFER               = DEFAULT_FEE_OFFER;
-    FEE_DEFAULT             = DEFAULT_FEE_DEFAULT;
-    FEE_CONTRACT_OPERATION  = DEFAULT_FEE_OPERATION;
+    FEE_ACCOUNT_RESERVE     = SYSTEM_FEE_ACCOUNT_RESERVE;
+    FEE_OWNER_RESERVE       = SYSTEM_FEE_OWNER_RESERVE;
+    FEE_OFFER               = SYSTEM_FEE_OFFER;
+    FEE_DEFAULT             = SYSTEM_FEE_DEFAULT;
+    FEE_CONTRACT_OPERATION  = SYSTEM_FEE_CONTRACT_OPERATION;
 
     LEDGER_HISTORY          = 256;
     FETCH_DEPTH             = 1000000000;
@@ -415,7 +405,7 @@ void Config::loadFromString (std::string const& fileContents)
         if (getSingleSection (secConfig, "database_path", dbPath))
         {
             boost::filesystem::path p(dbPath);
-            legacy("database_path", 
+            legacy("database_path",
                    boost::filesystem::absolute (p).string ());
         }
     }

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -201,7 +201,6 @@ Config::Config ()
 
     FEE_ACCOUNT_RESERVE     = SYSTEM_FEE_ACCOUNT_RESERVE;
     FEE_OWNER_RESERVE       = SYSTEM_FEE_OWNER_RESERVE;
-    FEE_OFFER               = SYSTEM_FEE_OFFER;
     FEE_DEFAULT             = SYSTEM_FEE_DEFAULT;
     FEE_CONTRACT_OPERATION  = SYSTEM_FEE_CONTRACT_OPERATION;
 
@@ -487,9 +486,6 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_FEE_OWNER_RESERVE, strTemp))
         FEE_OWNER_RESERVE   = beast::lexicalCastThrow <std::uint64_t> (strTemp);
-
-    if (getSingleSection (secConfig, SECTION_FEE_OFFER, strTemp))
-        FEE_OFFER           = beast::lexicalCastThrow <int> (strTemp);
 
     if (getSingleSection (secConfig, SECTION_FEE_DEFAULT, strTemp))
         FEE_DEFAULT         = beast::lexicalCastThrow <int> (strTemp);

--- a/src/ripple/core/tests/LoadFeeTrack.test.cpp
+++ b/src/ripple/core/tests/LoadFeeTrack.test.cpp
@@ -41,7 +41,6 @@ public:
         expect (l.scaleFeeBase (d.FEE_DEFAULT, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 10);
         expect (l.scaleFeeBase (d.FEE_ACCOUNT_RESERVE, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 200 * SYSTEM_CURRENCY_PARTS);
         expect (l.scaleFeeBase (d.FEE_OWNER_RESERVE, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 50 * SYSTEM_CURRENCY_PARTS);
-        expect (l.scaleFeeBase (d.FEE_CONTRACT_OPERATION, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 1);
     }
 };
 

--- a/src/ripple/core/tests/LoadFeeTrack.test.cpp
+++ b/src/ripple/core/tests/LoadFeeTrack.test.cpp
@@ -41,7 +41,6 @@ public:
         expect (l.scaleFeeBase (d.FEE_DEFAULT, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 10);
         expect (l.scaleFeeBase (d.FEE_ACCOUNT_RESERVE, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 200 * SYSTEM_CURRENCY_PARTS);
         expect (l.scaleFeeBase (d.FEE_OWNER_RESERVE, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 50 * SYSTEM_CURRENCY_PARTS);
-        expect (l.scaleFeeBase (d.FEE_OFFER, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 10);
         expect (l.scaleFeeBase (d.FEE_CONTRACT_OPERATION, d.FEE_DEFAULT, d.TRANSACTION_FEE_BASE) == 1);
     }
 };

--- a/src/ripple/protocol/SystemParameters.h
+++ b/src/ripple/protocol/SystemParameters.h
@@ -78,10 +78,6 @@ SYSTEM_FEE_OWNER_RESERVE = 50 * SYSTEM_CURRENCY_PARTS;
 
 static
 std::uint64_t const
-SYSTEM_FEE_OFFER = SYSTEM_FEE_DEFAULT;
-
-static
-std::uint64_t const
 SYSTEM_TRANSACTION_FEE_BASE = 10;
 
 static

--- a/src/ripple/protocol/SystemParameters.h
+++ b/src/ripple/protocol/SystemParameters.h
@@ -63,6 +63,31 @@ systemCurrencyCode ()
     return code;
 }
 
+/** Default fees for system */
+static
+std::uint64_t const
+SYSTEM_FEE_DEFAULT = 10;
+
+static
+std::uint64_t const
+SYSTEM_FEE_ACCOUNT_RESERVE = 200 * SYSTEM_CURRENCY_PARTS;
+
+static
+std::uint64_t const
+SYSTEM_FEE_OWNER_RESERVE = 50 * SYSTEM_CURRENCY_PARTS;
+
+static
+std::uint64_t const
+SYSTEM_FEE_OFFER = SYSTEM_FEE_DEFAULT;
+
+static
+std::uint64_t const
+SYSTEM_TRANSACTION_FEE_BASE = 10;
+
+static
+int const
+SYSTEM_FEE_CONTRACT_OPERATION = 1;
+
 } // ripple
 
 #endif

--- a/src/ripple/protocol/SystemParameters.h
+++ b/src/ripple/protocol/SystemParameters.h
@@ -80,10 +80,6 @@ static
 std::uint64_t const
 SYSTEM_TRANSACTION_FEE_BASE = 10;
 
-static
-int const
-SYSTEM_FEE_CONTRACT_OPERATION = 1;
-
 } // ripple
 
 #endif


### PR DESCRIPTION
This is just a cleanup, consolidating default configuration parameters in a single file and replacing macros with language constants. Some unneeded configuration parameters are removed.
 
This should play nice with the existing fee work, but if it causes problems, then it can just be discarded and redone later.

Reviews by @ximinez, @rec, and a heads-up to @JoelKatz.