### PR TITLE
Convert WebSocket::Server to use std::thread (RIPD-236)

### DIFF
--- a/src/ripple/websocket/WebSocket02.cpp
+++ b/src/ripple/websocket/WebSocket02.cpp
@@ -95,7 +95,7 @@ void Server <WebSocket02>::listen()
 {
     try
     {
-        m_endpoint->listen (desc_.port.ip, desc_.port.port);
+        endpoint_->listen (desc_.port.ip, desc_.port.port);
     }
     catch (std::exception const& e)
     {
@@ -106,7 +106,7 @@ void Server <WebSocket02>::listen()
             // https://github.com/zaphoyd/websocketpp/issues/98
             try
             {
-                m_endpoint->get_io_service ().run ();
+                endpoint_->get_io_service ().run ();
                 break;
             }
             catch (std::exception const& e)

--- a/src/ripple/websocket/WebSocket04.cpp
+++ b/src/ripple/websocket/WebSocket04.cpp
@@ -138,9 +138,9 @@ boost::asio::io_service::strand& WebSocket04::getStrand (Connection& con)
 template <>
 void Server <WebSocket04>::listen()
 {
-    m_endpoint->listen (desc_.port.ip, desc_.port.port);
-    m_endpoint->start_accept();
-    auto c = m_endpoint->get_io_service ().run ();
+    endpoint_->listen (desc_.port.ip, desc_.port.port);
+    endpoint_->start_accept();
+    auto c = endpoint_->get_io_service ().run ();
     JLOG (j_.warning)
             << "Server run with: '" << c;
 


### PR DESCRIPTION
This pull request converts WebSocket::Server from using beast::Thread to std::thread.  Tom, the websocket guy, has looked over the change and he's okay with it.

My primary concern was that if there's a race between `onStop()` and the destructor, then `endpoint->stop()` could be called twice on an endpoint.  Tom says that's okay.  The State comment here:

https://github.com/ripple/rippled/blob/develop/src/websocketpp_02/src/endpoint.hpp#L366-L368

should actually read...

`Returns immediately if state is not RUNNING`

I'm not changing the comment because it's not in part of the rippled source code.

Reviewers: @vinniefalco, @seelabs
