### PR TITLE
Distinguish between path_find responses (RIPD-1013)

### DIFF
--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -393,12 +393,14 @@ Json::Value PathRequest::doClose (Json::Value const&)
 {
     m_journal.debug << iIdentifier << " closed";
     ScopedLockType sl (mLock);
+    jvStatus[jss::closed] = true;
     return jvStatus;
 }
 
 Json::Value PathRequest::doStatus (Json::Value const&)
 {
     ScopedLockType sl (mLock);
+    jvStatus[jss::status] = jss::success;
     return jvStatus;
 }
 


### PR DESCRIPTION
Distinguish between the path_find subcommand responses by including new fields.

Reviewers: @rec @scottschurr 
