### PR TITLE
Improve error code lookup

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1873,10 +1873,6 @@ void applyTransactions (
     ApplyFlags flags)
 {
 
-    // Switch to new transaction ordering on
-    // October 27, 2015 at 11:00AM PDT
-    bool const newTxOrder = checkLedger->info().closeTime > 499284000;
-
     auto j = app.journal ("LedgerConsensus");
     if (set)
     {
@@ -1900,17 +1896,8 @@ void applyTransactions (
 
             if (txn)
             {
-                if (newTxOrder)
-                {
-                    // All transactions execute in canonical order
-                    retriableTxs.insert (txn);
-                }
-                else if (applyTransaction(app, view, txn, true, flags, j) ==
-                    LedgerConsensusImp::resultRetry)
-                {
-                    // Failures are retried in canonical order
-                    retriableTxs.insert (txn);
-                }
+                // All transactions execute in canonical order
+                retriableTxs.insert (txn);
             }
         }
     }

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1840,7 +1840,7 @@ applyTransaction (Application& app, OpenView& view,
         if (result.second)
         {
             JLOG (j.debug)
-            << "Transaction applied: " << transHuman (result.first);
+                << "Transaction applied: " << transHuman (result.first);
             return LedgerConsensusImp::resultSuccess;
         }
 

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -24,15 +24,6 @@
 namespace ripple {
 namespace path {
 
-static
-bool enableDirRestartFix (
-    std::uint32_t parentCloseTime)
-{
-    // Mon Aug 17 11:00:00am PDT
-    static std::uint32_t const enableAfter = 493149600;
-    return parentCloseTime > enableAfter;
-}
-
 // At the right most node of a list of consecutive offer nodes, given the amount
 // requested to be delivered, push towards the left nodes the amount requested
 // for the right nodes so we can compute how much to deliver from the source.
@@ -53,11 +44,6 @@ TER PathCursor::deliverNodeReverseImpl (
                                         ) const
 {
     TER resultCode   = tesSUCCESS;
-
-    if (!enableDirRestartFix (rippleCalc_.view.info ().parentCloseTime))
-    {
-        node().directory.restart(multiQuality_);
-    }
 
     // Accumulation of what the previous node must deliver.
     // Possible optimization: Note this gets zeroed on each increment, ideally
@@ -370,11 +356,8 @@ TER PathCursor::deliverNodeReverse (
                                     // increment
                                     ) const
 {
-    if (enableDirRestartFix (rippleCalc_.view.info ().parentCloseTime))
-    {
-        for (int i = nodeIndex_; i >= 0 && !node (i).isAccount(); --i)
-            node (i).directory.restart (multiQuality_);
-    }
+    for (int i = nodeIndex_; i >= 0 && !node (i).isAccount(); --i)
+        node (i).directory.restart (multiQuality_);
 
     return deliverNodeReverseImpl(uOutAccountID, saOutReq, saOutAct);
 }

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -658,8 +658,6 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
 
     auto const sleCreator = view.peek (keylet::account(account_));
 
-    deprecatedWrongOwnerCount_ = (*sleCreator)[sfOwnerCount];
-
     auto const uSequence = ctx_.tx.getSequence ();
 
     // This is the original rate of the offer, and is the rate at which
@@ -809,19 +807,8 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
     }
 
     {
-        // Mon Aug 17 11:00:00am PDT
-        static NetClock::time_point const switchoverTime (
-            std::chrono::seconds (493149600));
-
-        XRPAmount reserve;
-
-        if (ctx_.view().info().parentCloseTime <=
-                switchoverTime.time_since_epoch().count())
-            reserve = ctx_.view().fees().accountReserve(
-                deprecatedWrongOwnerCount_+1);
-        else
-            reserve = ctx_.view().fees().accountReserve(
-                sleCreator->getFieldU32 (sfOwnerCount) + 1);
+        XRPAmount reserve = ctx_.view().fees().accountReserve(
+            sleCreator->getFieldU32 (sfOwnerCount) + 1);
 
         if (mPriorBalance < reserve)
         {

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -387,7 +387,7 @@ CreateOffer::bridged_cross (
 
             cross_result = taker.cross(offers_direct.tip ());
 
-            j_.debug << "Direct Result: " << transToken (cross_result);
+            JLOG (j_.debug) << "Direct Result: " << transToken (cross_result);
 
             if (dry_offer (view, offers_direct.tip ()))
             {
@@ -424,7 +424,7 @@ CreateOffer::bridged_cross (
 
             cross_result = taker.cross(offers_leg1.tip (), offers_leg2.tip ());
 
-            j_.debug << "Bridge Result: " << transToken (cross_result);
+            JLOG (j_.debug) << "Bridge Result: " << transToken (cross_result);
 
             if (dry_offer (view, offers_leg1.tip ()))
             {
@@ -511,7 +511,7 @@ CreateOffer::direct_cross (
 
         cross_result = taker.cross (offer);
 
-        j_.debug << "Direct Result: " << transToken (cross_result);
+        JLOG (j_.debug) << "Direct Result: " << transToken (cross_result);
 
         if (dry_offer (view, offer))
         {
@@ -744,7 +744,7 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
 
         if (result != tesSUCCESS)
         {
-            j_.debug << "final result: " << transToken (result);
+            JLOG (j_.debug) << "final result: " << transToken (result);
             return { result, true };
         }
 
@@ -781,7 +781,7 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
 
     if (result != tesSUCCESS)
     {
-        j_.debug << "final result: " << transToken (result);
+        JLOG (j_.debug) << "final result: " << transToken (result);
         return { result, true };
     }
 
@@ -832,7 +832,10 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
                 result = tecINSUF_RESERVE_OFFER;
 
             if (result != tesSUCCESS)
-                j_.debug << "final result: " << transToken (result);
+            {
+                JLOG (j_.debug) <<
+                    "final result: " << transToken (result);
+            }
 
             return { result, true };
         }
@@ -897,7 +900,10 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
     }
 
     if (result != tesSUCCESS)
-        j_.debug << "final result: " << transToken (result);
+    {
+        JLOG (j_.debug) <<
+            "final result: " << transToken (result);
+    }
 
     return { result, true };
 }

--- a/src/ripple/app/tx/impl/CreateOffer.h
+++ b/src/ripple/app/tx/impl/CreateOffer.h
@@ -122,7 +122,6 @@ private:
 private:
     // What kind of offer we are placing
     CrossType cross_type_;
-    std::uint32_t deprecatedWrongOwnerCount_;
 
     // The number of steps to take through order books while crossing
     OfferStream::StepCounter stepCounter_;

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -28,17 +28,6 @@ namespace ripple {
 
 // See https://ripple.com/wiki/Transaction_Format#Payment_.280.29
 
-// Mon Aug 17 11:00:00am PDT
-static std::uint32_t const deliverMinTime = 493149600;
-
-static
-bool
-allowDeliverMin (ReadView const& view, ApplyFlags const& flags)
-{
-    return view.info().parentCloseTime > deliverMinTime ||
-        (flags & tapENABLE_TESTING);
-}
-
 TER
 Payment::preflight (PreflightContext const& ctx)
 {
@@ -199,14 +188,6 @@ Payment::preflight (PreflightContext const& ctx)
 TER
 Payment::preclaim(PreclaimContext const& ctx)
 {
-    auto const deliverMin = ctx.tx[~sfDeliverMin];
-
-    if (deliverMin)
-    {
-        if (!allowDeliverMin(ctx.view, ctx.flags))
-            return temMALFORMED;
-    }
-
     // Ripple if source or destination is non-native or if there are paths.
     std::uint32_t const uTxFlags = ctx.tx.getFlags();
     bool const partialPaymentAllowed = uTxFlags & tfPartialPayment;

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -456,19 +456,6 @@ Payment::doApply ()
         }
     }
 
-    std::string strToken;
-    std::string strHuman;
-
-    if (transResultInfo (terResult, strToken, strHuman))
-    {
-        JLOG(j_.trace) <<
-            strToken << ": " << strHuman;
-    }
-    else
-    {
-        assert (false);
-    }
-
     return terResult;
 }
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -542,21 +542,6 @@ void removeUnfundedOffers (ApplyView& view, std::vector<uint256> const& offers, 
 }
 
 //------------------------------------------------------------------------------
-
-static
-inline
-void
-log (std::pair<
-    TER, bool> const& result,
-        beast::Journal j)
-{
-#if 0
-    JLOG(j.error) <<
-        "apply: { " << transToken(result.first) <<
-        ", " << (result.second ? "true" : "false") << " }";
-#endif
-}
-
 std::pair<TER, bool>
 Transactor::operator()()
 {
@@ -694,14 +679,15 @@ Transactor::operator()()
         }
 
         ctx_.apply(terResult);
-        // VFALCO NOTE since we called apply(), it is not
-        //             okay to look at view() past this point.
+        // since we called apply(), it is not okay to look
+        // at view() past this point.
     }
 
-    auto const result =
-        std::make_pair(terResult, didApply);
-    log(result, j_);
-    return result;
+    JLOG(j_.trace) <<
+        "apply: " << transToken(terResult) <<
+        ", " << (didApply ? "true" : "false");
+
+    return { terResult, didApply };
 }
 
 }

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -19,141 +19,133 @@
 
 #include <BeastConfig.h>
 #include <ripple/protocol/TER.h>
+#include <unordered_map>
+#include <type_traits>
 
 namespace ripple {
 
 bool transResultInfo (TER code, std::string& token, std::string& text)
 {
-    struct TxResultInfo
-    {
-        TER code;
-        char const* token;
-        char const* text;
-    };
-
-    // FIXME: replace this with a function-static std::map and the lookup
-    // code with std::map::find when the problem with magic statics on
-    // Visual Studio is fixed.
     static
-    TxResultInfo const results[] =
+    std::unordered_map<
+        std::underlying_type_t<TER>,
+        std::pair<char const* const, char const* const>> const
+    results
     {
-        { tecCLAIM,                 "tecCLAIM",                 "Fee claimed. Sequence used. No action."                        },
-        { tecDIR_FULL,              "tecDIR_FULL",              "Can not add entry to full directory."                          },
-        { tecFAILED_PROCESSING,     "tecFAILED_PROCESSING",     "Failed to correctly process transaction."                      },
-        { tecINSUF_RESERVE_LINE,    "tecINSUF_RESERVE_LINE",    "Insufficient reserve to add trust line."                       },
-        { tecINSUF_RESERVE_OFFER,   "tecINSUF_RESERVE_OFFER",   "Insufficient reserve to create offer."                         },
-        { tecNO_DST,                "tecNO_DST",                "Destination does not exist. Send XRP to create it."            },
-        { tecNO_DST_INSUF_XRP,      "tecNO_DST_INSUF_XRP",      "Destination does not exist. Too little XRP sent to create it." },
-        { tecNO_LINE_INSUF_RESERVE, "tecNO_LINE_INSUF_RESERVE", "No such line. Too little reserve to create it."                },
-        { tecNO_LINE_REDUNDANT,     "tecNO_LINE_REDUNDANT",     "Can't set non-existent line to default."                       },
-        { tecPATH_DRY,              "tecPATH_DRY",              "Path could not send partial amount."                           },
-        { tecPATH_PARTIAL,          "tecPATH_PARTIAL",          "Path could not send full amount."                              },
-        { tecNO_ALTERNATIVE_KEY,    "tecNO_ALTERNATIVE_KEY",    "The operation would remove the ability to sign transactions with the account."},
-        { tecNO_REGULAR_KEY,        "tecNO_REGULAR_KEY",        "Regular key is not set."                                       },
-        { tecOVERSIZE,              "tecOVERSIZE",              "Object exceeded serialization limits."                         },
+        { tecCLAIM,                  { "tecCLAIM",                 "Fee claimed. Sequence used. No action."                                        } },
+        { tecDIR_FULL,               { "tecDIR_FULL",              "Can not add entry to full directory."                                          } },
+        { tecFAILED_PROCESSING,      { "tecFAILED_PROCESSING",     "Failed to correctly process transaction."                                      } },
+        { tecINSUF_RESERVE_LINE,     { "tecINSUF_RESERVE_LINE",    "Insufficient reserve to add trust line."                                       } },
+        { tecINSUF_RESERVE_OFFER,    { "tecINSUF_RESERVE_OFFER",   "Insufficient reserve to create offer."                                         } },
+        { tecNO_DST,                 { "tecNO_DST",                "Destination does not exist. Send XRP to create it."                            } },
+        { tecNO_DST_INSUF_XRP,       { "tecNO_DST_INSUF_XRP",      "Destination does not exist. Too little XRP sent to create it."                 } },
+        { tecNO_LINE_INSUF_RESERVE,  { "tecNO_LINE_INSUF_RESERVE", "No such line. Too little reserve to create it."                                } },
+        { tecNO_LINE_REDUNDANT,      { "tecNO_LINE_REDUNDANT",     "Can't set non-existent line to default."                                       } },
+        { tecPATH_DRY,               { "tecPATH_DRY",              "Path could not send partial amount."                                           } },
+        { tecPATH_PARTIAL,           { "tecPATH_PARTIAL",          "Path could not send full amount."                                              } },
+        { tecNO_ALTERNATIVE_KEY,     { "tecNO_ALTERNATIVE_KEY",    "The operation would remove the ability to sign transactions with the account." } },
+        { tecNO_REGULAR_KEY,         { "tecNO_REGULAR_KEY",        "Regular key is not set."                                                       } },
+        { tecOVERSIZE,               { "tecOVERSIZE",              "Object exceeded serialization limits."                                         } },
+        { tecUNFUNDED,               { "tecUNFUNDED",              "One of _ADD, _OFFER, or _SEND. Deprecated."                                    } },
+        { tecUNFUNDED_ADD,           { "tecUNFUNDED_ADD",          "Insufficient XRP balance for WalletAdd."                                       } },
+        { tecUNFUNDED_OFFER,         { "tecUNFUNDED_OFFER",        "Insufficient balance to fund created offer."                                   } },
+        { tecUNFUNDED_PAYMENT,       { "tecUNFUNDED_PAYMENT",      "Insufficient XRP balance to send."                                             } },
+        { tecOWNERS,                 { "tecOWNERS",                "Non-zero owner count."                                                         } },
+        { tecNO_ISSUER,              { "tecNO_ISSUER",             "Issuer account does not exist."                                                } },
+        { tecNO_AUTH,                { "tecNO_AUTH",               "Not authorized to hold asset."                                                 } },
+        { tecNO_LINE,                { "tecNO_LINE",               "No such line."                                                                 } },
+        { tecINSUFF_FEE,             { "tecINSUFF_FEE",            "Insufficient balance to pay fee."                                              } },
+        { tecFROZEN,                 { "tecFROZEN",                "Asset is frozen."                                                              } },
+        { tecNO_TARGET,              { "tecNO_TARGET",             "Target account does not exist."                                                } },
+        { tecNO_PERMISSION,          { "tecNO_PERMISSION",         "No permission to perform requested operation."                                 } },
+        { tecNO_ENTRY,               { "tecNO_ENTRY",              "No matching entry found."                                                      } },
+        { tecINSUFFICIENT_RESERVE,   { "tecINSUFFICIENT_RESERVE",  "Insufficient reserve to complete requested operation."                         } },
+        { tecNEED_MASTER_KEY,        { "tecNEED_MASTER_KEY",       "The operation requires the use of the Master Key."                             } },
+        { tecDST_TAG_NEEDED,         { "tecDST_TAG_NEEDED",        "A destination tag is required."                                                } },
+        { tecINTERNAL,               { "tecINTERNAL",              "An internal error has occurred during processing."                             } },
 
-        { tecUNFUNDED,              "tecUNFUNDED",              "One of _ADD, _OFFER, or _SEND. Deprecated."                    },
-        { tecUNFUNDED_ADD,          "tecUNFUNDED_ADD",          "Insufficient XRP balance for WalletAdd."                       },
-        { tecUNFUNDED_OFFER,        "tecUNFUNDED_OFFER",        "Insufficient balance to fund created offer."                   },
-        { tecUNFUNDED_PAYMENT,      "tecUNFUNDED_PAYMENT",      "Insufficient XRP balance to send."                             },
-        { tecOWNERS,                "tecOWNERS",                "Non-zero owner count."                                         },
-        { tecNO_ISSUER,             "tecNO_ISSUER",             "Issuer account does not exist."                                },
-        { tecNO_AUTH,               "tecNO_AUTH",               "Not authorized to hold asset."                                 },
-        { tecNO_LINE,               "tecNO_LINE",               "No such line."                                                 },
-        { tecINSUFF_FEE,            "tecINSUFF_FEE",            "Insufficient balance to pay fee."                              },
-        { tecFROZEN,                "tecFROZEN",                "Asset is frozen."                                              },
-        { tecNO_TARGET,             "tecNO_TARGET",             "Target account does not exist."                                },
-        { tecNO_PERMISSION,         "tecNO_PERMISSION",         "No permission to perform requested operation."                 },
-        { tecNO_ENTRY,              "tecNO_ENTRY",              "No matching entry found."                                      },
-        { tecINSUFFICIENT_RESERVE,  "tecINSUFFICIENT_RESERVE",  "Insufficient reserve to complete requested operation."         },
-        { tecNEED_MASTER_KEY,       "tecNEED_MASTER_KEY",       "The operation requires the use of the Master Key."             },
-        { tecDST_TAG_NEEDED,        "tecDST_TAG_NEEDED",        "A destination tag is required."                                },
-        { tecINTERNAL,              "tecINTERNAL",              "An internal error has occurred during processing."             },
+        { tefALREADY,                { "tefALREADY",               "The exact transaction was already in this ledger."                             } },
+        { tefBAD_ADD_AUTH,           { "tefBAD_ADD_AUTH",          "Not authorized to add account."                                                } },
+        { tefBAD_AUTH,               { "tefBAD_AUTH",              "Transaction's public key is not authorized."                                   } },
+        { tefBAD_LEDGER,             { "tefBAD_LEDGER",            "Ledger in unexpected state."                                                   } },
+        { tefBAD_QUORUM,             { "tefBAD_QUORUM",            "Signatures provided do not meet the quorum."                                   } },
+        { tefBAD_SIGNATURE,          { "tefBAD_SIGNATURE",         "A signature is provided for a non-signer."                                     } },
+        { tefCREATED,                { "tefCREATED",               "Can't add an already created account."                                         } },
+        { tefEXCEPTION,              { "tefEXCEPTION",             "Unexpected program state."                                                     } },
+        { tefFAILURE,                { "tefFAILURE",               "Failed to apply."                                                              } },
+        { tefINTERNAL,               { "tefINTERNAL",              "Internal error."                                                               } },
+        { tefMASTER_DISABLED,        { "tefMASTER_DISABLED",       "Master key is disabled."                                                       } },
+        { tefMAX_LEDGER,             { "tefMAX_LEDGER",            "Ledger sequence too high."                                                     } },
+        { tefNO_AUTH_REQUIRED,       { "tefNO_AUTH_REQUIRED",      "Auth is not required."                                                         } },
+        { tefNOT_MULTI_SIGNING,      { "tefNOT_MULTI_SIGNING",     "Account has no appropriate list of multi-signers."                             } },
+        { tefPAST_SEQ,               { "tefPAST_SEQ",              "This sequence number has already past."                                        } },
+        { tefWRONG_PRIOR,            { "tefWRONG_PRIOR",           "This previous transaction does not match."                                     } },
+        { tefBAD_AUTH_MASTER,        { "tefBAD_AUTH_MASTER",       "Auth for unclaimed account needs correct master key."                          } },
 
-        { tefALREADY,               "tefALREADY",               "The exact transaction was already in this ledger."             },
-        { tefBAD_ADD_AUTH,          "tefBAD_ADD_AUTH",          "Not authorized to add account."                                },
-        { tefBAD_AUTH,              "tefBAD_AUTH",              "Transaction's public key is not authorized."                   },
-        { tefBAD_LEDGER,            "tefBAD_LEDGER",            "Ledger in unexpected state."                                   },
-        { tefBAD_QUORUM,            "tefBAD_QUORUM",            "Signatures provided do not meet the quorum."                   },
-        { tefBAD_SIGNATURE,         "tefBAD_SIGNATURE",         "A signature is provided for a non-signer."                     },
-        { tefCREATED,               "tefCREATED",               "Can't add an already created account."                         },
-        { tefEXCEPTION,             "tefEXCEPTION",             "Unexpected program state."                                     },
-        { tefFAILURE,               "tefFAILURE",               "Failed to apply."                                              },
-        { tefINTERNAL,              "tefINTERNAL",              "Internal error."                                               },
-        { tefMASTER_DISABLED,       "tefMASTER_DISABLED",       "Master key is disabled."                                       },
-        { tefMAX_LEDGER,            "tefMAX_LEDGER",            "Ledger sequence too high."                                     },
-        { tefNO_AUTH_REQUIRED,      "tefNO_AUTH_REQUIRED",      "Auth is not required."                                         },
-        { tefNOT_MULTI_SIGNING,     "tefNOT_MULTI_SIGNING",     "Account has no appropriate list of multi-signers."             },
-        { tefPAST_SEQ,              "tefPAST_SEQ",              "This sequence number has already past."                        },
-        { tefWRONG_PRIOR,           "tefWRONG_PRIOR",           "This previous transaction does not match."                     },
-        { tefBAD_AUTH_MASTER,       "tefBAD_AUTH_MASTER",       "Auth for unclaimed account needs correct master key."          },
+        { telLOCAL_ERROR,            { "telLOCAL_ERROR",           "Local failure."                                                                } },
+        { telBAD_DOMAIN,             { "telBAD_DOMAIN",            "Domain too long."                                                              } },
+        { telBAD_PATH_COUNT,         { "telBAD_PATH_COUNT",        "Malformed: Too many paths."                                                    } },
+        { telBAD_PUBLIC_KEY,         { "telBAD_PUBLIC_KEY",        "Public key too long."                                                          } },
+        { telFAILED_PROCESSING,      { "telFAILED_PROCESSING",     "Failed to correctly process transaction."                                      } },
+        { telINSUF_FEE_P,            { "telINSUF_FEE_P",           "Fee insufficient."                                                             } },
+        { telNO_DST_PARTIAL,         { "telNO_DST_PARTIAL",        "Partial payment to create account not allowed."                                } },
 
-        { telLOCAL_ERROR,           "telLOCAL_ERROR",           "Local failure."                                                },
-        { telBAD_DOMAIN,            "telBAD_DOMAIN",            "Domain too long."                                              },
-        { telBAD_PATH_COUNT,        "telBAD_PATH_COUNT",        "Malformed: Too many paths."                                    },
-        { telBAD_PUBLIC_KEY,        "telBAD_PUBLIC_KEY",        "Public key too long."                                          },
-        { telFAILED_PROCESSING,     "telFAILED_PROCESSING",     "Failed to correctly process transaction."                      },
-        { telINSUF_FEE_P,           "telINSUF_FEE_P",           "Fee insufficient."                                             },
-        { telNO_DST_PARTIAL,        "telNO_DST_PARTIAL",        "Partial payment to create account not allowed."                },
+        { temMALFORMED,              { "temMALFORMED",             "Malformed transaction."                                                        } },
+        { temBAD_AMOUNT,             { "temBAD_AMOUNT",            "Can only send positive amounts."                                               } },
+        { temBAD_CURRENCY,           { "temBAD_CURRENCY",          "Malformed: Bad currency."                                                      } },
+        { temBAD_EXPIRATION,         { "temBAD_EXPIRATION",        "Malformed: Bad expiration."                                                    } },
+        { temBAD_FEE,                { "temBAD_FEE",               "Invalid fee, negative or not XRP."                                             } },
+        { temBAD_ISSUER,             { "temBAD_ISSUER",            "Malformed: Bad issuer."                                                        } },
+        { temBAD_LIMIT,              { "temBAD_LIMIT",             "Limits must be non-negative."                                                  } },
+        { temBAD_OFFER,              { "temBAD_OFFER",             "Malformed: Bad offer."                                                         } },
+        { temBAD_PATH,               { "temBAD_PATH",              "Malformed: Bad path."                                                          } },
+        { temBAD_PATH_LOOP,          { "temBAD_PATH_LOOP",         "Malformed: Loop in path."                                                      } },
+        { temBAD_QUORUM,             { "temBAD_QUORUM",            "Malformed: Quorum is unreachable."                                             } },
+        { temBAD_SEND_XRP_LIMIT,     { "temBAD_SEND_XRP_LIMIT",    "Malformed: Limit quality is not allowed for XRP to XRP."                       } },
+        { temBAD_SEND_XRP_MAX,       { "temBAD_SEND_XRP_MAX",      "Malformed: Send max is not allowed for XRP to XRP."                            } },
+        { temBAD_SEND_XRP_NO_DIRECT, { "temBAD_SEND_XRP_NO_DIRECT","Malformed: No Ripple direct is not allowed for XRP to XRP."                    } },
+        { temBAD_SEND_XRP_PARTIAL,   { "temBAD_SEND_XRP_PARTIAL",  "Malformed: Partial payment is not allowed for XRP to XRP."                     } },
+        { temBAD_SEND_XRP_PATHS,     { "temBAD_SEND_XRP_PATHS",    "Malformed: Paths are not allowed for XRP to XRP."                              } },
+        { temBAD_SEQUENCE,           { "temBAD_SEQUENCE",          "Malformed: Sequence is not in the past."                                       } },
+        { temBAD_SIGNATURE,          { "temBAD_SIGNATURE",         "Malformed: Bad signature."                                                     } },
+        { temBAD_SIGNER,             { "temBAD_SIGNER",            "Malformed: No signer may duplicate account or other signers."                  } },
+        { temBAD_SRC_ACCOUNT,        { "temBAD_SRC_ACCOUNT",       "Malformed: Bad source account."                                                } },
+        { temBAD_TRANSFER_RATE,      { "temBAD_TRANSFER_RATE",     "Malformed: Transfer rate must be >= 1.0"                                       } },
+        { temBAD_WEIGHT,             { "temBAD_WEIGHT",            "Malformed: Weight must be a positive value."                                   } },
+        { temDST_IS_SRC,             { "temDST_IS_SRC",            "Destination may not be source."                                                } },
+        { temDST_NEEDED,             { "temDST_NEEDED",            "Destination not specified."                                                    } },
+        { temINVALID,                { "temINVALID",               "The transaction is ill-formed."                                                } },
+        { temINVALID_FLAG,           { "temINVALID_FLAG",          "The transaction has an invalid flag."                                          } },
+        { temREDUNDANT,              { "temREDUNDANT",             "Sends same currency to self."                                                  } },
+        { temRIPPLE_EMPTY,           { "temRIPPLE_EMPTY",          "PathSet with no paths."                                                        } },
+        { temUNCERTAIN,              { "temUNCERTAIN",             "In process of determining result. Never returned."                             } },
+        { temUNKNOWN,                { "temUNKNOWN",               "The transaction requires logic that is not implemented yet."                   } },
+        { temDISABLED,               { "temDISABLED",              "The transaction requires logic that is currently disabled."                    } },
 
-        { temMALFORMED,             "temMALFORMED",             "Malformed transaction."                                        },
-        { temBAD_AMOUNT,            "temBAD_AMOUNT",            "Can only send positive amounts."                               },
-        { temBAD_CURRENCY,          "temBAD_CURRENCY",          "Malformed: Bad currency."                                      },
-        { temBAD_EXPIRATION,        "temBAD_EXPIRATION",        "Malformed: Bad expiration."                                    },
-        { temBAD_FEE,               "temBAD_FEE",               "Invalid fee, negative or not XRP."                             },
-        { temBAD_ISSUER,            "temBAD_ISSUER",            "Malformed: Bad issuer."                                        },
-        { temBAD_LIMIT,             "temBAD_LIMIT",             "Limits must be non-negative."                                  },
-        { temBAD_OFFER,             "temBAD_OFFER",             "Malformed: Bad offer."                                         },
-        { temBAD_PATH,              "temBAD_PATH",              "Malformed: Bad path."                                          },
-        { temBAD_PATH_LOOP,         "temBAD_PATH_LOOP",         "Malformed: Loop in path."                                      },
-        { temBAD_QUORUM,            "temBAD_QUORUM",            "Malformed: Quorum is unreachable."                             },
-        { temBAD_SEND_XRP_LIMIT,    "temBAD_SEND_XRP_LIMIT",    "Malformed: Limit quality is not allowed for XRP to XRP."       },
-        { temBAD_SEND_XRP_MAX,      "temBAD_SEND_XRP_MAX",      "Malformed: Send max is not allowed for XRP to XRP."            },
-        { temBAD_SEND_XRP_NO_DIRECT,"temBAD_SEND_XRP_NO_DIRECT","Malformed: No Ripple direct is not allowed for XRP to XRP."    },
-        { temBAD_SEND_XRP_PARTIAL,  "temBAD_SEND_XRP_PARTIAL",  "Malformed: Partial payment is not allowed for XRP to XRP."     },
-        { temBAD_SEND_XRP_PATHS,    "temBAD_SEND_XRP_PATHS",    "Malformed: Paths are not allowed for XRP to XRP."              },
-        { temBAD_SEQUENCE,          "temBAD_SEQUENCE",          "Malformed: Sequence is not in the past."                       },
-        { temBAD_SIGNATURE,         "temBAD_SIGNATURE",         "Malformed: Bad signature."                                     },
-        { temBAD_SIGNER,            "temBAD_SIGNER",            "Malformed: No signer may duplicate account or other signers."  },
-        { temBAD_SRC_ACCOUNT,       "temBAD_SRC_ACCOUNT",       "Malformed: Bad source account."                                },
-        { temBAD_TRANSFER_RATE,     "temBAD_TRANSFER_RATE",     "Malformed: Transfer rate must be >= 1.0"                       },
-        { temBAD_WEIGHT,            "temBAD_WEIGHT",            "Malformed: Weight must be a positive value."                   },
-        { temDST_IS_SRC,            "temDST_IS_SRC",            "Destination may not be source."                                },
-        { temDST_NEEDED,            "temDST_NEEDED",            "Destination not specified."                                    },
-        { temINVALID,               "temINVALID",               "The transaction is ill-formed."                                },
-        { temINVALID_FLAG,          "temINVALID_FLAG",          "The transaction has an invalid flag."                          },
-        { temREDUNDANT,             "temREDUNDANT",             "Sends same currency to self."                                  },
-        { temRIPPLE_EMPTY,          "temRIPPLE_EMPTY",          "PathSet with no paths."                                        },
-        { temUNCERTAIN,             "temUNCERTAIN",             "In process of determining result. Never returned."             },
-        { temUNKNOWN,               "temUNKNOWN",               "The transaction requires logic that is not implemented yet."   },
-        { temDISABLED,              "temDISABLED",              "The transaction requires logic that is currently disabled."    },
+        { terRETRY,                  { "terRETRY",                 "Retry transaction."                                                            } },
+        { terFUNDS_SPENT,            { "terFUNDS_SPENT",           "Can't set password, password set funds already spent."                         } },
+        { terINSUF_FEE_B,            { "terINSUF_FEE_B",           "Account balance can't pay fee."                                                } },
+        { terLAST,                   { "terLAST",                  "Process last."                                                                 } },
+        { terNO_RIPPLE,              { "terNO_RIPPLE",             "Path does not permit rippling."                                                } },
+        { terNO_ACCOUNT,             { "terNO_ACCOUNT",            "The source account does not exist."                                            } },
+        { terNO_AUTH,                { "terNO_AUTH",               "Not authorized to hold IOUs."                                                  } },
+        { terNO_LINE,                { "terNO_LINE",               "No such line."                                                                 } },
+        { terPRE_SEQ,                { "terPRE_SEQ",               "Missing/inapplicable prior transaction."                                       } },
+        { terOWNERS,                 { "terOWNERS",                "Non-zero owner count."                                                         } },
+        { terQUEUED,                 { "terQUEUED",                "Held until fee drops."                                                         } },
 
-        { terRETRY,                 "terRETRY",                 "Retry transaction."                                            },
-        { terFUNDS_SPENT,           "terFUNDS_SPENT",           "Can't set password, password set funds already spent."         },
-        { terINSUF_FEE_B,           "terINSUF_FEE_B",           "Account balance can't pay fee."                                },
-        { terLAST,                  "terLAST",                  "Process last."                                                 },
-        { terNO_RIPPLE,             "terNO_RIPPLE",             "Path does not permit rippling."                                },
-        { terNO_ACCOUNT,            "terNO_ACCOUNT",            "The source account does not exist."                            },
-        { terNO_AUTH,               "terNO_AUTH",               "Not authorized to hold IOUs."                                  },
-        { terNO_LINE,               "terNO_LINE",               "No such line."                                                 },
-        { terPRE_SEQ,               "terPRE_SEQ",               "Missing/inapplicable prior transaction."                       },
-        { terOWNERS,                "terOWNERS",                "Non-zero owner count."                                         },
-        { terQUEUED,                "terQUEUED",                "Held until fee drops." },
-
-        { tesSUCCESS,               "tesSUCCESS",               "The transaction was applied. Only final in a validated ledger." },
+        { tesSUCCESS,                { "tesSUCCESS",               "The transaction was applied. Only final in a validated ledger."                } },
     };
 
-    for (auto const& result : results)
-    {
-        if (result.code == code)
-        {
-            token = result.token;
-            text = result.text;
-            return true;
-        }
-    }
+    auto const r = results.find (
+        static_cast<std::underlying_type_t<TER>> (code));
 
-    return false;
+    if (r == results.end())
+        return false;
+
+    token = r->second.first;
+    text = r->second.second;
+    return true;
 }
 
 std::string transToken (TER code)


### PR DESCRIPTION
The existing implementation of `transResultInfo` uses a naive linear search. Use a `std::unordered_map` instead.

Remove already triggered ledger switches.