### PR TITLE
[TRIVIAL] Update ripple-lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash": "^3.5.0",
     "mocha": "^2.1.0",
     "request": "^2.47.0",
-    "ripple-lib": "0.13.0-rc6",
+    "ripple-lib": "0.13.0-rc6.0",
     "simple-jsonrpc": "~0.0.2"
   },
   "scripts": {


### PR DESCRIPTION
Resolves the problem where rc6 was removed from the repo
