### PR TITLE
Submit transactions with Tickets (RIPD-837):

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1573,6 +1573,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\misc\tests\CanonicalTXSet.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\misc\UniqueNodeList.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -1733,6 +1737,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tx\impl\CheckAndConsumeTicket.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\app\tx\impl\CheckAndConsumeTicket.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\tx\impl\CreateOffer.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -1838,6 +1848,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tx\tests\Taker.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tx\tests\Ticket.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2313,6 +2313,9 @@
     <ClCompile Include="..\..\src\ripple\app\misc\tests\AmendmentTable.test.cpp">
       <Filter>ripple\app\misc\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\misc\tests\CanonicalTXSet.test.cpp">
+      <Filter>ripple\app\misc\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\misc\UniqueNodeList.cpp">
       <Filter>ripple\app\misc</Filter>
     </ClCompile>
@@ -2463,6 +2466,12 @@
     <ClCompile Include="..\..\src\ripple\app\tx\impl\Change.cpp">
       <Filter>ripple\app\tx\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tx\impl\CheckAndConsumeTicket.cpp">
+      <Filter>ripple\app\tx\impl</Filter>
+    </ClCompile>
+    <ClInclude Include="..\..\src\ripple\app\tx\impl\CheckAndConsumeTicket.h">
+      <Filter>ripple\app\tx\impl</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\tx\impl\CreateOffer.cpp">
       <Filter>ripple\app\tx\impl</Filter>
     </ClCompile>
@@ -2554,6 +2563,9 @@
       <Filter>ripple\app\tx\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tx\tests\Taker.test.cpp">
+      <Filter>ripple\app\tx\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tx\tests\Ticket.test.cpp">
       <Filter>ripple\app\tx\tests</Filter>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\app\tx\Transaction.h">

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -26,6 +26,7 @@
 #include <ripple/app/misc/FeeVote.h>
 #include <ripple/app/tx/InboundTransactions.h>
 #include <ripple/app/tx/LocalTxs.h>
+#include <ripple/app/tx/TransactionEngine.h>
 #include <ripple/json/json_value.h>
 #include <ripple/overlay/Peer.h>
 #include <ripple/protocol/RippleLedgerHash.h>
@@ -73,10 +74,25 @@ make_LedgerConsensus (
     LedgerHash const & prevLCLHash, Ledger::ref previousLedger,
         std::uint32_t closeTime, FeeVote& feeVote);
 
+/** Apply a set of transactions to a ledger
+
+  @param set         The set of transactions to apply
+  @param applyLedger The ledger to which the transactions should be applied.
+  @param checkLedger A reference ledger for determining error messages (
+                       typically new last closed ledger).
+  @param retriables  Collect failed transactions in this set.
+  @param openLgr     True if applyLedger is open, else false.
+*/
 void
 applyTransactions(SHAMap const* set, Ledger::ref applyLedger,
                   Ledger::ref checkLedger,
-                  CanonicalTXSet& retriableTransactions, bool openLgr);
+                  CanonicalTXSet& retriables, bool openLgr);
+
+// A version of applyTransactions() that can be used for unit tests.
+void
+applyTransactions(SHAMap const* set, TransactionEngine& engine,
+                  Ledger::ref checkLedger,
+                  CanonicalTXSet& retriables, bool openLgr);
 
 } // ripple
 

--- a/src/ripple/app/ledger/tests/common_ledger.h
+++ b/src/ripple/app/ledger/tests/common_ledger.h
@@ -40,6 +40,10 @@
 #include <string>
 
 namespace ripple {
+
+// Forward declarations.
+class LocalTxs;
+
 namespace test {
 
 struct TestAccount
@@ -134,7 +138,7 @@ TestAccount
 createAccount(std::string const& passphrase, KeyType keyType);
 
 TestAccount
-createAndFundAccount(TestAccount& from, std::string const& passphrase, 
+createAndFundAccount(TestAccount& from, std::string const& passphrase,
     KeyType keyType, std::uint64_t amountDrops,
     Ledger::pointer const& ledger, bool sign = true);
 
@@ -236,11 +240,23 @@ trust(TestAccount& from, TestAccount const& issuer,
                 std::string const& currency, double amount,
                 Ledger::pointer const& ledger, bool sign = true);
 
+// Simplest form of close_and_advance.
 void
 close_and_advance(Ledger::pointer& ledger, std::shared_ptr<Ledger const>& LCL);
 
-Json::Value findPath(Ledger::pointer ledger, TestAccount const& src, 
-    TestAccount const& dest, std::vector<Currency> srcCurrencies, 
+// Call this function if you want to advance the ledger time.
+void
+close_and_advance(Ledger::pointer& ledger,
+    std::shared_ptr<Ledger const>& LCL, std::uint32_t advSeconds);
+
+// Call this function if you want to retry transactions that fail with
+// a `ter` or `tec`.
+void
+close_and_advance(Ledger::pointer& ledger, std::shared_ptr<Ledger const>& LCL,
+    std::uint32_t advSeconds, std::unique_ptr<LocalTxs>& retries);
+
+Json::Value findPath(Ledger::pointer ledger, TestAccount const& src,
+    TestAccount const& dest, std::vector<Currency> srcCurrencies,
     Amount const& dstAmount, beast::abstract_ostream& log,
     boost::optional<Json::Value> contextPaths = boost::none);
 

--- a/src/ripple/app/misc/CanonicalTXSet.h
+++ b/src/ripple/app/misc/CanonicalTXSet.h
@@ -39,36 +39,54 @@ public:
     class Key
     {
     public:
-        Key (uint256 const& account, std::uint32_t seq, uint256 const& id)
-            : mAccount (account)
-            , mTXid (id)
-            , mSeq (seq)
+        Key (uint256 const& account,
+            std::uint32_t seq,
+            AccountID const& ticketOwner,
+            std::uint32_t ticketSeq,
+            uint256 const& txnId)
+            : account_ (account)
+            , txId_ (txnId)
+            , ticketOwner_ (ticketOwner)
+            , ticketSeq_ (ticketSeq)
+            , seq_ (seq)
         {
         }
 
-        bool operator<  (Key const& rhs) const;
-        bool operator>  (Key const& rhs) const;
-        bool operator<= (Key const& rhs) const;
-        bool operator>= (Key const& rhs) const;
+        friend bool operator<  (Key const& lhs, Key const& rhs);
+
+        inline friend bool operator>  (Key const& lhs, Key const& rhs)
+        {
+            return rhs < lhs;
+        }
+        inline friend bool operator<= (Key const& lhs, Key const& rhs)
+        {
+            return ! (lhs > rhs);
+        }
+        inline friend bool operator>= (Key const& lhs, Key const& rhs)
+        {
+            return ! (lhs < rhs);
+        }
 
         bool operator== (Key const& rhs) const
         {
-            return mTXid == rhs.mTXid;
+            return txId_ == rhs.txId_;
         }
         bool operator!= (Key const& rhs) const
         {
-            return mTXid != rhs.mTXid;
+            return txId_ != rhs.txId_;
         }
 
         uint256 const& getTXID () const
         {
-            return mTXid;
+            return txId_;
         }
 
     private:
-        uint256 mAccount;
-        uint256 mTXid;
-        std::uint32_t mSeq;
+        uint256 account_;
+        uint256 txId_;
+        AccountID ticketOwner_;
+        std::uint32_t ticketSeq_;
+        std::uint32_t seq_;
     };
 
     using iterator = std::map <Key, STTx::pointer>::iterator;

--- a/src/ripple/app/misc/tests/CanonicalTXSet.test.cpp
+++ b/src/ripple/app/misc/tests/CanonicalTXSet.test.cpp
@@ -1,0 +1,158 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/misc/CanonicalTXSet.h>
+#include <ripple/basics/TestSuite.h>
+
+namespace ripple {
+namespace test {
+
+class CanonicalTXSet_test : public TestSuite
+{
+    void test_txset_key_ordering()
+    {
+        // Verify that CanonicalTXSet::Key sorts as expected.
+        using Key = CanonicalTXSet::Key;
+
+        uint256 const acctRef {2000};
+        uint256 const acctLo  {1999};
+        uint256 const acctMid {2000};
+        uint256 const acctHi  {2001};
+
+        std::uint32_t const seq0         {0};
+        std::uint32_t const seqRef {7000000};
+        std::uint32_t const seqLo  {6999999};
+        std::uint32_t const seqMid {7000000};
+        std::uint32_t const seqHi  {7000001};
+
+        AccountID const tktOwner0          {0};
+        AccountID const tktOwnerRef {90000000};
+        AccountID const tktOwnerLo  {89999999};
+        AccountID const tktOwnerMid {90000000};
+        AccountID const tktOwnerHi  {90000001};
+
+        std::uint32_t const tktSeq0        {0};
+        std::uint32_t const tktSeqRef {300000};
+        std::uint32_t const tktSeqLo  {299999};
+        std::uint32_t const tktSeqMid {300000};
+        std::uint32_t const tktSeqHi  {300001};
+
+        uint256 const txIdRef {50000};
+        uint256 const txIdLo  {49999};
+        uint256 const txIdMid {50000};
+        uint256 const txIdHi  {50001};
+
+        auto eqTest = [this] (Key const& lhs, Key const& rhs)
+        {
+            this->expect ((lhs <  rhs) == false);
+            this->expect ((lhs <= rhs) == true);
+            this->expect ((lhs >  rhs) == false);
+            this->expect ((lhs >= rhs) == true);
+        };
+
+        auto ltTest = [this] (Key const& lhs, Key const& rhs)
+        {
+            this->expect ((lhs <  rhs) == true);
+            this->expect ((lhs <= rhs) == true);
+            this->expect ((lhs >  rhs) == false);
+            this->expect ((lhs >= rhs) == false);
+        };
+
+        auto gtTest = [this] (Key const& lhs, Key const& rhs)
+        {
+            this->expect ((lhs <  rhs) == false);
+            this->expect ((lhs <= rhs) == false);
+            this->expect ((lhs >  rhs) == true);
+            this->expect ((lhs >= rhs) == true);
+        };
+
+        // Test cases with no Tickets
+        Key const keyRef {acctRef, seqRef, tktOwner0, tktSeq0, txIdRef};
+        {
+            Key const keySame {acctMid, seqMid, tktOwner0, tktSeq0, txIdMid};
+            eqTest (keySame, keyRef);
+        }
+        {
+            Key const keyLoAccount {acctLo, seqHi, tktOwner0, tktSeq0, txIdHi};
+            ltTest (keyLoAccount, keyRef);
+        }
+        {
+            Key const keyHiAccount {acctHi, seqLo, tktOwner0, tktSeq0, txIdLo};
+            gtTest (keyHiAccount, keyRef);
+        }
+        {
+            Key const keyLoSeq {acctRef, seqLo, tktOwner0, tktSeq0, txIdHi};
+            ltTest (keyLoSeq, keyRef);
+        }
+        {
+            Key const keyHiSeq {acctRef, seqHi, tktOwner0, tktSeq0, txIdLo};
+            gtTest (keyHiSeq, keyRef);
+        }
+        {
+            Key const keyLoTxId {acctRef, seqRef, tktOwner0, tktSeq0, txIdLo};
+            ltTest (keyLoTxId, keyRef);
+        }
+        {
+            Key const keyHiTxId {acctRef, seqRef, tktOwner0, tktSeq0, txIdHi};
+            gtTest (keyHiTxId, keyRef);
+        }
+
+        Key const keyRefTicket {acctRef, seq0, tktOwnerRef, tktSeqRef, txIdRef};
+
+        // Test cases with one Ticket.  A Key with a Ticket should always sort
+        // greater than a Key without a Ticket.
+        {
+            ltTest (keyRef, keyRefTicket);
+            gtTest (keyRefTicket, keyRef);
+        }
+
+        // Test cases with two Tickets
+        {
+            Key const keySame {acctMid, seq0, tktOwnerMid, tktSeqMid, txIdMid};
+            eqTest (keySame, keyRefTicket);
+        }
+        {
+            Key const keyLoOwner {acctMid, seq0, tktOwnerLo, tktSeqHi, txIdHi};
+            ltTest (keyLoOwner, keyRefTicket);
+        }
+        {
+            Key const keyHiOwner {acctMid, seq0, tktOwnerHi, tktSeqLo, txIdLo};
+            gtTest (keyHiOwner, keyRefTicket);
+        }
+        {
+            Key const keyLoSeq {acctMid, seq0, tktOwnerMid, tktSeqLo, txIdHi};
+            ltTest (keyLoSeq, keyRefTicket);
+        }
+        {
+            Key const keyHiSeq {acctMid, seq0, tktOwnerMid, tktSeqHi, txIdLo};
+            gtTest (keyHiSeq, keyRefTicket);
+        }
+    }
+
+public:
+    void run()
+    {
+        test_txset_key_ordering();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(CanonicalTXSet, app, ripple);
+
+} // test
+} // ripple

--- a/src/ripple/app/tx/LocalTxs.h
+++ b/src/ripple/app/tx/LocalTxs.h
@@ -29,6 +29,9 @@ namespace ripple {
 // Ensure we always apply them to our open ledger
 // Hold them until we see them in a fully-validated ledger
 
+// NOTE: This class may be made OBSOLETE by the TxQ.  Consider that when
+// making modifications to LocalTxs.
+
 class LocalTxs
 {
 public:

--- a/src/ripple/app/tx/impl/CheckAndConsumeTicket.cpp
+++ b/src/ripple/app/tx/impl/CheckAndConsumeTicket.cpp
@@ -1,0 +1,197 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/tx/impl/CheckAndConsumeTicket.h>
+#include <ripple/app/tx/TransactionEngine.h>              // TransactionEngine
+#include <ripple/app/ledger/MetaView.h>                   // MetaView
+#include <ripple/protocol/Indexes.h>                      // getOwnerDirIndex
+#include <ripple/protocol/STTx.h>                         // STTx
+
+
+namespace ripple {
+
+namespace
+{
+
+struct TicketContents
+{
+    AccountID owner;
+    std::uint32_t seq;
+
+    TicketContents () = delete;
+    TicketContents (AccountID owner_, std::uint32_t seq_)
+    : owner (owner_)
+    , seq (seq_)
+    { }
+};
+
+TicketContents getTicketContents (STTx const& txn)
+{
+    auto const& ticketID = txn.getFieldObject (sfTicketID);
+
+    return {ticketID.getAccountID (sfAccount),
+        ticketID.getFieldU32 (sfSequence)};
+}
+
+// Return the appropriate error code for this missing Ticket.
+TER missingTicketTER (TicketContents const& ticket, SLE::ref sleOwner)
+{
+    // If the account owner can't be found give up.
+    if (! sleOwner)
+        return tefNO_ENTRY;
+
+    // 1. If the Ticket sequence exceeds the ticket owner's seq, then the
+    //    Ticket may not have been created in this ledger yet.  Retry.
+    //
+    // 2. If the Ticket sequence is the same or less than the ticket owner's
+    //    seq, then the Ticket was either never created or was consumed.  Fail.
+    auto const ownerSeq = sleOwner->getFieldU32 (sfSequence);
+    return ticket.seq >= ownerSeq ? terPRE_TICKET : tefNO_ENTRY;
+}
+
+bool authorizedToUseTicket (SLE::ref sleTicket,
+    AccountID const& txnAccountID, AccountID const& ticketOwner)
+{
+    if (txnAccountID == ticketOwner)
+        return true;
+
+    // The target can also always consume a ticket.
+    if (sleTicket->isFieldPresent (sfTarget))
+        return (txnAccountID == sleTicket->getAccountID (sfTarget));
+
+    return false;
+}
+
+bool expiredTicket (SLE::ref sleTicket, TransactionEngine* const txnEngine)
+{
+    if (sleTicket->isFieldPresent (sfExpiration))
+    {
+        std::uint32_t const expiration = sleTicket->getFieldU32 (sfExpiration);
+
+        if (txnEngine->getLedger()->getParentCloseTimeNC() >= expiration)
+            return true;
+    }
+    return false;
+}
+
+TER consumeTicket (
+    SLE::ref sleTicket,
+    SLE::ref sleOwner,
+    AccountID const& owner,
+    uint256 const& ticketIndex,
+    MetaView& view)
+{
+    std::uint64_t const hint = sleTicket->getFieldU64 (sfOwnerNode);
+
+    TER const result = dirDelete (view,
+        false, hint, getOwnerDirIndex (owner), ticketIndex, false, (hint == 0));
+
+    // If result != tesSUCCESS do we still want to do the adjustOwnerCount()
+    // and erase()???  Seems like we're in big trouble either way.
+    adjustOwnerCount (view, view.peek (keylet::account(owner)), -1);
+    view.erase (sleTicket);
+
+    return result;
+}
+
+} // anonymous namespace
+
+// checkAndConsumeSeqTicket() only allows an authorized user to consume
+// the Ticket.  This is in contrast to checkAndConsumeCancelTicket().
+//
+// Precondition: txn must contain a valid TicketID object.
+TER checkAndConsumeSeqTicket (STTx const& txn,
+    AccountID const& txnAccountID, TransactionEngine* const txnEngine)
+{
+    // Anyone calling this function should have verified txn has a Ticket.
+    {
+        auto hasTicket = txn.isFieldPresent (sfTicketID);
+        assert (hasTicket);
+        if (! hasTicket)
+            return temINVALID;
+    }
+    // Get the TicketIndex so we can see if it's usable.
+    MetaView& view = txnEngine->view();
+    TicketContents const ticket = getTicketContents (txn);
+    uint256 ticketIndex = getTicketIndex (ticket.owner, ticket.seq);
+    SLE::pointer sleTicket = view.peek (keylet::ticket(ticketIndex));
+    SLE::pointer sleOwner = view.peek (keylet::account(ticket.owner));
+
+    if (!sleTicket)
+        return missingTicketTER (ticket, sleOwner);
+
+    // Only allow authorized users to consume a Ticket.
+    if (! authorizedToUseTicket (sleTicket, txnAccountID, ticket.owner))
+        return tefNO_PERMISSION;
+
+    // See if the Ticket is expired.
+    TER const result = expiredTicket (sleTicket, txnEngine) ?
+        tecEXPIRED_TICKET : tesSUCCESS;
+
+    // Even if the Ticket is expired consume the Ticket.
+    {
+        TER const terConsume =
+            consumeTicket(sleTicket, sleOwner, ticket.owner, ticketIndex, view);
+
+        // If the consume failed then something went very badly.
+        if (terConsume != tesSUCCESS)
+            return terConsume;
+    }
+    return result;
+}
+
+// checkAndConsumeCancelTicket() allows anyone to consume an expired Ticket.
+// Only authorized users can consume an un-expired Ticket.  This is in
+// contrast to checkAndConsumeSeqTicket().
+//
+// Precondition: txn must contain a valid TicketID object.
+TER checkAndConsumeCancelTicket (STTx const& txn,
+    AccountID const& txnAccountID, TransactionEngine* const txnEngine)
+{
+    // Anyone calling this function should have verified txn has a Ticket.
+    {
+        auto hasTicket = txn.isFieldPresent (sfTicketID);
+        assert (hasTicket);
+        if (! hasTicket)
+            return temINVALID;
+    }
+    // Get the TicketIndex so we can see if it's usable.
+    MetaView& view = txnEngine->view();
+    TicketContents const ticket = getTicketContents (txn);
+    uint256 ticketIndex = getTicketIndex (ticket.owner, ticket.seq);
+    SLE::pointer sleTicket = view.peek (keylet::ticket(ticketIndex));
+    SLE::pointer sleOwner = view.peek (keylet::account(ticket.owner));
+
+    if (!sleTicket)
+        return missingTicketTER (ticket, sleOwner);
+
+    // See if the Ticket is expired.
+    if (! expiredTicket (sleTicket, txnEngine))
+    {
+        // Only allow authorized users to consume an un-expired Ticket.
+        if (! authorizedToUseTicket (sleTicket, txnAccountID, ticket.owner))
+            return tefNO_PERMISSION;
+    }
+
+    // If we got here attempt to consume the Ticket.
+    return consumeTicket(sleTicket, sleOwner, ticket.owner, ticketIndex, view);
+}
+
+} // ripple

--- a/src/ripple/app/tx/impl/CheckAndConsumeTicket.h
+++ b/src/ripple/app/tx/impl/CheckAndConsumeTicket.h
@@ -17,19 +17,25 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
+#ifndef RIPPLE_TX_CHECKANDCONSUMETICKET_H_INCLUDED
+#define RIPPLE_TX_CHECKANDCONSUMETICKET_H_INCLUDED
 
-#include <ripple/app/misc/AmendmentTableImpl.cpp>
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
-#include <ripple/app/misc/UniqueNodeList.cpp>
-#include <ripple/app/misc/Validations.cpp>
+#include <ripple/protocol/TER.h>
+#include <ripple/protocol/UintTypes.h>                    // Account
 
-#include <ripple/app/misc/impl/AccountTxPaging.cpp>
+namespace ripple
+{
+// Forward declarations
+class STTx;
+class TransactionEngine;
 
-#include <ripple/app/misc/tests/AccountTxPaging.test.cpp>
-#include <ripple/app/misc/tests/AmendmentTable.test.cpp>
-#include <ripple/app/misc/tests/CanonicalTXSet.test.cpp>
+// Function that checks and consumes a ticket used as a transaction sequence.
+TER checkAndConsumeSeqTicket (STTx const& txn,
+    AccountID const& txnAccountID, TransactionEngine* const txnEngine);
+
+// Function that checks and consumes a Ticket for a TICKET_CANCEL transaction.
+TER checkAndConsumeCancelTicket (STTx const& txn,
+    AccountID const& txnAccountID, TransactionEngine* const txnEngine);
+}
+
+#endif // RIPPLE_TX_CHECKANDCONSUMETICKET_H_INCLUDED

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -131,7 +131,7 @@ public:
 
         sleTicket->setFieldU64(sfOwnerNode, hint);
 
-        // If we succeeded, the new entry counts agains the creator's reserve.
+        // If we succeeded, the new entry counts against the creator's reserve.
         adjustOwnerCount(mEngine->view(), mTxnAccount, 1);
 
         return result;

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -60,6 +60,9 @@ protected:
     TER preCheckSigningKey ();
 
     virtual TER checkSeq ();
+    TER checkSeq0 ();                       // If seq == 0 check for Ticket.
+    TER checkSeqNon0 (std::uint32_t t_seq); // If seq != 0 verify seq number.
+
     virtual TER payFee ();
 
     void calculateFee ();

--- a/src/ripple/app/tx/tests/MultiSign.test.cpp
+++ b/src/ripple/app/tx/tests/MultiSign.test.cpp
@@ -1542,11 +1542,9 @@ class MultiSign_test : public beast::unit_test::suite
                 aliceBalanceCheck (stdFee);
             }
         }
-#if RIPPLE_ENABLE_TICKETS
-#if 0
         // Multi-sign a ttTICKET_CREATE and cancel it using ttTICKET_CANCEL.
         {
-            uint256 ticketIndex {7}; // Any non-zero value so we see it change.
+            std::uint32_t ticketSeq {0};
             // Multi-sign to give alice an un-targeted ticket
             {
                 STTx tx = getCreateTicketTx (alice);
@@ -1560,21 +1558,18 @@ class MultiSign_test : public beast::unit_test::suite
             }
             // Make sure Alice has the ticket.
             {
-                auto
+                auto tickets =
                     getTicketsOnAccount (ledger, alice);
                 expect (tickets.size() == 1);
                 if (! tickets.empty())
                 {
-                    SLE::pointer const& ticket = tickets[0];
-                    std::uint32_t const ticketSeq =
-                        ticket->getFieldU32(sfSequence);
-                    // getTicketIndex() hashes the account and seq for the ID.
-                    ticketIndex = getTicketIndex (alice.getID(), ticketSeq);
+                    auto& ticket = tickets[0];
+                    ticketSeq = ticket->getFieldU32(sfSequence);
                 }
             }
             // Multi-sign to cancel alice's ticket.
             {
-                STTx tx = getCancelTicketTx (alice, ticketIndex);
+                STTx tx = getCancelTicketTx (alice, alice, ticketSeq);
                 std::vector<MultiSig> multiSigs {
                     {alice, bogie, tx},
                     {becky, ghost, tx}
@@ -1590,8 +1585,6 @@ class MultiSign_test : public beast::unit_test::suite
                 expect (tickets.size() == 0);
             }
         }
-#endif
-#endif // RIPPLE_ENABLE_TICKETS
     }
 
 public:
@@ -1600,8 +1593,6 @@ public:
         for (auto kType : {KeyType::secp256k1, KeyType::ed25519})
         {
             test_singleSig (kType);
-#if RIPPLE_ENABLE_MULTI_SIGN
-            test_noReserve(kType);
             test_noReserve(kType);
             test_signerListSet (kType);
             test_phantomSigners (kType);
@@ -1610,7 +1601,6 @@ public:
             test_heterogeneousSigners (kType);
             test_twoLevel (kType);
             test_txTypes (kType);
-#endif // RIPPLE_ENABLE_MULTI_SIGN
         }
     }
 };

--- a/src/ripple/app/tx/tests/Ticket.test.cpp
+++ b/src/ripple/app/tx/tests/Ticket.test.cpp
@@ -1,0 +1,664 @@
+//------------------------------------------------------------------------------
+/*
+  This file is part of rippled: https://github.com/ripple/rippled
+  Copyright (c) 2012-2015 Ripple Labs Inc.
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose  with  or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+  MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/main/Application.h>               // getApp
+#include <ripple/app/ledger/tests/common_ledger.h>
+#include <ripple/test/jtx.h>
+
+
+namespace ripple {
+namespace test {
+
+//------------------------------------------------------------------------------
+
+/** All information that can be associated with a Ticket. */
+struct TicketInfo
+{
+    AccountID owner;
+    std::uint32_t seq;
+    AccountID target;
+    std::uint32_t expiration;
+
+    TicketInfo (AccountID const& ownerID, std::uint32_t sequence)
+    : owner (ownerID)
+    , seq (sequence)
+    , target {}
+    , expiration (std::numeric_limits<std::uint32_t>::max()) { }
+
+    TicketInfo (AccountID const& ownerID, std::uint32_t sequence,
+        AccountID const& targetID, std::uint32_t expry)
+    : owner (ownerID)
+    , seq (sequence)
+    , target (targetID)
+    , expiration (expry) { }
+};
+
+/** Return information on all Tickets in Ledger owned by acct. */
+std::vector <TicketInfo>
+getTicketsOnAccount (
+    std::shared_ptr<Ledger>& ledger, jtx::Account const& acct)
+{
+    std::vector <TicketInfo> tickets;
+
+    forEachItem (*ledger, acct,
+        [&tickets](const std::shared_ptr<const SLE>& sleCur)
+        {
+            // If sleCur is an ltTICKET save it.
+            if (sleCur && sleCur->getType () == ltTICKET)
+            {
+                AccountID const acct = sleCur->getAccountID (sfAccount);
+                std::uint32_t const seq = sleCur->getFieldU32 (sfSequence);
+                AccountID target {};
+                std::uint32_t expiration =
+                    std::numeric_limits<std::uint32_t>::max();
+
+                // Deal with optional Ticket fields.
+                if (sleCur->isFieldPresent (sfTarget))
+                    target = sleCur->getAccountID (sfTarget);
+                if (sleCur->isFieldPresent (sfExpiration))
+                    expiration = sleCur->getFieldU32 (sfExpiration);
+
+                tickets.emplace_back (acct, seq, target, expiration);
+            }
+        });
+    return tickets;
+}
+
+//------------------------------------------------------------------------------
+
+// EnvTicket -- A specialized jtx::Env that supports transaction retries.
+//
+// Initially Tickets had problems with 'ter' and 'tec' transaction errors.
+// They would get bollixed up when the retry occurred.  I saw instances where
+// the Fee was applied twice on a `tec`.
+//
+// In order to test for regressions of these problems, the Env for Tickets
+// is enhanced so it supports retrying of transactions.
+
+class EnvTicket : public jtx::Env
+{
+public:
+    /** The local transactions. */
+    std::unique_ptr<LocalTxs> local_txs;
+
+    EnvTicket(beast::unit_test::suite& test_)
+    : Env (test_)
+    , local_txs (LocalTxs::New())
+    {
+    }
+
+    ~EnvTicket() override = default;
+
+    /** Submit an existing JTx.
+        This calls postconditions.
+    */
+    void
+    submit (jtx::JTx const& jt) override;
+};
+
+void
+EnvTicket::submit (jtx::JTx const& jt)
+{
+    auto const stx = st(jt);
+    TER ter;
+    bool didApply;
+    if (stx)
+    {
+        // Save the transaction for retries.
+        local_txs->push_back (
+            ledger->getLedgerSeq(), std::make_shared<STTx>(*stx));
+
+        TransactionEngine txe (ledger, tx_enable_test);
+        std::tie(ter, didApply) = txe.applyTransaction(
+            *stx, tapOPEN_LEDGER |
+                (true ? tapNONE : tapNO_CHECK_SIGN));
+    }
+    else
+    {
+        // Convert the exception into a TER so that
+        // callers can expect it using ter(temMALFORMED)
+        ter = temMALFORMED;
+        didApply = false;
+    }
+    if (! test.expect(ter == jt.ter,
+        "apply: " + transToken(ter) +
+            " (" + transHuman(ter) + ")"))
+    {
+        test.log << pretty(jt.jv);
+        // Don't check postconditions if
+        // we didn't get the expected result.
+        return;
+    }
+    for (auto const& f : jt.requires)
+        f(*this);
+}
+
+//------------------------------------------------------------------------------
+
+namespace jtx {
+namespace ticket {
+/** Return JSON for a TicketCancel transaction. */
+Json::Value
+cancel (jtx::Account const& account, TicketInfo const& ticketInfo)
+{
+    Json::Value jv;
+    auto& ticketID = jv["TicketID"];
+    ticketID[jss::Account] = to_string(ticketInfo.owner);
+    ticketID[jss::Sequence] = ticketInfo.seq;
+
+    jv[jss::Account] = account.human();
+    jv[jss::TransactionType] = "TicketCancel";
+    return jv;
+}
+
+} // ticket
+} // jtx
+
+//------------------------------------------------------------------------------
+
+/** Funclet to set a Ticket on a transaction in the jtx framework.
+
+I would prefer to call this funclet "ticket", but that name was taken
+by the jtx::ticket namespace.  So "tckt" will have to do.
+*/
+class tckt
+{
+private:
+    AccountID owner_;
+    std::uint32_t seq_;
+
+public:
+    explicit
+    tckt (TicketInfo const& ticketInf)
+        : owner_ (ticketInf.owner)
+        , seq_ (ticketInf.seq)
+    {
+    }
+
+    void
+    operator()(jtx::Env const&, jtx::JTx& tx) const;
+};
+
+void
+tckt::operator()(jtx::Env const&, jtx::JTx& tx) const
+{
+    auto& ticketID = tx["TicketID"];
+    ticketID[jss::Account] = to_string(owner_);
+    ticketID[jss::Sequence] = seq_;
+
+    // A transaction with a Ticket always has a Sequence of zero.
+    tx[jss::Sequence] = 0;
+}
+
+//------------------------------------------------------------------------------
+
+/** Funclet to set LastLedgerSequence on a transaction in the JTx framework. */
+class last_ledger_seq
+{
+private:
+    std::uint32_t last_seq_;
+
+public:
+    last_ledger_seq (std::uint32_t last_seq)
+        : last_seq_(last_seq)
+    {
+    }
+
+    void
+    operator()(jtx::Env const&, jtx::JTx& tx) const;
+};
+
+void
+last_ledger_seq::operator() (jtx::Env const&, jtx::JTx& tx) const
+{
+    tx[jss::LastLedgerSequence] = last_seq_;
+}
+
+//------------------------------------------------------------------------------
+
+class Ticket_test : public beast::unit_test::suite
+{
+public:
+    // Used to generate a 'tel' error.
+    static Json::Value
+    set_message_key (jtx::Account const& account, std::string const& key)
+    {
+        Json::Value jv;
+        jv[jss::Account] = account.human();
+        jv[jss::MessageKey] = key;
+        jv[jss::TransactionType] = "AccountSet";
+        return jv;
+    }
+
+    void
+    testTicket()
+    {
+        using namespace jtx;
+        namespace ticket = jtx::ticket;
+
+        EnvTicket env(*this);
+
+        // We need to be able to advance the ledger to test Ticket expiration.
+        std::shared_ptr<Ledger const> lastClosedLedger =
+            std::make_shared<Ledger>(false, *env.ledger);
+
+        // This lambda makes it easy to advance the ledger
+        auto advanceLedger = [this, &env, &lastClosedLedger] ()
+        {
+            // Advance time enough so we have a new ledger time.
+            close_and_advance (
+                env.ledger, lastClosedLedger,
+                env.ledger->getCloseResolution(), env.local_txs);
+        };
+
+        Account const alice ("alice", KeyType::ed25519);
+        Account const becky ("becky", KeyType::secp256k1);
+        Account const cheri ("cheri", KeyType::ed25519);
+
+        env.fund (XRP(10000), alice, becky, cheri);
+
+        advanceLedger();
+
+        // Get alice's tickets.  Should be empty.
+        auto aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        env.require (owners (alice, 0), tickets (alice, 0));
+
+        // Have alice create a Ticket.
+        env (ticket::create (alice));
+
+        advanceLedger();
+
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        env.require (owners (alice, 1), tickets (alice, 1));
+
+        std::uint64_t const baseFee = env.ledger->getBaseFee();
+        // Use that Ticket to submit a transaction.
+        {
+            std::uint32_t const aliceSeq = env.seq (alice);
+            STAmount const aliceOldBalance = env.balance (alice, XRP);
+            STAmount const alicePays = drops (1000) - baseFee;
+            env (pay (alice, env.master, alicePays),
+                fee (baseFee), tckt (aliceTickets[0]));
+
+            // The transaction should have consumed alice's Ticket.
+            advanceLedger();
+
+            env.require (owners (alice, 0), tickets (alice, 0));
+            auto const aliceNewBalance = env.balance (alice, XRP);
+            expect (aliceOldBalance == aliceNewBalance + drops (1000));
+
+            // Since we used a Ticket, alice's Sequence should be unchanged.
+            expect (aliceSeq == env.seq (alice));
+        }
+
+        //----------------------------------------------------------------------
+        // It should not be possible to re-use the Ticket.
+        env (pay (alice, env.master, drops (1000)),
+            tckt (aliceTickets[0]), ter (tefNO_ENTRY));
+
+        //----------------------------------------------------------------------
+        // Have alice create a couple of Tickets with cheri as the target.
+        env (ticket::create (alice, cheri));
+        env (ticket::create (alice, cheri));
+        advanceLedger();
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        env.require (owners (alice, 2), tickets (alice, 2));
+
+        // becky should not be able to use those Tickets.
+        env (pay (becky, env.master, drops (1000)),
+            tckt (aliceTickets[0]), ter (tefNO_PERMISSION));
+        advanceLedger();
+
+        // alice's Tickets should still be available.
+        env.require (owners (alice, 2), tickets (alice, 2));
+
+        // Have alice and cheri use the Tickets.  Should work.  Since they
+        // are using Tickets the Sequence on the accounts should not change.
+        {
+            std::uint32_t const aliceSeq = env.seq (alice);
+            std::uint32_t const cheriSeq = env.seq (cheri);
+
+            env (pay (alice, env.master, drops (1000)),
+                tckt (aliceTickets[0]));
+            env (pay (cheri, env.master, drops (1000)),
+                tckt (aliceTickets[1]));
+            advanceLedger();
+
+            // Both of alice's Tickets should be consumed and the account
+            // sequences should not have moved.
+            env.require (owners (alice, 0), tickets (alice, 0));
+            expect (aliceSeq == env.seq (alice));
+            expect (cheriSeq == env.seq (cheri));
+        }
+
+        // Test tickets with expirations.
+        std::uint32_t const expResolution = env.ledger->getCloseResolution();
+        std::uint32_t const halfResolution = expResolution / 2;
+        assert (halfResolution > 0); // Sanity check on assumptions.
+
+        // Create a Ticket with an expiration time that has already passed.
+        // Should succeed but no Ticket should be created.
+        {
+            std::uint32_t const now = env.ledger->getParentCloseTimeNC();
+            env (ticket::create (alice, now - halfResolution));
+            env.require (owners (alice, 0), tickets (alice, 0));
+        }
+
+        // Create a couple of Tickets with expirations.  Consume one in a
+        // timely fashion.  Let the other expire and then use it.
+        {
+            std::uint32_t const now = env.ledger->getParentCloseTimeNC();
+            env (ticket::create (alice, now + halfResolution + expResolution));
+            env (ticket::create (alice, now + halfResolution + expResolution));
+            advanceLedger();
+
+            std::uint32_t const aliceSeq = env.seq (alice);
+            aliceTickets = getTicketsOnAccount (env.ledger, alice);
+            env.require (owners (alice, 2), tickets (alice, 2));
+            env (pay (alice, env.master, drops (1000)),
+                tckt (aliceTickets[1]));
+
+            // Advancing the ledger causes time to pass.  The remaining Ticket
+            // should now expire.
+            advanceLedger();
+
+            STAmount const aliceOldBalance = env.balance (alice, XRP);
+            env (pay (alice, env.master, drops (1000)), fee (baseFee),
+                tckt (aliceTickets[0]), ter (tecEXPIRED_TICKET));
+
+            advanceLedger();
+
+            // Since the error was a 'tec' make sure that the Fee was charged.
+            // Charging the Fee should also consume the Ticket.
+            expect (aliceOldBalance == env.balance (alice, XRP) + baseFee);
+            env.require (owners (alice, 0), tickets (alice, 0));
+            expect (aliceSeq == env.seq (alice));
+        }
+
+        // Create a couple of Tickets with a targets and an expiration.
+        // Consume one in a timely fashion.  Use the other after it expires.
+        {
+            std::uint32_t const expry = halfResolution + expResolution +
+                env.ledger->getParentCloseTimeNC();
+
+            env (ticket::create (alice, cheri, expry));
+            env (ticket::create (alice, cheri, expry));
+            advanceLedger();
+
+            std::uint32_t const aliceSeq = env.seq (alice);
+            std::uint32_t const cheriSeq = env.seq (cheri);
+            aliceTickets = getTicketsOnAccount (env.ledger, alice);
+            expect (aliceTickets.size () == 2);
+            env (pay (cheri, env.master, drops (1000)),
+                tckt (aliceTickets[1]));
+
+            // Advancing the ledger causes time to pass.  The remaining Ticket
+            // should now expire.
+            advanceLedger();
+
+            STAmount const aliceOldBalance = env.balance (alice, XRP);
+            STAmount const cheriOldBalance = env.balance (cheri, XRP);
+            env (pay (cheri, env.master, drops (1000)), fee (baseFee),
+                tckt (aliceTickets[0]), ter (tecEXPIRED_TICKET));
+
+            advanceLedger();
+
+            // Since the error was a 'tec' make sure that the Fee was charged.
+            // Charging the Fee should also consume the Ticket.
+            expect (aliceOldBalance == env.balance (alice, XRP));
+            expect (cheriOldBalance == env.balance (cheri, XRP) + baseFee);
+            expect (aliceSeq == env.seq (alice));
+            expect (cheriSeq == env.seq (cheri));
+            env.require (owners (alice, 0), tickets (alice, 0));
+        }
+
+        // See if retries really work.  To simulate a network anomaly:
+        //  a. Construct a Ticket representation that isn't created yet.
+        //  b. Submit a transaction using that Ticket.  Should get a `ter`.
+        //  c. Advance the ledger.
+        //  d. Create the Ticket.
+        //  e. Advance the ledger.
+        //  f. The Ticket should be consumed and the transaction completed
+        {
+            TicketInfo const futureTicket {alice, env.seq (alice)};
+
+            STAmount const aliceOldBalance = env.balance (alice, XRP);
+            STAmount const alicePays = drops (1000) - (2 * baseFee);
+            env (pay (alice, env.master, alicePays),
+                fee (baseFee), tckt (futureTicket), ter (terPRE_TICKET));
+            advanceLedger();
+
+            expect (aliceOldBalance == env.balance (alice, XRP));
+            env (ticket::create (alice), fee (baseFee));
+            aliceTickets = getTicketsOnAccount (env.ledger, alice);
+            advanceLedger();
+
+            env.require (owners (alice, 0), tickets (alice, 0));
+            expect (aliceOldBalance == env.balance (alice, XRP) + drops (1000));
+        }
+
+        //----------------------------------------------------------------------
+        //  It should not be possible to create a Ticket using a Ticket.
+        env (ticket::create (alice));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        env (ticket::create (alice),
+            tckt (aliceTickets[0]), ter (temMALFORMED));
+
+        //  Consume the Ticket so there are no leftovers for the next tests.
+        env (noop (alice), tckt (aliceTickets[0]));
+
+        //----------------------------------------------------------------------
+        // Let's cancel some Tickets.
+        // Create two Tickets with a Target.
+        //  a. A cancel transaction from neither should fail.
+        //  b. A cancel transaction from the Target should succeed.
+        //  c. A cancel transaction from the owner should succeed.
+        //  d. Canceling an already canceled Ticket should succeed.
+        env (ticket::create (alice, cheri));
+        env (ticket::create (alice, cheri));
+        advanceLedger();
+
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        env (ticket::cancel (becky, aliceTickets[0]), ter (tefNO_PERMISSION));
+        env (ticket::cancel (cheri, aliceTickets[0]));
+        env (ticket::cancel (alice, aliceTickets[1]));
+        advanceLedger();
+
+        // Canceling a consumed ticket should be an error
+        env.require (owners (alice, 0), tickets (alice, 0));
+        env (ticket::cancel (alice, aliceTickets[0]), ter (tefNO_ENTRY));
+
+        // The rule is that anyone, not just the owner and target, can cancel
+        // an expired ticket.
+        {
+            std::uint32_t const now = env.ledger->getParentCloseTimeNC();
+            env (ticket::create (alice, cheri, now + halfResolution));
+            env (ticket::create (alice, cheri, now + halfResolution));
+            env (ticket::create (alice, cheri, now + halfResolution));
+
+            // Advancing the ledger should make all three tickets expire.
+            advanceLedger();
+
+            aliceTickets = getTicketsOnAccount (env.ledger, alice);
+            env.require (owners (alice, 3), tickets (alice, 3));
+
+            // Anyone should be able to cancel the expired Tickets.
+            env (ticket::cancel (alice, aliceTickets[0]));
+            env (ticket::cancel (becky, aliceTickets[1]));
+            env (ticket::cancel (cheri, aliceTickets[2]));
+            advanceLedger();
+
+            aliceTickets = getTicketsOnAccount (env.ledger, alice);
+            env.require (owners (alice, 0), tickets (alice, 0));
+        }
+
+        //----------------------------------------------------------------------
+        // Calling TicketCancel with a Sequence of 0 should fail.
+        env (ticket::create (alice));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        advanceLedger();
+
+        env (ticket::cancel (alice, aliceTickets[0]),
+            seq (0), ter (temBAD_SEQUENCE));
+        advanceLedger();
+
+        env.require (owners (alice, 1), tickets (alice, 1));
+        env (ticket::cancel (alice, aliceTickets[0]));
+        advanceLedger();
+
+        env.require (owners (alice, 0), tickets (alice, 0));
+
+        // Try each of the transaction error ranges: tel, tem, tef, ter, tec.
+
+        //----------------------------------------------------------------------
+        // Generate a "telBAD_PUBLIC_KEY" by setting a long MessageKey.
+        env (ticket::create (alice));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        advanceLedger();
+
+        env (set_message_key (alice,
+            "012345789ABCDEF0123456789ABCDEF0123456789ABCDEF123456789ABCDEF"
+            "0123456789ABCDEF0123456789ABCDEF"), tckt (aliceTickets[0]),
+            ter (telBAD_PUBLIC_KEY));
+        advanceLedger();
+
+        // The tckt should be unaffected and usable.
+        env (noop (alice), tckt (aliceTickets[0]));
+        advanceLedger();
+
+        env.require (owners (alice, 0), tickets (alice, 0));
+
+        //----------------------------------------------------------------------
+        // Generate a "temINVALID_FLAG" by setting funky flags.
+        env (ticket::create (alice));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        advanceLedger();
+
+        env (noop (alice), txflags (0x80000001), ter (temINVALID_FLAG));
+        advanceLedger();
+
+        // The ticket should be unaffected and usable.
+        env (noop (alice), tckt (aliceTickets[0]));
+        advanceLedger();
+
+        env.require (owners (alice, 0), tickets (alice, 0));
+
+        //----------------------------------------------------------------------
+        // Generate a tefMAX_LEDGER.
+        env (ticket::create (alice));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        advanceLedger();
+
+        env (noop (alice), last_ledger_seq (1), ter (tefMAX_LEDGER));
+        advanceLedger();
+
+        // The ticket should be unaffected and usable.
+        env (noop (alice), tckt (aliceTickets[0]));
+        advanceLedger();
+
+        env.require (owners (alice, 0), tickets (alice, 0));
+
+        //----------------------------------------------------------------------
+        // Force terINSUF_FEE_B with a transaction without funds to pay the Fee.
+        Account const piker ("piker", KeyType::secp256k1);
+        env.fund (XRP (200), piker);
+        advanceLedger();
+
+        env (ticket::create (alice, piker));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        advanceLedger();
+
+        {
+            // We'll only use Tickets, so piker's sequence should not change.
+            std::uint32_t const aliceSeq = env.seq (alice);
+            std::uint32_t const pikerSeq = env.seq (piker);
+
+            // Give piker a transaction with a fee higher than the balance.
+            env (noop (piker), fee (drops (200001000)),
+                tckt (aliceTickets[0]), ter (terINSUF_FEE_B));
+
+            // Let the transaction circulate a few ledgers.
+            advanceLedger();
+            advanceLedger();
+            advanceLedger();
+            expect (env.balance (piker, XRP) == XRP (200));
+            expect (env.seq (piker) == pikerSeq);
+            env.require (owners (alice, 1), tickets (alice, 1));
+
+            // Fund piker enough to pay the fee.
+            env (pay (env.master, piker, drops (1020)));
+            advanceLedger();
+            expect (env.balance (piker, XRP) == drops (20));
+            expect (env.seq (alice) == aliceSeq);
+            expect (env.seq (piker) == pikerSeq);
+            env.require (owners (alice, 0), tickets (alice, 0));
+
+            // Just on principle, advance a few more times.  There used to
+            // be a problem that the retry would re-apply and cause havoc.
+            advanceLedger();
+            advanceLedger();
+            expect (env.balance (piker, XRP) == drops (20));
+            expect (env.seq (alice) == aliceSeq);
+            expect (env.seq (piker) == pikerSeq);
+            env.require (owners (alice, 0), tickets (alice, 0));
+        }
+
+        //----------------------------------------------------------------------
+        // Cause an tecUNFUNDED_PAYMENT since piker hasn't got the funds.
+        env (ticket::create (alice, piker));
+        aliceTickets = getTicketsOnAccount (env.ledger, alice);
+        advanceLedger();
+
+        {
+            // We'll only use Tickets, so piker's sequence should not change.
+            std::uint32_t const aliceSeq = env.seq (alice);
+            std::uint32_t const pikerSeq = env.seq (piker);
+
+            env (pay (piker, env.master, drops (1000)),
+                tckt (aliceTickets[0]),
+                fee (drops (10)),
+                ter (tecUNFUNDED_PAYMENT));
+            advanceLedger();
+
+            // alice's ticket should be consumed by the 'tec'.
+            env.require (owners (alice, 0), tickets (alice, 0));
+
+            // piker's balance should be reduced by the fee.
+            expect (env.balance (piker, XRP) == drops (10));
+
+            // Nobody's sequences should have moved.
+            expect (env.seq (alice) == aliceSeq);
+            expect (env.seq (piker) == pikerSeq);
+        }
+        env.require (owners (alice, 0), owners (becky, 0), owners (cheri, 0));
+        env.require (owners (piker, 0));
+    }
+
+    void
+    run()
+    {
+        testTicket();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Ticket,app,ripple)
+
+} // test
+} // ripple

--- a/src/ripple/app/tx/tests/common_transactor.h
+++ b/src/ripple/app/tx/tests/common_transactor.h
@@ -324,7 +324,8 @@ STTx getCreateTicketTx (UserAccount& acct);
 STTx getCreateTicketTx (UserAccount& acct, UserAccount const& target);
 
 // Return a transaction that cancels a ticket.
-STTx getCancelTicketTx (UserAccount& acct, uint256 const& ticketID);
+STTx getCancelTicketTx (
+    UserAccount& acct, UserAccount& ticketOwner, std::uint32_t ticketSeq);
 
 // Return an unsigned trust set transaction.
 STTx getTrustSetTx (UserAccount& from, Issue const& issuer, int limit);

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -341,7 +341,7 @@ cdirFirst (BasicView const& view,
     return cdirNext (view, uRootIndex, sleNode, uDirEntry, uEntryIndex);
 }
 
-bool 
+bool
 cdirNext (BasicView const& view,
     uint256 const& uRootIndex,  // --> Root of directory
     std::shared_ptr<SLE const>& sleNode,      // <-> current node
@@ -393,9 +393,13 @@ adjustOwnerCount (View& view,
         int amount)
 {
     assert(amount != 0);
-    auto const current =
+    std::uint32_t const current =
         sle->getFieldU32 (sfOwnerCount);
-    auto adjusted = current + amount;
+    std::uint32_t adjusted = current + amount;
+
+    // The following tests rely on "current" and "adjusted" being unsigned.
+    static_assert (std::is_unsigned<decltype(current)>::value, "");
+    static_assert (std::is_unsigned<decltype(adjusted)>::value, "");
     if (amount > 0)
     {
         // Overflow is well defined on unsigned
@@ -437,7 +441,7 @@ dirFirst (View& view,
     return dirNext (view, uRootIndex, sleNode, uDirEntry, uEntryIndex);
 }
 
-bool 
+bool
 dirNext (View& view,
     uint256 const& uRootIndex,  // --> Root of directory
     std::shared_ptr<SLE>& sleNode,      // <-> current node

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -39,10 +39,13 @@ JSS ( Account );                    // in: TransactionSign; field.
 JSS ( Amount );                     // in: TransactionSign; field.
 JSS ( ClearFlag );                  // field.
 JSS ( Destination );                // in: TransactionSign; field.
+JSS ( Expiration );                 // field.
 JSS ( Fee );                        // in/out: TransactionSign; field.
 JSS ( Flags );                      // in/out: TransactionSign; field.
 JSS ( Invalid );                    //
+JSS ( LastLedgerSequence );         // field.
 JSS ( LimitAmount );                // field.
+JSS ( MessageKey );                 // field.
 JSS ( OfferSequence );              // field.
 JSS ( Paths );                      // in/out: TransactionSign
 JSS ( TransferRate );               // in: TransferRate
@@ -54,6 +57,7 @@ JSS ( SetFlag );                    // field.
 JSS ( SigningPubKey );              // field
 JSS ( TakerGets );                  // field.
 JSS ( TakerPays );                  // field.
+JSS ( Target );                     // field.
 JSS ( TxnSignature );               // field
 JSS ( TransactionType );            // in: TransactionSign
 JSS ( aborted );                    // out: InboundLedger

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -363,7 +363,6 @@ extern SField const sfBookDirectory;
 extern SField const sfInvoiceID;
 extern SField const sfNickname;
 extern SField const sfAmendment;
-extern SField const sfTicketID;
 
 // 160-bit (common)
 extern SField const sfTakerPaysCurrency;
@@ -435,6 +434,7 @@ extern SField const sfMemo;
 extern SField const sfSignerEntry;
 extern SField const sfSigningAccount;
 extern SField const sfSigningFor;
+extern SField const sfTicketID;
 
 // array of objects
 // ARRAY/1 is reserved for end of array

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -114,8 +114,10 @@ enum TER    // aka TransactionEngineResult
     tefMAX_LEDGER,
     tefBAD_SIGNATURE,
     tefBAD_QUORUM,
+    tefNO_ENTRY,
     tefNOT_MULTI_SIGNING,
     tefBAD_AUTH_MASTER,
+    tefNO_PERMISSION,
 
     // -99 .. -1: R Retry
     //   sequence too high, no funds for txn fee, originating -account
@@ -142,6 +144,7 @@ enum TER    // aka TransactionEngineResult
                          // burden network.
     terLAST,             // Process after all other transactions
     terNO_RIPPLE,        // Rippling not allowed
+    terPRE_TICKET,       // Ticket might be from the future.
 
     // 0: S Success (success)
     // Causes:
@@ -158,7 +161,7 @@ enum TER    // aka TransactionEngineResult
     // Causes:
     // - Success, but does not achieve optimal result.
     // - Invalid transaction or no effect, but claim fee to use the sequence
-    //   number.
+    //   number or ticket.
     //
     // Implications:
     // - Applied
@@ -198,6 +201,7 @@ enum TER    // aka TransactionEngineResult
     tecNEED_MASTER_KEY          = 142,
     tecDST_TAG_NEEDED           = 143,
     tecINTERNAL                 = 144,
+    tecEXPIRED_TICKET           = 145
 };
 
 inline bool isTelLocal(TER x)

--- a/src/ripple/protocol/impl/InnerObjectFormats.cpp
+++ b/src/ripple/protocol/impl/InnerObjectFormats.cpp
@@ -22,22 +22,27 @@
 
 namespace ripple {
 
-InnerObjectFormats::InnerObjectFormats ()
+InnerObjectFormats::InnerObjectFormats()
 {
-    add (sfSignerEntry.getJsonName ().c_str (), sfSignerEntry.getCode ())
+    add (sfSignerEntry.getJsonName().c_str(), sfSignerEntry.getCode())
         << SOElement (sfAccount,              SOE_REQUIRED)
         << SOElement (sfSignerWeight,         SOE_REQUIRED)
         ;
 
-    add (sfSigningFor.getJsonName ().c_str (), sfSigningFor.getCode ())
+    add (sfSigningFor.getJsonName().c_str(), sfSigningFor.getCode())
         << SOElement (sfAccount,              SOE_REQUIRED)
         << SOElement (sfSigningAccounts,      SOE_REQUIRED)
         ;
 
-    add (sfSigningAccount.getJsonName ().c_str (), sfSigningAccount.getCode ())
+    add (sfSigningAccount.getJsonName().c_str(), sfSigningAccount.getCode())
         << SOElement (sfAccount,              SOE_REQUIRED)
         << SOElement (sfSigningPubKey,        SOE_REQUIRED)
         << SOElement (sfMultiSignature,       SOE_REQUIRED)
+        ;
+
+    add (sfTicketID.getJsonName().c_str(), sfTicketID.getCode())
+        << SOElement (sfAccount,              SOE_REQUIRED)
+        << SOElement (sfSequence,             SOE_REQUIRED)
         ;
 }
 
@@ -46,7 +51,7 @@ void InnerObjectFormats::addCommonFields (Item& item)
 }
 
 InnerObjectFormats const&
-InnerObjectFormats::getInstance ()
+InnerObjectFormats::getInstance()
 {
     static InnerObjectFormats instance;
     return instance;
@@ -56,7 +61,7 @@ SOTemplate const*
 InnerObjectFormats::findSOTemplateBySField (SField const& sField) const
 {
     SOTemplate const* ret = nullptr;
-    auto itemPtr = findByType (sField.getCode ());
+    auto itemPtr = findByType (sField.getCode());
     if (itemPtr)
         ret = &(itemPtr->elements);
 

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -104,6 +104,8 @@ LedgerFormats::LedgerFormats ()
             << SOElement (sfOwnerNode,           SOE_REQUIRED)
             << SOElement (sfTarget,              SOE_OPTIONAL)
             << SOElement (sfExpiration,          SOE_OPTIONAL)
+            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
+            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
             ;
 
     // All three fields are SOE_REQUIRED because there is always a

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -151,7 +151,6 @@ SField const sfBookDirectory = make::one(&sfBookDirectory, STI_HASH256, 16, "Boo
 SField const sfInvoiceID     = make::one(&sfInvoiceID,     STI_HASH256, 17, "InvoiceID");
 SField const sfNickname      = make::one(&sfNickname,      STI_HASH256, 18, "Nickname");
 SField const sfAmendment     = make::one(&sfAmendment,     STI_HASH256, 19, "Amendment");
-SField const sfTicketID      = make::one(&sfTicketID,      STI_HASH256, 20, "TicketID");
 
 // 160-bit (common)
 SField const sfTakerPaysCurrency = make::one(&sfTakerPaysCurrency, STI_HASH160, 1, "TakerPaysCurrency");
@@ -221,6 +220,7 @@ SField const sfNewFields           = make::one(&sfNewFields,           STI_OBJEC
 SField const sfTemplateEntry       = make::one(&sfTemplateEntry,       STI_OBJECT,  9, "TemplateEntry");
 SField const sfMemo                = make::one(&sfMemo,                STI_OBJECT, 10, "Memo");
 SField const sfSignerEntry         = make::one(&sfSignerEntry,         STI_OBJECT, 11, "SignerEntry");
+SField const sfTicketID            = make::one(&sfTicketID,            STI_OBJECT, 12, "TicketID");
 
 // inner object (uncommon)
 SField const sfSigningAccount      = make::one(&sfSigningAccount,      STI_OBJECT, 16, "SigningAccount");

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -68,6 +68,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tecNEED_MASTER_KEY,       "tecNEED_MASTER_KEY",       "The operation requires the use of the Master Key."             },
         { tecDST_TAG_NEEDED,        "tecDST_TAG_NEEDED",        "A destination tag is required."                                },
         { tecINTERNAL,              "tecINTERNAL",              "An internal error has occurred during processing."             },
+        { tecEXPIRED_TICKET,        "tecEXPIRED_TICKET",        "Ticket is expired."                                            },
 
         { tefALREADY,               "tefALREADY",               "The exact transaction was already in this ledger."             },
         { tefBAD_ADD_AUTH,          "tefBAD_ADD_AUTH",          "Not authorized to add account."                                },
@@ -82,6 +83,8 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tefMASTER_DISABLED,       "tefMASTER_DISABLED",       "Master key is disabled."                                       },
         { tefMAX_LEDGER,            "tefMAX_LEDGER",            "Ledger sequence too high."                                     },
         { tefNO_AUTH_REQUIRED,      "tefNO_AUTH_REQUIRED",      "Auth is not required."                                         },
+        { tefNO_ENTRY,              "tefNO_ENTRY",              "No matching entry found."                                      },
+        { tefNO_PERMISSION,         "tefNO_PERMISSION",         "No permission to perform requested operation."                 },
         { tefNOT_MULTI_SIGNING,     "tefNOT_MULTI_SIGNING",     "Account has no appropriate list of multi-signers."             },
         { tefPAST_SEQ,              "tefPAST_SEQ",              "This sequence number has already past."                        },
         { tefWRONG_PRIOR,           "tefWRONG_PRIOR",           "This previous transaction does not match."                     },
@@ -136,6 +139,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { terNO_LINE,               "terNO_LINE",               "No such line."                                                 },
         { terPRE_SEQ,               "terPRE_SEQ",               "Missing/inapplicable prior transaction."                       },
         { terOWNERS,                "terOWNERS",                "Non-zero owner count."                                         },
+        { terPRE_TICKET,            "terPRE_TICKET",            "Ticket does not exist yet."                                    },
 
         { tesSUCCESS,               "tesSUCCESS",               "The transaction was applied. Only final in a validated ledger." },
     };

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -34,12 +34,14 @@ TxFormats::TxFormats ()
         << SOElement (sfTransferRate,        SOE_OPTIONAL)
         << SOElement (sfSetFlag,             SOE_OPTIONAL)
         << SOElement (sfClearFlag,           SOE_OPTIONAL)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 
     add ("TrustSet", ttTRUST_SET)
         << SOElement (sfLimitAmount,         SOE_OPTIONAL)
         << SOElement (sfQualityIn,           SOE_OPTIONAL)
         << SOElement (sfQualityOut,          SOE_OPTIONAL)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 
     add ("OfferCreate", ttOFFER_CREATE)
@@ -47,14 +49,17 @@ TxFormats::TxFormats ()
         << SOElement (sfTakerGets,           SOE_REQUIRED)
         << SOElement (sfExpiration,          SOE_OPTIONAL)
         << SOElement (sfOfferSequence,       SOE_OPTIONAL)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 
     add ("OfferCancel", ttOFFER_CANCEL)
         << SOElement (sfOfferSequence,       SOE_REQUIRED)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 
     add ("SetRegularKey", ttREGULAR_KEY_SET)
         << SOElement (sfRegularKey,          SOE_OPTIONAL)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 
     add ("Payment", ttPAYMENT)
@@ -64,6 +69,7 @@ TxFormats::TxFormats ()
         << SOElement (sfPaths,               SOE_DEFAULT)
         << SOElement (sfInvoiceID,           SOE_OPTIONAL)
         << SOElement (sfDestinationTag,      SOE_OPTIONAL)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 
     add ("EnableAmendment", ttAMENDMENT)
@@ -93,6 +99,7 @@ TxFormats::TxFormats ()
     add ("SignerListSet", ttSIGNER_LIST_SET)
         << SOElement (sfSignerQuorum,        SOE_REQUIRED)
         << SOElement (sfSignerEntries,       SOE_OPTIONAL)
+        << SOElement (sfTicketID,            SOE_OPTIONAL)
         ;
 }
 

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -125,6 +125,7 @@ public:
 
 public:
     Env (beast::unit_test::suite& test_);
+    virtual ~Env() = default;
     
     /** Turn on JSON tracing.
         With no arguments, trace all
@@ -215,7 +216,7 @@ public:
     }
 
     /** Check a set of requirements.
-        
+
         The requirements are formed
         from condition functors.
     */

--- a/src/ripple/unity/app_tx.cpp
+++ b/src/ripple/unity/app_tx.cpp
@@ -23,6 +23,7 @@
 #include <ripple/app/tx/impl/CancelOffer.cpp>
 #include <ripple/app/tx/impl/CancelTicket.cpp>
 #include <ripple/app/tx/impl/Change.cpp>
+#include <ripple/app/tx/impl/CheckAndConsumeTicket.cpp>
 #include <ripple/app/tx/impl/CreateOffer.cpp>
 #include <ripple/app/tx/impl/CreateTicket.cpp>
 #include <ripple/app/tx/impl/InboundTransactions.cpp>
@@ -47,3 +48,4 @@
 #include <ripple/app/tx/tests/OfferStream.test.cpp>
 #include <ripple/app/tx/tests/Offer.test.cpp>
 #include <ripple/app/tx/tests/Taker.test.cpp>
+#include <ripple/app/tx/tests/Ticket.test.cpp>


### PR DESCRIPTION
There are a number of changes to Tickets with this commit:

 o A Ticket can be used in place of a Sequence in a transaction.

 o The external JSON representation of a Ticket has changed from
   a 256-bit hash to a two-entry object.

 o In TicketCreate and TicketCancel transactions it is not valid
   to use a Ticket instead of a Sequence.

 o Transactions with Tickets sort behind transactions without
   Tickets when they are applied to the ledger.  This will tend
   to keep TicketCreate and TicketCancel operations in front of
   transactions that consume Tickets.

 o There are C++ unit tests for Ticket functionality.

Work remaining:

 o There is some question about whether Tickets need to be
   threaded.  If they do, then threading will need to be added.

 o Documentation needs to be amended.

 o There may be additional fallout when David reviews the code.