### PR TITLE
Add '--valid" command line option to consider starting ledger valid

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -463,7 +463,7 @@ public:
             logs_->journal("TaggedCache"))
 
         , m_networkOPs (make_NetworkOPs (*this, stopwatch(),
-            config_->RUN_STANDALONE, config_->NETWORK_QUORUM,
+            config_->RUN_STANDALONE, config_->NETWORK_QUORUM, config_->START_VALID,
             *m_jobQueue, *m_ledgerMaster, *m_jobQueue,
             logs_->journal("NetworkOPs")))
 

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -292,6 +292,7 @@ int run (int argc, char** argv)
     ("quorum", po::value <int> (), "Set the validation quorum.")
     ("verbose,v", "Verbose logging.")
     ("load", "Load the current ledger from the local DB.")
+    ("valid", "Consider the initial ledger a valid network ledger.")
     ("replay","Replay a ledger close.")
     ("ledger", po::value<std::string> (), "Load the specified ledger and start from .")
     ("ledgerfile", po::value<std::string> (), "Load the specified ledger file.")
@@ -409,8 +410,22 @@ int run (int argc, char** argv)
     {
         config->START_UP = Config::LOAD;
     }
-    else if (vm.count ("net"))
+
+    if (vm.count ("valid"))
     {
+        config->START_VALID = true;
+    }
+
+    if (vm.count ("net"))
+    {
+        if ((config->START_UP == Config::LOAD) ||
+            (config->START_UP == Config::REPLAY))
+        {
+            std::cerr <<
+                "Net and load/reply options are incompatible" << std::endl;
+            return -1;
+        }
+
         config->START_UP = Config::NETWORK;
 
         if (config->VALIDATION_QUORUM < 2)

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -117,7 +117,7 @@ public:
     //
     NetworkOPsImp (
         Application& app, clock_type& clock, bool standalone,
-            std::size_t network_quorum, JobQueue& job_queue,
+            std::size_t network_quorum, bool start_valid, JobQueue& job_queue,
                 LedgerMaster& ledgerMaster, Stoppable& parent,
                     beast::Journal journal)
         : NetworkOPs (parent)
@@ -125,7 +125,7 @@ public:
         , m_clock (clock)
         , m_journal (journal)
         , m_localTX (make_LocalTxs ())
-        , mMode (omDISCONNECTED)
+        , mMode (start_valid ? omFULL : omDISCONNECTED)
         , mNeedNetworkLedger (false)
         , m_amendmentBlocked (false)
         , m_heartbeatTimer (this)
@@ -136,7 +136,7 @@ public:
         , mLastLoadFactor (256)
         , m_job_queue (job_queue)
         , m_standalone (standalone)
-        , m_network_quorum (network_quorum)
+        , m_network_quorum (start_valid ? 0 : network_quorum)
     {
     }
 
@@ -2927,11 +2927,12 @@ NetworkOPs::~NetworkOPs ()
 
 std::unique_ptr<NetworkOPs>
 make_NetworkOPs (Application& app, NetworkOPs::clock_type& clock, bool standalone,
-    std::size_t network_quorum, JobQueue& job_queue, LedgerMaster& ledgerMaster,
+    std::size_t network_quorum, bool startvalid,
+    JobQueue& job_queue, LedgerMaster& ledgerMaster,
     beast::Stoppable& parent, beast::Journal journal)
 {
     return std::make_unique<NetworkOPsImp> (app, clock, standalone, network_quorum,
-        job_queue, ledgerMaster, parent, journal);
+        startvalid, job_queue, ledgerMaster, parent, journal);
 }
 
 } // ripple

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -236,7 +236,8 @@ public:
 
 std::unique_ptr<NetworkOPs>
 make_NetworkOPs (Application& app, NetworkOPs::clock_type& clock, bool standalone,
-    std::size_t network_quorum, JobQueue& job_queue, LedgerMaster& ledgerMaster,
+    std::size_t network_quorum, bool start_valid,
+    JobQueue& job_queue, LedgerMaster& ledgerMaster,
     beast::Stoppable& parent, beast::Journal journal);
 
 } // ripple

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -185,7 +185,7 @@ public:
     };
     StartUpType                 START_UP = NORMAL;
 
-
+    bool                        START_VALID = false;
 
     std::string                 START_LEDGER;
 


### PR DESCRIPTION
Also, output an error if "--net" is specified with incompatible ledger start options.