### PR TITLE
Enable simple multisign with a Feature (RIPD-182)

### DIFF
--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -171,15 +171,6 @@
 #define RIPPLE_ENABLE_TICKETS 0
 #endif
 
-/** Config: RIPPLE_ENABLE_MULTI_SIGN
-    When set, activates the current state of the multi-sign feature which is
-    under development.  When the feature is complete and released this
-    #define should be removed.
-*/
-#ifndef RIPPLE_ENABLE_MULTI_SIGN
-#define RIPPLE_ENABLE_MULTI_SIGN 0
-#endif
-
 // Uses OpenSSL instead of alternatives
 #ifndef RIPPLE_USE_OPENSSL
 #define RIPPLE_USE_OPENSSL 0

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -81,6 +81,9 @@ public:
     // The validated ledger is the last fully validated ledger
     virtual Ledger::pointer getValidatedLedger () = 0;
 
+    // The Rules are in the last fully validated ledger if there is one.
+    virtual Rules getValidatedRules() = 0;
+
     // This is the last ledger we published to clients and can lag the validated
     // ledger
     virtual Ledger::ref getPublishedLedger () = 0;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1376,6 +1376,18 @@ public:
         return mValidLedger.get ();
     }
 
+    Rules getValidatedRules ()
+    {
+        // Once we have a guarantee that there's always a last validated
+        // ledger then we can dispense with the if.
+
+        // Return the Rules from the last validated ledger.
+        if (auto const ledger = getValidatedLedger())
+            return ledger->rules();
+
+        return Rules();
+   }
+
     // This is the last ledger we published to clients and can lag the validated
     // ledger.
     Ledger::ref getPublishedLedger ()

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -146,14 +146,10 @@ void printHelp (const po::options_description& desc)
            "     version\n"
            "     server_info\n"
            "     sign <private_key> <json> [offline]\n"
-#if RIPPLE_ENABLE_MULTI_SIGN
            "     sign_for\n"
-#endif // RIPPLE_ENABLE_MULTI_SIGN
            "     stop\n"
            "     submit <tx_blob>|[<private_key> <json>]\n"
-#if RIPPLE_ENABLE_MULTI_SIGN
            "     submit_multisigned\n"
-#endif // RIPPLE_ENABLE_MULTI_SIGN
            "     tx <id>\n"
            "     validation_create [<seed>|<pass_phrase>|<key>]\n"
            "     validation_seed [<seed>|<pass_phrase>|<key>]\n"

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -56,6 +56,7 @@
 #include <ripple/overlay/Overlay.h>
 #include <ripple/overlay/predicates.h>
 #include <ripple/protocol/BuildInfo.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/HashPrefix.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/resource/Fees.h>
@@ -675,7 +676,10 @@ void NetworkOPsImp::submitTransaction (Job&, STTx::pointer iTrans)
     {
         try
         {
-            if (! passesLocalChecks (*trans, reason) || ! trans->checkSign ())
+            // Tell the call to checkSign() whether multisign is enabled.
+            if (!passesLocalChecks (*trans, reason) ||
+                !trans->checkSign (m_ledgerMaster.getValidatedRules().enabled(
+                    featureMultiSign, getConfig().features)))
             {
                 m_journal.warning << "Submitted transaction " <<
                     (reason.empty () ? "has bad signature" : "error: " + reason);

--- a/src/ripple/app/tests/MultiSign.test.cpp
+++ b/src/ripple/app/tests/MultiSign.test.cpp
@@ -219,7 +219,7 @@ public:
         expect (env.seq(alice) == aliceSeq + 1);
 
         // Make sure multisign is disabled in production.
-        // NOTE: THESE FOUR TESTS FAIL IF RIPPLE_ENABLE_MULTI_SIGN != 0
+        // NOTE: These four tests will fail when multisign is default enabled.
         env.disable_testing();
         aliceSeq = env.seq (alice);
         env(noop(alice), msig(bogie), fee(2 * baseFee), ter(temINVALID));

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -191,8 +191,18 @@ SetAccount::doApply ()
             return tecNEED_MASTER_KEY;
         }
 
-        if (!sle->isFieldPresent (sfRegularKey))
+        if ((!sle->isFieldPresent (sfRegularKey)) &&
+            (!view().peek (keylet::signers (account_))))
+        {
+            // Account has no regular key or multi-signer signer list.
+
+            // Prevent transaction changes until we're ready.
+            if ((RIPPLE_ENABLE_MULTI_SIGN) ||
+                view().flags() & tapENABLE_TESTING)
+                    return tecNO_ALTERNATIVE_KEY;
+
             return tecNO_REGULAR_KEY;
+        }
 
         j_.trace << "Set lsfDisableMaster.";
         uFlagsOut |= lsfDisableMaster;

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -21,6 +21,7 @@
 #include <ripple/app/tx/impl/SetAccount.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/Quality.h>
 #include <ripple/protocol/TxFlags.h>
@@ -197,8 +198,8 @@ SetAccount::doApply ()
             // Account has no regular key or multi-signer signer list.
 
             // Prevent transaction changes until we're ready.
-            if ((RIPPLE_ENABLE_MULTI_SIGN) ||
-                view().flags() & tapENABLE_TESTING)
+            if (view().flags() & tapENABLE_TESTING ||
+                view().rules().enabled(featureMultiSign, ctx_.config.features))
                     return tecNO_ALTERNATIVE_KEY;
 
             return tecNO_REGULAR_KEY;

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -77,8 +77,11 @@ SetRegularKey::doApply ()
     }
     else
     {
-        if (sle->isFlag (lsfDisableMaster))
-            return tecMASTER_DISABLED;
+        if (sle->isFlag (lsfDisableMaster) &&
+            !view().peek (keylet::signers (account_)))
+            // Account has disabled master key and no multi-signer signer list.
+            return tecNO_ALTERNATIVE_KEY;
+
         sle->makeFieldAbsent (sfRegularKey);
     }
 

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -21,6 +21,7 @@
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/tx/impl/SetSignerList.h>
 #include <ripple/app/tx/impl/SignerEntries.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/STObject.h>
 #include <ripple/protocol/STArray.h>
 #include <ripple/protocol/STTx.h>
@@ -74,10 +75,10 @@ SetSignerList::determineOperation(STTx const& tx,
 TER
 SetSignerList::preflight (PreflightContext const& ctx)
 {
-#if ! RIPPLE_ENABLE_MULTI_SIGN
-    if (! (ctx.flags & tapENABLE_TESTING))
+    if (! (ctx.flags & tapENABLE_TESTING) &&
+        ! ctx.rules.enabled(featureMultiSign,
+            ctx.config.features))
         return temDISABLED;
-#endif
 
     auto const ret = preflight1 (ctx);
     if (!isTesSuccess (ret))

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -76,12 +76,14 @@ private:
                 AccountID const& account,
                     beast::Journal j);
 
-    TER replaceSignerList (uint256 const& index);
-    TER destroySignerList (uint256 const& index);
+    TER replaceSignerList ();
+    TER destroySignerList ();
 
-    void writeSignersToLedger (SLE::pointer ledgerEntry);
+    TER removeSignersFromLedger (Keylet const& accountKeylet,
+        Keylet const& ownerDirKeylet, Keylet const& signerListKeylet);
+    void writeSignersToSLE (SLE::pointer const& ledgerEntry) const;
 
-    static std::size_t ownerCountDelta (std::size_t entryCount);
+    static int ownerCountDelta (std::size_t entryCount);
 };
 
 } // ripple

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -28,6 +28,7 @@
 #include <ripple/net/HTTPClient.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/SystemParameters.h>
 #include <ripple/protocol/types.h>
 #include <ripple/server/ServerHandler.h>
@@ -922,13 +923,9 @@ public:
             {   "random",               &RPCParser::parseAsIs,                  0,  0   },
             {   "ripple_path_find",     &RPCParser::parseRipplePathFind,        1,  2   },
             {   "sign",                 &RPCParser::parseSignSubmit,            2,  3   },
-#if RIPPLE_ENABLE_MULTI_SIGN
             {   "sign_for",             &RPCParser::parseSignFor,               4,  4   },
-#endif // RIPPLE_ENABLE_MULTI_SIGN
             {   "submit",               &RPCParser::parseSignSubmit,            1,  3   },
-#if RIPPLE_ENABLE_MULTI_SIGN
             {   "submit_multisigned",   &RPCParser::parseSubmitMultiSigned,     1,  1   },
-#endif // RIPPLE_ENABLE_MULTI_SIGN
             {   "server_info",          &RPCParser::parseAsIs,                  0,  0   },
             {   "server_state",         &RPCParser::parseAsIs,                  0,  0   },
             {   "stop",                 &RPCParser::parseAsIs,                  0,  0   },

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -34,6 +34,7 @@ uint256
 feature (const char* name);
 /** @} */
 
+extern uint256 const featureMultiSign;
 extern uint256 const featureSusPay;
 
 } // ripple

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -122,13 +122,7 @@ public:
 
     void sign (RippleAddress const& private_key);
 
-    bool checkSign(bool allowMultiSign =
-#if RIPPLE_ENABLE_MULTI_SIGN
-        true
-#else
-        false
-#endif
-            ) const;
+    bool checkSign(bool allowMultiSign) const;
 
     // SQL Functions with metadata.
     static

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -185,7 +185,7 @@ enum TER
     tecNO_LINE_REDUNDANT        = 127,
     tecPATH_DRY                 = 128,
     tecUNFUNDED                 = 129,  // Deprecated, old ambiguous unfunded.
-    tecMASTER_DISABLED          = 130,
+    tecNO_ALTERNATIVE_KEY       = 130,
     tecNO_REGULAR_KEY           = 131,
     tecOWNERS                   = 132,
     tecNO_ISSUER                = 133,

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -45,6 +45,7 @@ feature (const char* name)
     return feature(name, std::strlen(name));
 }
 
+uint256 const featureMultiSign = feature("MultiSign");
 uint256 const featureSusPay = feature("SusPay");
 
 } // ripple

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -48,7 +48,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tecNO_LINE_REDUNDANT,     "tecNO_LINE_REDUNDANT",     "Can't set non-existent line to default."                       },
         { tecPATH_DRY,              "tecPATH_DRY",              "Path could not send partial amount."                           },
         { tecPATH_PARTIAL,          "tecPATH_PARTIAL",          "Path could not send full amount."                              },
-        { tecMASTER_DISABLED,       "tecMASTER_DISABLED",       "Master key is disabled."                                       },
+        { tecNO_ALTERNATIVE_KEY,    "tecNO_ALTERNATIVE_KEY",    "The operation would remove the last way to sign a transaction."},
         { tecNO_REGULAR_KEY,        "tecNO_REGULAR_KEY",        "Regular key is not set."                                       },
 
         { tecUNFUNDED,              "tecUNFUNDED",              "One of _ADD, _OFFER, or _SEND. Deprecated."                    },

--- a/src/ripple/protocol/tests/STTx.test.cpp
+++ b/src/ripple/protocol/tests/STTx.test.cpp
@@ -44,7 +44,7 @@ public:
         j.setFieldVL (sfMessageKey, publicAcct.getAccountPublic ());
         j.sign (privateAcct);
 
-        unexpected (!j.checkSign (), "Transaction fails signature test");
+        unexpected (!j.checkSign (true), "Transaction fails signature test");
 
         Serializer rawTxn;
         j.add (rawTxn);

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -332,7 +332,7 @@ public:
         env.require(nflags("alice", asfDisableMaster));
         env(fset("alice", asfDisableMaster), sig("alice"));
         env.require(flags("alice", asfDisableMaster));
-        env(regkey("alice", disabled),                          ter(tecMASTER_DISABLED));
+        env(regkey("alice", disabled),                          ter(tecNO_ALTERNATIVE_KEY));
         env(noop("alice"));
         env(noop("alice"), sig("alice"),                        ter(tefMASTER_DISABLED));
         env(noop("alice"), sig("eric"));

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -72,8 +72,8 @@
 #include <ripple/rpc/handlers/RipplePathFind.cpp>
 #include <ripple/rpc/handlers/ServerInfo.cpp>
 #include <ripple/rpc/handlers/ServerState.cpp>
-#include <ripple/rpc/handlers/SignHandler.cpp>
 #include <ripple/rpc/handlers/SignFor.cpp>
+#include <ripple/rpc/handlers/SignHandler.cpp>
 #include <ripple/rpc/handlers/Stop.cpp>
 #include <ripple/rpc/handlers/Submit.cpp>
 #include <ripple/rpc/handlers/SubmitMultiSigned.cpp>


### PR DESCRIPTION
This pull request consist of three commits:

 - The first commit is a duplicate of a commit that has already passed review.  Later commits in this branch have a dependency on this first commit.  However, since that commit has already passed review, reviewers do not need to review it.

 - The middle commit is tiny and provides a facility that the last commit relies on.  It allows software outside of the transactors (e.g., RPC handlers) to access the Rules.  I left this as a separate commit since it is independent of the other two.  However the last two commits could be squashed together.

 - The final commit does the actual work of switching multisign from being compile-time enabled to being run-time enabled with a Feature.  This commit removes the RIPPLE_ENABLE_MULTI_SIGN macro and replaces it with a "featureMultiSign" check.  The Feature checks are modeled after those used to enable SusPay.

You can now enable multisign on a local standalone rippled by adding a Feature to the config file.  To do so, add a section like this:
```
[features]
MultiSign
```
There is a minor issue.  The `sign_for` and `submit_multisigned` RPC commands are only enabled if multisign is enabled.  However those commands are still shown in the help message even if multisign is disabled.  This is because the code that produces the help message doesn't read the config file (where the Features are kept).  This problem will become irrelevant once multisign is enabled onto the network.

Reviewers: @nbougalis @vinniefalco
