### PR TITLE
Rules, Transactor preflight, and track STTx validity with HashRouter (RIPD-977)

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1150,8 +1150,10 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
                 newLCL, retriableTransactions, tapNONE);
         }
         for (auto const& item : localTx)
-            apply (accum, *item.second, tapNONE, getConfig(),
-                deprecatedLogs().journal("LedgerConsensus"));
+            apply (accum, *item.second, tapNONE,
+                getApp().getHashRouter().sigVerify(),
+                    getConfig(), deprecatedLogs().
+                        journal("LedgerConsensus"));
         accum.apply(*newOL);
         // We have a new Last Closed Ledger and new Open Ledger
         ledgerMaster_.pushLedger (newLCL, newOL);
@@ -1787,8 +1789,10 @@ applyTransaction (OpenView& view,
 
     try
     {
-        auto const result = apply(view, *txn, flags, getConfig(),
-            deprecatedLogs().journal("LedgerConsensus"));
+        auto const result = apply(view, *txn, flags,
+            getApp().getHashRouter().sigVerify(),
+                getConfig(), deprecatedLogs().
+                    journal("LedgerConsensus"));
         if (result.second)
         {
             WriteLog (lsDEBUG, LedgerConsensus)

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -379,7 +379,8 @@ public:
                     if (getApp().getHashRouter().addSuppressionFlags (it.first.getTXID (), SF_SIGGOOD))
                         flags = flags | tapNO_CHECK_SIGN;
                     auto const result = apply(view,
-                        *it.second, flags, getConfig(), j);
+                        *it.second, flags, getApp().getHashRouter(
+                            ).sigVerify(), getConfig(), j);
                     if (result.second)
                         any = true;
                 }
@@ -396,9 +397,9 @@ public:
                 if (getApp().getHashRouter ().addSuppressionFlags (it.first.getTXID (), SF_SIGGOOD))
                     tepFlags = static_cast<ApplyFlags> (tepFlags | tapNO_CHECK_SIGN);
 
-                auto const ret = apply(
-                    view, *it.second, tepFlags, getConfig(),
-                        deprecatedLogs().journal("LedgerMaster"));
+                auto const ret = apply(view, *it.second,
+                    tepFlags, getApp().getHashRouter().sigVerify(),
+                        getConfig(), deprecatedLogs().journal("LedgerMaster"));
 
                 if (ret.second)
                     ++recovers;

--- a/src/ripple/app/ledger/impl/OpenLedger.cpp
+++ b/src/ripple/app/ledger/impl/OpenLedger.cpp
@@ -111,7 +111,8 @@ OpenLedger::accept(Rules const& rules,
     // Apply local tx
     for (auto const& item : locals)
         ripple::apply(*next, *item.second,
-            flags, config_, j_);
+            flags, router.sigVerify(),
+                config_, j_);
     // Switch to the new open view
     std::lock_guard<
         std::mutex> lock2(current_mutex_);
@@ -144,7 +145,8 @@ OpenLedger::apply_one (OpenView& view,
             SF_SIGGOOD)
         flags = flags | tapNO_CHECK_SIGN;
     auto const result = ripple::apply(
-        view, *tx, flags, config, j);
+        view, *tx, flags, router.
+            sigVerify(), config, j);
     if (result.second)
         return Result::success;
     if (isTefFailure (result.first) ||

--- a/src/ripple/app/misc/IHashRouter.h
+++ b/src/ripple/app/misc/IHashRouter.h
@@ -22,9 +22,12 @@
 
 #include <ripple/basics/base_uint.h>
 #include <cstdint>
+#include <functional>
 #include <set>
 
 namespace ripple {
+
+class STTx;
 
 // VFALCO NOTE Are these the flags?? Why aren't we using a packed struct?
 // VFALCO TODO convert these macros to int constants
@@ -80,6 +83,15 @@ public:
     virtual int getFlags (uint256 const& index) = 0;
 
     virtual bool swapSet (uint256 const& index, std::set<PeerShortID>& peers, int flag) = 0;
+
+    /**
+        Function wrapper that will check the signature status
+        of a STTx before calling an expensive signature
+        checking function.
+    */
+    virtual
+    std::function<bool(STTx const&, std::function<bool(STTx const&)>)>
+    sigVerify() = 0;
 };
 
 } // ripple

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -42,7 +42,8 @@ convertBlobsToTxResult (
     STTx::pointer txn = std::make_shared<STTx> (it);
     std::string reason;
 
-    auto tr = std::make_shared<Transaction> (txn, Validate::NO, reason);
+    auto tr = std::make_shared<Transaction> (txn, Validate::NO,
+        directSigVerify, reason);
 
     tr->setStatus (Transaction::sqlTransactionStatus(status));
     tr->setLedger (ledger_index);

--- a/src/ripple/app/tx/Transaction.h
+++ b/src/ripple/app/tx/Transaction.h
@@ -62,7 +62,7 @@ public:
     using ref = const pointer&;
 
 public:
-    Transaction (STTx::ref, Validate, std::string&) noexcept;
+    Transaction (STTx::ref, Validate, SigVerify, std::string&) noexcept;
 
     static
     Transaction::pointer
@@ -80,7 +80,7 @@ public:
     TransStatus
     sqlTransactionStatus(boost::optional<std::string> const& status);
 
-    bool checkSign (std::string&) const;
+    bool checkSign (std::string&, SigVerify) const;
 
     STTx::ref getSTransaction ()
     {

--- a/src/ripple/app/tx/apply.h
+++ b/src/ripple/app/tx/apply.h
@@ -30,12 +30,55 @@
 
 namespace ripple {
 
+/** Gate a transaction based on static information.
+
+    The transaction is checked against all possible
+    validity constraints that do not require a ledger.
+
+    @return The TER code (a `tem` or tesSUCCESS)
+*/
+TER
+preflight (Rules const& rules, STTx const& tx,
+    ApplyFlags flags,
+        Config const& config, beast::Journal j);
+
+/** Apply a prechecked transaction to an OpenView.
+
+    See also: apply()
+
+    Precondition: The transaction has been checked
+    and validated using the above function(s).
+
+    @return A pair with the TER and a bool indicating
+            whether or not the transaction was applied.
+*/
+std::pair<TER, bool>
+doapply(OpenView& view, STTx const& tx,
+    ApplyFlags flags, Config const& config,
+        beast::Journal j);
+
 /** Apply a transaction to a ReadView.
 
     Throws:
         
-        Does not throw. Exceptions generated during
-        tx application will return tefEXCEPTION.
+        Does not throw.
+
+        For open ledgers, the Transactor will catch and
+        return tefEXCEPTION. For closed ledgers, the
+        Transactor will attempt to only charge a fee,
+        and return tecFAILED_PROCESSING.
+
+        If the Transactor gets an exception while trying
+        to charge the fee, it will be caught here and
+        turned into tefEXCEPTION.
+
+        This try/catch handler is the last resort, any
+        uncaught exceptions will be turned into
+        tefEXCEPTION.
+
+        For network health, a Transactor makes its
+        best effort to at least charge a fee if the
+        ledger is closed.
 
     @return A pair with the TER and a bool indicating
             whether or not the transaction was applied.

--- a/src/ripple/app/tx/apply.h
+++ b/src/ripple/app/tx/apply.h
@@ -39,7 +39,7 @@ namespace ripple {
 */
 TER
 preflight (Rules const& rules, STTx const& tx,
-    ApplyFlags flags,
+    ApplyFlags flags, SigVerify verify,
         Config const& config, beast::Journal j);
 
 /** Apply a prechecked transaction to an OpenView.
@@ -86,8 +86,9 @@ doapply(OpenView& view, STTx const& tx,
 std::pair<TER, bool>
 apply (OpenView& view,
     STTx const& tx, ApplyFlags flags,
-        Config const& config,
-            beast::Journal journal);
+        SigVerify verify,
+            Config const& config,
+                beast::Journal journal);
 
 } // ripple
 

--- a/src/ripple/app/tx/impl/ApplyContext.h
+++ b/src/ripple/app/tx/impl/ApplyContext.h
@@ -88,7 +88,6 @@ public:
 private:
     OpenView& base_;
     ApplyFlags flags_;
-    beast::Journal j_;
     boost::optional<ApplyViewImpl> view_;
 };
 

--- a/src/ripple/app/tx/impl/CancelOffer.cpp
+++ b/src/ripple/app/tx/impl/CancelOffer.cpp
@@ -1,4 +1,4 @@
-
+//------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
     Copyright (c) 2012, 2013 Ripple Labs Inc.
@@ -27,33 +27,34 @@
 namespace ripple {
 
 TER
-CancelOffer::preCheck ()
+CancelOffer::preflight (PreflightContext const& ctx)
 {
-    std::uint32_t const uTxFlags (mTxn.getFlags ());
+    auto const uTxFlags = ctx.tx.getFlags();
 
     if (uTxFlags & tfUniversalMask)
     {
-        j_.trace << "Malformed transaction: " <<
+        JLOG(ctx.j.trace) << "Malformed transaction: " <<
             "Invalid flags set.";
         return temINVALID_FLAG;
     }
 
-    std::uint32_t const uOfferSequence = mTxn.getFieldU32 (sfOfferSequence);
-
-    if (!uOfferSequence)
+    auto const seq = ctx.tx.getFieldU32 (sfOfferSequence);
+    if (! seq)
     {
-        j_.trace << "Malformed transaction: " <<
-            "No sequence specified.";
+        JLOG(ctx.j.trace) <<
+            "CancelOffer::preflight: missing sequence";
         return temBAD_SEQUENCE;
     }
 
-    return Transactor::preCheck ();
+    return Transactor::preflight(ctx);
 }
+
+//------------------------------------------------------------------------------
 
 TER
 CancelOffer::doApply ()
 {
-    std::uint32_t const uOfferSequence = mTxn.getFieldU32 (sfOfferSequence);
+    std::uint32_t const uOfferSequence = tx().getFieldU32 (sfOfferSequence);
 
     auto const sle = view().read(
         keylet::account(account_));

--- a/src/ripple/app/tx/impl/CancelOffer.h
+++ b/src/ripple/app/tx/impl/CancelOffer.h
@@ -31,14 +31,14 @@ class CancelOffer
     : public Transactor
 {
 public:
-    template <class... Args>
-    CancelOffer (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    CancelOffer (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
-    TER preCheck () override;
+    static
+    TER
+    preflight (PreflightContext const& ctx);
 
     TER doApply () override;
 };

--- a/src/ripple/app/tx/impl/CancelTicket.cpp
+++ b/src/ripple/app/tx/impl/CancelTicket.cpp
@@ -26,19 +26,19 @@
 namespace ripple {
 
 TER
-CancelTicket::preCheck()
+CancelTicket::preflight (PreflightContext const& ctx)
 {
 #if ! RIPPLE_ENABLE_TICKETS
-    if (! (view().flags() & tapENABLE_TESTING))
+    if (! (ctx.flags & tapENABLE_TESTING))
         return temDISABLED;
 #endif
-    return Transactor::preCheck ();
+    return Transactor::preflight(ctx);
 }
 
 TER
 CancelTicket::doApply ()
 {
-    uint256 const ticketId = mTxn.getFieldH256 (sfTicketID);
+    uint256 const ticketId = tx().getFieldH256 (sfTicketID);
 
     // VFALCO This is highly suspicious, we're requiring that the
     //        transaction provide the return value of getTicketIndex?

--- a/src/ripple/app/tx/impl/CancelTicket.h
+++ b/src/ripple/app/tx/impl/CancelTicket.h
@@ -30,14 +30,15 @@ class CancelTicket
     : public Transactor
 {
 public:
-    template <class... Args>
-    CancelTicket (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    CancelTicket (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
-    TER preCheck() override;
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
     TER doApply () override;
 };
 

--- a/src/ripple/app/tx/impl/Change.h
+++ b/src/ripple/app/tx/impl/Change.h
@@ -33,18 +33,20 @@ class Change
     : public Transactor
 {
 public:
-    template <class... Args>
-    Change (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    Change (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
+
+    static
+    TER
+    preflight (PreflightContext const& ctx);
 
     TER doApply () override;
     TER checkSign () override;
     TER checkSeq () override;
     TER payFee () override;
-    TER preCheck () override;
+    void preCompute() override;
 
 private:
     TER applyAmendment ();

--- a/src/ripple/app/tx/impl/CreateOffer.h
+++ b/src/ripple/app/tx/impl/CreateOffer.h
@@ -39,20 +39,22 @@ class CreateOffer
     : public Transactor
 {
 public:
-    template <class... Args>
-    CreateOffer (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    CreateOffer (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
+
+    static
+    TER
+    preflight (PreflightContext const& ctx);
 
     /** Returns the reserve the account would have if an offer was added. */
     // VFALCO This function is not needed just inline the behavior
     STAmount
     getAccountReserve (SLE::pointer account); // const?
 
-    TER
-    preCheck () override;
+    void
+    preCompute() override;
 
     std::pair<TER, bool>
     applyGuts (ApplyView& view, ApplyView& view_cancel);

--- a/src/ripple/app/tx/impl/CreateTicket.h
+++ b/src/ripple/app/tx/impl/CreateTicket.h
@@ -31,15 +31,14 @@ class CreateTicket
     : public Transactor
 {
 public:
-    template <class... Args>
-    CreateTicket (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    CreateTicket (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
+    static
     TER
-    preCheck () override;
+    preflight (PreflightContext const& ctx);
 
     /** Returns the reserve the account would have if an offer was added. */
     // VFALCO Not needed, just inline the behavior.

--- a/src/ripple/app/tx/impl/Payment.h
+++ b/src/ripple/app/tx/impl/Payment.h
@@ -39,14 +39,15 @@ class Payment
     static std::size_t const MaxPathLength = 8;
 
 public:
-    template <class... Args>
-    Payment (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    Payment (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
-    TER preCheck () override;
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
     TER doApply () override;
 };
 

--- a/src/ripple/app/tx/impl/SetAccount.h
+++ b/src/ripple/app/tx/impl/SetAccount.h
@@ -36,14 +36,15 @@ class SetAccount
     static std::size_t const PUBLIC_BYTES_MAX = 33;
 
 public:
-    template <class... Args>
-    SetAccount (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    SetAccount (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
-    TER preCheck () override;
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
     TER doApply () override;
 };
 

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -42,19 +42,19 @@ SetRegularKey::calculateBaseFee ()
 }
 
 TER
-SetRegularKey::preCheck ()
+SetRegularKey::preflight (PreflightContext const& ctx)
 {
-    std::uint32_t const uTxFlags = mTxn.getFlags ();
+    std::uint32_t const uTxFlags = ctx.tx.getFlags ();
 
     if (uTxFlags & tfUniversalMask)
     {
-        if (j_.trace) j_.trace <<
+        JLOG(ctx.j.trace) <<
             "Malformed transaction: Invalid flags set.";
 
         return temINVALID_FLAG;
     }
 
-    return Transactor::preCheck ();
+    return Transactor::preflight(ctx);
 }
 
 TER
@@ -66,10 +66,10 @@ SetRegularKey::doApply ()
     if (mFeeDue == zero)
         sle->setFlag (lsfPasswordSpent);
 
-    if (mTxn.isFieldPresent (sfRegularKey))
+    if (tx().isFieldPresent (sfRegularKey))
     {
         sle->setAccountID (sfRegularKey,
-            mTxn.getAccountID (sfRegularKey));
+            tx().getAccountID (sfRegularKey));
     }
     else
     {

--- a/src/ripple/app/tx/impl/SetRegularKey.h
+++ b/src/ripple/app/tx/impl/SetRegularKey.h
@@ -33,14 +33,15 @@ class SetRegularKey
     std::uint64_t calculateBaseFee () override;
 
 public:
-    template <class... Args>
-    SetRegularKey (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    SetRegularKey (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
-    TER preCheck () override;
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
     TER doApply () override;
 };
 

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -42,28 +42,39 @@ this class implements.
 class SetSignerList : public Transactor
 {
 private:
-    // Values determined during preCheck for use later.
+    // Values determined during preCompute for use later.
     enum Operation {unknown, set, destroy};
     Operation do_ {unknown};
     std::uint32_t quorum_ {0};
     std::vector<SignerEntries::SignerEntry> signers_;
 
 public:
-    template <class... Args>
-    SetSignerList (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    SetSignerList (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
     TER doApply () override;
-    TER preCheck () override;
+    void preCompute() override;
 
 private:
-    // `signers` is sorted on return
+    static
+    std::tuple<TER, std::uint32_t,
+        std::vector<SignerEntries::SignerEntry>,
+            Operation>
+    determineOperation(STTx const& tx,
+        ApplyFlags flags, beast::Journal j);
+
+    static
     TER validateQuorumAndSignerEntries (
         std::uint32_t quorum,
-        std::vector<SignerEntries::SignerEntry>& signers) const;
+            std::vector<SignerEntries::SignerEntry> const& signers,
+                AccountID const& account,
+                    beast::Journal j);
 
     TER replaceSignerList (uint256 const& index);
     TER destroySignerList (uint256 const& index);

--- a/src/ripple/app/tx/impl/SetTrust.h
+++ b/src/ripple/app/tx/impl/SetTrust.h
@@ -32,14 +32,15 @@ class SetTrust
     : public Transactor
 {
 public:
-    template <class... Args>
-    SetTrust (Args&&... args)
-        : Transactor(std::forward<
-            Args>(args)...)
+    SetTrust (ApplyContext& ctx)
+        : Transactor(ctx)
     {
     }
 
-    TER preCheck () override;
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
     TER doApply () override;
 };
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -31,12 +31,12 @@ struct PreflightContext
 public:
     explicit PreflightContext(STTx const& tx_,
         Rules const& rules_, ApplyFlags flags_,
-            //SigVerify verify_,
+            SigVerify verify_,
                 beast::Journal j_ = {})
         : tx(tx_)
         , rules(rules_)
         , flags(flags_)
-        //, verify(verify_)
+        , verify(verify_)
         , j(j_)
     {
     }
@@ -44,7 +44,7 @@ public:
     STTx const& tx;
     Rules const& rules;
     ApplyFlags flags;
-    //SigVerify verify;
+    SigVerify verify;
     beast::Journal j;
 };
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -25,10 +25,32 @@
 
 namespace ripple {
 
+/** State information when preflighting a tx. */
+struct PreflightContext
+{
+public:
+    explicit PreflightContext(STTx const& tx_,
+        Rules const& rules_, ApplyFlags flags_,
+            //SigVerify verify_,
+                beast::Journal j_ = {})
+        : tx(tx_)
+        , rules(rules_)
+        , flags(flags_)
+        //, verify(verify_)
+        , j(j_)
+    {
+    }
+
+    STTx const& tx;
+    Rules const& rules;
+    ApplyFlags flags;
+    //SigVerify verify;
+    beast::Journal j;
+};
+
 class Transactor
 {
 protected:
-    STTx const& mTxn;
     ApplyContext& ctx_;
     beast::Journal j_;
 
@@ -57,6 +79,16 @@ public:
         return ctx_.view();
     }
 
+    STTx const&
+    tx() const
+    {
+        return ctx_.tx;
+    }
+
+    static
+    TER
+    preflight (PreflightContext const& ctx);
+
 protected:
     TER
     apply();
@@ -64,8 +96,6 @@ protected:
     explicit
     Transactor (ApplyContext& ctx);
 
-    TER preCheckAccount ();
-    TER preCheckSigningKey ();
     void calculateFee ();
 
     // VFALCO This is the equivalent of dynamic_cast
@@ -81,7 +111,7 @@ protected:
     // Returns the fee, not scaled for load (Should be in fee units. FIXME)
     virtual std::uint64_t calculateBaseFee ();
 
-    virtual TER preCheck ();
+    virtual void preCompute();
     virtual TER checkSeq ();
     virtual TER payFee ();
     virtual TER checkSign ();

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -81,13 +81,13 @@ invoke_apply (ApplyContext& ctx)
 
 TER
 preflight (Rules const& rules, STTx const& tx,
-    ApplyFlags flags,
+    ApplyFlags flags, SigVerify verify,
         Config const& config, beast::Journal j)
 {
     try
     {
         PreflightContext pfctx(
-            tx, rules, flags, j);
+            tx, rules, flags, verify, j);
         return invoke_preflight(pfctx);
     }
     catch (std::exception const& e)
@@ -131,11 +131,11 @@ doapply(OpenView& view, STTx const& tx,
 
 std::pair<TER, bool>
 apply (OpenView& view, STTx const& tx,
-    ApplyFlags flags,
+    ApplyFlags flags, SigVerify verify,
         Config const& config, beast::Journal j)
 {
     auto pfresult = preflight(view.rules(),
-        tx, flags, config, j);
+        tx, flags, verify, config, j);
     if (pfresult != tesSUCCESS)
         return { pfresult, false };
     return doapply(view, tx, flags, config, j);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1706,7 +1706,9 @@ PeerImp::checkTransaction (Job&, int flags,
 
         auto validate = (flags & SF_SIGGOOD) ? Validate::NO : Validate::YES;
         std::string reason;
-        auto tx = std::make_shared<Transaction> (stx, validate, reason);
+        auto tx = std::make_shared<Transaction> (stx, validate,
+            directSigVerify,
+            reason);
 
         if (tx->getStatus () == INVALID)
         {

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -129,23 +129,6 @@ public:
 #endif
             ) const;
 
-    bool isKnownGood () const
-    {
-        return (sig_state_ == true);
-    }
-    bool isKnownBad () const
-    {
-        return (sig_state_ == false);
-    }
-    void setGood () const
-    {
-        sig_state_ = true;
-    }
-    void setBad () const
-    {
-        sig_state_ = false;
-    }
-
     // SQL Functions with metadata.
     static
     std::string const&
@@ -165,11 +148,17 @@ private:
     bool checkMultiSign () const;
 
     TxType tx_type_;
-
-    mutable boost::tribool sig_state_;
 };
 
 bool passesLocalChecks (STObject const& st, std::string&);
+
+using SigVerify = std::function < bool(STTx const&, std::function<bool(STTx const&)>) > ;
+
+inline
+bool directSigVerify(STTx const& tx, std::function<bool(STTx const&)> sigCheck)
+{
+    return sigCheck(tx);
+}
 
 } // ripple
 

--- a/src/ripple/rpc/handlers/Submit.cpp
+++ b/src/ripple/rpc/handlers/Submit.cpp
@@ -18,7 +18,9 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/app/main/Application.h>
 #include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/app/misc/IHashRouter.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/strHex.h>
 #include <ripple/net/RPCErr.h>
@@ -79,7 +81,8 @@ Json::Value doSubmit (RPC::Context& context)
 
     Transaction::pointer            tpTrans;
     std::string reason;
-    tpTrans = std::make_shared<Transaction> (stpTrans, Validate::YES, reason);
+    tpTrans = std::make_shared<Transaction> (stpTrans, Validate::YES,
+        getApp().getHashRouter().sigVerify(), reason);
     if (tpTrans->getStatus() != NEW)
     {
         jvResult[jss::error]            = "invalidTransaction";

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -721,7 +721,8 @@ transactionConstructImpl (STTx::pointer stpTrans)
     Transaction::pointer tpTrans;
     {
         std::string reason;
-        tpTrans = std::make_shared<Transaction>(stpTrans, Validate::NO, reason);
+        tpTrans = std::make_shared<Transaction>(stpTrans, Validate::NO,
+            directSigVerify, reason);
         if (tpTrans->getStatus () != NEW)
         {
             ret.first = RPC::make_error (rpcINTERNAL,

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -262,8 +262,9 @@ Env::submit (JTx const& jt)
             [&](OpenView& view, beast::Journal j)
             {
                 std::tie(ter, didApply) = ripple::apply(
-                    view, *stx, applyFlags(), config,
-                        beast::Journal{});
+                    view, *stx, applyFlags(), 
+                        directSigVerify, config,
+                            beast::Journal{});
                 return didApply;
             });
     }


### PR DESCRIPTION
Note: These changes are based on @vinniefalco's `cache` branch, which is already pending in PR #1187, so the first *five* commits can safely be ignored. The new code starts with "Add Rules to ReadView:".

There are three interdependent, but separate changes in this PR:
1. Rules. Similar to the Fees object, allows looking up transaction processing change rules (ie. the result of Amendment and Change transactions).
2. `preflight`. Checks the transaction without the overhead of reading or trying to apply to a `Ledger`/`OpenView`. Takes an `OpenView`, but only to get the `Rules` object. If successful, returns a function that can be called to apply the transaction to the `OpenView` without duplicating the checks (or allowing an shenanigans caused by changing the inputs).  Application: the transaction queue will use `preflight` to determine whether the transaction is viable _before_ storing it in the queue and broadcasting it to peers.
3. Track `STTx` validity with `HashRouter`. https://ripplelabs.atlassian.net/browse/RIPD-977. Gets rid of the mutable `STTx::sig_state_` member and brings all signature / validity checking into a single source. Also adds a `sigVerify()` function member to the `HashRouter` that can be passed to `preflight` and `apply` to hide the result caching, and prevent duplicate implementations.