### PR TITLE
Make the SHAMap hash a distinct type from a uint256.

### DIFF
--- a/src/ripple/app/ledger/impl/ConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/ConsensusImp.cpp
@@ -148,7 +148,7 @@ ConsensusImp::storeProposal (
 void
 ConsensusImp::takePosition (int seq, std::shared_ptr<SHAMap> const& position)
 {
-    recentPositions_[position->getHash ()] = std::make_pair (seq, position);
+    recentPositions_[position->getHash ().as_uint256()] = std::make_pair (seq, position);
 
     if (recentPositions_.size () > 4)
     {

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -217,7 +217,7 @@ bool InboundLedger::tryLocal ()
             TransactionStateSF filter(app_);
 
             if (mLedger->txMap().fetchRoot (
-                mLedger->info().txHash, &filter))
+                SHAMapHash{mLedger->info().txHash}, &filter))
             {
                 auto h (mLedger->getNeededTransactionHashes (1, &filter));
 
@@ -245,7 +245,7 @@ bool InboundLedger::tryLocal ()
             AccountStateSF filter(app_);
 
             if (mLedger->stateMap().fetchRoot (
-                mLedger->info().accountHash, &filter))
+                SHAMapHash{mLedger->info().accountHash}, &filter))
             {
                 auto h (mLedger->getNeededAccountStateHashes (1, &filter));
 
@@ -854,7 +854,7 @@ bool InboundLedger::takeTxNode (const std::vector<SHAMapNodeID>& nodeIDs,
         if (nodeIDit->isRoot ())
         {
             san += mLedger->txMap().addRootNode (
-                mLedger->info().txHash, *nodeDatait, snfWIRE, &tFilter);
+                SHAMapHash{mLedger->info().txHash}, *nodeDatait, snfWIRE, &tFilter);
             if (!san.isGood())
                 return false;
         }
@@ -920,7 +920,7 @@ bool InboundLedger::takeAsNode (const std::vector<SHAMapNodeID>& nodeIDs,
         if (nodeIDit->isRoot ())
         {
             san += mLedger->stateMap().addRootNode (
-                mLedger->info().accountHash, *nodeDatait, snfWIRE, &tFilter);
+                SHAMapHash{mLedger->info().accountHash}, *nodeDatait, snfWIRE, &tFilter);
             if (!san.isGood ())
             {
                 if (m_journal.warning) m_journal.warning <<
@@ -977,7 +977,7 @@ bool InboundLedger::takeAsRootNode (Blob const& data, SHAMapAddNode& san)
 
     AccountStateSF tFilter(app_);
     san += mLedger->stateMap().addRootNode (
-        mLedger->info().accountHash, data, snfWIRE, &tFilter);
+        SHAMapHash{mLedger->info().accountHash}, data, snfWIRE, &tFilter);
     return san.isGood();
 }
 
@@ -1000,7 +1000,7 @@ bool InboundLedger::takeTxRootNode (Blob const& data, SHAMapAddNode& san)
 
     TransactionStateSF tFilter(app_);
     san += mLedger->txMap().addRootNode (
-        mLedger->info().txHash, data, snfWIRE, &tFilter);
+        SHAMapHash{mLedger->info().txHash}, data, snfWIRE, &tFilter);
     return san.isGood();
 }
 

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -257,7 +257,7 @@ public:
 
                 auto newNode = SHAMapAbstractNode::make(
                     Blob (node.nodedata().begin(), node.nodedata().end()),
-                    0, snfWIRE, uZero, false, app_.journal ("SHAMapNodeID"));
+                    0, snfWIRE, SHAMapHash{uZero}, false, app_.journal ("SHAMapNodeID"));
 
                 if (!newNode)
                     return;
@@ -268,7 +268,7 @@ public:
                 auto blob = std::make_shared<Blob> (s.begin(), s.end());
 
                 app_.getLedgerMaster().addFetchPack(
-                    newNode->getNodeHash(), blob);
+                    newNode->getNodeHash().as_uint256(), blob);
             }
         }
         catch (...)

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -437,7 +437,7 @@ void LedgerConsensusImp::mapCompleteInternal (
         return;
     }
 
-    assert (hash == map->getHash ());
+    assert (hash == map->getHash ().as_uint256());
 
     auto it = mAcquired.find (hash);
 
@@ -497,7 +497,7 @@ void LedgerConsensusImp::mapCompleteInternal (
     std::vector<NodeID> peers;
     for (auto& it : mPeerPositions)
     {
-        if (it.second->getCurrentHash () == map->getHash ())
+        if (it.second->getCurrentHash () == map->getHash ().as_uint256())
             peers.push_back (it.second->getPeerID ());
     }
 
@@ -979,7 +979,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         if (set->getHash ().isNonZero ())
            consensus_.takePosition (mPreviousLedger->info().seq, set);
 
-        assert (set->getHash () == mOurPosition->getCurrentHash ());
+        assert (set->getHash ().as_uint256() == mOurPosition->getCurrentHash ());
         // these are now obsolete
         consensus_.peekStoredProposals ().clear ();
     }
@@ -1028,7 +1028,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         << ", close " << closeTime << (closeTimeCorrect ? "" : "X");
 
     // Put transactions into a deterministic, but unpredictable, order
-    CanonicalTXSet retriableTxs (set->getHash ());
+    CanonicalTXSet retriableTxs (set->getHash ().as_uint256());
 
     // Build the new last closed ledger
     auto newLCL = std::make_shared<Ledger>(
@@ -1472,7 +1472,7 @@ void LedgerConsensusImp::takeInitialPosition (
     // Tell the ledger master not to acquire the ledger we're probably building
     ledgerMaster_.setBuildingLedger (mPreviousLedger->info().seq + 1);
 
-    uint256 txSet = initialSet->getHash ();
+    auto txSet = initialSet->getHash ().as_uint256();
     JLOG (j_.info) << "initial position " << txSet;
     mapCompleteInternal (txSet, initialSet, false);
 
@@ -1497,7 +1497,7 @@ void LedgerConsensusImp::takeInitialPosition (
 
             if (iit != mAcquired.end ())
             {
-                mCompares.insert(iit->second->getHash());
+                mCompares.insert(iit->second->getHash().as_uint256());
                 createDisputes (initialSet, iit->second);
             }
         }
@@ -1685,7 +1685,7 @@ void LedgerConsensusImp::updateOurPositions ()
 
     if (changes)
     {
-        uint256 newHash = ourPosition->getHash ();
+        auto newHash = ourPosition->getHash ().as_uint256();
         JLOG (j_.info)
             << "Position change: CTime " << closeTime
             << ", tx " << newHash;

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -204,7 +204,8 @@ SHAMapAddNode TransactionAcquire::takeNodes (const std::list<SHAMapNodeID>& node
             {
                 if (mHaveRoot)
                     JLOG (j_.debug) << "Got root TXS node, already have it";
-                else if (!mMap->addRootNode (getHash (), *nodeDatait, snfWIRE, nullptr).isGood())
+                else if (!mMap->addRootNode (SHAMapHash{getHash ()},
+                                             *nodeDatait, snfWIRE, nullptr).isGood())
                 {
                     JLOG (j_.warning) << "TX acquire got bad root node";
                 }

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -254,7 +254,7 @@ SHAMapStoreImp::copyNode (std::uint64_t& nodeCount,
         SHAMapAbstractNode const& node)
 {
     // Copy a single record from node to database_
-    database_->fetchNode (node.getNodeHash());
+    database_->fetchNode (node.getNodeHash().as_uint256());
     if (! (++nodeCount % checkHealthInterval_))
     {
         if (health())

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -190,9 +190,9 @@ private:
     {
         std::uint64_t check = 0;
 
-        for (uint256 it: cache.getKeys())
+        for (uint256 const& key: cache.getKeys())
         {
-            database_->fetchNode (it);
+            database_->fetchNode (key);
             if (! (++check % checkHealthInterval_) && health())
                 return true;
         }

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -135,14 +135,14 @@ public:
     // Handles copy on write for mutable snapshots.
     std::shared_ptr<SHAMap> snapShot (bool isMutable) const;
     void setLedgerSeq (std::uint32_t lseq);
-    bool fetchRoot (uint256 const& hash, SHAMapSyncFilter * filter);
+    bool fetchRoot (SHAMapHash const& hash, SHAMapSyncFilter * filter);
 
     // normal hash access functions
     bool hasItem (uint256 const& id) const;
     bool delItem (uint256 const& id);
     bool addItem (SHAMapItem const& i, bool isTransaction, bool hasMeta);
     bool addItem (SHAMapItem&& i, bool isTransaction, bool hasMeta);
-    uint256 getHash () const;
+    SHAMapHash getHash () const;
 
     // save a copy if you have a temporary anyway
     bool updateGiveItem (std::shared_ptr<SHAMapItem const> const&,
@@ -164,7 +164,7 @@ public:
     // of the SHAMapItem beyond this SHAMap
     std::shared_ptr<SHAMapItem const> const& peekItem (uint256 const& id) const;
     std::shared_ptr<SHAMapItem const> const&
-        peekItem (uint256 const& id, uint256 & hash) const;
+        peekItem (uint256 const& id, SHAMapHash& hash) const;
     std::shared_ptr<SHAMapItem const> const&
         peekItem (uint256 const& id, SHAMapTreeNode::TNType & type) const;
 
@@ -187,8 +187,8 @@ public:
 
     bool getRootNode (Serializer & s, SHANodeFormat format) const;
     std::vector<uint256> getNeededHashes (int max, SHAMapSyncFilter * filter);
-    SHAMapAddNode addRootNode (uint256 const& hash, Blob const& rootNode, SHANodeFormat format,
-                               SHAMapSyncFilter * filter);
+    SHAMapAddNode addRootNode (SHAMapHash const& hash, Blob const& rootNode,
+                               SHANodeFormat format, SHAMapSyncFilter * filter);
     SHAMapAddNode addRootNode (Blob const& rootNode, SHANodeFormat format,
                                SHAMapSyncFilter * filter);
     SHAMapAddNode addKnownNode (SHAMapNodeID const& nodeID, Blob const& rawNode,
@@ -230,18 +230,18 @@ private:
     int unshare ();
 
      // tree node cache operations
-    std::shared_ptr<SHAMapAbstractNode> getCache (uint256 const& hash) const;
-    void canonicalize (uint256 const& hash, std::shared_ptr<SHAMapAbstractNode>&) const;
+    std::shared_ptr<SHAMapAbstractNode> getCache (SHAMapHash const& hash) const;
+    void canonicalize (SHAMapHash const& hash, std::shared_ptr<SHAMapAbstractNode>&) const;
 
     // database operations
-    std::shared_ptr<SHAMapAbstractNode> fetchNodeFromDB (uint256 const& hash) const;
-    std::shared_ptr<SHAMapAbstractNode> fetchNodeNT (uint256 const& hash) const;
+    std::shared_ptr<SHAMapAbstractNode> fetchNodeFromDB (SHAMapHash const& hash) const;
+    std::shared_ptr<SHAMapAbstractNode> fetchNodeNT (SHAMapHash const& hash) const;
     std::shared_ptr<SHAMapAbstractNode> fetchNodeNT (
         SHAMapNodeID const& id,
-        uint256 const& hash,
+        SHAMapHash const& hash,
         SHAMapSyncFilter *filter) const;
-    std::shared_ptr<SHAMapAbstractNode> fetchNode (uint256 const& hash) const;
-    std::shared_ptr<SHAMapAbstractNode> checkFilter(uint256 const& hash,
+    std::shared_ptr<SHAMapAbstractNode> fetchNode (SHAMapHash const& hash) const;
+    std::shared_ptr<SHAMapAbstractNode> checkFilter(SHAMapHash const& hash,
         SHAMapNodeID const& id, SHAMapSyncFilter* filter) const;
 
     /** Update hashes up to the root */
@@ -295,8 +295,8 @@ private:
     /** If there is only one leaf below this node, get its contents */
     std::shared_ptr<SHAMapItem const> const& onlyBelow (SHAMapAbstractNode*) const;
 
-    bool hasInnerNode (SHAMapNodeID const& nodeID, uint256 const& hash) const;
-    bool hasLeafNode (uint256 const& tag, uint256 const& hash) const;
+    bool hasInnerNode (SHAMapNodeID const& nodeID, SHAMapHash const& hash) const;
+    bool hasLeafNode (uint256 const& tag, SHAMapHash const& hash) const;
 
     SHAMapItem const* peekFirstItem(NodeStack& stack) const;
     SHAMapItem const* peekNextItem(uint256 const& id, NodeStack& stack) const;

--- a/src/ripple/shamap/SHAMapMissingNode.h
+++ b/src/ripple/shamap/SHAMapMissingNode.h
@@ -21,6 +21,7 @@
 #define RIPPLE_SHAMAP_SHAMAPMISSINGNODE_H_INCLUDED
 
 #include <ripple/basics/base_uint.h>
+#include <ripple/shamap/SHAMapTreeNode.h>
 #include <iosfwd>
 #include <stdexcept>
 
@@ -38,28 +39,27 @@ class SHAMapMissingNode
 {
 private:
     SHAMapType mType;
-    uint256 mNodeHash;
+    SHAMapHash mNodeHash;
+    uint256    mNodeID;
 public:
     SHAMapMissingNode (SHAMapType t,
-                       uint256 const& nodeHash)
+                       SHAMapHash const& nodeHash)
         : std::runtime_error ("SHAMapMissingNode")
         , mType (t)
         , mNodeHash (nodeHash)
     {
     }
 
-    SHAMapType getMapType () const
+    SHAMapMissingNode (SHAMapType t,
+                       uint256 const& nodeID)
+        : std::runtime_error ("SHAMapMissingNode")
+        , mType (t)
+        , mNodeID (nodeID)
     {
-        return mType;
     }
 
-    uint256 const& getNodeHash () const
-    {
-        return mNodeHash;
-    }
+    friend std::ostream& operator<< (std::ostream&, SHAMapMissingNode const&);
 };
-
-extern std::ostream& operator<< (std::ostream&, SHAMapMissingNode const&);
 
 } // ripple
 

--- a/src/ripple/shamap/impl/SHAMapMissingNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapMissingNode.cpp
@@ -26,22 +26,27 @@ namespace ripple {
 std::ostream&
 operator<< (std::ostream& out, const SHAMapMissingNode& mn)
 {
-    switch (mn.getMapType ())
+    switch (mn.mType)
     {
     case SHAMapType::TRANSACTION:
-        out << "Missing/TXN(" << mn.getNodeHash () << ")";
+        out << "Missing/TXN(";
         break;
 
     case SHAMapType::STATE:
-        out << "Missing/STA(" << mn.getNodeHash () << ")";
+        out << "Missing/STA(";
         break;
 
     case SHAMapType::FREE:
     default:
-        out << "Missing/" << mn.getNodeHash ();
+        out << "Missing/(";
         break;
     };
 
+    if (mn.mNodeHash == zero)
+        out << "id : " << mn.mNodeID;
+    else
+        out << "hash : " << mn.mNodeHash;
+    out << ")";
     return out;
 }
 

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -87,7 +87,7 @@ public:
         unexpected (i != e, "bad traverse");
 
         testcase ("snapshot");
-        uint256 mapHash = sMap.getHash ();
+        SHAMapHash mapHash = sMap.getHash ();
         std::shared_ptr<SHAMap> map2 = sMap.snapShot (false);
         unexpected (sMap.getHash () != mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
@@ -119,19 +119,19 @@ public:
 
             SHAMap map (SHAMapType::FREE, f);
 
-            expect (map.getHash() == uint256(), "bad initial empty map hash");
+            expect (map.getHash() == zero, "bad initial empty map hash");
             for (int i = 0; i < keys.size(); ++i)
             {
                 SHAMapItem item (keys[i], IntToVUC (i));
                 map.addItem (item, true, false);
-                expect (map.getHash() == hashes[i], "bad buildup map hash");
+                expect (map.getHash().as_uint256() == hashes[i], "bad buildup map hash");
             }
             for (int i = keys.size() - 1; i >= 0; --i)
             {
-                expect (map.getHash() == hashes[i], "bad teardown hash");
+                expect (map.getHash().as_uint256() == hashes[i], "bad teardown hash");
                 map.delItem (keys[i]);
             }
-            expect (map.getHash() == uint256(), "bad final empty map hash");
+            expect (map.getHash() == zero, "bad final empty map hash");
         }
     }
 };

--- a/src/ripple/shamap/tests/SHAMapSync.test.cpp
+++ b/src/ripple/shamap/tests/SHAMapSync.test.cpp
@@ -50,7 +50,7 @@ public:
     {
         // add a bunch of random states to a map, then remove them
         // map should be the same
-        uint256 beforeHash = map.getHash ();
+        SHAMapHash beforeHash = map.getHash ();
 
         std::list<uint256> items;
 


### PR DESCRIPTION
* Implement a type safe distinction between a node hash and a node id.
* This is just the first phase, limited to SHAMap's internals.
@JoelKatz @scottschurr 