### PR TITLE
Report the performance of historical ledger acquisition

### DIFF
--- a/src/ripple/app/ledger/InboundLedger.cpp
+++ b/src/ripple/app/ledger/InboundLedger.cpp
@@ -353,9 +353,9 @@ void InboundLedger::done ()
     {
         mLedger->setClosed ();
         mLedger->setImmutable ();
-
         if (mReason != fcHISTORY)
             getApp().getLedgerMaster ().storeLedger (mLedger);
+        getApp().getInboundLedgers().onLedgerFetched(mReason);
     }
     else
         getApp().getInboundLedgers ().logFailure (mHash);

--- a/src/ripple/app/ledger/InboundLedgers.h
+++ b/src/ripple/app/ledger/InboundLedgers.h
@@ -71,6 +71,12 @@ public:
 
     virtual Json::Value getInfo() = 0;
 
+    /** Returns the rate of historical ledger fetches per minute. */
+    virtual std::size_t fetchRate() = 0;
+
+    /** Called when a complete ledger is obtained. */
+    virtual void onLedgerFetched (InboundLedger::fcReason why) = 0;
+
     virtual void gotFetchPack (Job&) = 0;
     virtual void sweep () = 0;
 

--- a/src/ripple/basics/DecayingSample.h
+++ b/src/ripple/basics/DecayingSample.h
@@ -21,7 +21,8 @@
 #define RIPPLE_BASICS_DECAYINGSAMPLE_H_INCLUDED
 
 #include <chrono>
-    
+#include <cmath>
+
 namespace ripple {
 
 /** Sampling function using exponential decay to provide a continuous value.
@@ -98,6 +99,55 @@ private:
 
     // Last time the aging function was applied
     time_point m_when;
+};
+
+//------------------------------------------------------------------------------
+
+/** Sampling function using exponential decay to provide a continuous value.
+    @tparam HalfLife The half life of a sample, in seconds.
+*/
+template <int HalfLife, class Clock>
+class DecayWindow
+{
+public:
+    using time_point = typename Clock::time_point;
+
+    explicit
+    DecayWindow (time_point now)
+        : value_(0)
+        , when_(now)
+    {
+    }
+
+    void
+    add (double value, time_point now)
+    {
+        decay(now);
+        value_ += value;
+    }
+
+    double
+    value (time_point now)
+    {
+        decay(now);
+        return value_ / HalfLife;
+    }
+
+private:
+    void
+    decay (time_point now)
+    {
+        if (now <= when_)
+            return;
+        using namespace std::chrono;
+        auto const elapsed =
+            duration<double>(now - when_).count();
+        value_ *= std::pow(2.0, - elapsed / HalfLife);
+        when_ = now;
+    }
+
+    double value_;
+    time_point when_;
 };
 
 }

--- a/src/ripple/basics/RangeSet.h
+++ b/src/ripple/basics/RangeSet.h
@@ -57,6 +57,10 @@ public:
 
     std::string toString () const;
 
+    /** Returns the sum of the Lebesgue measures of all sub-ranges. */
+    std::size_t
+    lebesgue_sum() const;
+
     /** Check invariants of the data.
 
         This is for diagnostics, and does nothing in release builds.

--- a/src/ripple/basics/impl/RangeSet.cpp
+++ b/src/ripple/basics/impl/RangeSet.cpp
@@ -235,6 +235,15 @@ void RangeSet::simplify ()
     }
 }
 
+std::size_t
+RangeSet::lebesgue_sum() const
+{
+    std::size_t sum = mRanges.size();
+    for (auto const& e : mRanges)
+        sum += e.second - e.first;
+    return sum;
+}
+
 void RangeSet::checkInternalConsistency () const noexcept
 {
 #ifndef NDEBUG

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -43,6 +43,7 @@ JSS ( Invalid );                    // out: app/misc/AccountState
 JSS ( LimitAmount );                // field.
 JSS ( OfferSequence );              // field.
 JSS ( Paths );                      // in/out: TransactionSign
+JSS ( historical_perminute );       // historical_perminute
 JSS ( SLE_hit_rate );               // out: GetCounts
 JSS ( SendMax );                    // in: TransactionSign
 JSS ( Sequence );                   // in/out: TransactionSign; field.

--- a/src/ripple/rpc/handlers/GetCounts.cpp
+++ b/src/ripple/rpc/handlers/GetCounts.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/data/DatabaseCon.h>
 #include <ripple/app/ledger/AcceptedLedger.h>
+#include <ripple/app/ledger/InboundLedgers.h>
 #include <ripple/basics/UptimeTimer.h>
 #include <ripple/nodestore/Database.h>
 
@@ -69,6 +70,8 @@ Json::Value doGetCounts (RPC::Context& context)
 
     ret[jss::write_load] = app.getNodeStore ().getWriteLoad ();
 
+    ret[jss::historical_perminute] = static_cast<int>(
+        app.getInboundLedgers().fetchRate());
     ret[jss::SLE_hit_rate] = app.getSLECache ().getHitRate ();
     ret[jss::node_hit_rate] = app.getNodeStore ().getCacheHitRate ();
     ret[jss::ledger_hit_rate] = app.getLedgerMaster ().getCacheHitRate ();


### PR DESCRIPTION
`get_counts` will report "historical_perminute", representing the number of complete historical ledgers fetched per minute.
