### PR TITLE
Silence warning

### DIFF
--- a/src/ripple/basics/impl/contract.cpp
+++ b/src/ripple/basics/impl/contract.cpp
@@ -29,8 +29,8 @@ accessViolation()
 {
     // dereference memory
     // location zero
-    int* j = 0;
-    *j++;
+    int volatile* j = 0;
+    (void)*j;
 }
 
 // This hook lets you do pre or post


### PR DESCRIPTION
On clang the current code produces
````
src/ripple/basics/impl/contract.cpp:33:5: warning: expression result unused [-Wunused-value]
    *j++;
    ^~~~
1 warning generated.
````
@vinniefalco 