### PR TITLE
Defer checking whether master key was used for signing

### DIFF
--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -79,8 +79,6 @@ protected:
     XRPAmount     mFeeDue;
     XRPAmount     mPriorBalance;  // Balance before fees.
     XRPAmount     mSourceBalance; // Balance after fees.
-    bool          mSigMaster;
-    RippleAddress mSigningPubKey;
 
 public:
     /** Process the transaction. */
@@ -151,7 +149,6 @@ protected:
 private:
     void setSeq ();
     TER payFee ();
-    void checkMasterSign ();
     static TER checkSingleSign (PreclaimContext const& ctx);
     static TER checkMultiSign (PreclaimContext const& ctx);
 };


### PR DESCRIPTION
We extracted the `SigningPubKey` in the `Transactor` and used to determine if a single-signature was made using the master or the regular key. This information is only needed in `SetAccount` so we move it there, deferring the check.

Reviews: @ximinez, @scottschurr