### PR TITLE
Shamapitem buffer

### DIFF
--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -312,13 +312,13 @@ void LedgerHistory::handleMismatch (LedgerHash const& built, LedgerHash const& v
     builtLedger->txMap().visitLeaves(
         [&builtTx](std::shared_ptr<SHAMapItem const> const& item)
         {
-            builtTx.push_back({item->getTag(), item->peekData()});
+            builtTx.push_back({item->key(), item->peekData()});
         });
     // Get valid ledger hashes and metadata
     validLedger->txMap().visitLeaves(
         [&validTx](std::shared_ptr<SHAMapItem const> const& item)
         {
-            validTx.push_back({item->getTag(), item->peekData()});
+            validTx.push_back({item->key(), item->peekData()});
         });
 
     // Sort both by hash

--- a/src/ripple/app/ledger/LedgerToJson.h
+++ b/src/ripple/app/ledger/LedgerToJson.h
@@ -129,7 +129,7 @@ void fillJson (Object& json, LedgerFill const& fill)
         CountedYield count (
             fill.yieldStrategy.transactionYieldCount, fill.yield);
         for (auto item = txMap.peekFirstItem (type); item;
-             item = txMap.peekNextItem (item->getTag (), type))
+             item = txMap.peekNextItem (item->key(), type))
         {
             count.yield();
             if (bFull || bExpand)
@@ -167,7 +167,7 @@ void fillJson (Object& json, LedgerFill const& fill)
                         STTx txn (tsit);
 
                         TxMeta meta (
-                            item->getTag (), ledger.getLedgerSeq(), sit.getVL ());
+                            item->key(), ledger.getLedgerSeq(), sit.getVL ());
 
                         auto&& txJson = appendObject (txns);
                         copyFrom(txJson, txn.getJson (0));
@@ -177,12 +177,12 @@ void fillJson (Object& json, LedgerFill const& fill)
                 else
                 {
                     auto&& error = appendObject (txns);
-                    error[to_string (item->getTag ())] = (int) type;
+                    error[to_string (item->key())] = (int) type;
                 }
             }
             else
             {
-                txns.append (to_string (item->getTag ()));
+                txns.append (to_string (item->key()));
             }
         }
     }
@@ -201,7 +201,7 @@ void fillJson (Object& json, LedgerFill const& fill)
                      [&array] (std::shared_ptr<SHAMapItem const> const& smi)
                      {
                          auto&& obj = appendObject (array);
-                         obj[jss::hash] = to_string(smi->getTag ());
+                         obj[jss::hash] = to_string(smi->key());
                          obj[jss::tx_blob] = strHex(smi->peekData ());
                      });
              }
@@ -221,7 +221,7 @@ void fillJson (Object& json, LedgerFill const& fill)
                 [&array, &count] (std::shared_ptr<SHAMapItem const> const& smi)
                 {
                     count.yield();
-                    array.append (to_string(smi->getTag ()));
+                    array.append (to_string(smi->key()));
                 });
         }
     }

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1825,7 +1825,7 @@ void applyTransactions (
 
             // The transaction isn't in the check ledger, try to apply it
             WriteLog (lsDEBUG, LedgerConsensus) <<
-                "Processing candidate transaction: " << item->getTag ();
+                "Processing candidate transaction: " << item->key();
 
             try
             {

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1331,16 +1331,16 @@ bool ApplicationImp::loadOldLedger (
             for (auto const& item : txns)
             {
                 auto const txn =
-                    getTransaction(*replayLedger, item->getTag(),
+                    getTransaction(*replayLedger, item->key(),
                         getApp().getMasterTransaction());
                 if (m_journal.info) m_journal.info <<
                     txn->getJson(0);
                 Serializer s;
                 txn->getSTransaction()->add(s);
-                cur->txInsert(item->getTag(),
+                cur->txInsert(item->key(),
                     std::make_shared<Serializer const>(
                         std::move(s)), nullptr);
-                getApp().getHashRouter().setFlag (item->getTag(), SF_SIGGOOD);
+                getApp().getHashRouter().setFlag (item->key(), SF_SIGGOOD);
             }
 
             // Switch to the mutable snapshot

--- a/src/ripple/app/tx/impl/TransactionMaster.cpp
+++ b/src/ripple/app/tx/impl/TransactionMaster.cpp
@@ -64,7 +64,7 @@ STTx::pointer TransactionMaster::fetch (std::shared_ptr<SHAMapItem> const& item,
         bool checkDisk, std::uint32_t uCommitLedger)
 {
     STTx::pointer  txn;
-    Transaction::pointer            iTx = getApp().getMasterTransaction ().fetch (item->getTag (), false);
+    auto iTx = getApp().getMasterTransaction ().fetch (item->key(), false);
 
     if (!iTx)
     {
@@ -76,12 +76,8 @@ STTx::pointer TransactionMaster::fetch (std::shared_ptr<SHAMapItem> const& item,
         }
         else if (type == SHAMapTreeNode::tnTRANSACTION_MD)
         {
-            Serializer s;
-            int length;
-            item->peekSerializer().getVL (s.modData (), 0, length);
-            SerialIter sit (s.slice());
-
-            txn = std::make_shared<STTx> (std::ref (sit));
+            auto blob = SerialIter{item->data(), item->size()}.getVL();
+            txn = std::make_shared<STTx>(SerialIter{blob.data(), blob.size()});
         }
     }
     else

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -48,6 +48,8 @@ public:
     STLedgerEntry (const Serializer & s, uint256 const& index);
     
     STLedgerEntry (SerialIter & sit, uint256 const& index);
+    STLedgerEntry(SerialIter&& sit, uint256 const& index)
+        : STLedgerEntry(sit, index) {}
   
         
     STLedgerEntry (const STObject & object, uint256 const& index);

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -54,6 +54,7 @@ public:
     STTx (STTx const& other) = default;
 
     explicit STTx (SerialIter& sit);
+    explicit STTx (SerialIter&& sit) : STTx(sit) {}
     explicit STTx (TxType type);
 
     explicit STTx (STObject&& object);

--- a/src/ripple/rpc/handlers/LedgerData.cpp
+++ b/src/ripple/rpc/handlers/LedgerData.cpp
@@ -82,7 +82,7 @@ Json::Value doLedgerData (RPC::Context& context)
        auto item = map.peekNextItem (resumePoint);
        if (!item)
            break;
-       resumePoint = item->getTag();
+       resumePoint = item->key();
 
        if (limit-- <= 0)
        {
@@ -96,13 +96,13 @@ Json::Value doLedgerData (RPC::Context& context)
            Json::Value& entry = nodes.append (Json::objectValue);
            entry[jss::data] = strHex (
                item->peekData().begin(), item->peekData().size());
-           entry[jss::index] = to_string (item->getTag ());
+           entry[jss::index] = to_string (item->key());
        }
        else
        {
-           SLE sle (item->peekSerializer(), item->getTag ());
+           SLE sle (SerialIter{item->data(), item->size()}, item->key());
            Json::Value& entry = nodes.append (sle.getJson (0));
-           entry[jss::index] = to_string (item->getTag ());
+           entry[jss::index] = to_string (item->key());
        }
     }
 

--- a/src/ripple/shamap/SHAMapItem.h
+++ b/src/ripple/shamap/SHAMapItem.h
@@ -20,9 +20,10 @@
 #ifndef RIPPLE_SHAMAP_SHAMAPITEM_H_INCLUDED
 #define RIPPLE_SHAMAP_SHAMAPITEM_H_INCLUDED
 
-#include <ripple/protocol/Serializer.h>
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/Blob.h>
 #include <ripple/basics/Slice.h>
+#include <ripple/protocol/Serializer.h>
 #include <beast/utility/Journal.h>
 
 #include <cstddef>
@@ -33,87 +34,58 @@ namespace ripple {
 class SHAMapItem
 {
 private:
-    uint256 mTag;
-    Serializer mData;
+    uint256    tag_;
+    Blob       data_;
 
 public:
-    explicit SHAMapItem (uint256 const& tag);
     SHAMapItem (uint256 const& tag, Blob const & data);
     SHAMapItem (uint256 const& tag, Serializer const& s);
-    SHAMapItem (uint256 const& key, Serializer&& s);
 
     Slice slice() const;
 
-    uint256 const&
-    key() const
-    {
-        return mTag;
-    }
-
-    // DEPRECATED
-    uint256 const& getTag() const;
+    uint256 const& key() const;
 
     Blob const& peekData() const;
-    Serializer const& peekSerializer() const;
 
-public:  // public only to SHAMapTreeNode
     std::size_t size() const;
-
-private:
-    explicit SHAMapItem (Blob const& data);
-
     void const* data() const;
-    void dump (beast::Journal journal);
 };
 
 //------------------------------------------------------------------------------
 
 inline
-SHAMapItem::SHAMapItem (uint256 const& tag)
-    : mTag (tag)
-{
-}
-
-inline
 Slice
 SHAMapItem::slice() const
 {
-    return mData.slice();
+    return {data_.data(), data_.size()};
 }
 
 inline
 std::size_t
 SHAMapItem::size() const
 {
-    return mData.peekData().size();
+    return data_.size();
 }
 
 inline
 void const*
 SHAMapItem::data() const
 {
-    return mData.peekData().data();
+    return data_.data();
 }
 
 inline
 uint256 const&
-SHAMapItem::getTag() const
+SHAMapItem::key() const
 {
-    return mTag;
+    return tag_;
 }
 
 inline
 Blob const&
 SHAMapItem::peekData() const
 {
-    return mData.peekData();
-}
-
-inline
-Serializer const&
-SHAMapItem::peekSerializer() const
-{
-    return mData;
+    return data_;
 }
 
 } // ripple

--- a/src/ripple/shamap/impl/SHAMapDelta.cpp
+++ b/src/ripple/shamap/impl/SHAMapDelta.cpp
@@ -58,14 +58,14 @@ bool SHAMap::walkBranch (SHAMapAbstractNode* node,
             // This is a leaf node, process its item
             auto item = static_cast<SHAMapTreeNode*>(node)->peekItem();
 
-            if (emptyBranch || (item->getTag () != otherMapItem->getTag ()))
+            if (emptyBranch || (item->key() != otherMapItem->key()))
             {
                 // unmatched
                 if (isFirstMap)
-                    differences.insert (std::make_pair (item->getTag (),
+                    differences.insert (std::make_pair (item->key(),
                         DeltaRef (item, std::shared_ptr<SHAMapItem const> ())));
                 else
-                    differences.insert (std::make_pair (item->getTag (),
+                    differences.insert (std::make_pair (item->key(),
                         DeltaRef (std::shared_ptr<SHAMapItem const> (), item)));
 
                 if (--maxCount <= 0)
@@ -75,10 +75,10 @@ bool SHAMap::walkBranch (SHAMapAbstractNode* node,
             {
                 // non-matching items with same tag
                 if (isFirstMap)
-                    differences.insert (std::make_pair (item->getTag (),
+                    differences.insert (std::make_pair (item->key(),
                                                 DeltaRef (item, otherMapItem)));
                 else
-                    differences.insert (std::make_pair (item->getTag (),
+                    differences.insert (std::make_pair (item->key(),
                                                 DeltaRef (otherMapItem, item)));
 
                 if (--maxCount <= 0)
@@ -98,11 +98,11 @@ bool SHAMap::walkBranch (SHAMapAbstractNode* node,
     {
         // otherMapItem was unmatched, must add
         if (isFirstMap) // this is first map, so other item is from second
-            differences.insert(std::make_pair(otherMapItem->getTag (),
+            differences.insert(std::make_pair(otherMapItem->key(),
                                               DeltaRef(std::shared_ptr<SHAMapItem const>(),
                                                        otherMapItem)));
         else
-            differences.insert(std::make_pair(otherMapItem->getTag (),
+            differences.insert(std::make_pair(otherMapItem->key(),
                 DeltaRef(otherMapItem, std::shared_ptr<SHAMapItem const>())));
 
         if (--maxCount <= 0)
@@ -147,11 +147,11 @@ SHAMap::compare (std::shared_ptr<SHAMap> const& otherMap,
             // two leaves
             auto ours = static_cast<SHAMapTreeNode*>(ourNode);
             auto other = static_cast<SHAMapTreeNode*>(otherNode);
-            if (ours->peekItem()->getTag () == other->peekItem()->getTag ())
+            if (ours->peekItem()->key() == other->peekItem()->key())
             {
                 if (ours->peekItem()->peekData () != other->peekItem()->peekData ())
                 {
-                    differences.insert (std::make_pair (ours->peekItem()->getTag (),
+                    differences.insert (std::make_pair (ours->peekItem()->key(),
                                                  DeltaRef (ours->peekItem (),
                                                  other->peekItem ())));
                     if (--maxCount <= 0)
@@ -160,13 +160,13 @@ SHAMap::compare (std::shared_ptr<SHAMap> const& otherMap,
             }
             else
             {
-                differences.insert (std::make_pair(ours->peekItem()->getTag (),
+                differences.insert (std::make_pair(ours->peekItem()->key(),
                                                    DeltaRef(ours->peekItem(),
                                                    std::shared_ptr<SHAMapItem const>())));
                 if (--maxCount <= 0)
                     return false;
 
-                differences.insert(std::make_pair(other->peekItem()->getTag (),
+                differences.insert(std::make_pair(other->peekItem()->key(),
                     DeltaRef(std::shared_ptr<SHAMapItem const>(), other->peekItem ())));
                 if (--maxCount <= 0)
                     return false;

--- a/src/ripple/shamap/impl/SHAMapItem.cpp
+++ b/src/ripple/shamap/impl/SHAMapItem.cpp
@@ -18,35 +18,23 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/protocol/Serializer.h>
 #include <ripple/shamap/SHAMapItem.h>
-    
+
 namespace ripple {
 
 class SHAMap;
 
 SHAMapItem::SHAMapItem (uint256 const& tag, Blob const& data)
-    : mTag (tag)
-    , mData (data.data(), data.size())
+    : tag_(tag)
+    , data_(data)
 {
 }
 
 SHAMapItem::SHAMapItem (uint256 const& tag, const Serializer& data)
-    : mTag (tag)
-    , mData (data.data(), data.size())
+    : tag_ (tag)
+    , data_(data.peekData())
 {
-}
-
-SHAMapItem::SHAMapItem (uint256 const& key, Serializer&& s)
-    : mTag(key)
-    , mData(std::move(s))
-{
-}
-
-// VFALCO This function appears not to be called
-void SHAMapItem::dump (beast::Journal journal)
-{
-    if (journal.info) journal.info <<
-        "SHAMapItem(" << mTag << ") " << mData.size () << "bytes";
 }
 
 } // ripple

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -606,7 +606,7 @@ bool SHAMap::deepCompare (SHAMap& other) const
                  return false;
             auto& nodePeek = static_cast<SHAMapTreeNode*>(node)->peekItem();
             auto& otherNodePeek = static_cast<SHAMapTreeNode*>(otherNode)->peekItem();
-            if (nodePeek->getTag() != otherNodePeek->getTag())
+            if (nodePeek->key() != otherNodePeek->key())
                 return false;
             if (nodePeek->peekData() != otherNodePeek->peekData())
                 return false;
@@ -742,7 +742,7 @@ SHAMap::visitDifferences(SHAMap* have,
     if (root_->isLeaf ())
     {
         auto leaf = std::static_pointer_cast<SHAMapTreeNode>(root_);
-        if (!have || !have->hasLeafNode(leaf->peekItem()->getTag(), leaf->getNodeHash()))
+        if (!have || !have->hasLeafNode(leaf->peekItem()->key(), leaf->getNodeHash()))
             func (*root_);
 
         return;
@@ -779,7 +779,7 @@ SHAMap::visitDifferences(SHAMap* have,
                         stack.push ({static_cast<SHAMapInnerNode*>(next), childID});
                 }
                 else if (!have || !have->hasLeafNode(
-                         static_cast<SHAMapTreeNode*>(next)->peekItem()->getTag(),
+                         static_cast<SHAMapTreeNode*>(next)->peekItem()->key(),
                          childHash))
                 {
                     if (! func (*next))

--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -328,13 +328,13 @@ SHAMapTreeNode::updateHash()
     {
         nh = sha512Half(HashPrefix::leafNode,
             make_Slice(mItem->peekData()),
-                mItem->getTag());
+                mItem->key());
     }
     else if (mType == tnTRANSACTION_MD)
     {
         nh = sha512Half(HashPrefix::txNode,
             make_Slice(mItem->peekData()),
-                mItem->getTag());
+                mItem->key());
     }
     else
         assert (false);
@@ -414,12 +414,12 @@ SHAMapTreeNode::addRaw(Serializer& s, SHANodeFormat format) const
         {
             s.add32 (HashPrefix::leafNode);
             s.addRaw (mItem->peekData ());
-            s.add256 (mItem->getTag ());
+            s.add256 (mItem->key());
         }
         else
         {
             s.addRaw (mItem->peekData ());
-            s.add256 (mItem->getTag ());
+            s.add256 (mItem->key());
             s.add8 (1);
         }
     }
@@ -442,12 +442,12 @@ SHAMapTreeNode::addRaw(Serializer& s, SHANodeFormat format) const
         {
             s.add32 (HashPrefix::txNode);
             s.addRaw (mItem->peekData ());
-            s.add256 (mItem->getTag ());
+            s.add256 (mItem->key());
         }
         else
         {
             s.addRaw (mItem->peekData ());
-            s.add256 (mItem->getTag ());
+            s.add256 (mItem->key());
             s.add8 (4);
         }
     }
@@ -534,7 +534,7 @@ SHAMapTreeNode::getString(const SHAMapNodeID & id) const
         ret += ",leaf\n";
 
     ret += "  Tag=";
-    ret += to_string (peekItem()->getTag ());
+    ret += to_string (peekItem()->key());
     ret += "\n  Hash=";
     ret += to_string (mHash);
     ret += "/";

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -29,10 +29,10 @@ namespace ripple {
 namespace shamap {
 namespace tests {
 
-inline bool operator== (SHAMapItem const& a, SHAMapItem const& b) { return a.getTag() == b.getTag(); }
-inline bool operator!= (SHAMapItem const& a, SHAMapItem const& b) { return a.getTag() != b.getTag(); }
-inline bool operator== (SHAMapItem const& a, uint256 const& b) { return a.getTag() == b; }
-inline bool operator!= (SHAMapItem const& a, uint256 const& b) { return a.getTag() != b; }
+inline bool operator== (SHAMapItem const& a, SHAMapItem const& b) { return a.key() == b.key(); }
+inline bool operator!= (SHAMapItem const& a, SHAMapItem const& b) { return a.key() != b.key(); }
+inline bool operator== (SHAMapItem const& a, uint256 const& b) { return a.key() == b; }
+inline bool operator!= (SHAMapItem const& a, uint256 const& b) { return a.key() != b; }
 
 class SHAMap_test : public beast::unit_test::suite
 {
@@ -71,20 +71,20 @@ public:
         std::shared_ptr<SHAMapItem const> i;
         i = sMap.peekFirstItem ();
         unexpected (!i || (*i != i1), "bad traverse");
-        i = sMap.peekNextItem (i->getTag ());
+        i = sMap.peekNextItem (i->key());
         unexpected (!i || (*i != i2), "bad traverse");
-        i = sMap.peekNextItem (i->getTag ());
+        i = sMap.peekNextItem (i->key());
         unexpected (i, "bad traverse");
         sMap.addItem (i4, true, false);
-        sMap.delItem (i2.getTag ());
+        sMap.delItem (i2.key());
         sMap.addItem (i3, true, false);
         i = sMap.peekFirstItem ();
         unexpected (!i || (*i != i1), "bad traverse");
-        i = sMap.peekNextItem (i->getTag ());
+        i = sMap.peekNextItem (i->key());
         unexpected (!i || (*i != i3), "bad traverse");
-        i = sMap.peekNextItem (i->getTag ());
+        i = sMap.peekNextItem (i->key());
         unexpected (!i || (*i != i4), "bad traverse");
-        i = sMap.peekNextItem (i->getTag ());
+        i = sMap.peekNextItem (i->key());
         unexpected (i, "bad traverse");
 
         testcase ("snapshot");
@@ -92,7 +92,7 @@ public:
         std::shared_ptr<SHAMap> map2 = sMap.snapShot (false);
         unexpected (sMap.getHash () != mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
-        unexpected (!sMap.delItem (sMap.peekFirstItem ()->getTag ()), "bad mod");
+        unexpected (!sMap.delItem (sMap.peekFirstItem ()->key()), "bad mod");
         unexpected (sMap.getHash () == mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
 

--- a/src/ripple/shamap/tests/SHAMapSync.test.cpp
+++ b/src/ripple/shamap/tests/SHAMapSync.test.cpp
@@ -58,7 +58,7 @@ public:
         for (int i = 0; i < count; ++i)
         {
             std::shared_ptr<SHAMapItem> item = makeRandomAS ();
-            items.push_back (item->getTag ());
+            items.push_back (item->key());
 
             if (!map.addItem (*item, false, false))
             {


### PR DESCRIPTION
Replace Serializer with Blob in SHAMapItem:
* This helps decouples SHAMap and Serializer.
* Restyle data member names.
* Rename getTag() to key().

@ximinez @rec 