### PR TITLE
Improve non sign_for multisign features

### DIFF
--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -305,6 +305,11 @@ STTx::checkMultiSign () const
     if (!isFieldPresent (sfSigners))
         return false;
 
+    // We don't allow both an sfSigners and an sfTxnSignature.  Both fields
+    // being present would indicate that the transaction is signed both ways.
+    if (isFieldPresent (sfTxnSignature))
+        return false;
+
     STArray const& signers {getFieldArray (sfSigners)};
 
     // There are well known bounds that the number of signers must be within.

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -48,7 +48,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { tecNO_LINE_REDUNDANT,     "tecNO_LINE_REDUNDANT",     "Can't set non-existent line to default."                       },
         { tecPATH_DRY,              "tecPATH_DRY",              "Path could not send partial amount."                           },
         { tecPATH_PARTIAL,          "tecPATH_PARTIAL",          "Path could not send full amount."                              },
-        { tecNO_ALTERNATIVE_KEY,    "tecNO_ALTERNATIVE_KEY",    "The operation would remove the last way to sign a transaction."},
+        { tecNO_ALTERNATIVE_KEY,    "tecNO_ALTERNATIVE_KEY",    "The operation would remove the ability to sign transactions with the account."},
         { tecNO_REGULAR_KEY,        "tecNO_REGULAR_KEY",        "Regular key is not set."                                       },
         { tecOVERSIZE,              "tecOVERSIZE",              "Object exceeded serialization limits."                         },
 

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -989,44 +989,35 @@ Json::Value transactionSubmitMultiSigned (
         }
     }
 
-    // Check Signers for valid entries.
-    STArray signers;
-    {
-        // Verify that the Signers field is present and an array.
-        char const* signersArrayName {sfSigners.getJsonName ().c_str ()};
-        if (! jvRequest.isMember (signersArrayName))
-            return RPC::missing_field_error (signersArrayName);
+    // Verify that the Signers field is present.
+    if (! stpTrans->isFieldPresent (sfSigners))
+        return RPC::missing_field_error ("tx_json.Signers");
 
-        Json::Value& signersValue (
-            jvRequest [signersArrayName]);
-
-        if (! signersValue.isArray ())
-        {
-            std::ostringstream err;
-            err << "Expected "
-                << signersArrayName << " to be an array.";
-            return RPC::make_param_error (err.str ());
-        }
-
-        // Convert signers into SerializedTypes.
-        STParsedJSONArray parsedSigners (signersArrayName, signersValue);
-
-        if (!parsedSigners.array)
-        {
-            Json::Value jvResult;
-            jvResult ["error"] = parsedSigners.error ["error"];
-            jvResult ["error_code"] = parsedSigners.error ["error_code"];
-            jvResult ["error_message"] = parsedSigners.error ["error_message"];
-            return jvResult;
-        }
-        signers = std::move (parsedSigners.array.get());
-    }
+    // If the Signers field is present the SField guarantees it to be an array.
+    // Get a reference to the Signers array so we can verify and sort it.
+    auto& signers = stpTrans->peekFieldArray (sfSigners);
 
     if (signers.empty ())
-        return RPC::make_param_error ("Signers array may not be empty.");
+        return RPC::make_param_error("tx_json.Signers array may not be empty.");
+
+    // the Signers array may only contain Signer objects.
+    if (std::find_if_not(signers.begin(), signers.end(), [](STObject const& obj)
+        {
+            return (
+                // A Signer object always contains these fields and no others.
+                obj.isFieldPresent (sfAccount) &&
+                obj.isFieldPresent (sfSigningPubKey) &&
+                obj.isFieldPresent (sfTxnSignature) &&
+                obj.getCount() == 3);
+        }) != signers.end())
+    {
+        return RPC::make_param_error (
+            "Signers array may only contain Signer entries.");
+    }
 
     // Signers must be sorted by Account.
-    signers.sort ([] (STObject const& a, STObject const& b)
+    std::sort (signers.begin(), signers.end(),
+        [](STObject const& a, STObject const& b)
     {
         return (a.getAccountID (sfAccount) < b.getAccountID (sfAccount));
     });
@@ -1060,9 +1051,6 @@ Json::Value transactionSubmitMultiSigned (
             << toBase58(srcAddressID) << ").";
         return RPC::make_param_error(err.str ());
     }
-
-    // Insert signers into the transaction.
-    stpTrans->setFieldArray (sfSigners, std::move(signers));
 
     // Make sure the SerializedTransaction makes a legitimate Transaction.
     std::pair <Json::Value, Transaction::pointer> txn =

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -665,7 +665,7 @@ R"({
 "Secret does not match account.",
 "Secret does not match account.",
 "",
-"Missing field 'Signers'."}},
+"Missing field 'tx_json.Signers'."}},
 
 { "Missing 'Account' in sign_for.",
 R"({
@@ -831,21 +831,21 @@ R"({
 { "Minimal submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -878,20 +878,20 @@ R"({
 { "Missing sequence in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -905,20 +905,20 @@ R"({
 { "Missing SigningPubKey in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "Sequence": 0,
         "TransactionType": "Payment"
     }
@@ -932,21 +932,21 @@ R"({
 { "Non-empty SigningPubKey in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8",
         "TransactionType": "Payment"
     }
@@ -960,20 +960,20 @@ R"({
 { "Missing TransactionType in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "Sequence": 0,
         "SigningPubKey": "",
     }
@@ -987,20 +987,20 @@ R"({
 { "Missing Account in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1014,21 +1014,21 @@ R"({
 { "Malformed Account in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "NotAnAccount",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1042,21 +1042,21 @@ R"({
 { "Account not in ledger in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rDg53Haik2475DJx8bjMDSDPj4VX7htaMd",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1070,20 +1070,20 @@ R"({
 { "Missing Fee in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1097,21 +1097,21 @@ R"({
 { "Non-numeric Fee in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50.1,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1125,20 +1125,20 @@ R"({
 { "Missing Amount in submit_multisigned Payment.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50000000,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1152,21 +1152,21 @@ R"({
 { "Invalid Amount in submit_multisigned Payment.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "NotANumber",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1181,21 +1181,21 @@ R"({
 R"({
     "command": "submit_multisigned",
     "build_path": 1,
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1209,20 +1209,20 @@ R"({
 { "Missing Destination in submit_multisigned Payment.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1236,21 +1236,21 @@ R"({
 { "Malformed Destination in submit_multisigned Payment.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "NotADestination",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1278,22 +1278,22 @@ R"({
 "Missing field 'secret'.",
 "Missing field 'secret'.",
 "Missing field 'account'.",
-"Missing field 'Signers'."}},
+"Missing field 'tx_json.Signers'."}},
 
 { "Signers not an array in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": {
-        "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-        "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-        "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-    },
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": {
+            "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+            "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+            "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+        },
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1302,19 +1302,19 @@ R"({
 "Missing field 'secret'.",
 "Missing field 'secret'.",
 "Missing field 'account'.",
-"Expected Signers to be an array."}},
+"Field 'tx_json.Signers' is not a JSON array."}},
 
 { "Empty Signers array in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1323,33 +1323,33 @@ R"({
 "Missing field 'secret'.",
 "Missing field 'secret'.",
 "Missing field 'account'.",
-"Signers array may not be empty."}},
+"tx_json.Signers array may not be empty."}},
 
 { "Duplicate Signer in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        },
-        {
-            "Signer": {
-                "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            },
+            {
+                "Signer": {
+                    "Account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }
@@ -1363,21 +1363,21 @@ R"({
 { "Signer is tx_json Account in submit_multisigned.",
 R"({
     "command": "submit_multisigned",
-    "Signers": [
-        {
-            "Signer": {
-                "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-                "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
-                "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
-            }
-        }
-    ],
     "tx_json": {
         "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "Amount": "1000000000",
         "Destination": "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
         "Fee": 50,
         "Sequence": 0,
+        "Signers": [
+            {
+                "Signer": {
+                    "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                    "TxnSignature": "3045022100F9ED357606932697A4FAB2BE7F222C21DD93CA4CFDD90357AADD07465E8457D6022038173193E3DFFFB5D78DD738CC0905395F885DA65B98FDB9793901FE3FD26ECE",
+                    "SigningPubKey": "02FE36A690D6973D55F88553F5D2C4202DE75F2CF8A6D0E17C70AC223F044501F8"
+                }
+            }
+        ],
         "SigningPubKey": "",
         "TransactionType": "Payment"
     }


### PR DESCRIPTION
This is a small collection of multi-sign related fixes:

 - During testing it was noted that one form of malformed
   transaction was not being trapped.  That's been addressed.

 - An improvement was suggested for the tecNO_ALTERNATIVE_KEY text.

 - During use, the submit_multisigned was found to be improved by
   moving the "Signers" argument inside the "tx_json".

Each commit is independent, so they can logically be merged
as separate commits.  But the code changes are small, so if
reviewers prefer that the commits be squashed that will be fine
as well.

The sign_for RPC command has bigger issues which will be
addressed in a separate pull request.

Reviewers: @nbougalis, @sublimator 

Other concerned parties might include @wltsmrz, and @mDuo13 
