### PR TITLE
Latency-aware fetch pack target selection

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -596,19 +596,22 @@ public:
             return;
         }
 
+        // Select target Peer based on highest score.
+        // The score is randomized but biased in favor of Peers with low latency.
         Peer::ptr target;
-        int targetScore = 0;
-
-        Overlay::PeerSequence peerList = getApp().overlay ().getActivePeers ();
-        for (auto const& peer : peerList)
         {
-            if (peer->hasRange (missingIndex, missingIndex + 1))
+            int maxScore = 0;
+            Overlay::PeerSequence peerList = getApp().overlay ().getActivePeers ();
+            for (auto const& peer : peerList)
             {
-                int score = peer->getScore (true);
-                if (! target || (score > targetScore))
+                if (peer->hasRange (missingIndex, missingIndex + 1))
                 {
-                    target = peer;
-                    targetScore = score;
+                    int score = peer->getScore (true);
+                    if (! target || (score > maxScore))
+                    {
+                        target = peer;
+                        maxScore = score;
+                    }
                 }
             }
         }

--- a/src/ripple/app/ledger/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/LedgerMaster.cpp
@@ -597,15 +597,19 @@ public:
         }
 
         Peer::ptr target;
-        int count = 0;
+        int targetScore = 0;
 
         Overlay::PeerSequence peerList = getApp().overlay ().getActivePeers ();
         for (auto const& peer : peerList)
         {
             if (peer->hasRange (missingIndex, missingIndex + 1))
             {
-                if ((count++ == 0) || ((rand() % count) == 0))
+                int score = peer->getScore (true);
+                if (! target || (score > targetScore))
+                {
                     target = peer;
+                    targetScore = score;
+                }
             }
         }
 

--- a/src/ripple/overlay/Peer.h
+++ b/src/ripple/overlay/Peer.h
@@ -82,6 +82,10 @@ public:
     isHighLatency() const = 0;
 
     virtual
+    int
+    getScore (bool) const = 0;
+
+    virtual
     RippleAddress const&
     getNodePublic() const = 0;
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -379,7 +379,7 @@ PeerImp::supportsVersion (int version)
 bool
 PeerImp::hasRange (std::uint32_t uMin, std::uint32_t uMax)
 {
-    return (uMin >= minLedger_) && (uMax <= maxLedger_);
+    return (sanity_ != Sanity::insane) && (uMin >= minLedger_) && (uMax <= maxLedger_);
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -2171,7 +2171,7 @@ PeerImp::peerTXData (Job&, uint256 const& hash,
 }
 
 int
-PeerImp::getScore (bool haveItem)
+PeerImp::getScore (bool haveItem) const
 {
    // Random component of score, used to break ties and avoid
    // overloading the "best" peer

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -305,7 +305,7 @@ public:
 
     // Called to determine our priority for querying
     int
-    getScore (bool haveItem) const;
+    getScore (bool haveItem) const override;
 
     bool
     isHighLatency() const override;

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -305,7 +305,7 @@ public:
 
     // Called to determine our priority for querying
     int
-    getScore (bool haveItem);
+    getScore (bool haveItem) const;
 
     bool
     isHighLatency() const override;


### PR DESCRIPTION
Use the new latency-aware scoring scheme to select the peer we request a fetch pack from.