### PR TITLE
Change example configuration protocol on loopback IP (RIPD-886)

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -149,7 +149,7 @@
 #       to. To bind to all available interfaces, uses 0.0.0.0
 #
 #   port = <number>
-v#
+#
 #       Required. Sets the port number to use for this port.
 #
 #   protocol = [ http, https, peer ]
@@ -831,29 +831,29 @@ v#
 #       run with administrator privileges, or else rippled will not start.
 
 [server]
-port_rpc
+port_rpc_admin_local
 port_peer
-port_wss_admin
+port_ws_admin_local
 #port_ws_public
 #ssl_key = /etc/ssl/private/server.key
 #ssl_cert = /etc/ssl/certs/server.crt
 
-[port_rpc]
+[port_rpc_admin_local]
 port = 5005
 ip = 127.0.0.1
 admin = 127.0.0.1
-protocol = https
+protocol = http
 
 [port_peer]
 port = 51235
 ip = 0.0.0.0
 protocol = peer
 
-[port_wss_admin]
+[port_ws_admin_local]
 port = 6006
 ip = 127.0.0.1
 admin = 127.0.0.1
-protocol = wss
+protocol = ws
 
 #[port_ws_public]
 #port = 5005


### PR DESCRIPTION
Disable SSL on loopback addresses specified in the example configuration file.

@reviers @vinniefalco @nbougalis