### PR TITLE
Add override keyword on all derived funcitons:This silences warnings …

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -430,6 +430,8 @@ def config_env(toolchain, variant, env):
             env.Append(CXXFLAGS=[
                 '-Wno-mismatched-tags',
                 '-Wno-deprecated-register',
+                '-Wno-unused-local-typedefs',
+                '-Wno-unknown-warning-option',
                 ])
 
         elif toolchain == 'gcc':

--- a/src/beast/beast/module/core/streams/MemoryOutputStream.h
+++ b/src/beast/beast/module/core/streams/MemoryOutputStream.h
@@ -117,7 +117,7 @@ public:
         capacity off the block, so that its length matches the amount of actual data that
         has been written so far.
     */
-    void flush();
+    void flush() override;
 
     bool write (const void*, size_t) override;
     std::int64_t getPosition() override                                 { return position; }

--- a/src/beast/beast/utility/WrappedSink.h
+++ b/src/beast/beast/utility/WrappedSink.h
@@ -69,17 +69,17 @@ public:
     }
 
     beast::Journal::Severity
-    severity() const
+    severity() const override
     {
         return sink_.severity();
     }
 
-    void severity (beast::Journal::Severity level)
+    void severity (beast::Journal::Severity level) override
     {
         sink_.severity (level);
     }
 
-    void write (beast::Journal::Severity level, std::string const& text)
+    void write (beast::Journal::Severity level, std::string const& text) override
     {
         using beast::Journal;
         sink_.write (level, prefix_ + text);

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -132,7 +132,7 @@ public:
     //
 
     LedgerInfo const&
-    info() const
+    info() const override
     {
         return info_;
     }

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -177,18 +177,18 @@ public:
     {
     }
 
-    LedgerIndex getCurrentLedgerIndex ()
+    LedgerIndex getCurrentLedgerIndex () override
     {
         return mCurrentLedger.get ()->info().seq;
     }
 
-    LedgerIndex getValidLedgerIndex ()
+    LedgerIndex getValidLedgerIndex () override
     {
         return mValidLedgerSeq;
     }
 
     bool isCompatible (Ledger::pointer ledger,
-        beast::Journal::Stream s, const char* reason)
+        beast::Journal::Stream s, const char* reason) override
     {
         auto validLedger = getValidatedLedger();
 
@@ -212,7 +212,7 @@ public:
         return true;
     }
 
-    int getPublishedLedgerAge ()
+    int getPublishedLedgerAge () override
     {
         std::uint32_t pubClose = mPubLedgerClose.load();
         if (!pubClose)
@@ -230,7 +230,7 @@ public:
         return static_cast<int> (ret);
     }
 
-    int getValidatedLedgerAge ()
+    int getValidatedLedgerAge () override
     {
         std::uint32_t valClose = mValidLedgerSign.load();
         if (!valClose)
@@ -247,7 +247,7 @@ public:
         return static_cast<int> (ret);
     }
 
-    bool isCaughtUp(std::string& reason)
+    bool isCaughtUp(std::string& reason) override
     {
         if (getPublishedLedgerAge() > 180)
         {
@@ -304,14 +304,14 @@ public:
         mPubLedgerSeq = l->info().seq;
     }
 
-    void addHeldTransaction (Transaction::ref transaction)
+    void addHeldTransaction (Transaction::ref transaction) override
     {
         // returns true if transaction was added
         ScopedLockType ml (m_mutex);
         mHeldTransactions.insert (transaction->getSTransaction ());
     }
 
-    void pushLedger (Ledger::pointer newLedger)
+    void pushLedger (Ledger::pointer newLedger) override
     {
         // Caller should already have properly assembled this ledger into
         // "ready-to-close" form -- all candidate transactions must already be
@@ -342,7 +342,7 @@ public:
             checkAccept(newLedger);
     }
 
-    void pushLedger (Ledger::pointer newLCL, Ledger::pointer newOL)
+    void pushLedger (Ledger::pointer newLCL, Ledger::pointer newOL) override
     {
         assert (! newLCL->info().open);
         assert (newOL->info().open);
@@ -364,7 +364,7 @@ public:
         }
     }
 
-    void switchLedgers (Ledger::pointer lastClosed, Ledger::pointer current)
+    void switchLedgers (Ledger::pointer lastClosed, Ledger::pointer current) override
     {
         assert (lastClosed && current);
 
@@ -382,18 +382,18 @@ public:
         checkAccept (lastClosed);
     }
 
-    bool fixIndex (LedgerIndex ledgerIndex, LedgerHash const& ledgerHash)
+    bool fixIndex (LedgerIndex ledgerIndex, LedgerHash const& ledgerHash) override
     {
         return mLedgerHistory.fixIndex (ledgerIndex, ledgerHash);
     }
 
-    bool storeLedger (Ledger::pointer ledger)
+    bool storeLedger (Ledger::pointer ledger) override
     {
         // Returns true if we already had the ledger
         return mLedgerHistory.addLedger (ledger, false);
     }
 
-    void forceValid (Ledger::pointer ledger)
+    void forceValid (Ledger::pointer ledger) override
     {
         ledger->setValidated();
         setFullLedger(ledger, true, false);
@@ -404,7 +404,7 @@ public:
         The open ledger remains open to handle new transactions
         until a new open ledger is built.
     */
-    void applyHeldTransactions ()
+    void applyHeldTransactions () override
     {
         ScopedLockType sl (m_mutex);
 
@@ -471,31 +471,31 @@ public:
         mCurrentLedger.set (newOL);
     }
 
-    LedgerIndex getBuildingLedger ()
+    LedgerIndex getBuildingLedger () override
     {
         // The ledger we are currently building, 0 of none
         return mBuildingLedgerSeq.load ();
     }
 
-    void setBuildingLedger (LedgerIndex i)
+    void setBuildingLedger (LedgerIndex i) override
     {
         mBuildingLedgerSeq.store (i);
     }
 
-    bool haveLedger (std::uint32_t seq)
+    bool haveLedger (std::uint32_t seq) override
     {
         ScopedLockType sl (mCompleteLock);
         return mCompleteLedgers.hasValue (seq);
     }
 
-    void clearLedger (std::uint32_t seq)
+    void clearLedger (std::uint32_t seq) override
     {
         ScopedLockType sl (mCompleteLock);
         return mCompleteLedgers.clearValue (seq);
     }
 
     // returns Ledgers we have all the nodes for
-    bool getFullValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal)
+    bool getFullValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal) override
     {
         maxVal = mPubLedgerSeq.load();
 
@@ -516,7 +516,7 @@ public:
     }
 
     // Returns Ledgers we have all the nodes for and are indexed
-    bool getValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal)
+    bool getValidatedRange (std::uint32_t& minVal, std::uint32_t& maxVal) override
     {
         maxVal = mPubLedgerSeq.load();
 
@@ -569,7 +569,7 @@ public:
     }
 
     // Get the earliest ledger we will let peers fetch
-    std::uint32_t getEarliestFetch ()
+    std::uint32_t getEarliestFetch () override
     {
         // The earliest ledger we will let people fetch is ledger zero,
         // unless that creates a larger range than allowed
@@ -690,7 +690,7 @@ public:
             WriteLog (lsDEBUG, LedgerMaster) << "No peer for fetch pack";
     }
 
-    void fixMismatch (Ledger::ref ledger)
+    void fixMismatch (Ledger::ref ledger) override
     {
         int invalidate = 0;
         boost::optional<uint256> hash;
@@ -737,7 +737,7 @@ public:
     }
 
     void setFullLedger (
-        Ledger::pointer ledger, bool isSynchronous, bool isCurrent)
+        Ledger::pointer ledger, bool isSynchronous, bool isCurrent) override
     {
         // A new ledger has been accepted as part of the trusted chain
         WriteLog (lsDEBUG, LedgerMaster) << "Ledger " << ledger->info().seq
@@ -795,7 +795,7 @@ public:
         }
     }
 
-    void failedSave(std::uint32_t seq, uint256 const& hash)
+    void failedSave(std::uint32_t seq, uint256 const& hash) override
     {
         clearLedger(seq);
         getApp().getInboundLedgers().acquire(
@@ -804,7 +804,7 @@ public:
 
     // Check if the specified ledger can become the new last fully-validated
     // ledger.
-    void checkAccept (uint256 const& hash, std::uint32_t seq)
+    void checkAccept (uint256 const& hash, std::uint32_t seq) override
     {
 
         int valCount;
@@ -887,7 +887,7 @@ public:
         return minVal;
     }
 
-    void checkAccept (Ledger::ref ledger)
+    void checkAccept (Ledger::ref ledger) override
     {
         if (ledger->info().seq <= mValidLedgerSeq)
             return;
@@ -1190,7 +1190,7 @@ public:
         return ret;
     }
 
-    void tryAdvance()
+    void tryAdvance() override
     {
         ScopedLockType ml (m_mutex);
 
@@ -1208,7 +1208,7 @@ public:
     // Return the hash of the valid ledger with a particular sequence, given a
     // subsequent ledger known valid.
     // VFALCO NOTE This should return boost::optional<uint256>
-    uint256 getLedgerHash(std::uint32_t desiredSeq, Ledger::ref knownGoodLedger)
+    uint256 getLedgerHash(std::uint32_t desiredSeq, Ledger::ref knownGoodLedger) override
     {
         assert(desiredSeq < knownGoodLedger->info().seq);
 
@@ -1308,7 +1308,7 @@ public:
         }
     }
 
-    void newPathRequest ()
+    void newPathRequest () override
     {
         ScopedLockType ml (m_mutex);
         mPathFindNewRequest = true;
@@ -1316,7 +1316,7 @@ public:
         newPFWork("pf:newRequest");
     }
 
-    bool isNewPathRequest ()
+    bool isNewPathRequest () override
     {
         ScopedLockType ml (m_mutex);
         if (!mPathFindNewRequest)
@@ -1327,7 +1327,7 @@ public:
 
     // If the order book is radically updated, we need to reprocess all
     // pathfinding requests.
-    void newOrderBookDB ()
+    void newOrderBookDB () override
     {
         ScopedLockType ml (m_mutex);
         mPathLedger.reset();
@@ -1348,13 +1348,13 @@ public:
         }
     }
 
-    LockType& peekMutex ()
+    LockType& peekMutex () override
     {
         return m_mutex;
     }
 
     // The current ledger is the ledger we believe new transactions should go in
-    Ledger::pointer getCurrentLedger ()
+    Ledger::pointer getCurrentLedger () override
     {
         return mCurrentLedger.get ();
     }
@@ -1365,18 +1365,18 @@ public:
     }
 
     // The finalized ledger is the last closed/accepted ledger
-    Ledger::pointer getClosedLedger ()
+    Ledger::pointer getClosedLedger () override
     {
         return mClosedLedger.get ();
     }
 
     // The validated ledger is the last fully validated ledger
-    Ledger::pointer getValidatedLedger ()
+    Ledger::pointer getValidatedLedger () override
     {
         return mValidLedger.get ();
     }
 
-    Rules getValidatedRules ()
+    Rules getValidatedRules () override
     {
         // Once we have a guarantee that there's always a last validated
         // ledger then we can dispense with the if.
@@ -1390,7 +1390,7 @@ public:
 
     // This is the last ledger we published to clients and can lag the validated
     // ledger.
-    Ledger::ref getPublishedLedger ()
+    Ledger::ref getPublishedLedger () override
     {
         return mPubLedger;
     }
@@ -1425,24 +1425,24 @@ public:
         return true;
     }
 
-    int getMinValidations ()
+    int getMinValidations () override
     {
         return mMinValidations;
     }
 
-    void setMinValidations (int v)
+    void setMinValidations (int v) override
     {
         WriteLog (lsINFO, LedgerMaster) << "Validation quorum: " << v;
         mMinValidations = v;
     }
 
-    std::string getCompleteLedgers ()
+    std::string getCompleteLedgers () override
     {
         ScopedLockType sl (mCompleteLock);
         return mCompleteLedgers.toString ();
     }
 
-    uint256 getHashBySeq (std::uint32_t index)
+    uint256 getHashBySeq (std::uint32_t index) override
     {
         uint256 hash = mLedgerHistory.getLedgerHash (index);
 
@@ -1453,7 +1453,7 @@ public:
     }
 
     // VFALCO NOTE This should return boost::optional<uint256>
-    uint256 walkHashBySeq (std::uint32_t index)
+    uint256 walkHashBySeq (std::uint32_t index) override
     {
         uint256 ledgerHash;
         Ledger::pointer referenceLedger;
@@ -1472,7 +1472,7 @@ public:
         in the node store.
     */
     // VFALCO NOTE This should return boost::optional<uint256>
-    uint256 walkHashBySeq (std::uint32_t index, Ledger::ref referenceLedger)
+    uint256 walkHashBySeq (std::uint32_t index, Ledger::ref referenceLedger) override
     {
         if (!referenceLedger || (referenceLedger->info().seq < index))
         {
@@ -1522,7 +1522,7 @@ public:
         return ledgerHash ? *ledgerHash : zero; // kludge
     }
 
-    Ledger::pointer getLedgerBySeq (std::uint32_t index)
+    Ledger::pointer getLedgerBySeq (std::uint32_t index) override
     {
         if (index <= mValidLedgerSeq)
         {
@@ -1562,7 +1562,7 @@ public:
         return Ledger::pointer();
     }
 
-    Ledger::pointer getLedgerByHash (uint256 const& hash)
+    Ledger::pointer getLedgerByHash (uint256 const& hash) override
     {
         if (hash.isZero ())
             return mCurrentLedger.get ();
@@ -1582,33 +1582,33 @@ public:
         return Ledger::pointer ();
     }
 
-    void doLedgerCleaner(Json::Value const& parameters)
+    void doLedgerCleaner(Json::Value const& parameters) override
     {
         mLedgerCleaner->doClean (parameters);
     }
 
-    void setLedgerRangePresent (std::uint32_t minV, std::uint32_t maxV)
+    void setLedgerRangePresent (std::uint32_t minV, std::uint32_t maxV) override
     {
         ScopedLockType sl (mCompleteLock);
         mCompleteLedgers.setRange (minV, maxV);
     }
-    void tune (int size, int age)
+    void tune (int size, int age) override
     {
         mLedgerHistory.tune (size, age);
     }
 
-    void sweep ()
+    void sweep () override
     {
         mLedgerHistory.sweep ();
         fetch_packs_.sweep ();
     }
 
-    float getCacheHitRate ()
+    float getCacheHitRate () override
     {
         return mLedgerHistory.getCacheHitRate ();
     }
 
-    beast::PropertyStream::Source& getPropertySource ()
+    beast::PropertyStream::Source& getPropertySource () override
     {
         return *mLedgerCleaner;
     }
@@ -1647,7 +1647,7 @@ public:
         uint256 haveLedgerHash,
         std::uint32_t uUptime) override;
 
-    std::size_t getFetchPackCacheSize () const;
+    std::size_t getFetchPackCacheSize () const override;
 };
 
 bool LedgerMasterImp::shouldAcquire (

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -455,61 +455,61 @@ public:
 
     //--------------------------------------------------------------------------
 
-    CollectorManager& getCollectorManager ()
+    CollectorManager& getCollectorManager () override
     {
         return *m_collectorManager;
     }
 
     shamap::Family&
-    family()
+    family() override
     {
         return family_;
     }
 
     TimeKeeper&
-    timeKeeper()
+    timeKeeper() override
     {
         return *timeKeeper_;
     }
 
-    JobQueue& getJobQueue ()
+    JobQueue& getJobQueue () override
     {
         return *m_jobQueue;
     }
 
-    LocalCredentials& getLocalCredentials ()
+    LocalCredentials& getLocalCredentials () override
     {
         return m_localCredentials ;
     }
 
-    NetworkOPs& getOPs ()
+    NetworkOPs& getOPs () override
     {
         return *m_networkOPs;
     }
 
-    boost::asio::io_service& getIOService ()
+    boost::asio::io_service& getIOService () override
     {
         return get_io_service();
     }
 
-    std::chrono::milliseconds getIOLatency ()
+    std::chrono::milliseconds getIOLatency () override
     {
         std::unique_lock <std::mutex> m_IOLatencyLock;
 
         return m_io_latency_sampler.get ();
     }
 
-    LedgerMaster& getLedgerMaster ()
+    LedgerMaster& getLedgerMaster () override
     {
         return *m_ledgerMaster;
     }
 
-    InboundLedgers& getInboundLedgers ()
+    InboundLedgers& getInboundLedgers () override
     {
         return *m_inboundLedgers;
     }
 
-    InboundTransactions& getInboundTransactions ()
+    InboundTransactions& getInboundTransactions () override
     {
         return *m_inboundTransactions;
     }
@@ -519,73 +519,73 @@ public:
         m_networkOPs->mapComplete (setHash, set);
     }
 
-    TransactionMaster& getMasterTransaction ()
+    TransactionMaster& getMasterTransaction () override
     {
         return m_txMaster;
     }
 
-    NodeCache& getTempNodeCache ()
+    NodeCache& getTempNodeCache () override
     {
         return m_tempNodeCache;
     }
 
-    NodeStore::Database& getNodeStore ()
+    NodeStore::Database& getNodeStore () override
     {
         return *m_nodeStore;
     }
 
-    Application::MutexType& getMasterMutex ()
+    Application::MutexType& getMasterMutex () override
     {
         return m_masterMutex;
     }
 
-    LoadManager& getLoadManager ()
+    LoadManager& getLoadManager () override
     {
         return *m_loadManager;
     }
 
-    Resource::Manager& getResourceManager ()
+    Resource::Manager& getResourceManager () override
     {
         return *m_resourceManager;
     }
 
-    OrderBookDB& getOrderBookDB ()
+    OrderBookDB& getOrderBookDB () override
     {
         return m_orderBookDB;
     }
 
-    PathRequests& getPathRequests ()
+    PathRequests& getPathRequests () override
     {
         return *m_pathRequests;
     }
 
     CachedSLEs&
-    cachedSLEs()
+    cachedSLEs() override
     {
         return cachedSLEs_;
     }
 
-    AmendmentTable& getAmendmentTable()
+    AmendmentTable& getAmendmentTable() override
     {
         return *m_amendmentTable;
     }
 
-    LoadFeeTrack& getFeeTrack ()
+    LoadFeeTrack& getFeeTrack () override
     {
         return *mFeeTrack;
     }
 
-    HashRouter& getHashRouter ()
+    HashRouter& getHashRouter () override
     {
         return *mHashRouter;
     }
 
-    Validations& getValidations ()
+    Validations& getValidations () override
     {
         return *mValidations;
     }
 
-    UniqueNodeList& getUNL ()
+    UniqueNodeList& getUNL () override
     {
         return *m_deprecatedUNL;
     }
@@ -612,34 +612,34 @@ public:
         return *openLedger_;
     }
 
-    Overlay& overlay ()
+    Overlay& overlay () override
     {
         return *m_overlay;
     }
 
     // VFALCO TODO Move these to the .cpp
-    bool running ()
+    bool running () override
     {
         return mTxnDB != nullptr;
     }
 
-    DatabaseCon& getTxnDB ()
+    DatabaseCon& getTxnDB () override
     {
         assert (mTxnDB.get() != nullptr);
         return *mTxnDB;
     }
-    DatabaseCon& getLedgerDB ()
+    DatabaseCon& getLedgerDB () override
     {
         assert (mLedgerDB.get() != nullptr);
         return *mLedgerDB;
     }
-    DatabaseCon& getWalletDB ()
+    DatabaseCon& getWalletDB () override
     {
         assert (mWalletDB.get() != nullptr);
         return *mWalletDB;
     }
 
-    bool isShutdown ()
+    bool isShutdown () override
     {
         // from Stoppable mixin
         return isStopped();
@@ -689,7 +689,7 @@ public:
     //             Or better yet refactor these initializations into RAII classes
     //             which are members of the Application object.
     //
-    void setup ()
+    void setup () override
     {
         // VFALCO NOTE: 0 means use heuristics to determine the thread count.
         m_jobQueue->setThreadCount (0, getConfig ().RUN_STANDALONE);
@@ -872,7 +872,7 @@ public:
     {
     }
 
-    void onStart ()
+    void onStart () override
     {
         m_journal.info << "Application starting. Build is " << gitCommitID();
 
@@ -885,7 +885,7 @@ public:
     }
 
     // Called to indicate shutdown.
-    void onStop ()
+    void onStop () override
     {
         m_journal.debug << "Application stopping";
 
@@ -922,13 +922,13 @@ public:
     // PropertyStream
     //
 
-    void onWrite (beast::PropertyStream::Map& stream)
+    void onWrite (beast::PropertyStream::Map& stream) override
     {
     }
 
     //------------------------------------------------------------------------------
 
-    void run ()
+    void run () override
     {
         // VFALCO NOTE I put this here in the hopes that when unit tests run (which
         //             tragically require an Application object to exist or else they
@@ -967,14 +967,14 @@ public:
         std::exit(code);
     }
 
-    void signalStop ()
+    void signalStop () override
     {
         // Unblock the main thread (which is sitting in run()).
         //
         m_stop.signal();
     }
 
-    void onDeadlineTimer (beast::DeadlineTimer& timer)
+    void onDeadlineTimer (beast::DeadlineTimer& timer) override
     {
         if (timer == m_entropyTimer)
         {

--- a/src/ripple/app/main/NodeStoreScheduler.h
+++ b/src/ripple/app/main/NodeStoreScheduler.h
@@ -40,9 +40,9 @@ public:
     //
     void setJobQueue (JobQueue& jobQueue);
 
-    void onStop ();
-    void onChildrenStopped ();
-    void scheduleTask (NodeStore::Task& task);
+    void onStop () override;
+    void onChildrenStopped () override;
+    void scheduleTask (NodeStore::Task& task) override;
     void onFetch (NodeStore::FetchReport const& report) override;
     void onBatchWrite (NodeStore::BatchWriteReport const& report) override;
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -349,14 +349,14 @@ public:
     void unsubAccount (
         InfoSub::ref ispListener,
         hash_set<AccountID> const& vnaAccountIDs,
-        bool rt);
+        bool rt) override;
 
     // Just remove the subscription from the tracking
     // not from the InfoSub. Needed for InfoSub destruction
     void unsubAccountInternal (
         std::uint64_t seq,
         hash_set<AccountID> const& vnaAccountIDs,
-        bool rt);
+        bool rt) override;
 
     bool subLedger (InfoSub::ref ispListener, Json::Value& jvResult) override;
     bool unsubLedger (std::uint64_t uListener) override;

--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -79,7 +79,7 @@ public:
     }
 
 private:
-    bool addValidation (STValidation::ref val, std::string const& source)
+    bool addValidation (STValidation::ref val, std::string const& source) override
     {
         RippleAddress signer = val->getSignerPublic ();
         bool isCurrent = false;
@@ -151,13 +151,13 @@ private:
         return false;
     }
 
-    void tune (int size, int age)
+    void tune (int size, int age) override
     {
         mValidations.setTargetSize (size);
         mValidations.setTargetAge (age);
     }
 
-    ValidationSet getValidations (uint256 const& ledger)
+    ValidationSet getValidations (uint256 const& ledger) override
     {
         {
             ScopedLockType sl (mLock);
@@ -169,7 +169,8 @@ private:
         return ValidationSet ();
     }
 
-    void getValidationCount (uint256 const& ledger, bool currentOnly, int& trusted, int& untrusted)
+    void getValidationCount (uint256 const& ledger, bool currentOnly,
+                             int& trusted, int& untrusted) override
     {
         trusted = untrusted = 0;
         ScopedLockType sl (mLock);
@@ -205,7 +206,7 @@ private:
         WriteLog (lsTRACE, Validations) << "VC: " << ledger << "t:" << trusted << " u:" << untrusted;
     }
 
-    void getValidationTypes (uint256 const& ledger, int& full, int& partial)
+    void getValidationTypes (uint256 const& ledger, int& full, int& partial) override
     {
         full = partial = 0;
         ScopedLockType sl (mLock);
@@ -229,7 +230,7 @@ private:
     }
 
 
-    int getTrustedValidationCount (uint256 const& ledger)
+    int getTrustedValidationCount (uint256 const& ledger) override
     {
         int trusted = 0;
         ScopedLockType sl (mLock);
@@ -270,7 +271,7 @@ private:
         return result;
     }
 
-    int getNodesAfter (uint256 const& ledger)
+    int getNodesAfter (uint256 const& ledger) override
     {
         // Number of trusted nodes that have moved past this ledger
         int count = 0;
@@ -283,7 +284,7 @@ private:
         return count;
     }
 
-    int getLoadRatio (bool overLoaded)
+    int getLoadRatio (bool overLoaded) override
     {
         // how many trusted nodes are able to keep up, higher is better
         int goodNodes = overLoaded ? 1 : 0;
@@ -304,7 +305,7 @@ private:
         return (goodNodes * 100) / (goodNodes + badNodes);
     }
 
-    std::list<STValidation::pointer> getCurrentTrustedValidations ()
+    std::list<STValidation::pointer> getCurrentTrustedValidations () override
     {
         // VFALCO LEDGER_VAL_INTERVAL should be a NetClock::duration
         auto const cutoff = getApp().timeKeeper().now().time_since_epoch().count() - LEDGER_VAL_INTERVAL;
@@ -340,7 +341,7 @@ private:
     }
 
     LedgerToValidationCounter getCurrentValidations (
-        uint256 currentLedger, uint256 priorLedger)
+        uint256 currentLedger, uint256 priorLedger) override
     {
         auto const cutoff = getApp().timeKeeper().now().time_since_epoch().count() - LEDGER_VAL_INTERVAL;
         bool valCurrentLedger = currentLedger.isNonZero ();
@@ -391,7 +392,7 @@ private:
     }
 
     std::vector<uint32_t>
-    getValidationTimes (uint256 const& hash)
+    getValidationTimes (uint256 const& hash) override
     {
         std::vector <std::uint32_t> times;
         ScopedLockType sl (mLock);
@@ -402,7 +403,7 @@ private:
         return times;
     }
 
-    void flush ()
+    void flush () override
     {
         bool anyNew = false;
 
@@ -480,7 +481,7 @@ private:
         mWriting = false;
     }
 
-    void sweep ()
+    void sweep () override
     {
         ScopedLockType sl (mLock);
         mValidations.sweep ();

--- a/src/ripple/app/tx/impl/InboundTransactions.cpp
+++ b/src/ripple/app/tx/impl/InboundTransactions.cpp
@@ -140,7 +140,7 @@ public:
     */
     void gotData (LedgerHash const& hash,
             std::shared_ptr<Peer> peer,
-            std::shared_ptr<protocol::TMLedgerData> packet_ptr)
+            std::shared_ptr<protocol::TMLedgerData> packet_ptr) override
     {
         protocol::TMLedgerData& packet = *packet_ptr;
 

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -553,7 +553,7 @@ private:
     // Invariants:
     //  <none>
     //
-    void processTask ()
+    void processTask () override
     {
         Job job;
 
@@ -624,7 +624,7 @@ private:
 
     //--------------------------------------------------------------------------
 
-    void onStop ()
+    void onStop () override
     {
         // VFALCO NOTE I wanted to remove all the jobs that are skippable
         //             but then the Workers count of tasks to process
@@ -676,7 +676,7 @@ private:
         */
     }
 
-    void onChildrenStopped ()
+    void onChildrenStopped () override
     {
         ScopedLock lock (m_mutex);
 

--- a/src/ripple/nodestore/DummyScheduler.h
+++ b/src/ripple/nodestore/DummyScheduler.h
@@ -31,7 +31,7 @@ class DummyScheduler : public Scheduler
 public:
     DummyScheduler ();
     ~DummyScheduler ();
-    void scheduleTask (Task& task);
+    void scheduleTask (Task& task) override;
     void scheduledTasksStopped ();
     void onFetch (FetchReport const& report) override;
     void onBatchWrite (BatchWriteReport const& report) override;

--- a/src/ripple/nodestore/backend/MemoryFactory.cpp
+++ b/src/ripple/nodestore/backend/MemoryFactory.cpp
@@ -98,7 +98,7 @@ public:
     }
 
     std::string
-    getName ()
+    getName () override
     {
         return name_;
     }
@@ -112,7 +112,7 @@ public:
     //--------------------------------------------------------------------------
 
     Status
-    fetch (void const* key, std::shared_ptr<NodeObject>* pObject)
+    fetch (void const* key, std::shared_ptr<NodeObject>* pObject) override
     {
         uint256 const hash (uint256::fromVoid (key));
 
@@ -142,28 +142,28 @@ public:
     }
 
     void
-    store (std::shared_ptr<NodeObject> const& object)
+    store (std::shared_ptr<NodeObject> const& object) override
     {
         std::lock_guard<std::mutex> _(db_->mutex);
         db_->table.emplace (object->getHash(), object);
     }
 
     void
-    storeBatch (Batch const& batch)
+    storeBatch (Batch const& batch) override
     {
         for (auto const& e : batch)
             store (e);
     }
 
     void
-    for_each (std::function <void(std::shared_ptr<NodeObject>)> f)
+    for_each (std::function <void(std::shared_ptr<NodeObject>)> f) override
     {
         for (auto const& e : db_->table)
             f (e.second);
     }
 
     int
-    getWriteLoad()
+    getWriteLoad() override
     {
         return 0;
     }

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -107,7 +107,7 @@ public:
     }
 
     std::string
-    getName()
+    getName() override
     {
         return name_;
     }
@@ -126,7 +126,7 @@ public:
     }
 
     Status
-    fetch (void const* key, std::shared_ptr<NodeObject>* pno)
+    fetch (void const* key, std::shared_ptr<NodeObject>* pno) override
     {
         Status status;
         pno->reset();
@@ -201,7 +201,7 @@ public:
     }
 
     void
-    for_each (std::function <void(std::shared_ptr<NodeObject>)> f)
+    for_each (std::function <void(std::shared_ptr<NodeObject>)> f) override
     {
         auto const dp = db_.dat_path();
         auto const kp = db_.key_path();
@@ -224,7 +224,7 @@ public:
     }
 
     int
-    getWriteLoad ()
+    getWriteLoad () override
     {
         return 0;
     }

--- a/src/ripple/nodestore/backend/NullFactory.cpp
+++ b/src/ripple/nodestore/backend/NullFactory.cpp
@@ -37,7 +37,7 @@ public:
     }
 
     std::string
-    getName()
+    getName() override
     {
         return std::string ();
     }
@@ -48,7 +48,7 @@ public:
     }
 
     Status
-    fetch (void const*, std::shared_ptr<NodeObject>*)
+    fetch (void const*, std::shared_ptr<NodeObject>*) override
     {
         return notFound;
     }
@@ -67,22 +67,22 @@ public:
     }
 
     void
-    store (std::shared_ptr<NodeObject> const& object)
+    store (std::shared_ptr<NodeObject> const& object) override
     {
     }
 
     void
-    storeBatch (Batch const& batch)
+    storeBatch (Batch const& batch) override
     {
     }
 
     void
-    for_each (std::function <void(std::shared_ptr<NodeObject>)> f)
+    for_each (std::function <void(std::shared_ptr<NodeObject>)> f) override
     {
     }
 
     int
-    getWriteLoad ()
+    getWriteLoad () override
     {
         return 0;
     }

--- a/src/ripple/nodestore/impl/DatabaseImp.h
+++ b/src/ripple/nodestore/impl/DatabaseImp.h
@@ -119,7 +119,7 @@ public:
 
     //------------------------------------------------------------------------------
 
-    bool asyncFetch (uint256 const& hash, std::shared_ptr<NodeObject>& object)
+    bool asyncFetch (uint256 const& hash, std::shared_ptr<NodeObject>& object) override
     {
         // See if the object is in cache
         object = m_cache.fetch (hash);
@@ -150,7 +150,7 @@ public:
 
     }
 
-    int getDesiredAsyncReadCount ()
+    int getDesiredAsyncReadCount () override
     {
         // We prefer a client not fill our cache
         // We don't want to push data out of the cache
@@ -306,12 +306,12 @@ public:
 
     //------------------------------------------------------------------------------
 
-    float getCacheHitRate ()
+    float getCacheHitRate () override
     {
         return m_cache.getHitRate ();
     }
 
-    void tune (int size, int age)
+    void tune (int size, int age) override
     {
         m_cache.setTargetSize (size);
         m_cache.setTargetAge (age);
@@ -319,7 +319,7 @@ public:
         m_negCache.setTargetAge (age);
     }
 
-    void sweep ()
+    void sweep () override
     {
         m_cache.sweep ();
         m_negCache.sweep ();
@@ -381,7 +381,7 @@ public:
         m_backend->for_each (f);
     }
 
-    void import (Database& source)
+    void import (Database& source) override
     {
         importInternal (source, *m_backend.get());
     }

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -317,7 +317,7 @@ private:
     //
 
     void
-    onWrite (beast::PropertyStream::Map& stream);
+    onWrite (beast::PropertyStream::Map& stream) override;
 
     //--------------------------------------------------------------------------
 

--- a/src/ripple/peerfinder/impl/PeerfinderManager.cpp
+++ b/src/ripple/peerfinder/impl/PeerfinderManager.cpp
@@ -219,18 +219,18 @@ public:
     //--------------------------------------------------------------------------
 
     void
-    onPrepare ()
+    onPrepare () override
     {
         m_store.open (m_sociConfig);
         m_logic.load ();
     }
 
     void
-    onStart()
+    onStart() override
     {
     }
 
-    void onStop ()
+    void onStop () override
     {
         close();
         stopped();
@@ -242,7 +242,7 @@ public:
     //
     //--------------------------------------------------------------------------
 
-    void onWrite (beast::PropertyStream::Map& map)
+    void onWrite (beast::PropertyStream::Map& map) override
     {
         m_logic.onWrite (map);
     }

--- a/src/ripple/server/tests/Server.test.cpp
+++ b/src/ripple/server/tests/Server.test.cpp
@@ -137,7 +137,7 @@ public:
         }
 
         void
-        onStopped (Server& server)
+        onStopped (Server& server) override
         {
         }
     };

--- a/src/ripple/unity/rocksdb.h
+++ b/src/ripple/unity/rocksdb.h
@@ -22,6 +22,14 @@
 
 #include <beast/Config.h>
 
+#ifdef __clang_major__
+#if __clang_major__ >= 7
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Winconsistent-missing-override"
+# pragma clang diagnostic ignored "-Wuninitialized"
+#endif
+#endif
+
 #ifndef RIPPLE_ROCKSDB_AVAILABLE
 #if BEAST_WIN32
 # define ROCKSDB_PLATFORM_WINDOWS

--- a/src/ripple/websocket/Handler.h
+++ b/src/ripple/websocket/Handler.h
@@ -455,17 +455,17 @@ public:
     }
 
     boost::asio::ssl::context&
-    get_ssl_context ()
+    get_ssl_context () override
     {
         return *port().context;
     }
 
-    bool plain_only()
+    bool plain_only() override
     {
         return port().protocol.count("wss") == 0;
     }
 
-    bool secure_only()
+    bool secure_only() override
     {
         return port().protocol.count("ws") == 0;
     }

--- a/src/ripple/websocket/WebSocket04.h
+++ b/src/ripple/websocket/WebSocket04.h
@@ -48,6 +48,9 @@ struct WebSocket04
         virtual void on_message (ConnectionPtr, MessagePtr) = 0;
         // This is a new method added by Ripple.
         virtual void on_send_empty (ConnectionPtr) = 0;
+        virtual boost::asio::ssl::context& get_ssl_context() = 0;
+        virtual bool plain_only() = 0;
+        virtual bool secure_only() = 0;
     };
 
     using HandlerPtr = std::shared_ptr<Handler>;


### PR DESCRIPTION
…on latest clang compiler.

This gets rippled compiling with no errors on OS X, with the existing clang, and with the new (updated yesterday) clang.  There are no logic changes, just warning suppression, mainly adding override in a bunch of places.

Looking for volunteer reviewers.  This is a light read.  If it compiles on your platform it passes.