### PR TITLE
Command line option to not log to console after

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -926,6 +926,8 @@ void ApplicationImp::setup()
             logs_->severity (beast::Journal::kDebug);
     }
 
+    logs_->silent (config_->SILENT);
+
     if (!config_->RUN_STANDALONE)
         timeKeeper_->run(config_->SNTP_SERVERS);
 

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -271,6 +271,7 @@ int run (int argc, char** argv)
     ("parameters", po::value< vector<string> > (), "Specify comma separated parameters.")
     ("quiet,q", "Reduce diagnotics.")
     ("quorum", po::value <int> (), "Set the validation quorum.")
+    ("silent", "No output to the console after startup.")
     ("verbose,v", "Verbose logging.")
     ("load", "Load the current ledger from the local DB.")
     ("valid", "Consider the initial ledger a valid network ledger.")
@@ -354,6 +355,9 @@ int run (int argc, char** argv)
 
     // config file, quiet flag.
     config->setup (configFile, bool (vm.count ("quiet")));
+
+    if (vm.count ("silent"))
+        config->SILENT = true;
 
     if (vm.count ("standalone"))
     {

--- a/src/ripple/basics/Log.h
+++ b/src/ripple/basics/Log.h
@@ -148,6 +148,7 @@ private:
     std::map <std::string, Sink, beast::ci_less> sinks_;
     beast::Journal::Severity level_;
     File file_;
+    bool silent_ = false;
 
 public:
     Logs();
@@ -182,6 +183,17 @@ public:
 
     std::string
     rotate();
+
+    /**
+     * Set flag to write logs to stderr (false) or not (true).
+     *
+     * @param bSilent Set flag accordingly.
+     */
+    void
+    silent (bool bSilent)
+    {
+        silent_ = bSilent;
+    }
 
 public:
     static

--- a/src/ripple/basics/impl/Log.cpp
+++ b/src/ripple/basics/impl/Log.cpp
@@ -176,7 +176,8 @@ Logs::write (beast::Journal::Severity level, std::string const& partition,
     format (s, text, level, partition);
     std::lock_guard <std::mutex> lock (mutex_);
     file_.writeln (s);
-    std::cerr << s << '\n';
+    if (! silent_)
+        std::cerr << s << '\n';
     // VFALCO TODO Fix console output
     //if (console)
     //    out_.write_console(s);

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -160,7 +160,8 @@ public:
     beast::File getModuleDatabasePath () const;
 
     bool doImport = false;
-    bool                        QUIET = false;
+    bool                        QUIET = false;          // Minimize logging verbosity.
+    bool                        SILENT = false;         // No output to console after startup.
     bool                        ELB_SUPPORT = false;
 
     std::string                 VALIDATORS_SITE;        // Where to find validators.txt on the Internet.


### PR DESCRIPTION
startup.

Redhat's systemd sends console output to a logger process. This logger process consumes a high amount of CPU because rippled's console is so chatty.