### PR TITLE
Three requested features from my backlog

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -503,6 +503,9 @@
 # [path_search_max]
 #   When searching for paths, the minimum and maximum search aggressiveness.
 #
+#   If you do not need pathfinding, you can set path_search_max to zero to
+#   disable it and avoid some expensive bookkeeping.
+#
 #   The default for 'path_search_fast' is 2. The default for 'path_search_max' is 10.
 #
 # [path_search_old]

--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -66,6 +66,10 @@ void OrderBookDB::setup(
         mSeq = seq;
     }
 
+    if (app_.config().PATH_SEARCH_MAX == 0)
+    {
+        // nothing to do
+    }
     if (app_.config().RUN_STANDALONE)
         update(ledger);
     else
@@ -83,6 +87,12 @@ void OrderBookDB::update(
     hash_set< Issue > XRPBooks;
 
     JLOG (j_.debug) << "OrderBookDB::update>";
+
+    if (app_.config().PATH_SEARCH_MAX == 0)
+    {
+        // pathfinding has been disabled
+        return;
+    }
 
     // walk through the entire ledger looking for orderbook entries
     int books = 0;

--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -70,7 +70,7 @@ void OrderBookDB::setup(
     {
         // nothing to do
     }
-    if (app_.config().RUN_STANDALONE)
+    else if (app_.config().RUN_STANDALONE)
         update(ledger);
     else
         app_.getJobQueue().addJob(

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -379,6 +379,10 @@ public:
     bool subValidations (InfoSub::ref ispListener) override;
     bool unsubValidations (std::uint64_t uListener) override;
 
+    bool subPeerStatus (InfoSub::ref ispListener) override;
+    bool unsubPeerStatus (std::uint64_t uListener) override;
+    void pubPeerStatus (std::function<Json::Value(void)> const&) override;
+
     InfoSub::pointer findRpcSub (std::string const& strUrl) override;
     InfoSub::pointer addRpcSub (
         std::string const& strUrl, InfoSub::ref) override;
@@ -461,6 +465,7 @@ private:
     SubMapType mSubTransactions;      // All accepted transactions.
     SubMapType mSubRTTransactions;    // All proposed and accepted transactions.
     SubMapType mSubValidations;       // Received validations.
+    SubMapType mSubPeerStatus;        // peer status changes
 
     std::uint32_t mLastLoadBase;
     std::uint32_t mLastLoadFactor;
@@ -1514,6 +1519,33 @@ void NetworkOPsImp::pubValidation (STValidation::ref val)
     }
 }
 
+void NetworkOPsImp::pubPeerStatus (
+    std::function<Json::Value(void)> const& func)
+{
+    ScopedLockType sl (mSubLock);
+
+    if (!mSubPeerStatus.empty ())
+    {
+        Json::Value jvObj (func());
+
+        jvObj [jss::type]                  = "peerStatusChange";
+
+        for (auto i = mSubPeerStatus.begin (); i != mSubPeerStatus.end (); )
+        {
+            InfoSub::pointer p = i->second.lock ();
+
+            if (p)
+            {
+                p->send (jvObj, true);
+                ++i;
+            }
+            else
+            {
+                i = mSubValidations.erase (i);
+            }
+        }
+    }
+}
 
 void NetworkOPsImp::setMode (OperatingMode om)
 {
@@ -2512,6 +2544,20 @@ bool NetworkOPsImp::unsubValidations (std::uint64_t uSeq)
 {
     ScopedLockType sl (mSubLock);
     return mSubValidations.erase (uSeq);
+}
+
+// <-- bool: true=added, false=already there
+bool NetworkOPsImp::subPeerStatus (InfoSub::ref isrListener)
+{
+    ScopedLockType sl (mSubLock);
+    return mSubPeerStatus.emplace (isrListener->getSeq (), isrListener).second;
+}
+
+// <-- bool: true=erased, false=was not there
+bool NetworkOPsImp::unsubPeerStatus (std::uint64_t uSeq)
+{
+    ScopedLockType sl (mSubLock);
+    return mSubPeerStatus.erase (uSeq);
 }
 
 InfoSub::pointer NetworkOPsImp::findRpcSub (std::string const& strUrl)

--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -101,6 +101,10 @@ public:
         virtual bool subValidations (ref ispListener) = 0;
         virtual bool unsubValidations (std::uint64_t uListener) = 0;
 
+        virtual bool subPeerStatus (ref ispListener) = 0;
+        virtual bool unsubPeerStatus (std::uint64_t uListener) = 0;
+        virtual void pubPeerStatus (std::function<Json::Value(void)> const&) = 0;
+
         // VFALCO TODO Remove
         //             This was added for one particular partner, it
         //             "pushes" subscription data to a particular URL.

--- a/src/ripple/net/impl/InfoSub.cpp
+++ b/src/ripple/net/impl/InfoSub.cpp
@@ -58,6 +58,7 @@ InfoSub::~InfoSub ()
     m_source.unsubLedger (mSeq);
     m_source.unsubServer (mSeq);
     m_source.unsubValidations (mSeq);
+    m_source.unsubPeerStatus (mSeq);
 
     // Use the internal unsubscribe so that it won't call
     // back to us and modify its own parameter

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1334,6 +1334,78 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMStatusChange> const& m)
     {
         checkSanity (m->ledgerseq(), app_.getLedgerMaster().getValidLedgerIndex());
     }
+
+    app_.getOPs().pubPeerStatus (
+        [=]() -> Json::Value
+        {
+            Json::Value j = Json::objectValue;
+
+            if (m->has_newstatus ())
+            {
+               switch (m->newstatus ())
+               {
+                   case protocol::nsCONNECTING:
+                       j[jss::status] = "CONNECTING";
+                       break;
+                   case protocol::nsCONNECTED:
+                       j[jss::status] = "CONNECTED";
+                       break;
+                   case protocol::nsMONITORING:
+                       j[jss::status] = "MONITORING";
+                       break;
+                   case protocol::nsVALIDATING:
+                       j[jss::status] = "VALIDATING";
+                       break;
+                   case protocol::nsSHUTTING:
+                       j[jss::status] = "SHUTTING";
+                       break;
+               }
+            }
+
+            if (m->has_newevent())
+            {
+                switch (m->newevent ())
+                {
+                    case protocol::neCLOSING_LEDGER:
+                        j[jss::action] = "CLOSING_LEDGER";
+                        break;
+                    case protocol::neACCEPTED_LEDGER:
+                        j[jss::action] = "ACCEPTED_LEDGER";
+                        break;
+                    case protocol::neSWITCHED_LEDGER:
+                        j[jss::action] = "SWITCHED_LEDGER";
+                        break;
+                    case protocol::neLOST_SYNC:
+                        j[jss::action] = "LOST_SYNC";
+                        break;
+                }
+            }
+
+            if (m->has_ledgerseq ())
+            {
+                j[jss::ledger_index] = m->ledgerseq();
+            }
+
+            if (m->has_ledgerhash ())
+            {
+                j[jss::ledger_hash] = to_string (closedLedgerHash_);
+            }
+
+            if (m->has_networktime ())
+            {
+                j[jss::date] = Json::UInt (m->networktime());
+            }
+
+            if (m->has_firstseq () && m->has_lastseq ())
+            {
+                j[jss::ledger_index_min] =
+                    Json::UInt (m->firstseq ());
+                j[jss::ledger_index_max] =
+                    Json::UInt (m->lastseq ());
+            }
+
+            return j;
+        });
 }
 
 void

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -293,6 +293,9 @@ PeerImp::json()
             ret[jss::latency] = static_cast<Json::UInt> (latency.count());
     }
 
+    ret[jss::uptime] = static_cast<Json::UInt>(
+        std::chrono::duration_cast<std::chrono::seconds>(uptime()).count());
+
     std::uint32_t minSeq, maxSeq;
     ledgerRange(minSeq, maxSeq);
 

--- a/src/ripple/rpc/handlers/PathFind.cpp
+++ b/src/ripple/rpc/handlers/PathFind.cpp
@@ -32,6 +32,9 @@ namespace ripple {
 
 Json::Value doPathFind (RPC::Context& context)
 {
+    if (context.app.config().PATH_SEARCH_MAX == 0)
+        return rpcError (rpcNOT_SUPPORTED);
+
     auto lpLedger = context.ledgerMaster.getClosedLedger();
 
     if (!context.params.isMember (jss::subcommand) ||

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -70,6 +70,9 @@ buildSrcCurrencies(AccountID const& account,
 // This interface is deprecated.
 Json::Value doRipplePathFind (RPC::Context& context)
 {
+    if (context.app.config().PATH_SEARCH_MAX == 0)
+        return rpcError (rpcNOT_SUPPORTED);
+
     RPC::LegacyPathFind lpf (context.role == Role::ADMIN, context.app);
     if (!lpf.isOk ())
         return rpcError (rpcTOO_BUSY);

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -143,6 +143,13 @@ Json::Value doSubscribe (RPC::Context& context)
                 {
                     context.netOps.subValidations (ispSub);
                 }
+                else if (streamName == "peer_status")
+                {
+                    if (context.role != Role::ADMIN)
+                        jvResult[jss::error] = "noPermission";
+                    else
+                        context.netOps.subPeerStatus (ispSub);
+                }
                 else
                 {
                     jvResult[jss::error]   = "unknownStream";

--- a/src/ripple/rpc/handlers/Unsubscribe.cpp
+++ b/src/ripple/rpc/handlers/Unsubscribe.cpp
@@ -83,6 +83,9 @@ Json::Value doUnsubscribe (RPC::Context& context)
                 else if (streamName == "validations")
                     context.netOps.unsubValidations (ispSub->getSeq ());
 
+                else if (streamName == "peer_status")
+                    context.netOps.unsubPeerStatus (ispSub->getSeq ());
+
                 else
                     jvResult[jss::error] = "Unknown stream: " + streamName;
             }


### PR DESCRIPTION
1) Report peer connection uptime in the output of the "peers" command (RIPD-927)

2) Permit pathfinding to be disabled to avoid the effort of maintaining the orderbook db on validators and other servers that don't need to do pathfinding. (RIPD-271)

3) Permit admin users to subscribe to peer status change notifications (RIPD-579).