### PR TITLE
Make submit_multisigned command line consistent (RIPD-182):

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -671,18 +671,16 @@ private:
     // submit_multisigned <json>
     Json::Value parseSubmitMultiSigned (Json::Value const& jvParams)
     {
-        Json::Value     jvRequest;
-        Json::Reader    reader;
-        bool const      bOffline    = 2 == jvParams.size () && jvParams[1u].asString () == "offline";
-
-        if ((1 == jvParams.size () || bOffline)
-            && reader.parse (jvParams[0u].asString (), jvRequest))
+        if (1 == jvParams.size ())
         {
-            // Multisigned.
-            if (bOffline)
-                jvRequest["offline"]    = true;
-
-            return jvRequest;
+            Json::Value     txJSON;
+            Json::Reader    reader;
+            if (reader.parse (jvParams[0u].asString (), txJSON))
+            {
+                Json::Value jvRequest;
+                jvRequest[jss::tx_json] = txJSON;
+                return jvRequest;
+            }
         }
 
         return rpcError (rpcINVALID_PARAMS);


### PR DESCRIPTION
In command line usage (only), the "sign", "submit", and "sign_for"
commands do not require the submitted JSON to be wrapped in a
tx_json object.  Make the submit_multisigned command line behave
consistently with the command line form of those other commands.
While we're in there, remove support for the (useless) "offline"
argument.

Reviewers: @miguelportilla, @nbougalis

Other possibly interested observers: @mDuo13, @wltsmrz