### PR TITLE
Remove unused parameter to `accountFromString()`.

### DIFF
--- a/src/ripple/rpc/handlers/AccountCurrencies.cpp
+++ b/src/ripple/rpc/handlers/AccountCurrencies.cpp
@@ -58,8 +58,8 @@ Json::Value doAccountCurrencies (RPC::Context& context)
     // Get info on account.
     bool bIndex; // out param
     RippleAddress naAccount; // out param
-    Json::Value jvAccepted (RPC::accountFromString (
-        ledger, naAccount, bIndex, strIdent, iIndex, bStrict, context.netOps));
+    Json::Value jvAccepted (
+        RPC::accountFromString (naAccount, bIndex, strIdent, iIndex, bStrict));
 
     if (!jvAccepted.empty ())
         return jvAccepted;

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -55,8 +55,8 @@ Json::Value doAccountInfo (RPC::Context& context)
 
     // Get info on account.
 
-    Json::Value jvAccepted = RPC::accountFromString (
-        ledger, naAccount, bIndex, strIdent, iIndex, bStrict, context.netOps);
+    auto jvAccepted = RPC::accountFromString (
+        naAccount, bIndex, strIdent, iIndex, bStrict);
 
     if (!jvAccepted.empty ())
         return jvAccepted;

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -90,11 +90,11 @@ Json::Value doAccountLines (RPC::Context& context)
     int iIndex (bIndex ? params[jss::account_index].asUInt () : 0);
     RippleAddress rippleAddress;
 
-    Json::Value const jv (RPC::accountFromString (ledger, rippleAddress, bIndex,
-        strIdent, iIndex, false, context.netOps));
+    auto jv = RPC::accountFromString (
+        rippleAddress, bIndex, strIdent, iIndex, false);
     if (! jv.empty ())
     {
-        for (Json::Value::const_iterator it (jv.begin ()); it != jv.end (); ++it)
+        for (auto it = jv.begin (); it != jv.end (); ++it)
             result[it.memberName ()] = it.key ();
 
         return result;
@@ -117,8 +117,8 @@ Json::Value doAccountLines (RPC::Context& context)
         if (bPeerIndex)
             result[jss::peer_index] = iPeerIndex;
 
-        result = RPC::accountFromString (ledger, rippleAddressPeer, bPeerIndex,
-            strPeer, iPeerIndex, false, context.netOps);
+        result = RPC::accountFromString (
+            rippleAddressPeer, bPeerIndex, strPeer, iPeerIndex, false);
 
         if (! result.empty ())
             return result;

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -28,7 +28,7 @@
 
 namespace ripple {
 
-/** General RPC command that can retrieve objects in the account root.    
+/** General RPC command that can retrieve objects in the account root.
     {
       account: <account>|<account_public_key>
       account_index: <integer> // optional, defaults to 0
@@ -57,8 +57,8 @@ Json::Value doAccountObjects (RPC::Context& context)
         auto const strIdent = params[jss::account].asString ();
         auto iIndex = context.params.isMember (jss::account_index)
             ? context.params[jss::account_index].asUInt () : 0;
-        auto jv = RPC::accountFromString (ledger, raAccount, bIndex,
-            strIdent, iIndex, false, context.netOps);
+        auto jv = RPC::accountFromString (
+            raAccount, bIndex, strIdent, iIndex, false);
         if (! jv.empty ())
         {
             for (auto it = jv.begin (); it != jv.end (); ++it)
@@ -99,7 +99,7 @@ Json::Value doAccountObjects (RPC::Context& context)
                 { return t.first == filter; });
         if (iter == types->end ())
             return RPC::invalid_field_error (jss::type);
-        
+
         type = iter->second;
     }
 
@@ -119,7 +119,7 @@ Json::Value doAccountObjects (RPC::Context& context)
                 std::min (limit, RPC::Tuning::maxObjectsPerRequest));
         }
     }
-    
+
     uint256 dirIndex;
     uint256 entryIndex;
     if (params.isMember (jss::marker))
@@ -127,7 +127,7 @@ Json::Value doAccountObjects (RPC::Context& context)
         auto const& marker = params[jss::marker];
         if (! marker.isString ())
             return RPC::expected_field_error (jss::marker, "string");
-        
+
         std::stringstream ss (marker.asString ());
         std::string s;
         if (!std::getline(ss, s, ','))
@@ -138,7 +138,7 @@ Json::Value doAccountObjects (RPC::Context& context)
 
         if (! std::getline (ss, s, ','))
             return RPC::invalid_field_error (jss::marker);
-        
+
         if (! entryIndex.SetHex (s))
             return RPC::invalid_field_error (jss::marker);
     }
@@ -149,7 +149,7 @@ Json::Value doAccountObjects (RPC::Context& context)
         return RPC::invalid_field_error (jss::marker);
     }
 
-    result[jss::account] = raAccount.humanAccountID ();    
+    result[jss::account] = raAccount.humanAccountID ();
     context.loadType = Resource::feeMediumBurdenRPC;
     return result;
 }

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -46,8 +46,8 @@ Json::Value doAccountOffers (RPC::Context& context)
     int const iIndex (bIndex ? params[jss::account_index].asUInt () : 0);
     RippleAddress rippleAddress;
 
-    Json::Value const jv (RPC::accountFromString (ledger, rippleAddress, bIndex,
-        strIdent, iIndex, false, context.netOps));
+    Json::Value const jv = RPC::accountFromString (
+        rippleAddress, bIndex, strIdent, iIndex, false);
     if (! jv.empty ())
     {
         for (Json::Value::const_iterator it (jv.begin ()); it != jv.end (); ++it)

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -96,8 +96,8 @@ Json::Value doNoRippleCheck (RPC::Context& context)
     int iIndex (bIndex ? params[jss::account_index].asUInt () : 0);
     RippleAddress rippleAddress;
 
-    Json::Value const jv (RPC::accountFromString (ledger, rippleAddress, bIndex,
-        strIdent, iIndex, false, context.netOps));
+    Json::Value const jv = RPC::accountFromString (
+        rippleAddress, bIndex, strIdent, iIndex, false);
     if (! jv.empty ())
     {
         for (Json::Value::const_iterator it (jv.begin ()); it != jv.end (); ++it)

--- a/src/ripple/rpc/handlers/OwnerInfo.cpp
+++ b/src/ripple/rpc/handlers/OwnerInfo.cpp
@@ -46,26 +46,22 @@ Json::Value doOwnerInfo (RPC::Context& context)
 
     auto const& closedLedger = context.netOps.getClosedLedger ();
     Json::Value jAccepted = RPC::accountFromString (
-        closedLedger,
         raAccount,
         bIndex,
         strIdent,
         iIndex,
-        false,
-        context.netOps);
+        false);
 
     ret[jss::accepted] = jAccepted.empty () ? context.netOps.getOwnerInfo (
         closedLedger, raAccount) : jAccepted;
 
     auto const& currentLedger = context.netOps.getCurrentLedger ();
     Json::Value jCurrent = RPC::accountFromString (
-        currentLedger,
         raAccount,
         bIndex,
         strIdent,
         iIndex,
-        false,
-        context.netOps);
+        false);
 
     ret[jss::current] = jCurrent.empty () ? context.netOps.getOwnerInfo (
         currentLedger, raAccount) : jCurrent;

--- a/src/ripple/rpc/impl/AccountFromString.cpp
+++ b/src/ripple/rpc/impl/AccountFromString.cpp
@@ -29,13 +29,11 @@ namespace RPC {
 //
 // Returns a Json::objectValue, containing error information if there was one.
 Json::Value accountFromString (
-    Ledger::ref lrLedger,
     RippleAddress& naAccount,
     bool& bIndex,
     std::string const& strIdent,
     int const iIndex,
-    bool const bStrict,
-    NetworkOPs& netOps)
+    bool const bStrict)
 {
     RippleAddress   naSeed;
 

--- a/src/ripple/rpc/impl/AccountFromString.h
+++ b/src/ripple/rpc/impl/AccountFromString.h
@@ -27,13 +27,11 @@ namespace ripple {
 namespace RPC {
 
 Json::Value accountFromString (
-    Ledger::ref lrLedger,
     RippleAddress& naAccount,
     bool& bIndex,
     std::string const& strIdent,
-    const int iIndex,
-    const bool bStrict,
-    NetworkOPs& netOps);
+    int iIndex,
+    bool bStrict);
 
 } // RPC
 } // ripple


### PR DESCRIPTION
Was there some reason that this was there?  Should that function use the current ledger, or was it never used?

@JoelKatz @vinniefalco @nbougalis 