### PR TITLE
Devirtualize HashRouter

### DIFF
--- a/Builds/VisualStudio2013/RippleD.vcxproj
+++ b/Builds/VisualStudio2013/RippleD.vcxproj
@@ -1531,7 +1531,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
-    <ClInclude Include="..\..\src\ripple\app\misc\IHashRouter.h">
+    <ClInclude Include="..\..\src\ripple\app\misc\HashRouter.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\misc\impl\AccountTxPaging.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2013/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2013/RippleD.vcxproj.filters
@@ -2283,7 +2283,7 @@
     <ClCompile Include="..\..\src\ripple\app\misc\HashRouter.cpp">
       <Filter>ripple\app\misc</Filter>
     </ClCompile>
-    <ClInclude Include="..\..\src\ripple\app\misc\IHashRouter.h">
+    <ClInclude Include="..\..\src\ripple\app\misc\HashRouter.h">
       <Filter>ripple\app\misc</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\misc\impl\AccountTxPaging.cpp">

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -27,7 +27,7 @@
 #include <ripple/app/ledger/OrderBookDB.h>
 #include <ripple/app/ledger/PendingSaves.h>
 #include <ripple/app/main/Application.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/tx/TransactionMaster.h>
 #include <ripple/basics/contract.h>
@@ -1294,7 +1294,7 @@ void Ledger::updateSkipList ()
 */
 bool Ledger::pendSaveValidated (bool isSynchronous, bool isCurrent)
 {
-    if (!getApp().getHashRouter ().setFlag (getHash (), SF_SAVED))
+    if (!getApp().getHashRouter ().setFlags (getHash (), SF_SAVED))
     {
         WriteLog (lsDEBUG, Ledger) << "Double pend save for " << info().seq;
         return true;

--- a/src/ripple/app/ledger/OpenLedger.h
+++ b/src/ripple/app/ledger/OpenLedger.h
@@ -24,7 +24,7 @@
 #include <ripple/ledger/CachedSLEs.h>
 #include <ripple/ledger/OpenView.h>
 #include <ripple/app/misc/CanonicalTXSet.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/core/Config.h>
@@ -151,7 +151,7 @@ public:
         std::shared_ptr<Ledger const> const& ledger,
             OrderedTxs const& locals, bool retriesFirst,
                 OrderedTxs& retries, ApplyFlags flags,
-                    IHashRouter& router,
+                    HashRouter& router,
                         std::string const& suffix = "");
 
     /** Algorithm for applying transactions.
@@ -164,7 +164,7 @@ public:
     void
     apply (OpenView& view, ReadView const& check,
         FwdRange const& txs, OrderedTxs& retries,
-            ApplyFlags flags, IHashRouter& router,
+            ApplyFlags flags, HashRouter& router,
                 Config const& config, beast::Journal j);
 
 private:
@@ -183,7 +183,7 @@ private:
     Result
     apply_one (OpenView& view, std::shared_ptr<
         STTx const> const& tx, bool retry,
-            ApplyFlags flags, IHashRouter& router,
+            ApplyFlags flags, HashRouter& router,
                 Config const& config, beast::Journal j);
 
 public:
@@ -205,7 +205,7 @@ void
 OpenLedger::apply (OpenView& view,
     ReadView const& check, FwdRange const& txs,
         OrderedTxs& retries, ApplyFlags flags,
-            IHashRouter& router, Config const& config,
+            HashRouter& router, Config const& config,
                 beast::Journal j)
 {
     for (auto iter = txs.begin();

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -28,7 +28,7 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/app/misc/CanonicalTXSet.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/Validations.h>
 #include <ripple/app/tx/TransactionAcquire.h>
@@ -1294,7 +1294,7 @@ void LedgerConsensusImp::addDisputedTransaction (
     }
 
     // If we didn't relay this transaction recently, relay it
-    if (getApp().getHashRouter ().setFlag (txID, SF_RELAYED))
+    if (getApp().getHashRouter ().setFlags (txID, SF_RELAYED))
     {
         protocol::TMTransaction msg;
         msg.set_rawtransaction (& (tx.front ()), tx.size ());

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -28,7 +28,7 @@
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/AmendmentTable.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/CanonicalTXSet.h>
 #include <ripple/app/misc/SHAMapStore.h>

--- a/src/ripple/app/ledger/impl/OpenLedger.cpp
+++ b/src/ripple/app/ledger/impl/OpenLedger.cpp
@@ -77,7 +77,7 @@ OpenLedger::accept(Rules const& rules,
     std::shared_ptr<Ledger const> const& ledger,
         OrderedTxs const& locals, bool retriesFirst,
             OrderedTxs& retries, ApplyFlags flags,
-                IHashRouter& router, std::string const& suffix)
+                HashRouter& router, std::string const& suffix)
 {
     JLOG(j_.error) <<
         "accept ledger " << ledger->seq() << " " << suffix;
@@ -135,7 +135,7 @@ auto
 OpenLedger::apply_one (OpenView& view,
     std::shared_ptr<STTx const> const& tx,
         bool retry, ApplyFlags flags,
-            IHashRouter& router, Config const& config,
+            HashRouter& router, Config const& config,
                 beast::Journal j) -> Result
 {
     if (retry)

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -35,7 +35,7 @@
 #include <ripple/app/main/LocalCredentials.h>
 #include <ripple/app/main/NodeStoreScheduler.h>
 #include <ripple/app/misc/AmendmentTable.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/SHAMapStore.h>
 #include <ripple/app/misc/Validations.h>
@@ -294,7 +294,7 @@ public:
     std::unique_ptr <unl::Manager> m_validators;
     std::unique_ptr <AmendmentTable> m_amendmentTable;
     std::unique_ptr <LoadFeeTrack> mFeeTrack;
-    std::unique_ptr <IHashRouter> mHashRouter;
+    std::unique_ptr <HashRouter> mHashRouter;
     std::unique_ptr <Validations> mValidations;
     std::unique_ptr <LoadManager> m_loadManager;
     beast::DeadlineTimer m_sweepTimer;
@@ -416,7 +416,8 @@ public:
 
         , mFeeTrack (std::make_unique<LoadFeeTrack>(m_logs.journal("LoadManager")))
 
-        , mHashRouter (IHashRouter::New (IHashRouter::getDefaultHoldTime ()))
+        , mHashRouter (std::make_unique<HashRouter>(
+            HashRouter::getDefaultHoldTime ()))
 
         , mValidations (make_Validations ())
 
@@ -585,7 +586,7 @@ public:
         return *mFeeTrack;
     }
 
-    IHashRouter& getHashRouter ()
+    HashRouter& getHashRouter ()
     {
         return *mHashRouter;
     }
@@ -1336,7 +1337,7 @@ bool ApplicationImp::loadOldLedger (
                 cur->rawTxInsert(item.key(),
                     std::make_shared<Serializer const>(
                         std::move(s)), nullptr);
-                getApp().getHashRouter().setFlag (item.key(), SF_SIGGOOD);
+                getApp().getHashRouter().setFlags (item.key(), SF_SIGGOOD);
             }
 
             // Switch to the mutable snapshot

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -42,7 +42,7 @@ class CollectorManager;
 namespace shamap {
 class Family;
 } // shamap
-class IHashRouter;
+class HashRouter;
 class Logs;
 class LoadFeeTrack;
 class LocalCredentials;
@@ -100,7 +100,7 @@ public:
     virtual CachedSLEs&             cachedSLEs() = 0;
     virtual unl::Manager&           getValidators () = 0;
     virtual AmendmentTable&         getAmendmentTable() = 0;
-    virtual IHashRouter&            getHashRouter () = 0;
+    virtual HashRouter&            getHashRouter () = 0;
     virtual LoadFeeTrack&           getFeeTrack () = 0;
     virtual LoadManager&            getLoadManager () = 0;
     virtual Overlay&                overlay () = 0;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -33,7 +33,7 @@
 #include <ripple/app/ledger/OrderBookDB.h>
 #include <ripple/app/main/LoadManager.h>
 #include <ripple/app/main/LocalCredentials.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/Validations.h>
 #include <ripple/app/misc/impl/AccountTxPaging.h>
@@ -679,11 +679,11 @@ void NetworkOPsImp::submitTransaction (Job&, STTx::pointer iTrans)
             {
                 m_journal.warning << "Submitted transaction " <<
                     (reason.empty () ? "has bad signature" : "error: " + reason);
-                getApp().getHashRouter ().setFlag (suppress, SF_BAD);
+                getApp().getHashRouter ().setFlags (suppress, SF_BAD);
                 return;
             }
 
-            getApp().getHashRouter ().setFlag (suppress, SF_SIGGOOD);
+            getApp().getHashRouter ().setFlags (suppress, SF_SIGGOOD);
         }
         catch (...)
         {
@@ -728,12 +728,12 @@ void NetworkOPsImp::processTransaction (Transaction::pointer& transaction,
             m_journal.info << "Transaction has bad signature: " << reason;
             transaction->setStatus (INVALID);
             transaction->setResult (temBAD_SIGNATURE);
-            getApp().getHashRouter ().setFlag (transaction->getID (), SF_BAD);
+            getApp().getHashRouter ().setFlags (transaction->getID (), SF_BAD);
             return;
         }
     }
 
-    getApp().getHashRouter ().setFlag (transaction->getID (), SF_SIGGOOD);
+    getApp().getHashRouter ().setFlags (transaction->getID (), SF_SIGGOOD);
 
     // canonicalize can change our pointer
     getApp().getMasterTransaction ().canonicalize (&transaction);
@@ -916,7 +916,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
             e.transaction->setResult (e.result);
 
             if (isTemMalformed (e.result))
-                getApp().getHashRouter().setFlag (e.transaction->getID(), SF_BAD);
+                getApp().getHashRouter().setFlags (e.transaction->getID(), SF_BAD);
 
     #ifdef BEAST_DEBUG
             if (e.result != tesSUCCESS)

--- a/src/ripple/app/tx/impl/Transaction.cpp
+++ b/src/ripple/app/tx/impl/Transaction.cpp
@@ -23,7 +23,7 @@
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/main/Application.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/protocol/JsonFields.h>
 #include <boost/optional.hpp>
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -18,7 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/make_SSLContext.h>

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -23,7 +23,7 @@
 #include <ripple/overlay/impl/Tuning.h>
 #include <ripple/app/ledger/InboundLedgers.h>
 #include <ripple/app/ledger/LedgerMaster.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/overlay/ClusterNodeStatus.h>
 #include <ripple/app/misc/UniqueNodeList.h>
@@ -1704,7 +1704,7 @@ PeerImp::checkTransaction (Job&, int flags,
             (stx->getFieldU32 (sfLastLedgerSequence) <
             getApp().getLedgerMaster().getValidLedgerIndex()))
         {
-            getApp().getHashRouter().setFlag(stx->getTransactionID(), SF_BAD);
+            getApp().getHashRouter().setFlags(stx->getTransactionID(), SF_BAD);
             charge (Resource::feeUnwantedData);
             return;
         }
@@ -1720,13 +1720,13 @@ PeerImp::checkTransaction (Job&, int flags,
             if (! reason.empty ())
                 p_journal_.trace << "Exception checking transaction: " << reason;
 
-            getApp().getHashRouter ().setFlag (stx->getTransactionID (), SF_BAD);
+            getApp().getHashRouter ().setFlags (stx->getTransactionID (), SF_BAD);
             charge (Resource::feeInvalidSignature);
             return;
         }
         else
         {
-            getApp().getHashRouter ().setFlag (stx->getTransactionID (), SF_SIGGOOD);
+            getApp().getHashRouter ().setFlags (stx->getTransactionID (), SF_SIGGOOD);
         }
 
         bool const trusted (flags & SF_TRUSTED);
@@ -1735,7 +1735,7 @@ PeerImp::checkTransaction (Job&, int flags,
     }
     catch (...)
     {
-        getApp().getHashRouter ().setFlag (stx->getTransactionID (), SF_BAD);
+        getApp().getHashRouter ().setFlags (stx->getTransactionID (), SF_BAD);
         charge (Resource::feeBadData);
     }
 }

--- a/src/ripple/rpc/handlers/Submit.cpp
+++ b/src/ripple/rpc/handlers/Submit.cpp
@@ -20,7 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/NetworkOPs.h>
-#include <ripple/app/misc/IHashRouter.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/strHex.h>
 #include <ripple/net/RPCErr.h>

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -100,8 +100,7 @@ Env::close(NetClock::time_point const& closeTime)
     for (auto iter = cur->txs.begin();
             iter != cur->txs.end(); ++iter)
         txs.push_back(iter->first);
-    std::unique_ptr<IHashRouter> router(
-        IHashRouter::New(60));
+    auto router = std::make_unique<HashRouter>(60);
     OrderedTxs retries(uint256{});
     {
         OpenView accum(&*next);


### PR DESCRIPTION
* Include some simple renames

Other than renaming a couple of things, and calling `make_unique` instead of `IHashRouter::New`, none of the code here is new, just moved.

Reviewers: @vinniefalco @miguelportilla 