### PR TITLE
PROTOTYPE: Support multiple transactions per account in the fee escalation queue.

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1914,6 +1914,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\basics\impl\mulDiv.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\basics\impl\RangeSet.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -1955,6 +1959,8 @@
     <ClInclude Include="..\..\src\ripple\basics\Log.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\make_SSLContext.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\basics\mulDiv.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\qalloc.h">
     </ClInclude>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2649,6 +2649,9 @@
     <ClCompile Include="..\..\src\ripple\basics\impl\make_SSLContext.cpp">
       <Filter>ripple\basics\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\basics\impl\mulDiv.cpp">
+      <Filter>ripple\basics\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\basics\impl\RangeSet.cpp">
       <Filter>ripple\basics\impl</Filter>
     </ClCompile>
@@ -2683,6 +2686,9 @@
       <Filter>ripple\basics</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\make_SSLContext.h">
+      <Filter>ripple\basics</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\basics\mulDiv.h">
       <Filter>ripple\basics</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\qalloc.h">

--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -400,11 +400,56 @@
 #
 #   retry_sequence_percent = <number>
 #
-#       If a client resubmits a transaction, the new transaction's fee
+#       If a client resubmits a transaction (same sequence number as a
+#       transaction already in the queue), the new transaction's fee
 #       must be more than <number> percent higher than the original
 #       transaction's fee, or meet the current open ledger fee to be
 #       considered. Default: 25.
 #
+#   multi_txn_percent = <number>
+#
+#       If a client submits multiple transactions (different sequence
+#       numbers), later transactions must pay a fee at least <number>
+#       percent higher than the transaction with the previous sequence
+#       number, because that previous transaction must be test applied
+#       to a temporary ledger / view object, which is expensive.
+#       Default: 25.
+#
+#   invalidation_penalty_percent = <number>
+#
+#       If a transaction has been test applied to a temporary view, and
+#       anything causes that view to become invalid (eg. replacing a
+#       transaction in the view), later transactions must pay this
+#       penalty in addition to any relevant percentage described above.
+#       This penalty increases every time a transaction is invalidated.
+#       Default: 25.
+#
+#   minimum_escalation_multiplier = <number>
+#
+#       At ledger close time, the median fee level of the transactions
+#       in that ledger is used as a multiplier in escalation
+#       calculations of the next ledger. This minimum value ensures that
+#       the escalation is significant. Default: 500.
+#
+#   minimum_txn_in_ledger = <number>
+#
+#       Minimum number of transactions that must be allowed into the
+#       ledger at the minimum required fee before the required fee
+#       escalates. Default: 5.
+#
+#   minimum_txn_in_ledger_standalone = <number>
+#
+#       Like minimum_txn_in_ledger when rippled is running in standalone
+#       mode. Default: 1000.
+#
+#   target_txn_in_ledger = <number>
+#
+#       Number of transactions allowed into the ledger at the minimum
+#       required fee that the queued will "work toward" as long as
+#       consensus stays healthy. The limit will grow quickly until it
+#       reaches or exceeds this number. After that the limit may still
+#       change, but will stay above the target. If consensus is not
+#       healthy, the limit will be clamped to this value. Default: 50.
 #
 #
 #-------------------------------------------------------------------------------

--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -403,7 +403,7 @@
 #       If a client resubmits a transaction, the new transaction's fee
 #       must be more than <number> percent higher than the original
 #       transaction's fee, or meet the current open ledger fee to be
-#       considered. Default: 125.
+#       considered. Default: 25.
 #
 #
 #

--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -451,6 +451,12 @@
 #       change, but will stay above the target. If consensus is not
 #       healthy, the limit will be clamped to this value. Default: 50.
 #
+#   maximum_txn_in_ledger = <number>
+#
+#       (Optional) Maximum number of transactions that will be allowed
+#       into the ledger at the minimum required fee before the required
+#       fee escalates. Default: no maximum.
+#
 #
 #-------------------------------------------------------------------------------
 #

--- a/src/ripple/app/misc/FeeEscalation.md
+++ b/src/ripple/app/misc/FeeEscalation.md
@@ -57,7 +57,7 @@ in the fee escalation formula for the next open ledger.
   which is 15,000 drops for a
   [reference transaction](#reference-transaction).
   * This will cause the first 21 transactions only require 10
-  drops, but the 22st transaction will require
+  drops, but the 22nd transaction will require
   a level of about 110,000,000 or about 4.3 million drops (4.3XRP).
 
 ## Transaction Queue
@@ -93,17 +93,24 @@ but in practice, either
   * it will eventually get applied to the ledger,
   * its last ledger sequence number will expire,
   * the user will replace it by submitting another transaction with the same
-  sequence number and a higher fee, or
+  sequence number and at least a 25% higher fee, or
   * it will get dropped when the queue fills up with more valuable transactions.
   The size limit is computed dynamically, and can hold transactions for
   the next [20 ledgers](#other-constants).
   The lower the transaction's fee, the more likely that it will get dropped if the
   network is busy.
 
-Currently, there is an additional restriction that the queue can only hold one
-transaction per account at a time. Future development will make the queue
-aware of transaction dependencies so that more than one can be
-queued up at a time per account.
+If a transaction is submitted for an account with one or more transactions
+already in the queue, and a sequence number that is sequential with the other
+transactions in the queue for that account, it must pay a
+[fee level](#fee-level) at least 25% higher than the transaction with the
+previous sequence number, and will be considered for the queue if all prior
+transactions for that account are still valid against the open ledger.
+
+Currently, there is an additional restriction that the queue can not work with
+transactions using the `sfPreviousTxnID` or `sfAccountTxnID` fields.
+`sfPreviousTxnID` is deprecated and shouldn't be used anyway. Future
+development will make the queue aware of `sfAccountTxnID` mechanisms.
 
 ## Technical Details
 

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -33,92 +33,6 @@ namespace ripple {
 
 class Application;
 
-namespace detail {
-
-class FeeMetrics
-{
-private:
-    // Fee escalation
-
-    // Limit of the txnsExpected value after a
-    // time leap.
-    std::size_t const targetTxnCount_;
-    // Minimum value of txnsExpected.
-    std::size_t minimumTxnCount_;
-    // Number of transactions expected per ledger.
-    // One more than this value will be accepted
-    // before escalation kicks in.
-    std::size_t txnsExpected_;
-    // Minimum value of escalationMultiplier.
-    std::uint32_t const minimumMultiplier_;
-    // Based on the median fee of the LCL. Used
-    // when fee escalation kicks in.
-    std::uint32_t escalationMultiplier_;
-    beast::Journal j_;
-
-    std::mutex mutable lock_;
-
-public:
-    static const std::uint64_t baseLevel = 256;
-
-public:
-    FeeMetrics(bool standAlone, beast::Journal j)
-        : targetTxnCount_(50)
-        , minimumTxnCount_(standAlone ? 1000 : 5)
-        , txnsExpected_(minimumTxnCount_)
-        , minimumMultiplier_(500)
-        , escalationMultiplier_(minimumMultiplier_)
-        , j_(j)
-    {
-    }
-
-    /**
-    Updates fee metrics based on the transactions in the ReadView
-    for use in fee escalation calculations.
-
-    @param view View of the LCL that was just closed or received.
-    @param timeLeap Indicates that rippled is under load so fees
-    should grow faster.
-    */
-    std::size_t
-    updateFeeMetrics(Application& app,
-        ReadView const& view, bool timeLeap);
-
-    /** Used by tests only.
-    */
-    std::size_t
-    setMinimumTx(int m)
-    {
-        std::lock_guard <std::mutex> sl(lock_);
-
-        auto const old = minimumTxnCount_;
-        minimumTxnCount_ = m;
-        txnsExpected_ = m;
-        return old;
-    }
-
-    std::size_t
-    getTxnsExpected() const
-    {
-        std::lock_guard <std::mutex> sl(lock_);
-
-        return txnsExpected_;
-    }
-
-    std::uint32_t
-    getEscalationMultiplier() const
-    {
-        std::lock_guard <std::mutex> sl(lock_);
-
-        return escalationMultiplier_;
-    }
-
-    std::uint64_t
-    scaleFeeLevel(OpenView const& view) const;
-};
-
-}
-
 /**
     Transaction Queue. Used to manage transactions in conjunction with
     fee escalation. See also: RIPD-598, and subissues
@@ -144,6 +58,10 @@ public:
         std::uint32_t retrySequencePercent = 25;
         std::uint32_t multiTxnPercent = 25;
         std::uint32_t invalidationPenaltyPercent = 25;
+        std::uint32_t minimumEscalationMultiplier = 500;
+        std::uint32_t minimumTxnInLedger = 5;
+        std::uint32_t minimumTxnInLedgerSA = 1000;
+        std::uint32_t targetTxnInLedger = 50;
         bool standAlone = false;
     };
 
@@ -258,6 +176,90 @@ public:
     openLedgerFee(OpenView const& view) const;
 
 private:
+    class FeeMetrics
+    {
+    private:
+        // Fee escalation
+
+        // Limit of the txnsExpected value after a
+        // time leap.
+        std::size_t const targetTxnCount_;
+        // Minimum value of txnsExpected.
+        std::size_t minimumTxnCount_;
+        // Number of transactions expected per ledger.
+        // One more than this value will be accepted
+        // before escalation kicks in.
+        std::size_t txnsExpected_;
+        // Minimum value of escalationMultiplier.
+        std::uint32_t const minimumMultiplier_;
+        // Based on the median fee of the LCL. Used
+        // when fee escalation kicks in.
+        std::uint32_t escalationMultiplier_;
+        beast::Journal j_;
+
+        std::mutex mutable lock_;
+
+    public:
+        static const std::uint64_t baseLevel = 256;
+
+    public:
+        FeeMetrics(Setup const& setup, beast::Journal j)
+            : targetTxnCount_(setup.targetTxnInLedger)
+            , minimumTxnCount_(setup.standAlone ?
+                setup.minimumTxnInLedgerSA :
+                setup.minimumTxnInLedger)
+            , txnsExpected_(minimumTxnCount_)
+            , minimumMultiplier_(setup.minimumEscalationMultiplier)
+            , escalationMultiplier_(minimumMultiplier_)
+            , j_(j)
+        {
+        }
+
+        /**
+        Updates fee metrics based on the transactions in the ReadView
+        for use in fee escalation calculations.
+
+        @param view View of the LCL that was just closed or received.
+        @param timeLeap Indicates that rippled is under load so fees
+        should grow faster.
+        */
+        std::size_t
+        update(Application& app,
+            ReadView const& view, bool timeLeap);
+
+        /** Used by tests only.
+        */
+        std::size_t
+        setMinimumTx(int m)
+        {
+            std::lock_guard <std::mutex> sl(lock_);
+
+            auto const old = minimumTxnCount_;
+            minimumTxnCount_ = m;
+            txnsExpected_ = m;
+            return old;
+        }
+
+        std::size_t
+        getTxnsExpected() const
+        {
+            std::lock_guard <std::mutex> sl(lock_);
+
+            return txnsExpected_;
+        }
+
+        std::uint32_t
+        getEscalationMultiplier() const
+        {
+            std::lock_guard <std::mutex> sl(lock_);
+
+            return escalationMultiplier_;
+        }
+
+        std::uint64_t
+        scaleFeeLevel(OpenView const& view) const;
+    };
+
     class CandidateTxn
     {
     public:
@@ -368,7 +370,7 @@ private:
     Setup const setup_;
     beast::Journal j_;
 
-    detail::FeeMetrics feeMetrics_;
+    FeeMetrics feeMetrics_;
     FeeMultiSet byFee_;
     std::map <AccountID, TxQAccount> byAccount_;
     boost::optional<size_t> maxSize_;

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -24,6 +24,7 @@
 #include <ripple/protocol/st.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
+#include <ripple/basics/mulDiv.h>
 #include <boost/algorithm/clamp.hpp>
 #include <limits>
 

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -68,6 +68,7 @@ getFeeLevelPaid(
             refTxnCostDrops * requiredFee);
 }
 
+static
 std::uint64_t
 increaseWithPenalty(std::uint64_t level,
     std::uint32_t increasePercent,

--- a/src/ripple/app/tests/TxQ_test.cpp
+++ b/src/ripple/app/tests/TxQ_test.cpp
@@ -23,6 +23,7 @@
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/TestSuite.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/test/jtx.h>
@@ -69,21 +70,20 @@ class TxQ_test : public TestSuite
             // in the open ledger _will_ make it into the closed
             // ledger, but for metrics that's probably good enough.
             env.app().getTxQ().processValidatedLedger(
-                env.app(), *view, timeLeap, tapENABLE_TESTING);
+                env.app(), *view, timeLeap);
         }
 
         env.close(
             [&](OpenView& view, beast::Journal j)
             {
                 // Stuff the ledger with transactions from the queue.
-                return env.app().getTxQ().accept(env.app(), view,
-                    tapENABLE_TESTING);
+                return env.app().getTxQ().accept(env.app(), view);
             }
             );
     }
 
     void
-    submit(jtx::Env& env, jtx::JTx const& jt)
+    submit(jtx::Env& env, jtx::JTx const& jt, ApplyFlags flags = tapENABLE_TESTING)
     {
         // Env checks this, but this test shouldn't
         // generate any malformed txns.
@@ -97,7 +97,7 @@ class TxQ_test : public TestSuite
             {
                 std::tie(ter, didApply) =
                     env.app().getTxQ().apply(env.app(),
-                        view, jt.stx, tapENABLE_TESTING,
+                        view, jt.stx, flags,
                             env.journal);
 
                 return didApply;
@@ -117,7 +117,8 @@ class TxQ_test : public TestSuite
         section.set("ledgers_in_queue", "2");
         section.set("min_ledgers_to_compute_size_limit", "3");
         section.set("max_ledger_counts_to_store", "100");
-        section.set("retry_sequence_percent", "125");
+        section.set("retry_sequence_percent", "25");
+        p->features.insert(feature("FeeEscalation"));
         return std::move(p);
     }
 
@@ -155,7 +156,8 @@ public:
             env.jt(noop(alice), queued));
         checkMetrics(env, 1, boost::none, 4, 3, 256, 500);
 
-        // Alice - Alice is already in the queue, so can't hold.
+        // Alice - Alice is already in the queue and we're not
+        // bumping the fee up high enough, so can't hold.
         submit(env,
             env.jt(noop(alice), seq(env.seq(alice) + 1),
                 ter(telINSUF_FEE_P)));
@@ -166,12 +168,17 @@ public:
             {
                 return fee(txq.openLedgerFee(*env.open()));
             };
+        /*
+        With multi-transaction support, this txn will get
+        queued, which screws up the rest of the test.
+
         // Alice's next transaction -
         // fails because the item in the TxQ hasn't applied.
         submit(env,
             env.jt(noop(alice), openLedgerFee(),
                 seq(env.seq(alice) + 1), ter(terPRE_SEQ)));
         checkMetrics(env, 1, boost::none, 4, 3, 256, 500);
+        */
 
         // Bob with really high fee - applies
         submit(env,
@@ -445,6 +452,7 @@ public:
 
         auto alice = Account("alice");
         auto bob = Account("bob");
+        auto carol = Account("carol");
 
         auto queued = ter(terQUEUED);
 
@@ -452,7 +460,7 @@ public:
 
         // Fund these accounts and close the ledger without
         // involving the queue, so that stats aren't affected.
-        env.fund(XRP(1000), noripple(alice, bob));
+        env.fund(XRP(1000), noripple(alice, bob, carol));
         env.close();
 
         // Fill the ledger
@@ -473,17 +481,83 @@ public:
             env.jt(regkey(alice, bob), fee(0)));
         checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
 
+        // Close out this ledger so we can get a maxsize
+        close(env, 4);
+        checkMetrics(env, 0, 8, 1, 4, 256, 500);
+
+        for (int i = 0; i < 4; ++i)
+            submit(env, env.jt(noop(bob)));
+        checkMetrics(env, 0, 8, 5, 4, 256, 500);
+
+        auto feeBob = 30;
+        auto seqBob = env.seq(bob);
+        for (int i = 0; i < 4; ++i)
+        {
+            submit(env,
+                env.jt(noop(bob), fee(feeBob),
+                    seq(seqBob), queued));
+            feeBob = (feeBob + 1) * 125 / 100;
+            ++seqBob;
+        }
+        checkMetrics(env, 4, 8, 5, 4, 256, 500);
+
         // This transaction also has an "infinite" fee level,
-        // but since bob has a txn in the queue, and multiple
-        // transactions aren't yet supported, this one fails
-        // with terPRE_SEQ (notably, *not* telINSUF_FEE_P).
-        // This implicitly relies on preclaim succeeding and
-        // canBeHeld failing under the hood.
+        // but since bob has txns in the queue, it gets queued.
         submit(env,
             env.jt(regkey(bob, alice), fee(0),
-                seq(env.seq(bob) + 1), ter(terPRE_SEQ)));
-        checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
+                seq(seqBob), queued));
+        ++seqBob;
+        checkMetrics(env, 5, 8, 5, 4, 256, 500);
 
+        // Unfortunately bob can't get any more txns into
+        // the queue, because off the multiTxnPercent.
+        // TANSTAAFL
+        submit(env,
+            env.jt(noop(bob), fee(XRP(100)),
+                seq(seqBob), ter(telINSUF_FEE_P)));
+
+        // Let carol overfill the queue, and kick out all
+        // of the transactions, except bob's "infinite".
+        auto feeCarol = feeBob;
+        auto seqCarol = env.seq(carol);
+        for (int i = 0; i < 7; ++i)
+        {
+            submit(env,
+                env.jt(noop(carol), fee(feeCarol),
+                    seq(seqCarol), queued));
+            feeCarol = (feeCarol + 1) * 125 / 100;
+            ++seqCarol;
+        }
+        checkMetrics(env, 8, 8, 5, 4, feeBob * 256 / 10 + 1, 500);
+
+        // Carol can not take that 8th entry away from Bob.
+        submit(env,
+            env.jt(noop(carol), fee(feeCarol),
+                seq(seqCarol), ter(terPRE_SEQ)));
+
+        close(env, 5);
+        // Ironically, though, bob's transaction is stuck
+        // because of the missing sequence numbers now.
+        checkMetrics(env, 2, 10, 6, 5, 256, 500);
+
+        close(env, 6);
+        auto lastMedian = 3520;
+        checkMetrics(env, 1, 12, 1, 6, 256, lastMedian);
+
+        // Fill in the missing seqs
+        for (int i = 0; i < 4; ++i)
+        {
+            submit(env,
+                env.jt(noop(bob)));
+        }
+        submit(env,
+            env.jt(noop(bob), ter(telINSUF_FEE_P)));
+        checkMetrics(env, 1, 12, 5, 6, 256, lastMedian);
+
+        close(env, 5);
+        close(env, 1);
+        lastMedian = 500;
+        checkMetrics(env, 0, 12, 0, 6, 256, lastMedian);
     }
 
     void testPreclaimFailures()
@@ -548,7 +622,321 @@ public:
         // Alice's queued transaction failed in TxQ::accept
         // with tefPAST_SEQ
         checkMetrics(env, 0, 8, 0, 4, 256, 500);
+    }
 
+    void testMultiTxnPerAccount()
+    {
+        using namespace jtx;
+
+        Env env(*this, makeConfig());
+
+        auto& txq = env.app().getTxQ();
+        txq.setMinimumTx(3);
+
+        auto alice = Account("alice");
+        auto bob = Account("bob");
+        auto charlie = Account("charlie");
+        auto daria = Account("daria");
+
+        auto queued = ter(terQUEUED);
+
+        expectEquals(env.open()->fees().base, 10);
+
+        auto lastMedian = 500;
+        checkMetrics(env, 0, boost::none, 0, 3, 256, lastMedian);
+
+        // Create several accounts while the fee is cheap so they all apply.
+        env.fund(XRP(50000), noripple(alice, bob, charlie, daria));
+        checkMetrics(env, 0, boost::none, 4, 3, 256, lastMedian);
+
+        // Alice - price starts exploding: held
+        submit(env,
+            env.jt(noop(alice), queued));
+        checkMetrics(env, 1, boost::none, 4, 3, 256, lastMedian);
+
+        // Alice - try to queue a second transaction, but don't
+        // set the fee high enough to overcome the multiTxnPercent.
+        submit(env,
+            env.jt(noop(alice), seq(env.seq(alice) + 1), fee(12),
+                ter(telINSUF_FEE_P)));
+        checkMetrics(env, 1, boost::none, 4, 3, 256, lastMedian);
+
+        // Alice - try to queue a second transaction, but leave a gap
+        submit(env,
+            env.jt(noop(alice), seq(env.seq(alice) + 2), fee(100),
+                ter(terPRE_SEQ)));
+        checkMetrics(env, 1, boost::none, 4, 3, 256, lastMedian);
+
+        // Alice - queue a second transaction. Yay.
+        submit(env,
+            env.jt(noop(alice), seq(env.seq(alice) + 1), fee(13),
+                queued));
+        checkMetrics(env, 2, boost::none, 4, 3, 256, lastMedian);
+
+        // Alice - try to queue a third transaction, but don't
+        // set fee high enough
+        submit(env,
+            env.jt(noop(alice), seq(env.seq(alice) + 2), fee(16),
+                ter(telINSUF_FEE_P)));
+        checkMetrics(env, 2, boost::none, 4, 3, 256, lastMedian);
+
+        // Alice - queue a third transaction. Yay.
+        submit(env,
+            env.jt(noop(alice), seq(env.seq(alice) + 2), fee(17),
+                queued));
+        checkMetrics(env, 3, boost::none, 4, 3, 256, lastMedian);
+
+        // Bob - queue a transaction
+        submit(env,
+            env.jt(noop(bob), queued));
+        checkMetrics(env, 4, boost::none, 4, 3, 256, lastMedian);
+
+        // Bob - queue a second transaction
+        submit(env,
+            env.jt(noop(bob), seq(env.seq(bob) + 1), fee(50),
+                queued));
+        checkMetrics(env, 5, boost::none, 4, 3, 256, lastMedian);
+
+        // Charlie - queue a transaction, with a higher fee
+        // than default
+        submit(env,
+            env.jt(noop(charlie), fee(15), queued));
+        checkMetrics(env, 6, boost::none, 4, 3, 256, lastMedian);
+
+        auto aliceSeq = env.seq(alice);
+        auto bobSeq = env.seq(bob);
+        auto charlieSeq = env.seq(charlie);
+
+        close(env, 4);
+        // Verify that all of but one of the queued transactions
+        // got applied.
+        lastMedian = 500;
+        checkMetrics(env, 1, 8, 5, 4, 256, lastMedian);
+
+        // Verify that the stuck transaction is Bob's second.
+        // Even though it had a higher fee than Alice's and
+        // Charlie's, it didn't get attempted until the fee escalated.
+        expect(env.seq(alice) == aliceSeq + 3);
+        expect(env.seq(bob) == bobSeq + 1);
+        expect(env.seq(charlie) == charlieSeq + 1);
+
+        // Alice - fill up the queue
+        std::int64_t aliceFee = 10;
+        aliceSeq = env.seq(alice);
+        auto lastLedgerSeq = env.closed()->info().seq + 2;
+        for (auto i = 0; i < 7; i++)
+        {
+            submit(env,
+                env.jt(noop(alice), seq(aliceSeq),
+                    json(jss::LastLedgerSequence, lastLedgerSeq + i),
+                        fee(aliceFee), queued));
+            aliceFee = (aliceFee + 1) * 125 / 100;
+            ++aliceSeq;
+        }
+        checkMetrics(env, 8, 8, 5, 4, 257, lastMedian);
+
+        // Alice attempts to add another item to the queue,
+        // but you can't force your own earlier txn off the
+        // queue.
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), ter(terPRE_SEQ)));
+        checkMetrics(env, 8, 8, 5, 4, 257, lastMedian);
+
+        // Charlie - add another item to the queue, which
+        // causes Alice's cheap txn to drop
+        submit(env,
+            env.jt(noop(charlie), fee(30), queued));
+        checkMetrics(env, 8, 8, 5, 4, 333, lastMedian);
+
+        // Alice - now attempt to add one more to the queue,
+        // which fails because the earliest txn is gone, so
+        // there is no complete chain, and rippled protects
+        // itself against wasting more resources.
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), ter(terPRE_SEQ)));
+        aliceFee = (aliceFee + 1) * 125 / 100;
+        ++aliceSeq;
+        checkMetrics(env, 8, 8, 5, 4, 333, lastMedian);
+
+        close(env, 5);
+        lastMedian = 500;
+        // Alice's transactions stayed in the queue
+        checkMetrics(env, 6, 10, 2, 5, 256, lastMedian);
+
+        // Since we lost a transaction, make a new one.
+        // (We could have replayed.)
+        // Note that there is nothing special about this
+        // txn because it uses the "next" sequence number,
+        // and it succeeds because the ledger is open.
+        submit(env,
+            env.jt(noop(alice)));
+        checkMetrics(env, 6, 10, 3, 5, 256, lastMedian);
+
+        // Try to replace a middle item in the queue
+        // without enough fee.
+        aliceSeq = env.seq(alice) + 2;
+        aliceFee = 27;
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), ter(telINSUF_FEE_P)));
+
+        // Replace a middle item from the queue successfully
+        ++aliceFee;
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), queued));
+        checkMetrics(env, 6, 10, 3, 5, 256, lastMedian);
+
+        // Try to replace the next item in the queue
+        // without enough fee. This time, we also pay
+        // the invalidation penalty.
+        ++aliceSeq;
+        aliceFee = aliceFee * 125 * 125 / (100 * 100);
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), ter(telINSUF_FEE_P)));
+
+        // Replace a middle item from the queue successfully
+        ++aliceFee;
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), queued));
+        checkMetrics(env, 6, 10, 3, 5, 256, lastMedian);
+
+        // Replace that item again with a transaction that will
+        // bankrupt Alice
+        aliceFee = env.le(alice)->getFieldAmount(sfBalance).xrp().drops()
+            - (14 + aliceFee);
+        submit(env,
+            env.jt(noop(alice), seq(aliceSeq),
+                fee(aliceFee), queued));
+        checkMetrics(env, 6, 10, 3, 5, 256, lastMedian);
+
+        // Alice - Attempt to queue a last transaction, but it
+        // fails because the intermediate transactions can't
+        // apply to the test view.
+        submit(env,
+            env.jt(noop(alice), seq(env.seq(alice) + 6),
+                fee(72), ter(terPRE_SEQ)));
+        checkMetrics(env, 6, 10, 3, 5, 256, lastMedian);
+
+        close(env, 3);
+        // Some of Alice's transactions applied, but the others
+        // get terINSUF_FEE_B and are stuck until Alice
+        // gets funded again.
+        lastMedian = 768;
+        checkMetrics(env, 2, 10, 4, 5, 256, lastMedian);
+
+        close(env, 4);
+        lastMedian = 576;
+        checkMetrics(env, 2, 10, 0, 5, 256, lastMedian);
+
+        close(env, 0);
+        lastMedian = 500;
+        checkMetrics(env, 2, 10, 0, 5, 256, lastMedian);
+
+        close(env, 0);
+        checkMetrics(env, 2, 10, 0, 5, 256, lastMedian);
+
+        close(env, 0);
+        checkMetrics(env, 2, 10, 0, 5, 256, lastMedian);
+
+        close(env, 0);
+        checkMetrics(env, 1, 10, 0, 5, 256, lastMedian);
+
+        close(env, 0);
+        checkMetrics(env, 0, 10, 0, 5, 256, lastMedian);
+
+        // Alice is still broke
+        submit(env,
+            env.jt(noop(alice), ter(terINSUF_FEE_B)));
+        checkMetrics(env, 0, 10, 0, 5, 256, lastMedian);
+    }
+
+    void testDisabled()
+    {
+        using namespace jtx;
+
+        Env env(*this);
+        env.disable_testing();
+
+        auto& txq = env.app().getTxQ();
+        txq.setMinimumTx(1);
+
+        auto alice = Account("alice");
+
+        auto lastMedian = 500;
+        checkMetrics(env, 0, boost::none, 0, 1, 256, lastMedian);
+
+        env.fund(XRP(50000), noripple(alice));
+        checkMetrics(env, 0, boost::none, 1, 1, 256, lastMedian);
+
+        // If the queue was enabled, most of these would
+        // return terQUEUED. (The required fee for the last
+        // would be 10 * 500 * 11^2 = 605,000.)
+        for (int i = 0; i < 10; ++i)
+            submit(env,
+                env.jt(noop(alice), fee(30)), tapNONE);
+
+        // Either way, we get metrics.
+        checkMetrics(env, 0, boost::none, 11, 1, 256, lastMedian);
+
+        close(env, 11);
+        // If the queue was enabled, it would have a limit, and the
+        // lastMedian would be 256*3 = 768.
+        checkMetrics(env, 0, boost::none, 0, 1, 256, lastMedian);
+    }
+
+    void testAcctTxnID()
+    {
+        using namespace jtx;
+
+        Env env(*this, makeConfig());
+
+        auto& txq = env.app().getTxQ();
+        txq.setMinimumTx(1);
+
+        auto alice = Account("alice");
+
+        auto queued = ter(terQUEUED);
+
+        expectEquals(env.open()->fees().base, 10);
+
+        auto lastMedian = 500;
+        checkMetrics(env, 0, boost::none, 0, 1, 256, lastMedian);
+
+        // Create several accounts while the fee is cheap so they all apply.
+        env.fund(XRP(50000), noripple(alice));
+        checkMetrics(env, 0, boost::none, 1, 1, 256, lastMedian);
+
+        submit(env,
+            env.jt(fset(alice, asfAccountTxnID)));
+        checkMetrics(env, 0, boost::none, 2, 1, 256, lastMedian);
+
+        // Immediately after the fset, the sfAccountTxnID field
+        // is still uninitialized, so preflight succeeds here,
+        // and this txn fails because it can't be stored in the queue.
+        submit(env,
+            env.jt(noop(alice), json(R"({"AccountTxnID": "0"})"),
+                ter(telINSUF_FEE_P)));
+
+        close(env, 2);
+        checkMetrics(env, 0, 4, 0, 2, 256, lastMedian);
+
+        // Now it succeeds.
+        submit(env,
+            env.jt(noop(alice), json(R"({"AccountTxnID": "0"})")));
+        checkMetrics(env, 0, 4, 1, 2, 256, lastMedian);
+        
+        submit(env,
+            env.jt(noop(alice)));
+        checkMetrics(env, 0, 4, 2, 2, 256, lastMedian);
+
+        submit(env,
+            env.jt(noop(alice), json(R"({"AccountTxnID": "0"})"),
+                ter(tefWRONG_PRIOR)));
     }
 
     void run()
@@ -558,6 +946,9 @@ public:
         testZeroFeeTxn();
         testPreclaimFailures();
         testQueuedFailure();
+        testMultiTxnPerAccount();
+        testDisabled();
+        testAcctTxnID();
     }
 };
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -227,11 +227,6 @@ Transactor::checkSeq (PreclaimContext const& ctx)
     {
         if (a_seq < t_seq)
         {
-            if (ctx.flags & tapPOST_SEQ)
-            {
-                return tesSUCCESS;
-            }
-
             JLOG(ctx.j.trace) <<
                 "applyTransaction: has future sequence number " <<
                 "a_seq=" << a_seq << " t_seq=" << t_seq;

--- a/src/ripple/basics/impl/mulDiv.cpp
+++ b/src/ripple/basics/impl/mulDiv.cpp
@@ -1,0 +1,66 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/basics/mulDiv.h>
+#include <ripple/basics/contract.h>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace ripple
+{
+
+// compute (value)*(mul)/(div) - avoid overflow but keep precision
+std::uint64_t
+mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
+{
+    if ((value == 0 || mul == 0) && div != 0)
+        return 0;
+    lowestTerms(value, div);
+    lowestTerms(mul, div);
+
+    if (value < mul)
+        std::swap(value, mul);
+    const auto max = std::numeric_limits<std::uint64_t>::max();
+    if (value > max / mul)
+    {
+        value /= div;
+        if (value > max / mul)
+            Throw<std::overflow_error> ("mulDiv");
+        return value * mul;
+    }
+    return value * mul / div;
+}
+
+// compute (value)*(mul)/(div) - avoid overflow but keep precision
+std::uint64_t
+mulDivNoThrow(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
+{
+    try
+    {
+        return mulDiv(value, mul, div);
+    }
+    catch (std::overflow_error)
+    {
+        return std::numeric_limits<std::uint64_t>::max();
+    }
+}
+
+} // ripple

--- a/src/ripple/basics/mulDiv.h
+++ b/src/ripple/basics/mulDiv.h
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_BASICS_MULDIV_H_INCLUDED
+#define RIPPLE_BASICS_MULDIV_H_INCLUDED
+
+#include <cstdint>
+
+namespace ripple
+{
+
+/**
+    A utility function to compute (value)*(mul)/(div) while avoiding
+    overflow but keeping precision.
+*/
+std::uint64_t
+mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div);
+
+/**
+    A utility function to compute (value)*(mul)/(div) while avoiding
+    overflow but keeping precision. Will return the max uint64_t
+    value if mulDiv would overflow anyway.
+*/
+std::uint64_t
+mulDivNoThrow(std::uint64_t value, std::uint64_t mul, std::uint64_t div);
+
+template <class T1, class T2>
+void lowestTerms(T1& a,  T2& b)
+{
+    std::uint64_t x = a, y = b;
+    while (y != 0)
+    {
+        auto t = x % y;
+        x = y;
+        y = t;
+    }
+    a /= x;
+    b /= x;
+}
+
+} // ripple
+
+#endif

--- a/src/ripple/core/impl/LoadFeeTrack.cpp
+++ b/src/ripple/core/impl/LoadFeeTrack.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/basics/contract.h>
+#include <ripple/basics/mulDiv.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/core/Config.h>
 #include <ripple/protocol/STAmount.h>

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -38,10 +38,6 @@ enum ApplyFlags
     //
     tapENABLE_TESTING   = 0x02,
 
-    // We expect the transaction to have a later
-    // sequence number than the account in the ledger
-    tapPOST_SEQ         = 0x04,
-
     // This is not the transaction's last pass
     // Transaction can be retried, soft failures allowed
     tapRETRY            = 0x20,

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -43,6 +43,7 @@ JSS ( DeliverMin );                 // in: TransactionSign
 JSS ( Fee );                        // in/out: TransactionSign; field.
 JSS ( Flags );                      // in/out: TransactionSign; field.
 JSS ( Invalid );                    //
+JSS ( LastLedgerSequence );         // in: TransactionSign; field
 JSS ( LimitAmount );                // field.
 JSS ( OfferSequence );              // field.
 JSS ( Paths );                      // in/out: TransactionSign

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -417,35 +417,6 @@ inline bool isXRP(STAmount const& amount)
     return isXRP (amount.issue().currency);
 }
 
-/**
-    A utility function to compute (value)*(mul)/(div) while avoiding
-    overflow but keeping precision.
-*/
-std::uint64_t
-mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div);
-
-/**
-    A utility function to compute (value)*(mul)/(div) while avoiding
-    overflow but keeping precision. Will return the max uint64_t
-    value if mulDiv would overflow anyway.
-*/
-std::uint64_t
-mulDivNoThrow(std::uint64_t value, std::uint64_t mul, std::uint64_t div);
-
-template <class T1, class T2>
-void lowestTerms(T1& a,  T2& b)
-{
-    std::uint64_t x = a, y = b;
-    while (y != 0)
-    {
-        auto t = x % y;
-        x = y;
-        y = t;
-    }
-    a /= x;
-    b /= x;
-}
-
 } // ripple
 
 #endif

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -1275,40 +1275,6 @@ divRound (STAmount const& num, STAmount const& den,
     return result;
 }
 
-// compute (value)*(mul)/(div) - avoid overflow but keep precision
-std::uint64_t
-mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
-{
-    lowestTerms(value, div);
-    lowestTerms(mul, div);
-
-    if (value < mul)
-        std::swap(value, mul);
-    const auto max = std::numeric_limits<std::uint64_t>::max();
-    if (value > max / mul)
-    {
-        value /= div;
-        if (value > max / mul)
-            Throw<std::overflow_error> ("mulDiv");
-        return value * mul;
-    }
-    return value * mul / div;
-}
-
-// compute (value)*(mul)/(div) - avoid overflow but keep precision
-std::uint64_t
-mulDivNoThrow(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
-{
-    try
-    {
-        return mulDiv(value, mul, div);
-    }
-    catch (std::overflow_error)
-    {
-        return std::numeric_limits<std::uint64_t>::max();
-    }
-}
-
 std::uint32_t
 STAmountCalcSwitchovers::enableUnderflowFixCloseTime ()
 {

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -25,6 +25,7 @@
 #include <ripple/app/paths/Pathfinder.h>
 #include <ripple/app/tx/apply.h>              // Validity::Valid
 #include <ripple/basics/Log.h>
+#include <ripple/basics/mulDiv.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/json/json_writer.h>
 #include <ripple/net/RPCErr.h>

--- a/src/ripple/unity/basics.cpp
+++ b/src/ripple/unity/basics.cpp
@@ -25,6 +25,7 @@
 #include <ripple/basics/impl/CountedObject.cpp>
 #include <ripple/basics/impl/Log.cpp>
 #include <ripple/basics/impl/make_SSLContext.cpp>
+#include <ripple/basics/impl/mulDiv.cpp>
 #include <ripple/basics/impl/RangeSet.cpp>
 #include <ripple/basics/impl/ResolverAsio.cpp>
 #include <ripple/basics/impl/strHex.cpp>


### PR DESCRIPTION
This is a prototype / proof of concept / first approximation of support for multiple transactions per account in the `TxQ`. I don't expect this to be merged to develop as such, but I would love some feedback while we work toward a complete solution.

The biggest problem with this changeset is https://github.com/ximinez/rippled/blob/fee-multi/src/ripple/app/misc/impl/TxQ.cpp#L532-L534, which creates and keeps a copy of an `OpenView` indefinitely. We already know that copying `OpenView` is a big performance hit. Keeping a bunch of them around (up to one per account in the queue) will probably be a big memory hit. The mitigation is that the copy won't be made until it's needed (ie. when a second transaction is attempted while one is already in the queue).

However, a lot of the other stuff in here will be useful for managing the multiple transactions, so once we solve that little issue, we'll be in pretty good shape.

Reviewers: @nbougalis, @scottschurr, @JoelKatz 

PS. The commits before "mulDiv returns 0 if numerator is 0 and denominator isn't:" are part of #1394, and can be safely ignored.