### PR TITLE
Allow multiple incoming connections from the same IP

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -372,6 +372,15 @@
 #       Peers will use this information to reject attempt to proxy
 #       connections to or from this server.
 #
+#   ip_limit = <number>
+#
+#       The maximum number of incoming peer connections allowed by a single
+#       IP that isn't classified as "private" in RFC1918. The implementation
+#       imposes some hard and soft upper limits on this value to prevent a
+#       single host from consuming all inbound slots. If the value is not
+#       present the server will autoconfigure an appropriate limit.
+#
+#
 #
 # [transaction_queue] EXPERIMENTAL
 #

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -208,7 +208,7 @@ public:
 
     // Peer networking parameters
     bool                        PEER_PRIVATE = false;           // True to ask peers not to relay current IP.
-    unsigned int                PEERS_MAX = 0;
+    int                         PEERS_MAX = 0;
 
     int                         WEBSOCKET_PING_FREQ = 5 * 60;
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -371,11 +371,12 @@ void Config::loadFromString (std::string const& fileContents)
     (void) getSingleSection (secConfig, SECTION_VALIDATORS_SITE, VALIDATORS_SITE, j_);
 
     std::string strTemp;
+
     if (getSingleSection (secConfig, SECTION_PEER_PRIVATE, strTemp, j_))
         PEER_PRIVATE        = beast::lexicalCastThrow <bool> (strTemp);
 
     if (getSingleSection (secConfig, SECTION_PEERS_MAX, strTemp, j_))
-        PEERS_MAX           = beast::lexicalCastThrow <int> (strTemp);
+        PEERS_MAX = std::max (0, beast::lexicalCastThrow <int> (strTemp));
 
     if (getSingleSection (secConfig, SECTION_NODE_SIZE, strTemp, j_))
     {

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -28,6 +28,7 @@
 #include <beast/http/URL.h>
 #include <beast/module/core/text/LexicalCast.h>
 #include <beast/streams/debug_ostream.h>
+#include <beast/utility/ci_char_traits.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
@@ -378,15 +379,15 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_NODE_SIZE, strTemp, j_))
     {
-        if (strTemp == "tiny")
+        if (beast::ci_equal(strTemp, "tiny"))
             NODE_SIZE = 0;
-        else if (strTemp == "small")
+        else if (beast::ci_equal(strTemp, "small"))
             NODE_SIZE = 1;
-        else if (strTemp == "medium")
+        else if (beast::ci_equal(strTemp, "medium"))
             NODE_SIZE = 2;
-        else if (strTemp == "large")
+        else if (beast::ci_equal(strTemp, "large"))
             NODE_SIZE = 3;
-        else if (strTemp == "huge")
+        else if (beast::ci_equal(strTemp, "huge"))
             NODE_SIZE = 4;
         else
         {
@@ -453,11 +454,9 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_LEDGER_HISTORY, strTemp, j_))
     {
-        boost::to_lower (strTemp);
-
-        if (strTemp == "full")
+        if (beast::ci_equal(strTemp, "full"))
             LEDGER_HISTORY = 1000000000u;
-        else if (strTemp == "none")
+        else if (beast::ci_equal(strTemp, "none"))
             LEDGER_HISTORY = 0;
         else
             LEDGER_HISTORY = beast::lexicalCastThrow <std::uint32_t> (strTemp);
@@ -465,11 +464,9 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_FETCH_DEPTH, strTemp, j_))
     {
-        boost::to_lower (strTemp);
-
-        if (strTemp == "none")
+        if (beast::ci_equal(strTemp, "none"))
             FETCH_DEPTH = 0;
-        else if (strTemp == "full")
+        else if (beast::ci_equal(strTemp, "full"))
             FETCH_DEPTH = 1000000000u;
         else
             FETCH_DEPTH = beast::lexicalCastThrow <std::uint32_t> (strTemp);

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -70,6 +70,7 @@ public:
         std::shared_ptr<boost::asio::ssl::context> context;
         bool expire = false;
         beast::IP::Address public_ip;
+        int ipLimit = 0;
     };
 
     using PeerSequence = std::vector <Peer::ptr>;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -506,6 +506,7 @@ OverlayImpl::onPrepare()
         !app_.config().PEER_PRIVATE;
     config.listeningPort = port;
     config.features = "";
+    config.ipLimit = setup_.ipLimit;
 
     // Enforce business rules
     config.applyTuning();
@@ -1053,6 +1054,10 @@ setup_Overlay (BasicConfig const& config)
     auto const& section = config.section("overlay");
     setup.context = make_SSLContext();
     setup.expire = get<bool>(section, "expire", false);
+
+    set (setup.ipLimit, "ip_limit", section);
+    if (setup.ipLimit < 0)
+        throw std::runtime_error ("Configured IP limit is invalid");
 
     std::string ip;
     set (ip, "public_ip", section);

--- a/src/ripple/peerfinder/PeerfinderManager.h
+++ b/src/ripple/peerfinder/PeerfinderManager.h
@@ -73,6 +73,9 @@ struct Config
     /** The set of features we advertise. */
     std::string features;
 
+    /** Limit how many incoming connections we allow per IP */
+    int ipLimit;
+
     //--------------------------------------------------------------------------
 
     /** Create a configuration with default values. */

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -263,13 +263,13 @@ public:
         // Check for duplicate connection
         if (is_public (remote_endpoint))
         {
-            auto const iter = connectedAddresses_.find (
+            auto const count = connectedAddresses_.count (
                 remote_endpoint.address());
-            if (iter != connectedAddresses_.end())
+            if (count > config_.ipLimit)
             {
                 if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
                     "Logic dropping inbound " << remote_endpoint <<
-                    " as duplicate";
+                    " because of ip limits.";
                 return SlotImp::ptr();
             }
         }


### PR DESCRIPTION
Multiple servers behind NAT might share a single public IP, making it difficult for them to connect to the Ripple network since multiple incoming connections from the same non-private IP are currently not allowed.

RippleD can now automatically allow between 2 and 5 incoming connections, from the same public IP based on the total number of peers that it is configured to accept.

Administrators can manually change the limit by including an `[ip_limit]` stanza in their configuration file specifying a positive non-zero number. For example:

    [ip_limit]
    3

The server will automatically adjust this value to prevent a single IP from consuming all inbound slots.

The previous "one connection per IP" strategy can be emulated by simply setting `[ip_limit]` to 1 in the configuration file.
