### PR TITLE
Add gateway_balance RPC command

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -3122,6 +3122,11 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\impl\DoPrint.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\rpc\impl\FieldReader.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\rpc\impl\FieldReader.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\impl\GetAccountObjects.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
@@ -3194,12 +3199,22 @@
     <ClCompile Include="..\..\src\ripple\rpc\tests\Coroutine.test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\FieldReader.test.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\JSONRPC.test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\KeyGeneration.test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\MockContext.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\rpc\tests\MockContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\rpc\tests\MockNetworkOPs.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\tests\Status.test.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2964,6 +2964,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\handlers\FetchInfo.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\GatewayBalances.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\GetCounts.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3648,6 +3648,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\handlers\FetchInfo.cpp">
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\GatewayBalances.cpp">
+      <Filter>ripple\rpc\handlers</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\GetCounts.cpp">
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -3813,6 +3813,12 @@
     <ClInclude Include="..\..\src\ripple\rpc\impl\DoPrint.h">
       <Filter>ripple\rpc\impl</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\rpc\impl\FieldReader.cpp">
+      <Filter>ripple\rpc\impl</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\rpc\impl\FieldReader.h">
+      <Filter>ripple\rpc\impl</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\impl\GetAccountObjects.cpp">
       <Filter>ripple\rpc\impl</Filter>
     </ClCompile>
@@ -3900,12 +3906,24 @@
     <ClCompile Include="..\..\src\ripple\rpc\tests\Coroutine.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\FieldReader.test.cpp">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\JSONRPC.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\KeyGeneration.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\MockContext.cpp">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\rpc\tests\MockContext.h">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\rpc\tests\MockNetworkOPs.h">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\tests\Status.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>

--- a/src/ripple/app/paths/RippleState.h
+++ b/src/ripple/app/paths/RippleState.h
@@ -43,6 +43,9 @@ public:
 
 public:
     RippleState() = delete;
+    RippleState (
+        STLedgerEntry::ref ledgerEntry,
+        Account const& viewAccount);
 
     virtual ~RippleState() = default;
 

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -790,6 +790,46 @@ private:
         return jvRequest;
     }
 
+    // parse gateway balances
+    // gateway_balances [<ledger>] <issuer_account> [ <hotwallet> [ <hotwallet> ]]
+
+    Json::Value parseGatewayBalances (Json::Value const& jvParams)
+    {
+        unsigned int index = 0;
+        const unsigned int size = jvParams.size ();
+
+        Json::Value jvRequest;
+
+        std::string param = jvParams[index++].asString ();
+        if (param.empty ())
+            return RPC::make_param_error ("Invalid first parameter");
+
+        if (param[0] != 'r')
+        {
+            if (param.size() == 64)
+                jvRequest[jss::ledger_hash] = param;
+            else
+                jvRequest[jss::ledger_index] = param;
+
+            if (size <= index)
+                return RPC::make_param_error ("Invalid hotwallet");
+
+            param = jvParams[index++].asString ();
+        }
+
+        jvRequest[jss::account] = param;
+
+        if (index < size)
+        {
+            Json::Value& hotWallets =
+                (jvRequest["hotwallet"] = Json::arrayValue);
+            while (index < size)
+                hotWallets.append (jvParams[index++].asString ());
+        }
+
+        return jvRequest;
+    }
+
 public:
     //--------------------------------------------------------------------------
 
@@ -858,6 +898,7 @@ public:
             {   "consensus_info",       &RPCParser::parseAsIs,                  0,  0   },
             {   "feature",              &RPCParser::parseFeature,               0,  2   },
             {   "fetch_info",           &RPCParser::parseFetchInfo,             0,  1   },
+            {   "gateway_balances",     &RPCParser::parseGatewayBalances  ,     1,  -1  },
             {   "get_counts",           &RPCParser::parseGetCounts,             0,  1   },
             {   "json",                 &RPCParser::parseJson,                  2,  2   },
             {   "ledger",               &RPCParser::parseLedger,                0,  2   },

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -168,6 +168,7 @@ JSS ( have_header );                // out: InboundLedger
 JSS ( have_state );                 // out: InboundLedger
 JSS ( have_transactions );          // out: InboundLedger
 JSS ( hostid );                     // out: NetworkOPs
+JSS ( hotwallet );                  // in: GatewayBalances.
 JSS ( id );                         // websocket.
 JSS ( ident );                      // in: AccountCurrencies, AccountInfo,
                                     //     OwnerInfo

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -79,8 +79,10 @@ JSS ( age );                        // out: UniqueNodeList, NetworkOPs
 JSS ( alternatives );               // out: PathRequest, RipplePathFind
 JSS ( amendment_blocked );          // out: NetworkOPs
 JSS ( asks );                       // out: Subscribe
+JSS ( assets );                     // out: GatewayBalances
 JSS ( authorized );                 // out: AccountLines
 JSS ( balance );                    // out: AccountLines
+JSS ( balances );                   // out: GatewayBalances
 JSS ( base );                       // out: LogLevel
 JSS ( base_fee );                   // out: NetworkOPs
 JSS ( base_fee_xrp );               // out: NetworkOPs
@@ -252,6 +254,7 @@ JSS ( node_reads_total );           // out: GetCounts
 JSS ( node_writes );                // out: GetCounts
 JSS ( node_written_bytes );         // out: GetCounts
 JSS ( nodes );                      // out: LedgerEntrySet, PathState
+JSS ( obligations );                // out: GatewayBalances
 JSS ( offer );                      // in: LedgerEntry
 JSS ( offers );                     // out: NetworkOPs, AccountOffers, Subscribe
 JSS ( offline );                    // in: TransactionSign

--- a/src/ripple/rpc/handlers/GatewayBalances.cpp
+++ b/src/ripple/rpc/handlers/GatewayBalances.cpp
@@ -19,209 +19,131 @@
 
 #include <BeastConfig.h>
 #include <ripple/rpc/impl/AccountFromString.h>
+#include <ripple/rpc/impl/FieldReader.h>
 #include <ripple/rpc/impl/LookupLedger.h>
 #include <ripple/app/paths/RippleState.h>
 
 namespace ripple {
 
-// Query:
-// 1) Specify ledger to query.
-// 2) Specify issuer account (cold wallet) in "account" field.
-// 3) Specify accounts that hold gateway assets (such as hot wallets)
-//    using "hotwallet" field which should be either a string (if just
-//    one wallet) or an array of strings (if more than one).
+/**
+    Query:
+    1) Specify ledger to query.
 
-// Response:
-// 1) Array, "obligations", indicating the total obligations of the
-//    gateway in each currency. Obligations to specified hot wallets
-//    are not counted here.
-// 2) Object, "balances", indicating balances in each account
-//    that holds gateway assets. (Those specified in the "hotwallet"
-//    field.)
-// 3) Object of "assets" indicating accounts that owe the gateway.
-//    (Gateways typically do not hold positive balances. This is unusual.)
+    2) Specify issuer account (cold wallet) in "account" field.
+
+    3) Specify accounts that hold gateway assets (such as hot wallets)
+       using "hotwallet" field which should be either a string (if just
+       one wallet) or an array of strings (if more than one).
+
+    Response:
+    A Json object with three fields:
+
+    1) "obligations", an array indicating the total obligations of the
+       gateway in each currency. Obligations to specified hot wallets
+       are not counted here.
+
+    2) "balances", an object indicating balances in each account
+       that holds gateway assets. (Those specified in the "hotwallet"
+       field.)
+
+    3) "assets", an object indicating accounts that owe the gateway.
+       (Gateways typically do not hold positive balances. This is unusual.)
+*/
 
 // gateway_balances [<ledger>] <account> [<howallet> [<hotwallet [...
 
 Json::Value doGatewayBalances (RPC::Context& context)
 {
-    auto& params = context.params;
-
-    // Get the current ledger
     Ledger::pointer ledger;
-    Json::Value result (RPC::lookupLedger (params, ledger, context.netOps));
+    std::set <Account> hotWallets;
+    RippleAddress naAccount;
 
-    if (!ledger)
-        return result;
-
-    if (!(params.isMember (jss::account) || params.isMember (jss::ident)))
-        return RPC::missing_field_error (jss::account);
-
-    std::string const strIdent (params.isMember (jss::account)
-        ? params[jss::account].asString ()
-        : params[jss::ident].asString ());
-
-    int iIndex = 0;
-
-    if (params.isMember (jss::account_index))
     {
-        auto const& accountIndex = params[jss::account_index];
-        if (!accountIndex.isUInt() && !accountIndex.isInt ())
-            return RPC::invalid_field_message (jss::account_index);
-        iIndex = accountIndex.asUInt ();
+        RPC::FieldReader reader {context};
+        auto success =
+                readLedger (reader, ledger) &&
+                readRequired (reader, hotWallets, jss::hotwallet) &&
+                readAccountAddress (reader, naAccount);
+
+        if (! success)
+            return reader.error;
     }
 
-    bool const bStrict = params.isMember (jss::strict) &&
-            params[jss::strict].asBool ();
-
-    // Get info on account.
-    bool bIndex; // out param
-    RippleAddress naAccount; // out param
-    Json::Value jvAccepted (RPC::accountFromString (
-        naAccount, bIndex, strIdent, iIndex, bStrict));
-
-    if (!jvAccepted.empty ())
-        return jvAccepted;
-
     context.loadType = Resource::feeHighBurdenRPC;
+
+    Json::Value result;
+    std::map <Currency, STAmount> obligations;
+
+    using AccountBalances = std::map <Account, std::vector <STAmount>>;
+    AccountBalances hotBalances, assets;
 
     result[jss::account] = naAccount.humanAccountID();
     auto accountID = naAccount.getAccountID();
 
-    // Parse the specified hotwallet(s), if any
-    std::set <Account> hotWallets;
-
-    if (params.isMember ("hotwallet"))
-    {
-        Json::Value const& hw = params["hotwallet"];
-        bool valid = true;
-
-        auto addHotWallet = [&valid, &hotWallets](Json::Value const& j)
-        {
-            if (j.isString())
-            {
-                RippleAddress ra;
-                if (! ra.setAccountPublic (j.asString ()) &&
-                    ! ra.setAccountID (j.asString()))
-                {
-                    valid = false;
-                }
-                else
-                    hotWallets.insert (ra.getAccountID ());
-            }
-            else
-            {
-                valid = false;
-            }
-        };
-
-        if (hw.isArray())
-        {
-            for (unsigned i = 0; i < hw.size(); ++i)
-                addHotWallet (hw[i]);
-        }
-        else if (hw.isString())
-        {
-            addHotWallet (hw);
-        }
-        else
-        {
-            valid = false;
-        }
-
-        if (! valid)
-        {
-            result[jss::error]   = "invalidHotWallet";
-            return result;
-        }
-
-    }
-
-    std::map <Currency, STAmount> sums;
-    std::map <Account, std::vector <STAmount>> hotBalances;
-    std::map <Account, std::vector <STAmount>> assets;
-
-    // Traverse the cold wallet's trust lines
+    // Traverse the cold wallet's trust lines.
     forEachItem (*ledger, accountID, getApp().getSLECache(),
                  [&] (std::shared_ptr<SLE const> const& sle)
     {
-        if (sle->getType() == ltRIPPLE_STATE)
+        if (sle->getType() != ltRIPPLE_STATE)
+            return;
+
+        auto rs = RippleState::makeItem (accountID, sle);
+        auto balance = rs->getBalance ();
+        if (! balance)
+            return;
+
+        // Get the counterparty for the trustline.
+        auto const& peer = rs->getAccountIDPeer();
+
+        // A negative balance means the cold wallet owes (normal).
+        // A positive balance means the cold wallet has an asset (unusual).
+
+        if (hotWallets.count (peer) > 0)  // This is a specified hot wallet.
+            hotBalances[peer].push_back (- balance);
+
+        else if (balance > zero)          // This is a gateway asset.
+            assets[peer].push_back (balance);
+
+        else   // Normal negative balance: an obligation to a customer.
         {
-            auto rs = RippleState::makeItem (accountID, sle);
-
-            int balSign = rs->getBalance().signum();
-            if (balSign == 0)
-                return;
-
-            auto const& peer = rs->getAccountIDPeer();
-
-            // Here, a negative balance means the cold wallet owes (normal)
-            // A positive balance means the cold wallet has an asset (unusual)
-
-            if (hotWallets.count (peer) > 0)
-            {
-                // This is a specified hot wallt
-                hotBalances[peer].push_back (-rs->getBalance ());
-            }
-            else if (balSign > 0)
-            {
-                // This is a gateway asset
-                assets[peer].push_back (rs->getBalance ());
-            }
+            auto& o = obligations[balance.getCurrency()];
+            if (o == zero)
+                o = - balance;  // o might not have a currency code yet.
             else
-            {
-                // normal negative balance, obligation to customer
-                auto& bal = sums[rs->getBalance().getCurrency()];
-                if (bal == zero)
-                {
-                    // This is needed to set the currency code correctly
-                    bal = -rs->getBalance();
-                }
-                else
-                    bal -= rs->getBalance();
-            }
+                o -= balance;
+            // TODO(tom): should this be the default behavior for
+            // STAmount::operator+= and STAmount::operator-=?
         }
     });
 
-    if (! sums.empty())
+    if (! obligations.empty())
     {
-        Json::Value& j = (result [jss::obligations] = Json::objectValue);
-        for (auto const& e : sums)
-        {
-            j[to_string (e.first)] = e.second.getText ();
-        }
+        Json::Value& j = result [jss::obligations];
+        for (auto const& o : obligations)
+            j[to_string (o.first)] = o.second.getText ();
     }
 
-    if (! hotBalances.empty())
+    auto balancesToJson = [&] (
+        AccountBalances const& balances, Json::StaticString field)
     {
-        Json::Value& j = (result [jss::balances] = Json::objectValue);
-        for (auto const& account : hotBalances)
+        if (balances.empty())
+            return;
+
+        auto& jsonBalances = result[field];
+        for (auto const& account : balances)
         {
-            Json::Value& balanceArray = (j[to_string (account.first)] = Json::arrayValue);
+            auto& balanceArray = jsonBalances[to_string (account.first)];
             for (auto const& balance : account.second)
             {
                 Json::Value& entry = balanceArray.append (Json::objectValue);
-                entry[jss::currency] = to_string (balance.getCurrency ());
+                entry[jss::currency] = to_string (balance.issue().currency);
                 entry[jss::value] = balance.getText();
             }
         }
-    }
+    };
 
-    if (! assets.empty())
-    {
-        Json::Value& j = (result [jss::assets] = Json::objectValue);
-
-        for (auto const& account : assets)
-        {
-            Json::Value& balanceArray = (j[to_string (account.first)] = Json::arrayValue);
-            for (auto const& balance : account.second)
-            {
-                Json::Value& entry = balanceArray.append (Json::objectValue);
-                entry[jss::currency] = to_string (balance.getCurrency ());
-                entry[jss::value] = balance.getText();
-            }
-        }
-    }
+    balancesToJson (hotBalances, jss::balances);
+    balancesToJson (assets, jss::assets);
 
     return result;
 }

--- a/src/ripple/rpc/handlers/GatewayBalances.cpp
+++ b/src/ripple/rpc/handlers/GatewayBalances.cpp
@@ -1,0 +1,229 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2014 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/rpc/impl/AccountFromString.h>
+#include <ripple/rpc/impl/LookupLedger.h>
+#include <ripple/app/paths/RippleState.h>
+
+namespace ripple {
+
+// Query:
+// 1) Specify ledger to query.
+// 2) Specify issuer account (cold wallet) in "account" field.
+// 3) Specify accounts that hold gateway assets (such as hot wallets)
+//    using "hotwallet" field which should be either a string (if just
+//    one wallet) or an array of strings (if more than one).
+
+// Response:
+// 1) Array, "obligations", indicating the total obligations of the
+//    gateway in each currency. Obligations to specified hot wallets
+//    are not counted here.
+// 2) Object, "balances", indicating balances in each account
+//    that holds gateway assets. (Those specified in the "hotwallet"
+//    field.)
+// 3) Object of "assets" indicating accounts that owe the gateway.
+//    (Gateways typically do not hold positive balances. This is unusual.)
+
+// gateway_balances [<ledger>] <account> [<howallet> [<hotwallet [...
+
+Json::Value doGatewayBalances (RPC::Context& context)
+{
+    auto& params = context.params;
+
+    // Get the current ledger
+    Ledger::pointer ledger;
+    Json::Value result (RPC::lookupLedger (params, ledger, context.netOps));
+
+    if (!ledger)
+        return result;
+
+    if (!(params.isMember (jss::account) || params.isMember (jss::ident)))
+        return RPC::missing_field_error (jss::account);
+
+    std::string const strIdent (params.isMember (jss::account)
+        ? params[jss::account].asString ()
+        : params[jss::ident].asString ());
+
+    int iIndex = 0;
+
+    if (params.isMember (jss::account_index))
+    {
+        auto const& accountIndex = params[jss::account_index];
+        if (!accountIndex.isUInt() && !accountIndex.isInt ())
+            return RPC::invalid_field_message (jss::account_index);
+        iIndex = accountIndex.asUInt ();
+    }
+
+    bool const bStrict = params.isMember (jss::strict) &&
+            params[jss::strict].asBool ();
+
+    // Get info on account.
+    bool bIndex; // out param
+    RippleAddress naAccount; // out param
+    Json::Value jvAccepted (RPC::accountFromString (
+        naAccount, bIndex, strIdent, iIndex, bStrict));
+
+    if (!jvAccepted.empty ())
+        return jvAccepted;
+
+    context.loadType = Resource::feeHighBurdenRPC;
+
+    result[jss::account] = naAccount.humanAccountID();
+    auto accountID = naAccount.getAccountID();
+
+    // Parse the specified hotwallet(s), if any
+    std::set <Account> hotWallets;
+
+    if (params.isMember ("hotwallet"))
+    {
+        Json::Value const& hw = params["hotwallet"];
+        bool valid = true;
+
+        auto addHotWallet = [&valid, &hotWallets](Json::Value const& j)
+        {
+            if (j.isString())
+            {
+                RippleAddress ra;
+                if (! ra.setAccountPublic (j.asString ()) &&
+                    ! ra.setAccountID (j.asString()))
+                {
+                    valid = false;
+                }
+                else
+                    hotWallets.insert (ra.getAccountID ());
+            }
+            else
+            {
+                valid = false;
+            }
+        };
+
+        if (hw.isArray())
+        {
+            for (unsigned i = 0; i < hw.size(); ++i)
+                addHotWallet (hw[i]);
+        }
+        else if (hw.isString())
+        {
+            addHotWallet (hw);
+        }
+        else
+        {
+            valid = false;
+        }
+
+        if (! valid)
+        {
+            result[jss::error]   = "invalidHotWallet";
+            return result;
+        }
+
+    }
+
+    std::map <Currency, STAmount> sums;
+    std::map <Account, std::vector <STAmount>> hotBalances;
+    std::map <Account, std::vector <STAmount>> assets;
+
+    // Traverse the cold wallet's trust lines
+    forEachItem (*ledger, accountID, getApp().getSLECache(),
+                 [&] (std::shared_ptr<SLE const> const& sle)
+    {
+        if (sle->getType() == ltRIPPLE_STATE)
+        {
+            auto rs = RippleState::makeItem (accountID, sle);
+
+            int balSign = rs->getBalance().signum();
+            if (balSign == 0)
+                return;
+
+            auto const& peer = rs->getAccountIDPeer();
+
+            // Here, a negative balance means the cold wallet owes (normal)
+            // A positive balance means the cold wallet has an asset (unusual)
+
+            if (hotWallets.count (peer) > 0)
+            {
+                // This is a specified hot wallt
+                hotBalances[peer].push_back (-rs->getBalance ());
+            }
+            else if (balSign > 0)
+            {
+                // This is a gateway asset
+                assets[peer].push_back (rs->getBalance ());
+            }
+            else
+            {
+                // normal negative balance, obligation to customer
+                auto& bal = sums[rs->getBalance().getCurrency()];
+                if (bal == zero)
+                {
+                    // This is needed to set the currency code correctly
+                    bal = -rs->getBalance();
+                }
+                else
+                    bal -= rs->getBalance();
+            }
+        }
+    });
+
+    if (! sums.empty())
+    {
+        Json::Value& j = (result [jss::obligations] = Json::objectValue);
+        for (auto const& e : sums)
+        {
+            j[to_string (e.first)] = e.second.getText ();
+        }
+    }
+
+    if (! hotBalances.empty())
+    {
+        Json::Value& j = (result [jss::balances] = Json::objectValue);
+        for (auto const& account : hotBalances)
+        {
+            Json::Value& balanceArray = (j[to_string (account.first)] = Json::arrayValue);
+            for (auto const& balance : account.second)
+            {
+                Json::Value& entry = balanceArray.append (Json::objectValue);
+                entry[jss::currency] = to_string (balance.getCurrency ());
+                entry[jss::value] = balance.getText();
+            }
+        }
+    }
+
+    if (! assets.empty())
+    {
+        Json::Value& j = (result [jss::assets] = Json::objectValue);
+
+        for (auto const& account : assets)
+        {
+            Json::Value& balanceArray = (j[to_string (account.first)] = Json::arrayValue);
+            for (auto const& balance : account.second)
+            {
+                Json::Value& entry = balanceArray.append (Json::objectValue);
+                entry[jss::currency] = to_string (balance.getCurrency ());
+                entry[jss::value] = balance.getText();
+            }
+        }
+    }
+
+    return result;
+}
+
+} // ripple

--- a/src/ripple/rpc/handlers/Handlers.h
+++ b/src/ripple/rpc/handlers/Handlers.h
@@ -37,6 +37,7 @@ Json::Value doConnect               (RPC::Context&);
 Json::Value doConsensusInfo         (RPC::Context&);
 Json::Value doFeature               (RPC::Context&);
 Json::Value doFetchInfo             (RPC::Context&);
+Json::Value doGatewayBalances       (RPC::Context&);
 Json::Value doGetCounts             (RPC::Context&);
 Json::Value doInternal              (RPC::Context&);
 Json::Value doLedgerAccept          (RPC::Context&);

--- a/src/ripple/rpc/impl/FieldReader.cpp
+++ b/src/ripple/rpc/impl/FieldReader.cpp
@@ -1,0 +1,134 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/rpc/impl/FieldReader.h>
+#include <ripple/rpc/impl/AccountFromString.h>
+#include <ripple/rpc/impl/LookupLedger.h>
+
+namespace ripple {
+namespace RPC {
+
+void readImpl (bool& result, FieldRequest const& req)
+{
+    if (req.value.isBool())
+        result = req.value.asBool();
+    else
+        req.reader.error = expected_field_error (req.field, "bool");
+}
+
+void readImpl (std::string& result, FieldRequest const& req)
+{
+    if (req.value.isString())
+        result = req.value.asString();
+    else
+        req.reader.error = expected_field_error (req.field, "string");
+}
+
+void readImpl (Account& result, FieldRequest const& req)
+{
+    std::string account;
+    readImpl (account, req);
+    if (req.reader.error.empty())
+        readAccount (req.reader, result, account);
+}
+
+void readImpl (std::vector <std::string>& result, FieldRequest const& req)
+{
+    auto& value = req.value;
+    if (value.isString())
+    {
+        result.push_back (value.asString());
+        return;
+    }
+
+    if (!value.isArray())
+    {
+        req.reader.error = expected_field_error (req.field, "list of strings");
+        return;
+    }
+
+    for (auto& v: value)
+    {
+        if (!v.isString())
+        {
+            req.reader.error = expected_field_error (
+                req.field, "list of strings");
+            return;
+        }
+        result.push_back (v.asString());
+    }
+}
+
+void readImpl (std::set <Account>& result, FieldRequest const& req)
+{
+    std::vector <std::string> accounts;
+
+    readImpl (accounts, req);
+    if (! req.reader.error.empty())
+        return;
+
+    for (auto a : accounts)
+    {
+        Account account;
+        if (! readAccount (req.reader, account, a))
+            return;
+        result.insert (std::move (account));
+    }
+}
+
+bool readLedger (FieldReader& reader, Ledger::pointer& result)
+{
+    auto error = RPC::lookupLedger (
+        reader.context.params, result, reader.context.netOps);
+    if (result)
+        return true;
+    reader.error = error;
+    return false;
+}
+
+bool readAccount (
+    FieldReader& reader, Account& result, std::string const& value)
+{
+    RippleAddress ra;
+    if (! (ra.setAccountPublic (value) || ra.setAccountID (value)))
+    {
+        reader.error = RPC::make_error (rpcACT_MALFORMED);
+        return false;
+    }
+    result = ra.getAccountID();
+    return true;
+}
+
+bool readAccountAddress (FieldReader& reader, RippleAddress& result)
+{
+    bool bIndex;
+    bool strict = false;
+    std::string name;
+    if (readOptional (reader, strict, jss::strict) &&
+        readRequired (reader, name, jss::account))
+    {
+        auto error = RPC::accountFromString (result, bIndex, name, 0, strict);
+        if (! error.empty())
+            reader.error = error;
+    }
+    return reader.error.empty();
+}
+
+} // RPC
+} // ripple

--- a/src/ripple/rpc/impl/FieldReader.cpp
+++ b/src/ripple/rpc/impl/FieldReader.cpp
@@ -57,8 +57,10 @@ void readImpl (std::vector <std::string>& result, FieldRequest const& req)
         return;
     }
 
-    if (!value.isArray())
+    if (!(value.isArray() && value.size()))
     {
+        // An empty array is an error, because if you allowed an empty array,
+        // you might as well make this field optional.
         req.reader.error = expected_field_error (req.field, "list of strings");
         return;
     }

--- a/src/ripple/rpc/impl/FieldReader.h
+++ b/src/ripple/rpc/impl/FieldReader.h
@@ -1,0 +1,120 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_RPC_FIELDREADER_H_INCLUDED
+#define RIPPLE_RPC_FIELDREADER_H_INCLUDED
+
+#include <ripple/app/ledger/Ledger.h>
+
+namespace ripple {
+namespace RPC {
+
+class Context;
+
+/** A FieldReader and its associated free functions are used to read parameters
+    from an RPC request.
+
+    The classes that can be read are:
+      * bool
+      * std::string
+      * std::vector <std::string>
+      * Account
+      * std::set <Account>
+
+    Additionally, there are free functions to read compound types like Ledger
+    or RippleAddress.
+ */
+struct FieldReader
+{
+    Context const& context;
+    Json::Value error;
+
+    FieldReader (Context const& context_) : context(context_)
+    {}
+};
+
+/** Read a required field of type T from a FieldReader.
+
+    Return true on success;  on failure, fill FieldReader::error and
+    return false.
+ */
+template <class T>
+bool readRequired (FieldReader&, T& result, Json::StaticString fieldname);
+
+
+/** Read an optional field of type T from a FieldReader.
+
+    Return true on success, or if the field was missing; on failure, fill
+    FieldReader::error and return false.
+ */
+template <class T>
+bool readOptional (FieldReader&, T& result, Json::StaticString fieldName);
+
+bool readLedger (FieldReader&, Ledger::pointer& result);
+bool readAccount (FieldReader&, Account& result, std::string const& name);
+bool readAccountAddress (FieldReader&, RippleAddress&);
+
+////////////////////////////////////////////////////////////////////////////////
+// Implementation details follow.
+
+/** A request for a specific field follows. */
+struct FieldRequest {
+    FieldReader& reader;
+    Json::StaticString field;
+    Json::Value const& value;
+};
+
+/**
+   This are the implementations of field reading for specific classes.  For a
+   new class to be readable, there must be an implementation of readImpl -
+   note that name-dependent lookup will work.
+ */
+
+void readImpl (bool&, FieldRequest const&);
+void readImpl (std::string&, FieldRequest const&);
+void readImpl (Account&, FieldRequest const&);
+void readImpl (std::vector <std::string>&, FieldRequest const&);
+void readImpl (std::set <Account>&, FieldRequest const&);
+
+template <class T>
+bool readRequired (FieldReader& reader, T& result, Json::StaticString field)
+{
+    auto& value = reader.context.params[field];
+    if (! value)
+        reader.error = missing_field_error (field);
+    else
+        readImpl (result, {reader, field, value});
+    return reader.error.empty();
+}
+
+template <class T>
+bool readOptional (FieldReader& reader, T& result, Json::StaticString field)
+{
+    auto& value = reader.context.params[field];
+    if (! value)
+        return true;
+
+    readImpl (result, {reader, field, value});
+    return reader.error.empty();
+}
+
+} // RPC
+} // ripple
+
+#endif

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -109,6 +109,7 @@ HandlerTable HANDLERS({
     {   "can_delete",           byRef (&doCanDelete),           Role::ADMIN,   NO_CONDITION     },
     {   "connect",              byRef (&doConnect),             Role::ADMIN,   NO_CONDITION     },
     {   "consensus_info",       byRef (&doConsensusInfo),       Role::ADMIN,   NO_CONDITION     },
+    {   "gateway_balances",     byRef (&doGatewayBalances),     Role::USER,  NO_CONDITION  },
     {   "get_counts",           byRef (&doGetCounts),           Role::ADMIN,   NO_CONDITION     },
     {   "internal",             byRef (&doInternal),            Role::ADMIN,   NO_CONDITION     },
     {   "feature",              byRef (&doFeature),             Role::ADMIN,   NO_CONDITION     },

--- a/src/ripple/rpc/tests/FieldReader.test.cpp
+++ b/src/ripple/rpc/tests/FieldReader.test.cpp
@@ -1,0 +1,121 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/rpc/impl/FieldReader.h>
+#include <ripple/rpc/tests/MockContext.h>
+#include <ripple/rpc/tests/TestOutputSuite.test.h>
+
+namespace ripple {
+namespace RPC {
+
+struct FieldReader_test : TestOutputSuite
+{
+    MockContext mockContext;
+    std::unique_ptr<FieldReader> reader;
+
+    void setup (std::string const& testName)
+    {
+        TestOutputSuite::setup (testName);
+        reader = std::make_unique<FieldReader> (mockContext.context());
+        params().clear();
+    }
+
+    Json::Value& params()
+    {
+        return mockContext.context().params;
+    }
+
+    void run() override
+    {
+        // TODO:  we can't yet unit test Account reading because we need
+        // more of MockContext to be operational...
+        {
+            setup ("required bool");
+            params()[jss::strict] = true;
+            bool strict = false;
+            expect (readRequired (*reader, strict, jss::strict));
+            expect (strict);
+            expect (!reader->error);
+        }
+        {
+            setup ("required bool missing");
+            bool strict = false;
+            expect (!readRequired (*reader, strict, jss::strict));
+            expectEquals (reader->error[jss::error], "invalidParams");
+            expectEquals (reader->error[jss::error_code], rpcINVALID_PARAMS);
+            expectEquals (reader->error[jss::error_message],
+                          "Missing field 'strict'.");
+        }
+        {
+            setup ("optional bool");
+            params()[jss::strict] = true;
+            bool strict = false;
+            expect (readOptional (*reader, strict, jss::strict));
+            expect (strict);
+            expect (!reader->error);
+        }
+        {
+            setup ("optional bool missing");
+            bool strict = false;
+            expect (readOptional (*reader, strict, jss::strict));
+            expect (!strict);
+            expect (!reader->error);
+        }
+        {
+            setup ("required string");
+            params()[jss::account] = "xyzzy";
+            std::string account;
+            expect (readRequired (*reader, account, jss::account));
+            expectEquals (account, "xyzzy");
+        }
+        {
+            setup ("required vector zero");
+            params()[jss::paths] = Json::arrayValue;
+            std::vector<std::string> paths;
+            expect (readRequired (*reader, paths, jss::paths));
+            expectEquals (paths.size(), 0);
+        }
+        {
+            setup ("required vector one");
+            params()[jss::paths] = "xyzzy";
+            std::vector<std::string> paths;
+            expect (readRequired (*reader, paths, jss::paths));
+            expectEquals (paths.size(), 1);
+            expectEquals (paths[0], "xyzzy");
+        }
+        {
+            setup ("required vector two");
+            auto& jvPaths = params()[jss::paths];
+            jvPaths.append ("xyzzy");
+            jvPaths.append ("wombat");
+
+            std::vector<std::string> paths;
+            expect (readRequired (*reader, paths, jss::paths));
+            expectEquals (paths.size(), 2);
+            expectEquals (paths[0], "xyzzy");
+            expectEquals (paths[1], "wombat");
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(FieldReader, RPC, ripple);
+
+} // RPC
+} // ripple

--- a/src/ripple/rpc/tests/FieldReader.test.cpp
+++ b/src/ripple/rpc/tests/FieldReader.test.cpp
@@ -89,8 +89,11 @@ struct FieldReader_test : TestOutputSuite
             setup ("required vector zero");
             params()[jss::paths] = Json::arrayValue;
             std::vector<std::string> paths;
-            expect (readRequired (*reader, paths, jss::paths));
-            expectEquals (paths.size(), 0);
+            expect (!readRequired (*reader, paths, jss::paths));
+            expectEquals (reader->error[jss::error], "invalidParams");
+            expectEquals (reader->error[jss::error_code], rpcINVALID_PARAMS);
+            expectEquals (reader->error[jss::error_message],
+                          "Invalid field 'paths', not list of strings.");
         }
         {
             setup ("required vector one");

--- a/src/ripple/rpc/tests/MockContext.cpp
+++ b/src/ripple/rpc/tests/MockContext.cpp
@@ -1,0 +1,53 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/rpc/tests/MockContext.h>
+#include <ripple/rpc/tests/MockNetworkOPs.h>
+#include <ripple/rpc/Context.h>
+
+namespace ripple {
+namespace RPC {
+
+struct MockContext::Impl
+{
+    beast::RootStoppable parent;
+    MockNetworkOPs netOps;
+    Resource::Charge loadType = Resource::Charge (0);
+    Context context;
+
+    Impl() : parent ("MockContext"),
+             netOps (parent),
+             context {Json::objectValue, loadType, netOps, Role::USER}
+    {
+        context.yield = [] () {};
+    }
+};
+
+MockContext::MockContext() : impl_ (std::make_unique<Impl>())
+{}
+
+MockContext::~MockContext() = default;
+
+Context& MockContext::context()
+{
+    return impl_->context;
+}
+
+} // RPC
+} // ripple

--- a/src/ripple/rpc/tests/MockContext.h
+++ b/src/ripple/rpc/tests/MockContext.h
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_RPC_MOCKCONTEXT_H_INCLUDED
+#define RIPPLE_RPC_MOCKCONTEXT_H_INCLUDED
+
+namespace ripple {
+namespace RPC {
+
+struct Context;
+
+class MockContext
+{
+public:
+    MockContext();
+    ~MockContext();
+
+    Context& context();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // RPC
+} // ripple
+
+#endif

--- a/src/ripple/rpc/tests/MockNetworkOPs.h
+++ b/src/ripple/rpc/tests/MockNetworkOPs.h
@@ -154,12 +154,12 @@ public:
         return {};
     }
 
-    virtual bool getValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal)
+    virtual bool getValidatedRange (std::uint32_t&, std::uint32_t&)
     {
         return {};
     }
 
-    virtual bool getFullValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal)
+    virtual bool getFullValidatedRange (std::uint32_t&, std::uint32_t&)
     {
         return {};
     }
@@ -174,21 +174,23 @@ public:
     }
 
     using stCallback = std::function<void (Transaction::pointer, TER)>;
-    virtual void submitTransaction (Job&, STTx::pointer,
-        stCallback callback = stCallback ()) { }
+    virtual void submitTransaction (Job&, STTx::pointer)
+    {
+    }
+
     virtual Transaction::pointer processTransactionCb (Transaction::pointer,
         bool bAdmin, bool bLocal, FailHard failType, stCallback)
     {
         return {};
     }
 
-    virtual Transaction::pointer processTransaction (Transaction::pointer transaction,
+    virtual void processTransaction (Transaction::pointer transaction,
         bool bAdmin, bool bLocal, FailHard failType)
     {
-        return {};
     }
 
-    virtual Transaction::pointer findTransactionByID (uint256 const& transactionID)
+    virtual Transaction::pointer findTransactionByID (
+        uint256 const& transactionID)
     {
         return {};
     }

--- a/src/ripple/rpc/tests/MockNetworkOPs.h
+++ b/src/ripple/rpc/tests/MockNetworkOPs.h
@@ -1,0 +1,554 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_RPC_MOCKNETWORKOPS_H_INCLUDED
+#define RIPPLE_RPC_MOCKNETWORKOPS_H_INCLUDED
+
+#include <ripple/app/misc/NetworkOPs.h>
+
+namespace ripple {
+namespace RPC {
+
+class MockNetworkOPs : public NetworkOPs
+{
+public:
+    using NetworkOPs::AccountTx;
+    using NetworkOPs::AccountTxs;
+    using NetworkOPs::FailHard;
+    using NetworkOPs::OperatingMode;
+
+    MockNetworkOPs (beast::Stoppable& parent) : NetworkOPs (parent)
+    {
+    }
+
+    virtual ~MockNetworkOPs ()
+    {
+    }
+
+    virtual std::uint32_t getNetworkTimeNC () const
+    {
+        return {};
+    }
+
+    virtual std::uint32_t getCloseTimeNC () const
+    {
+        return {};
+    }
+
+    virtual std::uint32_t getValidationTimeNC ()
+    {
+        return {};
+    }
+
+    virtual void closeTimeOffset (int)
+    {
+    }
+
+    virtual boost::posix_time::ptime getNetworkTimePT (int& offset) const
+    {
+        return {};
+    }
+
+    virtual std::uint32_t getLedgerID (uint256 const& hash)
+    {
+        return {};
+    }
+
+    virtual std::uint32_t getCurrentLedgerID ()
+    {
+        return {};
+    }
+
+    virtual OperatingMode getOperatingMode () const
+    {
+        return {};
+    }
+
+    virtual std::string strOperatingMode () const
+    {
+        return {};
+    }
+
+    virtual Ledger::pointer getClosedLedger ()
+    {
+        return {};
+    }
+
+    virtual Ledger::pointer getValidatedLedger ()
+    {
+        return {};
+    }
+
+    virtual Ledger::pointer getPublishedLedger ()
+    {
+        return {};
+    }
+
+    virtual Ledger::pointer getCurrentLedger ()
+    {
+        return {};
+    }
+
+    virtual Ledger::pointer getLedgerByHash (uint256 const& hash)
+    {
+        return {};
+    }
+
+    virtual Ledger::pointer getLedgerBySeq (const std::uint32_t seq)
+    {
+        return {};
+    }
+
+    virtual void            missingNodeInLedger (const std::uint32_t seq)
+    {
+    }
+
+    virtual uint256         getClosedLedgerHash ()
+    {
+        return {};
+    }
+
+    virtual bool haveLedgerRange (std::uint32_t from, std::uint32_t to)
+    {
+        return {};
+    }
+
+    virtual bool haveLedger (std::uint32_t seq)
+    {
+        return {};
+    }
+
+    virtual std::uint32_t getValidatedSeq ()
+    {
+        return {};
+    }
+
+    virtual bool isValidated (std::uint32_t seq)
+    {
+        return {};
+    }
+
+    virtual bool isValidated (std::uint32_t seq, uint256 const& hash)
+    {
+        return {};
+    }
+
+    virtual bool isValidated (Ledger::ref l)
+    {
+        return {};
+    }
+
+    virtual bool getValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal)
+    {
+        return {};
+    }
+
+    virtual bool getFullValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal)
+    {
+        return {};
+    }
+
+    virtual STValidation::ref getLastValidation () {
+        static STValidation::pointer const stv;
+        return stv;
+    }
+
+    virtual void setLastValidation (STValidation::ref v)
+    {
+    }
+
+    using stCallback = std::function<void (Transaction::pointer, TER)>;
+    virtual void submitTransaction (Job&, STTx::pointer,
+        stCallback callback = stCallback ()) { }
+    virtual Transaction::pointer processTransactionCb (Transaction::pointer,
+        bool bAdmin, bool bLocal, FailHard failType, stCallback)
+    {
+        return {};
+    }
+
+    virtual Transaction::pointer processTransaction (Transaction::pointer transaction,
+        bool bAdmin, bool bLocal, FailHard failType)
+    {
+        return {};
+    }
+
+    virtual Transaction::pointer findTransactionByID (uint256 const& transactionID)
+    {
+        return {};
+    }
+
+    virtual int findTransactionsByDestination (std::list<Transaction::pointer>&,
+        RippleAddress const& destinationAccount, std::uint32_t startLedgerSeq,
+            std::uint32_t endLedgerSeq, int maxTransactions)
+    {
+        return {};
+    }
+
+    virtual AccountState::pointer getAccountState (Ledger::ref lrLedger,
+        RippleAddress const& accountID)
+    {
+        return {};
+    }
+
+    virtual STVector256 getDirNodeInfo (Ledger::ref lrLedger,
+        uint256 const& uRootIndex, std::uint64_t& uNodePrevious,
+                                   std::uint64_t& uNodeNext)
+    {
+        return {};
+    }
+
+    virtual Json::Value getOwnerInfo (Ledger::pointer lpLedger,
+        RippleAddress const& naAccount)
+    {
+        return {};
+    }
+
+    virtual void getBookPage (
+        bool bAdmin,
+        Ledger::pointer lpLedger,
+        Book const& book,
+        Account const& uTakerID,
+        bool const bProof,
+        const unsigned int iLimit,
+        Json::Value const& jvMarker,
+        Json::Value& jvResult)
+    {
+    }
+
+    virtual void processTrustedProposal (LedgerProposal::pointer proposal,
+        std::shared_ptr<protocol::TMProposeSet> set,
+            RippleAddress const& nodePublic)
+    {
+    }
+
+    virtual bool recvValidation (STValidation::ref val,
+        std::string const& source)
+    {
+        return {};
+    }
+
+    virtual void takePosition (int seq,
+                               std::shared_ptr<SHAMap> const& position)
+    {
+    }
+
+    virtual void mapComplete (uint256 const& hash,
+                              std::shared_ptr<SHAMap> const& map)
+    {
+    }
+
+    virtual void makeFetchPack (Job&, std::weak_ptr<Peer> peer,
+        std::shared_ptr<protocol::TMGetObjectByHash> request,
+        uint256 wantLedger, std::uint32_t uUptime)
+    {
+    }
+
+    virtual bool shouldFetchPack (std::uint32_t seq)
+    {
+        return {};
+    }
+
+    virtual void gotFetchPack (bool progress, std::uint32_t seq)
+    {
+    }
+
+    virtual void addFetchPack (
+        uint256 const& hash, std::shared_ptr< Blob >& data)
+    {
+    }
+
+    virtual bool getFetchPack (uint256 const& hash, Blob& data)
+    {
+        return {};
+    }
+
+    virtual int getFetchSize ()
+    {
+        return {};
+    }
+
+    virtual void sweepFetchPack ()
+    {
+    }
+
+    virtual void endConsensus (bool correctLCL)
+    {
+    }
+
+    virtual void setStandAlone ()
+    {
+    }
+
+    virtual void setStateTimer ()
+    {
+    }
+
+    virtual void newLCL (
+        int proposers, int convergeTime, uint256 const& ledgerHash)
+    {
+    }
+
+    virtual void needNetworkLedger ()
+    {
+    }
+
+    virtual void clearNeedNetworkLedger ()
+    {
+    }
+
+    virtual bool isNeedNetworkLedger ()
+    {
+        return {};
+    }
+
+    virtual bool isFull ()
+    {
+        return {};
+    }
+
+    virtual void setProposing (bool isProposing, bool isValidating)
+    {
+    }
+
+    virtual bool isProposing ()
+    {
+        return {};
+    }
+
+    virtual bool isValidating ()
+    {
+        return {};
+    }
+
+    virtual bool isAmendmentBlocked ()
+    {
+        return {};
+    }
+
+    virtual void setAmendmentBlocked ()
+    {
+    }
+
+    virtual void consensusViewChange ()
+    {
+    }
+
+    virtual std::uint32_t getLastCloseTime ()
+    {
+        return {};
+    }
+
+    virtual void setLastCloseTime (std::uint32_t t)
+    {
+    }
+
+    virtual Json::Value getConsensusInfo ()
+    {
+        return {};
+    }
+
+    virtual Json::Value getServerInfo (bool human, bool admin)
+    {
+        return {};
+    }
+
+    virtual void clearLedgerFetch ()
+    {
+    }
+
+    virtual Json::Value getLedgerFetchInfo ()
+    {
+        return {};
+    }
+
+    virtual std::uint32_t acceptLedger ()
+    {
+        return {};
+    }
+
+    using Proposals = hash_map <NodeID, std::deque<LedgerProposal::pointer>>;
+    virtual Proposals& peekStoredProposals () {
+        static Proposals proposals;
+        return proposals;
+    }
+
+    virtual void storeProposal (LedgerProposal::ref proposal,
+        RippleAddress const& peerPublic)
+    {
+    }
+
+    virtual uint256 getConsensusLCL ()
+    {
+        return {};
+    }
+
+    virtual void reportFeeChange ()
+    {
+    }
+
+    virtual void updateLocalTx (Ledger::ref newValidLedger)
+    {
+    }
+
+    virtual void addLocalTx (Ledger::ref openLedger, STTx::ref txn)
+    {
+    }
+
+    virtual std::size_t getLocalTxCount ()
+    {
+        return {};
+    }
+
+    virtual std::string transactionsSQL (std::string selection,
+        RippleAddress const&, std::int32_t minLedger, std::int32_t maxLedger,
+        bool descending, std::uint32_t offset, int limit, bool binary,
+            bool count, bool bAdmin)
+    {
+        return {};
+    }
+
+    virtual AccountTxs getAccountTxs (
+        RippleAddress const& account,
+        std::int32_t minLedger, std::int32_t maxLedger,  bool descending,
+        std::uint32_t offset, int limit, bool bAdmin)
+    {
+        return {};
+    }
+
+    virtual AccountTxs getTxsAccount (
+        RippleAddress const& account,
+        std::int32_t minLedger, std::int32_t maxLedger, bool forward,
+        Json::Value& token, int limit, bool bAdmin)
+    {
+        return {};
+    }
+
+    virtual MetaTxsList getAccountTxsB (RippleAddress const& account,
+        std::int32_t minLedger, std::int32_t maxLedger,  bool descending,
+            std::uint32_t offset, int limit, bool bAdmin)
+    {
+        return {};
+    }
+
+    virtual MetaTxsList getTxsAccountB (RippleAddress const& account,
+        std::int32_t minLedger, std::int32_t maxLedger,  bool forward,
+        Json::Value& token, int limit, bool bAdmin)
+    {
+        return {};
+    }
+
+    virtual std::vector<RippleAddress> getLedgerAffectedAccounts (
+        std::uint32_t ledgerSeq)
+    {
+        return {};
+    }
+
+    virtual void pubLedger (Ledger::ref lpAccepted)
+    {
+    }
+
+    virtual void pubProposedTransaction (Ledger::ref lpCurrent,
+        STTx::ref stTxn, TER terResult)
+    {
+    }
+
+    virtual void subAccount (InfoSub::ref ispListener,
+        const hash_set<RippleAddress>& vnaAccountIDs,
+        bool realTime)
+    {
+    }
+
+    virtual void unsubAccount (InfoSub::ref isplistener,
+        const hash_set<RippleAddress>& vnaAccountIDs,
+        bool realTime)
+    {
+    }
+
+    virtual void unsubAccountInternal (std::uint64_t uListener,
+        const hash_set<RippleAddress>& vnaAccountIDs,
+        bool realTime)
+    {
+    }
+
+    virtual bool subLedger (InfoSub::ref ispListener, Json::Value& jvResult)
+    {
+        return {};
+    }
+
+    virtual bool unsubLedger (std::uint64_t uListener)
+    {
+        return {};
+    }
+
+    virtual bool subServer (InfoSub::ref ispListener, Json::Value& jvResult,
+        bool admin)
+    {
+        return {};
+    }
+
+    virtual bool unsubServer (std::uint64_t uListener)
+    {
+        return {};
+    }
+
+    virtual bool subBook (InfoSub::ref ispListener, Book const&)
+    {
+        return {};
+    }
+
+    virtual bool unsubBook (std::uint64_t uListener, Book const&)
+    {
+        return {};
+    }
+
+    virtual bool subTransactions (InfoSub::ref ispListener)
+    {
+        return {};
+    }
+
+    virtual bool unsubTransactions (std::uint64_t uListener)
+    {
+        return {};
+    }
+
+    virtual bool subRTTransactions (InfoSub::ref ispListener)
+    {
+        return {};
+    }
+
+    virtual bool unsubRTTransactions (std::uint64_t uListener)
+    {
+        return {};
+    }
+
+    virtual InfoSub::pointer findRpcSub (std::string const& strUrl)
+    {
+        return {};
+    }
+
+    virtual InfoSub::pointer addRpcSub (std::string const& strUrl, InfoSub::ref)
+    {
+        return {};
+    }
+};
+
+} // RPC
+} // ripple
+
+#endif

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -49,6 +49,7 @@
 #include <ripple/rpc/handlers/ConsensusInfo.cpp>
 #include <ripple/rpc/handlers/Feature.cpp>
 #include <ripple/rpc/handlers/FetchInfo.cpp>
+#include <ripple/rpc/handlers/GatewayBalances.cpp>
 #include <ripple/rpc/handlers/GetCounts.cpp>
 #include <ripple/rpc/handlers/Internal.cpp>
 #include <ripple/rpc/handlers/Ledger.cpp>

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -27,6 +27,7 @@
 #include <ripple/rpc/RPCHandler.h>
 
 #include <ripple/rpc/impl/Coroutine.cpp>
+#include <ripple/rpc/impl/FieldReader.cpp>
 #include <ripple/rpc/impl/Manager.cpp>
 #include <ripple/rpc/impl/RPCHandler.cpp>
 #include <ripple/rpc/impl/Status.cpp>
@@ -107,7 +108,9 @@
 #include <ripple/rpc/impl/RPCVersion.cpp>
 
 #include <ripple/rpc/tests/Coroutine.test.cpp>
+#include <ripple/rpc/tests/FieldReader.test.cpp>
 #include <ripple/rpc/tests/JSONRPC.test.cpp>
 #include <ripple/rpc/tests/KeyGeneration.test.cpp>
+#include <ripple/rpc/tests/MockContext.cpp>
 #include <ripple/rpc/tests/Status.test.cpp>
 #include <ripple/rpc/tests/Yield.test.cpp>

--- a/test/gateway-balance-test.js
+++ b/test/gateway-balance-test.js
@@ -1,0 +1,157 @@
+/**
+   Test the "gateway_balances" RPC command.
+*/
+
+var assert       = require('assert');
+var async        = require('async');
+var testutils    = require('./testutils');
+var config       = testutils.init_config();
+
+var Account      = require('ripple-lib').UInt160;
+var LedgerState  = require('./ledger-state').LedgerState;
+var Request      = require('ripple-lib').Request;
+
+function noop() {}
+
+function account_objects(remote, account, params, callback) {
+  if (lodash.isFunction(params)) {
+    callback = params;
+    params = null;
+  }
+
+  var request = new Request(remote, 'account_objects');
+  request.message.account = Account.json_rewrite(account);
+  lodash.forOwn(params || {}, function(v, k) { request.message[k] = v; });
+
+  request.callback(callback);
+}
+
+function filter_threading_fields(entries) {
+  return entries.map(function(entry) {
+    return lodash.omit(entry, ['PreviousTxnID', 'PreviousTxnLgrSeq']);
+  });
+}
+
+suite('Gateway balance', function() {
+  var $ = {};
+  var opts = {};
+
+  // Taken from account_objects-test.js.
+  // TODO: Figure out how to share this code with that file.
+
+  // A declarative description of the ledger
+  var ledger_state = {
+    accounts: {
+      // Gateways
+      G1 : {balance: ["1000.0"]},
+      G2 : {balance: ["1000.0"]},
+
+      // Bob has two RippleState and two Offer account objects.
+      bob : {
+        balance: ["1000.0", "1000/USD/G1",
+                            "1000/USD/G2"],
+        // these offers will be in `Sequence`
+        offers: [["100.0", "1/USD/bob"],
+                 ["100.0", "1/USD/G1"]]
+      }
+    }
+  };
+
+  // After setup we bind the remote to `account_objects` helper above.
+  var request_account_objects;
+  var bob;
+  var G1;
+  var G2;
+
+  suiteSetup(function(done) {
+    testutils.build_setup().call($, function() {
+      request_account_objects = account_objects.bind(null, $.remote);
+      var ledger = new LedgerState(ledger_state,
+                                   assert, $.remote,
+                                   config);
+
+      // Get references to the account objects for usage later.
+      bob = Account.json_rewrite('bob');
+      G1 = Account.json_rewrite('G1');
+      G2 = Account.json_rewrite('G2');
+
+      // Run the ledger setup util. This compiles the declarative description
+      // into a series of transactions and executes them.
+      ledger.setup(noop /*logger*/, function(){
+        done();
+      })
+    });
+  });
+
+  suiteTeardown(function(done) {
+    testutils.build_teardown().call($, done);
+  });
+
+  test('Gateway balance', function (done) {
+    var self = this;
+
+    var steps = [
+      function(callback) {
+        testutils.create_accounts(
+          $.remote,
+          'root',
+          '20000.0',
+          ['alice', 'bob', 'mtgox'],
+          callback
+        );
+      },
+
+      function(callback) {
+        var tx = $.remote.createTransaction('TrustSet', {
+          account: 'mtgox',
+          limit: '100/USD/alice'
+        });
+        testutils.submit_transaction(tx, callback);
+      },
+
+      function(state, callback) {
+        var tx = $.remote.createTransaction('TrustSet', {
+          account: 'mtgox',
+          limit: '100/USD/bob'
+        });
+        testutils.submit_transaction(tx, callback);
+      },
+
+      function(state, callback) {
+        $.remote.once('ledger_closed', function() { callback(); });
+        $.remote.ledger_accept();
+      },
+
+      function(callback) {
+        testutils.verify_balance(
+          $.remote,
+          [ 'alice', 'bob', 'mtgox'],
+          '19999999988',
+          callback
+        );
+      },
+
+      function(callback) {
+        var request = new Request($.remote, 'gateway_balances');
+        request.message.account = Account.json_rewrite('mtgox');
+        request.message.ledger = 'validated';
+        request.message.hotwallet = [
+          Account.json_rewrite('alice'),
+          Account.json_rewrite('bob')
+        ];
+        request.callback(callback);
+      },
+
+      function(result, callback) {
+        assert(result.account == Account.json_rewrite('mtgox'));
+        // TODO: where are the rest of the fields?!
+        callback();
+      },
+    ];
+
+    async.waterfall(steps, function (error) {
+      assert(!error, self.what + ': ' + error);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
RPC command to get gateway balances and obligations. Without this, it's difficult for gateways to obtain and understand their obligations and hot wallet balances.

Here's an example query, specifying Bitstamp's hot and cold wallets:

    ./rippled gateway_balances \
        validated \
        rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B \
        rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX
 
And here's the reponse:

    {
       "result" : {
          "account" : "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
          "assets" : { // These are odd quirks
             "rHXK7KaoGmVDqV11r4Y8VtY349rXYstV9" : [
                {
                   "currency" : "USD",
                   "value" : "0.002"
                }
             ],
             "rhmZPqY4Gex3gq3n3DN36G47RaKTmTyFQw" : [
                {
                   "currency" : "USD",
                   "value" : "0.002"
                }
             ]
          },
          "balances" : { // These are hotwallet balances
             "rGFuMiw48HdbnrUbkRYuitXTmfrDBNTCnX" : [
                {
                   "currency" : "BTC",
                   "value" : "84.52753163536"
                },
                {
                   "currency" : "USD",
                   "value" : "23110.764199"
                }
             ]
          },
          "ledger_hash" :    "F8CA7A0DC8D97A63<truncated>"
          "ledger_index" : 13466553,
          "obligations" : { // these are normal obligations to customers
             "AUD" : "9214.56682400764",
             "BTC" : "3436.621720038995",
             "CHF" : "9004.559881079594",
             "EUR" : "1147.570044225127",
             "GBP" : "8184.759773422656",
             "JPY" : "954252.5394915505",
             "USD" : "3037736.307337416"
          },
          "status" : "success",
          "validated" : true
       }
    }
