### PR TITLE
Do not open peer port in standalone mode

### DIFF
--- a/src/ripple/server/ServerHandler.h
+++ b/src/ripple/server/ServerHandler.h
@@ -21,6 +21,7 @@
 #define RIPPLE_SERVER_SERVERHANDLER_H_INCLUDED
 
 #include <ripple/basics/BasicConfig.h>
+#include <ripple/core/Config.h>
 #include <ripple/server/Port.h>
 #include <ripple/overlay/Overlay.h>
 #include <beast/utility/Journal.h>
@@ -96,7 +97,9 @@ public:
 //------------------------------------------------------------------------------
 
 ServerHandler::Setup
-setup_ServerHandler (BasicConfig const& c, std::ostream& log);
+setup_ServerHandler (
+    Config const& c,
+    std::ostream& log);
 
 } // ripple
 


### PR DESCRIPTION
Currently, even if you are in standalone mode, the server will open its peer port and accept incoming connections. This contradicts the documentation of standalone mode and makes no sense.

During setup, if running in standalone, remove the "peer" protocol on any port that has it specified, and remove the port if it is left with no configured protocols.