### PR TITLE
Eliminate redundant traversal logic of SHAMap:

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -888,9 +888,8 @@ boost::optional<uint256>
 Ledger::succ (uint256 const& key,
     boost::optional<uint256> last) const
 {
-    auto const item =
-        stateMap_->peekNextItem(key);
-    if (! item)
+    auto item = stateMap_->upper_bound(key);
+    if (item == stateMap_->end())
         return boost::none;
     if (last && item->key() >= last)
         return boost::none;
@@ -1140,16 +1139,6 @@ void Ledger::visitStateItems (std::function<void (SLE::ref)> callback) const
         }
         throw;
     }
-}
-
-uint256 Ledger::getNextLedgerIndex (uint256 const& hash,
-    boost::optional<uint256> const& last) const
-{
-    auto const node =
-        stateMap_->peekNextItem(hash);
-    if ((! node) || (last && node->key() >= *last))
-        return {};
-    return node->key();
 }
 
 bool Ledger::walkLedger () const

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -317,10 +317,6 @@ public:
 
     bool pendSaveValidated (bool isSynchronous, bool isCurrent);
 
-    // first node >hash, <last
-    uint256 getNextLedgerIndex (uint256 const& hash,
-        boost::optional<uint256> const& last = boost::none) const;
-
     std::vector<uint256> getNeededTransactionHashes (
         int max, SHAMapSyncFilter* filter) const;
 

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -165,16 +165,7 @@ public:
         peekItem (uint256 const& id, SHAMapTreeNode::TNType & type) const;
 
     // traverse functions
-    std::shared_ptr<SHAMapItem const> const& peekFirstItem () const;
-    std::shared_ptr<SHAMapItem const> const&
-        peekFirstItem (SHAMapTreeNode::TNType & type) const;
-    SHAMapItem const* peekFirstItem(NodeStack& stack) const;
-    std::shared_ptr<SHAMapItem const> const& peekLastItem () const;
-    std::shared_ptr<SHAMapItem const> const& peekNextItem (uint256 const& ) const;
-    std::shared_ptr<SHAMapItem const> const&
-        peekNextItem (uint256 const& , SHAMapTreeNode::TNType & type) const;
-    SHAMapItem const* peekNextItem(uint256 const& id, NodeStack& stack) const;
-    std::shared_ptr<SHAMapItem const> const& peekPrevItem (uint256 const& ) const;
+    const_iterator upper_bound(uint256 const& id) const;
 
     void visitNodes (std::function<bool (SHAMapAbstractNode&)> const&) const;
     void
@@ -275,9 +266,7 @@ private:
         writeNode(NodeObjectType t, std::uint32_t seq,
                   std::shared_ptr<SHAMapAbstractNode> node) const;
 
-    SHAMapTreeNode* firstBelow (SHAMapAbstractNode*) const;
     SHAMapTreeNode* firstBelow (SHAMapAbstractNode*, NodeStack& stack) const;
-    SHAMapTreeNode* lastBelow (SHAMapAbstractNode*) const;
 
     // Simple descent
     // Get a child of the specified node
@@ -305,6 +294,8 @@ private:
     bool hasInnerNode (SHAMapNodeID const& nodeID, uint256 const& hash) const;
     bool hasLeafNode (uint256 const& tag, uint256 const& hash) const;
 
+    SHAMapItem const* peekFirstItem(NodeStack& stack) const;
+    SHAMapItem const* peekNextItem(uint256 const& id, NodeStack& stack) const;
     bool walkBranch (SHAMapAbstractNode* node,
                      std::shared_ptr<SHAMapItem const> const& otherMapItem,
                      bool isFirstMap, Delta & differences, int & maxCount) const;
@@ -389,6 +380,7 @@ public:
 private:
     explicit const_iterator(SHAMap const* map);
     const_iterator(SHAMap const* map, pointer item);
+    const_iterator(SHAMap const* map, pointer item, NodeStack&& stack);
 
     friend bool operator==(const_iterator const& x, const_iterator const& y);
     friend class SHAMap;
@@ -404,6 +396,15 @@ SHAMap::const_iterator::const_iterator(SHAMap const* map)
 inline
 SHAMap::const_iterator::const_iterator(SHAMap const* map, pointer item)
     : map_(map)
+    , item_(item)
+{
+}
+
+inline
+SHAMap::const_iterator::const_iterator(SHAMap const* map, pointer item,
+                                       NodeStack&& stack)
+    : stack_(std::move(stack))
+    , map_(map)
     , item_(item)
 {
 }

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -68,31 +68,32 @@ public:
         unexpected (!sMap.addItem (i2, true, false), "no add");
         unexpected (!sMap.addItem (i1, true, false), "no add");
 
-        std::shared_ptr<SHAMapItem const> i;
-        i = sMap.peekFirstItem ();
-        unexpected (!i || (*i != i1), "bad traverse");
-        i = sMap.peekNextItem (i->key());
-        unexpected (!i || (*i != i2), "bad traverse");
-        i = sMap.peekNextItem (i->key());
-        unexpected (i, "bad traverse");
+        auto i = sMap.begin();
+        auto e = sMap.end();
+        unexpected (i == e || (*i != i1), "bad traverse");
+        ++i;
+        unexpected (i == e || (*i != i2), "bad traverse");
+        ++i;
+        unexpected (i != e, "bad traverse");
         sMap.addItem (i4, true, false);
         sMap.delItem (i2.key());
         sMap.addItem (i3, true, false);
-        i = sMap.peekFirstItem ();
-        unexpected (!i || (*i != i1), "bad traverse");
-        i = sMap.peekNextItem (i->key());
-        unexpected (!i || (*i != i3), "bad traverse");
-        i = sMap.peekNextItem (i->key());
-        unexpected (!i || (*i != i4), "bad traverse");
-        i = sMap.peekNextItem (i->key());
-        unexpected (i, "bad traverse");
+        i = sMap.begin();
+        e = sMap.end();
+        unexpected (i == e || (*i != i1), "bad traverse");
+        ++i;
+        unexpected (i == e || (*i != i3), "bad traverse");
+        ++i;
+        unexpected (i == e || (*i != i4), "bad traverse");
+        ++i;
+        unexpected (i != e, "bad traverse");
 
         testcase ("snapshot");
         uint256 mapHash = sMap.getHash ();
         std::shared_ptr<SHAMap> map2 = sMap.snapShot (false);
         unexpected (sMap.getHash () != mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
-        unexpected (!sMap.delItem (sMap.peekFirstItem ()->key()), "bad mod");
+        unexpected (!sMap.delItem (sMap.begin()->key()), "bad mod");
         unexpected (sMap.getHash () == mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
 


### PR DESCRIPTION
*  Only the const_iterator interface remains.

@miguelportilla @scottschurr 