### PR TITLE
Remove warnings discovered with -Wshadow.

### DIFF
--- a/src/beast/beast/module/core/native/linux_Files.cpp
+++ b/src/beast/beast/module/core/native/linux_Files.cpp
@@ -63,8 +63,7 @@ File File::getSpecialLocation (const SpecialLocationType type)
         case userHomeDirectory:
         {
             const char* homeDir = getenv ("HOME");
-
-            if (const char* homeDir = getenv ("HOME"))
+            if (homeDir)
                 return File (CharPointer_UTF8 (homeDir));
 
             if (struct passwd* const pw = getpwuid (getuid()))
@@ -166,8 +165,8 @@ private:
     DIR* dir;
 };
 
-DirectoryIterator::NativeIterator::NativeIterator (const File& directory, const String& wildCard)
-    : pimpl (new DirectoryIterator::NativeIterator::Pimpl (directory, wildCard))
+DirectoryIterator::NativeIterator::NativeIterator (const File& directory, const String& wildCard_)
+    : pimpl (new DirectoryIterator::NativeIterator::Pimpl (directory, wildCard_))
 {
 }
 

--- a/src/beast/beast/net/IPAddressV4.h
+++ b/src/beast/beast/net/IPAddressV4.h
@@ -38,9 +38,9 @@ struct AddressV4
     AddressV4 ();
 
     /** Construct from a 32-bit unsigned.
-        @note Octets are formed in order from the MSB to the LSB.       
+        @note Octets are formed in order from the MSB to the LSB.
     */
-    explicit AddressV4 (std::uint32_t value_);
+    explicit AddressV4 (std::uint32_t);
 
     /** Construct from four individual octets..
         @note The resulting address is a.b.c.d

--- a/src/beast/beast/utility/ci_char_traits.h
+++ b/src/beast/beast/utility/ci_char_traits.h
@@ -43,9 +43,9 @@ struct ci_less
         using char_type = typename String::value_type;
         return std::lexicographical_compare (
             begin(lhs), end(lhs), begin(rhs), end(rhs),
-            [] (char_type lhs, char_type rhs)
+            [] (char_type x, char_type y)
             {
-                return std::tolower(lhs) < std::tolower(rhs);
+                return std::tolower(x) < std::tolower(y);
             }
         );
     }
@@ -60,9 +60,9 @@ ci_equal(std::pair<const char*, std::size_t> lhs,
 {
     return std::equal (lhs.first, lhs.first + lhs.second,
                        rhs.first, rhs.first + rhs.second,
-        [] (char lhs, char rhs)
+        [] (char x, char y)
         {
-            return std::tolower(lhs) == std::tolower(rhs);
+            return std::tolower(x) == std::tolower(y);
         }
     );
 }

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -465,8 +465,6 @@ void InboundLedger::trigger (Peer::ptr const& peer)
                 Message::pointer packet (std::make_shared <Message> (
                     tmBH, protocol::mtGET_OBJECTS));
                 {
-                    ScopedLockType sl (mLock);
-
                     for (PeerSetMap::iterator it = mPeers.begin (), end = mPeers.end ();
                             it != end; ++it)
                     {

--- a/src/ripple/app/ledger/impl/LedgerConsensus.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensus.cpp
@@ -401,10 +401,10 @@ public:
 
         // Adjust tracking for each peer that takes this position
         std::vector<NodeID> peers;
-        for (auto& it : mPeerPositions)
+        for (auto& i : mPeerPositions)
         {
-            if (it.second->getCurrentHash () == map->getHash ())
-                peers.push_back (it.second->getPeerID ());
+            if (i.second->getCurrentHash () == map->getHash ())
+                peers.push_back (i.second->getPeerID ());
         }
 
         if (!peers.empty ())
@@ -1068,8 +1068,8 @@ private:
             }
 
             // Apply local transactions
-            TransactionEngine engine (newOL);
-            m_localTX.apply (engine);
+            TransactionEngine localEngine (newOL);
+            m_localTX.apply (localEngine);
 
             // We have a new Last Closed Ledger and new Open Ledger
             getApp().getLedgerMaster ().pushLedger (newLCL, newOL);
@@ -1453,11 +1453,11 @@ private:
         }
 
         // Update votes on disputed transactions
-        for (auto& it : mDisputes)
+        for (auto& dispute : mDisputes)
         {
             // Because the threshold for inclusion increases,
             //  time can change our position on a dispute
-            if (it.second->updateVote (mClosePercent, mProposing))
+            if (dispute.second->updateVote (mClosePercent, mProposing))
             {
                 if (!changes)
                 {
@@ -1467,16 +1467,16 @@ private:
                     changes = true;
                 }
 
-                if (it.second->getOurVote ()) // now a yes
+                if (dispute.second->getOurVote ()) // now a yes
                 {
-                    ourPosition->addItem (SHAMapItem (it.first
-                        , it.second->peekTransaction ()), true, false);
-                    //              addedTx.push_back(it.first);
+                    ourPosition->addItem (SHAMapItem (dispute.first
+                        , dispute.second->peekTransaction ()), true, false);
+                    //              addedTx.push_back(dispute.first);
                 }
                 else // now a no
                 {
-                    ourPosition->delItem (it.first);
-                    //              removedTx.push_back(it.first);
+                    ourPosition->delItem (dispute.first);
+                    //              removedTx.push_back(dispute.first);
                 }
             }
         }
@@ -1522,20 +1522,19 @@ private:
                 << mPeerPositions.size () << " nw:" << neededWeight
                 << " thrV:" << threshVote << " thrC:" << threshConsensus;
 
-            for (auto it = closeTimes.begin ()
-                , end = closeTimes.end (); it != end; ++it)
+            for (auto& i: closeTimes)
             {
                 WriteLog (lsDEBUG, LedgerConsensus) << "CCTime: seq"
                     << mPreviousLedger->getLedgerSeq () + 1 << ": "
-                    << it->first << " has " << it->second << ", "
+                    << i.first << " has " << i.second << ", "
                     << threshVote << " required";
 
-                if (it->second >= threshVote)
+                if (i.second >= threshVote)
                 {
                     WriteLog (lsDEBUG, LedgerConsensus)
-                        << "Close time consensus reached: " << it->first;
-                    closeTime = it->first;
-                    threshVote = it->second;
+                        << "Close time consensus reached: " << i.first;
+                    closeTime = i.first;
+                    threshVote = i.second;
 
                     if (threshVote >= threshConsensus)
                         mHaveCloseTimeConsensus = true;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -904,9 +904,8 @@ public:
                 // If we still don't know the sequence, get it
                 if (v.second.ledgerSeq_ == 0)
                 {
-                    Ledger::pointer ledger = getLedgerByHash (v.first);
-                    if (ledger)
-                        v.second.ledgerSeq_ = ledger->getLedgerSeq();
+                    if (Ledger::pointer seqLedger = getLedgerByHash (v.first))
+                        v.second.ledgerSeq_ = seqLedger->getLedgerSeq();
                 }
 
                 if (v.second.ledgerSeq_ > maxSeq)
@@ -1024,8 +1023,9 @@ public:
                                     setFullLedger(ledger, false, false);
                                     mHistLedger = ledger;
                                     if ((mFillInProgress == 0) && (Ledger::getHashByIndex(ledger->getLedgerSeq() - 1) == ledger->getParentHash()))
-                                    { // Previous ledger is in DB
-                                        ScopedLockType sl(m_mutex);
+                                    {
+                                        // Previous ledger is in DB
+                                        ScopedLockType lock (m_mutex);
                                         mFillInProgress = ledger->getLedgerSeq();
                                         getApp().getJobQueue().addJob(jtADVANCE, "tryFill", std::bind (
                                             &LedgerMasterImp::tryFill, this,
@@ -1040,9 +1040,9 @@ public:
                                         for (int i = 0; i < ledger_fetch_size_; ++i)
                                         {
                                             std::uint32_t seq = missing - i;
-                                            uint256 hash = getLedgerHashForHistory (seq);
-                                            if (hash.isNonZero())
-                                                getApp().getInboundLedgers().acquire(hash,
+                                            uint256 hash2 = getLedgerHashForHistory (seq);
+                                            if (hash2.isNonZero())
+                                                getApp().getInboundLedgers().acquire(hash2,
                                                      seq, InboundLedger::fcHISTORY);
                                         }
                                     }

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -71,7 +71,7 @@ void SHAMapStoreImp::SavedStateDB::init (BasicConfig const& config,
                 "INSERT INTO DbState VALUES (1, '', '', 0);";
     }
 
-    
+
     {
         boost::optional<std::int64_t> countO;
         session_ <<
@@ -277,18 +277,19 @@ SHAMapStoreImp::run()
         healthy_ = true;
         validatedLedger_.reset();
 
-        std::unique_lock <std::mutex> lock (mutex_);
-        if (stop_)
         {
-            stopped();
-            return;
+            std::unique_lock <std::mutex> lock (mutex_);
+            if (stop_)
+            {
+                stopped();
+                return;
+            }
+            cond_.wait (lock);
+            if (newLedger_)
+                validatedLedger_ = std::move (newLedger_);
+            else
+                continue;
         }
-        cond_.wait (lock);
-        if (newLedger_)
-            validatedLedger_ = std::move (newLedger_);
-        else
-            continue;
-        lock.unlock();
 
         LedgerIndex validatedSeq = validatedLedger_->getLedgerSeq();
         if (!lastRotated)

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -110,7 +110,7 @@ void PathRequests::updateAll (Ledger::ref inLedger,
 
             if (remove)
             {
-                PathRequest::pointer pRequest = wRequest.lock ();
+                PathRequest::pointer removeRequest = wRequest.lock ();
 
                 ScopedLockType sl (mLock);
 
@@ -119,7 +119,7 @@ void PathRequests::updateAll (Ledger::ref inLedger,
                 while (it != mRequests.end())
                 {
                     PathRequest::pointer itRequest = it->lock ();
-                    if (!itRequest || (itRequest == pRequest))
+                    if (!itRequest || (itRequest == removeRequest))
                     {
                         ++removed;
                         it = mRequests.erase (it);
@@ -196,8 +196,8 @@ Json::Value PathRequests::makePathRequest(
             std::vector<PathRequest::wptr>::iterator it = mRequests.begin ();
             while (it != mRequests.end ())
             {
-                PathRequest::pointer req = it->lock ();
-                if (req && !req->isNew ())
+                PathRequest::pointer validReq = it->lock ();
+                if (validReq && !req->isNew ())
                     break; // This request has been handled, we come before it
 
                 // This is a newer request, we come after it

--- a/src/ripple/app/paths/PathState.cpp
+++ b/src/ripple/app/paths/PathState.cpp
@@ -265,15 +265,15 @@ TER PathState::pushNode (
 
         if (resultCode == tesSUCCESS && !nodes_.empty ())
         {
-            auto const& backNode = nodes_.back ();
-            if (backNode.isAccount())
+            auto const& newBackNode = nodes_.back ();
+            if (newBackNode.isAccount())
             {
                 auto sleRippleState = lesEntries_->entryCache (
                     ltRIPPLE_STATE,
                     getRippleStateIndex (
-                        backNode.account_,
+                        newBackNode.account_,
                         node.account_,
-                        backNode.issue_.currency));
+                        newBackNode.issue_.currency));
 
                 // A "RippleState" means a balance betweeen two accounts for a
                 // specific currency.
@@ -281,7 +281,7 @@ TER PathState::pushNode (
                 {
                     WriteLog (lsTRACE, RippleCalc)
                             << "pushNode: No credit line between "
-                            << backNode.account_ << " and " << node.account_
+                            << newBackNode.account_ << " and " << node.account_
                             << " for " << node.issue_.currency << "." ;
 
                     WriteLog (lsTRACE, RippleCalc) << getJson ();
@@ -292,20 +292,20 @@ TER PathState::pushNode (
                 {
                     WriteLog (lsTRACE, RippleCalc)
                             << "pushNode: Credit line found between "
-                            << backNode.account_ << " and " << node.account_
+                            << newBackNode.account_ << " and " << node.account_
                             << " for " << node.issue_.currency << "." ;
 
                     auto sleBck  = lesEntries_->entryCache (
                         ltACCOUNT_ROOT,
-                        getAccountRootIndex (backNode.account_));
+                        getAccountRootIndex (newBackNode.account_));
                     // Is the source account the highest numbered account ID?
-                    bool bHigh = backNode.account_ > node.account_;
+                    bool bHigh = newBackNode.account_ > node.account_;
 
                     if (!sleBck)
                     {
                         WriteLog (lsWARNING, RippleCalc)
                             << "pushNode: delay: can't receive IOUs from "
-                            << "non-existent issuer: " << backNode.account_;
+                            << "non-existent issuer: " << newBackNode.account_;
 
                         resultCode   = terNO_ACCOUNT;
                     }
@@ -324,14 +324,14 @@ TER PathState::pushNode (
                     if (resultCode == tesSUCCESS)
                     {
                         STAmount saOwed = creditBalance (*lesEntries_,
-                            node.account_, backNode.account_,
+                            node.account_, newBackNode.account_,
                             node.issue_.currency);
                         STAmount saLimit;
 
                         if (saOwed <= zero) {
                             saLimit = creditLimit (*lesEntries_,
                                 node.account_,
-                                backNode.account_,
+                                newBackNode.account_,
                                 node.issue_.currency);
                             if (-saOwed >= saLimit)
                             {

--- a/src/ripple/app/paths/cursor/RippleLiquidity.cpp
+++ b/src/ripple/app/paths/cursor/RippleLiquidity.cpp
@@ -172,12 +172,12 @@ void rippleLiquidity (
                 // going the other way
 
                 Issue issue{currency, uCurIssuerID};
-                auto numerator = mulRound (
+                auto numerator2 = mulRound (
                     saPrv, uQualityIn, issue, true);
                 // A part of current. All of previous. (Cur is the driver
                 // variable.)
                 STAmount saCurOut = divRound (
-                    numerator, uQualityOut, issue, true);
+                    numerator2, uQualityOut, issue, true);
 
                 WriteLog (lsTRACE, RippleCalc)
                     << "rippleLiquidity:4: saCurReq=" << saCurReq;

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -236,12 +236,17 @@ public:
         return *this;
     }
 
+    // be32toh and htobe32 are macros that somehow cause shadowing
+    // warnings in this header file, so we hide them...
+    static uint32_t bigendToHost (uint32_t x) { return be32toh(x); }
+    static uint32_t hostToBigend (uint32_t x) { return htobe32(x); }
+
     base_uint& operator++ ()
     {
         // prefix operator
         for (int i = WIDTH - 1; i >= 0; --i)
         {
-            pn[i] = htobe32 (be32toh (pn[i]) + 1);
+            pn[i] = hostToBigend (bigendToHost (pn[i]) + 1);
 
             if (pn[i] != 0)
                 break;
@@ -264,7 +269,7 @@ public:
         for (int i = WIDTH - 1; i >= 0; --i)
         {
             std::uint32_t prev = pn[i];
-            pn[i] = htobe32 (be32toh (pn[i]) - 1);
+            pn[i] = hostToBigend (bigendToHost (pn[i]) - 1);
 
             if (prev != 0)
                 break;
@@ -288,9 +293,10 @@ public:
 
         for (int i = WIDTH; i--;)
         {
-            std::uint64_t n = carry + be32toh (pn[i]) + be32toh (b.pn[i]);
+            std::uint64_t n = carry + bigendToHost (pn[i]) +
+                    bigendToHost (b.pn[i]);
 
-            pn[i] = htobe32 (n & 0xffffffff);
+            pn[i] = hostToBigend (n & 0xffffffff);
             carry = n >> 32;
         }
 

--- a/src/ripple/basics/impl/strHex.cpp
+++ b/src/ripple/basics/impl/strHex.cpp
@@ -41,9 +41,9 @@ int charUnHex (unsigned char c)
                 hex ['a'+i] = 10 + i;
             }
         }
-        int operator[] (unsigned char c) const
+        int operator[] (unsigned char cc) const
         {
-            return hex[c];
+            return hex[cc];
         }
     };
 

--- a/src/ripple/net/impl/SNTPClient.cpp
+++ b/src/ripple/net/impl/SNTPClient.cpp
@@ -142,8 +142,8 @@ public:
             return;
         }
 
-        for (auto const& it : servers)
-            addServer (it);
+        for (auto const& i : servers)
+            addServer (i);
         queryAll ();
     }
 

--- a/src/ripple/nodestore/impl/codec.h
+++ b/src/ripple/nodestore/impl/codec.h
@@ -249,9 +249,9 @@ zero32()
     static std::array<char, 32> v =
         []
         {
-            std::array<char, 32> v;
-            v.fill(0);
-            return v;
+            std::array<char, 32> vv;
+            vv.fill(0);
+            return vv;
         }();
     return v.data();
 }
@@ -300,8 +300,8 @@ nodeobject_compress (void const* in,
             if (n < 16)
             {
                 // 2 = inner node compressed
-                auto const type = 2U;
-                auto const vs = size_varint(type);
+                auto const type2 = 2U;
+                auto const vs = size_varint(type2);
                 result.second =
                     vs +
                     field<std::uint16_t>::size +    // mask
@@ -310,14 +310,14 @@ nodeobject_compress (void const* in,
                     std::uint8_t*>(bf(result.second));
                 result.first = out;
                 ostream os(out, result.second);
-                write<varint>(os, type);
+                write<varint>(os, type2);
                 write<std::uint16_t>(os, mask);
                 write(os, vh.data(), n * 32);
                 return result;
             }
             // 3 = full inner node
-            auto const type = 3U;
-            auto const vs = size_varint(type);
+            auto const type3 = 3U;
+            auto const vs = size_varint(type3);
             result.second =
                 vs +
                 n * 32;                         // hashes
@@ -325,7 +325,7 @@ nodeobject_compress (void const* in,
                 std::uint8_t*>(bf(result.second));
             result.first = out;
             ostream os(out, result.second);
-            write<varint>(os, type);
+            write<varint>(os, type3);
             write(os, vh.data(), n * 32);
             return result;
         }

--- a/src/ripple/nodestore/tests/Timing.test.cpp
+++ b/src/ripple/nodestore/tests/Timing.test.cpp
@@ -112,7 +112,7 @@ public:
     {
         gen_.seed(n+1);
         uint256 key;
-        auto const data = 
+        auto const data =
             static_cast<std::uint8_t*>(&*key.begin());
         *data = prefix_;
         rngcpy (data + 1, key.size() - 1, gen_);
@@ -286,9 +286,9 @@ public:
 
         public:
             explicit
-            Body (suite& s, Backend& backend)
+            Body (suite& s, Backend& be)
                 : suite_ (s)
-                , backend_ (backend)
+                , backend_ (be)
                 , seq_(1)
             {
             }
@@ -342,12 +342,12 @@ public:
 
         public:
             Body (std::size_t id, suite& s,
-                    Params const& params, Backend& backend)
+                    Params const& params_, Backend& be)
                 : suite_(s)
-                , backend_ (backend)
+                , backend_ (be)
                 , seq1_ (1)
                 , gen_ (id + 1)
-                , dist_ (0, params.items - 1)
+                , dist_ (0, params_.items - 1)
             {
             }
 
@@ -404,13 +404,13 @@ public:
 
         public:
             Body (std::size_t id, suite& s,
-                    Params const& params, Backend& backend)
+                    Params const& pr, Backend& be)
                 : suite_ (s)
                 //, params_ (params)
-                , backend_ (backend)
+                , backend_ (be)
                 , seq2_ (2)
                 , gen_ (id + 1)
-                , dist_ (0, params.items - 1)
+                , dist_ (0, pr.items - 1)
             {
             }
 
@@ -469,15 +469,15 @@ public:
 
         public:
             Body (std::size_t id, suite& s,
-                    Params const& params, Backend& backend)
+                    Params const& pr, Backend& be)
                 : suite_ (s)
                 //, params_ (params)
-                , backend_ (backend)
+                , backend_ (be)
                 , seq1_ (1)
                 , seq2_ (2)
                 , gen_ (id + 1)
                 , rand_ (0, 99)
-                , dist_ (0, params.items - 1)
+                , dist_ (0, pr.items - 1)
             {
             }
 
@@ -508,7 +508,7 @@ public:
                 }
             }
         };
-        
+
         try
         {
             parallel_for_id<Body>(params.items, params.threads,
@@ -552,15 +552,15 @@ public:
 
         public:
             Body (std::size_t id, suite& s,
-                    Params const& params, Backend& backend)
+                    Params const& pr, Backend& be)
                 : suite_ (s)
-                , params_ (params)
-                , backend_ (backend)
+                , params_ (pr)
+                , backend_ (be)
                 , seq1_ (1)
                 , gen_ (id + 1)
                 , rand_ (0, 99)
-                , recent_ (params.items, params.items * 2 - 1)
-                , older_ (0, params.items - 1)
+                , recent_ (pr.items, pr.items * 2 - 1)
+                , older_ (0, pr.items - 1)
             {
             }
 
@@ -748,4 +748,3 @@ BEAST_DEFINE_TESTSUITE_MANUAL(Timing,NodeStore,ripple);
 
 }
 }
-

--- a/src/ripple/overlay/impl/Manifest.h
+++ b/src/ripple/overlay/impl/Manifest.h
@@ -164,10 +164,10 @@ private:
         MappedType(MappedType&&) = default;
         MappedType& operator=(MappedType&&) = default;
 #endif
-        MappedType(std::string comment,
+        MappedType(std::string comment_,
                    std::string serialized,
                    AnyPublicKey pk, AnyPublicKey spk, std::uint32_t seq)
-            :comment (std::move(comment))
+            :comment (std::move(comment_))
         {
             m.emplace (std::move(serialized), std::move(pk), std::move(spk),
                        seq);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -2061,27 +2061,27 @@ PeerImp::getLedger (std::shared_ptr<protocol::TMGetLedger> const& m)
             reply.add_nodes ()->set_nodedata (
                 nData.getDataPtr (), nData.getLength ());
 
-            std::shared_ptr<SHAMap> map = ledger->peekAccountStateMap ();
+            std::shared_ptr<SHAMap> subMap = ledger->peekAccountStateMap ();
 
-            if (map && map->getHash ().isNonZero ())
+            if (subMap && subMap->getHash ().isNonZero ())
             {
                 // return account state root node if possible
                 Serializer rootNode (768);
 
-                if (map->getRootNode (rootNode, snfWIRE))
+                if (subMap->getRootNode (rootNode, snfWIRE))
                 {
                     reply.add_nodes ()->set_nodedata (
                         rootNode.getDataPtr (), rootNode.getLength ());
 
                     if (ledger->getTransHash ().isNonZero ())
                     {
-                        map = ledger->peekTransactionMap ();
+                        subMap = ledger->peekTransactionMap ();
 
-                        if (map && map->getHash ().isNonZero ())
+                        if (subMap && subMap->getHash ().isNonZero ())
                         {
                             rootNode.erase ();
 
-                            if (map->getRootNode (rootNode, snfWIRE))
+                            if (subMap->getRootNode (rootNode, snfWIRE))
                                 reply.add_nodes ()->set_nodedata (
                                     rootNode.getDataPtr (),
                                         rootNode.getLength ());

--- a/src/ripple/overlay/impl/TMHello.cpp
+++ b/src/ripple/overlay/impl/TMHello.cpp
@@ -183,10 +183,10 @@ parse_ProtocolVersions (std::string const& s)
 
     auto const list = beast::rfc2616::split_commas (s);
     std::vector<ProtocolVersion> result;
-    for (auto const& s : list)
+    for (auto const& i : list)
     {
         boost::smatch m;
-        if (! boost::regex_match (s, m, *re))
+        if (! boost::regex_match (i, m, *re))
             continue;
         int major;
         int minor;

--- a/src/ripple/overlay/tests/manifest_test.cpp
+++ b/src/ripple/overlay/tests/manifest_test.cpp
@@ -125,7 +125,7 @@ public:
         testcase ("load/store");
 
         std::string const dbName("ManifestCacheTestDB");
-        { 
+        {
             // create a database, save the manifest to the db and reload and
             // check that the manifest caches are the same
             DatabaseCon::Setup setup;
@@ -144,8 +144,8 @@ public:
                         std::vector<Manifest const*> result;
                         result.reserve (32);
                         cache.for_each_manifest (
-                            [&result](Manifest const& m)
-            {result.push_back (&m);});
+                            [&result](Manifest const& manifest)
+            {result.push_back (&manifest);});
                         return result;
                     };
             auto sort =

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -534,14 +534,14 @@ Livecache <Allocator>::hops_t::insert (Element& e)
 
 template <class Allocator>
 void
-Livecache <Allocator>::hops_t::reinsert (Element& e, int hops)
+Livecache <Allocator>::hops_t::reinsert (Element& e, int newHops)
 {
-    assert (hops >= 0 && hops <= Tuning::maxHops + 1);
+    assert (newHops >= 0 && newHops <= Tuning::maxHops + 1);
     list_type& list (m_lists [e.endpoint.hops]);
     list.erase (list.iterator_to (e));
     --m_hist [e.endpoint.hops];
 
-    e.endpoint.hops = hops;
+    e.endpoint.hops = newHops;
     insert (e);
 }
 

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -888,18 +888,18 @@ public:
         // Remove the key if present
         if (slot->public_key () != boost::none)
         {
-            Keys::iterator const iter (state->keys.find (*slot->public_key()));
+            Keys::iterator const iter2 (state->keys.find (*slot->public_key()));
             // Key must exist
-            assert (iter != state->keys.end ());
-            state->keys.erase (iter);
+            assert (iter2 != state->keys.end ());
+            state->keys.erase (iter2);
         }
         // Remove from connected address table
         {
-            auto const iter (state->connected_addresses.find (
+            auto const iter2 (state->connected_addresses.find (
                 slot->remote_endpoint().address()));
             // Address must exist
-            assert (iter != state->connected_addresses.end ());
-            state->connected_addresses.erase (iter);
+            assert (iter2 != state->connected_addresses.end ());
+            state->connected_addresses.erase (iter2);
         }
 
         // Update counts

--- a/src/ripple/peerfinder/impl/StoreSqdb.h
+++ b/src/ripple/peerfinder/impl/StoreSqdb.h
@@ -293,7 +293,7 @@ public:
         }
 
         {
-            int const version (currentSchemaVersion);
+            int const currentVersion (currentSchemaVersion);
             m_session <<
                 "INSERT OR REPLACE INTO SchemaVersion ("
                 "   name "
@@ -301,7 +301,7 @@ public:
                 ") VALUES ( "
                 "  'PeerFinder', :version "
                 ");"
-                , soci::use (version);
+                , soci::use (currentVersion);
         }
 
         tr.commit ();

--- a/src/ripple/peerfinder/sim/Predicates.h
+++ b/src/ripple/peerfinder/sim/Predicates.h
@@ -30,13 +30,18 @@ template <typename Node>
 class is_remote_node_pred
 {
 public:
-    is_remote_node_pred (Node const& node)
-        : node (node)
-        { }
+    is_remote_node_pred (Node const& node_)
+        : node (node_)
+    {
+    }
+
     template <typename Link>
     bool operator() (Link const& l) const
-        { return &node == &l.remote_node(); }
-private:
+    {
+        return &node == &l.remote_node();
+    }
+
+  private:
     Node const& node;
 };
 

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -45,9 +45,9 @@ public:
     SField const&     e_field;
     SOE_Flags const   flags;
 
-    SOElement (SField const& fieldName, SOE_Flags flags)
+    SOElement (SField const& fieldName, SOE_Flags flags_)
         : e_field (fieldName)
-        , flags (flags)
+        , flags (flags_)
     {
     }
 };

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -327,10 +327,10 @@ SField::getField (int code)
         // yet exist.
         StaticScopedLockType sl (SField_mutex);
 
-        auto it = unknownCodeToField.find (code);
+        auto i = unknownCodeToField.find (code);
 
-        if (it != unknownCodeToField.end ())
-            return * (it->second);
+        if (i != unknownCodeToField.end ())
+            return * (i->second);
         return *(unknownCodeToField[code] = std::unique_ptr<SField const>(
                        new SField(static_cast<SerializedTypeID>(type), field)));
     }

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -134,9 +134,9 @@ STTx::getMentionedAccounts () const
             if (std::find (accounts.cbegin (), accounts.cend (), na) == accounts.cend ())
                 accounts.push_back (na);
         }
-        else if (auto sa = dynamic_cast<STAmount const*> (&it))
+        else if (auto sa2 = dynamic_cast<STAmount const*> (&it))
         {
-            auto const& issuer = sa->getIssuer ();
+            auto const& issuer = sa2->getIssuer ();
 
             if (isXRP (issuer))
                 continue;

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -249,10 +249,10 @@ void executeRPC (
         auto wo = Json::stringWriterObject (output);
         getResult (context, method, *wo, handler->name_);
     }
-    else if (auto method = handler->valueMethod_)
+    else if (auto method2 = handler->valueMethod_)
     {
         auto object = Json::Value (Json::objectValue);
-        getResult (context, method, object, handler->name_);
+        getResult (context, method2, object, handler->name_);
         if (strategy.streaming == YieldStrategy::Streaming::yes)
             output = jsonAsString (object);
         else

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -256,14 +256,14 @@ SHAMap::getMissingNodes(std::vector<SHAMapNodeID>& nodeIDs, std::vector<uint256>
 
         // Process all deferred reads
         int hits = 0;
-        for (auto const& node : deferredReads)
+        for (auto const& deferredNode : deferredReads)
         {
-            auto parent = std::get<0>(node);
-            auto branch = std::get<1>(node);
-            auto const& nodeID = std::get<2>(node);
+            auto parent = std::get<0>(deferredNode);
+            auto branch = std::get<1>(deferredNode);
+            auto const& deferredNodeID = std::get<2>(deferredNode);
             auto const& nodeHash = parent->getChildHash (branch);
 
-            auto nodePtr = fetchNodeNT(nodeID, nodeHash, filter);
+            auto nodePtr = fetchNodeNT (deferredNodeID, nodeHash, filter);
             if (nodePtr)
             {
                 ++hits;
@@ -273,7 +273,7 @@ SHAMap::getMissingNodes(std::vector<SHAMapNodeID>& nodeIDs, std::vector<uint256>
             }
             else if ((max > 0) && (missingHashes.insert (nodeHash).second))
             {
-                nodeIDs.push_back (nodeID);
+                nodeIDs.push_back (deferredNodeID);
                 hashes.push_back (nodeHash);
 
                 --max;
@@ -386,10 +386,10 @@ bool SHAMap::getNodeFat (SHAMapNodeID wanted,
                         else if (childNode->isInner() || fatLeaves)
                         {
                             // Just include this node
-                            Serializer s;
-                            childNode->addRaw (s, snfWIRE);
+                            Serializer s2;
+                            childNode->addRaw (s2, snfWIRE);
                             nodeIDs.push_back (childID);
-                            rawNodes.push_back (std::move (s.peekData ()));
+                            rawNodes.push_back (std::move (s2.peekData ()));
                         }
                     }
                 }


### PR DESCRIPTION
@nbougalis @scottschurr 

Unfortunately, we can't yet turn on -Wshadow.

Some of the third party libraries have issues - we could fix those in the SConstruct - but boost has a warning that appears several times, even in 1.58.  I'll look at how I might contribute to the boost repo to get rid of this warning...