### PR TITLE
Refactor LedgerEntrySet:

### DIFF
--- a/src/ripple/app/ledger/AcceptedLedgerTx.cpp
+++ b/src/ripple/app/ledger/AcceptedLedgerTx.cpp
@@ -99,7 +99,8 @@ void AcceptedLedgerTx::buildJson ()
         if (account != amount.issue ().account)
         {
             LedgerEntrySet les (mLedger, tapNONE, true);
-            auto const ownerFunds (les.accountFunds (account, amount, fhIGNORE_FREEZE));
+            auto const ownerFunds (funds(
+                les, account, amount, fhIGNORE_FREEZE));
 
             mJson[jss::transaction][jss::owner_funds] = ownerFunds.getText ();
         }

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -984,20 +984,19 @@ Ledger::insert (SLE const& sle)
     assert(success);
 }
 
-boost::optional<SLE>
+std::shared_ptr<SLE>
 Ledger::fetch (uint256 const& key,
     boost::optional<LedgerEntryType> type) const
 {
     auto const item =
         mAccountStateMap->peekItem(key);
     if (! item)
-        return boost::none;
-    boost::optional<SLE> result;
-    result.emplace(item->peekSerializer(),
-        item->getTag());
-    if (type && result->getType() != type)
-        return {};
-    return result;
+        return nullptr;
+    auto const sle = std::make_shared<SLE>(
+        item->peekSerializer(), item->getTag());
+    if (type && sle->getType() != type)
+        return nullptr;
+    return sle;
 }
 
 void
@@ -1171,7 +1170,8 @@ void Ledger::updateSkipList ()
         bool created;
         if (! sle)
         {
-            sle.emplace(ltLEDGER_HASHES, key);
+            sle = std::make_shared<SLE>(
+                ltLEDGER_HASHES, key);
             created = true;
         }
         else
@@ -1198,7 +1198,8 @@ void Ledger::updateSkipList ()
     bool created;
     if (! sle)
     {
-        sle.emplace(ltLEDGER_HASHES, key);
+        sle = std::make_shared<SLE>(
+            ltLEDGER_HASHES, key);
         created = true;
     }
     else

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -25,6 +25,7 @@
 #include <ripple/app/tx/TransactionMeta.h>
 #include <ripple/app/ledger/SLECache.h>
 #include <ripple/app/misc/AccountState.h>
+#include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/basics/CountedObject.h>
 #include <ripple/protocol/Serializer.h>
@@ -138,9 +139,15 @@ public:
                     then boost::none is returned.
         @return `empty` if the key is not present
     */
-    boost::optional<SLE>
+    std::shared_ptr<SLE>
     fetch (uint256 const& key, boost::optional<
         LedgerEntryType> type = boost::none) const;
+
+    std::shared_ptr<SLE>
+    fetch (Keylet const& k) const
+    {
+        return fetch(k.key, k.type);
+    }
 
     // DEPRECATED
     // Retrieve immutable ledger entry

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1194,6 +1194,8 @@ bool ApplicationImp::loadOldLedger (
 
                              if (stp.object && (uIndex.isNonZero()))
                              {
+                                 // VFALCO TODO This is the only place that
+                                 //             constructor is used, try to remove it
                                  STLedgerEntry sle (*stp.object, uIndex);
                                  bool ok = loadLedger->addSLE (sle);
                                  if (!ok)

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2316,9 +2316,10 @@ Json::Value NetworkOPsImp::transJson(
         // If the offer create is not self funded then add the owner balance
         if (account != amount.issue ().account)
         {
+            // VFALCO Why are we doing this hack?
             LedgerEntrySet les (lpCurrent, tapNONE, true);
-            auto const ownerFunds (les.accountFunds (account, amount, fhIGNORE_FREEZE));
-
+            auto const ownerFunds = funds(
+                les,account, amount, fhIGNORE_FREEZE);
             jvObj[jss::transaction][jss::owner_funds] = ownerFunds.getText ();
         }
     }
@@ -2767,8 +2768,13 @@ void NetworkOPsImp::getBookPage (
 
             m_journal.trace << "getBookPage: bDirectAdvance";
 
-            sleOfferDir = lesActive.entryCache (
-                ltDIR_NODE, lpLedger->getNextLedgerIndex (uTipIndex, uBookEnd));
+            uint256 const ledgerIndex = 
+                    lpLedger->getNextLedgerIndex (uTipIndex, uBookEnd);
+            if (ledgerIndex.isNonZero())
+                sleOfferDir = lesActive.entryCache (
+                    ltDIR_NODE, ledgerIndex);
+            else
+                sleOfferDir.reset();
 
             if (!sleOfferDir)
             {

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -32,7 +32,7 @@
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/UintTypes.h>
 #include <beast/module/core/text/LexicalCast.h>
-#include <boost/log/trivial.hpp>
+#include <boost/optional.hpp>
 #include <tuple>
 
 namespace ripple {
@@ -480,7 +480,8 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
 
         if (valid)
         {
-            LedgerEntrySet lesSandbox (cache->getLedger (), tapNONE);
+            LedgerEntrySet lesSandbox(
+                cache->getLedger(), tapNONE);
             auto& sourceAccount = !isXRP (currIssuer.account)
                     ? currIssuer.account
                     : isXRP (currIssuer.currency)
@@ -505,7 +506,7 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
                 m_journal.debug
                         << iIdentifier << " Trying with an extra path element";
                 spsPaths.push_back (fullLiquidityPath);
-                lesSandbox.clear();
+                reconstruct(lesSandbox, cache->getLedger (), tapNONE);
                 rc = path::RippleCalc::rippleCalculate (
                     lesSandbox,
                     saMaxAmount,

--- a/src/ripple/app/paths/PathState.cpp
+++ b/src/ripple/app/paths/PathState.cpp
@@ -268,7 +268,7 @@ TER PathState::pushNode (
             auto const& backNode = nodes_.back ();
             if (backNode.isAccount())
             {
-                auto sleRippleState = lesEntries.entryCache (
+                auto sleRippleState = lesEntries_->entryCache (
                     ltRIPPLE_STATE,
                     getRippleStateIndex (
                         backNode.account_,
@@ -295,7 +295,7 @@ TER PathState::pushNode (
                             << backNode.account_ << " and " << node.account_
                             << " for " << node.issue_.currency << "." ;
 
-                    auto sleBck  = lesEntries.entryCache (
+                    auto sleBck  = lesEntries_->entryCache (
                         ltACCOUNT_ROOT,
                         getAccountRootIndex (backNode.account_));
                     // Is the source account the highest numbered account ID?
@@ -323,13 +323,13 @@ TER PathState::pushNode (
 
                     if (resultCode == tesSUCCESS)
                     {
-                        STAmount saOwed = creditBalance (lesEntries,
+                        STAmount saOwed = creditBalance (*lesEntries_,
                             node.account_, backNode.account_,
                             node.issue_.currency);
                         STAmount saLimit;
 
                         if (saOwed <= zero) {
-                            saLimit = creditLimit (lesEntries,
+                            saLimit = creditLimit (*lesEntries_,
                                 node.account_,
                                 backNode.account_,
                                 node.issue_.currency);
@@ -437,7 +437,7 @@ TER PathState::expandPath (
     WriteLog (lsTRACE, RippleCalc)
         << "expandPath> " << spSourcePath.getJson (0);
 
-    lesEntries = lesSource.duplicate ();
+    lesEntries_.emplace(lesSource);
 
     terStatus = tesSUCCESS;
 
@@ -632,7 +632,7 @@ void PathState::checkFreeze()
         // Check each order book for a global freeze
         if (nodes_[i].uFlags & STPathElement::typeIssuer)
         {
-            sle = lesEntries.entryCache (ltACCOUNT_ROOT,
+            sle = lesEntries_->entryCache (ltACCOUNT_ROOT,
                 getAccountRootIndex (nodes_[i].issue_.account));
 
             if (sle && sle->isFlag (lsfGlobalFreeze))
@@ -651,7 +651,7 @@ void PathState::checkFreeze()
 
             if (inAccount != outAccount)
             {
-                sle = lesEntries.entryCache (ltACCOUNT_ROOT,
+                sle = lesEntries_->entryCache (ltACCOUNT_ROOT,
                     getAccountRootIndex (outAccount));
 
                 if (sle && sle->isFlag (lsfGlobalFreeze))
@@ -660,7 +660,7 @@ void PathState::checkFreeze()
                     return;
                 }
 
-                sle = lesEntries.entryCache (ltRIPPLE_STATE,
+                sle = lesEntries_->entryCache (ltRIPPLE_STATE,
                     getRippleStateIndex (inAccount,
                         outAccount, currencyID));
 
@@ -688,9 +688,9 @@ TER PathState::checkNoRipple (
     Currency const& currency)
 {
     // fetch the ripple lines into and out of this node
-    SLE::pointer sleIn = lesEntries.entryCache (ltRIPPLE_STATE,
+    SLE::pointer sleIn = lesEntries_->entryCache (ltRIPPLE_STATE,
         getRippleStateIndex (firstAccount, secondAccount, currency));
-    SLE::pointer sleOut = lesEntries.entryCache (ltRIPPLE_STATE,
+    SLE::pointer sleOut = lesEntries_->entryCache (ltRIPPLE_STATE,
         getRippleStateIndex (secondAccount, thirdAccount, currency));
 
     if (!sleIn || !sleOut)

--- a/src/ripple/app/paths/PathState.h
+++ b/src/ripple/app/paths/PathState.h
@@ -23,6 +23,7 @@
 #include <ripple/app/ledger/LedgerEntrySet.h>
 #include <ripple/app/paths/Node.h>
 #include <ripple/app/paths/Types.h>
+#include <boost/optional.hpp>
 
 namespace ripple {
 
@@ -102,19 +103,36 @@ class PathState : public CountedObject <PathState>
 
     static bool lessPriority (PathState const& lhs, PathState const& rhs);
 
-    LedgerEntrySet& ledgerEntries() { return lesEntries; }
+    // VFALCO Remove or rename to view, 
+    LedgerEntrySet& ledgerEntries()
+    {
+        return *lesEntries_;
+    }
 
     bool isDry() const
     {
         return !(saInPass && saOutPass);
     }
 
-  private:
+private:
     TER checkNoRipple (
         Account const&, Account const&, Account const&, Currency const&);
 
     /** Clear path structures, and clear each node. */
     void clear();
+
+    TER pushNode (
+        int const iType,
+        Account const& account,
+        Currency const& currency,
+        Account const& issuer);
+
+    TER pushImpliedNodes (
+        Account const& account,
+        Currency const& currency,
+        Account const& issuer);
+    
+    Json::Value getJson () const;
 
     TER terStatus;
     path::Node::List nodes_;
@@ -132,7 +150,7 @@ class PathState : public CountedObject <PathState>
     // Source may only be used there if not mentioned by an account.
     AccountIssueToNodeIndex umReverse;
 
-    LedgerEntrySet lesEntries;
+    boost::optional<LedgerEntrySet> lesEntries_;
 
     int                         mIndex;    // Index/rank amoung siblings.
     std::uint64_t               uQuality;  // 0 = no quality/liquity left.
@@ -147,19 +165,6 @@ class PathState : public CountedObject <PathState>
 
     // If true, all liquidity on this path has been consumed.
     bool allLiquidityConsumed_ = false;
-
-    TER pushNode (
-        int const iType,
-        Account const& account,
-        Currency const& currency,
-        Account const& issuer);
-
-    TER pushImpliedNodes (
-        Account const& account,
-        Currency const& currency,
-        Account const& issuer);
-    
-    Json::Value getJson () const;
 };
 
 } // ripple

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -288,7 +288,9 @@ TER RippleCalc::rippleCalculate ()
                         assert (mActiveLedger.isValid ());
                         mActiveLedger.swapWith (pathState->ledgerEntries());
                         // For the path, save ledger state.
-                        mActiveLedger.invalidate ();
+
+                        // VFALCO Can this be done without the function call?
+                        mActiveLedger.deprecatedInvalidate();
 
                         iBest   = pathState->index ();
                     }
@@ -339,7 +341,10 @@ TER RippleCalc::rippleCalculate ()
             // return.
             assert (pathState->ledgerEntries().isValid ());
             mActiveLedger.swapWith (pathState->ledgerEntries());
-            pathState->ledgerEntries().invalidate ();
+            
+            // VFALCO Why is this needed? Can it be done
+            //        without the function call?
+            pathState->ledgerEntries().deprecatedInvalidate();
 
             actualAmountIn_ += pathState->inPass();
             actualAmountOut_ += pathState->outPass();

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -128,7 +128,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                         = node().sleOffer->getFieldAmount (sfTakerGets);
 
                 // Funds left.
-                node().saOfferFunds = ledger().accountFunds (
+                node().saOfferFunds = funds (ledger(),
                     node().offerOwnerAccount_,
                     node().saTakerGets,
                     fhZERO_IF_FROZEN);
@@ -329,7 +329,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
 
                 // Only the current node is allowed to use the source.
 
-                node().saOfferFunds = ledger().accountFunds (
+                node().saOfferFunds = funds(ledger(),
                     node().offerOwnerAccount_,
                     node().saTakerGets,
                     fhZERO_IF_FROZEN);

--- a/src/ripple/app/paths/cursor/Liquidity.cpp
+++ b/src/ripple/app/paths/cursor/Liquidity.cpp
@@ -30,7 +30,9 @@ TER PathCursor::liquidity (LedgerEntrySet const& lesCheckpoint) const
     TER resultCode = tecPATH_DRY;
     PathCursor pc = *this;
 
-    ledger() = lesCheckpoint.duplicate ();
+    // duplicate
+    reconstruct(rippleCalc_.mActiveLedger, lesCheckpoint);
+
     for (pc.nodeIndex_ = pc.nodeSize(); pc.nodeIndex_--; )
     {
         WriteLog (lsTRACE, RippleCalc)
@@ -59,7 +61,9 @@ TER PathCursor::liquidity (LedgerEntrySet const& lesCheckpoint) const
         return resultCode;
 
     // Do forward.
-    ledger() = lesCheckpoint.duplicate ();
+    // duplicate
+    reconstruct(rippleCalc_.mActiveLedger, lesCheckpoint);
+
     for (pc.nodeIndex_ = 0; pc.nodeIndex_ < pc.nodeSize(); ++pc.nodeIndex_)
     {
         WriteLog (lsTRACE, RippleCalc)

--- a/src/ripple/app/paths/cursor/PathCursor.h
+++ b/src/ripple/app/paths/cursor/PathCursor.h
@@ -55,7 +55,8 @@ public:
 private:
     PathCursor(PathCursor const&) = default;
 
-    PathCursor increment(int delta = 1) const {
+    PathCursor increment(int delta = 1) const
+    {
         return {rippleCalc_, pathState_, multiQuality_, nodeIndex_ + delta};
     }
 
@@ -89,11 +90,6 @@ private:
         STAmount const& saInReq,
         STAmount& saInAct,
         STAmount& saInFees) const;
-
-    RippleCalc& rippleCalc_;
-    PathState& pathState_;
-    bool multiQuality_;
-    NodeIndex nodeIndex_;
 
     LedgerEntrySet& ledger() const
     {
@@ -129,6 +125,11 @@ private:
     {
         return node (restrict (nodeIndex_ + 1));
     }
+
+    RippleCalc& rippleCalc_;
+    PathState& pathState_;
+    bool multiQuality_;
+    NodeIndex nodeIndex_;
 };
 
 } // path

--- a/src/ripple/app/tests/Env.h
+++ b/src/ripple/app/tests/Env.h
@@ -46,7 +46,7 @@ class AccountInfo
 private:
     Account account_;
     std::shared_ptr<Ledger> ledger_;
-    boost::optional<SLE const> root_;
+    std::shared_ptr<SLE const> root_;
 
 public:
     AccountInfo(Account const& account,

--- a/src/ripple/app/tx/TransactionEngine.h
+++ b/src/ripple/app/tx/TransactionEngine.h
@@ -22,6 +22,7 @@
 
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/ledger/LedgerEntrySet.h>
+#include <boost/optional.hpp>
 #include <utility>
 
 namespace ripple {
@@ -35,11 +36,7 @@ static multisign_t const multisign;
 // One instance per ledger.
 // Only one transaction applied at a time.
 class TransactionEngine
-    : public CountedObject <TransactionEngine>
 {
-public:
-    static char const* getCountedObjectName () { return "TransactionEngine"; }
-
 private:
     bool enableMultiSign_ =
 #if RIPPLE_ENABLE_MULTI_SIGN
@@ -48,17 +45,16 @@ private:
         false;
 #endif
 
-    LedgerEntrySet mNodes;
-
-    void txnWrite ();
+    boost::optional<LedgerEntrySet> mNodes;
 
 protected:
     Ledger::pointer mLedger;
     int mTxnSeq = 0;
 
 public:
-    TransactionEngine () = default;
+    TransactionEngine() = default;
 
+    explicit
     TransactionEngine (Ledger::ref ledger)
         : mLedger (ledger)
     {
@@ -81,7 +77,7 @@ public:
     LedgerEntrySet&
     view ()
     {
-        return mNodes;
+        return *mNodes;
     }
 
     Ledger::ref

--- a/src/ripple/app/tx/impl/CancelTicket.cpp
+++ b/src/ripple/app/tx/impl/CancelTicket.cpp
@@ -52,9 +52,11 @@ public:
         if (!sleTicket)
             return tecNO_ENTRY;
 
-        Account const ticket_owner (sleTicket->getFieldAccount160 (sfAccount));
+        auto const ticket_owner =
+            sleTicket->getFieldAccount160 (sfAccount);
 
-        bool authorized (mTxnAccountID == ticket_owner);
+        bool authorized =
+            mTxnAccountID == ticket_owner;
 
         // The target can also always remove a ticket
         if (!authorized && sleTicket->isFieldPresent (sfTarget))
@@ -77,7 +79,8 @@ public:
         TER const result = mEngine->view ().dirDelete (false, hint,
             getOwnerDirIndex (ticket_owner), ticketId, false, (hint == 0));
 
-        mEngine->view ().decrementOwnerCount (ticket_owner);
+        adjustOwnerCount(mEngine->view(), mEngine->view().entryCache(
+            ltACCOUNT_ROOT, getAccountRootIndex(ticket_owner)), -1);
         mEngine->view ().entryDelete (sleTicket);
 
         return result;

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -122,15 +122,18 @@ private:
         SLE::pointer amendmentObject (mEngine->view().entryCache (ltAMENDMENTS, index));
 
         if (!amendmentObject)
-            amendmentObject = mEngine->view().entryCreate(ltAMENDMENTS, index);
+        {
+            amendmentObject = std::make_shared<SLE>(
+                ltAMENDMENTS, index);
+            mEngine->view().entryCreate(amendmentObject);
+        }
 
-        STVector256 amendments (amendmentObject->getFieldV256 (sfAmendments));
+        STVector256 amendments =
+            amendmentObject->getFieldV256(sfAmendments);
 
         if (std::find (amendments.begin(), amendments.end(),
-            amendment) != amendments.end ())
-        {
+                amendment) != amendments.end ())
             return tefALREADY;
-        }
 
         amendments.push_back (amendment);
         amendmentObject->setFieldV256 (sfAmendments, amendments);
@@ -151,7 +154,11 @@ private:
         SLE::pointer feeObject = mEngine->view().entryCache (ltFEE_SETTINGS, index);
 
         if (!feeObject)
-            feeObject = mEngine->view().entryCreate (ltFEE_SETTINGS, index);
+        {
+            feeObject = std::make_shared<SLE>(
+                ltFEE_SETTINGS, index);
+            mEngine->view().entryCreate(feeObject);
+        }
 
         // VFALCO-FIXME this generates errors
         // m_journal.trace <<

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -85,14 +85,13 @@ public:
                 return tesSUCCESS;
         }
 
-        SLE::pointer sleTicket = mEngine->view().entryCreate (ltTICKET,
+        SLE::pointer sleTicket = std::make_shared<SLE>(ltTICKET,
             getTicketIndex (mTxnAccountID, mTxn.getSequence ()));
-
         sleTicket->setFieldAccount (sfAccount, mTxnAccountID);
         sleTicket->setFieldU32 (sfSequence, mTxn.getSequence ());
-
         if (expiration != 0)
             sleTicket->setFieldU32 (sfExpiration, expiration);
+        mEngine->view().entryCreate (sleTicket);
 
         if (mTxn.isFieldPresent (sfTarget))
         {
@@ -134,7 +133,7 @@ public:
         sleTicket->setFieldU64(sfOwnerNode, hint);
 
         // If we succeeded, the new entry counts agains the creator's reserve.
-        mEngine->view ().incrementOwnerCount (mTxnAccount);
+        adjustOwnerCount(mEngine->view(), mTxnAccount, 1);
 
         return result;
     }

--- a/src/ripple/app/tx/impl/LocalTxs.cpp
+++ b/src/ripple/app/tx/impl/LocalTxs.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/tx/LocalTxs.h>
+#include <ripple/app/main/Application.h>
 #include <ripple/app/misc/CanonicalTXSet.h>
 #include <ripple/protocol/Indexes.h>
 
@@ -125,8 +126,9 @@ public:
             return true;
         if (ledger->hasTransaction (txn.getID ()))
             return true;
-        auto const sle = ledger->fetch(
-            getAccountRootIndex(txn.getAccount()));
+        auto const sle = fetch(*ledger,
+            getAccountRootIndex(txn.getAccount().getAccountID()),
+                getApp().getSLECache());
         if (! sle)
             return false;
         if (sle->getFieldU32 (sfSequence) > txn.getSeq ())

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -122,8 +122,8 @@ OfferStream::step ()
         // Calculate owner funds
         // NIKB NOTE The calling code also checks the funds, how expensive is
         //           looking up the funds twice?
-        STAmount const owner_funds (view().accountFunds (
-            m_offer.owner(), amount.out, fhZERO_IF_FROZEN));
+        auto const owner_funds = funds(view(),
+            m_offer.owner(), amount.out, fhZERO_IF_FROZEN);
 
         // Check for unfunded offer
         if (owner_funds <= zero)
@@ -131,7 +131,7 @@ OfferStream::step ()
             // If the owner's balance in the pristine view is the same,
             // we haven't modified the balance and therefore the
             // offer is "found unfunded" versus "became unfunded"
-            auto const original_funds = view_cancel().accountFunds (
+            auto const original_funds = funds(view_cancel(),
                 m_offer.owner(), amount.out, fhZERO_IF_FROZEN);
 
             if (original_funds == owner_funds)

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -233,10 +233,11 @@ public:
             }
 
             // Create the account.
-            auto const newIndex = getAccountRootIndex (uDstAccountID);
-            sleDst = mEngine->view().entryCreate (ltACCOUNT_ROOT, newIndex);
+            sleDst = std::make_shared<SLE>(ltACCOUNT_ROOT,
+                getAccountRootIndex (uDstAccountID));
             sleDst->setFieldAccount (sfAccount, uDstAccountID);
             sleDst->setFieldU32 (sfSequence, 1);
+            mEngine->view().entryCreate(sleDst);
         }
         else if ((sleDst->getFlags () & lsfRequireDestTag) &&
                  !mTxn.isFieldPresent (sfDestinationTag))

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -339,7 +339,8 @@ public:
             if (bLowReserveSet && !bLowReserved)
             {
                 // Set reserve for low account.
-                mEngine->view ().incrementOwnerCount (sleLowAccount);
+                adjustOwnerCount(mEngine->view(),
+                    sleLowAccount, 1);
                 uFlagsOut |= lsfLowReserve;
 
                 if (!bHigh)
@@ -349,14 +350,16 @@ public:
             if (bLowReserveClear && bLowReserved)
             {
                 // Clear reserve for low account.
-                mEngine->view ().decrementOwnerCount (sleLowAccount);
+                adjustOwnerCount(mEngine->view(),
+                    sleLowAccount, -1);
                 uFlagsOut &= ~lsfLowReserve;
             }
 
             if (bHighReserveSet && !bHighReserved)
             {
                 // Set reserve for high account.
-                mEngine->view ().incrementOwnerCount (sleHighAccount);
+                adjustOwnerCount(mEngine->view(),
+                    sleHighAccount, 1);
                 uFlagsOut |= lsfHighReserve;
 
                 if (bHigh)
@@ -366,7 +369,8 @@ public:
             if (bHighReserveClear && bHighReserved)
             {
                 // Clear reserve for high account.
-                mEngine->view ().decrementOwnerCount (sleHighAccount);
+                adjustOwnerCount(mEngine->view(),
+                    sleHighAccount, -1);
                 uFlagsOut &= ~lsfHighReserve;
             }
 

--- a/src/ripple/app/tx/impl/Taker.cpp
+++ b/src/ripple/app/tx/impl/Taker.cpp
@@ -581,9 +581,9 @@ Taker::consume_offer (Offer const& offer, Amounts const& order)
 }
 
 STAmount
-Taker::get_funds (Account const& account, STAmount const& funds) const
+Taker::get_funds (Account const& account, STAmount const& amount) const
 {
-    return view_.accountFunds (account, funds, fhZERO_IF_FROZEN);
+    return funds(view_, account, amount, fhZERO_IF_FROZEN);
 }
 
 TER Taker::transfer_xrp (

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -21,11 +21,13 @@
 #define RIPPLE_PROTOCOL_INDEXES_H_INCLUDED
 
 #include <ripple/protocol/LedgerFormats.h>
+#include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/RippleAddress.h>
 #include <ripple/protocol/Serializer.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/basics/base_uint.h>
 #include <ripple/protocol/Book.h>
+#include <cstdint>
 
 namespace ripple {
 
@@ -89,6 +91,137 @@ getRippleStateIndex (Account const& a, Issue const& issue);
 
 uint256
 getSignerListIndex (Account const& account);
+
+//------------------------------------------------------------------------------
+
+/** A pair of SHAMap key and LedgerEntryType.
+    
+    A Keylet identifies both a key in the state map
+    and its ledger entry type.
+*/
+struct Keylet
+{
+    LedgerEntryType type;
+    uint256 key;
+
+    Keylet (LedgerEntryType type_,
+            uint256 const& key_)
+        : type(type_)
+        , key(key_)
+    {
+    }
+};
+
+/** Keylet computation funclets. */
+namespace keylet {
+
+/** Account root */
+struct account_t
+{
+    Keylet operator()(Account const& id) const;
+
+    // DEPRECATED
+    Keylet operator()(RippleAddress const& ra) const;
+};
+static account_t const account {};
+
+/** OWner directory */
+struct owndir_t
+{
+    Keylet operator()(Account const& id) const;
+};
+static owndir_t const ownerDir {};
+
+/** Skip list */
+struct skip_t
+{
+    Keylet operator()() const;
+
+    Keylet operator()(LedgerIndex ledger) const;
+};
+static skip_t const skip {};
+
+/** The amendment table */
+struct amendments_t
+{
+    Keylet operator()() const;
+};
+static amendments_t const amendments {};
+
+/** The ledger fees */
+struct fee_t
+{
+    Keylet operator()() const;
+};
+static fee_t const fee {};
+
+/** The beginning of an order book */
+struct book_t
+{
+    Keylet operator()(Book const& b) const;
+};
+static book_t const book {};
+
+/** An offer from an account */
+struct offer_t
+{
+    Keylet operator()(Account const& id,
+        std::uint32_t seq) const;
+};
+static offer_t const offer {};
+
+/** An item in a directory */
+struct item_t
+{
+    Keylet operator()(Keylet const& k,
+        std::uint64_t index,
+            LedgerEntryType type) const;
+};
+static item_t const item {};
+
+/** The directory for a specific quality */
+struct quality_t
+{
+    Keylet operator()(Keylet const& k,
+        std::uint64_t q) const;
+};
+static quality_t const quality {};
+
+/** The directry for the next lower quality */
+struct next_t
+{
+    Keylet operator()(Keylet const& k) const;
+};
+static next_t const next {};
+
+/** A ticket belonging to an account */
+struct ticket_t
+{
+    Keylet operator()(Account const& id,
+        std::uint32_t seq) const;
+};
+static ticket_t const ticket {};
+
+/** A trust line */
+struct trust_t
+{
+    Keylet operator()(Account const& id0,
+        Account const& id1, Currency const& currency) const;
+
+    Keylet operator()(Account const& id,
+        Issue const& issue) const;
+};
+static trust_t const trust {};
+
+/** A SignerList */
+struct signers_t
+{
+    Keylet operator()(Account const& id) const;
+};
+static signers_t const signers {};
+
+} // keylet
+
 }
 
 #endif

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -20,7 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_STLEDGERENTRY_H_INCLUDED
 #define RIPPLE_PROTOCOL_STLEDGERENTRY_H_INCLUDED
 
-#include <ripple/protocol/LedgerFormats.h>
+#include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/STObject.h>
 
 namespace ripple {
@@ -35,10 +35,21 @@ public:
     using pointer = std::shared_ptr<STLedgerEntry>;
     using ref     = const std::shared_ptr<STLedgerEntry>&;
 
-public:
+    /** Create an empty object with the given key and type. */
+    explicit
+    STLedgerEntry (Keylet const& k);
+
+    STLedgerEntry (LedgerEntryType type,
+            uint256 const& key)
+        : STLedgerEntry(Keylet(type, key))
+    {
+    }
+
     STLedgerEntry (const Serializer & s, uint256 const& index);
+    
     STLedgerEntry (SerialIter & sit, uint256 const& index);
-    STLedgerEntry (LedgerEntryType type, uint256 const& index);
+  
+        
     STLedgerEntry (const STObject & object, uint256 const& index);
 
     STBase*
@@ -57,69 +68,81 @@ public:
     {
         return STI_LEDGERENTRY;
     }
+
     std::string getFullText () const override;
+    
     std::string getText () const override;
+    
     Json::Value getJson (int options) const override;
 
     /** Returns the 'key' (or 'index') of this item.
         The key identifies this entry's position in
         the SHAMap associative container.
     */
+    uint256 const&
+    key() const
+    {
+        return key_;
+    }
+
+    // DEPRECATED
     uint256 const& getIndex () const
     {
-        return mIndex;
-    }
-    void setIndex (uint256 const& i)
-    {
-        mIndex = i;
+        return key_;
     }
 
     void setImmutable ()
     {
         mMutable = false;
     }
+
     bool isMutable ()
     {
         return mMutable;
     }
-    STLedgerEntry::pointer getMutable () const;
 
     LedgerEntryType getType () const
     {
-        return mType;
+        return type_;
     }
+
     std::uint16_t getVersion () const
     {
         return getFieldU16 (sfLedgerEntryType);
     }
-    LedgerFormats::Item const* getFormat ()
-    {
-        return mFormat;
-    }
-
+    
     bool isThreadedType() const; // is this a ledger entry that can be threaded
+    
     bool isThreaded () const;     // is this ledger entry actually threaded
+    
     bool hasOneOwner () const;    // This node has one other node that owns it
+    
     bool hasTwoOwners () const;   // This node has two nodes that own it (like ripple balance)
+    
     RippleAddress getOwner () const;
+    
     RippleAddress getFirstOwner () const;
+    
     RippleAddress getSecondOwner () const;
+    
     uint256 getThreadedTransaction () const;
+    
     std::uint32_t getThreadedLedger () const;
+    
     bool thread (uint256 const& txID, std::uint32_t ledgerSeq, uint256 & prevTxID,
                  std::uint32_t & prevLedgerID);
 
 private:
-    /** Make STObject comply with the template for this SLE type
+    /*  Make STObject comply with the template for this SLE type
         Can throw
     */
     void setSLEType ();
 
 private:
-    uint256                     mIndex;
-    LedgerEntryType             mType;
+    uint256 key_;
+    LedgerEntryType type_;
     LedgerFormats::Item const*  mFormat;
-    bool                        mMutable;
+    bool mMutable;
 };
 
 using SLE = STLedgerEntry;

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -21,6 +21,7 @@
 #include <ripple/basics/SHA512Half.h>
 #include <ripple/protocol/Indexes.h>
 #include <beast/utility/static_initializer.h>
+#include <cassert>
 
 namespace ripple {
 
@@ -191,5 +192,119 @@ getSignerListIndex (Account const& account)
         std::uint16_t(spaceSignerList),
         account);
 }
+
+//------------------------------------------------------------------------------
+
+namespace keylet {
+
+Keylet account_t::operator()(
+    Account const& id) const
+{
+    return { ltACCOUNT_ROOT,
+        getAccountRootIndex(id) };
+}
+
+Keylet account_t::operator()(
+    RippleAddress const& ra) const
+{
+    return { ltACCOUNT_ROOT,
+        getAccountRootIndex(ra.getAccountID()) };
+}
+
+Keylet owndir_t::operator()(
+    Account const& id) const
+{
+    return { ltDIR_NODE,
+        getOwnerDirIndex(id) };
+}
+
+Keylet skip_t::operator()() const
+{
+    return { ltLEDGER_HASHES,
+        getLedgerHashIndex() };
+}
+
+Keylet skip_t::operator()(LedgerIndex ledger) const
+{
+    return { ltLEDGER_HASHES,
+        getLedgerHashIndex(ledger) };
+}
+
+Keylet amendments_t::operator()() const
+{
+    return { ltAMENDMENTS,
+        getLedgerAmendmentIndex() };
+}
+
+Keylet fee_t::operator()() const
+{
+    return { ltFEE_SETTINGS,
+        getLedgerFeeIndex() };
+}
+
+Keylet book_t::operator()(Book const& b) const
+{
+    return { ltDIR_NODE,
+        getBookBase(b) };
+}
+
+Keylet offer_t::operator()(Account const& id,
+    std::uint32_t seq) const
+{
+    return { ltOFFER,
+        getOfferIndex(id, seq) };
+}
+
+Keylet item_t::operator()(Keylet const& k,
+    std::uint64_t index,
+        LedgerEntryType type) const
+{
+    return { type,
+        getDirNodeIndex(k.key, index) };
+}
+
+Keylet quality_t::operator()(Keylet const& k,
+    std::uint64_t q) const
+{
+    assert(k.type == ltDIR_NODE);
+    return { ltDIR_NODE,
+        getQualityIndex(k.key, q) };
+}
+
+Keylet next_t::operator()(Keylet const& k) const
+{
+    assert(k.type == ltDIR_NODE);
+    return { ltDIR_NODE,
+        getQualityNext(k.key) };
+}
+
+Keylet ticket_t::operator()(Account const& id,
+    std::uint32_t seq) const
+{
+    return { ltTICKET,
+        getTicketIndex(id, seq) };
+}
+
+Keylet trust_t::operator()(Account const& id0,
+    Account const& id1, Currency const& currency) const
+{
+    return { ltRIPPLE_STATE,
+        getRippleStateIndex(id0, id1, currency) };
+}
+
+Keylet trust_t::operator()(Account const& id,
+    Issue const& issue) const
+{
+    return { ltRIPPLE_STATE,
+        getRippleStateIndex(id, issue) };
+}
+
+Keylet signers_t::operator()(Account const& id) const
+{
+    return { ltSIGNER_LIST,
+        getSignerListIndex(id) };
+}
+
+} // keylet
 
 } // ripple

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -306,7 +306,7 @@ ripplePathFind(RippleLineCache::pointer const& cache,
                     << "Trying with an extra path element";
 
                 spsComputed.push_back(fullLiquidityPath);
-                lesSandbox.clear();
+                reconstruct(lesSandbox, lpLedger, tapNONE);
                 rc = path::RippleCalc::rippleCalculate(
                     lesSandbox,
                     saMaxAmount,            // --> Amount to send is unlimited


### PR DESCRIPTION
* Remove duplicate:
    This changes behavior to fix an apparent bug. The
    copy will now correctly inherit mParams instead
    of reverting to tapNONE
* Tidy up LedgerEntrySet declarations
* Tidy up TransactionEngine
* Tidy PathCursor declarations
* Add LedgerEntrySet::apply
* Add LedgerEntrySet ctor
* Add Keylet, keylet namespace
* Add defaulted copy members
* Use optional in TransactionEngine
* Use optional<LedgerEntrySet> in PathState
* Return shared_ptr in Ledger::fetch
* Don't call entryCache with zero
* Deprecate invalidate
* Remove default constructor
* Remove unused container API
* Remove CountedObject base class
* Remove insert, clear
* Remove entryCreate overload
* Remove unused and tidy up STLedgerEntry
* Make getEntry private and tidy
* Replace members with adjustOwnerCount free function
* Replace accountFunds with funds free function