### PR TITLE
Changes for server synch stability

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -405,8 +405,7 @@ void Ledger::setAccepted (
     std::uint32_t closeTime, int closeResolution, bool correctCloseTime,
         Config const& config)
 {
-    // Used when we witnessed the consensus.  Rounds the close time, updates the
-    // hash, and sets the ledger accepted and immutable.
+    // Used when we witnessed the consensus.
     assert (closed());
 
     info_.closeTime = closeTime;

--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -391,7 +391,7 @@ void LedgerHistory::handleMismatch (
         log_one (validLedger, (*v)->key(), "built", j_);
 }
 
-void LedgerHistory::builtLedger (Ledger::ref ledger, Json::Value&& consensus)
+void LedgerHistory::builtLedger (Ledger::ref ledger, Json::Value consensus)
 {
     LedgerIndex index = ledger->info().seq;
     LedgerHash hash = ledger->getHash();

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -83,7 +83,7 @@ public:
 
     /** Report that we have locally built a particular ledger
     */
-    void builtLedger (Ledger::ref);
+    void builtLedger (Ledger::ref, Json::Value &&);
 
     /** Report that we have validated a particular ledger
     */
@@ -104,8 +104,10 @@ private:
         validate a different one.
         @param built The hash of the ledger we built
         @param valid The hash of the ledger we deemed fully valid
+        @param consensus The status of the consensus round
     */
-    void handleMismatch (LedgerHash const& built, LedgerHash const& valid);
+    void handleMismatch (LedgerHash const& built, LedgerHash const& valid,
+        Json::Value const& consensus);
 
     Application& app_;
     beast::insight::Collector::ptr collector_;
@@ -117,10 +119,14 @@ private:
 
     // Maps ledger indexes to the corresponding hashes
     // For debug and logging purposes
-    // 1) The hash of a ledger with that index we build
-    // 2) The hash of a ledger with that index we validated
-    using ConsensusValidated = TaggedCache <LedgerIndex,
-        std::pair< LedgerHash, LedgerHash >>;
+    class cv_entry
+    {
+        public:
+        boost::optional<LedgerHash> built;
+        boost::optional<LedgerHash> validated;
+        boost::optional<Json::Value> consensus;
+    };
+    using ConsensusValidated = TaggedCache <LedgerIndex, cv_entry>;
     ConsensusValidated m_consensus_validated;
 
 

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -119,9 +119,8 @@ private:
 
     // Maps ledger indexes to the corresponding hashes
     // For debug and logging purposes
-    class cv_entry
+    struct cv_entry
     {
-        public:
         boost::optional<LedgerHash> built;
         boost::optional<LedgerHash> validated;
         boost::optional<Json::Value> consensus;

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -83,7 +83,7 @@ public:
 
     /** Report that we have locally built a particular ledger
     */
-    void builtLedger (Ledger::ref, Json::Value &&);
+    void builtLedger (Ledger::ref, Json::Value);
 
     /** Report that we have validated a particular ledger
     */

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -153,7 +153,7 @@ public:
 
     virtual void checkAccept (Ledger::ref ledger) = 0;
     virtual void checkAccept (uint256 const& hash, std::uint32_t seq) = 0;
-    virtual void consensusBuilt (Ledger::ref ledger, Json::Value&& consensus) = 0;
+    virtual void consensusBuilt (Ledger::ref ledger, Json::Value consensus) = 0;
 
     virtual LedgerIndex getBuildingLedger () = 0;
     virtual void setBuildingLedger (LedgerIndex index) = 0;

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -153,7 +153,7 @@ public:
 
     virtual void checkAccept (Ledger::ref ledger) = 0;
     virtual void checkAccept (uint256 const& hash, std::uint32_t seq) = 0;
-    virtual void consensusBuilt (Ledger::ref ledger) = 0;
+    virtual void consensusBuilt (Ledger::ref ledger, Json::Value&& consensus) = 0;
 
     virtual LedgerIndex getBuildingLedger () = 0;
     virtual void setBuildingLedger (LedgerIndex index) = 0;

--- a/src/ripple/app/ledger/impl/ConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/ConsensusImp.cpp
@@ -138,7 +138,7 @@ ConsensusImp::storeProposal (
 {
     auto& props = storedProposals_[peerPublic.getNodeID ()];
 
-    if (props.size () >= (unsigned) (getLastCloseProposers () + 10))
+    if (props.size () >= 10)
         props.pop_front ();
 
     props.push_back (proposal);

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -442,7 +442,7 @@ void LedgerConsensusImp::mapCompleteInternal (
     auto it = mAcquired.find (hash);
 
     // If we have already acquired this transaction set
-    if (mAcquired.find (hash) != mAcquired.end ())
+    if (it != mAcquired.end ())
     {
         if (it->second)
         {
@@ -595,13 +595,11 @@ void LedgerConsensusImp::checkLCL ()
         JLOG (j_.warning)
             << ripple::getJson (*mPreviousLedger);
 
-        if (ShouldLog (lsDEBUG, LedgerConsensus))
+        if (j_.debug)
         {
             for (auto& it : vals)
-            {
-                JLOG (j_.debug)
+                j_.debug
                     << "V: " << it.first << ", " << it.second.first;
-            }
         }
 
         if (mHaveCorrectLCL)
@@ -1641,7 +1639,7 @@ void LedgerConsensusImp::updateOurPositions ()
         for (auto it = closeTimes.begin ()
             , end = closeTimes.end (); it != end; ++it)
         {
-            JLOG (j_.debug) << "CCTime: seq"
+            JLOG (j_.debug) << "CCTime: seq "
                 << mPreviousLedger->info().seq + 1 << ": "
                 << it->first << " has " << it->second << ", "
                 << threshVote << " required";

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1144,7 +1144,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
             << "CNF newLCL " << newLCLHash;
 
     // See if we can accept a ledger as fully-validated
-    ledgerMaster_.consensusBuilt (newLCL);
+    ledgerMaster_.consensusBuilt (newLCL, getJson (true));
 
     {
         // Apply disputed transactions that didn't get in

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -745,14 +745,17 @@ void LedgerConsensusImp::statePreClose ()
     // This ledger is open. This computes how long since last ledger closed
     int sinceClose;
     {
-        bool previousCloseCorrect = mHaveCorrectLCL && getCloseAgree (mPreviousLedger->info())
-            && (mPreviousLedger->info().closeTime != (mPreviousLedger->info().parentCloseTime + 1));
+        bool previousCloseCorrect = mHaveCorrectLCL
+            && getCloseAgree (mPreviousLedger->info())
+            && (mPreviousLedger->info().closeTime !=
+                (mPreviousLedger->info().parentCloseTime + 1));
 
-        std::uint32_t closeTime = previousCloseCorrect
+        auto closeTime = previousCloseCorrect
             ? mPreviousLedger->info().closeTime // use consensus timing
             : consensus_.getLastCloseTime(); // use the time we saw
 
-        std::uint32_t now = app_.timeKeeper().closeTime().time_since_epoch().count();
+        auto now =
+            app_.timeKeeper().closeTime().time_since_epoch().count();
         if (now >= closeTime)
             sinceClose = static_cast<int> (1000 * (now - closeTime));
         else
@@ -975,7 +978,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         assert (set->getHash () == mOurPosition->getCurrentHash ());
     }
 
-    std::uint32_t closeTime = mOurPosition->getCloseTime ();
+    auto  closeTime = mOurPosition->getCloseTime ();
     bool closeTimeCorrect;
 
     auto replay = ledgerMaster_.releaseReplay();
@@ -1630,7 +1633,7 @@ void LedgerConsensusImp::updateOurPositions ()
             << mPeerPositions.size () << " nw:" << neededWeight
             << " thrV:" << threshVote << " thrC:" << threshConsensus;
 
-        for (auto const it : closeTimes)
+        for (auto const& it : closeTimes)
         {
             JLOG (j_.debug) << "CCTime: seq "
                 << mPreviousLedger->info().seq + 1 << ": "

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -300,6 +300,8 @@ LedgerConsensusImp::LedgerConsensusImp (
         // update the network status table as to whether we're
         // proposing/validating
         consensus_.setProposing (mProposing, mValidating);
+
+    playbackProposals ();
 }
 
 Json::Value LedgerConsensusImp::getJson (bool full)
@@ -971,8 +973,6 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
            consensus_.takePosition (mPreviousLedger->info().seq, set);
 
         assert (set->getHash () == mOurPosition->getCurrentHash ());
-        // these are now obsolete
-        consensus_.peekStoredProposals ().clear ();
     }
 
     std::uint32_t closeTime = mOurPosition->getCloseTime ();

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -302,6 +302,12 @@ LedgerConsensusImp::LedgerConsensusImp (
         consensus_.setProposing (mProposing, mValidating);
 
     playbackProposals ();
+    if (mPeerPositions.size() > (mPreviousProposers / 2))
+    {
+        // We may be falling behind, don't wait for the timer
+        // consider closing the ledger immediately
+        timerEntry ();
+    }
 }
 
 Json::Value LedgerConsensusImp::getJson (bool full)

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -600,6 +600,7 @@ void LedgerConsensusImp::checkLCL ()
             for (auto& it : vals)
                 j_.debug
                     << "V: " << it.first << ", " << it.second.first;
+            j_.debug << getJson (true);
         }
 
         if (mHaveCorrectLCL)
@@ -741,31 +742,23 @@ void LedgerConsensusImp::statePreClose ()
 
     // This ledger is open. This computes how long since last ledger closed
     int sinceClose;
-    int idleInterval = 0;
-
-    if (mHaveCorrectLCL && getCloseAgree(mPreviousLedger->info()))
     {
-        // we can use consensus timing
-        sinceClose = 1000 * (
-            app_.timeKeeper().closeTime().time_since_epoch().count()
-            - mPreviousLedger->info().closeTime);
-        idleInterval = 2 * mPreviousLedger->info().closeTimeResolution;
+        bool previousCloseCorrect = mHaveCorrectLCL && getCloseAgree (mPreviousLedger->info())
+            && (mPreviousLedger->info().closeTime != (mPreviousLedger->info().parentCloseTime + 1));
 
-        if (idleInterval < LEDGER_IDLE_INTERVAL)
-            idleInterval = LEDGER_IDLE_INTERVAL;
-    }
-    else
-    {
-        // Use the time we saw the last ledger close
-        sinceClose = 1000 * (
-            app_.timeKeeper().closeTime().time_since_epoch().count()
-            - consensus_.getLastCloseTime ());
-        idleInterval = LEDGER_IDLE_INTERVAL;
+        std::uint32_t closeTime = previousCloseCorrect
+            ? mPreviousLedger->info().closeTime // use consensus timing
+            : consensus_.getLastCloseTime(); // use the time we saw
+
+        std::uint32_t now = app_.timeKeeper().closeTime().time_since_epoch().count();
+        if (now >= closeTime)
+            sinceClose = static_cast<int> (1000 * (now - closeTime));
+        else
+            sinceClose = - static_cast<int> (1000 * (closeTime - now));
     }
 
-    idleInterval = std::max (idleInterval, LEDGER_IDLE_INTERVAL);
-    idleInterval = std::max (
-        idleInterval, 2 * mPreviousLedger->info().closeTimeResolution);
+    auto const idleInterval = std::max (LEDGER_IDLE_INTERVAL,
+        2 * mPreviousLedger->info().closeTimeResolution);
 
     // Decide if we should close the ledger
     if (shouldCloseLedger (anyTransactions
@@ -982,35 +975,27 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         consensus_.peekStoredProposals ().clear ();
     }
 
-    auto closeTime = mOurPosition->getCloseTime();
+    std::uint32_t closeTime = mOurPosition->getCloseTime ();
+    bool closeTimeCorrect;
 
     auto replay = ledgerMaster_.releaseReplay();
-
     if (replay)
     {
-        // If we're replaying a close, use the time the ledger
-        // we're replaying closed
+        // replaying, use the time the ledger we're replaying closed
         closeTime = replay->closeTime_;
-
-        if ((replay->closeFlags_ & sLCF_NoConsensusTime) != 0)
-            closeTime = 0;
+        closeTimeCorrect = ((replay->closeFlags_ & sLCF_NoConsensusTime) == 0);
     }
-
-    closeTime = roundCloseTime (closeTime, mCloseResolution);
-
-    // If we don't have a close time, then we just agree to disagree
-    bool const closeTimeCorrect = (closeTime != 0);
-
-    // Switch to new semantics on Oct 27, 2015 at 11:00:00am PDT
-    if (mPreviousLedger->info().closeTime > 499284000)
+    else if (closeTime == 0)
     {
-        // Ledger close times should increase strictly monotonically
-        if (closeTime <= mPreviousLedger->info().closeTime)
-            closeTime = mPreviousLedger->info().closeTime + 1;
-    }
-    else if (!closeTimeCorrect)
-    {
+        // We agreed to disagree on the close time
         closeTime = mPreviousLedger->info().closeTime + 1;
+        closeTimeCorrect = false;
+    }
+    else
+    {
+        // We agreed on a close time
+        closeTime = effectiveCloseTime (closeTime);
+        closeTimeCorrect = true;
     }
 
     JLOG (j_.debug)
@@ -1526,6 +1511,16 @@ participantsNeeded (int participants, int percent)
     return (result == 0) ? 1 : result;
 }
 
+std::uint32_t LedgerConsensusImp::effectiveCloseTime (std::uint32_t closeTime)
+{
+    if (closeTime == 0)
+        return 0;
+
+    return std::max (
+        roundCloseTime (closeTime, mCloseResolution),
+        mPreviousLedger->info().closeTime + 1);
+}
+
 void LedgerConsensusImp::updateOurPositions ()
 {
     // Compute a cutoff time
@@ -1558,8 +1553,8 @@ void LedgerConsensusImp::updateOurPositions ()
         else
         {
             // proposal is still fresh
-            ++closeTimes[roundCloseTime (
-                it->second->getCloseTime (), mCloseResolution)];
+            ++closeTimes[effectiveCloseTime (
+                it->second->getCloseTime ())];
             ++it;
         }
     }
@@ -1611,16 +1606,15 @@ void LedgerConsensusImp::updateOurPositions ()
     {
         // no other times
         mHaveCloseTimeConsensus = true;
-        closeTime = roundCloseTime (
-            mOurPosition->getCloseTime (), mCloseResolution);
+        closeTime = effectiveCloseTime (mOurPosition->getCloseTime ());
     }
     else
     {
         int participants = mPeerPositions.size ();
         if (mProposing)
         {
-            ++closeTimes[roundCloseTime (
-                mOurPosition->getCloseTime (), mCloseResolution)];
+            ++closeTimes[
+                effectiveCloseTime (mOurPosition->getCloseTime ())];
             ++participants;
         }
 
@@ -1636,31 +1630,22 @@ void LedgerConsensusImp::updateOurPositions ()
             << mPeerPositions.size () << " nw:" << neededWeight
             << " thrV:" << threshVote << " thrC:" << threshConsensus;
 
-        for (auto it = closeTimes.begin ()
-            , end = closeTimes.end (); it != end; ++it)
+        for (auto const it : closeTimes)
         {
             JLOG (j_.debug) << "CCTime: seq "
                 << mPreviousLedger->info().seq + 1 << ": "
-                << it->first << " has " << it->second << ", "
+                << it.first << " has " << it.second << ", "
                 << threshVote << " required";
 
-            if (it->second >= threshVote)
+            if (it.second >= threshVote)
             {
-                JLOG (j_.debug)
-                    << "Close time consensus reached: " << it->first;
-                closeTime = it->first;
-                threshVote = it->second;
+                // A close time has enough votes for us to try to agree
+                closeTime = it.first;
+                threshVote = it.second;
 
                 if (threshVote >= threshConsensus)
                     mHaveCloseTimeConsensus = true;
             }
-        }
-
-        // If we agree to disagree on the close time, don't delay consensus
-        if (!mHaveCloseTimeConsensus && (closeTimes[0] > threshConsensus))
-        {
-            closeTime = 0;
-            mHaveCloseTimeConsensus = true;
         }
 
         CondLog (!mHaveCloseTimeConsensus, lsDEBUG, LedgerConsensus)
@@ -1669,9 +1654,12 @@ void LedgerConsensusImp::updateOurPositions ()
             << threshConsensus << " Pos:" << closeTime;
     }
 
+    // Temporarily send a new proposal if there's any change to our
+    // claimed close time. Once the new close time code is deployed
+    // to the full network, this can be relaxed to force a change
+    // only if the rounded close time has changed.
     if (!changes &&
-            ((closeTime != roundCloseTime (
-                mOurPosition->getCloseTime (), mCloseResolution))
+            ((closeTime != mOurPosition->getCloseTime ())
             || mOurPosition->isStale (ourCutoff)))
     {
         // close time changed or our position is stale

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -338,7 +338,7 @@ private:
     hash_map<uint256, std::shared_ptr <DisputedTx>> mDisputes;
     hash_set<uint256> mCompares;
 
-    // Close time estimates
+    // Close time estimates, keep ordered for predictable traverse
     std::map<std::uint32_t, int> mCloseTimes;
 
     // nodes that have bowed out of this consensus process

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -293,6 +293,9 @@ private:
     /** Add our load fee to our validation */
     void addLoad(STValidation::ref val);
 
+    /** Convert an advertised close time to an effective close time */
+    std::uint32_t effectiveCloseTime (std::uint32_t closeTime);
+
 private:
     Application& app_;
     ConsensusImp& consensus_;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -877,7 +877,7 @@ public:
     }
 
     /** Report that the consensus process built a particular ledger */
-    void consensusBuilt (Ledger::ref ledger, Json::Value&& consensus) override
+    void consensusBuilt (Ledger::ref ledger, Json::Value consensus) override
     {
 
         // Because we just built a ledger, we are no longer building one

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -877,7 +877,7 @@ public:
     }
 
     /** Report that the consensus process built a particular ledger */
-    void consensusBuilt (Ledger::ref ledger) override
+    void consensusBuilt (Ledger::ref ledger, Json::Value&& consensus) override
     {
 
         // Because we just built a ledger, we are no longer building one
@@ -970,7 +970,7 @@ public:
             checkAccept (maxLedger, maxSeq);
         }
 
-        mLedgerHistory.builtLedger (ledger);
+        mLedgerHistory.builtLedger (ledger, std::move (consensus));
     }
 
     void advanceThread()

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1410,6 +1410,11 @@ void NetworkOPsImp::processTrustedProposal (
 
         bool relay = true;
 
+        if (mConsensus)
+            mConsensus->storeProposal (proposal, nodePublic);
+        else
+            m_journal.warning << "Unable to store proposal";
+
         if (!haveConsensusObject ())
         {
             m_journal.info << "Received proposal outside consensus window";
@@ -1417,17 +1422,15 @@ void NetworkOPsImp::processTrustedProposal (
             if (mMode == omFULL)
                 relay = false;
         }
-        else
+        else if (mLedgerConsensus->getLCL () == proposal->getPrevLedger ())
         {
-            mConsensus->storeProposal (proposal, nodePublic);
-
-            if (mLedgerConsensus->getLCL () == proposal->getPrevLedger ())
-            {
-                relay = mLedgerConsensus->peerPosition (proposal);
-                m_journal.trace
-                    << "Proposal processing finished, relay=" << relay;
-            }
+            relay = mLedgerConsensus->peerPosition (proposal);
+            m_journal.trace
+                << "Proposal processing finished, relay=" << relay;
         }
+        else
+            m_journal.debug << "Got proposal for " << proposal->getPrevLedger ()
+                << " but we are on " << mLedgerConsensus->getLCL();
 
         if (relay)
             app_.overlay().relay(*set, proposal->getSuppressionID());


### PR DESCRIPTION
This has a few changes:

1) The trivial LedgerConsensusImp cleanups that were already reviewed and approved.
2) Removal of an obsolete comment.
3) Better logging of discrepancies between built and validated ledgers, including logging the final consensus status so we can see how many participants there were and what transaction sets they proposed.
4) Improvements to how we detect whether we have a close time consensus that take into account the monotonic close time rules. There's some code to send extra "end of round" proposals to help servers that don't have this fix reliably detect round endings.
5) Improved storage of proposals that arrive at the wrong time.

I will make a minimal, hotfix version of changes 4 and 5 for the release.