### PR TITLE
Cleanup object templates:

### DIFF
--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -21,7 +21,7 @@
 #define RIPPLE_PROTOCOL_SOTEMPLATE_H_INCLUDED
 
 #include <ripple/protocol/SField.h>
-#include <memory>
+#include <boost/range.hpp>
 
 namespace ripple {
 
@@ -60,22 +60,28 @@ public:
 class SOTemplate
 {
 public:
-    using value_type = std::unique_ptr <SOElement const>;
-    using list_type = std::vector <value_type>;
+    using list_type = std::vector <std::unique_ptr <SOElement const>>;
+
+    using iterator_range = boost::iterator_range<
+        SOTemplate::list_type::const_iterator>;
 
     /** Create an empty template.
         After creating the template, call @ref push_back with the
         desired fields.
         @see push_back
     */
-    SOTemplate ();
+    SOTemplate () = default;
 
-    // VFALCO NOTE Why do we even bother with the 'private' keyword if
-    //             this function is present?
-    //
-    list_type const& peek () const
+    /* Provide for the enumeration of fields */
+    iterator_range enumerate () const
     {
-        return mTypes;
+        return boost::make_iterator_range(mTypes);
+    }
+
+    /** The number of entries in this template */
+    std::size_t size () const
+    {
+        return mTypes.size ();
     }
 
     /** Add an element to the template. */

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -22,6 +22,7 @@
 
 #include <ripple/protocol/SField.h>
 #include <boost/range.hpp>
+#include <beast/cxx14/memory.h> // <memory>
 
 namespace ripple {
 

--- a/src/ripple/protocol/impl/SOTemplate.cpp
+++ b/src/ripple/protocol/impl/SOTemplate.cpp
@@ -19,12 +19,9 @@
 
 #include <BeastConfig.h>
 #include <ripple/protocol/SOTemplate.h>
+#include <beast/cxx14/memory.h> // <memory>
 
 namespace ripple {
-
-SOTemplate::SOTemplate ()
-{
-}
 
 void SOTemplate::push_back (SOElement const& r)
 {
@@ -52,7 +49,7 @@ void SOTemplate::push_back (SOElement const& r)
 
     // Append the new element.
     //
-    mTypes.push_back (value_type (new SOElement (r)));
+    mTypes.push_back (std::make_unique<SOElement const> (r));
 }
 
 int SOTemplate::getIndex (SField const& f) const

--- a/src/ripple/protocol/impl/SOTemplate.cpp
+++ b/src/ripple/protocol/impl/SOTemplate.cpp
@@ -19,7 +19,6 @@
 
 #include <BeastConfig.h>
 #include <ripple/protocol/SOTemplate.h>
-#include <beast/cxx14/memory.h> // <memory>
 
 namespace ripple {
 

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -68,7 +68,7 @@ STObject::STObject (SOTemplate const& type,
         SerialIter & sit, SField const& name)
     : STBase (name)
 {
-    v_.reserve(type.peek().size());
+    v_.reserve(type.size());
     set (sit);
     setType (type);
 }
@@ -92,10 +92,10 @@ STObject::operator= (STObject&& other)
 void STObject::set (const SOTemplate& type)
 {
     v_.clear();
-    v_.reserve(type.peek().size());
+    v_.reserve(type.size());
     mType = &type;
 
-    for (auto const& elem : type.peek())
+    for (auto const& elem : type.enumerate())
     {
         if (elem->flags != SOE_REQUIRED)
             v_.emplace_back(detail::nonPresentObject, elem->e_field);
@@ -109,8 +109,8 @@ bool STObject::setType (const SOTemplate& type)
     bool valid = true;
     mType = &type;
     decltype(v_) v;
-    v.reserve(type.peek().size());
-    for (auto const& e : type.peek())
+    v.reserve(type.size());
+    for (auto const& e : type.enumerate())
     {
         auto const iter = std::find_if(
             v_.begin(), v_.end(), [&](detail::STVar const& b)
@@ -173,7 +173,7 @@ STObject::setTypeFromSField (SField const& sField)
 bool STObject::isValidForType ()
 {
     auto it = v_.begin();
-    for (SOTemplate::value_type const& elem : mType->peek())
+    for (auto const& elem : mType->enumerate())
     {
         if (it == v_.end())
             return false;


### PR DESCRIPTION
* Avoid exposing class members - use boost::iterator_range instead
* Use std::make_unique instead of naked new