### PR TITLE
Don't touch a failed InboundLedger

### DIFF
--- a/src/ripple/app/ledger/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/InboundLedgers.cpp
@@ -67,9 +67,12 @@ public:
                 auto it = mLedgers.find (hash);
                 if (it != mLedgers.end ())
                 {
-                    it->second->update (seq);
-                    if (it->second->isComplete() && !it->second->isFailed())
-                        ret = it->second->getLedger();
+                    if (! it->second->isFailed ())
+                    {
+                        it->second->update (seq);
+                        if (it->second->isComplete ())
+                            ret = it->second->getLedger ();
+                    }
 
                 }
                 else


### PR DESCRIPTION
We want failed acquires to expire, so don't touch them. Otherwise, the ledger acquire engine can stall on a failed acquire that it repeatedly prevents from expiring.