### PR TITLE
Workaround for LZ4 on gcc5

### DIFF
--- a/src/lz4/lib/lz4.c
+++ b/src/lz4/lib/lz4.c
@@ -268,7 +268,8 @@ static void LZ4_copy4(void* dstPtr, const void* srcPtr)
 
 static void LZ4_copy8(void* dstPtr, const void* srcPtr)
 {
-#if GCC_VERSION!=409  /* disabled on GCC 4.9, as it generates invalid opcode (crash) */
+/* disabled on GCC 4.9, 5.0+ as it generates invalid opcode (crash) */
+#if (GCC_VERSION != 409) && (GCC_VERSION < 500)
     if (LZ4_UNALIGNED_ACCESS)
     {
         if (LZ4_64bits())


### PR DESCRIPTION
The LZ4 library uses unaligned accesses on platforms that support them without a penalty. This causes gcc5's optimizer to build invalid code in the LZ4_copy4 function.

Without this change, RippleD release builds made on gcc5 will crash when they try to store to a NuDB database.