### PR TITLE
Consensus helpers cleanup

### DIFF
--- a/src/ripple/app/consensus/LedgerConsensus.h
+++ b/src/ripple/app/consensus/LedgerConsensus.h
@@ -46,30 +46,14 @@ public:
 
     virtual Json::Value getJson (bool full) = 0;
 
-    virtual Ledger::ref peekPreviousLedger () = 0;
-
     virtual uint256 getLCL () = 0;
 
     virtual void mapComplete (uint256 const& hash,
         std::shared_ptr<SHAMap> const& map, bool acquired) = 0;
 
-    virtual void checkLCL () = 0;
-
-    virtual void handleLCL (uint256 const& lclHash) = 0;
-
     virtual void timerEntry () = 0;
 
-    // state handlers
-    virtual void statePreClose () = 0;
-    virtual void stateEstablish () = 0;
-    virtual void stateFinished () = 0;
-    virtual void stateAccepted () = 0;
-
-    virtual bool haveConsensus (bool forReal) = 0;
-
     virtual bool peerPosition (LedgerProposal::ref) = 0;
-
-    virtual bool isOurPubKey (const RippleAddress & k) = 0;
 
     // test/debug
     virtual void simulate () = 0;

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -53,7 +53,7 @@ Ledger::Ledger (RippleAddress const& masterID, std::uint64_t startAmount)
     , mLedgerSeq (1) // First Ledger
     , mCloseTime (0)
     , mParentCloseTime (0)
-    , mCloseResolution (LEDGER_TIME_ACCURACY)
+    , mCloseResolution (ledgerDefaultTimeResolution)
     , mCloseFlags (0)
     , mClosed (false)
     , mValidated (false)
@@ -179,10 +179,8 @@ Ledger::Ledger (bool /* dummy */,
 
     assert (mParentHash.isNonZero ());
 
-    mCloseResolution = ContinuousLedgerTiming::getNextLedgerTimeResolution (
-                           prevLedger.mCloseResolution,
-                           prevLedger.getCloseAgree (),
-                           mLedgerSeq);
+    mCloseResolution = getNextLedgerTimeResolution (prevLedger.mCloseResolution,
+        prevLedger.getCloseAgree (), mLedgerSeq);
 
     if (prevLedger.mCloseTime == 0)
     {
@@ -230,7 +228,7 @@ Ledger::Ledger (std::uint32_t ledgerSeq, std::uint32_t closeTime)
       mLedgerSeq (ledgerSeq),
       mCloseTime (closeTime),
       mParentCloseTime (0),
-      mCloseResolution (LEDGER_TIME_ACCURACY),
+      mCloseResolution (ledgerDefaultTimeResolution),
       mCloseFlags (0),
       mClosed (false),
       mValidated (false),

--- a/src/ripple/app/ledger/LedgerTiming.h
+++ b/src/ripple/app/ledger/LedgerTiming.h
@@ -20,41 +20,114 @@
 #ifndef RIPPLE_APP_LEDGER_LEDGERTIMING_H_INCLUDED
 #define RIPPLE_APP_LEDGER_LEDGERTIMING_H_INCLUDED
 
+#include <cstdint>
+
 namespace ripple {
+
+/** Determines whether the current ledger should close at this time.
+
+    This function should be called when a ledger is open and there is no close
+    in progress, or when a transaction is received and no close is in progress.
+
+    @param anyTransactions indicates whether any transactions have been received
+    @param previousProposers proposers in the last closing
+    @param proposersClosed proposers who have currently closed this ledger
+    @param proposersValidated proposers who have validated the last closed ledger
+    @param previousMSeconds time, in milliseconds, for the previous ledger to
+                            reach consensus (in milliseconds)
+    @param currentMSeconds time, in milliseconds since the previous ledger closed
+    @param openMSeconds time, in milliseconds, since the previous LCL was computed
+    @param idleInterval the network's desired idle interval
+*/
+bool shouldCloseLedger (
+    bool anyTransactions,
+    int previousProposers,
+    int proposersClosed,
+    int proposersValidated,
+    int previousMSeconds,
+    int currentMSeconds,
+    int openMSeconds,
+    int idleInterval);
+
+/** What state the consensus process is on. */
+enum class ConsensusState
+{
+    No,           // We do not have consensus
+    MovedOn,      // The network has consensus without us
+    Yes           // We have consensus along with the network
+};
+
+/** Determine whether the network reached consensus and whether we joined.
+
+    @param previousProposers proposers in the last closing (not including us)
+    @param currentProposers proposers in this closing so far (not including us)
+    @param currentAgree proposers who agree with us
+    @param currentFinished proposers who have validated a ledger after this one
+    @param previousAgreeTime how long, in milliseconds, it took to agree on the
+                             last ledger
+    @param currentAgreeTime how long, in milliseconds, we've been trying to agree
+*/
+ConsensusState checkConsensus (
+    int previousProposers,
+    int currentProposers,
+    int currentAgree,
+    int currentClosed,
+    int previousAgreeTime,
+    int currentAgreeTime);
+
+/** Calculates the close time resolution for the specified ledger.
+
+    The Ripple protocol uses binning to represent time intervals using only one
+    timestamp. This allows servers to derive a common time for the next ledger,
+    without the need for perfectly synchronized clocks.
+    The time resolution (i.e. the size of the intervals) is adjusted dynamically
+    based on what happened in the last ledger, to try to avoid disagreements.
+*/
+int getNextLedgerTimeResolution (
+    int previousResolution,
+    bool previousAgree,
+    std::uint32_t ledgerSeq);
+
+//------------------------------------------------------------------------------
+
+// These are protocol parameters used to control the behavior of the system and
+// they should not be changed arbitrarily.
+
+// The percentage threshold above which we can declare consensus.
+int const minimumConsensusPercentage = 80;
+
+// All possible close time resolutions. Values should not be duplicated.
+int const ledgerPossibleTimeResolutions[] = { 10, 20, 30, 60, 90, 120 };
+
+// Initial resolution of ledger close time.
+int const ledgerDefaultTimeResolution = ledgerPossibleTimeResolutions[2];
+
+// How often we increase the close time resolution
+int const increaseLedgerTimeResolutionEvery = 8;
+
+// How often we decrease the close time resolution
+int const decreaseLedgerTimeResolutionEvery = 1;
 
 // The number of seconds a ledger may remain idle before closing
 const int LEDGER_IDLE_INTERVAL = 15;
 
-// The number of seconds a validation remains current after its ledger's close time
-// This is a safety to protect against very old validations and the time it takes to adjust
-// the close time accuracy window
+// The number of seconds a validation remains current after its ledger's close
+// time. This is a safety to protect against very old validations and the time
+// it takes to adjust the close time accuracy window
 const int LEDGER_VAL_INTERVAL = 300;
 
-// The number of seconds before a close time that we consider a validation acceptable
-// This protects against extreme clock errors
+// The number of seconds before a close time that we consider a validation
+// acceptable. This protects against extreme clock errors
 const int LEDGER_EARLY_INTERVAL = 180;
 
 // The number of milliseconds we wait minimum to ensure participation
 const int LEDGER_MIN_CONSENSUS = 2000;
 
-// The number of milliseconds we wait minimum to ensure others have computed the LCL
+// Minimum number of milliseconds to wait to ensure others have computed the LCL
 const int LEDGER_MIN_CLOSE = 2000;
-
-// Initial resolution of ledger close time
-const int LEDGER_TIME_ACCURACY = 30;
-
-// How often to increase resolution
-const int LEDGER_RES_INCREASE = 8;
-
-// How often to decrease resolution
-const int LEDGER_RES_DECREASE = 1;
 
 // How often we check state or change positions (in milliseconds)
 const int LEDGER_GRANULARITY = 1000;
-
-// The percentage of active trusted validators that must be able to
-// keep up with the network or we consider the network overloaded
-const int LEDGER_NET_RATIO = 70;
 
 // How long we consider a proposal fresh
 const int PROPOSE_FRESHNESS = 20;
@@ -82,29 +155,6 @@ const int AV_STUCK_CONSENSUS_TIME = 200;
 const int AV_STUCK_CONSENSUS_PCT = 95;
 
 const int AV_CT_CONSENSUS_PCT = 75;
-
-class ContinuousLedgerTiming
-{
-public:
-
-    static int LedgerTimeResolution[];
-
-    // Returns the number of seconds the ledger was or should be open
-    // Call when a consensus is reached and when any transaction is relayed to be added
-    static bool shouldClose (
-        bool anyTransactions,
-        int previousProposers,      int proposersClosed,    int proposerersValidated,
-        int previousMSeconds,       int currentMSeconds,    int openMSeconds,
-        int idleInterval);
-
-    static bool haveConsensus (
-        int previousProposers,      int currentProposers,
-        int currentAgree,           int currentClosed,
-        int previousAgreeTime,      int currentAgreeTime,
-        bool forReal,               bool& failed);
-
-    static int getNextLedgerTimeResolution (int previousResolution, bool previousAgree, int ledgerSeq);
-};
 
 } // ripple
 

--- a/src/ripple/app/tests/common_ledger.cpp
+++ b/src/ripple/app/tests/common_ledger.cpp
@@ -449,7 +449,7 @@ close_and_advance(Ledger::pointer& ledger, Ledger::pointer& LCL)
     std::uint32_t closeTime = time_point_cast<seconds>  // now
         (system_clock::now() - epoch_offset).
         time_since_epoch().count();
-    int closeResolution = seconds(LEDGER_TIME_ACCURACY).count();
+    int closeResolution = seconds(ledgerDefaultTimeResolution).count();
     bool closeTimeCorrect = true;
     newLCL->setAccepted(closeTime, closeResolution, closeTimeCorrect);
 

--- a/src/ripple/shamap/impl/SHAMapDelta.cpp
+++ b/src/ripple/shamap/impl/SHAMapDelta.cpp
@@ -19,7 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/shamap/SHAMap.h>
-    
+
 namespace ripple {
 
 // This code is used to compare another node's transaction tree
@@ -123,11 +123,11 @@ SHAMap::compare (std::shared_ptr<SHAMap> const& otherMap,
 
     assert (isValid () && otherMap && otherMap->isValid ());
 
-    using StackEntry = std::pair <SHAMapTreeNode*, SHAMapTreeNode*>;
-    std::stack <StackEntry, std::vector<StackEntry>> nodeStack; // track nodes we've pushed
-
     if (getHash () == otherMap->getHash ())
         return true;
+
+    using StackEntry = std::pair <SHAMapTreeNode*, SHAMapTreeNode*>;
+    std::stack <StackEntry, std::vector<StackEntry>> nodeStack; // track nodes we've pushed
 
     nodeStack.push ({root_.get(), otherMap->root_.get()});
     while (!nodeStack.empty ())
@@ -221,11 +221,11 @@ SHAMap::compare (std::shared_ptr<SHAMap> const& otherMap,
 
 void SHAMap::walkMap (std::vector<SHAMapMissingNode>& missingNodes, int maxMissing) const
 {
-    std::stack <std::shared_ptr<SHAMapTreeNode>,
-        std::vector <std::shared_ptr<SHAMapTreeNode>>> nodeStack;
-
     if (!root_->isInner ())  // root_ is only node, and we have it
         return;
+
+    using StackEntry = std::shared_ptr<SHAMapTreeNode>;
+    std::stack <StackEntry, std::vector <StackEntry>> nodeStack;
 
     nodeStack.push (root_);
 


### PR DESCRIPTION
This cleanup focuses on some of the consensus helper functions, which haven't been groomed in a long time.

Unnecessary classes have been removed, argument lists have been simplified, helpful comments have been added, types have been fixed, and code should be generally easier to read and understand. Split in multiple commits for your reviewing pleasure.

Since this touches critical consensus code, I am adding four reviewers, including David.

Reviews: @scottschurr, @rec, @HowardHinnant, @JoelKatz 
