### PR TITLE
Use [ips_fixed] over r.ripple.com as the default [ips]

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -293,6 +293,7 @@
 #   [ips]
 #   r.ripple.com 51235
 #
+#   The default is: [ips_fixed] addresses (if present) or r.ripple.com 51235
 #
 #
 # [ips_fixed]

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -512,10 +512,12 @@ OverlayImpl::onPrepare()
 
     m_peerFinder->setConfig (config);
 
-    auto bootstrapIps (app_.config().IPS);
-
-    // If no IPs are specified, use the Ripple Labs round robin
-    // pool to get some servers to insert into the boot cache.
+    // Populate our boot cache: if there are no entries in [ips] then we use
+    // the entries in [ips_fixed]. If both are empty, we resort to a round-robin
+    // pool.
+    auto bootstrapIps = app_.config().IPS.empty()
+        ? app_.config().IPS_FIXED
+        : app_.config().IPS;
     if (bootstrapIps.empty ())
         bootstrapIps.push_back ("r.ripple.com 51235");
 


### PR DESCRIPTION
If someone wants to run a validator behind a public-facing rippled, they currently have to include that rippled in both `[ips]` and `[ips_fixed]`. If they only specify `[ips_fixed]`, they would inadvertently bootstrap to r.ripple.com.

This change causes `[ips_fixed]` to be used for bootstrapping when `[ips]` is not configured. r.ripple.com remains the default if neither are configured.