### PR TITLE
Fix misuse of SetHexExact

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -640,7 +640,7 @@ std::tuple<Ledger::pointer, std::uint32_t, uint256>
 loadLedgerHelper(std::string const& sqlSuffix)
 {
     Ledger::pointer ledger;
-    uint256 ledgerHash;
+    uint256 ledgerHash{};
     std::uint32_t ledgerSeq{0};
 
     auto db = getApp ().getLedgerDB ().checkoutDb ();
@@ -679,11 +679,15 @@ loadLedgerHelper(std::string const& sqlSuffix)
     ledgerSeq =
         rangeCheckedCast<std::uint32_t>(ledgerSeq64.value_or (0));
 
-    uint256 prevHash, accountHash, transHash;
-    ledgerHash.SetHexExact (sLedgerHash.value_or(""));
-    prevHash.SetHexExact (sPrevHash.value_or(""));
-    accountHash.SetHexExact (sAccountHash.value_or(""));
-    transHash.SetHexExact (sTransHash.value_or(""));
+    uint256 prevHash{}, accountHash{}, transHash{};
+    if (sLedgerHash)
+        ledgerHash.SetHexExact (*sLedgerHash);
+    if (sPrevHash)
+        prevHash.SetHexExact (*sPrevHash);
+    if (sAccountHash)
+        accountHash.SetHexExact (*sAccountHash);
+    if (sTransHash)
+        transHash.SetHexExact (*sTransHash);
 
     bool loaded = false;
     ledger = std::make_shared<Ledger>(prevHash,
@@ -835,7 +839,10 @@ Ledger::getHashesByIndex (std::uint32_t minSeq, std::uint32_t maxSeq)
         std::pair<uint256, uint256>& hashes =
                 ret[rangeCheckedCast<std::uint32_t>(ls)];
         hashes.first.SetHexExact (lh);
-        hashes.second.SetHexExact (ph.value_or (""));
+        if (ph)
+            hashes.second.SetHexExact (*ph);
+        else
+            hashes.second.zero ();
         if (!ph)
         {
             WriteLog (lsWARNING, Ledger)

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -68,8 +68,9 @@ extern create_genesis_t const create_genesis;
     3) Mutable ledgers cannot be shared.
 
     @note Presented to clients as ReadView
+    @note Calls virtuals in the constructor, so marked as final
 */
-class Ledger
+class Ledger final
     : public std::enable_shared_from_this <Ledger>
     , public DigestAwareReadView
     , public TxsRawView


### PR DESCRIPTION
@rec @HowardHinnant Please confirm `SetHexExact` was misused and this fixes the issue.