### PR TITLE
Optimizations to the way we handle ledger close times in RPC

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -137,6 +137,12 @@ public:
     virtual uint256 getLedgerHash(
         std::uint32_t desiredSeq, Ledger::ref knownGoodLedger) = 0;
 
+    virtual boost::optional <uint32_t> getCloseTimeBySeq (
+        LedgerIndex ledgerIndex) = 0;
+
+    virtual boost::optional <uint32_t> getCloseTimeByHash (
+        LedgerHash const& ledgerHash) = 0;
+
     virtual void addHeldTransaction (std::shared_ptr<Transaction> const& trans) = 0;
     virtual void fixMismatch (Ledger::ref ledger) = 0;
 

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -161,10 +161,10 @@ Json::Value Transaction::getJson (int options, bool binary) const
 
         if (options == 1)
         {
-            auto ledger = mApp.getLedgerMaster ().
-                    getLedgerBySeq (mInLedger);
-            if (ledger)
-                ret[jss::date] = ledger->info().closeTime;
+            auto ct = mApp.getLedgerMaster().
+                getCloseTimeBySeq (mInLedger);
+            if (ct)
+                ret[jss::date] = *ct;
         }
     }
 

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -479,7 +479,7 @@ private:
         return rpcError (rpcINVALID_PARAMS);
     }
 
-    // ledger [id|index|current|closed|validated] [full]
+    // ledger [id|index|current|closed|validated] [full|tx]
     Json::Value parseLedger (Json::Value const& jvParams)
     {
         Json::Value     jvRequest (Json::objectValue);
@@ -491,9 +491,17 @@ private:
 
         jvParseLedger (jvRequest, jvParams[0u].asString ());
 
-        if (2 == jvParams.size () && jvParams[1u].asString () == "full")
+        if (2 == jvParams.size ())
         {
-            jvRequest[jss::full]   = bool (1);
+            if (jvParams[1u].asString () == "full")
+            {
+                jvRequest[jss::full]   = true;
+            }
+            else if (jvParams[1u].asString () == "tx")
+            {
+                jvRequest[jss::transactions] = true;
+                jvRequest[jss::expand] = true;
+            }
         }
 
         return jvRequest;

--- a/src/ripple/protocol/Serializer.h
+++ b/src/ripple/protocol/Serializer.h
@@ -369,6 +369,9 @@ public:
     Blob
     getVL();
 
+    void
+    skip (int num);
+
     Buffer
     getVLBuffer();
 

--- a/src/ripple/protocol/impl/Serializer.cpp
+++ b/src/ripple/protocol/impl/Serializer.cpp
@@ -433,6 +433,17 @@ SerialIter::reset() noexcept
     used_ = 0;
 }
 
+void
+SerialIter::skip (int length)
+{
+    if (remain_ < length)
+        throw std::runtime_error(
+            "invalid SerialIter skip");
+    p_ += length;
+    used_ += length;
+    remain_ -= length;
+}
+
 unsigned char
 SerialIter::get8()
 {

--- a/src/ripple/rpc/impl/Utilities.cpp
+++ b/src/ripple/rpc/impl/Utilities.cpp
@@ -17,8 +17,8 @@
 */
 //==============================================================================
 
-#include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/rpc/impl/Utilities.h>
+#include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/misc/Transaction.h>
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/JsonFields.h>


### PR DESCRIPTION
1) Add SerialIter::Skip, needed for extracting just the close time
2) Add a "tx" option to the "ledger" command so you can now do `ledger validated tx` to see all transactions in the validated ledger. (Previously, you had to build the query in JSON to do that.)
3) Add a function to get a ledger's close time without constructing the ledger and crowding the ledger cache. Use this function to date-stamp transactions for RPC.
4) Use the ledger close time function to avoid falsely claiming that the `delivered_amount` is unavailable. We still use only the ledger sequence number in the vast majority of cases.