### PR TITLE
Split SHAMapTreeNode into leaf and inner nodes.

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -710,6 +710,9 @@
     <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_SystemStats.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_Threads.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\beast\beast\module\core\streams\InputSource.h">
     </ClInclude>
     <ClCompile Include="..\..\src\beast\beast\module\core\streams\InputStream.cpp">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -1248,6 +1248,9 @@
     <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_SystemStats.cpp">
       <Filter>beast\module\core\native</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_Threads.cpp">
+      <Filter>beast\module\core\native</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\beast\beast\module\core\streams\InputSource.h">
       <Filter>beast\module\core\streams</Filter>
     </ClInclude>

--- a/src/beast/beast/module/core/core.unity.cpp
+++ b/src/beast/beast/module/core/core.unity.cpp
@@ -176,6 +176,7 @@
 #elif BEAST_WINDOWS
 #include <beast/module/core/native/win32_Files.cpp>
 #include <beast/module/core/native/win32_SystemStats.cpp>
+#include <beast/module/core/native/win32_Threads.cpp>
 
 #elif BEAST_LINUX
 #include <beast/module/core/native/linux_Files.cpp>

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -235,16 +235,16 @@ public:
                 if (!node.has_nodeid () || !node.has_nodedata ())
                     return;
 
-                SHAMapTreeNode newNode(
+                auto newNode = SHAMapAbstractNode::make(
                     Blob (node.nodedata().begin(), node.nodedata().end()),
                     0, snfWIRE, uZero, false);
 
                 s.erase();
-                newNode.addRaw(s, snfPREFIX);
+                newNode->addRaw(s, snfPREFIX);
 
                 auto blob = std::make_shared<Blob> (s.begin(), s.end());
 
-                getApp().getOPs().addFetchPack (newNode.getNodeHash(), blob);
+                getApp().getOPs().addFetchPack (newNode->getNodeHash(), blob);
             }
         }
         catch (...)

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -245,7 +245,7 @@ SHAMapStoreImp::onLedgerClosed (Ledger::pointer validatedLedger)
 
 bool
 SHAMapStoreImp::copyNode (std::uint64_t& nodeCount,
-        SHAMapTreeNode const& node)
+        SHAMapAbstractNode const& node)
 {
     // Copy a single record from node to database_
     database_->fetchNode (node.getNodeHash());

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -159,7 +159,7 @@ public:
 
 private:
     // callback for visitNodes
-    bool copyNode (std::uint64_t& nodeCount, SHAMapTreeNode const &node);
+    bool copyNode (std::uint64_t& nodeCount, SHAMapAbstractNode const &node);
     void run();
     void dbPaths();
     std::shared_ptr <NodeStore::Backend> makeBackendRotating (

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -128,6 +128,7 @@ public:
              SHANodeFormat format, uint256 const& hash, bool hashValid);
 };
 
+// SHAMapTreeNode represents a leaf, and may eventually be renamed to reflect that.
 class SHAMapTreeNode
     : public SHAMapAbstractNode
 {
@@ -227,6 +228,14 @@ SHAMapAbstractNode::isValid () const
     return mType != tnERROR;
 }
 
+inline
+bool
+SHAMapAbstractNode::isInBounds (SHAMapNodeID const &id) const
+{
+    // Nodes at depth 64 must be leaves
+    return (!isInner() || (id.getDepth() < 64));
+}
+
 // SHAMapInnerNode
 
 inline
@@ -262,14 +271,6 @@ void
 SHAMapInnerNode::setFullBelowGen (std::uint32_t gen)
 {
     mFullBelowGen = gen;
-}
-
-inline
-bool
-SHAMapAbstractNode::isInBounds (SHAMapNodeID const &id) const
-{
-    // Nodes at depth 64 must be leaves
-    return (!isInner() || (id.getDepth() < 64));
 }
 
 // SHAMapTreeNode

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -39,7 +39,7 @@ enum SHANodeFormat
     snfHASH     = 3, // just the hash
 };
 
-class SHAMapTreeNode
+class SHAMapAbstractNode
 {
 public:
     enum TNType
@@ -51,112 +51,163 @@ public:
         tnACCOUNT_STATE     = 4
     };
 
-private:
-    uint256                         mHash;
-    uint256                         mHashes[16];
-    std::shared_ptr<SHAMapTreeNode> mChildren[16];
-    std::shared_ptr<SHAMapItem>     mItem;
-    std::uint32_t                   mSeq;
+protected:
     TNType                          mType;
-    int                             mIsBranch;
-    std::uint32_t                   mFullBelowGen;
+    uint256                         mHash;
+    std::uint32_t                   mSeq;
+
+protected:
+    virtual ~SHAMapAbstractNode() = 0;
+    SHAMapAbstractNode(SHAMapAbstractNode const&) = delete;
+    SHAMapAbstractNode& operator=(SHAMapAbstractNode const&) = delete;
+
+    SHAMapAbstractNode(TNType type, std::uint32_t seq);
+    SHAMapAbstractNode(TNType type, std::uint32_t seq, uint256 const& hash);
+
+public:
+    std::uint32_t getSeq () const;
+    void setSeq (std::uint32_t s);
+    uint256 const& getNodeHash () const;
+    TNType getType () const;
+    bool isLeaf () const;
+    bool isInner () const;
+    bool isValid () const;
+    bool isInBounds (SHAMapNodeID const &id) const;
+
+    virtual bool updateHash () = 0;
+    virtual void addRaw (Serializer&, SHANodeFormat format) = 0;
+    virtual std::string getString (SHAMapNodeID const&) const;
+    virtual std::shared_ptr<SHAMapAbstractNode> clone(std::uint32_t seq) const = 0;
+
+    static std::shared_ptr<SHAMapAbstractNode>
+        make(Blob const& rawNode, std::uint32_t seq, SHANodeFormat format,
+             uint256 const& hash, bool hashValid);
+
+    // debugging
+#ifdef BEAST_DEBUG
+    static void dump (SHAMapNodeID const&, beast::Journal journal);
+#endif
+};
+
+class SHAMapInnerNode
+    : public SHAMapAbstractNode
+{
+    uint256                         mHashes[16];
+    std::shared_ptr<SHAMapAbstractNode> mChildren[16];
+    int                             mIsBranch = 0;
+    std::uint32_t                   mFullBelowGen = 0;
 
     static std::mutex               childLock;
+public:
+    SHAMapInnerNode(std::uint32_t seq = 0);
+    std::shared_ptr<SHAMapAbstractNode> clone(std::uint32_t seq) const override;
+
+    bool isEmpty () const;
+    bool isEmptyBranch (int m) const;
+    int getBranchCount () const;
+    uint256 const& getChildHash (int m) const;
+
+    void setChild(int m, std::shared_ptr<SHAMapAbstractNode> const& child);
+    void shareChild (int m, std::shared_ptr<SHAMapAbstractNode> const& child);
+    SHAMapAbstractNode* getChildPointer (int branch);
+    std::shared_ptr<SHAMapAbstractNode> getChild (int branch);
+    std::shared_ptr<SHAMapAbstractNode>
+        canonicalizeChild (int branch, std::shared_ptr<SHAMapAbstractNode> node);
+
+    // sync functions
+    bool isFullBelow (std::uint32_t generation) const;
+    void setFullBelowGen (std::uint32_t gen);
+
+    bool updateHash () override;
+    void updateHashDeep();
+    void addRaw (Serializer&, SHANodeFormat format) override;
+    std::string getString (SHAMapNodeID const&) const override;
+
+    friend std::shared_ptr<SHAMapAbstractNode>
+        SHAMapAbstractNode::make(Blob const& rawNode, std::uint32_t seq,
+             SHANodeFormat format, uint256 const& hash, bool hashValid);
+};
+
+class SHAMapTreeNode
+    : public SHAMapAbstractNode
+{
+private:
+    std::shared_ptr<SHAMapItem>     mItem;
 
 public:
     SHAMapTreeNode (const SHAMapTreeNode&) = delete;
     SHAMapTreeNode& operator= (const SHAMapTreeNode&) = delete;
 
-    SHAMapTreeNode (std::uint32_t seq); // empty node
-    SHAMapTreeNode (const SHAMapTreeNode & node, std::uint32_t seq); // copy node from older tree
     SHAMapTreeNode (std::shared_ptr<SHAMapItem> const& item, TNType type, std::uint32_t seq);
-    SHAMapTreeNode (Blob const & data, std::uint32_t seq,
-                    SHANodeFormat format, uint256 const& hash, bool hashValid);
+    SHAMapTreeNode(std::shared_ptr<SHAMapItem> const& item, TNType type,
+                   std::uint32_t seq, uint256 const& hash);
+    std::shared_ptr<SHAMapAbstractNode> clone(std::uint32_t seq) const override;
 
-    void addRaw (Serializer&, SHANodeFormat format);
-    uint256 const& getNodeHash () const;
+    void addRaw (Serializer&, SHANodeFormat format) override;
 
 public:  // public only to SHAMap
-    void setChild (int m, std::shared_ptr<SHAMapTreeNode> const& child);
-    void shareChild (int m, std::shared_ptr<SHAMapTreeNode> const& child);
-
-    // node functions
-    std::uint32_t getSeq () const;
-    void setSeq (std::uint32_t s);
-    TNType getType () const;
-
-    // type functions
-    bool isLeaf () const;
-    bool isInner () const;
-    bool isInBounds (SHAMapNodeID const &id) const;
-    bool isValid () const;
 
     // inner node functions
     bool isInnerNode () const;
-    bool isEmptyBranch (int m) const;
-    bool isEmpty () const;
-    int getBranchCount () const;
-    void makeInner ();
-    uint256 const& getChildHash (int m) const;
 
     // item node function
     bool hasItem () const;
     std::shared_ptr<SHAMapItem> const& peekItem () const;
     bool setItem (std::shared_ptr<SHAMapItem> const& i, TNType type);
 
-    // sync functions
-    bool isFullBelow (std::uint32_t generation) const;
-    void setFullBelowGen (std::uint32_t gen);
-
-    SHAMapTreeNode* getChildPointer (int branch);
-    std::shared_ptr<SHAMapTreeNode> getChild (int branch);
-    void canonicalizeChild (int branch, std::shared_ptr<SHAMapTreeNode>& node);
-
-    // debugging
-#ifdef BEAST_DEBUG
-    void dump (SHAMapNodeID const&, beast::Journal journal);
-#endif
-    std::string getString (SHAMapNodeID const&) const;
-    bool updateHash ();
-    void updateHashDeep();
-
-private:
-    bool isTransaction () const;
-    bool hasMetaData () const;
-    bool isAccountState () const;
+    std::string getString (SHAMapNodeID const&) const override;
+    bool updateHash () override;
 };
+
+// SHAMapAbstractNode
+
+inline
+SHAMapAbstractNode::SHAMapAbstractNode(TNType type, std::uint32_t seq)
+    : mType(type)
+    , mSeq(seq)
+{
+}
+
+inline
+SHAMapAbstractNode::SHAMapAbstractNode(TNType type, std::uint32_t seq,
+                                       uint256 const& hash)
+    : mType(type)
+    , mHash(hash)
+    , mSeq(seq)
+{
+}
 
 inline
 std::uint32_t
-SHAMapTreeNode::getSeq () const
+SHAMapAbstractNode::getSeq () const
 {
     return mSeq;
 }
 
 inline
 void
-SHAMapTreeNode::setSeq (std::uint32_t s)
+SHAMapAbstractNode::setSeq (std::uint32_t s)
 {
     mSeq = s;
 }
 
 inline
 uint256 const&
-SHAMapTreeNode::getNodeHash () const
+SHAMapAbstractNode::getNodeHash () const
 {
     return mHash;
 }
 
 inline
-SHAMapTreeNode::TNType
-SHAMapTreeNode::getType () const
+SHAMapAbstractNode::TNType
+SHAMapAbstractNode::getType () const
 {
     return mType;
 }
 
 inline
 bool
-SHAMapTreeNode::isLeaf () const
+SHAMapAbstractNode::isLeaf () const
 {
     return (mType == tnTRANSACTION_NM) || (mType == tnTRANSACTION_MD) ||
            (mType == tnACCOUNT_STATE);
@@ -164,67 +215,70 @@ SHAMapTreeNode::isLeaf () const
 
 inline
 bool
-SHAMapTreeNode::isInner () const
+SHAMapAbstractNode::isInner () const
 {
     return mType == tnINNER;
 }
 
 inline
 bool
-SHAMapTreeNode::isInBounds (SHAMapNodeID const &id) const
-{
-    // Nodes at depth 64 must be leaves
-    return (!isInner() || (id.getDepth() < 64));
-}
-
-inline
-bool
-SHAMapTreeNode::isValid () const
+SHAMapAbstractNode::isValid () const
 {
     return mType != tnERROR;
 }
 
+// SHAMapInnerNode
+
 inline
-bool
-SHAMapTreeNode::isTransaction () const
+SHAMapInnerNode::SHAMapInnerNode(std::uint32_t seq)
+    : SHAMapAbstractNode(tnINNER, seq)
 {
-    return (mType == tnTRANSACTION_NM) || (mType == tnTRANSACTION_MD);
 }
 
 inline
 bool
-SHAMapTreeNode::hasMetaData () const
-{
-    return mType == tnTRANSACTION_MD;
-}
-
-inline
-bool
-SHAMapTreeNode::isAccountState () const
-{
-    return mType == tnACCOUNT_STATE;
-}
-
-inline
-bool
-SHAMapTreeNode::isInnerNode () const
-{
-    return !mItem;
-}
-
-inline
-bool
-SHAMapTreeNode::isEmptyBranch (int m) const
+SHAMapInnerNode::isEmptyBranch (int m) const
 {
     return (mIsBranch & (1 << m)) == 0;
 }
 
 inline
 uint256 const&
-SHAMapTreeNode::getChildHash (int m) const
+SHAMapInnerNode::getChildHash (int m) const
 {
-    assert ((m >= 0) && (m < 16) && (mType == tnINNER));
+    assert ((m >= 0) && (m < 16) && (getType() == tnINNER));
     return mHashes[m];
+}
+
+inline
+bool
+SHAMapInnerNode::isFullBelow (std::uint32_t generation) const
+{
+    return mFullBelowGen == generation;
+}
+
+inline
+void
+SHAMapInnerNode::setFullBelowGen (std::uint32_t gen)
+{
+    mFullBelowGen = gen;
+}
+
+inline
+bool
+SHAMapAbstractNode::isInBounds (SHAMapNodeID const &id) const
+{
+    // Nodes at depth 64 must be leaves
+    return (!isInner() || (id.getDepth() < 64));
+}
+
+// SHAMapTreeNode
+
+inline
+bool
+SHAMapTreeNode::isInnerNode () const
+{
+    return !mItem;
 }
 
 inline
@@ -239,20 +293,6 @@ std::shared_ptr<SHAMapItem> const&
 SHAMapTreeNode::peekItem () const
 {
     return mItem;
-}
-
-inline
-bool
-SHAMapTreeNode::isFullBelow (std::uint32_t generation) const
-{
-    return mFullBelowGen == generation;
-}
-
-inline
-void
-SHAMapTreeNode::setFullBelowGen (std::uint32_t gen)
-{
-    mFullBelowGen = gen;
 }
 
 } // ripple

--- a/src/ripple/shamap/TreeNodeCache.h
+++ b/src/ripple/shamap/TreeNodeCache.h
@@ -24,9 +24,9 @@
 
 namespace ripple {
 
-class SHAMapTreeNode;
+class SHAMapAbstractNode;
 
-using TreeNodeCache = TaggedCache <uint256, SHAMapTreeNode>;
+using TreeNodeCache = TaggedCache <uint256, SHAMapAbstractNode>;
 
 } // ripple
 

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -38,8 +38,7 @@ SHAMap::SHAMap (
 {
     assert (seq_ != 0);
 
-    root_ = std::make_shared<SHAMapTreeNode> (seq_);
-    root_->makeInner ();
+    root_ = std::make_shared<SHAMapInnerNode> (seq_);
 }
 
 SHAMap::SHAMap (
@@ -54,8 +53,7 @@ SHAMap::SHAMap (
     , state_ (SHAMapState::Synching)
     , type_ (t)
 {
-    root_ = std::make_shared<SHAMapTreeNode> (seq_);
-    root_->makeInner ();
+    root_ = std::make_shared<SHAMapInnerNode> (seq_);
 }
 
 SHAMap::~SHAMap ()
@@ -91,7 +89,7 @@ SHAMap::getStack (uint256 const& id, bool include_nonmatching_leaf) const
     // produce a stack of nodes along the way, with the terminal node at the top
     SharedPtrNodeStack stack;
 
-    std::shared_ptr<SHAMapTreeNode> node = root_;
+    std::shared_ptr<SHAMapAbstractNode> node = root_;
     SHAMapNodeID nodeID;
 
     while (!node->isLeaf ())
@@ -100,15 +98,16 @@ SHAMap::getStack (uint256 const& id, bool include_nonmatching_leaf) const
 
         int branch = nodeID.selectBranch (id);
         assert (branch >= 0);
-
-        if (node->isEmptyBranch (branch))
+        auto inner = std::static_pointer_cast<SHAMapInnerNode>(std::move(node));
+        if (inner->isEmptyBranch (branch))
             return stack;
 
-        node = descendThrow (node, branch);
+        node = descendThrow (inner, branch);
         nodeID = nodeID.getChildNodeID (branch);
     }
 
-    if (include_nonmatching_leaf || (node->peekItem ()->getTag () == id))
+    if (include_nonmatching_leaf ||
+        (std::static_pointer_cast<SHAMapTreeNode>(node)->peekItem()->getTag() == id))
         stack.push ({node, nodeID});
 
     return stack;
@@ -116,7 +115,7 @@ SHAMap::getStack (uint256 const& id, bool include_nonmatching_leaf) const
 
 void
 SHAMap::dirtyUp (SharedPtrNodeStack& stack,
-                 uint256 const& target, std::shared_ptr<SHAMapTreeNode> child)
+                 uint256 const& target, std::shared_ptr<SHAMapAbstractNode> child)
 {
     // walk the tree up from through the inner nodes to the root_
     // update hashes and links
@@ -128,15 +127,15 @@ SHAMap::dirtyUp (SharedPtrNodeStack& stack,
 
     while (!stack.empty ())
     {
-        std::shared_ptr<SHAMapTreeNode> node = stack.top ().first;
+        auto node = std::dynamic_pointer_cast<SHAMapInnerNode>(stack.top ().first);
         SHAMapNodeID nodeID = stack.top ().second;
         stack.pop ();
-        assert (node->isInnerNode ());
+        assert (node != nullptr);
 
         int branch = nodeID.selectBranch (target);
         assert (branch >= 0);
 
-        unshareNode (node, nodeID);
+        node = unshareNode(std::move(node), nodeID);
         node->setChild (branch, child);
 
     #ifdef ST_DEBUG
@@ -149,28 +148,29 @@ SHAMap::dirtyUp (SharedPtrNodeStack& stack,
 
 SHAMapTreeNode* SHAMap::walkToPointer (uint256 const& id) const
 {
-    SHAMapTreeNode* inNode = root_.get ();
+    auto inNode = root_.get();
     SHAMapNodeID nodeID;
     uint256 nodeHash;
 
     while (inNode->isInner ())
     {
         int branch = nodeID.selectBranch (id);
-
-        if (inNode->isEmptyBranch (branch))
+        auto inner = static_cast<SHAMapInnerNode*>(inNode);
+        if (inner->isEmptyBranch (branch))
             return nullptr;
 
-        inNode = descendThrow (inNode, branch);
+        inNode = descendThrow (inner, branch);
         nodeID = nodeID.getChildNodeID (branch);
     }
 
-    return (inNode->peekItem()->getTag () == id) ? inNode : nullptr;
+    auto ret = static_cast<SHAMapTreeNode*>(inNode);
+    return ret->peekItem()->getTag() == id ? ret : nullptr;
 }
 
-std::shared_ptr<SHAMapTreeNode>
+std::shared_ptr<SHAMapAbstractNode>
 SHAMap::fetchNodeFromDB (uint256 const& hash) const
 {
-    std::shared_ptr<SHAMapTreeNode> node;
+    std::shared_ptr<SHAMapAbstractNode> node;
 
     if (backed_)
     {
@@ -179,7 +179,7 @@ SHAMap::fetchNodeFromDB (uint256 const& hash) const
         {
             try
             {
-                node = std::make_shared <SHAMapTreeNode> (obj->getData(),
+                node = SHAMapAbstractNode::make(obj->getData(),
                     0, snfPREFIX, hash, true);
                 canonicalize (hash, node);
             }
@@ -201,36 +201,30 @@ SHAMap::fetchNodeFromDB (uint256 const& hash) const
 }
 
 // See if a sync filter has a node
-std::shared_ptr<SHAMapTreeNode> SHAMap::checkFilter (
-    uint256 const& hash,
-    SHAMapNodeID const& id,
-    SHAMapSyncFilter* filter) const
+std::shared_ptr<SHAMapAbstractNode>
+SHAMap::checkFilter(uint256 const& hash, SHAMapNodeID const& id,
+                    SHAMapSyncFilter* filter) const
 {
-    std::shared_ptr<SHAMapTreeNode> node;
+    std::shared_ptr<SHAMapAbstractNode> node;
     Blob nodeData;
-
     if (filter->haveNode (id, hash, nodeData))
     {
-        node = std::make_shared <SHAMapTreeNode> (
-            nodeData, 0, snfPREFIX, hash, true);
-
-       filter->gotNode (true, id, hash, nodeData, node->getType ());
-
-       if (backed_)
-           canonicalize (hash, node);
+        node = SHAMapAbstractNode::make(nodeData, 0, snfPREFIX, hash, true);
+        filter->gotNode (true, id, hash, nodeData, node->getType ());
+        if (backed_)
+            canonicalize (hash, node);
     }
-
     return node;
 }
 
 // Get a node without throwing
 // Used on maps where missing nodes are expected
-std::shared_ptr<SHAMapTreeNode> SHAMap::fetchNodeNT(
+std::shared_ptr<SHAMapAbstractNode> SHAMap::fetchNodeNT(
     SHAMapNodeID const& id,
     uint256 const& hash,
     SHAMapSyncFilter* filter) const
 {
-    std::shared_ptr<SHAMapTreeNode> node = getCache (hash);
+    std::shared_ptr<SHAMapAbstractNode> node = getCache (hash);
     if (node)
         return node;
 
@@ -250,9 +244,9 @@ std::shared_ptr<SHAMapTreeNode> SHAMap::fetchNodeNT(
     return node;
 }
 
-std::shared_ptr<SHAMapTreeNode> SHAMap::fetchNodeNT (uint256 const& hash) const
+std::shared_ptr<SHAMapAbstractNode> SHAMap::fetchNodeNT (uint256 const& hash) const
 {
-    std::shared_ptr<SHAMapTreeNode> node = getCache (hash);
+    auto node = getCache (hash);
 
     if (!node && backed_)
         node = fetchNodeFromDB (hash);
@@ -261,9 +255,9 @@ std::shared_ptr<SHAMapTreeNode> SHAMap::fetchNodeNT (uint256 const& hash) const
 }
 
 // Throw if the node is missing
-std::shared_ptr<SHAMapTreeNode> SHAMap::fetchNode (uint256 const& hash) const
+std::shared_ptr<SHAMapAbstractNode> SHAMap::fetchNode (uint256 const& hash) const
 {
-    std::shared_ptr<SHAMapTreeNode> node = fetchNodeNT (hash);
+    auto node = fetchNodeNT (hash);
 
     if (!node)
         throw SHAMapMissingNode (type_, hash);
@@ -271,9 +265,9 @@ std::shared_ptr<SHAMapTreeNode> SHAMap::fetchNode (uint256 const& hash) const
     return node;
 }
 
-SHAMapTreeNode* SHAMap::descendThrow (SHAMapTreeNode* parent, int branch) const
+SHAMapAbstractNode* SHAMap::descendThrow (SHAMapInnerNode* parent, int branch) const
 {
-    SHAMapTreeNode* ret = descend (parent, branch);
+    SHAMapAbstractNode* ret = descend (parent, branch);
 
     if (! ret && ! parent->isEmptyBranch (branch))
         throw SHAMapMissingNode (type_, parent->getChildHash (branch));
@@ -281,10 +275,10 @@ SHAMapTreeNode* SHAMap::descendThrow (SHAMapTreeNode* parent, int branch) const
     return ret;
 }
 
-std::shared_ptr<SHAMapTreeNode>
-SHAMap::descendThrow (std::shared_ptr<SHAMapTreeNode> const& parent, int branch) const
+std::shared_ptr<SHAMapAbstractNode>
+SHAMap::descendThrow (std::shared_ptr<SHAMapInnerNode> const& parent, int branch) const
 {
-    std::shared_ptr<SHAMapTreeNode> ret = descend (parent, branch);
+    std::shared_ptr<SHAMapAbstractNode> ret = descend (parent, branch);
 
     if (! ret && ! parent->isEmptyBranch (branch))
         throw SHAMapMissingNode (type_, parent->getChildHash (branch));
@@ -292,24 +286,24 @@ SHAMap::descendThrow (std::shared_ptr<SHAMapTreeNode> const& parent, int branch)
     return ret;
 }
 
-SHAMapTreeNode* SHAMap::descend (SHAMapTreeNode* parent, int branch) const
+SHAMapAbstractNode* SHAMap::descend (SHAMapInnerNode* parent, int branch) const
 {
-    SHAMapTreeNode* ret = parent->getChildPointer (branch);
+    SHAMapAbstractNode* ret = parent->getChildPointer (branch);
     if (ret || !backed_)
         return ret;
 
-    std::shared_ptr<SHAMapTreeNode> node = fetchNodeNT (parent->getChildHash (branch));
+    std::shared_ptr<SHAMapAbstractNode> node = fetchNodeNT (parent->getChildHash (branch));
     if (!node)
         return nullptr;
 
-    parent->canonicalizeChild (branch, node);
+    node = parent->canonicalizeChild (branch, std::move(node));
     return node.get ();
 }
 
-std::shared_ptr<SHAMapTreeNode>
-SHAMap::descend (std::shared_ptr<SHAMapTreeNode> const& parent, int branch) const
+std::shared_ptr<SHAMapAbstractNode>
+SHAMap::descend (std::shared_ptr<SHAMapInnerNode> const& parent, int branch) const
 {
-    std::shared_ptr<SHAMapTreeNode> node = parent->getChild (branch);
+    std::shared_ptr<SHAMapAbstractNode> node = parent->getChild (branch);
     if (node || !backed_)
         return node;
 
@@ -317,23 +311,23 @@ SHAMap::descend (std::shared_ptr<SHAMapTreeNode> const& parent, int branch) cons
     if (!node)
         return nullptr;
 
-    parent->canonicalizeChild (branch, node);
+    node = parent->canonicalizeChild (branch, std::move(node));
     return node;
 }
 
 // Gets the node that would be hooked to this branch,
 // but doesn't hook it up.
-std::shared_ptr<SHAMapTreeNode>
-SHAMap::descendNoStore (std::shared_ptr<SHAMapTreeNode> const& parent, int branch) const
+std::shared_ptr<SHAMapAbstractNode>
+SHAMap::descendNoStore (std::shared_ptr<SHAMapInnerNode> const& parent, int branch) const
 {
-    std::shared_ptr<SHAMapTreeNode> ret = parent->getChild (branch);
+    std::shared_ptr<SHAMapAbstractNode> ret = parent->getChild (branch);
     if (!ret && backed_)
         ret = fetchNode (parent->getChildHash (branch));
     return ret;
 }
 
-std::pair <SHAMapTreeNode*, SHAMapNodeID>
-SHAMap::descend (SHAMapTreeNode * parent, SHAMapNodeID const& parentID,
+std::pair <SHAMapAbstractNode*, SHAMapNodeID>
+SHAMap::descend (SHAMapInnerNode * parent, SHAMapNodeID const& parentID,
     int branch, SHAMapSyncFilter * filter) const
 {
     assert (parent->isInner ());
@@ -341,16 +335,16 @@ SHAMap::descend (SHAMapTreeNode * parent, SHAMapNodeID const& parentID,
     assert (!parent->isEmptyBranch (branch));
 
     SHAMapNodeID childID = parentID.getChildNodeID (branch);
-    SHAMapTreeNode* child = parent->getChildPointer (branch);
+    SHAMapAbstractNode* child = parent->getChildPointer (branch);
     uint256 const& childHash = parent->getChildHash (branch);
 
     if (!child)
     {
-        std::shared_ptr<SHAMapTreeNode> childNode = fetchNodeNT (childID, childHash, filter);
+        std::shared_ptr<SHAMapAbstractNode> childNode = fetchNodeNT (childID, childHash, filter);
 
         if (childNode)
         {
-            parent->canonicalizeChild (branch, childNode);
+            childNode = parent->canonicalizeChild (branch, std::move(childNode));
             child = childNode.get ();
         }
     }
@@ -358,18 +352,19 @@ SHAMap::descend (SHAMapTreeNode * parent, SHAMapNodeID const& parentID,
     return std::make_pair (child, childID);
 }
 
-SHAMapTreeNode* SHAMap::descendAsync (SHAMapTreeNode* parent, int branch,
+SHAMapAbstractNode*
+SHAMap::descendAsync (SHAMapInnerNode* parent, int branch,
     SHAMapNodeID const& childID, SHAMapSyncFilter * filter, bool & pending) const
 {
     pending = false;
 
-    SHAMapTreeNode* ret = parent->getChildPointer (branch);
+    SHAMapAbstractNode* ret = parent->getChildPointer (branch);
     if (ret)
         return ret;
 
     uint256 const& hash = parent->getChildHash (branch);
 
-    std::shared_ptr<SHAMapTreeNode> ptr = getCache (hash);
+    std::shared_ptr<SHAMapAbstractNode> ptr = getCache (hash);
     if (!ptr)
     {
         if (filter)
@@ -386,7 +381,7 @@ SHAMapTreeNode* SHAMap::descendAsync (SHAMapTreeNode* parent, int branch,
             if (!obj)
                 return nullptr;
 
-            ptr = std::make_shared <SHAMapTreeNode> (obj->getData(), 0, snfPREFIX, hash, true);
+            ptr = SHAMapAbstractNode::make(obj->getData(), 0, snfPREFIX, hash, true);
 
             if (backed_)
                 canonicalize (hash, ptr);
@@ -394,49 +389,49 @@ SHAMapTreeNode* SHAMap::descendAsync (SHAMapTreeNode* parent, int branch,
     }
 
     if (ptr)
-        parent->canonicalizeChild (branch, ptr);
+        ptr = parent->canonicalizeChild (branch, std::move(ptr));
 
     return ptr.get ();
 }
 
-void
-SHAMap::unshareNode (std::shared_ptr<SHAMapTreeNode>& node, SHAMapNodeID const& nodeID)
+template <class Node>
+std::shared_ptr<Node>
+SHAMap::unshareNode (std::shared_ptr<Node> node, SHAMapNodeID const& nodeID)
 {
     // make sure the node is suitable for the intended operation (copy on write)
     assert (node->isValid ());
     assert (node->getSeq () <= seq_);
-
     if (node->getSeq () != seq_)
     {
         // have a CoW
         assert (state_ != SHAMapState::Immutable);
-
-        node = std::make_shared<SHAMapTreeNode> (*node, seq_); // here's to the new node, same as the old node
+        node = std::static_pointer_cast<Node>(node->clone(seq_));
         assert (node->isValid ());
-
         if (nodeID.isRoot ())
             root_ = node;
     }
+    return node;
 }
 
 SHAMapTreeNode*
-SHAMap::firstBelow (SHAMapTreeNode* node) const
+SHAMap::firstBelow (SHAMapAbstractNode* node) const
 {
     // Return the first item below this node
     do
     {
         assert(node != nullptr);
 
-        if (node->hasItem ())
-            return node;
+        if (node->isLeaf ())
+            return static_cast<SHAMapTreeNode*>(node);
 
         // Walk down the tree
         bool foundNode = false;
+        auto inner = static_cast<SHAMapInnerNode*>(node);
         for (int i = 0; i < 16; ++i)
         {
-            if (!node->isEmptyBranch (i))
+            if (!inner->isEmptyBranch (i))
             {
-                node = descendThrow (node, i);
+                node = descendThrow (inner, i);
                 foundNode = true;
                 break;
             }
@@ -448,20 +443,21 @@ SHAMap::firstBelow (SHAMapTreeNode* node) const
 }
 
 SHAMapTreeNode*
-SHAMap::lastBelow (SHAMapTreeNode* node) const
+SHAMap::lastBelow (SHAMapAbstractNode* node) const
 {
     do
     {
-        if (node->hasItem ())
-            return node;
+        if (node->isLeaf ())
+            return static_cast<SHAMapTreeNode*>(node);
 
         // Walk down the tree
         bool foundNode = false;
+        auto inner = static_cast<SHAMapInnerNode*>(node);
         for (int i = 15; i >= 0; --i)
         {
-            if (!node->isEmptyBranch (i))
+            if (!inner->isEmptyBranch (i))
             {
-                node = descendThrow (node, i);
+                node = descendThrow (inner, i);
                 foundNode = true;
                 break;
             }
@@ -473,21 +469,22 @@ SHAMap::lastBelow (SHAMapTreeNode* node) const
 }
 
 std::shared_ptr<SHAMapItem>
-SHAMap::onlyBelow (SHAMapTreeNode* node) const
+SHAMap::onlyBelow (SHAMapAbstractNode* node) const
 {
     // If there is only one item below this node, return it
 
     while (!node->isLeaf ())
     {
-        SHAMapTreeNode* nextNode = nullptr;
+        SHAMapAbstractNode* nextNode = nullptr;
+        auto inner = static_cast<SHAMapInnerNode*>(node);
         for (int i = 0; i < 16; ++i)
         {
-            if (!node->isEmptyBranch (i))
+            if (!inner->isEmptyBranch (i))
             {
                 if (nextNode)
                     return std::shared_ptr<SHAMapItem> ();
 
-                nextNode = descendThrow (node, i);
+                nextNode = descendThrow (inner, i);
             }
         }
 
@@ -502,9 +499,10 @@ SHAMap::onlyBelow (SHAMapTreeNode* node) const
 
     // An inner node must have at least one leaf
     // below it, unless it's the root_
-    assert (node->hasItem () || (node == root_.get ()));
+    auto leaf = static_cast<SHAMapTreeNode*>(node);
+    assert (leaf->hasItem () || (leaf == root_.get ()));
 
-    return node->peekItem ();
+    return leaf->peekItem ();
 }
 
 static std::shared_ptr<
@@ -559,7 +557,8 @@ std::shared_ptr<SHAMapItem> SHAMap::peekNextItem (uint256 const& id) const
     return peekNextItem (id, type);
 }
 
-std::shared_ptr<SHAMapItem> SHAMap::peekNextItem (uint256 const& id, SHAMapTreeNode::TNType& type) const
+std::shared_ptr<SHAMapItem>
+SHAMap::peekNextItem (uint256 const& id, SHAMapTreeNode::TNType& type) const
 {
     // Get a pointer to the next item in the tree after a given item - item need not be in tree
 
@@ -567,32 +566,34 @@ std::shared_ptr<SHAMapItem> SHAMap::peekNextItem (uint256 const& id, SHAMapTreeN
 
     while (!stack.empty ())
     {
-        SHAMapTreeNode* node = stack.top().first.get();
-        SHAMapNodeID nodeID = stack.top().second;
+        auto node = stack.top().first.get();
+        auto nodeID = stack.top().second;
         stack.pop ();
 
         if (node->isLeaf ())
         {
-            if (node->peekItem ()->getTag () > id)
+            auto leaf = static_cast<SHAMapTreeNode*>(node);
+            if (leaf->peekItem ()->getTag () > id)
             {
-                type = node->getType ();
-                return node->peekItem ();
+                type = leaf->getType ();
+                return leaf->peekItem ();
             }
         }
         else
         {
             // breadth-first
+            auto inner = static_cast<SHAMapInnerNode*>(node);
             for (int i = nodeID.selectBranch (id) + 1; i < 16; ++i)
-                if (!node->isEmptyBranch (i))
+                if (!inner->isEmptyBranch (i))
                 {
-                    node = descendThrow (node, i);
-                    node = firstBelow (node);
+                    node = descendThrow (inner, i);
+                    auto leaf = firstBelow (node);
 
-                    if (!node || node->isInner ())
+                    if (!leaf)
                         throw (std::runtime_error ("missing/corrupt node"));
 
-                    type = node->getType ();
-                    return node->peekItem ();
+                    type = leaf->getType ();
+                    return leaf->peekItem ();
                 }
         }
     }
@@ -602,30 +603,33 @@ std::shared_ptr<SHAMapItem> SHAMap::peekNextItem (uint256 const& id, SHAMapTreeN
 }
 
 // Get a pointer to the previous item in the tree after a given item - item need not be in tree
-std::shared_ptr<SHAMapItem> SHAMap::peekPrevItem (uint256 const& id) const
+std::shared_ptr<SHAMapItem>
+SHAMap::peekPrevItem (uint256 const& id) const
 {
     auto stack = getStack (id, true);
 
     while (!stack.empty ())
     {
-        SHAMapTreeNode* node = stack.top ().first.get();
-        SHAMapNodeID nodeID = stack.top ().second;
+        auto node = stack.top ().first.get();
+        auto nodeID = stack.top ().second;
         stack.pop ();
 
         if (node->isLeaf ())
         {
-            if (node->peekItem ()->getTag () < id)
-                return node->peekItem ();
+            auto leaf = static_cast<SHAMapTreeNode*>(node);
+            if (leaf->peekItem ()->getTag () < id)
+                return leaf->peekItem ();
         }
         else
         {
+            auto inner = static_cast<SHAMapInnerNode*>(node);
             for (int i = nodeID.selectBranch (id) - 1; i >= 0; --i)
             {
-                if (!node->isEmptyBranch (i))
+                if (!inner->isEmptyBranch (i))
                 {
-                    node = descendThrow (node, i);
-                    node = lastBelow (node);
-                    return node->peekItem ();
+                    node = descendThrow (inner, i);
+                    auto leaf = lastBelow (node);
+                    return leaf->peekItem ();
                 }
             }
         }
@@ -685,10 +689,10 @@ bool SHAMap::delItem (uint256 const& id)
     if (stack.empty ())
         throw (std::runtime_error ("missing node"));
 
-    std::shared_ptr<SHAMapTreeNode> leaf = stack.top ().first;
+    auto leaf = std::dynamic_pointer_cast<SHAMapTreeNode>(stack.top ().first);
     stack.pop ();
 
-    if (!leaf || !leaf->hasItem () || (leaf->peekItem ()->getTag () != id))
+    if (!leaf || (leaf->peekItem ()->getTag () != id))
         return false;
 
     SHAMapTreeNode::TNType type = leaf->getType ();
@@ -696,17 +700,17 @@ bool SHAMap::delItem (uint256 const& id)
     // What gets attached to the end of the chain
     // (For now, nothing, since we deleted the leaf)
     uint256 prevHash;
-    std::shared_ptr<SHAMapTreeNode> prevNode;
+    std::shared_ptr<SHAMapAbstractNode> prevNode;
 
     while (!stack.empty ())
     {
-        std::shared_ptr<SHAMapTreeNode> node = stack.top ().first;
+        auto node = std::dynamic_pointer_cast<SHAMapInnerNode>(stack.top ().first);
         SHAMapNodeID nodeID = stack.top ().second;
         stack.pop ();
 
-        assert (node->isInner ());
+        assert (node);
 
-        unshareNode (node, nodeID);
+        node = unshareNode(std::move(node), nodeID);
         node->setChild (nodeID.selectBranch (id), prevNode);
 
         if (!nodeID.isRoot ())
@@ -736,11 +740,14 @@ bool SHAMap::delItem (uint256 const& id)
                             break;
                         }
                     }
-                    node->setItem (item, type);
+                    prevNode = std::make_shared<SHAMapTreeNode>(item, type, node->getSeq());
+                    prevHash = prevNode->getNodeHash();
                 }
-
-                prevHash = node->getNodeHash ();
-                prevNode = std::move (node);
+                else
+                {
+                    prevHash = node->getNodeHash ();
+                    prevNode = std::move (node);
+                }
             }
             else
             {
@@ -770,29 +777,34 @@ SHAMap::addGiveItem (std::shared_ptr<SHAMapItem> const& item,
     if (stack.empty ())
         throw (std::runtime_error ("missing node"));
 
-    std::shared_ptr<SHAMapTreeNode> node = stack.top ().first;
-    SHAMapNodeID nodeID = stack.top ().second;
+    auto node = stack.top ().first;
+    auto nodeID = stack.top ().second;
     stack.pop ();
 
-    if (node->isLeaf () && (node->peekItem ()->getTag () == tag))
-        return false;
-
-    unshareNode (node, nodeID);
+    if (node->isLeaf())
+    {
+        auto leaf = std::static_pointer_cast<SHAMapTreeNode>(node);
+        if (leaf->peekItem()->getTag() == tag)
+            return false;
+    }
+    node = unshareNode(std::move(node), nodeID);
     if (node->isInner ())
     {
         // easy case, we end on an inner node
+        auto inner = std::static_pointer_cast<SHAMapInnerNode>(node);
         int branch = nodeID.selectBranch (tag);
-        assert (node->isEmptyBranch (branch));
+        assert (inner->isEmptyBranch (branch));
         auto newNode = std::make_shared<SHAMapTreeNode> (item, type, seq_);
-        node->setChild (branch, newNode);
+        inner->setChild (branch, newNode);
     }
     else
     {
         // this is a leaf node that has to be made an inner node holding two items
-        std::shared_ptr<SHAMapItem> otherItem = node->peekItem ();
+        auto leaf = std::static_pointer_cast<SHAMapTreeNode>(node);
+        std::shared_ptr<SHAMapItem> otherItem = leaf->peekItem ();
         assert (otherItem && (tag != otherItem->getTag ()));
 
-        node->makeInner ();
+        node = std::make_shared<SHAMapInnerNode>(node->getSeq());
 
         int b1, b2;
 
@@ -803,8 +815,7 @@ SHAMap::addGiveItem (std::shared_ptr<SHAMapItem> const& item,
 
             // we need a new inner node, since both go on same branch at this level
             nodeID = nodeID.getChildNodeID (b1);
-            node = std::make_shared<SHAMapTreeNode> (seq_);
-            node->makeInner ();
+            node = std::make_shared<SHAMapInnerNode> (seq_);
         }
 
         // we can add the two leaf nodes here
@@ -813,11 +824,12 @@ SHAMap::addGiveItem (std::shared_ptr<SHAMapItem> const& item,
         std::shared_ptr<SHAMapTreeNode> newNode =
             std::make_shared<SHAMapTreeNode> (item, type, seq_);
         assert (newNode->isValid () && newNode->isLeaf ());
-        node->setChild (b1, newNode);
+        auto inner = std::static_pointer_cast<SHAMapInnerNode>(node);
+        inner->setChild (b1, newNode);
 
         newNode = std::make_shared<SHAMapTreeNode> (otherItem, type, seq_);
         assert (newNode->isValid () && newNode->isLeaf ());
-        node->setChild (b2, newNode);
+        inner->setChild (b2, newNode);
     }
 
     dirtyUp (stack, tag, node);
@@ -855,17 +867,17 @@ SHAMap::updateGiveItem (std::shared_ptr<SHAMapItem> const& item,
     if (stack.empty ())
         throw (std::runtime_error ("missing node"));
 
-    std::shared_ptr<SHAMapTreeNode> node = stack.top ().first;
-    SHAMapNodeID nodeID = stack.top ().second;
+    auto node = std::dynamic_pointer_cast<SHAMapTreeNode>(stack.top().first);
+    auto nodeID = stack.top ().second;
     stack.pop ();
 
-    if (!node->isLeaf () || (node->peekItem ()->getTag () != tag))
+    if (!node || (node->peekItem ()->getTag () != tag))
     {
         assert (false);
         return false;
     }
 
-    unshareNode (node, nodeID);
+    node = unshareNode(std::move(node), nodeID);
 
     if (!node->setItem (item, !isTransaction ? SHAMapTreeNode::tnACCOUNT_STATE :
                         (hasMeta ? SHAMapTreeNode::tnTRANSACTION_MD : SHAMapTreeNode::tnTRANSACTION_NM)))
@@ -903,7 +915,7 @@ bool SHAMap::fetchRoot (uint256 const& hash, SHAMapSyncFilter* filter)
         }
     }
 
-    std::shared_ptr<SHAMapTreeNode> newRoot = fetchNodeNT (SHAMapNodeID(), hash, filter);
+    auto newRoot = fetchNodeNT (SHAMapNodeID(), hash, filter);
 
     if (newRoot)
     {
@@ -924,8 +936,9 @@ bool SHAMap::fetchRoot (uint256 const& hash, SHAMapSyncFilter* filter)
 //
 // 2) An unshareable node is shared. This happens when you make
 // a mutable snapshot of a mutable SHAMap.
-void SHAMap::writeNode (
-    NodeObjectType t, std::uint32_t seq, std::shared_ptr<SHAMapTreeNode>& node) const
+std::shared_ptr<SHAMapAbstractNode>
+SHAMap::writeNode (
+    NodeObjectType t, std::uint32_t seq, std::shared_ptr<SHAMapAbstractNode> node) const
 {
     // Node is ours, so we can just make it shareable
     assert (node->getSeq() == seq_);
@@ -938,12 +951,15 @@ void SHAMap::writeNode (
     node->addRaw (s, snfPREFIX);
     f_.db().store (t,
         std::move (s.modData ()), node->getNodeHash ());
+    return node;
 }
 
 // We can't modify an inner node someone else might have a
 // pointer to because flushing modifies inner nodes -- it
 // makes them point to canonical/shared nodes.
-void SHAMap::preFlushNode (std::shared_ptr<SHAMapTreeNode>& node) const
+template <class Node>
+std::shared_ptr<Node>
+SHAMap::preFlushNode (std::shared_ptr<Node> node) const
 {
     // A shared node should never need to be flushed
     // because that would imply someone modified it
@@ -953,8 +969,9 @@ void SHAMap::preFlushNode (std::shared_ptr<SHAMapTreeNode>& node) const
     {
         // Node is not uniquely ours, so unshare it before
         // possibly modifying it
-        node = std::make_shared <SHAMapTreeNode> (*node, seq_);
+        node = std::static_pointer_cast<Node>(node->clone(seq_));
     }
+    return node;
 }
 
 int SHAMap::unshare ()
@@ -975,24 +992,26 @@ SHAMap::walkSubTree (bool doWrite, NodeObjectType t, std::uint32_t seq)
     int flushed = 0;
     Serializer s;
 
-    if (!root_ || (root_->getSeq() == 0) || root_->isEmpty ())
+    if (!root_ || (root_->getSeq() == 0))
         return flushed;
 
     if (root_->isLeaf())
     { // special case -- root_ is leaf
-        preFlushNode (root_);
+        root_ = preFlushNode (std::move(root_));
         if (doWrite && backed_)
-            writeNode (t, seq, root_);
+            root_ = writeNode(t, seq, std::move(root_));
         return 1;
     }
+    auto node = std::static_pointer_cast<SHAMapInnerNode>(root_);
+    if (node->isEmpty())
+        return flushed;
 
     // Stack of {parent,index,child} pointers representing
     // inner nodes we are in the process of flushing
-    using StackEntry = std::pair <std::shared_ptr<SHAMapTreeNode>, int>;
+    using StackEntry = std::pair <std::shared_ptr<SHAMapInnerNode>, int>;
     std::stack <StackEntry, std::vector<StackEntry>> stack;
 
-    std::shared_ptr<SHAMapTreeNode> node = root_;
-    preFlushNode (node);
+    node = preFlushNode(std::move(node));
 
     int pos = 0;
 
@@ -1010,7 +1029,7 @@ SHAMap::walkSubTree (bool doWrite, NodeObjectType t, std::uint32_t seq)
                 // No need to do I/O. If the node isn't linked,
                 // it can't need to be flushed
                 int branch = pos;
-                std::shared_ptr<SHAMapTreeNode> child = node->getChild (pos++);
+                auto child = node->getChild(pos++);
 
                 if (child && (child->getSeq() != 0))
                 {
@@ -1019,11 +1038,11 @@ SHAMap::walkSubTree (bool doWrite, NodeObjectType t, std::uint32_t seq)
                     if (child->isInner ())
                     {
                         // save our place and work on this node
-                        preFlushNode (child);
+                        child = preFlushNode(std::move(child));
 
                         stack.emplace (std::move (node), branch);
 
-                        node = std::move (child);
+                        node = std::static_pointer_cast<SHAMapInnerNode>(std::move(child));
                         pos = 0;
                     }
                     else
@@ -1031,13 +1050,13 @@ SHAMap::walkSubTree (bool doWrite, NodeObjectType t, std::uint32_t seq)
                         // flush this leaf
                         ++flushed;
 
-                        preFlushNode (child);
+                        child = preFlushNode(std::move(child));
 
                         assert (node->getSeq() == seq_);
                         child->updateHash();
 
                         if (doWrite && backed_)
-                            writeNode (t, seq, child);
+                            child = writeNode(t, seq, std::move(child));
 
                         node->shareChild (branch, child);
                     }
@@ -1050,14 +1069,15 @@ SHAMap::walkSubTree (bool doWrite, NodeObjectType t, std::uint32_t seq)
 
         // This inner node can now be shared
         if (doWrite && backed_)
-            writeNode (t, seq, node);
+            node = std::static_pointer_cast<SHAMapInnerNode>(writeNode(t, seq,
+                                                                       std::move(node)));
 
         ++flushed;
 
         if (stack.empty ())
            break;
 
-        std::shared_ptr<SHAMapTreeNode> parent = std::move (stack.top().first);
+        auto parent = std::move (stack.top().first);
         pos = stack.top().second;
         stack.pop();
 
@@ -1082,13 +1102,13 @@ void SHAMap::dump (bool hash) const
     if (journal_.info) journal_.info <<
         " MAP Contains";
 
-    std::stack <std::pair <SHAMapTreeNode*, SHAMapNodeID> > stack;
+    std::stack <std::pair <SHAMapAbstractNode*, SHAMapNodeID> > stack;
     stack.push ({root_.get (), SHAMapNodeID ()});
 
     do
     {
-        SHAMapTreeNode* node = stack.top().first;
-        SHAMapNodeID nodeID = stack.top().second;
+        auto node = stack.top().first;
+        auto nodeID = stack.top().second;
         stack.pop();
 
         if (journal_.info) journal_.info <<
@@ -1099,14 +1119,15 @@ void SHAMap::dump (bool hash) const
 
         if (node->isInner ())
         {
+            auto inner = static_cast<SHAMapInnerNode*>(node);
             for (int i = 0; i < 16; ++i)
             {
-                if (!node->isEmptyBranch (i))
+                if (!inner->isEmptyBranch (i))
                 {
-                    SHAMapTreeNode* child = node->getChildPointer (i);
+                    auto child = inner->getChildPointer (i);
                     if (child)
                     {
-                        assert (child->getNodeHash() == node->getChildHash (i));
+                        assert (child->getNodeHash() == inner->getChildHash (i));
                         stack.push ({child, nodeID.getChildNodeID (i)});
                      }
                 }
@@ -1121,14 +1142,15 @@ void SHAMap::dump (bool hash) const
         leafCount << " resident leaves";
 }
 
-std::shared_ptr<SHAMapTreeNode> SHAMap::getCache (uint256 const& hash) const
+std::shared_ptr<SHAMapAbstractNode> SHAMap::getCache (uint256 const& hash) const
 {
-    std::shared_ptr<SHAMapTreeNode> ret = f_.treecache().fetch (hash);
+    auto ret = f_.treecache().fetch (hash);
     assert (!ret || !ret->getSeq());
     return ret;
 }
 
-void SHAMap::canonicalize (uint256 const& hash, std::shared_ptr<SHAMapTreeNode>& node) const
+void
+SHAMap::canonicalize(uint256 const& hash, std::shared_ptr<SHAMapAbstractNode>& node) const
 {
     assert (backed_);
     assert (node->getSeq() == 0);

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -95,6 +95,45 @@ public:
         unexpected (!sMap.delItem (sMap.peekFirstItem ()->getTag ()), "bad mod");
         unexpected (sMap.getHash () == mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
+
+        testcase ("build/tear");
+        {
+            std::vector<uint256> keys(8);
+            keys[0].SetHex ("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[1].SetHex ("b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[2].SetHex ("b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[3].SetHex ("b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[4].SetHex ("b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[5].SetHex ("b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[6].SetHex ("f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[7].SetHex ("292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+
+            std::vector<uint256> hashes(8);
+            hashes[0].SetHex ("B7387CFEA0465759ADC718E8C42B52D2309D179B326E239EB5075C64B6281F7F");
+            hashes[1].SetHex ("FBC195A9592A54AB44010274163CB6BA95F497EC5BA0A8831845467FB2ECE266");
+            hashes[2].SetHex ("4E7D2684B65DFD48937FFB775E20175C43AF0C94066F7D5679F51AE756795B75");
+            hashes[3].SetHex ("7A2F312EB203695FFD164E038E281839EEF06A1B99BFC263F3CECC6C74F93E07");
+            hashes[4].SetHex ("395A6691A372387A703FB0F2C6D2C405DAF307D0817F8F0E207596462B0E3A3E");
+            hashes[5].SetHex ("D044C0A696DE3169CC70AE216A1564D69DE96582865796142CE7D98A84D9DDE4");
+            hashes[6].SetHex ("76DCC77C4027309B5A91AD164083264D70B77B5E43E08AEDA5EBF94361143615");
+            hashes[7].SetHex ("DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA02BBE7230E5");
+
+            SHAMap map (SHAMapType::FREE, f, beast::Journal());
+
+            expect (map.getHash() == uint256(), "bad initial empty map hash");
+            for (int i = 0; i < keys.size(); ++i)
+            {
+                SHAMapItem item (keys[i], IntToVUC (i));
+                map.addItem (item, true, false);
+                expect (map.getHash() == hashes[i], "bad buildup map hash");
+            }
+            for (int i = keys.size() - 1; i >= 0; --i)
+            {
+                expect (map.getHash() == hashes[i], "bad teardown hash");
+                map.delItem (keys[i]);
+            }
+            expect (map.getHash() == uint256(), "bad final empty map hash");
+        }
     }
 };
 


### PR DESCRIPTION
* This reduces the memory requirements of both leaf and inner nodes.
* The name SHAMapTreeNode is retained for leaf nodes so as to keep
  the public API of SHAMap stable.

This pull-request is purposefully doing as little as possible because it is already too big and it is touching business logic in a non-trivial way.  I've gone to pains to not even make unnecessary white-space corrections to make this easier to review.  I do not think we should lump other cleanups into this P/R no matter how trivial.  Further cleanups should be shuttled to a separate P/R.

I am observing a 25% decrease in memory usage of rippled after 10 minutes of  uptime compared to 0.28.2-b6 (release build).

@JoelKatz @ximinez 