### PR TITLE
Create zero balance trust lines with auth flag (RIPD-1003): 

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1713,6 +1713,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tests\SetAuth_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tests\SusPay_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2454,6 +2454,9 @@
     <ClCompile Include="..\..\src\ripple\app\tests\Regression_test.cpp">
       <Filter>ripple\app\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tests\SetAuth_test.cpp">
+      <Filter>ripple\app\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tests\SusPay_test.cpp">
       <Filter>ripple\app\tests</Filter>
     </ClCompile>

--- a/src/ripple/app/tests/SetAuth_test.cpp
+++ b/src/ripple/app/tests/SetAuth_test.cpp
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/test/jtx.h>
+#include <ripple/protocol/JsonFields.h>
+
+namespace ripple {
+namespace test {
+
+struct SetAuth_test : public beast::unit_test::suite
+{
+    // Set just the tfSetfAuth flag on a trust line
+    // If the trust line does not exist, then it should
+    // be created under the new rules.
+    static
+    Json::Value
+    auth (jtx::Account const& account,
+        jtx::Account const& dest,
+            std::string const& currency)
+    {
+        using namespace jtx;
+        Json::Value jv;
+        jv[jss::Account] = account.human();
+        jv[jss::LimitAmount] = STAmount(
+            { to_currency(currency), dest }).getJson(0);
+        jv[jss::TransactionType] = "TrustSet";
+        jv[jss::Flags] = tfSetfAuth;
+        return jv;
+    }
+
+    void testAuth()
+    {
+        using namespace jtx;
+        auto const gw = Account("gw");
+        auto const USD = gw["USD"];
+        {
+            Env env(*this);
+            env.disable_testing();
+            env.fund(XRP(100000), "alice", gw);
+            env(fset(gw, asfRequireAuth));
+            env(auth(gw, "alice", "USD"),       ter(tecNO_LINE_REDUNDANT));
+        }
+        {
+            Env env(*this);
+            env.fund(XRP(100000), "alice", "bob", gw);
+            env(fset(gw, asfRequireAuth));
+            env(auth(gw, "alice", "USD"));
+            expect(env.le(
+                keylet::line(Account("alice").id(),
+                    gw.id(), USD.currency)));
+            env(trust("alice", USD(1000)));
+            env(trust("bob", USD(1000)));
+            env(pay(gw, "alice", USD(100)));
+            env(pay(gw, "bob", USD(100)),       ter(tecPATH_DRY)); // Should be terNO_AUTH
+            env(pay("alice", "bob", USD(50)),   ter(tecPATH_DRY)); // Should be terNO_AUTH
+        }
+    }
+
+    void run() override
+    {
+        testAuth();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(SetAuth,test,ripple);
+
+} // test
+} // ripple

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Quality.h>
 #include <ripple/app/tx/impl/SetTrust.h>
 #include <ripple/basics/Log.h>
@@ -397,9 +398,12 @@ SetTrust::doApply ()
         }
     }
     // Line does not exist.
-    else if (!saLimitAmount                       // Setting default limit.
-                && (!bQualityIn || !uQualityIn)      // Not setting quality in or setting default quality in.
-                && (!bQualityOut || !uQualityOut))   // Not setting quality out or setting default quality out.
+    else if (! saLimitAmount &&                          // Setting default limit.
+        (! bQualityIn || ! uQualityIn) &&           // Not setting quality in or setting default quality in.
+        (! bQualityOut || ! uQualityOut) &&         // Not setting quality out or setting default quality out.
+        (! ((view().flags() & tapENABLE_TESTING) ||
+            view().rules().enabled(featureTrustSetAuth,
+                ctx_.config.features)) || ! bSetAuth))
     {
         j_.trace <<
             "Redundant: Setting non-existent ripple line to defaults.";

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -36,6 +36,7 @@ feature (const char* name);
 
 extern uint256 const featureMultiSign;
 extern uint256 const featureSusPay;
+extern uint256 const featureTrustSetAuth;
 
 } // ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -47,5 +47,6 @@ feature (const char* name)
 
 uint256 const featureMultiSign = feature("MultiSign");
 uint256 const featureSusPay = feature("SusPay");
+uint256 const featureTrustSetAuth = feature("TrustSetAuth");
 
 } // ripple

--- a/src/ripple/unity/app_tests.cpp
+++ b/src/ripple/unity/app_tests.cpp
@@ -29,3 +29,4 @@
 #include <ripple/app/tests/OfferStream.test.cpp>
 #include <ripple/app/tests/Offer.test.cpp>
 #include <ripple/app/tests/Taker.test.cpp>
+#include <ripple/app/tests/SetAuth_test.cpp>


### PR DESCRIPTION
This allows a TrustSet transaction to create a trust line if the only thing being changed is setting the `tfSetfAuth` flag.