### PR TITLE
[Trivial] Remove slice stream operator (RIPD-907)

### DIFF
--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -113,13 +113,6 @@ operator< (Slice const& lhs, Slice const& rhs) noexcept
             rhs.data(), rhs.data() + rhs.size());
 }
 
-template <class Stream>
-Stream& operator<<(Stream& s, Slice const& v)
-{
-    s << strHex(v.data(), v.size());
-    return s;
-}
-
 } // ripple
 
 #endif

--- a/src/ripple/overlay/impl/Manifest.cpp
+++ b/src/ripple/overlay/impl/Manifest.cpp
@@ -150,7 +150,7 @@ ManifestCache::configValidatorKey(
     std::string comment = std::move(words[1]);
 
     if (journal.debug) journal.debug
-        << masterKey << " " << comment;
+        << strHex (masterKey.data(), masterKey.size()) << " " << comment;
 
     addTrustedKey (masterKey, std::move(comment));
 }

--- a/src/ripple/overlay/impl/Manifest.cpp
+++ b/src/ripple/overlay/impl/Manifest.cpp
@@ -150,7 +150,7 @@ ManifestCache::configValidatorKey(
     std::string comment = std::move(words[1]);
 
     if (journal.debug) journal.debug
-        << strHex (masterKey.data(), masterKey.size()) << " " << comment;
+        << strHex (make_Slice(masterKey))) << " " << comment;
 
     addTrustedKey (masterKey, std::move(comment));
 }


### PR DESCRIPTION
Remove `Slice::operator<<` and force callers to use `strHex`

@scottschurr @HowardHinnant 