### PR TITLE
Travis build unity and nounity.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: cpp
 compiler:
   - clang
   - gcc
+env:
+  - TARGET=debug
+  - TARGET=debug.nounity
+  # We can specify any combination of builds here, for example, to
+  # include release builds, too, uncomment the following lines.
+  #- TARGET=release
+  #- TARGET=release.nounity
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq python-software-properties
@@ -38,10 +45,10 @@ script:
   - scons vcxproj
   - git diff --exit-code
   # $CC will be either `clang` or `gcc` (If only we could do -j12 ;)
-  - scons $CC.debug
-  # We can be sure we're using the build/$CC.debug variant (-f so never err)
+  - scons $CC.$TARGET
+  # We can be sure we're using the build/$CC.$TARGET variant (-f so never err)
   - rm -f build/rippled 
-  - export RIPPLED_PATH="$PWD/build/$CC.debug/rippled"
+  - export RIPPLED_PATH="$PWD/build/$CC.$TARGET/rippled"
   # See what we've actually built
   - ldd $RIPPLED_PATH
   # Run unittests (under gdb)
@@ -52,7 +59,7 @@ script:
     # gdb --help
   - cat script.gdb | gdb --ex 'set print thread-events off' --return-child-result --args $RIPPLED_PATH --unittest
   - npm install
-  # Use build/(gcc|clang).debug/rippled
+  # Use build/(gcc|clang).$TARGET/rippled
   - |
     echo "exports.default_server_config = {\"rippled_path\" : \"$RIPPLED_PATH\"};" > test/config.js
 

--- a/src/ripple/crypto/impl/CBigNum.cpp
+++ b/src/ripple/crypto/impl/CBigNum.cpp
@@ -27,6 +27,7 @@
 #include <ripple/crypto/CAutoBN_CTX.h>
 #include <stdexcept>
 #include <string>
+#include <algorithm>
 
 namespace ripple {
 


### PR DESCRIPTION
We've been getting a lot of PRs initially failing nounity builds because so few developers regularly build them. This culminated in 0.28.2-b5 getting merged with a broken nounity linux build. (That build error has since been fixed by https://github.com/ripple/rippled/pull/1094, which is has passed review and is pending merge at this moment.)

Additionally, I have cherry-picked the relevant commit from #1094 onto this branch to demonstrate that Travis fails to build the nounity builds without it (https://travis-ci.org/ximinez/rippled/builds/65422613), and succeeds on unity and nounity builds with it (https://travis-ci.org/ximinez/rippled/builds/65426852). Assuming this PR passes review, we can either remove the extra commit, or merge #1094 first, or close #1094 and only merge this one.

Reviewers: @seelabs, @nbougalis 