### PR TITLE
Resolve override and copy elision prevention issues:

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -715,6 +715,22 @@ def get_soci_sources(style):
                        CPPPATH=cpp_path)
     return result
 
+def use_shp(toolchain):
+    '''
+    Return True if we want to use the --system-header-prefix command-line switch
+    '''
+    if toolchain != 'clang':
+        return False
+    if use_shp.cache is None:
+        try:
+            ver = subprocess.check_output(
+                ['clang', '--version'], stderr=subprocess.STDOUT).strip()
+            use_shp.cache = 'version 3.4' not in ver and 'version 3.0' not in ver
+        except:
+            use_shp.cache = False
+    return use_shp.cache
+use_shp.cache = None
+
 def get_common_sources(toolchain):
     result = []
     if toolchain == 'msvc':
@@ -752,6 +768,11 @@ def get_classic_sources(toolchain):
     append_sources(result, *list_sources('src/ripple/test', '.cpp'))
     append_sources(result, *list_sources('src/ripple/unl', '.cpp'))
 
+    if use_shp(toolchain):
+        cc_flags = {'CCFLAGS': ['--system-header-prefix=rocksdb2']}
+    else:
+        cc_flags = {}
+
     append_sources(
         result,
         *list_sources('src/ripple/nodestore', '.cpp'),
@@ -759,7 +780,8 @@ def get_classic_sources(toolchain):
             'src/rocksdb2/include',
             'src/snappy/snappy',
             'src/snappy/config',
-        ])
+        ],
+        **cc_flags)
 
     result += get_soci_sources('classic')
     result += get_common_sources(toolchain)
@@ -791,6 +813,11 @@ def get_unity_sources(toolchain):
         'src/ripple/unity/unl.cpp',
     )
 
+    if use_shp(toolchain):
+        cc_flags = {'CCFLAGS': ['--system-header-prefix=rocksdb2']}
+    else:
+        cc_flags = {}
+
     append_sources(
         result,
         'src/ripple/unity/nodestore.cpp',
@@ -798,7 +825,8 @@ def get_unity_sources(toolchain):
             'src/rocksdb2/include',
             'src/snappy/snappy',
             'src/snappy/config',
-        ])
+        ],
+        **cc_flags)
 
     result += get_soci_sources('unity')
     result += get_common_sources(toolchain)
@@ -908,6 +936,11 @@ for tu_style in ['classic', 'unity']:
                 'src/ripple/unity/git_id.cpp',
                 **git_commit_tag)
 
+            if use_shp(toolchain):
+                cc_flags = {'CCFLAGS': ['--system-header-prefix=rocksdb2']}
+            else:
+                cc_flags = {}
+
             object_builder.add_source_files(
                 'src/beast/beast/unity/hash_unity.cpp',
                 'src/ripple/unity/beast.cpp',
@@ -916,7 +949,8 @@ for tu_style in ['classic', 'unity']:
                 'src/ripple/unity/ripple.proto.cpp',
                 'src/ripple/unity/resource.cpp',
                 'src/ripple/unity/server.cpp',
-                'src/ripple/unity/websocket02.cpp'
+                'src/ripple/unity/websocket02.cpp',
+                **cc_flags
             )
 
             object_builder.add_source_files(
@@ -924,9 +958,11 @@ for tu_style in ['classic', 'unity']:
                 CCFLAGS = ([] if toolchain == 'msvc' else ['-Wno-array-bounds']))
 
             if 'gcc' in toolchain:
-                no_uninitialized_warning = {'CCFLAGS': ['-Wno-maybe-uninitialized']}
+                cc_flags = {'CCFLAGS': ['-Wno-maybe-uninitialized']}
+            elif use_shp(toolchain):
+                cc_flags = {'CCFLAGS': ['--system-header-prefix=rocksdb2']}
             else:
-                no_uninitialized_warning = {}
+                cc_flags = {}
 
             object_builder.add_source_files(
                 'src/ripple/unity/ed25519.c',
@@ -943,7 +979,7 @@ for tu_style in ['classic', 'unity']:
                     'src/snappy/snappy',
                     'src/snappy/config',
                 ],
-                **no_uninitialized_warning
+                **cc_flags
             )
 
             object_builder.add_source_files(

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -757,9 +757,7 @@ Ledger::peek (Keylet const& k) const
         return nullptr;
     // VFALCO TODO Eliminate "immutable" runtime property
     sle->setImmutable();
-    // need move otherwise makes a copy
-    // because return type is different
-    return std::move(sle);
+    return sle;
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -196,7 +196,7 @@ public:
     }
 
     std::string
-    getName()
+    getName() override
     {
         return m_name;
     }
@@ -204,7 +204,7 @@ public:
     //--------------------------------------------------------------------------
 
     Status
-    fetch (void const* key, std::shared_ptr<NodeObject>* pObject)
+    fetch (void const* key, std::shared_ptr<NodeObject>* pObject) override
     {
         pObject->reset ();
 
@@ -267,13 +267,13 @@ public:
     }
 
     void
-    store (std::shared_ptr<NodeObject> const& object)
+    store (std::shared_ptr<NodeObject> const& object) override
     {
         m_batch.store (object);
     }
 
     void
-    storeBatch (Batch const& batch)
+    storeBatch (Batch const& batch) override
     {
         rocksdb::WriteBatch wb;
 
@@ -299,7 +299,7 @@ public:
     }
 
     void
-    for_each (std::function <void(std::shared_ptr<NodeObject>)> f)
+    for_each (std::function <void(std::shared_ptr<NodeObject>)> f) override
     {
         rocksdb::ReadOptions const options;
 
@@ -336,7 +336,7 @@ public:
     }
 
     int
-    getWriteLoad ()
+    getWriteLoad () override
     {
         return m_batch.getWriteLoad ();
     }
@@ -350,7 +350,7 @@ public:
     //--------------------------------------------------------------------------
 
     void
-    writeBatch (Batch const& batch)
+    writeBatch (Batch const& batch) override
     {
         storeBatch (batch);
     }

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -179,7 +179,7 @@ public:
     }
 
     std::string
-    getName()
+    getName() override
     {
         return m_name;
     }
@@ -201,7 +201,7 @@ public:
     //--------------------------------------------------------------------------
 
     Status
-    fetch (void const* key, std::shared_ptr<NodeObject>* pObject)
+    fetch (void const* key, std::shared_ptr<NodeObject>* pObject) override
     {
         pObject->reset ();
 
@@ -257,7 +257,7 @@ public:
     }
 
     void
-    store (std::shared_ptr<NodeObject> const& object)
+    store (std::shared_ptr<NodeObject> const& object) override
     {
         storeBatch(Batch{object});
     }
@@ -270,7 +270,7 @@ public:
     }
 
     void
-    storeBatch (Batch const& batch)
+    storeBatch (Batch const& batch) override
     {
         rocksdb::WriteBatch wb;
 
@@ -299,7 +299,7 @@ public:
     }
 
     void
-    for_each (std::function <void(std::shared_ptr<NodeObject>)> f)
+    for_each (std::function <void(std::shared_ptr<NodeObject>)> f) override
     {
         rocksdb::ReadOptions const options;
 
@@ -336,7 +336,7 @@ public:
     }
 
     int
-    getWriteLoad ()
+    getWriteLoad () override
     {
         return 0;
     }

--- a/src/ripple/protocol/impl/STParsedJSON.cpp
+++ b/src/ripple/protocol/impl/STParsedJSON.cpp
@@ -862,7 +862,7 @@ STParsedJSONObject::STParsedJSONObject (
     Json::Value const& json)
 {
     using namespace STParsedJSONDetail;
-    object = std::move (parseObject (name, json, sfGeneric, 0, error));
+    object = parseObject (name, json, sfGeneric, 0, error);
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -127,7 +127,7 @@ make_stvar(Args&&... args)
 {
     STVar st;
     st.construct<T>(std::forward<Args>(args)...);
-    return std::move(st);
+    return st;
 }
 
 inline

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -792,7 +792,7 @@ Json::Value transactionSignFor (
     {
         Json::Value err = checkMultiSignFields (jvRequest);
         if (RPC::contains_error (err))
-            return std::move (err);
+            return err;
     }
 
     // Add and amend fields based on the transaction type.
@@ -880,7 +880,7 @@ Json::Value transactionSubmitMultiSigned (
     {
         Json::Value err = checkMultiSignFields (jvRequest);
         if (RPC::contains_error (err))
-            return std::move (err);
+            return err;
     }
 
     Json::Value& tx_json (jvRequest ["tx_json"]);
@@ -913,7 +913,7 @@ Json::Value transactionSubmitMultiSigned (
             jvRequest, role, false, app.config(), app.getFeeTrack(), ledger);
 
         if (RPC::contains_error(err))
-            return std::move (err);
+            return err;
 
         err = checkPayment (
             jvRequest,
@@ -925,7 +925,7 @@ Json::Value transactionSubmitMultiSigned (
             false);
 
         if (RPC::contains_error(err))
-            return std::move (err);
+            return err;
     }
 
     // Grind through the JSON in tx_json to produce a STTx


### PR DESCRIPTION
* Add rocksdb to system-headers to squelch warnings from files we cannot change
* Add missing overrides to rocksdb functions in rippled proper
* Remove `moves` preventing copy elision

This PR is motivated from new warnings emitted from clang 3.6 and clang 3.7. Rippled should now build without warnings with these compilers.

@HowardHinnant @scottschurr (Welcome back guys!)