### PR TITLE
Integration test to validate the WS ledger results.

### DIFF
--- a/src/ripple/rpc/handlers/LedgerRequest.cpp
+++ b/src/ripple/rpc/handlers/LedgerRequest.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/ledger/InboundLedgers.h>
 #include <ripple/app/ledger/LedgerToJson.h>
+#include <ripple/rpc/impl/Tuning.h>
 
 namespace ripple {
 
@@ -52,7 +53,8 @@ Json::Value doLedgerRequest (RPC::Context& context)
             return RPC::invalid_field_message (jss::ledger_index);
 
         // We need a validated ledger to get the hash from the sequence
-        if (ledgerMaster.getValidatedLedgerAge() > 120)
+        if (ledgerMaster.getValidatedLedgerAge() >
+            RPC::Tuning::maxValidatedLedgerAge)
             return rpcError (rpcNO_CURRENT);
 
         auto ledgerIndex = jsonIndex.asInt();

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -375,7 +375,8 @@ transactionSign (
 
     // Check for current ledger.
     if (verify && !getConfig ().RUN_STANDALONE &&
-        (ledgerFacade.getValidatedLedgerAge () > 120))
+        (ledgerFacade.getValidatedLedgerAge () >
+            Tuning::maxValidatedLedgerAge))
         return rpcError (rpcNO_CURRENT);
 
     // Check for load.

--- a/test/ledger.js
+++ b/test/ledger.js
@@ -1,0 +1,180 @@
+var async       = require("async");
+var assert      = require('assert');
+var lodash      = require('lodash');
+var Amount      = require("ripple-lib").Amount;
+var Remote      = require("ripple-lib").Remote;
+var Transaction = require("ripple-lib").Transaction;
+var Server      = require("./server").Server;
+var testutils   = require("./testutils");
+var config      = testutils.init_config();
+
+suite('Ledger requests', function() {
+  var $ = { };
+
+  // Array of the ledger output expected from rippled.
+  // Indexes in this array represent (ledger_index - 1).
+  var expectedledgers = [
+    {
+      "ledger": {
+        "accepted": true,
+        "account_hash":
+          "A21ED30C04C88046FC61DB9DC19375EEDBD365FD8C17286F27127DF804E9CAA6",
+        "closed": true,
+        "ledger_index": "1",
+        "seqNum": "1",
+        "totalCoins": "100000000000000000",
+        "total_coins": "100000000000000000",
+        "transaction_hash":
+          "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "ledger_index": 1,
+      "validated": true
+    },
+    {
+      "ledger": {
+        "accepted": true,
+        "account_hash":
+          "A21ED30C04C88046FC61DB9DC19375EEDBD365FD8C17286F27127DF804E9CAA6",
+        "close_time_resolution": 30,
+        "closed": true,
+        "ledger_index": "2",
+        "seqNum": "2",
+        "totalCoins": "100000000000000000",
+        "total_coins": "100000000000000000",
+        "transaction_hash":
+          "0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "ledger_index": 2,
+      "validated": true
+    },
+    {
+      "ledger": {
+        "closed": false,
+        "ledger_index": "3",
+        "seqNum": "3"
+      },
+      "ledger_current_index": 3,
+      "validated": false
+    }
+  ];
+
+  // Indicates the ledger (as the index into
+  // expectedLedgers above) that is expected
+  // from rippled when it is requested by name.
+  var expectedIndexByLedgerName = {
+    "validated": 1,
+    "closed": 1,
+    "current": 2
+  };
+
+  function filterFields(ledger) {
+    if (typeof ledger === 'object') {
+      ledger = lodash.omit(ledger, ['close_time', 'close_time_human', 'hash', 'ledger_hash', 'parent_hash']);
+      Object.keys(ledger).map(function(key) {
+        ledger[key] = filterFields(ledger[key]);
+      });
+    }
+    return ledger;
+  }
+
+  function goodLedger(ledgerSelection, self, callback) {
+    self.what = "Good Ledger " + ledgerSelection;
+
+    var request = $.remote.request_ledger(ledgerSelection)
+      .on('success', function(ledger) {
+        ledger = filterFields(ledger);
+
+        var expectedIndex = expectedIndexByLedgerName[ledgerSelection];
+        if (typeof expectedIndex === 'undefined')
+          expectedIndex = ledgerSelection - 1;
+        assert.deepEqual(ledger, expectedledgers[expectedIndex]);
+
+        callback();
+      })
+      .on('error', function(ledger) {
+        assert(false, self.what);
+      })
+      .request();
+  }
+
+  setup(function(done) {
+    testutils.build_setup().call($, done);
+  });
+
+  teardown(function(done) {
+    testutils.build_teardown().call($, done);
+  });
+
+  test("get ledgers by index", function(done) {
+    var self = this;
+
+    async.waterfall([
+        function (callback) {
+          goodLedger(1, self, callback);
+        },
+        function (callback) {
+          goodLedger(2, self, callback);
+        },
+        function (callback) {
+          goodLedger(3, self, callback);
+        },
+        function (callback) {
+          self.what = "Bad Ledger (4)";
+
+          var expected = 
+            {
+              "error": "remoteError",
+              "error_message": "Remote reported an error.",
+              "remote": {
+                "error": "lgrNotFound",
+                "error_code": 20,
+                "error_message": "ledgerNotFound",
+                "id": 4,
+                "request": {
+                  "command": "ledger",
+                  "id": 4,
+                  "ledger_index": 4
+                },
+                "status": "error",
+                "type": "response"
+              }
+            };
+
+          var request = $.remote.request_ledger(ledgerSelection)
+            .on('success', function(ledger) {
+              assert(false, self.what);
+            })
+            .on('error', function(ledger) {
+              assert.deepEqual(ledger, expectedledgers[ledgerSelection - 1]);
+
+              callback();
+            })
+            .request();
+        },
+      ],
+      function(error) {
+        assert(!error, self.what);
+        done();
+      });
+  });
+
+  test("get ledgers by name", function(done) {
+    var self = this;
+
+    async.waterfall([
+        function (callback) {
+          goodLedger("validated", self, callback);
+        },
+        function (callback) {
+          goodLedger("closed", self, callback);
+        },
+        function (callback) {
+          goodLedger("current", self, callback);
+        },
+      ],
+      function(error) {
+        assert(!error, self.what);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
* Also replace a couple of magic values with the relevant Tuning param.

Though this test was inspired by #1045, it doesn't exercise the scenario that is addressed. This is because standalone mode sets up a validated ledger. I still think the test has value because we don't have any other tests that explicitly exercise lookups, or validate ledger request results. Feel free to disagree.

(And a C++ unit test isn't feasible, because the `Application` is not sufficiently initialized to call in to the relevant `NetworkOPs` functions.)

Reviewers: @miguelportilla @rec 