### PR TITLE
Search /etc/opt/ripple for rippled.cfg

### DIFF
--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -264,10 +264,11 @@ void Config::setup (std::string const& strConf, bool bQuiet)
             CONFIG_FILE = CONFIG_DIR / strConfFile;
             dataDir    = strXdgDataHome + "/" + systemName ();
 
-            boost::filesystem::create_directories (CONFIG_DIR, ec);
-
-            if (ec)
-                throw std::runtime_error (boost::str (boost::format ("Can not create %s") % CONFIG_DIR));
+            if (!boost::filesystem::exists (CONFIG_FILE))
+            {
+                CONFIG_DIR  = "/etc/opt/" + systemName ();
+                CONFIG_FILE = CONFIG_DIR / strConfFile;
+            }
         }
     }
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -268,6 +268,7 @@ void Config::setup (std::string const& strConf, bool bQuiet)
             {
                 CONFIG_DIR  = "/etc/opt/" + systemName ();
                 CONFIG_FILE = CONFIG_DIR / strConfFile;
+                dataDir = "/var/opt/" + systemName();
             }
         }
     }


### PR DESCRIPTION
If `rippled.cfg` isn't found in our usual places, look for it in `/etc/opt/ripple`. Please check that I can safely remove the `create_directories` call. I do not believe it is needed.

@HowardHinnant @scottschurr 
