### PR TITLE
Fix TxQ LastLedgerSequence handling & add tests

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -539,7 +539,7 @@ TxQ::processValidatedLedger(Application& app,
         && (!maxSize_ || keptCandidates < *maxSize_))
     {
         if (candidateIter->lastValid
-            && *candidateIter->lastValid >= ledgerSeq)
+            && *candidateIter->lastValid <= ledgerSeq)
         {
             candidateIter = erase(candidateIter);
         }


### PR DESCRIPTION
I left the fix and the tests as separate commits so anyone interested can revert the fix commit locally and verify the one test fails.

According to [the code coverage report](https://codecov.io/github/ximinez/rippled/src/ripple/app/misc/impl/TxQ.cpp?ref=fc0b6bd8b4f74761f49f8b67eb0158fdccfdf084), the only things in TxQ left untested after this are logging, the fallbacks when the feature is disabled, the RPC command function, a few edge cases, and stuff that I can't really test without support for multiple transactions per account.

Reviewers: @nbougalis @seelabs 