### PR TITLE
Apply open ledger transactions on a jump

### DIFF
--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -68,7 +68,7 @@ public:
             to `retries`.
 
             retries are reapplied in canonical ordering
-            until the execution policy terminates application.
+            until the execution policy stops applying.
             Any transactions which were not successfully
             applied remain in `retries`.
 

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -54,6 +54,37 @@ public:
 
     virtual bool peerPosition (LedgerProposal::ref) = 0;
 
+    /** Apply open ledger transactions to a view.
+
+        Preconditions:
+
+            Caller must have ownership of the master mutex.
+
+        Effects:
+
+            Transactions in the open ledger, if any, are
+            applied to the view in key order. Any of
+            these transactions which fail are inserted
+            to `retries`.
+
+            Transactions in `retries` are reapplied in
+            canonical ordering until the execution policy
+            terminates application. Any transactions which
+            were not successfully applied remain in `retries`.
+
+            Finally, any locally held transactions are applied
+            individually in canonical ordering. The list of
+            locally held transactions is not modified.
+
+        @note The caller is responsible for applying the view to
+              the appropriate ledger.
+    */
+    virtual
+    void
+    applyOpenAndLocalTxs (View& accum,
+        std::shared_ptr<Ledger> const& newLCL,
+            CanonicalTXSet& retries) = 0;
+
     /** Simulate the consensus process without any network traffic.
 
         The end result, is that consensus begins and completes as if everyone

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -67,14 +67,16 @@ public:
             these transactions which fail are inserted
             to `retries`.
 
-            Transactions in `retries` are reapplied in
-            canonical ordering until the execution policy
-            terminates application. Any transactions which
-            were not successfully applied remain in `retries`.
+            retries are reapplied in canonical ordering
+            until the execution policy terminates application.
+            Any transactions which were not successfully
+            applied remain in `retries`.
 
             Finally, any locally held transactions are applied
             individually in canonical ordering. The list of
-            locally held transactions is not modified.
+            locally held transactions is not modified. Locally
+            held transactions which fail are not added to
+            `retries`
 
         @note The caller is responsible for applying the view to
               the appropriate ledger.

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1172,7 +1172,6 @@ LedgerConsensusImp::applyOpenAndLocalTxs (View& accum,
     std::shared_ptr<Ledger> const& newLCL,
         CanonicalTXSet& retries)
 {
-    // Apply transactions from the old open ledger
     auto const oldOL = ledgerMaster_.getCurrentLedger();
     if (oldOL->txMap().getHash().isNonZero ())
     {
@@ -1181,23 +1180,9 @@ LedgerConsensusImp::applyOpenAndLocalTxs (View& accum,
         applyTransactions (&oldOL->txMap(),
             accum, newLCL, retries);
     }
-
-    // Apply local transactions
     for (auto const& item : m_localTX.getTxSet ())
-    {
-        try
-        {
-            apply (accum, *item.second, tapNONE, getConfig(),
-                deprecatedLogs().journal("LedgerConsensus"));
-        }
-        catch (...)
-        {
-            // Nothing special we need to do.
-            // It's possible a cleverly malformed transaction or
-            // corrupt back end database could cause an exception
-            // during transaction processing.
-        }
-    }
+        apply (accum, *item.second, tapNONE, getConfig(),
+            deprecatedLogs().journal("LedgerConsensus"));
 }
 
 void LedgerConsensusImp::createDisputes (

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1122,32 +1122,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         LedgerMaster::ScopedLockType sl (ledgerMaster_.peekMutex (), std::defer_lock);
         std::lock(lock, sl);
 
-        // Apply transactions from the old open ledger
-        Ledger::pointer oldOL = ledgerMaster_.getCurrentLedger();
-        if (oldOL->txMap().getHash().isNonZero ())
-        {
-            WriteLog (lsDEBUG, LedgerConsensus)
-                << "Applying transactions from current open ledger";
-            applyTransactions (&oldOL->txMap(),
-                accum, newLCL, retriableTransactions);
-        }
-
-        // Apply local transactions
-        for (auto it : m_localTX.getTxSet ())
-        {
-            try
-            {
-                apply (accum, *it.second, tapNONE, getConfig(),
-                    deprecatedLogs().journal("LedgerConsensus"));
-            }
-            catch (...)
-            {
-                // Nothing special we need to do.
-                // It's possible a cleverly malformed transaction or
-                // corrupt back end database could cause an exception
-                // during transaction processing.
-            }
-        }
+        applyOpenAndLocalTxs (accum, newLCL, retriableTransactions);
 
         accum.apply(*newOL,
             deprecatedLogs().journal("LedgerConsensus"));
@@ -1189,6 +1164,39 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
             << "Our close offset is estimated at "
             << offset << " (" << closeCount << ")";
         getApp().getOPs ().closeTimeOffset (offset);
+    }
+}
+
+void
+LedgerConsensusImp::applyOpenAndLocalTxs (View& accum,
+    std::shared_ptr<Ledger> const& newLCL,
+        CanonicalTXSet& retries)
+{
+    // Apply transactions from the old open ledger
+    auto const oldOL = ledgerMaster_.getCurrentLedger();
+    if (oldOL->txMap().getHash().isNonZero ())
+    {
+        WriteLog (lsDEBUG, LedgerConsensus)
+            << "Applying transactions from current open ledger";
+        applyTransactions (&oldOL->txMap(),
+            accum, newLCL, retries);
+    }
+
+    // Apply local transactions
+    for (auto it : m_localTX.getTxSet ())
+    {
+        try
+        {
+            apply (accum, *it.second, tapNONE, getConfig(),
+                deprecatedLogs().journal("LedgerConsensus"));
+        }
+        catch (...)
+        {
+            // Nothing special we need to do.
+            // It's possible a cleverly malformed transaction or
+            // corrupt back end database could cause an exception
+            // during transaction processing.
+        }
     }
 }
 

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1183,11 +1183,11 @@ LedgerConsensusImp::applyOpenAndLocalTxs (View& accum,
     }
 
     // Apply local transactions
-    for (auto it : m_localTX.getTxSet ())
+    for (auto const& item : m_localTX.getTxSet ())
     {
         try
         {
-            apply (accum, *it.second, tapNONE, getConfig(),
+            apply (accum, *item.second, tapNONE, getConfig(),
                 deprecatedLogs().journal("LedgerConsensus"));
         }
         catch (...)

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -198,6 +198,11 @@ private:
     */
     void accept (std::shared_ptr<SHAMap> set);
 
+    void
+    applyOpenAndLocalTxs (View& accum,
+        std::shared_ptr<Ledger> const& newLCL,
+            CanonicalTXSet& retries) override;
+
     /**
       Compare two proposed transaction sets and create disputed
         transctions structures for any mismatches

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1409,6 +1409,16 @@ void NetworkOPsImp::switchLastClosedLedger (
     clearNeedNetworkLedger ();
     newLedger->setClosed ();
     auto openLedger = std::make_shared<Ledger> (false, std::ref (*newLedger));
+    // Apply transactions from the current open ledger to
+    // this new one, including locally held transactions.
+    {
+        // VFALCO Which hash do we use?
+        CanonicalTXSet retries({});
+        MetaView accum(*newLedger, tapNONE);
+        mLedgerConsensus->applyOpenAndLocalTxs(
+            accum, newLedger, retries);
+        accum.apply(*openLedger, m_journal);
+    }
     m_ledgerMaster.switchLedgers (newLedger, openLedger);
 
     protocol::TMStatusChange s;

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -77,10 +77,25 @@ std::pair<TER, bool>
 apply (BasicView& view,
     STTx const& tx, ViewFlags flags,
         Config const& config,
-            beast::Journal journal)
+            beast::Journal j)
 {
-    return invoke (tx.getTxnType(),
-        view, tx, flags, config, journal);
+    try
+    {
+        return invoke (tx.getTxnType(),
+            view, tx, flags, config, j);
+    }
+    catch(std::exception const& e)
+    {
+        JLOG(j.fatal) <<
+            "Caught exception: " << e.what();
+        return { tefEXCEPTION, false };
+    }
+    catch(...)
+    {
+        JLOG(j.fatal) <<
+            "Caught unknown exception";
+        return { tefEXCEPTION, false };
+    }
 }
 
 } // ripple


### PR DESCRIPTION
This might fix a bug where transactions in the open ledger get lost
