### PR TITLE
Improve peer send queue management:

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -517,6 +517,12 @@ PeerImp::onTimer (error_code const& ec)
         return;
     }
 
+    if (++no_ping_ >= Tuning::noPing)
+    {
+        fail ("No ping reply received");
+        return;
+    }
+
     if (lastPingSeq_ == 0)
     {
         // Make sequence unpredictable enough that a peer
@@ -530,11 +536,6 @@ PeerImp::onTimer (error_code const& ec)
 
         send (std::make_shared<Message> (
             message, protocol::mtPING));
-    }
-    else if (++no_ping_ >= Tuning::noPing)
-    {
-        fail ("No ping reply received");
-        return;
     }
 
     setTimer();
@@ -1477,6 +1478,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMGetObjectByHash> const& m)
         {
             if (p_journal_.debug) p_journal_.debug <<
                 "GetObject: Large send queue";
+            return;
         }
 
 
@@ -1927,6 +1929,7 @@ PeerImp::getLedger (std::shared_ptr<protocol::TMGetLedger> const& m)
         {
             if (p_journal_.debug) p_journal_.debug <<
                 "GetLedger: Large send queue";
+            return;
         }
 
         if (getApp().getFeeTrack().isLoadedLocal() && ! cluster())

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -511,13 +511,13 @@ PeerImp::onTimer (error_code const& ec)
         return close();
     }
 
-    if (++large_sendq_ >= Tuning::sendqIntervals)
+    if (large_sendq_++ >= Tuning::sendqIntervals)
     {
         fail ("Large send queue");
         return;
     }
 
-    if (++no_ping_ >= Tuning::noPing)
+    if (no_ping_++ >= Tuning::noPing)
     {
         fail ("No ping reply received");
         return;

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -156,7 +156,8 @@ private:
     beast::asio::streambuf write_buffer_;
     std::queue<Message::pointer> send_queue_;
     bool gracefulClose_ = false;
-    bool recent_empty_ = true;
+    int large_sendq_ = 0;
+    int no_ping_ = 0;
     std::unique_ptr <LoadEvent> load_event_;
     std::unique_ptr<Validators::Connection> validatorsConnection_;
     bool hopsAware_ = false;

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -60,7 +60,7 @@ enum
     sendqIntervals      =    3,
 
     /** How many timer intervals we can go without a ping reply */
-    noPing              =    3,
+    noPing              =    4,
 
     /** How many messages on a send queue before we refuse queries */
     dropSendQueue       =    5,

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -52,6 +52,21 @@ enum
 
     /** How often we check connections (seconds) */
     checkSeconds        =   10,
+
+    /** How often we latency/sendq probe connections */
+    timerSeconds        =    3,
+
+    /** How many timer intervals a sendq has to stay large before we disconnect */
+    sendqIntervals      =    3,
+
+    /** How many timer intervals we can go without a ping reply */
+    noPing              =    3,
+
+    /** How many messages on a send queue before we refuse queries */
+    dropSendQueue       =    5,
+
+    /** How many messages we consider reasonable sustained on a send queue */
+    targetSendQueue     =   16,
 };
 
 } // Tuning


### PR DESCRIPTION
* Disconnect peers on sustained large send queues
* Disconnect peers on sustained failure to pong
* Refuse some queries if send queue is at target
* Allow latency to exceed ping timer interval

This fixes two bugs in the existing peer timer handling code. One was the incorrect logic to determine whether the timer was being set for the first time which could result in peers timing out too quickly. The other was the incorrect ping sequence reset logic which would cause the latency measuring to fail if the latency was greater than the timer interval.

There are two key bits of new behavior. One is the disconnection of peers that don't respond to our pings in a timely way. This catches cases where there's excessive queue lengths on the peer-to-peer connections.

The biggest is the dropping of ledger queries when our send queue is large. Without this change, large queues can result in slow responses, leading to timeouts, leading to more aggressive querying, leading to larger queues, causing a meltdown resulting in the connection being dropped. By dropping the queries (rather than replying when we know the other side will get the reply late), the other side still times out, but the queue shrinks because we didn't reply, leading to the problem resolving rather than getting worse.