### PR TITLE
Increased fees for multisigned transactions (RIPD-182):

### DIFF
--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -94,7 +94,7 @@ protected:
     explicit
     Transactor (ApplyContext& ctx);
 
-    // Returns the fee, not scaled for load (Should be in fee units. FIXME)
+    // Returns the fee in fee units, not scaled for load.
     virtual std::uint64_t calculateBaseFee ();
 
     virtual void preCompute();

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -360,10 +360,12 @@ public:
             { { "bob", 1 }, { "carol", 2 } }));
         env(noop("alice"));
 
-        env(noop("alice"), msig("bob"));
-        env(noop("alice"), msig("carol"));
-        env(noop("alice"), msig("bob", "carol"));
-        env(noop("alice"), msig("bob", "carol", "dilbert"),     ter(tefBAD_SIGNATURE));
+        auto const baseFee = env.config.FEE_DEFAULT;
+        env(noop("alice"), msig("bob"), fee(2 * baseFee));
+        env(noop("alice"), msig("carol"), fee(2 * baseFee));
+        env(noop("alice"), msig("bob", "carol"), fee(3 * baseFee));
+        env(noop("alice"), msig("bob", "carol", "dilbert"),
+            fee(4 * baseFee),                                   ter(tefBAD_SIGNATURE));
 
         env(signers("alice", none));
     }


### PR DESCRIPTION
Multisigned transactions place a higher load on the network than
regular (non-multisigned) transactions.  Therefore, a multisigned
transaction should demand a higher fee.

In this implementation:

 o A non-multisigned transaction always has a minimum fee.  That's
   called the network base fee.

 o Each signer in a multisigned transaction costs an additional
   base fee.

 o A regular (non-multisigned) transaction has the base fee as
   its minimum fee.

 o A transaction with 1 multisigner has a minimum fee of two
   times the base fee.  One for the transaction itself, plus one
   for the signer.

 o A transaction with 8 multisigners has a minimum fee of nine
   times the base fee.  One of the transaction itself, plus one
   for each of the eight signers.

In addition to the usual stuff, please review with an eye toward
potential impact on future fees work.  Thanks.

Reviewers: @nbougalis @ximinez @JoelKatz 
