### PR TITLE
Control query fatness based on latency

### DIFF
--- a/src/ripple/app/tx/TransactionAcquire.cpp
+++ b/src/ripple/app/tx/TransactionAcquire.cpp
@@ -124,6 +124,7 @@ void TransactionAcquire::trigger (Peer::ptr const& peer)
         protocol::TMGetLedger tmGL;
         tmGL.set_ledgerhash (mHash.begin (), mHash.size ());
         tmGL.set_itype (protocol::liTS_CANDIDATE);
+        tmGL.set_querydepth (3); // We probably need the whole thing
 
         if (getTimeouts () != 0)
             tmGL.set_querytype (protocol::qtINDIRECT);

--- a/src/ripple/overlay/Peer.h
+++ b/src/ripple/overlay/Peer.h
@@ -78,6 +78,10 @@ public:
     cluster() const = 0;
 
     virtual
+    bool
+    isHighLatency() const = 0;
+
+    virtual
     RippleAddress const&
     getNodePublic() const = 0;
 

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -144,7 +144,7 @@ private:
     std::uint64_t lastPingSeq_ = 0;
     clock_type::time_point lastPingTime_;
 
-    mutable std::mutex recentLock_;
+    std::mutex mutable recentLock_;
     protocol::TMStatusChange last_status_;
     protocol::TMHello hello_;
     Resource::Consumer usage_;
@@ -306,6 +306,9 @@ public:
     // Called to determine our priority for querying
     int
     getScore (bool haveItem);
+
+    bool
+    isHighLatency() const override;
 
 private:
     void

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -46,6 +46,10 @@ enum
         consider it insane */
     insaneLedgerLimit   =  128,
 
+    /** How many milliseconds to consider high latency
+        on a peer connection */
+    peerHighLatency     =  120,
+
     /** How often we check connections (seconds) */
     checkSeconds        =   10,
 };

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -300,6 +300,7 @@ message TMGetLedger
     repeated bytes nodeIDs          = 5;
     optional uint64 requestCookie   = 6;
     optional TMQueryType queryType  = 7;
+    optional uint32 queryDepth      = 8;    // How deep to go, number of extra levels
 }
 
 enum TMReplyError

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -146,8 +146,12 @@ public:
     // comparison/sync functions
     void getMissingNodes (std::vector<SHAMapNodeID>& nodeIDs, std::vector<uint256>& hashes, int max,
                           SHAMapSyncFilter * filter);
-    bool getNodeFat (SHAMapNodeID node, std::vector<SHAMapNodeID>& nodeIDs,
-                     std::vector<Blob >& rawNode, bool fatRoot, bool fatLeaves) const;
+    
+    bool getNodeFat (SHAMapNodeID node,
+        std::vector<SHAMapNodeID>& nodeIDs,
+            std::vector<Blob>& rawNode,
+                bool fatLeaves, std::uint32_t depth) const;
+    
     bool getRootNode (Serializer & s, SHANodeFormat format) const;
     std::vector<uint256> getNeededHashes (int max, SHAMapSyncFilter * filter);
     SHAMapAddNode addRootNode (uint256 const& hash, Blob const& rootNode, SHANodeFormat format,

--- a/src/ripple/shamap/tests/SHAMapSync.test.cpp
+++ b/src/ripple/shamap/tests/SHAMapSync.test.cpp
@@ -124,7 +124,8 @@ public:
 
         destination.setSynching ();
 
-        unexpected (!source.getNodeFat (SHAMapNodeID (), nodeIDs, gotNodes, (rand () % 2) == 0, (rand () % 2) == 0),
+        unexpected (!source.getNodeFat (SHAMapNodeID (), nodeIDs, gotNodes,
+            (rand () % 2) == 0, rand () % 3),
             "GetNodeFat");
 
         unexpected (gotNodes.size () < 1, "NodeSize");
@@ -152,7 +153,8 @@ public:
             // get as many nodes as possible based on this information
             for (nodeIDIterator = nodeIDs.begin (); nodeIDIterator != nodeIDs.end (); ++nodeIDIterator)
             {
-                if (!source.getNodeFat (*nodeIDIterator, gotNodeIDs, gotNodes, (rand () % 2) == 0, (rand () % 2) == 0))
+                if (!source.getNodeFat (*nodeIDIterator, gotNodeIDs, gotNodes,
+                    (rand () % 2) == 0, rand () % 3))
                 {
                     fail ("GetNodeFat");
                 }


### PR DESCRIPTION
For ledger and transaction set fetching, allow queries to include a requested "depth" for how deep below the requested node the query goes. Request deeper responses on high-latency connections and for transaction consensus sets (because we likely need the whole thing). For clients that don't know how to specify a query depth, we pick a sane default -- deeper if the connection has high latency.