### PR TITLE
Consensus ledger switch improvements

### DIFF
--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -175,7 +175,7 @@ private:
         // the signing time.
 
         auto const now =
-            app_.timeKeeper().now().time_since_epoch().count();
+            app_.timeKeeper().closeTime().time_since_epoch().count();
 
         auto const signTime = val->getSignTime();
 


### PR DESCRIPTION
* Expire validations faster based on when we first saw them.

* Never jump to a ledger prior to the latest fully-valid ledger

* Drop validations with signing times too far in the future immediately