### PR TITLE
Use coroutines to handle ripple_path_find better

### DIFF
--- a/src/ripple/app/paths/PathRequest.h
+++ b/src/ripple/app/paths/PathRequest.h
@@ -59,6 +59,12 @@ public:
         PathRequests&,
         beast::Journal journal);
 
+    PathRequest (
+        std::function <void (void)> const& completion,
+        int id,
+        PathRequests&,
+        beast::Journal journal);
+
     ~PathRequest ();
 
     bool        isValid ();
@@ -78,6 +84,7 @@ public:
     // update jvStatus
     Json::Value doUpdate (const std::shared_ptr<RippleLineCache>&, bool fast);
     InfoSub::pointer getSubscriber ();
+    bool hasCompletion ();
 
 private:
     bool isValid (RippleLineCache::ref crCache);
@@ -94,6 +101,7 @@ private:
     PathRequests& mOwner;
 
     std::weak_ptr<InfoSub> wpSubscriber; // Who this request came from
+    std::function <void (void)> fCompletion;
 
     Json::Value jvId;
     Json::Value jvStatus;                   // Last result

--- a/src/ripple/app/paths/PathRequests.h
+++ b/src/ripple/app/paths/PathRequests.h
@@ -49,6 +49,12 @@ public:
         const std::shared_ptr<Ledger>& ledger,
         Json::Value const& request);
 
+    Json::Value makeLegacyPathRequest (
+        PathRequest::pointer& req,
+        std::function <void (void)> completion,
+        const std::shared_ptr<Ledger>& inLedger,
+        Json::Value const& request);
+
     void reportFast (int milliseconds)
     {
         mFast.notify (static_cast < beast::insight::Event::value_type> (milliseconds));
@@ -60,6 +66,8 @@ public:
     }
 
 private:
+    void insertPathRequest (PathRequest::pointer const&);
+
     beast::Journal                   mJournal;
 
     beast::insight::Event            mFast;

--- a/src/ripple/rpc/Yield.h
+++ b/src/ripple/rpc/Yield.h
@@ -78,14 +78,9 @@ private:
 struct YieldStrategy
 {
     enum class Streaming {no, yes};
-    enum class UseCoroutines {no, yes};
 
     /** Is the data streamed, or generated monolithically? */
     Streaming streaming = Streaming::no;
-
-    /** Are results generated in a coroutine?  If this is no, then the code can
-        never yield. */
-    UseCoroutines useCoroutines = UseCoroutines::no;
 
     /** How many bytes do we emit before yielding?  0 means "never yield due to
         number of bytes sent". */

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -56,6 +56,25 @@ Json::Value doRipplePathFind (RPC::Context& context)
         if (!lpLedger)
             return jvResult;
     }
+    else
+    {
+        context.loadType = Resource::feeHighBurdenRPC;
+        lpLedger = context.netOps.getClosedLedger();
+
+        PathRequest::pointer request;
+        context.suspend ([&request, &context, &jvResult, &lpLedger](RPC::Callback const& c)
+        {
+            jvResult = getApp().getPathRequests().makeLegacyPathRequest (
+                request, c, lpLedger, context.params);
+            if (! request)
+                c();
+        });
+
+        if (request)
+            jvResult = request->doStatus (context.params);
+
+        return jvResult;
+    }
 
     if (!context.params.isMember (jss::source_account))
     {

--- a/src/ripple/rpc/impl/Yield.cpp
+++ b/src/ripple/rpc/impl/Yield.cpp
@@ -70,9 +70,6 @@ YieldStrategy makeYieldStrategy (Section const& s)
     ys.streaming = get<bool> (s, "streaming") ?
             YieldStrategy::Streaming::yes :
             YieldStrategy::Streaming::no;
-    ys.useCoroutines = get<bool> (s, "use_coroutines") ?
-            YieldStrategy::UseCoroutines::yes :
-            YieldStrategy::UseCoroutines::no;
     ys.byteYieldCount = get<std::size_t> (s, "byte_yield_count");
     ys.accountYieldCount = get<std::size_t> (s, "account_yield_count");
     ys.transactionYieldCount = get<std::size_t> (s, "transaction_yield_count");

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -181,24 +181,12 @@ ServerHandlerImp::onRequest (HTTP::Session& session)
 
     auto detach = session.detach();
 
-    if (setup_.yieldStrategy.useCoroutines ==
-        RPC::YieldStrategy::UseCoroutines::yes)
-    {
-        RPC::SuspendCallback suspend (
-            [this, detach] (RPC::Suspend const& suspend) {
-                processSession (detach, suspend);
-            });
-        RPC::Coroutine coroutine (suspend);
-        coroutine.run();
-    }
-    else
-    {
-        m_jobQueue.addJob (
-            jtCLIENT, "RPC-Client",
-            [=] (Job&) {
-                processSession (detach, RPC::Suspend());
-            });
-    }
+    RPC::SuspendCallback suspend (
+        [this, detach] (RPC::Suspend const& suspend) {
+            processSession (detach, suspend);
+        });
+    RPC::Coroutine coroutine (suspend);
+    coroutine.run();
 }
 
 void

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -60,7 +60,6 @@ ServerHandlerImp::ServerHandlerImp (Stoppable& parent,
     : ServerHandler (parent)
     , m_resourceManager (resourceManager)
     , m_journal (deprecatedLogs().journal("Server"))
-    , m_jobQueue (jobQueue)
     , m_networkOPs (networkOPs)
     , m_server (HTTP::make_Server(
         *this, io_service, deprecatedLogs().journal("Server")))

--- a/src/ripple/server/impl/ServerHandlerImp.h
+++ b/src/ripple/server/impl/ServerHandlerImp.h
@@ -37,7 +37,6 @@ class ServerHandlerImp
 private:
     Resource::Manager& m_resourceManager;
     beast::Journal m_journal;
-    JobQueue& m_jobQueue;
     NetworkOPs& m_networkOPs;
     std::unique_ptr<HTTP::Server> m_server;
     RPC::Continuation m_continuation;


### PR DESCRIPTION
Use coroutines to dispatch client requests.

Use the coroutine suspend/resume function to dramatically improve the handling of ripple_path_find requests that don't specify a ledger.