### PR TITLE
Implement new amendment majority semantics :

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1390,8 +1390,10 @@ void LedgerConsensusImp::takeInitialPosition (Ledger& initialLedger)
         // previous ledger was flag ledger
         std::shared_ptr<SHAMap> preSet
             = initialLedger.txMap().snapShot (true);
-        m_feeVote.doVoting (mPreviousLedger, preSet);
-        getApp().getAmendmentTable ().doVoting (mPreviousLedger, preSet);
+        ValidationSet parentSet = getApp().getValidations().getValidations (
+            mPreviousLedger->getParentHash ());
+        m_feeVote.doVoting (mPreviousLedger, parentSet, preSet);
+        getApp().getAmendmentTable ().doVoting (mPreviousLedger, parentSet, preSet);
         initialSet = preSet->snapShot (false);
     }
     else

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -27,6 +27,7 @@
 #include <ripple/app/ledger/impl/LedgerCleaner.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/app/misc/IHashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/CanonicalTXSet.h>
@@ -233,6 +234,7 @@ public:
         getApp().getOPs().updateLocalTx (l);
         getApp().getSHAMapStore().onLedgerClosed (getValidatedLedger());
         mLedgerHistory.validatedLedger (l);
+        getApp().getAmendmentTable().doValidatedLedger (l);
 
     #if RIPPLE_HOOK_VALIDATORS
         getApp().getValidators().onLedgerClosed (l->getLedgerSeq(),

--- a/src/ripple/app/main/DBInit.cpp
+++ b/src/ripple/app/main/DBInit.cpp
@@ -254,12 +254,6 @@ const char* WalletDBInit[] =
         PRIMARY KEY (Validator,Entry)                   \
     );",
 
-    "CREATE TABLE IF NOT EXISTS Features (              \
-        Hash            CHARACTER(64) PRIMARY KEY,      \
-        FirstMajority   BIGINT UNSIGNED,                \
-        LastMajority    BIGINT UNSIGNED                 \
-    );",
-
     "END TRANSACTION;"
 };
 

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -24,6 +24,7 @@
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/protocol/JsonFields.h>
+#include <ripple/protocol/TxFlags.h>
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
 #include <algorithm>
@@ -35,7 +36,7 @@ namespace ripple {
    Amendments are proposed and then adopted or rejected by the network. An
    Amendment is uniquely identified by its AmendmentID, a 256-bit key.
 */
-template<class AppApiFacade>
+
 class AmendmentTableImpl final : public AmendmentTable
 {
 protected:
@@ -47,16 +48,14 @@ protected:
     LockType mLock;
 
     amendmentMap_t m_amendmentMap;
+    std::uint32_t m_lastUpdateSeq;
+
     std::chrono::seconds m_majorityTime; // Seconds an amendment must hold a majority
     int mMajorityFraction;  // 256 = 100%
-    Clock::time_point m_firstReport; // close time of first majority report
-    Clock::time_point m_lastReport;  // close time of most recent majority report
     beast::Journal m_journal;
-    AppApiFacade m_appApiFacade;
 
     AmendmentState& getCreate (uint256 const& amendment);
     AmendmentState* getExisting (uint256 const& amendment);
-    bool shouldEnable (std::uint32_t closeTime, const AmendmentState& fs);
     void setJson (Json::Value& v, const AmendmentState&);
 
 public:
@@ -64,10 +63,9 @@ public:
         std::chrono::seconds majorityTime,
         int majorityFraction,
         beast::Journal journal)
-        : m_majorityTime (majorityTime)
+        : m_lastUpdateSeq (0)
+        , m_majorityTime (majorityTime)
         , mMajorityFraction (majorityFraction)
-        , m_firstReport (0)
-        , m_lastReport (0)
         , m_journal (journal)
     {
     }
@@ -90,19 +88,28 @@ public:
     void setEnabled (const std::vector<uint256>& amendments) override;
     void setSupported (const std::vector<uint256>& amendments) override;
 
-    void reportValidations (const AmendmentSet&) override;
-
     Json::Value getJson (int) override;
     Json::Value getJson (uint256 const&) override;
 
-    void doValidation (Ledger::ref lastClosedLedger, STObject& baseValidation) override;
-    void doVoting (Ledger::ref lastClosedLedger,
-                   std::shared_ptr<SHAMap> const& initialPosition) override;
+    bool needValidatedLedger (LedgerIndex seq) override;
+
+    void doValidatedLedger (LedgerIndex seq,
+        enabledAmendments_t enabled) override;
+
+    std::vector <uint256>
+        doValidation (enabledAmendments_t const& enabledAmendments)
+            override;
+
+    std::map <uint256, std::uint32_t> doVoting (std::uint32_t closeTime,
+        enabledAmendments_t const& enabledAmendments,
+        majorityAmendments_t const& majorityAmendments,
+        ValidationSet const& validations) override;
 
     amendmentList_t getVetoed();
     amendmentList_t getEnabled();
-    amendmentList_t getToEnable(Clock::time_point closeTime);   // gets amendments we would vote to enable
-    amendmentList_t getDesired();    // amendments we support, do not veto, are not enabled
+
+    // Amendments we support, do not veto, and are not enabled
+    amendmentList_t getDesired (enabledAmendments_t const&);
 };
 
 namespace detail
@@ -117,9 +124,8 @@ namespace detail
 std::vector<AmendmentName> const preEnabledAmendments;
 }
 
-template<class AppApiFacade>
 void
-AmendmentTableImpl<AppApiFacade>::addInitial (Section const& section)
+AmendmentTableImpl::addInitial (Section const& section)
 {
     for (auto const& a : detail::preEnabledAmendments)
     {
@@ -177,9 +183,8 @@ AmendmentTableImpl<AppApiFacade>::addInitial (Section const& section)
     }
 }
 
-template<class AppApiFacade>
 AmendmentState&
-AmendmentTableImpl<AppApiFacade>::getCreate (uint256 const& amendmentHash)
+AmendmentTableImpl::getCreate (uint256 const& amendmentHash)
 {
     // call with the mutex held
     auto iter (m_amendmentMap.find (amendmentHash));
@@ -187,16 +192,14 @@ AmendmentTableImpl<AppApiFacade>::getCreate (uint256 const& amendmentHash)
     if (iter == m_amendmentMap.end())
     {
         AmendmentState& amendment = m_amendmentMap[amendmentHash];
-        m_appApiFacade.setMajorityTimesFromDBToState (amendment, amendmentHash);
         return amendment;
     }
 
     return iter->second;
 }
 
-template<class AppApiFacade>
 AmendmentState*
-AmendmentTableImpl<AppApiFacade>::getExisting (uint256 const& amendmentHash)
+AmendmentTableImpl::getExisting (uint256 const& amendmentHash)
 {
     // call with the mutex held
     auto iter (m_amendmentMap.find (amendmentHash));
@@ -207,9 +210,8 @@ AmendmentTableImpl<AppApiFacade>::getExisting (uint256 const& amendmentHash)
     return & (iter->second);
 }
 
-template<class AppApiFacade>
 uint256
-AmendmentTableImpl<AppApiFacade>::get (std::string const& name)
+AmendmentTableImpl::get (std::string const& name)
 {
     ScopedLockType sl (mLock);
 
@@ -222,9 +224,8 @@ AmendmentTableImpl<AppApiFacade>::get (std::string const& name)
     return uint256 ();
 }
 
-template<class AppApiFacade>
 void
-AmendmentTableImpl<AppApiFacade>::addKnown (AmendmentName const& name)
+AmendmentTableImpl::addKnown (AmendmentName const& name)
 {
     if (!name.valid ())
     {
@@ -246,9 +247,8 @@ AmendmentTableImpl<AppApiFacade>::addKnown (AmendmentName const& name)
     amendment.mSupported = true;
 }
 
-template<class AppApiFacade>
 bool
-AmendmentTableImpl<AppApiFacade>::veto (uint256 const& amendment)
+AmendmentTableImpl::veto (uint256 const& amendment)
 {
     ScopedLockType sl (mLock);
     AmendmentState& s = getCreate (amendment);
@@ -260,9 +260,8 @@ AmendmentTableImpl<AppApiFacade>::veto (uint256 const& amendment)
     return true;
 }
 
-template<class AppApiFacade>
 bool
-AmendmentTableImpl<AppApiFacade>::unVeto (uint256 const& amendment)
+AmendmentTableImpl::unVeto (uint256 const& amendment)
 {
     ScopedLockType sl (mLock);
     AmendmentState* s = getExisting (amendment);
@@ -274,9 +273,8 @@ AmendmentTableImpl<AppApiFacade>::unVeto (uint256 const& amendment)
     return true;
 }
 
-template<class AppApiFacade>
 bool
-AmendmentTableImpl<AppApiFacade>::enable (uint256 const& amendment)
+AmendmentTableImpl::enable (uint256 const& amendment)
 {
     ScopedLockType sl (mLock);
     AmendmentState& s = getCreate (amendment);
@@ -288,9 +286,8 @@ AmendmentTableImpl<AppApiFacade>::enable (uint256 const& amendment)
     return true;
 }
 
-template<class AppApiFacade>
 bool
-AmendmentTableImpl<AppApiFacade>::disable (uint256 const& amendment)
+AmendmentTableImpl::disable (uint256 const& amendment)
 {
     ScopedLockType sl (mLock);
     AmendmentState* s = getExisting (amendment);
@@ -302,27 +299,24 @@ AmendmentTableImpl<AppApiFacade>::disable (uint256 const& amendment)
     return true;
 }
 
-template<class AppApiFacade>
 bool
-AmendmentTableImpl<AppApiFacade>::isEnabled (uint256 const& amendment)
+AmendmentTableImpl::isEnabled (uint256 const& amendment)
 {
     ScopedLockType sl (mLock);
     AmendmentState* s = getExisting (amendment);
     return s && s->mEnabled;
 }
 
-template<class AppApiFacade>
 bool
-AmendmentTableImpl<AppApiFacade>::isSupported (uint256 const& amendment)
+AmendmentTableImpl::isSupported (uint256 const& amendment)
 {
     ScopedLockType sl (mLock);
     AmendmentState* s = getExisting (amendment);
     return s && s->mSupported;
 }
 
-template<class AppApiFacade>
-typename AmendmentTableImpl<AppApiFacade>::amendmentList_t
-AmendmentTableImpl<AppApiFacade>::getVetoed ()
+AmendmentTableImpl::amendmentList_t
+AmendmentTableImpl::getVetoed ()
 {
     amendmentList_t ret;
     ScopedLockType sl (mLock);
@@ -334,9 +328,8 @@ AmendmentTableImpl<AppApiFacade>::getVetoed ()
     return ret;
 }
 
-template<class AppApiFacade>
-typename AmendmentTableImpl<AppApiFacade>::amendmentList_t
-AmendmentTableImpl<AppApiFacade>::getEnabled ()
+AmendmentTableImpl::amendmentList_t
+AmendmentTableImpl::getEnabled ()
 {
     amendmentList_t ret;
     ScopedLockType sl (mLock);
@@ -348,128 +341,24 @@ AmendmentTableImpl<AppApiFacade>::getEnabled ()
     return ret;
 }
 
-template<class AppApiFacade>
-bool
-AmendmentTableImpl<AppApiFacade>::shouldEnable (std::uint32_t closeTime,
-    const AmendmentState& fs)
-{
-    if (fs.mVetoed || fs.mEnabled || !fs.mSupported || (fs.m_lastMajority != m_lastReport))
-        return false;
-
-    if (fs.m_firstMajority == m_firstReport)
-    {
-        // had a majority when we first started the server, relaxed check
-        // WRITEME
-    }
-
-    // didn't have a majority when we first started the server, normal check
-    return (fs.m_lastMajority - fs.m_firstMajority) > m_majorityTime.count();
-}
-
-template<class AppApiFacade>
-typename AmendmentTableImpl<AppApiFacade>::amendmentList_t
-AmendmentTableImpl<AppApiFacade>::getToEnable (Clock::time_point closeTime)
-{
-    amendmentList_t ret;
-    ScopedLockType sl (mLock);
-
-    if (m_lastReport != 0)
-    {
-        for (auto const& e : m_amendmentMap)
-        {
-            if (shouldEnable (closeTime, e.second))
-                ret.insert (e.first);
-        }
-    }
-
-    return ret;
-}
-
-template<class AppApiFacade>
-typename AmendmentTableImpl<AppApiFacade>::amendmentList_t
-AmendmentTableImpl<AppApiFacade>::getDesired ()
+AmendmentTableImpl::amendmentList_t
+AmendmentTableImpl::getDesired (enabledAmendments_t const& enabled)
 {
     amendmentList_t ret;
     ScopedLockType sl (mLock);
 
     for (auto const& e : m_amendmentMap)
     {
-        if (e.second.mSupported && !e.second.mEnabled && !e.second.mVetoed)
+        if (e.second.mSupported && ! e.second.mVetoed &&
+            (enabled.count (e.first) == 0))
             ret.insert (e.first);
     }
 
     return ret;
 }
 
-template<class AppApiFacade>
 void
-AmendmentTableImpl<AppApiFacade>::reportValidations (const AmendmentSet& set)
-{
-    if (set.mTrustedValidations == 0)
-        return;
-
-    int threshold = (set.mTrustedValidations * mMajorityFraction) / 256;
-
-    using u256_int_pair = std::map<uint256, int>::value_type;
-
-    ScopedLockType sl (mLock);
-
-    if (m_firstReport == 0)
-        m_firstReport = set.mCloseTime;
-
-    std::vector<uint256> changedAmendments;
-    changedAmendments.reserve (set.mVotes.size());
-
-    for (auto const& e : set.mVotes)
-    {
-        AmendmentState& state = m_amendmentMap[e.first];
-        if (m_journal.debug) m_journal.debug <<
-            "Amendment " << to_string (e.first) <<
-            " has " << e.second <<
-            " votes, needs " << threshold;
-
-        if (e.second >= threshold)
-        {
-            // we have a majority
-            state.m_lastMajority = set.mCloseTime;
-
-            if (state.m_firstMajority == 0)
-            {
-                if (m_journal.warning) m_journal.warning <<
-                    "Amendment " << to_string (e.first) <<
-                    " attains a majority vote";
-
-                state.m_firstMajority = set.mCloseTime;
-                changedAmendments.push_back(e.first);
-            }
-        }
-        else // we have no majority
-        {
-            if (state.m_firstMajority != 0)
-            {
-                if (m_journal.warning) m_journal.warning <<
-                    "Amendment " << to_string (e.first) <<
-                    " loses majority vote";
-
-                state.m_firstMajority = 0;
-                state.m_lastMajority = 0;
-                changedAmendments.push_back(e.first);
-            }
-        }
-    }
-    m_lastReport = set.mCloseTime;
-
-    if (!changedAmendments.empty())
-    {
-        m_appApiFacade.setMajorityTimesFromStateToDB (changedAmendments,
-                                                      m_amendmentMap);
-        changedAmendments.clear ();
-    }
-}
-
-template<class AppApiFacade>
-void
-AmendmentTableImpl<AppApiFacade>::setEnabled (const std::vector<uint256>& amendments)
+AmendmentTableImpl::setEnabled (const std::vector<uint256>& amendments)
 {
     ScopedLockType sl (mLock);
     for (auto& e : m_amendmentMap)
@@ -482,9 +371,8 @@ AmendmentTableImpl<AppApiFacade>::setEnabled (const std::vector<uint256>& amendm
     }
 }
 
-template<class AppApiFacade>
 void
-AmendmentTableImpl<AppApiFacade>::setSupported (const std::vector<uint256>& amendments)
+AmendmentTableImpl::setSupported (const std::vector<uint256>& amendments)
 {
     ScopedLockType sl (mLock);
     for (auto &e : m_amendmentMap)
@@ -497,40 +385,34 @@ AmendmentTableImpl<AppApiFacade>::setSupported (const std::vector<uint256>& amen
     }
 }
 
-template<class AppApiFacade>
-void
-AmendmentTableImpl<AppApiFacade>::doValidation (Ledger::ref lastClosedLedger,
-    STObject& baseValidation)
+std::vector <uint256>
+AmendmentTableImpl::doValidation (
+    enabledAmendments_t const& enabledAmendments)
 {
-    auto lAmendments = getDesired();
+    auto lAmendments = getDesired (enabledAmendments);
 
     if (lAmendments.empty())
-        return;
+        return {};
 
-    STVector256 amendments (sfAmendments);
-
-    for (auto const& id : lAmendments)
-        amendments.push_back (id);
-
+    std::vector <uint256> amendments (lAmendments.begin(), lAmendments.end());
     std::sort (amendments.begin (), amendments.end ());
 
-    baseValidation.setFieldV256 (sfAmendments, amendments);
+    return amendments;
 }
 
-template<class AppApiFacade>
-void
-AmendmentTableImpl<AppApiFacade>::doVoting (Ledger::ref lastClosedLedger,
-    std::shared_ptr<SHAMap> const& initialPosition)
+std::map <uint256, std::uint32_t>
+AmendmentTableImpl::doVoting (
+    std::uint32_t closeTime,
+    enabledAmendments_t const& enabledAmendments,
+    majorityAmendments_t const& majorityAmendments,
+    ValidationSet const& valSet)
 {
-
     // LCL must be flag ledger
-    assert((lastClosedLedger->getLedgerSeq () % 256) == 0);
+    //assert((lastClosedLedger->getLedgerSeq () % 256) == 0);
 
-    AmendmentSet amendmentSet (lastClosedLedger->getParentCloseTimeNC ());
+    AmendmentSet amendmentSet (closeTime);
 
-    // get validations for ledger before flag ledger
-    ValidationSet valSet = m_appApiFacade.getValidations (
-        lastClosedLedger->getParentHash ());
+    // process validations for ledger before flag ledger
     for (auto const& entry : valSet)
     {
         auto const& val = *entry.second;
@@ -547,40 +429,83 @@ AmendmentTableImpl<AppApiFacade>::doVoting (Ledger::ref lastClosedLedger,
             }
         }
     }
-    reportValidations (amendmentSet);
+    int threshold =
+        (amendmentSet.mTrustedValidations * mMajorityFraction + 255) / 256;
 
-    amendmentList_t lAmendments = getToEnable (lastClosedLedger->getCloseTimeNC ());
-    for (auto const& uAmendment : lAmendments)
+    if (m_journal.trace)
+        m_journal.trace <<
+            amendmentSet.mTrustedValidations << " trusted validations, threshold is "
+            << threshold;
+
+    // Map of amendments to the action to be taken
+    // for each one. The action is the value of the
+    // flags in the pseudo-transaction
+    std::map <uint256, std::uint32_t> actions;
+
     {
-        if (m_journal.warning) m_journal.warning <<
-            "Voting for amendment: " << uAmendment;
+        ScopedLockType sl (mLock);
 
-        // Create the transaction to enable the amendment
-        STTx trans (ttAMENDMENT);
-        trans.setAccountID (sfAccount, AccountID ());
-        trans.setFieldH256 (sfAmendment, uAmendment);
-        uint256 txID = trans.getTransactionID ();
-
-        if (m_journal.warning) m_journal.warning <<
-            "Vote ID: " << txID;
-
-        // Inject the transaction into our initial proposal
-        Serializer s;
-        trans.add (s);
-#if RIPPLE_PROPOSE_AMENDMENTS
-        auto tItem = std::make_shared<SHAMapItem> (txID, s.peekData ());
-        if (!initialPosition->addGiveItem (tItem, true, false))
+        // process all amendments we know of
+        for (auto const& entry : m_amendmentMap)
         {
-            if (m_journal.warning) m_journal.warning <<
-                "Ledger already had amendment transaction";
+            bool const hasValMajority = amendmentSet.count (entry.first) >= threshold;
+
+            std::uint32_t majorityTime = 0;
+            auto const it = majorityAmendments.find (entry.first);
+            if (it != majorityAmendments.end ())
+                majorityTime = it->second;
+
+            // FIXME: Add logging here
+            if (enabledAmendments.count (entry.first) != 0)
+            {
+                // Already enabled, nothing to do
+            }
+            else  if (hasValMajority && (majorityTime == 0) && (! entry.second.mVetoed))
+            {
+                // Ledger says no majority, validators say yes
+                actions[entry.first] = tfGotMajority;
+            }
+            else if (! hasValMajority && (majorityTime != 0))
+            {
+                // Ledger says majority, validators say no
+                actions[entry.first] = tfLostMajority;
+            }
+            else if ((majorityTime != 0) &&
+                ((majorityTime + m_majorityTime.count()) <= closeTime) &&
+                ! entry.second.mVetoed)
+            {
+                // Ledger says majority held
+                actions[entry.first] = 0;
+            }
         }
-#endif
     }
+
+    return actions;
 }
 
-template<class AppApiFacade>
+bool
+AmendmentTableImpl::needValidatedLedger (LedgerIndex ledgerSeq)
+{
+    ScopedLockType sl (mLock);
+
+    // Is there a ledger in which an amendment could have been enabled
+    // between these two ledger sequences?
+
+    return ((ledgerSeq - 1) / 256) != ((m_lastUpdateSeq - 1) / 256);
+}
+
+void
+AmendmentTableImpl::doValidatedLedger (LedgerIndex ledgerSeq,
+    enabledAmendments_t enabled)
+{
+    ScopedLockType sl (mLock);
+
+    for (auto& e : m_amendmentMap)
+        e.second.mEnabled = (enabled.count (e.first) != 0);
+}
+
 Json::Value
-AmendmentTableImpl<AppApiFacade>::getJson (int)
+AmendmentTableImpl::getJson (int)
 {
     Json::Value ret(Json::objectValue);
     {
@@ -593,56 +518,19 @@ AmendmentTableImpl<AppApiFacade>::getJson (int)
     return ret;
 }
 
-template<class AppApiFacade>
 void
-AmendmentTableImpl<AppApiFacade>::setJson (Json::Value& v, const AmendmentState& fs)
+AmendmentTableImpl::setJson (Json::Value& v, const AmendmentState& fs)
 {
     if (!fs.mFriendlyName.empty())
         v[jss::name] = fs.mFriendlyName;
 
     v[jss::supported] = fs.mSupported;
     v[jss::vetoed] = fs.mVetoed;
-
-    if (fs.mEnabled)
-        v[jss::enabled] = true;
-    else
-    {
-        v[jss::enabled] = false;
-
-        if (m_lastReport != 0)
-        {
-            if (fs.m_lastMajority == 0)
-            {
-                v["majority"] = false;
-            }
-            else
-            {
-                if (fs.m_firstMajority != 0)
-                {
-                    if (fs.m_firstMajority == m_firstReport)
-                        v["majority_start"] = "start";
-                    else
-                        v["majority_start"] = fs.m_firstMajority;
-                }
-
-                if (fs.m_lastMajority != 0)
-                {
-                    if (fs.m_lastMajority == m_lastReport)
-                        v["majority_until"] = "now";
-                    else
-                        v["majority_until"] = fs.m_lastMajority;
-                }
-            }
-        }
-    }
-
-    if (fs.mVetoed)
-        v["veto"] = true;
+    v[jss::enabled] = fs.mEnabled;
 }
 
-template<class AppApiFacade>
 Json::Value
-AmendmentTableImpl<AppApiFacade>::getJson (uint256 const& amendmentID)
+AmendmentTableImpl::getJson (uint256 const& amendmentID)
 {
     Json::Value ret = Json::objectValue;
     Json::Value& jAmendment = (ret[to_string (amendmentID)] = Json::objectValue);
@@ -657,101 +545,13 @@ AmendmentTableImpl<AppApiFacade>::getJson (uint256 const& amendmentID)
     return ret;
 }
 
-namespace detail
-{
-class AppApiFacadeImpl final
-{
-public:
-    void setMajorityTimesFromDBToState (AmendmentState& toUpdate,
-                                        uint256 const& amendmentHash) const;
-    void setMajorityTimesFromStateToDB (
-        std::vector<uint256> const& changedAmendments,
-        hash_map<uint256, AmendmentState>& amendmentMap) const;
-    ValidationSet getValidations (uint256 const& hash) const;
-};
-
-class AppApiFacadeMock final
-{
-public:
-    void setMajorityTimesFromDBToState (AmendmentState& toUpdate,
-                                        uint256 const& amendmentHash) const {};
-    void setMajorityTimesFromStateToDB (
-        std::vector<uint256> const& changedAmendments,
-        hash_map<uint256, AmendmentState>& amendmentMap) const {};
-    ValidationSet getValidations (uint256 const& hash) const
-    {
-        return ValidationSet ();
-    };
-};
-
-void AppApiFacadeImpl::setMajorityTimesFromDBToState (
-    AmendmentState& toUpdate,
-    uint256 const& amendmentHash) const
-{
-    std::string query =
-        "SELECT FirstMajority,LastMajority FROM Features WHERE hash='";
-    query.append (to_string (amendmentHash));
-    query.append ("';");
-
-    auto db (getApp ().getWalletDB ().checkoutDb ());
-
-    boost::optional<std::uint64_t> fm, lm;
-    soci::statement st = (db->prepare << query,
-                          soci::into(fm),
-                          soci::into(lm));
-    st.execute ();
-    while (st.fetch ())
-    {
-        toUpdate.m_firstMajority = fm.value_or (0);
-        toUpdate.m_lastMajority = lm.value_or (0);
-    }
-}
-
-void AppApiFacadeImpl::setMajorityTimesFromStateToDB (
-    std::vector<uint256> const& changedAmendments,
-    hash_map<uint256, AmendmentState>& amendmentMap) const
-{
-    if (changedAmendments.empty ())
-        return;
-
-    auto db (getApp ().getWalletDB ().checkoutDb ());
-
-    soci::transaction tr(*db);
-    
-    for (auto const& hash : changedAmendments)
-    {
-        AmendmentState const& fState = amendmentMap[hash];
-        *db << boost::str (boost::format ("UPDATE Features SET FirstMajority "
-                                          "= %d WHERE Hash = '%s';") %
-                           fState.m_firstMajority % to_string (hash));
-        *db << boost::str (boost::format ("UPDATE Features SET LastMajority "
-                                          "= %d WHERE Hash = '%s';") %
-                           fState.m_lastMajority % to_string (hash));
-    }
-
-    tr.commit ();
-}
-
-ValidationSet AppApiFacadeImpl::getValidations (uint256 const& hash) const
-{
-    return getApp ().getValidations ().getValidations (hash);
-}
-}  // detail
-
 std::unique_ptr<AmendmentTable> make_AmendmentTable (
     std::chrono::seconds majorityTime,
     int majorityFraction,
-    beast::Journal journal,
-    bool useMockFacade)
+    beast::Journal journal)
 {
-    if (useMockFacade)
-    {
-        return std::make_unique<AmendmentTableImpl<detail::AppApiFacadeMock>>(
-            majorityTime, majorityFraction, std::move (journal));
-    }
-
-    return std::make_unique<AmendmentTableImpl<detail::AppApiFacadeImpl>>(
-        majorityTime, majorityFraction, std::move (journal));
+    return std::make_unique<AmendmentTableImpl>(
+        majorityTime, majorityFraction, journal);
 }
 
 }  // ripple

--- a/src/ripple/app/misc/FeeVote.h
+++ b/src/ripple/app/misc/FeeVote.h
@@ -21,6 +21,7 @@
 #define RIPPLE_APP_MISC_FEEVOTE_H_INCLUDED
 
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/misc/Validations.h>
 #include <ripple/basics/BasicConfig.h>
 #include <ripple/protocol/SystemParameters.h>
 
@@ -66,7 +67,7 @@ public:
     */
     virtual
     void
-    doVoting (Ledger::ref lastClosedLedger,
+    doVoting (Ledger::ref lastClosedLedger, ValidationSet const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition) = 0;
 };
 

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -102,6 +102,7 @@ public:
 
     void
     doVoting (Ledger::ref lastClosedLedger,
+        ValidationSet const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition) override;
 };
 
@@ -145,6 +146,7 @@ FeeVoteImpl::doValidation (Ledger::ref lastClosedLedger,
 
 void
 FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
+    ValidationSet const& set,
     std::shared_ptr<SHAMap> const& initialPosition)
 {
     // LCL must be flag ledger
@@ -159,10 +161,6 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
     detail::VotableInteger<std::uint32_t> incReserveVote (
         lastClosedLedger->getReserveInc (), target_.owner_reserve);
 
-    // get validations for ledger before flag
-    ValidationSet const set =
-        getApp().getValidations ().getValidations (
-            lastClosedLedger->getParentHash ());
     for (auto const& e : set)
     {
         STValidation const& val = *e.second;

--- a/src/ripple/app/misc/README.md
+++ b/src/ripple/app/misc/README.md
@@ -90,6 +90,22 @@ support for those Amendments. Just a few nodes vetoing an Amendment will normall
 keep it from being accepted. Nodes could also vote yes on an Amendments even 
 before it obtains a super-majority. This might make sense for a critical bug fix.
 
+Validators that support an amendment that is not yet enabled announce their
+support in their validations. If 80% support is achieved, they will introduce
+a pseudo-transaction to track the amendment's majority status in the ledger.
+
+If an amendment whose majority status is reported in a ledger loses that
+majority status, validators will introduce pseudo-transactions to remove
+the majority status from the ledger.
+
+If an amendment holds majority status for two weeks, validators will
+introduce a pseudo-transaction to enable the amendment.
+
+All amednements are assumed to be critical and irreversible. Thus there
+is no mechanism to disable or revoke an amendment, nor is there a way
+for a server to operate while an amendment it does not understand is
+enabled.
+
 ---
 
 # SHAMapStore: Online Delete

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -285,9 +285,6 @@ public:
     digest (key_type const& key) const = 0;
 };
 
-// For now
-using BasicView = ReadView;
-
 } // ripple
 
 #include <ripple/ledger/detail/ReadViewFwdRange.ipp>

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -131,6 +131,16 @@ cdirNext (ReadView const& view,
     unsigned int& uDirEntry,    // <-> next entry
     uint256& uEntryIndex);      // <-- The entry, if available. Otherwise, zero.
 
+// Return the list of enabled amendments
+using enabledAmendments_t = std::set <uint256>;
+enabledAmendments_t
+getEnabledAmendments (ReadView const& view);
+
+// Return a map of amendments that have achieved majority
+using majorityAmendments_t = std::map <uint256, std::uint32_t>;
+majorityAmendments_t
+getMajorityAmendments (ReadView const& view);
+
 //------------------------------------------------------------------------------
 //
 // Modifiers

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -23,6 +23,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/Quality.h>
+#include <ripple/protocol/STArray.h>
 
 namespace ripple {
 
@@ -386,6 +387,37 @@ cdirNext (ReadView const& view,
         " uDirEntry=" << uDirEntry <<
         " uEntryIndex=" << uEntryIndex;
     return true;
+}
+
+enabledAmendments_t
+getEnabledAmendments (ReadView const& view)
+{
+    enabledAmendments_t amendments;
+    auto const sleAmendments = view.read(keylet::amendments());
+
+    if (sleAmendments)
+    {
+        for (auto const &a : sleAmendments->getFieldV256 (sfAmendments))
+            amendments.insert (a);
+    }
+
+    return amendments;
+}
+
+majorityAmendments_t
+getMajorityAmendments (ReadView const& view)
+{
+    majorityAmendments_t majorities;
+    auto const sleAmendments = view.read(keylet::amendments());
+
+    if (sleAmendments && sleAmendments->isFieldPresent (sfMajorities))
+    {
+        auto const& majArray = sleAmendments->getFieldArray (sfMajorities);
+        for (auto const& m : majArray)
+            majorities[m.getFieldH256 (sfAmendment)] = m.getFieldU32 (sfCloseTime);
+    }
+
+    return majorities;
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -436,6 +436,7 @@ extern SField const sfMemo;
 extern SField const sfSignerEntry;
 extern SField const sfSigningAccount;
 extern SField const sfSigningFor;
+extern SField const sfMajority;
 
 // array of objects
 // ARRAY/1 is reserved for end of array
@@ -447,6 +448,7 @@ extern SField const sfNecessary;
 extern SField const sfSufficient;
 extern SField const sfAffectedNodes;
 extern SField const sfMemos;
+extern SField const sfMajorities;
 
 //------------------------------------------------------------------------------
 

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -41,6 +41,10 @@ public:
         : mValue (vector)
     { }
 
+    STVector256 (SField const& n, std::vector<uint256> const& vector)
+        : STBase (n), mValue (vector)
+    { }
+
     STVector256 (SerialIter& sit, SField const& name);
 
     STBase*

--- a/src/ripple/protocol/TxFlags.h
+++ b/src/ripple/protocol/TxFlags.h
@@ -91,6 +91,10 @@ const std::uint32_t tfClearFreeze          = 0x00200000;
 const std::uint32_t tfTrustSetMask         = ~ (tfUniversal | tfSetfAuth | tfSetNoRipple | tfClearNoRipple
                                              | tfSetFreeze | tfClearFreeze);
 
+// EnableAmendment flags:
+const std::uint32_t tfGotMajority          = 0x00010000;
+const std::uint32_t tfLostMajority         = 0x00020000;
+
 } // ripple
 
 #endif

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -87,11 +87,14 @@ LedgerFormats::LedgerFormats ()
             << SOElement (sfHashes,              SOE_REQUIRED)
             ;
 
-    add ("EnabledAmendments", ltAMENDMENTS)
-            << SOElement (sfAmendments,          SOE_REQUIRED)
+    add ("Amendments", ltAMENDMENTS)
+            << SOElement (sfLedgerSequence,      SOE_OPTIONAL)
+            << SOElement (sfAmendments,          SOE_OPTIONAL) // Enabled
+            << SOElement (sfMajorities,          SOE_OPTIONAL)
             ;
 
     add ("FeeSettings", ltFEE_SETTINGS)
+            << SOElement (sfLedgerSequence,      SOE_OPTIONAL)
             << SOElement (sfBaseFee,             SOE_REQUIRED)
             << SOElement (sfReferenceFeeUnits,   SOE_REQUIRED)
             << SOElement (sfReserveBase,         SOE_REQUIRED)

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -226,6 +226,7 @@ SField const sfSignerEntry         = make::one(&sfSignerEntry,         STI_OBJEC
 // inner object (uncommon)
 SField const sfSigningAccount      = make::one(&sfSigningAccount,      STI_OBJECT, 16, "SigningAccount");
 SField const sfSigningFor          = make::one(&sfSigningFor,          STI_OBJECT, 17, "SigningFor");
+SField const sfMajority            = make::one(&sfMajority,            STI_OBJECT, 18, "Majority");
 
 // array of objects
 // ARRAY/1 is reserved for end of array
@@ -237,6 +238,9 @@ SField const sfNecessary       = make::one(&sfNecessary,       STI_ARRAY, 6, "Ne
 SField const sfSufficient      = make::one(&sfSufficient,      STI_ARRAY, 7, "Sufficient");
 SField const sfAffectedNodes   = make::one(&sfAffectedNodes,   STI_ARRAY, 8, "AffectedNodes");
 SField const sfMemos           = make::one(&sfMemos,           STI_ARRAY, 9, "Memos");
+
+// array of objects (uncommon)
+SField const sfMajorities      = make::one(&sfMajorities,      STI_ARRAY, 16, "Majorities");
 
 SField::SField (SerializedTypeID tid, int fv, const char* fn,
                 int meta, IsSigning signing)


### PR DESCRIPTION
This implements the tracking of when an amendment achieved a majority in the ledger, ensuring that there's always network-wide agreement on which amendments have achieved a majority and how long they've held it.

* New fields
* Change transactor changes
* AmendmentTable API and implementation changes
* Update amendment enabled status on validated ledgers
* Reinstate support for ledger sequence in fee transactions