### PR TITLE
Optimize and cleanup SHAMap::iterator: 

### DIFF
--- a/src/ripple/app/ledger/AcceptedLedger.cpp
+++ b/src/ripple/app/ledger/AcceptedLedger.cpp
@@ -35,7 +35,7 @@ AcceptedLedger::AcceptedLedger (Ledger::ref ledger) : mLedger (ledger)
 {
     for (auto const& item : ledger->txMap())
     {
-        SerialIter sit (item->slice());
+        SerialIter sit (item.slice());
         insert (std::make_shared<AcceptedLedgerTx>(
             ledger, std::ref (sit)));
     }

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -59,7 +59,7 @@ class Ledger::txs_iter_impl
 private:
     bool metadata_;
     ReadView const* view_;
-    SHAMap::iterator iter_;
+    SHAMap::const_iterator iter_;
 
 public:
     txs_iter_impl() = delete;
@@ -68,7 +68,7 @@ public:
     txs_iter_impl (txs_iter_impl const&) = default;
 
     txs_iter_impl (bool metadata,
-        SHAMap::iterator iter,
+        SHAMap::const_iterator iter,
             ReadView const& view)
         : metadata_ (metadata)
         , view_ (&view)
@@ -102,8 +102,8 @@ public:
     {
         auto const item = *iter_;
         if (metadata_)
-            return deserializeTxPlusMeta(*item);
-        return { deserializeTx(*item), nullptr };
+            return deserializeTxPlusMeta(item);
+        return { deserializeTx(item), nullptr };
     }
 };
 

--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -275,16 +275,14 @@ log_metadata_difference(Ledger::pointer builtLedger, Ledger::pointer validLedger
 
 // Return list of leaves sorted by key
 static
-std::vector<std::shared_ptr<SHAMapItem const>>
+std::vector<SHAMapItem const*>
 leaves (SHAMap const& sm)
 {
-    std::vector<std::shared_ptr<
-        SHAMapItem const>> v;
+    std::vector<SHAMapItem const*> v;
     for (auto const& item : sm)
-        v.push_back(item);
+        v.push_back(&item);
     std::sort(v.begin(), v.end(),
-        [](std::shared_ptr<SHAMapItem const> const& lhs,
-           std::shared_ptr<SHAMapItem const> const& rhs)
+        [](SHAMapItem const* lhs, SHAMapItem const* rhs)
                 { return lhs->key() < rhs->key(); });
     return v;
 }

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1812,20 +1812,19 @@ void applyTransactions (
 {
     if (set)
     {
-        for (auto const item : *set)
+        for (auto const& item : *set)
         {
-            if (checkLedger->txExists (item->key()))
+            if (checkLedger->txExists (item.key()))
                 continue;
 
             // The transaction isn't in the check ledger, try to apply it
             WriteLog (lsDEBUG, LedgerConsensus) <<
-                "Processing candidate transaction: " << item->key();
+                "Processing candidate transaction: " << item.key();
             
             std::shared_ptr<STTx const> txn;
             try
             {
-                SerialIter sit (item->slice());
-                txn = std::make_shared<STTx const>(sit);
+                txn = std::make_shared<STTx const>(SerialIter{item.slice()});
             }
             catch (...)
             {

--- a/src/ripple/app/ledger/impl/OpenLedger.cpp
+++ b/src/ripple/app/ledger/impl/OpenLedger.cpp
@@ -207,7 +207,7 @@ debugTostr (SHAMap const& set)
     {
         try
         {
-            SerialIter sit(item->slice());
+            SerialIter sit(item.slice());
             auto const tx = std::make_shared<
                 STTx const>(sit);
             ss << debugTxstr(tx) << ", ";

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1343,16 +1343,16 @@ bool ApplicationImp::loadOldLedger (
             for (auto const& item : txns)
             {
                 auto const txn =
-                    getTransaction(*replayLedger, item->key(),
+                    getTransaction(*replayLedger, item.key(),
                         getApp().getMasterTransaction());
                 if (m_journal.info) m_journal.info <<
                     txn->getJson(0);
                 Serializer s;
                 txn->getSTransaction()->add(s);
-                cur->rawTxInsert(item->key(),
+                cur->rawTxInsert(item.key(),
                     std::make_shared<Serializer const>(
                         std::move(s)), nullptr);
-                getApp().getHashRouter().setFlag (item->key(), SF_SIGGOOD);
+                getApp().getHashRouter().setFlag (item.key(), SF_SIGGOOD);
             }
 
             // Switch to the mutable snapshot


### PR DESCRIPTION
* Remove dependence on boost::iterator_facade.
* Rename iterator to const_iterator.
* Change value_type from shared_ptr<SHAMapItem const> to SHAMapItem.
* Install a stack-path to the current SHAMapItem in the const_iterator.

There should be a small performance gain associated with this change.

I will squash after reviews, unless the reviewers prefer I squash first.

@scottschurr @nbougalis 