### PR TITLE
Change NetOps processTransaction to use ref param

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -214,7 +214,7 @@ public:
     void submitTransaction (Job&, STTx::pointer) override;
 
     void processTransaction (
-        Transaction::pointer transaction,
+        Transaction::pointer& transaction,
         bool bAdmin, bool bLocal, FailHard failType) override;
 
     /**
@@ -859,7 +859,7 @@ void NetworkOPsImp::submitTransaction (Job&, STTx::pointer iTrans)
                    FailHard::no));
 }
 
-void NetworkOPsImp::processTransaction (Transaction::pointer transaction,
+void NetworkOPsImp::processTransaction (Transaction::pointer& transaction,
         bool bAdmin, bool bLocal, FailHard failType)
 {
     auto ev = m_job_queue.getLoadEventAP (jtTXN_PROC, "ProcessTXN");
@@ -1059,7 +1059,6 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                     // transaction should be held
                     m_journal.debug << "Transaction should be held: " << e.result;
                     e.transaction->setStatus (HELD);
-                    getApp().getMasterTransaction().canonicalize (&e.transaction);
                     m_ledgerMaster.addHeldTransaction (e.transaction);
                 }
             }

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -143,7 +143,7 @@ public:
      * @param bLocal Client submission.
      * @param failType fail_hard setting from transaction submission.
      */
-    virtual void processTransaction (Transaction::pointer transaction,
+    virtual void processTransaction (Transaction::pointer& transaction,
         bool bAdmin, bool bLocal, FailHard failType) = 0;
 
     //--------------------------------------------------------------------------

--- a/src/ripple/app/tx/TransactionMaster.h
+++ b/src/ripple/app/tx/TransactionMaster.h
@@ -39,7 +39,7 @@ public:
 
     // return value: true = we had the transaction already
     bool inLedger (uint256 const& hash, std::uint32_t ledger);
-    bool canonicalize (Transaction::pointer* pTransaction);
+    void canonicalize (Transaction::pointer* pTransaction);
     void sweep (void);
     TaggedCache <uint256, Transaction>& getCache();
 

--- a/src/ripple/app/tx/impl/TransactionMaster.cpp
+++ b/src/ripple/app/tx/impl/TransactionMaster.cpp
@@ -91,25 +91,17 @@ STTx::pointer TransactionMaster::fetch (std::shared_ptr<SHAMapItem> const& item,
     return txn;
 }
 
-bool TransactionMaster::canonicalize (Transaction::pointer* pTransaction)
+void
+TransactionMaster::canonicalize(Transaction::pointer* pTransaction)
 {
-    Transaction::pointer txn (*pTransaction);
-
-    uint256 tid = txn->getID ();
-
-    if (!tid)
-        return false;
-
-    // VFALCO NOTE canonicalize can change the value of txn!
-    if (mCache.canonicalize (tid, txn))
+    uint256 const tid = (*pTransaction)->getID();
+    if (tid != zero)
     {
+        Transaction::pointer txn(*pTransaction);
+        // VFALCO NOTE canonicalize can change the value of txn!
+        mCache.canonicalize(tid, txn);
         *pTransaction = txn;
-        return true;
     }
-
-    // VFALCO NOTE I am unsure if this is necessary but better safe than sorry.
-    *pTransaction = txn;
-    return false;
 }
 
 void TransactionMaster::sweep (void)

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -133,7 +133,7 @@ std::uint32_t TxnSignApiFacade::getSeq () const
 }
 
 void TxnSignApiFacade::processTransaction (
-    Transaction::ref tpTrans,
+    Transaction::pointer& transaction,
     bool bAdmin,
     bool bLocal,
     NetworkOPs::FailHard failType)
@@ -141,7 +141,7 @@ void TxnSignApiFacade::processTransaction (
     if (!netOPs_) // Unit testing.
         return;
 
-    netOPs_->processTransaction (tpTrans, bAdmin, bLocal, failType);
+    netOPs_->processTransaction(transaction, bAdmin, bLocal, failType);
 }
 
 bool TxnSignApiFacade::findPathsForOneIssuer (

--- a/src/ripple/rpc/impl/TransactionSign.h
+++ b/src/ripple/rpc/impl/TransactionSign.h
@@ -76,7 +76,7 @@ public:
         STPath& fullLiquidityPath) const;
 
     void processTransaction (
-        Transaction::ref tpTrans,
+        Transaction::pointer& transaction,
         bool bAdmin,
         bool bLocal,
         NetworkOPs::FailHard failType);


### PR DESCRIPTION
Change the processTransaction transaction param to a reference. This allows the call to canonicalize to modify the callers tx.

Removed redundant canonicalize call in NetworkOps::apply.

@mtrippled @HowardHinnant 