### PR TITLE
Compute validated ledger age from signing time

### DIFF
--- a/src/ripple/app/misc/Validations.h
+++ b/src/ripple/app/misc/Validations.h
@@ -64,6 +64,9 @@ public:
     virtual LedgerToValidationCounter getCurrentValidations (
         uint256 currentLedger, uint256 previousLedger) = 0;
 
+    virtual std::uint32_t getValidationTime (
+        uint256 const& ledger, int minValidations) = 0;
+
     virtual std::list <STValidation::pointer>
     getCurrentTrustedValidations () = 0;
 


### PR DESCRIPTION
This will provide more accuracy in the reported validated ledger age as it won't be based on the ledger close time which is rounded.