### PR TITLE
Rename Account to AccountID, Tidy up jtx, add SHAMap::iterator

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -710,6 +710,9 @@
     <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_SystemStats.cpp">
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_Threads.cpp">
+      <ExcludedFromBuild>True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\beast\beast\module\core\streams\InputSource.h">
     </ClInclude>
     <ClCompile Include="..\..\src\beast\beast\module\core\streams\InputStream.cpp">

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -1248,6 +1248,9 @@
     <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_SystemStats.cpp">
       <Filter>beast\module\core\native</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\beast\beast\module\core\native\win32_Threads.cpp">
+      <Filter>beast\module\core\native</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\beast\beast\module\core\streams\InputSource.h">
       <Filter>beast\module\core\streams</Filter>
     </ClInclude>

--- a/src/beast/beast/module/core/core.unity.cpp
+++ b/src/beast/beast/module/core/core.unity.cpp
@@ -176,6 +176,7 @@
 #elif BEAST_WINDOWS
 #include <beast/module/core/native/win32_Files.cpp>
 #include <beast/module/core/native/win32_SystemStats.cpp>
+#include <beast/module/core/native/win32_Threads.cpp>
 
 #elif BEAST_LINUX
 #include <beast/module/core/native/linux_Files.cpp>

--- a/src/ripple/app/ledger/AcceptedLedger.cpp
+++ b/src/ripple/app/ledger/AcceptedLedger.cpp
@@ -33,13 +33,11 @@ TaggedCache <uint256, AcceptedLedger> AcceptedLedger::s_cache (
 
 AcceptedLedger::AcceptedLedger (Ledger::ref ledger) : mLedger (ledger)
 {
-    SHAMap& txSet = *ledger->peekTransactionMap ();
-
-    for (std::shared_ptr<SHAMapItem> item = txSet.peekFirstItem (); item;
-         item = txSet.peekNextItem (item->getTag ()))
+    for (auto const& item : *ledger->peekTransactionMap())
     {
         SerialIter sit (item->slice());
-        insert (std::make_shared<AcceptedLedgerTx> (ledger, std::ref (sit)));
+        insert (std::make_shared<AcceptedLedgerTx>(
+            ledger, std::ref (sit)));
     }
 }
 

--- a/src/ripple/app/ledger/DeferredCredits.cpp
+++ b/src/ripple/app/ledger/DeferredCredits.cpp
@@ -22,8 +22,8 @@
 
 namespace ripple {
 template <class TMap>
-void maybeLogCredit (Account const& sender,
-                     Account const& receiver,
+void maybeLogCredit (AccountID const& sender,
+                     AccountID const& receiver,
                      STAmount const& amount,
                      TMap const& adjMap)
 {
@@ -56,8 +56,8 @@ void maybeLogCredit (Account const& sender,
     WriteLog (lsTRACE, DeferredCredits) << str.str ();
 }
 
-void DeferredCredits::credit (Account const& sender,
-                              Account const& receiver,
+void DeferredCredits::credit (AccountID const& sender,
+                              AccountID const& receiver,
                               STAmount const& amount)
 {
     using std::get;
@@ -100,8 +100,8 @@ void DeferredCredits::credit (Account const& sender,
 
 // Get the adjusted balance of main for the
 // balance between main and other.
-STAmount DeferredCredits::adjustedBalance (Account const& main,
-                                           Account const& other,
+STAmount DeferredCredits::adjustedBalance (AccountID const& main,
+                                           AccountID const& other,
                                            STAmount const& curBalance) const
 {
     using std::get;

--- a/src/ripple/app/ledger/DeferredCredits.h
+++ b/src/ripple/app/ledger/DeferredCredits.h
@@ -30,11 +30,11 @@ class DeferredCredits
 {
 private:
     // lowAccount, highAccount
-    using Key = std::tuple<Account, Account, Currency>;
+    using Key = std::tuple<AccountID, AccountID, Currency>;
     // lowAccountCredits, highAccountCredits
     using Value = std::tuple<STAmount, STAmount>;
     static inline
-    Key makeKey(Account const& a1, Account const& a2, Currency const& c)
+    Key makeKey(AccountID const& a1, AccountID const& a2, Currency const& c)
     {
         if (a1 < a2)
             return std::make_tuple(a1, a2, c);
@@ -45,13 +45,13 @@ private:
     std::map<Key, Value> map_;
 
 public:
-    void credit (Account const& sender,
-                 Account const& receiver,
+    void credit (AccountID const& sender,
+                 AccountID const& receiver,
                  STAmount const& amount);
     // Get the adjusted balance of main for the
     // balance between main and other.
-    STAmount adjustedBalance (Account const& main,
-                              Account const& other,
+    STAmount adjustedBalance (AccountID const& main,
+                              AccountID const& other,
                               STAmount const& curBalance) const;
     void clear ();
 };

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -639,7 +639,7 @@ bool Ledger::saveValidatedLedger (bool current)
             if (!accts.empty ())
             {
                 std::string sql ("INSERT INTO AccountTransactions "
-                                 "(TransID, AccountID, LedgerSeq, TxnSeq) VALUES ");
+                                 "(TransID, Account, LedgerSeq, TxnSeq) VALUES ");
 
                 // Try to make an educated guess on how much space we'll need
                 // for our arguments. In argument order we have:

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -58,7 +58,7 @@ namespace ripple {
 */
 static
 std::shared_ptr<SLE const>
-makeGenesisAccount (Account const& id,
+makeGenesisAccount (AccountID const& id,
     std::uint64_t drops)
 {
     std::shared_ptr<SLE> sle =
@@ -639,7 +639,7 @@ bool Ledger::saveValidatedLedger (bool current)
             if (!accts.empty ())
             {
                 std::string sql ("INSERT INTO AccountTransactions "
-                                 "(TransID, Account, LedgerSeq, TxnSeq) VALUES ");
+                                 "(TransID, AccountID, LedgerSeq, TxnSeq) VALUES ");
 
                 // Try to make an educated guess on how much space we'll need
                 // for our arguments. In argument order we have:
@@ -1260,15 +1260,15 @@ bool Ledger::pendSaveValidated (bool isSynchronous, bool isCurrent)
     return true;
 }
 
-void Ledger::ownerDirDescriber (SLE::ref sle, bool, Account const& owner)
+void Ledger::ownerDirDescriber (SLE::ref sle, bool, AccountID const& owner)
 {
     sle->setFieldAccount (sfOwner, owner);
 }
 
 void Ledger::qualityDirDescriber (
     SLE::ref sle, bool isNew,
-    Currency const& uTakerPaysCurrency, Account const& uTakerPaysIssuer,
-    Currency const& uTakerGetsCurrency, Account const& uTakerGetsIssuer,
+    Currency const& uTakerPaysCurrency, AccountID const& uTakerPaysIssuer,
+    Currency const& uTakerGetsCurrency, AccountID const& uTakerGetsIssuer,
     const std::uint64_t& uRate)
 {
     sle->setFieldH160 (sfTakerPaysCurrency, uTakerPaysCurrency);
@@ -1389,7 +1389,7 @@ fetch (Ledger const& ledger, uint256 const& key,
 }
 
 void
-forEachItem (Ledger const& ledger, Account const& id, SLECache& cache,
+forEachItem (Ledger const& ledger, AccountID const& id, SLECache& cache,
     std::function<void(std::shared_ptr<SLE const> const&)> f)
 {
     auto rootIndex = getOwnerDirIndex (id);
@@ -1411,7 +1411,7 @@ forEachItem (Ledger const& ledger, Account const& id, SLECache& cache,
 }
 
 bool
-forEachItemAfter (Ledger const& ledger, Account const& id, SLECache& cache,
+forEachItemAfter (Ledger const& ledger, AccountID const& id, SLECache& cache,
     uint256 const& after, std::uint64_t const hint, unsigned int limit,
         std::function <bool (std::shared_ptr<SLE const> const&)> f)
 {

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -371,7 +371,7 @@ public:
     // Directories are doubly linked lists of nodes.
 
     // Given a directory root and and index compute the index of a node.
-    static void ownerDirDescriber (SLE::ref, bool, Account const& owner);
+    static void ownerDirDescriber (SLE::ref, bool, AccountID const& owner);
 
     //
     // Quality
@@ -379,8 +379,8 @@ public:
 
     static void qualityDirDescriber (
         SLE::ref, bool,
-        Currency const& uTakerPaysCurrency, Account const& uTakerPaysIssuer,
-        Currency const& uTakerGetsCurrency, Account const& uTakerGetsIssuer,
+        Currency const& uTakerPaysCurrency, AccountID const& uTakerPaysIssuer,
+        Currency const& uTakerGetsCurrency, AccountID const& uTakerGetsIssuer,
         const std::uint64_t & uRate);
 
     std::uint32_t getReferenceFeeUnits() const
@@ -517,7 +517,7 @@ fetch (Ledger const& ledger, uint256 const& key, SLECache& cache,
 
 /** Iterate all items in an account's owner directory. */
 void
-forEachItem (Ledger const& ledger, Account const& id, SLECache& cache,
+forEachItem (Ledger const& ledger, AccountID const& id, SLECache& cache,
     std::function<void (std::shared_ptr<SLE const> const&)> f);
 
 /** Iterate all items after an item in an owner directory.
@@ -527,7 +527,7 @@ forEachItem (Ledger const& ledger, Account const& id, SLECache& cache,
     @return `false` if the iteration failed
 */
 bool
-forEachItemAfter (Ledger const& ledger, Account const& id, SLECache& cache,
+forEachItemAfter (Ledger const& ledger, AccountID const& id, SLECache& cache,
     uint256 const& after, std::uint64_t const hint, unsigned int limit,
         std::function <bool (std::shared_ptr<SLE const> const&)>);
 

--- a/src/ripple/app/ledger/LedgerEntrySet.cpp
+++ b/src/ripple/app/ledger/LedgerEntrySet.cpp
@@ -2066,7 +2066,7 @@ adjustOwnerCount (LedgerEntrySet& view,
         if (adjusted < current)
         {
             WriteLog (lsFATAL, LedgerEntrySet) <<
-                "AccountID " << sle->getFieldAccount160(sfAccount) <<
+                "Account " << sle->getFieldAccount160(sfAccount) <<
                 " owner count exceeds max!";
             adjusted =
                 std::numeric_limits<std::uint32_t>::max ();
@@ -2078,7 +2078,7 @@ adjustOwnerCount (LedgerEntrySet& view,
         if (adjusted > current)
         {
             WriteLog (lsFATAL, LedgerEntrySet) <<
-                "AccountID " << sle->getFieldAccount160 (sfAccount) <<
+                "Account " << sle->getFieldAccount160 (sfAccount) <<
                 " owner count set below 0!";
             adjusted = 0;
             assert(false);

--- a/src/ripple/app/ledger/LedgerEntrySet.cpp
+++ b/src/ripple/app/ledger/LedgerEntrySet.cpp
@@ -1145,9 +1145,9 @@ TER LedgerEntrySet::offerDelete (SLE::pointer sleOffer)
 // negative.
 // <-- IOU's account has of issuer.
 STAmount LedgerEntrySet::rippleHolds (
-    Account const& account,
+    AccountID const& account,
     Currency const& currency,
-    Account const& issuer,
+    AccountID const& issuer,
     FreezeHandling zeroIfFrozen)
 {
     STAmount saBalance;
@@ -1183,9 +1183,9 @@ STAmount LedgerEntrySet::rippleHolds (
 //
 // <-- saAmount: amount of currency held by account. May be negative.
 STAmount LedgerEntrySet::accountHolds (
-    Account const& account,
+    AccountID const& account,
     Currency const& currency,
-    Account const& issuer,
+    AccountID const& issuer,
     FreezeHandling zeroIfFrozen)
 {
     STAmount    saAmount;
@@ -1230,7 +1230,7 @@ STAmount LedgerEntrySet::accountHolds (
 
 }
 
-bool LedgerEntrySet::isGlobalFrozen (Account const& issuer)
+bool LedgerEntrySet::isGlobalFrozen (AccountID const& issuer)
 {
     if (isXRP (issuer))
         return false;
@@ -1245,9 +1245,9 @@ bool LedgerEntrySet::isGlobalFrozen (Account const& issuer)
 // Can the specified account spend the specified currency issued by
 // the specified issuer or does the freeze flag prohibit it?
 bool LedgerEntrySet::isFrozen(
-    Account const& account,
+    AccountID const& account,
     Currency const& currency,
-    Account const& issuer)
+    AccountID const& issuer)
 {
     if (isXRP (currency))
         return false;
@@ -1272,8 +1272,8 @@ bool LedgerEntrySet::isFrozen(
 
 TER LedgerEntrySet::trustCreate (
     const bool      bSrcHigh,
-    Account const&  uSrcAccountID,
-    Account const&  uDstAccountID,
+    AccountID const&  uSrcAccountID,
+    AccountID const&  uDstAccountID,
     uint256 const&  uIndex,             // --> ripple state entry
     SLE::ref        sleAccount,         // --> the account being set.
     const bool      bAuth,              // --> authorize account.
@@ -1383,8 +1383,8 @@ TER LedgerEntrySet::trustCreate (
 }
 
 TER LedgerEntrySet::trustDelete (
-    SLE::ref sleRippleState, Account const& uLowAccountID,
-    Account const& uHighAccountID)
+    SLE::ref sleRippleState, AccountID const& uLowAccountID,
+    AccountID const& uHighAccountID)
 {
     // Detect legacy dirs.
     bool        bLowNode    = sleRippleState->isFieldPresent (sfLowNode);
@@ -1441,8 +1441,8 @@ bool LedgerEntrySet::areCreditsDeferred () const
     return static_cast<bool> (mDeferredCredits);
 }
 
-STAmount LedgerEntrySet::adjustedBalance (Account const& main,
-                                            Account const& other,
+STAmount LedgerEntrySet::adjustedBalance (AccountID const& main,
+                                            AccountID const& other,
                                             STAmount const& amount) const
 {
     if (mDeferredCredits)
@@ -1450,8 +1450,8 @@ STAmount LedgerEntrySet::adjustedBalance (Account const& main,
     return amount;
 }
 
-void LedgerEntrySet::cacheCredit (Account const& sender,
-                                  Account const& receiver,
+void LedgerEntrySet::cacheCredit (AccountID const& sender,
+                                  AccountID const& receiver,
                                   STAmount const& amount)
 {
     if (mDeferredCredits)
@@ -1463,7 +1463,7 @@ void LedgerEntrySet::cacheCredit (Account const& sender,
 // - Create trust line of needed.
 // --> bCheckIssuer : normally require issuer to be involved.
 TER LedgerEntrySet::rippleCredit (
-    Account const& uSenderID, Account const& uReceiverID,
+    AccountID const& uSenderID, AccountID const& uReceiverID,
     STAmount const& saAmount, bool bCheckIssuer)
 {
     auto issuer = saAmount.getIssuer ();
@@ -1601,9 +1601,9 @@ TER LedgerEntrySet::rippleCredit (
 
 // Calculate the fee needed to transfer IOU assets between two parties.
 STAmount LedgerEntrySet::rippleTransferFee (
-    Account const& from,
-    Account const& to,
-    Account const& issuer,
+    AccountID const& from,
+    AccountID const& to,
+    AccountID const& issuer,
     STAmount const& saAmount)
 {
     if (from != issuer && to != issuer)
@@ -1630,7 +1630,7 @@ STAmount LedgerEntrySet::rippleTransferFee (
 // --> saAmount: Amount/currency/issuer to deliver to reciever.
 // <-- saActual: Amount actually cost.  Sender pay's fees.
 TER LedgerEntrySet::rippleSend (
-    Account const& uSenderID, Account const& uReceiverID,
+    AccountID const& uSenderID, AccountID const& uReceiverID,
     STAmount const& saAmount, STAmount& saActual)
 {
     auto const issuer   = saAmount.getIssuer ();
@@ -1674,7 +1674,7 @@ TER LedgerEntrySet::rippleSend (
 }
 
 TER LedgerEntrySet::accountSend (
-    Account const& uSenderID, Account const& uReceiverID,
+    AccountID const& uSenderID, AccountID const& uReceiverID,
     STAmount const& saAmount)
 {
     assert (saAmount >= zero);
@@ -1778,7 +1778,7 @@ TER LedgerEntrySet::accountSend (
 bool LedgerEntrySet::checkState (
     SLE::pointer state,
     bool bSenderHigh,
-    Account const& sender,
+    AccountID const& sender,
     STAmount const& before,
     STAmount const& after)
 {
@@ -1826,7 +1826,7 @@ bool LedgerEntrySet::checkState (
 }
 
 TER LedgerEntrySet::issue_iou (
-    Account const& account,
+    AccountID const& account,
     STAmount const& amount,
     Issue const& issue)
 {
@@ -1900,7 +1900,7 @@ TER LedgerEntrySet::issue_iou (
 }
 
 TER LedgerEntrySet::redeem_iou (
-    Account const& account,
+    AccountID const& account,
     STAmount const& amount,
     Issue const& issue)
 {
@@ -1967,8 +1967,8 @@ TER LedgerEntrySet::redeem_iou (
 }
 
 TER LedgerEntrySet::transfer_xrp (
-    Account const& from,
-    Account const& to,
+    AccountID const& from,
+    AccountID const& to,
     STAmount const& amount)
 {
     assert (from != beast::zero);
@@ -2006,7 +2006,7 @@ TER LedgerEntrySet::transfer_xrp (
 }
 
 std::uint32_t
-rippleTransferRate (LedgerEntrySet& ledger, Account const& issuer)
+rippleTransferRate (LedgerEntrySet& ledger, AccountID const& issuer)
 {
     SLE::pointer sleAccount (ledger.entryCache (
         ltACCOUNT_ROOT, getAccountRootIndex (issuer)));
@@ -2020,8 +2020,8 @@ rippleTransferRate (LedgerEntrySet& ledger, Account const& issuer)
 }
 
 std::uint32_t
-rippleTransferRate (LedgerEntrySet& ledger, Account const& uSenderID,
-    Account const& uReceiverID, Account const& issuer)
+rippleTransferRate (LedgerEntrySet& ledger, AccountID const& uSenderID,
+    AccountID const& uReceiverID, AccountID const& issuer)
 {
     // If calculating the transfer rate from or to the issuer of the currency
     // no fees are assessed.
@@ -2066,7 +2066,7 @@ adjustOwnerCount (LedgerEntrySet& view,
         if (adjusted < current)
         {
             WriteLog (lsFATAL, LedgerEntrySet) <<
-                "Account " << sle->getFieldAccount160(sfAccount) <<
+                "AccountID " << sle->getFieldAccount160(sfAccount) <<
                 " owner count exceeds max!";
             adjusted =
                 std::numeric_limits<std::uint32_t>::max ();
@@ -2078,7 +2078,7 @@ adjustOwnerCount (LedgerEntrySet& view,
         if (adjusted > current)
         {
             WriteLog (lsFATAL, LedgerEntrySet) <<
-                "Account " << sle->getFieldAccount160 (sfAccount) <<
+                "AccountID " << sle->getFieldAccount160 (sfAccount) <<
                 " owner count set below 0!";
             adjusted = 0;
             assert(false);
@@ -2089,7 +2089,7 @@ adjustOwnerCount (LedgerEntrySet& view,
 }
 
 STAmount
-funds (LedgerEntrySet& view, Account const& id,
+funds (LedgerEntrySet& view, AccountID const& id,
     STAmount const& saDefault, FreezeHandling freezeHandling)
 {
     STAmount saFunds;

--- a/src/ripple/app/ledger/LedgerEntrySet.h
+++ b/src/ripple/app/ledger/LedgerEntrySet.h
@@ -211,32 +211,32 @@ public:
 
     // Balance functions.
     bool isFrozen (
-        Account const& account,
+        AccountID const& account,
         Currency const& currency,
-        Account const& issuer);
+        AccountID const& issuer);
 
-    bool isGlobalFrozen (Account const& issuer);
+    bool isGlobalFrozen (AccountID const& issuer);
 
     void enableDeferredCredits (bool enable=true);
 
     bool areCreditsDeferred () const;
 
     TER rippleCredit (
-        Account const& uSenderID, Account const& uReceiverID,
+        AccountID const& uSenderID, AccountID const& uReceiverID,
         const STAmount & saAmount, bool bCheckIssuer = true);
 
     STAmount accountHolds (
-        Account const& account, Currency const& currency,
-        Account const& issuer, FreezeHandling freezeHandling);
+        AccountID const& account, Currency const& currency,
+        AccountID const& issuer, FreezeHandling freezeHandling);
 
     TER accountSend (
-        Account const& uSenderID, Account const& uReceiverID,
+        AccountID const& uSenderID, AccountID const& uReceiverID,
         const STAmount & saAmount);
 
     TER trustCreate (
         const bool      bSrcHigh,
-        Account const&  uSrcAccountID,
-        Account const&  uDstAccountID,
+        AccountID const&  uSrcAccountID,
+        AccountID const&  uDstAccountID,
         uint256 const&  uIndex,
         SLE::ref        sleAccount,
         const bool      bAuth,
@@ -248,8 +248,8 @@ public:
         const std::uint32_t uSrcQualityOut = 0);
 
     TER trustDelete (
-        SLE::ref sleRippleState, Account const& uLowAccountID,
-        Account const& uHighAccountID);
+        SLE::ref sleRippleState, AccountID const& uLowAccountID,
+        AccountID const& uHighAccountID);
 
     Json::Value getJson (int) const;
 
@@ -260,13 +260,13 @@ public:
         mSet.setDeliveredAmount (amt);
     }
 
-    TER issue_iou (Account const& account,
+    TER issue_iou (AccountID const& account,
         STAmount const& amount, Issue const& issue);
 
-    TER redeem_iou (Account const& account,
+    TER redeem_iou (AccountID const& account,
         STAmount const& amount, Issue const& issue);
 
-    TER transfer_xrp (Account const& from, Account const& to, STAmount const& amount);
+    TER transfer_xrp (AccountID const& from, AccountID const& to, STAmount const& amount);
 
 private:
     SLE::pointer getEntry (uint256 const& index, Action&);
@@ -286,26 +286,26 @@ private:
         Ledger::ref ledger, NodeToLedgerEntry& newMods);
 
     TER rippleSend (
-        Account const& uSenderID, Account const& uReceiverID,
+        AccountID const& uSenderID, AccountID const& uReceiverID,
         const STAmount & saAmount, STAmount & saActual);
 
     STAmount rippleHolds (
-        Account const& account, Currency const& currency,
-        Account const& issuer, FreezeHandling zeroIfFrozen);
+        AccountID const& account, Currency const& currency,
+        AccountID const& issuer, FreezeHandling zeroIfFrozen);
 
     STAmount rippleTransferFee (
-        Account const& from, Account const& to,
-        Account const& issuer, STAmount const& saAmount);
+        AccountID const& from, AccountID const& to,
+        AccountID const& issuer, STAmount const& saAmount);
 
     bool checkState (SLE::pointer state, bool bSenderHigh,
-        Account const& sender, STAmount const& before, STAmount const& after);
+        AccountID const& sender, STAmount const& before, STAmount const& after);
 
-    STAmount adjustedBalance (Account const& main,
-                              Account const& other,
+    STAmount adjustedBalance (AccountID const& main,
+                              AccountID const& other,
                               STAmount const& amount) const;
 
-    void cacheCredit (Account const& sender,
-                      Account const& receiver,
+    void cacheCredit (AccountID const& sender,
+                      AccountID const& receiver,
                       STAmount const& amount);
 };
 
@@ -335,11 +335,11 @@ public:
 
 // NIKB FIXME: move these to the right place
 std::uint32_t
-rippleTransferRate (LedgerEntrySet& ledger, Account const& issuer);
+rippleTransferRate (LedgerEntrySet& ledger, AccountID const& issuer);
 
 std::uint32_t
-rippleTransferRate (LedgerEntrySet& ledger, Account const& uSenderID,
-    Account const& uReceiverID, Account const& issuer);
+rippleTransferRate (LedgerEntrySet& ledger, AccountID const& uSenderID,
+    AccountID const& uReceiverID, AccountID const& issuer);
 
 //------------------------------------------------------------------------------
 //
@@ -361,7 +361,7 @@ adjustOwnerCount (LedgerEntrySet& view,
 // If the issuer is the same as account, funds are unlimited, use result is
 // saDefault.
 STAmount
-funds (LedgerEntrySet& view, Account const& id,
+funds (LedgerEntrySet& view, AccountID const& id,
     STAmount const& saDefault,
         FreezeHandling freezeHandling);
 

--- a/src/ripple/app/ledger/OrderBookIterator.cpp
+++ b/src/ripple/app/ledger/OrderBookIterator.cpp
@@ -25,8 +25,8 @@ namespace ripple {
 
 /** Iterate through the directories in an order book */
 BookDirIterator::BookDirIterator(
-    Currency const& currencyIn, Account const& issuerIn,
-    Currency const& currencyOut, Account const& issuerOut)
+    Currency const& currencyIn, AccountID const& issuerIn,
+    Currency const& currencyOut, AccountID const& issuerOut)
 {
     mBase = ripple::getBookBase({{currencyIn, issuerIn},
             {currencyOut, issuerOut}});

--- a/src/ripple/app/ledger/OrderBookIterator.h
+++ b/src/ripple/app/ledger/OrderBookIterator.h
@@ -38,8 +38,8 @@ public:
     }
 
     BookDirIterator (
-        Currency const& currencyIn, Account const& issuerIn,
-        Currency const& currencyOut, Account const& issuerOut);
+        Currency const& currencyIn, AccountID const& issuerIn,
+        Currency const& currencyOut, AccountID const& issuerOut);
 
     uint256 const& getBookBase () const
     {
@@ -133,9 +133,9 @@ public:
     OrderBookIterator (
         LedgerEntrySet& set,
         Currency const& currencyIn,
-        Account const& issuerIn,
+        AccountID const& issuerIn,
         Currency const& currencyOut,
-        Account const& issuerOut) :
+        AccountID const& issuerOut) :
             mEntrySet (set),
             mDirectoryIterator (currencyIn, issuerIn, currencyOut, issuerOut)
     {

--- a/src/ripple/app/ledger/README.md
+++ b/src/ripple/app/ledger/README.md
@@ -253,9 +253,9 @@ such as the root node of the state tree.
 
 # Ledger Structures #
 
-## Account Root ##
+## AccountID Root ##
 
-**Account:** A 160-bit account ID.
+**AccountID:** A 160-bit account ID.
 
 **Balance:** Balance in the account.
 

--- a/src/ripple/app/ledger/README.md
+++ b/src/ripple/app/ledger/README.md
@@ -253,9 +253,9 @@ such as the root node of the state tree.
 
 # Ledger Structures #
 
-## AccountID Root ##
+## Account Root ##
 
-**AccountID:** A 160-bit account ID.
+**Account:** A 160-bit account ID.
 
 **Balance:** Balance in the account.
 

--- a/src/ripple/app/ledger/impl/LedgerConsensus.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensus.cpp
@@ -1857,8 +1857,7 @@ void applyTransactions (std::shared_ptr<SHAMap> const& set,
 
     if (set)
     {
-        for (std::shared_ptr<SHAMapItem> item = set->peekFirstItem (); !!item;
-            item = set->peekNextItem (item->getTag ()))
+        for (auto const item : *set)
         {
             // If the checkLedger doesn't have the transaction
             if (!checkLedger->hasTransaction (item->getTag ()))

--- a/src/ripple/app/ledger/tests/DeferredCredits.test.cpp
+++ b/src/ripple/app/ledger/tests/DeferredCredits.test.cpp
@@ -151,8 +151,8 @@ class DeferredCredits_test : public beast::unit_test::suite
         verifyBalance (ledger, alice, Amount (50, "USD", gw1));
         verifyBalance (ledger, alice, Amount (50, "USD", gw2));
 
-        ripple::Account const gw1Acc (gw1.pk.getAccountID ());
-        ripple::Account const aliceAcc (alice.pk.getAccountID ());
+        AccountID const gw1Acc (gw1.pk.getAccountID ());
+        AccountID const aliceAcc (alice.pk.getAccountID ());
         ripple::Currency const usd (to_currency ("USD"));
         ripple::Issue const issue (usd, gw1Acc);
         STAmount const toCredit (issue, 30);

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1502,7 +1502,7 @@ static void addTxnSeqField ()
     }
 
     WriteLog (lsINFO, Application) << "Building new index";
-    session << "CREATE INDEX AcctTxIndex ON AccountTransactions(Account, LedgerSeq, TxnSeq, TransID);";
+    session << "CREATE INDEX AcctTxIndex ON AccountTransactions(AccountID, LedgerSeq, TxnSeq, TransID);";
 
     tr.commit ();
 }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1317,16 +1317,18 @@ bool ApplicationImp::loadOldLedger (
             cur = std::make_shared <Ledger> (*cur, true);
             assert (!cur->isImmutable());
 
-            for (auto it = txns->peekFirstItem(); it != nullptr;
-                 it = txns->peekNextItem(it->getTag()))
+            for (auto const& item : *txns)
             {
-                Transaction::pointer txn = replayLedger->getTransaction(it->getTag());
-                m_journal.info << txn->getJson(0);
+                auto const txn =
+                    replayLedger->getTransaction(item->getTag());
+                if (m_journal.info) m_journal.info <<
+                    txn->getJson(0);
                 Serializer s;
                 txn->getSTransaction()->add(s);
-                if (!cur->addTransaction(it->getTag(), s))
-                    m_journal.warning << "Unable to add transaction " << it->getTag();
-                getApp().getHashRouter().setFlag (it->getTag(), SF_SIGGOOD);
+                if (! cur->addTransaction(item->getTag(), s))
+                    if (m_journal.warning) m_journal.warning <<
+                        "Unable to add transaction " << item->getTag();
+                getApp().getHashRouter().setFlag (item->getTag(), SF_SIGGOOD);
             }
 
             // Switch to the mutable snapshot

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1502,7 +1502,7 @@ static void addTxnSeqField ()
     }
 
     WriteLog (lsINFO, Application) << "Building new index";
-    session << "CREATE INDEX AcctTxIndex ON AccountTransactions(AccountID, LedgerSeq, TxnSeq, TransID);";
+    session << "CREATE INDEX AcctTxIndex ON AccountTransactions(Account, LedgerSeq, TxnSeq, TransID);";
 
     tr.commit ();
 }

--- a/src/ripple/app/main/DBInit.cpp
+++ b/src/ripple/app/main/DBInit.cpp
@@ -51,16 +51,16 @@ const char* TxnDBInit[] =
 
     "CREATE TABLE IF NOT EXISTS AccountTransactions (         \
         TransID     CHARACTER(64),              \
-        AccountID     CHARACTER(64),              \
+        Account     CHARACTER(64),              \
         LedgerSeq   BIGINT UNSIGNED,            \
         TxnSeq      INTEGER                     \
     );",
     "CREATE INDEX IF NOT EXISTS AcctTxIDIndex ON              \
         AccountTransactions(TransID);",
     "CREATE INDEX IF NOT EXISTS AcctTxIndex ON                \
-        AccountTransactions(AccountID, LedgerSeq, TxnSeq, TransID);",
+        AccountTransactions(Account, LedgerSeq, TxnSeq, TransID);",
     "CREATE INDEX IF NOT EXISTS AcctLgrIndex ON               \
-        AccountTransactions(LedgerSeq, AccountID, TransID);",
+        AccountTransactions(LedgerSeq, Account, TransID);",
 
     "END TRANSACTION;"
 };

--- a/src/ripple/app/main/DBInit.cpp
+++ b/src/ripple/app/main/DBInit.cpp
@@ -51,16 +51,16 @@ const char* TxnDBInit[] =
 
     "CREATE TABLE IF NOT EXISTS AccountTransactions (         \
         TransID     CHARACTER(64),              \
-        Account     CHARACTER(64),              \
+        AccountID     CHARACTER(64),              \
         LedgerSeq   BIGINT UNSIGNED,            \
         TxnSeq      INTEGER                     \
     );",
     "CREATE INDEX IF NOT EXISTS AcctTxIDIndex ON              \
         AccountTransactions(TransID);",
     "CREATE INDEX IF NOT EXISTS AcctTxIndex ON                \
-        AccountTransactions(Account, LedgerSeq, TxnSeq, TransID);",
+        AccountTransactions(AccountID, LedgerSeq, TxnSeq, TransID);",
     "CREATE INDEX IF NOT EXISTS AcctLgrIndex ON               \
-        AccountTransactions(LedgerSeq, Account, TransID);",
+        AccountTransactions(LedgerSeq, AccountID, TransID);",
 
     "END TRANSACTION;"
 };

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -557,7 +557,7 @@ AmendmentTableImpl<AppApiFacade>::doVoting (Ledger::ref lastClosedLedger,
 
         // Create the transaction to enable the amendment
         STTx trans (ttAMENDMENT);
-        trans.setFieldAccount (sfAccount, Account ());
+        trans.setFieldAccount (sfAccount, AccountID ());
         trans.setFieldH256 (sfAmendment, uAmendment);
         uint256 txID = trans.getTransactionID ();
 

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -214,7 +214,7 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
             "/" << incReserve;
 
         STTx trans (ttFEE);
-        trans.setFieldAccount (sfAccount, Account ());
+        trans.setFieldAccount (sfAccount, AccountID ());
         trans.setFieldU64 (sfBaseFee, baseFee);
         trans.setFieldU32 (sfReferenceFeeUnits, 10);
         trans.setFieldU32 (sfReserveBase, baseReserve);

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1911,7 +1911,7 @@ NetworkOPsImp::transactionsSQL (
         sql =
             boost::str (boost::format (
                 "SELECT %s FROM AccountTransactions "
-                "WHERE AccountID = '%s' %s %s LIMIT %u, %u;")
+                "WHERE Account = '%s' %s %s LIMIT %u, %u;")
             % selection
             % account.humanAccountID ()
             % maxClause
@@ -1925,7 +1925,7 @@ NetworkOPsImp::transactionsSQL (
                 "SELECT %s FROM "
                 "AccountTransactions INNER JOIN Transactions "
                 "ON Transactions.TransID = AccountTransactions.TransID "
-                "WHERE AccountID = '%s' %s %s "
+                "WHERE Account = '%s' %s %s "
                 "ORDER BY AccountTransactions.LedgerSeq %s, "
                 "AccountTransactions.TxnSeq %s, AccountTransactions.TransID %s "
                 "LIMIT %u, %u;")
@@ -2109,7 +2109,7 @@ NetworkOPsImp::getLedgerAffectedAccounts (std::uint32_t ledgerSeq)
 {
     std::vector<RippleAddress> accounts;
     std::string sql = str (boost::format (
-        "SELECT DISTINCT AccountID FROM AccountTransactions "
+        "SELECT DISTINCT Account FROM AccountTransactions "
         "INDEXED BY AcctLgrIndex WHERE LedgerSeq = '%u';")
                            % ledgerSeq);
     RippleAddress acct;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -318,7 +318,7 @@ public:
     //
 
     void getBookPage (bool bAdmin, Ledger::pointer lpLedger, Book const&,
-        Account const& uTakerID, const bool bProof, const unsigned int iLimit,
+        AccountID const& uTakerID, const bool bProof, const unsigned int iLimit,
             Json::Value const& jvMarker, Json::Value& jvResult) override;
 
     // Ledger proposal/close functions.
@@ -576,7 +576,7 @@ private:
 private:
     clock_type& m_clock;
 
-    using SubInfoMapType = hash_map <Account, SubMapType>;
+    using SubInfoMapType = hash_map <AccountID, SubMapType>;
     using subRpcMapType = hash_map<std::string, InfoSub::pointer>;
 
     // XXX Split into more locks.
@@ -1911,7 +1911,7 @@ NetworkOPsImp::transactionsSQL (
         sql =
             boost::str (boost::format (
                 "SELECT %s FROM AccountTransactions "
-                "WHERE Account = '%s' %s %s LIMIT %u, %u;")
+                "WHERE AccountID = '%s' %s %s LIMIT %u, %u;")
             % selection
             % account.humanAccountID ()
             % maxClause
@@ -1925,7 +1925,7 @@ NetworkOPsImp::transactionsSQL (
                 "SELECT %s FROM "
                 "AccountTransactions INNER JOIN Transactions "
                 "ON Transactions.TransID = AccountTransactions.TransID "
-                "WHERE Account = '%s' %s %s "
+                "WHERE AccountID = '%s' %s %s "
                 "ORDER BY AccountTransactions.LedgerSeq %s, "
                 "AccountTransactions.TxnSeq %s, AccountTransactions.TransID %s "
                 "LIMIT %u, %u;")
@@ -2109,7 +2109,7 @@ NetworkOPsImp::getLedgerAffectedAccounts (std::uint32_t ledgerSeq)
 {
     std::vector<RippleAddress> accounts;
     std::string sql = str (boost::format (
-        "SELECT DISTINCT Account FROM AccountTransactions "
+        "SELECT DISTINCT AccountID FROM AccountTransactions "
         "INDEXED BY AcctLgrIndex WHERE LedgerSeq = '%u';")
                            % ledgerSeq);
     RippleAddress acct;
@@ -2899,7 +2899,7 @@ void NetworkOPsImp::getBookPage (
     bool bAdmin,
     Ledger::pointer lpLedger,
     Book const& book,
-    Account const& uTakerID,
+    AccountID const& uTakerID,
     bool const bProof,
     const unsigned int iLimit,
     Json::Value const& jvMarker,
@@ -2908,7 +2908,7 @@ void NetworkOPsImp::getBookPage (
     Json::Value& jvOffers =
             (jvResult[jss::offers] = Json::Value (Json::arrayValue));
 
-    std::map<Account, STAmount> umBalance;
+    std::map<AccountID, STAmount> umBalance;
     const uint256   uBookBase   = getBookBase (book);
     const uint256   uBookEnd    = getQualityNext (uBookBase);
     uint256         uTipIndex   = uBookBase;
@@ -3123,7 +3123,7 @@ void NetworkOPsImp::getBookPage (
     bool bAdmin,
     Ledger::pointer lpLedger,
     Book const& book,
-    Account const& uTakerID,
+    AccountID const& uTakerID,
     bool const bProof,
     const unsigned int iLimit,
     Json::Value const& jvMarker,
@@ -3131,7 +3131,7 @@ void NetworkOPsImp::getBookPage (
 {
     auto& jvOffers = (jvResult[jss::offers] = Json::Value (Json::arrayValue));
 
-    std::map<Account, STAmount> umBalance;
+    std::map<AccountID, STAmount> umBalance;
 
     LedgerEntrySet  lesActive (lpLedger, tapNONE, true);
     OrderBookIterator obIterator (lesActive, book);

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -201,7 +201,7 @@ public:
         bool bAdmin,
         Ledger::pointer lpLedger,
         Book const& book,
-        Account const& uTakerID,
+        AccountID const& uTakerID,
         bool const bProof,
         const unsigned int iLimit,
         Json::Value const& jvMarker,

--- a/src/ripple/app/misc/OrderBook.h
+++ b/src/ripple/app/misc/OrderBook.h
@@ -61,12 +61,12 @@ public:
         return mBook.out.currency;
     }
 
-    Account const& getIssuerIn () const
+    AccountID const& getIssuerIn () const
     {
         return mBook.in.account;
     }
 
-    Account const& getIssuerOut () const
+    AccountID const& getIssuerOut () const
     {
         return mBook.out.account;
     }

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -117,7 +117,7 @@ accountTxPage (
           Status,RawTxn,TxnMeta
           FROM AccountTransactions INNER JOIN Transactions
           ON Transactions.TransID = AccountTransactions.TransID
-          AND AccountTransactions.AccountID = '%s' WHERE
+          AND AccountTransactions.Account = '%s' WHERE
           )");
 
     std::string sql;

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -117,7 +117,7 @@ accountTxPage (
           Status,RawTxn,TxnMeta
           FROM AccountTransactions INNER JOIN Transactions
           ON Transactions.TransID = AccountTransactions.TransID
-          AND AccountTransactions.Account = '%s' WHERE
+          AND AccountTransactions.AccountID = '%s' WHERE
           )");
 
     std::string sql;

--- a/src/ripple/app/paths/Credit.cpp
+++ b/src/ripple/app/paths/Credit.cpp
@@ -26,8 +26,8 @@ namespace ripple {
 
 STAmount creditLimit (
     LedgerEntrySet& ledger,
-    Account const& account,
-    Account const& issuer,
+    AccountID const& account,
+    AccountID const& issuer,
     Currency const& currency)
 {
     STAmount result ({currency, account});
@@ -49,8 +49,8 @@ STAmount creditLimit (
 
 STAmount creditBalance (
     LedgerEntrySet& ledger,
-    Account const& account,
-    Account const& issuer,
+    AccountID const& account,
+    AccountID const& issuer,
     Currency const& currency)
 {
     STAmount result ({currency, account});

--- a/src/ripple/app/paths/Credit.h
+++ b/src/ripple/app/paths/Credit.h
@@ -34,8 +34,8 @@ namespace ripple {
 */
 STAmount creditLimit (
     LedgerEntrySet& ledger,
-    Account const& account,
-    Account const& issuer,
+    AccountID const& account,
+    AccountID const& issuer,
     Currency const& currency);
 
 /** Returns the amount of IOUs issued by issuer that are held by an account
@@ -46,8 +46,8 @@ STAmount creditLimit (
 */
 STAmount creditBalance (
     LedgerEntrySet& ledger,
-    Account const& account,
-    Account const& issuer,
+    AccountID const& account,
+    AccountID const& issuer,
     Currency const& currency);
 
 } // ripple

--- a/src/ripple/app/paths/FindPaths.cpp
+++ b/src/ripple/app/paths/FindPaths.cpp
@@ -27,8 +27,8 @@ class FindPaths::Impl {
 public:
     Impl (
         RippleLineCache::ref cache,
-        Account const& srcAccount,
-        Account const& dstAccount,
+        AccountID const& srcAccount,
+        AccountID const& dstAccount,
         STAmount const& dstAmount,
         int searchLevel,
         unsigned int maxPaths)
@@ -61,8 +61,8 @@ private:
     hash_map<Currency, std::unique_ptr<Pathfinder>> currencyMap_;
 
     RippleLineCache::ref cache_;
-    Account const srcAccount_;
-    Account const dstAccount_;
+    AccountID const srcAccount_;
+    AccountID const dstAccount_;
     STAmount const dstAmount_;
     int const searchLevel_;
     unsigned int const maxPaths_;
@@ -87,8 +87,8 @@ private:
 
 FindPaths::FindPaths (
     RippleLineCache::ref cache,
-    Account const& srcAccount,
-    Account const& dstAccount,
+    AccountID const& srcAccount,
+    AccountID const& dstAccount,
     STAmount const& dstAmount,
     int level,
     unsigned int maxPaths)
@@ -109,8 +109,8 @@ bool FindPaths::findPathsForIssue (
 
 bool findPathsForOneIssuer (
     RippleLineCache::ref cache,
-    Account const& srcAccount,
-    Account const& dstAccount,
+    AccountID const& srcAccount,
+    AccountID const& dstAccount,
     Issue const& srcIssue,
     STAmount const& dstAmount,
     int searchLevel,

--- a/src/ripple/app/paths/FindPaths.h
+++ b/src/ripple/app/paths/FindPaths.h
@@ -29,8 +29,8 @@ class FindPaths
 public:
     FindPaths (
         RippleLineCache::ref cache,
-        Account const& srcAccount,
-        Account const& dstAccount,
+        AccountID const& srcAccount,
+        AccountID const& dstAccount,
         STAmount const& dstAmount,
         /** searchLevel is the maximum search level allowed in an output path.
          */
@@ -63,8 +63,8 @@ private:
 
 bool findPathsForOneIssuer (
     RippleLineCache::ref cache,
-    Account const& srcAccount,
-    Account const& dstAccount,
+    AccountID const& srcAccount,
+    AccountID const& dstAccount,
     Issue const& srcIssue,
     STAmount const& dstAmount,
 

--- a/src/ripple/app/paths/Node.h
+++ b/src/ripple/app/paths/Node.h
@@ -42,7 +42,7 @@ struct Node
 
     std::uint16_t uFlags;       // --> From path.
 
-    Account account_;           // --> Accounts: Receiving/sending account.
+    AccountID account_;           // --> Accounts: Receiving/sending account.
 
     Issue issue_;               // --> Accounts: Receive and send, Offers: send.
                                 // --- For offer's next has currency out.
@@ -87,7 +87,7 @@ struct Node
     unsigned int uEntry;
     uint256 offerIndex_;
     SLE::pointer sleOffer;
-    Account offerOwnerAccount_;
+    AccountID offerOwnerAccount_;
 
     // Do we need to refresh saOfferFunds, saTakerPays, & saTakerGets?
     bool bFundsDirty;

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -321,7 +321,7 @@ int PathRequest::parseJson (Json::Value const& jvParams, bool complete)
         {
             Json::Value const& jvCur = jvSrcCur[i];
             Currency uCur;
-            Account uIss;
+            AccountID uIss;
 
             if (!jvCur.isObject() || !jvCur.isMember (jss::currency) ||
                 !to_currency (uCur, jvCur[jss::currency].asString ()))

--- a/src/ripple/app/paths/PathState.cpp
+++ b/src/ripple/app/paths/PathState.cpp
@@ -103,9 +103,9 @@ bool PathState::lessPriority (PathState const& lhs, PathState const& rhs)
 //   an exact match.
 // - Real issuers must be specified for non-XRP.
 TER PathState::pushImpliedNodes (
-    Account const& account,    // --> Delivering to this account.
+    AccountID const& account,    // --> Delivering to this account.
     Currency const& currency,  // --> Delivering this currency.
-    Account const& issuer)    // --> Delivering this issuer.
+    AccountID const& issuer)    // --> Delivering this issuer.
 {
     TER resultCode = tesSUCCESS;
 
@@ -163,9 +163,9 @@ TER PathState::pushImpliedNodes (
 //                 terNO_LINE, tecPATH_DRY
 TER PathState::pushNode (
     const int iType,
-    Account const& account,    // If not specified, means an order book.
+    AccountID const& account,    // If not specified, means an order book.
     Currency const& currency,  // If not specified, default to previous.
-    Account const& issuer)     // If not specified, default to previous.
+    AccountID const& issuer)     // If not specified, default to previous.
 {
     path::Node node;
     const bool pathIsEmpty = nodes_.empty ();
@@ -227,7 +227,7 @@ TER PathState::pushNode (
     }
     else if (hasAccount)
     {
-        // Account link
+        // AccountID link
         node.account_ = account;
         node.issue_.account = hasIssuer ? issuer :
                 (isXRP (node.issue_) ? xrpAccount() : account);
@@ -420,17 +420,17 @@ TER PathState::pushNode (
 TER PathState::expandPath (
     const LedgerEntrySet& lesSource,
     STPath const& spSourcePath,
-    Account const& uReceiverID,
-    Account const& uSenderID)
+    AccountID const& uReceiverID,
+    AccountID const& uSenderID)
 {
     uQuality = 1;            // Mark path as active.
 
     Currency const& uMaxCurrencyID = saInReq.getCurrency ();
-    Account const& uMaxIssuerID = saInReq.getIssuer ();
+    AccountID const& uMaxIssuerID = saInReq.getIssuer ();
 
     Currency const& currencyOutID = saOutReq.getCurrency ();
-    Account const& issuerOutID = saOutReq.getIssuer ();
-    Account const& uSenderIssuerID
+    AccountID const& issuerOutID = saOutReq.getIssuer ();
+    AccountID const& uSenderIssuerID
         = isXRP(uMaxCurrencyID) ? xrpAccount() : uSenderID;
     // Sender is always issuer for non-XRP.
 
@@ -488,11 +488,11 @@ TER PathState::expandPath (
         // TODO(tom): complexify this next logic further in case someone
         // understands it.
         const auto nextAccountID   = spSourcePath.size ()
-                ? Account(spSourcePath. front ().getAccountID ())
+                ? AccountID(spSourcePath. front ().getAccountID ())
                 : !isXRP(currencyOutID)
                 ? (issuerOutID == uReceiverID)
-                ? Account(uReceiverID)
-                : Account(issuerOutID)                      // Use implied node.
+                ? AccountID(uReceiverID)
+                : AccountID(issuerOutID)                      // Use implied node.
                 : xrpAccount();
 
         WriteLog (lsDEBUG, RippleCalc)
@@ -646,8 +646,8 @@ void PathState::checkFreeze()
         if (nodes_[i].uFlags & STPathElement::typeAccount)
         {
             Currency const& currencyID = nodes_[i].issue_.currency;
-            Account const& inAccount = nodes_[i].account_;
-            Account const& outAccount = nodes_[i+1].account_;
+            AccountID const& inAccount = nodes_[i].account_;
+            AccountID const& outAccount = nodes_[i+1].account_;
 
             if (inAccount != outAccount)
             {
@@ -681,10 +681,10 @@ void PathState::checkFreeze()
     [second]->[third]
 */
 TER PathState::checkNoRipple (
-    Account const& firstAccount,
-    Account const& secondAccount,
+    AccountID const& firstAccount,
+    AccountID const& secondAccount,
     // This is the account whose constraints we are checking
-    Account const& thirdAccount,
+    AccountID const& thirdAccount,
     Currency const& currency)
 {
     // fetch the ripple lines into and out of this node
@@ -717,8 +717,8 @@ TER PathState::checkNoRipple (
 // Check a fully-expanded path to make sure it doesn't violate no-Ripple
 // settings.
 TER PathState::checkNoRipple (
-    Account const& uDstAccountID,
-    Account const& uSrcAccountID)
+    AccountID const& uDstAccountID,
+    AccountID const& uSrcAccountID)
 {
     // There must be at least one node for there to be two consecutive ripple
     // lines.

--- a/src/ripple/app/paths/PathState.cpp
+++ b/src/ripple/app/paths/PathState.cpp
@@ -227,7 +227,7 @@ TER PathState::pushNode (
     }
     else if (hasAccount)
     {
-        // AccountID link
+        // Account link
         node.account_ = account;
         node.issue_.account = hasIssuer ? issuer :
                 (isXRP (node.issue_) ? xrpAccount() : account);

--- a/src/ripple/app/paths/PathState.h
+++ b/src/ripple/app/paths/PathState.h
@@ -50,8 +50,8 @@ class PathState : public CountedObject <PathState>
     TER expandPath (
         LedgerEntrySet const&   lesSource,
         STPath const&           spSourcePath,
-        Account const&          uReceiverID,
-        Account const&          uSenderID
+        AccountID const&          uReceiverID,
+        AccountID const&          uSenderID
     );
 
     path::Node::List& nodes() { return nodes_; }
@@ -97,8 +97,8 @@ class PathState : public CountedObject <PathState>
     void setIndex (int i) { mIndex  = i; }
     int index() const { return mIndex; }
 
-    TER checkNoRipple (Account const& destinationAccountID,
-                       Account const& sourceAccountID);
+    TER checkNoRipple (AccountID const& destinationAccountID,
+                       AccountID const& sourceAccountID);
     void checkFreeze ();
 
     static bool lessPriority (PathState const& lhs, PathState const& rhs);
@@ -116,21 +116,21 @@ class PathState : public CountedObject <PathState>
 
 private:
     TER checkNoRipple (
-        Account const&, Account const&, Account const&, Currency const&);
+        AccountID const&, AccountID const&, AccountID const&, Currency const&);
 
     /** Clear path structures, and clear each node. */
     void clear();
 
     TER pushNode (
         int const iType,
-        Account const& account,
+        AccountID const& account,
         Currency const& currency,
-        Account const& issuer);
+        AccountID const& issuer);
 
     TER pushImpliedNodes (
-        Account const& account,
+        AccountID const& account,
         Currency const& currency,
-        Account const& issuer);
+        AccountID const& issuer);
     
     Json::Value getJson () const;
 

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -94,7 +94,7 @@ bool comparePathRank (
 struct AccountCandidate
 {
     int priority;
-    Account account;
+    AccountID account;
 
     static const int highPriority = 10000;
 };
@@ -168,10 +168,10 @@ std::string pathTypeToString (Pathfinder::PathType const& type)
 
 Pathfinder::Pathfinder (
     RippleLineCache::ref cache,
-    Account const& uSrcAccount,
-    Account const& uDstAccount,
+    AccountID const& uSrcAccount,
+    AccountID const& uDstAccount,
     Currency const& uSrcCurrency,
-    Account const& uSrcIssuer,
+    AccountID const& uSrcIssuer,
     STAmount const& saDstAmount)
     :   mSrcAccount (uSrcAccount),
         mDstAccount (uDstAccount),
@@ -189,8 +189,8 @@ Pathfinder::Pathfinder (
 
 Pathfinder::Pathfinder (
     RippleLineCache::ref cache,
-    Account const& uSrcAccount,
-    Account const& uDstAccount,
+    AccountID const& uSrcAccount,
+    AccountID const& uDstAccount,
     Currency const& uSrcCurrency,
     STAmount const& saDstAmount)
     :   mSrcAccount (uSrcAccount),
@@ -250,7 +250,7 @@ bool Pathfinder::findPaths (int searchLevel)
     bool useIssuerAccount
             = mSrcIssuer && !currencyIsXRP && !isXRP (*mSrcIssuer);
     auto& account = useIssuerAccount ? *mSrcIssuer : mSrcAccount;
-    auto issuer = currencyIsXRP ? Account() : account;
+    auto issuer = currencyIsXRP ? AccountID() : account;
     mSource = STPathElement (account, mSrcCurrency, issuer);
     auto issuerString = mSrcIssuer
             ? to_string (*mSrcIssuer) : std::string ("none");
@@ -554,7 +554,7 @@ STPathSet Pathfinder::getBestPaths (
     int maxPaths,
     STPath& fullLiquidityPath,
     STPathSet& extraPaths,
-    Account const& srcIssuer)
+    AccountID const& srcIssuer)
 {
     WriteLog (lsDEBUG, Pathfinder) << "findPaths: " <<
         mCompletePaths.size() << " paths and " <<
@@ -691,9 +691,9 @@ bool Pathfinder::issueMatchesOrigin (Issue const& issue)
 
 int Pathfinder::getPathsOut (
     Currency const& currency,
-    Account const& account,
+    AccountID const& account,
     bool isDstCurrency,
-    Account const& dstAccount)
+    AccountID const& dstAccount)
 {
     Issue const issue (currency, account);
 
@@ -836,8 +836,8 @@ STPathSet& Pathfinder::addPathsForType (PathType const& pathType)
 }
 
 bool Pathfinder::isNoRipple (
-    Account const& fromAccount,
-    Account const& toAccount,
+    AccountID const& fromAccount,
+    AccountID const& toAccount,
     Currency const& currency)
 {
     auto sleRipple = fetch (*mLedger,

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -39,17 +39,17 @@ public:
     /** Construct a pathfinder with an issuer.*/
     Pathfinder (
         RippleLineCache::ref cache,
-        Account const& srcAccount,
-        Account const& dstAccount,
+        AccountID const& srcAccount,
+        AccountID const& dstAccount,
         Currency const& uSrcCurrency,
-        Account const& uSrcIssuer,
+        AccountID const& uSrcIssuer,
         STAmount const& dstAmount);
 
     /** Construct a pathfinder without an issuer.*/
     Pathfinder (
         RippleLineCache::ref cache,
-        Account const& srcAccount,
-        Account const& dstAccount,
+        AccountID const& srcAccount,
+        AccountID const& dstAccount,
         Currency const& uSrcCurrency,
         STAmount const& dstAmount);
 
@@ -71,7 +71,7 @@ public:
         int maxPaths,
         STPath& fullLiquidityPath,
         STPathSet& extraPaths,
-        Account const& srcIssuer);
+        AccountID const& srcIssuer);
 
     enum NodeType
     {
@@ -134,9 +134,9 @@ private:
 
     int getPathsOut (
         Currency const& currency,
-        Account const& account,
+        AccountID const& account,
         bool isDestCurrency,
-        Account const& dest);
+        AccountID const& dest);
 
     void addLink (
         STPath const& currentPath,
@@ -164,8 +164,8 @@ private:
 
     // Is the "no ripple" flag set from one account to another?
     bool isNoRipple (
-        Account const& fromAccount,
-        Account const& toAccount,
+        AccountID const& fromAccount,
+        AccountID const& toAccount,
         Currency const& currency);
 
     void rankPaths (
@@ -173,12 +173,12 @@ private:
         STPathSet const& paths,
         std::vector <PathRank>& rankedPaths);
 
-    Account mSrcAccount;
-    Account mDstAccount;
-    Account mEffectiveDst; // The account the paths need to end at
+    AccountID mSrcAccount;
+    AccountID mDstAccount;
+    AccountID mEffectiveDst; // The account the paths need to end at
     STAmount mDstAmount;
     Currency mSrcCurrency;
-    boost::optional<Account> mSrcIssuer;
+    boost::optional<AccountID> mSrcIssuer;
     STAmount mSrcAmount;
     /** The amount remaining from mSrcAccount after the default liquidity has
         been removed. */

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -59,8 +59,8 @@ RippleCalc::Output RippleCalc::rippleCalculate (
     //           trust node.
     STAmount const& saDstAmountReq,
 
-    Account const& uDstAccountID,
-    Account const& uSrcAccountID,
+    AccountID const& uDstAccountID,
+    AccountID const& uSrcAccountID,
 
     // A set of paths that are included in the transaction that we'll
     // explore for liquidity.

--- a/src/ripple/app/paths/RippleCalc.h
+++ b/src/ripple/app/paths/RippleCalc.h
@@ -90,8 +90,8 @@ public:
         //           trust node.
         STAmount const& saDstAmountReq,
 
-        Account const& uDstAccountID,
-        Account const& uSrcAccountID,
+        AccountID const& uDstAccountID,
+        AccountID const& uSrcAccountID,
 
         // A set of paths that are included in the transaction that we'll
         // explore for liquidity.
@@ -119,8 +119,8 @@ private:
         STAmount const& saMaxAmountReq,             // --> -1 = no limit.
         STAmount const& saDstAmountReq,
 
-        Account const& uDstAccountID,
-        Account const& uSrcAccountID,
+        AccountID const& uDstAccountID,
+        AccountID const& uSrcAccountID,
         STPathSet const& spsPaths)
             : mActiveLedger (activeLedger),
               saDstAmountReq_(saDstAmountReq),
@@ -139,8 +139,8 @@ private:
 
     STAmount const& saDstAmountReq_;
     STAmount const& saMaxAmountReq_;
-    Account const& uDstAccountID_;
-    Account const& uSrcAccountID_;
+    AccountID const& uDstAccountID_;
+    AccountID const& uSrcAccountID_;
     STPathSet const& spsPaths_;
 
     // The computed input amount.

--- a/src/ripple/app/paths/RippleLineCache.cpp
+++ b/src/ripple/app/paths/RippleLineCache.cpp
@@ -28,7 +28,7 @@ RippleLineCache::RippleLineCache (Ledger::ref l)
 }
 
 RippleLineCache::RippleStateVector const&
-RippleLineCache::getRippleLines (Account const& accountID)
+RippleLineCache::getRippleLines (AccountID const& accountID)
 {
     AccountKey key (accountID, hasher_ (accountID));
 

--- a/src/ripple/app/paths/RippleLineCache.h
+++ b/src/ripple/app/paths/RippleLineCache.h
@@ -44,7 +44,7 @@ public:
     }
 
     std::vector<RippleState::pointer> const&
-    getRippleLines (Account const& accountID);
+    getRippleLines (AccountID const& accountID);
 
 private:
     using LockType = RippleMutex;
@@ -56,10 +56,10 @@ private:
 
     struct AccountKey
     {
-        Account account_;
+        AccountID account_;
         std::size_t hash_value_;
 
-        AccountKey (Account const& account, std::size_t hash)
+        AccountKey (AccountID const& account, std::size_t hash)
             : account_ (account)
             , hash_value_ (hash)
         { }

--- a/src/ripple/app/paths/RippleState.cpp
+++ b/src/ripple/app/paths/RippleState.cpp
@@ -28,7 +28,7 @@ namespace ripple {
 
 RippleState::pointer
 RippleState::makeItem (
-    Account const& accountID,
+    AccountID const& accountID,
         std::shared_ptr<SLE const> sle)
 {
     // VFALCO Does this ever happen in practice?
@@ -40,7 +40,7 @@ RippleState::makeItem (
 
 RippleState::RippleState (
     std::shared_ptr<SLE const>&& sle,
-        Account const& viewAccount)
+        AccountID const& viewAccount)
     : mLedgerEntry (std::move(sle))
     , mLowLimit (mLedgerEntry->getFieldAmount (sfLowLimit))
     , mHighLimit (mLedgerEntry->getFieldAmount (sfHighLimit))
@@ -72,7 +72,7 @@ Json::Value RippleState::getJson (int)
 
 std::vector <RippleState::pointer>
 getRippleStateItems (
-    Account const& accountID,
+    AccountID const& accountID,
     Ledger::ref ledger)
 {
     std::vector <RippleState::pointer> items;

--- a/src/ripple/app/paths/RippleState.h
+++ b/src/ripple/app/paths/RippleState.h
@@ -47,12 +47,12 @@ public:
     virtual ~RippleState() = default;
 
     static RippleState::pointer makeItem(
-        Account const& accountID,
+        AccountID const& accountID,
         std::shared_ptr<SLE const> sle);
 
     // Must be public, for make_shared
     RippleState (std::shared_ptr<SLE const>&& sle,
-        Account const& viewAccount);
+        AccountID const& viewAccount);
 
     /** Returns the state map key for the ledger entry. */
     uint256
@@ -63,12 +63,12 @@ public:
 
     // VFALCO Take off the "get" from each function name
 
-    Account const& getAccountID () const
+    AccountID const& getAccountID () const
     {
         return  mViewLowest ? mLowID : mHighID;
     }
 
-    Account const& getAccountIDPeer () const
+    AccountID const& getAccountIDPeer () const
     {
         return !mViewLowest ? mLowID : mHighID;
     }
@@ -143,8 +143,8 @@ private:
     STAmount const&                 mLowLimit;
     STAmount const&                 mHighLimit;
 
-    Account const&                  mLowID;
-    Account const&                  mHighID;
+    AccountID const&                  mLowID;
+    AccountID const&                  mHighID;
 
     std::uint64_t                   mLowQualityIn;
     std::uint64_t                   mLowQualityOut;
@@ -156,7 +156,7 @@ private:
 
 std::vector <RippleState::pointer>
 getRippleStateItems (
-    Account const& accountID,
+    AccountID const& accountID,
     Ledger::ref ledger);
 
 } // ripple

--- a/src/ripple/app/paths/Types.h
+++ b/src/ripple/app/paths/Types.h
@@ -23,7 +23,7 @@
 namespace ripple {
 
 // account id, issue.
-using AccountIssue = std::pair <Account, Issue>;
+using AccountIssue = std::pair <AccountID, Issue>;
 
 // Map of account, issue to node index.
 namespace path {

--- a/src/ripple/app/paths/cursor/DeliverNodeForward.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeForward.cpp
@@ -32,7 +32,7 @@ namespace path {
 // --> node.saRevDeliver: Do not exceed.
 
 TER PathCursor::deliverNodeForward (
-    Account const& uInAccountID,    // --> Input owner's account.
+    AccountID const& uInAccountID,    // --> Input owner's account.
     STAmount const& saInReq,        // --> Amount to deliver.
     STAmount& saInAct,              // <-- Amount delivered, this invocation.
     STAmount& saInFees) const       // <-- Fees charged, this invocation.

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -36,7 +36,7 @@ namespace path {
 
 // To deliver from an order book, when computing
 TER PathCursor::deliverNodeReverse (
-    Account const& uOutAccountID,  // --> Output owner's account.
+    AccountID const& uOutAccountID,  // --> Output owner's account.
     STAmount const& saOutReq,      // --> Funds requested to be
                                    // delivered for an increment.
     STAmount& saOutAct) const      // <-- Funds actually delivered for an

--- a/src/ripple/app/paths/cursor/ForwardLiquidityForAccount.cpp
+++ b/src/ripple/app/paths/cursor/ForwardLiquidityForAccount.cpp
@@ -47,11 +47,11 @@ TER PathCursor::forwardLiquidityForAccount () const
 
     std::uint64_t uRateMax = 0;
 
-    Account const& previousAccountID =
+    AccountID const& previousAccountID =
             previousNode().isAccount() ? previousNode().account_ :
             node().account_;
     // Offers are always issue.
-    Account const& nextAccountID =
+    AccountID const& nextAccountID =
             nextNode().isAccount() ? nextNode().account_ : node().account_;
 
     std::uint32_t uQualityIn = nodeIndex_

--- a/src/ripple/app/paths/cursor/PathCursor.h
+++ b/src/ripple/app/paths/cursor/PathCursor.h
@@ -81,12 +81,12 @@ private:
 
     // To deliver from an order book, when computing
     TER deliverNodeReverse (
-        Account const& uOutAccountID,
+        AccountID const& uOutAccountID,
         STAmount const& saOutReq,
         STAmount& saOutAct) const;
 
     TER deliverNodeForward (
-        Account const& uInAccountID,
+        AccountID const& uInAccountID,
         STAmount const& saInReq,
         STAmount& saInAct,
         STAmount& saInFees) const;

--- a/src/ripple/app/paths/cursor/ReverseLiquidityForAccount.cpp
+++ b/src/ripple/app/paths/cursor/ReverseLiquidityForAccount.cpp
@@ -57,9 +57,9 @@ TER PathCursor::reverseLiquidityForAccount () const
 
     const bool nextNodeIsAccount = isFinalNode || nextNode().isAccount();
 
-    Account const& previousAccountID = previousNodeIsAccount
+    AccountID const& previousAccountID = previousNodeIsAccount
         ? previousNode().account_ : node().account_;
-    Account const& nextAccountID = nextNodeIsAccount ? nextNode().account_
+    AccountID const& nextAccountID = nextNodeIsAccount ? nextNode().account_
         : node().account_;   // Offers are always issue.
 
     // This is the quality from from the previous node to this one.

--- a/src/ripple/app/paths/cursor/RippleLiquidity.cpp
+++ b/src/ripple/app/paths/cursor/RippleLiquidity.cpp
@@ -204,8 +204,8 @@ static
 std::uint32_t
 rippleQuality (
     LedgerEntrySet& ledger,
-    Account const& destination,
-    Account const& source,
+    AccountID const& destination,
+    AccountID const& source,
     Currency const& currency,
     SField const& sfLow,
     SField const& sfHigh)
@@ -238,8 +238,8 @@ rippleQuality (
 std::uint32_t
 quality_in (
     LedgerEntrySet& ledger,
-    Account const& uToAccountID,
-    Account const& uFromAccountID,
+    AccountID const& uToAccountID,
+    AccountID const& uFromAccountID,
     Currency const& currency)
 {
     return rippleQuality (ledger, uToAccountID, uFromAccountID, currency,
@@ -249,8 +249,8 @@ quality_in (
 std::uint32_t
 quality_out (
     LedgerEntrySet& ledger,
-    Account const& uToAccountID,
-    Account const& uFromAccountID,
+    AccountID const& uToAccountID,
+    AccountID const& uFromAccountID,
     Currency const& currency)
 {
     return rippleQuality (ledger, uToAccountID, uFromAccountID, currency,

--- a/src/ripple/app/paths/cursor/RippleLiquidity.h
+++ b/src/ripple/app/paths/cursor/RippleLiquidity.h
@@ -42,15 +42,15 @@ void rippleLiquidity (
 std::uint32_t
 quality_in (
     LedgerEntrySet& ledger,
-    Account const& uToAccountID,
-    Account const& uFromAccountID,
+    AccountID const& uToAccountID,
+    AccountID const& uFromAccountID,
     Currency const& currency);
 
 std::uint32_t
 quality_out (
     LedgerEntrySet& ledger,
-    Account const& uToAccountID,
-    Account const& uFromAccountID,
+    AccountID const& uToAccountID,
+    AccountID const& uFromAccountID,
     Currency const& currency);
 
 } // path

--- a/src/ripple/app/tx/README.md
+++ b/src/ripple/app/tx/README.md
@@ -126,18 +126,18 @@ general form:
 
     {
         "TransactionType": "SignerListSet",
-        "Account": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+        "AccountID": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
         "SignerQuorum": 7,
         "SignerEntries": [
             {
                 "SignerEntry": {
-                    "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                    "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                     "SignerWeight": 4
                 }
             },
             {
                 "SignerEntry": {
-                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "AccountID": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                     "SignerWeight": 3
                 }
             }
@@ -148,7 +148,7 @@ The data for a transaction that removes any signer list has this form:
 
     {
         "TransactionType": "SignerListSet",
-        "Account": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+        "AccountID": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
         "SignerQuorum": 0
     }
 

--- a/src/ripple/app/tx/README.md
+++ b/src/ripple/app/tx/README.md
@@ -126,18 +126,18 @@ general form:
 
     {
         "TransactionType": "SignerListSet",
-        "AccountID": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+        "Account": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
         "SignerQuorum": 7,
         "SignerEntries": [
             {
                 "SignerEntry": {
-                    "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                    "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                     "SignerWeight": 4
                 }
             },
             {
                 "SignerEntry": {
-                    "AccountID": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                     "SignerWeight": 3
                 }
             }
@@ -148,7 +148,7 @@ The data for a transaction that removes any signer list has this form:
 
     {
         "TransactionType": "SignerListSet",
-        "AccountID": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+        "Account": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
         "SignerQuorum": 0
     }
 

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -95,7 +95,7 @@ public:
 
         if (mTxn.isFieldPresent (sfTarget))
         {
-            Account const target_account (mTxn.getFieldAccount160 (sfTarget));
+            AccountID const target_account (mTxn.getFieldAccount160 (sfTarget));
 
             SLE::pointer sleTarget = mEngine->view().entryCache (ltACCOUNT_ROOT,
                 getAccountRootIndex (target_account));

--- a/src/ripple/app/tx/impl/Offer.h
+++ b/src/ripple/app/tx/impl/Offer.h
@@ -37,7 +37,7 @@ class Offer
 private:
     SLE::pointer m_entry;
     Quality m_quality;
-    Account m_account;
+    AccountID m_account;
 
     mutable Amounts m_amounts;
 
@@ -70,7 +70,7 @@ public:
     }
 
     /** Returns the account id of the offer's owner. */
-    Account const&
+    AccountID const&
     owner () const
     {
         return m_account;

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -90,7 +90,7 @@ public:
         if (!isLegalNet (saDstAmount) || !isLegalNet (maxSourceAmount))
             return temBAD_AMOUNT;
 
-        Account const uDstAccountID (mTxn.getFieldAccount160 (sfDestination));
+        AccountID const uDstAccountID (mTxn.getFieldAccount160 (sfDestination));
 
         if (!uDstAccountID)
         {
@@ -173,7 +173,7 @@ public:
         bool const defaultPathsAllowed = !(uTxFlags & tfNoRippleDirect);
         bool const bPaths = mTxn.isFieldPresent (sfPaths);
         bool const bMax = mTxn.isFieldPresent (sfSendMax);
-        Account const uDstAccountID (mTxn.getFieldAccount160 (sfDestination));
+        AccountID const uDstAccountID (mTxn.getFieldAccount160 (sfDestination));
         STAmount const saDstAmount (mTxn.getFieldAmount (sfAmount));
         STAmount maxSourceAmount;
         if (bMax)

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -102,7 +102,7 @@ public:
         bool const bQualityOut (mTxn.isFieldPresent (sfQualityOut));
 
         Currency const currency (saLimitAmount.getCurrency ());
-        Account uDstAccountID (saLimitAmount.getIssuer ());
+        AccountID uDstAccountID (saLimitAmount.getIssuer ());
 
         // true, iff current is high account.
         bool const bHigh = mTxnAccountID > uDstAccountID;

--- a/src/ripple/app/tx/impl/SignerEntries.cpp
+++ b/src/ripple/app/tx/impl/SignerEntries.cpp
@@ -55,7 +55,7 @@ SignerEntries::deserialize (
         }
 
         // Extract SignerEntry fields.
-        Account const account = sEntry.getFieldAccount160 (sfAccount);
+        AccountID const account = sEntry.getFieldAccount160 (sfAccount);
         std::uint16_t const weight = sEntry.getFieldU16 (sfSignerWeight);
         accountVec.emplace_back (account, weight);
     }

--- a/src/ripple/app/tx/impl/SignerEntries.h
+++ b/src/ripple/app/tx/impl/SignerEntries.h
@@ -21,7 +21,7 @@
 #define RIPPLE_TX_IMPL_SIGNER_ENTRIES_H_INCLUDED
 
 #include <ripple/protocol/STTx.h>      // STTx::maxMultiSigners
-#include <ripple/protocol/UintTypes.h> // Account
+#include <ripple/protocol/UintTypes.h> // AccountID
 #include <ripple/protocol/TER.h>       // temMALFORMED
 #include <beast/utility/Journal.h>     // beast::Journal
 
@@ -36,10 +36,10 @@ class SignerEntries
 public:
     struct SignerEntry
     {
-        Account account;
+        AccountID account;
         std::uint16_t weight;
 
-        SignerEntry (Account const& inAccount, std::uint16_t inWeight)
+        SignerEntry (AccountID const& inAccount, std::uint16_t inWeight)
         : account (inAccount)
         , weight (inWeight)
         { }

--- a/src/ripple/app/tx/impl/Taker.cpp
+++ b/src/ripple/app/tx/impl/Taker.cpp
@@ -51,7 +51,7 @@ BasicTaker::Rate::multiply (STAmount const& amount) const
 }
 
 BasicTaker::BasicTaker (
-        CrossType cross_type, Account const& account, Amounts const& amount,
+        CrossType cross_type, AccountID const& account, Amounts const& amount,
         Quality const& quality, std::uint32_t flags, std::uint32_t rate_in,
         std::uint32_t rate_out, beast::Journal journal)
     : account_ (account)
@@ -93,7 +93,7 @@ BasicTaker::BasicTaker (
 BasicTaker::Rate
 BasicTaker::effective_rate (
     std::uint32_t rate, Issue const &issue,
-    Account const& from, Account const& to)
+    AccountID const& from, AccountID const& to)
 {
     assert (rate != 0);
 
@@ -375,7 +375,7 @@ BasicTaker::flow_iou_to_iou (
 
 // Calculates the direct flow through the specified offer
 BasicTaker::Flow
-BasicTaker::do_cross (Amounts offer, Quality quality, Account const& owner)
+BasicTaker::do_cross (Amounts offer, Quality quality, AccountID const& owner)
 {
     assert (!done ());
 
@@ -414,8 +414,8 @@ BasicTaker::do_cross (Amounts offer, Quality quality, Account const& owner)
 // Calculates the bridged flow through the specified offers
 std::pair<BasicTaker::Flow, BasicTaker::Flow>
 BasicTaker::do_cross (
-    Amounts offer1, Quality quality1, Account const& owner1,
-    Amounts offer2, Quality quality2, Account const& owner2)
+    Amounts offer1, Quality quality1, AccountID const& owner1,
+    Amounts offer2, Quality quality2, AccountID const& owner2)
 {
     assert (!done ());
 
@@ -517,14 +517,14 @@ BasicTaker::do_cross (
 
 std::uint32_t
 Taker::calculateRate (
-    LedgerView& view, Account const& issuer, Account const& account)
+    LedgerView& view, AccountID const& issuer, AccountID const& account)
 {
     return isXRP (issuer) || (account == issuer)
         ? QUALITY_ONE
         : rippleTransferRate (view, issuer);
 }
 
-Taker::Taker (CrossType cross_type, LedgerView& view, Account const& account,
+Taker::Taker (CrossType cross_type, LedgerView& view, AccountID const& account,
         Amounts const& offer, std::uint32_t flags, beast::Journal journal)
     : BasicTaker (cross_type, account, offer, Quality(offer), flags,
         calculateRate(view, offer.in.getIssuer(), account),
@@ -581,14 +581,14 @@ Taker::consume_offer (Offer const& offer, Amounts const& order)
 }
 
 STAmount
-Taker::get_funds (Account const& account, STAmount const& amount) const
+Taker::get_funds (AccountID const& account, STAmount const& amount) const
 {
     return funds(view_, account, amount, fhZERO_IF_FROZEN);
 }
 
 TER Taker::transfer_xrp (
-    Account const& from,
-    Account const& to,
+    AccountID const& from,
+    AccountID const& to,
     STAmount const& amount)
 {
     if (!isXRP (amount))
@@ -605,7 +605,7 @@ TER Taker::transfer_xrp (
 }
 
 TER Taker::redeem_iou (
-    Account const& account,
+    AccountID const& account,
     STAmount const& amount,
     Issue const& issue)
 {
@@ -633,7 +633,7 @@ TER Taker::redeem_iou (
 }
 
 TER Taker::issue_iou (
-    Account const& account,
+    AccountID const& account,
     STAmount const& amount,
     Issue const& issue)
 {

--- a/src/ripple/app/tx/impl/Taker.h
+++ b/src/ripple/app/tx/impl/Taker.h
@@ -64,7 +64,7 @@ private:
     };
 
 private:
-    Account account_;
+    AccountID account_;
     Quality quality_;
     Quality threshold_;
 
@@ -132,18 +132,18 @@ private:
     static
     Rate
     effective_rate (std::uint32_t rate, Issue const &issue,
-        Account const& from, Account const& to);
+        AccountID const& from, AccountID const& to);
 
     // The transfer rate for the input currency between the given accounts
     Rate
-    in_rate (Account const& from, Account const& to) const
+    in_rate (AccountID const& from, AccountID const& to) const
     {
         return effective_rate (m_rate_in, original_.in.issue (), from, to);
     }
 
     // The transfer rate for the output currency between the given accounts
     Rate
-    out_rate (Account const& from, Account const& to) const
+    out_rate (AccountID const& from, AccountID const& to) const
     {
         return effective_rate (m_rate_out, original_.out.issue (), from, to);
     }
@@ -153,7 +153,7 @@ public:
     BasicTaker (BasicTaker const&) = delete;
 
     BasicTaker (
-        CrossType cross_type, Account const& account, Amounts const& amount,
+        CrossType cross_type, AccountID const& account, Amounts const& amount,
         Quality const& quality, std::uint32_t flags, std::uint32_t rate_in,
         std::uint32_t rate_out, beast::Journal journal = beast::Journal ());
 
@@ -173,7 +173,7 @@ public:
     original_offer () const;
 
     /** Returns the account identifier of the taker. */
-    Account const&
+    AccountID const&
     account () const noexcept
     {
         return account_;
@@ -218,19 +218,19 @@ public:
         @return an `Amounts` describing the flow achieved during cross
     */
     BasicTaker::Flow
-    do_cross (Amounts offer, Quality quality, Account const& owner);
+    do_cross (Amounts offer, Quality quality, AccountID const& owner);
 
     /** Perform bridged crossing through given offers.
         @return a pair of `Amounts` describing the flow achieved during cross
     */
     std::pair<BasicTaker::Flow, BasicTaker::Flow>
     do_cross (
-        Amounts offer1, Quality quality1, Account const& owner1,
-        Amounts offer2, Quality quality2, Account const& owner2);
+        Amounts offer1, Quality quality1, AccountID const& owner1,
+        Amounts offer2, Quality quality2, AccountID const& owner2);
 
     virtual
     STAmount
-    get_funds (Account const& account, STAmount const& funds) const = 0;
+    get_funds (AccountID const& account, STAmount const& funds) const = 0;
 };
 
 class Taker
@@ -239,7 +239,7 @@ class Taker
 private:
     static
     std::uint32_t
-    calculateRate (LedgerView& view, Account const& issuer, Account const& account);
+    calculateRate (LedgerView& view, AccountID const& issuer, AccountID const& account);
 
     // The underlying ledger entry we are dealing with
     LedgerView& view_;
@@ -262,19 +262,19 @@ private:
         BasicTaker::Flow const& flow2, Offer const& leg2);
 
     TER
-    transfer_xrp (Account const& from, Account const& to, STAmount const& amount);
+    transfer_xrp (AccountID const& from, AccountID const& to, STAmount const& amount);
 
     TER
-    redeem_iou (Account const& account, STAmount const& amount, Issue const& issue);
+    redeem_iou (AccountID const& account, STAmount const& amount, Issue const& issue);
 
     TER
-    issue_iou (Account const& account, STAmount const& amount, Issue const& issue);
+    issue_iou (AccountID const& account, STAmount const& amount, Issue const& issue);
 
 public:
     Taker () = delete;
     Taker (Taker const&) = delete;
 
-    Taker (CrossType cross_type, LedgerView& view, Account const& account,
+    Taker (CrossType cross_type, LedgerView& view, AccountID const& account,
         Amounts const& offer, std::uint32_t flags, beast::Journal journal);
     ~Taker () = default;
 
@@ -282,7 +282,7 @@ public:
     consume_offer (Offer const& offer, Amounts const& order);
 
     STAmount
-    get_funds (Account const& account, STAmount const& funds) const;
+    get_funds (AccountID const& account, STAmount const& funds) const;
 
     STAmount const&
     get_xrp_flow () const

--- a/src/ripple/app/tx/impl/TransactionEngine.cpp
+++ b/src/ripple/app/tx/impl/TransactionEngine.cpp
@@ -128,7 +128,7 @@ TransactionEngine::applyTransaction (
                 if ((balance == zero) ||
                     ((params & tapOPEN_LEDGER) && (balance < fee)))
                 {
-                    // Account has no funds or ledger is open
+                    // AccountID has no funds or ledger is open
                     terResult = terINSUF_FEE_B;
                 }
                 else

--- a/src/ripple/app/tx/impl/TransactionEngine.cpp
+++ b/src/ripple/app/tx/impl/TransactionEngine.cpp
@@ -128,7 +128,7 @@ TransactionEngine::applyTransaction (
                 if ((balance == zero) ||
                     ((params & tapOPEN_LEDGER) && (balance < fee)))
                 {
-                    // AccountID has no funds or ledger is open
+                    // Account has no funds or ledger is open
                     terResult = terINSUF_FEE_B;
                 }
                 else

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -359,7 +359,7 @@ struct GetSignerListResult
 // We need the SignerList for every SigningFor while multi-signing.
 GetSignerListResult
 getSignerList (
-    Account signingForAcctID, TransactionEngine* engine, beast::Journal journal)
+    AccountID signingForAcctID, TransactionEngine* engine, beast::Journal journal)
 {
     GetSignerListResult ret;
 
@@ -411,7 +411,7 @@ checkSigningAccounts (
     auto signerEntriesItr = signerEntries.begin ();
     for (auto const& signingAccount : signingAccounts)
     {
-        Account const signingAcctID =
+        AccountID const signingAcctID =
             signingAccount.getFieldAccount (sfAccount).getAccountID ();
 
         // Attempt to match the SignerEntry with a SigningAccount;
@@ -420,7 +420,7 @@ checkSigningAccounts (
             if (++signerEntriesItr == signerEntries.end ())
             {
                 journal.trace <<
-                    "applyTransaction: Invalid SigningAccount.Account.";
+                    "applyTransaction: Invalid SigningAccount.AccountID.";
                 ret.ter = tefBAD_SIGNATURE;
                 return ret;
             }
@@ -429,7 +429,7 @@ checkSigningAccounts (
         {
             // The SigningAccount is not in the SignerEntries.
             journal.trace <<
-                "applyTransaction: Invalid SigningAccount.Account.";
+                "applyTransaction: Invalid SigningAccount.AccountID.";
             ret.ter = tefBAD_SIGNATURE;
             return ret;
         }
@@ -437,7 +437,7 @@ checkSigningAccounts (
         {
             // The SigningAccount has a weight of zero and may not sign.
             journal.trace <<
-                "applyTransaction: SigningAccount.Account needs weight > 0.";
+                "applyTransaction: SigningAccount.AccountID needs weight > 0.";
             ret.ter = tefBAD_SIGNATURE;
             return ret;
         }
@@ -445,7 +445,7 @@ checkSigningAccounts (
         // We found the SigningAccount in the list of valid signers.  Now we
         // need to compute the accountID that is associated with the signer's
         // public key.
-        Account const signingAcctIDFromPubKey =
+        AccountID const signingAcctIDFromPubKey =
             RippleAddress::createAccountPublic (
                 signingAccount.getFieldVL (sfSigningPubKey)).getAccountID ();
 
@@ -484,7 +484,7 @@ checkSigningAccounts (
             // Either Phantom or Master.  Phantom's automatically pass.
             if (signersAccountRoot)
             {
-                // Master Key.  Account may not have asfDisableMaster set.
+                // Master Key.  AccountID may not have asfDisableMaster set.
                 std::uint32_t const signerAccountFlags =
                     signersAccountRoot->getFieldU32 (sfFlags);
 
@@ -512,7 +512,7 @@ checkSigningAccounts (
             if (!signersAccountRoot->isFieldPresent (sfRegularKey))
             {
                 journal.trace <<
-                    "applyTransaction: Account lacks RegularKey.";
+                    "applyTransaction: AccountID lacks RegularKey.";
                 ret.ter = tefBAD_SIGNATURE;
                 return ret;
             }
@@ -520,7 +520,7 @@ checkSigningAccounts (
                 signersAccountRoot->getFieldAccount160 (sfRegularKey))
             {
                 journal.trace <<
-                    "applyTransaction: Account doesn't match RegularKey.";
+                    "applyTransaction: AccountID doesn't match RegularKey.";
                 ret.ter = tefBAD_SIGNATURE;
                 return ret;
             }
@@ -558,7 +558,7 @@ TER Transactor::checkMultiSign ()
     auto signerEntriesItr = outer.signerEntries.begin ();
     for (auto const& signingFor : multiSigners)
     {
-        Account const signingForID =
+        AccountID const signingForID =
             signingFor.getFieldAccount (sfAccount).getAccountID ();
 
         STArray const& signingAccounts =
@@ -590,7 +590,7 @@ TER Transactor::checkMultiSign ()
                 if (++signerEntriesItr == outer.signerEntries.end ())
                 {
                     m_journal.trace <<
-                        "applyTransaction: Invalid SigningFor.Account.";
+                        "applyTransaction: Invalid SigningFor.AccountID.";
                     return tefBAD_SIGNATURE;
                 }
             }
@@ -598,14 +598,14 @@ TER Transactor::checkMultiSign ()
             {
                 // The signingForID is not in the SignerEntries.
                 m_journal.trace <<
-                    "applyTransaction: Invalid SigningFor.Account.";
+                    "applyTransaction: Invalid SigningFor.AccountID.";
                 return tefBAD_SIGNATURE;
             }
             if (signerEntriesItr->weight <= 0)
             {
                 // The SigningFor entry needs a weight greater than zero.
                 m_journal.trace <<
-                    "applyTransaction: SigningFor.Account needs weight > 0.";
+                    "applyTransaction: SigningFor.AccountID needs weight > 0.";
                 return tefBAD_SIGNATURE;
             }
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -420,7 +420,7 @@ checkSigningAccounts (
             if (++signerEntriesItr == signerEntries.end ())
             {
                 journal.trace <<
-                    "applyTransaction: Invalid SigningAccount.AccountID.";
+                    "applyTransaction: Invalid SigningAccount.Account.";
                 ret.ter = tefBAD_SIGNATURE;
                 return ret;
             }
@@ -429,7 +429,7 @@ checkSigningAccounts (
         {
             // The SigningAccount is not in the SignerEntries.
             journal.trace <<
-                "applyTransaction: Invalid SigningAccount.AccountID.";
+                "applyTransaction: Invalid SigningAccount.Account.";
             ret.ter = tefBAD_SIGNATURE;
             return ret;
         }
@@ -437,7 +437,7 @@ checkSigningAccounts (
         {
             // The SigningAccount has a weight of zero and may not sign.
             journal.trace <<
-                "applyTransaction: SigningAccount.AccountID needs weight > 0.";
+                "applyTransaction: SigningAccount.Account needs weight > 0.";
             ret.ter = tefBAD_SIGNATURE;
             return ret;
         }
@@ -484,7 +484,7 @@ checkSigningAccounts (
             // Either Phantom or Master.  Phantom's automatically pass.
             if (signersAccountRoot)
             {
-                // Master Key.  AccountID may not have asfDisableMaster set.
+                // Master Key.  Account may not have asfDisableMaster set.
                 std::uint32_t const signerAccountFlags =
                     signersAccountRoot->getFieldU32 (sfFlags);
 
@@ -512,7 +512,7 @@ checkSigningAccounts (
             if (!signersAccountRoot->isFieldPresent (sfRegularKey))
             {
                 journal.trace <<
-                    "applyTransaction: AccountID lacks RegularKey.";
+                    "applyTransaction: Account lacks RegularKey.";
                 ret.ter = tefBAD_SIGNATURE;
                 return ret;
             }
@@ -520,7 +520,7 @@ checkSigningAccounts (
                 signersAccountRoot->getFieldAccount160 (sfRegularKey))
             {
                 journal.trace <<
-                    "applyTransaction: AccountID doesn't match RegularKey.";
+                    "applyTransaction: Account doesn't match RegularKey.";
                 ret.ter = tefBAD_SIGNATURE;
                 return ret;
             }
@@ -590,7 +590,7 @@ TER Transactor::checkMultiSign ()
                 if (++signerEntriesItr == outer.signerEntries.end ())
                 {
                     m_journal.trace <<
-                        "applyTransaction: Invalid SigningFor.AccountID.";
+                        "applyTransaction: Invalid SigningFor.Account.";
                     return tefBAD_SIGNATURE;
                 }
             }
@@ -598,14 +598,14 @@ TER Transactor::checkMultiSign ()
             {
                 // The signingForID is not in the SignerEntries.
                 m_journal.trace <<
-                    "applyTransaction: Invalid SigningFor.AccountID.";
+                    "applyTransaction: Invalid SigningFor.Account.";
                 return tefBAD_SIGNATURE;
             }
             if (signerEntriesItr->weight <= 0)
             {
                 // The SigningFor entry needs a weight greater than zero.
                 m_journal.trace <<
-                    "applyTransaction: SigningFor.AccountID needs weight > 0.";
+                    "applyTransaction: SigningFor.Account needs weight > 0.";
                 return tefBAD_SIGNATURE;
             }
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -42,7 +42,7 @@ protected:
     TransactionEngine*              mEngine;
     TransactionEngineParams         mParams;
 
-    Account                         mTxnAccountID;
+    AccountID                         mTxnAccountID;
     STAmount                        mFeeDue;
     STAmount                        mPriorBalance;  // Balance before fees.
     STAmount                        mSourceBalance; // Balance after fees.

--- a/src/ripple/app/tx/tests/Taker.test.cpp
+++ b/src/ripple/app/tx/tests/Taker.test.cpp
@@ -40,7 +40,7 @@ class Taker_test : public beast::unit_test::suite
                 CrossType cross_type, Amounts const& amount, Quality const& quality,
                 STAmount const& funds, std::uint32_t flags, std::uint32_t rate_in,
                 std::uint32_t rate_out)
-            : BasicTaker (cross_type, Account(0x4701), amount, quality, flags, rate_in, rate_out)
+            : BasicTaker (cross_type, AccountID(0x4701), amount, quality, flags, rate_in, rate_out)
             , funds_ (funds)
         {
         }
@@ -52,7 +52,7 @@ class Taker_test : public beast::unit_test::suite
         }
 
         STAmount
-        get_funds (Account const& owner, STAmount const& funds) const
+        get_funds (AccountID const& owner, STAmount const& funds) const
         {
             if (owner == account ())
                 return funds_;
@@ -67,13 +67,13 @@ class Taker_test : public beast::unit_test::suite
                 return Amounts (offer.in.zeroed (), offer.out.zeroed ());
 
             // we need to emulate "unfunded offers" behavior
-            if (get_funds (Account (0x4702), offer.out) == zero)
+            if (get_funds (AccountID (0x4702), offer.out) == zero)
                 return Amounts (offer.in.zeroed (), offer.out.zeroed ());
 
             if (done ())
                 return Amounts (offer.in.zeroed (), offer.out.zeroed ());
 
-            auto result = do_cross (offer, quality, Account (0x4702));
+            auto result = do_cross (offer, quality, AccountID (0x4702));
 
             funds_ -= result.order.in;
 
@@ -97,8 +97,8 @@ class Taker_test : public beast::unit_test::suite
                     Amounts { offer2.in.zeroed (), offer2.out.zeroed () });
 
             auto result = do_cross (
-                offer1, quality1, Account (0x4703),
-                offer2, quality2, Account (0x4704));
+                offer1, quality1, AccountID (0x4703),
+                offer2, quality2, AccountID (0x4704));
 
             return std::make_pair (result.first.order, result.second.order);
         }
@@ -108,14 +108,14 @@ private:
     Issue const& usd () const
     {
         static Issue const issue (
-            Currency (0x5553440000000000), Account (0x4985601));
+            Currency (0x5553440000000000), AccountID (0x4985601));
         return issue;
     }
 
     Issue const& eur () const
     {
         static Issue const issue (
-            Currency (0x4555520000000000), Account (0x4985602));
+            Currency (0x4555520000000000), AccountID (0x4985602));
         return issue;
     }
 
@@ -235,8 +235,8 @@ public:
     // IN:OUT (with the last in the list being limiting factor)
     //  N  = Nothing
     //  T  = Taker Offer Balance
-    //  A  = Taker Account Balance
-    //  B  = Owner Account Balance
+    //  A  = Taker AccountID Balance
+    //  B  = Owner AccountID Balance
     //
     // (s) = sell semantics: taker wants unlimited output
     // (b) = buy semantics: taker wants a limited amount out

--- a/src/ripple/app/tx/tests/Taker.test.cpp
+++ b/src/ripple/app/tx/tests/Taker.test.cpp
@@ -235,8 +235,8 @@ public:
     // IN:OUT (with the last in the list being limiting factor)
     //  N  = Nothing
     //  T  = Taker Offer Balance
-    //  A  = Taker AccountID Balance
-    //  B  = Owner AccountID Balance
+    //  A  = Taker Account Balance
+    //  B  = Owner Account Balance
     //
     // (s) = sell semantics: taker wants unlimited output
     // (b) = buy semantics: taker wants a limited amount out

--- a/src/ripple/app/tx/tests/common_transactor.cpp
+++ b/src/ripple/app/tx/tests/common_transactor.cpp
@@ -195,7 +195,7 @@ void multiSign (STTx& tx, std::vector<MultiSig>& multiSigs)
 void insertMultiSigs (STTx& tx, std::vector<MultiSig> const& multiSigs)
 {
     // Know when to change out SigningFor containers.
-    Account prevSigningForID;
+    AccountID prevSigningForID;
 
     // Create the MultiSigners array one STObject at a time.
     STArray multiSigners;
@@ -294,7 +294,7 @@ STTx getPaymentTx (
 }
 
 // Return a transaction that sets a regular key
-STTx getSetRegularKeyTx (UserAccount& acct, Account const& regKey)
+STTx getSetRegularKeyTx (UserAccount& acct, AccountID const& regKey)
 {
     STTx tx = getSeqTx (acct, ttREGULAR_KEY_SET);
     tx.setFieldAccount (sfRegularKey,  regKey);

--- a/src/ripple/app/tx/tests/common_transactor.h
+++ b/src/ripple/app/tx/tests/common_transactor.h
@@ -36,7 +36,7 @@ class UserAccount
 {
 private:
     KeyPair master_;
-    Account acctID_;
+    AccountID acctID_;
     KeyPair regular_;
     bool useRegKey_ = false;
     std::uint32_t sequence_ = 0;
@@ -48,7 +48,7 @@ public:
 
     UserAccount (KeyType kType, std::string const& passphrase);
 
-    Account const& getID () const
+    AccountID const& getID () const
     {
         return acctID_;
     }
@@ -239,8 +239,8 @@ public:
 
     friend bool operator<(MultiSig const& lhs, MultiSig const& rhs)
     {
-        Account const& lhsSigingFor = lhs.signingFor_->getID();
-        Account const& rhsSigningFor = rhs.signingFor_->getID();
+        AccountID const& lhsSigingFor = lhs.signingFor_->getID();
+        AccountID const& rhsSigningFor = rhs.signingFor_->getID();
         if (lhsSigingFor < rhsSigningFor)
             return true;
 
@@ -253,12 +253,12 @@ public:
         return false;
     }
 
-    Account const& signingForAccount() const
+    AccountID const& signingForAccount() const
     {
         return signingFor_->getID();
     }
 
-    Account const& signingAccount() const
+    AccountID const& signingAccount() const
     {
         return signer_->getID();
     }
@@ -310,7 +310,7 @@ STTx getPaymentTx (
     UserAccount& from, UserAccount const& to, STAmount const& amount);
 
 // Return a transaction that sets a regular key.
-STTx getSetRegularKeyTx (UserAccount& acct, Account const& regKey);
+STTx getSetRegularKeyTx (UserAccount& acct, AccountID const& regKey);
 
 // Return a transaction that clears a regular key.
 STTx getClearRegularKeyTx (UserAccount& acct);

--- a/src/ripple/protocol/Book.h
+++ b/src/ripple/protocol/Book.h
@@ -178,13 +178,13 @@ namespace std {
 template <bool ByValue>
 struct hash <ripple::IssueType <ByValue>>
     : private boost::base_from_member <std::hash <ripple::Currency>, 0>
-    , private boost::base_from_member <std::hash <ripple::Account>, 1>
+    , private boost::base_from_member <std::hash <ripple::AccountID>, 1>
 {
 private:
     using currency_hash_type = boost::base_from_member <
         std::hash <ripple::Currency>, 0>;
     using issuer_hash_type = boost::base_from_member <
-        std::hash <ripple::Account>, 1>;
+        std::hash <ripple::AccountID>, 1>;
 
 public:
     using value_type = std::size_t;

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -50,22 +50,22 @@ uint256
 getLedgerFeeIndex ();
 
 uint256
-getAccountRootIndex (Account const& account);
+getAccountRootIndex (AccountID const& account);
 
 uint256
 getAccountRootIndex (const RippleAddress & account);
 
 uint256
-getGeneratorIndex (Account const& uGeneratorID);
+getGeneratorIndex (AccountID const& uGeneratorID);
 
 uint256
 getBookBase (Book const& book);
 
 uint256
-getOfferIndex (Account const& account, std::uint32_t uSequence);
+getOfferIndex (AccountID const& account, std::uint32_t uSequence);
 
 uint256
-getOwnerDirIndex (Account const& account);
+getOwnerDirIndex (AccountID const& account);
 
 uint256
 getDirNodeIndex (uint256 const& uDirRoot, const std::uint64_t uNodeIndex);
@@ -81,16 +81,16 @@ std::uint64_t
 getQuality (uint256 const& uBase);
 
 uint256
-getTicketIndex (Account const& account, std::uint32_t uSequence);
+getTicketIndex (AccountID const& account, std::uint32_t uSequence);
 
 uint256
-getRippleStateIndex (Account const& a, Account const& b, Currency const& currency);
+getRippleStateIndex (AccountID const& a, AccountID const& b, Currency const& currency);
 
 uint256
-getRippleStateIndex (Account const& a, Issue const& issue);
+getRippleStateIndex (AccountID const& a, Issue const& issue);
 
 uint256
-getSignerListIndex (Account const& account);
+getSignerListIndex (AccountID const& account);
 
 //------------------------------------------------------------------------------
 
@@ -115,10 +115,10 @@ struct Keylet
 /** Keylet computation funclets. */
 namespace keylet {
 
-/** Account root */
+/** AccountID root */
 struct account_t
 {
-    Keylet operator()(Account const& id) const;
+    Keylet operator()(AccountID const& id) const;
 
     // DEPRECATED
     Keylet operator()(RippleAddress const& ra) const;
@@ -128,7 +128,7 @@ static account_t const account {};
 /** OWner directory */
 struct owndir_t
 {
-    Keylet operator()(Account const& id) const;
+    Keylet operator()(AccountID const& id) const;
 };
 static owndir_t const ownerDir {};
 
@@ -165,7 +165,7 @@ static book_t const book {};
 /** An offer from an account */
 struct offer_t
 {
-    Keylet operator()(Account const& id,
+    Keylet operator()(AccountID const& id,
         std::uint32_t seq) const;
 };
 static offer_t const offer {};
@@ -197,7 +197,7 @@ static next_t const next {};
 /** A ticket belonging to an account */
 struct ticket_t
 {
-    Keylet operator()(Account const& id,
+    Keylet operator()(AccountID const& id,
         std::uint32_t seq) const;
 };
 static ticket_t const ticket {};
@@ -205,10 +205,10 @@ static ticket_t const ticket {};
 /** A trust line */
 struct trust_t
 {
-    Keylet operator()(Account const& id0,
-        Account const& id1, Currency const& currency) const;
+    Keylet operator()(AccountID const& id0,
+        AccountID const& id1, Currency const& currency) const;
 
-    Keylet operator()(Account const& id,
+    Keylet operator()(AccountID const& id,
         Issue const& issue) const;
 };
 static trust_t const trust {};
@@ -216,7 +216,7 @@ static trust_t const trust {};
 /** A SignerList */
 struct signers_t
 {
-    Keylet operator()(Account const& id) const;
+    Keylet operator()(AccountID const& id) const;
 };
 static signers_t const signers {};
 

--- a/src/ripple/protocol/Issue.h
+++ b/src/ripple/protocol/Issue.h
@@ -33,7 +33,7 @@ namespace ripple {
     When ByValue is `false`, this only stores references, and the caller
     is responsible for managing object lifetime.
 
-    @see Currency, Account, Issue, IssueRef, Book
+    @see Currency, AccountID, Issue, IssueRef, Book
 */
 template <bool ByValue>
 class IssueType
@@ -43,7 +43,7 @@ public:
         std::conditional <ByValue, Currency, Currency const&>::type;
 
     using IssueAccount = typename
-        std::conditional <ByValue, Account, Account const&>::type;
+        std::conditional <ByValue, AccountID, AccountID const&>::type;
 
     IssueCurrency currency;
     IssueAccount account;
@@ -52,7 +52,7 @@ public:
     {
     }
 
-    IssueType (Currency const& c, Account const& a)
+    IssueType (Currency const& c, AccountID const& a)
             : currency (c), account (a)
     {
     }

--- a/src/ripple/protocol/RippleAddress.h
+++ b/src/ripple/protocol/RippleAddress.h
@@ -123,16 +123,16 @@ public:
     //
     // Accounts IDs
     //
-    Account getAccountID () const;
+    AccountID getAccountID () const;
 
     std::string humanAccountID () const;
 
     bool setAccountID (
         std::string const& strAccountID,
         Base58::Alphabet const& alphabet = Base58::getRippleAlphabet());
-    void setAccountID (Account const& hash160In);
+    void setAccountID (AccountID const& hash160In);
 
-    static RippleAddress createAccountID (Account const& uiAccountID);
+    static RippleAddress createAccountID (AccountID const& uiAccountID);
 
     //
     // Accounts Public

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -35,7 +35,7 @@ public:
     {
         ;
     }
-    STAccount (SField const& n, Account const& v);
+    STAccount (SField const& n, AccountID const& v);
     STAccount (SField const& n) : STBlob (n)
     {
         ;

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -146,7 +146,7 @@ public:
 
     // These three are deprecated
     Currency const& getCurrency() const { return mIssue.currency; }
-    Account const& getIssuer() const { return mIssue.account; }
+    AccountID const& getIssuer() const { return mIssue.account; }
 
     int
     signum() const noexcept
@@ -219,7 +219,7 @@ public:
         clear();
     }
 
-    void setIssuer (Account const& uIssuer)
+    void setIssuer (AccountID const& uIssuer)
     {
         mIssue.account = uIssuer;
         setIssue(mIssue);

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -260,7 +260,7 @@ public:
     uint160 getFieldH160 (SField const& field) const;
     uint256 getFieldH256 (SField const& field) const;
     RippleAddress getFieldAccount (SField const& field) const;
-    Account getFieldAccount160 (SField const& field) const;
+    AccountID getFieldAccount160 (SField const& field) const;
 
     Blob getFieldVL (SField const& field) const;
     STAmount const& getFieldAmount (SField const& field) const;
@@ -282,7 +282,7 @@ public:
     void setFieldH128 (SField const& field, uint128 const&);
     void setFieldH256 (SField const& field, uint256 const& );
     void setFieldVL (SField const& field, Blob const&);
-    void setFieldAccount (SField const& field, Account const&);
+    void setFieldAccount (SField const& field, AccountID const&);
     void setFieldAccount (SField const& field, RippleAddress const& addr)
     {
         setFieldAccount (field, addr.getAccountID ());

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -49,8 +49,8 @@ private:
 
 public:
     STPathElement (
-        Account const& account, Currency const& currency,
-        Account const& issuer, bool forceCurrency = false)
+        AccountID const& account, Currency const& currency,
+        AccountID const& issuer, bool forceCurrency = false)
         : mType (typeNone), mAccountID (account), mCurrencyID (currency)
         , mIssuerID (issuer), is_offer_ (isXRP(mAccountID))
     {
@@ -67,8 +67,8 @@ public:
     }
 
     STPathElement (
-        unsigned int uType, Account const& account, Currency const& currency,
-        Account const& issuer)
+        unsigned int uType, AccountID const& account, Currency const& currency,
+        AccountID const& issuer)
         : mType (uType), mAccountID (account), mCurrencyID (currency)
         , mIssuerID (issuer), is_offer_ (isXRP(mAccountID))
     {
@@ -101,7 +101,7 @@ public:
 
     // Nodes are either an account ID or a offer prefix. Offer prefixs denote a
     // class of offers.
-    Account const&
+    AccountID const&
     getAccountID () const
     {
         return mAccountID;
@@ -113,7 +113,7 @@ public:
         return mCurrencyID;
     }
 
-    Account const&
+    AccountID const&
     getIssuerID () const
     {
         return mIssuerID;
@@ -131,9 +131,9 @@ public:
 
 private:
     unsigned int mType;
-    Account mAccountID;
+    AccountID mAccountID;
     Currency mCurrencyID;
-    Account mIssuerID;
+    AccountID mIssuerID;
 
     bool is_offer_;
     std::size_t hash_value_;
@@ -174,8 +174,8 @@ public:
 
     bool
     hasSeen (
-        Account const& account, Currency const& currency,
-        Account const& issuer) const;
+        AccountID const& account, Currency const& currency,
+        AccountID const& issuer) const;
 
     Json::Value
     getJson (int) const;

--- a/src/ripple/protocol/UintTypes.h
+++ b/src/ripple/protocol/UintTypes.h
@@ -37,8 +37,8 @@ class NodeIDTag {};
     The last 64 bits of this are the quality. */
 using Directory = base_uint<256, detail::DirectoryTag>;
 
-/** Account is a hash representing a specific account. */
-using Account = base_uint<160, detail::AccountTag>;
+/** AccountID is a hash representing a specific account. */
+using AccountID = base_uint<160, detail::AccountTag>;
 
 /** Currency is a hash representing a specific currency. */
 using Currency = base_uint<160, detail::CurrencyTag>;
@@ -49,13 +49,13 @@ using NodeID = base_uint<160, detail::NodeIDTag>;
 using CurrencySet = hash_set<Currency>;
 
 /** A special account that's used as the "issuer" for XRP. */
-Account const& xrpAccount();
+AccountID const& xrpAccount();
 
 /** XRP currency. */
 Currency const& xrpCurrency();
 
 /** A placeholder for empty accounts. */
-Account const& noAccount();
+AccountID const& noAccount();
 
 /** A placeholder for empty currencies. */
 Currency const& noCurrency();
@@ -71,13 +71,13 @@ inline bool isXRP(Currency const& c)
     return c == zero;
 }
 
-inline bool isXRP(Account const& c)
+inline bool isXRP(AccountID const& c)
 {
     return c == zero;
 }
 
 /** Returns a human-readable form of the account. */
-std::string to_string(Account const&);
+std::string to_string(AccountID const&);
 
 /** Returns "", "XRP", or three letter ISO code. */
 std::string to_string(Currency const& c);
@@ -88,11 +88,11 @@ bool to_currency(Currency&, std::string const&);
 /** Tries to convert a string to a Currency, returns noCurrency() on failure. */
 Currency to_currency(std::string const&);
 
-/** Tries to convert a string to an Account representing an issuer, returns true
+/** Tries to convert a string to an AccountID representing an issuer, returns true
  * on success. */
-bool to_issuer(Account&, std::string const&);
+bool to_issuer(AccountID&, std::string const&);
 
-inline std::ostream& operator<< (std::ostream& os, Account const& x)
+inline std::ostream& operator<< (std::ostream& os, AccountID const& x)
 {
     os << to_string (x);
     return os;
@@ -109,7 +109,7 @@ inline std::ostream& operator<< (std::ostream& os, Currency const& x)
 namespace std {
 
 template <>
-struct hash <ripple::Account> : ripple::Account::hasher
+struct hash <ripple::AccountID> : ripple::AccountID::hasher
 {
 };
 

--- a/src/ripple/protocol/UintTypes.h
+++ b/src/ripple/protocol/UintTypes.h
@@ -26,7 +26,7 @@
 namespace ripple {
 namespace detail {
 
-class AccountTag {};
+class AccountIDTag {};
 class CurrencyTag {};
 class DirectoryTag {};
 class NodeIDTag {};
@@ -38,7 +38,7 @@ class NodeIDTag {};
 using Directory = base_uint<256, detail::DirectoryTag>;
 
 /** AccountID is a hash representing a specific account. */
-using AccountID = base_uint<160, detail::AccountTag>;
+using AccountID = base_uint<160, detail::AccountIDTag>;
 
 /** Currency is a hash representing a specific currency. */
 using Currency = base_uint<160, detail::CurrencyTag>;

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -47,10 +47,10 @@ public:
     ErrorCategory ()
         : m_unknown (rpcUNKNOWN, "unknown", "An unknown error code.")
     {
-        add (rpcACT_BITCOIN,           "actBitcoin",        "Account is bitcoin address.");
-        add (rpcACT_EXISTS,            "actExists",         "Account already exists.");
-        add (rpcACT_MALFORMED,         "actMalformed",      "Account malformed.");
-        add (rpcACT_NOT_FOUND,         "actNotFound",       "Account not found.");
+        add (rpcACT_BITCOIN,           "actBitcoin",        "AccountID is bitcoin address.");
+        add (rpcACT_EXISTS,            "actExists",         "AccountID already exists.");
+        add (rpcACT_MALFORMED,         "actMalformed",      "AccountID malformed.");
+        add (rpcACT_NOT_FOUND,         "actNotFound",       "AccountID not found.");
         add (rpcATX_DEPRECATED,        "deprecated",        "Use the new API or specify a ledger range.");
         add (rpcBAD_BLOB,              "badBlob",           "Blob must be a non-empty hex string.");
         add (rpcBAD_FEATURE,           "badFeature",        "Feature unknown or invalid.");

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -47,10 +47,10 @@ public:
     ErrorCategory ()
         : m_unknown (rpcUNKNOWN, "unknown", "An unknown error code.")
     {
-        add (rpcACT_BITCOIN,           "actBitcoin",        "AccountID is bitcoin address.");
-        add (rpcACT_EXISTS,            "actExists",         "AccountID already exists.");
-        add (rpcACT_MALFORMED,         "actMalformed",      "AccountID malformed.");
-        add (rpcACT_NOT_FOUND,         "actNotFound",       "AccountID not found.");
+        add (rpcACT_BITCOIN,           "actBitcoin",        "Account is bitcoin address.");
+        add (rpcACT_EXISTS,            "actExists",         "Account already exists.");
+        add (rpcACT_MALFORMED,         "actMalformed",      "Account malformed.");
+        add (rpcACT_NOT_FOUND,         "actNotFound",       "Account not found.");
         add (rpcATX_DEPRECATED,        "deprecated",        "Use the new API or specify a ledger range.");
         add (rpcBAD_BLOB,              "badBlob",           "Blob must be a non-empty hex string.");
         add (rpcBAD_FEATURE,           "badFeature",        "Feature unknown or invalid.");

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -58,7 +58,7 @@ getLedgerFeeIndex ()
 }
 
 uint256
-getAccountRootIndex (Account const& account)
+getAccountRootIndex (AccountID const& account)
 {
     return sha512Half(
         std::uint16_t(spaceAccount),
@@ -72,7 +72,7 @@ getAccountRootIndex (const RippleAddress & account)
 }
 
 uint256
-getGeneratorIndex (Account const& uGeneratorID)
+getGeneratorIndex (AccountID const& uGeneratorID)
 {
     return sha512Half(
         std::uint16_t(spaceGenerator),
@@ -93,7 +93,7 @@ getBookBase (Book const& book)
 }
 
 uint256
-getOfferIndex (Account const& account, std::uint32_t uSequence)
+getOfferIndex (AccountID const& account, std::uint32_t uSequence)
 {
     return sha512Half(
         std::uint16_t(spaceOffer),
@@ -102,7 +102,7 @@ getOfferIndex (Account const& account, std::uint32_t uSequence)
 }
 
 uint256
-getOwnerDirIndex (Account const& account)
+getOwnerDirIndex (AccountID const& account)
 {
     return sha512Half(
         std::uint16_t(spaceOwnerDir),
@@ -155,7 +155,7 @@ getQuality (uint256 const& uBase)
 }
 
 uint256
-getTicketIndex (Account const& account, std::uint32_t uSequence)
+getTicketIndex (AccountID const& account, std::uint32_t uSequence)
 {
     return sha512Half(
         std::uint16_t(spaceTicket),
@@ -164,7 +164,7 @@ getTicketIndex (Account const& account, std::uint32_t uSequence)
 }
 
 uint256
-getRippleStateIndex (Account const& a, Account const& b, Currency const& currency)
+getRippleStateIndex (AccountID const& a, AccountID const& b, Currency const& currency)
 {
     if (a < b)
         return sha512Half(
@@ -180,13 +180,13 @@ getRippleStateIndex (Account const& a, Account const& b, Currency const& currenc
 }
 
 uint256
-getRippleStateIndex (Account const& a, Issue const& issue)
+getRippleStateIndex (AccountID const& a, Issue const& issue)
 {
     return getRippleStateIndex (a, issue.account, issue.currency);
 }
 
 uint256
-getSignerListIndex (Account const& account)
+getSignerListIndex (AccountID const& account)
 {
     return sha512Half(
         std::uint16_t(spaceSignerList),
@@ -198,7 +198,7 @@ getSignerListIndex (Account const& account)
 namespace keylet {
 
 Keylet account_t::operator()(
-    Account const& id) const
+    AccountID const& id) const
 {
     return { ltACCOUNT_ROOT,
         getAccountRootIndex(id) };
@@ -212,7 +212,7 @@ Keylet account_t::operator()(
 }
 
 Keylet owndir_t::operator()(
-    Account const& id) const
+    AccountID const& id) const
 {
     return { ltDIR_NODE,
         getOwnerDirIndex(id) };
@@ -248,7 +248,7 @@ Keylet book_t::operator()(Book const& b) const
         getBookBase(b) };
 }
 
-Keylet offer_t::operator()(Account const& id,
+Keylet offer_t::operator()(AccountID const& id,
     std::uint32_t seq) const
 {
     return { ltOFFER,
@@ -278,28 +278,28 @@ Keylet next_t::operator()(Keylet const& k) const
         getQualityNext(k.key) };
 }
 
-Keylet ticket_t::operator()(Account const& id,
+Keylet ticket_t::operator()(AccountID const& id,
     std::uint32_t seq) const
 {
     return { ltTICKET,
         getTicketIndex(id, seq) };
 }
 
-Keylet trust_t::operator()(Account const& id0,
-    Account const& id1, Currency const& currency) const
+Keylet trust_t::operator()(AccountID const& id0,
+    AccountID const& id1, Currency const& currency) const
 {
     return { ltRIPPLE_STATE,
         getRippleStateIndex(id0, id1, currency) };
 }
 
-Keylet trust_t::operator()(Account const& id,
+Keylet trust_t::operator()(AccountID const& id,
     Issue const& issue) const
 {
     return { ltRIPPLE_STATE,
         getRippleStateIndex(id, issue) };
 }
 
-Keylet signers_t::operator()(Account const& id) const
+Keylet signers_t::operator()(AccountID const& id) const
 {
     return { ltSIGNER_LIST,
         getSignerListIndex(id) };

--- a/src/ripple/protocol/impl/RippleAddress.cpp
+++ b/src/ripple/protocol/impl/RippleAddress.cpp
@@ -325,7 +325,7 @@ void RippleAddress::signNodePrivate (uint256 const& hash, Blob& vchSig) const
 // AccountID
 //
 
-Account RippleAddress::getAccountID () const
+AccountID RippleAddress::getAccountID () const
 {
     switch (nVersion)
     {
@@ -333,12 +333,12 @@ Account RippleAddress::getAccountID () const
         throw std::runtime_error ("unset source - getAccountID");
 
     case VER_ACCOUNT_ID:
-        return Account(vchData);
+        return AccountID(vchData);
 
     case VER_ACCOUNT_PUBLIC: {
         // Note, we are encoding the left.
         // TODO(tom): decipher this comment.
-        Account account;
+        AccountID account;
         account.copyFrom (Hash160 (vchData));
         return account;
     }
@@ -428,7 +428,7 @@ bool RippleAddress::setAccountID (
 {
     if (strAccountID.empty ())
     {
-        setAccountID (Account ());
+        setAccountID (AccountID ());
 
         mIsValid    = true;
     }
@@ -440,7 +440,7 @@ bool RippleAddress::setAccountID (
     return mIsValid;
 }
 
-void RippleAddress::setAccountID (Account const& hash160)
+void RippleAddress::setAccountID (AccountID const& hash160)
 {
     mIsValid        = true;
     SetData (VER_ACCOUNT_ID, hash160);
@@ -541,7 +541,7 @@ bool RippleAddress::accountPublicVerify (
             fullyCanonical);
 }
 
-RippleAddress RippleAddress::createAccountID (Account const& account)
+RippleAddress RippleAddress::createAccountID (AccountID const& account)
 {
     RippleAddress   na;
     na.setAccountID (account);

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -194,7 +194,7 @@ SField              const sfMemoFormat      = make::one(&sfMemoFormat,    STI_VL
 SField const sfMultiSignature = make::one(&sfMultiSignature, STI_VL, 16, "MultiSignature");
 
 // account
-SField const sfAccount     = make::one(&sfAccount,     STI_ACCOUNT, 1, "Account");
+SField const sfAccount     = make::one(&sfAccount,     STI_ACCOUNT, 1, "AccountID");
 SField const sfOwner       = make::one(&sfOwner,       STI_ACCOUNT, 2, "Owner");
 SField const sfDestination = make::one(&sfDestination, STI_ACCOUNT, 3, "Destination");
 SField const sfIssuer      = make::one(&sfIssuer,      STI_ACCOUNT, 4, "Issuer");

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -194,7 +194,7 @@ SField              const sfMemoFormat      = make::one(&sfMemoFormat,    STI_VL
 SField const sfMultiSignature = make::one(&sfMultiSignature, STI_VL, 16, "MultiSignature");
 
 // account
-SField const sfAccount     = make::one(&sfAccount,     STI_ACCOUNT, 1, "AccountID");
+SField const sfAccount     = make::one(&sfAccount,     STI_ACCOUNT, 1, "Account");
 SField const sfOwner       = make::one(&sfOwner,       STI_ACCOUNT, 2, "Owner");
 SField const sfDestination = make::one(&sfDestination, STI_ACCOUNT, 3, "Destination");
 SField const sfIssuer      = make::one(&sfIssuer,      STI_ACCOUNT, 4, "Issuer");

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -29,7 +29,7 @@ STAccount::STAccount (SerialIter& sit, SField const& name)
 
 std::string STAccount::getText () const
 {
-    Account u;
+    AccountID u;
     RippleAddress a;
 
     if (!getValueH160 (u))
@@ -45,7 +45,7 @@ STAccount::construct (SerialIter& u, SField const& name)
     return new STAccount (name, u.getVLBuffer ());
 }
 
-STAccount::STAccount (SField const& n, Account const& v)
+STAccount::STAccount (SField const& n, AccountID const& v)
         : STBlob (n, v.data (), v.size ())
 {
 }
@@ -58,7 +58,7 @@ bool STAccount::isValueH160 () const
 RippleAddress STAccount::getValueNCA () const
 {
     RippleAddress a;
-    Account account;
+    AccountID account;
 
     if (getValueH160 (account))
         a.setAccountID (account);

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -605,13 +605,13 @@ RippleAddress STObject::getFieldAccount (SField const& field) const
     return cf->getValueNCA ();
 }
 
-Account STObject::getFieldAccount160 (SField const& field) const
+AccountID STObject::getFieldAccount160 (SField const& field) const
 {
     auto rf = peekAtPField (field);
     if (!rf)
         throw std::runtime_error ("Field not found");
 
-    Account account;
+    AccountID account;
     if (rf->getSType () != STI_NOTPRESENT)
     {
         const STAccount* cf = dynamic_cast<const STAccount*> (rf);
@@ -715,7 +715,7 @@ void STObject::setFieldV256 (SField const& field, STVector256 const& v)
     setFieldUsingSetValue <STVector256> (field, v);
 }
 
-void STObject::setFieldAccount (SField const& field, Account const& v)
+void STObject::setFieldAccount (SField const& field, AccountID const& v)
 {
     STBase* rf = getPField (field, true);
 

--- a/src/ripple/protocol/impl/STParsedJSON.cpp
+++ b/src/ripple/protocol/impl/STParsedJSON.cpp
@@ -528,7 +528,7 @@ static boost::optional<detail::STVar> parseLeaf (
                     Json::Value const& currency = pathEl["currency"];
                     Json::Value const& issuer   = pathEl["issuer"];
                     bool hasCurrency            = false;
-                    Account uAccount, uIssuer;
+                    AccountID uAccount, uIssuer;
                     Currency uCurrency;
 
                     if (! account.isNull ())
@@ -623,7 +623,7 @@ static boost::optional<detail::STVar> parseLeaf (
 
             try
             {
-                Account account;
+                AccountID account;
                 if (!account.SetHexExact (strValue))
                 {
                     RippleAddress a;

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -87,9 +87,9 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
             auto hasCurrency = iType & STPathElement::typeCurrency;
             auto hasIssuer = iType & STPathElement::typeIssuer;
 
-            Account account;
+            AccountID account;
             Currency currency;
-            Account issuer;
+            AccountID issuer;
 
             if (hasAccount)
                 account.copyFrom (sit.get160 ());
@@ -135,8 +135,8 @@ STPathSet::isEquivalent (const STBase& t) const
 
 bool
 STPath::hasSeen (
-    Account const& account, Currency const& currency,
-    Account const& issuer) const
+    AccountID const& account, Currency const& currency,
+    AccountID const& issuer) const
 {
     for (auto& p: mPath)
     {

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -345,56 +345,58 @@ STTx::checkMultiSign () const
         ? ECDSA::strict
         : ECDSA::not_strict;
 
-    // We need to detect (and reject) if a multi-signer is both signing
-    // directly and using a SigningFor.  Here's an example:
-    //
-    // {
-    //     ...
-    //     "MultiSigners": [
-    //         {
-    //             "SigningFor": {
-    //                 "AccountID": "<alice>",
-    //                 "SigningAccounts": [
-    //                     {
-    //                         "SigningAccount": {
-    //                             // * becky says that becky signs for alice. *
-    //                             "AccountID": "<becky>",
-    //     ...
-    //             "SigningFor": {
-    //                 "AccountID": "<becky>",
-    //                 "SigningAccounts": [
-    //                     {
-    //                         "SigningAccount": {
-    //                             // * cheri says that becky signs for alice. *
-    //                             "AccountID": "<cheri>",
-    //     ...
-    //     "tx_json": {
-    //         "AccountID": "<alice>",
-    //         ...
-    //     }
-    // }
-    //
-    // Why is this way of signing a problem?  Alice has a signer list, and
-    // Becky can show up in that list only once.  By design.  So if Becky
-    // signs twice -- once directly and once indirectly -- we have three
-    // options:
-    //
-    //  1. We can add Becky's weight toward Alice's quorum twice, once for
-    //     each signature.  This seems both unexpected and counter to Alice's
-    //     intention.
-    //
-    //  2. We could allow both signatures, but only add Becky's weight
-    //     toward Alice's quorum once.  This seems a bit better.  But it allows
-    //     our clients to ask rippled to do more work than necessary.  We
-    //     should also let the client know that only one of the signatures
-    //     was necessary.
-    //
-    //  3. The only way to tell the client that they have done more work
-    //     than necessary (and that one of the signatures will be ignored) is
-    //     to declare the transaction malformed.  This behavior also aligns
-    //     well with rippled's behavior if Becky had signed directly twice:
-    //     the transaction would be marked as malformed.
-    //
+    /*
+        We need to detect (and reject) if a multi-signer is both signing
+        directly and using a SigningFor.  Here's an example:
+        
+        {
+            ...
+            "MultiSigners": [
+                {
+                    "SigningFor": {
+                        "Account": "<alice>",
+                        "SigningAccounts": [
+                            {
+                                "SigningAccount": {
+                                    // * becky says that becky signs for alice. *
+                                    "Account": "<becky>",
+            ...
+                    "SigningFor": {
+                        "Account": "<becky>",
+                        "SigningAccounts": [
+                            {
+                                "SigningAccount": {
+                                    // * cheri says that becky signs for alice. *
+                                    "Account": "<cheri>",
+            ...
+            "tx_json": {
+                "Account": "<alice>",
+                ...
+            }
+        }
+        
+        Why is this way of signing a problem?  Alice has a signer list, and
+        Becky can show up in that list only once.  By design.  So if Becky
+        signs twice -- once directly and once indirectly -- we have three
+        options:
+        
+         1. We can add Becky's weight toward Alice's quorum twice, once for
+            each signature.  This seems both unexpected and counter to Alice's
+            intention.
+        
+         2. We could allow both signatures, but only add Becky's weight
+            toward Alice's quorum once.  This seems a bit better.  But it allows
+            our clients to ask rippled to do more work than necessary.  We
+            should also let the client know that only one of the signatures
+            was necessary.
+        
+         3. The only way to tell the client that they have done more work
+            than necessary (and that one of the signatures will be ignored) is
+            to declare the transaction malformed.  This behavior also aligns
+            well with rippled's behavior if Becky had signed directly twice:
+            the transaction would be marked as malformed.
+    */
+
     // We use this std::set to detect this form of double-signing.
     std::set<RippleAddress> firstLevelSigners;
 

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -353,23 +353,23 @@ STTx::checkMultiSign () const
     //     "MultiSigners": [
     //         {
     //             "SigningFor": {
-    //                 "Account": "<alice>",
+    //                 "AccountID": "<alice>",
     //                 "SigningAccounts": [
     //                     {
     //                         "SigningAccount": {
     //                             // * becky says that becky signs for alice. *
-    //                             "Account": "<becky>",
+    //                             "AccountID": "<becky>",
     //     ...
     //             "SigningFor": {
-    //                 "Account": "<becky>",
+    //                 "AccountID": "<becky>",
     //                 "SigningAccounts": [
     //                     {
     //                         "SigningAccount": {
     //                             // * cheri says that becky signs for alice. *
-    //                             "Account": "<cheri>",
+    //                             "AccountID": "<cheri>",
     //     ...
     //     "tx_json": {
-    //         "Account": "<alice>",
+    //         "AccountID": "<alice>",
     //         ...
     //     }
     // }

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -82,7 +82,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tefMASTER_DISABLED,       "tefMASTER_DISABLED",       "Master key is disabled."                                       },
         { tefMAX_LEDGER,            "tefMAX_LEDGER",            "Ledger sequence too high."                                     },
         { tefNO_AUTH_REQUIRED,      "tefNO_AUTH_REQUIRED",      "Auth is not required."                                         },
-        { tefNOT_MULTI_SIGNING,     "tefNOT_MULTI_SIGNING",     "AccountID has no appropriate list of multi-signers."             },
+        { tefNOT_MULTI_SIGNING,     "tefNOT_MULTI_SIGNING",     "Account has no appropriate list of multi-signers."             },
         { tefPAST_SEQ,              "tefPAST_SEQ",              "This sequence number has already past."                        },
         { tefWRONG_PRIOR,           "tefWRONG_PRIOR",           "This previous transaction does not match."                     },
         { tefBAD_AUTH_MASTER,       "tefBAD_AUTH_MASTER",       "Auth for unclaimed account needs correct master key."          },
@@ -128,7 +128,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
 
         { terRETRY,                 "terRETRY",                 "Retry transaction."                                            },
         { terFUNDS_SPENT,           "terFUNDS_SPENT",           "Can't set password, password set funds already spent."         },
-        { terINSUF_FEE_B,           "terINSUF_FEE_B",           "AccountID balance can't pay fee."                                },
+        { terINSUF_FEE_B,           "terINSUF_FEE_B",           "Account balance can't pay fee."                                },
         { terLAST,                  "terLAST",                  "Process last."                                                 },
         { terNO_RIPPLE,             "terNO_RIPPLE",             "Path does not permit rippling."                                },
         { terNO_ACCOUNT,            "terNO_ACCOUNT",            "The source account does not exist."                            },

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -82,7 +82,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tefMASTER_DISABLED,       "tefMASTER_DISABLED",       "Master key is disabled."                                       },
         { tefMAX_LEDGER,            "tefMAX_LEDGER",            "Ledger sequence too high."                                     },
         { tefNO_AUTH_REQUIRED,      "tefNO_AUTH_REQUIRED",      "Auth is not required."                                         },
-        { tefNOT_MULTI_SIGNING,     "tefNOT_MULTI_SIGNING",     "Account has no appropriate list of multi-signers."             },
+        { tefNOT_MULTI_SIGNING,     "tefNOT_MULTI_SIGNING",     "AccountID has no appropriate list of multi-signers."             },
         { tefPAST_SEQ,              "tefPAST_SEQ",              "This sequence number has already past."                        },
         { tefWRONG_PRIOR,           "tefWRONG_PRIOR",           "This previous transaction does not match."                     },
         { tefBAD_AUTH_MASTER,       "tefBAD_AUTH_MASTER",       "Auth for unclaimed account needs correct master key."          },
@@ -128,7 +128,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
 
         { terRETRY,                 "terRETRY",                 "Retry transaction."                                            },
         { terFUNDS_SPENT,           "terFUNDS_SPENT",           "Can't set password, password set funds already spent."         },
-        { terINSUF_FEE_B,           "terINSUF_FEE_B",           "Account balance can't pay fee."                                },
+        { terINSUF_FEE_B,           "terINSUF_FEE_B",           "AccountID balance can't pay fee."                                },
         { terLAST,                  "terLAST",                  "Process last."                                                 },
         { terNO_RIPPLE,             "terNO_RIPPLE",             "Path does not permit rippling."                                },
         { terNO_ACCOUNT,            "terNO_ACCOUNT",            "The source account does not exist."                            },

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -26,7 +26,7 @@
 
 namespace ripple {
 
-std::string to_string(Account const& account)
+std::string to_string(AccountID const& account)
 {
     return RippleAddress::createAccountID (account).humanAccountID ();
 }
@@ -111,7 +111,7 @@ Currency to_currency(std::string const& code)
     return currency;
 }
 
-bool to_issuer(Account& issuer, std::string const& s)
+bool to_issuer(AccountID& issuer, std::string const& s)
 {
     if (s.size () == (160 / 4))
     {
@@ -125,9 +125,9 @@ bool to_issuer(Account& issuer, std::string const& s)
     return success;
 }
 
-Account const& xrpAccount()
+AccountID const& xrpAccount()
 {
-    static Account const account(0);
+    static AccountID const account(0);
     return account;
 }
 
@@ -137,9 +137,9 @@ Currency const& xrpCurrency()
     return currency;
 }
 
-Account const& noAccount()
+AccountID const& noAccount()
 {
-    static Account const account(1);
+    static AccountID const account(1);
     return account;
 }
 

--- a/src/ripple/protocol/tests/InnerObjectFormats.test.cpp
+++ b/src/ripple/protocol/tests/InnerObjectFormats.test.cpp
@@ -40,20 +40,20 @@ static TestJSONTxt const testArray[] =
 
 // Valid SignerEntry
 {R"({
-    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
         {
             "SignerEntry" :
             {
-                "Account" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                "AccountID" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                 "SignerWeight" : 3
             }
         }
@@ -63,15 +63,15 @@ static TestJSONTxt const testArray[] =
 })", false
 },
 
-// SignerEntry missing Account
+// SignerEntry missing AccountID
 {R"({
-    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
@@ -89,20 +89,20 @@ static TestJSONTxt const testArray[] =
 
 // SignerEntry missing SignerWeight
 {R"({
-    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
         {
             "SignerEntry" :
             {
-                "Account" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                "AccountID" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
             }
         }
     ],
@@ -113,13 +113,13 @@ static TestJSONTxt const testArray[] =
 
 // SignerEntry with unexpected Amount
 {R"({
-    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
@@ -127,7 +127,7 @@ static TestJSONTxt const testArray[] =
             "SignerEntry" :
             {
                 "Amount" : "1000000",
-                "Account" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                "AccountID" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                 "SignerWeight" : 3
             }
         }
@@ -137,15 +137,15 @@ static TestJSONTxt const testArray[] =
 })", true
 },
 
-// SignerEntry with no Account and unexpected Amount
+// SignerEntry with no AccountID and unexpected Amount
 {R"({
-    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },

--- a/src/ripple/protocol/tests/InnerObjectFormats.test.cpp
+++ b/src/ripple/protocol/tests/InnerObjectFormats.test.cpp
@@ -40,20 +40,20 @@ static TestJSONTxt const testArray[] =
 
 // Valid SignerEntry
 {R"({
-    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
         {
             "SignerEntry" :
             {
-                "AccountID" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                "Account" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                 "SignerWeight" : 3
             }
         }
@@ -63,15 +63,15 @@ static TestJSONTxt const testArray[] =
 })", false
 },
 
-// SignerEntry missing AccountID
+// SignerEntry missing Account
 {R"({
-    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
@@ -89,20 +89,20 @@ static TestJSONTxt const testArray[] =
 
 // SignerEntry missing SignerWeight
 {R"({
-    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
         {
             "SignerEntry" :
             {
-                "AccountID" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                "Account" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
             }
         }
     ],
@@ -113,13 +113,13 @@ static TestJSONTxt const testArray[] =
 
 // SignerEntry with unexpected Amount
 {R"({
-    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },
@@ -127,7 +127,7 @@ static TestJSONTxt const testArray[] =
             "SignerEntry" :
             {
                 "Amount" : "1000000",
-                "AccountID" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                "Account" : "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                 "SignerWeight" : 3
             }
         }
@@ -137,15 +137,15 @@ static TestJSONTxt const testArray[] =
 })", true
 },
 
-// SignerEntry with no AccountID and unexpected Amount
+// SignerEntry with no Account and unexpected Amount
 {R"({
-    "AccountID" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
+    "Account" : "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
     "SignerEntries" :
     [
         {
             "SignerEntry" :
             {
-                "AccountID" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+                "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
                 "SignerWeight" : 4
             }
         },

--- a/src/ripple/protocol/tests/Issue.test.cpp
+++ b/src/ripple/protocol/tests/Issue.test.cpp
@@ -79,9 +79,9 @@ public:
     template <class Issue>
     void testIssueType ()
     {
-        Currency const c1 (1); Account const i1 (1);
-        Currency const c2 (2); Account const i2 (2);
-        Currency const c3 (3); Account const i3 (3);
+        Currency const c1 (1); AccountID const i1 (1);
+        Currency const c2 (2); AccountID const i2 (2);
+        Currency const c3 (3); AccountID const i3 (3);
 
         expect (Issue (c1, i1) != Issue (c2, i1));
         expect (Issue (c1, i1) <  Issue (c2, i1));
@@ -125,9 +125,9 @@ public:
     void testIssueSet ()
     {
         Currency const c1 (1);
-        Account   const i1 (1);
+        AccountID   const i1 (1);
         Currency const c2 (2);
-        Account   const i2 (2);
+        AccountID   const i2 (2);
         IssueRef const a1 (c1, i1);
         IssueRef const a2 (c2, i2);
 
@@ -171,9 +171,9 @@ public:
     void testIssueMap ()
     {
         Currency const c1 (1);
-        Account   const i1 (1);
+        AccountID   const i1 (1);
         Currency const c2 (2);
-        Account   const i2 (2);
+        AccountID   const i2 (2);
         IssueRef const a1 (c1, i1);
         IssueRef const a2 (c2, i2);
 
@@ -259,9 +259,9 @@ public:
     template <class Book>
     void testBook ()
     {
-        Currency const c1 (1); Account const i1 (1);
-        Currency const c2 (2); Account const i2 (2);
-        Currency const c3 (3); Account const i3 (3);
+        Currency const c1 (1); AccountID const i1 (1);
+        Currency const c2 (2); AccountID const i2 (2);
+        Currency const c3 (3); AccountID const i3 (3);
 
         Issue a1 (c1, i1);
         Issue a2 (c1, i2);
@@ -317,9 +317,9 @@ public:
     void testBookSet ()
     {
         Currency const c1 (1);
-        Account   const i1 (1);
+        AccountID   const i1 (1);
         Currency const c2 (2);
-        Account   const i2 (2);
+        AccountID   const i2 (2);
         IssueRef const a1 (c1, i1);
         IssueRef const a2 (c2, i2);
         BookRef  const b1 (a1, a2);
@@ -365,9 +365,9 @@ public:
     void testBookMap ()
     {
         Currency const c1 (1);
-        Account   const i1 (1);
+        AccountID   const i1 (1);
         Currency const c2 (2);
-        Account   const i2 (2);
+        AccountID   const i2 (2);
         IssueRef const a1 (c1, i1);
         IssueRef const a2 (c2, i2);
         BookRef  const b1 (a1, a2);
@@ -462,8 +462,8 @@ public:
         testcase ("Currency");
         testUnsigned <Currency> ();
 
-        testcase ("Account");
-        testUnsigned <Account> ();
+        testcase ("AccountID");
+        testUnsigned <AccountID> ();
 
         // ---
 

--- a/src/ripple/protocol/tests/Quality.test.cpp
+++ b/src/ripple/protocol/tests/Quality.test.cpp
@@ -31,7 +31,7 @@ public:
     STAmount
     static raw (std::uint64_t mantissa, int exponent)
     {
-        return STAmount ({Currency(3), Account(3)}, mantissa, exponent);
+        return STAmount ({Currency(3), AccountID(3)}, mantissa, exponent);
     }
 
     template <class Integer>

--- a/src/ripple/protocol/tests/STAmount.test.cpp
+++ b/src/ripple/protocol/tests/STAmount.test.cpp
@@ -175,7 +175,7 @@ public:
         {
             testcase ("set value (iou)");
 
-            Issue const usd (Currency (0x5553440000000000), Account (0x4985601));
+            Issue const usd (Currency (0x5553440000000000), AccountID (0x4985601));
 
             testSetValue ("1", usd);
             testSetValue ("10", usd);

--- a/src/ripple/protocol/tests/STTx.test.cpp
+++ b/src/ripple/protocol/tests/STTx.test.cpp
@@ -101,10 +101,10 @@ public:
         RippleAddress const saGenerator = saSeed.createGeneratorPublic (saSeed);
         RippleAddress const saPublicAcct =
             saSeed.createAccountPublic (saGenerator, 1);
-        Account const saID = saPublicAcct.getAccountID ();
+        AccountID const saID = saPublicAcct.getAccountID ();
 
         // Create a field for SigningFor
-        Account const signingForID = txnPublicAcct.getAccountID ();
+        AccountID const signingForID = txnPublicAcct.getAccountID ();
 
         RippleAddress saPrivateAcct =
             saSeed.createAccountPrivate(saGenerator, saSeed, 0);
@@ -118,7 +118,7 @@ public:
         // The InnerObjectFormats say a SigningAccount is supposed to look
         // like this:
         // SigningAccount {
-        //     Account: "...",
+        //     AccountID: "...",
         //     MultiSignature: "...",
         //     PublicKey: "...""
         // }

--- a/src/ripple/protocol/tests/STTx.test.cpp
+++ b/src/ripple/protocol/tests/STTx.test.cpp
@@ -118,7 +118,7 @@ public:
         // The InnerObjectFormats say a SigningAccount is supposed to look
         // like this:
         // SigningAccount {
-        //     AccountID: "...",
+        //     Account: "...",
         //     MultiSignature: "...",
         //     PublicKey: "...""
         // }

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -71,7 +71,7 @@ Json::Value doAccountInfo (RPC::Context& context)
         asAccepted->addJson (jvAccepted);
 
         // See if there's a SignerEntries for this account.
-        Account const account = naAccount.getAccountID ();
+        AccountID const account = naAccount.getAccountID ();
         uint256 const signerListIndex = getSignerListIndex (account);
         auto const signerList = fetch(*ledger, signerListIndex,
             getApp().getSLECache());

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -27,9 +27,9 @@ namespace ripple {
 struct VisitData
 {
     std::vector <RippleState::pointer> items;
-    Account const& accountID;
+    AccountID const& accountID;
     RippleAddress const& rippleAddressPeer;
-    Account const& raPeerAccount;
+    AccountID const& raPeerAccount;
 };
 
 void addLine (Json::Value& jsonLines, RippleState const& line)
@@ -126,7 +126,7 @@ Json::Value doAccountLines (RPC::Context& context)
             return result;
     }
 
-    Account raPeerAccount;
+    AccountID raPeerAccount;
     if (rippleAddressPeer.isValid ())
         raPeerAccount = rippleAddressPeer.getAccountID ();
 
@@ -152,7 +152,7 @@ Json::Value doAccountLines (RPC::Context& context)
     }
 
     Json::Value& jsonLines (result[jss::lines] = Json::arrayValue);
-    Account const& raAccount(rippleAddress.getAccountID ());
+    AccountID const& raAccount(rippleAddress.getAccountID ());
     VisitData visitData = { {}, raAccount, rippleAddressPeer, raPeerAccount };
     unsigned int reserve (limit);
     uint256 startAfter;

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -88,7 +88,7 @@ Json::Value doAccountOffers (RPC::Context& context)
         limit = RPC::Tuning::defaultOffersPerRequest;
     }
 
-    Account const& raAccount (rippleAddress.getAccountID ());
+    AccountID const& raAccount (rippleAddress.getAccountID ());
     Json::Value& jsonOffers (result[jss::offers] = Json::arrayValue);
     std::vector <std::shared_ptr<SLE const>> offers;
     unsigned int reserve (limit);

--- a/src/ripple/rpc/handlers/BookOffers.cpp
+++ b/src/ripple/rpc/handlers/BookOffers.cpp
@@ -82,7 +82,7 @@ Json::Value doBookOffers (RPC::Context& context)
             "Invalid field 'taker_gets.currency', bad currency.");
     }
 
-    Account pay_issuer;
+    AccountID pay_issuer;
 
     if (taker_pays.isMember (jss::issuer))
     {
@@ -112,7 +112,7 @@ Json::Value doBookOffers (RPC::Context& context)
         return RPC::make_error (rpcSRC_ISR_MALFORMED,
             "Invalid field 'taker_pays.issuer', expected non-XRP issuer.");
 
-    Account get_issuer;
+    AccountID get_issuer;
 
     if (taker_gets.isMember (jss::issuer))
     {

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -32,7 +32,7 @@ static void fillTransaction (
     Ledger::ref ledger)
 {
     txArray["Sequence"] = Json::UInt (sequence++);
-    txArray["AccountID"] = account.humanAccountID ();
+    txArray["Account"] = account.humanAccountID ();
     txArray["Fee"] = Json::UInt (scaleFeeLoad (
         getApp().getFeeTrack(), *ledger, 10, false));
 }

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -32,7 +32,7 @@ static void fillTransaction (
     Ledger::ref ledger)
 {
     txArray["Sequence"] = Json::UInt (sequence++);
-    txArray["Account"] = account.humanAccountID ();
+    txArray["AccountID"] = account.humanAccountID ();
     txArray["Fee"] = Json::UInt (scaleFeeLoad (
         getApp().getFeeTrack(), *ledger, 10, false));
 }
@@ -162,7 +162,7 @@ Json::Value doNoRippleCheck (RPC::Context& context)
                 }
                 if (needFix)
                 {
-                    Account peer =
+                    AccountID peer =
                         ownedItem->getFieldAmount (bLow ? sfHighLimit : sfLowLimit).getIssuer();
                     STAmount peerLimit = ownedItem->getFieldAmount (bLow ? sfHighLimit : sfLowLimit);
                     problem += to_string (peerLimit.getCurrency());

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -288,8 +288,8 @@ ripplePathFind(RippleLineCache::pointer const& cache,
                 saMaxAmount,            // --> Amount to send is unlimited
                 //     to get an estimate.
                 saDstAmount,            // --> Amount to deliver.
-                raDst.getAccountID(),  // --> AccountID to deliver to.
-                raSrc.getAccountID(),  // --> AccountID sending from.
+                raDst.getAccountID(),   // --> Account to deliver to.
+                raSrc.getAccountID(),   // --> Account sending from.
                 spsComputed);           // --> Path set.
 
             WriteLog(lsWARNING, RPCHandler)
@@ -312,9 +312,9 @@ ripplePathFind(RippleLineCache::pointer const& cache,
                     saMaxAmount,            // --> Amount to send is unlimited
                     //     to get an estimate.
                     saDstAmount,            // --> Amount to deliver.
-                    raDst.getAccountID(),  // --> AccountID to deliver to.
-                    raSrc.getAccountID(),  // --> AccountID sending from.
-                    spsComputed);         // --> Path set.
+                    raDst.getAccountID(),   // --> Account to deliver to.
+                    raSrc.getAccountID(),   // --> Account sending from.
+                    spsComputed);           // --> Path set.
                 WriteLog(lsDEBUG, PathRequest)
                     << "Extra path element gives "
                     << transHuman(rc.result());

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -214,7 +214,7 @@ ripplePathFind(RippleLineCache::pointer const& cache,
         Json::Value jvSource = jvSrcCurrencies[i];
 
         Currency uSrcCurrencyID;
-        Account uSrcIssuerID;
+        AccountID uSrcIssuerID;
 
         if (!jvSource.isObject())
             return std::make_pair(false, rpcError(rpcINVALID_PARAMS));
@@ -275,7 +275,7 @@ ripplePathFind(RippleLineCache::pointer const& cache,
                 isXRP(uSrcIssuerID) ?
                 isXRP(uSrcCurrencyID) ? // Default to source account.
                 xrpAccount() :
-                Account(raSrc.getAccountID())
+                AccountID(raSrc.getAccountID())
                 : uSrcIssuerID;            // Use specifed issuer.
 
             STAmount saMaxAmount({ uSrcCurrencyID, issuer }, 1);
@@ -288,8 +288,8 @@ ripplePathFind(RippleLineCache::pointer const& cache,
                 saMaxAmount,            // --> Amount to send is unlimited
                 //     to get an estimate.
                 saDstAmount,            // --> Amount to deliver.
-                raDst.getAccountID(),  // --> Account to deliver to.
-                raSrc.getAccountID(),  // --> Account sending from.
+                raDst.getAccountID(),  // --> AccountID to deliver to.
+                raSrc.getAccountID(),  // --> AccountID sending from.
                 spsComputed);           // --> Path set.
 
             WriteLog(lsWARNING, RPCHandler)
@@ -312,8 +312,8 @@ ripplePathFind(RippleLineCache::pointer const& cache,
                     saMaxAmount,            // --> Amount to send is unlimited
                     //     to get an estimate.
                     saDstAmount,            // --> Amount to deliver.
-                    raDst.getAccountID(),  // --> Account to deliver to.
-                    raSrc.getAccountID(),  // --> Account sending from.
+                    raDst.getAccountID(),  // --> AccountID to deliver to.
+                    raSrc.getAccountID(),  // --> AccountID sending from.
                     spsComputed);         // --> Path set.
                 WriteLog(lsDEBUG, PathRequest)
                     << "Extra path element gives "

--- a/src/ripple/rpc/impl/GetAccountObjects.cpp
+++ b/src/ripple/rpc/impl/GetAccountObjects.cpp
@@ -26,7 +26,7 @@ namespace ripple {
 namespace RPC {
 
 bool
-getAccountObjects (Ledger const& ledger, Account const& account,
+getAccountObjects (Ledger const& ledger, AccountID const& account,
     LedgerEntryType const type, uint256 dirIndex, uint256 const& entryIndex,
     std::uint32_t const limit, Json::Value& jvResult)
 {

--- a/src/ripple/rpc/impl/GetAccountObjects.h
+++ b/src/ripple/rpc/impl/GetAccountObjects.h
@@ -27,7 +27,7 @@ namespace RPC {
 
 /** Gathers all objects for an account in a ledger.
     @param ledger Ledger to search account objects.
-    @param account Account to find objects for.
+    @param account AccountID to find objects for.
     @param type Gathers objects of this type. ltINVALID gathers all types.
     @param dirIndex Begin gathering account objects from this directory.
     @param entryIndex Begin gathering objects from this directory node.
@@ -35,7 +35,7 @@ namespace RPC {
     @param jvResult A JSON result that holds the request objects.
 */
 bool
-getAccountObjects (Ledger const& ledger, Account const& account,
+getAccountObjects (Ledger const& ledger, AccountID const& account,
     LedgerEntryType const type, uint256 dirIndex, uint256 const& entryIndex,
     std::uint32_t const limit, Json::Value& jvResult);
 

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -448,7 +448,7 @@ static Json::Value checkPayment(
 //
 // Returns a pair<Json::Value, RippleAddress>.  The Json::Value is non-empty
 // and contains as error if there was an error.  The returned RippleAddress
-// is the "AccountID" addressID if there was no error.
+// is the "Account" addressID if there was no error.
 //
 // This code does not check the "Sequence" field, since the expectations
 // for that field are particularly context sensitive.
@@ -476,7 +476,7 @@ checkTxJsonFields (
     if (! tx_json.isMember (jss::Account))
     {
         ret.first = RPC::make_error (rpcSRC_ACT_MISSING,
-            RPC::missing_field_message ("tx_json.AccountID"));
+            RPC::missing_field_message ("tx_json.Account"));
         return ret;
     }
 
@@ -485,7 +485,7 @@ checkTxJsonFields (
     if (! srcAddressID.setAccountID (tx_json[jss::Account].asString ()))
     {
         ret.first = RPC::make_error (rpcSRC_ACT_MALFORMED,
-            RPC::invalid_field_message ("tx_json.AccountID"));
+            RPC::invalid_field_message ("tx_json.Account"));
         return ret;
     }
 
@@ -1223,7 +1223,7 @@ Json::Value transactionSubmitMultiSigned (
         if (dupAccountItr != multiSignersEnd)
         {
             std::ostringstream err;
-            err << "Duplicate SigningFor:AccountID entries ("
+            err << "Duplicate SigningFor:Account entries ("
                 << dupAccountItr->getFieldAccount (sfAccount).humanAccountID ()
                 << ") are not allowed.";
             return RPC::make_param_error(err.str ());
@@ -1245,7 +1245,7 @@ Json::Value transactionSubmitMultiSigned (
         if (dupAccountItr != signingAcctsEnd)
         {
             std::ostringstream err;
-            err << "Duplicate SigningAccounts:SigningAccount:AccountID entries ("
+            err << "Duplicate SigningAccounts:SigningAccount:Account entries ("
                 << dupAccountItr->getFieldAccount (sfAccount).humanAccountID ()
                 << ") are not allowed.";
             return RPC::make_param_error(err.str ());

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -203,7 +203,7 @@ error_code_i acctMatchesPubKey (
     RippleAddress const& accountID,
     RippleAddress const& publicKey)
 {
-    Account const publicKeyAcctID = publicKey.getAccountID ();
+    AccountID const publicKeyAcctID = publicKey.getAccountID ();
     bool const isMasterKey = publicKeyAcctID == accountID.getAccountID ();
 
     // If we can't get the accountRoot, but the accountIDs match, that's
@@ -448,7 +448,7 @@ static Json::Value checkPayment(
 //
 // Returns a pair<Json::Value, RippleAddress>.  The Json::Value is non-empty
 // and contains as error if there was an error.  The returned RippleAddress
-// is the "Account" addressID if there was no error.
+// is the "AccountID" addressID if there was no error.
 //
 // This code does not check the "Sequence" field, since the expectations
 // for that field are particularly context sensitive.
@@ -476,7 +476,7 @@ checkTxJsonFields (
     if (! tx_json.isMember (jss::Account))
     {
         ret.first = RPC::make_error (rpcSRC_ACT_MISSING,
-            RPC::missing_field_message ("tx_json.Account"));
+            RPC::missing_field_message ("tx_json.AccountID"));
         return ret;
     }
 
@@ -485,7 +485,7 @@ checkTxJsonFields (
     if (! srcAddressID.setAccountID (tx_json[jss::Account].asString ()))
     {
         ret.first = RPC::make_error (rpcSRC_ACT_MALFORMED,
-            RPC::invalid_field_message ("tx_json.Account"));
+            RPC::invalid_field_message ("tx_json.AccountID"));
         return ret;
     }
 
@@ -1210,7 +1210,7 @@ Json::Value transactionSubmitMultiSigned (
                     b.getFieldAccount (sfAccount).getAccountID ()); };
 
     {
-        // MultiSigners are submitted sorted in Account order.  This
+        // MultiSigners are submitted sorted in AccountID order.  This
         // assures that the same list will always have the same hash.
         multiSigners.sort (byFieldAccountID);
 
@@ -1223,7 +1223,7 @@ Json::Value transactionSubmitMultiSigned (
         if (dupAccountItr != multiSignersEnd)
         {
             std::ostringstream err;
-            err << "Duplicate SigningFor:Account entries ("
+            err << "Duplicate SigningFor:AccountID entries ("
                 << dupAccountItr->getFieldAccount (sfAccount).humanAccountID ()
                 << ") are not allowed.";
             return RPC::make_param_error(err.str ());
@@ -1245,7 +1245,7 @@ Json::Value transactionSubmitMultiSigned (
         if (dupAccountItr != signingAcctsEnd)
         {
             std::ostringstream err;
-            err << "Duplicate SigningAccounts:SigningAccount:Account entries ("
+            err << "Duplicate SigningAccounts:SigningAccount:AccountID entries ("
                 << dupAccountItr->getFieldAccount (sfAccount).humanAccountID ()
                 << ") are not allowed.";
             return RPC::make_param_error(err.str ());

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -51,7 +51,7 @@ R"({
     "command": "doesnt_matter",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -70,7 +70,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Fee": 10,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -90,7 +90,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Sequence": 0,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -111,7 +111,7 @@ R"({
     "tx_json": {
         "Sequence": 0,
         "Fee": 10,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -132,7 +132,7 @@ R"({
     "fee_mult_max": 7,
     "tx_json": {
         "Sequence": 0,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -154,7 +154,7 @@ R"({
     "tx_json": {
         "Sequence": 0,
         "Fee": 10,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -175,7 +175,7 @@ R"({
     "fee_mult_max": "NotAFeeMultiplier",
     "tx_json": {
         "Sequence": 0,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -196,7 +196,7 @@ R"({
     "fee_mult_max": 0,
     "tx_json": {
         "Sequence": 0,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -215,7 +215,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
     }
@@ -233,7 +233,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "NotAnAmount",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -252,7 +252,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "TransactionType": "Payment"
     }
@@ -270,7 +270,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "NotADestination",
         "TransactionType": "Payment"
@@ -290,7 +290,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -310,7 +310,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -334,7 +334,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -359,7 +359,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -388,7 +388,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -411,7 +411,7 @@ R"({
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -430,7 +430,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -449,7 +449,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "rx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -468,7 +468,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     }
@@ -486,7 +486,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "tt"
@@ -505,7 +505,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": 0
@@ -517,7 +517,7 @@ R"({
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
-{ "'Account' must be present.",
+{ "'AccountID' must be present.",
 R"({
     "command": "doesnt_matter",
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -530,27 +530,27 @@ R"({
     }
 })",
 {
-"Missing field 'tx_json.Account'.",
-"Missing field 'tx_json.Account'.",
+"Missing field 'tx_json.AccountID'.",
+"Missing field 'tx_json.AccountID'.",
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
-{ "'Account' must be well formed.",
+{ "'AccountID' must be well formed.",
 R"({
     "command": "doesnt_matter",
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "NotAnAccount",
+        "AccountID": "NotAnAccount",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
     }
 })",
 {
-"Invalid field 'tx_json.Account'.",
-"Invalid field 'tx_json.Account'.",
+"Invalid field 'tx_json.AccountID'.",
+"Invalid field 'tx_json.AccountID'.",
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
@@ -562,7 +562,7 @@ R"({
     "secret": "masterpassphrase",
     "offline": 0,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -582,7 +582,7 @@ R"({
     "secret": "masterpassphrase",
     "offline": 1,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -603,7 +603,7 @@ R"({
     "offline": 1,
     "tx_json": {
         "Sequence": 0,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -623,7 +623,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Flags": 0,
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -643,7 +643,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Flags": "NotGoodFlags",
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -663,7 +663,7 @@ R"({
     "secret": "masterpassphrase",
     "debug_signing": 0,
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -682,7 +682,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -697,7 +697,7 @@ R"({
 "",
 "Missing field 'MultiSigners'."}},
 
-{ "Missing 'Account' in sign_for.",
+{ "Missing 'AccountID' in sign_for.",
 R"({
     "command": "doesnt_matter",
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -713,10 +713,10 @@ R"({
     }
 })",
 {
-"Missing field 'tx_json.Account'.",
-"Missing field 'tx_json.Account'.",
-"Missing field 'tx_json.Account'.",
-"Missing field 'tx_json.Account'."}},
+"Missing field 'tx_json.AccountID'.",
+"Missing field 'tx_json.AccountID'.",
+"Missing field 'tx_json.AccountID'.",
+"Missing field 'tx_json.AccountID'."}},
 
 { "Missing 'Amount' in sign_for.",
 R"({
@@ -725,7 +725,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
         "Sequence": 0,
@@ -746,7 +746,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Fee": 50,
         "Sequence": 0,
@@ -767,7 +767,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Sequence": 0,
@@ -788,7 +788,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -809,7 +809,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -830,7 +830,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -852,7 +852,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -872,11 +872,11 @@ R"({
     "MultiSigners": [
         {
             "SigningFor": {
-                "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
                 "SigningAccounts": [
                     {
                         "SigningAccount": {
-                            "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                            "AccountID": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                             "MultiSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
                             "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
                         }
@@ -886,7 +886,7 @@ R"({
         }
     ],
     "tx_json": {
-        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -51,7 +51,7 @@ R"({
     "command": "doesnt_matter",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -70,7 +70,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Fee": 10,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -90,7 +90,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Sequence": 0,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -111,7 +111,7 @@ R"({
     "tx_json": {
         "Sequence": 0,
         "Fee": 10,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -132,7 +132,7 @@ R"({
     "fee_mult_max": 7,
     "tx_json": {
         "Sequence": 0,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -154,7 +154,7 @@ R"({
     "tx_json": {
         "Sequence": 0,
         "Fee": 10,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -175,7 +175,7 @@ R"({
     "fee_mult_max": "NotAFeeMultiplier",
     "tx_json": {
         "Sequence": 0,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -196,7 +196,7 @@ R"({
     "fee_mult_max": 0,
     "tx_json": {
         "Sequence": 0,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -215,7 +215,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
     }
@@ -233,7 +233,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "NotAnAmount",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -252,7 +252,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "TransactionType": "Payment"
     }
@@ -270,7 +270,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "NotADestination",
         "TransactionType": "Payment"
@@ -290,7 +290,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -310,7 +310,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -334,7 +334,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -359,7 +359,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -388,7 +388,7 @@ R"({
     "secret": "masterpassphrase",
     "build_path": 1,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": {
             "value": "10",
             "currency": "USD",
@@ -411,7 +411,7 @@ R"({
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -430,7 +430,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -449,7 +449,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "rx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -468,7 +468,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     }
@@ -486,7 +486,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "tt"
@@ -505,7 +505,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": 0
@@ -517,7 +517,7 @@ R"({
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
-{ "'AccountID' must be present.",
+{ "'Account' must be present.",
 R"({
     "command": "doesnt_matter",
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -530,27 +530,27 @@ R"({
     }
 })",
 {
-"Missing field 'tx_json.AccountID'.",
-"Missing field 'tx_json.AccountID'.",
+"Missing field 'tx_json.Account'.",
+"Missing field 'tx_json.Account'.",
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
-{ "'AccountID' must be well formed.",
+{ "'Account' must be well formed.",
 R"({
     "command": "doesnt_matter",
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "NotAnAccount",
+        "Account": "NotAnAccount",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
     }
 })",
 {
-"Invalid field 'tx_json.AccountID'.",
-"Invalid field 'tx_json.AccountID'.",
+"Invalid field 'tx_json.Account'.",
+"Invalid field 'tx_json.Account'.",
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
@@ -562,7 +562,7 @@ R"({
     "secret": "masterpassphrase",
     "offline": 0,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -582,7 +582,7 @@ R"({
     "secret": "masterpassphrase",
     "offline": 1,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -603,7 +603,7 @@ R"({
     "offline": 1,
     "tx_json": {
         "Sequence": 0,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -623,7 +623,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Flags": 0,
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -643,7 +643,7 @@ R"({
     "secret": "masterpassphrase",
     "tx_json": {
         "Flags": "NotGoodFlags",
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -663,7 +663,7 @@ R"({
     "secret": "masterpassphrase",
     "debug_signing": 0,
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "TransactionType": "Payment"
@@ -682,7 +682,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -697,7 +697,7 @@ R"({
 "",
 "Missing field 'MultiSigners'."}},
 
-{ "Missing 'AccountID' in sign_for.",
+{ "Missing 'Account' in sign_for.",
 R"({
     "command": "doesnt_matter",
     "account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -713,10 +713,10 @@ R"({
     }
 })",
 {
-"Missing field 'tx_json.AccountID'.",
-"Missing field 'tx_json.AccountID'.",
-"Missing field 'tx_json.AccountID'.",
-"Missing field 'tx_json.AccountID'."}},
+"Missing field 'tx_json.Account'.",
+"Missing field 'tx_json.Account'.",
+"Missing field 'tx_json.Account'.",
+"Missing field 'tx_json.Account'."}},
 
 { "Missing 'Amount' in sign_for.",
 R"({
@@ -725,7 +725,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
         "Sequence": 0,
@@ -746,7 +746,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Fee": 50,
         "Sequence": 0,
@@ -767,7 +767,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Sequence": 0,
@@ -788,7 +788,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -809,7 +809,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -830,7 +830,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -852,7 +852,7 @@ R"({
     "signing_for": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
     "secret": "masterpassphrase",
     "tx_json": {
-        "AccountID": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Account": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Amount": "1000000000",
         "Destination": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Fee": 50,
@@ -872,11 +872,11 @@ R"({
     "MultiSigners": [
         {
             "SigningFor": {
-                "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
                 "SigningAccounts": [
                     {
                         "SigningAccount": {
-                            "AccountID": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                            "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
                             "MultiSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
                             "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
                         }
@@ -886,7 +886,7 @@ R"({
         }
     ],
     "tx_json": {
-        "AccountID": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -33,9 +33,11 @@
 #include <ripple/nodestore/Database.h>
 #include <ripple/nodestore/NodeObject.h>
 #include <beast/utility/Journal.h>
+#include <boost/iterator/iterator_facade.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/shared_lock_guard.hpp>
 #include <boost/thread/shared_mutex.hpp>
+#include <cassert>
 #include <stack>
 
 namespace ripple {
@@ -110,6 +112,19 @@ public:
         uint256 const& hash,
         Family& f,
         beast::Journal journal);
+
+    //--------------------------------------------------------------------------
+
+    /** Iterator to a SHAMap's leaves
+        This is always a const iterator.
+        Meets the requirements of ForwardRange.
+    */
+    class iterator;
+
+    iterator begin() const;
+    iterator end() const;
+
+    //--------------------------------------------------------------------------
 
     // Returns a new map that's a snapshot of this one.
     // Handles copy on write for mutable snapshots.
@@ -327,6 +342,70 @@ void
 SHAMap::setUnbacked ()
 {
     backed_ = false;
+}
+
+//------------------------------------------------------------------------------
+
+class SHAMap::iterator
+    : public boost::iterator_facade<
+        SHAMap::iterator,
+            std::shared_ptr<SHAMapItem const> const,
+                std::forward_iterator_tag>
+{
+private:
+    friend class boost::iterator_core_access;
+
+    SHAMap const* map_ = nullptr;
+    std::shared_ptr<
+        SHAMapItem const> item_;
+
+public:
+    iterator() = default;
+    iterator (iterator const&) = default;
+    iterator& operator= (iterator const&) = default;
+
+    iterator (SHAMap const& map,
+        std::shared_ptr<SHAMapItem const> const& item)
+        : map_(&map)
+        , item_(item)
+    {
+    }
+
+private:
+    void
+    increment()
+    {
+        item_ = map_->peekNextItem(
+            item_->key());
+    }
+
+    bool
+    equal (iterator const& other) const
+    {
+        assert(map_ == other.map_);
+        return item_ == other.item_;
+    }
+
+    std::shared_ptr<
+        SHAMapItem const> const&
+    dereference() const
+    {
+        return item_;
+    }
+};
+
+inline
+SHAMap::iterator
+SHAMap::begin() const
+{
+    return iterator(*this, peekFirstItem());
+}
+
+inline
+SHAMap::iterator
+SHAMap::end() const
+{
+    return iterator(*this, nullptr);
 }
 
 }

--- a/src/ripple/test/jtx/Account.h
+++ b/src/ripple/test/jtx/Account.h
@@ -41,7 +41,7 @@ private:
     //             instead of RippleAddress
     RippleAddress pk_;
     RippleAddress sk_;
-    ripple::Account id_;
+    AccountID id_;
     std::string human_; // base58 public key string
 
 public:
@@ -96,7 +96,7 @@ public:
 
         The Account ID is the uint160 hash of the public key.
     */
-    ripple::Account
+    AccountID
     id() const
     {
         return id_;
@@ -112,9 +112,9 @@ public:
     /** Implicit conversion to AccountID.
 
         This allows passing an Account
-        where a ripple::Account is expected.
+        where a AccountID is expected.
     */
-    operator ripple::Account() const
+    operator AccountID() const
     {
         return id_;
     }

--- a/src/ripple/test/jtx/Account.h
+++ b/src/ripple/test/jtx/Account.h
@@ -112,7 +112,7 @@ public:
     /** Implicit conversion to AccountID.
 
         This allows passing an Account
-        where a AccountID is expected.
+        where an AccountID is expected.
     */
     operator AccountID() const
     {

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -167,7 +167,7 @@ public:
     lookup (std::string const& base58ID) const;
 
     Account const&
-    lookup (ripple::Account const& id) const;
+    lookup (AccountID const& id) const;
     /** @} */
 
     /** Returns the XRP balance on an account.
@@ -467,7 +467,7 @@ protected:
 
     // Map of account IDs to Account
     std::unordered_map<
-        ripple::Account, Account> map_;
+        AccountID, Account> map_;
 
     bool fill_fee_ = true;
     bool fill_seq_ = true;

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -37,7 +37,6 @@
 #include <ripple/protocol/STTx.h>
 #include <beast/is_call_possible.h>
 #include <beast/unit_test/suite.h>
-#include <boost/logic/tribool.hpp>
 #include <beast/cxx14/type_traits.h> // <type_traits>
 #include <beast/cxx14/utility.h> // <utility>
 #include <functional>
@@ -48,36 +47,6 @@
 namespace ripple {
 namespace test {
 namespace jtx {
-
-/** A view to an account's account root. */
-class AccountInfo
-{
-private:
-    Account account_;
-    std::shared_ptr<Ledger> ledger_;
-    std::shared_ptr<SLE const> root_;
-
-public:
-    AccountInfo(Account const& account,
-            std::shared_ptr<Ledger> ledger)
-        : account_(account)
-        , ledger_(std::move(ledger))
-        , root_(ledger_->fetch(
-            getAccountRootIndex(account.id())))
-    {
-    }
-
-    STAmount
-    balance (Issue const& issue) const;
-
-    std::uint32_t
-    seq() const;
-
-    std::uint32_t
-    flags() const;
-};
-
-//------------------------------------------------------------------------------
 
 namespace detail {
 
@@ -164,10 +133,10 @@ public:
     /** Returns the Account given the AccountID. */
     /** @{ */
     Account const&
-    lookup (std::string const& base58ID) const;
+    lookup (AccountID const& id) const;
 
     Account const&
-    lookup (AccountID const& id) const;
+    lookup (std::string const& base58ID) const;
     /** @} */
 
     /** Returns the XRP balance on an account.
@@ -203,26 +172,6 @@ public:
     // VFALCO NOTE Use Keylet here
     std::shared_ptr<SLE const>
     le (uint256 const& key) const;
-
-    /** Set the fee autofill setting. */
-    void auto_fee (bool value)
-    {
-        fill_fee_ = value;
-    }
-
-    /** Set the sequence number autofill setting. */
-    void auto_seq (bool value)
-    {
-        fill_seq_ = value;
-    }
-
-    /** Set the signature autofill setting.
-        @note autofill multisigning is not supported
-    */
-    void auto_sig (bool value)
-    {
-        fill_sig_ = value;
-    }
 
     /** Create a JTx from parameters. */
     template <class JsonValue,
@@ -468,10 +417,6 @@ protected:
     // Map of account IDs to Account
     std::unordered_map<
         AccountID, Account> map_;
-
-    bool fill_fee_ = true;
-    bool fill_seq_ = true;
-    bool fill_sig_ = true;
 };
 
 } // jtx

--- a/src/ripple/test/jtx/JTx.h
+++ b/src/ripple/test/jtx/JTx.h
@@ -23,7 +23,6 @@
 #include <ripple/test/jtx/requires.h>
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/TER.h>
-#include <boost/logic/tribool.hpp>
 #include <functional>
 
 namespace ripple {
@@ -32,17 +31,15 @@ namespace jtx {
 
 class Env;
 
-BOOST_TRIBOOL_THIRD_STATE(use_default)
-
 /** Execution context for applying a JSON transaction.
     This augments the transaction with various settings.
 */
 struct JTx
 {
     Json::Value jv;
-    boost::tribool fill_fee = boost::logic::indeterminate;
-    boost::tribool fill_seq = boost::logic::indeterminate;
-    boost::tribool fill_sig = boost::logic::indeterminate;
+    bool fill_fee = true;
+    bool fill_seq = true;
+    bool fill_sig = true;
     std::function<void(Env&, JTx&)> signer;
     requires_t requires;
     TER ter = tesSUCCESS;

--- a/src/ripple/test/jtx/amount.h
+++ b/src/ripple/test/jtx/amount.h
@@ -358,7 +358,7 @@ struct AnyAmount
 
     // Reset the issue to a specific account
     void
-    to (ripple::Account const& id)
+    to (AccountID const& id)
     {
         if (! is_any)
             return;

--- a/src/ripple/test/jtx/fee.h
+++ b/src/ripple/test/jtx/fee.h
@@ -23,7 +23,7 @@
 #include <ripple/test/jtx/Env.h>
 #include <ripple/test/jtx/tags.h>
 #include <ripple/protocol/STAmount.h>
-#include <boost/logic/tribool.hpp>
+#include <boost/optional.hpp>
 
 namespace ripple {
 namespace test {
@@ -33,28 +33,26 @@ namespace jtx {
 class fee
 {
 private:
-    STAmount v_;
-    boost::tribool b_ =
-        boost::logic::indeterminate;
+    bool manual_ = true;
+    boost::optional<STAmount> amount_;
 
 public:
     explicit
     fee (autofill_t)
-        : b_(true)
+        : manual_(false)
     {
     }
 
     explicit
     fee (none_t)
-        : b_(false)
     {
     }
 
     explicit
-    fee (STAmount const& v)
-        : v_(v)
+    fee (STAmount const& amount)
+        : amount_(amount)
     {
-        if (! isXRP(v_))
+        if (! isXRP(*amount_))
             throw std::runtime_error(
                 "fee: not XRP");
     }

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -78,7 +78,7 @@ Env::lookup (std::string const& base58ID) const
 }
 
 Account const&
-Env::lookup (ripple::Account const& id) const
+Env::lookup (AccountID const& id) const
 {
     auto const iter = map_.find(id);
     if (iter == map_.end())

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -58,7 +58,7 @@ public:
         Account("alice", KeyType::secp256k1);
         Account("alice", KeyType::ed25519);
         auto const gw = Account("gw");
-        [](ripple::Account){}(gw);
+        [](AccountID){}(gw);
         auto const USD = gw["USD"];
         void(Account("alice") < gw);
         std::set<Account>().emplace(gw);

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -165,13 +165,6 @@ public:
             env.require(nflags("xavier", asfDefaultRipple));
             env.fund(n, "yana");
             env.require(flags("yana", asfDefaultRipple));
-
-            // fund always autofills
-            env.auto_fee(false);
-            env.auto_seq(false);
-            env.auto_sig(false);
-            env.fund(n, "zeke");
-            env.require(balance("zeke", n));
         }
 
         // trust
@@ -179,13 +172,6 @@ public:
             Env env(*this);
             env.fund(n, "alice", "bob", gw);
             env(trust("alice", USD(100)), require(lines("alice", 1)));
-
-            // trust always autofills
-            env.auto_fee(false);
-            env.auto_seq(false);
-            env.auto_sig(false);
-            env.trust(USD(100), "bob");
-            env.require(lines("bob", 1));
         }
 
         // balance
@@ -215,7 +201,6 @@ public:
         {
             Env env(*this);
             env.fund(n, "alice");
-            env.auto_fee(false);
             env.require(balance("alice", n));
             env(noop("alice"), fee(1),                  ter(telINSUF_FEE_P));
             env(noop("alice"), seq(none),               ter(temMALFORMED));
@@ -223,9 +208,7 @@ public:
             env(noop("alice"), fee(none),               ter(temMALFORMED));
             env(noop("alice"), sig(none),               ter(temMALFORMED));
             env(noop("alice"), fee(autofill));
-            env.auto_seq(false);
             env(noop("alice"), fee(autofill), seq(autofill));
-            env.auto_sig(false);
             env(noop("alice"), fee(autofill), seq(autofill), sig(autofill));
         }
     }

--- a/src/ripple/test/jtx/impl/fee.cpp
+++ b/src/ripple/test/jtx/impl/fee.cpp
@@ -28,11 +28,12 @@ namespace jtx {
 void
 fee::operator()(Env const&, JTx& jt) const
 {
-    if (boost::indeterminate(b_))
+    if (! manual_)
+        return;
+    jt.fill_fee = false;
+    if (amount_)
         jt[jss::Fee] =
-            v_.getJson(0);
-    else
-        jt.fill_fee = b_;
+            amount_->getJson(0);
 }
 
 } // jtx

--- a/src/ripple/test/jtx/impl/owners.cpp
+++ b/src/ripple/test/jtx/impl/owners.cpp
@@ -29,7 +29,7 @@ namespace detail {
 
 std::uint32_t
 owned_count_of(Ledger const& ledger,
-    ripple::Account const& id,
+    AccountID const& id,
         LedgerEntryType type)
 {
     std::uint32_t count = 0;
@@ -44,7 +44,7 @@ owned_count_of(Ledger const& ledger,
 
 void
 owned_count_helper(Env const& env,
-    ripple::Account const& id,
+    AccountID const& id,
         LedgerEntryType type,
             std::uint32_t value)
 {

--- a/src/ripple/test/jtx/impl/seq.cpp
+++ b/src/ripple/test/jtx/impl/seq.cpp
@@ -28,10 +28,11 @@ namespace jtx {
 void
 seq::operator()(Env const&, JTx& jt) const
 {
-    if (boost::indeterminate(b_))
-        jt[jss::Sequence] = v_;
-    else
-        jt.fill_seq = b_;
+    if (! manual_)
+        return;
+    jt.fill_seq = false;
+    if (num_)
+        jt[jss::Sequence] = *num_;
 }
 
 } // jtx

--- a/src/ripple/test/jtx/impl/sig.cpp
+++ b/src/ripple/test/jtx/impl/sig.cpp
@@ -28,18 +28,17 @@ namespace jtx {
 void
 sig::operator()(Env const&, JTx& jt) const
 {
-    if(boost::indeterminate(b_))
+    if (! manual_)
+        return;
+    jt.fill_sig = false;
+    if(account_)
     {
         // VFALCO Inefficient pre-C++14
-        auto const account = account_;
+        auto const account = *account_;
         jt.signer = [account](Env&, JTx& jt)
         {
             jtx::sign(jt.jv, account);
         };
-    }
-    else
-    {
-        jt.fill_sig = b_;
     }
 }
 

--- a/src/ripple/test/jtx/owners.h
+++ b/src/ripple/test/jtx/owners.h
@@ -34,12 +34,12 @@ namespace detail {
 
 std::uint32_t
 owned_count_of (Ledger const& ledger,
-    ripple::Account const& id,
+    AccountID const& id,
         LedgerEntryType type);
 
 void
 owned_count_helper(Env const& env,
-    ripple::Account const& id,
+    AccountID const& id,
         LedgerEntryType type,
             std::uint32_t value);
 

--- a/src/ripple/test/jtx/seq.h
+++ b/src/ripple/test/jtx/seq.h
@@ -22,7 +22,7 @@
 
 #include <ripple/test/jtx/Env.h>
 #include <ripple/test/jtx/tags.h>
-#include <boost/logic/tribool.hpp>
+#include <boost/optional.hpp>
 
 namespace ripple {
 namespace test {
@@ -32,26 +32,24 @@ namespace jtx {
 struct seq
 {
 private:
-    std::uint32_t v_;
-    boost::tribool b_ =
-        boost::logic::indeterminate;
+    bool manual_ = true;
+    boost::optional<std::uint32_t> num_;
 
 public:
     explicit
     seq (autofill_t)
-        : b_(true)
+        : manual_(false)
     {
     }
 
     explicit
     seq (none_t)
-        : b_(false)
     {
     }
 
     explicit
-    seq (std::uint32_t v)
-        : v_(v)
+    seq (std::uint32_t num)
+        : num_(num)
     {
     }
 

--- a/src/ripple/test/jtx/sig.h
+++ b/src/ripple/test/jtx/sig.h
@@ -21,6 +21,7 @@
 #define RIPPLE_TEST_JTX_SIG_H_INCLUDED
 
 #include <ripple/test/jtx/Env.h>
+#include <boost/optional.hpp>
 
 namespace ripple {
 namespace test {
@@ -32,20 +33,18 @@ namespace jtx {
 class sig
 {
 private:
-    Account account_;
-    boost::tribool b_ =
-        boost::logic::indeterminate;
+    bool manual_ = true;
+    boost::optional<Account> account_;
 
 public:
     explicit
     sig (autofill_t)
-        : b_(true)
+        : manual_(false)
     {
     }
 
     explicit
     sig (none_t)
-        : b_(false)
     {
     }
 


### PR DESCRIPTION
For the `AccountID` rename. Every line needs to be checked to make sure I didn't do something stupid like rename Account inside a SQL string. **NOTE** The first commit is the result of a search and replace while the second commit contains all the manual fixes.
