### PR TITLE
[TRIVIAL] Revert "Reduce SHAMapTreeNode copying during SHAMap unsharing:"

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -413,9 +413,8 @@ public:
         }
         if (didApply)
         {
-            ledger->setImmutable (); // So the next line doesn't have to copy
-            mCurrentLedger.set (ledger);
-            getApp().getOPs ().pubProposedTransaction (ledger, txn, result);
+           mCurrentLedger.set (ledger);
+           getApp().getOPs ().pubProposedTransaction (ledger, txn, result);
         }
         return result;
     }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1068,7 +1068,6 @@ void ApplicationImp::startNewLedger ()
         firstLedger->updateHash ();
         firstLedger->setClosed ();
         firstLedger->setAccepted ();
-        firstLedger->setImmutable();
         m_ledgerMaster->pushLedger (firstLedger);
 
         Ledger::pointer secondLedger = std::make_shared<Ledger> (true, std::ref (*firstLedger));

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -278,7 +278,6 @@ void
 SHAMap::setImmutable ()
 {
     assert (state_ != SHAMapState::Invalid);
-    unshare ();
     state_ = SHAMapState::Immutable;
 }
 

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -75,7 +75,7 @@ SHAMap::snapShot (bool isMutable) const
     newMap.seq_ = seq_ + 1;
     newMap.root_ = root_;
 
-    if ((state_ != SHAMapState::Immutable) || isMutable)
+    if ((state_ != SHAMapState::Immutable) || !isMutable)
     {
         // If either map may change, they cannot share nodes
         newMap.unshare ();


### PR DESCRIPTION
This reverts commit 47c6ab0ced4563fe473c9396cbaea874619c2921.