### PR TITLE
Structured Overlay support for TTL limit 

### DIFF
--- a/src/beast/beast/container/detail/aged_container_iterator.h
+++ b/src/beast/beast/container/detail/aged_container_iterator.h
@@ -49,7 +49,7 @@ class aged_container_iterator
     : public Base
 {
 public:
-    typedef typename Iterator::value_type::stashed::time_point time_point;
+    using time_point = typename Iterator::value_type::stashed::time_point;
 
     // Could be '= default', but Visual Studio 2013 chokes on it [Aug 2014]
     aged_container_iterator ()

--- a/src/beast/beast/container/detail/aged_ordered_container.h
+++ b/src/beast/beast/container/detail/aged_ordered_container.h
@@ -125,8 +125,8 @@ private:
         // need to see the container declaration.
         struct stashed
         {
-            typedef typename aged_ordered_container::value_type value_type;
-            typedef typename aged_ordered_container::time_point time_point;
+            using value_type = typename aged_ordered_container::value_type;
+            using time_point = typename aged_ordered_container::time_point;
         };
 
         element (
@@ -243,11 +243,10 @@ private:
         }
     };
 
-    typedef typename boost::intrusive::make_list <element,
-        boost::intrusive::constant_time_size <false>
-            >::type list_type;
+    using list_type = typename boost::intrusive::make_list <element,
+        boost::intrusive::constant_time_size <false>>::type;
 
-    typedef typename std::conditional <
+    using cont_type = typename std::conditional <
         IsMulti,
         typename boost::intrusive::make_multiset <element,
             boost::intrusive::constant_time_size <true>
@@ -255,10 +254,10 @@ private:
         typename boost::intrusive::make_set <element,
             boost::intrusive::constant_time_size <true>
                 >::type
-        >::type cont_type;
+        >::type;
 
-    typedef typename std::allocator_traits <
-        Allocator>::template rebind_alloc <element> ElementAllocator;
+    using ElementAllocator = typename std::allocator_traits <
+        Allocator>::template rebind_alloc <element>;
 
     using ElementAllocatorTraits = std::allocator_traits <ElementAllocator>;
 
@@ -426,29 +425,29 @@ private:
     }
 
 public:
-    typedef Compare key_compare;
-    typedef typename std::conditional <
+    using key_compare = Compare;
+    using value_compare = typename std::conditional <
         IsMap,
         pair_value_compare,
-        Compare>::type value_compare;
-    typedef Allocator allocator_type;
-    typedef value_type& reference;
-    typedef value_type const& const_reference;
-    typedef typename std::allocator_traits <
-        Allocator>::pointer pointer;
-    typedef typename std::allocator_traits <
-        Allocator>::const_pointer const_pointer;
+        Compare>::type;
+    using allocator_type = Allocator;
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using pointer = typename std::allocator_traits <
+        Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits <
+        Allocator>::const_pointer;
 
-    // A set (that is, !IsMap) iterator is aways const because the elements
-    // of a set are immutable.
-    typedef detail::aged_container_iterator <!IsMap,
-        typename cont_type::iterator> iterator;
-    typedef detail::aged_container_iterator <true,
-        typename cont_type::iterator> const_iterator;
-    typedef detail::aged_container_iterator <!IsMap,
-        typename cont_type::reverse_iterator> reverse_iterator;
-    typedef detail::aged_container_iterator <true,
-        typename cont_type::reverse_iterator> const_reverse_iterator;
+    // A set iterator (IsMap==false) is always const
+    // because the elements of a set are immutable.
+    using iterator = detail::aged_container_iterator<
+        ! IsMap, typename cont_type::iterator>;
+    using const_iterator = detail::aged_container_iterator<
+        true, typename cont_type::iterator>;
+    using reverse_iterator = detail::aged_container_iterator<
+        ! IsMap, typename cont_type::reverse_iterator>;
+    using const_reverse_iterator = detail::aged_container_iterator<
+        true, typename cont_type::reverse_iterator>;
 
     //--------------------------------------------------------------------------
     //
@@ -462,16 +461,16 @@ public:
     class chronological_t
     {
     public:
-        // A set (that is, !IsMap) iterator is aways const because the elements
-        // of a set are immutable.
-        typedef detail::aged_container_iterator <!IsMap,
-            typename list_type::iterator> iterator;
-        typedef detail::aged_container_iterator <true,
-            typename list_type::iterator> const_iterator;
-        typedef detail::aged_container_iterator <!IsMap,
-            typename list_type::reverse_iterator> reverse_iterator;
-        typedef detail::aged_container_iterator <true,
-            typename list_type::reverse_iterator> const_reverse_iterator;
+        // A set iterator (IsMap==false) is always const
+        // because the elements of a set are immutable.
+        using iterator = detail::aged_container_iterator<
+            ! IsMap, typename list_type::iterator>;
+        using const_iterator = detail::aged_container_iterator<
+            true, typename list_type::iterator>;
+        using reverse_iterator = detail::aged_container_iterator<
+            ! IsMap, typename list_type::reverse_iterator>;
+        using const_reverse_iterator = detail::aged_container_iterator<
+            true, typename list_type::reverse_iterator>;
 
         iterator begin ()
          {
@@ -568,6 +567,8 @@ public:
     // Construction
     //
     //--------------------------------------------------------------------------
+
+    aged_ordered_container() = delete;
 
     explicit aged_ordered_container (clock_type& clock);
 
@@ -1848,9 +1849,9 @@ operator== (
         Key, OtherT, OtherDuration, Compare,
             OtherAllocator> const& other) const
 {
-    typedef aged_ordered_container <OtherIsMulti, OtherIsMap,
+    using Other = aged_ordered_container <OtherIsMulti, OtherIsMap,
         Key, OtherT, OtherDuration, Compare,
-            OtherAllocator> Other;
+            OtherAllocator>;
     if (size() != other.size())
         return false;
     std::equal_to <void> eq;

--- a/src/beast/beast/container/detail/aged_unordered_container.h
+++ b/src/beast/beast/container/detail/aged_unordered_container.h
@@ -123,8 +123,8 @@ private:
         // need to see the container declaration.
         struct stashed
         {
-            typedef typename aged_unordered_container::value_type value_type;
-            typedef typename aged_unordered_container::time_point time_point;
+            using value_type = typename aged_unordered_container::value_type;
+            using time_point = typename aged_unordered_container::time_point;
         };
 
         element (
@@ -248,11 +248,10 @@ private:
         }
     };
 
-    typedef typename boost::intrusive::make_list <element,
-        boost::intrusive::constant_time_size <false>
-            >::type list_type;
+    using list_type = typename boost::intrusive::make_list <element,
+        boost::intrusive::constant_time_size <false>>::type ;
 
-    typedef typename std::conditional <
+    using cont_type = typename std::conditional <
         IsMulti,
         typename boost::intrusive::make_unordered_multiset <element,
             boost::intrusive::constant_time_size <true>,
@@ -266,18 +265,18 @@ private:
             boost::intrusive::equal <KeyValueEqual>,
             boost::intrusive::cache_begin <true>
                     >::type
-        >::type cont_type;
+        >::type;
 
-    typedef typename cont_type::bucket_type bucket_type;
-    typedef typename cont_type::bucket_traits bucket_traits;
+    using bucket_type = typename cont_type::bucket_type;
+    using bucket_traits = typename cont_type::bucket_traits;
 
-    typedef typename std::allocator_traits <
-        Allocator>::template rebind_alloc <element> ElementAllocator;
+    using ElementAllocator = typename std::allocator_traits <
+        Allocator>::template rebind_alloc <element>;
 
     using ElementAllocatorTraits = std::allocator_traits <ElementAllocator>;
 
-    typedef typename std::allocator_traits <
-        Allocator>::template rebind_alloc <element> BucketAllocator;
+    using BucketAllocator = typename std::allocator_traits <
+        Allocator>::template rebind_alloc <element>;
 
     using BucketAllocatorTraits = std::allocator_traits <BucketAllocator>;
 
@@ -471,10 +470,10 @@ private:
     class Buckets
     {
     public:
-        typedef std::vector <
+        using vec_type = std::vector<
             bucket_type,
             typename std::allocator_traits <Allocator>::
-                template rebind_alloc <bucket_type>> vec_type;
+                template rebind_alloc <bucket_type>>;
 
         Buckets ()
             : m_max_load_factor (1.f)
@@ -607,27 +606,27 @@ private:
     }
 
 public:
-    typedef Hash hasher;
-    typedef KeyEqual key_equal;
-    typedef Allocator allocator_type;
-    typedef value_type& reference;
-    typedef value_type const& const_reference;
-    typedef typename std::allocator_traits <
-        Allocator>::pointer pointer;
-    typedef typename std::allocator_traits <
-        Allocator>::const_pointer const_pointer;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+    using reference = value_type&;
+    using const_reference = value_type const&;
+    using pointer = typename std::allocator_traits <
+        Allocator>::pointer;
+    using const_pointer = typename std::allocator_traits <
+        Allocator>::const_pointer;
 
-    // A set (that is, !IsMap) iterator is aways const because the elements
-    // of a set are immutable.
-    typedef detail::aged_container_iterator <!IsMap,
-        typename cont_type::iterator> iterator;
-    typedef detail::aged_container_iterator <true,
-        typename cont_type::iterator> const_iterator;
+    // A set iterator (IsMap==false) is always const
+    // because the elements of a set are immutable.
+    using iterator= detail::aged_container_iterator <!IsMap,
+        typename cont_type::iterator>;
+    using const_iterator = detail::aged_container_iterator <true,
+        typename cont_type::iterator>;
 
-    typedef detail::aged_container_iterator <!IsMap,
-        typename cont_type::local_iterator> local_iterator;
-    typedef detail::aged_container_iterator <true,
-        typename cont_type::local_iterator> const_local_iterator;
+    using local_iterator = detail::aged_container_iterator <!IsMap,
+        typename cont_type::local_iterator>;
+    using const_local_iterator = detail::aged_container_iterator <true,
+        typename cont_type::local_iterator>;
 
     //--------------------------------------------------------------------------
     //
@@ -641,16 +640,16 @@ public:
     class chronological_t
     {
     public:
-        // A set (that is, !IsMap) iterator is aways const because the elements
-        // of a set are immutable.
-        typedef detail::aged_container_iterator <!IsMap,
-            typename list_type::iterator> iterator;
-        typedef detail::aged_container_iterator <true,
-            typename list_type::iterator> const_iterator;
-        typedef detail::aged_container_iterator <!IsMap,
-            typename list_type::reverse_iterator> reverse_iterator;
-        typedef detail::aged_container_iterator <true,
-            typename list_type::reverse_iterator> const_reverse_iterator;
+        // A set iterator (IsMap==false) is always const
+        // because the elements of a set are immutable.
+        using iterator = detail::aged_container_iterator <
+            ! IsMap, typename list_type::iterator>;
+        using const_iterator = detail::aged_container_iterator <
+            true, typename list_type::iterator>;
+        using reverse_iterator = detail::aged_container_iterator <
+            ! IsMap, typename list_type::reverse_iterator>;
+        using const_reverse_iterator = detail::aged_container_iterator <
+            true, typename list_type::reverse_iterator>;
 
         iterator begin ()
          {
@@ -747,6 +746,8 @@ public:
     // Construction
     //
     //--------------------------------------------------------------------------
+
+    aged_unordered_container() = delete;
 
     explicit aged_unordered_container (clock_type& clock);
 
@@ -2436,7 +2437,7 @@ operator== (
 {
     if (size() != other.size())
         return false;
-    typedef std::pair <const_iterator, const_iterator> EqRng;
+    using EqRng = std::pair <const_iterator, const_iterator>;
     for (auto iter (cbegin()), last (cend()); iter != last;)
     {
         auto const& k (extract (*iter));

--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -988,9 +988,7 @@ private:
             protocol::TMValidation val;
             val.set_validation (&validation[0], validation.size ());
             // Send signed validation to all of our directly connected peers
-            getApp ().overlay ().foreach (send_always (
-                std::make_shared <Message> (
-                    val, protocol::mtVALIDATION)));
+            getApp().overlay().send(val);
             WriteLog (lsINFO, LedgerConsensus)
                 << "CNF Val " << newLCLHash;
         }
@@ -1256,9 +1254,7 @@ private:
         Blob sig = mOurPosition->sign ();
         prop.set_nodepubkey (&pubKey[0], pubKey.size ());
         prop.set_signature (&sig[0], sig.size ());
-        getApp ().overlay ().foreach (send_always (
-            std::make_shared<Message> (
-                prop, protocol::mtPROPOSE_LEDGER)));
+        getApp().overlay().send(prop);
     }
 
     /** Let peers know that we a particular transactions set so they
@@ -1681,11 +1677,6 @@ private:
         Blob validation = v->getSigned ();
         protocol::TMValidation val;
         val.set_validation (&validation[0], validation.size ());
-    #if 0
-        getApp ().overlay ().visit (RelayMessage (
-            std::make_shared <Message> (
-                val, protocol::mtVALIDATION)));
-    #endif
         getApp().getOPs ().setLastValidation (v);
         WriteLog (lsWARNING, LedgerConsensus) << "Sending partial validation";
     }

--- a/src/ripple/app/consensus/LedgerConsensus.cpp
+++ b/src/ripple/app/consensus/LedgerConsensus.cpp
@@ -1619,28 +1619,6 @@ private:
                         << "We should do delayed relay of this proposal,"
                         << " but we cannot";
                 }
-
-    #if 0
-    // FIXME: We can't do delayed relay because we don't have the signature
-                std::set<Peer::id_t> peers
-
-                if (relay && getApp().getHashRouter ().swapSet (proposal.getSuppress (), set, SF_RELAYED))
-                {
-                    WriteLog (lsDEBUG, LedgerConsensus) << "Stored proposal delayed relay";
-                    protocol::TMProposeSet set;
-                    set.set_proposeseq
-                    set.set_currenttxhash (, 256 / 8);
-                    previousledger
-                    closetime
-                    nodepubkey
-                    signature
-                    getApp ().overlay ().foreach (send_if_not (
-                        std::make_shared<Message> (
-                            set, protocol::mtPROPOSE_LEDGER),
-                                peer_in_set(peers)));
-                }
-
-    #endif
             }
         }
     }

--- a/src/ripple/app/ledger/LedgerProposal.cpp
+++ b/src/ripple/app/ledger/LedgerProposal.cpp
@@ -70,6 +70,15 @@ uint256 LedgerProposal::getSigningHash () const
     return s.getSHA512Half ();
 }
 
+/*
+The "id" is a unique value computed on all fields that contribute to
+the signature, and including the signature. There is one caveat, the
+"last closed ledger" field may be omitted. However, the signer still
+computes the signature as if this field was present. Recipients of
+the proposal need to inject the last closed ledger in order to
+validate the signature. If the last closed ledger is left out, then
+it is considered as all zeroes for the purposes of signing.
+*/
 // Compute a unique identifier for this signed proposal
 uint256 LedgerProposal::computeSuppressionID (
     uint256 const& proposeHash,

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1710,21 +1710,10 @@ void NetworkOPsImp::processTrustedProposal (
         }
 
         if (relay)
-        {
-            std::set<Peer::id_t> peers;
-            if (getApp().getHashRouter ().swapSet (
-                proposal->getSuppressionID (), peers, SF_RELAYED))
-            {
-                getApp ().overlay ().foreach (send_if_not (
-                    std::make_shared<Message> (
-                        *set, protocol::mtPROPOSE_LEDGER),
-                    peer_in_set(peers)));
-            }
-        }
+            getApp().overlay().relay(*set,
+                proposal->getSuppressionID());
         else
-        {
             m_journal.info << "Not relaying trusted proposal";
-        }
     }
 }
 

--- a/src/ripple/basics/BasicConfig.h
+++ b/src/ripple/basics/BasicConfig.h
@@ -23,6 +23,7 @@
 #include <beast/container/const_container.h>
 #include <beast/utility/ci_char_traits.h>
 #include <boost/lexical_cast.hpp>
+#include <boost/optional.hpp>
 #include <map>
 #include <ostream>
 #include <string>
@@ -138,6 +139,16 @@ public:
     */
     std::pair <std::string, bool>
     find (std::string const& name) const;
+
+    template <class T>
+    boost::optional<T>
+    get (std::string const& name) const
+    {
+        auto const iter = cont().find(name);
+        if (iter == cont().end())
+            return boost::none;
+        return boost::lexical_cast<T>(iter->second);
+    }
 
     friend
     std::ostream&

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -31,6 +31,7 @@
 #include <beast/cxx14/type_traits.h> // <type_traits>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <boost/optional.hpp>
 
 namespace boost { namespace asio { namespace ssl { class context; } } }
 
@@ -65,6 +66,7 @@ public:
         bool auto_connect = true;
         Promote promote = Promote::automatic;
         std::shared_ptr<boost::asio::ssl::context> context;
+        bool expire = false;
     };
 
     typedef std::vector <Peer::ptr> PeerSequence;
@@ -130,6 +132,28 @@ public:
     virtual
     Peer::ptr
     findPeerByShortID (Peer::id_t const& id) = 0;
+
+    /** Broadcast a proposal. */
+    virtual
+    void
+    send (protocol::TMProposeSet& m) = 0;
+
+    /** Broadcast a validation. */
+    virtual
+    void
+    send (protocol::TMValidation& m) = 0;
+
+    /** Relay a proposal. */
+    virtual
+    void
+    relay (protocol::TMProposeSet& m,
+        uint256 const& uid) = 0;
+
+    /** Relay a validation. */
+    virtual
+    void
+    relay (protocol::TMValidation& m,
+        uint256 const& uid) = 0;
 
     /** Visit every active peer and return a value
         The functor must:

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -46,6 +46,11 @@ namespace ripple {
 class PeerImp;
 class BasicConfig;
 
+enum
+{
+    maxTTL = 2
+};
+
 class OverlayImpl : public Overlay
 {
 public:
@@ -173,6 +178,20 @@ public:
 
     Peer::ptr
     findPeerByShortID (Peer::id_t const& id) override;
+
+    void
+    send (protocol::TMProposeSet& m) override;
+
+    void
+    send (protocol::TMValidation& m) override;
+
+    void
+    relay (protocol::TMProposeSet& m,
+        uint256 const& uid) override;
+
+    void
+    relay (protocol::TMValidation& m,
+        uint256 const& uid) override;
 
     //--------------------------------------------------------------------------
     //

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -174,6 +174,11 @@ public:
     Peer::ptr
     findPeerByShortID (Peer::id_t const& id) override;
 
+    //--------------------------------------------------------------------------
+    //
+    // OverlayImpl
+    //
+
     void
     add_active (std::shared_ptr<PeerImp> const& peer);
 
@@ -191,6 +196,22 @@ public:
     /** Called when an active peer is destroyed. */
     void
     onPeerDeactivate (Peer::id_t id, RippleAddress const& publicKey);
+
+    // UnaryFunc will be called as
+    //  void(std::shared_ptr<PeerImp>&&)
+    //
+    template <class UnaryFunc>
+    void
+    for_each (UnaryFunc&& f)
+    {
+        std::lock_guard <decltype(mutex_)> lock (mutex_);
+        for (auto const& e : m_publicKeyMap)
+        {
+            auto sp = e.second.lock();
+            if (sp)
+                f(std::move(sp));
+        }
+    }
 
     static
     bool

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -153,6 +153,7 @@ private:
     bool gracefulClose_ = false;
     std::unique_ptr <LoadEvent> load_event_;
     std::unique_ptr<Validators::Connection> validatorsConnection_;
+    bool hopsAware_ = false;
 
     //--------------------------------------------------------------------------
 
@@ -235,6 +236,12 @@ public:
     cluster() const override
     {
         return slot_->cluster();
+    }
+
+    bool
+    hopsAware() const
+    {
+        return hopsAware_;
     }
 
     void

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -173,6 +173,7 @@ message TMProposeSet
     optional bool checkedSignature      = 7;    // node vouches signature is correct
     repeated bytes addedTransactions    = 10;   // not required if number is large
     repeated bytes removedTransactions  = 11;   // not required if number is large
+    optional uint32 hops                = 12;   // Number of hops traveled
 }
 
 enum TxSetStatus
@@ -192,8 +193,9 @@ message TMHaveTransactionSet
 // Used to sign a final closed ledger after reprocessing
 message TMValidation
 {
-    required bytes validation       = 1;        // in STValidation signed form
-    optional bool checkedSignature  = 2;        // node vouches signature is correct
+    required bytes validation       = 1;    // in STValidation signed form
+    optional bool checkedSignature  = 2;    // node vouches signature is correct
+    optional uint32 hops            = 3;    // Number of hops traveled
 }
 
 message TMGetPeers


### PR DESCRIPTION
When the [overlay] configuration key "expire" is set to 1, proposals and validations will include a hops field. The hops is incremented with each relay. Messages with a hop count will be dropped when they exceed the TTL (Time to Live). Messages containing a hops field will not be relayed or broadcast to older versions of rippled that don't understand the field.

This change will not affect normal operation of the network or rippled instances that do not set "expire" to 1.