### PR TITLE
Log ledger data request times:

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2684,6 +2684,12 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\overlay\impl\ConnectAttempt.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\overlay\impl\GetLedgerTracker.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\overlay\impl\GetLedgerTracker.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\overlay\impl\Message.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3213,6 +3213,12 @@
     <ClInclude Include="..\..\src\ripple\overlay\impl\ConnectAttempt.h">
       <Filter>ripple\overlay\impl</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\overlay\impl\GetLedgerTracker.cpp">
+      <Filter>ripple\overlay\impl</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\overlay\impl\GetLedgerTracker.h">
+      <Filter>ripple\overlay\impl</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\overlay\impl\Message.cpp">
       <Filter>ripple\overlay\impl</Filter>
     </ClCompile>

--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -498,8 +498,6 @@ void InboundLedger::trigger (Peer::ptr const& peer)
                     }
                 }
 
-                Message::pointer packet (std::make_shared <Message> (
-                    tmBH, protocol::mtGET_OBJECTS));
                 {
                     ScopedLockType sl (mLock);
 
@@ -512,7 +510,7 @@ void InboundLedger::trigger (Peer::ptr const& peer)
                         if (iPeer)
                         {
                             mByHash = false;
-                            iPeer->send (packet);
+                            iPeer->send (tmBH);
                         }
                     }
                 }

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -588,9 +588,7 @@ public:
             tmBH.set_query (true);
             tmBH.set_type (protocol::TMGetObjectByHash::otFETCH_PACK);
             tmBH.set_ledgerhash (nextLedger->getHash().begin (), 32);
-            Message::pointer packet = std::make_shared<Message> (tmBH, protocol::mtGET_OBJECTS);
-
-            target->send (packet);
+            target->send (tmBH);
             WriteLog (lsTRACE, LedgerMaster) << "Requested fetch pack for " << nextLedger->getLedgerSeq() - 1;
         }
         else

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -3364,8 +3364,7 @@ void NetworkOPsImp::makeFetchPack (
 
         m_journal.info
             << "Built fetch pack with " << reply.objects ().size () << " nodes";
-        auto msg = std::make_shared<Message> (reply, protocol::mtGET_OBJECTS);
-        peer->send (msg);
+        peer->send (reply);
     }
     catch (...)
     {

--- a/src/ripple/app/peers/PeerSet.cpp
+++ b/src/ripple/app/peers/PeerSet.cpp
@@ -151,30 +151,27 @@ bool PeerSet::isActive ()
     return !isDone ();
 }
 
-void PeerSet::sendRequest (const protocol::TMGetLedger& tmGL, Peer::ptr const& peer)
+void PeerSet::sendRequest (protocol::TMGetLedger& tmGL, Peer::ptr const& peer)
 {
     if (!peer)
         sendRequest (tmGL);
     else
-        peer->send (std::make_shared<Message> (tmGL, protocol::mtGET_LEDGER));
+        peer->send (tmGL);
 }
 
-void PeerSet::sendRequest (const protocol::TMGetLedger& tmGL)
+void PeerSet::sendRequest (protocol::TMGetLedger& tmGL)
 {
     ScopedLockType sl (mLock);
 
     if (mPeers.empty ())
         return;
 
-    Message::pointer packet (
-        std::make_shared<Message> (tmGL, protocol::mtGET_LEDGER));
-
     for (auto const& p : mPeers)
     {
         Peer::ptr peer (getApp().overlay ().findPeerByShortID (p.first));
 
         if (peer)
-            peer->send (packet);
+            peer->send (tmGL);
     }
 }
 

--- a/src/ripple/app/peers/PeerSet.h
+++ b/src/ripple/app/peers/PeerSet.h
@@ -134,8 +134,8 @@ protected:
     }
     void invokeOnTimer ();
 
-    void sendRequest (const protocol::TMGetLedger& message);
-    void sendRequest (const protocol::TMGetLedger& message, Peer::ptr const& peer);
+    void sendRequest (protocol::TMGetLedger& message);
+    void sendRequest (protocol::TMGetLedger& message, Peer::ptr const& peer);
 
 protected:
     beast::Journal m_journal;

--- a/src/ripple/overlay/Peer.h
+++ b/src/ripple/overlay/Peer.h
@@ -56,6 +56,18 @@ public:
     send (Message::pointer const& m) = 0;
 
     virtual
+    void
+    send (protocol::TMGetLedger& m) = 0;
+
+    virtual
+    void
+    send (protocol::TMLedgerData& m) = 0;
+
+    virtual
+    void
+    send (protocol::TMGetObjectByHash const& m) = 0;
+
+    virtual
     beast::IP::Endpoint
     getRemoteAddress() const = 0;
 

--- a/src/ripple/overlay/impl/GetLedgerTracker.cpp
+++ b/src/ripple/overlay/impl/GetLedgerTracker.cpp
@@ -1,0 +1,135 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/overlay/impl/GetLedgerTracker.h>
+#include <cassert>
+
+namespace ripple {
+
+#ifndef RIPPLE_TRACK_GETLEDGER_TIMES
+#define RIPPLE_TRACK_GETLEDGER_TIMES 0
+#endif
+
+#if RIPPLE_TRACK_GETLEDGER_TIMES
+static bool trackGetLedger = true;
+#else
+static bool trackGetLedger = false;
+#endif
+
+GetLedgerTracker::GetLedgerTracker (beast::Journal j)
+    : j_(j)
+    , map_(beast::get_abstract_clock<
+        std::chrono::steady_clock>())
+{
+}
+
+void
+GetLedgerTracker::onSend (protocol::TMGetLedger& m)
+{
+    if (! trackGetLedger)
+        return;
+    if (! m.has_requestcookie())
+        return;
+    beast::expire(map_,
+        std::chrono::seconds(30));
+    auto id = next_id_++;
+    if (id == 0)
+        id = next_id_++;
+    auto const result =
+        map_.emplace(id, std::move(Value{}));
+    assert(result.second);
+    auto& v = result.first->second;
+    v.when = clock_type::now();
+    if (m.has_requestcookie())
+        v.id = m.requestcookie();
+    v.count = m.nodeids().size();
+    for (auto const& n : m.nodeids())
+        v.bytes += n.size();
+    m.set_requestcookie(id);
+}
+
+void
+GetLedgerTracker::onReceive (protocol::TMGetLedger& m)
+{
+}
+
+// TMLedgerData
+
+void
+GetLedgerTracker::onSend (protocol::TMLedgerData& m)
+{
+}
+
+void
+GetLedgerTracker::onReceive (protocol::TMLedgerData& m)
+{
+    if (! trackGetLedger)
+        return;
+    if (! m.has_requestcookie())
+        return;
+
+    beast::expire(map_,
+        std::chrono::seconds(30));
+    if (! m.has_requestcookie())
+    {
+        j_.error <<
+            "TMLedgerData with no request cookie";
+        return;
+    }
+    auto const id = m.requestcookie();
+    auto const iter = map_.find(id);
+    if (iter == map_.end())
+    {
+        j_.error <<
+            "TMLedgerData with unknown request cookie";
+        return;
+    }
+    auto const& v = iter->second;
+    if (v.id)
+        m.set_requestcookie(*v.id);
+    else
+        m.clear_requestcookie();
+    auto const t = clock_type::now() - v.when;
+    auto bytes = 0;
+    for (auto const& n : m.nodes())
+        bytes += n.nodedata().size();
+    j_.info <<
+        "seq=" << m.ledgerseq() <<
+        ", in_count=" << v.count <<
+        ", in_bytes=" << v.bytes <<
+        ", count=" << m.nodes().size() <<
+        ", bytes=" << bytes <<
+        ", time=" << elapsed(t)
+        ;
+    map_.erase(iter);
+}
+
+void
+GetLedgerTracker::onSend (
+    protocol::TMGetObjectByHash const& m)
+{
+}
+
+void
+GetLedgerTracker::onReceive (
+    protocol::TMGetObjectByHash const& m)
+{
+}
+
+}

--- a/src/ripple/overlay/impl/GetLedgerTracker.h
+++ b/src/ripple/overlay/impl/GetLedgerTracker.h
@@ -1,0 +1,94 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_OVERLAY_GETLEDGERTRACKER_H_INCLUDED
+#define RIPPLE_OVERLAY_GETLEDGERTRACKER_H_INCLUDED
+
+#include "ripple.pb.h"
+#include <ripple/protocol/UintTypes.h>
+#include <ripple/overlay/Message.h>
+#include <beast/chrono/abstract_clock.h>
+#include <beast/container/aged_container_utility.h>
+#include <beast/container/aged_unordered_map.h>
+#include <beast/hash/hash_append.h>
+#include <beast/hash/uhash.h>
+#include <beast/utility/Journal.h>
+#include <boost/optional.hpp>
+#include <chrono>
+#include <utility>
+
+namespace ripple {
+
+class GetLedgerTracker
+{
+private:
+    using clock_type = std::chrono::high_resolution_clock;
+
+    struct Value
+    {
+        boost::optional<std::uint32_t> id;
+        clock_type::time_point when;
+        std::size_t count;
+        std::size_t bytes = 0;
+    };
+
+    using map_type = beast::aged_unordered_map<
+        std::uint32_t, Value, std::chrono::steady_clock,
+            beast::uhash<>>;
+    
+    beast::Journal j_;
+    std::uint32_t next_id_ = 1;
+    map_type map_;
+
+public:
+    explicit
+    GetLedgerTracker (beast::Journal j);
+
+    void
+    onSend (protocol::TMGetLedger& m);
+
+    void
+    onReceive (protocol::TMGetLedger& m);
+
+    void
+    onSend (protocol::TMLedgerData& m);
+
+    void
+    onReceive (protocol::TMLedgerData& m);
+
+    void
+    onSend (protocol::TMGetObjectByHash const& m);
+
+    void
+    onReceive (protocol::TMGetObjectByHash const& m);
+
+private:
+    template <class Rep, class Period>
+    std::string
+    elapsed (std::chrono::duration<Rep, Period> const& d)
+    {
+        auto const ms = std::chrono::duration_cast<
+            std::chrono::milliseconds>(d).count();
+        return std::to_string(ms) + "ms";
+    }
+};
+
+}
+
+#endif

--- a/src/ripple/unity/overlay.cpp
+++ b/src/ripple/unity/overlay.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 
 #include <ripple/overlay/impl/ConnectAttempt.cpp>
+#include <ripple/overlay/impl/GetLedgerTracker.cpp>
 #include <ripple/overlay/impl/Message.cpp>
 #include <ripple/overlay/impl/OverlayImpl.cpp>
 #include <ripple/overlay/impl/PeerImp.cpp>


### PR DESCRIPTION
Tracks the turnaround time between a TMGetLedger and its corresponding TMLedgerData. This works for both originated and relayed messages.

Reviewers: Only the most recent commit is part of this set, the others are from another pull request.