### PR TITLE
[TRIVIAL] Properly parse ledger hashes

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -499,7 +499,7 @@ private:
 
         std::string     strLedger   = jvParams[0u].asString ();
 
-        if (strLedger.length () == 32)
+        if (strLedger.length () == 64)
         {
             jvRequest[jss::ledger_hash]    = strLedger;
         }


### PR DESCRIPTION
Specifying a hash when doing `ledger_request` from the command line failed, because we were checking whether the length was 32. Ledger hashes are 64 hex characters long.

Reviews: @rec