### PR TITLE
Make ledger close times increase strictly monotonically

### DIFF
--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -230,8 +230,6 @@ public:
     void setAccepted (std::uint32_t closeTime,
         int closeResolution, bool correctCloseTime);
 
-    void setAccepted ();
-
     void setImmutable ();
 
     bool isImmutable () const

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -372,7 +372,7 @@ public:
             ScopedLockType ml (m_mutex);
 
             lastClosed->setClosed ();
-            lastClosed->setAccepted ();
+            lastClosed->setImmutable ();
 
             mCurrentLedger.set (current);
             mClosedLedger.set (lastClosed);

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1045,7 +1045,7 @@ void ApplicationImp::startGenesisLedger ()
     auto const next = std::make_shared<Ledger>(
         open_ledger, *genesis);
     next->setClosed ();
-    next->setAccepted ();
+    next->setImmutable ();
     m_networkOPs->setLastCloseTime (next->info().closeTime);
     openLedger_.emplace(next, getConfig(),
         cachedSLEs_, deprecatedLogs().journal("OpenLedger"));
@@ -1071,10 +1071,7 @@ ApplicationImp::getLastFullLedger()
         ledger->setImmutable();
 
         if (getApp().getLedgerMaster ().haveLedger (ledgerSeq))
-        {
-            ledger->setAccepted ();
             ledger->setValidated ();
-        }
 
         if (ledger->getHash () != ledgerHash)
         {


### PR DESCRIPTION
Due to close-time rounding, on occasion we end up with two consecutive ledgers that have the same closing time. While this is not a problem, it's nice to have the close time be, like ledger numbers, strictly monotonically increasing.

Reviews: @JoelKatz, @vinniefalco