### PR TITLE
Fix SHAMapTreeNode deserialization

### DIFF
--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -157,12 +157,11 @@ SHAMapAbstractNode::make(Blob const& rawNode, std::uint32_t seq, SHANodeFormat f
             for (int i = 0; i < (len / 33); ++i)
             {
                 int pos;
-                s.get8 (pos, 32 + (i * 33));
-
-                if ((pos < 0) || (pos >= 16)) throw std::runtime_error ("invalid CI node");
-
+                if (!s.get8 (pos, 32 + (i * 33)))
+                    throw std::runtime_error ("short CI node");
+                if ((pos < 0) || (pos >= 16))
+                    throw std::runtime_error ("invalid CI node");
                 s.get256 (ret->mHashes[pos], i * 33);
-
                 if (ret->mHashes[pos].isNonZero ())
                     ret->mIsBranch |= (1 << pos);
             }


### PR DESCRIPTION
If we couldn't read the position from a compressed inner node then we shouldn't try to access it.

Reviews: @HowardHinnant, @JoelKatz