### PR TITLE
Apply tx to new open ledger on switch (RIPD-972):

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1415,15 +1415,10 @@ void NetworkOPsImp::switchLastClosedLedger (
         // open ledger. Then apply local tx.
         auto const oldOL =
             m_ledgerMaster.getCurrentLedger();
-        // VFALCO What do we use for the hash?
-        CanonicalTXSet retries({});
         MetaView accum(*newLCL, tapNONE);
+        auto retries = m_localTX->getTxSet();
         applyTransactions (&oldOL->txMap(),
             accum, newLCL, retries);
-        auto const localTx = m_localTX->getTxSet();
-        for (auto const& item : localTx)
-            ripple::apply (accum, *item.second,
-            tapNONE, getConfig(), m_journal);
         accum.apply(*newOL, m_journal);
     }
 

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -77,10 +77,25 @@ std::pair<TER, bool>
 apply (BasicView& view,
     STTx const& tx, ViewFlags flags,
         Config const& config,
-            beast::Journal journal)
+            beast::Journal j)
 {
-    return invoke (tx.getTxnType(),
-        view, tx, flags, config, journal);
+    try
+    {
+        return invoke (tx.getTxnType(),
+            view, tx, flags, config, j);
+    }
+    catch(std::exception const& e)
+    {
+        JLOG(j.fatal) <<
+            "Caught exception: " << e.what();
+        return { tefEXCEPTION, false };
+    }
+    catch(...)
+    {
+        JLOG(j.fatal) <<
+            "Caught unknown exception";
+        return { tefEXCEPTION, false };
+    }
 }
 
 } // ripple


### PR DESCRIPTION
Reimplemented and reopened.

When the last closed ledger jumps, transactions from the old open ledger and local transactions need to be applied to the new open ledger or else transactions could get lost locally (but still relayed, and therefore make it into a ledger).

A harmful effect is that rippled will report that the transaction was not applied even when it was, making robust transaction submission malfunction.