### PR TITLE
Consolidate transaction signature checking

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1697,6 +1697,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tests\HashRouter_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tests\MultiSign.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2448,6 +2448,9 @@
     <ClCompile Include="..\..\src\ripple\app\tests\DeliverMin.test.cpp">
       <Filter>ripple\app\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tests\HashRouter_test.cpp">
+      <Filter>ripple\app\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tests\MultiSign.test.cpp">
       <Filter>ripple\app\tests</Filter>
     </ClCompile>

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -42,8 +42,8 @@
 #include <ripple/json/to_string.h>
 #include <ripple/overlay/Overlay.h>
 #include <ripple/overlay/predicates.h>
-#include <ripple/protocol/STValidation.h>
-#include <ripple/protocol/UintTypes.h>
+#include <ripple/protocol/st.h>
+#include <ripple/protocol/Feature.h>
 #include <beast/module/core/text/LexicalCast.h>
 #include <beast/utility/make_lock.h>
 #include <type_traits>
@@ -1820,10 +1820,6 @@ applyTransaction (Application& app, OpenView& view,
     if (retryAssured)
         flags = flags | tapRETRY;
 
-    if ((app.getHashRouter ().getFlags (txn->getTransactionID ())
-            & SF_SIGGOOD) == SF_SIGGOOD)
-        flags = flags | tapNO_CHECK_SIGN;
-
     JLOG (j.debug) << "TXN "
         << txn->getTransactionID ()
         //<< (engine.view().open() ? " open" : " closed")
@@ -1833,9 +1829,8 @@ applyTransaction (Application& app, OpenView& view,
 
     try
     {
-        auto const result = apply(app, view, *txn, flags,
-            app.getHashRouter().sigVerify(),
-                app.config(), j);
+        auto const result = apply(app,
+            view, *txn, flags, j);
         if (result.second)
         {
             JLOG (j.debug)

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -378,13 +378,8 @@ public:
                 for (auto const& it : mHeldTransactions)
                 {
                     ApplyFlags flags = tapNONE;
-                    if (app_.getHashRouter().addSuppressionFlags (
-                            it.first.getTXID (), SF_SIGGOOD))
-                        flags = flags | tapNO_CHECK_SIGN;
-
                     auto const result = apply(app_, view,
-                        *it.second, flags, app_.getHashRouter(
-                            ).sigVerify(), app_.config(), j);
+                        *it.second, flags, j);
                     if (result.second)
                         any = true;
                 }

--- a/src/ripple/app/misc/HashRouter.cpp
+++ b/src/ripple/app/misc/HashRouter.cpp
@@ -64,13 +64,13 @@ HashRouter::Entry& HashRouter::findCreateEntry (uint256 const& index, bool& crea
     int expireTime = now - mHoldTime;
 
     // See if any supressions need to be expired
-    std::map< int, std::list<uint256> >::iterator it = mSuppressionTimes.begin ();
+    auto it = mSuppressionTimes.begin ();
 
-    if ((it != mSuppressionTimes.end ()) && (it->first <= expireTime))
+    while ((it != mSuppressionTimes.end ()) && (it->first <= expireTime))
     {
         for(auto const& lit : it->second)
             mSuppressionMap.erase (lit);
-        mSuppressionTimes.erase (it);
+        it = mSuppressionTimes.erase (it);
     }
 
     mSuppressionTimes[now].push_back (index);

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -43,8 +43,7 @@ convertBlobsToTxResult (
     STTx::pointer txn = std::make_shared<STTx> (it);
     std::string reason;
 
-    auto tr = std::make_shared<Transaction> (txn, Validate::NO,
-        directSigVerify, reason, app);
+    auto tr = std::make_shared<Transaction> (txn, reason, app);
 
     tr->setStatus (Transaction::sqlTransactionStatus(status));
     tr->setLedger (ledger_index);

--- a/src/ripple/app/tests/HashRouter_test.cpp
+++ b/src/ripple/app/tests/HashRouter_test.cpp
@@ -1,0 +1,188 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/misc/HashRouter.h>
+#include <ripple/basics/UptimeTimer.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+namespace test {
+
+class HashRouter_test : public beast::unit_test::suite
+{
+    void
+    testExpiration()
+    {
+        HashRouter router(2);
+
+        uint256 const key1(1);
+        uint256 const key2(2);
+        uint256 const key3(3);
+        uint256 const key4(4);
+        expect(key1 != key2 &&
+            key2 != key3 &&
+            key3 != key4);
+
+        // t=0
+        router.setFlags(key1, 12345);
+        expect(router.getFlags(key1) == 12345);
+        // key1 : 0
+        // key2 : null
+        // key3 : null
+
+        UptimeTimer::getInstance().incrementElapsedTime();
+
+        // Expiration is triggered by insertion, so
+        // key1 will be expired after the second
+        // call to setFlags.
+        // t=1
+        router.setFlags(key2, 9999);
+        expect(router.getFlags(key1) == 12345);
+        expect(router.getFlags(key2) == 9999);
+        // key1 : 0
+        // key2 : 1
+        // key3 : null
+
+        UptimeTimer::getInstance().incrementElapsedTime();
+
+        // t=2
+        router.setFlags(key3, 2222);
+        expect(router.getFlags(key1) == 0);
+        expect(router.getFlags(key2) == 9999);
+        expect(router.getFlags(key3) == 2222);
+        // key1 : 2
+        // key2 : 1
+        // key3 : 2
+
+        UptimeTimer::getInstance().incrementElapsedTime();
+
+        // t=3
+        // No insertion, no expiration
+        router.setFlags(key1, 7654);
+        expect(router.getFlags(key1) == 7654);
+        expect(router.getFlags(key2) == 9999);
+        expect(router.getFlags(key3) == 2222);
+        // key1 : 2
+        // key2 : 1
+        // key3 : 2
+
+        UptimeTimer::getInstance().incrementElapsedTime();
+        UptimeTimer::getInstance().incrementElapsedTime();
+
+        // t=5
+        router.setFlags(key4, 7890);
+        expect(router.getFlags(key1) == 0);
+        expect(router.getFlags(key2) == 0);
+        expect(router.getFlags(key3) == 0);
+        expect(router.getFlags(key4) == 7890);
+        // key1 : 5
+        // key2 : 5
+        // key3 : 5
+        // key4 : 5
+    }
+
+    void testSuppression()
+    {
+        // Normal HashRouter
+        HashRouter router(2);
+
+        uint256 const key1(1);
+        uint256 const key2(2);
+        uint256 const key3(3);
+        uint256 const key4(4);
+        expect(key1 != key2 &&
+            key2 != key3 &&
+            key3 != key4);
+
+        int flags = 12345;  // This value is ignored
+        router.addSuppression(key1);
+        expect(router.addSuppressionPeer(key2, 15));
+        expect(router.addSuppressionPeer(key3, 20, flags));
+        expect(flags == 0);
+
+        UptimeTimer::getInstance().incrementElapsedTime();
+
+        expect(!router.addSuppressionPeer(key1, 2));
+        expect(!router.addSuppressionPeer(key2, 3));
+        expect(!router.addSuppressionPeer(key3, 4, flags));
+        expect(flags == 0);
+        expect(router.addSuppressionPeer(key4, 5));
+    }
+
+    void
+    testSetFlags()
+    {
+        HashRouter router(2);
+
+        uint256 const key1(1);
+        expect(router.setFlags(key1, 10));
+        expect(!router.setFlags(key1, 10));
+        expect(router.setFlags(key1, 20));
+    }
+
+    void
+    testSwapSet()
+    {
+        HashRouter router(2);
+
+        uint256 const key1(1);
+
+        std::set<HashRouter::PeerShortID> peers1;
+        std::set<HashRouter::PeerShortID> peers2;
+
+        peers1.emplace(1);
+        peers1.emplace(3);
+        peers1.emplace(5);
+        peers2.emplace(2);
+        peers2.emplace(4);
+
+        expect(router.swapSet(key1, peers1, 135));
+        expect(peers1.empty());
+        expect(router.getFlags(key1) == 135);
+        // No action, because flag matches
+        expect(!router.swapSet(key1, peers2, 135));
+        expect(peers2.size() == 2);
+        expect(router.getFlags(key1) == 135);
+        // Do a swap
+        expect(router.swapSet(key1, peers2, 24));
+        expect(peers2.size() == 3);
+        expect(router.getFlags(key1) == (135 | 24));
+    }
+
+public:
+
+    void
+    run()
+    {
+        UptimeTimer::getInstance().beginManualUpdates();
+
+        testExpiration();
+        testSuppression();
+        testSetFlags();
+        testSwapSet();
+
+        UptimeTimer::getInstance().endManualUpdates();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(HashRouter, app, ripple)
+
+}
+}

--- a/src/ripple/app/tests/Regression_test.cpp
+++ b/src/ripple/app/tests/Regression_test.cpp
@@ -67,8 +67,7 @@ struct Regression_test : public beast::unit_test::suite
 
             auto const result = ripple::apply(env.app(),
                 accum, *jt.stx, tapENABLE_TESTING,
-                    directSigVerify, env.app().config(),
-                        env.journal);
+                    env.journal);
             expect(result.first == tesSUCCESS);
             expect(result.second);
 
@@ -95,8 +94,7 @@ struct Regression_test : public beast::unit_test::suite
 
             auto const result = ripple::apply(env.app(),
                 accum, *jt.stx, tapENABLE_TESTING,
-                    directSigVerify, env.app().config(),
-                        env.journal);
+                    env.journal);
             expect(result.first == tecINSUFF_FEE);
             expect(result.second);
 

--- a/src/ripple/app/tx/Transaction.h
+++ b/src/ripple/app/tx/Transaction.h
@@ -35,6 +35,7 @@ namespace ripple {
 
 class Application;
 class Database;
+class Rules;
 
 enum TransStatus
 {
@@ -48,8 +49,6 @@ enum TransStatus
     OBSOLETE    = 7, // a compatible transaction has taken precedence
     INCOMPLETE  = 8  // needs more signatures
 };
-
-enum class Validate {NO, YES};
 
 // This class is for constructing and examining transactions.
 // Transactions are static so manipulation functions are unnecessary.
@@ -65,11 +64,11 @@ public:
 
 public:
     Transaction (
-        STTx::ref, Validate, SigVerify, std::string&, Application&) noexcept;
+        STTx::ref, std::string&, Application&) noexcept;
 
     static
     Transaction::pointer
-    sharedTransaction (Blob const&, Validate, Application& app);
+    sharedTransaction (Blob const&, Rules const& rules, Application& app);
 
     static
     Transaction::pointer
@@ -77,14 +76,19 @@ public:
         boost::optional<std::uint64_t> const& ledgerSeq,
         boost::optional<std::string> const& status,
         Blob const& rawTxn,
-        Validate validate,
+        Application& app);
+
+    static
+    Transaction::pointer
+    transactionFromSQLValidated (
+        boost::optional<std::uint64_t> const& ledgerSeq,
+        boost::optional<std::string> const& status,
+        Blob const& rawTxn,
         Application& app);
 
     static
     TransStatus
     sqlTransactionStatus(boost::optional<std::string> const& status);
-
-    bool checkSign (std::string&, SigVerify) const;
 
     STTx::ref getSTransaction ()
     {
@@ -160,8 +164,6 @@ public:
 
 private:
     uint256         mTransactionID;
-    RippleAddress   mFromPubKey;    // Sign transaction with this. mSignPubKey
-    RippleAddress   mSourcePrivate; // Sign transaction with this.
 
     LedgerIndex     mInLedger = 0;
     TransStatus     mStatus = INVALID;

--- a/src/ripple/app/tx/apply.h
+++ b/src/ripple/app/tx/apply.h
@@ -31,6 +31,54 @@
 namespace ripple {
 
 class Application;
+class HashRouter;
+
+enum class Validity
+{
+    SigBad,         // Signature is bad. Didn't do local checks.
+    SigGoodOnly,    // Signature is good, but local checks fail.
+    Valid           // Signature and local checks are good / passed.
+};
+
+/** Checks transaction signature and local checks. Returns
+    a Validity enum representing how valid the STTx is
+    and, if not Valid, a reason string.
+    Results are cached internally, so tests will not be
+    repeated over repeated calls, unless cache expires.
+
+    @return std::pair, where `.first` is the status, and
+            `.second` is the reason if appropriate.
+*/
+std::pair<Validity, std::string>
+checkValidity(HashRouter& router,
+    STTx const& tx,
+        bool allowMultiSign);
+
+/** Checks transaction signature and local checks. Returns
+    a Validity enum representing how valid the STTx is
+    and, if not Valid, a reason string.
+    Results are cached internally, so tests will not be
+    repeated over repeated calls, unless cache expires.
+
+    @return std::pair, where `.first` is the status, and
+            `.second` is the reason if appropriate.
+*/
+std::pair<Validity, std::string>
+checkValidity(HashRouter& router,
+    STTx const& tx, Rules const& rules,
+        Config const& config,
+            ApplyFlags const& flags = tapNONE);
+
+
+/** Sets the validity of a given transaction in the cache.
+    Use with extreme care.
+
+    @note Can only raise the validity to a more valid state,
+          and can not override anything cached bad.
+*/
+void
+forceValidity(HashRouter& router, uint256 const& txid,
+    Validity validity);
 
 /** Apply a transaction to a ReadView.
 
@@ -60,9 +108,7 @@ class Application;
 std::pair<TER, bool>
 apply (Application& app, OpenView& view,
     STTx const& tx, ApplyFlags flags,
-        SigVerify verify,
-            Config const& config,
-                beast::Journal journal);
+        beast::Journal journal);
 
 } // ripple
 

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -50,7 +50,9 @@ Change::preflight (PreflightContext const& ctx)
         return temBAD_FEE;
     }
 
-    if (!ctx.tx.getSigningPubKey ().empty () || !ctx.tx.getSignature ().empty ())
+    if (!ctx.tx.getSigningPubKey ().empty () ||
+        !ctx.tx.getSignature ().empty () ||
+        ctx.tx.isFieldPresent (sfSigners))
     {
         JLOG(ctx.j.warning) << "Change: Bad signature";
         return temBAD_SIGNATURE;

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -649,7 +649,6 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
     auto saTakerGets = ctx_.tx[sfTakerGets];
 
     auto const& uPaysIssuerID = saTakerPays.getIssuer ();
-    auto const& uPaysCurrency = saTakerPays.getCurrency ();
 
     auto const& uGetsIssuerID = saTakerGets.getIssuer ();
 
@@ -663,7 +662,6 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
 
     deprecatedWrongOwnerCount_ = (*sleCreator)[sfOwnerCount];
 
-    auto const uAccountSequenceNext = (*sleCreator)[sfSequence];
     auto const uSequence = ctx_.tx.getSequence ();
 
     // This is the original rate of the offer, and is the rate at which

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -207,8 +207,6 @@ Payment::preclaim(PreclaimContext const& ctx)
             return temMALFORMED;
     }
 
-    auto const id = ctx.tx[sfAccount];
-
     // Ripple if source or destination is non-native or if there are paths.
     std::uint32_t const uTxFlags = ctx.tx.getFlags();
     bool const partialPaymentAllowed = uTxFlags & tfPartialPayment;

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -75,8 +75,8 @@ TER
 SetSignerList::preflight (PreflightContext const& ctx)
 {
     if (! (ctx.flags & tapENABLE_TESTING) &&
-        ! ctx.rules.enabled(featureMultiSign,
-            ctx.config.features))
+            ! ctx.rules.enabled(featureMultiSign,
+                ctx.app.config().features))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/SusPay.cpp
+++ b/src/ripple/app/tx/impl/SusPay.cpp
@@ -133,7 +133,7 @@ SusPayCreate::preflight (PreflightContext const& ctx)
 {
     if (! (ctx.flags & tapENABLE_TESTING) &&
         ! ctx.rules.enabled(featureSusPay,
-            ctx.config.features))
+            ctx.app.config().features))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);
@@ -253,7 +253,7 @@ SusPayFinish::preflight (PreflightContext const& ctx)
 {
     if (! (ctx.flags & tapENABLE_TESTING) &&
         ! ctx.rules.enabled(featureSusPay,
-            ctx.config.features))
+            ctx.app.config().features))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);
@@ -373,7 +373,7 @@ SusPayCancel::preflight (PreflightContext const& ctx)
 {
     if (! (ctx.flags & tapENABLE_TESTING) &&
         ! ctx.rules.enabled(featureSusPay,
-            ctx.config.features))
+            ctx.app.config().features))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -672,7 +672,6 @@ Transactor::operator()()
             keylet::account(ctx_.tx.getAccountID(sfAccount)));
 
         std::uint32_t t_seq = ctx_.tx.getSequence ();
-        std::uint32_t a_seq = txnAcct->getFieldU32 (sfSequence);
 
         auto const balance = txnAcct->getFieldAmount (sfBalance).xrp ();
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/app/tx/apply.h>
 #include <ripple/app/tx/impl/Transactor.h>
 #include <ripple/app/tx/impl/SignerEntries.h>
 #include <ripple/basics/Log.h>
@@ -87,14 +88,10 @@ preflight2 (PreflightContext const& ctx)
     auto const pk = RippleAddress::createAccountPublic(
         ctx.tx.getSigningPubKey());
 
-    if(! ctx.verify(ctx.tx,
-        [&, ctx] (STTx const& tx)
-        {
-            return (ctx.flags & tapNO_CHECK_SIGN) ||
-                tx.checkSign(
-                    (ctx.flags & tapENABLE_TESTING) ||
-                    (ctx.rules.enabled(featureMultiSign, ctx.config.features)));
-        }))
+    if(!( ctx.flags & tapNO_CHECK_SIGN) &&
+        checkValidity(ctx.app.getHashRouter(),
+            ctx.tx, ctx.rules, ctx.app.config(),
+                ctx.flags).first == Validity::SigBad)
     {
         JLOG(ctx.j.debug) << "preflight2: bad signature";
         return temINVALID;
@@ -110,6 +107,19 @@ calculateFee(Application& app, std::uint64_t const baseFee,
 {
     return app.getFeeTrack().scaleFeeLoad(
         baseFee, fees.base, fees.units, flags & tapADMIN);
+}
+
+//------------------------------------------------------------------------------
+
+PreflightContext::PreflightContext(Application& app_, STTx const& tx_,
+    Rules const& rules_, ApplyFlags flags_,
+        beast::Journal j_)
+    : app(app_)
+    , tx(tx_)
+    , rules(rules_)
+    , flags(flags_)
+    , j(j_)
+{
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -30,25 +30,15 @@ namespace ripple {
 struct PreflightContext
 {
 public:
+    Application& app;
     STTx const& tx;
     Rules const& rules;
     ApplyFlags flags;
-    SigVerify verify;
-    Config const& config;
     beast::Journal j;
 
-    PreflightContext(STTx const& tx_,
+    PreflightContext(Application& app_, STTx const& tx_,
         Rules const& rules_, ApplyFlags flags_,
-            SigVerify verify_, Config const& config_,
-                beast::Journal j_)
-        : tx(tx_)
-        , rules(rules_)
-        , flags(flags_)
-        , verify(verify_)
-        , config(config_)
-        , j(j_)
-    {
-    }
+            beast::Journal j_);
 };
 
 struct PreflightResult

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/tx/impl/applyImpl.h>
 #include <ripple/app/tx/impl/ApplyContext.h>
@@ -32,8 +33,15 @@
 #include <ripple/app/tx/impl/SetSignerList.h>
 #include <ripple/app/tx/impl/SetTrust.h>
 #include <ripple/app/tx/impl/SusPay.h>
+#include <ripple/protocol/Feature.h>
 
 namespace ripple {
+
+// These are the same flags defined as SF_PRIVATE1-4 in HashRouter.h
+#define SF_SIGBAD      SF_PRIVATE1    // Signature is bad
+#define SF_SIGGOOD     SF_PRIVATE2    // Signature is good
+#define SF_LOCALBAD    SF_PRIVATE3    // Local checks failed
+#define SF_LOCALGOOD   SF_PRIVATE4    // Local checks passed
 
 static
 TER
@@ -160,13 +168,91 @@ invoke_apply (ApplyContext& ctx)
 
 //------------------------------------------------------------------------------
 
-PreflightResult
-preflight (Rules const& rules, STTx const& tx,
-    ApplyFlags flags, SigVerify verify,
-        Config const& config, beast::Journal j)
+std::pair<Validity, std::string>
+checkValidity(HashRouter& router, STTx const& tx, bool allowMultiSign)
 {
-    PreflightContext const pfctx(tx,
-        rules, flags, verify, config, j);
+    auto const id = tx.getTransactionID();
+    auto const flags = router.getFlags(id);
+    if (flags & SF_SIGBAD)
+        // Signature is known bad
+        return std::make_pair(Validity::SigBad,
+            "Transaction has bad signature.");
+    if (!(flags & SF_SIGGOOD))
+    {
+        // Don't know signature state. Check it.
+        if (!tx.checkSign(allowMultiSign))
+        {
+            router.setFlags(id, SF_SIGBAD);
+            return std::make_pair(Validity::SigBad,
+                "Transaction has bad signature.");
+        }
+        router.setFlags(id, SF_SIGGOOD);
+    }
+
+    // Signature is now known good
+    if (flags & SF_LOCALBAD)
+        // ...but the local checks
+        // are known bad.
+        return std::make_pair(Validity::SigGoodOnly,
+            "Local checks failed.");
+    if (flags & SF_LOCALGOOD)
+        // ...and the local checks
+        // are known good.
+        return std::make_pair(Validity::Valid, "");
+
+    // Do the local checks
+    std::string reason;
+    if (!passesLocalChecks(tx, reason))
+    {
+        router.setFlags(id, SF_LOCALBAD);
+        return std::make_pair(Validity::SigGoodOnly, reason);
+    }
+    router.setFlags(id, SF_LOCALGOOD);
+    return std::make_pair(Validity::Valid, "");
+}
+
+std::pair<Validity, std::string>
+checkValidity(HashRouter& router,
+    STTx const& tx, Rules const& rules,
+        Config const& config,
+            ApplyFlags const& flags)
+{
+    auto const allowMultiSign =
+        (flags & tapENABLE_TESTING) ||
+            (rules.enabled(featureMultiSign,
+                config.features));
+
+    return checkValidity(router, tx, allowMultiSign);
+}
+
+void
+forceValidity(HashRouter& router, uint256 const& txid,
+    Validity validity)
+{
+    int flags = 0;
+    switch (validity)
+    {
+    case Validity::Valid:
+        flags |= SF_LOCALGOOD;
+        // fall through
+    case Validity::SigGoodOnly:
+        flags |= SF_SIGGOOD;
+        // fall through
+    case Validity::SigBad:
+        // would be silly to call directly
+        break;
+    }
+    if (flags)
+        router.setFlags(txid, flags);
+}
+
+PreflightResult
+preflight (Application& app, Rules const& rules,
+    STTx const& tx, ApplyFlags flags,
+        beast::Journal j)
+{
+    PreflightContext const pfctx(app, tx,
+        rules, flags, j);
     try
     {
         return{ pfctx, invoke_preflight(pfctx) };
@@ -192,10 +278,9 @@ preclaim (PreflightResult const& preflightResult,
     boost::optional<PreclaimContext const> ctx;
     if (preflightResult.ctx.rules != view.rules())
     {
-        auto secondFlight = preflight(view.rules(),
+        auto secondFlight = preflight(app, view.rules(),
             preflightResult.ctx.tx, preflightResult.ctx.flags,
-                preflightResult.ctx.verify, preflightResult.ctx.config,
-                    preflightResult.ctx.j);
+                preflightResult.ctx.j);
         ctx.emplace(app, view, secondFlight.ter, secondFlight.ctx.tx,
             secondFlight.ctx.flags, secondFlight.ctx.j);
     }
@@ -240,8 +325,8 @@ doApply(PreclaimResult const& preclaimResult,
         if (preclaimResult.ter != tesSUCCESS
                 && !isTecClaim(preclaimResult.ter))
             return{ preclaimResult.ter, false };
-        ApplyContext ctx(
-            app, view, preclaimResult.ctx.tx, preclaimResult.ter,
+        ApplyContext ctx(app, view,
+            preclaimResult.ctx.tx, preclaimResult.ter,
             preclaimResult.baseFee, preclaimResult.ctx.flags,
             preclaimResult.ctx.j);
         return invoke_apply(ctx);
@@ -263,11 +348,10 @@ doApply(PreclaimResult const& preclaimResult,
 std::pair<TER, bool>
 apply (Application& app, OpenView& view,
     STTx const& tx, ApplyFlags flags,
-        SigVerify verify, Config const& config,
-            beast::Journal j)
+        beast::Journal j)
 {
-    auto pfresult = preflight(view.rules(),
-        tx, flags, verify, config, j);
+    auto pfresult = preflight(app, view.rules(),
+        tx, flags, j);
     auto pcresult = preclaim(pfresult, app, view);
     return doApply(pcresult, app, view);
 }

--- a/src/ripple/app/tx/impl/applyImpl.h
+++ b/src/ripple/app/tx/impl/applyImpl.h
@@ -35,9 +35,9 @@ validity constraints that do not require a ledger.
 other things, the TER code.
 */
 PreflightResult
-preflight(Rules const& rules, STTx const& tx,
-    ApplyFlags flags, SigVerify verify,
-    Config const& config, beast::Journal j);
+preflight(Application& app, Rules const& rules,
+    STTx const& tx, ApplyFlags flags,
+        beast::Journal j);
 
 /** Gate a transaction based on static ledger information.
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -28,6 +28,7 @@
 #include <ripple/overlay/ClusterNodeStatus.h>
 #include <ripple/app/misc/UniqueNodeList.h>
 #include <ripple/app/tx/InboundTransactions.h>
+#include <ripple/app/tx/apply.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/UptimeTimer.h>
@@ -1045,6 +1046,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
         p_journal_.debug <<
             "Got tx " << txID;
 
+        bool checkSignature = true;
         if (cluster())
         {
             if (! m->has_deferred () || ! m->deferred ())
@@ -1058,7 +1060,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
             {
                 // For now, be paranoid and have each validator
                 // check each transaction, regardless of source
-                flags |= SF_SIGGOOD;
+                checkSignature = false;
             }
         }
 
@@ -1071,9 +1073,10 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
             std::weak_ptr<PeerImp> weak = shared_from_this();
             app_.getJobQueue ().addJob (
                 jtTRANSACTION, "recvTransaction->checkTransaction",
-                [weak, flags, stx] (Job&) {
+                [weak, flags, checkSignature, stx] (Job&) {
                     if (auto peer = weak.lock())
-                        peer->checkTransaction(flags, stx);
+                        peer->checkTransaction(flags,
+                            checkSignature, stx);
                 });
         }
     }
@@ -1705,7 +1708,8 @@ PeerImp::doFetchPack (const std::shared_ptr<protocol::TMGetObjectByHash>& packet
 }
 
 void
-PeerImp::checkTransaction (int flags, STTx::pointer stx)
+PeerImp::checkTransaction (int flags,
+    bool checkSignature, STTx::pointer stx)
 {
     // VFALCO TODO Rewrite to not use exceptions
     try
@@ -1720,11 +1724,34 @@ PeerImp::checkTransaction (int flags, STTx::pointer stx)
             return;
         }
 
-        auto validate = (flags & SF_SIGGOOD) ? Validate::NO : Validate::YES;
+        if (checkSignature)
+        {
+            // Check the signature before handing off to the job queue.
+            auto valid = checkValidity(app_.getHashRouter(), *stx,
+                app_.getLedgerMaster().getValidatedRules(),
+                    app_.config());
+            if (valid.first != Validity::Valid)
+            {
+                if (!valid.second.empty())
+                    JLOG(p_journal_.trace) <<
+                        "Exception checking transaction: " <<
+                            valid.second;
+
+                // Probably not necessary to set SF_BAD, but doesn't hurt.
+                app_.getHashRouter().setFlags(stx->getTransactionID(), SF_BAD);
+                charge(Resource::feeInvalidSignature);
+                return;
+            }
+        }
+        else
+        {
+            forceValidity(app_.getHashRouter(),
+                stx->getTransactionID(), Validity::Valid);
+        }
+
         std::string reason;
-        auto tx = std::make_shared<Transaction> (stx, validate,
-            directSigVerify,
-            reason, app_);
+        auto tx = std::make_shared<Transaction> (
+            stx, reason, app_);
 
         if (tx->getStatus () == INVALID)
         {
@@ -1734,10 +1761,6 @@ PeerImp::checkTransaction (int flags, STTx::pointer stx)
             app_.getHashRouter ().setFlags (stx->getTransactionID (), SF_BAD);
             charge (Resource::feeInvalidSignature);
             return;
-        }
-        else
-        {
-            app_.getHashRouter ().setFlags (stx->getTransactionID (), SF_SIGGOOD);
         }
 
         bool const trusted (flags & SF_TRUSTED);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1070,10 +1070,10 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
             p_journal_.trace << "No new transactions until synchronized";
         else
         {
-            std::weak_ptr<PeerImp> weak = shared_from_this();
             app_.getJobQueue ().addJob (
                 jtTRANSACTION, "recvTransaction->checkTransaction",
-                [weak, flags, checkSignature, stx] (Job&) {
+                [weak = std::weak_ptr<PeerImp>(shared_from_this()),
+                flags, checkSignature, stx] (Job&) {
                     if (auto peer = weak.lock())
                         peer->checkTransaction(flags,
                             checkSignature, stx);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1733,9 +1733,11 @@ PeerImp::checkTransaction (int flags,
             if (valid.first != Validity::Valid)
             {
                 if (!valid.second.empty())
+                {
                     JLOG(p_journal_.trace) <<
                         "Exception checking transaction: " <<
                             valid.second;
+                }
 
                 // Probably not necessary to set SF_BAD, but doesn't hurt.
                 app_.getHashRouter().setFlags(stx->getTransactionID(), SF_BAD);

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -448,7 +448,7 @@ private:
     doFetchPack (const std::shared_ptr<protocol::TMGetObjectByHash>& packet);
 
     void
-    checkTransaction (int flags, STTx::pointer stx);
+    checkTransaction (int flags, bool checkSignature, STTx::pointer stx);
 
     void
     checkPropose (Job& job,

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -139,14 +139,6 @@ private:
 
 bool passesLocalChecks (STObject const& st, std::string&);
 
-using SigVerify = std::function < bool(STTx const&, std::function<bool(STTx const&)>) > ;
-
-inline
-bool directSigVerify(STTx const& tx, std::function<bool(STTx const&)> sigCheck)
-{
-    return sigCheck(tx);
-}
-
 } // ripple
 
 #endif

--- a/src/ripple/rpc/handlers/TxHistory.cpp
+++ b/src/ripple/rpc/handlers/TxHistory.cpp
@@ -81,7 +81,7 @@ Json::Value doTxHistory (RPC::Context& context)
                 rawTxn.clear ();
 
             if (auto trans = Transaction::transactionFromSQL (
-                    ledgerSeq, status, rawTxn, Validate::NO, context.app))
+                    ledgerSeq, status, rawTxn, context.app))
                 txs.append (trans->getJson (0));
         }
     }

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -506,7 +506,8 @@ transactionPreProcessImpl (
 
 static
 std::pair <Json::Value, Transaction::pointer>
-transactionConstructImpl (STTx::pointer stpTrans, Application& app)
+transactionConstructImpl (STTx::pointer stpTrans,
+    Rules const& rules, Application& app)
 {
     std::pair <Json::Value, Transaction::pointer> ret;
 
@@ -514,8 +515,8 @@ transactionConstructImpl (STTx::pointer stpTrans, Application& app)
     Transaction::pointer tpTrans;
     {
         std::string reason;
-        tpTrans = std::make_shared<Transaction>(stpTrans, Validate::NO,
-            directSigVerify, reason, app);
+        tpTrans = std::make_shared<Transaction>(
+            stpTrans, reason, app);
         if (tpTrans->getStatus () != NEW)
         {
             ret.first = RPC::make_error (rpcINTERNAL,
@@ -534,7 +535,7 @@ transactionConstructImpl (STTx::pointer stpTrans, Application& app)
             tpTrans->getSTransaction ()->add (s);
 
             Transaction::pointer tpTransNew =
-                Transaction::sharedTransaction(s.getData(), Validate::YES, app);
+                Transaction::sharedTransaction(s.getData(), rules, app);
 
             if (tpTransNew && (
                 !tpTransNew->getSTransaction ()->isEquivalent (
@@ -673,7 +674,8 @@ Json::Value transactionSign (
 
     // Make sure the STTx makes a legitimate Transaction.
     std::pair <Json::Value, Transaction::pointer> txn =
-        transactionConstructImpl (preprocResult.second, app);
+        transactionConstructImpl (preprocResult.second,
+            ledger->rules(), app);
 
     if (!txn.second)
         return txn.first;
@@ -707,7 +709,8 @@ Json::Value transactionSubmit (
 
     // Make sure the STTx makes a legitimate Transaction.
     std::pair <Json::Value, Transaction::pointer> txn =
-        transactionConstructImpl (preprocResult.second, app);
+        transactionConstructImpl (preprocResult.second,
+            ledger->rules(), app);
 
     if (!txn.second)
         return txn.first;
@@ -825,7 +828,8 @@ Json::Value transactionSignFor (
 
     // Make sure the STTx makes a legitimate Transaction.
     std::pair <Json::Value, Transaction::pointer> txn =
-        transactionConstructImpl (preprocResult.second, app);
+        transactionConstructImpl (preprocResult.second,
+            ledger->rules(), app);
 
     if (!txn.second)
         return txn.first;
@@ -1052,7 +1056,8 @@ Json::Value transactionSubmitMultiSigned (
 
     // Make sure the SerializedTransaction makes a legitimate Transaction.
     std::pair <Json::Value, Transaction::pointer> txn =
-        transactionConstructImpl (stpTrans, app);
+        transactionConstructImpl (stpTrans,
+            ledger->rules(), app);
 
     if (!txn.second)
         return txn.first;

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -43,6 +43,7 @@
 #include <ripple/protocol/TER.h>
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/types.h>
+#include <ripple/protocol/Feature.h>
 #include <memory>
 
 namespace ripple {
@@ -84,7 +85,7 @@ Env::Env (beast::unit_test::suite& test_)
     , closed_ (std::make_shared<Ledger>(
         create_genesis, app().config(), app().family()))
     , cachedSLEs_ (std::chrono::seconds(5), stopwatch_)
-    , openLedger (closed_, app().config(), cachedSLEs_, journal)
+    , openLedger (closed_, cachedSLEs_, journal)
 {
     memoize(master);
     Pathfinder::initPathTable();
@@ -122,7 +123,7 @@ Env::close(NetClock::time_point const& closeTime)
         OpenView accum(&*next);
         OpenLedger::apply(app(), accum, *closed_,
             txs, retries, applyFlags(), *router,
-                app().config(), journal);
+                journal);
         accum.apply(*next);
     }
     // To ensure that the close time is exact and not rounded, we don't
@@ -278,8 +279,7 @@ Env::submit (JTx const& jt)
             {
                 std::tie(ter_, didApply) = ripple::apply(
                     app(), view, *stx, applyFlags(),
-                        directSigVerify, app().config(),
-                            beast::Journal{});
+                        beast::Journal{});
                 return didApply;
             });
     }

--- a/src/ripple/unity/app_tests.cpp
+++ b/src/ripple/unity/app_tests.cpp
@@ -23,6 +23,7 @@
 #include <ripple/app/tests/AmendmentTable.test.cpp>
 #include <ripple/app/tests/CrossingLimits_test.cpp>
 #include <ripple/app/tests/DeliverMin.test.cpp>
+#include <ripple/app/tests/HashRouter_test.cpp>
 #include <ripple/app/tests/MultiSign.test.cpp>
 #include <ripple/app/tests/OfferStream.test.cpp>
 #include <ripple/app/tests/Offer.test.cpp>


### PR DESCRIPTION
The idea here is to clean up the wide variety of methodologies used to check transaction signatures, especially on receipt from:
*    Tx received from peer
*    Tx received from client
*    Tx signed and submitted locally.

Now, all checks aggressively go through a single function (`HashRouter::checkValidity`), and the `sigVerify` lambda callback has been eliminated from the `Transactor`.

Reviewers: @vinniefalco @miguelportilla. Should probably also be checked out by @JoelKatz when he is available.
*The first commit ("Devirtualize HashRouter") can be ignored*, since it's already covered by #1223.

Since I'm about to go on vacation, if there are any problems, either someone else can take ownership, or the PR can be closed until I get back.