### PR TITLE
Make transaction ordering much more difficult to predict

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1017,7 +1017,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         << "Report: TxSt = " << set->getHash ()
         << ", close " << closeTime << (closeTimeCorrect ? "" : "X");
 
-    // Put failed transactions into a deterministic order
+    // Put transactions into a deterministic, but unpredictable, order
     CanonicalTXSet retriableTxs (set->getHash ());
 
     // Build the new last closed ledger
@@ -1866,6 +1866,11 @@ void applyTransactions (
     CanonicalTXSet& retriableTxs,
     ApplyFlags flags)
 {
+
+    // Switch to new transaction ordering on
+    // October 27, 2015 at 11:00AM PDT
+    bool const newTxOrder = checkLedger->info().closeTime > 499284000;
+
     auto j = app.journal ("LedgerConsensus");
     if (set)
     {
@@ -1889,11 +1894,15 @@ void applyTransactions (
 
             if (txn)
             {
-                if (applyTransaction(app, view, txn, true, flags, j) ==
+                if (newTxOrder)
+                {
+                    // All transactions execute in canonical order
+                    retriableTxs.insert (txn);
+                }
+                else if (applyTransaction(app, view, txn, true, flags, j) ==
                     LedgerConsensusImp::resultRetry)
                 {
-                    // On failure, stash the failed transaction for
-                    // later retry.
+                    // Failures are retried in canonical order
                     retriableTxs.insert (txn);
                 }
             }

--- a/src/ripple/app/misc/CanonicalTXSet.h
+++ b/src/ripple/app/misc/CanonicalTXSet.h
@@ -76,17 +76,17 @@ public:
     using const_iterator = std::map <Key, std::shared_ptr<STTx const>>::const_iterator;
 
 public:
-    explicit CanonicalTXSet (LedgerHash const& lastClosedLedgerHash)
-        : mSetHash (lastClosedLedgerHash)
+    explicit CanonicalTXSet (LedgerHash const& saltHash)
+        : mSetHash (saltHash)
     {
     }
 
     void insert (std::shared_ptr<STTx const> const& txn);
 
     // VFALCO TODO remove this function
-    void reset (LedgerHash const& newLastClosedLedgerHash)
+    void reset (LedgerHash const& saltHash)
     {
-        mSetHash = newLastClosedLedgerHash;
+        mSetHash = saltHash;
 
         mMap.clear ();
     }


### PR DESCRIPTION
Randomize the initial transaction execution order for closed ledgers based on the hash of the consensus set.

Transaction processing change will take effect October 27, 2015 at 11:00 AM Pacific time.
