### PR TITLE
Allow an account to be exclusively multisigned (RIPD-182):

### DIFF
--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -191,8 +191,18 @@ SetAccount::doApply ()
             return tecNEED_MASTER_KEY;
         }
 
-        if (!sle->isFieldPresent (sfRegularKey))
+        if ((!sle->isFieldPresent (sfRegularKey)) &&
+            (!view().peek (keylet::signers (account_))))
+        {
+            // Account has no regular key or multi-signer signer list.
+
+            // Prevent transaction changes until we're ready.
+            if ((RIPPLE_ENABLE_MULTI_SIGN) ||
+                view().flags() & tapENABLE_TESTING)
+                    return tecNO_ALTERNATIVE_KEY;
+
             return tecNO_REGULAR_KEY;
+        }
 
         j_.trace << "Set lsfDisableMaster.";
         uFlagsOut |= lsfDisableMaster;

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -77,8 +77,11 @@ SetRegularKey::doApply ()
     }
     else
     {
-        if (sle->isFlag (lsfDisableMaster))
-            return tecMASTER_DISABLED;
+        if (sle->isFlag (lsfDisableMaster) &&
+            !view().peek (keylet::signers (account_)))
+            // Account has disabled master key and no multi-signer signer list.
+            return tecNO_ALTERNATIVE_KEY;
+
         sle->makeFieldAbsent (sfRegularKey);
     }
 

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -76,12 +76,14 @@ private:
                 AccountID const& account,
                     beast::Journal j);
 
-    TER replaceSignerList (uint256 const& index);
-    TER destroySignerList (uint256 const& index);
+    TER replaceSignerList ();
+    TER destroySignerList ();
 
-    void writeSignersToLedger (SLE::pointer ledgerEntry);
+    TER removeSignersFromLedger (Keylet const& accountKeylet,
+        Keylet const& ownerDirKeylet, Keylet const& signerListKeylet);
+    void writeSignersToSLE (SLE::pointer const& ledgerEntry) const;
 
-    static std::size_t ownerCountDelta (std::size_t entryCount);
+    static int ownerCountDelta (std::size_t entryCount);
 };
 
 } // ripple

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -185,7 +185,7 @@ enum TER
     tecNO_LINE_REDUNDANT        = 127,
     tecPATH_DRY                 = 128,
     tecUNFUNDED                 = 129,  // Deprecated, old ambiguous unfunded.
-    tecMASTER_DISABLED          = 130,
+    tecNO_ALTERNATIVE_KEY       = 130,
     tecNO_REGULAR_KEY           = 131,
     tecOWNERS                   = 132,
     tecNO_ISSUER                = 133,

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -48,7 +48,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tecNO_LINE_REDUNDANT,     "tecNO_LINE_REDUNDANT",     "Can't set non-existent line to default."                       },
         { tecPATH_DRY,              "tecPATH_DRY",              "Path could not send partial amount."                           },
         { tecPATH_PARTIAL,          "tecPATH_PARTIAL",          "Path could not send full amount."                              },
-        { tecMASTER_DISABLED,       "tecMASTER_DISABLED",       "Master key is disabled."                                       },
+        { tecNO_ALTERNATIVE_KEY,    "tecNO_ALTERNATIVE_KEY",    "The operation would remove the last way to sign a transaction."},
         { tecNO_REGULAR_KEY,        "tecNO_REGULAR_KEY",        "Regular key is not set."                                       },
 
         { tecUNFUNDED,              "tecUNFUNDED",              "One of _ADD, _OFFER, or _SEND. Deprecated."                    },

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -332,7 +332,7 @@ public:
         env.require(nflags("alice", asfDisableMaster));
         env(fset("alice", asfDisableMaster), sig("alice"));
         env.require(flags("alice", asfDisableMaster));
-        env(regkey("alice", disabled),                          ter(tecMASTER_DISABLED));
+        env(regkey("alice", disabled),                          ter(tecNO_ALTERNATIVE_KEY));
         env(noop("alice"));
         env(noop("alice"), sig("alice"),                        ter(tefMASTER_DISABLED));
         env(noop("alice"), sig("eric"));


### PR DESCRIPTION
The capabilities of multisigning are intended to be roughly
comparable to those of a regular key.  It is currently possible
to make an account that can only be signed using its regular key.
This is done by disabling the master key.  Since that's true, it
seems like it should be possible to do the same if an account is
multisignable (because it has a SignerList).

However, rippled goes to some effort to try and make sure an
account is always signable through some means.  So, for example,
rippled prevents a user from disabling their master key unless they
have a regular key in place.  Similarly, if an account's master key
is disabled rippled will not allow the user to remove their regular
key.  They can change the regular key, but they may not remove it.

To account for multisigning, and still provide comparable safety,
here are the rules this pull request employs:

 o An account can always add or replace a regular key or a
   SignerList as long as the fee and reserve can be met by the
   account.

 o The master key on an account can be disabled if either a
   regular key or a SignerList (or both) is present on the account.
   Either the regular key or the SignerList can be used to
   re-enable the master key later if that is desired.

 o The regular key on an account may only be removed if either the
   master key is enabled or the account has a SignerList (or both).

 o The SignerList on an account may only be removed if either the
   master key is enabled or a regular key is present (or both).

Reviewers: @nbougalis, @seelabs