### PR TITLE
Replace base_uint(string) with from_hex_text<> (RIPD-897)

### DIFF
--- a/src/ripple/app/ledger/tests/Ledger_test.cpp
+++ b/src/ripple/app/ledger/tests/Ledger_test.cpp
@@ -29,7 +29,7 @@ class Ledger_test : public beast::unit_test::suite
         std::uint64_t const xrp = std::mega::num;
 
         auto master = createAccount ("masterpassphrase", keyType);
-        
+
         Ledger::pointer LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger(100000*xrp, master);
@@ -120,7 +120,7 @@ class Ledger_test : public beast::unit_test::suite
 
     void test_getQuality ()
     {
-        uint256 uBig (
+        uint256 uBig = from_hex_text<uint256> (
             "D2DC44E5DC189318DB36EF87D2104CDF0A0FE3A4B698BEEE55038D7EA4C68000");
         expect (6125895493223874560 == getQuality (uBig));
 

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -141,13 +141,6 @@ public:
         *this = b;
     }
 
-    // NIKB TODO remove the need for this constructor - have a free function
-    //           to handle the hex string parsing.
-    explicit base_uint (std::string const& str)
-    {
-        SetHex (str);
-    }
-
     base_uint (base_uint<Bits, Tag> const& other) = default;
 
     template <class OtherTag>
@@ -511,6 +504,27 @@ template <std::size_t Bits, class Tag>
 inline std::string to_string (base_uint<Bits, Tag> const& a)
 {
     return strHex (a.begin (), a.size ());
+}
+
+// Function templates that return a base_uint given text in hexadecimal.
+// Invoke like:
+//   auto i = from_hex_text<uint256>("AAAAA");
+template <typename T>
+auto from_hex_text (char const* text) -> std::enable_if_t<
+    std::is_same<T, base_uint<T::bytes*8, typename T::tag_type>>::value, T>
+{
+    T ret;
+    ret.SetHex (text);
+    return ret;
+}
+
+template <typename T>
+auto from_hex_text (std::string const& text) -> std::enable_if_t<
+    std::is_same<T, base_uint<T::bytes*8, typename T::tag_type>>::value, T>
+{
+    T ret;
+    ret.SetHex (text);
+    return ret;
 }
 
 template <std::size_t Bits, class Tag>

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -334,7 +334,8 @@ public:
                 {
                     // Uh oh, corrupted data!
                     if (m_journal.fatal) m_journal.fatal <<
-                        "Corrupt NodeObject #" << uint256 (it->key ().data ());
+                        "Corrupt NodeObject #" <<
+                        from_hex_text<uint256>(it->key ().data ());
                 }
             }
             else

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -136,7 +136,7 @@ public:
 
         // overrride OptimizeLevelStyleCompaction
         options.min_write_buffer_number_to_merge = 1;
-        
+
         rocksdb::BlockBasedTableOptions table_options;
         // Use hash index
         table_options.index_type =
@@ -145,7 +145,7 @@ public:
             rocksdb::NewBloomFilterPolicy(10));
         options.table_factory.reset(
             NewBlockBasedTableFactory(table_options));
-        
+
         // Higher values make reads slower
         // table_options.block_size = 4096;
 
@@ -273,7 +273,7 @@ public:
     storeBatch (Batch const& batch)
     {
         rocksdb::WriteBatch wb;
- 
+
         EncodedBlob encoded;
 
         for (auto const& e : batch)
@@ -291,7 +291,7 @@ public:
 
         // Crucial to ensure good write speed and non-blocking writes to memtable
         options.disableWAL = true;
-        
+
         auto ret = m_db->Write (options, &wb);
 
         if (!ret.ok ())
@@ -321,7 +321,8 @@ public:
                 {
                     // Uh oh, corrupted data!
                     if (m_journal.fatal) m_journal.fatal <<
-                        "Corrupt NodeObject #" << uint256 (it->key ().data ());
+                        "Corrupt NodeObject #" <<
+                        from_hex_text<uint256>(it->key ().data ());
                 }
             }
             else

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/protocol/Indexes.h>
+#include <beast/utility/static_initializer.h>
 
 namespace ripple {
 
@@ -168,8 +169,10 @@ getQualityIndex (uint256 const& uBase, const std::uint64_t uNodeDir)
 uint256
 getQualityNext (uint256 const& uBase)
 {
-    static uint256 uNext ("10000000000000000");
-    return uBase + uNext;
+    static beast::static_initializer<uint256> const uNext (
+        from_hex_text<uint256>("10000000000000000"));
+
+    return uBase + *uNext;
 }
 
 std::uint64_t

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -22,6 +22,7 @@
 #include <ripple/protocol/SystemParameters.h>
 #include <ripple/protocol/RippleAddress.h>
 #include <ripple/protocol/UintTypes.h>
+#include <beast/utility/static_initializer.h>
 
 namespace ripple {
 
@@ -32,8 +33,6 @@ std::string to_string(Account const& account)
 
 std::string to_string(Currency const& currency)
 {
-    static Currency const sIsoBits ("FFFFFFFFFFFFFFFFFFFFFFFF000000FFFFFFFFFF");
-
     // Characters we are willing to allow in the ASCII representation of a
     // three-letter currency code.
     static std::string const allowed_characters =
@@ -48,7 +47,10 @@ std::string to_string(Currency const& currency)
     if (currency == noCurrency())
         return "1";
 
-    if ((currency & sIsoBits).isZero ())
+    static beast::static_initializer<Currency> const sIsoBits (
+        from_hex_text<Currency>("FFFFFFFFFFFFFFFFFFFFFFFF000000FFFFFFFFFF"));
+
+    if ((currency & *sIsoBits).isZero ())
     {
         // The offset of the 3 character ISO code in the currency descriptor
         int const isoOffset = 12;

--- a/src/ripple/protocol/tests/STAmount.test.cpp
+++ b/src/ripple/protocol/tests/STAmount.test.cpp
@@ -281,7 +281,8 @@ public:
         const std::string cur = "015841551A748AD2C1F76FF6ECB0CCCD00000000";
         unexpected (!to_currency (c, cur), "create custom currency");
         unexpected (to_string (c) != cur, "check custom currency");
-        unexpected (c != Currency (cur), "check custom currency");
+        unexpected (c != Currency (
+            from_hex_text<Currency>(cur)), "check custom currency");
     }
 
     //--------------------------------------------------------------------------

--- a/src/ripple/rpc/handlers/CanDelete.cpp
+++ b/src/ripple/rpc/handlers/CanDelete.cpp
@@ -70,9 +70,9 @@ Json::Value doCanDelete (RPC::Context& context)
                     canDeleteStr.find_first_not_of("0123456789abcdef") ==
                     std::string::npos)
             {
-                uint256 ledgerHash (canDeleteStr);
-                Ledger::pointer ledger =
-                        context.netOps.getLedgerByHash (ledgerHash);
+                Ledger::pointer ledger = context.netOps.getLedgerByHash (
+                    from_hex_text<uint256>(canDeleteStr));
+
                 if (!ledger)
                     return RPC::make_error(rpcLGR_NOT_FOUND, "ledgerNotFound");
 

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -55,7 +55,8 @@ Json::Value doTx (RPC::Context& context)
     if (!isHexTxID (txid))
         return rpcError (rpcNOT_IMPL);
 
-    auto txn = getApp().getMasterTransaction ().fetch (uint256 (txid), true);
+    auto txn = getApp().getMasterTransaction ().fetch (
+        from_hex_text<uint256>(txid), true);
 
     if (!txn)
         return rpcError (rpcTXN_NOT_FOUND);


### PR DESCRIPTION
Removes the base_uint constructor that took a string.  Replaces
that functionality with two free functions named from_hex_text<>.
Use of from_hex_text\<\> looks like this:

auto v = from_hex_text\<uint256\>("AAA555");
static_assert (std::is_same\<decltype(v), uint256\>::value, "Huh!");

from_hex_text\<\> only operates on base_uint types.  At the moment
the list of those types include:

 o uint128,
 o uint160,
 o uint256,
 o Directory,
 o Account,
 o Currency, and
 o NodeID.

Using from_hex_text\<\> with any other types will not compile due to
an enable_if.

The important changes are in base_uint.h.  All the other changes
result from switching to use the new functions.