### PR TITLE
Confirm valid suspend before relying on suspension

### DIFF
--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -82,7 +82,8 @@ Json::Value doRipplePathFind (RPC::Context& context)
 
     Json::Value jvResult;
 
-    if (getConfig().RUN_STANDALONE ||
+    if (! context.suspend ||
+        getConfig().RUN_STANDALONE ||
         context.params.isMember(jss::ledger) ||
         context.params.isMember(jss::ledger_index) ||
         context.params.isMember(jss::ledger_hash))


### PR DESCRIPTION
Don't use coroutine dispatch for ripple_path_find requests if coroutines aren't enabled.