### PR TITLE
Trivial cleanups in LedgerConsensusImp

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -405,8 +405,7 @@ void Ledger::setAccepted (
     std::uint32_t closeTime, int closeResolution, bool correctCloseTime,
         Config const& config)
 {
-    // Used when we witnessed the consensus.  Rounds the close time, updates the
-    // hash, and sets the ledger accepted and immutable.
+    // Used when we witnessed the consensus.
     assert (closed());
 
     info_.closeTime = closeTime;

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -83,7 +83,7 @@ public:
 
     /** Report that we have locally built a particular ledger
     */
-    void builtLedger (Ledger::ref);
+    void builtLedger (Ledger::ref, Json::Value &&);
 
     /** Report that we have validated a particular ledger
     */
@@ -104,8 +104,10 @@ private:
         validate a different one.
         @param built The hash of the ledger we built
         @param valid The hash of the ledger we deemed fully valid
+        @param consensus The status of the consensus round
     */
-    void handleMismatch (LedgerHash const& built, LedgerHash const& valid);
+    void handleMismatch (LedgerHash const& built, LedgerHash const& valid,
+        Json::Value const& consensus);
 
     Application& app_;
     beast::insight::Collector::ptr collector_;
@@ -117,10 +119,14 @@ private:
 
     // Maps ledger indexes to the corresponding hashes
     // For debug and logging purposes
-    // 1) The hash of a ledger with that index we build
-    // 2) The hash of a ledger with that index we validated
-    using ConsensusValidated = TaggedCache <LedgerIndex,
-        std::pair< LedgerHash, LedgerHash >>;
+    class cv_entry
+    {
+        public:
+        boost::optional<LedgerHash> built;
+        boost::optional<LedgerHash> validated;
+        boost::optional<Json::Value> consensus;
+    };
+    using ConsensusValidated = TaggedCache <LedgerIndex, cv_entry>;
     ConsensusValidated m_consensus_validated;
 
 

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -153,7 +153,7 @@ public:
 
     virtual void checkAccept (Ledger::ref ledger) = 0;
     virtual void checkAccept (uint256 const& hash, std::uint32_t seq) = 0;
-    virtual void consensusBuilt (Ledger::ref ledger) = 0;
+    virtual void consensusBuilt (Ledger::ref ledger, Json::Value&& consensus) = 0;
 
     virtual LedgerIndex getBuildingLedger () = 0;
     virtual void setBuildingLedger (LedgerIndex index) = 0;

--- a/src/ripple/app/ledger/impl/ConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/ConsensusImp.cpp
@@ -138,7 +138,7 @@ ConsensusImp::storeProposal (
 {
     auto& props = storedProposals_[peerPublic.getNodeID ()];
 
-    if (props.size () >= (unsigned) (getLastCloseProposers () + 10))
+    if (props.size () >= 10)
         props.pop_front ();
 
     props.push_back (proposal);

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -442,7 +442,7 @@ void LedgerConsensusImp::mapCompleteInternal (
     auto it = mAcquired.find (hash);
 
     // If we have already acquired this transaction set
-    if (mAcquired.find (hash) != mAcquired.end ())
+    if (it != mAcquired.end ())
     {
         if (it->second)
         {
@@ -595,13 +595,11 @@ void LedgerConsensusImp::checkLCL ()
         JLOG (j_.warning)
             << ripple::getJson (*mPreviousLedger);
 
-        if (ShouldLog (lsDEBUG, LedgerConsensus))
+        if (j_.debug)
         {
             for (auto& it : vals)
-            {
-                JLOG (j_.debug)
+                j_.debug
                     << "V: " << it.first << ", " << it.second.first;
-            }
         }
 
         if (mHaveCorrectLCL)
@@ -1641,7 +1639,7 @@ void LedgerConsensusImp::updateOurPositions ()
         for (auto it = closeTimes.begin ()
             , end = closeTimes.end (); it != end; ++it)
         {
-            JLOG (j_.debug) << "CCTime: seq"
+            JLOG (j_.debug) << "CCTime: seq "
                 << mPreviousLedger->info().seq + 1 << ": "
                 << it->first << " has " << it->second << ", "
                 << threshVote << " required";

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1144,7 +1144,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
             << "CNF newLCL " << newLCLHash;
 
     // See if we can accept a ledger as fully-validated
-    ledgerMaster_.consensusBuilt (newLCL);
+    ledgerMaster_.consensusBuilt (newLCL, getJson (true));
 
     {
         // Apply disputed transactions that didn't get in

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -300,6 +300,8 @@ LedgerConsensusImp::LedgerConsensusImp (
         // update the network status table as to whether we're
         // proposing/validating
         consensus_.setProposing (mProposing, mValidating);
+
+    playbackProposals ();
 }
 
 Json::Value LedgerConsensusImp::getJson (bool full)
@@ -971,8 +973,6 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
            consensus_.takePosition (mPreviousLedger->info().seq, set);
 
         assert (set->getHash () == mOurPosition->getCurrentHash ());
-        // these are now obsolete
-        consensus_.peekStoredProposals ().clear ();
     }
 
     std::uint32_t closeTime = mOurPosition->getCloseTime ();

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -293,6 +293,9 @@ private:
     /** Add our load fee to our validation */
     void addLoad(STValidation::ref val);
 
+    /** Convert an advertised close time to an effective close time */
+    std::uint32_t effectiveCloseTime (std::uint32_t closeTime);
+
 private:
     Application& app_;
     ConsensusImp& consensus_;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -877,7 +877,7 @@ public:
     }
 
     /** Report that the consensus process built a particular ledger */
-    void consensusBuilt (Ledger::ref ledger) override
+    void consensusBuilt (Ledger::ref ledger, Json::Value&& consensus) override
     {
 
         // Because we just built a ledger, we are no longer building one
@@ -970,7 +970,7 @@ public:
             checkAccept (maxLedger, maxSeq);
         }
 
-        mLedgerHistory.builtLedger (ledger);
+        mLedgerHistory.builtLedger (ledger, std::move (consensus));
     }
 
     void advanceThread()

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1410,6 +1410,11 @@ void NetworkOPsImp::processTrustedProposal (
 
         bool relay = true;
 
+        if (mConsensus)
+            mConsensus->storeProposal (proposal, nodePublic);
+        else
+            m_journal.warning << "Unable to store proposal";
+
         if (!haveConsensusObject ())
         {
             m_journal.info << "Received proposal outside consensus window";
@@ -1417,17 +1422,15 @@ void NetworkOPsImp::processTrustedProposal (
             if (mMode == omFULL)
                 relay = false;
         }
-        else
+        else if (mLedgerConsensus->getLCL () == proposal->getPrevLedger ())
         {
-            mConsensus->storeProposal (proposal, nodePublic);
-
-            if (mLedgerConsensus->getLCL () == proposal->getPrevLedger ())
-            {
-                relay = mLedgerConsensus->peerPosition (proposal);
-                m_journal.trace
-                    << "Proposal processing finished, relay=" << relay;
-            }
+            relay = mLedgerConsensus->peerPosition (proposal);
+            m_journal.trace
+                << "Proposal processing finished, relay=" << relay;
         }
+        else
+            m_journal.debug << "Got proposal for " << proposal->getPrevLedger ()
+                << " but we are on " << mLedgerConsensus->getLCL();
 
         if (relay)
             app_.overlay().relay(*set, proposal->getSuppressionID());


### PR DESCRIPTION
Just remove a redundant function call, fix a missing space in a log entry, and remove an obsolete ShouldLog.