### PR TITLE
Must hold lock to call LedgerConsensusImp::getJson.

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -970,6 +970,8 @@ void LedgerConsensusImp::simulate ()
 
 void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
 {
+    Json::Value consensusStatus;
+
     {
         auto lock = beast::make_lock(app_.getMasterMutex());
 
@@ -978,6 +980,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
            consensus_.takePosition (mPreviousLedger->info().seq, set);
 
         assert (set->getHash ().as_uint256() == mOurPosition->getCurrentHash ());
+        consensusStatus = getJson (true);
     }
 
     auto  closeTime = mOurPosition->getCloseTime ();
@@ -1134,7 +1137,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
             << "CNF newLCL " << newLCLHash;
 
     // See if we can accept a ledger as fully-validated
-    ledgerMaster_.consensusBuilt (newLCL, getJson (true));
+    ledgerMaster_.consensusBuilt (newLCL, std::move (consensusStatus));
 
     {
         // Apply disputed transactions that didn't get in


### PR DESCRIPTION
Calling LedgerConsensusImp::getJson without holding the lock that protects things like mPeerPositions can cause crashes.