### PR TITLE
Easier way to get the validated ledger index

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -849,7 +849,7 @@ bool NetworkOPsImp::haveLedger (std::uint32_t seq)
 
 std::uint32_t NetworkOPsImp::getValidatedSeq ()
 {
-    return m_ledgerMaster.getValidatedLedger ()->getLedgerSeq ();
+    return m_ledgerMaster.getValidLedgerIndex ();
 }
 
 bool NetworkOPsImp::isValidated (std::uint32_t seq, uint256 const& hash)


### PR DESCRIPTION
This is more efficient, and it also fixes a case where the new RPC validated ledger check can call this function before we have a validated ledger, causing a crash.