### PR TITLE
Fix rm funded offer issue (RIPD-113)

### DIFF
--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -24,6 +24,15 @@
 namespace ripple {
 namespace path {
 
+static
+bool enableDirRestartFix (
+    std::uint32_t parentCloseTime)
+{
+    // Mon Aug 3 11:00:00am PDT
+    static std::uint32_t const enableAfter = 491940000;
+    return parentCloseTime > enableAfter;
+}
+
 // At the right most node of a list of consecutive offer nodes, given the amount
 // requested to be delivered, push towards the left nodes the amount requested
 // for the right nodes so we can compute how much to deliver from the source.
@@ -44,6 +53,12 @@ TER PathCursor::deliverNodeReverseImpl (
                                         ) const
 {
     TER resultCode   = tesSUCCESS;
+
+    if (!enableDirRestartFix (rippleCalc_.view.info ().parentCloseTime))
+    {
+        node().directory.restart(multiQuality_);
+    }
+
     // Accumulation of what the previous node must deliver.
     // Possible optimization: Note this gets zeroed on each increment, ideally
     // only on first increment, then it could be a limit on the forward pass.
@@ -351,8 +366,11 @@ TER PathCursor::deliverNodeReverse (
                                     // increment
                                     ) const
 {
-    for (int i = nodeIndex_; i >= 0 && !node (i).isAccount(); --i)
-        node (i).directory.restart (multiQuality_);
+    if (enableDirRestartFix (rippleCalc_.view.info ().parentCloseTime))
+    {
+        for (int i = nodeIndex_; i >= 0 && !node (i).isAccount(); --i)
+            node (i).directory.restart (multiQuality_);
+    }
 
     return deliverNodeReverseImpl(uOutAccountID, saOutReq, saOutAct);
 }

--- a/src/ripple/app/paths/cursor/PathCursor.h
+++ b/src/ripple/app/paths/cursor/PathCursor.h
@@ -85,6 +85,12 @@ private:
         STAmount const& saOutReq,
         STAmount& saOutAct) const;
 
+    // To deliver from an order book, when computing
+    TER deliverNodeReverseImpl (
+        AccountID const& uOutAccountID,
+        STAmount const& saOutReq,
+        STAmount& saOutAct) const;
+
     TER deliverNodeForward (
         AccountID const& uInAccountID,
         STAmount const& saInReq,

--- a/src/ripple/basics/chrono.h
+++ b/src/ripple/basics/chrono.h
@@ -39,19 +39,6 @@ using weeks = std::chrono::duration
     <int, std::ratio_multiply<
         days::period, std::ratio<7>>>;
 
-/** A clock for measuring elapsed time.
-
-    The epoch is unspecified.
-*/
-using Stopwatch =
-    beast::abstract_clock<
-        std::chrono::steady_clock>;
-
-/** A manual clock for unit tests. */
-using TestClock =
-    beast::manual_clock<
-        Stopwatch::clock_type>;
-
 /** Clock for measuring Ripple Network Time.
   
     The epoch is January 1, 2000
@@ -77,8 +64,39 @@ public:
         std::chrono::time_point<
             NetClock, duration>;
 
-    // VFALCO now() intentionally omitted for the moment
+    static bool const /* constexpr? */ is_steady =
+        std::chrono::system_clock::is_steady;
+
+    static
+    time_point
+    now()
+    {
+        using namespace std;
+        auto const when =
+            chrono::system_clock::now();
+        return time_point(
+            chrono::duration_cast<duration>(
+                when.time_since_epoch() -
+                    days(10957)));
+    }
 };
+
+/** A manual NetClock for unit tests. */
+using TestNetClock =
+    beast::manual_clock<NetClock>;
+
+/** A clock for measuring elapsed time.
+
+    The epoch is unspecified.
+*/
+using Stopwatch =
+    beast::abstract_clock<
+        std::chrono::steady_clock>;
+
+/** A manual Stopwatch for unit tests. */
+using TestStopwatch =
+    beast::manual_clock<
+        std::chrono::steady_clock>;
 
 /** Returns an instance of a wall clock. */
 inline

--- a/src/ripple/basics/tests/KeyCache.test.cpp
+++ b/src/ripple/basics/tests/KeyCache.test.cpp
@@ -30,7 +30,7 @@ class KeyCache_test : public beast::unit_test::suite
 public:
     void run ()
     {
-        TestClock clock;
+        TestStopwatch clock;
         clock.set (0);
 
         using Key = std::string;

--- a/src/ripple/basics/tests/TaggedCache.test.cpp
+++ b/src/ripple/basics/tests/TaggedCache.test.cpp
@@ -42,7 +42,7 @@ public:
     {
         beast::Journal const j;
 
-        TestClock clock;
+        TestStopwatch clock;
         clock.set (0);
 
         using Key = int;

--- a/src/ripple/peerfinder/sim/Tests.cpp
+++ b/src/ripple/peerfinder/sim/Tests.cpp
@@ -65,7 +65,7 @@ private:
     Params m_params;
     Journal m_journal;
     int m_next_node_id;
-    TestClock m_clock;
+    TestNetClock m_clock;
     Peers m_nodes;
     Table m_table;
     FunctionQueue m_queue;

--- a/src/ripple/peerfinder/tests/Livecache.test.cpp
+++ b/src/ripple/peerfinder/tests/Livecache.test.cpp
@@ -29,7 +29,7 @@ namespace PeerFinder {
 class Livecache_test : public beast::unit_test::suite
 {
 public:
-    TestClock m_clock;
+    TestStopwatch m_clock;
 
     // Add the address as an endpoint
     template <class C>

--- a/src/ripple/peerfinder/tests/PeerFinder_test.cpp
+++ b/src/ripple/peerfinder/tests/PeerFinder_test.cpp
@@ -71,7 +71,7 @@ public:
         testcase("backoff 1");
         TestStore store;
         TestChecker checker;
-        TestClock clock;
+        TestStopwatch clock;
         Logic<TestChecker> logic (clock, store, checker, beast::Journal{});
         logic.addFixedPeer ("test",
             beast::IP::Endpoint::from_string("65.0.0.1:5"));
@@ -109,7 +109,7 @@ public:
         testcase("backoff 2");
         TestStore store;
         TestChecker checker;
-        TestClock clock;
+        TestStopwatch clock;
         Logic<TestChecker> logic (clock, store, checker, beast::Journal{});
         logic.addFixedPeer ("test",
             beast::IP::Endpoint::from_string("65.0.0.1:5"));

--- a/src/ripple/resource/impl/Logic.h
+++ b/src/ripple/resource/impl/Logic.h
@@ -23,6 +23,7 @@
 #include <ripple/resource/Fees.h>
 #include <ripple/resource/Gossip.h>
 #include <ripple/resource/impl/Import.h>
+#include <ripple/basics/chrono.h>
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/JsonFields.h>
@@ -37,7 +38,7 @@ namespace Resource {
 class Logic
 {
 private:
-    using clock_type = beast::abstract_clock <std::chrono::steady_clock>;
+    using clock_type = Stopwatch;
     using Imports = hash_map <std::string, Import>;
     using Table = hash_map <Key, Entry, Key::hasher, Key::key_equal>;
     using EntryIntrusiveList = beast::List <Entry>;
@@ -83,7 +84,7 @@ private:
 
     SharedState m_state;
     Stats m_stats;
-    beast::abstract_clock <std::chrono::steady_clock>& m_clock;
+    Stopwatch& m_clock;
     beast::Journal m_journal;
 
     //--------------------------------------------------------------------------

--- a/src/ripple/resource/tests/Logic.test.cpp
+++ b/src/ripple/resource/tests/Logic.test.cpp
@@ -31,13 +31,13 @@ class Manager_test : public beast::unit_test::suite
 {
 public:
     class TestLogic
-        : private boost::base_from_member<TestClock>
+        : private boost::base_from_member<TestStopwatch>
         , public Logic
 
     {
     private:
         using clock_type =
-            boost::base_from_member<TestClock>;
+            boost::base_from_member<TestStopwatch>;
 
     public:
         explicit TestLogic (beast::Journal journal)
@@ -50,7 +50,7 @@ public:
             ++member;
         }
 
-        TestClock& clock ()
+        TestStopwatch& clock ()
         {
             return member;
         }

--- a/src/ripple/shamap/tests/common.h
+++ b/src/ripple/shamap/tests/common.h
@@ -39,7 +39,7 @@ namespace tests {
 class TestFamily : public shamap::Family
 {
 private:
-    TestClock clock_;
+    TestStopwatch clock_;
     NodeStore::DummyScheduler scheduler_;
     TreeNodeCache treecache_;
     FullBelowCache fullbelow_;

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -117,7 +117,7 @@ noripple (Account const& account,
 class Env
 {
 public:
-    using clock_type = TestClock;
+    using clock_type = TestNetClock;
 
     clock_type clock;
 
@@ -190,7 +190,7 @@ public:
             The Env clock is set to the new time.
     */
     void
-    close (TestClock::time_point const& closeTime);
+    close (NetClock::time_point const& closeTime);
 
     /** Close and advance the ledger.
 
@@ -202,6 +202,7 @@ public:
     close (std::chrono::duration<
         Rep, Period> const& elapsed)
     {
+        stopwatch_.advance(elapsed);
         close (clock.now() + elapsed);
     }
 
@@ -452,6 +453,7 @@ public:
 protected:
     int trace_ = 0;
     bool testing_ = true;
+    TestStopwatch stopwatch_;
 
     void
     autofill_sig (JTx& jt);

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -70,7 +70,7 @@ Env::Env (beast::unit_test::suite& test_)
         KeyType::secp256k1,
             generateSeed("masterpassphrase")))
     , closed_ (genesis())
-    , cachedSLEs_ (std::chrono::seconds(5), clock)
+    , cachedSLEs_ (std::chrono::seconds(5), stopwatch_)
     , openLedger (closed_, config, cachedSLEs_, journal)
 {
     memoize(master);
@@ -91,7 +91,7 @@ Env::closed() const
 
 void
 Env::close(
-    TestClock::time_point const& closeTime)
+    TestNetClock::time_point const& closeTime)
 {
     clock.set(closeTime);
     // VFALCO TODO Fix the Ledger constructor
@@ -123,10 +123,12 @@ Env::close(
                 config, journal);
         accum.apply(*next);
     }
-    next->setAccepted(
-        closeTime.time_since_epoch().count(),
-            ledgerPossibleTimeResolutions[0],
-                true);
+    // To ensure that the close time is exact and not rounded, we don't
+    // claim to have reached consensus on what it should be.
+    next->setAccepted (
+        std::chrono::duration_cast<std::chrono::seconds> (
+            closeTime.time_since_epoch ()).count (),
+        ledgerPossibleTimeResolutions[0], false);
     OrderedTxs locals({});
     openLedger.accept(next, locals,
         false, retries, applyFlags(), *router);


### PR DESCRIPTION
In some cases, funded offers were incorrectly removed. This happened
when:

1) There are multiple payment paths.
2) A payment path has a "taker gets" XRP immediately followed by another offer.
3) There must be multiple offers at the same best quality for "taker gets" XRP. Neither offer should fully satisfy the payment.
4) There must be multiple offers at the same best quality for the offer immediately following the "taker gets" XRP offer. Neither offer should fully satisfy the payment.
5) The offer after the "taker gets" XRP causes the "taker gets" XRP offer to be added to the perm unfunded list when calculating reverse liquidity.
4) The payment path is not used to satisfy the payment (there are other paths at better quality that do the job).

@rec @nbougalis 