### PR TITLE
ConnectedAddresses stores Addresses to avoid port issues.

### DIFF
--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -177,14 +177,14 @@ OverlayImpl::onHandoff (std::unique_ptr <beast::asio::ssl_bundle>&& ssl_bundle,
 
     handoff.moved = true;
 
-    if (journal.trace) journal.trace <<
+    if (journal.debug) journal.debug<<
         "Peer connection upgrade from " << remote_endpoint;
 
     error_code ec;
     auto const local_endpoint (ssl_bundle->socket.local_endpoint(ec));
     if (ec)
     {
-        if (journal.trace) journal.trace <<
+        if (journal.debug) journal.debug <<
             remote_endpoint << " failed: " << ec.message();
         return handoff;
     }
@@ -252,7 +252,7 @@ OverlayImpl::onHandoff (std::unique_ptr <beast::asio::ssl_bundle>&& ssl_bundle,
         publicKey.toPublicKey(), cluster);
     if (result != PeerFinder::Result::success)
     {
-        if (journal.trace) journal.trace <<
+        if (journal.debug) journal.debug <<
             "Peer " << remote_endpoint << " redirected, slots full";
         handoff.moved = false;
         handoff.response = makeRedirectResponse(slot, request,

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -62,7 +62,7 @@ public:
 
     // A set of non-unique IPAddresses without ports, used
     // to filter duplicates when making outgoing connections.
-    using ConnectedAddresses = std::multiset <beast::IP::Endpoint>;
+    using ConnectedAddresses = std::multiset <beast::IP::Address>;
 
     struct State
     {
@@ -286,7 +286,8 @@ public:
 
         // Check for duplicate connection
         {
-            auto const iter = state->connected_addresses.find (remote_endpoint);
+            auto const iter = state->connected_addresses.find (
+                remote_endpoint.address());
             if (iter != state->connected_addresses.end())
             {
                 if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
@@ -339,7 +340,7 @@ public:
         // Remote address must not already exist
         assert (result.second);
         // Add to the connected address list
-        state->connected_addresses.emplace (remote_endpoint.at_port (0));
+        state->connected_addresses.emplace (remote_endpoint.address());
 
         // Update counts
         state->counts.add (*slot);
@@ -378,7 +379,7 @@ public:
         assert (result.second);
 
         // Add to the connected address list
-        state->connected_addresses.emplace (remote_endpoint.at_port (0));
+        state->connected_addresses.emplace (remote_endpoint.address());
 
         // Update counts
         state->counts.add (*slot);
@@ -895,7 +896,7 @@ public:
         // Remove from connected address table
         {
             auto const iter (state->connected_addresses.find (
-                slot->remote_endpoint().at_port (0)));
+                slot->remote_endpoint().address()));
             // Address must exist
             assert (iter != state->connected_addresses.end ());
             state->connected_addresses.erase (iter);


### PR DESCRIPTION
* Also change log level on a couple of Overlay messages.

Prevents fallacious assertion.

Reviewers: @vinniefalco, @miguelportilla  