### PR TITLE
Allow multi-sign to be enabled at runtime: …

### DIFF
--- a/src/ripple/app/tx/TransactionEngine.h
+++ b/src/ripple/app/tx/TransactionEngine.h
@@ -29,6 +29,9 @@ namespace ripple {
 // A TransactionEngine applies serialized transactions to a ledger
 // It can also, verify signatures, verify fees, and give rejection reasons
 
+struct multisign_t { multisign_t() { } };
+static multisign_t const multisign;
+
 // One instance per ledger.
 // Only one transaction applied at a time.
 class TransactionEngine
@@ -38,6 +41,13 @@ public:
     static char const* getCountedObjectName () { return "TransactionEngine"; }
 
 private:
+    bool enableMultiSign_ =
+#if RIPPLE_ENABLE_MULTI_SIGN
+        true;
+#else
+        false;
+#endif
+
     LedgerEntrySet mNodes;
 
     void txnWrite ();
@@ -53,6 +63,19 @@ public:
         : mLedger (ledger)
     {
         assert (mLedger);
+    }
+
+    TransactionEngine (Ledger::ref ledger, multisign_t)
+        : enableMultiSign_(true)
+        , mLedger (ledger)
+    {
+        assert (mLedger);
+    }
+
+    bool
+    enableMultiSign() const
+    {
+        return enableMultiSign_;
     }
 
     LedgerEntrySet&

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -357,6 +357,8 @@ transact_SetSignerList (
     TransactionEngineParams params,
     TransactionEngine* engine)
 {
+    if (! engine->enableMultiSign())
+        return temDISABLED;
     return SetSignerList (txn, params, engine).apply ();
 }
 

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -123,7 +123,13 @@ public:
 
     void sign (RippleAddress const& private_key);
 
-    bool checkSign () const;
+    bool checkSign(bool allowMultiSign =
+#if RIPPLE_ENABLE_MULTI_SIGN
+        true
+#else
+        false
+#endif
+            ) const;
 
     bool isKnownGood () const
     {

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -190,22 +190,25 @@ void STTx::sign (RippleAddress const& private_key)
     setFieldVL (sfTxnSignature, signature);
 }
 
-bool STTx::checkSign () const
+bool STTx::checkSign(bool allowMultiSign) const
 {
     if (boost::indeterminate (sig_state_))
     {
         try
         {
-#if RIPPLE_ENABLE_MULTI_SIGN
-            // Determine whether we're single- or multi-signing by looking
-            // at the SigningPubKey.  It it's empty we must be multi-signing.
-            // Otherwise we're single-signing.
-            Blob const& signingPubKey = getFieldVL (sfSigningPubKey);
-            sig_state_ = signingPubKey.empty () ?
-                checkMultiSign () : checkSingleSign ();
-#else
-            sig_state_ = checkSingleSign ();
-#endif // RIPPLE_ENABLE_MULTI_SIGN
+            if (allowMultiSign)
+            {
+                // Determine whether we're single- or multi-signing by looking
+                // at the SigningPubKey.  It it's empty we must be multi-signing.
+                // Otherwise we're single-signing.
+                Blob const& signingPubKey = getFieldVL (sfSigningPubKey);
+                sig_state_ = signingPubKey.empty () ?
+                    checkMultiSign () : checkSingleSign ();
+            }
+            else
+            {
+                sig_state_ = checkSingleSign ();
+            }
         }
         catch (...)
         {


### PR DESCRIPTION
This lets unit tests exercise multi-sign interfaces without having to set `RIPPLE_ENABLE_MULTI_SIGN`.