### PR TITLE
Unsubscribe from normal data feeds on destruction

### DIFF
--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -145,9 +145,8 @@ protected:
 private:
     Consumer                      m_consumer;
     Source&                       m_source;
-    hash_set <RippleAddress>      mSubAccountInfo_t; // real time subscriptions
-    hash_set <RippleAddress>      mSubAccountInfo_f; // normal subscriptions
-    hash_set <RippleAddress>      mSubAccountTransaction;
+    hash_set <RippleAddress>      realTimeSubscriptions_;
+    hash_set <RippleAddress>      normalSubscriptions_;
     std::shared_ptr <PathRequest> mPathRequest;
     std::uint64_t                 mSeq;
 };

--- a/src/ripple/net/impl/InfoSub.cpp
+++ b/src/ripple/net/impl/InfoSub.cpp
@@ -60,13 +60,13 @@ InfoSub::~InfoSub ()
 
     // Use the internal unsubscribe so that it won't call
     // back to us and modify its own parameter
-    if (! mSubAccountInfo_t.empty ())
+    if (! realTimeSubscriptions_.empty ())
         m_source.unsubAccountInternal
-            (mSeq, mSubAccountInfo_t, true);
+            (mSeq, realTimeSubscriptions_, true);
 
-    if (! mSubAccountInfo_t.empty ())
+    if (! normalSubscriptions_.empty ())
         m_source.unsubAccountInternal
-            (mSeq, mSubAccountInfo_f, false);
+            (mSeq, normalSubscriptions_, false);
 }
 
 Resource::Consumer& InfoSub::getConsumer()
@@ -93,14 +93,20 @@ void InfoSub::insertSubAccountInfo (RippleAddress addr, bool rt)
 {
     ScopedLockType sl (mLock);
 
-    (rt ? mSubAccountInfo_t : mSubAccountInfo_f).insert (addr);
+    if (rt)
+        realTimeSubscriptions_.insert (addr);
+    else
+        normalSubscriptions_.insert (addr);
 }
 
 void InfoSub::deleteSubAccountInfo (RippleAddress addr, bool rt)
 {
     ScopedLockType sl (mLock);
 
-    (rt ? mSubAccountInfo_t : mSubAccountInfo_f).erase (addr);
+    if (rt)
+        realTimeSubscriptions_.erase (addr);
+    else
+        normalSubscriptions_.erase (addr);
 }
 
 void InfoSub::clearPathRequest ()


### PR DESCRIPTION
During `InfoSub` destruction we go through and cancel any active subscriptions. We incorrectly condition canceling normal subscriptions, on whether there are any active real-time subscriptions.

Reviews: @scottschurr and @ximinez