### PR TITLE
Simplify SHAMap iteration

### DIFF
--- a/src/ripple/app/ledger/AccountStateSF.cpp
+++ b/src/ripple/app/ledger/AccountStateSF.cpp
@@ -37,7 +37,7 @@ void AccountStateSF::gotNode (bool fromFilter,
                               SHAMapNodeID const& id,
                               SHAMapHash const& nodeHash,
                               Blob& nodeData,
-                              SHAMapTreeNode::TNType)
+                              SHAMapTreeNode::TNType) const
 {
     // VFALCO SHAMapSync filters should be passed the SHAMap, the
     //        SHAMap should provide an accessor to get the injected Database,
@@ -48,7 +48,7 @@ void AccountStateSF::gotNode (bool fromFilter,
 
 bool AccountStateSF::haveNode (SHAMapNodeID const& id,
                                SHAMapHash const& nodeHash,
-                               Blob& nodeData)
+                               Blob& nodeData) const
 {
     return app_.getLedgerMaster ().getFetchPack (nodeHash.as_uint256(), nodeData);
 }

--- a/src/ripple/app/ledger/AccountStateSF.cpp
+++ b/src/ripple/app/ledger/AccountStateSF.cpp
@@ -35,7 +35,7 @@ AccountStateSF::AccountStateSF(Application& app)
 
 void AccountStateSF::gotNode (bool fromFilter,
                               SHAMapNodeID const& id,
-                              uint256 const& nodeHash,
+                              SHAMapHash const& nodeHash,
                               Blob& nodeData,
                               SHAMapTreeNode::TNType)
 {
@@ -43,14 +43,14 @@ void AccountStateSF::gotNode (bool fromFilter,
     //        SHAMap should provide an accessor to get the injected Database,
     //        and this should use that Database instad of getNodeStore
     app_.getNodeStore ().store (
-        hotACCOUNT_NODE, std::move (nodeData), nodeHash);
+        hotACCOUNT_NODE, std::move (nodeData), nodeHash.as_uint256());
 }
 
 bool AccountStateSF::haveNode (SHAMapNodeID const& id,
-                               uint256 const& nodeHash,
+                               SHAMapHash const& nodeHash,
                                Blob& nodeData)
 {
-    return app_.getLedgerMaster ().getFetchPack (nodeHash, nodeData);
+    return app_.getLedgerMaster ().getFetchPack (nodeHash.as_uint256(), nodeData);
 }
 
 } // ripple

--- a/src/ripple/app/ledger/AccountStateSF.h
+++ b/src/ripple/app/ledger/AccountStateSF.h
@@ -40,12 +40,12 @@ public:
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
                   SHAMapNodeID const& id,
-                  uint256 const& nodeHash,
+                  SHAMapHash const& nodeHash,
                   Blob& nodeData,
                   SHAMapTreeNode::TNType) override;
 
     bool haveNode (SHAMapNodeID const& id,
-                   uint256 const& nodeHash,
+                   SHAMapHash const& nodeHash,
                    Blob& nodeData) override;
 };
 

--- a/src/ripple/app/ledger/AccountStateSF.h
+++ b/src/ripple/app/ledger/AccountStateSF.h
@@ -42,11 +42,11 @@ public:
                   SHAMapNodeID const& id,
                   SHAMapHash const& nodeHash,
                   Blob& nodeData,
-                  SHAMapTreeNode::TNType) override;
+                  SHAMapTreeNode::TNType) const override;
 
     bool haveNode (SHAMapNodeID const& id,
                    SHAMapHash const& nodeHash,
-                   Blob& nodeData) override;
+                   Blob& nodeData) const override;
 };
 
 } // ripple

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -40,7 +40,7 @@ ConsensusTransSetSF::ConsensusTransSetSF (Application& app, NodeCache& nodeCache
 
 void ConsensusTransSetSF::gotNode (
     bool fromFilter, const SHAMapNodeID& id, SHAMapHash const& nodeHash,
-    Blob& nodeData, SHAMapTreeNode::TNType type)
+    Blob& nodeData, SHAMapTreeNode::TNType type) const
 {
     if (fromFilter)
         return;
@@ -76,7 +76,7 @@ void ConsensusTransSetSF::gotNode (
 }
 
 bool ConsensusTransSetSF::haveNode (
-    const SHAMapNodeID& id, SHAMapHash const& nodeHash, Blob& nodeData)
+    const SHAMapNodeID& id, SHAMapHash const& nodeHash, Blob& nodeData) const
 {
     if (m_nodeCache.retrieve (nodeHash, nodeData))
         return true;

--- a/src/ripple/app/ledger/ConsensusTransSetSF.h
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.h
@@ -43,11 +43,11 @@ public:
                   SHAMapNodeID const& id,
                   SHAMapHash const& nodeHash,
                   Blob& nodeData,
-                  SHAMapTreeNode::TNType) override;
+                  SHAMapTreeNode::TNType) const override;
 
     bool haveNode (SHAMapNodeID const& id,
                    SHAMapHash const& nodeHash,
-                   Blob& nodeData) override;
+                   Blob& nodeData) const override;
 
 private:
     Application& app_;

--- a/src/ripple/app/ledger/ConsensusTransSetSF.h
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.h
@@ -34,19 +34,19 @@ namespace ripple {
 class ConsensusTransSetSF : public SHAMapSyncFilter
 {
 public:
-    using NodeCache = TaggedCache <uint256, Blob>;
+    using NodeCache = TaggedCache <SHAMapHash, Blob>;
 
     ConsensusTransSetSF (Application& app, NodeCache& nodeCache);
 
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
                   SHAMapNodeID const& id,
-                  uint256 const& nodeHash,
+                  SHAMapHash const& nodeHash,
                   Blob& nodeData,
                   SHAMapTreeNode::TNType) override;
 
     bool haveNode (SHAMapNodeID const& id,
-                   uint256 const& nodeHash,
+                   SHAMapHash const& nodeHash,
                    Blob& nodeData) override;
 
 private:

--- a/src/ripple/app/ledger/TransactionStateSF.cpp
+++ b/src/ripple/app/ledger/TransactionStateSF.cpp
@@ -38,7 +38,7 @@ void TransactionStateSF::gotNode (bool fromFilter,
                                   SHAMapNodeID const& id,
                                   SHAMapHash const& nodeHash,
                                   Blob& nodeData,
-                                  SHAMapTreeNode::TNType type)
+                                  SHAMapTreeNode::TNType type) const
 {
     // VFALCO SHAMapSync filters should be passed the SHAMap, the
     //        SHAMap should provide an accessor to get the injected Database,
@@ -52,7 +52,7 @@ void TransactionStateSF::gotNode (bool fromFilter,
 
 bool TransactionStateSF::haveNode (SHAMapNodeID const& id,
                                    SHAMapHash const& nodeHash,
-                                   Blob& nodeData)
+                                   Blob& nodeData) const
 {
     return app_.getLedgerMaster ().getFetchPack (nodeHash.as_uint256(), nodeData);
 }

--- a/src/ripple/app/ledger/TransactionStateSF.cpp
+++ b/src/ripple/app/ledger/TransactionStateSF.cpp
@@ -36,7 +36,7 @@ TransactionStateSF::TransactionStateSF(Application& app)
 // VFALCO This might be better as Blob&&
 void TransactionStateSF::gotNode (bool fromFilter,
                                   SHAMapNodeID const& id,
-                                  uint256 const& nodeHash,
+                                  SHAMapHash const& nodeHash,
                                   Blob& nodeData,
                                   SHAMapTreeNode::TNType type)
 {
@@ -47,14 +47,14 @@ void TransactionStateSF::gotNode (bool fromFilter,
         SHAMapTreeNode::tnTRANSACTION_NM);
     app_.getNodeStore().store(
         hotTRANSACTION_NODE,
-            std::move (nodeData), nodeHash);
+            std::move (nodeData), nodeHash.as_uint256());
 }
 
 bool TransactionStateSF::haveNode (SHAMapNodeID const& id,
-                                   uint256 const& nodeHash,
+                                   SHAMapHash const& nodeHash,
                                    Blob& nodeData)
 {
-    return app_.getLedgerMaster ().getFetchPack (nodeHash, nodeData);
+    return app_.getLedgerMaster ().getFetchPack (nodeHash.as_uint256(), nodeData);
 }
 
 } // ripple

--- a/src/ripple/app/ledger/TransactionStateSF.h
+++ b/src/ripple/app/ledger/TransactionStateSF.h
@@ -43,11 +43,11 @@ public:
                   SHAMapNodeID const& id,
                   SHAMapHash const& nodeHash,
                   Blob& nodeData,
-                  SHAMapTreeNode::TNType) override;
+                  SHAMapTreeNode::TNType) const override;
 
     bool haveNode (SHAMapNodeID const& id,
                    SHAMapHash const& nodeHash,
-                   Blob& nodeData) override;
+                   Blob& nodeData) const override;
 };
 
 } // ripple

--- a/src/ripple/app/ledger/TransactionStateSF.h
+++ b/src/ripple/app/ledger/TransactionStateSF.h
@@ -41,13 +41,13 @@ public:
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
                   SHAMapNodeID const& id,
-                  uint256 const& nodeHash,
+                  SHAMapHash const& nodeHash,
                   Blob& nodeData,
-                  SHAMapTreeNode::TNType);
+                  SHAMapTreeNode::TNType) override;
 
     bool haveNode (SHAMapNodeID const& id,
-                   uint256 const& nodeHash,
-                   Blob& nodeData);
+                   SHAMapHash const& nodeHash,
+                   Blob& nodeData) override;
 };
 
 } // ripple

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1915,12 +1915,12 @@ void LedgerMasterImp::makeFetchPack (
     auto fpAppender = [](
         protocol::TMGetObjectByHash* reply,
         std::uint32_t ledgerSeq,
-        uint256 const& hash,
+        SHAMapHash const& hash,
         const Blob& blob)
     {
         protocol::TMIndexedObject& newObj = * (reply->add_objects ());
         newObj.set_ledgerseq (ledgerSeq);
-        newObj.set_hash (hash.begin (), 256 / 8);
+        newObj.set_hash (hash.as_uint256().begin (), 256 / 8);
         newObj.set_data (&blob[0], blob.size ());
     };
 

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -69,7 +69,7 @@ class Cluster;
 class DatabaseCon;
 class SHAMapStore;
 
-using NodeCache     = TaggedCache <uint256, Blob>;
+using NodeCache     = TaggedCache <SHAMapHash, Blob>;
 
 class Application : public beast::PropertyStream::Source
 {

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -190,7 +190,7 @@ private:
     {
         std::uint64_t check = 0;
 
-        for (uint256 const& key: cache.getKeys())
+        for (auto const& key: cache.getKeys())
         {
             database_->fetchNode (key);
             if (! (++check % checkHealthInterval_) && health())

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -215,7 +215,7 @@ public:
     void visitDifferences(SHAMap* have, std::function<bool(SHAMapAbstractNode&)>) const;
 
     void getFetchPack (SHAMap * have, bool includeLeaves, int max,
-        std::function<void (uint256 const&, const Blob&)>) const;
+        std::function<void (SHAMapHash const&, const Blob&)>) const;
 
     void setUnbacked ();
 

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -245,7 +245,10 @@ private:
     /** Walk towards the specified id, returning the node.  Caller must check
         if the return is nullptr, and if not, if the node->peekItem()->key() == id */
     SHAMapTreeNode*
-        walkToKey(uint256 const& id, NodeStack* stack = nullptr) const;
+        walkTowardsKey(uint256 const& id, NodeStack* stack = nullptr) const;
+    /** Return nullptr if key not found */
+    SHAMapTreeNode*
+        findKey(uint256 const& id) const;
 
     /** Unshare the node, allowing it to be modified */
     template <class Node>

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -150,16 +150,6 @@ public:
     bool addGiveItem (std::shared_ptr<SHAMapItem const> const&,
                       bool isTransaction, bool hasMeta);
 
-    /** Fetch an item given its key.
-        This retrieves the item whose key matches.
-        If the item does not exist, an empty pointer is returned.
-        Exceptions:
-            Can throw SHAMapMissingNode
-        @note This can cause NodeStore reads
-    */
-    std::shared_ptr<SHAMapItem const> const&
-        fetch (uint256 const& key) const;
-
     // Save a copy if you need to extend the life
     // of the SHAMapItem beyond this SHAMap
     std::shared_ptr<SHAMapItem const> const& peekItem (uint256 const& id) const;

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -242,8 +242,10 @@ private:
     SharedPtrNodeStack
         getStack (uint256 const& id, bool include_nonmatching_leaf) const;
 
-    /** Walk to the specified index, returning the node */
-    SHAMapTreeNode* walkToPointer (uint256 const& id) const;
+    /** Walk towards the specified id, returning the node.  Caller must check
+        if the return is nullptr, and if not, if the node->peekItem()->key() == id */
+    SHAMapTreeNode*
+        walkToKey(uint256 const& id, NodeStack* stack = nullptr) const;
 
     /** Unshare the node, allowing it to be modified */
     template <class Node>

--- a/src/ripple/shamap/SHAMapSyncFilter.h
+++ b/src/ripple/shamap/SHAMapSyncFilter.h
@@ -39,11 +39,11 @@ public:
                           SHAMapNodeID const& id,
                           SHAMapHash const& nodeHash,
                           Blob& nodeData,
-                          SHAMapTreeNode::TNType type) = 0;
+                          SHAMapTreeNode::TNType type) const = 0;
 
     virtual bool haveNode (SHAMapNodeID const& id,
                            SHAMapHash const& nodeHash,
-                           Blob& nodeData) = 0;
+                           Blob& nodeData) const = 0;
 };
 
 }

--- a/src/ripple/shamap/SHAMapSyncFilter.h
+++ b/src/ripple/shamap/SHAMapSyncFilter.h
@@ -37,12 +37,12 @@ public:
     // Note that the nodeData is overwritten by this call
     virtual void gotNode (bool fromFilter,
                           SHAMapNodeID const& id,
-                          uint256 const& nodeHash,
+                          SHAMapHash const& nodeHash,
                           Blob& nodeData,
                           SHAMapTreeNode::TNType type) = 0;
 
     virtual bool haveNode (SHAMapNodeID const& id,
-                           uint256 const& nodeHash,
+                           SHAMapHash const& nodeHash,
                            Blob& nodeData) = 0;
 };
 

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -73,6 +73,14 @@ public:
     }
 
     friend std::string to_string(SHAMapHash const& x) {return to_string(x.hash_);}
+
+    template <class H>
+    friend
+    void
+    hash_append(H& h, SHAMapHash const& x)
+    {
+        hash_append(h, x.hash_);
+    }
 };
 
 inline

--- a/src/ripple/shamap/TreeNodeCache.h
+++ b/src/ripple/shamap/TreeNodeCache.h
@@ -20,7 +20,8 @@
 #ifndef RIPPLE_SHAMAP_TREENODECACHE_H_INCLUDED
 #define RIPPLE_SHAMAP_TREENODECACHE_H_INCLUDED
 
-#include <ripple/basics/TaggedCache.h>
+#include <ripple/shamap/TreeNodeCache.h>
+#include <ripple/shamap/SHAMapTreeNode.h>
 
 namespace ripple {
 

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -205,13 +205,13 @@ SHAMap::checkFilter(SHAMapHash const& hash, SHAMapNodeID const& id,
 {
     std::shared_ptr<SHAMapAbstractNode> node;
     Blob nodeData;
-    if (filter->haveNode (id, hash.as_uint256(), nodeData))
+    if (filter->haveNode (id, hash, nodeData))
     {
         node = SHAMapAbstractNode::make(
             nodeData, 0, snfPREFIX, hash, true, f_.journal ());
         if (node)
         {
-            filter->gotNode (true, id, hash.as_uint256(), nodeData, node->getType ());
+            filter->gotNode (true, id, hash, nodeData, node->getType ());
             if (backed_)
                 canonicalize (hash, node);
         }

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -485,16 +485,6 @@ SHAMap::onlyBelow (SHAMapAbstractNode* node) const
 static std::shared_ptr<
     SHAMapItem const> const nullConstSHAMapItem;
 
-std::shared_ptr<SHAMapItem const> const&
-SHAMap::fetch (uint256 const& key) const
-{
-    SHAMapTreeNode const* const leaf =
-        walkToPointer(key);
-    if (! leaf)
-        return nullConstSHAMapItem;
-    return leaf->peekItem();
-}
-
 SHAMapItem const*
 SHAMap::peekFirstItem(NodeStack& stack) const
 {

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -575,22 +575,17 @@ SHAMap::upper_bound(uint256 const& id) const
     NodeStack stack;
     auto node = root_.get();
     auto nodeID = SHAMapNodeID{};
-    auto foundLeaf = true;
+    stack.push ({node, nodeID});
     while (!node->isLeaf())
     {
-        stack.push ({node, nodeID});
         auto branch = nodeID.selectBranch(id);
         auto inner = static_cast<SHAMapInnerNode*>(node);
         if (inner->isEmptyBranch(branch))
-        {
-            foundLeaf = false;
             break;
-        }
         node = descendThrow(inner, branch);
         nodeID = nodeID.getChildNodeID(branch);
+        stack.push ({node, nodeID});
     }
-    if (foundLeaf)
-        stack.push({node, nodeID});
     while (!stack.empty())
     {
         std::tie(node, nodeID) = stack.top();

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -711,7 +711,7 @@ Note: a caller should set includeLeaves to false for transaction trees.
 There's no point in including the leaves of transaction trees.
 */
 void SHAMap::getFetchPack (SHAMap* have, bool includeLeaves, int max,
-                           std::function<void (uint256 const&, const Blob&)> func) const
+                           std::function<void (SHAMapHash const&, const Blob&)> func) const
 {
     visitDifferences (have,
         [includeLeaves, &max, &func] (SHAMapAbstractNode& smn) -> bool
@@ -720,7 +720,7 @@ void SHAMap::getFetchPack (SHAMap* have, bool includeLeaves, int max,
             {
                 Serializer s;
                 smn.addRaw (s, snfPREFIX);
-                func (smn.getNodeHash().as_uint256(), s.peekData());
+                func (smn.getNodeHash(), s.peekData());
 
                 if (--max <= 0)
                     return false;

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -439,7 +439,7 @@ SHAMapAddNode SHAMap::addRootNode (Blob const& rootNode,
     {
         Serializer s;
         root_->addRaw (s, snfPREFIX);
-        filter->gotNode (false, SHAMapNodeID{}, root_->getNodeHash ().as_uint256(),
+        filter->gotNode (false, SHAMapNodeID{}, root_->getNodeHash (),
                          s.modData (), root_->getType ());
     }
 
@@ -476,7 +476,7 @@ SHAMapAddNode SHAMap::addRootNode (SHAMapHash const& hash, Blob const& rootNode,
     {
         Serializer s;
         root_->addRaw (s, snfPREFIX);
-        filter->gotNode (false, SHAMapNodeID{}, root_->getNodeHash ().as_uint256(), 
+        filter->gotNode (false, SHAMapNodeID{}, root_->getNodeHash (),
                          s.modData (), root_->getType ());
     }
 
@@ -563,7 +563,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
             {
                 Serializer s;
                 newNode->addRaw (s, snfPREFIX);
-                filter->gotNode (false, node, childHash.as_uint256(),
+                filter->gotNode (false, node, childHash,
                                  s.modData (), newNode->getType ());
             }
 

--- a/src/ripple/shamap/tests/FetchPack.test.cpp
+++ b/src/ripple/shamap/tests/FetchPack.test.cpp
@@ -62,12 +62,12 @@ public:
 
         void gotNode (bool fromFilter,
             SHAMapNodeID const& id, SHAMapHash const& nodeHash,
-                Blob& nodeData, SHAMapTreeNode::TNType type) override
+                Blob& nodeData, SHAMapTreeNode::TNType type) const override
         {
         }
 
         bool haveNode (SHAMapNodeID const& id,
-            SHAMapHash const& nodeHash, Blob& nodeData) override
+            SHAMapHash const& nodeHash, Blob& nodeData) const override
         {
             Map::iterator it = mMap.find (nodeHash);
             if (it == mMap.end ())

--- a/src/ripple/shamap/tests/FetchPack.test.cpp
+++ b/src/ripple/shamap/tests/FetchPack.test.cpp
@@ -42,7 +42,7 @@ public:
         tableItemsExtra = 20
     };
 
-    using Map   = hash_map <uint256, Blob>;
+    using Map   = hash_map <SHAMapHash, Blob>;
     using Table = SHAMap;
     using Item  = SHAMapItem;
 
@@ -61,13 +61,13 @@ public:
         }
 
         void gotNode (bool fromFilter,
-            SHAMapNodeID const& id, uint256 const& nodeHash,
-                Blob& nodeData, SHAMapTreeNode::TNType type)
+            SHAMapNodeID const& id, SHAMapHash const& nodeHash,
+                Blob& nodeData, SHAMapTreeNode::TNType type) override
         {
         }
 
         bool haveNode (SHAMapNodeID const& id,
-            uint256 const& nodeHash, Blob& nodeData)
+            SHAMapHash const& nodeHash, Blob& nodeData) override
         {
             Map::iterator it = mMap.find (nodeHash);
             if (it == mMap.end ())
@@ -106,9 +106,9 @@ public:
         }
     }
 
-    void on_fetch (Map& map, uint256 const& hash, Blob const& blob)
+    void on_fetch (Map& map, SHAMapHash const& hash, Blob const& blob)
     {
-        expect (sha512Half(makeSlice(blob)) == hash,
+        expect (sha512Half(makeSlice(blob)) == hash.as_uint256(),
             "Hash mismatch");
         map.emplace (hash, blob);
     }

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -133,6 +133,31 @@ public:
             }
             expect (map.getHash() == zero, "bad final empty map hash");
         }
+
+        testcase ("iterate");
+        {
+            std::vector<uint256> keys(8);
+            keys[0].SetHex ("f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[1].SetHex ("b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[2].SetHex ("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[3].SetHex ("b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[4].SetHex ("b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[5].SetHex ("b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[6].SetHex ("b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+            keys[7].SetHex ("292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
+
+            tests::TestFamily f{beast::Journal{}};
+            SHAMap map{SHAMapType::FREE, f};
+            for (auto const& k : keys)
+                map.addItem(SHAMapItem{k, IntToVUC(0)}, true, false);
+
+            int i = 7;
+            for (auto const& k : map)
+            {
+                expect(k.key() == keys[i]);
+                --i;
+            }
+        }
     }
 };
 


### PR DESCRIPTION
Remove unused code.  Consolidate and simplify iteration.  Add test to ensure no change in functionality.

@scottschurr @seelabs 

NOTE:  This P/R builds on the already passed P/R 1414.  Don't bother re-reviewing those commits.  This P/R starts with the commit titled "Remove unused SHAMap::fetch" and continues with the 3 commits below that one.