### PR TITLE
Three changes

### DIFF
--- a/src/ripple/app/ledger/InboundLedgers.h
+++ b/src/ripple/app/ledger/InboundLedgers.h
@@ -63,7 +63,7 @@ public:
 
     virtual int getFetchCount (int& timeoutCount) = 0;
 
-    virtual void logFailure (uint256 const& h) = 0;
+    virtual void logFailure (uint256 const& h, std::uint32_t seq) = 0;
 
     virtual bool isFailure (uint256 const& h) = 0;
 

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -330,6 +330,9 @@ static void LADispatch (
         getApp().getLedgerMaster().checkAccept(la->getLedger());
         getApp().getLedgerMaster().tryAdvance();
     }
+    else
+        getApp().getInboundLedgers().logFailure (la->getHash(), la->getSeq());
+
     for (unsigned int i = 0; i < trig.size (); ++i)
         trig[i] (la);
 }
@@ -361,8 +364,6 @@ void InboundLedger::done ()
             getApp().getLedgerMaster ().storeLedger (mLedger);
         getApp().getInboundLedgers().onLedgerFetched(mReason);
     }
-    else
-        getApp().getInboundLedgers ().logFailure (mHash);
 
     // We hold the PeerSet lock, so must dispatch
     getApp().getJobQueue ().addJob (jtLEDGER_DATA, "triggers",

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -24,6 +24,7 @@
 #include <ripple/basics/DecayingSample.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/JobQueue.h>
+#include <ripple/protocol/JsonFields.h>
 #include <beast/cxx14/memory.h> // <memory>
 #include <beast/module/core/text/LexicalCast.h>
 #include <beast/container/aged_map.h>
@@ -42,7 +43,7 @@ private:
 public:
     using u256_acq_pair = std::pair<uint256, InboundLedger::pointer>;
     // How long before we try again to acquire the same ledger
-    static const int kReacquireIntervalSeconds = 300;
+    static const std::chrono::minutes kReacquireInterval;
 
     InboundLedgersImp (clock_type& clock, Stoppable& parent,
                        beast::insight::Collector::ptr const& collector)
@@ -211,7 +212,7 @@ public:
     {
         ScopedLockType sl (mLock);
 
-        beast::expire (mRecentFailures, std::chrono::seconds (kReacquireIntervalSeconds));
+        beast::expire (mRecentFailures, kReacquireInterval);
         return mRecentFailures.find (h) != mRecentFailures.end();
     }
 
@@ -373,7 +374,7 @@ public:
                 }
             }
 
-            beast::expire (mRecentFailures, std::chrono::seconds (kReacquireIntervalSeconds));
+            beast::expire (mRecentFailures, kReacquireInterval);
 
         }
 
@@ -408,6 +409,8 @@ private:
 };
 
 //------------------------------------------------------------------------------
+
+decltype(InboundLedgersImp::kReacquireInterval) InboundLedgersImp::kReacquireInterval{5};
 
 InboundLedgers::~InboundLedgers()
 {

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -537,6 +537,17 @@ PeerImp::onTimer (error_code const& ec)
         send (std::make_shared<Message> (
             message, protocol::mtPING));
     }
+    else
+    {
+        // We have an outstanding ping, raise latency        
+        auto minLatency = std::chrono::duration_cast <std::chrono::milliseconds>
+            (clock_type::now() - lastPingTime_);
+
+        std::lock_guard<std::mutex> sl(recentLock_);
+
+        if (latency_ < minLatency)
+            latency_ = minLatency;
+    }
 
     setTimer();
 }

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -54,16 +54,16 @@ enum
     checkSeconds        =   10,
 
     /** How often we latency/sendq probe connections */
-    timerSeconds        =    3,
+    timerSeconds        =    4,
 
     /** How many timer intervals a sendq has to stay large before we disconnect */
-    sendqIntervals      =    3,
+    sendqIntervals      =    4,
 
     /** How many timer intervals we can go without a ping reply */
-    noPing              =    4,
+    noPing              =   10,
 
     /** How many messages on a send queue before we refuse queries */
-    dropSendQueue       =    5,
+    dropSendQueue       =    8,
 
     /** How many messages we consider reasonable sustained on a send queue */
     targetSendQueue     =   16,


### PR DESCRIPTION
1) Make InboundLedgers tracking of recent failures more accurate and better reported in fetch_info.
2) Avoid lock overlap in InboundLedgers.
3) Don't be so quick to disconnect a peer that takes some time to respond to pings.