### PR TITLE
Force STAccount to 160-bit size (RIPD-994)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3046,6 +3046,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\protocol\tests\STAccount.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\protocol\tests\STAmount.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3741,6 +3741,9 @@
     <ClCompile Include="..\..\src\ripple\protocol\tests\RippleAddress.test.cpp">
       <Filter>ripple\protocol\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\protocol\tests\STAccount.test.cpp">
+      <Filter>ripple\protocol\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\protocol\tests\STAmount.test.cpp">
       <Filter>ripple\protocol\tests</Filter>
     </ClCompile>

--- a/src/ripple/ledger/impl/TxMeta.cpp
+++ b/src/ripple/ledger/impl/TxMeta.cpp
@@ -136,15 +136,11 @@ TxMeta::getAffectedAccounts() const
             {
                 for (auto const& field : *inner)
                 {
-                    STAccount const* sa =
-                        dynamic_cast<STAccount const*> (&field);
-
-                    if (sa)
+                    if (auto sa = dynamic_cast<STAccount const*> (&field))
                     {
-                        AccountID id;
-                        assert(sa->isValueH160());
-                        if (sa->getValueH160(id))
-                            list.insert(id);
+                        assert (! sa->isDefault());
+                        if (! sa->isDefault())
+                            list.insert(sa->value());
                     }
                     else if ((field.getFName () == sfLowLimit) || (field.getFName () == sfHighLimit) ||
                              (field.getFName () == sfTakerPays) || (field.getFName () == sfTakerGets))

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -22,7 +22,6 @@
 
 #include <ripple/protocol/AccountID.h>
 #include <ripple/protocol/STBase.h>
-#include <ripple/protocol/STBlob.h>
 #include <string>
 
 namespace ripple {
@@ -95,7 +94,7 @@ public:
     STAccount&
     operator= (AccountID const& value)
     {
-        setValueH160(value);
+        setValue (value);
         return *this;
     }
 
@@ -103,33 +102,14 @@ public:
     value() const noexcept
     {
         AccountID result;
-        getValueH160(result);
+        result.copyFrom (value_);
         return result;
     }
 
-    template <typename Tag>
-    void setValueH160 (base_uint<160, Tag> const& v)
+    void setValue (AccountID const& v)
     {
         value_.copyFrom (v);
         default_ = false;
-    }
-
-    // VFALCO This is a clumsy interface, it should return
-    //        the value. And it should not be possible to
-    //        have anything other than a uint160 in here.
-    //        The base_uint tag should always be `AccountIDTag`.
-    template <typename Tag>
-    bool getValueH160 (base_uint<160, Tag>& v) const
-    {
-        bool const success = isValueH160();
-        if (success)
-            v.copyFrom (value_);
-        return success;
-    }
-
-    bool isValueH160 () const
-    {
-        return ! isDefault();
     }
 };
 

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -98,12 +98,6 @@ public:
         s.addBitString<Bits> (value_);
     }
 
-    const value_type&
-    getValue () const
-    {
-        return value_;
-    }
-
     template <typename Tag>
     void setValue (base_uint<Bits, Tag> const& v)
     {

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -147,12 +147,6 @@ public:
         return value_;
     }
 
-    Buffer
-    getValue () const
-    {
-        return Buffer(value_.data (), value_.size ());
-    }
-
     void
     setValue (Buffer&& b)
     {

--- a/src/ripple/protocol/STExchange.h
+++ b/src/ripple/protocol/STExchange.h
@@ -50,7 +50,7 @@ struct STExchange<STInteger<U>, T>
     get (boost::optional<T>& t,
         STInteger<U> const& u)
     {
-        t = u.getValue();
+        t = u.value();
     }
 
     static

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -71,12 +71,6 @@ public:
         s.addInteger (value_);
     }
 
-    Integer
-    getValue () const
-    {
-        return value_;
-    }
-
     STInteger& operator= (value_type const& v)
     {
         value_ = v;

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -487,7 +487,7 @@ public:
     operator[](OptionaledField<T> const& of) const;
 
     /** Return a modifiable field value.
-        
+
         Throws:
 
             missing_field_error if the field is
@@ -585,11 +585,11 @@ private:
     // Implementation for getting (most) fields that return by value.
     //
     // The remove_cv and remove_reference are necessitated by the STBitString
-    // types.  Their getValue returns by const ref.  We return those types
+    // types.  Their value() returns by const ref.  We return those types
     // by value.
     template <typename T, typename V =
         typename std::remove_cv < typename std::remove_reference <
-            decltype (std::declval <T> ().getValue ())>::type >::type >
+            decltype (std::declval <T> ().value ())>::type >::type >
     V getFieldByValue (SField const& field) const
     {
         const STBase* rf = peekAtPField (field);
@@ -607,7 +607,7 @@ private:
         if (!cf)
             throw std::runtime_error ("Wrong field type");
 
-        return cf->getValue ();
+        return cf->value ();
     }
 
     // Implementations for getting (most) fields that return by const reference.

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -19,32 +19,58 @@
 
 #include <BeastConfig.h>
 #include <ripple/protocol/STAccount.h>
-#include <ripple/protocol/types.h>
 
 namespace ripple {
+
+STAccount::STAccount ()
+    : STBase ()
+    , value_ (beast::zero)
+    , default_ (true)
+{
+}
+
+STAccount::STAccount (SField const& n)
+    : STBase (n)
+    , value_ (beast::zero)
+    , default_ (true)
+{
+}
+
+STAccount::STAccount (SField const& n, Buffer&& v)
+    : STAccount (n)
+{
+    if (v.empty())
+        return;  // Zero is a valid size for a defaulted STAccount.
+
+    // Is it safe to throw from this constructor?  Today (November 2015)
+    // the only place that calls this constructor is
+    //    STVar::STVar (SerialIter&, SField const&)
+    // which throws.  If STVar can throw in its constructor, then so can
+    // STAccount.
+    if (v.size() != uint160::bytes)
+        throw std::runtime_error ("Invalid STAccount size");
+
+    default_ = false;
+    memcpy (value_.begin(), v.data (), uint160::bytes);
+}
 
 STAccount::STAccount (SerialIter& sit, SField const& name)
     : STAccount(name, sit.getVLBuffer())
 {
 }
 
+STAccount::STAccount (SField const& n, AccountID const& v)
+    : STBase (n)
+    , default_ (false)
+{
+    value_.copyFrom (v);
+}
+
 std::string STAccount::getText () const
 {
-    AccountID u;
-    RippleAddress a;
-    if (! getValueH160 (u))
-        return STBlob::getText ();
-    return toBase58(u);
-}
-
-STAccount::STAccount (SField const& n, AccountID const& v)
-        : STBlob (n, v.data (), v.size ())
-{
-}
-
-bool STAccount::isValueH160 () const
-{
-    return peekValue ().size () == (160 / 8);
+    if (isDefault())
+        return "";
+    return toBase58 (value());
 }
 
 } // ripple

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -134,10 +134,9 @@ STTx::getMentionedAccounts () const
     {
         if (auto sa = dynamic_cast<STAccount const*> (&it))
         {
-            AccountID id;
-            assert(sa->isValueH160());
-            if (sa->getValueH160(id))
-                list.insert(id);
+            assert(! sa->isDefault());
+            if (! sa->isDefault())
+                list.insert(sa->value());
         }
         else if (auto sa = dynamic_cast<STAmount const*> (&it))
         {
@@ -488,7 +487,7 @@ isAccountFieldOkay (STObject const& st)
     for (int i = 0; i < st.getCount(); ++i)
     {
         auto t = dynamic_cast<STAccount const*>(st.peekAtPIndex (i));
-        if (t && !t->isValueH160 ())
+        if (t && t->isDefault ())
             return false;
     }
 

--- a/src/ripple/protocol/tests/STAccount.test.cpp
+++ b/src/ripple/protocol/tests/STAccount.test.cpp
@@ -35,7 +35,6 @@ struct STAccount_test : public beast::unit_test::suite
             expect (defaultAcct.getText() == "");
             expect (defaultAcct.isDefault() == true);
             expect (defaultAcct.value() == AccountID {});
-            expect (! defaultAcct.isValueH160());
             {
 #ifdef NDEBUG // Qualified because the serialization asserts in a debug build.
                 Serializer s;
@@ -45,7 +44,6 @@ struct STAccount_test : public beast::unit_test::suite
                 SerialIter sit (s.slice ());
                 STAccount const deserializedDefault (sit, sfAccount);
                 expect (deserializedDefault.isEquivalent (defaultAcct));
-                expect (! deserializedDefault.isValueH160());
 #endif // NDEBUG
             }
             {
@@ -55,7 +53,6 @@ struct STAccount_test : public beast::unit_test::suite
                 SerialIter sit (s.slice ());
                 STAccount const deserializedDefault (sit, sfAccount);
                 expect (deserializedDefault.isEquivalent (defaultAcct));
-                expect (! deserializedDefault.isValueH160());
             }
 
             // Test constructor from SField.
@@ -64,7 +61,6 @@ struct STAccount_test : public beast::unit_test::suite
             expect (sfAcct.getText() == "");
             expect (sfAcct.isDefault());
             expect (sfAcct.value() == AccountID {});
-            expect (! sfAcct.isValueH160());
             expect (sfAcct.isEquivalent (defaultAcct));
             {
                 Serializer s;
@@ -74,7 +70,6 @@ struct STAccount_test : public beast::unit_test::suite
                 SerialIter sit (s.slice ());
                 STAccount const deserializedSf (sit, sfAccount);
                 expect (deserializedSf.isEquivalent(sfAcct));
-                expect (! deserializedSf.isValueH160());
             }
 
             // Test constructor from SField and AccountID.
@@ -82,7 +77,6 @@ struct STAccount_test : public beast::unit_test::suite
             expect (zeroAcct.getText() == "rrrrrrrrrrrrrrrrrrrrrhoLvTp");
             expect (! zeroAcct.isDefault());
             expect (zeroAcct.value() == AccountID {0});
-            expect (zeroAcct.isValueH160());
             expect (! zeroAcct.isEquivalent (defaultAcct));
             expect (! zeroAcct.isEquivalent (sfAcct));
             {
@@ -94,7 +88,6 @@ struct STAccount_test : public beast::unit_test::suite
                 SerialIter sit (s.slice ());
                 STAccount const deserializedZero (sit, sfAccount);
                 expect (deserializedZero.isEquivalent (zeroAcct));
-                expect (deserializedZero.isValueH160());
             }
             {
                 // Construct from a VL that is not exactly 160 bits.

--- a/src/ripple/protocol/tests/STAccount.test.cpp
+++ b/src/ripple/protocol/tests/STAccount.test.cpp
@@ -102,8 +102,16 @@ struct STAccount_test : public beast::unit_test::suite
                 const std::uint8_t bits128[] {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
                 s.addVL (bits128, sizeof (bits128));
                 SerialIter sit (s.slice ());
-                STAccount const deserializedBadSize (sit, sfAccount);
-                expect (! deserializedBadSize.isValueH160());
+                try
+                {
+                    // Constructing an STAccount with a bad size should throw.
+                    STAccount const deserializedBadSize (sit, sfAccount);
+                }
+                catch (std::runtime_error const& ex)
+                {
+                    expect (ex.what() == std::string("Invalid STAccount size"));
+                }
+
             }
 
             // Interestingly, equal values but different types are equivalent!

--- a/src/ripple/protocol/tests/STAccount.test.cpp
+++ b/src/ripple/protocol/tests/STAccount.test.cpp
@@ -1,0 +1,133 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/protocol/STAccount.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+
+struct STAccount_test : public beast::unit_test::suite
+{
+    void
+    testSTAccount()
+    {
+        {
+            // Test default constructor.
+            STAccount const defaultAcct;
+            expect (defaultAcct.getSType() == STI_ACCOUNT);
+            expect (defaultAcct.getText() == "");
+            expect (defaultAcct.isDefault() == true);
+            expect (defaultAcct.value() == AccountID {});
+            expect (! defaultAcct.isValueH160());
+            {
+#ifdef NDEBUG // Qualified because the serialization asserts in a debug build.
+                Serializer s;
+                defaultAcct.add (s); // Asserts in debug build
+                expect (s.size() == 1);
+                expect (s.getHex() == "00");
+                SerialIter sit (s.slice ());
+                STAccount const deserializedDefault (sit, sfAccount);
+                expect (deserializedDefault.isEquivalent (defaultAcct));
+                expect (! deserializedDefault.isValueH160());
+#endif // NDEBUG
+            }
+            {
+                // Construct a deserialized default STAccount.
+                Serializer s;
+                s.addVL (nullptr, 0);
+                SerialIter sit (s.slice ());
+                STAccount const deserializedDefault (sit, sfAccount);
+                expect (deserializedDefault.isEquivalent (defaultAcct));
+                expect (! deserializedDefault.isValueH160());
+            }
+
+            // Test constructor from SField.
+            STAccount const sfAcct {sfAccount};
+            expect (sfAcct.getSType() == STI_ACCOUNT);
+            expect (sfAcct.getText() == "");
+            expect (sfAcct.isDefault());
+            expect (sfAcct.value() == AccountID {});
+            expect (! sfAcct.isValueH160());
+            expect (sfAcct.isEquivalent (defaultAcct));
+            {
+                Serializer s;
+                sfAcct.add (s);
+                expect (s.size() == 1);
+                expect (s.getHex() == "00");
+                SerialIter sit (s.slice ());
+                STAccount const deserializedSf (sit, sfAccount);
+                expect (deserializedSf.isEquivalent(sfAcct));
+                expect (! deserializedSf.isValueH160());
+            }
+
+            // Test constructor from SField and AccountID.
+            STAccount const zeroAcct {sfAccount, AccountID{}};
+            expect (zeroAcct.getText() == "rrrrrrrrrrrrrrrrrrrrrhoLvTp");
+            expect (! zeroAcct.isDefault());
+            expect (zeroAcct.value() == AccountID {0});
+            expect (zeroAcct.isValueH160());
+            expect (! zeroAcct.isEquivalent (defaultAcct));
+            expect (! zeroAcct.isEquivalent (sfAcct));
+            {
+                Serializer s;
+                zeroAcct.add (s);
+                expect (s.size() == 21);
+                expect (s.getHex() ==
+                    "140000000000000000000000000000000000000000");
+                SerialIter sit (s.slice ());
+                STAccount const deserializedZero (sit, sfAccount);
+                expect (deserializedZero.isEquivalent (zeroAcct));
+                expect (deserializedZero.isValueH160());
+            }
+            {
+                // Construct from a VL that is not exactly 160 bits.
+                Serializer s;
+                const std::uint8_t bits128[] {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+                s.addVL (bits128, sizeof (bits128));
+                SerialIter sit (s.slice ());
+                STAccount const deserializedBadSize (sit, sfAccount);
+                expect (! deserializedBadSize.isValueH160());
+            }
+
+            // Interestingly, equal values but different types are equivalent!
+            STAccount const regKey {sfRegularKey, AccountID{}};
+            expect (regKey.isEquivalent (zeroAcct));
+
+            // Test assignment.
+            STAccount assignAcct;
+            expect (assignAcct.isEquivalent (defaultAcct));
+            expect (assignAcct.isDefault());
+            assignAcct = AccountID{};
+            expect (! assignAcct.isEquivalent (defaultAcct));
+            expect (assignAcct.isEquivalent (zeroAcct));
+            expect (! assignAcct.isDefault());
+        }
+    }
+
+    void
+    run() override
+    {
+        testSTAccount();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(STAccount,protocol,ripple);
+
+}

--- a/src/ripple/unity/protocol.cpp
+++ b/src/ripple/unity/protocol.cpp
@@ -71,6 +71,7 @@
 #include <ripple/protocol/tests/PublicKey_test.cpp>
 #include <ripple/protocol/tests/Quality.test.cpp>
 #include <ripple/protocol/tests/RippleAddress.test.cpp>
+#include <ripple/protocol/tests/STAccount.test.cpp>
 #include <ripple/protocol/tests/STAmount.test.cpp>
 #include <ripple/protocol/tests/STObject.test.cpp>
 #include <ripple/protocol/tests/STTx.test.cpp>


### PR DESCRIPTION
Things to consider in this pull request:

 1. Do you agree with my assessment that it is okay to throw in the STAccount constructor? If not, what is the alternative?

 2. Do you agree that these changes correctly enforce that a non-default STAccount is always 160 bits?

 3. Do the added unit tests provide adequate coverage?

 4. Did I correctly leave the serialization format of STAccount unchanged?

I have enough uncertainty about the serialization consequences that I'd like really knowledgeable reviewers: @nbougalis, @JoelKatz. There are not a lot of changes. Hopefully the review will be quick. Thanks.
