### PR TITLE
Add owner_funds to txs in RPC ledger (RIPD-1050)

### DIFF
--- a/src/ripple/app/ledger/LedgerToJson.h
+++ b/src/ripple/app/ledger/LedgerToJson.h
@@ -45,7 +45,8 @@ struct LedgerFill
     }
 
     enum Options {
-        dumpTxrp = 1, dumpState = 2, expand = 4, full = 8, binary = 16};
+        dumpTxrp = 1, dumpState = 2, expand = 4, full = 8, binary = 16,
+        ownerFunds = 32};
 
     ReadView const& ledger;
     int options;

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -101,19 +101,37 @@ void fillJsonTx (Object& json, LedgerFill const& fill)
             {
                 txns.append(to_string(i.first->getTransactionID()));
             }
-            else if (bBinary)
-            {
-                auto&& txJson = appendObject (txns);
-                txJson[jss::tx_blob] = serializeHex(*i.first);
-                if (i.second)
-                    txJson[jss::meta] = serializeHex(*i.second);
-            }
             else
             {
-                auto&& txJson = appendObject (txns);
-                copyFrom(txJson, i.first->getJson(0));
-                if (i.second)
-                    txJson[jss::metaData] = i.second->getJson(0);
+                auto&& txJson = appendObject(txns);
+                if (bBinary)
+                {
+                    txJson[jss::tx_blob] = serializeHex(*i.first);
+                    if (i.second)
+                        txJson[jss::meta] = serializeHex(*i.second);
+                }
+                else
+                {
+                    copyFrom(txJson, i.first->getJson(0));
+                    if (i.second)
+                        txJson[jss::metaData] = i.second->getJson(0);
+                }
+
+                if ((fill.options & LedgerFill::ownerFunds) &&
+                    i.first->getTxnType() == ttOFFER_CREATE)
+                {
+                    auto const account = i.first->getAccountID(sfAccount);
+                    auto const amount = i.first->getFieldAmount(sfTakerGets);
+
+                    // If the offer create is not self funded then add the
+                    // owner balance
+                    if (account != amount.getIssuer())
+                    {
+                        auto const ownerFunds = accountFunds(fill.ledger,
+                            account, amount, fhIGNORE_FREEZE, beast::Journal());
+                        txJson[jss::owner_funds] = ownerFunds.getText ();
+                    }
+                }
             }
         }
     }

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -275,7 +275,7 @@ JSS ( open );                       // out: handlers/Ledger
 JSS ( open_ledger_fee );            // out: TxQ
 JSS ( open_ledger_level );          // out: TxQ
 JSS ( owner );                      // in: LedgerEntry, out: NetworkOPs
-JSS ( owner_funds );                // out: NetworkOPs, AcceptedLedgerTx
+JSS ( owner_funds );                // in/out: Ledger, NetworkOPs, AcceptedLedgerTx
 JSS ( params );                     // RPC
 JSS ( parent_close_time );          // out: LedgerToJson
 JSS ( parent_hash );                // out: LedgerToJson

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -53,12 +53,14 @@ Status LedgerHandler::check()
     bool bAccounts = params[jss::accounts].asBool();
     bool bExpand = params[jss::expand].asBool();
     bool bBinary = params[jss::binary].asBool();
+    bool const owner_funds = params[jss::owner_funds].asBool();
 
     options_ = (bFull ? LedgerFill::full : 0)
             | (bExpand ? LedgerFill::expand : 0)
             | (bTransactions ? LedgerFill::dumpTxrp : 0)
             | (bAccounts ? LedgerFill::dumpState : 0)
-            | (bBinary ? LedgerFill::binary : 0);
+            | (bBinary ? LedgerFill::binary : 0)
+            | (owner_funds ? LedgerFill::ownerFunds : 0);
 
     if (bFull || bAccounts)
     {


### PR DESCRIPTION
Add a new field (owner_funds) to the ledger command that when set, returns the current owner funds for each transaction offer create in the specified ledger.

Reviewers: @JoelKatz @HowardHinnant 