### PR TITLE
Better escalation of fees in response to load (RIPD-598)

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1498,11 +1498,21 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\ledger\tests\TxQ_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\ledger\TransactionStateSF.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\ledger\TransactionStateSF.h">
+    </ClInclude>
+    <ClCompile Include="..\..\src\ripple\app\ledger\TxHold.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\app\ledger\TxHold.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\main\Application.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
@@ -2981,6 +2991,9 @@
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\Feature.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\Fee.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\FetchInfo.cpp">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2220,10 +2220,19 @@
     <ClCompile Include="..\..\src\ripple\app\ledger\tests\Ledger_test.cpp">
       <Filter>ripple\app\ledger\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\ledger\tests\TxQ_test.cpp">
+      <Filter>ripple\app\ledger\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\ledger\TransactionStateSF.cpp">
       <Filter>ripple\app\ledger</Filter>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\ledger\TransactionStateSF.h">
+      <Filter>ripple\app\ledger</Filter>
+    </ClInclude>
+    <ClCompile Include="..\..\src\ripple\app\ledger\TxHold.cpp">
+      <Filter>ripple\app\ledger</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\app\ledger\TxHold.h">
       <Filter>ripple\app\ledger</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\main\Application.cpp">
@@ -3661,6 +3670,9 @@
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\Feature.cpp">
+      <Filter>ripple\rpc\handlers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\Fee.cpp">
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\FetchInfo.cpp">

--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -393,6 +393,31 @@
 #
 #
 #
+# [transaction_queue]
+#
+#   A set of key/value pair parameters to tune the performance of the
+#   transaction queue.
+#
+#   min_ledgers_to_compute_size_limit = <number>
+#
+#       Will not compute or impose a limit on the queue until this many 
+#       ledgers have been processed. Default: 200.
+#
+#   max_ledger_counts_to_store = <number>
+#
+#       To prevent size information from growing without bound, will
+#       only use the <number> ledgers to compute the limit.
+#       Default: 1000.
+#
+#   ledgers_in_queue = <number>
+#
+#       The queue will be limited to this <number> of average ledgers'
+#       worth of transactions. If the queue fills up, the transactions
+#       with the lowest fees will be dropped from the queue any time a
+#       transaction with a higher fee is added. Default: 20.
+#
+#
+#
 #-------------------------------------------------------------------------------
 #
 # 3. Ripple Protocol
@@ -689,7 +714,7 @@
 #
 # [debug_logfile]
 #
-#   Specifies were a debug logfile is kept. By default, no debug log is kept.
+#   Specifies where a debug logfile is kept. By default, no debug log is kept.
 #   Unless absolute, the path is relative the directory containing this file.
 #
 #   Example: debug.log

--- a/src/beast/beast/unit_test/suite.h
+++ b/src/beast/beast/unit_test/suite.h
@@ -131,7 +131,7 @@ protected:
         }
 
         void
-            write(beast::Journal::Severity level,
+        write(beast::Journal::Severity level,
             std::string const& text) override
         {
             suite_.log << text;

--- a/src/beast/beast/unit_test/suite.h
+++ b/src/beast/beast/unit_test/suite.h
@@ -23,6 +23,7 @@
 #include <beast/unit_test/runner.h>
 
 #include <beast/utility/noexcept.h>
+#include <beast/utility/Journal.h>
 #include <string>
 #include <sstream>
 
@@ -116,6 +117,28 @@ private:
         operator<< (T const& t);
         /** @} */
     };
+
+protected:
+    // Memberspace
+    class TestSink : public Journal::Sink
+    {
+        beast::unit_test::suite& suite_;
+
+    public:
+        TestSink(beast::unit_test::suite& suite)
+            : suite_(suite)
+        {
+        }
+
+        void
+            write(beast::Journal::Severity level,
+            std::string const& text) override
+        {
+            suite_.log << text;
+        }
+    };
+
+
 
 public:
     /** Type for scoped stream logging.

--- a/src/ripple/app/ledger/LedgerConsensus.cpp
+++ b/src/ripple/app/ledger/LedgerConsensus.cpp
@@ -1008,42 +1008,42 @@ private:
         getApp().getLedgerMaster().consensusBuilt (newLCL);
 
         // Build new open ledger
-        Ledger::pointer newOL = std::make_shared<Ledger>
-            (true, *newLCL);
+        auto newOL = std::make_shared<Ledger>(true, *newLCL);
 
-        // Apply disputed transactions that didn't get in
-        TransactionEngine engine (newOL);
-        bool anyDisputes = false;
-        for (auto& it : mDisputes)
         {
-            if (!it.second->getOurVote ())
+            // Apply disputed transactions that didn't get in
+            bool anyDisputes = false;
+            for (auto& it : mDisputes)
             {
-                // we voted NO
-                try
+                if (!it.second->getOurVote())
                 {
-                    WriteLog (lsDEBUG, LedgerConsensus)
-                        << "Test applying disputed transaction that did"
-                        << " not get in";
-                    SerialIter sit (it.second->peekTransaction ());
-                    STTx::pointer txn = std::make_shared<STTx>(sit);
+                    // we voted NO
+                    try
+                    {
+                        WriteLog(lsDEBUG, LedgerConsensus)
+                            << "Test applying disputed transaction that did"
+                            << " not get in";
+                        SerialIter sit(it.second->peekTransaction());
+                        STTx::pointer txn = std::make_shared<STTx>(sit);
 
-                    retriableTransactions.push_back (txn);
-                    anyDisputes = true;
-                }
-                catch (...)
-                {
-                    WriteLog (lsDEBUG, LedgerConsensus)
-                        << "Failed to apply transaction we voted NO on";
+                        retriableTransactions.push_back(txn);
+                        anyDisputes = true;
+                    }
+                    catch (...)
+                    {
+                        WriteLog(lsDEBUG, LedgerConsensus)
+                            << "Failed to apply transaction we voted NO on";
+                    }
                 }
             }
-        }
 
-        if (anyDisputes)
-        {
-            // Attempt re-applying any disputed transactions
-            // where we voted NO
-            applyTransactions(TxSet(),
-                newOL, newLCL, retriableTransactions, true);
+            if (anyDisputes)
+            {
+                // Attempt re-applying any disputed transactions
+                // where we voted NO
+                applyTransactions(TxSet(),
+                    newOL, newLCL, retriableTransactions, true);
+            }
         }
 
         {
@@ -1883,8 +1883,8 @@ std::size_t countLedgerNodes(ripple::Ledger::pointer ledger)
     return nodes;
 }
 
-// Build a transaction set from a transaction map
-// This allows us to serialize the transactions only once,
+// Build a transaction set from a transaction map.
+// This allows us to deserialize the transactions only once.
 TxSet buildTxSet(std::shared_ptr<SHAMap> const& map)
 {
     TxSet txSet;
@@ -1901,7 +1901,7 @@ TxSet buildTxSet(std::shared_ptr<SHAMap> const& map)
         catch (...)
         {
             WriteLog (lsWARNING, LedgerConsensus) << "Transaction " <<
-            item->getTag() << " throws";
+                item->getTag() << " throws";
         }
     });
 
@@ -1927,7 +1927,7 @@ void applyTransactions (
 {
     TransactionEngine engine (applyLedger);
 
-    for (auto& tx : set)
+    for (auto const& tx : set)
     {
         // If the checkLedger doesn't have the transaction
         if (!checkLedger->hasTransaction (tx.first))

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -32,6 +32,8 @@
 
 namespace ripple {
 
+class LoadFeeTrack;
+
 /** Manager for achieving consensus on the next ledger.
 
     This object is created when the consensus process starts, and
@@ -59,15 +61,25 @@ public:
     virtual void simulate () = 0;
 };
 
+using TxSet = std::vector <std::pair <uint256, STTx::pointer>>;
+
 std::shared_ptr <LedgerConsensus>
 make_LedgerConsensus (LocalTxs& localtx,
     LedgerHash const & prevLCLHash, Ledger::ref previousLedger,
         std::uint32_t closeTime, FeeVote& feeVote);
 
+std::size_t countLedgerNodes(ripple::Ledger::pointer ledger);
+
+TxSet buildTxSet(std::shared_ptr<SHAMap> const& set);
+
 void
-applyTransactions(std::shared_ptr<SHAMap> const& set, Ledger::ref applyLedger,
+applyTransactions(TxSet const& set, Ledger::ref applyLedger,
                   Ledger::ref checkLedger,
                   CanonicalTXSet& retriableTransactions, bool openLgr);
+
+// Used by tests only
+void updateFeeTracking(ripple::Ledger::pointer openLedger, TxSet const& txSet,
+    LoadFeeTrack& feeTrack, std::uint64_t refTxnCost, std::function<int()> const& msFunction);
 
 } // ripple
 

--- a/src/ripple/app/ledger/LedgerEntrySet.h
+++ b/src/ripple/app/ledger/LedgerEntrySet.h
@@ -46,6 +46,10 @@ enum TransactionEngineParams
     // Transaction can be retried, soft failures allowed
     tapRETRY            = 0x20,
 
+    // Transaction is being tested for non-fee
+    // sanity. Don't fail if the fee is too low.
+    tapIGNORE_FEE       = 0x40,
+
     // Transaction came from a privileged source
     tapADMIN            = 0x400,
 };

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -31,6 +31,9 @@
 
 namespace ripple {
 
+class LoadFeeTrack;
+class TxQ;
+
 // Tracks the current ledger and any ledgers in the process of closing
 // Tracks ledger history
 // Tracks held transactions
@@ -67,6 +70,9 @@ public:
 
     // The validated ledger is the last fully validated ledger
     virtual Ledger::pointer getValidatedLedger () = 0;
+
+    // Holds transactions which don't have high enough fees to be put into the ledger yet.
+    virtual TxQ& getTransactionQueue() = 0;
 
     // This is the last ledger we published to clients and can lag the validated ledger
     virtual Ledger::ref getPublishedLedger () = 0;
@@ -159,6 +165,7 @@ public:
 
 std::unique_ptr <LedgerMaster>
 make_LedgerMaster (Config const& config, beast::Stoppable& parent,
+    LoadFeeTrack& loadFeeTrack,
     beast::insight::Collector::ptr const& collector, beast::Journal journal);
 
 } // ripple

--- a/src/ripple/app/ledger/TxHold.cpp
+++ b/src/ripple/app/ledger/TxHold.cpp
@@ -1,0 +1,727 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/ledger/TxHold.h>
+#include <ripple/app/tx/TransactionEngine.h>
+#include <ripple/app/ledger/LedgerConsensus.h>
+#include <numeric>
+
+namespace ripple {
+
+class CandidateTxn
+{
+    friend class TxQImpl;
+
+protected:
+    boost::intrusive::set_member_hook<> byFee_;
+
+private:
+    STTx::pointer txn_;
+
+     uint64_t      feeLevel_;
+     uint32_t      lastRelayed_;
+     uint256       txID_;
+     boost::optional<uint256> priorTxID_;
+     Account       account_;
+     boost::optional<uint32_t> lastValid_;
+     uint32_t      sequence_;
+     TransactionEngineParams transactionParams_;
+
+public:
+    CandidateTxn (STTx::ref, TransactionEngine& engine,
+        std::uint32_t loadBase, TransactionEngineParams params);
+
+    STTx::pointer getTransaction()
+    {
+        return txn_;
+    }
+
+    uint64_t getFeeLevel() const
+    {
+        return feeLevel_;
+    }
+
+    uint32_t getSequence() const
+    {
+        return sequence_;
+    }
+};
+
+CandidateTxn::CandidateTxn(
+    STTx::ref txn,
+    TransactionEngine& engine,
+    std::uint32_t loadBase,
+    TransactionEngineParams params)
+    : txn_(txn)
+    , lastRelayed_(0), txID_(txn->getTransactionID())
+    , account_(txn->getSourceAccount().getAccountID())
+    , sequence_(txn->getSequence())
+    , transactionParams_(params)
+{
+    feeLevel_ = txn->getFeeLevelPaid(loadBase, engine.getLedger()->getBaseFee());
+
+    if (txn->isFieldPresent(sfLastLedgerSequence))
+    {
+        lastValid_ = txn->getFieldU32(sfLastLedgerSequence);
+    }
+
+    if (txn->isFieldPresent(sfAccountTxnID))
+    {
+        priorTxID_ = txn->getFieldH256(sfAccountTxnID);
+    }
+}
+
+class TxQAccount
+{
+    friend class TxQImpl;
+
+protected:
+    //boost::intrusive::set_member_hook<> byAccount_;
+
+private:
+
+    Account                    account_;
+    //uint64_t                   feeLevel_;
+    uint64_t                   totalFees_;
+    // Sequence number will be used as the key.
+    std::map <uint32_t, CandidateTxn> transactions_;
+
+public:
+    TxQAccount(STTx::ref txn);
+    TxQAccount(const Account& account);
+
+    //int getFeeLevel() const
+    //{
+    //    return feeLevel_;
+    //}
+
+    int getTxnCount() const
+    {
+        return transactions_.size();
+    }
+
+    bool empty() const
+    {
+        return !getTxnCount();
+    }
+
+    // Returns true if this is the new head transaction
+    // for this account
+    CandidateTxn&  addCandidate (CandidateTxn&&);
+    bool removeCandidate(uint32_t const&);
+
+    std::pair<bool, CandidateTxn const*> findCandidateAt(uint32_t const&);
+};
+
+TxQAccount::TxQAccount(STTx::ref txn)
+    :TxQAccount(txn->getFieldAccount160(sfAccount))
+{
+}
+
+TxQAccount::TxQAccount(const Account& account)
+    : account_(account)
+    //, feeLevel_(0)
+    , totalFees_(0)
+{ 
+}
+
+CandidateTxn&
+TxQAccount::addCandidate(CandidateTxn&& txn)
+{
+    auto fee = txn.getFeeLevel();
+    totalFees_ += fee;
+    auto sequence = txn.getSequence();
+
+    transactions_.emplace(std::make_pair(sequence, std::move(txn)));
+    assert(&transactions_.at(sequence) != &txn);
+
+    return transactions_.at(sequence);
+}
+
+bool
+TxQAccount::removeCandidate(uint32_t const& sequence)
+{
+    return transactions_.erase(sequence) != 0;
+}
+
+std::pair<bool, CandidateTxn const*>
+TxQAccount::findCandidateAt(uint32_t const& sequence)
+{
+    auto iter = transactions_.find(sequence);
+    if (iter == transactions_.end())
+        return std::make_pair(false, nullptr);
+
+    return std::make_pair(true, &iter->second);
+}
+
+
+class GreaterFee
+{
+public:
+    bool operator() (const CandidateTxn& lhs, const CandidateTxn& rhs) const
+    {
+        return lhs.getFeeLevel() > rhs.getFeeLevel();
+    }
+};
+
+/*
+class LessAccount
+{
+public:
+    bool operator() (const TxQAccount& lhs, const TxQAccount& rhs) const
+    {
+        return lhs.getAccount() < rhs.getAccount();
+    }
+};
+
+class CompareAccount
+{
+public:
+    bool operator() (const Account& lhs, const Account& rhs) const
+    {
+        return lhs == rhs;
+    }
+};
+*/
+
+class TxQImpl : public TxQ
+{
+public:
+
+    TxQImpl(Setup const& setup, LoadFeeTrack &lft,
+        beast::Journal journal)
+        : setup_(setup)
+        , journal_(journal)
+        , loadFeeTrack_(lft)
+    { }
+
+    virtual ~TxQImpl()
+    {
+        byFee_.clear();
+    }
+
+    std::pair <TxDisposition, TER>
+        addTransaction (
+            STTx::ref txn,
+            TransactionEngineParams params,
+            TransactionEngine& engine) override;
+
+    void fillOpenLedger(TransactionEngine&) override;
+
+    void processValidatedLedger (Ledger::ref) override;
+
+    struct TxQ::TxFeeMetrics getFeeMetrics () override;
+
+    Json::Value doRPC(Json::Value const& query) override;
+
+protected:
+
+    using FeeHook = boost::intrusive::member_hook
+        <CandidateTxn, boost::intrusive::set_member_hook<>,
+        &CandidateTxn::byFee_>;
+
+    using FeeMultiSet = boost::intrusive::multiset
+        < CandidateTxn, FeeHook, boost::intrusive::compare <GreaterFee> >;
+
+    using AccountSet = std::map < Account, TxQAccount > ;
+
+    const Setup setup_;
+    beast::Journal journal_;
+    
+    LoadFeeTrack& loadFeeTrack_;
+    FeeMultiSet   byFee_;
+    AccountSet    byAccount_;
+    boost::optional<size_t> maxSize_;
+
+    // Used to compute maxSize_
+    std::map<uint32_t, size_t> ledgerTransactionCounts_;
+
+    std::mutex mutable mutex_;
+
+private:
+    bool isFull() const
+    {
+        return maxSize_.is_initialized() && byFee_.size() >= maxSize_.value();
+    }
+
+    bool canBeHeld(STTx::ref);
+
+    FeeMultiSet::iterator_type erase(FeeMultiSet::const_iterator_type);
+
+};
+
+TxQ::Setup
+setup_TxQ(Config const& config)
+{
+    TxQ::Setup setup;
+    auto const& section = config.section("transaction_queue");
+    set(setup.ledgersInQueue_, "ledgers_in_queue", section);
+    set(setup.minLedgersToComputeSizeLimit_, "min_ledgers_to_compute_size_limit",
+        section);
+    set(setup.maxLedgerCountsToStore_, "max_ledger_counts_to_store", section);
+    return setup;
+}
+
+
+std::unique_ptr<TxQ>
+make_TxQ(TxQ::Setup const& setup, 
+    LoadFeeTrack& lft, beast::Journal journal)
+{
+    return std::make_unique<TxQImpl>(setup, lft, std::move(journal));
+}
+
+const TER TxQ::txnResultHeld = terQUEUED;
+const TER TxQ::txnResultLowFee = telINSUF_FEE_P;
+
+bool TxQImpl::canBeHeld (STTx::ref tx)
+{
+    // PreviousTxnID is deprecated and should never be used
+    // AccountTxnID is not supported by the transaction
+    // queue yet, but should be added in the future
+    bool canBeHeld =
+        ! tx->isFieldPresent (sfPreviousTxnID) &&
+        ! tx->isFieldPresent (sfAccountTxnID);
+    if (canBeHeld)
+    {
+        auto accountIter = byAccount_.find(tx->getFieldAccount160(sfAccount));
+        canBeHeld = accountIter == byAccount_.end()
+            || accountIter->second.empty();
+    }
+    return canBeHeld;
+}
+
+TxQImpl::FeeMultiSet::iterator_type
+TxQImpl::erase(TxQImpl::FeeMultiSet::const_iterator_type candidateIter)
+{
+    auto& txQAccount = byAccount_.at(candidateIter->account_);
+    auto sequence = candidateIter->sequence_;
+    auto newCandidateIter = byFee_.erase(candidateIter);
+    // Now that the candidate has been removed from the 
+    // intrusive list remove it from the TxQAccount
+    // so the memory can be freed.
+    auto found = txQAccount.removeCandidate(sequence);
+    (void)found;
+    assert(found);
+
+    return newCandidateIter;
+}
+
+std::pair <TxQ::TxDisposition, TER>
+    TxQImpl::addTransaction (
+        STTx::ref txn,
+        TransactionEngineParams params,
+        TransactionEngine& engine)
+{
+    auto loadBase = loadFeeTrack_.getLoadBase();
+    auto account = txn->getFieldAccount160(sfAccount);
+    auto fee_level = txn->getFeeLevelPaid
+        (loadBase, engine.getLedger()->getBaseFee());
+
+    if (fee_level < loadBase)
+    {
+        // This transaction can never succeed. Don't even bother.
+        journal_.trace << "Transaction for " << account
+            << " has fee level " << fee_level 
+            << " which is below minimum of " << loadBase;
+        return { TD_low_fee, txnResultLowFee };
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Is there a transaction for the same account with the
+    // same sequence number already in the queue?
+    auto accountIter = byAccount_.find(account);
+    if (accountIter != byAccount_.end())
+    {
+        auto sequence = txn->getSequence();
+        auto& txQAcct = accountIter->second;
+        auto existingCandidate =
+            txQAcct.findCandidateAt(sequence);
+        if (existingCandidate.first)
+        {
+            // Is the current transaction's fee higher than
+            // the queued transaction's fee?
+            journal_.trace << "Found transaction in queue for account "
+                << account << " with sequence number " << sequence
+                << " new txn fee level is " << fee_level
+                << " old txn fee level is "
+                << existingCandidate.second->feeLevel_;
+            if (fee_level > existingCandidate.second->feeLevel_)
+            {
+                // Remove the queued transaction and continue
+                journal_.trace
+                    << "Removing transaction from queue "
+                    << existingCandidate.second->txID_
+                    << " in favor of "
+                    << txn->getTransactionID();
+                auto byFeeIter = byFee_.iterator_to(*existingCandidate.second);
+                assert(byFeeIter != byFee_.end());
+                assert(existingCandidate.second == &*byFeeIter);
+                assert(byFeeIter->sequence_ == sequence);
+                assert(byFeeIter->account_ == txQAcct.account_);
+                erase(byFeeIter);
+            }
+            else
+            {
+                // Drop the current transaction
+                journal_.trace
+                    << "Ignoring transaction "
+                    << txn->getTransactionID()
+                    << " in favor of queued "
+                    << existingCandidate.second->txID_;
+                return { TD_low_fee, txnResultLowFee };
+            }
+        }
+    }
+
+    auto requiredFeeLevel = loadFeeTrack_.scaleTxnFee(loadBase);
+    journal_.trace << "Transaction " << txn->getTransactionID()
+        << " from account " << account
+        << " has fee level of " << fee_level
+        << " needs at least " << requiredFeeLevel;
+
+    // Can transaction go in open ledger?
+    if (fee_level >= requiredFeeLevel)
+    {
+        // Transaction fee is sufficient to go in open ledger immediately
+
+        // TODO EHENNIS Check for dependencies in the hold queue. Return
+        //              TD_missing_prior if any.
+
+        journal_.trace << "Applying transaction "
+            << txn->getTransactionID()
+            << " to open ledger.";
+        ripple::TER txnResult;
+        bool didApply;
+        std::tie(txnResult, didApply) = engine.applyTransaction(*txn,
+            params);
+
+        if (didApply)
+        {
+            journal_.trace << "Transaction "
+                << txn->getTransactionID()
+                << " applied successfully.";
+            loadFeeTrack_.onTx(txn->getTransactionFee().mantissa());
+
+            return { TD_open_ledger, txnResult };
+        }
+        // failure
+        if (journal_.trace)
+        {
+            journal_.trace << "Transaction "
+                << txn->getTransactionID()
+                << " failed with " << transToken(txnResult);
+        }
+        if (isTemMalformed(txnResult))
+        {
+            return { TD_malformed, txnResult };
+        }
+
+        return { TD_failed, txnResult };
+    }
+
+    if (! canBeHeld (txn))
+    {
+        // Bail, transaction cannot be held
+        journal_.trace << "Transaction "
+            << txn->getTransactionID()
+            << " can not be held";
+        return { TD_low_fee, txnResultLowFee };
+    }
+
+    // Are preconditions met?
+
+    // Is the queue full?
+    // It's pretty unlikely that the queue will be "overfilled",
+    // but should it happen, take the opportunity to fix it now.
+    while (isFull())
+    {
+        auto lastRIter = byFee_.rbegin();
+        if (fee_level > lastRIter->feeLevel_)
+        {
+            // The queue is full, and this transaction is more
+            // valuable, so kick out the cheapest transaction.
+            journal_.trace
+                << "Removing end item from queue with fee of"
+                << lastRIter->feeLevel_ << " in favor of "
+                << txn->getTransactionID() << " with fee of "
+                << fee_level;
+            auto lastFIter = byFee_.iterator_to(*lastRIter);
+            erase(lastFIter);
+        }
+        else
+        {
+            journal_.trace << "Queue is full, and transaction "
+                << txn->getTransactionID()
+                << " fee is lower than end item";
+            return { TD_low_fee, txnResultLowFee };
+        }
+    }
+
+    {
+        // see if the transaction can get into the ledger/engine,
+        // but don't return success, because there's no point if
+        // it has no hope of success.
+        ripple::TER txnResult;
+        bool didApply;
+        std::tie(txnResult, didApply) = engine.applyTransaction(*txn,
+            params | tapIGNORE_FEE);
+
+        if (!didApply && !isTerRetry(txnResult))
+        {
+            if (journal_.trace)
+            {
+                journal_.trace << "Not adding transaction "
+                    << txn->getTransactionID()
+                    << " to queue. Fails with " << transToken(txnResult);
+            }
+            return { TD_malformed, txnResult };
+        }
+    }
+
+    // Hold the transaction
+    if (accountIter == byAccount_.end())
+    {
+        // Create a new TxQAccount object and add the byAccount lookup.
+        byAccount_.emplace(
+            std::make_pair(account, TxQAccount(txn)));
+        auto& candidate = byAccount_.at(account).addCandidate(
+            { txn, engine, loadBase, params });
+        // Then index it into the byFee lookup.
+        byFee_.insert(candidate);
+        journal_.debug << "Added transaction " << candidate.txID_
+            << " from new account " << candidate.account_
+            << " to queue.";
+    }
+    else
+    {
+        auto& candidate = accountIter->second.addCandidate(
+            { txn, engine, loadBase, params });
+        byFee_.insert(candidate);
+        journal_.debug << "Added transaction " << candidate.txID_
+            << " from existing account " << candidate.account_
+            << " to queue.";
+    }
+
+    return { TD_held, txnResultHeld };
+}
+
+void TxQImpl::processValidatedLedger (Ledger::ref validatedLedger)
+{
+    auto ledgerSeq = validatedLedger->getLedgerSeq();
+    auto ledgerSize = countLedgerNodes(validatedLedger);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Empty ledgers aren't interesting.
+    if (ledgerSize > 0)
+    {
+        journal_.debug << "Ledger number " << ledgerSeq
+            << " has " << ledgerSize << " transactions";
+        ledgerTransactionCounts_.emplace(std::make_pair(ledgerSeq, ledgerSize));
+
+        if (ledgerTransactionCounts_.size() %
+            setup_.minLedgersToComputeSizeLimit_ == 0)
+        {
+            auto total = std::accumulate(
+                ledgerTransactionCounts_.begin(),
+                ledgerTransactionCounts_.end(),
+                (size_t)0,
+                [] (const size_t&a, const std::pair<uint32_t, size_t>&b)
+                {
+                    return a + b.second;
+                });
+            maxSize_ = total * setup_.ledgersInQueue_ /
+                ledgerTransactionCounts_.size();
+            journal_.debug << "Changed queue maxsize to "
+                << *maxSize_;
+
+            while (ledgerTransactionCounts_.size() > 
+                setup_.maxLedgerCountsToStore_)
+            {
+                ledgerTransactionCounts_.erase(ledgerTransactionCounts_.begin());
+            }
+        }
+    }
+
+    // Remove any queued candidates whos LastLedgerSequence has gone by.
+    // Stop if we leave maxSize_ candidates.
+    size_t keptCandidates = 0;
+    auto candidateIter = byFee_.begin();
+    while (candidateIter != byFee_.end()
+        && (!maxSize_ || keptCandidates < maxSize_.value()))
+    {
+        if (candidateIter->lastValid_.is_initialized()
+            && candidateIter->lastValid_.value() >= ledgerSeq)
+        {
+            candidateIter = erase(candidateIter);
+        }
+        else
+        {
+            ++keptCandidates;
+            ++candidateIter;
+        }
+    }
+    // Erase any candidates more than maxSize_.
+    // This can help keep the queue from getting overfull.
+    for (; candidateIter != byFee_.end(); ++candidateIter)
+    {
+        candidateIter = erase(candidateIter);
+    }
+
+    // Remove any TxQAccounts that don't have candidates
+    // under them
+    for (auto txQAccountIter = byAccount_.begin();
+        txQAccountIter != byAccount_.end();)
+    {
+        if (txQAccountIter->second.empty())
+            txQAccountIter = byAccount_.erase(txQAccountIter);
+        else
+            ++txQAccountIter;
+    }
+}
+
+void TxQImpl::fillOpenLedger(TransactionEngine& engine)
+{
+    /* Move transactions from the queue from largest fee to smallest.
+       As we add more transactions, the required fee will increase.
+       Stop when the transaction fee gets lower than the required fee.
+    */
+
+#ifndef NDEBUG
+    auto lastFeeLevel = boost::optional<uint32>();
+#endif
+
+    auto loadBase = loadFeeTrack_.getLoadBase();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    for (auto candidateIter = byFee_.begin(); candidateIter != byFee_.end();)
+    {
+        auto requiredFee = loadFeeTrack_.scaleTxnFee(loadBase);
+        auto txnFeeLevel = candidateIter->feeLevel_;
+#ifndef NDEBUG
+        assert(!lastFeeLevel || *lastFeeLevel >= txnFeeLevel);
+        lastFeeLevel = txnFeeLevel;
+#endif
+        journal_.trace << "Queued transaction " << candidateIter->txID_
+            << " from account " << candidateIter->account_
+            << " has fee level of " << txnFeeLevel
+            << " needs at least " << requiredFee;
+        if (txnFeeLevel >= requiredFee)
+        {
+            auto firstTxn = candidateIter->getTransaction();
+
+            journal_.trace << "Applying queued transaction "
+                << candidateIter->txID_
+                << " to open ledger.";
+            // first approximation based on LedgerMasterImp::doTransaction
+            TER txnResult;
+            bool didApply;
+            std::tie(txnResult, didApply) = engine.applyTransaction(*firstTxn,
+                candidateIter->transactionParams_);
+
+            if (didApply)
+            {
+                // Remove the candidate from the queue
+                journal_.trace << "Queued transaction "
+                    << candidateIter->txID_
+                    << " applied successfully. Remove from queue.";
+                loadFeeTrack_.onTx(firstTxn->getTransactionFee().mantissa());
+
+                candidateIter = erase(candidateIter);
+            }
+            else if (isTefFailure(txnResult) || isTemMalformed(txnResult) ||
+                isTelLocal(txnResult))
+            {
+                if (journal_.trace)
+                {
+                    journal_.trace << "Queued transaction "
+                        << candidateIter->txID_
+                        << " failed with " << transToken(txnResult)
+                        << ". Remove from queue.";
+                }
+                candidateIter = erase(candidateIter);
+            }
+            else
+            {
+                if (journal_.trace)
+                {
+                    journal_.trace << "Transaction "
+                        << candidateIter->txID_
+                        << " failed with " << transToken(txnResult)
+                        << ". Leave in queue.";
+                }
+                candidateIter++;
+            }
+
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+TxQ::TxFeeMetrics TxQImpl::getFeeMetrics ()
+{
+    TxFeeMetrics result;
+
+    auto base = loadFeeTrack_.getLoadBase();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    result.txCount = byFee_.size();
+    result.txPerLedger = loadFeeTrack_.getExpectedLedgerSize();
+    result.referenceFeeLevel = base;
+    if (isFull())
+    {
+        auto lastRIter = byFee_.rbegin();
+        result.minFeeLevel = lastRIter->feeLevel_ + 1;
+    }
+    else
+    {
+        result.minFeeLevel = base;
+    }
+    result.medFeeLevel = loadFeeTrack_.getMedianFee();
+    result.expFeeLevel = loadFeeTrack_.scaleTxnFee(base);
+
+    return std::move(result);
+}
+
+Json::Value TxQImpl::doRPC(Json::Value const& query)
+{
+    using std::to_string;
+
+    Json::Value ret(Json::objectValue);
+
+    auto& levels = ret[jss::levels] = Json::objectValue;
+
+    auto metrics = getFeeMetrics();
+
+    levels[jss::expected_ledger_size] = to_string(metrics.txPerLedger);
+    levels[jss::reference_level] = to_string(metrics.referenceFeeLevel);
+    levels[jss::minimum_level] = to_string(metrics.minFeeLevel);
+    levels[jss::median_level] = to_string(metrics.medFeeLevel);
+    levels[jss::open_ledger_level] = to_string(metrics.expFeeLevel);
+
+    return ret;
+}
+
+} // ripple

--- a/src/ripple/app/ledger/TxHold.h
+++ b/src/ripple/app/ledger/TxHold.h
@@ -1,0 +1,103 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-14 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TXHOLD_H_INCLUDED
+#define RIPPLE_TXHOLD_H_INCLUDED
+
+#include <boost/intrusive/set.hpp>
+
+#include <ripple/core/Config.h>
+#include <ripple/core/impl/LoadFeeTrackImp.h>
+#include <ripple/protocol/TER.h>
+#include <ripple/protocol/STTx.h>
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/ledger/LedgerEntrySet.h>
+
+namespace ripple {
+
+class TransactionEngine;
+
+class TxQ
+{
+public:
+    struct Setup
+    {
+        size_t ledgersInQueue_ = 20;
+        size_t minLedgersToComputeSizeLimit_ = ledgersInQueue_ * 10;
+        size_t maxLedgerCountsToStore_ = minLedgersToComputeSizeLimit_ * 5;
+    };
+
+    struct TxFeeMetrics
+    {
+        int txCount;            // Transactions in the queue
+        int txPerLedger;        // Amount expected per ledger
+        int referenceFeeLevel;  // Reference transaction fee level
+        int minFeeLevel;        // Minimum fee level to get in the queue
+        int medFeeLevel;        // Median fee level of the last ledger
+        int expFeeLevel;        // Estimated fee level to get in next ledger
+    };
+
+    enum TxDisposition
+    {
+        TD_malformed,     // Transaction is broken
+        TD_superceded,    // Transaction can never succeed on network
+        TD_low_fee,       // Fee is too low
+        TD_failed,        // Not likely to claim a fee
+        TD_missing_prior, // Dependent on non-present transaction
+        TD_held,          // Waiting for emptier ledger
+        TD_open_ledger    // Placed in the open ledger
+    };
+
+    // ALMOST DEFINITELY THE WRONG TER CODES
+    static const TER txnResultHeld;
+    static const TER txnResultLowFee;
+
+    virtual ~TxQ () { }
+
+    // Add a new transaction to the open ledger or hold
+    // (Or reject it)
+    virtual std::pair <TxDisposition, TER>
+        addTransaction (
+            STTx::ref txn,
+            TransactionEngineParams params,
+            TransactionEngine& engine) = 0;
+
+    // Fill the new open ledger with transactions from the hold
+    virtual void fillOpenLedger(TransactionEngine&) = 0;
+
+    // We have a new last validated ledger, update the hold
+    virtual void processValidatedLedger (Ledger::ref) = 0;
+
+    virtual struct TxFeeMetrics getFeeMetrics () = 0;
+
+    virtual Json::Value doRPC(Json::Value const& query) = 0;
+};
+
+TxQ::Setup
+setup_TxQ(Config const& c);
+
+std::unique_ptr<TxQ>
+make_TxQ(TxQ::Setup const& setup,
+    LoadFeeTrack& lft, beast::Journal journal);
+
+
+
+} // ripple
+
+#endif

--- a/src/ripple/app/ledger/tests/TxQ_test.cpp
+++ b/src/ripple/app/ledger/tests/TxQ_test.cpp
@@ -1,0 +1,649 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/main/Application.h>
+#include <ripple/app/ledger/tests/common_ledger.h>
+#include <ripple/app/ledger/TxHold.h>
+#include <ripple/app/ledger/LedgerHolder.h>
+#include <ripple/core/LoadFeeTrack.h>
+#include <ripple/basics/Log.h>
+#include <ripple/basics/TestSuite.h>
+
+namespace ripple {
+namespace test {
+
+class TxQ_test : public TestSuite
+{
+    // Acts as a wrapper for to unconditionally
+    // get, use, and set a mutable ledger from
+    // a LedgerHolder.
+    // Obviously, this class is not appropriate
+    // for test cases where you might not want to
+    // set the ledger back to the LedgerHolder.
+    class LedgerHelper
+    {
+    public:
+        LedgerHelper(LedgerHolder& ledgerHolder)
+            : ledgerHolder_(ledgerHolder)
+        {
+            ledger_ = ledgerHolder_.getMutable();
+        }
+        ~LedgerHelper()
+        {
+            ledger_->setImmutable();
+            ledgerHolder_.set(ledger_);
+        }
+
+        operator Ledger::pointer()
+        {
+            return ledger_;
+        }
+
+    private:
+        LedgerHolder& ledgerHolder_;
+        Ledger::pointer ledger_;
+    };
+
+    TestAccount
+    createAndQueueAccount(TxQ& txQ,
+        TransactionEngineParams params,
+        TransactionEngine& engine,
+        TestAccount& from,
+        std::string const& password, KeyType keyType,
+        std::uint64_t amountDrops, std::uint64_t feeDrops)
+    {
+        auto to = createAccount(password, keyType);
+        queuePaymentToApply(txQ, params, engine,
+            from, to, amountDrops, feeDrops);
+
+        return to;
+    }
+
+    void
+    queuePaymentToApply(TxQ& txQ,
+        TransactionEngineParams params,
+        TransactionEngine& engine,
+        TestAccount& from, TestAccount& to,
+        std::uint64_t amountDrops, std::uint64_t feeDrops = 10)
+    {
+        std::shared_ptr<STTx> payment(new STTx(parseTransaction(
+            from, getPaymentJson(from, to, amountDrops, feeDrops))));
+        auto addResult = txQ.addTransaction(payment, params, engine);
+        expectEquals(addResult.first, TxQ::TD_open_ledger);
+        expectEquals(addResult.second, tesSUCCESS);
+    }
+
+    void
+    queuePaymentToHold(TxQ& txQ,
+        TransactionEngineParams params,
+        TransactionEngine& engine,
+        TestAccount& from, TestAccount& to,
+        std::uint64_t amountDrops, std::uint64_t feeDrops = 10)
+    {
+        auto paymentJson = getPaymentJson(from, to,
+            amountDrops, feeDrops);
+        std::shared_ptr<STTx> payment(new STTx(
+            parseTransaction(from, paymentJson)));
+        auto addResult = txQ.addTransaction(payment, params, engine);
+        expectEquals(addResult.first, TxQ::TD_held);
+        expectEquals(addResult.second, TxQ::txnResultHeld);
+    }
+
+    void
+    simulateConsensus(TxQ& txQ, LoadFeeTrack& loadFeeTrack,
+        Ledger::pointer& LCL, LedgerHolder& ledgerHolder,
+        size_t expectedTxSetSize)
+    {
+        auto ledger = ledgerHolder.getMutable();
+
+        auto txSet = close_and_advance(ledger, LCL);
+        expectEquals(txSet.size(), expectedTxSetSize);
+
+        // TODO EHENNIS This is stolen from LedgerConsensus::accept
+        //              until I understand simulating consensus better.
+        //              Yes, it is a kludge.
+        // processValidatedLedger is called indirectly by 
+        // LedgerMaster::consensusBuilt in 
+        // LedgerConsensusImp::accept
+        txQ.processValidatedLedger(LCL);
+        auto refTxnCost = LCL->getBaseFee();
+        /*
+        if (oldOL->peekTransactionMap()->getHash().isNonZero())
+        {
+            WriteLog(lsDEBUG, LedgerConsensus)
+                << "Applying transactions from current open ledger";
+            applyTransactions(buildTxSet(LCL->peekTransactionMap()),
+                ledger, LCL, retriableTransactions, true);
+        }
+        */
+
+        // Update fee computations.
+        updateFeeTracking(ledger, txSet, loadFeeTrack, refTxnCost, nullptr);
+        // Stuff the ledger with transactions from the queue.
+        TransactionEngine engine(ledger);
+        txQ.fillOpenLedger(engine);
+
+        ledger->setImmutable();
+        ledgerHolder.set(ledger);
+    }
+
+    void checkMetrics(
+        TxQ& txQ,
+        int expectedCount,
+        int expectedPerLedger,
+        int expectedMinFeeLevel,
+        int expectedMedFeeLevel,
+        int expectedCurFeeLevel)
+    {
+        auto metrics = txQ.getFeeMetrics();
+        expectEquals(metrics.referenceFeeLevel, 256);
+        expectEquals(metrics.txCount, expectedCount);
+        expectEquals(metrics.txPerLedger, expectedPerLedger);
+        expectEquals(metrics.minFeeLevel, expectedMinFeeLevel);
+        expectEquals(metrics.medFeeLevel, expectedMedFeeLevel);
+        expectEquals(metrics.expFeeLevel, expectedCurFeeLevel);
+    }
+
+
+public:
+    void run()
+    {
+        TestSink sink { *this };
+        sink.severity(beast::Journal::Severity::kAll);
+        beast::Journal journal { sink };
+        // We need the LoadFeeTrack object from getApp() because
+        // some dependencies (notably Ledger::scaleFeeLoad call
+        // back to the app to get the same object.
+        // TODO EHENNIS: Inject LoadFeeTrack into Ledger.
+        auto& loadFeeTrack = getApp().getFeeTrack();
+        auto const oldMinimum = loadFeeTrack.setMinimumTx(3);
+        TxQ::Setup txSetup;
+        txSetup.ledgersInQueue_ = 1;
+        txSetup.minLedgersToComputeSizeLimit_ = 3;
+        txSetup.maxLedgerCountsToStore_ = 100;
+        auto txQ = make_TxQ(txSetup, loadFeeTrack, journal);
+        auto transactionParams = tapOPEN_LEDGER;    // | tapNO_CHECK_SIGN;
+
+        std::uint64_t const xrp = std::mega::num;
+        auto master = createAccount("masterpassphrase", KeyType::ed25519);
+        Ledger::pointer LCL;
+        LedgerHolder ledgerHolder;
+        {
+            Ledger::pointer ledger;
+            std::tie(LCL, ledger) = createGenesisLedger(100000 * xrp, master);
+            ledger->setImmutable();
+            ledgerHolder.set(ledger);
+        }
+
+        expectEquals(LCL->getBaseFee(), 10);
+        expectEquals(ledgerHolder.get()->getBaseFee(), 10);
+
+        checkMetrics(*txQ, 0, 3, 256, 256, 256);
+
+        TestAccount alice, bob, charlie, daria;
+        int highFeeBob;
+        {
+            LedgerHelper ledger(ledgerHolder);
+            TransactionEngine engine(ledger);
+
+            // Create several accounts while the fee is cheap so they all apply.
+            alice = createAndQueueAccount(*txQ,
+                transactionParams, engine, master,
+                "alice", KeyType::secp256k1, 10000 * xrp, 20);
+            bob = createAndQueueAccount(*txQ,
+                transactionParams, engine, master,
+                "bob", KeyType::ed25519, 2000 * xrp, 15);
+            charlie = createAndQueueAccount(*txQ,
+                transactionParams, engine, master,
+                "charlie", KeyType::ed25519, 3000 * xrp, 10);
+            checkMetrics(*txQ, 0, 3, 256, 256, 256);
+            daria = createAndQueueAccount(*txQ,
+                transactionParams, engine, master,
+                "daria", KeyType::secp256k1, 50000 * xrp, 500);
+            checkMetrics(*txQ, 0, 3, 256, 256, 256 * 500 * 16 / 9);
+        }
+
+        {
+            // Not using a LedgerHelper here, because we want to throw
+            // the ledger changes away when done.
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+
+            // Alice -> Bob - price starts exploding: held
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                alice, bob, 2000 * xrp);
+            checkMetrics(*txQ, 1, 3, 256, 256, 256 * 500 * 16 / 9);
+
+            // Alice -> Charlie - Alice is already in the queue, so can't hold.
+            expectEquals(loadFeeTrack.scaleTxnFee(loadFeeTrack.getLoadBase()),
+                256 * 500 * 16 / 9);
+            std::shared_ptr<STTx> aliceToCharlie(new STTx(getPaymentTx(alice,
+                charlie, 500 * xrp)));
+            auto addResult = txQ->addTransaction(aliceToCharlie,
+                transactionParams, engine);
+            expectEquals(addResult.first, TxQ::TD_low_fee);
+            expectEquals(addResult.second, TxQ::txnResultLowFee);
+            checkMetrics(*txQ, 1, 3, 256, 256, 256 * 500 * 16 / 9);
+
+            // Alice -> Charlie with really high fee - fails because of the item in the TxQ
+            expectEquals(loadFeeTrack.scaleTxnFee(loadFeeTrack.getLoadBase()),
+                256 * 500 * 16 / 9);
+            auto aliceToCharlieHighFeeJson = getPaymentJson(alice, charlie,
+                3000 * xrp, 10 * 500 * 16 / 9 + 1);
+            std::shared_ptr<STTx> aliceToCharlieHighFee(new STTx(
+                parseTransaction(alice, aliceToCharlieHighFeeJson)));
+            addResult = txQ->addTransaction(aliceToCharlieHighFee,
+                transactionParams, engine);
+            expectEquals(addResult.first, TxQ::TD_failed);
+            expectEquals(addResult.second, terPRE_SEQ);
+            checkMetrics(*txQ, 1, 3, 256, 256, 256 * 500 * 16 / 9);
+
+            // Two transactions for alice failed
+            alice.sequence -= 2;
+        }
+
+        {
+            LedgerHelper ledger(ledgerHolder);
+            TransactionEngine engine(ledger);
+
+            // Bob -> Charlie with really high fee - applies
+            expectEquals(loadFeeTrack.scaleTxnFee(loadFeeTrack.getLoadBase()),
+                256 * 500 * 16 / 9);
+            highFeeBob = 10 * 500 * 16 / 9 + 1;
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                bob, charlie, 500 * xrp, highFeeBob);
+            checkMetrics(*txQ, 1, 3, 256, 256, 256 * 500 * 25 / 9);
+        }
+
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+
+            // Daria -> Bob with low fee: hold
+            queuePaymentToHold(*txQ, transactionParams,
+                engine, daria, bob, 9000 * xrp, 1000);
+            checkMetrics(*txQ, 2, 3, 256, 256, 256 * 500 * 25 / 9);
+        }
+
+        {
+            auto ledger = ledgerHolder.get();
+
+            // Confirm balances
+            verifyBalance(ledger, alice, 10000 * xrp);
+            verifyBalance(ledger, bob, 1500 * xrp - highFeeBob);
+            verifyBalance(ledger, charlie, 3500 * xrp);
+            verifyBalance(ledger, daria, 50000 * xrp);
+        }
+
+        // Advance the ledger.
+        auto lastMedian = 512;
+        simulateConsensus(*txQ, loadFeeTrack, LCL, ledgerHolder, 5);
+        checkMetrics(*txQ, 0, 5, 256, lastMedian, 256);
+
+        // Verify that the held transactions got applied
+        {
+            auto ledger = ledgerHolder.get();
+
+            expectEquals(countLedgerNodes(ledger), 2);
+            expectEquals(loadFeeTrack.scaleTxnFee(loadFeeTrack.getLoadBase()),
+                256);
+            verifyBalance(ledger, alice, 8000 * xrp - 10);
+            verifyBalance(ledger, bob, 12500 * xrp - highFeeBob);
+            verifyBalance(ledger, charlie, 3500 * xrp);
+            verifyBalance(ledger, daria, 41000 * xrp - 1000);
+        }
+
+        TestAccount elmo, fred, gwen, hank;
+        {
+            LedgerHelper ledger(ledgerHolder);
+            TransactionEngine engine(ledger);
+
+            // Make some more accounts. We'll need them later to abuse the queue.
+            checkMetrics(*txQ, 0, 5, 256, lastMedian, 256);
+            elmo = createAndQueueAccount(*txQ,
+                transactionParams, engine,
+                master, "elmo", KeyType::ed25519, 2000 * xrp, 1000);
+            fred = createAndQueueAccount(*txQ,
+                transactionParams, engine,
+                master, "fred", KeyType::secp256k1, 1500 * xrp, 1500);
+            gwen = createAndQueueAccount(*txQ,
+                transactionParams, engine,
+                master, "gwen", KeyType::ed25519, 1000 * xrp, 2000);
+            hank = createAndQueueAccount(*txQ,
+                transactionParams, engine,
+                master, "hank", KeyType::secp256k1, 500 * xrp, 2500);
+            checkMetrics(*txQ, 0, 5, 256, lastMedian, 256 * lastMedian * 36 / 25);
+        }
+
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+
+            // Now get a bunch of transactions held.
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                alice, bob, 2 * xrp, 12);
+            checkMetrics(*txQ, 1, 5, 256, lastMedian, 256 * lastMedian * 36 / 25);
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                bob, charlie, 10 * xrp, 10);  // won't clear the queue
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                charlie, daria, 3 * xrp, 20);
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                daria, elmo, 50 * xrp, 15);
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                elmo, fred, 100 * xrp, 11);
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                fred, gwen, 15 * xrp, 19);
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                gwen, hank, 40 * xrp, 16);
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                hank, alice, 190 * xrp, 18);
+            checkMetrics(*txQ, 8, 5, 256, lastMedian, 256 * lastMedian * 36 / 25);
+        }
+
+        {
+            auto ledger = ledgerHolder.get();
+
+            verifyBalance(ledger, alice, 8000 * xrp - 10);
+            verifyBalance(ledger, bob, 12500 * xrp - highFeeBob);
+            verifyBalance(ledger, charlie, 3500 * xrp);
+            verifyBalance(ledger, daria, 41000 * xrp - 1000);
+            verifyBalance(ledger, elmo, 2000 * xrp);
+            verifyBalance(ledger, fred, 1500 * xrp);
+            verifyBalance(ledger, gwen, 1000 * xrp);
+            verifyBalance(ledger, hank, 500 * xrp);
+        }
+
+        // Advance the ledger.
+        lastMedian = 32000;
+        simulateConsensus(*txQ, loadFeeTrack, LCL, ledgerHolder, 6);
+        checkMetrics(*txQ, 1, 6, 256, lastMedian, 256 * lastMedian * 49 / 36);
+
+        {
+            auto ledger = ledgerHolder.get();
+
+            // Verify that the held transactions got applied
+            expectEquals(countLedgerNodes(ledger), 7);
+            // The fee jumps up even more because the last round had so
+            // many expensive transactions. The median level ended up at
+            // 32000.
+            expectEquals(loadFeeTrack.scaleTxnFee(loadFeeTrack.getLoadBase()),
+                256 * lastMedian * 49 / 36);
+            verifyBalance(ledger, alice, 8188 * xrp - 22);
+            verifyBalance(ledger, bob, 12502 * xrp - highFeeBob);
+            verifyBalance(ledger, charlie, 3497 * xrp - 20);
+            verifyBalance(ledger, daria, 40953 * xrp - 1015);
+            verifyBalance(ledger, elmo, 1950 * xrp - 11);
+            verifyBalance(ledger, fred, 1585 * xrp - 19);
+            verifyBalance(ledger, gwen, 975 * xrp - 16);
+            verifyBalance(ledger, hank, 350 * xrp - 18);
+        }
+
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+
+            // Hank sends another payment
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                hank, charlie, 50 * xrp, 10);
+            checkMetrics(*txQ, 2, 6, 256, lastMedian, 256 * lastMedian * 49 / 36);
+        }
+
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+
+            // Hank sees his payment got held and bumps the fee, 
+            // but doesn't bump it enough
+            --hank.sequence;
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                hank, charlie, 50 * xrp, 10000);
+            checkMetrics(*txQ, 2, 6, 256, lastMedian, 256 * lastMedian * 49 / 36);
+        }
+
+        int highFeeHank;
+        {
+            LedgerHelper ledger(ledgerHolder);
+            TransactionEngine engine(ledger);
+
+            // Hank sees his payment got held and bumps the fee, 
+            // because he doesn't want to wait.
+            --hank.sequence;
+            highFeeHank = 10 * lastMedian * 49 / 36 + 1;
+            queuePaymentToApply(*txQ, transactionParams,
+                engine, hank, charlie, 50 * xrp, highFeeHank);
+            checkMetrics(*txQ, 1, 6, 256, lastMedian, 256 * lastMedian * 64 / 36);
+        }
+
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+            // Hank then sends another, less important payment
+            // (This will verify that the original payment got removed.)
+            queuePaymentToHold(*txQ,
+                transactionParams, engine,
+                hank, fred, 1 * xrp, 10);
+            checkMetrics(*txQ, 2, 6, 256, lastMedian, 256 * lastMedian * 64 / 36);
+        }
+
+        {
+            auto ledger = ledgerHolder.get();
+
+            verifyBalance(ledger, alice, 8188 * xrp - 22);
+            verifyBalance(ledger, bob, 12502 * xrp - highFeeBob);
+            verifyBalance(ledger, charlie, 3547 * xrp - 20);
+            verifyBalance(ledger, daria, 40953 * xrp - 1015);
+            verifyBalance(ledger, elmo, 1950 * xrp - 11);
+            verifyBalance(ledger, fred, 1585 * xrp - 19);
+            verifyBalance(ledger, gwen, 975 * xrp - 16);
+            verifyBalance(ledger, hank, 300 * xrp - highFeeHank - 18);
+        }
+
+        // Advance the ledger
+        lastMedian = 435;
+        simulateConsensus(*txQ, loadFeeTrack, LCL, ledgerHolder, 8);
+        {
+            auto ledger = ledgerHolder.get();
+
+            // At this point, the queue's size limit should be 6.
+            // Verify that bob and hank's payments were applied
+            expectEquals(countLedgerNodes(ledger), 2);
+            checkMetrics(*txQ, 0, 8, 256, lastMedian, 256);
+
+            verifyBalance(ledger, alice, 8188 * xrp - 22);
+            verifyBalance(ledger, bob, 12492 * xrp - highFeeBob - 10);
+            verifyBalance(ledger, charlie, 3557 * xrp - 20);
+            verifyBalance(ledger, daria, 40953 * xrp - 1015);
+            verifyBalance(ledger, elmo, 1950 * xrp - 11);
+            verifyBalance(ledger, fred, 1586 * xrp - 19);
+            verifyBalance(ledger, gwen, 975 * xrp - 16);
+            verifyBalance(ledger, hank, 299 * xrp - highFeeHank - 28);
+        }
+
+        {
+            LedgerHelper ledger(ledgerHolder);
+            TransactionEngine engine(ledger);
+
+            // At this point, the queue should have a limit of 6.
+            // Stuff the ledger and queue so we can verify that
+            // stuff gets kicked out.
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                hank, gwen, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                gwen, fred, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                fred, elmo, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                elmo, daria, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                daria, charlie, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                charlie, bob, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                bob, alice, 10 * xrp);
+
+            checkMetrics(*txQ, 0, 8, 256, lastMedian, 256 * 500 * 81 / 64);
+
+            verifyBalance(ledger, alice, 8198 * xrp - 22);
+            verifyBalance(ledger, bob, 12492 * xrp - highFeeBob - 20);
+            verifyBalance(ledger, charlie, 3557 * xrp - 30);
+            verifyBalance(ledger, daria, 40953 * xrp - 1025);
+            verifyBalance(ledger, elmo, 1950 * xrp - 21);
+            verifyBalance(ledger, fred, 1586 * xrp - 29);
+            verifyBalance(ledger, gwen, 975 * xrp - 26);
+            verifyBalance(ledger, hank, 289 * xrp - highFeeHank - 38);
+        }
+
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+            // Use explicit fees so we deterministically which txn 
+            // will get dropped
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                alice, hank, 10 * xrp, 20);
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                hank, gwen, 10 * xrp, 19);
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                gwen, fred, 10 * xrp, 18);
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                fred, elmo, 10 * xrp, 17);
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                elmo, daria, 10 * xrp, 16);
+            // This one gets into the queue, but gets dropped when the
+            // higher fee one is added later.
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                daria, charlie, 10 * xrp, 15);
+            --daria.sequence;
+
+            // Queue is full now.
+            checkMetrics(*txQ, 6, 8, 385, lastMedian, 256 * 500 * 81 / 64);
+
+            // Try to add another transaction, it should fail because
+            // the queue is full.
+            std::shared_ptr<STTx> charlieToBob(new STTx(getPaymentTx(charlie,
+                bob, 10 * xrp)));
+            auto addResult = txQ->addTransaction(charlieToBob,
+                transactionParams, engine);
+            expectEquals(addResult.first, TxQ::TD_low_fee);
+            expectEquals(addResult.second, TxQ::txnResultLowFee);
+            --charlie.sequence;
+
+            // Add another transaction, with a higher fee,
+            // Not high enough to get into the ledger, but high 
+            // enough to get into the queue (and kick somebody out)
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                charlie, bob, 10 * xrp, 100);
+
+            // Queue is still full, of course, but the min fee has gone up
+            checkMetrics(*txQ, 6, 8, 410, lastMedian, 256 * 500 * 81 / 64);
+        }
+
+        // Advance the ledger
+        lastMedian = 256;
+        simulateConsensus(*txQ, loadFeeTrack, LCL, ledgerHolder, 9);
+        checkMetrics(*txQ, 0, 9, 256, lastMedian, 256);
+        {
+            auto ledger = ledgerHolder.get();
+
+            expectEquals(countLedgerNodes(ledger), 6);
+
+            verifyBalance(ledger, alice, 8188 * xrp - 42);
+            verifyBalance(ledger, bob, 12502 * xrp - highFeeBob - 20);
+            verifyBalance(ledger, charlie, 3547 * xrp - 130);
+            verifyBalance(ledger, daria, 40963 * xrp - 1025);
+            verifyBalance(ledger, elmo, 1950 * xrp - 37);
+            verifyBalance(ledger, fred, 1586 * xrp - 46);
+            verifyBalance(ledger, gwen, 975 * xrp - 44);
+            verifyBalance(ledger, hank, 289 * xrp - highFeeHank - 57);
+        }
+
+        {
+            // These should be the last two blocks, no matter what
+            // else changes: Create a few more transactions, so that
+            // we can be sure that there's one in the queue when the
+            // test ends and the TxQ is destructed.
+
+            LedgerHelper ledger(ledgerHolder);
+            TransactionEngine engine(ledger);
+
+            // Stuff the ledger.
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                hank, gwen, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                gwen, fred, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                fred, elmo, 10 * xrp);
+            queuePaymentToApply(*txQ, transactionParams, engine,
+                elmo, daria, 10 * xrp);
+
+            checkMetrics(*txQ, 0, 9, 256, lastMedian, 256 * 500 * 100 / 81);
+
+            verifyBalance(ledger, alice, 8188 * xrp - 42);
+            verifyBalance(ledger, bob, 12502 * xrp - highFeeBob - 20);
+            verifyBalance(ledger, charlie, 3547 * xrp - 130);
+            verifyBalance(ledger, daria, 40973 * xrp - 1025);
+            verifyBalance(ledger, elmo, 1950 * xrp - 47);
+            verifyBalance(ledger, fred, 1586 * xrp - 56);
+            verifyBalance(ledger, gwen, 975 * xrp - 54);
+            verifyBalance(ledger, hank, 279 * xrp - highFeeHank - 67);
+        }
+        {
+            auto ledger = ledgerHolder.getMutable();
+            TransactionEngine engine(ledger);
+
+            // Queue one straightforward transaction
+            queuePaymentToHold(*txQ, transactionParams,
+                engine,
+                alice, hank, 10 * xrp, 20);
+
+            checkMetrics(*txQ, 1, 9, 256, lastMedian, 256 * 500 * 100 / 81);
+        }
+
+        // The loadFeeTrack is global, so we need to reset it
+        // as much as possible, else we're going to break other
+        // tests.
+        loadFeeTrack.onLedger(0, {}, true);
+        loadFeeTrack.setMinimumTx(oldMinimum);
+        checkMetrics(*txQ, 1, 9, 256, 256, 256);
+
+        pass();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(TxQ,app,ripple);
+    
+}
+}

--- a/src/ripple/app/ledger/tests/common_ledger.h
+++ b/src/ripple/app/ledger/tests/common_ledger.h
@@ -180,6 +180,10 @@ freezeAccount(TestAccount& account, Ledger::pointer const& ledger, bool sign = t
 void
 unfreezeAccount(TestAccount& account, Ledger::pointer const& ledger, bool sign = true);
 
+Json::Value
+getPaymentJson(TestAccount& from, TestAccount const& to,
+    std::uint64_t amountDrops, std::uint64_t feeDrops);
+
 STTx
 getPaymentTx(TestAccount& from, TestAccount const& to,
             std::uint64_t amountDrops,
@@ -236,7 +240,8 @@ trust(TestAccount& from, TestAccount const& issuer,
                 std::string const& currency, double amount,
                 Ledger::pointer const& ledger, bool sign = true);
 
-void
+// Returns the set of transactions applied to the ledger
+TxSet
 close_and_advance(Ledger::pointer& ledger, Ledger::pointer& LCL);
 
 Json::Value findPath(Ledger::pointer ledger, TestAccount const& src, 
@@ -286,7 +291,12 @@ get_ledger_entry_ripple_state(Ledger::pointer ledger,
     Currency currency);
 
 void
-verifyBalance(Ledger::pointer ledger, TestAccount const& account, Amount const& amount);
+verifyBalance(Ledger::pointer ledger, TestAccount const& account,
+    std::uint64_t amountDrops);
+
+void
+verifyBalance(Ledger::pointer ledger, TestAccount const& account,
+    Amount const& amount);
 
 } // test
 } // ripple

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -170,11 +170,11 @@ public:
             {
                 if (m_journal.info)
                     m_journal.info << getApp().getJobQueue ().getJson (0);
-                change = getApp().getFeeTrack ().raiseLocalFee ();
+                change = getApp().getFeeTrack ().raiseLocalLevel ();
             }
             else
             {
-                change = getApp().getFeeTrack ().lowerLocalFee ();
+                change = getApp().getFeeTrack ().lowerLocalLevel ();
             }
 
             if (change)

--- a/src/ripple/app/misc/UniqueNodeList.h
+++ b/src/ripple/app/misc/UniqueNodeList.h
@@ -54,8 +54,10 @@ public:
     virtual void start () = 0;
 
     // VFALCO TODO rename all these, the "node" prefix is redundant (lol)
-    virtual void nodeAddPublic (RippleAddress const& naNodePublic, ValidatorSource vsWhy, std::string const& strComment) = 0;
-    virtual void nodeAddDomain (std::string strDomain, ValidatorSource vsWhy, std::string const& strComment = "") = 0;
+    virtual void nodeAddPublic (RippleAddress const& naNodePublic,
+        ValidatorSource vsWhy, std::string const& strComment) = 0;
+    virtual void nodeAddDomain (std::string strDomain, ValidatorSource vsWhy,
+        std::string const& strComment = "") = 0;
     virtual void nodeRemovePublic (RippleAddress const& naNodePublic) = 0;
     virtual void nodeRemoveDomain (std::string strDomain) = 0;
     virtual void nodeReset () = 0;
@@ -65,9 +67,10 @@ public:
     virtual bool nodeInUNL (RippleAddress const& naNodePublic) = 0;
     virtual bool nodeInCluster (RippleAddress const& naNodePublic) = 0;
     virtual bool nodeInCluster (RippleAddress const& naNodePublic, std::string& name) = 0;
-    virtual bool nodeUpdate (RippleAddress const& naNodePublic, ClusterNodeStatus const& cnsStatus) = 0;
+    virtual bool nodeUpdate (RippleAddress const& naNodePublic,
+        ClusterNodeStatus const& cnsStatus) = 0;
     virtual std::map<RippleAddress, ClusterNodeStatus> getClusterStatus () = 0;
-    virtual std::uint32_t getClusterFee () = 0;
+    virtual std::uint32_t getClusterLevel () = 0;
     virtual void addClusterStatus (Json::Value&) = 0;
 
     virtual void nodeBootstrap () = 0;

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -120,7 +120,8 @@ TER Transactor::payFee ()
         return temBAD_AMOUNT;
 
     // Only check fee is sufficient when the ledger is open.
-    if ((mParams & tapOPEN_LEDGER) && saPaid < mFeeDue)
+    if ((mParams & tapOPEN_LEDGER) && !(mParams & tapIGNORE_FEE)
+        && saPaid < mFeeDue)
     {
         m_journal.trace << "Insufficient fee paid: " <<
             saPaid.getText () << "/" << mFeeDue.getText ();

--- a/src/ripple/core/LoadFeeTrack.h
+++ b/src/ripple/core/LoadFeeTrack.h
@@ -41,33 +41,49 @@ class LoadFeeTrack
 public:
     /** Create a new tracker.
     */
-    static LoadFeeTrack* New (beast::Journal journal);
+    static LoadFeeTrack* New (bool standAlone, beast::Journal journal);
 
     virtual ~LoadFeeTrack () { }
 
-    // Scale from fee units to millionths of a ripple
+    // Scale from fee units to drops
     virtual std::uint64_t scaleFeeBase (std::uint64_t fee, std::uint64_t baseFee,
-                                        std::uint32_t referenceFeeUnits) = 0;
+                                        std::uint32_t referenceFeeUnits) const = 0;
 
     // Scale using load as well as base rate
     virtual std::uint64_t scaleFeeLoad (std::uint64_t fee, std::uint64_t baseFee,
                                         std::uint32_t referenceFeeUnits,
                                         bool bAdmin) = 0;
 
-    virtual void setRemoteFee (std::uint32_t) = 0;
+    // Get transaction scaling factor
+    virtual std::uint64_t scaleTxnFee (std::uint64_t fee) = 0;
 
-    virtual std::uint32_t getRemoteFee () = 0;
-    virtual std::uint32_t getLocalFee () = 0;
-    virtual std::uint32_t getClusterFee () = 0;
+    // Get load factor to report to clients
+    virtual std::uint64_t getTxnFeeReport () = 0;
+
+    // Set minimum transactions per ledger before fee escalation
+    virtual int setMinimumTx (int minimumTx) = 0;
+
+    // A new open ledger has been built
+    virtual void onLedger (
+        std::size_t openCount,
+        std::vector<int> const& feesPaid,
+        bool healthy) = 0;
+
+    // A transaction has been accepted into the open ledger
+    virtual void onTx (std::uint64_t feeRatio) = 0;
+
+    virtual std::uint32_t getLocalLevel () = 0;
+    virtual std::uint32_t getClusterLevel () = 0;
 
     virtual std::uint32_t getLoadBase () = 0;
     virtual std::uint32_t getLoadFactor () = 0;
 
-    virtual Json::Value getJson (std::uint64_t baseFee, std::uint32_t referenceFeeUnits) = 0;
+    virtual int getMedianFee() = 0;
+    virtual int getExpectedLedgerSize() = 0;
 
-    virtual void setClusterFee (std::uint32_t) = 0;
-    virtual bool raiseLocalFee () = 0;
-    virtual bool lowerLocalFee () = 0;
+    virtual void setClusterLevel (std::uint32_t) = 0;
+    virtual bool raiseLocalLevel () = 0;
+    virtual bool lowerLocalLevel () = 0;
     virtual bool isLoadedLocal () = 0;
     virtual bool isLoadedCluster () = 0;
 };

--- a/src/ripple/core/impl/LoadFeeTrackImp.cpp
+++ b/src/ripple/core/impl/LoadFeeTrackImp.cpp
@@ -17,15 +17,17 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
 #include <ripple/core/impl/LoadFeeTrackImp.h>
 #include <ripple/core/Config.h>
+#include <beast/unit_test/suite.h>
 
 namespace ripple {
 
-LoadFeeTrack* LoadFeeTrack::New (beast::Journal journal)
+LoadFeeTrack* LoadFeeTrack::New (bool standAlone, beast::Journal journal)
 {
-    return new LoadFeeTrackImp (journal);
+    return new LoadFeeTrackImp (standAlone, journal);
 }
+
+//------------------------------------------------------------------------------
 
 } // ripple

--- a/src/ripple/core/impl/LoadFeeTrackImp.h
+++ b/src/ripple/core/impl/LoadFeeTrackImp.h
@@ -154,7 +154,8 @@ public:
         if (mLocalLoadLevel < mRemoteLoadLevel)
             mLocalLoadLevel = mRemoteLoadLevel;
 
-        mLocalLoadLevel += (mLocalLoadLevel / lftLevelIncFraction); // increment by 1/16th
+        // increase slowly.
+        mLocalLoadLevel += (mLocalLoadLevel / lftLevelIncFraction);
 
         if (mLocalLoadLevel > lftLevelMax)
             mLocalLoadLevel = lftLevelMax;
@@ -173,7 +174,8 @@ public:
         std::uint32_t origLevel = mLocalLoadLevel;
         raiseCount = 0;
 
-        mLocalLoadLevel -= (mLocalLoadLevel / lftLevelDecFraction ); // reduce by 1/4
+        // reduce slowly.
+        mLocalLoadLevel -= (mLocalLoadLevel / lftLevelDecFraction );
 
         if (mLocalLoadLevel < lftReference)
             mLocalLoadLevel = lftReference;

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -409,6 +409,20 @@ private:
         return jvRequest;
     }
 
+    // fee [true|false] [<multiplier>]
+    Json::Value parseFee (Json::Value const& jvParams)
+    {
+        Json::Value     jvRequest (Json::objectValue);
+
+        if (jvParams.size () > 0)
+            jvRequest["enforcing"] = beast::lexicalCastThrow <bool> (jvParams[0u].asString ());
+
+        if (jvParams.size () > 1)
+            jvRequest["target_multiplier"] = jvParams[1u].asUInt ();
+
+        return jvRequest;
+    }
+
     // get_counts [<min_count>]
     Json::Value parseGetCounts (Json::Value const& jvParams)
     {
@@ -857,6 +871,7 @@ public:
             {   "connect",              &RPCParser::parseConnect,               1,  2   },
             {   "consensus_info",       &RPCParser::parseAsIs,                  0,  0   },
             {   "feature",              &RPCParser::parseFeature,               0,  2   },
+            {   "fee",                  &RPCParser::parseFee,                   0,  2   },
             {   "fetch_info",           &RPCParser::parseFetchInfo,             0,  1   },
             {   "get_counts",           &RPCParser::parseGetCounts,             0,  1   },
             {   "json",                 &RPCParser::parseJson,                  2,  2   },

--- a/src/ripple/overlay/ClusterNodeStatus.h
+++ b/src/ripple/overlay/ClusterNodeStatus.h
@@ -26,15 +26,15 @@ class ClusterNodeStatus
 {
 public:
 
-    ClusterNodeStatus() : mLoadFee(0), mReportTime(0)
+    ClusterNodeStatus() : mLoadLevel(0), mReportTime(0)
     { ; }
 
-    explicit ClusterNodeStatus(std::string const& name) : mNodeName(name), mLoadFee(0), mReportTime(0)
+    explicit ClusterNodeStatus(std::string const& name) : mNodeName(name), mLoadLevel(0), mReportTime(0)
     { ; }
 
-    ClusterNodeStatus(std::string const& name, std::uint32_t fee, std::uint32_t rtime) :
+    ClusterNodeStatus(std::string const& name, std::uint32_t level, std::uint32_t rtime) :
         mNodeName(name),
-        mLoadFee(fee),
+        mLoadLevel(level),
         mReportTime(rtime)
     { ; }
 
@@ -43,9 +43,9 @@ public:
         return mNodeName;
     }
 
-    std::uint32_t getLoadFee()
+    std::uint32_t getLoadLevel()
     {
-        return mLoadFee;
+        return mLoadLevel;
     }
 
     std::uint32_t getReportTime()
@@ -57,7 +57,7 @@ public:
     {
         if (status.mReportTime <= mReportTime)
             return false;
-        mLoadFee = status.mLoadFee;
+        mLoadLevel = status.mLoadLevel;
         mReportTime = status.mReportTime;
         if (mNodeName.empty() || !status.mNodeName.empty())
             mNodeName = status.mNodeName;
@@ -66,7 +66,7 @@ public:
 
 private:
     std::string       mNodeName;
-    std::uint32_t     mLoadFee;
+    std::uint32_t     mLoadLevel;
     std::uint32_t     mReportTime;
 };
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -857,7 +857,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMCluster> const& m)
         overlay_.resourceManager().importConsumers (name_, gossip);
     }
 
-    getApp().getFeeTrack().setClusterFee(getApp().getUNL().getClusterFee());
+    getApp().getFeeTrack().setClusterLevel(getApp().getUNL().getClusterLevel());
 }
 
 void

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -139,6 +139,7 @@ JSS ( error_code );                 // out: error
 JSS ( error_exception );            // out: Submit
 JSS ( error_message );              // out: error
 JSS ( expand );                     // in: handler/Ledger
+JSS ( expected_ledger_size );       // out: LoadFeeTrackImp
 JSS ( fail_hard );                  // in: Sign, Submit
 JSS ( failed );                     // out: InboundLedger
 JSS ( feature );                    // in: Feature
@@ -202,7 +203,7 @@ JSS ( ledger_index_min );           // in, out: AccountTx*
 JSS ( ledger_max );                 // in, out: AccountTx*
 JSS ( ledger_min );                 // in, out: AccountTx*
 JSS ( ledger_time );                // out: NetworkOPs
-JSS ( levels );                     // LogLevels
+JSS ( levels );                     // LogLevels, out: LoadFeeTrackImp
 JSS ( limit );                      // in/out: AccountTx*, AccountOffers,
                                     //         AccountLines, AccountObjects
                                     // in: LedgerData, BookOffers
@@ -214,7 +215,6 @@ JSS ( load_factor );                // out: NetworkOPs
 JSS ( load_factor_cluster );        // out: NetworkOPs
 JSS ( load_factor_local );          // out: NetworkOPs
 JSS ( load_factor_net );            // out: NetworkOPs
-JSS ( load_fee );                   // out: LoadFeeTrackImp
 JSS ( local );                      // out: resource/Logic.h
 JSS ( local_txs );                  // out: GetCounts
 JSS ( marker );                     // in/out: AccountTx, AccountOffers,
@@ -225,6 +225,7 @@ JSS ( master_key );                 // out: WalletPropose
 JSS ( master_seed );                // out: WalletPropose
 JSS ( master_seed_hex );            // out: WalletPropose
 JSS ( max_ledger );                 // in/out: LedgerCleaner
+JSS ( median_level );               // out: LoadFeeTrackImp
 JSS ( message );                    // error.
 JSS ( meta );                       // out: NetworkOPs, AccountTx*, Tx
 JSS ( metaData );                   // out: LedgerEntrySet, LedgerToJson
@@ -232,6 +233,7 @@ JSS ( metadata );                   // out: TransactionEntry
 JSS ( method );                     // RPC
 JSS ( min_count );                  // in: GetCounts
 JSS ( min_ledger );                 // in: LedgerCleaner
+JSS ( minimum_level );              // out: LoadFeeTrackImp
 JSS ( missingCommand );             // error
 JSS ( name );                       // out: AmendmentTableImpl, PeerImp
 JSS ( needed_state_hashes );        // out: InboundLedger
@@ -254,6 +256,7 @@ JSS ( offers );                     // out: NetworkOPs, AccountOffers, Subscribe
 JSS ( offline );                    // in: TransactionSign
 JSS ( offset );                     // in/out: AccountTxOld
 JSS ( open );                       // out: handlers/Ledger
+JSS ( open_ledger_level );          // out: LoadFeeTrackImp
 JSS ( owner );                      // in: LedgerEntry, out: NetworkOPs
 JSS ( owner_funds );                // out: NetworkOPs, AcceptedLedgerTx
 JSS ( params );                     // RPC
@@ -286,6 +289,7 @@ JSS ( quality_out );                // out: AccountLines
 JSS ( random );                     // out: Random
 JSS ( raw_meta );                   // out: AcceptedLedgerTx
 JSS ( receive_currencies );         // out: AccountCurrencies
+JSS ( reference_level );            // out: LoadFeeTrackImp
 JSS ( regular_seed );               // in/out: LedgerEntry
 JSS ( remote );                     // out: Logic.h
 JSS ( request );                    // RPC

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -142,7 +142,17 @@ public:
         sig_state_ = false;
     }
 
-    // SQL Functions with metadata.
+    // Returns the cost in fee units
+    std::uint64_t getRequiredFeeUnits () const;
+
+    // Returns the XRP cost of the transactions in drops
+    std::uint64_t getRequiredFeeDrops (std::uint64_t refTxnCost) const;
+
+    // Returns the fee level the transaction paid
+    // relative to the specified base
+    std::uint64_t getFeeLevelPaid (std::uint64_t baseReference, std::uint64_t refTxnCost) const;
+
+    // SQL Functions with metadata
     static
     std::string const&
     getMetaSQLInsertReplaceHeader ();

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -142,6 +142,7 @@ enum TER    // aka TransactionEngineResult
                          // burden network.
     terLAST,             // Process after all other transactions
     terNO_RIPPLE,        // Rippling not allowed
+    terQUEUED,           // Transaction is being held in TxQ until fee drops
 
     // 0: S Success (success)
     // Causes:

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -495,6 +495,36 @@ STTx::checkMultiSign () const
 
 //------------------------------------------------------------------------------
 
+std::uint64_t STTx::getRequiredFeeUnits () const
+{
+    if ((tx_type_ == ttAMENDMENT) || (tx_type_ == ttFEE))
+        return 0;
+
+    // For now, all valid non-pseudo transactions cost 10 fee units
+    // This code can be changed to support variable transaction fees
+    return 10;
+}
+
+std::uint64_t STTx::getRequiredFeeDrops (std::uint64_t refTxnCost) const
+{
+    return getRequiredFeeUnits() * refTxnCost / 10;
+}
+
+std::uint64_t STTx::getFeeLevelPaid (
+    std::uint64_t baseRef,
+    std::uint64_t refTxnCost) const
+{
+    // Compute the minimum XRP fee the transaction could pay
+    std::uint64_t required_fee = getRequiredFeeDrops (refTxnCost);
+
+    if (required_fee == 0)
+        return 0;
+
+    return getTransactionFee().mantissa() * baseRef / required_fee;
+}
+
+//------------------------------------------------------------------------------
+
 static
 bool
 isMemoOkay (STObject const& st, std::string& reason)

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -136,6 +136,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { terNO_LINE,               "terNO_LINE",               "No such line."                                                 },
         { terPRE_SEQ,               "terPRE_SEQ",               "Missing/inapplicable prior transaction."                       },
         { terOWNERS,                "terOWNERS",                "Non-zero owner count."                                         },
+        { terQUEUED,                "terQUEUED",                "Held until fee drops." },
 
         { tesSUCCESS,               "tesSUCCESS",               "The transaction was applied. Only final in a validated ledger." },
     };

--- a/src/ripple/rpc/handlers/Fee.cpp
+++ b/src/ripple/rpc/handlers/Fee.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012-2014 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -17,5 +17,13 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
+#include <ripple/app/ledger/TxHold.h>
 
+namespace ripple {
+
+Json::Value doFee (RPC::Context& context)
+{
+    return getApp().getLedgerMaster().getTransactionQueue().doRPC (context.params);
+}
+
+} // ripple

--- a/src/ripple/rpc/handlers/Handlers.h
+++ b/src/ripple/rpc/handlers/Handlers.h
@@ -36,6 +36,7 @@ Json::Value doCanDelete             (RPC::Context&);
 Json::Value doConnect               (RPC::Context&);
 Json::Value doConsensusInfo         (RPC::Context&);
 Json::Value doFeature               (RPC::Context&);
+Json::Value doFee                   (RPC::Context&);
 Json::Value doFetchInfo             (RPC::Context&);
 Json::Value doGetCounts             (RPC::Context&);
 Json::Value doInternal              (RPC::Context&);

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -112,6 +112,7 @@ HandlerTable HANDLERS({
     {   "get_counts",           byRef (&doGetCounts),           Role::ADMIN,   NO_CONDITION     },
     {   "internal",             byRef (&doInternal),            Role::ADMIN,   NO_CONDITION     },
     {   "feature",              byRef (&doFeature),             Role::ADMIN,   NO_CONDITION     },
+    {   "fee",                  byRef (&doFee),                 Role::ADMIN,   NO_CONDITION     },
     {   "fetch_info",           byRef (&doFetchInfo),           Role::ADMIN,   NO_CONDITION     },
     {   "ledger_accept",        byRef (&doLedgerAccept),        Role::ADMIN,   NEEDS_CURRENT_LEDGER  },
     {   "ledger_cleaner",       byRef (&doLedgerCleaner),       Role::ADMIN,   NEEDS_NETWORK_CONNECTION  },
@@ -157,7 +158,6 @@ HandlerTable HANDLERS({
     {   "validation_seed",      byRef (&doValidationSeed),      Role::ADMIN,   NO_CONDITION     },
     {   "wallet_propose",       byRef (&doWalletPropose),       Role::ADMIN,   NO_CONDITION     },
     {   "wallet_seed",          byRef (&doWalletSeed),          Role::ADMIN,   NO_CONDITION     },
-
     // Evented methods
     {   "subscribe",            byRef (&doSubscribe),           Role::USER,  NO_CONDITION     },
     {   "unsubscribe",          byRef (&doUnsubscribe),         Role::USER,  NO_CONDITION     },

--- a/src/ripple/server/tests/Server.test.cpp
+++ b/src/ripple/server/tests/Server.test.cpp
@@ -68,26 +68,6 @@ public:
 
     //--------------------------------------------------------------------------
 
-    class TestSink : public beast::Journal::Sink
-    {
-        beast::unit_test::suite& suite_;
-
-    public:
-        TestSink (beast::unit_test::suite& suite)
-            : suite_ (suite)
-        {
-        }
-
-        void
-        write (beast::Journal::Severity level,
-            std::string const& text) override
-        {
-            suite_.log << text;
-        }
-    };
-
-    //--------------------------------------------------------------------------
-
     struct TestHandler : Handler
     {
         void

--- a/src/ripple/unity/app_ledger.cpp
+++ b/src/ripple/unity/app_ledger.cpp
@@ -40,9 +40,11 @@
 #include <ripple/app/ledger/OrderBookDB.cpp>
 #include <ripple/app/ledger/OrderBookIterator.cpp>
 #include <ripple/app/ledger/TransactionStateSF.cpp>
+#include <ripple/app/ledger/TxHold.cpp>
 
 #include <ripple/app/ledger/impl/LedgerFees.cpp>
 
 #include <ripple/app/ledger/tests/common_ledger.cpp>
 #include <ripple/app/ledger/tests/DeferredCredits.test.cpp>
 #include <ripple/app/ledger/tests/Ledger_test.cpp>
+#include <ripple/app/ledger/tests/TxQ_test.cpp>

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -48,6 +48,7 @@
 #include <ripple/rpc/handlers/Connect.cpp>
 #include <ripple/rpc/handlers/ConsensusInfo.cpp>
 #include <ripple/rpc/handlers/Feature.cpp>
+#include <ripple/rpc/handlers/Fee.cpp>
 #include <ripple/rpc/handlers/FetchInfo.cpp>
 #include <ripple/rpc/handlers/GetCounts.cpp>
 #include <ripple/rpc/handlers/Internal.cpp>


### PR DESCRIPTION
* Fee grows exponentially once a minimum of txs are in the ledger.
* There is always a fee that can be paid to get into the open ledger.
* Any transaction below the fee will be put into a queue until the ledger closes.
* Transactions put in the queue are broadcast to peers with the "deferred" flag set.
* New TER code: terQUEUED.
* Transactions put into the queue can be resubmitted with the *same* sequence number *and* a larger Fee. The new tx will replace the original in the queue, or be applied to the open ledger.
* Transaction queue is size limited. When full, the smallest fee txs will be dropped.
* On ledger close, the queue txs will be applied, from highest fee down until either the queue is empty or the fee rises again beyond the tx's Fee.
* Also on ledger close, fee cutoff parameters are adjusted based on the last ledger.
* New RPC command: 'fee'. Currently returns information about fee levels to get into the queue and open ledger.
* Unit tests.


I've left this as 4 separate commits, mainly so I can remember what @JoelKatz did before I took over. I intend to merge it down to 2 before it gets merged (one commit has `beast` changes which need to remain separate).

There's a lot going on here, so don't hold back on criticisms or questions.

Reviewers: @JoelKatz, @nbougalis, ??, ??