### PR TITLE
Peer latency tracking, plus tiny bugfix

### DIFF
--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -38,8 +38,14 @@ namespace ripple {
 
 enum
 {
+    // Number of peers to start with
+    peerCountStart = 4
+
+    // Number of peers to add on a timeout
+    ,peerCountAdd = 2
+
     // millisecond for each ledger timeout
-    ledgerAcquireTimeoutMillis = 2500
+    ,ledgerAcquireTimeoutMillis = 2500
 
     // how many timeouts before we giveup
     ,ledgerTimeoutRetriesMax = 10
@@ -282,7 +288,9 @@ void InboundLedger::onTimer (bool wasProgress, ScopedLockType&)
 /** Add more peers to the set, if possible */
 void InboundLedger::addPeers ()
 {
-    getApp().overlay().selectPeers (&this, 6, ScoreHasLedger (getHash(), mSeq));
+    getApp().overlay().selectPeers (*this,
+        (getPeerCount() > 0) ? peerCountStart : peerCountAdd,
+        ScoreHasLedger (getHash(), mSeq));
 }
 
 std::weak_ptr<PeerSet> InboundLedger::pmDowncast ()

--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -273,8 +273,7 @@ void InboundLedger::onTimer (bool wasProgress, ScopedLockType&)
         // so each peer gets triggered once
         if (mReason != fcHISTORY)
             trigger (Peer::ptr ());
-        if (pc < 4)
-            addPeers ();
+        addPeers ();
         if (mReason == fcHISTORY)
             trigger (Peer::ptr ());
     }
@@ -283,72 +282,7 @@ void InboundLedger::onTimer (bool wasProgress, ScopedLockType&)
 /** Add more peers to the set, if possible */
 void InboundLedger::addPeers ()
 {
-    Overlay::PeerSequence peerList = getApp().overlay ().getActivePeers ();
-
-    int vSize = peerList.size ();
-
-    if (vSize == 0)
-    {
-        WriteLog (lsERROR, InboundLedger) <<
-            "No peers to add for ledger acquisition";
-        return;
-    }
-
-    // FIXME-NIKB why are we doing this convoluted thing here instead of simply
-    // shuffling this vector and then pulling however many entries we need?
-
-    // We traverse the peer list in random order so as not to favor
-    // any particular peer
-    //
-    // VFALCO Use random_shuffle
-    //        http://en.cppreference.com/w/cpp/algorithm/random_shuffle
-    //
-    int firstPeer = rand () % vSize;
-
-    int found = 0;
-
-    // First look for peers that are likely to have this ledger
-    for (int i = 0; i < vSize; ++i)
-    {
-        Peer::ptr const& peer = peerList[ (i + firstPeer) % vSize];
-
-        if (peer->hasLedger (getHash (), mSeq))
-        {
-           if (peerHas (peer) && (++found > 6))
-               break;
-        }
-    }
-
-    if (!found)
-    { // Oh well, try some random peers
-        for (int i = 0; (i < 6) && (i < vSize); ++i)
-        {
-            if (peerHas (peerList[ (i + firstPeer) % vSize]))
-                ++found;
-        }
-        if (mSeq != 0)
-        {
-            if (m_journal.debug) m_journal.debug <<
-                "Chose " << found << " peer(s) for ledger " << mSeq;
-        }
-        else
-        {
-            if (m_journal.debug) m_journal.debug <<
-                "Chose " << found << " peer(s) for ledger " <<
-                    to_string (getHash ());
-        }
-    }
-    else if (mSeq != 0)
-    {
-        if (m_journal.debug) m_journal.debug <<
-            "Found " << found << " peer(s) with ledger " << mSeq;
-    }
-    else
-    {
-        if (m_journal.debug) m_journal.debug <<
-            "Found " << found << " peer(s) with ledger " <<
-                to_string (getHash ());
-    }
+    getApp().overlay().selectPeers (&this, 6, ScoreHasLedger (getHash(), mSeq));
 }
 
 std::weak_ptr<PeerSet> InboundLedger::pmDowncast ()
@@ -982,7 +916,7 @@ bool InboundLedger::takeAsRootNode (Blob const& data, SHAMapAddNode& san)
 */
 bool InboundLedger::takeTxRootNode (Blob const& data, SHAMapAddNode& san)
 {
-    if (mFailed || mHaveState)
+    if (mFailed || mHaveTransactions)
     {
         san.incDuplicate();
         return true;

--- a/src/ripple/app/tx/TransactionAcquire.cpp
+++ b/src/ripple/app/tx/TransactionAcquire.cpp
@@ -232,50 +232,7 @@ SHAMapAddNode TransactionAcquire::takeNodes (const std::list<SHAMapNodeID>& node
 
 void TransactionAcquire::addPeers (int numPeers)
 {
-    std::vector <Peer::ptr> peerVec1, peerVec2;
-
-    {
-        auto peers = getApp().overlay().getActivePeers();
-        for (auto const& peer : peers)
-        {
-            if (peer->hasTxSet (mHash))
-                peerVec1.push_back (peer);
-            else
-                peerVec2.push_back (peer);
-        }
-    }
-
-    WriteLog (lsDEBUG, TransactionAcquire) << peerVec1.size() << " peers known to have " << mHash;
-
-    if (peerVec1.size() != 0)
-    {
-        // First try peers known to have the set
-        std::random_shuffle (peerVec1.begin (), peerVec1.end ());
-
-        for (auto const& peer : peerVec1)
-        {
-            if (peerHas (peer))
-            {
-                if (--numPeers <= 0)
-                    return;
-            }
-        }
-    }
-
-    if (peerVec2.size() != 0)
-    {
-        // Then try peers not known to have the set
-        std::random_shuffle (peerVec2.begin (), peerVec2.end ());
-
-        for (auto const& peer : peerVec2)
-        {
-            if (peerHas (peer))
-            {
-                if (--numPeers <= 0)
-                    return;
-            }
-        }
-    }
+    getApp().overlay().selectPeers (*this, numPeers, ScoreHasTxSet (getHash()));
 }
 
 void TransactionAcquire::init (int numPeers)

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_OVERLAY_OVERLAY_H_INCLUDED
 #define RIPPLE_OVERLAY_OVERLAY_H_INCLUDED
 
+#include <ripple/app/peers/PeerSet.h>
 #include <ripple/json/json_value.h>
 #include <ripple/overlay/Peer.h>
 #include <ripple/server/Handoff.h>
@@ -31,7 +32,7 @@
 #include <beast/cxx14/type_traits.h> // <type_traits>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/optional.hpp>
+#include <functional>
 
 namespace boost { namespace asio { namespace ssl { class context; } } }
 
@@ -203,6 +204,48 @@ public:
         for(PeerSequence::const_iterator i = peers.begin(); i != peers.end(); ++i)
             f (*i);
     }
+
+    /** Select from active peers
+
+        Scores all active peers.
+        Tries to accept the highest scoring peers, up to the requested count,
+        Returns the number of selected peers accepted.
+
+        The score function must:
+        - Be callable as:
+           bool (PeerImp::ptr)
+        - Return a true if the peer is prefered
+
+        The accept function must:
+        - Be callable as:
+           bool (PeerImp::ptr)
+        - Return a true if the peer is accepted
+
+    */
+    virtual
+    std::size_t
+    selectPeers (PeerSet& set, std::size_t limit, std::function<
+        bool(std::shared_ptr<Peer> const&)> score) = 0;
+};
+
+struct ScoreHasLedger
+{
+    uint256 const& hash_;
+    std::uint32_t seq_;
+    bool operator()(std::shared_ptr<Peer> const&) const;
+
+    ScoreHasLedger (uint256 const& hash, std::uint32_t seq)
+        : hash_ (hash), seq_ (seq)
+    {}
+};
+
+struct ScoreHasTxSet
+{
+    uint256 const& hash_;
+    bool operator()(std::shared_ptr<Peer> const&) const;
+
+    ScoreHasTxSet (uint256 const& hash) : hash_ (hash)
+    {}
 };
 
 }

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -221,9 +221,8 @@ public:
     //
     template <class UnaryFunc>
     void
-    for_each (UnaryFunc&& f)
+    for_each_unlocked (UnaryFunc&& f)
     {
-        std::lock_guard <decltype(mutex_)> lock (mutex_);
         for (auto const& e : m_publicKeyMap)
         {
             auto sp = e.second.lock();
@@ -231,6 +230,18 @@ public:
                 f(std::move(sp));
         }
     }
+
+    template <class UnaryFunc>
+    void
+    for_each (UnaryFunc&& f)
+    {
+        std::lock_guard <decltype(mutex_)> lock (mutex_);
+        for_each_unlocked(f);
+    }
+
+    std::size_t
+    selectPeers (PeerSet& set, std::size_t limit, std::function<
+        bool(std::shared_ptr<Peer> const&)> score) override;
 
     static
     bool

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -139,6 +139,11 @@ private:
     uint256 previousLedgerHash_;
     std::deque<uint256> recentLedgers_;
     std::deque<uint256> recentTxSets_;
+
+    std::chrono::milliseconds latency_ = std::chrono::milliseconds (-1);
+    std::uint64_t lastPingSeq_ = 0;
+    clock_type::time_point lastPingTime_;
+
     mutable std::mutex recentLock_;
     protocol::TMStatusChange last_status_;
     protocol::TMHello hello_;
@@ -151,6 +156,7 @@ private:
     beast::asio::streambuf write_buffer_;
     std::queue<Message::pointer> send_queue_;
     bool gracefulClose_ = false;
+    bool recent_empty_ = true;
     std::unique_ptr <LoadEvent> load_event_;
     std::unique_ptr<Validators::Connection> validatorsConnection_;
     bool hopsAware_ = false;
@@ -297,6 +303,10 @@ public:
     bool
     hasRange (std::uint32_t uMin, std::uint32_t uMax) override;
 
+    // Called to determine our priority for querying
+    int
+    getScore (bool haveItem);
+
 private:
     void
     close();
@@ -395,8 +405,6 @@ public:
     void onMessage (std::shared_ptr <protocol::TMHaveTransactionSet> const& m);
     void onMessage (std::shared_ptr <protocol::TMValidation> const& m);
     void onMessage (std::shared_ptr <protocol::TMGetObjectByHash> const& m);
-
-    //--------------------------------------------------------------------------
 
 private:
     State state() const

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -180,6 +180,7 @@ JSS ( issuer );                     // in: RipplePathFind, Subscribe,
                                     // out: paths/Node, STPathSet, STAmount
 JSS ( key );                        // out: WalletSeed
 JSS ( key_type );                   // in/out: WalletPropose, TransactionSign
+JSS ( latency );                    // out: PeerImp
 JSS ( last );                       // out: RPCVersion
 JSS ( last_close );                 // out: NetworkOPs
 JSS ( ledger );                     // in: NetworkOPs, LedgerCleaner,


### PR DESCRIPTION
The first commit is a tiny bugfix to the way InboundLedger::takeTxRootNode. By luck, it almost never matters.

The main commit tracks the query/response latency for all peer connections, reports this in RPC, and uses it to decide which server(s) to query for ledgers and transaction sets.

The PeerSet timer logic was slightly reworked to reset itself when it fires, rather than on activity. This reduces the number of times we need to reset the timer and also allows it to trigger the ping logic that the latency uses. (That's why they're in one commit.)