### PR TITLE
Support gcc 5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ bin/rippled
 Debug/*.*
 Release/*.*
 
+# Ignore coverage files.
+*.gcno
+*.gcda
+*.gcov
+
 # Ignore locally installed node_modules
 /node_modules
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
 language: cpp
 
-compiler:
-  - clang
-  - gcc
-
 env:
   global:
     # Maintenance note: to move to a new version
@@ -14,44 +10,64 @@ env:
     # to boost's .tar.gz.
     - BOOST_ROOT=$HOME/boost_1_59_0
     - BOOST_URL='http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.59.0%2Fboost_1_59_0.tar.gz%2Fdownload&ts=1441761349&use_mirror=skylineservers'
-    # We need gcc >= 4.8 for some c++11 features.
-    # To change, also change the packages: entry.
-    # Env vars are not translated there.
-    - GCC_VER=4.8
-  matrix:
-    - TARGET=coverage
-    - TARGET=debug
-    - TARGET=debug.nounity
-    # We can specify any combination of builds here, for example, to
-    # include release builds, too, uncomment the following lines.
-    #- TARGET=release
-    #- TARGET=release.nounity
-matrix:
-  exclude:
-    # Because gcov won't work (easily) with clang
-    - env: TARGET=coverage
-      compiler: clang
-    # Because coverage target is basically debug + --coverage flags
-    - env: TARGET=debug
-      compiler: gcc
+    - RIPPLED_OLD_GCC_ABI=1
 
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - python-software-properties
-    # See also GCC_VER.
-    - g++-4.8
-    - gcc-4.8
-    - protobuf-compiler
-    - libprotobuf-dev
-    - libssl-dev
-    # Not available, but not needed
-    # - exuberant-ctags
-    - binutils-gold
-    # Provides a backtrace if the unittests crash
-    - gdb
+
+packages: &gcc5_pkgs
+  - gcc-5
+  - g++-5
+  - python-software-properties
+  - protobuf-compiler
+  - libprotobuf-dev
+  - libssl-dev
+  - libstdc++6
+  - binutils-gold
+  # Provides a backtrace if the unittests crash
+  - gdb
+
+packages: &gcc48_pkgs
+  - gcc-4.8
+  - g++-4.8
+  - python-software-properties
+  - protobuf-compiler
+  - libprotobuf-dev
+  - libssl-dev
+  - libstdc++6
+  - binutils-gold
+  # Provides a backtrace if the unittests crash
+  - gdb
+
+matrix:
+  include:
+    - compiler: gcc
+      env: GCC_VER=5 TARGET=debug.nounity
+      addons: &ao_gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: *gcc5_pkgs
+
+    - compiler: gcc
+      env: GCC_VER=5 TARGET=coverage
+      addons: *ao_gcc5
+
+    - compiler: clang
+      env: GCC_VER=4.8 TARGET=debug
+      addons: &ao_gcc48
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: *gcc48_pkgs
+
+    - compiler: clang
+      env: GCC_VER=4.8 TARGET=debug.nounity
+      addons: *ao_gcc48
+
+    - compiler: gcc
+      env: GCC_VER=4.8 TARGET=debug
+      addons: *ao_gcc48
+
+    - compiler: gcc
+      env: GCC_VER=4.8 TARGET=debug.nounity
+      addons: *ao_gcc48
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,21 @@ env:
     # Env vars are not translated there.
     - GCC_VER=4.8
   matrix:
+    - TARGET=coverage
     - TARGET=debug
     - TARGET=debug.nounity
     # We can specify any combination of builds here, for example, to
     # include release builds, too, uncomment the following lines.
     #- TARGET=release
     #- TARGET=release.nounity
+matrix:
+  exclude:
+    # Because gcov won't work (easily) with clang
+    - env: TARGET=coverage
+      compiler: clang
+    # Because coverage target is basically debug + --coverage flags
+    - env: TARGET=debug
+      compiler: gcc
 
 addons:
   apt:
@@ -34,6 +43,7 @@ addons:
     - python-software-properties
     # See also GCC_VER.
     - g++-4.8
+    - gcc-4.8
     - protobuf-compiler
     - libprotobuf-dev
     - libssl-dev
@@ -48,55 +58,10 @@ cache:
   - $BOOST_ROOT
 
 before_install:
-  # Override gcc version to $GCC_VER.
-  # Put an appropriate symlink at the front of the path.
-  - mkdir -v $HOME/bin
-  - test -x $( type -p gcc-$GCC_VER )
-  - ln -sv $(type -p gcc-$GCC_VER) $HOME/bin/gcc
-  - test -x $( type -p g++-$GCC_VER )
-  - ln -sv $(type -p g++-$GCC_VER) $HOME/bin/g++
-  - export PATH=$PWD/bin:$PATH
-
-  # What versions are we ACTUALLY running?
-  - g++ -v
-  - clang -v
-  # Avoid `spurious errors` caused by ~/.npm permission issues
-  # Does it already exist? Who owns? What permissions?
-  - ls -lah ~/.npm || mkdir ~/.npm
-  # Make sure we own it
-  - chown -Rc $USER ~/.npm
-
-  - bash bin/sh/install-boost.sh
+  - bin/ci/ubuntu/install-dependencies.sh
 
 script:
-  # Set so any failing command will abort the build
-  - set -e
-  # Make sure vcxproj is up to date
-  - scons vcxproj
-  - git diff --exit-code
-  # $CC will be either `clang` or `gcc`
-  # http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
-  #   indicates that 2 cores are available to containers.
-  - scons -j2 $CC.$TARGET
-  # We can be sure we're using the build/$CC.$TARGET variant (-f so never err)
-  - rm -f build/rippled 
-  - export RIPPLED_PATH="$PWD/build/$CC.$TARGET/rippled"
-  # See what we've actually built
-  - ldd $RIPPLED_PATH
-  # Run unittests (under gdb)
-  - | # create gdb script
-    echo "set env MALLOC_CHECK_=3" > script.gdb 
-    echo "run" >> script.gdb
-    echo "backtrace full" >> script.gdb 
-    # gdb --help
-  - cat script.gdb | gdb --ex 'set print thread-events off' --return-child-result --args $RIPPLED_PATH --unittest
-  - npm install
-  # Use build/(gcc|clang).$TARGET/rippled
-  - |
-    echo "exports.default_server_config = {\"rippled_path\" : \"$RIPPLED_PATH\"};" > test/config.js
-
-  # Run integration tests
-  - npm test
+  - bin/ci/ubuntu/build-and-test.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,62 @@
+sudo: false
 language: cpp
+
 compiler:
   - clang
   - gcc
+
 env:
-  - TARGET=debug
-  - TARGET=debug.nounity
-  # We can specify any combination of builds here, for example, to
-  # include release builds, too, uncomment the following lines.
-  #- TARGET=release
-  #- TARGET=release.nounity
+  global:
+    # Maintenance note: to move to a new version
+    # of boost, update both BOOST_ROOT and BOOST_URL.
+    # Note that for simplicity, BOOST_ROOT's final
+    # namepart must match the folder name internal
+    # to boost's .tar.gz.
+    - BOOST_ROOT=$HOME/boost_1_59_0
+    - BOOST_URL='http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fboost%2Ffiles%2Fboost%2F1.59.0%2Fboost_1_59_0.tar.gz%2Fdownload&ts=1441761349&use_mirror=skylineservers'
+    # We need gcc >= 4.8 for some c++11 features.
+    # To change, also change the packages: entry.
+    # Env vars are not translated there.
+    - GCC_VER=4.8
+  matrix:
+    - TARGET=debug
+    - TARGET=debug.nounity
+    # We can specify any combination of builds here, for example, to
+    # include release builds, too, uncomment the following lines.
+    #- TARGET=release
+    #- TARGET=release.nounity
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - python-software-properties
+    # See also GCC_VER.
+    - g++-4.8
+    - protobuf-compiler
+    - libprotobuf-dev
+    - libssl-dev
+    # Not available, but not needed
+    # - exuberant-ctags
+    - binutils-gold
+    # Provides a backtrace if the unittests crash
+    - gdb
+
+cache:
+  directories:
+  - $BOOST_ROOT
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq python-software-properties
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo add-apt-repository -y ppa:afrank/boost
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq g++-4.8
-  - sudo apt-get install -qq libboost1.57-all-dev
-  - sudo apt-get install -qq mlocate
-  - sudo updatedb
-  - sudo locate libboost | grep /lib | grep -e ".a$"
-  - sudo apt-get install -qq protobuf-compiler libprotobuf-dev libssl-dev exuberant-ctags
-  # We need gcc >= 4.8 for some c++11 features
-  - sudo apt-get install -qq gcc-4.8
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
-  - sudo update-alternatives --set gcc /usr/bin/gcc-4.8
-  # Stuff is gold. Nuff said ;)
-  - sudo apt-get -y install binutils-gold
-  # We can get a backtrace if the guy crashes
-  - sudo apt-get -y install gdb
+  # Override gcc version to $GCC_VER.
+  # Put an appropriate symlink at the front of the path.
+  - mkdir -v $HOME/bin
+  - test -x $( type -p gcc-$GCC_VER )
+  - ln -sv $(type -p gcc-$GCC_VER) $HOME/bin/gcc
+  - test -x $( type -p g++-$GCC_VER )
+  - ln -sv $(type -p g++-$GCC_VER) $HOME/bin/g++
+  - export PATH=$PWD/bin:$PATH
+
   # What versions are we ACTUALLY running?
   - g++ -v
   - clang -v
@@ -36,7 +64,9 @@ before_install:
   # Does it already exist? Who owns? What permissions?
   - ls -lah ~/.npm || mkdir ~/.npm
   # Make sure we own it
-  - sudo chown -R $USER ~/.npm
+  - chown -Rc $USER ~/.npm
+
+  - bash bin/sh/install-boost.sh
 
 script:
   # Set so any failing command will abort the build
@@ -44,8 +74,10 @@ script:
   # Make sure vcxproj is up to date
   - scons vcxproj
   - git diff --exit-code
-  # $CC will be either `clang` or `gcc` (If only we could do -j12 ;)
-  - scons $CC.$TARGET
+  # $CC will be either `clang` or `gcc`
+  # http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
+  #   indicates that 2 cores are available to containers.
+  - scons -j2 $CC.$TARGET
   # We can be sure we're using the build/$CC.$TARGET variant (-f so never err)
   - rm -f build/rippled 
   - export RIPPLED_PATH="$PWD/build/$CC.$TARGET/rippled"
@@ -65,6 +97,7 @@ script:
 
   # Run integration tests
   - npm test
+
 notifications:
   email:
     false

--- a/SConstruct
+++ b/SConstruct
@@ -15,11 +15,13 @@
 
     clang           All clang variants
     clang.debug     clang debug variant
+    clang.coverage  clang coverage variant
     clang.release   clang release variant
     clang.profile   clang profile variant
 
     gcc             All gcc variants
     gcc.debug       gcc debug variant
+    gcc.coverage    gcc coverage variant
     gcc.release     gcc release variant
     gcc.profile     gcc profile variant
 
@@ -250,6 +252,9 @@ def print_coms(target, source, env):
     # TODO Add 'PROTOCCOM' to this list and make it work
     Beast.print_coms(['CXXCOM', 'CCCOM', 'LINKCOM'], env)
 
+def is_debug_variant(variant):
+  return variant in ('debug', 'coverage')
+
 #-------------------------------------------------------------------------------
 
 # Set construction variables for the base environment
@@ -311,7 +316,7 @@ def config_base(env):
 
 # Set toolchain and variant specific construction variables
 def config_env(toolchain, variant, env):
-    if variant == 'debug':
+    if is_debug_variant(variant):
         env.Append(CPPDEFINES=['DEBUG', '_DEBUG'])
 
     elif variant == 'release' or variant == 'profile':
@@ -416,6 +421,12 @@ def config_env(toolchain, variant, env):
                 '-fno-strict-aliasing'
                 ])
 
+        if variant == 'coverage':
+             env.Append(CXXFLAGS=[
+                 '-fprofile-arcs', '-ftest-coverage'])
+             env.Append(LINKFLAGS=[
+                 '-fprofile-arcs', '-ftest-coverage'])
+
         if toolchain == 'clang':
             if Beast.system.osx:
                 env.Replace(CC='clang', CXX='clang++', LINK='clang++')
@@ -443,7 +454,7 @@ def config_env(toolchain, variant, env):
             # If we are in debug mode, use GCC-specific functionality to add
             # extra error checking into the code (e.g. std::vector will throw
             # for out-of-bounds conditions)
-            if variant == 'debug':
+            if is_debug_variant(variant):
                 env.Append(CPPDEFINES={
                     '_FORTIFY_SOURCE': 2
                     })
@@ -562,7 +573,7 @@ base.Decider('MD5-timestamp')
 set_implicit_cache()
 
 # Configure the toolchains, variants, default toolchain, and default target
-variants = ['debug', 'release', 'profile']
+variants = ['debug', 'coverage', 'release', 'profile']
 all_toolchains = ['clang', 'gcc', 'msvc']
 if Beast.system.osx:
     toolchains = ['clang']
@@ -684,7 +695,7 @@ def get_classic_sources(toolchain):
     append_sources(result, *list_sources('src/ripple/shamap', '.cpp'))
     append_sources(result, *list_sources('src/ripple/test', '.cpp'))
     append_sources(result, *list_sources('src/ripple/unl', '.cpp'))
-   
+
     append_sources(
         result,
         *list_sources('src/ripple/nodestore', '.cpp'),
@@ -802,7 +813,7 @@ for tu_style in ['classic', 'unity']:
         for variant in variants:
             if not should_prepare_targets(tu_style, toolchain, variant):
                 continue
-            if variant == 'profile' and toolchain == 'msvc':
+            if variant in ['profile', 'coverage'] and toolchain == 'msvc':
                 continue
             # Configure this variant's construction environment
             env = base.Clone()

--- a/bin/ci/ubuntu/build-and-test.sh
+++ b/bin/ci/ubuntu/build-and-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -u
+# We use set -e and bash with -u to bail on first non zero exit code of any
+# processes launched or upon any unbound variable
+set -e
+__dirname=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+echo "using CC: $CC"
+echo "using TARGET: $TARGET"
+export RIPPLED_PATH="$PWD/build/$CC.$TARGET/rippled"
+echo "using RIPPLED_PATH: $RIPPLED_PATH"
+# Make sure vcxproj is up to date
+scons vcxproj
+git diff --exit-code
+# $CC will be either `clang` or `gcc`
+# http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
+#   indicates that 2 cores are available to containers.
+scons -j${NUM_PROCESSORS:-2} $CC.$TARGET
+# We can be sure we're using the build/$CC.$TARGET variant
+# (-f so never err)
+rm -f build/rippled
+
+# See what we've actually built
+ldd $RIPPLED_PATH
+if [[ $TARGET == "coverage" ]]; then
+  $RIPPLED_PATH --unittest
+  # We pass along -p to keep path segments so as to avoid collisions
+  codecov --gcov-args=-p --gcov-source-match='^src/(ripple|beast)'
+else
+  # Run unittests (under gdb)
+  cat $__dirname/unittests.gdb | gdb \
+      --return-child-result \
+      --args $RIPPLED_PATH --unittest
+fi
+
+# Run NPM tests
+npm install
+npm test --rippled=$RIPPLED_PATH

--- a/bin/ci/ubuntu/install-dependencies.sh
+++ b/bin/ci/ubuntu/install-dependencies.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -u
+# Exit if anything fails.
+set -e
+# Override gcc version to $GCC_VER.
+# Put an appropriate symlink at the front of the path.
+mkdir -v $HOME/bin
+for g in gcc g++ gcov gcc-ar gcc-nm gcc-ranlib
+do
+  test -x $( type -p ${g}-$GCC_VER )
+  ln -sv $(type -p ${g}-$GCC_VER) $HOME/bin/${g}
+done
+export PATH=$PWD/bin:$PATH
+
+# What versions are we ACTUALLY running?
+g++ -v
+clang -v
+# Avoid `spurious errors` caused by ~/.npm permission issues
+# Does it already exist? Who owns? What permissions?
+ls -lah ~/.npm || mkdir ~/.npm
+# Make sure we own it
+chown -Rc $USER ~/.npm
+# We use this so we can filter the subtrees from our coverage report
+pip install --user https://github.com/sublimator/codecov-python/zipball/source-match
+
+bash bin/sh/install-boost.sh

--- a/bin/ci/ubuntu/unittests.gdb
+++ b/bin/ci/ubuntu/unittests.gdb
@@ -1,0 +1,4 @@
+set env MALLOC_CHECK_=3
+set print thread-events off
+run
+backtrace full

--- a/bin/sh/install-boost.sh
+++ b/bin/sh/install-boost.sh
@@ -12,7 +12,8 @@ then
   tar xzf /tmp/boost.tar.gz
   cd $BOOST_ROOT && \
     ./bootstrap.sh --prefix=$BOOST_ROOT && \
-      ./b2 -d1 && ./b2 -d0 install
+    ./b2 -d1 define=-D_GLIBCXX_USE_CXX11_ABI=0 && ./b2 -d0 define=-D_GLIBCXX_USE_CXX11_ABI=0 install
+  define=-D_GLIBCXX_USE_CXX11_ABI=0
 else
   echo "Using cached boost at $BOOST_ROOT"
 fi

--- a/bin/sh/install-boost.sh
+++ b/bin/sh/install-boost.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Assumptions:
+# 1) BOOST_ROOT and BOOST_URL are already defined,
+# and contain valid values.
+# 2) The last namepart of BOOST_ROOT matches the
+# folder name internal to boost's .tar.gz
+set -e
+if [ ! -d "$BOOST_ROOT/lib" ]
+then
+  wget $BOOST_URL -O /tmp/boost.tar.gz
+  cd `dirname $BOOST_ROOT`
+  tar xzf /tmp/boost.tar.gz
+  cd $BOOST_ROOT && \
+    ./bootstrap.sh --prefix=$BOOST_ROOT && \
+      ./b2 -d1 && ./b2 -d0 install
+else
+  echo "Using cached boost at $BOOST_ROOT"
+fi
+


### PR DESCRIPTION
Support for user-built gcc 5. Will also build with gcc 4. clang and visual studio targets should be unaffected by these changes.

When we upgrade to distros that ship with gcc 5 (i.e. ubuntu 15.10), we can remove most of these edits. We will need to remove the _GLIBCXX_USE_CXX11_ABI flag for sure.

@miguelportilla @ximinez 