### PR TITLE
Clocks

### DIFF
--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -264,7 +264,7 @@ public:
     {
         // Ask implementation what to do
         auto actions = doVoting (
-            lastClosedLedger->parentCloseTime(),
+            lastClosedLedger->parentCloseTime().time_since_epoch().count(),
             getEnabledAmendments(*lastClosedLedger),
             getMajorityAmendments(*lastClosedLedger),
             parentValidations);

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -212,7 +212,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
 
                 if (node().sleOffer->isFieldPresent (sfExpiration) &&
                         (node().sleOffer->getFieldU32 (sfExpiration) <=
-                            view().parentCloseTime()))
+                            view().parentCloseTime().time_since_epoch().count()))
                 {
                     // Offer is expired.
                     JLOG (j_.trace)

--- a/src/ripple/app/tx/impl/CancelTicket.cpp
+++ b/src/ripple/app/tx/impl/CancelTicket.cpp
@@ -65,7 +65,9 @@ CancelTicket::doApply ()
     // And finally, anyone can remove an expired ticket
     if (!authorized && sleTicket->isFieldPresent (sfExpiration))
     {
-        std::uint32_t const expiration = sleTicket->getFieldU32 (sfExpiration);
+        using d = NetClock::duration;
+        using tp = NetClock::time_point;
+        auto const expiration = tp{d{sleTicket->getFieldU32 (sfExpiration)}};
 
         if (view().parentCloseTime() >= expiration)
             authorized = true;

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -166,7 +166,7 @@ Change::applyAmendment()
         auto& entry = newMajorities.back ();
         entry.emplace_back (STHash256 (sfAmendment, amendment));
         entry.emplace_back (STUInt32 (sfCloseTime,
-            view().parentCloseTime()));
+            view().parentCloseTime().time_since_epoch().count()));
     }
     else if (!lostMajority)
     {

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -315,7 +315,7 @@ CreateOffer::bridged_cross (
     Taker& taker,
     ApplyView& view,
     ApplyView& view_cancel,
-    Clock::time_point const when)
+    NetClock::time_point const when)
 {
     auto const& taker_amount = taker.original_offer ();
 
@@ -472,7 +472,7 @@ CreateOffer::direct_cross (
     Taker& taker,
     ApplyView& view,
     ApplyView& view_cancel,
-    Clock::time_point const when)
+    NetClock::time_point const when)
 {
     OfferStream offers (
         view, view_cancel,
@@ -581,8 +581,8 @@ CreateOffer::cross (
     ApplyView& cancel_view,
     Amounts const& taker_amount)
 {
-    Clock::time_point const when =
-        ctx_.view().parentCloseTime();
+    NetClock::time_point const when{
+        NetClock::duration{ctx_.view().parentCloseTime()}};
 
     beast::WrappedSink takerSink (j_, "Taker ");
 

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -176,13 +176,15 @@ CreateOffer::preclaim(PreclaimContext const& ctx)
         return temBAD_SEQUENCE;
     }
 
+    using d = NetClock::duration;
+    using tp = NetClock::time_point;
     auto const expiration = ctx.tx[~sfExpiration];
 
     // Expiration is defined in terms of the close time of the parent ledger,
     // because we definitively know the time that it closed but we do not
     // know the closing time of the ledger that is under construction.
     if (expiration &&
-        (ctx.view.parentCloseTime() >= *expiration))
+        (ctx.view.parentCloseTime() >= tp{d{*expiration}}))
     {
         // Note that this will get checked again in applyGuts,
         // but it saves us a call to checkAcceptAsset and
@@ -582,7 +584,7 @@ CreateOffer::cross (
     Amounts const& taker_amount)
 {
     NetClock::time_point const when{
-        NetClock::duration{ctx_.view().parentCloseTime()}};
+        NetClock::time_point{ctx_.view().parentCloseTime()}};
 
     beast::WrappedSink takerSink (j_, "Taker ");
 
@@ -688,12 +690,14 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
     }
 
     auto const expiration = ctx_.tx[~sfExpiration];
+    using d = NetClock::duration;
+    using tp = NetClock::time_point;
 
     // Expiration is defined in terms of the close time of the parent ledger,
     // because we definitively know the time that it closed but we do not
     // know the closing time of the ledger that is under construction.
     if (expiration &&
-        (ctx_.view().parentCloseTime() >= *expiration))
+        (ctx_.view().parentCloseTime() >= tp{d{*expiration}}))
     {
         // If the offer has expired, the transaction has successfully
         // done nothing, so short circuit from here.

--- a/src/ripple/app/tx/impl/CreateOffer.h
+++ b/src/ripple/app/tx/impl/CreateOffer.h
@@ -24,9 +24,10 @@
 #include <ripple/app/tx/impl/OfferStream.h>
 #include <ripple/app/tx/impl/Taker.h>
 #include <ripple/app/tx/impl/Transactor.h>
-#include <ripple/protocol/Quality.h>
+#include <ripple/basics/chrono.h>
 #include <ripple/basics/Log.h>
 #include <ripple/json/to_string.h>
+#include <ripple/protocol/Quality.h>
 #include <beast/utility/Journal.h>
 #include <beast/utility/WrappedSink.h>
 #include <memory>
@@ -84,14 +85,14 @@ private:
         Taker& taker,
         ApplyView& view,
         ApplyView& view_cancel,
-        Clock::time_point const when);
+        NetClock::time_point const when);
 
     std::pair<TER, Amounts>
     direct_cross (
         Taker& taker,
         ApplyView& view,
         ApplyView& view_cancel,
-        Clock::time_point const when);
+        NetClock::time_point const when);
 
     // Step through the stream for as long as possible, skipping any offers
     // that are from the taker or which cross the taker's threshold.

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -66,11 +66,13 @@ CreateTicket::doApply ()
             return tecINSUFFICIENT_RESERVE;
     }
 
-    std::uint32_t expiration (0);
+    NetClock::time_point expiration{};
 
     if (ctx_.tx.isFieldPresent (sfExpiration))
     {
-        expiration = ctx_.tx.getFieldU32 (sfExpiration);
+        using d = NetClock::duration;
+        using tp = NetClock::time_point;
+        expiration = tp{d{ctx_.tx.getFieldU32 (sfExpiration)}};
 
         if (view().parentCloseTime() >= expiration)
             return tesSUCCESS;
@@ -80,8 +82,8 @@ CreateTicket::doApply ()
         getTicketIndex (account_, ctx_.tx.getSequence ()));
     sleTicket->setAccountID (sfAccount, account_);
     sleTicket->setFieldU32 (sfSequence, ctx_.tx.getSequence ());
-    if (expiration != 0)
-        sleTicket->setFieldU32 (sfExpiration, expiration);
+    if (expiration != NetClock::time_point{})
+        sleTicket->setFieldU32 (sfExpiration, expiration.time_since_epoch().count());
     view().insert (sleTicket);
 
     if (ctx_.tx.isFieldPresent (sfTarget))

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -24,13 +24,13 @@
 namespace ripple {
 
 OfferStream::OfferStream (ApplyView& view, ApplyView& cancelView,
-    Book const& book, Clock::time_point when,
+    Book const& book, NetClock::rep when,
         StepCounter& counter, beast::Journal journal)
     : j_ (journal)
     , view_ (view)
     , cancelView_ (cancelView)
     , book_ (book)
-    , expire_ (when)
+    , expire_ (NetClock::duration{when})
     , tip_ (view, book_)
     , counter_ (counter)
 {
@@ -104,8 +104,10 @@ OfferStream::step (Logs& l)
         }
 
         // Remove if expired
+        using d = NetClock::duration;
+        using tp = NetClock::time_point;
         if (entry->isFieldPresent (sfExpiration) &&
-            entry->getFieldU32 (sfExpiration) <= expire_)
+            tp{d{entry->getFieldU32(sfExpiration)}} <= expire_)
         {
             JLOG(j_.trace) <<
                 "Removing expired offer " << entry->getIndex();

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -24,13 +24,13 @@
 namespace ripple {
 
 OfferStream::OfferStream (ApplyView& view, ApplyView& cancelView,
-    Book const& book, NetClock::rep when,
+    Book const& book, NetClock::time_point when,
         StepCounter& counter, beast::Journal journal)
     : j_ (journal)
     , view_ (view)
     , cancelView_ (cancelView)
     , book_ (book)
-    , expire_ (NetClock::duration{when})
+    , expire_ (when)
     , tip_ (view, book_)
     , counter_ (counter)
 {

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -22,6 +22,7 @@
 
 #include <ripple/app/tx/impl/BookTip.h>
 #include <ripple/app/tx/impl/Offer.h>
+#include <ripple/basics/chrono.h>
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Quality.h>
 #include <beast/utility/Journal.h>
@@ -81,7 +82,7 @@ private:
     ApplyView& view_;
     ApplyView& cancelView_;
     Book book_;
-    Clock::time_point const expire_;
+    NetClock::time_point const expire_;
     BookTip tip_;
     Offer offer_;
     StepCounter& counter_;
@@ -91,7 +92,7 @@ private:
 
 public:
     OfferStream (ApplyView& view, ApplyView& cancelView,
-        Book const& book, Clock::time_point when,
+        Book const& book, NetClock::rep when,
             StepCounter& counter, beast::Journal journal);
 
     /** Returns the offer at the tip of the order book.

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -92,7 +92,7 @@ private:
 
 public:
     OfferStream (ApplyView& view, ApplyView& cancelView,
-        Book const& book, NetClock::rep when,
+        Book const& book, NetClock::time_point when,
             StepCounter& counter, beast::Journal journal);
 
     /** Returns the offer at the tip of the order book.

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -247,10 +247,12 @@ public:
     }
 
     /** Returns the close time of the previous ledger. */
-    std::uint32_t
+    NetClock::time_point
     parentCloseTime() const
     {
-        return info().parentCloseTime;
+        using d = NetClock::duration;
+        using tp = NetClock::time_point;
+        return tp{d{info().parentCloseTime}};
     }
 
     /** Returns the sequence number of the base ledger. */

--- a/src/ripple/ledger/tests/View_test.cpp
+++ b/src/ripple/ledger/tests/View_test.cpp
@@ -342,6 +342,7 @@ class View_test
     testContext()
     {
         using namespace jtx;
+        using namespace std::chrono;
         {
             Env env(*this);
             wipe(env.openLedger);
@@ -349,7 +350,7 @@ class View_test
             OpenView v0(open.get());
             expect(v0.seq() != 98);
             expect(v0.seq() == open->seq());
-            expect(v0.parentCloseTime() != 99);
+            expect(v0.parentCloseTime() != NetClock::time_point{99s});
             expect(v0.parentCloseTime() ==
                 open->parentCloseTime());
             {

--- a/src/ripple/protocol/Protocol.h
+++ b/src/ripple/protocol/Protocol.h
@@ -46,17 +46,6 @@ struct Protocol
     static int const txMaxSizeBytes = 1024 * 1024; // 1048576
 };
 
-/** A clock representing network time.
-    This measures seconds since the Ripple epoch as seen
-    by the ledger close clock.
-*/
-class Clock // : public abstract_clock <std::chrono::seconds>
-{
-public:
-    using time_point = std::uint32_t;
-    using duration = std::chrono::seconds;
-};
-
 /** A ledger index. */
 using LedgerIndex = std::uint32_t;
 


### PR DESCRIPTION
This removes a little used `Clock` type which offered no type-safety, and changes a few type-unsafe time points into `chrono::time_point`s.

@nbougalis @scottschurr 