### PR TITLE
Implement subscriptions to received validations (RIPD-504)

### DIFF
--- a/src/ripple/app/ledger/README.md
+++ b/src/ripple/app/ledger/README.md
@@ -420,7 +420,7 @@ ledger's sequence number, it attempts to publish those ledgers, retrieving
 them if needed.
 
 If there are no new ledgers to publish, `doAdvance` determines if it can
-backfill history. If the publication is not caught up, bakfilling is not
+backfill history. If the publication is not caught up, backfilling is not
 attempted to conserve resources.
 
 If history can be backfilled, the missing ledger with the highest

--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -98,6 +98,9 @@ public:
         virtual bool subRTTransactions (ref ispListener) = 0;
         virtual bool unsubRTTransactions (std::uint64_t uListener) = 0;
 
+        virtual bool subValidations (ref ispListener) = 0;
+        virtual bool unsubValidations (std::uint64_t uListener) = 0;
+
         // VFALCO TODO Remove
         //             This was added for one particular partner, it
         //             "pushes" subscription data to a particular URL.

--- a/src/ripple/net/impl/InfoSub.cpp
+++ b/src/ripple/net/impl/InfoSub.cpp
@@ -57,6 +57,7 @@ InfoSub::~InfoSub ()
     m_source.unsubRTTransactions (mSeq);
     m_source.unsubLedger (mSeq);
     m_source.unsubServer (mSeq);
+    m_source.unsubValidations (mSeq);
 
     // Use the internal unsubscribe so that it won't call
     // back to us and modify its own parameter

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -314,6 +314,7 @@ JSS ( seqNum );                     // out: LedgerToJson
 JSS ( server_state );               // out: NetworkOPs
 JSS ( server_status );              // out: NetworkOPs
 JSS ( severity );                   // in: LogLevel
+JSS ( signature );                  // out: NetworkOPs
 JSS ( snapshot );                   // in: Subscribe
 JSS ( source_account );             // in: PathRequest, RipplePathFind
 JSS ( source_amount );              // in: PathRequest, RipplePathFind

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -123,6 +123,10 @@ Json::Value doSubscribe (RPC::Context& context)
                 {
                     context.netOps.subRTTransactions (ispSub);
                 }
+                else if (streamName == "validations")
+                {
+                    context.netOps.subValidations (ispSub);
+                }
                 else
                 {
                     jvResult[jss::error]   = "unknownStream";

--- a/src/ripple/rpc/handlers/Unsubscribe.cpp
+++ b/src/ripple/rpc/handlers/Unsubscribe.cpp
@@ -73,6 +73,9 @@ Json::Value doUnsubscribe (RPC::Context& context)
                          || streamName == "rt_transactions") // DEPRECATED
                     context.netOps.unsubRTTransactions (ispSub->getSeq ());
 
+                else if (streamName == "validations")
+                    context.netOps.unsubValidations (ispSub->getSeq ());
+
                 else
                     jvResult[jss::error] = "Unknown stream: " + streamName;
             }

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -169,4 +169,20 @@ suite('JSON-RPC', function() {
       done();
     });
   });
+
+  test('subscribe validations', function(done) {
+    var rippled_config = testutils.get_server_config(config);
+    var client         = jsonrpc.client("http://" + rippled_config.rpc_ip + ":" + rippled_config.rpc_port);
+    var http_config    = config.http_servers["zed"];
+
+    client.call('subscribe', [{
+      'url' :  "http://" + http_config.ip + ":" + http_config.port,
+      'streams' : [ 'validations' ],
+    }], function (result) {
+      // console.log(JSON.stringify(result, undefined, 2));
+      assert(typeof result === 'object');
+      assert(result.status === 'success');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Accept `validations` as a `subscribe` stream for rpc/websockets.
Received validations are published with:
* ledger_hash
* validation_public_key
* signature of validation