### PR TITLE
[TRIVIAL] Use unabbreviated `"SuspendedPayment"` in json

### DIFF
--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -81,7 +81,7 @@ LedgerFormats::LedgerFormats ()
             << SOElement (sfHighQualityOut,      SOE_OPTIONAL)
             ;
 
-    add ("SusPay", ltSUSPAY) <<
+    add ("SuspendedPayment", ltSUSPAY) <<
         SOElement (sfAccount,           SOE_REQUIRED) <<
         SOElement (sfDestination,       SOE_REQUIRED) <<
         SOElement (sfAmount,            SOE_REQUIRED) <<


### PR DESCRIPTION
This aligns LedgerEntryType with the form used for TransactionType: "SuspendedPayment(Create|Finish|Cancel)"