### PR TITLE
Disconnect peers on sustained large send queues

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -193,7 +193,12 @@ PeerImp::send (Message::pointer const& m)
     auto sendq_size = send_queue_.size();
 
     if (sendq_size < Tuning::targetSendQueue)
+    {
+        // To detect a peer that does not read from their
+        // side of the connection, we expect a peer to have
+        // a small send queue at least once per timer interval
         low_sendq_ = true;
+    }
 
     send_queue_.push(m);
 

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -156,7 +156,7 @@ private:
     beast::asio::streambuf write_buffer_;
     std::queue<Message::pointer> send_queue_;
     bool gracefulClose_ = false;
-    bool recent_empty_ = true;
+    bool low_sendq_ = true;
     std::unique_ptr <LoadEvent> load_event_;
     std::unique_ptr<Validators::Connection> validatorsConnection_;
     bool hopsAware_ = false;

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -52,6 +52,9 @@ enum
 
     /** How often we check connections (seconds) */
     checkSeconds        =   10,
+
+    /** How many messages we consider reasonable sustained on a send queue */
+    targetSendQueue     =  100,
 };
 
 } // Tuning


### PR DESCRIPTION
Previous behavior was sustained failure to empty a send queue, but this could trigger spuriously on aggressive ledger fetching.