### PR TITLE
[TRIVIAL] Initialize HTTP client after the config is loaded

### DIFF
--- a/Builds/rpm/rippled.spec
+++ b/Builds/rpm/rippled.spec
@@ -1,5 +1,5 @@
 Name:           rippled
-Version:        0.29.1-rc1
+Version:        0.29.1-rc2
 Release:        1%{?dist}
 Summary:        Ripple peer-to-peer network daemon
 

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -479,9 +479,15 @@ void LedgerConsensusImp::mapCompleteInternal (
         else
             assert (false); // We don't have our own position?!
     }
-    else
+    else if (!mOurPosition)
+        JLOG (j_.debug)
+            << "Not creating disputes: no position yet.";
+    else if (mOurPosition->isBowOut ())
         JLOG (j_.warning)
-            << "Not ready to create disputes";
+            << "Not creating disputes: not participating.";
+    else
+        JLOG (j_.debug)
+            << "Not creating disputes: identical position.";
 
     mAcquired[hash] = map;
 
@@ -993,8 +999,8 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
     // If we don't have a close time, then we just agree to disagree
     bool const closeTimeCorrect = (closeTime != 0);
 
-    // Switch to new semantics on Sep 30, 2015 at 11:00:00am PDT
-    if (mPreviousLedger->info().closeTime > 497296800)
+    // Switch to new semantics on Oct 21, 2015 at 11:00:00am PDT
+    if (mPreviousLedger->info().closeTime > 498765600)
     {
         // Ledger close times should increase strictly monotonically
         if (closeTime <= mPreviousLedger->info().closeTime)

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -282,7 +282,7 @@ int run (int argc, char** argv)
     ("conf", po::value<std::string> (), "Specify the configuration file.")
     ("rpc", "Perform rpc command (default).")
     ("rpc_ip", po::value <std::string> (), "Specify the IP address for RPC command. Format: <ip-address>[':'<port-number>]")
-    ("rpc_port", po::value <int> (), "Specify the port number for RPC command.")
+    ("rpc_port", po::value <std::uint16_t> (), "Specify the port number for RPC command.")
     ("standalone,a", "Run with no peers.")
     ("shutdowntest", po::value <std::string> ()->implicit_value (""), "Perform shutdown tests.")
     ("unittest,u", po::value <std::string> ()->implicit_value (""), "Perform unit tests.")
@@ -438,9 +438,9 @@ int run (int argc, char** argv)
     {
         try
         {
-            config->rpc_ip =
+            config->rpc_ip.emplace (
                 boost::asio::ip::address_v4::from_string(
-                    vm["rpc_ip"].as<std::string>());
+                    vm["rpc_ip"].as<std::string>()));
         }
         catch(...)
         {
@@ -456,7 +456,8 @@ int run (int argc, char** argv)
     {
         try
         {
-            config->rpc_port = vm["rpc_port"].as<std::uint16_t>();
+            config->rpc_port.emplace (
+                vm["rpc_port"].as<std::uint16_t>());
 
             if (*config->rpc_port == 0)
                 throw std::domain_error ("");

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -270,8 +270,6 @@ void Config::setup (std::string const& strConf, bool bQuiet)
         }
     }
 
-    HTTPClient::initializeSSLContext(*this);
-
     // Update default values
     load ();
     {
@@ -290,6 +288,8 @@ void Config::setup (std::string const& strConf, bool bQuiet)
             boost::str (boost::format ("Can not create %s") % dataDir));
 
     legacy ("database_path", boost::filesystem::absolute (dataDir).string ());
+
+    HTTPClient::initializeSSLContext(*this);
 }
 
 void Config::load ()

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -35,7 +35,7 @@ char const* getRawVersionString ()
     //
     //  The build version number (edit this for each release)
     //
-        "0.29.1-rc1"
+        "0.29.1-rc2"
     //
     //  Must follow the format described here:
     //


### PR DESCRIPTION
Previously the `HTTPClient` determined whether SSL certificate validation should be performed by looking at the `Config` object directly. When we injected the config, `HTTPClient` cached the value during initialization - at a time when the relevant variable still contained its default value. As a result, the `[ssl_verify]` configuration option would not be respected.

@vinniefalco, @yana-novikova