### PR TITLE
Open view, replay, and missing node changes

### DIFF
--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -176,9 +176,4 @@
 #define RIPPLE_USE_OPENSSL 0
 #endif
 
-// Enables the experimental OpenLedger
-#ifndef RIPPLE_OPEN_LEDGER
-#define RIPPLE_OPEN_LEDGER 0
-#endif
-
 #endif

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -367,7 +367,9 @@ private:
     class sles_iter_impl;
     class txs_iter_impl;
 
-    void
+    bool saveValidatedLedger (bool current);
+
+    bool
     setup (Config const& config);
 
     std::shared_ptr<SLE>

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -87,6 +87,19 @@ void applyTransactions (
     CanonicalTXSet& retriableTransactions,
     ApplyFlags flags);
 
+/** Apply a single transaction to a ledger
+  @param view                   The open view to apply to
+  @param txn                    The transaction to apply
+  @param retryAssured           True if another pass is assured
+  @param flags                  Flags for transactor
+  @return                       resultSuccess, resultFail or resultRetry
+*/
+int applyTransaction (
+    OpenView& view,
+    std::shared_ptr<STTx const> const& txn,
+    bool retryAssured,
+    ApplyFlags flags);
+
 } // ripple
 
 #endif

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -95,6 +95,7 @@ void applyTransactions (
   @return                       resultSuccess, resultFail or resultRetry
 */
 int applyTransaction (
+    Application& app,
     OpenView& view,
     std::shared_ptr<STTx const> const& txn,
     bool retryAssured,

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -38,6 +38,14 @@ namespace ripple {
 
 class Peer;
 
+struct LedgerReplay
+{
+    std::map< int, std::shared_ptr<STTx const> > txns_;
+    std::uint32_t closeTime_;
+    int closeFlags_;
+    Ledger::pointer prevLedger_;
+};
+
 // Tracks the current ledger and any ledgers in the process of closing
 // Tracks ledger history
 // Tracks held transactions
@@ -166,6 +174,10 @@ public:
     virtual void clearPriorLedgers (LedgerIndex seq) = 0;
 
     virtual void clearLedgerCachePrior (LedgerIndex seq) = 0;
+
+    // ledger replay
+    virtual void takeReplay (std::unique_ptr<LedgerReplay> replay) = 0;
+    virtual std::unique_ptr<LedgerReplay> releaseReplay () = 0;
 
     // Fetch Packs
     virtual

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -70,10 +70,7 @@ public:
     virtual LockType& peekMutex () = 0;
 
     // The current ledger is the ledger we believe new transactions should go in
-    virtual Ledger::pointer getCurrentLedger () = 0;
-
-    // The holder for the current ledger
-    virtual LedgerHolder& getCurrentLedgerHolder() = 0;
+    virtual std::shared_ptr<ReadView const> getCurrentLedger () = 0;
 
     // The finalized ledger is the last closed/accepted ledger
     virtual Ledger::pointer getClosedLedger () = 0;
@@ -100,16 +97,13 @@ public:
 
     virtual std::uint32_t getEarliestFetch () = 0;
 
-    virtual void pushLedger (Ledger::pointer newLedger) = 0;
-    virtual void pushLedger (Ledger::pointer newLCL, Ledger::pointer newOL) = 0;
     virtual bool storeLedger (Ledger::pointer) = 0;
     virtual void forceValid (Ledger::pointer) = 0;
 
     virtual void setFullLedger (
         Ledger::pointer ledger, bool isSynchronous, bool isCurrent) = 0;
 
-    virtual void switchLedgers (
-        Ledger::pointer lastClosed, Ledger::pointer newCurrent) = 0;
+    virtual void switchLCL (Ledger::pointer lastClosed) = 0;
 
     virtual void failedSave(std::uint32_t seq, uint256 const& hash) = 0;
 

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -970,8 +970,21 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         consensus_.peekStoredProposals ().clear ();
     }
 
-    std::uint32_t closeTime = roundCloseTime (
-        mOurPosition->getCloseTime (), mCloseResolution);
+    auto closeTime = mOurPosition->getCloseTime();
+
+    auto replay = ledgerMaster_.releaseReplay();
+
+    if (replay)
+    {
+        // If we're replaying a close, use the time the ledger
+        // we're replaying closed
+        closeTime = replay->closeTime_;
+
+        if ((replay->closeFlags_ & sLCF_NoConsensusTime) != 0)
+            closeTime = 0;
+    }
+
+    closeTime = roundCloseTime (closeTime, mCloseResolution);
 
     // If we don't have a close time, then we just agree to disagree
     bool const closeTimeCorrect = (closeTime != 0);
@@ -1018,8 +1031,18 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
     {
         OpenView accum(&*newLCL);
         assert(accum.closed());
-        applyTransactions (app_, set.get(), accum,
-            newLCL, retriableTxs, tapNONE);
+        if (replay)
+        {
+            // Special case, we are replaying a ledger close
+            for (auto& tx : replay->txns_)
+                applyTransaction (accum, tx.second, false, tapNO_CHECK_SIGN);
+        }
+        else
+        {
+            // Normal case, we are not replaying a ledger close
+            applyTransactions (app_, set.get(), accum,
+                newLCL, retriableTxs, tapNONE);
+        }
         accum.apply(*newLCL);
     }
 
@@ -1782,14 +1805,6 @@ make_LedgerConsensus (Application& app, ConsensusImp& consensus, int previousPro
 
 //------------------------------------------------------------------------------
 
-/** Apply a transaction to a ledger
-
-  @param engine       The transaction engine containing the ledger.
-  @param txn          The transaction to be applied to ledger.
-  @param retryAssured true if the transaction should be retried on failure.
-  @return             One of resultSuccess, resultFail or resultRetry.
-*/
-static
 int
 applyTransaction (Application& app, OpenView& view,
     std::shared_ptr<STTx const> const& txn,

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1035,7 +1035,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         {
             // Special case, we are replaying a ledger close
             for (auto& tx : replay->txns_)
-                applyTransaction (accum, tx.second, false, tapNO_CHECK_SIGN);
+                applyTransaction (app_, accum, tx.second, false, tapNO_CHECK_SIGN);
         }
         else
         {

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -261,7 +261,7 @@ private:
 
       @param initialLedger The ledger that contains our initial position.
     */
-    void takeInitialPosition (Ledger& initialLedger);
+    void takeInitialPosition (std::shared_ptr<ReadView const> const& initialLedger);
 
     /**
        Called while trying to avalanche towards consensus.

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -96,6 +96,9 @@ public:
 
     CanonicalTXSet mHeldTransactions;
 
+    // A set of transactions to replay during the next close
+    std::unique_ptr<LedgerReplay> replayData;
+
     LockType mCompleteLock;
     RangeSet mCompleteLedgers;
 
@@ -1536,6 +1539,16 @@ public:
     void clearLedgerCachePrior (LedgerIndex seq) override
     {
         mLedgerHistory.clearLedgerCachePrior (seq);
+    }
+
+    void takeReplay (std::unique_ptr<LedgerReplay> replay) override
+    {
+        replayData = std::move (replay);
+    }
+
+    std::unique_ptr<LedgerReplay> releaseReplay () override
+    {
+        return std::move (replayData);
     }
 
     // Fetch packs:

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -239,8 +239,7 @@ private:
         Ledger::pointer newLedger, bool duringConsensus);
     bool checkLastClosedLedger (
         const Overlay::PeerSequence&, uint256& networkClosed);
-    bool beginConsensus (
-        uint256 const& networkClosed, Ledger::pointer closingLedger);
+    bool beginConsensus (uint256 const& networkClosed);
     void tryStartConsensus ();
 
 public:
@@ -815,25 +814,6 @@ void NetworkOPsImp::transactionBatch()
     }
 }
 
-#if RIPPLE_OPEN_LEDGER
-static
-void
-mismatch (std::shared_ptr<SLE const> const& sle1, TER ter1,
-    std::shared_ptr<SLE const> const& sle2, TER ter2,
-        std::shared_ptr<STTx const> tx,
-            beast::Journal j)
-{
-    JLOG(j.error) <<
-    "TER " << (ter1 == ter2 ? "        " : "MISMATCH ") <<
-        transToken(ter1) << " vs " <<
-            transToken(ter2);
-    JLOG(j.error) <<
-        tx->getJson(0) << '\n' <<
-        (sle1 ? sle1->getJson(0) : "MISSING ACCOUNTROOT1") << '\n' <<
-        (sle2 ? sle2->getJson(0) : "MISSING ACCOUNTROOT2") << '\n';
-}
-#endif
-
 void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
 {
     std::vector<TransactionStatus> transactions;
@@ -846,19 +826,11 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
     batchLock.unlock();
 
     {
-        std::shared_ptr<Ledger> newOL;
-        bool applied = false;
-        boost::optional<OpenView> accum;
         auto lock = beast::make_lock(app_.getMasterMutex());
         {
             std::lock_guard <std::recursive_mutex> lock (
                 m_ledgerMaster.peekMutex());
-        #if RIPPLE_OPEN_LEDGER
-            auto const oldOL = m_ledgerMaster.getCurrentLedgerHolder().get();
-            app_.openLedger().verify(*oldOL, "apply before");
-        #endif
-            newOL = m_ledgerMaster.getCurrentLedgerHolder().getMutable();
-            accum.emplace(&*newOL);
+
             for (TransactionStatus& e : transactions)
             {
                 ApplyFlags flags = tapNONE;
@@ -866,48 +838,22 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                 if (e.admin)
                     flags = flags | tapADMIN;
 
-            #if RIPPLE_OPEN_LEDGER
-                auto const sle1 = accum->read(
-                    keylet::account(e.transaction->getSTransaction()->getAccountID(sfAccount)));
-            #endif
-
-                std::tie (e.result, e.applied) =
-                    ripple::apply (app_, *accum,
-                        *e.transaction->getSTransaction(), flags,
-                            app_.getHashRouter().sigVerify(),
-                                getConfig(), deprecatedLogs().journal(
-                                    "NetworkOPs"));
-                applied |= e.applied;
-
-            #if RIPPLE_OPEN_LEDGER
-                auto const sle2 = app_.openLedger().current()->read(keylet::account(e.transaction->getSTransaction()->getAccountID(sfAccount)));
                 // VFALCO Should do the loop inside modify()
                 app_.openLedger().modify(
                     [&](OpenView& view, beast::Journal j)
                     {
-                        auto const result = ripple::apply(
+                        auto const result = ripple::apply(app_,
                             view, *e.transaction->getSTransaction(), flags,
                                 app_.getHashRouter().sigVerify(),
                                     getConfig(), j);
-                        if (result.first != e.result)
-                            mismatch(sle1,  e.result, sle2, result.first,
-                                    e.transaction->getSTransaction(), j);
+                        e.result = result.first;
+                        e.applied = result.second;
                         return result.second;
                     });
-            #endif
             }
         }
 
-        if (applied)
-        {
-            accum->apply(*newOL);
-        #if RIPPLE_OPEN_LEDGER
-            app_.openLedger().verify(*newOL, "apply after");
-        #endif
-            newOL->setImmutable();
-            m_ledgerMaster.getCurrentLedgerHolder().set (newOL);
-        }
-
+        auto newOL = app_.openLedger().current();
         for (TransactionStatus& e : transactions)
         {
             if (e.applied)
@@ -1148,7 +1094,7 @@ void NetworkOPsImp::tryStartConsensus ()
     }
 
     if ((!mLedgerConsensus) && (mMode != omDISCONNECTED))
-        beginConsensus (networkClosed, m_ledgerMaster.getCurrentLedger ());
+        beginConsensus (networkClosed);
 }
 
 bool NetworkOPsImp::checkLastClosedLedger (
@@ -1306,40 +1252,17 @@ void NetworkOPsImp::switchLastClosedLedger (
     // set the newLCL as our last closed ledger -- this is abnormal code
 
     auto msg = duringConsensus ? "JUMPdc" : "JUMP";
-#if RIPPLE_OPEN_LEDGER
-    m_journal.fatal
-#else
     m_journal.error
-#endif
         << msg << " last closed ledger to " << newLCL->getHash ();
 
     clearNeedNetworkLedger ();
     newLCL->setClosed ();
-    auto const newOL = std::make_shared<
-        Ledger>(open_ledger, std::ref (*newLCL),
-            app_.timeKeeper().closeTime());
     // Caller must own master lock
     {
-        auto const oldOL =
-            m_ledgerMaster.getCurrentLedger();
-    #if RIPPLE_OPEN_LEDGER
-        app_.openLedger().verify(
-            *oldOL, "jump before");
-    #endif
         // Apply tx in old open ledger to new
         // open ledger. Then apply local tx.
-        OpenView accum(&*newOL);
-        assert(accum.open());
-        auto const localTx = m_localTX->getTxSet();
-        {
-            auto retries = localTx;
-            applyTransactions (app_, &oldOL->txMap(),
-                accum, newLCL, retries, tapNONE);
-        }
-        accum.apply(*newOL);
 
-    #if RIPPLE_OPEN_LEDGER
-        auto retries = localTx;
+        auto retries = m_localTX->getTxSet();
         auto const lastVal =
             app_.getLedgerMaster().getValidatedLedger();
         boost::optional<Rules> rules;
@@ -1347,15 +1270,12 @@ void NetworkOPsImp::switchLastClosedLedger (
             rules.emplace(*lastVal);
         else
             rules.emplace();
-        app_.openLedger().accept(*rules,
+        app_.openLedger().accept(app_, *rules,
             newLCL, OrderedTxs({}), false, retries,
                 tapNONE, app_.getHashRouter(), "jump");
-        app_.openLedger().verify(
-            *newOL, "jump after");
-    #endif
     }
 
-    m_ledgerMaster.switchLedgers (newLCL, newOL);
+    m_ledgerMaster.switchLCL (newLCL);
 
     protocol::TMStatusChange s;
     s.set_newevent (protocol::neSWITCHED_LEDGER);
@@ -1370,15 +1290,18 @@ void NetworkOPsImp::switchLastClosedLedger (
         std::make_shared<Message> (s, protocol::mtSTATUS_CHANGE)));
 }
 
-bool NetworkOPsImp::beginConsensus (
-    uint256 const& networkClosed, Ledger::pointer closingLedger)
+bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
 {
+    assert (networkClosed.isNonZero ());
+
+    auto closingInfo = m_ledgerMaster.getCurrentLedger()->info();
+
     if (m_journal.info) m_journal.info <<
-        "Consensus time for #" << closingLedger->info().seq <<
-        " with LCL " << closingLedger->info().parentHash;
+        "Consensus time for #" << closingInfo.seq <<
+        " with LCL " << closingInfo.parentHash;
 
     auto prevLedger = m_ledgerMaster.getLedgerByHash (
-        closingLedger->info().parentHash);
+        closingInfo.parentHash);
 
     if (!prevLedger)
     {
@@ -1392,8 +1315,8 @@ bool NetworkOPsImp::beginConsensus (
         return false;
     }
 
-    assert (prevLedger->getHash () == closingLedger->info().parentHash);
-    assert (closingLedger->info().parentHash ==
+    assert (prevLedger->getHash () == closingInfo.parentHash);
+    assert (closingInfo.parentHash ==
             m_ledgerMaster.getClosedLedger ()->getHash ());
 
     // Create a consensus object to get consensus on this ledger
@@ -1407,7 +1330,7 @@ bool NetworkOPsImp::beginConsensus (
         m_ledgerMaster,
         networkClosed,
         prevLedger,
-        m_ledgerMaster.getCurrentLedger ()->info().closeTime);
+        closingInfo.closeTime);
 
     m_journal.debug << "Initiating consensus engine";
     return true;
@@ -1435,7 +1358,7 @@ bool NetworkOPsImp::haveConsensusObject ()
             if ( ((mMode == omTRACKING) || (mMode == omSYNCING)) &&
                  (mConsensus->getLastCloseProposers() >= m_ledgerMaster.getMinValidations()) )
                 setMode (omFULL);
-            beginConsensus (networkClosed, m_ledgerMaster.getCurrentLedger ());
+            beginConsensus (networkClosed);
         }
     }
 
@@ -2477,9 +2400,7 @@ std::uint32_t NetworkOPsImp::acceptLedger ()
 
     // FIXME Could we improve on this and remove the need for a specialized
     // API in LedgerConsensus?
-    beginConsensus (
-        m_ledgerMaster.getClosedLedger ()->getHash (),
-        m_ledgerMaster.getCurrentLedger ());
+    beginConsensus (m_ledgerMaster.getClosedLedger ()->getHash ());
     mLedgerConsensus->simulate ();
     return m_ledgerMaster.getCurrentLedger ()->info().seq;
 }

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -95,8 +95,11 @@ OpenView::OpenView (open_ledger_t,
     , hold_ (std::move(hold))
 {
     info_.open = true;
+    info_.validated = false;
+    info_.accepted = false;
     info_.seq = base_->info().seq + 1;
     info_.parentCloseTime = base_->info().closeTime;
+    info_.parentHash = base_->info().hash;
 }
 
 OpenView::OpenView (ReadView const* base,

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -81,6 +81,14 @@ Status ledgerFromRequest (T& ledger, Context& context)
     else if (indexValue.isNumeric())
     {
         ledger = ledgerMaster.getLedgerBySeq (indexValue.asInt ());
+
+        if (ledger == nullptr)
+        {
+            auto cur = ledgerMaster.getCurrentLedger();
+            if (cur->info().seq == indexValue.asInt())
+                ledger = cur;
+        }
+
         if (ledger == nullptr)
             return {rpcLGR_NOT_FOUND, "ledgerNotFound"};
 
@@ -140,11 +148,11 @@ Status ledgerFromRequest (T& ledger, Context& context)
 bool isValidated (LedgerMaster& ledgerMaster, ReadView const& ledger,
     Application& app)
 {
-    if (ledger.info().validated)
-        return true;
-
     if (ledger.info().open)
         return false;
+
+    if (ledger.info().validated)
+        return true;
 
     auto seq = ledger.info().seq;
     try

--- a/src/ripple/shamap/Family.h
+++ b/src/ripple/shamap/Family.h
@@ -62,7 +62,7 @@ public:
 
     virtual
     void
-    missing_node (uint256 const& hash) = 0;
+    missing_node (uint256 const& refHash) = 0;
 };
 
 } // ripple

--- a/src/ripple/shamap/tests/common.h
+++ b/src/ripple/shamap/tests/common.h
@@ -104,9 +104,9 @@ public:
     {
         throw std::runtime_error("missing node");
     }
-    
+
     void
-    missing_node (uint256 const& hash) override
+    missing_node (uint256 const& refHash) override
     {
         throw std::runtime_error("missing node");
     }


### PR DESCRIPTION
This pull request combines three patches in the correct order and without conflicts.

1) Use the new OpenView/OpenLedger classes everywhere. This eliminates all expensive Ledger operations when operating on open ledgers.

2) Improve ledger replay logic so that transactions are replayed without retries in the order they actually applied. We still can't perfectly replay failures and retries, but this should let us perfectly replay all transactions that had effects.

3) Improve the handing of missing nodes encountered in the Ledger constructor and avoid recursive invocation of the missing node logic. This also fixes a regression caused by doing SHAMap operations that can throw in a Ledger constructor that could cause a server with an inconsistent database to crash.