### PR TITLE
Consensus and validator work

### DIFF
--- a/src/ripple/app/ledger/Consensus.h
+++ b/src/ripple/app/ledger/Consensus.h
@@ -62,14 +62,20 @@ public:
     int
     getLastCloseDuration () const = 0;
 
-    /** Called when a new round of consensus is about to begin */
+    /** Called to create a LedgerConsensus instance */
     virtual
     std::shared_ptr<LedgerConsensus>
-    startRound (
+    makeLedgerConsensus (
         Application& app,
         InboundTransactions& inboundTransactions,
-        LocalTxs& localtx,
         LedgerMaster& ledgerMaster,
+        LocalTxs& localTxs) = 0;
+
+    /** Called when a new round of consensus is about to begin */
+    virtual
+    void
+    startRound (
+        LedgerConsensus& consensus,
         LedgerHash const &prevLCLHash,
         Ledger::ref previousLedger,
         std::uint32_t closeTime) = 0;

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -54,6 +54,11 @@ public:
 
     virtual bool peerPosition (LedgerProposal::ref) = 0;
 
+    virtual void startRound (LedgerHash const& prevLCLHash,
+        Ledger::ref prevLedger, std::uint32_t closeTime,
+        int previousProposers,
+        int previousConvergeTime) = 0;
+
     /** Simulate the consensus process without any network traffic.
 
         The end result, is that consensus begins and completes as if everyone

--- a/src/ripple/app/ledger/LedgerProposal.h
+++ b/src/ripple/app/ledger/LedgerProposal.h
@@ -68,7 +68,7 @@ public:
         std::uint32_t closeTime);
 
     uint256 getSigningHash () const;
-    bool checkSign (std::string const& signature) const;
+    bool checkSign () const;
 
     NodeID const& getPeerID () const
     {
@@ -81,6 +81,10 @@ public:
     uint256 const& getPrevLedger () const
     {
         return mPreviousLedger;
+    }
+    RippleAddress const& getPublicKey () const
+    {
+        return mPublicKey;
     }
     uint256 const& getSuppressionID () const
     {
@@ -95,7 +99,17 @@ public:
         return mCloseTime;
     }
 
-    Blob sign (RippleAddress const& privateKey);
+    Blob const& sign (RippleAddress const& privateKey);
+
+    void setSignature (Blob sig)
+    {
+        signature_ = sig;
+    }
+
+    Blob const& getSignature () const
+    {
+        return signature_;
+    }
 
     bool isPrevLedger (uint256 const& pl) const
     {
@@ -138,7 +152,8 @@ private:
 
     NodeID          mPeerID;
     RippleAddress   mPublicKey;
-    PublicKey publicKey_;
+    PublicKey       publicKey_;
+    Blob            signature_;
 
     std::chrono::steady_clock::time_point mTime;
 };

--- a/src/ripple/app/ledger/LedgerTiming.h
+++ b/src/ripple/app/ledger/LedgerTiming.h
@@ -74,6 +74,11 @@ const int LEDGER_IDLE_INTERVAL = 15;
 // it takes to adjust the close time accuracy window
 const int LEDGER_VAL_INTERVAL = 300;
 
+// The number of seconds a validation remains current after the time we first
+// saw it. This provides faster recovery in very rare cases where the number
+// of validations produced by the network is lower than normal
+const int LEDGER_VAL_LOCAL = 180;
+
 // The number of seconds before a close time that we consider a validation
 // acceptable. This protects against extreme clock errors
 const int LEDGER_EARLY_INTERVAL = 180;

--- a/src/ripple/app/ledger/impl/ConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/ConsensusImp.cpp
@@ -64,18 +64,25 @@ ConsensusImp::getLastCloseDuration () const
 }
 
 std::shared_ptr<LedgerConsensus>
-ConsensusImp::startRound (
+ConsensusImp::makeLedgerConsensus (
     Application& app,
     InboundTransactions& inboundTransactions,
-    LocalTxs& localtx,
     LedgerMaster& ledgerMaster,
+    LocalTxs& localTxs)
+{
+    return make_LedgerConsensus (app, *this,
+        inboundTransactions, localTxs, ledgerMaster, *feeVote_);
+}
+
+void
+ConsensusImp::startRound (
+    LedgerConsensus& consensus,
     LedgerHash const &prevLCLHash,
     Ledger::ref previousLedger,
     std::uint32_t closeTime)
 {
-    return make_LedgerConsensus (app, *this, lastCloseProposers_,
-        lastCloseConvergeTook_, inboundTransactions, localtx, ledgerMaster,
-        prevLCLHash, previousLedger, closeTime, *feeVote_);
+    consensus.startRound (prevLCLHash, previousLedger,
+        closeTime, lastCloseProposers_, lastCloseConvergeTook_);
 }
 
 
@@ -101,12 +108,10 @@ ConsensusImp::setLastValidation (STValidation::ref v)
 void
 ConsensusImp::newLCL (
     int proposers,
-    int convergeTime,
-    uint256 const& ledgerHash)
+    int convergeTime)
 {
     lastCloseProposers_ = proposers;
     lastCloseConvergeTook_ = convergeTime;
-    lastCloseHash_ = ledgerHash;
 }
 
 std::uint32_t
@@ -136,6 +141,8 @@ ConsensusImp::storeProposal (
     LedgerProposal::ref proposal,
     RippleAddress const& peerPublic)
 {
+    std::lock_guard <std::mutex> _(lock_);
+
     auto& props = storedProposals_[peerPublic.getNodeID ()];
 
     if (props.size () >= 10)
@@ -148,6 +155,8 @@ ConsensusImp::storeProposal (
 void
 ConsensusImp::takePosition (int seq, std::shared_ptr<SHAMap> const& position)
 {
+    std::lock_guard <std::mutex> _(lock_);
+
     recentPositions_[position->getHash ().as_uint256()] = std::make_pair (seq, position);
 
     if (recentPositions_.size () > 4)
@@ -165,10 +174,15 @@ ConsensusImp::takePosition (int seq, std::shared_ptr<SHAMap> const& position)
     }
 }
 
-Consensus::Proposals&
-ConsensusImp::peekStoredProposals ()
+void
+ConsensusImp::visitStoredProposals (
+    std::function<void(LedgerProposal::ref)> const& f)
 {
-    return storedProposals_;
+    std::lock_guard <std::mutex> _(lock_);
+
+    for (auto const& it : storedProposals_)
+        for (auto const& prop : it.second)
+            f(prop);
 }
 
 //==============================================================================

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -550,8 +550,9 @@ void LedgerConsensusImp::checkLCL ()
     // Get validators that are on our ledger, or  "close" to being on
     // our ledger.
     hash_map<uint256, ValidationCounter> vals =
-        app_.getValidations ().getCurrentValidations
-        (favoredLedger, priorLedger);
+        app_.getValidations ().getCurrentValidations(
+            favoredLedger, priorLedger,
+            ledgerMaster_.getValidLedgerIndex ());
 
     for (auto& it : vals)
     {

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -210,14 +210,9 @@ ConsensusState checkConsensus (
 LedgerConsensusImp::LedgerConsensusImp (
         Application& app,
         ConsensusImp& consensus,
-        int previousProposers,
-        int previousConvergeTime,
         InboundTransactions& inboundTransactions,
         LocalTxs& localtx,
         LedgerMaster& ledgerMaster,
-        LedgerHash const & prevLCLHash,
-        Ledger::ref previousLedger,
-        std::uint32_t closeTime,
         FeeVote& feeVote)
     : app_ (app)
     , consensus_ (consensus)
@@ -226,90 +221,30 @@ LedgerConsensusImp::LedgerConsensusImp (
     , ledgerMaster_ (ledgerMaster)
     , m_feeVote (feeVote)
     , state_ (State::open)
-    , mCloseTime (closeTime)
-    , mPrevLedgerHash (prevLCLHash)
-    , mPreviousLedger (previousLedger)
+    , mCloseTime (0)
     , mValPublic (app_.config().VALIDATION_PUB)
     , mValPrivate (app_.config().VALIDATION_PRIV)
+    , mProposing (false)
+    , mValidating (false)
+    , mHaveCorrectLCL (true)
     , mConsensusFail (false)
     , mCurrentMSeconds (0)
     , mClosePercent (0)
+    , mCloseResolution (30)
     , mHaveCloseTimeConsensus (false)
     , mConsensusStartTime (std::chrono::steady_clock::now ())
-    , mPreviousProposers (previousProposers)
-    , mPreviousMSeconds (previousConvergeTime)
+    , mPreviousProposers (0)
+    , mPreviousMSeconds (0)
     , j_ (app.journal ("LedgerConsensus"))
 {
     JLOG (j_.debug) << "Creating consensus object";
-    JLOG (j_.trace)
-        << "LCL:" << previousLedger->getHash () << ", ct=" << closeTime;
-
-    assert (mPreviousMSeconds);
-
-    inboundTransactions_.newRound (mPreviousLedger->info().seq);
-
-    // Adapt close time resolution to recent network conditions
-    mCloseResolution = getNextLedgerTimeResolution (
-        mPreviousLedger->info().closeTimeResolution,
-        getCloseAgree (mPreviousLedger->info()),
-        mPreviousLedger->info().seq + 1);
-
-    if (mValPublic.isSet () && mValPrivate.isSet ()
-        && !app_.getOPs ().isNeedNetworkLedger ())
-    {
-        // If the validation keys were set, and if we need a ledger,
-        // then we want to validate, and possibly propose a ledger.
-        JLOG (j_.info)
-            << "Entering consensus process, validating";
-        mValidating = true;
-        // Propose if we are in sync with the network
-        mProposing =
-            app_.getOPs ().getOperatingMode () == NetworkOPs::omFULL;
-    }
-    else
-    {
-        // Otherwise we just want to monitor the validation process.
-        JLOG (j_.info)
-            << "Entering consensus process, watching";
-        mProposing = mValidating = false;
-    }
-
-    mHaveCorrectLCL = (mPreviousLedger->getHash () == mPrevLedgerHash);
-
-    if (!mHaveCorrectLCL)
-    {
-        // If we were not handed the correct LCL, then set our state
-        // to not proposing.
-        consensus_.setProposing (false, false);
-        handleLCL (mPrevLedgerHash);
-
-        if (!mHaveCorrectLCL)
-        {
-            //          mProposing = mValidating = false;
-            JLOG (j_.info)
-                << "Entering consensus with: "
-                << previousLedger->getHash ();
-            JLOG (j_.info)
-                << "Correct LCL is: " << prevLCLHash;
-        }
-    }
-    else
-        // update the network status table as to whether we're
-        // proposing/validating
-        consensus_.setProposing (mProposing, mValidating);
-
-    playbackProposals ();
-    if (mPeerPositions.size() > (mPreviousProposers / 2))
-    {
-        // We may be falling behind, don't wait for the timer
-        // consider closing the ledger immediately
-        timerEntry ();
-    }
 }
 
 Json::Value LedgerConsensusImp::getJson (bool full)
 {
     Json::Value ret (Json::objectValue);
+    std::lock_guard<std::recursive_mutex> _(lock_);
+
     ret["proposing"] = mProposing;
     ret["validating"] = mValidating;
     ret["proposers"] = static_cast<int> (mPeerPositions.size ());
@@ -333,8 +268,8 @@ Json::Value LedgerConsensusImp::getJson (bool full)
         ret[jss::state] = "consensus";
         break;
 
-    case State::finished:
-        ret[jss::state] = "finished";
+    case State::processing:
+        ret[jss::state] = "processing";
         break;
 
     case State::accepted:
@@ -422,6 +357,7 @@ Json::Value LedgerConsensusImp::getJson (bool full)
 
 uint256 LedgerConsensusImp::getLCL ()
 {
+    std::lock_guard<std::recursive_mutex> _(lock_);
     return mPrevLedgerHash;
 }
 
@@ -523,6 +459,8 @@ void LedgerConsensusImp::mapComplete (
     std::shared_ptr<SHAMap> const& map,
     bool acquired)
 {
+    std::lock_guard<std::recursive_mutex> _(lock_);
+
     try
     {
         mapCompleteInternal (hash, map, acquired);
@@ -579,8 +517,8 @@ void LedgerConsensusImp::checkLCL ()
             status = "establish";
             break;
 
-        case State::finished:
-            status = "finished";
+        case State::processing:
+            status = "processing";
             break;
 
         case State::accepted:
@@ -639,6 +577,7 @@ void LedgerConsensusImp::handleLCL (uint256 const& lclHash)
         mProposing = false;
         mPeerPositions.clear ();
         mDisputes.clear ();
+        mCompares.clear ();
         mCloseTimes.clear ();
         mDeadNodes.clear ();
         // To get back in sync:
@@ -677,25 +616,20 @@ void LedgerConsensusImp::handleLCL (uint256 const& lclHash)
 
     assert (!newLCL->info().open && newLCL->isImmutable ());
     assert (newLCL->getHash () == lclHash);
-    mPreviousLedger = newLCL;
-    mPrevLedgerHash = lclHash;
-
     JLOG (j_.info) <<
         "Have the consensus ledger " << mPrevLedgerHash;
-    mHaveCorrectLCL = true;
-
-    mCloseResolution = getNextLedgerTimeResolution (
-        mPreviousLedger->info().closeTimeResolution,
-        getCloseAgree(mPreviousLedger->info()),
-        mPreviousLedger->info().seq + 1);
+    startRound (lclHash, newLCL, mCloseTime, mPreviousProposers, mPreviousMSeconds);
+    mProposing = false;
 }
 
 void LedgerConsensusImp::timerEntry ()
 {
+    std::lock_guard<std::recursive_mutex> _(lock_);
+
     try
     {
-       if ((state_ != State::finished) && (state_ != State::accepted))
-            checkLCL ();
+       if ((state_ != State::processing) && (state_ != State::accepted))
+           checkLCL ();
 
         mCurrentMSeconds = std::chrono::duration_cast<std::chrono::milliseconds>
             (std::chrono::steady_clock::now() - mConsensusStartTime).count ();
@@ -705,24 +639,24 @@ void LedgerConsensusImp::timerEntry ()
         {
         case State::open:
             statePreClose ();
-            return;
+
+            if (state_ != State::establish) return;
+
+            // Fall through
 
         case State::establish:
             stateEstablish ();
+            return;
 
-            if (state_ != State::finished) return;
-
-            // Fall through
-
-        case State::finished:
-            stateFinished ();
-
-            if (state_ != State::accepted) return;
-
-            // Fall through
+        case State::processing:
+            // We are processing the finished ledger
+            // logic of calculating next ledger advances us out of this state
+            // nothing to do
+            return;
 
         case State::accepted:
-            stateAccepted ();
+            // NetworkOPs needs to setup the next round
+            // nothing to do
             return;
         }
 
@@ -800,21 +734,8 @@ void LedgerConsensusImp::stateEstablish ()
 
     JLOG (j_.info) <<
         "Converge cutoff (" << mPeerPositions.size () << " participants)";
-    state_ = State::finished;
+    state_ = State::processing;
     beginAccept (false);
-}
-
-void LedgerConsensusImp::stateFinished ()
-{
-    // we are processing the finished ledger
-    // logic of calculating next ledger advances us out of this state
-    // nothing to do
-}
-
-void LedgerConsensusImp::stateAccepted ()
-{
-    // we have accepted a new ledger
-    endConsensus ();
 }
 
 bool LedgerConsensusImp::haveConsensus ()
@@ -882,6 +803,8 @@ bool LedgerConsensusImp::haveConsensus ()
 std::shared_ptr<SHAMap> LedgerConsensusImp::getTransactionTree (
     uint256 const& hash)
 {
+    std::lock_guard<std::recursive_mutex> _(lock_);
+
     auto it = mAcquired.find (hash);
     if (it != mAcquired.end() && it->second)
         return it->second;
@@ -896,7 +819,16 @@ std::shared_ptr<SHAMap> LedgerConsensusImp::getTransactionTree (
 
 bool LedgerConsensusImp::peerPosition (LedgerProposal::ref newPosition)
 {
+    std::lock_guard<std::recursive_mutex> _(lock_);
     auto const peerID = newPosition->getPeerID ();
+
+    if (newPosition->getPrevLedger() != mPrevLedgerHash)
+    {
+        JLOG (j_.debug) << "Got proposal for "
+            << newPosition->getPrevLedger ()
+            << " but we are on " << mPrevLedgerHash;
+        return false;
+    }
 
     if (mDeadNodes.find (peerID) != mDeadNodes.end ())
     {
@@ -962,28 +894,20 @@ bool LedgerConsensusImp::peerPosition (LedgerProposal::ref newPosition)
 
 void LedgerConsensusImp::simulate ()
 {
+    std::lock_guard<std::recursive_mutex> _(lock_);
+
     JLOG (j_.info) << "Simulating consensus";
     closeLedger ();
     mCurrentMSeconds = 100;
     beginAccept (true);
-    endConsensus ();
     JLOG (j_.info) << "Simulation complete";
 }
 
 void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
 {
-    Json::Value consensusStatus;
-
-    {
-        auto lock = beast::make_lock(app_.getMasterMutex());
-
-        // put our set where others can get it later
-        if (set->getHash ().isNonZero ())
-           consensus_.takePosition (mPreviousLedger->info().seq, set);
-
-        assert (set->getHash ().as_uint256() == mOurPosition->getCurrentHash ());
-        consensusStatus = getJson (true);
-    }
+    // put our set where others can get it later
+    if (set->getHash ().isNonZero ())
+       consensus_.takePosition (mPreviousLedger->info().seq, set);
 
     auto  closeTime = mOurPosition->getCloseTime ();
     bool closeTimeCorrect;
@@ -1139,7 +1063,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
             << "CNF newLCL " << newLCLHash;
 
     // See if we can accept a ledger as fully-validated
-    ledgerMaster_.consensusBuilt (newLCL, std::move (consensusStatus));
+    ledgerMaster_.consensusBuilt (newLCL, getJson (true));
 
     {
         // Apply disputed transactions that didn't get in
@@ -1207,9 +1131,7 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
                     });
     }
 
-    mNewLedgerHash = newLCL->getHash ();
     ledgerMaster_.switchLCL (newLCL);
-    state_ = State::accepted;
 
     assert (ledgerMaster_.getClosedLedger()->getHash() == newLCL->getHash());
     assert (app_.openLedger().current()->info().parentHash == newLCL->getHash());
@@ -1246,6 +1168,17 @@ void LedgerConsensusImp::accept (std::shared_ptr<SHAMap> set)
         app_.timeKeeper().adjustCloseTime(
             std::chrono::seconds(offset));
     }
+
+    // we have accepted a new ledger
+    bool correct;
+    {
+        std::lock_guard<std::recursive_mutex> _(lock_);
+
+        state_ = State::accepted;
+        correct = mHaveCorrectLCL;
+    }
+
+    endConsensus (correct);
 }
 
 void LedgerConsensusImp::createDisputes (
@@ -1698,19 +1631,15 @@ void LedgerConsensusImp::updateOurPositions ()
 
 void LedgerConsensusImp::playbackProposals ()
 {
-    for (auto const& it: consensus_.peekStoredProposals ())
-    {
-        for (auto const& proposal : it.second)
+    consensus_.visitStoredProposals (
+        [this](LedgerProposal::ref proposal)
         {
             if (proposal->isPrevLedger (mPrevLedgerHash) &&
                 peerPosition (proposal))
             {
-                JLOG (j_.warning)
-                    << "We should do delayed relay of this proposal,"
-                    << " but we cannot";
+                // FIXME: Should do delayed relay
             }
-        }
-    }
+        });
 }
 
 void LedgerConsensusImp::closeLedger ()
@@ -1779,7 +1708,7 @@ void LedgerConsensusImp::beginAccept (bool synchronous)
     }
 
     consensus_.newLCL (
-        mPeerPositions.size (), mCurrentMSeconds, mNewLedgerHash);
+        mPeerPositions.size (), mCurrentMSeconds);
 
     if (synchronous)
         accept (consensusSet);
@@ -1791,10 +1720,103 @@ void LedgerConsensusImp::beginAccept (bool synchronous)
     }
 }
 
-void LedgerConsensusImp::endConsensus ()
+void LedgerConsensusImp::endConsensus (bool correctLCL)
 {
-    app_.getOPs ().endConsensus (mHaveCorrectLCL);
+    app_.getOPs ().endConsensus (correctLCL);
 }
+
+void LedgerConsensusImp::startRound (LedgerHash const& prevLCLHash,
+    Ledger::ref prevLedger, std::uint32_t closeTime,
+    int previousProposers, int previousConvergeTime)
+{
+    std::lock_guard<std::recursive_mutex> _(lock_);
+
+    if (state_ == State::processing)
+    {
+        // We can't start a new round while we're processing
+        return;
+    }
+
+    state_ = State::open;
+    mCloseTime = closeTime;
+    mPrevLedgerHash = prevLCLHash;
+    mPreviousLedger = prevLedger;
+    mOurPosition.reset();
+    mConsensusFail = false;
+    mCurrentMSeconds = 0;
+    mClosePercent = 0;
+    mHaveCloseTimeConsensus = false;
+    mConsensusStartTime = std::chrono::steady_clock::now();
+    mPreviousProposers = previousProposers;
+    mPreviousMSeconds = previousConvergeTime;
+    inboundTransactions_.newRound (mPreviousLedger->info().seq);
+
+    mPeerPositions.clear();
+    mAcquired.clear();
+    mDisputes.clear();
+    mCompares.clear();
+    mCloseTimes.clear();
+    mDeadNodes.clear();
+
+    mCloseResolution = getNextLedgerTimeResolution (
+        mPreviousLedger->info().closeTimeResolution,
+        getCloseAgree (mPreviousLedger->info()),
+        mPreviousLedger->info().seq + 1);
+
+    if (mValPublic.isSet () && mValPrivate.isSet ()
+        && !app_.getOPs ().isNeedNetworkLedger ())
+    {
+        // If the validation keys were set, and if we need a ledger,
+        // then we want to validate, and possibly propose a ledger.
+        JLOG (j_.info)
+            << "Entering consensus process, validating";
+        mValidating = true;
+        // Propose if we are in sync with the network
+        mProposing =
+            app_.getOPs ().getOperatingMode () == NetworkOPs::omFULL;
+    }
+    else
+    {
+        // Otherwise we just want to monitor the validation process.
+        JLOG (j_.info)
+            << "Entering consensus process, watching";
+        mProposing = mValidating = false;
+    }
+
+    mHaveCorrectLCL = (mPreviousLedger->getHash () == mPrevLedgerHash);
+
+    if (!mHaveCorrectLCL)
+    {
+        // If we were not handed the correct LCL, then set our state
+        // to not proposing.
+        consensus_.setProposing (false, false);
+        handleLCL (mPrevLedgerHash);
+
+        if (!mHaveCorrectLCL)
+        {
+            //          mProposing = mValidating = false;
+            JLOG (j_.info)
+                << "Entering consensus with: "
+                << mPreviousLedger->getHash ();
+            JLOG (j_.info)
+                << "Correct LCL is: " << prevLCLHash;
+        }
+    }
+    else
+        // update the network status table as to whether we're
+        // proposing/validating
+        consensus_.setProposing (mProposing, mValidating);
+
+    playbackProposals ();
+    if (mPeerPositions.size() > (mPreviousProposers / 2))
+    {
+        // We may be falling behind, don't wait for the timer
+        // consider closing the ledger immediately
+        timerEntry ();
+    }
+
+}
+
 
 void LedgerConsensusImp::addLoad(STValidation::ref val)
 {
@@ -1808,15 +1830,12 @@ void LedgerConsensusImp::addLoad(STValidation::ref val)
 
 //------------------------------------------------------------------------------
 std::shared_ptr <LedgerConsensus>
-make_LedgerConsensus (Application& app, ConsensusImp& consensus, int previousProposers,
-    int previousConvergeTime, InboundTransactions& inboundTransactions,
-    LocalTxs& localtx, LedgerMaster& ledgerMaster,
-    LedgerHash const &prevLCLHash,
-    Ledger::ref previousLedger, std::uint32_t closeTime, FeeVote& feeVote)
+make_LedgerConsensus (Application& app, ConsensusImp& consensus,
+    InboundTransactions& inboundTransactions, LocalTxs& localtx,
+    LedgerMaster& ledgerMaster, FeeVote& feeVote)
 {
-    return std::make_shared <LedgerConsensusImp> (app, consensus, previousProposers,
-        previousConvergeTime, inboundTransactions, localtx, ledgerMaster,
-        prevLCLHash, previousLedger, closeTime, feeVote);
+    return std::make_shared <LedgerConsensusImp> (app, consensus,
+        inboundTransactions, localtx, ledgerMaster, feeVote);
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -60,10 +60,12 @@ private:
         // Establishing consensus
         establish,
 
-        // We have closed on a transaction set
-        finished,
+        // We have closed on a transaction set and are
+        // processing the new ledger
+        processing,
 
         // We have accepted / validated a new last closed ledger
+        // and need to start a new round
         accepted,
     };
 
@@ -81,29 +83,32 @@ public:
     ~LedgerConsensusImp () = default;
 
     /**
-        @param previousProposers the number of participants in the last round
-        @param previousConvergeTime how long the last round took (ms)
-        @param inboundTransactions
         @param localtx transactions issued by local clients
-        @param inboundTransactions the set of
+        @param inboundTransactions set of inbound transaction sets
         @param localtx A set of local transactions to apply
-        @param prevLCLHash The hash of the Last Closed Ledger (LCL).
-        @param previousLedger Best guess of what the LCL was.
-        @param closeTime Closing time point of the LCL.
         @param feeVote Our desired fee levels and voting logic.
     */
     LedgerConsensusImp (
         Application& app,
         ConsensusImp& consensus,
-        int previousProposers,
-        int previousConvergeTime,
         InboundTransactions& inboundTransactions,
         LocalTxs& localtx,
         LedgerMaster& ledgerMaster,
-        LedgerHash const & prevLCLHash,
-        Ledger::ref previousLedger,
-        std::uint32_t closeTime,
         FeeVote& feeVote);
+
+    /**
+        @param prevLCLHash The hash of the Last Closed Ledger (LCL).
+        @param previousLedger Best guess of what the LCL was.
+        @param closeTime Closing time point of the LCL.
+        @param previousProposers the number of participants in the last round
+        @param previousConvergeTime how long the last round took (ms)
+    */
+    void startRound (
+        LedgerHash const& prevLCLHash,
+        Ledger::ref prevLedger,
+        std::uint32_t closeTime,
+        int previousProposers,
+        int previousConvergeTime) override;
 
     /**
       Get the Json state of the consensus process.
@@ -130,43 +135,9 @@ public:
         bool acquired) override;
 
     /**
-      Check if our last closed ledger matches the network's.
-      This tells us if we are still in sync with the network.
-      This also helps us if we enter the consensus round with
-      the wrong ledger, to leave it with the correct ledger so
-      that we can participate in the next round.
-    */
-    void checkLCL ();
-
-    /**
-      Change our view of the last closed ledger
-
-      @param lclHash Hash of the last closed ledger.
-    */
-    void handleLCL (uint256 const& lclHash);
-
-    /**
       On timer call the correct handler for each state.
     */
     void timerEntry () override;
-
-    /**
-      Handle pre-close state.
-    */
-    void statePreClose ();
-
-    /** We are establishing a consensus
-       Update our position only on the timer, and in this state.
-       If we have consensus, move to the finish state
-    */
-    void stateEstablish ();
-
-    void stateFinished ();
-
-    void stateAccepted ();
-
-    /** Check if we've reached consensus */
-    bool haveConsensus ();
 
     std::shared_ptr<SHAMap> getTransactionTree (uint256 const& hash);
 
@@ -182,6 +153,36 @@ public:
     void simulate () override;
 
 private:
+    /**
+      Handle pre-close state.
+    */
+    void statePreClose ();
+
+    /** We are establishing a consensus
+       Update our position only on the timer, and in this state.
+       If we have consensus, move to the finish state
+    */
+    void stateEstablish ();
+
+    /** Check if we've reached consensus */
+    bool haveConsensus ();
+
+    /**
+      Check if our last closed ledger matches the network's.
+      This tells us if we are still in sync with the network.
+      This also helps us if we enter the consensus round with
+      the wrong ledger, to leave it with the correct ledger so
+      that we can participate in the next round.
+    */
+    void checkLCL ();
+
+    /**
+      Change our view of the last closed ledger
+
+      @param lclHash Hash of the last closed ledger.
+    */
+    void handleLCL (uint256 const& lclHash);
+
     /**
       We have a complete transaction set, typically acquired from the network
 
@@ -288,7 +289,8 @@ private:
     /** We have a new LCL and must accept it */
     void beginAccept (bool synchronous);
 
-    void endConsensus ();
+    void endConsensus (bool correctLCL);
+
 
     /** Add our load fee to our validation */
     void addLoad(STValidation::ref val);
@@ -303,10 +305,11 @@ private:
     LocalTxs& m_localTX;
     LedgerMaster& ledgerMaster_;
     FeeVote& m_feeVote;
+    std::recursive_mutex lock_;
 
     State state_;
     std::uint32_t mCloseTime;      // The wall time this ledger closed
-    uint256 mPrevLedgerHash, mNewLedgerHash, mAcquiringLedger;
+    uint256 mPrevLedgerHash, mAcquiringLedger;
     Ledger::pointer mPreviousLedger;
     LedgerProposal::pointer mOurPosition;
     RippleAddress mValPublic, mValPrivate;
@@ -349,11 +352,10 @@ private:
 //------------------------------------------------------------------------------
 
 std::shared_ptr <LedgerConsensus>
-make_LedgerConsensus (Application& app, ConsensusImp& consensus, int previousProposers,
-    int previousConvergeTime, InboundTransactions& inboundTransactions,
+make_LedgerConsensus (Application& app, ConsensusImp& consensus,
+    InboundTransactions& inboundTransactions,
     LocalTxs& localtx, LedgerMaster& ledgerMaster,
-    LedgerHash const &prevLCLHash, Ledger::ref previousLedger,
-    std::uint32_t closeTime, FeeVote& feeVote);
+    FeeVote& feeVote);
 
 } // ripple
 

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -198,7 +198,7 @@ public:
         if (mStrictValCount)
         {
             // If we're only using validation count, then we can't
-            // reject a ledger even if it's ioncompatible
+            // reject a ledger even if it's incompatible
             return true;
         }
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1029,6 +1029,12 @@ void ApplicationImp::setup()
         *config_);
     add (*m_overlay); // add to PropertyStream
 
+    // start first consensus round
+    if (! m_networkOPs->beginConsensus(m_ledgerMaster->getClosedLedger()->info().hash))
+    {
+        LogicError ("Unable to start consensus");
+    }
+
     m_overlay->setupValidatorKeyManifests (*config_, getWalletDB ());
 
     {

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1218,7 +1218,8 @@ bool NetworkOPsImp::checkLastClosedLedger (
     hash_map<uint256, ValidationCount> ledgers;
     {
         auto current = app_.getValidations ().getCurrentValidations (
-            closedLedger, prevClosedLedger);
+            closedLedger, prevClosedLedger,
+            m_ledgerMaster.getValidLedgerIndex());
 
         for (auto& it: current)
         {

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -193,6 +193,8 @@ public:
         , m_heartbeatTimer (this)
         , m_clusterTimer (this)
         , mConsensus (make_Consensus (app_.config(), app_.logs()))
+        , mLedgerConsensus (mConsensus->makeLedgerConsensus (
+            app, app.getInboundTransactions(), ledgerMaster, *m_localTX))
         , m_ledgerMaster (ledgerMaster)
         , mLastLoadBase (256)
         , mLastLoadFactor (256)
@@ -303,10 +305,10 @@ private:
         Ledger::pointer newLedger, bool duringConsensus);
     bool checkLastClosedLedger (
         const Overlay::PeerSequence&, uint256& networkClosed);
-    bool beginConsensus (uint256 const& networkClosed);
     void tryStartConsensus ();
 
 public:
+    bool beginConsensus (uint256 const& networkClosed) override;
     void endConsensus (bool correctLCL) override;
     void setStandAlone () override
     {
@@ -474,7 +476,6 @@ private:
     Json::Value transJson (
         const STTx& stTxn, TER terResult, bool bValidated,
         std::shared_ptr<ReadView const> const& lpCurrent);
-    bool haveConsensusObject ();
 
     void pubValidatedTransaction (
         Ledger::ref alAccepted, const AcceptedLedgerTx& alTransaction);
@@ -659,12 +660,9 @@ void NetworkOPsImp::processHeartbeatTimer ()
         else if (mMode == omCONNECTED)
             setMode (omCONNECTED);
 
-        if (!mLedgerConsensus)
-            tryStartConsensus ();
-
-        if (mLedgerConsensus)
-            mLedgerConsensus->timerEntry ();
     }
+
+    mLedgerConsensus->timerEntry ();
 
     setHeartbeatTimer ();
 }
@@ -1191,7 +1189,7 @@ void NetworkOPsImp::tryStartConsensus ()
         }
     }
 
-    if ((!mLedgerConsensus) && (mMode != omDISCONNECTED))
+    if (mMode != omDISCONNECTED)
         beginConsensus (networkClosed);
 }
 
@@ -1428,15 +1426,10 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
     assert (closingInfo.parentHash ==
             m_ledgerMaster.getClosedLedger ()->getHash ());
 
-    // Create a consensus object to get consensus on this ledger
-    assert (!mLedgerConsensus);
     prevLedger->setImmutable (app_.config());
 
-    mLedgerConsensus = mConsensus->startRound (
-        app_,
-        app_.getInboundTransactions(),
-        *m_localTX,
-        m_ledgerMaster,
+    mConsensus->startRound (
+        *mLedgerConsensus,
         networkClosed,
         prevLedger,
         closingInfo.closeTime);
@@ -1445,40 +1438,8 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
     return true;
 }
 
-bool NetworkOPsImp::haveConsensusObject ()
-{
-    if (mLedgerConsensus != nullptr)
-        return true;
-
-    if ((mMode == omFULL) || (mMode == omTRACKING))
-    {
-        tryStartConsensus ();
-    }
-    else
-    {
-        // we need to get into the consensus process
-        uint256 networkClosed;
-        Overlay::PeerSequence peerList = app_.overlay ().getActivePeers ();
-        bool ledgerChange = checkLastClosedLedger (peerList, networkClosed);
-
-        if (!ledgerChange)
-        {
-            m_journal.info << "Beginning consensus due to peer action";
-            if ( ((mMode == omTRACKING) || (mMode == omSYNCING)) &&
-                 (mConsensus->getLastCloseProposers() >= m_ledgerMaster.getMinValidations()) )
-                setMode (omFULL);
-            beginConsensus (networkClosed);
-        }
-    }
-
-    return mLedgerConsensus != nullptr;
-}
-
 uint256 NetworkOPsImp::getConsensusLCL ()
 {
-    if (!haveConsensusObject ())
-        return uint256 ();
-
     return mLedgerConsensus->getLCL ();
 }
 
@@ -1487,33 +1448,9 @@ void NetworkOPsImp::processTrustedProposal (
     std::shared_ptr<protocol::TMProposeSet> set, const RippleAddress& nodePublic)
 {
     {
-        auto lock = beast::make_lock(app_.getMasterMutex());
+        mConsensus->storeProposal (proposal, nodePublic);
 
-        bool relay = true;
-
-        if (mConsensus)
-            mConsensus->storeProposal (proposal, nodePublic);
-        else
-            m_journal.warning << "Unable to store proposal";
-
-        if (!haveConsensusObject ())
-        {
-            m_journal.info << "Received proposal outside consensus window";
-
-            if (mMode == omFULL)
-                relay = false;
-        }
-        else if (mLedgerConsensus->getLCL () == proposal->getPrevLedger ())
-        {
-            relay = mLedgerConsensus->peerPosition (proposal);
-            m_journal.trace
-                << "Proposal processing finished, relay=" << relay;
-        }
-        else
-            m_journal.debug << "Got proposal for " << proposal->getPrevLedger ()
-                << " but we are on " << mLedgerConsensus->getLCL();
-
-        if (relay)
+        if (mLedgerConsensus->peerPosition (proposal))
             app_.overlay().relay(*set, proposal->getSuppressionID());
         else
             m_journal.info << "Not relaying trusted proposal";
@@ -1524,10 +1461,7 @@ void
 NetworkOPsImp::mapComplete (uint256 const& hash,
                             std::shared_ptr<SHAMap> const& map)
 {
-    std::lock_guard<Application::MutexType> lock(app_.getMasterMutex());
-
-    if (haveConsensusObject ())
-        mLedgerConsensus->mapComplete (hash, map, true);
+    mLedgerConsensus->mapComplete (hash, map, true);
 }
 
 void NetworkOPsImp::endConsensus (bool correctLCL)
@@ -1546,7 +1480,7 @@ void NetworkOPsImp::endConsensus (bool correctLCL)
         }
     }
 
-    mLedgerConsensus = std::shared_ptr<LedgerConsensus> ();
+    tryStartConsensus();
 }
 
 void NetworkOPsImp::consensusViewChange ()
@@ -1951,12 +1885,7 @@ bool NetworkOPsImp::recvValidation (
 
 Json::Value NetworkOPsImp::getConsensusInfo ()
 {
-    if (mLedgerConsensus)
-        return mLedgerConsensus->getJson (true);
-
-    Json::Value info = Json::objectValue;
-    info[jss::consensus] = "none";
-    return info;
+    return mLedgerConsensus->getJson (true);
 }
 
 Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
@@ -2025,8 +1954,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
     info[jss::last_close] = lastClose;
 
-    //  if (mLedgerConsensus)
-    //      info[jss::consensus] = mLedgerConsensus->getJson();
+    //  info[jss::consensus] = mLedgerConsensus->getJson();
 
     if (admin)
         info[jss::load] = m_job_queue.getJson ();

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -162,6 +162,7 @@ public:
                               std::shared_ptr<SHAMap> const& map) = 0;
 
     // network state machine
+    virtual bool beginConsensus (uint256 const& netLCL) = 0;
     virtual void endConsensus (bool correctLCL) = 0;
     virtual void setStandAlone () = 0;
     virtual void setStateTimer () = 0;

--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -75,7 +75,7 @@ private:
 public:
     ValidationsImp (Application& app)
         : app_ (app)
-        , mValidations ("Validations", 128, 600, stopwatch(),
+        , mValidations ("Validations", 4096, 600, stopwatch(),
             app.journal("TaggedCache"))
         , mWriting (false)
         , j_ (app.journal ("Validations"))
@@ -144,7 +144,8 @@ private:
         }
 
         JLOG (j_.debug) << "Val for " << hash << " from " << signer.humanNodePublic ()
-                                        << " added " << (val->isTrusted () ? "trusted/" : "UNtrusted/") << (isCurrent ? "current" : "stale");
+            << " added " << (val->isTrusted () ? "trusted/" : "UNtrusted/")
+            << (isCurrent ? "current" : "stale");
 
         if (val->isTrusted () && isCurrent)
         {
@@ -346,9 +347,12 @@ private:
     }
 
     LedgerToValidationCounter getCurrentValidations (
-        uint256 currentLedger, uint256 priorLedger) override
+        uint256 currentLedger,
+        uint256 priorLedger,
+        LedgerIndex cutoffBefore) override
     {
         auto const cutoff = app_.timeKeeper().now().time_since_epoch().count() - LEDGER_VAL_INTERVAL;
+        auto const lCutoff = cutoff + LEDGER_VAL_INTERVAL - LEDGER_VAL_LOCAL;
         bool valCurrentLedger = currentLedger.isNonZero ();
         bool valPriorLedger = priorLedger.isNonZero ();
 
@@ -361,7 +365,8 @@ private:
         {
             if (!it->second) // contains no record
                 it = mCurrentValidations.erase (it);
-            else if (it->second->getSignTime () < cutoff)
+            else if ((it->second->getSignTime () < cutoff) ||
+                ((it->second->getSeenTime() != 0) && (it->second->getSeenTime() < lCutoff)))
             {
                 // contains a stale record
                 mStaleValidations.push_back (it->second);
@@ -369,7 +374,8 @@ private:
                 condWrite ();
                 it = mCurrentValidations.erase (it);
             }
-            else
+            else if (! it->second->isFieldPresent (sfLedgerSequence) ||
+                (it->second->getFieldU32 (sfLedgerSequence) >= cutoffBefore))
             {
                 // contains a live record
                 bool countPreferred = valCurrentLedger && (it->second->getLedgerHash () == currentLedger);

--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -397,6 +397,10 @@ private:
 
                 ++it;
             }
+            else
+            {
+                ++it;
+            }
         }
 
         return ret;

--- a/src/ripple/app/misc/Validations.h
+++ b/src/ripple/app/misc/Validations.h
@@ -21,6 +21,7 @@
 #define RIPPLE_APP_MISC_VALIDATIONS_H_INCLUDED
 
 #include <ripple/app/main/Application.h>
+#include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STValidation.h>
 #include <memory>
 #include <vector>

--- a/src/ripple/app/misc/Validations.h
+++ b/src/ripple/app/misc/Validations.h
@@ -63,7 +63,8 @@ public:
 
     // VFALCO TODO make a type alias for this ugly return value!
     virtual LedgerToValidationCounter getCurrentValidations (
-        uint256 currentLedger, uint256 previousLedger) = 0;
+        uint256 currentLedger, uint256 previousLedger,
+        LedgerIndex cutoffBefore) = 0;
 
     /** Return the times of all validations for a particular ledger hash. */
     virtual std::vector<std::uint32_t> getValidationTimes (

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1569,11 +1569,19 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMValidation> const& m)
             SerialIter sit (makeSlice(m->validation()));
             val = std::make_shared <
                 STValidation> (std::ref (sit), false);
+            val->setSeen (closeTime);
         }
 
         if (closeTime > (120 + val->getFieldU32(sfSigningTime)))
         {
             p_journal_.trace << "Validation: Too old";
+            fee_ = Resource::feeUnwantedData;
+            return;
+        }
+
+        if ((closeTime + 120) < val->getFieldU32(sfSigningTime))
+        {
+            p_journal_.debug << "Validation: Too new";
             fee_ = Resource::feeUnwantedData;
             return;
         }

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1918,13 +1918,7 @@ PeerImp::checkPropose (Job& job,
     }
     else
     {
-        uint256 consensusLCL;
-        {
-            std::lock_guard<Application::MutexType> lock (app_.getMasterMutex());
-            consensusLCL = app_.getOPs ().getConsensusLCL ();
-        }
-
-        if (consensusLCL == proposal->getPrevLedger())
+        if (app_.getOPs().getConsensusLCL() == proposal->getPrevLedger())
         {
             // relay untrusted proposal
             p_journal_.trace <<

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1283,6 +1283,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMProposeSet> const& m)
         prevLedger, set.proposeseq (), proposeHash, set.closetime (),
             signerPublic, PublicKey(makeSlice(set.nodepubkey())),
                 suppression);
+    proposal->setSignature (Blob (set.signature().begin(), set.signature().end()));
 
     std::weak_ptr<PeerImp> weak = shared_from_this();
     app_.getJobQueue ().addJob (
@@ -1903,7 +1904,7 @@ PeerImp::checkPropose (Job& job,
     assert (packet);
     protocol::TMProposeSet& set = *packet;
 
-    if (! cluster() && ! proposal->checkSign (set.signature ()))
+    if (! cluster() && ! proposal->checkSign ())
     {
         p_journal_.warning <<
             "Proposal fails sig check";

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -117,8 +117,8 @@ private:
 
     uint256 mPreviousHash;
     NodeID mNodeID;
-    bool mTrusted;
-    std::uint32_t mSeen;
+    bool mTrusted = false;
+    std::uint32_t mSeen = 0;
 };
 
 } // ripple

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -66,6 +66,7 @@ public:
 
     uint256         getLedgerHash ()     const;
     std::uint32_t   getSignTime ()       const;
+    std::uint32_t   getSeenTime ()       const;
     std::uint32_t   getFlags ()          const;
     RippleAddress   getSignerPublic ()   const;
     NodeID          getNodeID ()         const
@@ -81,9 +82,13 @@ public:
     uint256         getSigningHash ()    const;
     bool            isValid (uint256 const& ) const;
 
-    void                        setTrusted ()
+    void            setTrusted ()
     {
         mTrusted = true;
+    }
+    void            setSeen (std::uint32_t s)
+    {
+        mSeen = s;
     }
     Blob    getSigned ()                 const;
     Blob    getSignature ()              const;
@@ -113,6 +118,7 @@ private:
     uint256 mPreviousHash;
     NodeID mNodeID;
     bool mTrusted;
+    std::uint32_t mSeen;
 };
 
 } // ripple

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -28,7 +28,6 @@ namespace ripple {
 
 STValidation::STValidation (SerialIter& sit, bool checkSignature)
     : STObject (getFormat (), sit, sfValidation)
-    , mTrusted (false), mSeen (0)
 {
     mNodeID = RippleAddress::createNodePublic (getFieldVL (sfSigningPubKey)).getNodeID ();
     assert (mNodeID.isNonZero ());
@@ -44,7 +43,7 @@ STValidation::STValidation (
     uint256 const& ledgerHash, std::uint32_t signTime,
     RippleAddress const& raPub, bool isFull)
     : STObject (getFormat (), sfValidation)
-    , mTrusted (false), mSeen (0)
+    , mSeen (signTime)
 {
     // Does not sign
     setFieldH256 (sfLedgerHash, ledgerHash);
@@ -52,7 +51,6 @@ STValidation::STValidation (
 
     setFieldVL (sfSigningPubKey, raPub.getNodePublic ());
     mNodeID = raPub.getNodeID ();
-    mSeen = signTime;
     assert (mNodeID.isNonZero ());
 
     if (!isFull)

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -28,7 +28,7 @@ namespace ripple {
 
 STValidation::STValidation (SerialIter& sit, bool checkSignature)
     : STObject (getFormat (), sit, sfValidation)
-    , mTrusted (false)
+    , mTrusted (false), mSeen (0)
 {
     mNodeID = RippleAddress::createNodePublic (getFieldVL (sfSigningPubKey)).getNodeID ();
     assert (mNodeID.isNonZero ());
@@ -44,7 +44,7 @@ STValidation::STValidation (
     uint256 const& ledgerHash, std::uint32_t signTime,
     RippleAddress const& raPub, bool isFull)
     : STObject (getFormat (), sfValidation)
-    , mTrusted (false)
+    , mTrusted (false), mSeen (0)
 {
     // Does not sign
     setFieldH256 (sfLedgerHash, ledgerHash);
@@ -52,6 +52,7 @@ STValidation::STValidation (
 
     setFieldVL (sfSigningPubKey, raPub.getNodePublic ());
     mNodeID = raPub.getNodeID ();
+    mSeen = signTime;
     assert (mNodeID.isNonZero ());
 
     if (!isFull)
@@ -83,6 +84,11 @@ uint256 STValidation::getLedgerHash () const
 std::uint32_t STValidation::getSignTime () const
 {
     return getFieldU32 (sfSigningTime);
+}
+
+std::uint32_t STValidation::getSeenTime () const
+{
+    return mSeen;
 }
 
 std::uint32_t STValidation::getFlags () const


### PR DESCRIPTION
This fixes proposal relaying so that we can always relay a proposal and a proposal will get relayed even if we are unable to verify it when we first receive it. (Because we don't know if the previous ledger is correct.)

LedgerConsensus is now a singleton. This eliminates a lot of ugly edge cases where we may not have a LedgerCosnensus object or have to figure out how to create one.

LedgerConsensus and Consensus now have their own locks so they no longer need the master mutex.

There are three commits that are not part of this PR, they are the "Consensus ledger switch improvements" and two "FOLD" commits after it. They are part of another PR.