### PR TITLE
Add jtx ledger advance.

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -3337,6 +3337,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\Account.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\advance.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\amount.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\balance.h">
@@ -3348,6 +3350,10 @@
     <ClInclude Include="..\..\src\ripple\test\jtx\flags.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\test\jtx\impl\Account.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\jtx\impl\advance.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -4068,6 +4068,9 @@
     <ClInclude Include="..\..\src\ripple\test\jtx\Account.h">
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\advance.h">
+      <Filter>ripple\test\jtx</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\amount.h">
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
@@ -4084,6 +4087,9 @@
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\test\jtx\impl\Account.cpp">
+      <Filter>ripple\test\jtx\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\jtx\impl\advance.cpp">
       <Filter>ripple\test\jtx\impl</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\test\jtx\impl\amount.cpp">

--- a/src/ripple/app/ledger/tests/DeferredCredits.test.cpp
+++ b/src/ripple/app/ledger/tests/DeferredCredits.test.cpp
@@ -57,7 +57,7 @@ class DeferredCredits_test : public beast::unit_test::suite
 
         auto master = createAccount ("masterpassphrase", keyType);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie (LCL, ledger) = createGenesisLedger (100000 * xrp, master);
 
@@ -124,7 +124,7 @@ class DeferredCredits_test : public beast::unit_test::suite
 
         auto master = createAccount ("masterpassphrase", keyType);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie (LCL, ledger) = createGenesisLedger (100000 * xrp, master);
 

--- a/src/ripple/app/ledger/tests/Ledger_test.cpp
+++ b/src/ripple/app/ledger/tests/Ledger_test.cpp
@@ -30,7 +30,7 @@ class Ledger_test : public beast::unit_test::suite
 
         auto master = createAccount ("masterpassphrase", keyType);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger(100000*xrp, master);
 
@@ -96,7 +96,7 @@ class Ledger_test : public beast::unit_test::suite
 
         auto master = createAccount ("masterpassphrase", keyType);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger (100000 * xrp, master);
 

--- a/src/ripple/app/ledger/tests/common_ledger.h
+++ b/src/ripple/app/ledger/tests/common_ledger.h
@@ -125,7 +125,7 @@ applyTransaction(Ledger::pointer const& ledger, STTx const& tx, bool check = tru
 
 // Create genesis ledger from a start amount in drops, and the public
 // master RippleAddress
-std::pair<Ledger::pointer, Ledger::pointer>
+std::pair<std::shared_ptr<Ledger const>, Ledger::pointer>
 createGenesisLedger(std::uint64_t start_amount_drops, TestAccount const& master);
 
 // Create an account represented by public RippleAddress and private
@@ -148,7 +148,7 @@ createAndFundAccountsWithFlags(TestAccount& from,
     std::vector<std::string> passphrases,
     KeyType keyType, std::uint64_t amountDrops,
     Ledger::pointer& ledger,
-    Ledger::pointer& LCL,
+    std::shared_ptr<Ledger const>& LCL,
     const std::uint32_t flags, bool sign = true);
 
 void
@@ -237,7 +237,7 @@ trust(TestAccount& from, TestAccount const& issuer,
                 Ledger::pointer const& ledger, bool sign = true);
 
 void
-close_and_advance(Ledger::pointer& ledger, Ledger::pointer& LCL);
+close_and_advance(Ledger::pointer& ledger, std::shared_ptr<Ledger const>& LCL);
 
 Json::Value findPath(Ledger::pointer ledger, TestAccount const& src, 
     TestAccount const& dest, std::vector<Currency> srcCurrencies, 

--- a/src/ripple/app/paths/tests/Path_test.cpp
+++ b/src/ripple/app/paths/tests/Path_test.cpp
@@ -37,7 +37,7 @@ class Path_test : public TestSuite
 
         auto master = createAccount("masterpassphrase", KeyType::ed25519);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger(100000 * xrp, master);
 
@@ -62,7 +62,7 @@ class Path_test : public TestSuite
 
         auto master = createAccount("masterpassphrase", KeyType::ed25519);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger(100000 * xrp, master);
 
@@ -100,7 +100,7 @@ class Path_test : public TestSuite
 
         auto master = createAccount("masterpassphrase", KeyType::ed25519);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger(100000 * xrp, master);
 
@@ -140,7 +140,7 @@ class Path_test : public TestSuite
 
         auto master = createAccount("masterpassphrase", KeyType::ed25519);
 
-        Ledger::pointer LCL;
+        std::shared_ptr<Ledger const> LCL;
         Ledger::pointer ledger;
         std::tie(LCL, ledger) = createGenesisLedger(100000 * xrp, master);
 

--- a/src/ripple/app/tx/tests/common_transactor.cpp
+++ b/src/ripple/app/tx/tests/common_transactor.cpp
@@ -103,7 +103,6 @@ std::pair<TER, bool> TestLedger::applyTransaction (STTx const& tx, bool check)
     // call to this method gets applied individually.  So this transaction
     // is guaranteed to be applied before the next one.
     close_and_advance(openLedger_, lastClosedLedger_);
-    suite_.expect (lastClosedLedger_->assertSane() == true);
 
     // Check for the transaction in the closed ledger.
     bool const foundTx =

--- a/src/ripple/app/tx/tests/common_transactor.h
+++ b/src/ripple/app/tx/tests/common_transactor.h
@@ -101,7 +101,7 @@ public:
 class TestLedger
 {
 private:
-    Ledger::pointer lastClosedLedger_;
+    std::shared_ptr<Ledger const> lastClosedLedger_;
     Ledger::pointer openLedger_;
     beast::unit_test::suite& suite_;
 

--- a/src/ripple/test/jtx/advance.h
+++ b/src/ripple/test/jtx/advance.h
@@ -17,38 +17,22 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_TEST_JTX_H_INCLUDED
-#define RIPPLE_TEST_JTX_H_INCLUDED
+#ifndef RIPPLE_TEST_JTX_ADVANCE_H_INCLUDED
+#define RIPPLE_TEST_JTX_ADVANCE_H_INCLUDED
 
-// Convenience header that includes everything
-
-#include <ripple/test/jtx/Account.h>
-#include <ripple/test/jtx/advance.h>
-#include <ripple/test/jtx/amount.h>
-#include <ripple/test/jtx/balance.h>
 #include <ripple/test/jtx/Env.h>
-#include <ripple/test/jtx/fee.h>
-#include <ripple/test/jtx/flags.h>
-#include <ripple/test/jtx/JTx.h>
-#include <ripple/test/jtx/multisign.h>
-#include <ripple/test/jtx/noop.h>
-#include <ripple/test/jtx/offer.h>
-#include <ripple/test/jtx/owners.h>
-#include <ripple/test/jtx/paths.h>
-#include <ripple/test/jtx/pay.h>
-#include <ripple/test/jtx/rate.h>
-#include <ripple/test/jtx/regkey.h>
-#include <ripple/test/jtx/require.h>
-#include <ripple/test/jtx/requires.h>
-#include <ripple/test/jtx/sendmax.h>
-#include <ripple/test/jtx/seq.h>
-#include <ripple/test/jtx/sig.h>
-#include <ripple/test/jtx/tags.h>
-#include <ripple/test/jtx/ter.h>
-#include <ripple/test/jtx/ticket.h>
-#include <ripple/test/jtx/trust.h>
-#include <ripple/test/jtx/txflags.h>
-#include <ripple/test/jtx/utility.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+// TODO EHENNIS: Return the transaction list.
+// (Coming soon.)
+void
+advance(Env& env, std::shared_ptr<Ledger>& last);
+
+} // jtx
+} // test
+} // ripple
 
 #endif
-

--- a/src/ripple/test/jtx/advance.h
+++ b/src/ripple/test/jtx/advance.h
@@ -29,7 +29,7 @@ namespace jtx {
 // TODO EHENNIS: Return the transaction list.
 // (Coming soon.)
 void
-advance(Env& env, std::shared_ptr<Ledger>& last);
+advance(Env& env, std::shared_ptr<Ledger const>& last);
 
 } // jtx
 } // test

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -414,6 +414,38 @@ public:
     }
 
     void
+    testAdvance()
+    {
+        using namespace jtx;
+        Env env(*this);
+        // Create the LCL as a copy of the Env's
+        // ledger. This will have the side effect
+        // of skipping one seq in Env.ledger the
+        // first time it is advanced. This can be
+        // worked around if desired by assigning
+        // an advanced ledger back to Env before
+        // starting, but it won't matter to most
+        // tests.
+        auto lastClosedLedger = 
+            std::make_shared<Ledger>(
+                *env.ledger, false);
+
+        auto firstSeq = env.ledger->seq();
+
+        expect(lastClosedLedger->seq() == firstSeq);
+
+        advance(env, lastClosedLedger);
+
+        expect(lastClosedLedger->seq() == firstSeq + 1);
+        expect(env.ledger->seq() == firstSeq + 2);
+
+        advance(env, lastClosedLedger);
+
+        expect(lastClosedLedger->seq() == firstSeq + 2);
+        expect(env.ledger->seq() == firstSeq + 3);
+    }
+
+    void
     run()
     {
         // Hack to silence logging
@@ -430,6 +462,8 @@ public:
         testMultiSign();
         testMultiSign2();
         testTicket();
+
+        testAdvance();
     }
 };
 

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -427,7 +427,7 @@ public:
         // starting, but it won't matter to most
         // tests.
         auto lastClosedLedger = 
-            std::make_shared<Ledger>(
+            std::make_shared<Ledger const>(
                 *env.ledger, false);
 
         auto firstSeq = env.ledger->seq();

--- a/src/ripple/test/jtx/impl/advance.cpp
+++ b/src/ripple/test/jtx/impl/advance.cpp
@@ -17,38 +17,22 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_TEST_JTX_H_INCLUDED
-#define RIPPLE_TEST_JTX_H_INCLUDED
-
-// Convenience header that includes everything
-
-#include <ripple/test/jtx/Account.h>
+#include <BeastConfig.h>
 #include <ripple/test/jtx/advance.h>
-#include <ripple/test/jtx/amount.h>
-#include <ripple/test/jtx/balance.h>
-#include <ripple/test/jtx/Env.h>
-#include <ripple/test/jtx/fee.h>
-#include <ripple/test/jtx/flags.h>
-#include <ripple/test/jtx/JTx.h>
-#include <ripple/test/jtx/multisign.h>
-#include <ripple/test/jtx/noop.h>
-#include <ripple/test/jtx/offer.h>
-#include <ripple/test/jtx/owners.h>
-#include <ripple/test/jtx/paths.h>
-#include <ripple/test/jtx/pay.h>
-#include <ripple/test/jtx/rate.h>
-#include <ripple/test/jtx/regkey.h>
-#include <ripple/test/jtx/require.h>
-#include <ripple/test/jtx/requires.h>
-#include <ripple/test/jtx/sendmax.h>
-#include <ripple/test/jtx/seq.h>
-#include <ripple/test/jtx/sig.h>
-#include <ripple/test/jtx/tags.h>
-#include <ripple/test/jtx/ter.h>
-#include <ripple/test/jtx/ticket.h>
-#include <ripple/test/jtx/trust.h>
-#include <ripple/test/jtx/txflags.h>
-#include <ripple/test/jtx/utility.h>
+#include <ripple/app/ledger/tests/common_ledger.h>
+#include <ripple/app/ledger/LedgerConsensus.h>
 
-#endif
+namespace ripple {
+namespace test {
+namespace jtx {
 
+void
+advance(Env& env, std::shared_ptr<Ledger>& last)
+{
+    return close_and_advance(env.ledger, last);
+}
+
+
+} // jtx
+} // test
+} // ripple

--- a/src/ripple/test/jtx/impl/advance.cpp
+++ b/src/ripple/test/jtx/impl/advance.cpp
@@ -27,9 +27,11 @@ namespace test {
 namespace jtx {
 
 void
-advance(Env& env, std::shared_ptr<Ledger>& last)
+advance(Env& env, std::shared_ptr<Ledger const>& last)
 {
-    return close_and_advance(env.ledger, last);
+    std::shared_ptr<Ledger> temp;
+    close_and_advance(env.ledger, temp);
+    last = temp;
 }
 
 

--- a/src/ripple/test/jtx/impl/advance.cpp
+++ b/src/ripple/test/jtx/impl/advance.cpp
@@ -29,9 +29,7 @@ namespace jtx {
 void
 advance(Env& env, std::shared_ptr<Ledger const>& last)
 {
-    std::shared_ptr<Ledger> temp;
-    close_and_advance(env.ledger, temp);
-    last = temp;
+    close_and_advance(env.ledger, last);
 }
 
 

--- a/src/ripple/unity/test.cpp
+++ b/src/ripple/unity/test.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 
 #include <ripple/test/jtx/impl/Account.cpp>
+#include <ripple/test/jtx/impl/advance.cpp>
 #include <ripple/test/jtx/impl/amount.cpp>
 #include <ripple/test/jtx/impl/balance.cpp>
 #include <ripple/test/jtx/impl/Env.cpp>


### PR DESCRIPTION
jtx framework's version of common_ledger's `close_and_advance` function using a locally created last closed ledger variable. (Actually calls `close_and_advance` under the hood.)

Reviewers: @vinniefalco, @scottschurr (because I know he's working on something similar, and it would be good to integrate early.)