### PR TITLE
[TRIVIAL] Make rippled C++14-ready.

### DIFF
--- a/src/beast/beast/cxx14/config.h
+++ b/src/beast/beast/cxx14/config.h
@@ -20,6 +20,8 @@
 #ifndef BEAST_CXX14_CONFIG_H_INCLUDED
 #define BEAST_CXX14_CONFIG_H_INCLUDED
 
+#include <ciso646>  // detect libc++ verison
+
 // Sets C++14 compatibility configuration macros based on build environment
 
 // Disables beast c++14 compatibility additions when set to 1
@@ -28,7 +30,7 @@
 #ifndef BEAST_NO_CXX14_COMPATIBILITY
 # ifdef _MSC_VER
 #  define BEAST_NO_CXX14_COMPATIBILITY 1
-# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201305
+# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201402
 #  define BEAST_NO_CXX14_COMPATIBILITY 1
 # else
 #  define BEAST_NO_CXX14_COMPATIBILITY 0
@@ -39,7 +41,7 @@
 #ifndef BEAST_NO_CXX14_MAKE_UNIQUE
 # ifdef _MSC_VER
 #  define BEAST_NO_CXX14_MAKE_UNIQUE 1
-# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201305
+# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201402
 #  define BEAST_NO_CXX14_MAKE_UNIQUE 1
 # else
 #  define BEAST_NO_CXX14_MAKE_UNIQUE 0
@@ -48,7 +50,35 @@
 
 // Disables beast's std::equal safe iterator overloads
 #ifndef BEAST_NO_CXX14_EQUAL
-# define BEAST_NO_CXX14_EQUAL 0
+# ifdef _MSC_VER
+#  define BEAST_NO_CXX14_EQUAL 0
+# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201402
+#  define BEAST_NO_CXX14_EQUAL 1
+# else
+#  define BEAST_NO_CXX14_EQUAL 0
+# endif
+#endif
+
+// Disables beast's std::integer_sequence
+#ifndef BEAST_NO_CXX14_INTEGER_SEQUENCE
+# ifdef _MSC_VER
+#  define BEAST_NO_CXX14_INTEGER_SEQUENCE 0
+# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201402
+#  define BEAST_NO_CXX14_INTEGER_SEQUENCE 1
+# else
+#  define BEAST_NO_CXX14_INTEGER_SEQUENCE 0
+# endif
+#endif
+
+// Disables beast's std::make_reverse_iterator
+#ifndef BEAST_NO_CXX14_MAKE_REVERSE_ITERATOR
+# ifdef _MSC_VER
+#  define BEAST_NO_CXX14_MAKE_REVERSE_ITERATOR 0
+# elif defined(__clang__) && defined(_LIBCPP_VERSION) && __cplusplus >= 201402
+#  define BEAST_NO_CXX14_MAKE_REVERSE_ITERATOR 1
+# else
+#  define BEAST_NO_CXX14_MAKE_REVERSE_ITERATOR 0
+# endif
 #endif
 
 #endif

--- a/src/beast/beast/cxx14/iterator.h
+++ b/src/beast/beast/cxx14/iterator.h
@@ -24,6 +24,8 @@
 
 #include <iterator>
 
+#if ! BEAST_NO_CXX14_MAKE_REVERSE_ITERATOR
+
 namespace std {
 
 // C++14 implementation of std::make_reverse_iterator to allow creation of a
@@ -37,5 +39,7 @@ make_reverse_iterator(Iter i)
 }
 
 }
+
+#endif
 
 #endif

--- a/src/beast/beast/cxx14/tests/integer_sequence.test.cpp
+++ b/src/beast/beast/cxx14/tests/integer_sequence.test.cpp
@@ -21,6 +21,8 @@
 #include <BeastConfig.h>
 #endif
 
+#if ! BEAST_NO_CXX14_INTEGER_SEQUENCE
+
 #include <beast/cxx14/utility.h>
 
 #include <beast/unit_test/suite.h>
@@ -107,3 +109,5 @@ BEAST_DEFINE_TESTSUITE(integer_sequence,cxx14,beast);
 
 }
 }
+
+#endif

--- a/src/beast/beast/cxx14/utility.h
+++ b/src/beast/beast/cxx14/utility.h
@@ -26,6 +26,8 @@
 #include <type_traits>
 #include <utility>
 
+#if ! BEAST_NO_CXX14_INTEGER_SEQUENCE
+
 namespace std {
 
 template <class T, T... Ints>
@@ -165,5 +167,7 @@ using index_sequence_for =
 #endif
 
 }
+
+#endif
 
 #endif


### PR DESCRIPTION
This makes rippled portable to `-std=c++14` on clang/libc++, but it does not actually flip the switch in SConstruct.  The configuration should be tested out on each platform of interest.  I suspect we may want to move to gcc-5.x prior to moving to `-std=c++14`.

@vinniefalco @nbougalis 