### PR TITLE
Some trivial cleanups/fixes:

### DIFF
--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -257,7 +257,9 @@ void OrderBookDB::processTxn (
                         auto data = dynamic_cast<const STObject*> (
                             node.peekAtPField (*field));
 
-                        if (data)
+                        if (data &&
+                            data->isFieldPresent (sfTakerPays) &&
+                            data->isFieldPresent (sfTakerGets))
                         {
                             // determine the OrderBook
                             auto listeners = getBookListeners (

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -670,7 +670,7 @@ public:
     {
         // A new ledger has been accepted as part of the trusted chain
         JLOG (m_journal.debug) << "Ledger " << ledger->info().seq
-                                         << "accepted :" << ledger->getHash ();
+                               << " accepted :" << ledger->getHash ();
         assert (ledger->stateMap().getHash ().isNonZero ());
 
         ledger->setValidated();

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -113,8 +113,6 @@ void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
 
             if (remove)
             {
-                PathRequest::pointer pRequest = wRequest.lock ();
-
                 ScopedLockType sl (mLock);
 
                 // Remove any dangling weak pointers or weak pointers that refer to this path request.
@@ -179,8 +177,8 @@ void PathRequests::insertPathRequest (PathRequest::pointer const& req)
     std::vector<PathRequest::wptr>::iterator it = mRequests.begin ();
     while (it != mRequests.end ())
     {
-        PathRequest::pointer req = it->lock ();
-        if (req && !req->isNew ())
+        PathRequest::pointer r = it->lock ();
+        if (r && !r->isNew ())
             break; // This request has been handled, we come before it
 
         // This is a newer request, we come after it

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -177,7 +177,7 @@ void PathRequests::insertPathRequest (PathRequest::pointer const& req)
     std::vector<PathRequest::wptr>::iterator it = mRequests.begin ();
     while (it != mRequests.end ())
     {
-        PathRequest::pointer r = it->lock ();
+        auto r = it->lock ();
         if (r && !r->isNew ())
             break; // This request has been handled, we come before it
 

--- a/src/ripple/rpc/impl/Coroutine.cpp
+++ b/src/ripple/rpc/impl/Coroutine.cpp
@@ -52,8 +52,10 @@ void runOnCoroutineImpl(std::shared_ptr<Pull> pull)
 
 void runOnCoroutine(Coroutine const& coroutine)
 {
-    auto pullFunction = [coroutine] (Push& push) {
-        Suspend suspend = [&push] (CoroutineType const& cbc) {
+    auto pullFunction = [coroutine] (Push& push)
+    {
+        Suspend suspend = [&push] (CoroutineType const& cbc)
+        {
             if (push)
                 push (cbc);
         };

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -347,7 +347,7 @@ ServerHandlerImp::processRequest (
 
     // Provide the JSON-RPC method as the field "command" in the request.
     params[jss::command] = strMethod;
-    JLOG (m_journal.trace) 
+    JLOG (m_journal.trace)
         << "doRpcCommand:" << strMethod << ":" << params;
 
     auto const start (std::chrono::high_resolution_clock::now ());


### PR DESCRIPTION
Fix a few little things that have been annoying me.

* Avoid throwing in OrderBookDB::processTxn
This can fix a bug that could cause, in rare cases, a transaction not to be sent to all subscribers of an order book it affects if it affects an offer by only changing its metadata.

* Fix missing space in debug output
This cosmetically improves one log message.

All further changes are believed to have no effect on code execution:
* Avoid duplicate lock of PathRequest in updateAll
* Avoid shadowing in insertPathRequest
* Improve indentation in runOnCoroutine
* Remove extraneous space in ServerHandlerImp::processRequest