### PR TITLE
Force STAccount to 160-bit size (RIPD-994)

### DIFF
--- a/src/ripple/ledger/impl/TxMeta.cpp
+++ b/src/ripple/ledger/impl/TxMeta.cpp
@@ -136,15 +136,9 @@ TxMeta::getAffectedAccounts() const
             {
                 for (auto const& field : *inner)
                 {
-                    STAccount const* sa =
-                        dynamic_cast<STAccount const*> (&field);
-
-                    if (sa)
+                    if (auto sa = dynamic_cast<STAccount const*> (&field))
                     {
-                        AccountID id;
-                        assert(sa->isValueH160());
-                        if (sa->getValueH160(id))
-                            list.insert(id);
+                        list.insert(sa->value());
                     }
                     else if ((field.getFName () == sfLowLimit) || (field.getFName () == sfHighLimit) ||
                              (field.getFName () == sfTakerPays) || (field.getFName () == sfTakerGets))

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -21,45 +21,44 @@
 #define RIPPLE_PROTOCOL_STACCOUNT_H_INCLUDED
 
 #include <ripple/protocol/AccountID.h>
-#include <ripple/protocol/RippleAddress.h>
+#include <ripple/protocol/STBase.h>
 #include <ripple/protocol/STBlob.h>
 #include <string>
 
 namespace ripple {
 
 class STAccount final
-    : public STBlob
+    : public STBase
 {
+private:
+    // The original implementation of STAccount kept the value in an STBlob.
+    // But, over time, it was determined that an STAccount is always 160
+    // bits.  So we can store it with less overhead in a ripple::uint160.
+    //
+    // However, we need to leave the serialization format of the STAccount
+    // unchanged.  So, even though we store the value in an uint160, we
+    // serialize and deserialize like an STBlob.
+    uint160 value_;
+
 public:
     using value_type = AccountID;
 
-    STAccount (SField const& n, Buffer&& v)
-            : STBlob (n, std::move(v))
-    {
-        ;
-    }
-    STAccount (SField const& n, AccountID const& v);
-    STAccount (SField const& n) : STBlob (n)
-    {
-        ;
-    }
-    STAccount ()
-    {
-        ;
-    }
-
+    STAccount ();
+    STAccount (SField const& n);
+    STAccount (SField const& n, Buffer&& v);
     STAccount (SerialIter& sit, SField const& name);
+    STAccount (SField const& n, AccountID const& v);
 
     STBase*
     copy (std::size_t n, void* buf) const override
     {
-        return emplace(n, buf, *this);
+        return emplace (n, buf, *this);
     }
 
     STBase*
     move (std::size_t n, void* buf) override
     {
-        return emplace(n, buf, std::move(*this));
+        return emplace (n, buf, std::move(*this));
     }
 
     SerializedTypeID getSType () const override
@@ -69,14 +68,37 @@ public:
 
     std::string getText () const override;
 
+    void
+    add (Serializer& s) const override
+    {
+        assert (fName->isBinary ());
+        assert ((fName->fieldType == STI_VL) ||
+            (fName->fieldType == STI_ACCOUNT));
+
+        s.addVL (value_.data(), (160 / 8));
+    }
+
+    bool
+    isEquivalent (const STBase& t) const override
+    {
+        auto const* const tPtr = dynamic_cast<STAccount const*>(&t);
+        return (tPtr && (value_ == tPtr->value_));
+    }
+
+    bool
+    isDefault () const override
+    {
+        return value_ == beast::zero;
+    }
+
     STAccount&
-    operator= (value_type const& value)
+    operator= (AccountID const& value)
     {
         setValueH160(value);
         return *this;
     }
 
-    value_type
+    AccountID
     value() const noexcept
     {
         AccountID result;
@@ -87,8 +109,7 @@ public:
     template <typename Tag>
     void setValueH160 (base_uint<160, Tag> const& v)
     {
-        peekValue () = Buffer (v.data (), v.size ());
-        assert (peekValue ().size () == (160 / 8));
+        value_.copyFrom (v);
     }
 
     // VFALCO This is a clumsy interface, it should return
@@ -98,10 +119,8 @@ public:
     template <typename Tag>
     bool getValueH160 (base_uint<160, Tag>& v) const
     {
-        auto success = isValueH160 ();
-        if (success)
-            memcpy (v.begin (), peekValue ().data (), (160 / 8));
-        return success;
+        v.copyFrom (value_);
+        return true;
     }
 
     bool isValueH160 () const;

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -22,7 +22,6 @@
 
 #include <ripple/protocol/AccountID.h>
 #include <ripple/protocol/STBase.h>
-#include <ripple/protocol/STBlob.h>
 #include <string>
 
 namespace ripple {
@@ -36,7 +35,7 @@ private:
     // bits.  So we can store it with less overhead in a ripple::uint160.
     //
     // However, we need to leave the serialization format of the STAccount
-    // unchanged.  So, even though we store the value in an uint160, we
+    // unchanged.  So, even though we store the value in a uint160, we
     // serialize and deserialize like an STBlob.
     uint160 value_;
 
@@ -94,7 +93,7 @@ public:
     STAccount&
     operator= (AccountID const& value)
     {
-        setValueH160(value);
+        setValue (value);
         return *this;
     }
 
@@ -102,28 +101,14 @@ public:
     value() const noexcept
     {
         AccountID result;
-        getValueH160(result);
+        result.copyFrom (value_);
         return result;
     }
 
-    template <typename Tag>
-    void setValueH160 (base_uint<160, Tag> const& v)
+    void setValue (AccountID const& v)
     {
         value_.copyFrom (v);
     }
-
-    // VFALCO This is a clumsy interface, it should return
-    //        the value. And it should not be possible to
-    //        have anything other than a uint160 in here.
-    //        The base_uint tag should always be `AccountIDTag`.
-    template <typename Tag>
-    bool getValueH160 (base_uint<160, Tag>& v) const
-    {
-        v.copyFrom (value_);
-        return true;
-    }
-
-    bool isValueH160 () const;
 };
 
 } // ripple

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -98,12 +98,6 @@ public:
         s.addBitString<Bits> (value_);
     }
 
-    const value_type&
-    getValue () const
-    {
-        return value_;
-    }
-
     template <typename Tag>
     void setValue (base_uint<Bits, Tag> const& v)
     {

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -147,12 +147,6 @@ public:
         return value_;
     }
 
-    Buffer
-    getValue () const
-    {
-        return Buffer(value_.data (), value_.size ());
-    }
-
     void
     setValue (Buffer&& b)
     {

--- a/src/ripple/protocol/STExchange.h
+++ b/src/ripple/protocol/STExchange.h
@@ -50,7 +50,7 @@ struct STExchange<STInteger<U>, T>
     get (boost::optional<T>& t,
         STInteger<U> const& u)
     {
-        t = u.getValue();
+        t = u.value();
     }
 
     static

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -71,12 +71,6 @@ public:
         s.addInteger (value_);
     }
 
-    Integer
-    getValue () const
-    {
-        return value_;
-    }
-
     STInteger& operator= (value_type const& v)
     {
         value_ = v;

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -487,7 +487,7 @@ public:
     operator[](OptionaledField<T> const& of) const;
 
     /** Return a modifiable field value.
-        
+
         Throws:
 
             missing_field_error if the field is
@@ -585,11 +585,11 @@ private:
     // Implementation for getting (most) fields that return by value.
     //
     // The remove_cv and remove_reference are necessitated by the STBitString
-    // types.  Their getValue returns by const ref.  We return those types
+    // types.  Their value() returns by const ref.  We return those types
     // by value.
     template <typename T, typename V =
         typename std::remove_cv < typename std::remove_reference <
-            decltype (std::declval <T> ().getValue ())>::type >::type >
+            decltype (std::declval <T> ().value ())>::type >::type >
     V getFieldByValue (SField const& field) const
     {
         const STBase* rf = peekAtPField (field);
@@ -607,7 +607,7 @@ private:
         if (!cf)
             throw std::runtime_error ("Wrong field type");
 
-        return cf->getValue ();
+        return cf->value ();
     }
 
     // Implementations for getting (most) fields that return by const reference.

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -68,9 +68,4 @@ std::string STAccount::getText () const
     return toBase58 (value());
 }
 
-bool STAccount::isValueH160 () const
-{
-    return true;
-}
-
 } // ripple

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -134,10 +134,7 @@ STTx::getMentionedAccounts () const
     {
         if (auto sa = dynamic_cast<STAccount const*> (&it))
         {
-            AccountID id;
-            assert(sa->isValueH160());
-            if (sa->getValueH160(id))
-                list.insert(id);
+            list.insert(sa->value());
         }
         else if (auto sa = dynamic_cast<STAmount const*> (&it))
         {
@@ -480,31 +477,10 @@ isMemoOkay (STObject const& st, std::string& reason)
     return true;
 }
 
-// Ensure all account fields are 160-bits
-static
-bool
-isAccountFieldOkay (STObject const& st)
-{
-    for (int i = 0; i < st.getCount(); ++i)
-    {
-        auto t = dynamic_cast<STAccount const*>(st.peekAtPIndex (i));
-        if (t && !t->isValueH160 ())
-            return false;
-    }
-
-    return true;
-}
-
 bool passesLocalChecks (STObject const& st, std::string& reason)
 {
     if (!isMemoOkay (st, reason))
         return false;
-
-    if (!isAccountFieldOkay (st))
-    {
-        reason = "An account field is invalid.";
-        return false;
-    }
 
     return true;
 }


### PR DESCRIPTION
Things to consider in this pull request:

 1. Do you agree with my assessment that it is okay to throw in the STAccount constructor?  If not, what is the alternative?

 2. Do you agree that these changes correctly enforce that an STAccount is always 160 bits?

 3. Did I correctly leave the serialization format of STAccount unchanged?

 4. One serialization change I just realized is that a default constructed STAccount will be serialized as 20 8-bit zeros, not as an empty blob.  Will that be a problem?

 5. Previously the default state of an STAccount was empty (a zero-length STBlob).  Now the default state of an STAccount is all zeros.  Is that an acceptable change?

 6. Two places used to check that a constructed STAccount was actually 160 bits.  Those checks no longer makes sense.  However, does it make sense to check for a default constructed STAccount (all zeros) in those same locations?

I have enough uncertainty about the serialization consequences that I'd like really knowledgeable reviewers: @nbougalis, @JoelKatz.  There are not a lot of changes.  Hopefully the review will be quick.  Thanks.