### PR TITLE
DeliverMin enable switch and precheck greater than dest amount

### DIFF
--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -192,13 +192,6 @@
 #define RIPPLE_USE_OPENSSL 0
 #endif
 
-/** Config: RIPPLE_ENABLE_DELIVERMIN
-    Enables processing of delivermin in transactions
-*/
-#ifndef RIPPLE_ENABLE_DELIVERMIN
-#define RIPPLE_ENABLE_DELIVERMIN 0
-#endif
-
 // Enables the experimental OpenLedger
 #ifndef RIPPLE_OPEN_LEDGER
 #define RIPPLE_OPEN_LEDGER 0

--- a/src/ripple/app/tx/tests/DeliverMin.test.cpp
+++ b/src/ripple/app/tx/tests/DeliverMin.test.cpp
@@ -49,23 +49,14 @@ public:
                 delivermin(Account("carol")["USD"](5)),
                 txflags(tfPartialPayment),                          ter(temBAD_AMOUNT));
             env(pay("alice", "bob", USD(10)), delivermin(USD(15)),
-                txflags(tfPartialPayment),                          ter(tecPATH_DRY));
-            env(pay("alice", "bob", USD(10)),
-                delivermin(USD(10)), txflags(tfPartialPayment),
-                sendmax(USD(9)),                                    ter(temBAD_AMOUNT));
+                txflags(tfPartialPayment),                          ter(temBAD_AMOUNT));
             env(pay(gw, "carol", USD(50)));
             env(offer("carol", XRP(5), USD(5)));
             env(pay("alice", "bob", USD(10)), paths(XRP),
                 delivermin(USD(7)), txflags(tfPartialPayment),
-                sendmax(XRP(20)),                                   ter(tecPATH_PARTIAL));
-            env.require(balance("alice", XRP(9999.99998)));
+                sendmax(XRP(5)),                                   ter(tecPATH_PARTIAL));
+            env.require(balance("alice", XRP(9999.99999)));
             env.require(balance("bob", XRP(10000)));
-
-            // DeliverMin greater than destination amount
-            env(pay("alice", "bob", USD(5)), paths(XRP),
-                delivermin(USD(50)), txflags(tfPartialPayment),
-                sendmax(XRP(5)));
-            env.require(balance("bob", USD(5)));
         }
 
         {

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -163,7 +163,7 @@ public:
         open ledger at the moment of the call.
         Transactions applied after the call to open()
         will not be visible.
-        
+
     */
     std::shared_ptr<ReadView const>
     open() const;
@@ -221,16 +221,23 @@ public:
         With no arguments, trace all
     */
     void
-    trace(int howMany = -1)
+    trace (int howMany = -1)
     {
         trace_ = howMany;
     }
 
     /** Turn off JSON tracing. */
     void
-    notrace()
+    notrace ()
     {
         trace_ = 0;
+    }
+
+    /** Turn off testing. */
+    void
+    disable_testing ()
+    {
+        testing_ = false;
     }
 
     /** Associate AccountID with account. */
@@ -306,7 +313,7 @@ public:
     }
 
     /** Check a set of requirements.
-        
+
         The requirements are formed
         from condition functors.
     */
@@ -445,6 +452,7 @@ public:
 
 protected:
     int trace_ = 0;
+    bool testing_ = true;
 
     void
     autofill_sig (JTx& jt);


### PR DESCRIPTION
* Added in payment::precheck to return a tem if the deliverMin amount is larger than the destination amount.
* Removed precheck where sendMax greater than deliverMin.
* Modified unit test accordingly.

Revierwers: @JoelKatz @seelabs @nbougalis 