### PR TITLE
Simplify InboundLedger expiration

### DIFF
--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -67,6 +67,20 @@ InboundLedger::InboundLedger (uint256 const& hash, std::uint32_t seq, fcReason r
         "Acquiring ledger " << mHash;
 }
 
+void InboundLedger::update (std::uint32_t seq)
+{
+    ScopedLockType sl (mLock);
+
+    if ((seq != 0) && (mSeq == 0))
+    {
+        // If we didn't know the sequence number, but now do, save it
+        mSeq = seq;
+    }
+
+    // Prevent this from being swept
+    touch ();
+}
+
 bool InboundLedger::checkLocal ()
 {
     ScopedLockType sl (mLock);

--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -55,6 +55,9 @@ public:
 
     ~InboundLedger ();
 
+    // Called when another attempt is made to fetch this same ledger
+    void update (std::uint32_t seq);
+
     bool isHeader () const
     {
         return mHaveHeader;


### PR DESCRIPTION
This allows the sweep logic to remove "stale" inbound ledger requests, touching them if they're requested again. Also, the sequence of the inbound ledger object is updated if the request provides one and the old request didn't have one. This should produce more reasonable retention times for ledger requests, keeping current/validated requests around longer but still expiring stale requests if they build up.

This may result in slightly worse performance for connections with poor bandwith, allowing more inbound ledger requests to accumulate (about 18, worst case) when the server falls way behind. We will need all these ledgers eventually to catch up anyway.