### PR TITLE
Trivial: Change ArchLinux/PKGBUILD to have correct ripple build line.

### DIFF
--- a/Builds/ArchLinux/PKGBUILD
+++ b/Builds/ArchLinux/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: Roberto Catini <roberto.catini@gmail.com> 
+# Maintainer: Roberto Catini <roberto.catini@gmail.com>
 
 pkgname=rippled
 pkgrel=1
@@ -21,7 +21,7 @@ pkgver() {
 
 build() {
 	cd "$srcdir/$pkgname"
-	scons build/rippled
+	scons
 }
 
 check() {


### PR DESCRIPTION
@robcat @vinniefalco

I can't actually test this on ArchLinux but wanted to make sure that the build line was right.