### PR TITLE
Remove deprecated fee interfaces

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -1140,46 +1140,6 @@ qualityDirDescriber (
     }
 }
 
-void Ledger::deprecatedUpdateCachedFees() const
-{
-    if (mBaseFee)
-        return;
-    std::uint64_t baseFee = getConfig ().FEE_DEFAULT;
-    std::uint32_t referenceFeeUnits = getConfig ().TRANSACTION_FEE_BASE;
-    std::uint32_t reserveBase = getConfig ().FEE_ACCOUNT_RESERVE;
-    std::int64_t reserveIncrement = getConfig ().FEE_OWNER_RESERVE;
-
-    // VFALCO NOTE this doesn't go through the CachedSLEs
-    auto const sle = this->read(keylet::fees());
-    if (sle)
-    {
-        if (sle->getFieldIndex (sfBaseFee) != -1)
-            baseFee = sle->getFieldU64 (sfBaseFee);
-
-        if (sle->getFieldIndex (sfReferenceFeeUnits) != -1)
-            referenceFeeUnits = sle->getFieldU32 (sfReferenceFeeUnits);
-
-        if (sle->getFieldIndex (sfReserveBase) != -1)
-            reserveBase = sle->getFieldU32 (sfReserveBase);
-
-        if (sle->getFieldIndex (sfReserveIncrement) != -1)
-            reserveIncrement = sle->getFieldU32 (sfReserveIncrement);
-    }
-
-    {
-        // VFALCO Why not do this before calling getASNode?
-        std::lock_guard<
-            std::mutex> lock(mutex_);
-        if (mBaseFee == 0)
-        {
-            mBaseFee = baseFee;
-            mReferenceFeeUnits = referenceFeeUnits;
-            mReserveBase = reserveBase;
-            mReserveIncrement = reserveIncrement;
-        }
-    }
-}
-
 std::vector<uint256>
 Ledger::getNeededTransactionHashes (
     int max, SHAMapSyncFilter* filter) const

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -329,36 +329,6 @@ public:
     std::vector<uint256> getNeededAccountStateHashes (
         int max, SHAMapSyncFilter* filter) const;
 
-    std::uint32_t getReferenceFeeUnits() const
-    {
-        // Returns the cost of the reference transaction in fee units
-        deprecatedUpdateCachedFees ();
-        return mReferenceFeeUnits;
-    }
-
-    std::uint64_t getBaseFee() const
-    {
-        // Returns the cost of the reference transaction in drops
-        deprecatedUpdateCachedFees ();
-        return mBaseFee;
-    }
-
-    // DEPRECATED use fees()
-    std::uint64_t getReserve (int increments) const
-    {
-        // Returns the required reserve in drops
-        deprecatedUpdateCachedFees ();
-        return static_cast<std::uint64_t> (increments) * mReserveIncrement
-            + mReserveBase;
-    }
-
-    // DEPRECATED use fees()
-    std::uint64_t getReserveInc () const
-    {
-        deprecatedUpdateCachedFees ();
-        return mReserveIncrement;
-    }
-
     bool walkLedger () const;
 
     bool assertSane ();
@@ -376,13 +346,6 @@ private:
     void
     updateHash();
 
-    // Updates the fees cached in the ledger.
-    // Safe to call concurrently. We shouldn't be storing
-    // fees in the Ledger object, they should be a local side-structure
-    // associated with a particular module (rpc, tx processing, consensus)
-    //
-    void deprecatedUpdateCachedFees() const;
-
     // The basic Ledger structure, can be opened, closed, or synching
 
     bool mValidHash = false;
@@ -397,17 +360,6 @@ private:
     Fees fees_;
     Rules rules_;
     LedgerInfo info_;
-
-    // Ripple cost of the reference transaction
-    std::uint64_t mutable mBaseFee = 0;
-
-    // Fee units for the reference transaction
-    std::uint32_t mutable mReferenceFeeUnits = 0;
-
-    // Reserve base in drops
-    std::uint32_t mutable mReserveBase = 0;
-    // Reserve increment in drops
-    std::uint32_t mutable mReserveIncrement = 0;
 };
 
 /** A ledger wrapped in a CachedView. */

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -119,7 +119,7 @@ void
 FeeVoteImpl::doValidation (Ledger::ref lastClosedLedger,
     STObject& baseValidation)
 {
-    if (lastClosedLedger->getBaseFee () != target_.reference_fee)
+    if (lastClosedLedger->fees().base != target_.reference_fee)
     {
         if (journal_.info) journal_.info <<
             "Voting for base fee of " << target_.reference_fee;
@@ -127,7 +127,7 @@ FeeVoteImpl::doValidation (Ledger::ref lastClosedLedger,
         baseValidation.setFieldU64 (sfBaseFee, target_.reference_fee);
     }
 
-    if (lastClosedLedger->getReserve (0) != target_.account_reserve)
+    if (lastClosedLedger->fees().accountReserve(0) != target_.account_reserve)
     {
         if (journal_.info) journal_.info <<
             "Voting for base resrve of " << target_.account_reserve;
@@ -135,7 +135,7 @@ FeeVoteImpl::doValidation (Ledger::ref lastClosedLedger,
         baseValidation.setFieldU32(sfReserveBase, target_.account_reserve);
     }
 
-    if (lastClosedLedger->getReserveInc () != target_.owner_reserve)
+    if (lastClosedLedger->fees().increment != target_.owner_reserve)
     {
         if (journal_.info) journal_.info <<
             "Voting for reserve increment of " << target_.owner_reserve;
@@ -154,13 +154,13 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
     assert ((lastClosedLedger->info().seq % 256) == 0);
 
     detail::VotableInteger<std::uint64_t> baseFeeVote (
-        lastClosedLedger->getBaseFee (), target_.reference_fee);
+        lastClosedLedger->fees().base, target_.reference_fee);
 
     detail::VotableInteger<std::uint32_t> baseReserveVote (
-        lastClosedLedger->getReserve (0), target_.account_reserve);
+        lastClosedLedger->fees().accountReserve(0).drops(), target_.account_reserve);
 
     detail::VotableInteger<std::uint32_t> incReserveVote (
-        lastClosedLedger->getReserveInc (), target_.owner_reserve);
+        lastClosedLedger->fees().increment, target_.owner_reserve);
 
     for (auto const& e : set)
     {
@@ -203,9 +203,9 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
     std::uint32_t const incReserve = incReserveVote.getVotes ();
 
     // add transactions to our position
-    if ((baseFee != lastClosedLedger->getBaseFee ()) ||
-            (baseReserve != lastClosedLedger->getReserve (0)) ||
-            (incReserve != lastClosedLedger->getReserveInc ()))
+    if ((baseFee != lastClosedLedger->fees().base) ||
+            (baseReserve != lastClosedLedger->fees().accountReserve(0)) ||
+            (incReserve != lastClosedLedger->fees().increment))
     {
         if (journal_.warning) journal_.warning <<
             "We are voting for a fee change: " << baseFee <<

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2003,8 +2003,8 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
     if (lpClosed)
     {
-        std::uint64_t baseFee = lpClosed->getBaseFee ();
-        std::uint64_t baseRef = lpClosed->getReferenceFeeUnits ();
+        std::uint64_t baseFee = lpClosed->fees().base;
+        std::uint64_t baseRef = lpClosed->fees().units;
         Json::Value l (Json::objectValue);
         l[jss::seq] = Json::UInt (lpClosed->info().seq);
         l[jss::hash] = to_string (lpClosed->getHash ());
@@ -2012,9 +2012,9 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
         if (!human)
         {
             l[jss::base_fee] = Json::Value::UInt (baseFee);
-            l[jss::reserve_base] = Json::Value::UInt (lpClosed->getReserve (0));
+            l[jss::reserve_base] = Json::Value::UInt (lpClosed->fees().accountReserve(0).drops());
             l[jss::reserve_inc] =
-                    Json::Value::UInt (lpClosed->getReserveInc ());
+                    Json::Value::UInt (lpClosed->fees().increment);
             l[jss::close_time] =
                     Json::Value::UInt (lpClosed->info().closeTime);
         }
@@ -2024,11 +2024,11 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
                     SYSTEM_CURRENCY_PARTS;
             l[jss::reserve_base_xrp]   =
                 static_cast<double> (Json::UInt (
-                    lpClosed->getReserve (0) * baseFee / baseRef))
+                    lpClosed->fees().accountReserve(0).drops() * baseFee / baseRef))
                     / SYSTEM_CURRENCY_PARTS;
             l[jss::reserve_inc_xrp]    =
                 static_cast<double> (Json::UInt (
-                    lpClosed->getReserveInc () * baseFee / baseRef))
+                    lpClosed->fees().increment * baseFee / baseRef))
                     / SYSTEM_CURRENCY_PARTS;
 
             auto const nowOffset = app_.timeKeeper().nowOffset();
@@ -2137,10 +2137,10 @@ void NetworkOPsImp::pubLedger (Ledger::ref lpAccepted)
                     = Json::Value::UInt (lpAccepted->info().closeTime);
 
             jvObj[jss::fee_ref]
-                    = Json::UInt (lpAccepted->getReferenceFeeUnits ());
-            jvObj[jss::fee_base] = Json::UInt (lpAccepted->getBaseFee ());
-            jvObj[jss::reserve_base] = Json::UInt (lpAccepted->getReserve (0));
-            jvObj[jss::reserve_inc] = Json::UInt (lpAccepted->getReserveInc ());
+                    = Json::UInt (lpAccepted->fees().units);
+            jvObj[jss::fee_base] = Json::UInt (lpAccepted->fees().base);
+            jvObj[jss::reserve_base] = Json::UInt (lpAccepted->fees().accountReserve(0).drops());
+            jvObj[jss::reserve_inc] = Json::UInt (lpAccepted->fees().increment);
 
             jvObj[jss::txn_count] = Json::UInt (alpAccepted->getTxnCount ());
 
@@ -2496,10 +2496,10 @@ bool NetworkOPsImp::subLedger (InfoSub::ref isrListener, Json::Value& jvResult)
         jvResult[jss::ledger_time]
                 = Json::Value::UInt (lpClosed->info().closeTime);
         jvResult[jss::fee_ref]
-                = Json::UInt (lpClosed->getReferenceFeeUnits ());
-        jvResult[jss::fee_base]        = Json::UInt (lpClosed->getBaseFee ());
-        jvResult[jss::reserve_base]    = Json::UInt (lpClosed->getReserve (0));
-        jvResult[jss::reserve_inc]     = Json::UInt (lpClosed->getReserveInc ());
+                = Json::UInt (lpClosed->fees().units);
+        jvResult[jss::fee_base]        = Json::UInt (lpClosed->fees().base);
+        jvResult[jss::reserve_base]    = Json::UInt (lpClosed->fees().accountReserve(0).drops());
+        jvResult[jss::reserve_inc]     = Json::UInt (lpClosed->fees().increment);
     }
 
     if ((mMode >= omSYNCING) && !isNeedNetworkLedger ())

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -261,7 +261,7 @@ Payment::doApply ()
         }
         else if (saDstAmount < STAmount (view().fees().accountReserve(0)))
         {
-            // getReserve() is the minimum amount that an account can have.
+            // accountReserve is the minimum amount that an account can have.
             // Reserve is not scaled by load.
             j_.trace <<
                 "Delay transaction: Destination account does not exist. " <<


### PR DESCRIPTION
This eliminates the need for `getConfig` in Ledger.cpp, and gets rid of some redundant state members.

Reviewers: @nbougalis @JoelKatz 