### PR TITLE
Convert throws and catch alls (RIPD-1046)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1980,6 +1980,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\basics\tests\contract.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\basics\tests\hardened_hash_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2718,6 +2718,9 @@
     <ClCompile Include="..\..\src\ripple\basics\tests\CheckLibraryVersions.test.cpp">
       <Filter>ripple\basics\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\basics\tests\contract.test.cpp">
+      <Filter>ripple\basics\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\basics\tests\hardened_hash_test.cpp">
       <Filter>ripple\basics\tests</Filter>
     </ClCompile>

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -67,7 +67,7 @@ void ConsensusTransSetSF::gotNode (
                     pap->getOPs().submitTransaction(stx);
                 });
         }
-        catch (...)
+        catch (std::exception const&)
         {
             JLOG (j_.warning)
                     << "Fetched invalid transaction in proposed set";

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -243,7 +243,7 @@ Ledger::Ledger (uint256 const& parentHash,
 
     if (! setup(config))
         loaded = false;
-    
+
     if (! loaded)
     {
         updateHash ();
@@ -456,7 +456,7 @@ deserializeTxPlusMeta (SHAMapItem const& item)
 void Ledger::setAcquiring (void)
 {
     if (!txMap_ || !stateMap_)
-        throw std::runtime_error ("invalid map");
+        Throw<std::runtime_error> ("invalid map");
 
     txMap_->setSynching ();
     stateMap_->setSynching ();
@@ -721,11 +721,10 @@ Ledger::setup (Config const& config)
     {
         ret = false;
     }
-    catch (...)
+    catch (std::exception const&)
     {
-        throw;
+        Throw();
     }
-
 
     try
     {
@@ -735,9 +734,9 @@ Ledger::setup (Config const& config)
     {
         ret = false;
     }
-    catch (...)
+    catch (std::exception const&)
     {
-        throw;
+        Throw();
     }
 
     return ret;
@@ -783,7 +782,7 @@ void Ledger::visitStateItems (std::function<void (SLE::ref)> callback) const
     catch (SHAMapMissingNode&)
     {
         stateMap_->family().missing_node (info_.hash);
-        throw;
+        Throw();
     }
 }
 
@@ -999,7 +998,7 @@ static bool saveValidatedLedger (
             app.getAcceptedLedgerCache().canonicalize(ledger->info().hash, aLedger);
         }
     }
-    catch (...)
+    catch (std::exception const&)
     {
         JLOG (j.warning) << "An accepted ledger was missing nodes";
         app.getLedgerMaster().failedSave(seq, ledger->info().hash);

--- a/src/ripple/app/ledger/OpenLedger.h
+++ b/src/ripple/app/ledger/OpenLedger.h
@@ -224,7 +224,7 @@ OpenLedger::apply (Application& app, OpenView& view,
             if (result == Result::retry)
                 retries.insert(tx);
         }
-        catch(...)
+        catch(std::exception const&)
         {
             JLOG(j.error) <<
                 "Caught exception";

--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -282,7 +282,7 @@ void OrderBookDB::processTxn (
                     }
                 }
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 JLOG (j_.info)
                     << "Fields not found in OrderBookDB::processTxn";

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -271,7 +271,7 @@ public:
                     newNode->getNodeHash().as_uint256(), blob);
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
     }

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -35,6 +35,7 @@
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/app/misc/Validations.h>
 #include <ripple/app/tx/apply.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/CountedObject.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
@@ -531,7 +532,7 @@ void LedgerConsensusImp::mapComplete (
         leaveConsensus();
         JLOG (j_.error) <<
             "Missing node processing complete map " << mn;
-        throw;
+        Throw();
     }
 }
 
@@ -731,7 +732,7 @@ void LedgerConsensusImp::timerEntry ()
         leaveConsensus ();
         JLOG (j_.error) <<
            "Missing node during consensus process " << mn;
-        throw;
+        Throw();
     }
 }
 
@@ -1167,7 +1168,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
 
                     anyDisputes = true;
                 }
-                catch (...)
+                catch (std::exception const&)
                 {
                     JLOG (j_.debug)
                         << "Failed to apply transaction we voted NO on";
@@ -1857,7 +1858,7 @@ applyTransaction (Application& app, OpenView& view,
             << "Transaction retry: " << transHuman (result.first);
         return LedgerConsensusImp::resultRetry;
     }
-    catch (...)
+    catch (std::exception const&)
     {
         JLOG (j.warning) << "Throws";
         return LedgerConsensusImp::resultFail;
@@ -1893,7 +1894,7 @@ void applyTransactions (
             {
                 txn = std::make_shared<STTx const>(SerialIter{item.slice()});
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 JLOG (j.warning) << "  Throws";
             }
@@ -1946,7 +1947,7 @@ void applyTransactions (
                     ++it;
                 }
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 JLOG (j.warning)
                     << "Transaction throws";

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -629,7 +629,7 @@ public:
                 {
                     hash = hashOfSeq(*ledger, lSeq, m_journal);
                 }
-                catch (...)
+                catch (std::exception const&)
                 {
                     JLOG (m_journal.warning) <<
                         "fixMismatch encounters partial ledger";
@@ -984,7 +984,7 @@ public:
         {
             doAdvance();
         }
-        catch (...)
+        catch (std::exception const&)
         {
             JLOG (m_journal.fatal) << "doAdvance throws an exception";
         }
@@ -1106,7 +1106,7 @@ public:
 
                 }
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 JLOG (m_journal.error)
                     << "findNewLedgersToPublish catches an exception";
@@ -1501,7 +1501,7 @@ public:
                     if (hash)
                         return mLedgerHistory.getLedgerByHash (*hash);
                 }
-                catch (...)
+                catch (std::exception const&)
                 {
                     // Missing nodes are already handled
                 }
@@ -1734,7 +1734,7 @@ void LedgerMasterImp::doAdvance ()
                                                      InboundLedger::fcHISTORY);
                                     }
                                 }
-                                catch (...)
+                                catch (std::exception const&)
                                 {
                                     JLOG (m_journal.warning) <<
                                     "Threw while prefetching";
@@ -1962,7 +1962,7 @@ void LedgerMasterImp::makeFetchPack (
         auto msg = std::make_shared<Message> (reply, protocol::mtGET_OBJECTS);
         peer->send (msg);
     }
-    catch (...)
+    catch (std::exception const&)
     {
         m_journal.warning << "Exception building fetch pach";
     }

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -117,7 +117,7 @@ void fillJsonTx (Object& json, LedgerFill const& fill)
             }
         }
     }
-    catch (...)
+    catch (std::exception const&)
     {
         // Nothing the user can do about this.
     }

--- a/src/ripple/app/ledger/impl/OpenLedger.cpp
+++ b/src/ripple/app/ledger/impl/OpenLedger.cpp
@@ -184,7 +184,7 @@ debugTostr (SHAMap const& set)
                 STTx const>(sit);
             ss << debugTxstr(tx) << ", ";
         }
-        catch(...)
+        catch(std::exception const&)
         {
             ss << "THRO, ";
         }

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -226,7 +226,7 @@ SHAMapAddNode TransactionAcquire::takeNodes (const std::list<SHAMapNodeID>& node
         progress ();
         return SHAMapAddNode::useful ();
     }
-    catch (...)
+    catch (std::exception const&)
     {
         JLOG (j_.error) << "Peer sends us junky transaction node data";
         return SHAMapAddNode::invalid ();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -46,6 +46,7 @@
 #include <ripple/app/paths/PathRequests.h>
 #include <ripple/app/misc/UniqueNodeList.h>
 #include <ripple/app/tx/apply.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/ResolverAsio.h>
 #include <ripple/basics/Sustain.h>
@@ -1047,7 +1048,7 @@ void ApplicationImp::setup()
         {
             m_journal.fatal << "Could not create Websocket for [" <<
                 port.name << "]";
-            throw std::exception();
+            Throw<std::exception> ();
         }
         websocketServers_.emplace_back (std::move (server));
     }
@@ -1526,7 +1527,7 @@ static bool schemaHas (
     if (static_cast<int> (schema.size ()) <= line)
     {
         JLOG (j.fatal) << "Schema for " << dbName << " has too few lines";
-        throw std::runtime_error ("bad schema");
+        Throw<std::runtime_error> ("bad schema");
     }
 
     return schema[line].find (content) != std::string::npos;

--- a/src/ripple/app/main/LocalCredentials.cpp
+++ b/src/ripple/app/main/LocalCredentials.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/main/LocalCredentials.h>
 #include <ripple/app/misc/UniqueNodeList.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/core/Config.h>
@@ -46,7 +47,7 @@ void LocalCredentials::start ()
         nodeIdentityCreate ();
 
         if (!nodeIdentityLoad ())
-            throw std::runtime_error ("unable to retrieve new node identity.");
+            Throw<std::runtime_error> ("unable to retrieve new node identity.");
     }
 
     if (!app_.config().QUIET)

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -22,6 +22,7 @@
 #include <ripple/protocol/digest.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/basics/CheckLibraryVersions.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/Sustain.h>
 #include <ripple/basics/ThreadName.h>
@@ -298,7 +299,7 @@ int run (int argc, char** argv)
             vm);
         po::notify (vm);                  // Invoke option notify functions.
     }
-    catch (...)
+    catch (std::exception const&)
     {
         std::cerr << "rippled: Incorrect command line syntax." << std::endl;
         std::cerr << "Use '--help' for a list of options." << std::endl;
@@ -421,7 +422,7 @@ int run (int argc, char** argv)
                 boost::asio::ip::address_v4::from_string(
                     vm["rpc_ip"].as<std::string>()));
         }
-        catch(...)
+        catch(std::exception const&)
         {
             std::cerr << "Invalid rpc_ip = " <<
                 vm["rpc_ip"].as<std::string>() << std::endl;
@@ -439,9 +440,9 @@ int run (int argc, char** argv)
                 vm["rpc_port"].as<std::uint16_t>());
 
             if (*config->rpc_port == 0)
-                throw std::domain_error ("");
+                Throw<std::domain_error> ("");
         }
-        catch(...)
+        catch(std::exception const&)
         {
             std::cerr << "Invalid rpc_port = " <<
                 vm["rpc_port"].as<std::string>() << std::endl;
@@ -457,9 +458,9 @@ int run (int argc, char** argv)
             config->LOCK_QUORUM = true;
 
             if (config->VALIDATION_QUORUM < 0)
-                throw std::domain_error ("");
+                Throw<std::domain_error> ("");
         }
-        catch(...)
+        catch(std::exception const&)
         {
             std::cerr << "Invalid quorum = " <<
                 vm["quorum"].as <std::string> () << std::endl;

--- a/src/ripple/app/misc/AmendmentTableImpl.cpp
+++ b/src/ripple/app/misc/AmendmentTableImpl.cpp
@@ -21,6 +21,7 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/app/misc/Validations.h>
+#include <ripple/basics/contract.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/protocol/JsonFields.h>
@@ -135,7 +136,7 @@ AmendmentTableImpl::addInitial (Section const& section)
                      "preEnabledAmendments contains an invalid hash (expected "
                      "a hex number). Value was: %1%") %
                  a.hexString ()).str ();
-            throw std::runtime_error (errorMsg);
+            Throw<std::runtime_error> (errorMsg);
         }
     }
 
@@ -157,7 +158,7 @@ AmendmentTableImpl::addInitial (Section const& section)
                          "items. Found %3%. Line was: %4%") %
                      SECTION_AMENDMENTS % numExpectedToks % tokens.size () %
                      line).str ();
-                throw std::runtime_error (errorMsg);
+                Throw<std::runtime_error> (errorMsg);
             }
 
             toAdd.emplace_back (std::move (tokens[0]), std::move (tokens[1]));
@@ -170,7 +171,7 @@ AmendmentTableImpl::addInitial (Section const& section)
                          "%3%") %
                      toAdd.back ().hexString () % SECTION_AMENDMENTS %
                      line).str ();
-                throw std::runtime_error (errorMsg);
+                Throw<std::runtime_error> (errorMsg);
             }
         }
     }
@@ -233,7 +234,7 @@ AmendmentTableImpl::addKnown (AmendmentName const& name)
                  "addKnown was given an invalid hash (expected a hex number). "
                  "Value was: %1%") %
              name.hexString ()).str ();
-        throw std::runtime_error (errorMsg);
+        Throw<std::runtime_error> (errorMsg);
     }
 
     std::lock_guard <std::mutex> sl (mLock);

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -43,6 +43,7 @@
 #include <ripple/app/misc/impl/AccountTxPaging.h>
 #include <ripple/app/misc/UniqueNodeList.h>
 #include <ripple/app/tx/apply.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/Time.h>
 #include <ripple/protocol/digest.h>
@@ -767,7 +768,7 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
             return;
         }
     }
-    catch (...)
+    catch (std::exception const&)
     {
         JLOG(m_journal.warning) << "Exception checking transaction" << txid;
 
@@ -1259,7 +1260,7 @@ bool NetworkOPsImp::checkLastClosedLedger (
 
                 ++vc.nodesUsing;
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 // Peer is likely not connected anymore
             }
@@ -2539,7 +2540,7 @@ std::uint32_t NetworkOPsImp::acceptLedger ()
     assert (m_standalone);
 
     if (!m_standalone)
-        throw std::runtime_error ("Operation only possible in STANDALONE mode.");
+        Throw<std::runtime_error> ("Operation only possible in STANDALONE mode.");
 
     // FIXME Could we improve on this and remove the need for a specialized
     // API in LedgerConsensus?

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -23,6 +23,7 @@
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/ledger/TransactionMaster.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/basics/contract.h>
 #include <ripple/core/ConfigSections.h>
 #include <boost/format.hpp>
 #include <boost/format.hpp>
@@ -62,7 +63,7 @@ void SHAMapStoreImp::SavedStateDB::init (BasicConfig const& config,
                 "SELECT COUNT(Key) FROM DbState WHERE Key = 1;"
                 , soci::into (countO);
         if (!countO)
-            throw std::runtime_error("Failed to fetch Key Count from DbState.");
+            Throw<std::runtime_error> ("Failed to fetch Key Count from DbState.");
         count = *countO;
     }
 
@@ -79,7 +80,7 @@ void SHAMapStoreImp::SavedStateDB::init (BasicConfig const& config,
                 "SELECT COUNT(Key) FROM CanDelete WHERE Key = 1;"
                 , soci::into (countO);
         if (!countO)
-            throw std::runtime_error("Failed to fetch Key Count from CanDelete.");
+            Throw<std::runtime_error> ("Failed to fetch Key Count from CanDelete.");
         count = *countO;
     }
 
@@ -185,13 +186,13 @@ SHAMapStoreImp::SHAMapStoreImp (
     {
         if (setup_.deleteInterval < minimumDeletionInterval_)
         {
-            throw std::runtime_error ("online_delete must be at least " +
+            Throw<std::runtime_error> ("online_delete must be at least " +
                 std::to_string (minimumDeletionInterval_));
         }
 
         if (setup_.ledgerHistory > setup_.deleteInterval)
         {
-            throw std::runtime_error (
+            Throw<std::runtime_error> (
                 "online_delete must be less than ledger_history (currently " +
                 std::to_string (setup_.ledgerHistory) + ")");
         }
@@ -419,7 +420,7 @@ SHAMapStoreImp::dbPaths()
         {
             std::cerr << "node db path must be a directory. "
                     << dbPath.string();
-            throw std::runtime_error (
+            Throw<std::runtime_error> (
                     "node db path must be a directory.");
         }
     }
@@ -465,7 +466,7 @@ SHAMapStoreImp::dbPaths()
                 << get<std::string>(setup_.nodeDatabase, "path")
                 << std::endl;
 
-        throw std::runtime_error ("state db error");
+        Throw<std::runtime_error> ("state db error");
     }
 }
 

--- a/src/ripple/app/misc/UniqueNodeList.cpp
+++ b/src/ripple/app/misc/UniqueNodeList.cpp
@@ -23,6 +23,7 @@
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/UniqueNodeList.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/basics/Slice.h>
@@ -861,7 +862,7 @@ int UniqueNodeListImp::iSourceScore (ValidatorSource vsWhy)
         break;
 
     default:
-        throw std::runtime_error ("Internal error: bad ValidatorSource.");
+        Throw<std::runtime_error> ("Internal error: bad ValidatorSource.");
     }
 
     return iScore;

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -106,7 +106,7 @@ accountTxPage (
             findLedger = token[jss::ledger].asInt();
             findSeq = token[jss::seq].asInt();
         }
-        catch (...)
+        catch (std::exception const&)
         {
             return;
         }

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -47,11 +47,6 @@ Transaction::Transaction (std::shared_ptr<STTx const> const& stx,
         reason = e.what();
         return;
     }
-    catch (...)
-    {
-        reason = "Unexpected exception";
-        return;
-    }
 
     mStatus = NEW;
 }

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -439,7 +439,7 @@ void Pathfinder::computePathRanks (int maxPaths)
                 << "Default path fails: " << transToken (rc.result ());
         }
     }
-    catch (...)
+    catch (std::exception const&)
     {
         JLOG (j_.debug) << "Default path causes exception";
     }

--- a/src/ripple/app/paths/cursor/NextIncrement.cpp
+++ b/src/ripple/app/paths/cursor/NextIncrement.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/paths/cursor/RippleLiquidity.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 
 namespace ripple {
@@ -54,7 +55,7 @@ void PathCursor::nextIncrement () const
             << " inPass()=" << pathState_.inPass();
 
         if (isDry)
-            throw std::runtime_error ("Made no progress.");
+            Throw<std::runtime_error> ("Made no progress.");
 
         // Calculate relative quality.
         pathState_.setQuality(getRate (

--- a/src/ripple/app/tests/AmendmentTable.test.cpp
+++ b/src/ripple/app/tests/AmendmentTable.test.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/basics/BasicConfig.h>
 #include <ripple/basics/chrono.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/protocol/TxFlags.h>
@@ -196,7 +197,7 @@ public:
                         // line above should throw
                         fail ("didn't throw");
                     }
-                    catch (...)
+                    catch (std::exception const&)
                     {
                         pass ();
                     }
@@ -207,7 +208,7 @@ public:
                         // line above should throw
                         fail ("didn't throw");
                     }
-                    catch (...)
+                    catch (std::exception const&)
                     {
                         pass ();
                     }
@@ -233,7 +234,7 @@ public:
                     // line above should throw
                     fail ("didn't throw");
                 }
-                catch (...)
+                catch (std::exception const&)
                 {
                     pass ();
                 }
@@ -243,7 +244,7 @@ public:
                     // line above should throw
                     fail ("didn't throw");
                 }
-                catch (...)
+                catch (std::exception const&)
                 {
                     pass ();
                 }
@@ -457,28 +458,28 @@ public:
                 case 0:
                 // amendment goes from majority to enabled
                     if (enabled.find (hash) != enabled.end ())
-                        throw std::runtime_error ("enabling already enabled");
+                        Throw<std::runtime_error> ("enabling already enabled");
                     if (majority.find (hash) == majority.end ())
-                        throw std::runtime_error ("enabling without majority");
+                        Throw<std::runtime_error> ("enabling without majority");
                     enabled.insert (hash);
                     majority.erase (hash);
                     break;
 
                 case tfGotMajority:
                     if (majority.find (hash) != majority.end ())
-                        throw std::runtime_error ("got majority while having majority");
+                        Throw<std::runtime_error> ("got majority while having majority");
                     majority[hash] = roundTime;
                     break;
 
                 case tfLostMajority:
                     if (majority.find (hash) == majority.end ())
-                        throw std::runtime_error ("lost majority without majority");
+                        Throw<std::runtime_error> ("lost majority without majority");
                     majority.erase (hash);
                     break;
 
                 default:
                     assert (false);
-                    throw std::runtime_error ("unknown action");
+                    Throw<std::runtime_error> ("unknown action");
             }
         }
     }

--- a/src/ripple/app/tests/Path_test.cpp
+++ b/src/ripple/app/tests/Path_test.cpp
@@ -18,6 +18,8 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/app/paths/AccountCurrencies.h>
+#include <ripple/basics/contract.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/json/to_string.h>
 #include <ripple/protocol/JsonFields.h>
@@ -26,7 +28,6 @@
 #include <ripple/rpc/RipplePathFind.h>
 #include <ripple/test/jtx.h>
 #include <beast/unit_test/suite.h>
-#include <ripple/app/paths/AccountCurrencies.h>
 
 namespace ripple {
 namespace test {
@@ -158,7 +159,7 @@ find_paths(jtx::Env& env,
                 level, saSendMax, convert_all, env.app());
     if (! result.first)
     {
-        throw std::runtime_error(
+        Throw<std::runtime_error> (
             "Path_test::findPath: ripplePathFind find failed");
     }
     auto const& jv = result.second[0u];

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/tx/impl/CreateOffer.h>
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/st.h>
 #include <ripple/basics/Log.h>
 #include <ripple/json/to_string.h>
@@ -322,7 +323,7 @@ CreateOffer::bridged_cross (
     assert (!isXRP (taker_amount.in) && !isXRP (taker_amount.out));
 
     if (isXRP (taker_amount.in) || isXRP (taker_amount.out))
-        throw std::logic_error ("Bridging with XRP and an endpoint.");
+        Throw<std::logic_error> ("Bridging with XRP and an endpoint.");
 
     OfferStream offers_direct (view, view_cancel,
         Book (taker.issue_in (), taker.issue_out ()),
@@ -461,7 +462,7 @@ CreateOffer::bridged_cross (
         assert (direct_consumed || leg1_consumed || leg2_consumed);
 
         if (!direct_consumed && !leg1_consumed && !leg2_consumed)
-            throw std::logic_error ("bridged crossing: nothing was fully consumed.");
+            Throw<std::logic_error> ("bridged crossing: nothing was fully consumed.");
     }
 
     return std::make_pair(cross_result, taker.remaining_offer ());
@@ -542,7 +543,7 @@ CreateOffer::direct_cross (
         assert (direct_consumed);
 
         if (!direct_consumed)
-            throw std::logic_error ("direct crossing: nothing was fully consumed.");
+            Throw<std::logic_error> ("direct crossing: nothing was fully consumed.");
     }
 
     return std::make_pair(cross_result, taker.remaining_offer ());
@@ -599,11 +600,6 @@ CreateOffer::cross (
     catch (std::exception const& e)
     {
         j_.error << "Exception during offer crossing: " << e.what ();
-        return std::make_pair (tecINTERNAL, taker.remaining_offer ());
-    }
-    catch (...)
-    {
-        j_.error << "Exception during offer crossing.";
         return std::make_pair (tecINTERNAL, taker.remaining_offer ());
     }
 }

--- a/src/ripple/app/tx/impl/Offer.h
+++ b/src/ripple/app/tx/impl/Offer.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_APP_BOOK_OFFER_H_INCLUDED
 #define RIPPLE_APP_BOOK_OFFER_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Quality.h>
 #include <ripple/protocol/STLedgerEntry.h>
@@ -99,10 +100,10 @@ public:
         Amounts const& consumed) const
     {
         if (consumed.in > m_amounts.in)
-            throw std::logic_error ("can't consume more than is available.");
+            Throw<std::logic_error> ("can't consume more than is available.");
 
         if (consumed.out > m_amounts.out)
-            throw std::logic_error ("can't produce more than is available.");
+            Throw<std::logic_error> ("can't produce more than is available.");
 
         m_amounts.in -= consumed.in;
         m_amounts.out -= consumed.out;

--- a/src/ripple/app/tx/impl/Taker.cpp
+++ b/src/ripple/app/tx/impl/Taker.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/tx/impl/Taker.h>
+#include <ripple/basics/contract.h>
 
 namespace ripple {
 
@@ -401,7 +402,7 @@ BasicTaker::do_cross (Amounts offer, Quality quality, AccountID const& owner)
     }
 
     if (!result.sanity_check ())
-        throw std::logic_error ("Computed flow fails sanity check.");
+        Throw<std::logic_error> ("Computed flow fails sanity check.");
 
     remaining_.out -= result.order.out;
     remaining_.in -= result.order.in;
@@ -476,12 +477,12 @@ BasicTaker::do_cross (
     auto flow1 = flow_iou_to_xrp (offer1, quality1, xrp_funds, leg1_in_funds, leg1_rate);
 
     if (!flow1.sanity_check ())
-        throw std::logic_error ("Computed flow1 fails sanity check.");
+        Throw<std::logic_error> ("Computed flow1 fails sanity check.");
 
     auto flow2 = flow_xrp_to_iou (offer2, quality2, leg2_out_funds, xrp_funds, leg2_rate);
 
     if (!flow2.sanity_check ())
-        throw std::logic_error ("Computed flow2 fails sanity check.");
+        Throw<std::logic_error> ("Computed flow2 fails sanity check.");
 
     // We now have the maximal flows across each leg individually. We need to
     // equalize them, so that the amount of XRP that flows out of the first leg
@@ -505,7 +506,7 @@ BasicTaker::do_cross (
     }
 
     if (flow1.order.out != flow2.order.in)
-        throw std::logic_error ("Bridged flow is out of balance.");
+        Throw<std::logic_error> ("Bridged flow is out of balance.");
 
     remaining_.out -= flow2.order.out;
     remaining_.in -= flow1.order.in;
@@ -555,10 +556,10 @@ void
 Taker::consume_offer (Offer const& offer, Amounts const& order)
 {
     if (order.in < zero)
-        throw std::logic_error ("flow with negative input.");
+        Throw<std::logic_error> ("flow with negative input.");
 
     if (order.out < zero)
-        throw std::logic_error ("flow with negative output.");
+        Throw<std::logic_error> ("flow with negative output.");
 
     if (journal_.debug) journal_.debug << "Consuming from offer " << offer;
 
@@ -585,7 +586,7 @@ TER Taker::transferXRP (
     STAmount const& amount)
 {
     if (!isXRP (amount))
-        throw std::logic_error ("Using transferXRP with IOU");
+        Throw<std::logic_error> ("Using transferXRP with IOU");
 
     if (from == to)
         return tesSUCCESS;
@@ -603,7 +604,7 @@ TER Taker::redeemIOU (
     Issue const& issue)
 {
     if (isXRP (amount))
-        throw std::logic_error ("Using redeemIOU with XRP");
+        Throw<std::logic_error> ("Using redeemIOU with XRP");
 
     if (account == issue.account)
         return tesSUCCESS;
@@ -615,12 +616,12 @@ TER Taker::redeemIOU (
     // If we are trying to redeem some amount, then the account
     // must have a credit balance.
     if (get_funds (account, amount) <= zero)
-        throw std::logic_error ("redeemIOU has no funds to redeem");
+        Throw<std::logic_error> ("redeemIOU has no funds to redeem");
 
     auto ret = ripple::redeemIOU (view_, account, amount, issue, journal_);
 
     if (get_funds (account, amount) < zero)
-        throw std::logic_error ("redeemIOU redeemed more funds than available");
+        Throw<std::logic_error> ("redeemIOU redeemed more funds than available");
 
     return ret;
 }
@@ -631,7 +632,7 @@ TER Taker::issueIOU (
     Issue const& issue)
 {
     if (isXRP (amount))
-        throw std::logic_error ("Using issueIOU with XRP");
+        Throw<std::logic_error> ("Using issueIOU with XRP");
 
     if (account == issue.account)
         return tesSUCCESS;

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/tx/impl/Transactor.h>
 #include <ripple/app/tx/impl/SignerEntries.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/LoadFeeTrack.h>
@@ -686,7 +687,7 @@ Transactor::operator()()
             {
                 // VFALCO Log to journal here
                 // JLOG(journal.fatal) << "invalid fee";
-                throw std::logic_error("amount is negative!");
+                Throw<std::logic_error> ("amount is negative!");
             }
 
             if (fee != zero)

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -199,12 +199,6 @@ preflight(Application& app, Rules const& rules,
             "apply: " << e.what();
         return{ pfctx, tefEXCEPTION };
     }
-    catch (...)
-    {
-        JLOG(j.fatal) <<
-            "apply: <unknown exception>";
-        return{ pfctx, tefEXCEPTION };
-    }
 }
 
 PreclaimResult
@@ -236,12 +230,6 @@ preclaim (PreflightResult const& preflightResult,
     {
         JLOG(ctx->j.fatal) <<
             "apply: " << e.what();
-        return{ *ctx, tefEXCEPTION, 0 };
-    }
-    catch (...)
-    {
-        JLOG(ctx->j.fatal) <<
-            "apply: <unknown exception>";
         return{ *ctx, tefEXCEPTION, 0 };
     }
 }
@@ -281,12 +269,6 @@ doApply(PreclaimResult const& preclaimResult,
     {
         JLOG(preclaimResult.j.fatal) <<
             "apply: " << e.what();
-        return { tefEXCEPTION, false };
-    }
-    catch (...)
-    {
-        JLOG(preclaimResult.j.fatal) <<
-            "apply: <unknown exception>";
         return { tefEXCEPTION, false };
     }
 }

--- a/src/ripple/basics/BasicConfig.h
+++ b/src/ripple/basics/BasicConfig.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_BASICS_BASICCONFIG_H_INCLUDED
 #define RIPPLE_BASICS_BASICCONFIG_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <beast/container/const_container.h>
 #include <beast/utility/ci_char_traits.h>
 #include <boost/lexical_cast.hpp>
@@ -104,7 +105,7 @@ public:
         if (lines_.empty ())
             return "";
         else if (lines_.size () > 1)
-            throw std::runtime_error (
+            Throw<std::runtime_error> (
                 "A legacy value must have exactly one line. Section: " + name_);
         return lines_[0];
     }
@@ -323,7 +324,7 @@ get (Section const& section,
     {
         return boost::lexical_cast <std::string> (result.first);
     }
-    catch(...)
+    catch(std::exception const&)
     {
     }
     return defaultValue;

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_BASICS_SLICE_H_INCLUDED
 #define RIPPLE_BASICS_SLICE_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/basics/strHex.h>
 #include <algorithm>
 #include <cassert>
@@ -100,7 +101,7 @@ public:
     operator+= (std::size_t n)
     {
         if (n > size_)
-            throw std::domain_error("too small");
+            Throw<std::domain_error> ("too small");
         data_ += n;
         size_ -= n;
         return *this;

--- a/src/ripple/basics/TestSuite.h
+++ b/src/ripple/basics/TestSuite.h
@@ -110,7 +110,8 @@ public:
         try
         {
             f();
-        } catch (...)
+        }
+        catch (std::exception const&)
         {
             success = true;
         }

--- a/src/ripple/basics/contract.h
+++ b/src/ripple/basics/contract.h
@@ -22,6 +22,7 @@
 
 #include <exception>
 #include <string>
+#include <typeinfo>
 #include <utility>
 
 namespace ripple {
@@ -32,22 +33,16 @@ namespace ripple {
     preconditions, postconditions, and invariants.
 */
 
-namespace detail {
-
 void
-throwException(
-    std::exception_ptr ep);
+Throw ();
 
-} // detail
-
-template <class Exception, class... Args>
+template <class E, class... Args>
 void
 Throw (Args&&... args)
 {
-    detail::throwException(
-        std::make_exception_ptr(
-            Exception(std::forward<
-                Args>(args)...)));
+    static_assert (std::is_convertible<E*, std::exception*>::value,
+        "Exception must derive from std::exception.");
+    throw E(std::forward<Args>(args)...);
 }
 
 /** Called when faulty logic causes a broken invariant. */
@@ -55,11 +50,6 @@ Throw (Args&&... args)
 void
 LogicError (
     std::string const& how) noexcept;
-
-/** Called to throw an exception. */
-#ifndef THROW
-#define THROW(T, arg) Throw<T>(arg)
-#endif
 
 } // ripple
 

--- a/src/ripple/basics/impl/CheckLibraryVersions.cpp
+++ b/src/ripple/basics/impl/CheckLibraryVersions.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/impl/CheckLibraryVersionsImpl.h>
 #include <beast/unit_test/suite.h>
 #include <beast/module/core/diagnostic/SemanticVersion.h>
@@ -58,19 +59,23 @@ std::string openSSLVersion(VersionNumber openSSLVersion)
 void checkVersion(std::string name, std::string required, std::string actual)
 {
     beast::SemanticVersion r, a;
-    if (!r.parse(required)) {
-        throw std::runtime_error("Didn't understand required version of " +
-                                 name + ": " + required);
-    }
-    if (!a.parse(actual)) {
-        throw std::runtime_error("Didn't understand actual version of " +
-                                 name + ": " + required);
+    if (! r.parse(required))
+    {
+        Throw<std::runtime_error> (
+            "Didn't understand required version of " + name + ": " + required);
     }
 
-    if (a < r) {
-        throw std::runtime_error("Your " + name + " library is out of date.\n" +
-                                 "Your version: " + actual + "\n" +
-                                 "Required version: " +  "\n");
+    if (! a.parse(actual))
+    {
+        Throw<std::runtime_error> (
+            "Didn't understand actual version of " + name + ": " + required);
+    }
+
+    if (a < r)
+    {
+        Throw<std::runtime_error> (
+            "Your " + name + " library is out of date.\n" + "Your version: " +
+                actual + "\nRequired version: " + required + "\n");
     }
 }
 

--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/ToString.h>
 #include <beast/module/core/text/LexicalCast.h>
@@ -89,14 +90,14 @@ uint64_t uintFromHex (std::string const& strSrc)
     uint64_t uValue (0);
 
     if (strSrc.size () > 16)
-        throw std::invalid_argument("overlong 64-bit value");
+        Throw<std::invalid_argument> ("overlong 64-bit value");
 
     for (auto c : strSrc)
     {
         int ret = charUnHex (c);
 
         if (ret == -1)
-            throw std::invalid_argument("invalid hex digit");
+            Throw<std::invalid_argument> ("invalid hex digit");
 
         uValue = (uValue << 4) | ret;
     }

--- a/src/ripple/basics/impl/contract.cpp
+++ b/src/ripple/basics/impl/contract.cpp
@@ -36,14 +36,6 @@ accessViolation() noexcept
     std::abort ();
 }
 
-// This hook lets you do pre or post
-// processing on exceptions to suit needs.
-void
-throwException (std::exception_ptr ep)
-{
-    std::rethrow_exception(ep);
-}
-
 } // detail
 
 [[noreturn]]
@@ -51,6 +43,12 @@ void
 LogicError (std::string const&) noexcept
 {
     detail::accessViolation();
+}
+
+void
+Throw ()
+{
+    throw;
 }
 
 } // ripple

--- a/src/ripple/basics/tests/contract.test.cpp
+++ b/src/ripple/basics/tests/contract.test.cpp
@@ -18,30 +18,45 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/test/jtx/trust.h>
-#include <ripple/protocol/JsonFields.h>
 #include <ripple/basics/contract.h>
-#include <stdexcept>
+#include <beast/unit_test/suite.h>
+#include <string>
 
 namespace ripple {
-namespace test {
-namespace jtx {
 
-Json::Value
-trust (Account const& account,
-    STAmount const& amount)
+class contract_test : public beast::unit_test::suite
 {
-    if (isXRP(amount))
-        Throw<std::runtime_error> (
-            "trust() requires IOU");
-    Json::Value jv;
-    jv[jss::Account] = account.human();
-    jv[jss::LimitAmount] = amount.getJson(0);
-    jv[jss::TransactionType] = "TrustSet";
-    jv[jss::Flags] = 0;    // tfClearNoRipple;
-    return jv;
-}
+public:
+    void run ()
+    {
+        try
+        {
+            Throw<std::runtime_error>("Throw test");
+        }
+        catch (std::runtime_error const& e)
+        {
+            expect(std::string(e.what()) == "Throw test");
 
-} // jtx
-} // test
-} // ripple
+            try
+            {
+                Throw();
+            }
+            catch (std::runtime_error const& e)
+            {
+                expect(std::string(e.what()) == "Throw test");
+            }
+            catch (...)
+            {
+                expect(false);
+            }
+        }
+        catch (...)
+        {
+            expect(false);
+        }
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(contract,basics,ripple);
+
+}

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/Feature.h>
@@ -267,7 +268,8 @@ void Config::setup (std::string const& strConf, bool bQuiet)
             boost::filesystem::create_directories (CONFIG_DIR, ec);
 
             if (ec)
-                throw std::runtime_error (boost::str (boost::format ("Can not create %s") % CONFIG_DIR));
+                Throw<std::runtime_error> (
+                    boost::str(boost::format ("Can not create %s") % CONFIG_DIR));
         }
     }
 
@@ -285,7 +287,7 @@ void Config::setup (std::string const& strConf, bool bQuiet)
     boost::filesystem::create_directories (dataDir, ec);
 
     if (ec)
-        throw std::runtime_error (
+        Throw<std::runtime_error> (
             boost::str (boost::format ("Can not create %s") % dataDir));
 
     legacy ("database_path", boost::filesystem::absolute (dataDir).string ());
@@ -349,10 +351,11 @@ void Config::loadFromString (std::string const& fileContents)
             Json::Reader    jrReader;
             Json::Value     jvCommand;
 
-            if (!jrReader.parse (strJson, jvCommand))
-                throw std::runtime_error (
+            if (! jrReader.parse (strJson, jvCommand))
+                Throw<std::runtime_error> (
                     boost::str (boost::format (
-                        "Couldn't parse [" SECTION_RPC_STARTUP "] command: %s") % strJson));
+                        "Couldn't parse [" SECTION_RPC_STARTUP "] command: %s")
+                            % strJson));
 
             RPC_STARTUP.append (jvCommand);
         }

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/core/SociDB.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <memory>
 
@@ -68,7 +69,7 @@ DatabaseCon::Setup setup_DatabaseCon (Config const& c)
 void DatabaseCon::setupCheckpointing (JobQueue* q, Logs& l)
 {
     if (! q)
-        throw std::logic_error ("No JobQueue");
+        Throw<std::logic_error> ("No JobQueue");
     checkpointer_ = makeCheckpointer (session_, *q, l);
 }
 

--- a/src/ripple/core/impl/DummySociDynamicBackend.cpp
+++ b/src/ripple/core/impl/DummySociDynamicBackend.cpp
@@ -25,8 +25,9 @@
 */
 
 #include <BeastConfig.h>
-
+#include <ripple/basics/contract.h>
 #include <ripple/core/SociDB.h>
+#include <soci/sqlite3/soci-sqlite3.h>
 
 // dummy soci-backend
 namespace soci {
@@ -34,7 +35,8 @@ namespace dynamic_backends {
 // used internally by session
 backend_factory const& get (std::string const& name)
 {
-    throw std::runtime_error ("Not Supported");
+    ripple::Throw<std::runtime_error> ("Not Supported");
+    return std::ref(soci::sqlite3); // Silence compiler warning.
 };
 
 // provided for advanced user-level management

--- a/src/ripple/core/impl/LoadFeeTrack.cpp
+++ b/src/ripple/core/impl/LoadFeeTrack.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/core/Config.h>
 #include <ripple/protocol/STAmount.h>
@@ -75,7 +76,7 @@ LoadFeeTrack::scaleFeeLoad (std::uint64_t fee, std::uint64_t baseFee,
     // If baseFee * feeFactor overflows, the final result will overflow
     const auto max = std::numeric_limits<std::uint64_t>::max();
     if (baseFee > max / feeFactor)
-        throw std::overflow_error("scaleFeeLoad");
+        Throw<std::overflow_error> ("scaleFeeLoad");
     baseFee *= feeFactor;
     // Reorder fee and baseFee
     if (fee < baseFee)
@@ -86,7 +87,7 @@ LoadFeeTrack::scaleFeeLoad (std::uint64_t fee, std::uint64_t baseFee,
         // Do the division first, on the larger of fee and baseFee
         fee /= den;
         if (fee > max / baseFee)
-            throw std::overflow_error("scaleFeeLoad");
+            Throw<std::overflow_error> ("scaleFeeLoad");
         fee *= baseFee;
     }
     else

--- a/src/ripple/core/tests/Config.test.cpp
+++ b/src/ripple/core/tests/Config.test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
@@ -171,8 +172,8 @@ public:
             {
                 // Cannot run the test someone created a file where we want to
                 // put out directory
-                throw std::runtime_error ("Cannot create directory: " +
-                                          subDir_.string ());
+                Throw<std::runtime_error> (
+                    "Cannot create directory: " + subDir_.string ());
             }
         }
 
@@ -183,9 +184,9 @@ public:
         }
         else
         {
-            throw std::runtime_error (
+            Throw<std::runtime_error> (
                 "Refusing to overwrite existing config file: " +
-                configFile_.string ());
+                    configFile_.string ());
         }
 
         rmDataDir_ = !exists (dataDir_);

--- a/src/ripple/core/tests/SociDB.test.cpp
+++ b/src/ripple/core/tests/SociDB.test.cpp
@@ -21,6 +21,7 @@
 
 #include <ripple/core/ConfigSections.h>
 #include <ripple/core/SociDB.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/TestSuite.h>
 #include <ripple/basics/BasicConfig.h>
 #include <boost/filesystem.hpp>
@@ -59,8 +60,8 @@ private:
         if (!is_directory (dbPath))
         {
             // someone created a file where we want to put out directory
-            throw std::runtime_error ("Cannot create directory: " +
-                                      dbPath.string ());
+            Throw<std::runtime_error> (
+                "Cannot create directory: " + dbPath.string ());
         }
     }
     static boost::filesystem::path getDatabasePath ()
@@ -75,7 +76,7 @@ public:
         {
             setupDatabaseDir (getDatabasePath ());
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
     }
@@ -85,7 +86,7 @@ public:
         {
             cleanupDatabaseDir (getDatabasePath ());
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
     }

--- a/src/ripple/crypto/CAutoBN_CTX.h
+++ b/src/ripple/crypto/CAutoBN_CTX.h
@@ -25,6 +25,8 @@
 #ifndef RIPPLE_CRYPTO_CAUTOBN_CTX_H_INCLUDED
 #define RIPPLE_CRYPTO_CAUTOBN_CTX_H_INCLUDED
 
+#include <ripple/basics/contract.h>
+
 #include <openssl/bn.h>
 
 #include <stdexcept>
@@ -43,7 +45,7 @@ public:
         pctx = BN_CTX_new ();
 
         if (pctx == nullptr)
-            throw std::runtime_error ("CAutoBN_CTX : BN_CTX_new() returned nullptr");
+            Throw<std::runtime_error> ("CAutoBN_CTX : BN_CTX_new() returned nullptr");
     }
 
     ~CAutoBN_CTX ()

--- a/src/ripple/crypto/impl/Base58.cpp
+++ b/src/ripple/crypto/impl/Base58.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/crypto/Base58.h>
 #include <ripple/crypto/CAutoBN_CTX.h>
 #include <ripple/crypto/CBigNum.h>
@@ -89,7 +90,7 @@ std::string Base58::raw_encode (unsigned char const* begin,
     while (bn > bn0)
     {
         if (!BN_div (&dv, &rem, &bn, &bn58, pctx))
-            throw std::runtime_error ("EncodeBase58 : BN_div failed");
+            Throw<std::runtime_error> ("EncodeBase58 : BN_div failed");
 
         bn = dv;
         unsigned int c = rem.getuint ();
@@ -199,7 +200,7 @@ bool Base58::decode (const char* psz, Blob& vchRet, Alphabet const& alphabet)
         bnChar.setuint (p1 - alphabet.chars());
 
         if (!BN_mul (&bn, &bn, &bn58, pctx))
-            throw std::runtime_error ("DecodeBase58 : BN_mul failed");
+            Throw<std::runtime_error> ("DecodeBase58 : BN_mul failed");
 
         bn += bnChar;
     }

--- a/src/ripple/crypto/impl/CBigNum.cpp
+++ b/src/ripple/crypto/impl/CBigNum.cpp
@@ -23,6 +23,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/crypto/CBigNum.h>
 #include <ripple/crypto/CAutoBN_CTX.h>
 #include <stdexcept>
@@ -43,14 +44,14 @@ CBigNum::CBigNum (const CBigNum& b)
     if (!BN_copy (this, &b))
     {
         BN_clear_free (this);
-        throw std::runtime_error ("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
+        Throw<std::runtime_error> ("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
     }
 }
 
 CBigNum& CBigNum::operator= (const CBigNum& b)
 {
     if (!BN_copy (this, &b))
-        throw std::runtime_error ("CBigNum::operator= : BN_copy failed");
+        Throw<std::runtime_error> ("CBigNum::operator= : BN_copy failed");
 
     return (*this);
 }
@@ -202,7 +203,7 @@ std::uint64_t CBigNum::getuint64 () const
     int len = BN_num_bytes (this);
 
     if (len > 8)
-        throw std::runtime_error ("BN getuint64 overflow");
+        Throw<std::runtime_error> ("BN getuint64 overflow");
 
     unsigned char buf[8];
     memset (buf, 0, sizeof (buf));
@@ -381,7 +382,7 @@ std::string CBigNum::ToString (int nBase) const
     while (BN_cmp (&bn, &bn0) > 0)
     {
         if (!BN_div (&dv, &rem, &bn, &bnBase, pctx))
-            throw std::runtime_error ("CBigNum::ToString() : BN_div failed");
+            Throw<std::runtime_error> ("CBigNum::ToString() : BN_div failed");
 
         bn = dv;
         unsigned int c = rem.getuint ();
@@ -408,7 +409,7 @@ bool CBigNum::operator! () const
 CBigNum& CBigNum::operator+= (const CBigNum& b)
 {
     if (!BN_add (this, this, &b))
-        throw std::runtime_error ("CBigNum::operator+= : BN_add failed");
+        Throw<std::runtime_error> ("CBigNum::operator+= : BN_add failed");
 
     return *this;
 }
@@ -424,7 +425,7 @@ CBigNum& CBigNum::operator*= (const CBigNum& b)
     CAutoBN_CTX pctx;
 
     if (!BN_mul (this, this, &b, pctx))
-        throw std::runtime_error ("CBigNum::operator*= : BN_mul failed");
+        Throw<std::runtime_error> ("CBigNum::operator*= : BN_mul failed");
 
     return *this;
 }
@@ -444,7 +445,7 @@ CBigNum& CBigNum::operator%= (const CBigNum& b)
 CBigNum& CBigNum::operator<<= (unsigned int shift)
 {
     if (!BN_lshift (this, this, shift))
-        throw std::runtime_error ("CBigNum:operator<<= : BN_lshift failed");
+        Throw<std::runtime_error> ("CBigNum:operator<<= : BN_lshift failed");
 
     return *this;
 }
@@ -462,8 +463,8 @@ CBigNum& CBigNum::operator>>= (unsigned int shift)
         return *this;
     }
 
-    if (!BN_rshift (this, this, shift))
-        throw std::runtime_error ("CBigNum:operator>>= : BN_rshift failed");
+    if (! BN_rshift (this, this, shift))
+        Throw<std::runtime_error> ("CBigNum:operator>>= : BN_rshift failed");
 
     return *this;
 }
@@ -472,8 +473,8 @@ CBigNum& CBigNum::operator>>= (unsigned int shift)
 CBigNum& CBigNum::operator++ ()
 {
     // prefix operator
-    if (!BN_add (this, this, BN_value_one ()))
-        throw std::runtime_error ("CBigNum::operator++ : BN_add failed");
+    if (! BN_add (this, this, BN_value_one ()))
+        Throw<std::runtime_error> ("CBigNum::operator++ : BN_add failed");
 
     return *this;
 }
@@ -491,8 +492,8 @@ CBigNum& CBigNum::operator-- ()
     // prefix operator
     CBigNum r;
 
-    if (!BN_sub (&r, this, BN_value_one ()))
-        throw std::runtime_error ("CBigNum::operator-- : BN_sub failed");
+    if (! BN_sub (&r, this, BN_value_one ()))
+        Throw<std::runtime_error> ("CBigNum::operator-- : BN_sub failed");
 
     *this = r;
     return *this;
@@ -508,8 +509,9 @@ const CBigNum CBigNum::operator-- (int)
 
 void CBigNum::setulong (unsigned long n)
 {
-    if (!BN_set_word (this, n))
-        throw std::runtime_error ("CBigNum conversion from unsigned long : BN_set_word failed");
+    if (! BN_set_word (this, n))
+        Throw<std::runtime_error> (
+            "CBigNum conversion from unsigned long : BN_set_word failed");
 }
 
 unsigned long CBigNum::getulong () const
@@ -521,8 +523,8 @@ const CBigNum operator+ (const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
 
-    if (!BN_add (&r, &a, &b))
-        throw std::runtime_error ("CBigNum::operator+ : BN_add failed");
+    if (! BN_add (&r, &a, &b))
+        Throw<std::runtime_error> ("CBigNum::operator+ : BN_add failed");
 
     return r;
 }
@@ -531,8 +533,8 @@ const CBigNum operator- (const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
 
-    if (!BN_sub (&r, &a, &b))
-        throw std::runtime_error ("CBigNum::operator- : BN_sub failed");
+    if (! BN_sub (&r, &a, &b))
+        Throw<std::runtime_error> ("CBigNum::operator- : BN_sub failed");
 
     return r;
 }
@@ -549,8 +551,8 @@ const CBigNum operator* (const CBigNum& a, const CBigNum& b)
     CAutoBN_CTX pctx;
     CBigNum r;
 
-    if (!BN_mul (&r, &a, &b, pctx))
-        throw std::runtime_error ("CBigNum::operator* : BN_mul failed");
+    if (! BN_mul (&r, &a, &b, pctx))
+        Throw<std::runtime_error> ("CBigNum::operator* : BN_mul failed");
 
     return r;
 }
@@ -560,8 +562,8 @@ const CBigNum operator/ (const CBigNum& a, const CBigNum& b)
     CAutoBN_CTX pctx;
     CBigNum r;
 
-    if (!BN_div (&r, nullptr, &a, &b, pctx))
-        throw std::runtime_error ("CBigNum::operator/ : BN_div failed");
+    if (! BN_div (&r, nullptr, &a, &b, pctx))
+        Throw<std::runtime_error> ("CBigNum::operator/ : BN_div failed");
 
     return r;
 }
@@ -571,8 +573,8 @@ const CBigNum operator% (const CBigNum& a, const CBigNum& b)
     CAutoBN_CTX pctx;
     CBigNum r;
 
-    if (!BN_mod (&r, &a, &b, pctx))
-        throw std::runtime_error ("CBigNum::operator% : BN_div failed");
+    if (! BN_mod (&r, &a, &b, pctx))
+        Throw<std::runtime_error> ("CBigNum::operator% : BN_div failed");
 
     return r;
 }
@@ -581,8 +583,8 @@ const CBigNum operator<< (const CBigNum& a, unsigned int shift)
 {
     CBigNum r;
 
-    if (!BN_lshift (&r, &a, shift))
-        throw std::runtime_error ("CBigNum:operator<< : BN_lshift failed");
+    if (! BN_lshift (&r, &a, shift))
+        Throw<std::runtime_error> ("CBigNum:operator<< : BN_lshift failed");
 
     return r;
 }

--- a/src/ripple/crypto/impl/ECDSAKey.cpp
+++ b/src/ripple/crypto/impl/ECDSAKey.cpp
@@ -23,6 +23,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/crypto/impl/ECDSAKey.h>
 #include <openssl/ec.h>
 #include <openssl/hmac.h>
@@ -36,9 +37,8 @@ static EC_KEY* new_initialized_EC_KEY()
     EC_KEY* key = EC_KEY_new_by_curve_name (NID_secp256k1);
 
     if (key == nullptr)
-    {
-        throw std::runtime_error ("new_initialized_EC_KEY() : EC_KEY_new_by_curve_name failed");
-    }
+        Throw<std::runtime_error> (
+            "new_initialized_EC_KEY() : EC_KEY_new_by_curve_name failed");
 
     EC_KEY_set_conv_form (key, POINT_CONVERSION_COMPRESSED);
 
@@ -50,9 +50,7 @@ ec_key ECDSAPrivateKey (uint256 const& serialized)
     BIGNUM* bn = BN_bin2bn (serialized.begin(), serialized.size(), nullptr);
 
     if (bn == nullptr)
-    {
-        throw std::runtime_error ("ec_key::ec_key: BN_bin2bn failed");
-    }
+        Throw<std::runtime_error> ("ec_key::ec_key: BN_bin2bn failed");
 
     EC_KEY* key = new_initialized_EC_KEY();
     ec_key::pointer_t ptr = nullptr;

--- a/src/ripple/crypto/impl/RandomNumbers.cpp
+++ b/src/ripple/crypto/impl/RandomNumbers.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/crypto/RandomNumbers.h>
 #include <openssl/rand.h>
 #include <cassert>
@@ -65,7 +66,7 @@ void random_fill (void* buffer, int count)
     assert (count > 0);
 
     if (RAND_bytes (reinterpret_cast <unsigned char*> (buffer), count) != 1)
-        throw std::runtime_error ("Insufficient entropy in pool.");
+        Throw<std::runtime_error> ("Insufficient entropy in pool.");
 }
 
 }

--- a/src/ripple/crypto/impl/ec_key.cpp
+++ b/src/ripple/crypto/impl/ec_key.cpp
@@ -23,6 +23,7 @@
 // file license.txt or http://www.opensource.org/licenses/mit-license.php.
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/crypto/impl/ec_key.h>
 #include <openssl/ec.h>
 
@@ -45,9 +46,7 @@ ec_key::ec_key (const ec_key& that)
     ptr = (pointer_t) EC_KEY_dup (get_EC_KEY (that));
 
     if (ptr == nullptr)
-    {
-        throw std::runtime_error ("ec_key::ec_key() : EC_KEY_dup failed");
-    }
+        Throw<std::runtime_error> ("ec_key::ec_key() : EC_KEY_dup failed");
 
     EC_KEY_set_conv_form (get_EC_KEY (*this), POINT_CONVERSION_COMPRESSED);
 }

--- a/src/ripple/crypto/impl/openssl.cpp
+++ b/src/ripple/crypto/impl/openssl.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <ripple/basics/contract.h>
 #include <ripple/crypto/impl/openssl.h>
 #include <openssl/hmac.h>
 
@@ -26,22 +27,16 @@ namespace openssl {
 bignum::bignum()
 {
     ptr = BN_new();
-
     if (ptr == nullptr)
-    {
-        throw std::runtime_error ("BN_new() failed");
-    }
+        Throw<std::runtime_error> ("BN_new() failed");
 }
 
 void bignum::assign (uint8_t const* data, size_t size)
 {
     // This reuses and assigns ptr
     BIGNUM* bn = BN_bin2bn (data, size, ptr);
-
     if (bn == nullptr)
-    {
-        throw std::runtime_error ("BN_bin2bn() failed");
-    }
+        Throw<std::runtime_error> ("BN_bin2bn() failed");
 }
 
 void bignum::assign_new (uint8_t const* data, size_t size)
@@ -49,31 +44,22 @@ void bignum::assign_new (uint8_t const* data, size_t size)
     // ptr must not be allocated
 
     ptr = BN_bin2bn (data, size, nullptr);
-
     if (ptr == nullptr)
-    {
-        throw std::runtime_error ("BN_bin2bn() failed");
-    }
+        Throw<std::runtime_error> ("BN_bin2bn() failed");
 }
 
 bn_ctx::bn_ctx()
 {
     ptr = BN_CTX_new();
-
     if (ptr == nullptr)
-    {
-        throw std::runtime_error ("BN_CTX_new() failed");
-    }
+        Throw<std::runtime_error> ("BN_CTX_new() failed");
 }
 
 bignum get_order (EC_GROUP const* group, bn_ctx& ctx)
 {
     bignum result;
-
-    if (!EC_GROUP_get_order (group, result.get(), ctx.get()))
-    {
-        throw std::runtime_error ("EC_GROUP_get_order() failed");
-    }
+    if (! EC_GROUP_get_order (group, result.get(), ctx.get()))
+        Throw<std::runtime_error> ("EC_GROUP_get_order() failed");
 
     return result;
 }
@@ -81,11 +67,8 @@ bignum get_order (EC_GROUP const* group, bn_ctx& ctx)
 ec_point::ec_point (EC_GROUP const* group)
 {
     ptr = EC_POINT_new (group);
-
     if (ptr == nullptr)
-    {
-        throw std::runtime_error ("EC_POINT_new() failed");
-    }
+        Throw<std::runtime_error> ("EC_POINT_new() failed");
 }
 
 void add_to (EC_GROUP const* group,
@@ -94,9 +77,7 @@ void add_to (EC_GROUP const* group,
              bn_ctx& ctx)
 {
     if (!EC_POINT_add (group, b.get(), a.get(), b.get(), ctx.get()))
-    {
-        throw std::runtime_error ("EC_POINT_add() failed");
-    }
+        Throw<std::runtime_error> ("EC_POINT_add() failed");
 }
 
 ec_point multiply (EC_GROUP const* group,
@@ -104,11 +85,8 @@ ec_point multiply (EC_GROUP const* group,
                    bn_ctx& ctx)
 {
     ec_point result (group);
-
-    if (!EC_POINT_mul (group, result.get(), n.get(), nullptr, nullptr, ctx.get()))
-    {
-        throw std::runtime_error ("EC_POINT_mul() failed");
-    }
+    if (! EC_POINT_mul (group, result.get(), n.get(), nullptr, nullptr, ctx.get()))
+        Throw<std::runtime_error> ("EC_POINT_mul() failed");
 
     return result;
 }
@@ -116,11 +94,8 @@ ec_point multiply (EC_GROUP const* group,
 ec_point bn2point (EC_GROUP const* group, BIGNUM const* number)
 {
     EC_POINT* result = EC_POINT_bn2point (group, number, nullptr, nullptr);
-
     if (result == nullptr)
-    {
-        throw std::runtime_error ("EC_POINT_bn2point() failed");
-    }
+        Throw<std::runtime_error> ("EC_POINT_bn2point() failed");
 
     return ec_point::acquire (result);
 }
@@ -129,7 +104,7 @@ static ec_key ec_key_new_secp256k1_compressed()
 {
     EC_KEY* key = EC_KEY_new_by_curve_name (NID_secp256k1);
 
-    if (key == nullptr)  throw std::runtime_error ("EC_KEY_new_by_curve_name() failed");
+    if (key == nullptr)  Throw<std::runtime_error> ("EC_KEY_new_by_curve_name() failed");
 
     EC_KEY_set_conv_form (key, POINT_CONVERSION_COMPRESSED);
 
@@ -139,11 +114,8 @@ static ec_key ec_key_new_secp256k1_compressed()
 void serialize_ec_point (ec_point const& point, std::uint8_t* ptr)
 {
     ec_key key = ec_key_new_secp256k1_compressed();
-
     if (EC_KEY_set_public_key((EC_KEY*) key.get(), point.get()) <= 0)
-    {
-        throw std::runtime_error ("EC_KEY_set_public_key() failed");
-    }
+        Throw<std::runtime_error> ("EC_KEY_set_public_key() failed");
 
     int const size = i2o_ECPublicKey ((EC_KEY*) key.get(), &ptr);
 

--- a/src/ripple/json/Writer.h
+++ b/src/ripple/json/Writer.h
@@ -20,9 +20,10 @@
 #ifndef RIPPLE_JSON_WRITER_H_INCLUDED
 #define RIPPLE_JSON_WRITER_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/basics/ToString.h>
 #include <ripple/json/Output.h>
- #include <ripple/json/json_value.h>
+#include <ripple/json/json_value.h>
 #include <memory>
 
 namespace Json {
@@ -232,8 +233,8 @@ private:
 
 inline void check (bool condition, std::string const& message)
 {
-    if (!condition)
-        throw std::logic_error (message);
+    if (! condition)
+        ripple::Throw<std::logic_error> (message);
 }
 
 } // Json

--- a/src/ripple/json/impl/Object.cpp
+++ b/src/ripple/json/impl/Object.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/json/Object.h>
 
 namespace Json {
@@ -61,10 +62,10 @@ Collection::Collection (Collection&& that) noexcept
 
 void Collection::checkWritable (std::string const& label)
 {
-    if (!enabled_)
-        throw std::logic_error (label + ": not enabled");
-    if (!writer_)
-        throw std::logic_error (label + ": not writable");
+    if (! enabled_)
+        ripple::Throw<std::logic_error> (label + ": not enabled");
+    if (! writer_)
+        ripple::Throw<std::logic_error> (label + ": not writable");
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/json/impl/json_assert.h
+++ b/src/ripple/json/impl/json_assert.h
@@ -22,6 +22,6 @@
 
 #define JSON_ASSERT_UNREACHABLE assert( false )
 #define JSON_ASSERT( condition ) assert( condition );  // @todo <= change this into an exception throw
-#define JSON_ASSERT_MESSAGE( condition, message ) if (!( condition )) throw std::runtime_error( message );
+#define JSON_ASSERT_MESSAGE( condition, message ) if (!( condition )) ripple::Throw<std::runtime_error> ( message );
 
 #endif

--- a/src/ripple/json/impl/json_reader.cpp
+++ b/src/ripple/json/impl/json_reader.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/json/json_reader.h>
 #include <string>
 #include <cctype>
@@ -949,7 +950,8 @@ std::istream& operator>> ( std::istream& sin, Value& root )
     bool ok = reader.parse (sin, root);
 
     //JSON_ASSERT( ok );
-    if (!ok) throw std::runtime_error (reader.getFormatedErrorMessages ());
+    if (! ok)
+        ripple::Throw<std::runtime_error> (reader.getFormatedErrorMessages ());
 
     return sin;
 }

--- a/src/ripple/json/impl/json_value.cpp
+++ b/src/ripple/json/impl/json_value.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/json/impl/json_assert.h>
 #include <ripple/json/to_string.h>
 #include <ripple/json/json_writer.h>

--- a/src/ripple/ledger/impl/TxMeta.cpp
+++ b/src/ripple/ledger/impl/TxMeta.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/ledger/TxMeta.h>
 #include <ripple/basics/Log.h>
 #include <ripple/json/to_string.h>
@@ -194,7 +195,8 @@ STObject& TxMeta::getAffectedNode (uint256 const& node)
             return n;
     }
     assert (false);
-    throw std::runtime_error ("Affected node not found");
+    Throw<std::runtime_error> ("Affected node not found");
+    return *(mNodes.begin()); // Silence compiler warning.
 }
 
 const STObject& TxMeta::peekAffectedNode (uint256 const& node) const
@@ -205,7 +207,8 @@ const STObject& TxMeta::peekAffectedNode (uint256 const& node) const
             return n;
     }
 
-    throw std::runtime_error ("Affected node not found");
+    Throw<std::runtime_error> ("Affected node not found");
+    return *(mNodes.begin()); // Silence compiler warning.
 }
 
 void TxMeta::init (uint256 const& id, std::uint32_t ledger)

--- a/src/ripple/net/impl/HTTPClient.cpp
+++ b/src/ripple/net/impl/HTTPClient.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/net/HTTPClient.h>
@@ -50,8 +51,10 @@ public:
             m_context.set_default_verify_paths (ec);
 
             if (ec && config.SSL_VERIFY_DIR.empty ())
-                throw std::runtime_error (boost::str (
-                    boost::format ("Failed to set_default_verify_paths: %s") % ec.message ()));
+                Throw<std::runtime_error> (
+                    boost::str (boost::format (
+                        "Failed to set_default_verify_paths: %s") %
+                            ec.message ()));
         }
         else
         {
@@ -63,8 +66,9 @@ public:
             m_context.add_verify_path (config.SSL_VERIFY_DIR, ec);
 
             if (ec)
-                throw std::runtime_error (boost::str (
-                    boost::format ("Failed to add verify path: %s") % ec.message ()));
+                Throw<std::runtime_error> (
+                    boost::str (boost::format (
+                        "Failed to add verify path: %s") % ec.message ()));
         }
     }
 

--- a/src/ripple/net/impl/RPCSub.cpp
+++ b/src/ripple/net/impl/RPCSub.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/net/RPCSub.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/json/to_string.h>
@@ -49,19 +50,13 @@ public:
         std::string strScheme;
 
         if (!parseUrl (strUrl, strScheme, mIp, mPort, mPath))
-        {
-            throw std::runtime_error ("Failed to parse url.");
-        }
+            Throw<std::runtime_error> ("Failed to parse url.");
         else if (strScheme == "https")
-        {
-            mSSL    = true;
-        }
+            mSSL = true;
         else if (strScheme != "http")
-        {
-            throw std::runtime_error ("Only http and https is supported.");
-        }
+            Throw<std::runtime_error> ("Only http and https is supported.");
 
-        mSeq    = 1;
+        mSeq = 1;
 
         if (mPort < 0)
             mPort   = mSSL ? 443 : 80;

--- a/src/ripple/nodestore/backend/MemoryFactory.cpp
+++ b/src/ripple/nodestore/backend/MemoryFactory.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
 #include <beast/utility/ci_char_traits.h>
@@ -63,7 +64,7 @@ public:
             std::make_tuple(path), std::make_tuple());
         MemoryDB& db = result.first->second;
         if (db.open)
-            throw std::runtime_error("already open");
+            Throw<std::runtime_error> ("already open");
         return db;
     }
 };
@@ -88,7 +89,7 @@ public:
         , journal_ (journal)
     {
         if (name_.empty())
-            throw std::runtime_error ("Missing path in Memory backend");
+            Throw<std::runtime_error> ("Missing path in Memory backend");
         db_ = &memoryFactory.open(name_);
     }
 
@@ -137,7 +138,7 @@ public:
     std::vector<std::shared_ptr<NodeObject>>
     fetchBatch (std::size_t n, void const* const* keys) override
     {
-        throw std::runtime_error("pure virtual called");
+        Throw<std::runtime_error> ("pure virtual called");
         return {};
     }
 

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 
+#include <ripple/basics/contract.h>
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/nodestore/impl/codec.h>
@@ -71,7 +72,7 @@ public:
         , scheduler_ (scheduler)
     {
         if (name_.empty())
-            throw std::runtime_error (
+            Throw<std::runtime_error> (
                 "nodestore: Missing path in NuDB backend");
         auto const folder = boost::filesystem::path (name_);
         boost::filesystem::create_directories (folder);
@@ -85,13 +86,10 @@ public:
             0.50);
         try
         {
-            if (! db_.open (dp, kp, lp,
-                    arena_alloc_size))
-                throw std::runtime_error(
-                    "nodestore: open failed");
+            if (! db_.open (dp, kp, lp, arena_alloc_size))
+                Throw<std::runtime_error> ("nodestore: open failed");
             if (db_.appnum() != currentType)
-                throw std::runtime_error(
-                    "nodestore: unknown appnum");
+                Throw<std::runtime_error> ("nodestore: unknown appnum");
         }
         catch (std::exception const& e)
         {
@@ -157,7 +155,7 @@ public:
     std::vector<std::shared_ptr<NodeObject>>
     fetchBatch (std::size_t n, void const* const* keys) override
     {
-        throw std::runtime_error("pure virtual called");
+        Throw<std::runtime_error> ("pure virtual called");
         return {};
     }
 

--- a/src/ripple/nodestore/backend/NullFactory.cpp
+++ b/src/ripple/nodestore/backend/NullFactory.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
 #include <memory>
@@ -62,7 +63,7 @@ public:
     std::vector<std::shared_ptr<NodeObject>>
     fetchBatch (std::size_t n, void const* const* keys) override
     {
-        throw std::runtime_error("pure virtual called");
+        Throw<std::runtime_error> ("pure virtual called");
         return {};
     }
 

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -23,6 +23,7 @@
 
 #if RIPPLE_ROCKSDB_AVAILABLE
 
+#include <ripple/basics/contract.h>
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
@@ -107,8 +108,8 @@ public:
         , m_scheduler (scheduler)
         , m_batch (*this, scheduler)
     {
-        if (!get_if_exists(keyValues, "path", m_name))
-            throw std::runtime_error ("Missing path in RocksDBFactory backend");
+        if (! get_if_exists(keyValues, "path", m_name))
+            Throw<std::runtime_error> ("Missing path in RocksDBFactory backend");
 
         rocksdb::Options options;
         rocksdb::BlockBasedTableOptions table_options;
@@ -170,8 +171,9 @@ public:
 
         rocksdb::DB* db = nullptr;
         rocksdb::Status status = rocksdb::DB::Open (options, m_name, &db);
-        if (!status.ok () || !db)
-            throw std::runtime_error (std::string("Unable to open/create RocksDB: ") + status.ToString());
+        if (! status.ok () || ! db)
+            Throw<std::runtime_error> (
+                std::string("Unable to open/create RocksDB: ") + status.ToString());
 
         m_db.reset (db);
     }
@@ -262,7 +264,7 @@ public:
     std::vector<std::shared_ptr<NodeObject>>
     fetchBatch (std::size_t n, void const* const* keys) override
     {
-        throw std::runtime_error("pure virtual called");
+        Throw<std::runtime_error> ("pure virtual called");
         return {};
     }
 
@@ -294,8 +296,8 @@ public:
 
         auto ret = m_db->Write (options, &wb);
 
-        if (!ret.ok ())
-            throw std::runtime_error ("storeBatch failed: " + ret.ToString());
+        if (! ret.ok ())
+            Throw<std::runtime_error> ("storeBatch failed: " + ret.ToString());
     }
 
     void

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -23,6 +23,7 @@
 
 #if RIPPLE_ROCKSDB_AVAILABLE
 
+#include <ripple/basics/contract.h>
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
@@ -103,7 +104,8 @@ public:
         , m_name (get<std::string>(keyValues, "path"))
     {
         if (m_name.empty())
-            throw std::runtime_error ("Missing path in RocksDBQuickFactory backend");
+            Throw<std::runtime_error> (
+                "Missing path in RocksDBQuickFactory backend");
 
         // Defaults
         std::uint64_t budget = 512 * 1024 * 1024;  // 512MB
@@ -167,8 +169,10 @@ public:
         rocksdb::DB* db = nullptr;
 
         rocksdb::Status status = rocksdb::DB::Open (options, m_name, &db);
-        if (!status.ok () || !db)
-            throw std::runtime_error (std::string("Unable to open/create RocksDBQuick: ") + status.ToString());
+        if (! status.ok () || ! db)
+            Throw<std::runtime_error> (
+                std::string("Unable to open/create RocksDBQuick: ") +
+                    status.ToString());
 
         m_db.reset (db);
     }
@@ -265,7 +269,7 @@ public:
     std::vector<std::shared_ptr<NodeObject>>
     fetchBatch (std::size_t n, void const* const* keys) override
     {
-        throw std::runtime_error("pure virtual called");
+        Throw<std::runtime_error> ("pure virtual called");
         return {};
     }
 
@@ -294,8 +298,8 @@ public:
 
         auto ret = m_db->Write (options, &wb);
 
-        if (!ret.ok ())
-            throw std::runtime_error ("storeBatch failed: " + ret.ToString());
+        if (! ret.ok ())
+            Throw<std::runtime_error> ("storeBatch failed: " + ret.ToString());
     }
 
     void

--- a/src/ripple/nodestore/impl/ManagerImp.cpp
+++ b/src/ripple/nodestore/impl/ManagerImp.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/nodestore/impl/ManagerImp.h>
 #include <ripple/nodestore/impl/DatabaseImp.h>
 #include <ripple/nodestore/impl/DatabaseRotatingImp.h>
@@ -39,7 +40,7 @@ ManagerImp::instance()
 void
 ManagerImp::missing_backend()
 {
-    throw std::runtime_error (
+    Throw<std::runtime_error> (
         "Your rippled.cfg is missing a [node_db] entry, "
         "please see the rippled-example.cfg file!"
         );

--- a/src/ripple/nodestore/tests/Timing.test.cpp
+++ b/src/ripple/nodestore/tests/Timing.test.cpp
@@ -312,12 +312,12 @@ public:
             parallel_for<Body>(params.items,
                 params.threads, std::ref(*this), std::ref(*backend));
         }
-        catch(...)
+        catch (std::exception const&)
         {
         #if NODESTORE_TIMING_DO_VERIFY
             backend->verify();
         #endif
-            throw;
+            Throw();
         }
         backend->close();
     }
@@ -373,12 +373,12 @@ public:
             parallel_for_id<Body>(params.items, params.threads,
                 std::ref(*this), std::ref(params), std::ref(*backend));
         }
-        catch(...)
+        catch (std::exception const&)
         {
         #if NODESTORE_TIMING_DO_VERIFY
             backend->verify();
         #endif
-            throw;
+            Throw();
         }
         backend->close();
     }
@@ -436,12 +436,12 @@ public:
             parallel_for_id<Body>(params.items, params.threads,
                 std::ref(*this), std::ref(params), std::ref(*backend));
         }
-        catch(...)
+        catch (std::exception const&)
         {
         #if NODESTORE_TIMING_DO_VERIFY
             backend->verify();
         #endif
-            throw;
+            Throw();
         }
         backend->close();
     }
@@ -514,12 +514,12 @@ public:
             parallel_for_id<Body>(params.items, params.threads,
                 std::ref(*this), std::ref(params), std::ref(*backend));
         }
-        catch(...)
+        catch (std::exception const&)
         {
         #if NODESTORE_TIMING_DO_VERIFY
             backend->verify();
         #endif
-            throw;
+            Throw();
         }
         backend->close();
     }
@@ -626,12 +626,12 @@ public:
             parallel_for_id<Body>(params.items, params.threads,
                 std::ref(*this), std::ref(params), std::ref(*backend));
         }
-        catch(...)
+        catch (std::exception const&)
         {
         #if NODESTORE_TIMING_DO_VERIFY
             backend->verify();
         #endif
-            throw;
+            Throw();
         }
         backend->close();
     }

--- a/src/ripple/nodestore/tests/import_test.cpp
+++ b/src/ripple/nodestore/tests/import_test.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <beast/hash/xxhasher.h>
+#include <ripple/basics/contract.h>
 #include <ripple/nodestore/impl/codec.h>
 #include <beast/chrono/basic_seconds_clock.h>
 #include <beast/chrono/chrono_io.h>
@@ -280,12 +281,12 @@ parse_args(std::string const& s)
     {
         boost::smatch m;
         if (! boost::regex_match (kv, m, re1))
-            throw std::runtime_error(
+            Throw<std::runtime_error> (
                 "invalid parameter " + kv);
         auto const result =
             map.emplace(m[1], m[2]);
         if (! result.second)
-            throw std::runtime_error(
+            Throw<std::runtime_error> (
                 "duplicate parameter " + m[1]);
     }
     return map;
@@ -379,7 +380,7 @@ public:
                 rocksdb::DB::OpenForReadOnly(
                     options, from_path, &pdb);
             if (! status.ok () || ! pdb)
-                throw std::runtime_error (
+                Throw<std::runtime_error> (
                     "Can't open '" + from_path + "': " +
                         status.ToString());
             db.reset(pdb);
@@ -413,7 +414,7 @@ public:
             for (it->SeekToFirst (); it->Valid (); it->Next())
             {
                 if (it->key().size() != 32)
-                    throw std::runtime_error(
+                    Throw<std::runtime_error> (
                         "Unexpected key size " +
                             std::to_string(it->key().size()));
                 void const* const key = it->key().data();
@@ -829,7 +830,7 @@ read (File& f, dat_file_header& dh)
     }
     catch (file_short_read_error const&)
     {
-        throw store_corrupt_error(
+        Throw<store_corrupt_error> (
             "short data file header");
     }
     istream is(buf);
@@ -888,7 +889,7 @@ read (File& f, key_file_header& kh)
     }
     catch (file_short_read_error const&)
     {
-        throw store_corrupt_error(
+        Throw<store_corrupt_error> (
             "short key file header");
     }
     istream is(buf);

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/core/DatabaseCon.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/make_SSLContext.h>
 #include <ripple/protocol/JsonFields.h>
@@ -466,7 +467,7 @@ OverlayImpl::setupValidatorKeyManifests (BasicConfig const& config,
         }
         else
         {
-            throw std::runtime_error("Malformed manifest in config");
+            Throw<std::runtime_error> ("Malformed manifest in config");
         }
     }
     else
@@ -532,7 +533,7 @@ OverlayImpl::onPrepare()
             {
                 if (addr.port () == 0)
                 {
-                    throw std::runtime_error ("Port not specified for "
+                    Throw<std::runtime_error> ("Port not specified for "
                         "address:" + addr.to_string ());
                 }
 
@@ -1070,7 +1071,7 @@ setup_Overlay (BasicConfig const& config)
             beast::IP::Address::from_string (ip);
         if (! valid || ! setup.public_ip.is_v4() ||
                 is_private (setup.public_ip))
-            throw std::runtime_error ("Configured public IP is invalid");
+            Throw<std::runtime_error> ("Configured public IP is invalid");
     }
     return setup;
 }

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1119,7 +1119,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
                 });
         }
     }
-    catch (...)
+    catch (std::exception const&)
     {
         p_journal_.warning << "Transaction invalid: " <<
             strHex(m->rawtransaction ());
@@ -1614,12 +1614,6 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMValidation> const& m)
             "Validation: Exception, " << e.what();
         fee_ = Resource::feeInvalidRequest;
     }
-    catch (...)
-    {
-        p_journal_.warning <<
-            "Validation: Unknown exception";
-        fee_ = Resource::feeInvalidRequest;
-    }
 }
 
 void
@@ -1880,7 +1874,7 @@ PeerImp::checkTransaction (int flags,
         app_.getOPs ().processTransaction (
             tx, trusted, false, NetworkOPs::FailHard::no);
     }
-    catch (...)
+    catch (std::exception const&)
     {
         app_.getHashRouter ().setFlags (stx->getTransactionID (), SF_BAD);
         charge (Resource::feeBadData);
@@ -1957,7 +1951,7 @@ PeerImp::checkValidation (STValidation::pointer val,
                 val, std::to_string(id())))
             overlay_.relay(*packet, signingHash);
     }
-    catch (...)
+    catch (std::exception const&)
     {
         p_journal_.trace <<
             "Exception processing validation";

--- a/src/ripple/overlay/tests/manifest_test.cpp
+++ b/src/ripple/overlay/tests/manifest_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/TestSuite.h>
 #include <ripple/overlay/impl/Manifest.h>
 #include <ripple/core/DatabaseCon.h>
@@ -55,7 +56,7 @@ private:
         if (!is_directory (dbPath))
         {
             // someone created a file where we want to put our directory
-            throw std::runtime_error ("Cannot create directory: " +
+            Throw<std::runtime_error> ("Cannot create directory: " +
                                       dbPath.string ());
         }
     }
@@ -70,7 +71,7 @@ public:
         {
             setupDatabaseDir (getDatabasePath ());
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
     }
@@ -80,7 +81,7 @@ public:
         {
             cleanupDatabaseDir (getDatabasePath ());
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
     }
@@ -110,10 +111,9 @@ public:
 
         std::string const m (static_cast<char const*> (s.data()), s.size());
         if (auto r = ripple::make_Manifest (std::move (m)))
-        {
             return std::move (*r);
-        }
-        throw std::runtime_error("Could not create a manifest");
+        Throw<std::runtime_error> ("Could not create a manifest");
+        return *ripple::make_Manifest(std::move(m)); // Silence compiler warning.
     }
 
     Manifest

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PEERFINDER_LOGIC_H_INCLUDED
 #define RIPPLE_PEERFINDER_LOGIC_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/peerfinder/PeerfinderManager.h>
 #include <ripple/peerfinder/impl/Bootcache.h>
 #include <ripple/peerfinder/impl/Counts.h>
@@ -189,7 +190,7 @@ public:
         {
             if (remote_address.port () == 0)
             {
-                throw std::runtime_error ("Port not specified for address:" +
+                Throw<std::runtime_error> ("Port not specified for address:" +
                     remote_address.to_string ());
             }
 

--- a/src/ripple/peerfinder/impl/StoreSqdb.h
+++ b/src/ripple/peerfinder/impl/StoreSqdb.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PEERFINDER_STORESQDB_H_INCLUDED
 #define RIPPLE_PEERFINDER_STORESQDB_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/core/SociDB.h>
 #include <beast/utility/Debug.h>
 #include <boost/optional.hpp>
@@ -161,7 +162,7 @@ public:
                     "Updating database to version " << currentSchemaVersion;
             else if (version > currentSchemaVersion)
             {
-                throw std::runtime_error (
+                Throw<std::runtime_error> (
                     "The PeerFinder database version is higher than expected");
             }
         }

--- a/src/ripple/protocol/KnownFormats.h
+++ b/src/ripple/protocol/KnownFormats.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_KNOWNFORMATS_H_INCLUDED
 #define RIPPLE_PROTOCOL_KNOWNFORMATS_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/SOTemplate.h>
 #include <memory>
 
@@ -110,13 +111,9 @@ public:
         Item const* const result = findByName (name);
 
         if (result != nullptr)
-        {
             return result->getType ();
-        }
-        else
-        {
-            throw std::runtime_error ("Unknown format name");
-        }
+        Throw<std::runtime_error> ("Unknown format name");
+        return {}; // Silence compiler warning.
     }
 
     /** Retrieve a format based on its type.

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_STBASE_H_INCLUDED
 #define RIPPLE_PROTOCOL_STBASE_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/Serializer.h>
 #include <ostream>
@@ -91,7 +92,7 @@ public:
     {
         D* ptr = dynamic_cast<D*> (this);
         if (ptr == nullptr)
-            throw std::bad_cast();
+            Throw<std::bad_cast> ();
         return *ptr;
     }
 
@@ -101,7 +102,7 @@ public:
     {
         D const * ptr = dynamic_cast<D const*> (this);
         if (ptr == nullptr)
-            throw std::bad_cast();
+            Throw<std::bad_cast> ();
         return *ptr;
     }
 

--- a/src/ripple/protocol/STExchange.h
+++ b/src/ripple/protocol/STExchange.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_STEXCHANGE_H_INCLUDED
 
 #include <ripple/basics/Buffer.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/STBlob.h>
@@ -139,7 +140,7 @@ get (STObject const& st,
         dynamic_cast<U const*>(b);
     // This should never happen
     if (! u)
-        throw std::runtime_error (
+        Throw<std::runtime_error> (
             "Wrong field type");
     STExchange<U, T>::get(t, *u);
     return t;

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -533,8 +533,8 @@ public:
     {
         STBase* rf = getPField (field, true);
 
-        if (!rf)
-            throw std::runtime_error ("Field not found");
+        if (! rf)
+            Throw<std::runtime_error> ("Field not found");
 
         if (rf->getSType () == STI_NOTPRESENT)
             rf = makeFieldPresent (field);
@@ -543,7 +543,7 @@ public:
         if (auto cf = dynamic_cast<Bits*> (rf))
             cf->setValue (v);
         else
-            throw std::runtime_error ("Wrong field type");
+            Throw<std::runtime_error> ("Wrong field type");
     }
 
     STObject& peekFieldObject (SField const& field);
@@ -594,8 +594,8 @@ private:
     {
         const STBase* rf = peekAtPField (field);
 
-        if (!rf)
-            throw std::runtime_error ("Field not found");
+        if (! rf)
+            Throw<std::runtime_error> ("Field not found");
 
         SerializedTypeID id = rf->getSType ();
 
@@ -604,8 +604,8 @@ private:
 
         const T* cf = dynamic_cast<const T*> (rf);
 
-        if (!cf)
-            throw std::runtime_error ("Wrong field type");
+        if (! cf)
+            Throw<std::runtime_error> ("Wrong field type");
 
         return cf->value ();
     }
@@ -620,8 +620,8 @@ private:
     {
         const STBase* rf = peekAtPField (field);
 
-        if (!rf)
-            throw std::runtime_error ("Field not found");
+        if (! rf)
+            Throw<std::runtime_error> ("Field not found");
 
         SerializedTypeID id = rf->getSType ();
 
@@ -630,8 +630,8 @@ private:
 
         const T* cf = dynamic_cast<const T*> (rf);
 
-        if (!cf)
-            throw std::runtime_error ("Wrong field type");
+        if (! cf)
+            Throw<std::runtime_error> ("Wrong field type");
 
         return *cf;
     }
@@ -644,16 +644,16 @@ private:
 
         STBase* rf = getPField (field, true);
 
-        if (!rf)
-            throw std::runtime_error ("Field not found");
+        if (! rf)
+            Throw<std::runtime_error> ("Field not found");
 
         if (rf->getSType () == STI_NOTPRESENT)
             rf = makeFieldPresent (field);
 
         T* cf = dynamic_cast<T*> (rf);
 
-        if (!cf)
-            throw std::runtime_error ("Wrong field type");
+        if (! cf)
+            Throw<std::runtime_error> ("Wrong field type");
 
         cf->setValue (std::move (value));
     }
@@ -664,16 +664,16 @@ private:
     {
         STBase* rf = getPField (field, true);
 
-        if (!rf)
-            throw std::runtime_error ("Field not found");
+        if (! rf)
+            Throw<std::runtime_error> ("Field not found");
 
         if (rf->getSType () == STI_NOTPRESENT)
             rf = makeFieldPresent (field);
 
         T* cf = dynamic_cast<T*> (rf);
 
-        if (!cf)
-            throw std::runtime_error ("Wrong field type");
+        if (! cf)
+            Throw<std::runtime_error> ("Wrong field type");
 
         (*cf) = value;
     }
@@ -684,16 +684,16 @@ private:
     {
         STBase* rf = getPField (field, true);
 
-        if (!rf)
-            throw std::runtime_error ("Field not found");
+        if (! rf)
+            Throw<std::runtime_error> ("Field not found");
 
         if (rf->getSType () == STI_NOTPRESENT)
             rf = makeFieldPresent (field);
 
         T* cf = dynamic_cast<T*> (rf);
 
-        if (!cf)
-            throw std::runtime_error ("Wrong field type");
+        if (! cf)
+            Throw<std::runtime_error> ("Wrong field type");
 
         return *cf;
     }
@@ -710,7 +710,7 @@ STObject::Proxy<T>::Proxy (STObject* st, TypedField<T> const* f)
     {
         // STObject has associated template
         if (! st_->peekAtPField(*f_))
-            THROW(template_field_error, *f);
+            Throw<template_field_error> (*f);
         style_ = st_->mType->style(*f_);
     }
     else
@@ -728,7 +728,7 @@ STObject::Proxy<T>::value() const ->
     if (t)
         return t->value();
     if (style_ != SOE_DEFAULT)
-        THROW(missing_field_error, *f_);
+        Throw<missing_field_error> (*f_);
     return value_type{};
 }
 
@@ -884,7 +884,7 @@ STObject::OptionalProxy<T>::disengage()
 {
     if (this->style_ == SOE_REQUIRED ||
             this->style_ == SOE_DEFAULT)
-        THROW(template_field_error, *this->f_);
+        Throw<template_field_error> (*this->f_);
     if (this->style_ == SOE_INVALID)
         this->st_->delField(*this->f_);
     else
@@ -911,7 +911,7 @@ STObject::operator[](TypedField<T> const& f) const
     if (! b)
         // This is a free object (no constraints)
         // with no template
-        THROW(missing_field_error, f);
+        Throw<missing_field_error> (f);
     auto const u =
         dynamic_cast<T const*>(b);
     if (! u)
@@ -919,7 +919,7 @@ STObject::operator[](TypedField<T> const& f) const
         assert(mType);
         assert(b->getSType() == STI_NOTPRESENT);
         if(mType->style(f) == SOE_OPTIONAL)
-            THROW(missing_field_error, f);
+            Throw<missing_field_error> (f);
         assert(mType->style(f) == SOE_DEFAULT);
         // Handle the case where value_type is a
         // const reference, otherwise we return

--- a/src/ripple/protocol/Serializer.h
+++ b/src/ripple/protocol/Serializer.h
@@ -22,6 +22,7 @@
 
 #include <ripple/protocol/SField.h>
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Buffer.h>
 #include <ripple/basics/Slice.h>
 #include <cassert>
@@ -386,7 +387,7 @@ SerialIter::getBitString()
     base_uint<Bits, Tag> u;
     auto const n = Bits/8;
     if (remain_ < n)
-        throw std::runtime_error(
+        Throw<std::runtime_error> (
             "invalid SerialIter getBitString");
     std::memcpy (u.begin(), p_, n);
     p_ += n;

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <unordered_map>
 #include <utility>
@@ -132,7 +133,7 @@ private:
                 std::forward_as_tuple (code), std::forward_as_tuple (
                     code, token, message)));
         if (! result.second)
-            throw std::invalid_argument ("duplicate error code");
+            Throw<std::invalid_argument> ("duplicate error code");
     }
 
 private:

--- a/src/ripple/protocol/impl/IOUAmount.cpp
+++ b/src/ripple/protocol/impl/IOUAmount.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/IOUAmount.h>
 #include <algorithm>
 #include <iterator>
@@ -56,7 +57,7 @@ IOUAmount::normalize ()
     while (mantissa_ > maxMantissa)
     {
         if (exponent_ >= maxExponent)
-            throw std::overflow_error ("IOUAmount::normalize");
+            Throw<std::overflow_error> ("IOUAmount::normalize");
 
         mantissa_ /= 10;
         ++exponent_;
@@ -69,7 +70,7 @@ IOUAmount::normalize ()
     }
 
     if (exponent_ > maxExponent)
-        throw std::overflow_error ("value overflow");
+        Throw<std::overflow_error> ("value overflow");
 
     if (negative)
         mantissa_ = -mantissa_;

--- a/src/ripple/protocol/impl/RippleAddress.cpp
+++ b/src/ripple/protocol/impl/RippleAddress.cpp
@@ -18,8 +18,8 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
-#include <ripple/protocol/digest.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/crypto/ECDSA.h>
 #include <ripple/crypto/ECIES.h>
@@ -151,20 +151,15 @@ RippleAddress::toPublicKey() const
     return RipplePublicKey (vchData.begin(), vchData.end());
 }
 
-static
-std::runtime_error badSourceError (int nVersion)
-{
-    return std::runtime_error ("bad source: " + std::to_string (nVersion));
-}
-
 NodeID RippleAddress::getNodeID () const
 {
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getNodeID");
+        Throw<std::runtime_error> ("unset source - getNodeID");
 
-    case TOKEN_NODE_PUBLIC: {
+    case TOKEN_NODE_PUBLIC:
+    {
         // Note, we are encoding the left.
         NodeID node;
         node.copyFrom(Hash160 (vchData));
@@ -172,8 +167,9 @@ NodeID RippleAddress::getNodeID () const
     }
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 Blob const& RippleAddress::getNodePublic () const
@@ -181,14 +177,15 @@ Blob const& RippleAddress::getNodePublic () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getNodePublic");
+        Throw<std::runtime_error> ("unset source - getNodePublic");
 
     case TOKEN_NODE_PUBLIC:
         return vchData;
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error>("bad source: " + std::to_string(nVersion));
     }
+    return vchData; // Silence compiler warning.
 }
 
 std::string RippleAddress::humanNodePublic () const
@@ -196,14 +193,15 @@ std::string RippleAddress::humanNodePublic () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - humanNodePublic");
+        Throw<std::runtime_error> ("unset source - humanNodePublic");
 
     case TOKEN_NODE_PUBLIC:
         return ToString ();
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error>("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 bool RippleAddress::setNodePublic (std::string const& strPublic)
@@ -253,14 +251,15 @@ Blob const& RippleAddress::getNodePrivateData () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getNodePrivateData");
+        Throw<std::runtime_error> ("unset source - getNodePrivateData");
 
     case TOKEN_NODE_PRIVATE:
         return vchData;
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return vchData; // Silence compiler warning.
 }
 
 uint256 RippleAddress::getNodePrivate () const
@@ -268,14 +267,15 @@ uint256 RippleAddress::getNodePrivate () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source = getNodePrivate");
+        Throw<std::runtime_error> ("unset source = getNodePrivate");
 
     case TOKEN_NODE_PRIVATE:
         return uint256 (vchData);
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 std::string RippleAddress::humanNodePrivate () const
@@ -283,14 +283,15 @@ std::string RippleAddress::humanNodePrivate () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - humanNodePrivate");
+        Throw<std::runtime_error> ("unset source - humanNodePrivate");
 
     case TOKEN_NODE_PRIVATE:
         return ToString ();
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 bool RippleAddress::setNodePrivate (std::string const& strPrivate)
@@ -320,7 +321,7 @@ void RippleAddress::signNodePrivate (uint256 const& hash, Blob& vchSig) const
     vchSig = ECDSASign (hash, getNodePrivate());
 
     if (vchSig.empty())
-        throw std::runtime_error ("Signing failed.");
+        Throw<std::runtime_error> ("Signing failed.");
 }
 
 //
@@ -342,18 +343,18 @@ Blob const& RippleAddress::getAccountPublic () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getAccountPublic");
+        Throw<std::runtime_error> ("unset source - getAccountPublic");
 
     case TOKEN_ACCOUNT_ID:
-        throw std::runtime_error ("public not available from account id");
-        break;
+        Throw<std::runtime_error> ("public not available from account id");
 
     case TOKEN_ACCOUNT_PUBLIC:
         return vchData;
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return vchData; // Silence compiler warning.
 }
 
 std::string RippleAddress::humanAccountPublic () const
@@ -361,17 +362,18 @@ std::string RippleAddress::humanAccountPublic () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - humanAccountPublic");
+        Throw<std::runtime_error> ("unset source - humanAccountPublic");
 
     case TOKEN_ACCOUNT_ID:
-        throw std::runtime_error ("public not available from account id");
+        Throw<std::runtime_error> ("public not available from account id");
 
     case TOKEN_ACCOUNT_PUBLIC:
         return ToString ();
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 bool RippleAddress::setAccountPublic (std::string const& strPublic)
@@ -437,14 +439,15 @@ uint256 RippleAddress::getAccountPrivate () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getAccountPrivate");
+        Throw<std::runtime_error> ("unset source - getAccountPrivate");
 
     case TOKEN_ACCOUNT_SECRET:
         return uint256::fromVoid (vchData.data() + (vchData.size() - 32));
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 bool RippleAddress::setAccountPrivate (std::string const& strPrivate)
@@ -518,7 +521,7 @@ Blob RippleAddress::accountPrivateEncrypt (
         {
             vucCipherText = encryptECIES (secretKey, publicKey, vucPlainText);
         }
-        catch (...)
+        catch (std::exception const&)
         {
             // TODO: log this or explain why this is unimportant!
         }
@@ -540,7 +543,7 @@ Blob RippleAddress::accountPrivateDecrypt (
         {
             vucPlainText = decryptECIES (secretKey, publicKey, vucCipherText);
         }
-        catch (...)
+        catch (std::exception const&)
         {
             // TODO: log this or explain why this is unimportant!
         }
@@ -559,15 +562,16 @@ Blob const& RippleAddress::getGenerator () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getGenerator");
+        Throw<std::runtime_error> ("unset source - getGenerator");
 
     case TOKEN_FAMILY_GENERATOR:
         // Do nothing.
         return vchData;
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return vchData; // Silence compiler warning.
 }
 
 std::string RippleAddress::humanGenerator () const
@@ -575,14 +579,15 @@ std::string RippleAddress::humanGenerator () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - humanGenerator");
+        Throw<std::runtime_error> ("unset source - humanGenerator");
 
     case TOKEN_FAMILY_GENERATOR:
         return ToString ();
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 void RippleAddress::setGenerator (Blob const& vPublic)
@@ -607,14 +612,15 @@ uint128 RippleAddress::getSeed () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - getSeed");
+        Throw<std::runtime_error> ("unset source - getSeed");
 
     case TOKEN_FAMILY_SEED:
         return uint128 (vchData);
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 std::string RippleAddress::humanSeed1751 () const
@@ -622,7 +628,7 @@ std::string RippleAddress::humanSeed1751 () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - humanSeed1751");
+        Throw<std::runtime_error> ("unset source - humanSeed1751");
 
     case TOKEN_FAMILY_SEED:
     {
@@ -641,8 +647,9 @@ std::string RippleAddress::humanSeed1751 () const
     }
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 std::string RippleAddress::humanSeed () const
@@ -650,14 +657,15 @@ std::string RippleAddress::humanSeed () const
     switch (nVersion)
     {
     case TOKEN_NONE:
-        throw std::runtime_error ("unset source - humanSeed");
+        Throw<std::runtime_error> ("unset source - humanSeed");
 
     case TOKEN_FAMILY_SEED:
         return ToString ();
 
     default:
-        throw badSourceError (nVersion);
+        Throw<std::runtime_error> ("bad source: " + std::to_string(nVersion));
     }
+    return {}; // Silence compiler warning.
 }
 
 int RippleAddress::setSeed1751 (std::string const& strHuman1751)

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/protocol/STBase.h>
 #include <ripple/protocol/STArray.h>
@@ -77,7 +78,7 @@ STArray::STArray (SerialIter& sit, SField const& f)
         {
             WriteLog (lsWARNING, STObject) <<
                 "Encountered array with end of object marker";
-            throw std::runtime_error ("Illegal terminator in array");
+            Throw<std::runtime_error> ("Illegal terminator in array");
         }
 
         auto const& fn = SField::getField (type, field);
@@ -86,13 +87,13 @@ STArray::STArray (SerialIter& sit, SField const& f)
         {
             WriteLog (lsTRACE, STObject) <<
                 "Unknown field: " << type << "/" << field;
-            throw std::runtime_error ("Unknown field");
+            Throw<std::runtime_error> ("Unknown field");
         }
 
         if (fn.fieldType != STI_OBJECT)
         {
             WriteLog (lsTRACE, STObject) << "Array contains non-object";
-            throw std::runtime_error ("Non-object in array");
+            Throw<std::runtime_error> ("Non-object in array");
         }
 
         v_.emplace_back(fn);
@@ -100,7 +101,7 @@ STArray::STArray (SerialIter& sit, SField const& f)
 
         if (v_.back().setTypeFromSField (fn) == STObject::typeSetFail)
         {
-            throw std::runtime_error ("Malformed object in array");
+            Throw<std::runtime_error> ("Malformed object in array");
         }
     }
 }

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/json/to_string.h>
 #include <ripple/protocol/Indexes.h>
@@ -36,7 +37,7 @@ STLedgerEntry::STLedgerEntry (Keylet const& k)
     mFormat =
         LedgerFormats::getInstance().findByType (type_);
     if (mFormat == nullptr)
-        throw std::runtime_error ("invalid ledger entry type");
+        Throw<std::runtime_error> ("invalid ledger entry type");
     set (mFormat->elements);
     setFieldU16 (sfLedgerEntryType,
         static_cast <std::uint16_t> (mFormat->getType ()));
@@ -72,7 +73,7 @@ void STLedgerEntry::setSLEType ()
         static_cast <LedgerEntryType> (getFieldU16 (sfLedgerEntryType)));
 
     if (mFormat == nullptr)
-        throw std::runtime_error ("invalid ledger entry type");
+        Throw<std::runtime_error> ("invalid ledger entry type");
 
     type_ = mFormat->getType ();
     if (!setType (mFormat->elements))
@@ -80,7 +81,7 @@ void STLedgerEntry::setSLEType ()
         WriteLog (lsWARNING, SerializedLedger)
             << "Ledger entry not valid for type " << mFormat->getName ();
         WriteLog (lsWARNING, SerializedLedger) << getJson (0);
-        throw std::runtime_error ("ledger entry not valid for type");
+        Throw<std::runtime_error> ("ledger entry not valid for type");
     }
 }
 

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -210,7 +210,7 @@ bool STObject::set (SerialIter& sit, int depth)
         {
             WriteLog (lsWARNING, STObject) <<
                 "Encountered object with end of array marker";
-            throw std::runtime_error ("Illegal terminator in object");
+            Throw<std::runtime_error> ("Illegal terminator in object");
         }
 
         if (!reachedEndOfObject)
@@ -224,7 +224,7 @@ bool STObject::set (SerialIter& sit, int depth)
                 WriteLog (lsWARNING, STObject) <<
                     "Unknown field: field_type=" << type <<
                     ", field_name=" << field;
-                throw std::runtime_error ("Unknown field");
+                Throw<std::runtime_error> ("Unknown field");
             }
 
             // Unflatten the field
@@ -234,7 +234,7 @@ bool STObject::set (SerialIter& sit, int depth)
             STObject* const obj = dynamic_cast <STObject*> (&(v_.back().get()));
             if (obj && (obj->setTypeFromSField (fn) == typeSetFail))
             {
-                throw std::runtime_error ("field deserialization error");
+                Throw<std::runtime_error> ("field deserialization error");
             }
         }
     }
@@ -352,7 +352,7 @@ const STBase& STObject::peekAtField (SField const& field) const
     int index = getFieldIndex (field);
 
     if (index == -1)
-        throw std::runtime_error ("Field not found");
+        Throw<std::runtime_error> ("Field not found");
 
     return peekAtIndex (index);
 }
@@ -362,7 +362,7 @@ STBase& STObject::getField (SField const& field)
     int index = getFieldIndex (field);
 
     if (index == -1)
-        throw std::runtime_error ("Field not found");
+        Throw<std::runtime_error> ("Field not found");
 
     return getIndex (index);
 }
@@ -462,7 +462,7 @@ STBase* STObject::makeFieldPresent (SField const& field)
     if (index == -1)
     {
         if (!isFree ())
-            throw std::runtime_error ("Field not found");
+            Throw<std::runtime_error> ("Field not found");
 
         return getPIndex (emplace_back(detail::nonPresentObject, field));
     }
@@ -482,7 +482,7 @@ void STObject::makeFieldAbsent (SField const& field)
     int index = getFieldIndex (field);
 
     if (index == -1)
-        throw std::runtime_error ("Field not found");
+        Throw<std::runtime_error> ("Field not found");
 
     const STBase& f = peekAtIndex (index);
 
@@ -512,7 +512,7 @@ std::string STObject::getFieldString (SField const& field) const
 {
     const STBase* rf = peekAtPField (field);
 
-    if (!rf) throw std::runtime_error ("Field not found");
+    if (! rf) Throw<std::runtime_error> ("Field not found");
 
     return rf->getText ();
 }
@@ -606,7 +606,7 @@ STObject::set (std::unique_ptr<STBase> v)
     else
     {
         if (! isFree())
-            throw std::runtime_error(
+            Throw<std::runtime_error> (
                 "missing field in templated STObject");
         v_.emplace_back(std::move(*v));
     }

--- a/src/ripple/protocol/impl/STParsedJSON.cpp
+++ b/src/ripple/protocol/impl/STParsedJSON.cpp
@@ -18,8 +18,8 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/StringUtilities.h>
-#include <ripple/protocol/STInteger.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/LedgerFormats.h>
 #include <ripple/protocol/STAccount.h>
@@ -28,6 +28,7 @@
 #include <ripple/protocol/STBitString.h>
 #include <ripple/protocol/STBlob.h>
 #include <ripple/protocol/STVector256.h>
+#include <ripple/protocol/STInteger.h>
 #include <ripple/protocol/STParsedJSON.h>
 #include <ripple/protocol/STPathSet.h>
 #include <ripple/protocol/TxFormats.h>
@@ -46,7 +47,7 @@ template <typename T, typename U>
 static T range_check_cast (U value, T minimum, T maximum)
 {
     if ((value < minimum) || (value > maximum))
-        throw std::runtime_error ("Value out of range");
+        Throw<std::runtime_error> ("Value out of range");
 
     return static_cast<T> (value);
 }
@@ -212,7 +213,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -282,7 +283,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -316,7 +317,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -349,7 +350,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -370,7 +371,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -391,7 +392,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -412,7 +413,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 return ret;
             }
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -431,13 +432,13 @@ static boost::optional<detail::STVar> parseLeaf (
         {
             std::pair<Blob, bool> vBlob (strUnHex (value.asString ()));
 
-            if (!vBlob.second)
-                throw std::invalid_argument ("invalid data");
+            if (! vBlob.second)
+                Throw<std::invalid_argument> ("invalid data");
 
             ret = detail::make_stvar <STBlob> (field, vBlob.first.data (),
                                              vBlob.first.size ());
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -450,7 +451,7 @@ static boost::optional<detail::STVar> parseLeaf (
         {
             ret = detail::make_stvar <STAmount> (amountFromJson (field, value));
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -476,7 +477,7 @@ static boost::optional<detail::STVar> parseLeaf (
             }
             ret = detail::make_stvar <STVector256> (std::move (tail));
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -606,7 +607,7 @@ static boost::optional<detail::STVar> parseLeaf (
             }
             ret = detail::make_stvar <STPathSet> (std::move (tail));
         }
-        catch (...)
+        catch (std::exception const&)
         {
             error = invalid_data (json_name, fieldName);
             return ret;
@@ -638,7 +639,7 @@ static boost::optional<detail::STVar> parseLeaf (
                 ret = detail::make_stvar <STAccount>(
                     field, *account);
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 error = invalid_data (json_name, fieldName);
                 return ret;
@@ -721,7 +722,7 @@ static boost::optional <STObject> parseObject (
                     return boost::none;
                 data.emplace_back (std::move (*ret));
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 error = invalid_data (json_name, fieldName);
                 return boost::none;
@@ -739,7 +740,7 @@ static boost::optional <STObject> parseObject (
                     return boost::none;
                 data.emplace_back (std::move (*array));
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 error = invalid_data (json_name, fieldName);
                 return boost::none;
@@ -846,7 +847,7 @@ static boost::optional <detail::STVar> parseArray (
 
         return detail::make_stvar <STArray> (std::move (tail));
     }
-    catch (...)
+    catch (std::exception const&)
     {
         error = invalid_data (json_name);
         return boost::none;

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/protocol/STPathSet.h>
 #include <ripple/protocol/JsonFields.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/strHex.h>
 #include <ripple/basics/StringUtilities.h>
@@ -65,7 +66,7 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
             {
                 WriteLog (lsINFO, STBase)
                     << "STPathSet: Empty path.";
-                throw std::runtime_error ("empty path");
+                Throw<std::runtime_error> ("empty path");
             }
 
             push_back (path);
@@ -79,7 +80,7 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
             WriteLog (lsINFO, STBase)
                 << "STPathSet: Bad path element: " << iType;
 
-            throw std::runtime_error ("bad path element");
+            Throw<std::runtime_error> ("bad path element");
         }
         else
         {

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -49,7 +49,7 @@ STTx::STTx (TxType type)
     {
         WriteLog (lsWARNING, STTx) <<
             "Transaction type: " << type;
-        throw std::runtime_error ("invalid transaction type");
+        Throw<std::runtime_error> ("invalid transaction type");
     }
 
     set (format->elements);
@@ -67,14 +67,14 @@ STTx::STTx (STObject&& object)
     {
         WriteLog (lsWARNING, STTx) <<
             "Transaction type: " << tx_type_;
-        throw std::runtime_error ("invalid transaction type");
+        Throw<std::runtime_error> ("invalid transaction type");
     }
 
     if (!setType (format->elements))
     {
         WriteLog (lsWARNING, STTx) <<
             "Transaction not legal for format";
-        throw std::runtime_error ("transaction not valid");
+        Throw<std::runtime_error> ("transaction not valid");
     }
 
     tid_ = getHash(HashPrefix::transactionID);
@@ -89,7 +89,7 @@ STTx::STTx (SerialIter& sit)
     {
         WriteLog (lsERROR, STTx) <<
             "Transaction has invalid length: " << length;
-        throw std::runtime_error ("Transaction length invalid");
+        Throw<std::runtime_error> ("Transaction length invalid");
     }
 
     set (sit);
@@ -101,14 +101,14 @@ STTx::STTx (SerialIter& sit)
     {
         WriteLog (lsWARNING, STTx) <<
             "Invalid transaction type: " << tx_type_;
-        throw std::runtime_error ("invalid transaction type");
+        Throw<std::runtime_error> ("invalid transaction type");
     }
 
     if (!setType (format->elements))
     {
         WriteLog (lsWARNING, STTx) <<
             "Transaction not legal for format";
-        throw std::runtime_error ("transaction not valid");
+        Throw<std::runtime_error> ("transaction not valid");
     }
 
     tid_ = getHash(HashPrefix::transactionID);
@@ -178,7 +178,7 @@ Blob STTx::getSignature () const
     {
         return getFieldVL (sfTxnSignature);
     }
-    catch (...)
+    catch (std::exception const&)
     {
         return Blob ();
     }
@@ -210,7 +210,7 @@ bool STTx::checkSign(bool allowMultiSign) const
             sigGood = checkSingleSign ();
         }
     }
-    catch (...)
+    catch (std::exception const&)
     {
     }
     return sigGood;
@@ -298,7 +298,7 @@ STTx::checkSingleSign () const
         ret = n.accountPublicVerify (getSigningData (*this),
             getFieldVL (sfTxnSignature), fullyCanonical);
     }
-    catch (...)
+    catch (std::exception const&)
     {
         // Assume it was a signature failure.
         ret = false;
@@ -372,7 +372,7 @@ STTx::checkMultiSign () const
             validSig = pubKey.accountPublicVerify (
                 s.getData(), signature, fullyCanonical);
         }
-        catch (...)
+        catch (std::exception const&)
         {
             // We assume any problem lies with the signature.
             validSig = false;

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/protocol/STValidation.h>
 #include <ripple/protocol/HashPrefix.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/json/to_string.h>
 
@@ -35,7 +36,7 @@ STValidation::STValidation (SerialIter& sit, bool checkSignature)
     if  (checkSignature && !isValid ())
     {
         WriteLog (lsTRACE, Ledger) << "Invalid validation " << getJson (0);
-        throw std::runtime_error ("Invalid validation");
+        Throw<std::runtime_error> ("Invalid validation");
     }
 }
 
@@ -104,7 +105,7 @@ bool STValidation::isValid (uint256 const& signingHash) const
         return raPublicKey.isValid () &&
             raPublicKey.verifyNodePublic (signingHash, getFieldVL (sfSignature), fullyCanonical);
     }
-    catch (...)
+    catch (std::exception const&)
     {
         WriteLog (lsINFO, Ledger) << "exception validating validation";
         return false;

--- a/src/ripple/protocol/impl/STVar.cpp
+++ b/src/ripple/protocol/impl/STVar.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/STAccount.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/STArray.h>
@@ -142,7 +143,7 @@ STVar::STVar (SerialIter& sit, SField const& name)
     case STI_OBJECT:        construct<STObject>(sit, name); return;
     case STI_ARRAY:         construct<STArray>(sit, name); return;
     default:
-        throw std::runtime_error ("Unknown object type");
+        Throw<std::runtime_error> ("Unknown object type");
     }
 }
 
@@ -167,7 +168,7 @@ STVar::STVar (SerializedTypeID id, SField const& name)
     case STI_OBJECT:        construct<STObject>(name); return;
     case STI_ARRAY:         construct<STArray>(name); return;
     default:
-        throw std::runtime_error ("Unknown object type");
+        Throw<std::runtime_error> ("Unknown object type");
     }
 }
 

--- a/src/ripple/protocol/tests/InnerObjectFormats.test.cpp
+++ b/src/ripple/protocol/tests/InnerObjectFormats.test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/InnerObjectFormats.h>
 #include <ripple/protocol/ErrorCodes.h>          // RPC::containsError
 #include <ripple/json/json_reader.h>             // Json::Reader
@@ -180,7 +181,7 @@ public:
             Json::Reader ().parse (test.txt, req);
             if (RPC::contains_error (req))
             {
-                throw std::runtime_error (
+                Throw<std::runtime_error> (
                     "Internal InnerObjectFormatsParsedJSON error.  Bad JSON.");
             }
             STParsedJSONObject parsed ("request", req);

--- a/src/ripple/protocol/tests/STAmount.test.cpp
+++ b/src/ripple/protocol/tests/STAmount.test.cpp
@@ -593,7 +593,7 @@ public:
         {
             pass ();
         }
-        catch (...)
+        catch (std::exception const&)
         {
             fail ("wrong exception");
         }
@@ -625,7 +625,7 @@ public:
         {
             pass ();
         }
-        catch (...)
+        catch (std::exception const&)
         {
             fail ("wrong exception");
         }

--- a/src/ripple/protocol/tests/STTx.test.cpp
+++ b/src/ripple/protocol/tests/STTx.test.cpp
@@ -152,7 +152,7 @@ public:
                 STTx copy (sit);
                 serialized = true;
             }
-            catch (...)
+            catch (std::exception const&)
             {
                 ; // If it threw then serialization failed.
             }

--- a/src/ripple/rpc/Status.h
+++ b/src/ripple/rpc/Status.h
@@ -35,7 +35,7 @@ namespace RPC {
     A Status can also be used to fill a Json::Value with a JSON-RPC 2.0
     error response:  see http://www.jsonrpc.org/specification#error_object
  */
-struct Status
+struct Status : public std::exception
 {
 public:
     enum class Type {none, TER, error_code_i};

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -186,7 +186,7 @@ Json::Value doAccountTx (RPC::Context& context)
         return ret;
 #ifndef BEAST_DEBUG
     }
-    catch (...)
+    catch (std::exception const&)
     {
         return rpcError (rpcINTERNAL);
     }

--- a/src/ripple/rpc/handlers/AccountTxOld.cpp
+++ b/src/ripple/rpc/handlers/AccountTxOld.cpp
@@ -215,7 +215,7 @@ Json::Value doAccountTxOld (RPC::Context& context)
         return ret;
 #ifndef BEAST_DEBUG
     }
-    catch (...)
+    catch (std::exception const&)
     {
         return rpcError (rpcINTERNAL);
     }

--- a/src/ripple/rpc/handlers/Random.cpp
+++ b/src/ripple/rpc/handlers/Random.cpp
@@ -48,7 +48,7 @@ Json::Value doRandom (RPC::Context& context)
         jvResult[jss::random]  = to_string (rand);
         return jvResult;
     }
-    catch (...)
+    catch (std::exception const&)
     {
         return rpcError (rpcINTERNAL);
     }

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -26,6 +26,7 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/JobQueue.h>
@@ -266,7 +267,7 @@ void executeRPC (
     {
         // Can't ever get here.
         assert (false);
-        throw std::logic_error ("RPC handler with no method");
+        Throw<std::logic_error> ("RPC handler with no method");
     }
 }
 

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/ErrorCodes.h>
@@ -1699,7 +1700,7 @@ public:
                 Json::Value req;
                 Json::Reader ().parse (txnTest.json, req);
                 if (RPC::contains_error (req))
-                    throw std::runtime_error (
+                    Throw<std::runtime_error> (
                         "Internal JSONRPC_test error.  Bad test JSON.");
 
                 static Role const testedRoles[] =

--- a/src/ripple/rpc/tests/Status.test.cpp
+++ b/src/ripple/rpc/tests/Status.test.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/rpc/Status.h>
+#include <ripple/basics/contract.h>
 #include <beast/unit_test/suite.h>
 
 namespace ripple {
@@ -183,7 +184,7 @@ private:
         testcase ("throw");
         try
         {
-            throw Status (temBAD_PATH, {"path=sdcdfd"});
+            Throw<Status> (Status(temBAD_PATH, { "path=sdcdfd" }));
         }
         catch (Status const& s)
         {
@@ -192,7 +193,7 @@ private:
             expect (msgs.size () == 1, "Wrong number of messages");
             expect (msgs[0] == "path=sdcdfd", msgs[0]);
         }
-        catch (...)
+        catch (std::exception const&)
         {
             expect (false, "Didn't catch a Status");
         }

--- a/src/ripple/server/impl/Door.cpp
+++ b/src/ripple/server/impl/Door.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/server/impl/Door.h>
 #include <ripple/server/impl/PlainPeer.h>
 #include <ripple/server/impl/SSLPeer.h>
@@ -180,8 +181,7 @@ Door::Door (boost::asio::io_service& io_service,
     {
         if (server_.journal().error) server_.journal().error <<
             "Open port '" << port.name << "' failed:" << ec.message();
-        throw std::exception();
-        return;
+        Throw<std::exception> ();
     }
 
     acceptor_.set_option(
@@ -190,8 +190,7 @@ Door::Door (boost::asio::io_service& io_service,
     {
         if (server_.journal().error) server_.journal().error <<
             "Option for port '" << port.name << "' failed:" << ec.message();
-        throw std::exception();
-        return;
+        Throw<std::exception> ();
     }
 
     acceptor_.bind(local_address, ec);
@@ -199,8 +198,7 @@ Door::Door (boost::asio::io_service& io_service,
     {
         if (server_.journal().error) server_.journal().error <<
             "Bind port '" << port.name << "' failed:" << ec.message();
-        throw std::exception();
-        return;
+        Throw<std::exception> ();
     }
 
     acceptor_.listen(boost::asio::socket_base::max_connections, ec);
@@ -208,8 +206,7 @@ Door::Door (boost::asio::io_service& io_service,
     {
         if (server_.journal().error) server_.journal().error <<
             "Listen on port '" << port.name << "' failed:" << ec.message();
-        throw std::exception();
-        return;
+        Throw<std::exception> ();
     }
 
     if (server_.journal().info) server_.journal().info <<

--- a/src/ripple/server/impl/ServerImpl.cpp
+++ b/src/ripple/server/impl/ServerImpl.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/server/impl/ServerImpl.h>
 #include <ripple/server/impl/Peer.h>
 #include <beast/chrono/chrono_io.h>
@@ -60,7 +61,7 @@ void
 ServerImpl::ports (std::vector<Port> const& ports)
 {
     if (closed())
-        throw std::logic_error("ports() on closed HTTP::Server");
+        Throw<std::logic_error> ("ports() on closed HTTP::Server");
     for(auto const& _ : ports)
         if (! _.websockets())
             std::make_shared<Door>(

--- a/src/ripple/shamap/impl/SHAMapDelta.cpp
+++ b/src/ripple/shamap/impl/SHAMapDelta.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/shamap/SHAMap.h>
 
 namespace ripple {
@@ -139,7 +140,7 @@ SHAMap::compare (SHAMap const& otherMap,
         if (!ourNode || !otherNode)
         {
             assert (false);
-            throw SHAMapMissingNode (type_, uint256 ());
+            Throw<SHAMapMissingNode> (type_, uint256 ());
         }
 
         if (ourNode->isLeaf () && otherNode->isLeaf ())

--- a/src/ripple/shamap/tests/FetchPack.test.cpp
+++ b/src/ripple/shamap/tests/FetchPack.test.cpp
@@ -21,6 +21,7 @@
 #include <ripple/shamap/SHAMap.h>
 #include <ripple/shamap/tests/common.h>
 #include <ripple/protocol/digest.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/protocol/UInt160.h>
@@ -49,7 +50,7 @@ public:
     {
         void operator()(std::uint32_t refNum) const
         {
-            throw std::runtime_error("missing node");
+            Throw<std::runtime_error> ("missing node");
         }
     };
 
@@ -153,7 +154,7 @@ public:
 //             expect (t3->getHash () == t2->getHash (), "root hashes do not match");
 //             expect (t3->deepCompare (*t2), "failed compare");
 //         }
-//         catch (...)
+//         catch (std::exception const&)
 //         {
 //             fail ("unhandled exception");
 //         }

--- a/src/ripple/shamap/tests/common.h
+++ b/src/ripple/shamap/tests/common.h
@@ -21,6 +21,7 @@
 #define RIPPLE_SHAMAP_TESTS_COMMON_H_INCLUDED
 
 #include <BeastConfig.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/chrono.h>
 #include <ripple/shamap/Family.h>
 #include <ripple/shamap/FullBelowCache.h>
@@ -108,13 +109,13 @@ public:
     void
     missing_node (std::uint32_t refNum) override
     {
-        throw std::runtime_error("missing node");
+        Throw<std::runtime_error> ("missing node");
     }
 
     void
     missing_node (uint256 const& refHash) override
     {
-        throw std::runtime_error("missing node");
+        Throw<std::runtime_error> ("missing node");
     }
 };
 

--- a/src/ripple/test/jtx/amount.h
+++ b/src/ripple/test/jtx/amount.h
@@ -25,6 +25,7 @@
 #include <ripple/test/jtx/tags.h>
 #include <ripple/protocol/Issue.h>
 #include <ripple/protocol/STAmount.h>
+#include <ripple/basics/contract.h>
 #include <cstdint>
 #include <ostream>
 #include <string>
@@ -197,14 +198,14 @@ struct XRP_t
             auto const d = std::uint64_t(
                 std::round(v * c));
             if (double(d) / c != v)
-                throw std::domain_error(
+                Throw<std::domain_error> (
                     "unrepresentable");
             return { d };
         }
         auto const d = std::int64_t(
             std::round(v * c));
         if (double(d) / c != v)
-            throw std::domain_error(
+            Throw<std::domain_error> (
                 "unrepresentable");
         return { d };
     }

--- a/src/ripple/test/jtx/fee.h
+++ b/src/ripple/test/jtx/fee.h
@@ -23,6 +23,7 @@
 #include <ripple/test/jtx/Env.h>
 #include <ripple/test/jtx/tags.h>
 #include <ripple/protocol/STAmount.h>
+#include <ripple/basics/contract.h>
 #include <boost/optional.hpp>
 
 namespace ripple {
@@ -53,7 +54,7 @@ public:
         : amount_(amount)
     {
         if (! isXRP(*amount_))
-            throw std::runtime_error(
+            Throw<std::runtime_error> (
                 "fee: not XRP");
     }
 

--- a/src/ripple/test/jtx/flags.h
+++ b/src/ripple/test/jtx/flags.h
@@ -23,6 +23,7 @@
 #include <ripple/test/jtx/Env.h>
 #include <ripple/protocol/LedgerFormats.h>
 #include <ripple/protocol/TxFlags.h>
+#include <ripple/basics/contract.h>
 
 namespace ripple {
 namespace test {
@@ -72,7 +73,7 @@ private:
         case asfGlobalFreeze:   mask_ |= lsfGlobalFreeze; break;
         case asfDefaultRipple:  mask_ |= lsfDefaultRipple; break;
         default:
-        throw std::runtime_error(
+        Throw<std::runtime_error> (
             "unknown flag");
         }
     }

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -31,6 +31,7 @@
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/ledger/LedgerTiming.h>
 #include <ripple/app/paths/Pathfinder.h>
+#include <ripple/basics/contract.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/json/to_string.h>
 #include <ripple/protocol/ErrorCodes.h>
@@ -155,7 +156,7 @@ Env::lookup (AccountID const& id) const
 {
     auto const iter = map_.find(id);
     if (iter == map_.end())
-        throw std::runtime_error(
+        Throw<std::runtime_error> (
             "Env::lookup:: unknown account ID");
     return iter->second;
 }
@@ -166,7 +167,7 @@ Env::lookup (std::string const& base58ID) const
     auto const account =
         parseBase58<AccountID>(base58ID);
     if (! account)
-        throw std::runtime_error(
+        Throw<std::runtime_error>(
             "Env::lookup: invalid account ID");
     return lookup(*account);
 }
@@ -206,7 +207,7 @@ Env::seq (Account const& account) const
 {
     auto const sle = le(account);
     if (! sle)
-        throw std::runtime_error(
+        Throw<std::runtime_error> (
             "missing account root");
     return sle->getFieldU32(sfSequence);
 }
@@ -371,7 +372,7 @@ Env::autofill (JTx& jt)
         test.log <<
             "parse failed:\n" <<
             pretty(jv);
-        throw;
+        Throw();
     }
 }
 
@@ -390,14 +391,14 @@ Env::st (JTx const& jt)
         test.log <<
             "Exception: parse_error\n" <<
             pretty(jt.jv);
-        throw;
+        Throw();
     }
 
     try
     {
         return sterilize(STTx{std::move(*obj)});
     }
-    catch(...)
+    catch(std::exception const&)
     {
     }
     return nullptr;

--- a/src/ripple/test/jtx/impl/jtx_json.cpp
+++ b/src/ripple/test/jtx/impl/jtx_json.cpp
@@ -21,6 +21,7 @@
 #include <ripple/test/jtx/jtx_json.h>
 #include <ripple/test/jtx/utility.h>
 #include <ripple/json/json_reader.h>
+#include <ripple/basics/contract.h>
 
 namespace ripple {
 namespace test {
@@ -29,7 +30,7 @@ namespace jtx {
 json::json(std::string const& s)
 {
     if (! Json::Reader().parse(s, jv_))
-        throw parse_error("bad json");
+        Throw<parse_error> ("bad json");
 
 }
 

--- a/src/ripple/test/jtx/impl/multisign.cpp
+++ b/src/ripple/test/jtx/impl/multisign.cpp
@@ -24,6 +24,7 @@
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/types.h>
+#include <ripple/basics/contract.h>
 
 namespace ripple {
 namespace test {
@@ -88,7 +89,7 @@ msig::operator()(Env& env, JTx& jt) const
         catch(parse_error const&)
         {
             env.test.log << pretty(jt.jv);
-            throw;
+            Throw();
         }
         auto& js = jt[sfSigners.getJsonName()];
         js.resize(mySigners.size());

--- a/src/ripple/test/jtx/impl/rate.cpp
+++ b/src/ripple/test/jtx/impl/rate.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/test/jtx/rate.h>
 #include <ripple/protocol/JsonFields.h>
+#include <ripple/basics/contract.h>
 #include <stdexcept>
 
 namespace ripple {
@@ -30,7 +31,7 @@ Json::Value
 rate (Account const& account, double multiplier)
 {
     if (multiplier > 4)
-        throw std::runtime_error(
+        Throw<std::runtime_error> (
             "rate multiplier out of range");
     Json::Value jv;
     jv[jss::Account] = account.human();

--- a/src/ripple/test/jtx/impl/utility.cpp
+++ b/src/ripple/test/jtx/impl/utility.cpp
@@ -25,6 +25,7 @@
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/STParsedJSON.h>
 #include <ripple/protocol/types.h>
+#include <ripple/basics/contract.h>
 #include <cstring>
 
 namespace ripple {
@@ -36,7 +37,7 @@ parse (Json::Value const& jv)
 {
     STParsedJSONObject p("tx_json", jv);
     if (! p.object)
-        throw parse_error(
+        Throw<parse_error> (
             rpcErrorString(p.error));
     return std::move(*p.object);
 }
@@ -77,12 +78,12 @@ fill_seq (Json::Value& jv,
         parseBase58<AccountID>(
             jv[jss::Account].asString());
     if (! account)
-        throw parse_error(
+        Throw<parse_error> (
             "unexpected invalid Account");
     auto const ar = view.read(
         keylet::account(*account));
     if (! ar)
-        throw parse_error(
+        Throw<parse_error> (
             "unexpected missing account root");
     jv[jss::Sequence] =
         ar->getFieldU32(sfSequence);

--- a/src/ripple/unity/basics.cpp
+++ b/src/ripple/unity/basics.cpp
@@ -36,6 +36,7 @@
 #include <ripple/basics/impl/UptimeTimer.cpp>
 
 #include <ripple/basics/tests/CheckLibraryVersions.test.cpp>
+#include <ripple/basics/tests/contract.test.cpp>
 #include <ripple/basics/tests/hardened_hash_test.cpp>
 #include <ripple/basics/tests/KeyCache.test.cpp>
 #include <ripple/basics/tests/RangeSet.test.cpp>

--- a/src/ripple/unl/tests/qalloc.h
+++ b/src/ripple/unl/tests/qalloc.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_SIM_QALLOC_H_INCLUDED
 #define RIPPLE_SIM_QALLOC_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <boost/intrusive/list.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -266,7 +267,7 @@ qalloc_impl<_>::allocate(
     block* const b =
         new(std::malloc(n)) block(n);
     if (! b)
-        throw std::bad_alloc();
+        Throw<std::bad_alloc> ();
     used_ = b;
     // VFALCO This has to succeed
     return used_->allocate(bytes, align);
@@ -313,7 +314,7 @@ qalloc_type<T>::alloc (std::size_t n)
 {
     if (n > std::numeric_limits<
             std::size_t>::max() / sizeof(U))
-        throw std::bad_alloc();
+        Throw<std::bad_alloc> ();
     auto const bytes = n * sizeof(U);
     return static_cast<U*>(
         impl_->allocate(bytes,

--- a/src/ripple/websocket/Handler.h
+++ b/src/ripple/websocket/Handler.h
@@ -116,7 +116,7 @@ public:
             cpClient->send (
                 mpMessage->get_payload (), mpMessage->get_opcode ());
         }
-        catch (...)
+        catch (std::exception const&)
         {
             WebSocket::closeTooSlowClient (*cpClient, crTooSlow);
         }
@@ -133,7 +133,7 @@ public:
 
             cpClient->send (strMessage);
         }
-        catch (...)
+        catch (std::exception const&)
         {
             WebSocket::closeTooSlowClient (*cpClient, crTooSlow);
         }
@@ -170,7 +170,7 @@ public:
                     // cpClient->get_socket ().remote_endpoint ().to_string ()
                      ")";
             }
-            catch (...)
+            catch (std::exception const&)
             {
             }
         }
@@ -217,7 +217,7 @@ public:
             JLOG (j_.debug) <<
                 "Ws:: on_open(" << remoteEndpoint << ")";
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
     }
@@ -239,7 +239,7 @@ public:
             JLOG (j_.debug) <<
            "Ws:: on_pong(" << cpClient->get_socket ().remote_endpoint() << ")";
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
         ptr->onPong (data);
@@ -273,7 +273,7 @@ public:
                            cpClient->get_socket ().remote_endpoint() <<
                            ") not found";
                 }
-                catch (...)
+                catch (std::exception const&)
                 {
                 }
                 return;
@@ -291,7 +291,7 @@ public:
                 "Ws:: " << reason << "(" <<
                    cpClient->get_socket ().remote_endpoint () << ") found";
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
 
@@ -334,7 +334,7 @@ public:
                     cpClient->get_socket().remote_endpoint() <<
                     ") '" << mpMessage->get_payload () << "'";
             }
-            catch (...)
+            catch (std::exception const&)
             {
             }
         }
@@ -391,7 +391,7 @@ public:
                     << cpClient->get_socket ().remote_endpoint ()
                     << ") '" << mpMessage->get_payload () << "'";
         }
-        catch (...)
+        catch (std::exception const&)
         {
         }
 

--- a/src/ripple/websocket/WebSocket02.cpp
+++ b/src/ripple/websocket/WebSocket02.cpp
@@ -20,6 +20,7 @@
 #include <ripple/websocket/WebSocket02.h>
 #include <ripple/websocket/Handler.h>
 #include <ripple/websocket/Server.h>
+#include <ripple/basics/contract.h>
 #include <beast/weak_fn.h>
 
 // This file contains websocket::WebSocket02 implementations for the WebSocket
@@ -122,7 +123,7 @@ void Server <WebSocket02>::listen()
                 }
             }
         }
-        throw e;
+        Throw<std::exception> (e);
     }
 }
 


### PR DESCRIPTION
* Convert all throws to use Throw which guarantees all exceptions will be std::exception derived. This also allows project auditing of any throw.
* Convert catch alls to catch std:exceptions to avoid errors with exceptions thrown within coroutines.

Reviewers: @HowardHinnant @nbougalis 