### PR TITLE
[TRIVIAL] Implicitly add localhost to RPC allow list

### DIFF
--- a/src/ripple/server/impl/Role.cpp
+++ b/src/ripple/server/impl/Role.cpp
@@ -50,8 +50,12 @@ bool
 isAdmin (HTTP::Port const& port, Json::Value const& params,
          beast::IP::Address const& remoteIp)
 {
-    return ipAllowed (remoteIp, port.admin_ip) &&
-        passwordUnrequiredOrSentCorrect (port, params);
+    bool ipOk = is_loopback (remoteIp);
+
+    if (!ipOk)
+        ipOk = ipAllowed (remoteIp, port.admin_ip);
+
+    return ipOk && passwordUnrequiredOrSentCorrect (port, params);
 }
 
 Role


### PR DESCRIPTION
It should not be necessary to explicitly add 127.0.0.1 to the list of IPs that are allowed administrative access.