### PR TITLE
Trivial: Reference fee unit clean up

### DIFF
--- a/src/ripple/app/misc/FeeVote.h
+++ b/src/ripple/app/misc/FeeVote.h
@@ -41,6 +41,9 @@ public:
         /** The cost of a reference transaction in drops. */
         std::uint64_t reference_fee = 10;
 
+        /** The cost of a reference transaction in fee units. */
+        std::uint32_t const reference_fee_units = 10;
+
         /** The account reserve requirement in drops. */
         std::uint64_t account_reserve = 20 * SYSTEM_CURRENCY_PARTS;
 

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/protocol/st.h>
 #include <ripple/app/misc/FeeVote.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/Validations.h>
@@ -212,11 +213,11 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
             "/" << incReserve;
 
         STTx trans (ttFEE);
-        trans.setAccountID (sfAccount, AccountID ());
-        trans.setFieldU64 (sfBaseFee, baseFee);
-        trans.setFieldU32 (sfReferenceFeeUnits, 10);
-        trans.setFieldU32 (sfReserveBase, baseReserve);
-        trans.setFieldU32 (sfReserveIncrement, incReserve);
+        trans[sfAccount] = AccountID();
+        trans[sfBaseFee] = baseFee;
+        trans[sfReferenceFeeUnits] = target_.reference_fee_units;
+        trans[sfReserveBase] = baseReserve;
+        trans[sfReserveIncrement] = incReserve;
 
         uint256 txID = trans.getTransactionID ();
 

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -41,11 +41,11 @@ static void fillTransaction (
 {
     txArray["Sequence"] = Json::UInt (sequence++);
     txArray["Account"] = getApp().accountIDCache().toBase58 (accountID);
-    // VFALCO Needs audit
-    // Why are we hard-coding 10?
     auto& fees = ledger.fees();
+    // Convert the reference transaction cost in fee units to drops
+    // scaled to represent the current fee load.
     txArray["Fee"] = Json::UInt (getApp().getFeeTrack().scaleFeeLoad(
-        10, fees.base, fees.units, false));
+        fees.units, fees.base, fees.units, false));
 }
 
 // {


### PR DESCRIPTION
* Use config object or ledger instead of hard coded value.
* The value is still const, and has no change mechanism.

Reviewers: @vinniefalco @rec 