### PR TITLE
Add jtx properties.

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -3341,6 +3341,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\balance.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\basic_prop.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\Env.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\fee.h">
@@ -3444,6 +3446,8 @@
     <ClInclude Include="..\..\src\ripple\test\jtx\paths.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\pay.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\prop.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\rate.h">
     </ClInclude>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -4074,6 +4074,9 @@
     <ClInclude Include="..\..\src\ripple\test\jtx\balance.h">
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\basic_prop.h">
+      <Filter>ripple\test\jtx</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\Env.h">
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
@@ -4165,6 +4168,9 @@
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\pay.h">
+      <Filter>ripple\test\jtx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\prop.h">
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\rate.h">

--- a/src/ripple/test/jtx/basic_prop.h
+++ b/src/ripple/test/jtx/basic_prop.h
@@ -1,0 +1,67 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TEST_JTX_BASIC_PROP_H_INCLUDED
+#define RIPPLE_TEST_JTX_BASIC_PROP_H_INCLUDED
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+struct basic_prop
+{
+    virtual ~basic_prop() = default;
+    virtual std::unique_ptr<
+        basic_prop> clone() const = 0;
+    virtual bool assignable(
+        basic_prop const*) const = 0;
+};
+
+template <class T>
+struct prop_type : basic_prop
+{
+    T t;
+
+    template <class... Args>
+    prop_type(Args&&... args)
+        : t(std::forward <Args>(args)...)
+    {
+    }
+
+    std::unique_ptr<
+        basic_prop> clone() const override
+    {
+        return std::make_unique<
+            prop_type<T>>(t);
+    }
+
+    bool assignable(
+        basic_prop const* src) const override
+    {
+        return dynamic_cast<
+            prop_type<T> const*>(
+                src);
+    }
+};
+
+} // jtx
+} // test
+} // ripple
+
+#endif

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -226,7 +226,7 @@ Env::autofill_sig (JTx& jt)
         auto const account =
             lookup(jv[jss::Account].asString());
         auto const ar = le(account);
-        if (ar->isFieldPresent(sfRegularKey))
+        if (ar && ar->isFieldPresent(sfRegularKey))
             jtx::sign(jv, lookup(
                 ar->getFieldAccount160(sfRegularKey)));
         else

--- a/src/ripple/test/jtx/impl/utility.cpp
+++ b/src/ripple/test/jtx/impl/utility.cpp
@@ -76,6 +76,9 @@ fill_seq (Json::Value& jv,
     auto const ar = ledger.fetch(
         getAccountRootIndex(ra.getAccountID()));
 
+    if (!ar)
+        return;
+
     jv[jss::Sequence] =
         ar->getFieldU32(sfSequence);
 }

--- a/src/ripple/test/jtx/prop.h
+++ b/src/ripple/test/jtx/prop.h
@@ -17,38 +17,39 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_TEST_JTX_H_INCLUDED
-#define RIPPLE_TEST_JTX_H_INCLUDED
+#ifndef RIPPLE_TEST_JTX_PROP_H_INCLUDED
+#define RIPPLE_TEST_JTX_PROP_H_INCLUDED
 
-// Convenience header that includes everything
-
-#include <ripple/test/jtx/Account.h>
-#include <ripple/test/jtx/amount.h>
-#include <ripple/test/jtx/balance.h>
 #include <ripple/test/jtx/Env.h>
-#include <ripple/test/jtx/fee.h>
-#include <ripple/test/jtx/flags.h>
-#include <ripple/test/jtx/JTx.h>
-#include <ripple/test/jtx/multisign.h>
-#include <ripple/test/jtx/noop.h>
-#include <ripple/test/jtx/offer.h>
-#include <ripple/test/jtx/owners.h>
-#include <ripple/test/jtx/paths.h>
-#include <ripple/test/jtx/pay.h>
-#include <ripple/test/jtx/prop.h>
-#include <ripple/test/jtx/rate.h>
-#include <ripple/test/jtx/regkey.h>
-#include <ripple/test/jtx/require.h>
-#include <ripple/test/jtx/requires.h>
-#include <ripple/test/jtx/sendmax.h>
-#include <ripple/test/jtx/seq.h>
-#include <ripple/test/jtx/sig.h>
-#include <ripple/test/jtx/tags.h>
-#include <ripple/test/jtx/ter.h>
-#include <ripple/test/jtx/ticket.h>
-#include <ripple/test/jtx/trust.h>
-#include <ripple/test/jtx/txflags.h>
-#include <ripple/test/jtx/utility.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+/** Set a property on a JTx. */
+template <class Prop>
+struct prop
+{
+    std::unique_ptr<basic_prop> p_;
+
+    template <class... Args>
+    prop(Args&&... args)
+        : p_(std::make_unique<
+            prop_type<Prop>>(
+                std::forward <Args> (
+                    args)...))
+    {
+    }
+
+    void
+    operator()(Env const& env, JTx& jt) const
+    {
+        jt.set(p_->clone());
+    }
+};
+
+} // jtx
+} // test
+} // ripple
 
 #endif
-


### PR DESCRIPTION
Allows additional arbitrary information to be stored in a `JTx` for use by overrides that need to do additional processing. 

Reviewers: @vinniefalco, @seelabs 