### PR TITLE
Improve Ledger Replay Logic

### DIFF
--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -185,9 +185,4 @@
 #define RIPPLE_USE_OPENSSL 0
 #endif
 
-// Enables the experimental OpenLedger
-#ifndef RIPPLE_OPEN_LEDGER
-#define RIPPLE_OPEN_LEDGER 0
-#endif
-
 #endif

--- a/src/ripple/app/ledger/Consensus.h
+++ b/src/ripple/app/ledger/Consensus.h
@@ -74,6 +74,11 @@ public:
     void
     setLastCloseTime (std::uint32_t t) = 0;
 
+    /** Get the network time when the last ledger closed */
+    virtual
+    std::uint32_t
+    getLastCloseTime () const = 0;
+
     virtual
     void
     storeProposal (

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -240,7 +240,15 @@ Ledger::Ledger (uint256 const& parentHash,
 
     txMap_->setImmutable ();
     stateMap_->setImmutable ();
-    setup(config);
+
+    if (! setup(config))
+        loaded = false;
+
+    if (! loaded)
+    {
+        updateHash ();
+        getApp().family().missing_node (info_.hash);
+    }
 }
 
 // Create a new ledger that's a snapshot of this one
@@ -1070,31 +1078,61 @@ Ledger::rawTxInsert (uint256 const& key,
     }
 }
 
-void
+bool
 Ledger::setup (Config const& config)
 {
+    bool ret = true;
+
     fees_.base = config.FEE_DEFAULT;
     fees_.units = config.TRANSACTION_FEE_BASE;
     fees_.reserve = config.FEE_ACCOUNT_RESERVE;
     fees_.increment = config.FEE_OWNER_RESERVE;
-    auto const sle = read(keylet::fees());
-    if (sle)
+
+    try
     {
-        // VFALCO NOTE Why getFieldIndex and not isFieldPresent?
+        auto const sle = read(keylet::fees());
 
-        if (sle->getFieldIndex (sfBaseFee) != -1)
-            fees_.base = sle->getFieldU64 (sfBaseFee);
+        if (sle)
+        {
+            // VFALCO NOTE Why getFieldIndex and not isFieldPresent?
 
-        if (sle->getFieldIndex (sfReferenceFeeUnits) != -1)
-            fees_.units = sle->getFieldU32 (sfReferenceFeeUnits);
+            if (sle->getFieldIndex (sfBaseFee) != -1)
+                fees_.base = sle->getFieldU64 (sfBaseFee);
 
-        if (sle->getFieldIndex (sfReserveBase) != -1)
-            fees_.reserve = sle->getFieldU32 (sfReserveBase);
+            if (sle->getFieldIndex (sfReferenceFeeUnits) != -1)
+                fees_.units = sle->getFieldU32 (sfReferenceFeeUnits);
 
-        if (sle->getFieldIndex (sfReserveIncrement) != -1)
-            fees_.increment = sle->getFieldU32 (sfReserveIncrement);
+            if (sle->getFieldIndex (sfReserveBase) != -1)
+                fees_.reserve = sle->getFieldU32 (sfReserveBase);
+
+            if (sle->getFieldIndex (sfReserveIncrement) != -1)
+                fees_.increment = sle->getFieldU32 (sfReserveIncrement);
+        }
     }
-    rules_ = Rules(*this);
+    catch (SHAMapMissingNode &)
+    {
+        ret = false;
+    }
+    catch (...)
+    {
+        throw;
+    }
+
+
+    try
+    {
+        rules_ = Rules(*this);
+    }
+    catch (SHAMapMissingNode &)
+    {
+        ret = false;
+    }
+    catch (...)
+    {
+        throw;
+    }
+
+    return ret;
 }
 
 std::shared_ptr<SLE>

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -380,7 +380,7 @@ private:
     }
     bool saveValidatedLedger (bool current);
 
-    void
+    bool
     setup (Config const& config);
 
     std::shared_ptr<SLE>

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -85,6 +85,18 @@ void applyTransactions (
     CanonicalTXSet& retriableTransactions,
     ApplyFlags flags);
 
+/** Apply a single transaction to a ledger
+  @param view                   The open view to apply to
+  @param txn                    The transaction to apply
+  @param retryAssured           True if another pass is assured
+  @param flags                  Flags for transactor
+*/
+int applyTransaction (
+    OpenView& view,
+    std::shared_ptr<STTx const> const& txn,
+    bool retryAssured,
+    ApplyFlags flags);
+
 } // ripple
 
 #endif

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -38,6 +38,13 @@ namespace ripple {
 
 class Peer;
 
+struct LedgerReplay
+{
+    std::map< int, std::shared_ptr<STTx const> > txns_;
+    std::uint32_t closeTime_;
+    int closeFlags_;
+};
+
 // Tracks the current ledger and any ledgers in the process of closing
 // Tracks ledger history
 // Tracks held transactions
@@ -163,6 +170,10 @@ public:
     virtual void clearPriorLedgers (LedgerIndex seq) = 0;
 
     virtual void clearLedgerCachePrior (LedgerIndex seq) = 0;
+
+    // ledger replay
+    virtual void takeReplay (std::unique_ptr<LedgerReplay> replay) = 0;
+    virtual std::unique_ptr<LedgerReplay> releaseReplay () = 0;
 
     // Fetch Packs
     virtual

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -70,10 +70,7 @@ public:
     virtual LockType& peekMutex () = 0;
 
     // The current ledger is the ledger we believe new transactions should go in
-    virtual Ledger::pointer getCurrentLedger () = 0;
-
-    // The holder for the current ledger
-    virtual LedgerHolder& getCurrentLedgerHolder() = 0;
+    virtual std::shared_ptr<ReadView const> getCurrentLedger () = 0;
 
     // The finalized ledger is the last closed/accepted ledger
     virtual Ledger::pointer getClosedLedger () = 0;
@@ -97,16 +94,13 @@ public:
 
     virtual std::uint32_t getEarliestFetch () = 0;
 
-    virtual void pushLedger (Ledger::pointer newLedger) = 0;
-    virtual void pushLedger (Ledger::pointer newLCL, Ledger::pointer newOL) = 0;
     virtual bool storeLedger (Ledger::pointer) = 0;
     virtual void forceValid (Ledger::pointer) = 0;
 
     virtual void setFullLedger (
         Ledger::pointer ledger, bool isSynchronous, bool isCurrent) = 0;
 
-    virtual void switchLedgers (
-        Ledger::pointer lastClosed, Ledger::pointer newCurrent) = 0;
+    virtual void switchLCL (Ledger::pointer lastClosed) = 0;
 
     virtual void failedSave(std::uint32_t seq, uint256 const& hash) = 0;
 

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -259,7 +259,7 @@ private:
 
       @param initialLedger The ledger that contains our initial position.
     */
-    void takeInitialPosition (Ledger& initialLedger);
+    void takeInitialPosition (std::shared_ptr<ReadView const> const& initialLedger);
 
     /**
        Called while trying to avalanche towards consensus.

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -95,6 +95,9 @@ public:
 
     CanonicalTXSet mHeldTransactions;
 
+    // A set of transactions to replay during the next close
+    std::unique_ptr<LedgerReplay> replayData;
+
     LockType mCompleteLock;
     RangeSet mCompleteLedgers;
 
@@ -1521,6 +1524,16 @@ public:
     void clearLedgerCachePrior (LedgerIndex seq) override
     {
         mLedgerHistory.clearLedgerCachePrior (seq);
+    }
+
+    void takeReplay (std::unique_ptr<LedgerReplay> replay) override
+    {
+        replayData = std::move (replay);
+    }
+
+    std::unique_ptr<LedgerReplay> releaseReplay () override
+    {
+        return std::move (replayData);
     }
 
     // Fetch packs:

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -73,9 +73,6 @@ public:
 
     LockType m_mutex;
 
-    // The ledger we are currently processing.
-    LedgerHolder mCurrentLedger;
-
     // The ledger that most recently closed.
     LedgerHolder mClosedLedger;
 
@@ -177,12 +174,12 @@ public:
     {
     }
 
-    LedgerIndex getCurrentLedgerIndex ()
+    LedgerIndex getCurrentLedgerIndex () override
     {
-        return mCurrentLedger.get ()->info().seq;
+        return getApp().openLedger().current()->info().seq;
     }
 
-    LedgerIndex getValidLedgerIndex ()
+    LedgerIndex getValidLedgerIndex () override
     {
         return mValidLedgerSeq;
     }
@@ -311,75 +308,26 @@ public:
         mHeldTransactions.insert (transaction->getSTransaction ());
     }
 
-    void pushLedger (Ledger::pointer newLedger)
+    void switchLCL (Ledger::pointer lastClosed)
     {
-        // Caller should already have properly assembled this ledger into
-        // "ready-to-close" form -- all candidate transactions must already be
-        // applied
-        WriteLog (lsINFO, LedgerMaster) << "PushLedger: "
-                                        << newLedger->getHash();
+        assert (lastClosed);
+
+        lastClosed->setClosed ();
+        lastClosed->setAccepted ();
 
         {
             ScopedLockType ml (m_mutex);
 
-            Ledger::pointer closedLedger = mCurrentLedger.getMutable ();
-            if (closedLedger)
-            {
-                closedLedger->setClosed ();
-                closedLedger->setImmutable ();
-                mClosedLedger.set (closedLedger);
-            }
-
-            mCurrentLedger.set (newLedger);
-        }
-
-        if (standalone_)
-        {
-            setFullLedger(newLedger, true, false);
-            tryAdvance();
-        }
-        else
-            checkAccept(newLedger);
-    }
-
-    void pushLedger (Ledger::pointer newLCL, Ledger::pointer newOL)
-    {
-        assert (! newLCL->info().open);
-        assert (newOL->info().open);
-
-        {
-            ScopedLockType ml (m_mutex);
-            mClosedLedger.set (newLCL);
-            mCurrentLedger.set (newOL);
-        }
-
-        if (standalone_)
-        {
-            setFullLedger(newLCL, true, false);
-            tryAdvance();
-        }
-        else
-        {
-            mLedgerHistory.builtLedger (newLCL);
-        }
-    }
-
-    void switchLedgers (Ledger::pointer lastClosed, Ledger::pointer current)
-    {
-        assert (lastClosed && current);
-
-        {
-            ScopedLockType ml (m_mutex);
-
-            lastClosed->setClosed ();
-            lastClosed->setAccepted ();
-
-            mCurrentLedger.set (current);
             mClosedLedger.set (lastClosed);
-
-            assert (current->info().open);
         }
-        checkAccept (lastClosed);
+
+        if (standalone_)
+        {
+            setFullLedger (lastClosed, true, false);
+            tryAdvance();
+        }
+        else
+            checkAccept (lastClosed);
     }
 
     bool fixIndex (LedgerIndex ledgerIndex, LedgerHash const& ledgerHash)
@@ -408,12 +356,6 @@ public:
     {
         ScopedLockType sl (m_mutex);
 
-        // Start with a mutable snapshot of the open ledger
-        auto const newOL =
-            mCurrentLedger.getMutable();
-        int recovers = 0;
-
-    #if RIPPLE_OPEN_LEDGER
         getApp().openLedger().modify(
             [&](OpenView& view, beast::Journal j)
             {
@@ -433,42 +375,13 @@ public:
                 }
                 return any;
             });
-    #endif
-
-        {
-            OpenView view(&*newOL);
-            for (auto const& it : mHeldTransactions)
-            {
-                ApplyFlags tepFlags = tapNONE;
-
-                if (getApp().getHashRouter ().addSuppressionFlags (
-                        it.first.getTXID (), SF_SIGGOOD))
-                    tepFlags = static_cast<ApplyFlags> (
-                        tepFlags | tapNO_CHECK_SIGN);
-
-                auto const ret = apply(view, *it.second,
-                    tepFlags, getApp().getHashRouter().sigVerify(),
-                        getConfig(), deprecatedLogs().journal("LedgerMaster"));
-
-                if (ret.second)
-                    ++recovers;
-
-                // If a transaction is recovered but hasn't been relayed,
-                // it will become disputed in the consensus process, which
-                // will cause it to be relayed.
-            }
-            view.apply(*newOL);
-        }
-
-        CondLog (recovers != 0, lsINFO, LedgerMaster)
-                << "Recovered " << recovers << " held transactions";
 
         // VFALCO TODO recreate the CanonicalTxSet object instead of resetting
         // it.
         // VFALCO NOTE The hash for an open ledger is undefined so we use
         // something that is a reasonable substitute.
-        mHeldTransactions.reset (newOL->info().hash);
-        mCurrentLedger.set (newOL);
+        mHeldTransactions.reset (
+            getApp().openLedger().current()->info().parentHash);
     }
 
     LedgerIndex getBuildingLedger ()
@@ -741,7 +654,7 @@ public:
     {
         // A new ledger has been accepted as part of the trusted chain
         WriteLog (lsDEBUG, LedgerMaster) << "Ledger " << ledger->info().seq
-                                         << "accepted :" << ledger->getHash ();
+                                         << " accepted :" << ledger->getHash ();
         assert (ledger->stateMap().getHash ().isNonZero ());
 
         ledger->setValidated();
@@ -1245,8 +1158,7 @@ public:
     {
         {
             ScopedLockType ml (m_mutex);
-            if (getApp().getOPs().isNeedNetworkLedger() ||
-                mCurrentLedger.empty())
+            if (getApp().getOPs().isNeedNetworkLedger())
             {
                 --mPathFindThread;
                 return;
@@ -1256,7 +1168,7 @@ public:
 
         while (! job.shouldCancel())
         {
-            Ledger::pointer lastLedger;
+            std::shared_ptr<ReadView const> lastLedger;
             {
                 ScopedLockType ml (m_mutex);
 
@@ -1269,7 +1181,7 @@ public:
                 }
                 else if (mPathFindNewRequest)
                 { // We have a new request but no new ledger
-                    lastLedger = mCurrentLedger.get ();
+                    lastLedger = getApp().openLedger().current();
                 }
                 else
                 { // Nothing to do
@@ -1301,9 +1213,20 @@ public:
             {
                 WriteLog (lsINFO, LedgerMaster)
                         << "Missing node detected during pathfinding";
-                getApp().getInboundLedgers().acquire(
-                    lastLedger->getHash (), lastLedger->info().seq,
-                    InboundLedger::fcGENERIC);
+                if (lastLedger->info().open)
+                {
+                    // our parent is the problem
+                    getApp().getInboundLedgers().acquire(
+                        lastLedger->info().parentHash, lastLedger->info().seq - 1,
+                        InboundLedger::fcGENERIC);
+                }
+                else
+                {
+                    // this ledger is the problem
+                    getApp().getInboundLedgers().acquire(
+                        lastLedger->info().hash, lastLedger->info().seq,
+                        InboundLedger::fcGENERIC);
+                 }
             }
         }
     }
@@ -1354,14 +1277,9 @@ public:
     }
 
     // The current ledger is the ledger we believe new transactions should go in
-    Ledger::pointer getCurrentLedger ()
+    std::shared_ptr<ReadView const> getCurrentLedger ()
     {
-        return mCurrentLedger.get ();
-    }
-
-    LedgerHolder& getCurrentLedgerHolder() override
-    {
-        return mCurrentLedger;
+        return getApp().openLedger().current();
     }
 
     // The finalized ledger is the last closed/accepted ledger
@@ -1538,10 +1456,6 @@ public:
         if (ret)
             return ret;
 
-        ret = mCurrentLedger.get ();
-        if (ret && (ret->info().seq == index))
-            return ret;
-
         ret = mClosedLedger.get ();
         if (ret && (ret->info().seq == index))
             return ret;
@@ -1552,15 +1466,8 @@ public:
 
     Ledger::pointer getLedgerByHash (uint256 const& hash)
     {
-        if (hash.isZero ())
-            return mCurrentLedger.get ();
-
         Ledger::pointer ret = mLedgerHistory.getLedgerByHash (hash);
         if (ret)
-            return ret;
-
-        ret = mCurrentLedger.get ();
-        if (ret && (ret->getHash () == hash))
             return ret;
 
         ret = mClosedLedger.get ();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -117,6 +117,10 @@ private:
     FullBelowCache fullbelow_;
     NodeStore::Database& db_;
 
+    // missing node handler
+    std::uint32_t maxSeq = 0;
+    std::mutex maxSeqLock;
+
 public:
     AppFamily (AppFamily const&) = delete;
     AppFamily& operator= (AppFamily const&) = delete;
@@ -171,10 +175,49 @@ public:
     void
     missing_node (std::uint32_t seq) override
     {
-        uint256 const hash = getApp().getLedgerMaster ().getHashBySeq (seq);
-        if (hash.isZero())
+        WriteLog (lsERROR, Ledger) << "Missing node in " << seq;
+
+        // prevent recursive invocation
+        std::unique_lock <std::mutex> lock (maxSeqLock);
+
+        if (maxSeq == 0)
+        {
+            maxSeq = seq;
+
+            do
+            {
+                // Try to acquire the most recent missing ledger
+                seq = maxSeq;
+
+                lock.unlock();
+
+                // This can invoke the missing node handler
+                uint256 hash = getApp().getLedgerMaster().getHashBySeq (seq);
+
+                if (hash.isNonZero())
+                    getApp().getInboundLedgers().acquire (
+                        hash, seq, InboundLedger::fcGENERIC);
+
+                lock.lock();
+            }
+            while (maxSeq != seq);
+        }
+        else if (maxSeq < seq)
+        {
+            // We found a more recent ledger with a missing node
+            maxSeq = seq;
+        }
+    }
+
+    void
+    missing_node (uint256 const& hash) override
+    {
+        WriteLog (lsERROR, Ledger) << "Missing node in "
+            << to_string (hash);
+
+        if (hash.isNonZero())
             getApp().getInboundLedgers ().acquire (
-                hash, seq, InboundLedger::fcGENERIC);
+                hash, 0, InboundLedger::fcGENERIC);
     }
 };
 
@@ -1206,6 +1249,8 @@ bool ApplicationImp::loadOldLedger (
                          }
 
                          loadLedger->setClosed ();
+                         loadLedger->stateMap().flushDirty
+                             (hotACCOUNT_NODE, loadLedger->info().seq);
                          loadLedger->setAccepted (closeTime,
                              closeTimeResolution, ! closeTimeEstimated);
                      }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1357,22 +1357,35 @@ bool ApplicationImp::loadOldLedger (
         if (replay)
         {
             // inject transaction(s) from the replayLedger into our open ledger
+            // and build replay structure
             auto const& txns = replayLedger->txMap();
+            auto replayData = std::make_unique <LedgerReplay> ();
+
+            replayData->closeTime_ = replayLedger->info().closeTime;
+            replayData->closeFlags_ = replayLedger->info().closeFlags;
 
             for (auto const& item : txns)
             {
-                getApp().getHashRouter().setFlags (item.key(), SF_SIGGOOD);
+                auto txID = item.key();
+                auto txPair = replayLedger->txRead (txID);
+                auto txIndex = (*txPair.second)[sfTransactionIndex];
+
+                auto s = std::make_shared <Serializer> ();
+                txPair.first->add(*s);
+
+                getApp().getHashRouter().setFlags (txID, SF_SIGGOOD);
+
+                replayData->txns_.emplace (txIndex, txPair.first);
+
                 openLedger_->modify(
-                    [&replayLedger, &item](OpenView& view, beast::Journal j)
+                    [&txID, &s](OpenView& view, beast::Journal j)
                     {
-                        auto s = std::make_shared <Serializer> ();
-                        replayLedger->txRead(item.key()).first->add(*s);
-                        view.rawTxInsert (item.key(), std::move (s), nullptr);
+                        view.rawTxInsert (txID, std::move (s), nullptr);
                         return true;
                     });
             }
 
-            m_ledgerMaster->switchLCL (loadLedger);
+            m_ledgerMaster->takeReplay (std::move (replayData));
         }
     }
     catch (SHAMapMissingNode&)

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1039,18 +1039,22 @@ private:
 
 void ApplicationImp::startGenesisLedger ()
 {
-    std::shared_ptr<Ledger const> const genesis =
+    std::shared_ptr<Ledger> const genesis =
         std::make_shared<Ledger>(
             create_genesis, getConfig());
+    m_ledgerMaster->storeLedger (genesis);
+
     auto const next = std::make_shared<Ledger>(
         open_ledger, *genesis);
+    next->updateSkipList ();
     next->setClosed ();
     next->setAccepted ();
+    m_ledgerMaster->storeLedger (next);
+
     m_networkOPs->setLastCloseTime (next->info().closeTime);
     openLedger_.emplace(next, getConfig(),
         cachedSLEs_, deprecatedLogs().journal("OpenLedger"));
-    m_ledgerMaster->pushLedger (next,
-        std::make_shared<Ledger>(open_ledger, *next));
+    m_ledgerMaster->switchLCL (next);
 }
 
 Ledger::pointer
@@ -1299,7 +1303,7 @@ bool ApplicationImp::loadOldLedger (
 
         auto const openLedger =
             std::make_shared<Ledger>(open_ledger, *loadLedger);
-        m_ledgerMaster->switchLedgers (loadLedger, openLedger);
+        m_ledgerMaster->switchLCL (loadLedger);
         m_ledgerMaster->forceValid(loadLedger);
         m_networkOPs->setLastCloseTime (loadLedger->info().closeTime);
         openLedger_.emplace(loadLedger, getConfig(),
@@ -1310,27 +1314,20 @@ bool ApplicationImp::loadOldLedger (
             // inject transaction(s) from the replayLedger into our open ledger
             auto const& txns = replayLedger->txMap();
 
-            // Get a mutable snapshot of the open ledger
-            Ledger::pointer cur = getLedgerMaster().getCurrentLedger();
-            cur = std::make_shared <Ledger> (*cur, true);
-            assert (!cur->isImmutable());
-
             for (auto const& item : txns)
             {
-                auto const txn =
-                    replayLedger->txRead(item.key()).first;
-                if (m_journal.info) m_journal.info <<
-                    txn->getJson(0);
-                Serializer s;
-                txn->add(s);
-                cur->rawTxInsert(item.key(),
-                    std::make_shared<Serializer const>(
-                        std::move(s)), nullptr);
                 getApp().getHashRouter().setFlags (item.key(), SF_SIGGOOD);
+                openLedger_->modify(
+                    [&replayLedger, &item](OpenView& view, beast::Journal j)
+                    {
+                        auto s = std::make_shared <Serializer> ();
+                        replayLedger->txRead(item.key()).first->add(*s);
+                        view.rawTxInsert (item.key(), std::move (s), nullptr);
+                        return true;
+                    });
             }
 
-            // Switch to the mutable snapshot
-            m_ledgerMaster->switchLedgers (loadLedger, cur);
+            m_ledgerMaster->switchLCL (loadLedger);
         }
     }
     catch (SHAMapMissingNode&)

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1301,6 +1301,25 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
     auto prevLedger = m_ledgerMaster.getLedgerByHash (
         closingInfo.parentHash);
 
+    if (!prevLedger && (mConsensus->getLastCloseTime() == 0))
+    {
+        // On startup, not having the prior ledger is okay
+        // For example, if we loaded a ledger
+        bool loaded;
+        prevLedger = std::make_shared<Ledger> (
+            closingLedger->getHash(),
+            uint256(),
+            closingLedger->info().accountHash,
+            closingLedger->info().drops,
+            closingLedger->info().closeTime,
+            closingLedger->info().parentCloseTime,
+            0,
+            closingLedger->info().closeTimeResolution,
+            closingLedger->info().seq - 1,
+            loaded,
+            getConfig());
+    }
+
     if (!prevLedger)
     {
         // this shouldn't happen unless we jump ledgers

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -237,8 +237,7 @@ private:
         Ledger::pointer newLedger, bool duringConsensus);
     bool checkLastClosedLedger (
         const Overlay::PeerSequence&, uint256& networkClosed);
-    bool beginConsensus (
-        uint256 const& networkClosed, Ledger::pointer closingLedger);
+    bool beginConsensus (uint256 const& networkClosed);
     void tryStartConsensus ();
 
 public:
@@ -812,25 +811,6 @@ void NetworkOPsImp::transactionBatch()
     }
 }
 
-#if RIPPLE_OPEN_LEDGER
-static
-void
-mismatch (std::shared_ptr<SLE const> const& sle1, TER ter1,
-    std::shared_ptr<SLE const> const& sle2, TER ter2,
-        std::shared_ptr<STTx const> tx,
-            beast::Journal j)
-{
-    JLOG(j.error) <<
-    "TER " << (ter1 == ter2 ? "        " : "MISMATCH ") <<
-        transToken(ter1) << " vs " <<
-            transToken(ter2);
-    JLOG(j.error) <<
-        tx->getJson(0) << '\n' <<
-        (sle1 ? sle1->getJson(0) : "MISSING ACCOUNTROOT1") << '\n' <<
-        (sle2 ? sle2->getJson(0) : "MISSING ACCOUNTROOT2") << '\n';
-}
-#endif
-
 void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
 {
     std::vector<TransactionStatus> transactions;
@@ -843,19 +823,11 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
     batchLock.unlock();
 
     {
-        std::shared_ptr<Ledger> newOL;
-        bool applied = false;
-        boost::optional<OpenView> accum;
         auto lock = beast::make_lock(getApp().getMasterMutex());
         {
             std::lock_guard <std::recursive_mutex> lock (
                 m_ledgerMaster.peekMutex());
-        #if RIPPLE_OPEN_LEDGER
-            auto const oldOL = m_ledgerMaster.getCurrentLedgerHolder().get();
-            getApp().openLedger().verify(*oldOL, "apply before");
-        #endif
-            newOL = m_ledgerMaster.getCurrentLedgerHolder().getMutable();
-            accum.emplace(&*newOL);
+
             for (TransactionStatus& e : transactions)
             {
                 ApplyFlags flags = tapNONE;
@@ -863,21 +835,6 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                 if (e.admin)
                     flags = flags | tapADMIN;
 
-            #if RIPPLE_OPEN_LEDGER
-                auto const sle1 = accum->read(
-                    keylet::account(e.transaction->getSTransaction()->getAccountID(sfAccount)));
-            #endif
-
-                std::tie (e.result, e.applied) =
-                    ripple::apply (*accum,
-                        *e.transaction->getSTransaction(), flags,
-                            getApp().getHashRouter().sigVerify(),
-                                getConfig(), deprecatedLogs().journal(
-                                    "NetworkOPs"));
-                applied |= e.applied;
-
-            #if RIPPLE_OPEN_LEDGER
-                auto const sle2 = getApp().openLedger().current()->read(keylet::account(e.transaction->getSTransaction()->getAccountID(sfAccount)));
                 // VFALCO Should do the loop inside modify()
                 getApp().openLedger().modify(
                     [&](OpenView& view, beast::Journal j)
@@ -886,25 +843,15 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                             view, *e.transaction->getSTransaction(), flags,
                                 getApp().getHashRouter().sigVerify(),
                                     getConfig(), j);
-                        if (result.first != e.result)
-                            mismatch(sle1,  e.result, sle2, result.first,
-                                    e.transaction->getSTransaction(), j);
+                        e.result = result.first;
+                        e.applied = result.second;
                         return result.second;
                     });
-            #endif
             }
         }
 
-        if (applied)
-        {
-            accum->apply(*newOL);
-        #if RIPPLE_OPEN_LEDGER
-            getApp().openLedger().verify(*newOL, "apply after");
-        #endif
-            newOL->setImmutable();
-            m_ledgerMaster.getCurrentLedgerHolder().set (newOL);
-        }
 
+        auto newOL = getApp().openLedger().current();
         for (TransactionStatus& e : transactions)
         {
             if (e.applied)
@@ -1145,7 +1092,7 @@ void NetworkOPsImp::tryStartConsensus ()
     }
 
     if ((!mLedgerConsensus) && (mMode != omDISCONNECTED))
-        beginConsensus (networkClosed, m_ledgerMaster.getCurrentLedger ());
+        beginConsensus (networkClosed);
 }
 
 bool NetworkOPsImp::checkLastClosedLedger (
@@ -1303,39 +1250,17 @@ void NetworkOPsImp::switchLastClosedLedger (
     // set the newLCL as our last closed ledger -- this is abnormal code
 
     auto msg = duringConsensus ? "JUMPdc" : "JUMP";
-#if RIPPLE_OPEN_LEDGER
-    m_journal.fatal
-#else
     m_journal.error
-#endif
         << msg << " last closed ledger to " << newLCL->getHash ();
 
     clearNeedNetworkLedger ();
     newLCL->setClosed ();
-    auto const newOL = std::make_shared<
-        Ledger>(open_ledger, std::ref (*newLCL));
     // Caller must own master lock
     {
-        auto const oldOL =
-            m_ledgerMaster.getCurrentLedger();
-    #if RIPPLE_OPEN_LEDGER
-        getApp().openLedger().verify(
-            *oldOL, "jump before");
-    #endif
         // Apply tx in old open ledger to new
         // open ledger. Then apply local tx.
-        OpenView accum(&*newOL);
-        assert(accum.open());
-        auto const localTx = m_localTX->getTxSet();
-        {
-            auto retries = localTx;
-            applyTransactions (&oldOL->txMap(),
-                accum, newLCL, retries, tapNONE);
-        }
-        accum.apply(*newOL);
 
-    #if RIPPLE_OPEN_LEDGER
-        auto retries = localTx;
+        auto retries = m_localTX->getTxSet();
         auto const lastVal =
             getApp().getLedgerMaster().getValidatedLedger();
         boost::optional<Rules> rules;
@@ -1346,12 +1271,9 @@ void NetworkOPsImp::switchLastClosedLedger (
         getApp().openLedger().accept(*rules,
             newLCL, OrderedTxs({}), false, retries,
                 tapNONE, getApp().getHashRouter(), "jump");
-        getApp().openLedger().verify(
-            *newOL, "jump after");
-    #endif
     }
 
-    m_ledgerMaster.switchLedgers (newLCL, newOL);
+    m_ledgerMaster.switchLCL (newLCL);
 
     protocol::TMStatusChange s;
     s.set_newevent (protocol::neSWITCHED_LEDGER);
@@ -1366,15 +1288,18 @@ void NetworkOPsImp::switchLastClosedLedger (
         std::make_shared<Message> (s, protocol::mtSTATUS_CHANGE)));
 }
 
-bool NetworkOPsImp::beginConsensus (
-    uint256 const& networkClosed, Ledger::pointer closingLedger)
+bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
 {
+    assert (networkClosed.isNonZero ());
+
+    auto closingInfo = m_ledgerMaster.getCurrentLedger()->info();
+
     if (m_journal.info) m_journal.info <<
-        "Consensus time for #" << closingLedger->info().seq <<
-        " with LCL " << closingLedger->info().parentHash;
+        "Consensus time for #" << closingInfo.seq <<
+        " with LCL " << closingInfo.parentHash;
 
     auto prevLedger = m_ledgerMaster.getLedgerByHash (
-        closingLedger->info().parentHash);
+        closingInfo.parentHash);
 
     if (!prevLedger)
     {
@@ -1388,8 +1313,8 @@ bool NetworkOPsImp::beginConsensus (
         return false;
     }
 
-    assert (prevLedger->getHash () == closingLedger->info().parentHash);
-    assert (closingLedger->info().parentHash ==
+    assert (prevLedger->getHash () == closingInfo.parentHash);
+    assert (closingInfo.parentHash ==
             m_ledgerMaster.getClosedLedger ()->getHash ());
 
     // Create a consensus object to get consensus on this ledger
@@ -1402,7 +1327,7 @@ bool NetworkOPsImp::beginConsensus (
         m_ledgerMaster,
         networkClosed,
         prevLedger,
-        m_ledgerMaster.getCurrentLedger ()->info().closeTime);
+        closingInfo.closeTime);
 
     m_journal.debug << "Initiating consensus engine";
     return true;
@@ -1430,7 +1355,7 @@ bool NetworkOPsImp::haveConsensusObject ()
             if ( ((mMode == omTRACKING) || (mMode == omSYNCING)) &&
                  (mConsensus->getLastCloseProposers() >= m_ledgerMaster.getMinValidations()) )
                 setMode (omFULL);
-            beginConsensus (networkClosed, m_ledgerMaster.getCurrentLedger ());
+            beginConsensus (networkClosed);
         }
     }
 
@@ -2454,9 +2379,7 @@ std::uint32_t NetworkOPsImp::acceptLedger ()
 
     // FIXME Could we improve on this and remove the need for a specialized
     // API in LedgerConsensus?
-    beginConsensus (
-        m_ledgerMaster.getClosedLedger ()->getHash (),
-        m_ledgerMaster.getCurrentLedger ());
+    beginConsensus (m_ledgerMaster.getClosedLedger ()->getHash ());
     mLedgerConsensus->simulate ();
     return m_ledgerMaster.getCurrentLedger ()->info().seq;
 }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1307,17 +1307,24 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
         // For example, if we loaded a ledger
         bool loaded;
         prevLedger = std::make_shared<Ledger> (
-            closingLedger->getHash(),
+            closingInfo.parentHash,
             uint256(),
-            closingLedger->info().accountHash,
-            closingLedger->info().drops,
-            closingLedger->info().closeTime,
-            closingLedger->info().parentCloseTime,
+            closingInfo.accountHash,
+            closingInfo.drops,
+            closingInfo.closeTime,
+            closingInfo.parentCloseTime,
             0,
-            closingLedger->info().closeTimeResolution,
-            closingLedger->info().seq - 1,
+            closingInfo.closeTimeResolution,
+            closingInfo.seq - 1,
             loaded,
             getConfig());
+    }
+    else
+    {
+        prevLedger->setImmutable ();
+        assert (prevLedger->getHash () == closingInfo.parentHash);
+        assert (closingInfo.parentHash ==
+            m_ledgerMaster.getClosedLedger ()->getHash ());
     }
 
     if (!prevLedger)
@@ -1332,13 +1339,8 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
         return false;
     }
 
-    assert (prevLedger->getHash () == closingInfo.parentHash);
-    assert (closingInfo.parentHash ==
-            m_ledgerMaster.getClosedLedger ()->getHash ());
-
     // Create a consensus object to get consensus on this ledger
     assert (!mLedgerConsensus);
-    prevLedger->setImmutable ();
 
     mLedgerConsensus = mConsensus->startRound (
         getApp().getInboundTransactions(),

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -95,8 +95,11 @@ OpenView::OpenView (open_ledger_t,
     , hold_ (std::move(hold))
 {
     info_.open = true;
+    info_.validated = false;
+    info_.accepted = false;
     info_.seq = base_->info().seq + 1;
     info_.parentCloseTime = base_->info().closeTime;
+    info_.parentHash = base_->info().hash;
 }
 
 OpenView::OpenView (ReadView const* base,

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -81,6 +81,14 @@ Status ledgerFromRequest (T& ledger, Context& context)
     else if (indexValue.isNumeric())
     {
         ledger = ledgerMaster.getLedgerBySeq (indexValue.asInt ());
+
+        if (ledger == nullptr)
+        {
+            auto cur = ledgerMaster.getCurrentLedger();
+            if (cur->info().seq == indexValue.asInt())
+                ledger = cur;
+        }
+
         if (ledger == nullptr)
             return {rpcLGR_NOT_FOUND, "ledgerNotFound"};
 
@@ -139,11 +147,11 @@ Status ledgerFromRequest (T& ledger, Context& context)
 
 bool isValidated (LedgerMaster& ledgerMaster, ReadView const& ledger)
 {
-    if (ledger.info().validated)
-        return true;
-
     if (ledger.info().open)
         return false;
+
+    if (ledger.info().validated)
+        return true;
 
     auto seq = ledger.info().seq;
     try

--- a/src/ripple/shamap/Family.h
+++ b/src/ripple/shamap/Family.h
@@ -60,6 +60,10 @@ public:
     virtual
     void
     missing_node (std::uint32_t refNum) = 0;
+
+    virtual
+    void
+    missing_node (uint256 const& refHash) = 0;
 };
 
 } // shamap

--- a/src/ripple/shamap/tests/common.h
+++ b/src/ripple/shamap/tests/common.h
@@ -105,6 +105,12 @@ public:
     {
         throw std::runtime_error("missing node");
     }
+
+    void
+    missing_node (uint256 const& refHash) override
+    {
+        throw std::runtime_error("missing node");
+    }
 };
 
 } // tests


### PR DESCRIPTION
This pull request implements smarter ledger replay logic, accurately preserving the actual execution order of transactions and the close time. This should permit a ledger to be perfectly reconstructed so long as the code understands the transaction execution rules in affect during the original close.

This is built on top of both the OpenView and missing node changes to avoid conflicts. It also contains a patch (the "[FOLD] change) to make those two changes compatible as they had an internal conflict.