### PR TITLE
Use the new OpenView/OpenLedger classes

### DIFF
--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -185,9 +185,4 @@
 #define RIPPLE_USE_OPENSSL 0
 #endif
 
-// Enables the experimental OpenLedger
-#ifndef RIPPLE_OPEN_LEDGER
-#define RIPPLE_OPEN_LEDGER 0
-#endif
-
 #endif

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -70,10 +70,7 @@ public:
     virtual LockType& peekMutex () = 0;
 
     // The current ledger is the ledger we believe new transactions should go in
-    virtual Ledger::pointer getCurrentLedger () = 0;
-
-    // The holder for the current ledger
-    virtual LedgerHolder& getCurrentLedgerHolder() = 0;
+    virtual std::shared_ptr<ReadView const> getCurrentLedger () = 0;
 
     // The finalized ledger is the last closed/accepted ledger
     virtual Ledger::pointer getClosedLedger () = 0;
@@ -97,16 +94,13 @@ public:
 
     virtual std::uint32_t getEarliestFetch () = 0;
 
-    virtual void pushLedger (Ledger::pointer newLedger) = 0;
-    virtual void pushLedger (Ledger::pointer newLCL, Ledger::pointer newOL) = 0;
     virtual bool storeLedger (Ledger::pointer) = 0;
     virtual void forceValid (Ledger::pointer) = 0;
 
     virtual void setFullLedger (
         Ledger::pointer ledger, bool isSynchronous, bool isCurrent) = 0;
 
-    virtual void switchLedgers (
-        Ledger::pointer lastClosed, Ledger::pointer newCurrent) = 0;
+    virtual void switchLCL (Ledger::pointer lastClosed) = 0;
 
     virtual void failedSave(std::uint32_t seq, uint256 const& hash) = 0;
 

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -259,7 +259,7 @@ private:
 
       @param initialLedger The ledger that contains our initial position.
     */
-    void takeInitialPosition (Ledger& initialLedger);
+    void takeInitialPosition (std::shared_ptr<ReadView const> const& initialLedger);
 
     /**
        Called while trying to avalanche towards consensus.

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -174,12 +174,12 @@ public:
     {
     }
 
-    LedgerIndex getCurrentLedgerIndex ()
+    LedgerIndex getCurrentLedgerIndex () override
     {
         return getApp().openLedger().current()->info().seq;
     }
 
-    LedgerIndex getValidLedgerIndex ()
+    LedgerIndex getValidLedgerIndex () override
     {
         return mValidLedgerSeq;
     }
@@ -1213,20 +1213,20 @@ public:
             {
                 WriteLog (lsINFO, LedgerMaster)
                         << "Missing node detected during pathfinding";
-		if (lastLedger->info().open)
-		{
-		    // our parent is the problem
+                if (lastLedger->info().open)
+                {
+                    // our parent is the problem
                     getApp().getInboundLedgers().acquire(
                         lastLedger->info().parentHash, lastLedger->info().seq - 1,
                         InboundLedger::fcGENERIC);
-		}
-		else
-		{
-		    // this ledger is the problem
+                }
+                else
+                {
+                    // this ledger is the problem
                     getApp().getInboundLedgers().acquire(
                         lastLedger->info().hash, lastLedger->info().seq,
                         InboundLedger::fcGENERIC);
-		}
+                 }
             }
         }
     }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1322,7 +1322,7 @@ bool ApplicationImp::loadOldLedger (
                     {
                         auto s = std::make_shared <Serializer> ();
                         replayLedger->txRead(item.key()).first->add(*s);
-                        view.rawTxInsert (item.key(), s, nullptr);
+                        view.rawTxInsert (item.key(), std::move (s), nullptr);
                         return true;
                     });
             }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1290,16 +1290,16 @@ void NetworkOPsImp::switchLastClosedLedger (
 
 bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
 {
-    assert (networkClosed != uint256());
+    assert (networkClosed.isNonZero ());
 
-    auto closingLedger = m_ledgerMaster.getCurrentLedger ();
+    auto closingInfo = m_ledgerMaster.getCurrentLedger()->info();
 
     if (m_journal.info) m_journal.info <<
-        "Consensus time for #" << closingLedger->info().seq <<
-        " with LCL " << closingLedger->info().parentHash;
+        "Consensus time for #" << closingInfo.seq <<
+        " with LCL " << closingInfo.parentHash;
 
     auto prevLedger = m_ledgerMaster.getLedgerByHash (
-        closingLedger->info().parentHash);
+        closingInfo.parentHash);
 
     if (!prevLedger)
     {
@@ -1313,8 +1313,8 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
         return false;
     }
 
-    assert (prevLedger->getHash () == closingLedger->info().parentHash);
-    assert (closingLedger->info().parentHash ==
+    assert (prevLedger->getHash () == closingInfo.parentHash);
+    assert (closingInfo.parentHash ==
             m_ledgerMaster.getClosedLedger ()->getHash ());
 
     // Create a consensus object to get consensus on this ledger
@@ -1327,7 +1327,7 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
         m_ledgerMaster,
         networkClosed,
         prevLedger,
-        m_ledgerMaster.getCurrentLedger ()->info().closeTime);
+        closingInfo.closeTime);
 
     m_journal.debug << "Initiating consensus engine";
     return true;

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -97,6 +97,7 @@ OpenView::OpenView (open_ledger_t,
     info_.open = true;
     info_.seq = base_->info().seq + 1;
     info_.parentCloseTime = base_->info().closeTime;
+    info_.parentHash = base_->info().hash;
 }
 
 OpenView::OpenView (ReadView const* base,

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -95,6 +95,8 @@ OpenView::OpenView (open_ledger_t,
     , hold_ (std::move(hold))
 {
     info_.open = true;
+    info_.validated = false;
+    info_.accepted = false;
     info_.seq = base_->info().seq + 1;
     info_.parentCloseTime = base_->info().closeTime;
     info_.parentHash = base_->info().hash;

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -147,11 +147,11 @@ Status ledgerFromRequest (T& ledger, Context& context)
 
 bool isValidated (LedgerMaster& ledgerMaster, ReadView const& ledger)
 {
-    if (ledger.info().validated)
-        return true;
-
     if (ledger.info().open)
         return false;
+
+    if (ledger.info().validated)
+        return true;
 
     auto seq = ledger.info().seq;
     try

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -81,6 +81,14 @@ Status ledgerFromRequest (T& ledger, Context& context)
     else if (indexValue.isNumeric())
     {
         ledger = ledgerMaster.getLedgerBySeq (indexValue.asInt ());
+
+        if (ledger == nullptr)
+        {
+            auto cur = ledgerMaster.getCurrentLedger();
+            if (cur->info().seq == indexValue.asInt())
+                ledger = cur;
+        }
+
         if (ledger == nullptr)
             return {rpcLGR_NOT_FOUND, "ledgerNotFound"};
 


### PR DESCRIPTION
The server's open ledger is now an instance of the OpenView class, managed by an instance of the OpenLedger class. This should improve the performance of operations on open ledgers because they are no longer Ledger/SHAMap operation.

Things to look at during review:
1) Valid transactions must not be lost from the open ledger when the open ledger is replaced as a result of consensus or jumping ledgers.
2) Disputed transactions that are rejected by consensus should be properly recovered.
3) All security checks surrounding transactions getting into the open ledger should be undisturbed.
4) Transactions first seen during consensus should still be subject to signature checking.
