### PR TITLE
Fix documentation error

### DIFF
--- a/src/ripple/nodestore/NodeObject.h
+++ b/src/ripple/nodestore/NodeObject.h
@@ -39,9 +39,9 @@ enum NodeObjectType
 
 /** A simple object that the Ledger uses to store entries.
     NodeObjects are comprised of a type, a hash, a ledger index and a blob.
-    They can be uniquely identified by the hash, which is a SHA 256 of the
-    blob. The blob is a variable length block of serialized data. The type
-    identifies what the blob contains.
+    They can be uniquely identified by the hash, which is a half-SHA512 of 
+    the blob. The blob is a variable length block of serialized data. The 
+    type identifies what the blob contains.
 
     @note No checking is performed to make sure the hash matches the data.
     @see SHAMap

--- a/src/ripple/shamap/SHAMapNodeID.h
+++ b/src/ripple/shamap/SHAMapNodeID.h
@@ -29,7 +29,7 @@
 
 namespace ripple {
 
-// Identifies a node in a SHA256 hash map
+// Identifies a node in a half-SHA512 (256 bit) hash map
 class SHAMapNodeID
 {
 private:


### PR DESCRIPTION
To my knowledge rippled doesn't use SHA256 anywhere (potential TLS handshakes aside), SHAmap nodes definitely are always hashed with SHA512.