### PR TITLE
Path find cleanup (RIPD-1023)

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -39,7 +39,7 @@
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/SHAMapStore.h>
 #include <ripple/app/misc/Validations.h>
-#include <ripple/app/paths/FindPaths.h>
+#include <ripple/app/paths/Pathfinder.h>
 #include <ripple/app/paths/PathRequests.h>
 #include <ripple/app/misc/UniqueNodeList.h>
 #include <ripple/app/tx/InboundTransactions.h>
@@ -830,7 +830,7 @@ public:
 
         m_amendmentTable->addInitial (
             config_->section (SECTION_AMENDMENTS));
-        initializePathfinding ();
+        Pathfinder::initPathTable();
 
         m_ledgerMaster->setMinValidations (
             config_->VALIDATION_QUORUM, config_->LOCK_QUORUM);

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -311,8 +311,7 @@ int PathRequest::parseJson (Json::Value const& jvParams)
         return PFR_PJ_INVALID;
     }
 
-    convert_all_ =
-        saDstAmount == STAmount(saDstAmount.issue(), 1u, 0, true);
+    convert_all_ = saDstAmount == STAmount(saDstAmount.issue(), 1u, 0, true);
 
     if ((saDstAmount.getCurrency ().isZero () &&
             saDstAmount.getIssuer ().isNonZero ()) ||
@@ -446,97 +445,155 @@ void PathRequest::resetLevel (int l)
         iLastLevel = l;
 }
 
-bool
-PathRequest::findPaths (
-    RippleLineCache::ref cache,
-        FindPaths& fp, Issue const& issue,
-            Json::Value& jvArray)
+std::unique_ptr<Pathfinder> const&
+PathRequest::getPathFinder(RippleLineCache::ref cache,
+    hash_map<Currency, std::unique_ptr<Pathfinder>>& currency_map,
+        Currency const& currency, STAmount const& dst_amount,
+            int const level)
 {
-    STPath fullLiquidityPath;
-    auto result = fp.findPathsForIssue(issue,
-        mContext[issue], fullLiquidityPath, app_);
-    if (! result)
+    auto i = currency_map.find(currency);
+    if (i != currency_map.end())
+        return i->second;
+    auto pathfinder = std::make_unique<Pathfinder>(
+        cache, *raSrcAccount, *raDstAccount, currency,
+            boost::none, dst_amount, saSendMax, app_);
+    if (pathfinder->findPaths(level))
+        pathfinder->computePathRanks(max_paths_);
+    else
+        pathfinder.reset();  // It's a bad request - clear it.
+    return currency_map[currency] = std::move(pathfinder);
+}
+
+void
+PathRequest::findPaths (RippleLineCache::ref cache, int const level,
+    Json::Value& jvArray)
+{
+    auto sourceCurrencies = sciSourceCurrencies;
+    if (sourceCurrencies.empty ())
     {
-        m_journal.debug << iIdentifier << " No paths found";
-        return false;
-    }
-    mContext[issue] = *result;
-
-    boost::optional<PaymentSandbox> sandbox;
-    sandbox.emplace(&*cache->getLedger(), tapNONE);
-
-    auto& sourceAccount = ! isXRP(issue.account)
-        ? issue.account
-        : isXRP(issue.currency)
-        ? xrpAccount()
-        : *raSrcAccount;
-
-    STAmount saMaxAmount = saSendMax.value_or(
-        STAmount({issue.currency, sourceAccount}, 1u, 0, true));
-
-    m_journal.debug << iIdentifier
-        << " Paths found, calling rippleCalc";
-
-    path::RippleCalc::Input rcInput;
-    if (convert_all_)
-        rcInput.partialPaymentAllowed = true;
-
-    auto rc = path::RippleCalc::rippleCalculate(
-        *sandbox, saMaxAmount,
-        convert_all_ ? STAmount(saDstAmount.issue(), STAmount::cMaxValue,
-            STAmount::cMaxOffset) : saDstAmount,
-        *raDstAccount, *raSrcAccount, *result,
-        app_.logs (), &rcInput);
-
-    if (! convert_all_ &&
-        ! fullLiquidityPath.empty() &&
-        (rc.result() == terNO_LINE || rc.result() == tecPATH_PARTIAL))
-    {
-        m_journal.debug << iIdentifier
-            << " Trying with an extra path element";
-        result->push_back(fullLiquidityPath);
-        sandbox.emplace(&*cache->getLedger(), tapNONE);
-
-        rc = path::RippleCalc::rippleCalculate(
-            *sandbox, saMaxAmount, saDstAmount,
-                *raDstAccount, *raSrcAccount, *result, app_.logs ());
-        if (rc.result() != tesSUCCESS)
+        auto usCurrencies =
+            accountSourceCurrencies(*raSrcAccount, cache, true);
+        bool sameAccount = *raSrcAccount == *raDstAccount;
+        for (auto const& c : usCurrencies)
         {
-            m_journal.warning << iIdentifier
-                << " Failed with covering path "
-                << transHuman(rc.result());
+            if (!sameAccount || (c != saDstAmount.getCurrency()))
+            {
+                sourceCurrencies.insert(
+                    {c, c.isZero() ? xrpAccount() : *raSrcAccount});
+            }
+        }
+    }
+
+    auto const dst_amount = convert_all_ ?
+        STAmount(saDstAmount.issue(), STAmount::cMaxValue, STAmount::cMaxOffset)
+            : saDstAmount;
+    hash_map<Currency, std::unique_ptr<Pathfinder>> currency_map;
+    for (auto const& issue : sourceCurrencies)
+    {
+        JLOG(m_journal.debug)
+            << iIdentifier
+            << " Trying to find paths: "
+            << STAmount(issue, 1).getFullText();
+
+        auto& pathfinder = getPathFinder(cache, currency_map,
+            issue.currency, dst_amount, level);
+        if (! pathfinder)
+        {
+            assert(false);
+            m_journal.debug << iIdentifier << " No paths found";
+            continue;
+        }
+
+        STPath fullLiquidityPath;
+        auto ps = pathfinder->getBestPaths(max_paths_,
+            fullLiquidityPath, mContext[issue], issue.account);
+        mContext[issue] = ps;
+
+        auto& sourceAccount = ! isXRP(issue.account)
+            ? issue.account
+            : isXRP(issue.currency)
+            ? xrpAccount()
+            : *raSrcAccount;
+        STAmount saMaxAmount = saSendMax.value_or(
+            STAmount({issue.currency, sourceAccount}, 1u, 0, true));
+
+        m_journal.debug << iIdentifier
+            << " Paths found, calling rippleCalc";
+
+        path::RippleCalc::Input rcInput;
+        if (convert_all_)
+            rcInput.partialPaymentAllowed = true;
+        auto sandbox = std::make_unique<PaymentSandbox>
+            (&*cache->getLedger(), tapNONE);
+        auto rc = path::RippleCalc::rippleCalculate(
+            *sandbox,
+            saMaxAmount,    // --> Amount to send is unlimited
+                            //     to get an estimate.
+            dst_amount,     // --> Amount to deliver.
+            *raDstAccount,  // --> Account to deliver to.
+            *raSrcAccount,  // --> Account sending from.
+            ps,             // --> Path set.
+            app_.logs(),
+            &rcInput);
+
+        if (! convert_all_ &&
+            ! fullLiquidityPath.empty() &&
+            (rc.result() == terNO_LINE || rc.result() == tecPATH_PARTIAL))
+        {
+            m_journal.debug << iIdentifier
+                << " Trying with an extra path element";
+
+            ps.push_back(fullLiquidityPath);
+            sandbox = std::make_unique<PaymentSandbox>
+                (&*cache->getLedger(), tapNONE);
+            rc = path::RippleCalc::rippleCalculate(
+                *sandbox,
+                saMaxAmount,    // --> Amount to send is unlimited
+                                //     to get an estimate.
+                dst_amount,     // --> Amount to deliver.
+                *raDstAccount,  // --> Account to deliver to.
+                *raSrcAccount,  // --> Account sending from.
+                ps,             // --> Path set.
+                app_.logs());
+
+            if (rc.result() != tesSUCCESS)
+            {
+                m_journal.warning << iIdentifier
+                    << " Failed with covering path "
+                    << transHuman(rc.result());
+            }
+            else
+            {
+                m_journal.debug << iIdentifier
+                    << " Extra path element gives "
+                    << transHuman(rc.result());
+            }
+        }
+
+        if (rc.result () == tesSUCCESS)
+        {
+            Json::Value jvEntry (Json::objectValue);
+            rc.actualAmountIn.setIssuer (sourceAccount);
+            jvEntry[jss::source_amount] = rc.actualAmountIn.getJson (0);
+            jvEntry[jss::paths_computed] = ps.getJson(0);
+
+            if (convert_all_)
+                jvEntry[jss::destination_amount] = rc.actualAmountOut.getJson(0);
+
+            if (hasCompletion ())
+            {
+                // Old ripple_path_find API requires this
+                jvEntry[jss::paths_canonical] = Json::arrayValue;
+            }
+
+            jvArray.append (jvEntry);
         }
         else
         {
-            m_journal.debug << iIdentifier
-                << " Extra path element gives "
+            m_journal.debug << iIdentifier << " rippleCalc returns "
                 << transHuman(rc.result());
         }
     }
-
-    if (rc.result () == tesSUCCESS)
-    {
-        Json::Value jvEntry (Json::objectValue);
-        rc.actualAmountIn.setIssuer (sourceAccount);
-        jvEntry[jss::source_amount] = rc.actualAmountIn.getJson (0);
-        jvEntry[jss::paths_computed] = result->getJson(0);
-
-        if (convert_all_)
-            jvEntry[jss::destination_amount] = rc.actualAmountOut.getJson(0);
-
-        if (hasCompletion ())
-        {
-            // Old ripple_path_find API requires this
-            jvEntry[jss::paths_canonical] = Json::arrayValue;
-        }
-
-        jvArray.append (jvEntry);
-        return true;
-    }
-
-    m_journal.debug << iIdentifier << " rippleCalc returns "
-        << transHuman (rc.result ());
-    return false;
 }
 
 Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
@@ -548,25 +605,6 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
     if (!isValid (cache))
         return jvStatus;
     jvStatus = Json::objectValue;
-
-    auto sourceCurrencies = sciSourceCurrencies;
-
-    if (sourceCurrencies.empty ())
-    {
-        auto usCurrencies =
-                accountSourceCurrencies (*raSrcAccount, cache, true);
-        bool sameAccount = *raSrcAccount == *raDstAccount;
-        for (auto const& c: usCurrencies)
-        {
-            if (!sameAccount || (c != saDstAmount.getCurrency ()))
-            {
-                if (c.isZero ())
-                    sourceCurrencies.insert ({c, xrpAccount()});
-                else
-                    sourceCurrencies.insert ({c, *raSrcAccount});
-            }
-        }
-    }
 
     if (hasCompletion ())
     {
@@ -621,29 +659,10 @@ Json::Value PathRequest::doUpdate (RippleLineCache::ref cache, bool fast)
 
     m_journal.debug << iIdentifier << " processing at level " << iLevel;
 
-    bool found = false;
     Json::Value jvArray = Json::arrayValue;
-    FindPaths fp (
-        cache,
-        *raSrcAccount,
-        *raDstAccount,
-        convert_all_ ? STAmount(saDstAmount.issue(), STAmount::cMaxValue,
-            STAmount::cMaxOffset) : saDstAmount,
-        saSendMax,
-        iLevel,
-        4);  // iMaxPaths
-    for (auto const& i: sourceCurrencies)
-    {
-        JLOG(m_journal.debug)
-            << iIdentifier
-            << " Trying to find paths: "
-            << STAmount(i, 1).getFullText();
-        if (findPaths(cache, fp, i, jvArray))
-            found = true;
-    }
-
+    findPaths(cache, iLevel, jvArray);
+    bLastSuccess = jvArray.size();
     iLastLevel = iLevel;
-    bLastSuccess = found;
 
     if (fast && ptQuickReply.is_not_a_date_time())
     {

--- a/src/ripple/app/paths/PathRequest.h
+++ b/src/ripple/app/paths/PathRequest.h
@@ -21,7 +21,7 @@
 #define RIPPLE_APP_PATHS_PATHREQUEST_H_INCLUDED
 
 #include <ripple/app/ledger/Ledger.h>
-#include <ripple/app/paths/FindPaths.h>
+#include <ripple/app/paths/Pathfinder.h>
 #include <ripple/app/paths/RippleLineCache.h>
 #include <ripple/json/json_value.h>
 #include <ripple/net/InfoSub.h>
@@ -95,10 +95,13 @@ private:
     void setValid ();
     void resetLevel (int level);
 
-    bool
-    findPaths (RippleLineCache::ref,
-        FindPaths&, Issue const&,
-            Json::Value& jvArray);
+    std::unique_ptr<Pathfinder> const&
+    getPathFinder(RippleLineCache::ref,
+        hash_map<Currency, std::unique_ptr<Pathfinder>>&, Currency const&,
+            STAmount const&, int const);
+
+    void
+    findPaths (RippleLineCache::ref, int const, Json::Value&);
 
     int parseJson (Json::Value const&);
 
@@ -140,6 +143,8 @@ private:
     boost::posix_time::ptime ptCreated;
     boost::posix_time::ptime ptQuickReply;
     boost::posix_time::ptime ptFullReply;
+
+    static unsigned int const max_paths_ = 4;
 };
 
 } // ripple

--- a/src/ripple/app/tests/Path_test.cpp
+++ b/src/ripple/app/tests/Path_test.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/basics/Log.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/json/to_string.h>
 #include <ripple/protocol/JsonFields.h>
@@ -151,16 +150,17 @@ find_paths(jtx::Env& env,
         jvCurrency[jss::currency] = to_string(c);
         jvSrcCurrencies.append(jvCurrency);
     }
-
+    auto const convert_all =
+        saDstAmount == STAmount(saDstAmount.issue(), 1u, 0, true);
     auto result = ripplePathFind(cache, src.id(), dst.id(),
-        saDstAmount, jvSrcCurrencies, boost::none, level, saSendMax,
-            saDstAmount == STAmount(saDstAmount.issue(), 1u, 0, true), env.app ());
+        (convert_all ? STAmount(saDstAmount.issue(), STAmount::cMaxValue,
+            STAmount::cMaxOffset) : saDstAmount), jvSrcCurrencies, boost::none,
+                level, saSendMax, convert_all, env.app());
     if (! result.first)
     {
         throw std::runtime_error(
             "Path_test::findPath: ripplePathFind find failed");
     }
-
     auto const& jv = result.second[0u];
     Json::Value paths;
     paths["Paths"] = jv["paths_computed"];

--- a/src/ripple/rpc/RipplePathFind.h
+++ b/src/ripple/rpc/RipplePathFind.h
@@ -31,7 +31,7 @@ ripplePathFind (RippleLineCache::pointer const& cache,
         STAmount const& saDstAmount,
             Json::Value const& jvSrcCurrencies,
                 boost::optional<Json::Value> const& contextPaths,
-                    int const& level, boost::optional<STAmount> saSendMax,
+                    int const level, boost::optional<STAmount> saSendMax,
                         bool convert_all, Application& app);
 
 }

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -30,7 +30,7 @@
 #include <ripple/test/jtx/utility.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/ledger/LedgerTiming.h>
-#include <ripple/app/paths/FindPaths.h>
+#include <ripple/app/paths/Pathfinder.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/json/to_string.h>
 #include <ripple/protocol/ErrorCodes.h>
@@ -63,7 +63,7 @@ Env::Env (beast::unit_test::suite& test_)
     , openLedger (closed_, config, cachedSLEs_, journal)
 {
     memoize(master);
-    initializePathfinding();
+    Pathfinder::initPathTable();
 }
 
 std::shared_ptr<ReadView const>

--- a/src/ripple/unity/app_paths.cpp
+++ b/src/ripple/unity/app_paths.cpp
@@ -22,7 +22,6 @@
 #include <ripple/app/paths/RippleState.cpp>
 #include <ripple/app/paths/AccountCurrencies.cpp>
 #include <ripple/app/paths/Credit.cpp>
-#include <ripple/app/paths/FindPaths.cpp>
 #include <ripple/app/paths/Pathfinder.cpp>
 #include <ripple/app/paths/Node.cpp>
 #include <ripple/app/paths/PathRequest.cpp>


### PR DESCRIPTION
Remove the FindPaths class, reducing indirection with path finding requests. A little bit of code duplication is introduced in RipplePathFind, which is marked deprecated and will be removed in the future.

Reviewers:  @ximinez @nbougalis @vinniefalco 