### PR TITLE
Additional consensus/validation protections

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -666,7 +666,7 @@ loadLedgerHelper(std::string const& sqlSuffix)
 
     if (!db->got_data ())
     {
-        WriteLog (lsINFO, Ledger) << "Ledger not found: " << sqlSuffix;
+        WriteLog (lsDEBUG, Ledger) << "Ledger not found: " << sqlSuffix;
         return std::make_tuple (Ledger::pointer (), ledgerSeq, ledgerHash);
     }
 

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -64,6 +64,9 @@ public:
     virtual LedgerIndex getCurrentLedgerIndex () = 0;
     virtual LedgerIndex getValidLedgerIndex () = 0;
 
+    virtual bool isCompatible (Ledger::pointer,
+        beast::Journal::Stream, const char* reason) = 0;
+
     virtual LockType& peekMutex () = 0;
 
     // The current ledger is the ledger we believe new transactions should go in

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1038,6 +1038,14 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
     // Tell directly connected peers that we have a new LCL
     statusChange (protocol::neACCEPTED_LEDGER, *newLCL);
 
+    if (mValidating &&
+        ! ledgerMaster_.isCompatible (newLCL,
+            deprecatedLogs().journal("LedgerConsensus").warning,
+            "Not validating"))
+    {
+        mValidating = false;
+    }
+
     if (mValidating && !mConsensusFail)
     {
         // Build validation

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -695,6 +695,15 @@ public:
         if (isCurrent)
             mLedgerHistory.addLedger(ledger, true);
 
+        {
+            // Check the SQL database's entry for the sequence before this ledger,
+            // if it's not this ledger's parent, invalidate it
+            uint256 prevHash = Ledger::getHashByIndex (ledger->info().seq - 1);
+            if (prevHash.isNonZero () && (prevHash != ledger->info().parentHash))
+                clearLedger (ledger->info().seq - 1);
+        }
+
+
         ledger->pendSaveValidated (isSynchronous, isCurrent);
 
         {

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -169,6 +169,17 @@ getCandidateLedger (LedgerIndex requested)
     return (requested + 255) & (~255);
 }
 
+/** Return false if the test ledger is provably incompatible
+    with the valid ledger, that is, they could not possibly
+    both be valid. Use the first form if you have both ledgers,
+    use the second form if you have not acquired the valid ledger yet
+*/
+bool areCompatible (ReadView const& validLedger, ReadView const& testLedger,
+    beast::Journal::Stream& s, const char* reason);
+
+bool areCompatible (uint256 const& validHash, LedgerIndex validIndex,
+    ReadView const& testLedger, beast::Journal::Stream& s, const char* reason);
+
 //------------------------------------------------------------------------------
 //
 // Modifiers

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -313,9 +313,9 @@ areCompatible (ReadView const& validLedger, ReadView const& testLedger,
 {
     bool ret = true;
 
-    // valid -> ... -> test
     if (validLedger.info().seq < testLedger.info().seq)
     {
+        // valid -> ... -> test
         auto hash = hashOfSeq (testLedger, validLedger.info().seq,
             beast::Journal());
         if (hash && (*hash != validLedger.info().hash))
@@ -327,10 +327,9 @@ areCompatible (ReadView const& validLedger, ReadView const& testLedger,
             ret = false;
         }
     }
-
-    // test -> ... -> valid
-    if (validLedger.info().seq > testLedger.info().seq)
+    else if (validLedger.info().seq > testLedger.info().seq)
     {
+        // test -> ... -> valid
         auto hash = hashOfSeq (validLedger, testLedger.info().seq,
             beast::Journal());
         if (hash && (*hash != testLedger.info().hash))
@@ -342,11 +341,10 @@ areCompatible (ReadView const& validLedger, ReadView const& testLedger,
             ret = false;
         }
     }
-
-    // Same sequence number, different hash
-    if ((validLedger.info().seq == testLedger.info().seq) &&
+    else if ((validLedger.info().seq == testLedger.info().seq) &&
          (validLedger.info().hash != testLedger.info().hash))
     {
+        // Same sequence number, different hash
         JLOG(s) << reason << " incompatible ledger";
 
         ret = false;
@@ -382,8 +380,7 @@ bool areCompatible (uint256 const& validHash, LedgerIndex validIndex,
             ret = false;
         }
     }
-
-    if ((validIndex == testLedger.info().seq) &&
+    else if ((validIndex == testLedger.info().seq) &&
         (testLedger.info().hash != validHash))
     {
         JLOG(s) << reason << " incompatible ledger";

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -308,6 +308,102 @@ rippleTransferRate (ReadView const& view,
 }
 
 bool
+areCompatible (ReadView const& validLedger, ReadView const& testLedger,
+    beast::Journal::Stream& s, const char* reason)
+{
+    bool ret = true;
+
+    // valid -> ... -> test
+    if (validLedger.info().seq < testLedger.info().seq)
+    {
+        auto hash = hashOfSeq (testLedger, validLedger.info().seq,
+            beast::Journal());
+        if (hash && (*hash != validLedger.info().hash))
+        {
+            JLOG(s) << reason << " incompatible with valid ledger";
+
+            JLOG(s) << "Hash(VSeq): " << to_string (*hash);
+
+            ret = false;
+        }
+    }
+
+    // test -> ... -> valid
+    if (validLedger.info().seq > testLedger.info().seq)
+    {
+        auto hash = hashOfSeq (validLedger, testLedger.info().seq,
+            beast::Journal());
+        if (hash && (*hash != testLedger.info().hash))
+        {
+            JLOG(s) << reason << " incompatible preceding ledger";
+
+            JLOG(s) << "Hash(NSeq): " << to_string (*hash);
+
+            ret = false;
+        }
+    }
+
+    // Same sequence number, different hash
+    if ((validLedger.info().seq == testLedger.info().seq) &&
+         (validLedger.info().hash != testLedger.info().hash))
+    {
+        JLOG(s) << reason << " incompatible ledger";
+
+        ret = false;
+    }
+
+    if (! ret)
+    {
+        JLOG(s) << "Val: " << validLedger.info().seq <<
+            " " << to_string (validLedger.info().hash);
+
+        JLOG(s) << "New: " << testLedger.info().seq <<
+            " " << to_string (testLedger.info().hash);
+    }
+
+    return ret;
+}
+
+bool areCompatible (uint256 const& validHash, LedgerIndex validIndex,
+    ReadView const& testLedger, beast::Journal::Stream& s, const char* reason)
+{
+    bool ret = true;
+
+    if (testLedger.info().seq > validIndex)
+    {
+        // Ledger we are testing follows last valid ledger
+        auto hash = hashOfSeq (testLedger, validIndex,
+            beast::Journal());
+        if (hash && (*hash != validHash))
+        {
+            JLOG(s) << reason << " incompatible following ledger";
+            JLOG(s) << "Hash(VSeq): " << to_string (*hash);
+
+            ret = false;
+        }
+    }
+
+    if ((validIndex == testLedger.info().seq) &&
+        (testLedger.info().hash != validHash))
+    {
+        JLOG(s) << reason << " incompatible ledger";
+
+        ret = false;
+    }
+
+    if (! ret)
+    {
+        JLOG(s) << "Val: " << validIndex <<
+            " " << to_string (validHash);
+
+        JLOG(s) << "New: " << testLedger.info().seq <<
+            " " << to_string (testLedger.info().hash);
+    }
+
+    return ret;
+}
+
+bool
 dirIsEmpty (ReadView const& view,
     Keylet const& k)
 {

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -152,8 +152,21 @@ bool isValidated (LedgerMaster& ledgerMaster, ReadView const& ledger)
         // comes before the last validated ledger (and thus has been
         // validated).
         auto hash = ledgerMaster.walkHashBySeq (seq);
+
         if (ledger.info().hash != hash)
+        {
+            // This ledger's hash is not the hash of the validated ledger
+            if (hash.isNonZero ())
+            {
+                uint256 valHash = Ledger::getHashByIndex (seq);
+                if (valHash == ledger.info().hash)
+                {
+                    // SQL database doesn't match ledger chain
+                    ledgerMaster.clearLedger (seq);
+                }
+            }
             return false;
+        }
     }
     catch (SHAMapMissingNode const&)
     {


### PR DESCRIPTION
Bump up the minimum required number of validations if it's unreasonably low. Don't validate a ledger that conflicts with a fully-validated ledger. Don't switch to a closed ledger that conflicts with the latest fully-validated ledger. Protect even in cases where we don't yet have the last fully-validated ledger.

Also, sanely handle the case where the SQL database conflicts with the ledger chain. And reduce the severity of a chatty log message.