### PR TITLE
Correctly compare JSON values.

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -2282,7 +2282,7 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\json\Output.h">
     </ClInclude>
-    <ClCompile Include="..\..\src\ripple\json\tests\JsonCpp.test.cpp">
+    <ClCompile Include="..\..\src\ripple\json\tests\json_value.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2976,7 +2976,7 @@
     <ClInclude Include="..\..\src\ripple\json\Output.h">
       <Filter>ripple\json</Filter>
     </ClInclude>
-    <ClCompile Include="..\..\src\ripple\json\tests\JsonCpp.test.cpp">
+    <ClCompile Include="..\..\src\ripple\json\tests\json_value.test.cpp">
       <Filter>ripple\json\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\json\tests\Object.test.cpp">

--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -89,6 +89,18 @@ private:
     const char* str_;
 };
 
+inline bool operator!= (StaticString x, StaticString y)
+{
+    // TODO(tom): could I use x != y here because StaticStrings are supposed to
+    // be unique?
+    return strcmp (x, y);
+}
+
+inline bool operator== (StaticString x, StaticString y)
+{
+    return ! (x != y);
+}
+
 inline bool operator== (std::string const& x, StaticString y)
 {
     return x == y.c_str();
@@ -234,16 +246,6 @@ public:
 
     ValueType type () const;
 
-    bool operator < ( const Value& other ) const;
-    bool operator <= ( const Value& other ) const;
-    bool operator >= ( const Value& other ) const;
-    bool operator > ( const Value& other ) const;
-
-    bool operator == ( const Value& other ) const;
-    bool operator != ( const Value& other ) const;
-
-    int compare ( const Value& other );
-
     const char* asCString () const;
     std::string asString () const;
     Int asInt () const;
@@ -369,6 +371,9 @@ public:
     iterator begin ();
     iterator end ();
 
+    friend bool operator== (const Value&, const Value&);
+    friend bool operator< (const Value&, const Value&);
+
 private:
     Value& resolveReference ( const char* key,
                               bool isStatic );
@@ -386,6 +391,34 @@ private:
     ValueType type_ : 8;
     int allocated_ : 1;     // Notes: if declared as bool, bitfield is useless.
 };
+
+bool operator== (const Value&, const Value&);
+
+inline
+bool operator!= (const Value& x, const Value& y)
+{
+    return ! (x == y);
+}
+
+bool operator< (const Value&, const Value&);
+
+inline
+bool operator<= (const Value& x, const Value& y)
+{
+    return ! (y < x);
+}
+
+inline
+bool operator> (const Value& x, const Value& y)
+{
+    return y < x;
+}
+
+inline
+bool operator>= (const Value& x, const Value& y)
+{
+    return ! (x < y);
+}
 
 /** \brief Experimental do not use: Allocator to customize member name and string value memory management done by Value.
  *

--- a/src/ripple/json/tests/json_value.test.cpp
+++ b/src/ripple/json/tests/json_value.test.cpp
@@ -25,7 +25,7 @@
 
 namespace ripple {
 
-class JsonCpp_test : public beast::unit_test::suite
+class json_value_test : public beast::unit_test::suite
 {
 public:
     void test_bad_json ()
@@ -139,15 +139,72 @@ public:
         pass ();
     }
 
+    void
+    test_comparisons()
+    {
+        Json::Value a, b;
+        auto testEquals = [&] (std::string const& name) {
+            expect (a == b, "a == b " + name);
+            expect (a <= b, "a <= b " + name);
+            expect (a >= b, "a >= b " + name);
+
+            expect (! (a != b), "! (a != b) " + name);
+            expect (! (a < b), "! (a < b) " + name);
+            expect (! (a > b), "! (a > b) " + name);
+
+            expect (b == a, "b == a " + name);
+            expect (b <= a, "b <= a " + name);
+            expect (b >= a, "b >= a " + name);
+
+            expect (! (b != a), "! (b != a) " + name);
+            expect (! (b < a), "! (b < a) " + name);
+            expect (! (b > a), "! (b > a) " + name);
+        };
+
+        auto testGreaterThan = [&] (std::string const& name) {
+            expect (! (a == b), "! (a == b) " + name);
+            expect (! (a <= b), "! (a <= b) " + name);
+            expect (a >= b, "a >= b " + name);
+
+            expect (a != b, "a != b " + name);
+            expect (! (a < b), "! (a < b) " + name);
+            expect (a > b, "a > b " + name);
+
+            expect (! (b == a), "! (b == a) " + name);
+            expect (b <= a, "b <= a " + name);
+            expect (! (b >= a), "! (b >= a) " + name);
+
+            expect (b != a, "b != a " + name);
+            expect (b < a, "b < a " + name);
+            expect (! (b > a), "! (b > a) " + name);
+        };
+
+        a["a"] = Json::UInt (0);
+        b["a"] = Json::Int (0);
+        testEquals ("zero");
+
+        b["a"] = Json::Int (-1);
+        testGreaterThan ("negative");
+
+        Json::Int big = std::numeric_limits<int>::max();
+        Json::UInt bigger = big;
+        bigger++;
+
+        a["a"] = bigger;
+        b["a"] = big;
+        testGreaterThan ("big");
+    }
+
     void run ()
     {
         test_bad_json ();
         test_edge_cases ();
         test_copy ();
         test_move ();
+        test_comparisons ();
     }
 };
 
-BEAST_DEFINE_TESTSUITE(JsonCpp,json,ripple);
+BEAST_DEFINE_TESTSUITE(json_value, json, ripple);
 
 } // ripple

--- a/src/ripple/unity/json.cpp
+++ b/src/ripple/unity/json.cpp
@@ -42,7 +42,7 @@
 #include <ripple/json/impl/Object.cpp>
 #include <ripple/json/impl/Output.cpp>
 
-#include <ripple/json/tests/JsonCpp.test.cpp>
+#include <ripple/json/tests/json_value.test.cpp>
 #include <ripple/json/tests/Object.test.cpp>
 #include <ripple/json/tests/Output.test.cpp>
 #include <ripple/json/tests/Writer.test.cpp>


### PR DESCRIPTION
You can see that we as yet make no essential use of the comparisons by looking at this branch, where I commented them out:  https://github.com/rec/rippled/tree/json-comparisons-commented-out

And in fact one of the six comparisons was just plain wrong, I discovered when I wrote unit tests, so we have that fixed now too.

@miguelportilla @nbougalis 