### PR TITLE
Refactor jtx::Env

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3628,6 +3628,10 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\shamap\TreeNodeCache.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\test\impl\ManualTimeKeeper.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\test\jtx.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\Account.h">
@@ -3793,6 +3797,8 @@
     <ClInclude Include="..\..\src\ripple\test\jtx\txflags.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\utility.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\ManualTimeKeeper.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\test\mao\impl\Net.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -412,6 +412,9 @@
     <Filter Include="ripple\test">
       <UniqueIdentifier>{B25F5854-84AE-1CBD-DFFC-6515DD055652}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ripple\test\impl">
+      <UniqueIdentifier>{CF7F0C3F-3D61-7764-BA8B-5FF38018425C}</UniqueIdentifier>
+    </Filter>
     <Filter Include="ripple\test\jtx">
       <UniqueIdentifier>{A21A3B94-5C44-3746-4F10-6FF8FF990CE3}</UniqueIdentifier>
     </Filter>
@@ -4284,6 +4287,9 @@
     <ClInclude Include="..\..\src\ripple\shamap\TreeNodeCache.h">
       <Filter>ripple\shamap</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\test\impl\ManualTimeKeeper.cpp">
+      <Filter>ripple\test\impl</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\test\jtx.h">
       <Filter>ripple\test</Filter>
     </ClInclude>
@@ -4457,6 +4463,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\utility.h">
       <Filter>ripple\test\jtx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\ManualTimeKeeper.h">
+      <Filter>ripple\test</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\test\mao\impl\Net.cpp">
       <Filter>ripple\test\mao\impl</Filter>

--- a/Builds/VisualStudio2015/ripple.sln
+++ b/Builds/VisualStudio2015/ripple.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RippleD", "RippleD.vcxproj", "{26B7D9AC-1A80-8EF8-6703-D061F1BECB75}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CF990ABA-EAE4-47AB-BF5E-0BCBB95CE325}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		debug.classic|x64 = debug.classic|x64

--- a/src/BeastConfig.h
+++ b/src/BeastConfig.h
@@ -164,13 +164,6 @@
 #define RIPPLE_SINGLE_IO_SERVICE_THREAD 0
 #endif
 
-/** Config: RIPPLE_ENABLE_TICKETS
-    Enables processing of ticket transactions
-*/
-#ifndef RIPPLE_ENABLE_TICKETS
-#define RIPPLE_ENABLE_TICKETS 0
-#endif
-
 // Uses OpenSSL instead of alternatives
 #ifndef RIPPLE_USE_OPENSSL
 #define RIPPLE_USE_OPENSSL 1

--- a/src/beast/beast/threads/Stoppable.h
+++ b/src/beast/beast/threads/Stoppable.h
@@ -266,8 +266,8 @@ private:
 
     void prepareRecursive ();
     void startRecursive ();
-    void stopAsyncRecursive ();
-    void stopRecursive (Journal journal);
+    void stopAsyncRecursive (Journal j);
+    void stopRecursive (Journal j);
 
     std::string m_name;
     RootStoppable& m_root;
@@ -314,15 +314,16 @@ public:
         Thread safety:
             Safe to call from any thread not associated with a Stoppable.
     */
-    void stop (Journal journal = Journal());
+    void stop (Journal j);
+
 private:
-    /** Notify a root stoppable and children to stop, without waiting.
+    /*  Notify a root stoppable and children to stop, without waiting.
         Has no effect if the stoppable was already notified.
 
         Thread safety:
             Safe to call from any thread at any time.
     */
-    void stopAsync ();
+    void stopAsync(Journal j);
 
     std::atomic<bool> m_prepared;
     std::atomic<bool> m_calledStop;

--- a/src/beast/beast/threads/impl/Stoppable.cpp
+++ b/src/beast/beast/threads/impl/Stoppable.cpp
@@ -106,21 +106,28 @@ void Stoppable::startRecursive ()
         iter->stoppable->startRecursive ();
 }
 
-void Stoppable::stopAsyncRecursive ()
+void Stoppable::stopAsyncRecursive (Journal j)
 {
+    using namespace std::chrono;
+    auto const start = high_resolution_clock::now();
     onStop ();
+    auto const ms = duration_cast<milliseconds>(
+        high_resolution_clock::now() - start).count();
+    if (ms >= 10)
+        j.fatal << m_name << "::onStop took " << ms << "ms";
+
     for (Children::const_iterator iter (m_children.cbegin ());
         iter != m_children.cend(); ++iter)
-        iter->stoppable->stopAsyncRecursive ();
+        iter->stoppable->stopAsyncRecursive(j);
 }
 
-void Stoppable::stopRecursive (Journal journal)
+void Stoppable::stopRecursive (Journal j)
 {
     // Block on each child from the bottom of the tree up.
     //
     for (Children::const_iterator iter (m_children.cbegin ());
         iter != m_children.cend(); ++iter)
-        iter->stoppable->stopRecursive (journal);
+        iter->stoppable->stopRecursive (j);
 
     // if we get here then all children have stopped
     //
@@ -132,7 +139,7 @@ void Stoppable::stopRecursive (Journal journal)
     bool const timedOut (! m_stoppedEvent.wait (1 * 1000)); // milliseconds
     if (timedOut)
     {
-        journal.warning << "Waiting for '" << m_name << "' to stop";
+        j.warning << "Waiting for '" << m_name << "' to stop";
         m_stoppedEvent.wait ();
     }
 
@@ -171,25 +178,25 @@ void RootStoppable::start ()
         startRecursive ();
 }
 
-void RootStoppable::stop (Journal journal)
+void RootStoppable::stop (Journal j)
 {
     // Must have a prior call to start()
     bassert (m_started);
 
     if (m_calledStop.exchange (true) == true)
     {
-        journal.warning << "Stoppable::stop called again";
+        j.warning << "Stoppable::stop called again";
         return;
     }
 
-    stopAsync ();
-    stopRecursive (journal);
+    stopAsync (j);
+    stopRecursive (j);
 }
 
-void RootStoppable::stopAsync ()
+void RootStoppable::stopAsync(Journal j)
 {
     if (m_calledStopAsync.exchange (true) == false)
-        stopAsyncRecursive ();
+        stopAsyncRecursive(j);
 }
 
 }

--- a/src/beast/beast/threads/impl/Stoppable.cpp
+++ b/src/beast/beast/threads/impl/Stoppable.cpp
@@ -183,12 +183,16 @@ void RootStoppable::stop (Journal j)
     // Must have a prior call to start()
     bassert (m_started);
 
-    if (m_calledStop.exchange (true) == true)
     {
-        j.warning << "Stoppable::stop called again";
-        return;
+        std::lock_guard<std::mutex> lock(m_);
+        if (m_calledStop)
+        {
+            j.warning << "Stoppable::stop called again";
+            return;
+        }
+        m_calledStop = true;
+        c_.notify_all();
     }
-
     stopAsync (j);
     stopRecursive (j);
 }

--- a/src/beast/beast/threads/impl/Stoppable.test.cpp
+++ b/src/beast/beast/threads/impl/Stoppable.test.cpp
@@ -403,7 +403,7 @@ class Stoppable_test
         {
             prepare();
             start();
-            stop();
+            stop(Journal{});
         }
 
         void onPrepare() override

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -179,7 +179,7 @@ Ledger::Ledger (create_genesis_t, Config const& config, Family& family)
     info_.seq = 1;
     info_.drops = SYSTEM_CURRENCY_START;
     info_.closeTimeResolution = ledgerDefaultTimeResolution;
-    auto const id = calcAccountID(
+    static auto const id = calcAccountID(
         generateKeyPair(KeyType::secp256k1,
             generateSeed("masterpassphrase")).first);
     auto const sle = std::make_shared<SLE>(keylet::account(id));

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -70,7 +70,8 @@ public:
         server in standalone mode and SHOULD NOT be used during the normal
         consensus process.
     */
-    virtual void simulate () = 0;
+    virtual void simulate (
+        boost::optional<std::chrono::milliseconds> consensusDelay) = 0;
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -902,13 +902,14 @@ bool LedgerConsensusImp::peerPosition (LedgerProposal::ref newPosition)
     return true;
 }
 
-void LedgerConsensusImp::simulate ()
+void LedgerConsensusImp::simulate (
+    boost::optional<std::chrono::milliseconds> consensusDelay)
 {
     std::lock_guard<std::recursive_mutex> _(lock_);
 
     JLOG (j_.info) << "Simulating consensus";
     closeLedger ();
-    mCurrentMSeconds = 100ms;
+    mCurrentMSeconds = consensusDelay.value_or(100ms);
     beginAccept (true);
     JLOG (j_.info) << "Simulation complete";
 }

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -150,7 +150,8 @@ public:
     */
     bool peerPosition (LedgerProposal::ref newPosition) override;
 
-    void simulate () override;
+    void simulate(
+        boost::optional<std::chrono::milliseconds> consensusDelay) override;
 
 private:
     /**

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -847,15 +847,18 @@ public:
         {
             // VFALCO TODO Move all this into doSweep
 
-            boost::filesystem::space_info space =
-                    boost::filesystem::space (config_->legacy ("database_path"));
-
-            // VFALCO TODO Give this magic constant a name and move it into a well documented header
-            //
-            if (space.available < (512 * 1024 * 1024))
+            if (! config_->RUN_STANDALONE)
             {
-                m_journal.fatal << "Remaining free disk space is less than 512MB";
-                signalStop ();
+                boost::filesystem::space_info space =
+                        boost::filesystem::space (config_->legacy ("database_path"));
+
+                // VFALCO TODO Give this magic constant a name and move it into a well documented header
+                //
+                if (space.available < (512 * 1024 * 1024))
+                {
+                    m_journal.fatal << "Remaining free disk space is less than 512MB";
+                    signalStop ();
+                }
             }
 
             m_jobQueue->addJob(jtSWEEP, "sweep", [this] (Job&) { doSweep(); });

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -286,12 +286,12 @@ private:
     };
 
 public:
-    std::unique_ptr<Config const> config_;
+    std::unique_ptr<Config> config_;
     std::unique_ptr<Logs> logs_;
+    std::unique_ptr<TimeKeeper> timeKeeper_;
+
     beast::Journal m_journal;
     Application::MutexType m_masterMutex;
-
-    std::unique_ptr<TimeKeeper> timeKeeper_;
 
     // Required by the SHAMapStore
     TransactionMaster m_txMaster;
@@ -363,17 +363,16 @@ public:
     //--------------------------------------------------------------------------
 
     ApplicationImp (
-            std::unique_ptr<Config const> config,
-            std::unique_ptr<Logs> logs)
+            std::unique_ptr<Config> config,
+            std::unique_ptr<Logs> logs,
+            std::unique_ptr<TimeKeeper> timeKeeper)
         : RootStoppable ("Application")
         , BasicApp (numberOfThreads(*config))
         , config_ (std::move(config))
         , logs_ (std::move(logs))
+        , timeKeeper_ (std::move(timeKeeper))
 
         , m_journal (logs_->journal("Application"))
-
-        , timeKeeper_ (make_TimeKeeper(
-            logs_->journal("TimeKeeper")))
 
         , m_txMaster (*this)
 
@@ -518,8 +517,8 @@ public:
         return *logs_;
     }
 
-    Config const&
-    config() const override
+    Config&
+    config() override
     {
         return *config_;
     }
@@ -687,6 +686,12 @@ public:
 
     OpenLedger&
     openLedger() override
+    {
+        return *openLedger_;
+    }
+
+    OpenLedger const&
+    openLedger() const override
     {
         return *openLedger_;
     }
@@ -1676,21 +1681,13 @@ Application::Application ()
 
 std::unique_ptr<Application>
 make_Application (
-    std::unique_ptr<Config const> config,
-    std::unique_ptr<Logs> logs)
+    std::unique_ptr<Config> config,
+    std::unique_ptr<Logs> logs,
+    std::unique_ptr<TimeKeeper> timeKeeper)
 {
     return std::make_unique<ApplicationImp> (
-        std::move(config), std::move(logs));
-}
-
-void
-setupConfigForUnitTests (Config& config)
-{
-    config.overwrite (ConfigSection::nodeDatabase (), "type", "memory");
-    config.overwrite (ConfigSection::nodeDatabase (), "path", "main");
-
-    config.deprecatedClearSection (ConfigSection::importNodeDatabase ());
-    config.legacy("database_path", "DummyForUnitTests");
+        std::move(config), std::move(logs),
+            std::move(timeKeeper));
 }
 
 }

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -103,7 +103,7 @@ public:
     //
 
     virtual Logs& logs() = 0;
-    virtual Config const& config() const = 0;
+    virtual Config& config() = 0;
     virtual boost::asio::io_service& getIOService () = 0;
     virtual CollectorManager&       getCollectorManager () = 0;
     virtual Family&                 family() = 0;
@@ -136,6 +136,7 @@ public:
     virtual PendingSaves&           pendingSaves() = 0;
     virtual AccountIDCache const&   accountIDCache() const = 0;
     virtual OpenLedger&             openLedger() = 0;
+    virtual OpenLedger const&       openLedger() const = 0;
     virtual DatabaseCon& getTxnDB () = 0;
     virtual DatabaseCon& getLedgerDB () = 0;
 
@@ -156,12 +157,9 @@ public:
 
 std::unique_ptr <Application>
 make_Application(
-    std::unique_ptr<Config const> config,
-    std::unique_ptr<Logs> logs);
-
-extern
-void
-setupConfigForUnitTests (Config& config);
+    std::unique_ptr<Config> config,
+    std::unique_ptr<Logs> logs,
+    std::unique_ptr<TimeKeeper> timeKeeper);
 
 }
 

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -190,7 +190,7 @@ void LoadManager::run ()
         }
         else
         {
-            std::this_thread::sleep_for (duration);
+            alertable_sleep_for(duration);
         }
     }
 

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -28,6 +28,7 @@
 #include <ripple/basics/ThreadName.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
+#include <ripple/core/TimeKeeper.h>
 #include <ripple/crypto/RandomNumbers.h>
 #include <ripple/json/to_string.h>
 #include <ripple/net/RPCCall.h>
@@ -162,37 +163,6 @@ void printHelp (const po::options_description& desc)
 
 //------------------------------------------------------------------------------
 
-static int runShutdownTests (std::unique_ptr<Config> config)
-{
-    // Shutdown tests can not be part of the normal unit tests in 'runUnitTests'
-    // because it needs to create and destroy an application object.
-    // FIXME: we only loop once, since the Config object will get destroyed
-    int const numShutdownIterations = 1; //20;
-
-    // Give it enough time to sync and run a bit while synced.
-    std::chrono::seconds const serverUptimePerIteration (4 * 60);
-    for (int i = 0; i < numShutdownIterations; ++i)
-    {
-        std::cerr << "\n\nStarting server. Iteration: " << i << "\n"
-                  << std::endl;
-        auto app = make_Application (
-            std::move(config),
-            std::make_unique<Logs>());
-        auto shutdownApp = [&app](std::chrono::seconds sleepTime, int iteration)
-        {
-            std::this_thread::sleep_for (sleepTime);
-            std::cerr << "\n\nStopping server. Iteration: " << iteration << "\n"
-                      << std::endl;
-            app->signalStop();
-        };
-        std::thread shutdownThread (shutdownApp, serverUptimePerIteration, i);
-        setupServer(*app);
-        startServer(*app);
-        shutdownThread.join();
-    }
-    return EXIT_SUCCESS;
-}
-
 static int runUnitTests(
     std::string const& pattern,
     std::string const& argument)
@@ -265,7 +235,6 @@ int run (int argc, char** argv)
     ("rpc_ip", po::value <std::string> (), "Specify the IP address for RPC command. Format: <ip-address>[':'<port-number>]")
     ("rpc_port", po::value <std::uint16_t> (), "Specify the port number for RPC command.")
     ("standalone,a", "Run with no peers.")
-    ("shutdowntest", po::value <std::string> ()->implicit_value (""), "Perform shutdown tests.")
     ("unittest,u", po::value <std::string> ()->implicit_value (""), "Perform unit tests.")
     ("unittest-arg", po::value <std::string> ()->implicit_value (""), "Supplies argument to unit tests.")
     ("parameters", po::value< vector<string> > (), "Specify comma separated parameters.")
@@ -325,7 +294,6 @@ int run (int argc, char** argv)
         && !vm.count ("parameters")
         && !vm.count ("fg")
         && !vm.count ("standalone")
-        && !vm.count ("shutdowntest")
         && !vm.count ("unittest"))
     {
         std::string logMe = DoSustain ();
@@ -471,13 +439,12 @@ int run (int argc, char** argv)
         }
     }
 
-    if (vm.count ("shutdowntest"))
-        return runShutdownTests (std::move(config));
-
     // No arguments. Run server.
     if (!vm.count ("parameters"))
     {
         auto logs = std::make_unique<Logs>();
+        auto timeKeeper = make_TimeKeeper(
+            logs->journal("TimeKeeper"));
 
         if (vm.count ("quiet"))
             logs->severity (beast::Journal::kFatal);
@@ -486,9 +453,10 @@ int run (int argc, char** argv)
         else
             logs->severity (beast::Journal::kInfo);
 
-        auto app = make_Application (
+        auto app = make_Application(
             std::move(config),
-            std::move (logs));
+            std::move(logs),
+            std::move(timeKeeper));
         setupServer (*app);
         startServer (*app);
         return 0;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -350,7 +350,8 @@ public:
     Json::Value getServerInfo (bool human, bool admin) override;
     void clearLedgerFetch () override;
     Json::Value getLedgerFetchInfo () override;
-    std::uint32_t acceptLedger () override;
+    std::uint32_t acceptLedger (
+        boost::optional<std::chrono::milliseconds> consensusDelay) override;
     uint256 getConsensusLCL () override;
     void reportFeeChange () override;
 
@@ -2465,7 +2466,8 @@ bool NetworkOPsImp::unsubBook (std::uint64_t uSeq, Book const& book)
     return true;
 }
 
-std::uint32_t NetworkOPsImp::acceptLedger ()
+std::uint32_t NetworkOPsImp::acceptLedger (
+    boost::optional<std::chrono::milliseconds> consensusDelay)
 {
     // This code-path is exclusively used when the server is in standalone
     // mode via `ledger_accept`
@@ -2477,7 +2479,7 @@ std::uint32_t NetworkOPsImp::acceptLedger ()
     // FIXME Could we improve on this and remove the need for a specialized
     // API in LedgerConsensus?
     beginConsensus (m_ledgerMaster.getClosedLedger ()->getHash ());
-    mLedgerConsensus->simulate ();
+    mLedgerConsensus->simulate (consensusDelay);
     return m_ledgerMaster.getCurrentLedger ()->info().seq;
 }
 

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -190,7 +190,8 @@ public:
         performs a virtual consensus round, with all the transactions we are
         proposing being accepted.
     */
-    virtual std::uint32_t acceptLedger () = 0;
+    virtual std::uint32_t acceptLedger (
+        boost::optional<std::chrono::milliseconds> consensusDelay = boost::none) = 0;
 
     virtual uint256 getConsensusLCL () = 0;
 

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -214,8 +214,7 @@ public:
         @return Whether any txs were added to the view.
     */
     bool
-    accept(Application& app, OpenView& view,
-        ApplyFlags flags = tapNONE);
+    accept(Application& app, OpenView& view);
 
     /**
         We have a new last validated ledger, update and clean up the
@@ -233,8 +232,7 @@ public:
     */
     void
     processValidatedLedger(Application& app,
-        OpenView const& view, bool timeLeap,
-            ApplyFlags flags = tapNONE);
+        OpenView const& view, bool timeLeap);
 
     /** Used by tests only.
     */

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -304,9 +304,8 @@ TxQ::apply(Application& app, OpenView& view,
         ApplyFlags flags, beast::Journal j)
 {
     auto const allowEscalation =
-        (flags & tapENABLE_TESTING) ||
-            (view.rules().enabled(featureFeeEscalation,
-                app.config().features));
+        (view.rules().enabled(featureFeeEscalation,
+            app.config().features));
     if (!allowEscalation)
     {
         return ripple::apply(app, view, *tx, flags, j);
@@ -502,11 +501,9 @@ TxQ::apply(Application& app, OpenView& view,
 
 void
 TxQ::processValidatedLedger(Application& app,
-    OpenView const& view, bool timeLeap,
-        ApplyFlags flags)
+    OpenView const& view, bool timeLeap)
 {
     auto const allowEscalation =
-        (flags & tapENABLE_TESTING) ||
         (view.rules().enabled(featureFeeEscalation,
             app.config().features));
     if (!allowEscalation)
@@ -560,10 +557,9 @@ TxQ::processValidatedLedger(Application& app,
 
 bool
 TxQ::accept(Application& app,
-    OpenView& view, ApplyFlags flags)
+    OpenView& view)
 {
     auto const allowEscalation =
-        (flags & tapENABLE_TESTING) ||
         (view.rules().enabled(featureFeeEscalation,
             app.config().features));
     if (!allowEscalation)

--- a/src/ripple/app/tests/MultiSign.test.cpp
+++ b/src/ripple/app/tests/MultiSign.test.cpp
@@ -17,6 +17,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/protocol/JsonFields.h>     // jss:: definitions
+#include <ripple/protocol/Feature.h>
 #include <ripple/test/jtx.h>
 
 namespace ripple {
@@ -38,7 +39,7 @@ public:
     void test_noReserve()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::secp256k1};
 
         // Pay alice enough to meet the initial reserve, but not enough to
@@ -86,7 +87,7 @@ public:
     void test_signerListSet()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::ed25519};
         env.fund(XRP(1000), alice);
 
@@ -131,7 +132,7 @@ public:
     void test_phantomSigners()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::ed25519};
         env.fund(XRP(1000), alice);
         env.close();
@@ -225,22 +226,15 @@ public:
         env.fund(XRP(1000), alice);
         env.close();
 
-        // Add a signer list to alice.  Should succeed.
-        env(signers(alice, 1, {{bogie, 1}}));
+        // Make sure multisign is disabled in production.
+        // NOTE: These six tests will fail when multisign is default enabled.
+        env.disable_testing();
+        env(signers(alice, 1, {{bogie, 1}}), ter(temDISABLED));
         env.close();
-        env.require (owners (alice, 3));
+        env.require (owners (alice, 0));
 
-        // alice multisigns a transaction.  Should succeed.
         std::uint32_t aliceSeq = env.seq (alice);
         auto const baseFee = env.app().config().FEE_DEFAULT;
-        env(noop(alice), msig(bogie), fee(2 * baseFee));
-        env.close();
-        expect (env.seq(alice) == aliceSeq + 1);
-
-        // Make sure multisign is disabled in production.
-        // NOTE: These four tests will fail when multisign is default enabled.
-        env.disable_testing();
-        aliceSeq = env.seq (alice);
         env(noop(alice), msig(bogie), fee(2 * baseFee), ter(temINVALID));
         env.close();
         expect (env.seq(alice) == aliceSeq);
@@ -253,7 +247,7 @@ public:
     void test_fee ()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::ed25519};
         env.fund(XRP(1000), alice);
         env.close();
@@ -303,7 +297,7 @@ public:
     void test_misorderedSigners()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::ed25519};
         env.fund(XRP(1000), alice);
         env.close();
@@ -325,7 +319,7 @@ public:
     void test_masterSigners()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::ed25519};
         Account const becky {"becky", KeyType::secp256k1};
         Account const cheri {"cheri", KeyType::ed25519};
@@ -377,7 +371,7 @@ public:
     void test_regularSigners()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::secp256k1};
         Account const becky {"becky", KeyType::ed25519};
         Account const cheri {"cheri", KeyType::secp256k1};
@@ -436,7 +430,7 @@ public:
     void test_heterogeneousSigners()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::secp256k1};
         Account const becky {"becky", KeyType::ed25519};
         Account const cheri {"cheri", KeyType::secp256k1};
@@ -551,7 +545,7 @@ public:
     void test_keyDisable()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::ed25519};
         env.fund(XRP(1000), alice);
 
@@ -626,7 +620,7 @@ public:
     void test_regKey()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::secp256k1};
         env.fund(XRP(1000), alice);
 
@@ -658,7 +652,7 @@ public:
     void test_txTypes()
     {
         using namespace jtx;
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         Account const alice {"alice", KeyType::secp256k1};
         Account const becky {"becky", KeyType::ed25519};
         Account const zelda {"zelda", KeyType::secp256k1};

--- a/src/ripple/app/tests/Offer.test.cpp
+++ b/src/ripple/app/tests/Offer.test.cpp
@@ -149,8 +149,11 @@ public:
 
         auto const switchoverTime = STAmountCalcSwitchovers::enableUnderflowFixCloseTime ();
 
-        for (auto timeDelta : {-10s, 10s}){
-            NetClock::time_point const closeTime = switchoverTime + timeDelta;
+        for (auto timeDelta : {
+            - env.closed()->info().closeTimeResolution,
+                env.closed()->info().closeTimeResolution} )
+        {
+            auto const closeTime = switchoverTime + timeDelta;
             STAmountCalcSwitchovers switchover (closeTime);
             env.close (closeTime);
             // Will fail without the underflow fix

--- a/src/ripple/app/tests/Path_test.cpp
+++ b/src/ripple/app/tests/Path_test.cpp
@@ -141,7 +141,7 @@ find_paths(jtx::Env& env,
             boost::optional<STAmount> const& saSendMax = boost::none)
 {
     static int const level = 8;
-    auto const& view = env.open ();
+    auto const& view = env.current();
     auto cache = std::make_shared<RippleLineCache>(view);
     auto currencies = accountSourceCurrencies(src, cache, true);
     auto jvSrcCurrencies = Json::Value(Json::arrayValue);

--- a/src/ripple/app/tests/Regression_test.cpp
+++ b/src/ripple/app/tests/Regression_test.cpp
@@ -66,8 +66,7 @@ struct Regression_test : public beast::unit_test::suite
             OpenView accum(&*next);
 
             auto const result = ripple::apply(env.app(),
-                accum, *jt.stx, tapENABLE_TESTING,
-                    env.journal);
+                accum, *jt.stx, tapNONE, env.journal);
             expect(result.first == tesSUCCESS);
             expect(result.second);
 
@@ -93,8 +92,7 @@ struct Regression_test : public beast::unit_test::suite
             OpenView accum(&*next);
 
             auto const result = ripple::apply(env.app(),
-                accum, *jt.stx, tapENABLE_TESTING,
-                    env.journal);
+                accum, *jt.stx, tapNONE, env.journal);
             expect(result.first == tecINSUFF_FEE);
             expect(result.second);
 

--- a/src/ripple/app/tests/SetAuth_test.cpp
+++ b/src/ripple/app/tests/SetAuth_test.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/test/jtx.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 
 namespace ripple {
@@ -52,13 +53,12 @@ struct SetAuth_test : public beast::unit_test::suite
         auto const USD = gw["USD"];
         {
             Env env(*this);
-            env.disable_testing();
             env.fund(XRP(100000), "alice", gw);
             env(fset(gw, asfRequireAuth));
             env(auth(gw, "alice", "USD"),       ter(tecNO_LINE_REDUNDANT));
         }
         {
-            Env env(*this);
+            Env env(*this, features(featureTrustSetAuth));
             env.fund(XRP(100000), "alice", "bob", gw);
             env(fset(gw, asfRequireAuth));
             env(auth(gw, "alice", "USD"));

--- a/src/ripple/app/tests/SusPay_test.cpp
+++ b/src/ripple/app/tests/SusPay_test.cpp
@@ -148,7 +148,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob");
             auto const c = cond("receipt");
             // syntax
@@ -171,7 +171,7 @@ struct SusPay_test : public beast::unit_test::suite
             Env env(*this);
             auto const alice = Account("alice");
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), alice, "bob");
             auto const c = cond("receipt");
             auto const seq = env.seq(alice);
@@ -192,7 +192,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob");
             auto const c = cond("receipt");
             // VFALCO Should we enforce this?
@@ -224,7 +224,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob");
             auto const seq = env.seq("alice");
             env(lockup("alice", "alice", XRP(1000), T(S{1})));
@@ -246,7 +246,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
             auto const c = cond("receipt");
             auto const seq = env.seq("alice");
@@ -272,7 +272,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
             auto const c = cond("receipt");
             auto const seq = env.seq("alice");
@@ -289,7 +289,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
             env.close();
             auto const c = cond("receipt");
@@ -308,7 +308,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
             auto const c = cond("receipt");
             auto const seq = env.seq("alice");
@@ -320,7 +320,7 @@ struct SusPay_test : public beast::unit_test::suite
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
-                { return env.clock.now() + d; };
+                { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
             auto const p = from_hex_text<uint128>(
                 "0102030405060708090A0B0C0D0E0F");
@@ -340,7 +340,7 @@ struct SusPay_test : public beast::unit_test::suite
         using S = seconds;
         Env env(*this);
         auto T = [&env](NetClock::duration const& d)
-            { return env.clock.now() + d; };
+            { return env.now() + d; };
         env.fund(XRP(5000), "alice", "bob", "carol");
         auto const c = cond("receipt");
         env(condpay("alice", "carol", XRP(1000), c.first, T(S{1})));

--- a/src/ripple/app/tests/SusPay_test.cpp
+++ b/src/ripple/app/tests/SusPay_test.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/test/jtx.h>
 #include <ripple/protocol/digest.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/TxFlags.h>
@@ -145,15 +146,20 @@ struct SusPay_test : public beast::unit_test::suite
         using namespace jtx;
         using namespace std::chrono;
         using S = seconds;
+        auto const c = cond("receipt");
+        {
+            Env env(*this, features(featureSusPay));
+            auto T = [&env](NetClock::duration const& d)
+                { return env.now() + d; };
+            env.fund(XRP(5000), "alice", "bob");
+            // syntax
+            env(condpay("alice", "bob", XRP(1000), c.first, T(S{1})));
+        }
         {
             Env env(*this);
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob");
-            auto const c = cond("receipt");
-            // syntax
-            env(condpay("alice", "bob", XRP(1000), c.first, T(S{1})));
-            env.disable_testing();
             // disabled in production
             env(condpay("alice", "bob", XRP(1000), c.first, T(S{1})),       ter(temDISABLED));
             env(finish("bob", "alice", 1),                                  ter(temDISABLED));
@@ -168,7 +174,7 @@ struct SusPay_test : public beast::unit_test::suite
         using namespace std::chrono;
         using S = seconds;
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto const alice = Account("alice");
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
@@ -190,7 +196,7 @@ struct SusPay_test : public beast::unit_test::suite
         using namespace std::chrono;
         using S = seconds;
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob");
@@ -222,7 +228,7 @@ struct SusPay_test : public beast::unit_test::suite
         using namespace std::chrono;
         using S = seconds;
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob");
@@ -244,7 +250,7 @@ struct SusPay_test : public beast::unit_test::suite
         using namespace std::chrono;
         using S = seconds;
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
@@ -270,7 +276,7 @@ struct SusPay_test : public beast::unit_test::suite
             env.close();
         }
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
@@ -287,7 +293,7 @@ struct SusPay_test : public beast::unit_test::suite
             expect(! env.le(keylet::susPay(Account("alice").id(), seq)));
         }
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
@@ -306,7 +312,7 @@ struct SusPay_test : public beast::unit_test::suite
             env.require(balance("carol", XRP(5000)));
         }
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
@@ -318,7 +324,7 @@ struct SusPay_test : public beast::unit_test::suite
             env(finish("bob", "alice", seq, cx.first, cx.second),           ter(tecNO_PERMISSION));
         }
         {
-            Env env(*this);
+            Env env(*this, features(featureSusPay));
             auto T = [&env](NetClock::duration const& d)
                 { return env.now() + d; };
             env.fund(XRP(5000), "alice", "bob", "carol");
@@ -338,7 +344,7 @@ struct SusPay_test : public beast::unit_test::suite
         using namespace jtx;
         using namespace std::chrono;
         using S = seconds;
-        Env env(*this);
+        Env env(*this, features(featureSusPay));
         auto T = [&env](NetClock::duration const& d)
             { return env.now() + d; };
         env.fund(XRP(5000), "alice", "bob", "carol");

--- a/src/ripple/app/tests/TxQ_test.cpp
+++ b/src/ripple/app/tests/TxQ_test.cpp
@@ -20,9 +20,11 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/app/ledger/LedgerConsensus.h>
+#include <ripple/app/tx/apply.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/TestSuite.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/test/jtx.h>
@@ -58,41 +60,6 @@ class TxQ_test : public TestSuite
         expect(metrics.expFeeLevel == expectedCurFeeLevel, "expFeeLevel");
     }
 
-    void
-    close(jtx::Env& env, size_t expectedTxSetSize, bool timeLeap = false)
-    {
-        {
-            auto const view = env.current();
-            expect(view->txCount() == expectedTxSetSize, "TxSet size mismatch");
-        }
-        env.close();
-    }
-
-    void
-    submit(jtx::Env& env, jtx::JTx const& jt)
-    {
-        // Env checks this, but this test shouldn't
-        // generate any malformed txns.
-        expect(jt.stx);
-
-        bool didApply;
-        TER ter;
-
-        env.app().openLedger().modify(
-            [&](OpenView& view, beast::Journal j)
-            {
-                std::tie(ter, didApply) =
-                    env.app().getTxQ().apply(env.app(),
-                        view, jt.stx, tapENABLE_TESTING,
-                            env.journal);
-
-                return didApply;
-            }
-        );
-
-        env.postconditions(jt, ter, didApply);
-    }
-
     static
     std::unique_ptr<Config>
     makeConfig()
@@ -111,8 +78,9 @@ public:
     void testQueue()
     {
         using namespace jtx;
+        using namespace std::chrono;
 
-        Env env(*this, makeConfig());
+        Env env(*this, makeConfig(), features(featureFeeEscalation));
 
         auto& txq = env.app().getTxQ();
         txq.setMinimumTx(3);
@@ -137,14 +105,12 @@ public:
         checkMetrics(env, 0, boost::none, 4, 3, 256, 500);
 
         // Alice - price starts exploding: held
-        submit(env,
-            env.jt(noop(alice), queued));
+        env(noop(alice), queued);
         checkMetrics(env, 1, boost::none, 4, 3, 256, 500);
 
         // Alice - Alice is already in the queue, so can't hold.
-        submit(env,
-            env.jt(noop(alice), seq(env.seq(alice) + 1),
-                ter(telINSUF_FEE_P)));
+        env(noop(alice), seq(env.seq(alice) + 1),
+            ter(telINSUF_FEE_P));
         checkMetrics(env, 1, boost::none, 4, 3, 256, 500);
 
         auto openLedgerFee = 
@@ -154,22 +120,19 @@ public:
             };
         // Alice's next transaction -
         // fails because the item in the TxQ hasn't applied.
-        submit(env,
-            env.jt(noop(alice), openLedgerFee(),
-                seq(env.seq(alice) + 1), ter(terPRE_SEQ)));
+        env(noop(alice), openLedgerFee(),
+            seq(env.seq(alice) + 1), ter(terPRE_SEQ));
         checkMetrics(env, 1, boost::none, 4, 3, 256, 500);
 
         // Bob with really high fee - applies
-        submit(env,
-            env.jt(noop(bob), openLedgerFee()));
+        env(noop(bob), openLedgerFee());
         checkMetrics(env, 1, boost::none, 5, 3, 256, 500);
 
         // Daria with low fee: hold
-        submit(env,
-            env.jt(noop(daria), fee(1000), queued));
+        env(noop(daria), fee(1000), queued);
         checkMetrics(env, 2, boost::none, 5, 3, 256, 500);
 
-        close(env, 5);
+        env.close();
         // Verify that the held transactions got applied
         auto lastMedian = 500;
         checkMetrics(env, 0, 10, 2, 5, 256, lastMedian);
@@ -181,27 +144,19 @@ public:
         checkMetrics(env, 0, 10, 6, 5, 256, lastMedian);
 
         // Now get a bunch of transactions held.
-        submit(env,
-            env.jt(noop(alice), fee(12), queued));
+        env(noop(alice), fee(12), queued);
         checkMetrics(env, 1, 10, 6, 5, 256, lastMedian);
 
-        submit(env,
-            env.jt(noop(bob), fee(10), queued)); // won't clear the queue
-        submit(env,
-            env.jt(noop(charlie), fee(20), queued));
-        submit(env,
-            env.jt(noop(daria), fee(15), queued));
-        submit(env,
-            env.jt(noop(elmo), fee(11), queued));
-        submit(env,
-            env.jt(noop(fred), fee(19), queued));
-        submit(env,
-            env.jt(noop(gwen), fee(16), queued));
-        submit(env,
-            env.jt(noop(hank), fee(18), queued));
+        env(noop(bob), fee(10), queued); // won't clear the queue
+        env(noop(charlie), fee(20), queued);
+        env(noop(daria), fee(15), queued);
+        env(noop(elmo), fee(11), queued);
+        env(noop(fred), fee(19), queued);
+        env(noop(gwen), fee(16), queued);
+        env(noop(hank), fee(18), queued);
         checkMetrics(env, 8, 10, 6, 5, 256, lastMedian);
 
-        close(env, 6);
+        env.close();
         // Verify that the held transactions got applied
         lastMedian = 500;
         checkMetrics(env, 1, 12, 7, 6, 256, lastMedian);
@@ -211,40 +166,35 @@ public:
         //////////////////////////////////////////////////////////////
 
         // Hank sends another txn
-        submit(env,
-            env.jt(noop(hank), fee(10), queued));
+        env(noop(hank), fee(10), queued);
         // But he's not going to leave it in the queue
         checkMetrics(env, 2, 12, 7, 6, 256, lastMedian);
 
         // Hank sees his txn  got held and bumps the fee,
         // but doesn't even bump it enough to requeue
-        submit(env,
-            env.jt(noop(hank), fee(11), ter(telINSUF_FEE_P)));
+        env(noop(hank), fee(11), ter(telINSUF_FEE_P));
         checkMetrics(env, 2, 12, 7, 6, 256, lastMedian);
 
         // Hank sees his txn got held and bumps the fee,
         // enough to requeue, but doesn't bump it enough to
         // apply to the ledger
-        submit(env,
-            env.jt(noop(hank), fee(6000), queued));
+        env(noop(hank), fee(6000), queued);
         // But he's not going to leave it in the queue
         checkMetrics(env, 2, 12, 7, 6, 256, lastMedian);
 
         // Hank sees his txn got held and bumps the fee,
         // high enough to get into the open ledger, because
         // he doesn't want to wait.
-        submit(env,
-            env.jt(noop(hank), openLedgerFee()));
+        env(noop(hank), openLedgerFee());
         checkMetrics(env, 1, 12, 8, 6, 256, lastMedian);
 
         // Hank then sends another, less important txn
         // (In addition to the metrics, this will verify that
         //  the original txn got removed.)
-        submit(env,
-            env.jt(noop(hank), fee(6000), queued));
+        env(noop(hank), fee(6000), queued);
         checkMetrics(env, 2, 12, 8, 6, 256, lastMedian);
 
-        close(env, 8);
+        env.close();
 
         // Verify that bob and hank's txns were applied
         lastMedian = 500;
@@ -253,12 +203,12 @@ public:
         // Close again with a simulated time leap to
         // reset the escalation limit down to minimum
         lastMedian = 76928;
-        close(env, 2, true);
+        env.close(env.now() + 5s, 10000ms);
         checkMetrics(env, 0, 16, 0, 3, 256, lastMedian);
         // Then close once more without the time leap
         // to reset the queue maxsize down to minimum
         lastMedian = 500;
-        close(env, 0);
+        env.close();
         checkMetrics(env, 0, 6, 0, 3, 256, lastMedian);
 
         //////////////////////////////////////////////////////////////
@@ -266,56 +216,44 @@ public:
         // At this point, the queue should have a limit of 6.
         // Stuff the ledger and queue so we can verify that
         // stuff gets kicked out.
-        submit(env,
-            env.jt(noop(hank)));
-        submit(env,
-            env.jt(noop(gwen)));
-        submit(env,
-            env.jt(noop(fred)));
-        submit(env,
-            env.jt(noop(elmo)));
+        env(noop(hank));
+        env(noop(gwen));
+        env(noop(fred));
+        env(noop(elmo));
         checkMetrics(env, 0, 6, 4, 3, 256, lastMedian);
 
         // Use explicit fees so we can control which txn
         // will get dropped
-        submit(env,
-            env.jt(noop(alice), fee(20), queued));
-        submit(env,
-            env.jt(noop(hank), fee(19), queued));
-        submit(env,
-            env.jt(noop(gwen), fee(18), queued));
-        submit(env,
-            env.jt(noop(fred), fee(17), queued));
-        submit(env,
-            env.jt(noop(elmo), fee(16), queued));
+        env(noop(alice), fee(20), queued);
+        env(noop(hank), fee(19), queued);
+        env(noop(gwen), fee(18), queued);
+        env(noop(fred), fee(17), queued);
+        env(noop(elmo), fee(16), queued);
         // This one gets into the queue, but gets dropped when the
         // higher fee one is added later.
-        submit(env,
-            env.jt(noop(daria), fee(15), queued));
+        env(noop(daria), fee(15), queued);
 
         // Queue is full now.
         checkMetrics(env, 6, 6, 4, 3, 385, lastMedian);
 
         // Try to add another transaction with the default (low) fee,
         // it should fail because the queue is full.
-        submit(env,
-            env.jt(noop(charlie), ter(telINSUF_FEE_P)));
+        env(noop(charlie), ter(telINSUF_FEE_P));
 
         // Add another transaction, with a higher fee,
         // Not high enough to get into the ledger, but high
         // enough to get into the queue (and kick somebody out)
-        submit(env,
-            env.jt(noop(charlie), fee(100), queued));
+        env(noop(charlie), fee(100), queued);
 
         // Queue is still full, of course, but the min fee has gone up
         checkMetrics(env, 6, 6, 4, 3, 410, lastMedian);
 
-        close(env, 4);
+        env.close();
         lastMedian = 500;
         checkMetrics(env, 1, 8, 5, 4, 256, lastMedian);
 
         lastMedian = 500;
-        close(env, 5);
+        env.close();
         checkMetrics(env, 0, 10, 1, 5, 256, lastMedian);
 
         //////////////////////////////////////////////////////////////
@@ -332,13 +270,11 @@ public:
         // Stuff the ledger.
         for (int i = 0; i <= txnsNeeded; ++i)
         {
-            submit(env,
-                env.jt(noop(env.master)));
+            env(noop(env.master));
         }
 
         // Queue one straightforward transaction
-        submit(env,
-            env.jt(noop(env.master), fee(20), queued));
+        env(noop(env.master), fee(20), queued);
         ++metrics.txCount;
 
         checkMetrics(env, metrics.txCount,
@@ -350,8 +286,9 @@ public:
     void testLastLedgerSeq()
     {
         using namespace jtx;
+        using namespace std::chrono;
 
-        Env env(*this, makeConfig());
+        Env env(*this, makeConfig(), features(featureFeeEscalation));
 
         auto& txq = env.app().getTxQ();
         txq.setMinimumTx(2);
@@ -367,53 +304,43 @@ public:
 
         checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
 
-        // Fund these accounts and close the ledger without
-        // involving the queue, so that stats aren't affected.
-        env.fund(XRP(1000), noripple(alice, bob, charlie, daria, edgar, felicia));
-        env.close();
+        // Fund across several ledgers so the TxQ metrics stay restricted.
+        env.fund(XRP(1000), noripple(alice, bob));
+        env.close(env.now() + 5s, 10000ms);
+        env.fund(XRP(1000), noripple(charlie, daria));
+        env.close(env.now() + 5s, 10000ms);
+        env.fund(XRP(1000), noripple(edgar, felicia));
+        env.close(env.now() + 5s, 10000ms);
 
         checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
-        submit(env,
-            env.jt(noop(bob)));
-        submit(env,
-            env.jt(noop(charlie)));
-        submit(env,
-            env.jt(noop(daria)));
+        env(noop(bob));
+        env(noop(charlie));
+        env(noop(daria));
         checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
 
         // Queue an item with a LastLedgerSeq.
-        submit(env,
-            env.jt(noop(alice), json(R"({"LastLedgerSequence":4})"),
-                queued));
+        env(noop(alice), json(R"({"LastLedgerSequence":7})"),
+            queued);
         // Queue items with higher fees to force the previous
         // txn to wait.
-        submit(env,
-            env.jt(noop(bob), fee(20), queued));
-        submit(env,
-            env.jt(noop(charlie), fee(20), queued));
-        submit(env,
-            env.jt(noop(daria), fee(20), queued));
-        submit(env,
-            env.jt(noop(edgar), fee(20), queued));
+        env(noop(bob), fee(20), queued);
+        env(noop(charlie), fee(20), queued);
+        env(noop(daria), fee(20), queued);
+        env(noop(edgar), fee(20), queued);
         checkMetrics(env, 5, boost::none, 3, 2, 256, 500);
 
-        close(env, 3);
+        env.close();
         checkMetrics(env, 1, 6, 4, 3, 256, 500);
 
         // Keep alice's transaction waiting.
-        submit(env,
-            env.jt(noop(bob), fee(20), queued));
-        submit(env,
-            env.jt(noop(charlie), fee(20), queued));
-        submit(env,
-            env.jt(noop(daria), fee(20), queued));
-        submit(env,
-            env.jt(noop(edgar), fee(20), queued));
-        submit(env,
-            env.jt(noop(felicia), fee(20), queued));
+        env(noop(bob), fee(20), queued);
+        env(noop(charlie), fee(20), queued);
+        env(noop(daria), fee(20), queued);
+        env(noop(edgar), fee(20), queued);
+        env(noop(felicia), fee(20), queued);
         checkMetrics(env, 6, 6, 4, 3, 257, 500);
 
-        close(env, 4);
+        env.close();
         // alice's transaction expired without getting
         // into the ledger, so the queue is now empty.
         checkMetrics(env, 0, 8, 5, 4, 256, 512);
@@ -423,8 +350,9 @@ public:
     void testZeroFeeTxn()
     {
         using namespace jtx;
+        using namespace std::chrono;
 
-        Env env(*this, makeConfig());
+        Env env(*this, makeConfig(), features(featureFeeEscalation));
 
         auto& txq = env.app().getTxQ();
         txq.setMinimumTx(2);
@@ -439,24 +367,22 @@ public:
         // Fund these accounts and close the ledger without
         // involving the queue, so that stats aren't affected.
         env.fund(XRP(1000), noripple(alice, bob));
-        env.close();
+        env.close(env.now() + 5s, 10000ms);
 
         // Fill the ledger
-        submit(env, env.jt(noop(alice)));
-        submit(env, env.jt(noop(alice)));
-        submit(env, env.jt(noop(alice)));
+        env(noop(alice));
+        env(noop(alice));
+        env(noop(alice));
         checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
 
-        submit(env,
-            env.jt(noop(bob), queued));
+        env(noop(bob), queued);
         checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
 
         // Even though this transaction has a 0 fee,
         // SetRegularKey::calculateBaseFee indicates this is
         // a "free" transaction, so it has an "infinite" fee
         // level and goes into the open ledger.
-        submit(env,
-            env.jt(regkey(alice, bob), fee(0)));
+        env(regkey(alice, bob), fee(0));
         checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
 
         // This transaction also has an "infinite" fee level,
@@ -465,9 +391,8 @@ public:
         // with terPRE_SEQ (notably, *not* telINSUF_FEE_P).
         // This implicitly relies on preclaim succeeding and
         // canBeHeld failing under the hood.
-        submit(env,
-            env.jt(regkey(bob, alice), fee(0),
-                seq(env.seq(bob) + 1), ter(terPRE_SEQ)));
+        env(regkey(bob, alice), fee(0),
+            seq(env.seq(bob) + 1), ter(terPRE_SEQ));
         checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
 
     }
@@ -476,7 +401,7 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig());
+        Env env(*this, makeConfig(), features(featureFeeEscalation));
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -488,21 +413,19 @@ public:
         // expected.
 
         // Fail in preflight
-        submit(env,
-            env.jt(pay(alice, bob, XRP(-1000)),
-                ter(temBAD_AMOUNT)));
+        env(pay(alice, bob, XRP(-1000)),
+            ter(temBAD_AMOUNT));
 
         // Fail in preclaim
-        submit(env,
-            env.jt(noop(alice), fee(XRP(100000)),
-                ter(terINSUF_FEE_B)));
+        env(noop(alice), fee(XRP(100000)),
+            ter(terINSUF_FEE_B));
     }
 
     void testQueuedFailure()
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig());
+        Env env(*this, makeConfig(), features(featureFeeEscalation));
 
         auto& txq = env.app().getTxQ();
         txq.setMinimumTx(2);
@@ -519,18 +442,36 @@ public:
         checkMetrics(env, 0, boost::none, 2, 2, 256, 500);
 
         // Fill the ledger
-        submit(env, env.jt(noop(alice)));
+        env(noop(alice));
         checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
 
         // Put a transaction in the queue
-        submit(env, env.jt(noop(alice), queued));
+        env(noop(alice), queued);
         checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
 
         // Now cheat, and bypass the queue.
-        env(noop(alice));
+        {
+            auto const& jt = env.jt(noop(alice));
+            expect(jt.stx);
+
+            bool didApply;
+            TER ter;
+
+            env.app().openLedger().modify(
+                [&](OpenView& view, beast::Journal j)
+                {
+                    std::tie(ter, didApply) =
+                        ripple::apply(env.app(),
+                            view, *jt.stx, tapNONE,
+                                env.journal);
+                    return didApply;
+                }
+                );
+            env.postconditions(jt, ter, didApply);
+        }
         checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
 
-        close(env, 4);
+        env.close();
         // Alice's queued transaction failed in TxQ::accept
         // with tefPAST_SEQ
         checkMetrics(env, 0, 8, 0, 4, 256, 500);

--- a/src/ripple/app/tx/impl/CancelTicket.cpp
+++ b/src/ripple/app/tx/impl/CancelTicket.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/tx/impl/CancelTicket.h>
 #include <ripple/basics/Log.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/ledger/View.h>
 
@@ -28,10 +29,9 @@ namespace ripple {
 TER
 CancelTicket::preflight (PreflightContext const& ctx)
 {
-#if ! RIPPLE_ENABLE_TICKETS
-    if (! (ctx.flags & tapENABLE_TESTING))
+    if (! ctx.rules.enabled(featureTickets,
+            ctx.app.config().features))
         return temDISABLED;
-#endif
 
     auto const ret = preflight1 (ctx);
     if (!isTesSuccess (ret))

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -21,6 +21,7 @@
 #include <ripple/app/tx/impl/CreateTicket.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/basics/Log.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 
 namespace ripple {
@@ -28,10 +29,9 @@ namespace ripple {
 TER
 CreateTicket::preflight (PreflightContext const& ctx)
 {
-#if ! RIPPLE_ENABLE_TICKETS
-    if (! (ctx.flags & tapENABLE_TESTING))
+    if (! ctx.rules.enabled(featureTickets,
+            ctx.app.config().features))
         return temDISABLED;
-#endif
 
     auto const ret = preflight1 (ctx);
     if (!isTesSuccess (ret))

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -253,9 +253,8 @@ SetAccount::doApply ()
             // Account has no regular key or multi-signer signer list.
 
             // Prevent transaction changes until we're ready.
-            if (view().flags() & tapENABLE_TESTING ||
-                    view().rules().enabled(featureMultiSign,
-                        ctx_.app.config().features))
+            if (view().rules().enabled(featureMultiSign,
+                    ctx_.app.config().features))
                 return tecNO_ALTERNATIVE_KEY;
 
             return tecNO_REGULAR_KEY;

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -73,9 +73,8 @@ SetSignerList::determineOperation(STTx const& tx,
 TER
 SetSignerList::preflight (PreflightContext const& ctx)
 {
-    if (! (ctx.flags & tapENABLE_TESTING) &&
-            ! ctx.rules.enabled(featureMultiSign,
-                ctx.app.config().features))
+    if (! ctx.rules.enabled(featureMultiSign,
+            ctx.app.config().features))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -430,9 +430,7 @@ SetTrust::doApply ()
     else if (! saLimitAmount &&                          // Setting default limit.
         (! bQualityIn || ! uQualityIn) &&           // Not setting quality in or setting default quality in.
         (! bQualityOut || ! uQualityOut) &&         // Not setting quality out or setting default quality out.
-        (! ((view().flags() & tapENABLE_TESTING) ||
-            view().rules().enabled(featureTrustSetAuth,
-                ctx_.app.config().features)) || ! bSetAuth))
+        (! (view().rules().enabled(featureTrustSetAuth, ctx_.app.config().features)) || ! bSetAuth))
     {
         j_.trace <<
             "Redundant: Setting non-existent ripple line to defaults.";

--- a/src/ripple/app/tx/impl/SusPay.cpp
+++ b/src/ripple/app/tx/impl/SusPay.cpp
@@ -131,8 +131,7 @@ namespace ripple {
 TER
 SusPayCreate::preflight (PreflightContext const& ctx)
 {
-    if (! (ctx.flags & tapENABLE_TESTING) &&
-        ! ctx.rules.enabled(featureSusPay,
+    if (! ctx.rules.enabled(featureSusPay,
             ctx.app.config().features))
         return temDISABLED;
 
@@ -251,8 +250,7 @@ SusPayCreate::doApply()
 TER
 SusPayFinish::preflight (PreflightContext const& ctx)
 {
-    if (! (ctx.flags & tapENABLE_TESTING) &&
-        ! ctx.rules.enabled(featureSusPay,
+    if (! ctx.rules.enabled(featureSusPay,
             ctx.app.config().features))
         return temDISABLED;
 
@@ -371,8 +369,7 @@ SusPayFinish::doApply()
 TER
 SusPayCancel::preflight (PreflightContext const& ctx)
 {
-    if (! (ctx.flags & tapENABLE_TESTING) &&
-        ! ctx.rules.enabled(featureSusPay,
+    if (! ctx.rules.enabled(featureSusPay,
             ctx.app.config().features))
         return temDISABLED;
 

--- a/src/ripple/app/tx/impl/SusPay.cpp
+++ b/src/ripple/app/tx/impl/SusPay.cpp
@@ -168,8 +168,9 @@ SusPayCreate::doApply()
                            weeks{1}).time_since_epoch().count();
     if (ctx_.tx[~sfDigest])
     {
-        if (! ctx_.tx[~sfCancelAfter] ||
-                maxExpire <= ctx_.tx[sfCancelAfter])
+        if (! ctx_.tx[~sfCancelAfter])
+            return tecNO_PERMISSION;
+        if (maxExpire <= ctx_.tx[sfCancelAfter])
             return tecNO_PERMISSION;
     }
     else

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -314,8 +314,7 @@ TER
 Transactor::checkSign (PreclaimContext const& ctx)
 {
     // Make sure multisigning is enabled before we check for multisignatures.
-    if ((ctx.flags & tapENABLE_TESTING) ||
-        (ctx.view.rules().enabled(featureMultiSign,
+    if ((ctx.view.rules().enabled(featureMultiSign,
             ctx.app.config().features)))
     {
         auto pk =

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -83,9 +83,8 @@ checkValidity(HashRouter& router,
             ApplyFlags const& flags)
 {
     auto const allowMultiSign =
-        (flags & tapENABLE_TESTING) ||
-            (rules.enabled(featureMultiSign,
-                config.features));
+        rules.enabled(featureMultiSign,
+            config.features);
 
     return checkValidity(router, tx, allowMultiSign);
 }

--- a/src/ripple/basics/chrono.h
+++ b/src/ripple/basics/chrono.h
@@ -55,10 +55,6 @@ public:
     static bool const is_steady = false;
 };
 
-/** A manual NetClock for unit tests. */
-using TestNetClock =
-    beast::manual_clock<NetClock>;
-
 /** A clock for measuring elapsed time.
 
     The epoch is unspecified.

--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -514,15 +514,20 @@ initAuthenticated (boost::asio::ssl::context& context,
 std::shared_ptr<boost::asio::ssl::context>
 make_SSLContext()
 {
-    std::shared_ptr<boost::asio::ssl::context> context =
-        std::make_shared<boost::asio::ssl::context> (
-            boost::asio::ssl::context::sslv23);
-    // By default, allow anonymous DH.
-    openssl::detail::initAnonymous (
-        *context, "ALL:!LOW:!EXP:!MD5:@STRENGTH");
-    // VFALCO NOTE, It seems the WebSocket context never has
-    // set_verify_mode called, for either setting of WEBSOCKET_SECURE
-    context->set_verify_mode (boost::asio::ssl::verify_none);
+    static auto const context =
+        []()
+        {
+            auto const context = std::make_shared<
+                boost::asio::ssl::context>(
+                    boost::asio::ssl::context::sslv23);
+            // By default, allow anonymous DH.
+            openssl::detail::initAnonymous(
+                *context, "ALL:!LOW:!EXP:!MD5:@STRENGTH");
+            // VFALCO NOTE, It seems the WebSocket context never has
+            // set_verify_mode called, for either setting of WEBSOCKET_SECURE
+            context->set_verify_mode(boost::asio::ssl::verify_none);
+            return context;
+        }();
     return context;
 }
 

--- a/src/ripple/core/TimeKeeper.h
+++ b/src/ripple/core/TimeKeeper.h
@@ -21,6 +21,7 @@
 #define RIPPLE_CORE_TIMEKEEPER_H_INCLUDED
 
 #include <beast/chrono/abstract_clock.h>
+#include <beast/utility/Journal.h>
 #include <ripple/basics/chrono.h>
 #include <string>
 #include <vector>
@@ -90,7 +91,6 @@ public:
     virtual
     std::chrono::duration<std::int32_t>
     closeOffset() const = 0;
-
 };
 
 extern

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -62,6 +62,11 @@ DatabaseCon::Setup setup_DatabaseCon (Config const& c)
     setup.startUp = c.START_UP;
     setup.standAlone = c.RUN_STANDALONE;
     setup.dataDir = c.legacy ("database_path");
+    if (!setup.standAlone && setup.dataDir.empty())
+    {
+        Throw<std::runtime_error>(
+            "database_path must be set.");
+    }
 
     return setup;
 }

--- a/src/ripple/core/impl/SociDB.cpp
+++ b/src/ripple/core/impl/SociDB.cpp
@@ -38,7 +38,7 @@ getSociSqliteInit (std::string const& name,
                    std::string const& dir,
                    std::string const& ext)
 {
-    if (dir.empty () || name.empty ())
+    if (name.empty ())
     {
         Throw<std::runtime_error> (
             "Sqlite databases must specify a dir and a name. Name: " +

--- a/src/ripple/ledger/tests/BookDirs_test.cpp
+++ b/src/ripple/ledger/tests/BookDirs_test.cpp
@@ -35,26 +35,26 @@ struct BookDirs_test : public beast::unit_test::suite
         {
             Book book(xrpIssue(), USD.issue());
             {
-                auto d = BookDirs(*env.open(), book);
+                auto d = BookDirs(*env.current(), book);
                 expect(std::begin(d) == std::end(d));
                 expect(std::distance(d.begin(), d.end()) == 0);
             }
             {
-                auto d = BookDirs(*env.open(), reversed(book));
+                auto d = BookDirs(*env.current(), reversed(book));
                 expect(std::distance(d.begin(), d.end()) == 0);
             }
         }
 
         {
             env(offer("alice", Account("alice")["USD"](50), XRP(10)));
-            auto d = BookDirs(*env.open(),
+            auto d = BookDirs(*env.current(),
                 Book(Account("alice")["USD"].issue(), xrpIssue()));
             expect(std::distance(d.begin(), d.end()) == 1);
         }
 
         {
             env(offer("alice", gw["CNY"](50), XRP(10)));
-            auto d = BookDirs(*env.open(),
+            auto d = BookDirs(*env.current(),
                 Book(gw["CNY"].issue(), xrpIssue()));
             expect(std::distance(d.begin(), d.end()) == 1);
         }
@@ -63,7 +63,7 @@ struct BookDirs_test : public beast::unit_test::suite
             env.trust(Account("bob")["CNY"](10), "alice");
             env(pay("bob", "alice", Account("bob")["CNY"](10)));
             env(offer("alice", USD(50), Account("bob")["CNY"](10)));
-            auto d = BookDirs(*env.open(),
+            auto d = BookDirs(*env.current(),
                 Book(USD.issue(), Account("bob")["CNY"].issue()));
             expect(std::distance(d.begin(), d.end()) == 1);
         }
@@ -74,7 +74,7 @@ struct BookDirs_test : public beast::unit_test::suite
                 for (auto k = 0; k < 80; ++k)
                     env(offer("alice", AUD(i), XRP(j)));
 
-            auto d = BookDirs(*env.open(),
+            auto d = BookDirs(*env.current(),
                 Book(AUD.issue(), xrpIssue()));
             expect(std::distance(d.begin(), d.end()) == 240);
             auto i = 1, j = 3, k = 0;

--- a/src/ripple/ledger/tests/Directory_test.cpp
+++ b/src/ripple/ledger/tests/Directory_test.cpp
@@ -32,7 +32,7 @@ struct Directory_test : public beast::unit_test::suite
         auto USD = gw["USD"];
 
         {
-            auto dir = Dir(*env.open(),
+            auto dir = Dir(*env.current(),
                 keylet::ownerDir(Account("alice")));
             expect(std::begin(dir) == std::end(dir));
             expect(std::end(dir) == dir.find(uint256(), uint256()));
@@ -46,13 +46,13 @@ struct Directory_test : public beast::unit_test::suite
         env(offer("bob", USD(500), XRP(10)));
 
         {
-            auto dir = Dir(*env.open(),
+            auto dir = Dir(*env.current(),
                 keylet::ownerDir(Account("bob")));
             expect(std::begin(dir)->get()->
                 getFieldAmount(sfTakerPays) == USD(500));
         }
 
-        auto dir = Dir(*env.open(),
+        auto dir = Dir(*env.current(),
             keylet::ownerDir(Account("alice")));
         i = 0;
         for (auto const& e : dir)

--- a/src/ripple/ledger/tests/PathSet.h
+++ b/src/ripple/ledger/tests/PathSet.h
@@ -34,7 +34,7 @@ isOffer (jtx::Env& env,
     STAmount const& takerGets)
 {
     bool exists = false;
-    forEachItem (*env.open(), account,
+    forEachItem (*env.current(), account,
         [&](std::shared_ptr<SLE const> const& sle)
         {
             if (sle->getType () == ltOFFER &&

--- a/src/ripple/ledger/tests/PaymentSandbox_test.cpp
+++ b/src/ripple/ledger/tests/PaymentSandbox_test.cpp
@@ -120,7 +120,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
         STAmount const toDebit (USD_gw1 (20));
         {
             // accountSend, no deferredCredits
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
 
             auto const iss = USD_gw1.issue ();
             auto const startingAmount = accountHolds (
@@ -139,7 +139,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
 
         {
             // rippleCredit, no deferredCredits
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
 
             auto const iss = USD_gw1.issue ();
             auto const startingAmount = accountHolds (
@@ -158,7 +158,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
 
         {
             // accountSend, w/ deferredCredits
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
             PaymentSandbox pv (&av);
 
             auto const iss = USD_gw1.issue ();
@@ -178,7 +178,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
 
         {
             // rippleCredit, w/ deferredCredits
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
             PaymentSandbox pv (&av);
 
             auto const iss = USD_gw1.issue ();
@@ -193,7 +193,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
 
         {
             // redeemIOU, w/ deferredCredits
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
             PaymentSandbox pv (&av);
 
             auto const iss = USD_gw1.issue ();
@@ -208,7 +208,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
 
         {
             // issueIOU, w/ deferredCredits
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
             PaymentSandbox pv (&av);
 
             auto const iss = USD_gw1.issue ();
@@ -223,7 +223,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
 
         {
             // accountSend, w/ deferredCredits and stacked views
-            ApplyViewImpl av (&*env.open(), tapNONE);
+            ApplyViewImpl av (&*env.current(), tapNONE);
             PaymentSandbox pv (&av);
 
             auto const iss = USD_gw1.issue ();

--- a/src/ripple/ledger/tests/View_test.cpp
+++ b/src/ripple/ledger/tests/View_test.cpp
@@ -183,8 +183,8 @@ class View_test
     {
         using namespace jtx;
         Env env(*this);
-        wipe(env.openLedger);
-        auto const open = env.open();
+        wipe(env.app().openLedger());
+        auto const open = env.current();
         ApplyViewImpl v(&*open, tapNONE);
         succ(v, 0, boost::none);
         v.insert(sle(1));
@@ -214,8 +214,8 @@ class View_test
     {
         using namespace jtx;
         Env env(*this);
-        wipe(env.openLedger);
-        auto const open = env.open();
+        wipe(env.app().openLedger());
+        auto const open = env.current();
         ApplyViewImpl v0(&*open, tapNONE);
         v0.insert(sle(1));
         v0.insert(sle(2));
@@ -278,8 +278,8 @@ class View_test
     {
         using namespace jtx;
         Env env(*this);
-        wipe(env.openLedger);
-        auto const open = env.open();
+        wipe(env.app().openLedger());
+        auto const open = env.current();
         ApplyViewImpl v0 (&*open, tapNONE);
         v0.rawInsert(sle(1, 1));
         v0.rawInsert(sle(2, 2));
@@ -345,8 +345,8 @@ class View_test
         using namespace std::chrono;
         {
             Env env(*this);
-            wipe(env.openLedger);
-            auto const open = env.open();
+            wipe(env.app().openLedger());
+            auto const open = env.current();
             OpenView v0(open.get());
             expect(v0.seq() != 98);
             expect(v0.seq() == open->seq());
@@ -556,9 +556,9 @@ class View_test
         // Make sure OpenLedger::empty works
         {
             Env env(*this);
-            expect(env.openLedger.empty());
+            expect(env.app().openLedger().empty());
             env.fund(XRP(10000), Account("test"));
-            expect(!env.openLedger.empty());
+            expect(! env.app().openLedger().empty());
         }
     }
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -35,6 +35,7 @@ feature (const char* name);
 /** @} */
 
 extern uint256 const featureMultiSign;
+extern uint256 const featureTickets;
 extern uint256 const featureSusPay;
 extern uint256 const featureTrustSetAuth;
 extern uint256 const featureFeeEscalation;

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -46,8 +46,8 @@ feature (const char* name)
 }
 
 uint256 const featureMultiSign = feature("MultiSign");
+uint256 const featureTickets = feature("Tickets");
 uint256 const featureSusPay = feature("SusPay");
 uint256 const featureTrustSetAuth = feature("TrustSetAuth");
 uint256 const featureFeeEscalation = feature("FeeEscalation");
-
 } // ripple

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -1658,7 +1658,7 @@ public:
         env(pay(g, env.master, USD(50)));
         env.close();
 
-        auto const ledger = env.open();
+        auto const ledger = env.current();
 
         ProcessTransactionFn processTxn = fakeProcessTransaction;
 

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -22,6 +22,7 @@
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/rpc/impl/TransactionSign.h>
 #include <ripple/test/jtx.h>
 #include <beast/unit_test/suite.h>
@@ -1648,7 +1649,7 @@ public:
         // "b" (not in the ledger) is rDg53Haik2475DJx8bjMDSDPj4VX7htaMd.
         // "c" (phantom signer) is rPcNzota6B8YBokhYtcTNqQVCngtbnWfux.
 
-        test::jtx::Env env(*this);
+        test::jtx::Env env(*this, test::jtx::features(featureMultiSign));
         env.fund(test::jtx::XRP(100000), a, g);
         env.close();
 

--- a/src/ripple/test/impl/ManualTimeKeeper.cpp
+++ b/src/ripple/test/impl/ManualTimeKeeper.cpp
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/test/ManualTimeKeeper.h>
+
+namespace ripple {
+namespace test {
+
+using namespace std::chrono_literals;
+
+ManualTimeKeeper::ManualTimeKeeper()
+    : closeOffset_ {}
+    , now_ (0s)
+{
+}
+
+void
+ManualTimeKeeper::run (std::vector<std::string> const& servers)
+{
+}
+
+auto
+ManualTimeKeeper::now() const ->
+    time_point
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return now_;
+}
+    
+auto
+ManualTimeKeeper::closeTime() const ->
+    time_point
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return now_ + closeOffset_;
+}
+
+void
+ManualTimeKeeper::adjustCloseTime(
+    std::chrono::duration<std::int32_t> amount)
+{
+    // Copied from TimeKeeper::adjustCloseTime
+    using namespace std::chrono;
+    auto const s = amount.count();
+    std::lock_guard<std::mutex> lock(mutex_);
+    // Take large offsets, ignore small offsets,
+    // push the close time towards our wall time.
+    if (s > 1)
+        closeOffset_ += seconds((s + 3) / 4);
+    else if (s < -1)
+        closeOffset_ += seconds((s - 3) / 4);
+    else
+        closeOffset_ = (closeOffset_ * 3) / 4;
+}
+
+std::chrono::duration<std::int32_t>
+ManualTimeKeeper::nowOffset() const
+{
+    return {};
+}
+
+std::chrono::duration<std::int32_t>
+ManualTimeKeeper::closeOffset() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return closeOffset_;
+}
+
+void
+ManualTimeKeeper::set (time_point now)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    now_ = now;
+}
+
+auto
+ManualTimeKeeper::adjust(
+        std::chrono::system_clock::time_point when) ->
+    time_point
+{
+    return time_point(
+        std::chrono::duration_cast<duration>(
+            when.time_since_epoch() -
+                days(10957)));
+}
+} // test
+} // ripple

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -224,7 +224,8 @@ public:
             the close time of the resulting ledger.
     */
     void
-    close (NetClock::time_point closeTime);
+    close (NetClock::time_point closeTime,
+        boost::optional<std::chrono::milliseconds> consensusDelay = boost::none);
 
     /** Close and advance the ledger.
 

--- a/src/ripple/test/jtx/impl/Account.cpp
+++ b/src/ripple/test/jtx/impl/Account.cpp
@@ -26,8 +26,16 @@ namespace ripple {
 namespace test {
 namespace jtx {
 
+std::unordered_map<
+    std::pair<std::string, KeyType>,
+        Account, beast::uhash<>> Account::cache_;
+
+Account const Account::master("master",
+    generateKeyPair(KeyType::secp256k1,
+        generateSeed("masterpassphrase")), Account::privateCtorTag{});
+
 Account::Account(std::string name,
-        std::pair<PublicKey, SecretKey> const& keys)
+        std::pair<PublicKey, SecretKey> const& keys, Account::privateCtorTag)
     : name_(std::move(name))
     , pk_ (keys.first)
     , sk_ (keys.second)
@@ -36,15 +44,23 @@ Account::Account(std::string name,
 {
 }
 
-Account::Account (std::string name, KeyType type)
-    : name_(std::move(name))
+Account Account::fromCache(std::string name, KeyType type)
 {
-    auto const keys = generateKeyPair(
-        type, generateSeed(name_));
-    pk_ = keys.first;
-    sk_ = keys.second;
-    id_ = calcAccountID(pk_);
-    human_ = toBase58(id_);
+    auto const p = std::make_pair (name, type);
+    auto const iter = cache_.find (p);
+    if (iter != cache_.end ())
+        return iter->second;
+
+    auto const keys = generateKeyPair (type, generateSeed (name));
+    auto r = cache_.emplace (std::piecewise_construct,
+        std::forward_as_tuple (std::move (p)),
+        std::forward_as_tuple (std::move (name), keys, privateCtorTag{}));
+    return r.first->second;
+}
+
+Account::Account (std::string name, KeyType type)
+    : Account (fromCache (std::move (name), type))
+{
 }
 
 IOU

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -59,7 +59,7 @@ setupConfigForUnitTests (Config& config)
     config.overwrite (ConfigSection::nodeDatabase (), "path", "main");
 
     config.deprecatedClearSection (ConfigSection::importNodeDatabase ());
-    config.legacy("database_path", "DummyForUnitTests");
+    config.legacy("database_path", "");
 
     config.RUN_STANDALONE = true;
     config["server"].append("port_peer");

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -516,14 +516,14 @@ public:
     {
         using namespace jtx;
         Env env(*this);
-        auto seq = env.open()->seq();
+        auto seq = env.current()->seq();
         expect(seq == env.closed()->seq() + 1);
         env.close();
         expect(env.closed()->seq() == seq);
-        expect(env.open()->seq() == seq + 1);
+        expect(env.current()->seq() == seq + 1);
         env.close();
         expect(env.closed()->seq() == seq + 1);
-        expect(env.open()->seq() == seq + 2);
+        expect(env.current()->seq() == seq + 2);
     }
 
     void

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -21,6 +21,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/test/jtx.h>
 #include <ripple/json/to_string.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/TxFlags.h>
 #include <beast/hash/uhash.h>
 #include <beast/unit_test/suite.h>
@@ -352,7 +353,7 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this);
+        Env env(*this, features(featureMultiSign));
         env.fund(XRP(10000), "alice");
         env(signers("alice", 1,
             { { "alice", 1 }, { "bob", 2 } }),                  ter(temBAD_SIGNER));
@@ -381,14 +382,12 @@ public:
         ticket::create("alice", 60, "bob");
 
         {
-            Env env(*this);
+            Env env(*this, features(featureTickets));
             env.fund(XRP(10000), "alice");
             env(noop("alice"),                  require(owners("alice", 0), tickets("alice", 0)));
             env(ticket::create("alice"),        require(owners("alice", 1), tickets("alice", 1)));
             env(ticket::create("alice"),        require(owners("alice", 2), tickets("alice", 2)));
         }
-
-        Env env(*this);
     }
 
     struct UDT

--- a/src/ripple/test/jtx/impl/paths.cpp
+++ b/src/ripple/test/jtx/impl/paths.cpp
@@ -37,7 +37,7 @@ paths::operator()(Env& env, JTx& jt) const
     auto const amount = amountFromJson(
         sfAmount, jv[jss::Amount]);
     Pathfinder pf (
-        std::make_shared<RippleLineCache>(env.open()),
+        std::make_shared<RippleLineCache>(env.current()),
             from, to, in_.currency, in_.account,
                 amount, boost::none, env.app());
     if (! pf.findPaths(depth_))

--- a/src/ripple/test/jtx/impl/utility.cpp
+++ b/src/ripple/test/jtx/impl/utility.cpp
@@ -52,8 +52,7 @@ sign (Json::Value& jv,
     ss.add32 (HashPrefix::txSign);
     parse(jv).add(ss);
     auto const sig = ripple::sign(
-        *publicKeyType(account.pk().slice()),
-            account.sk(), ss.slice());
+        account.pk(), account.sk(), ss.slice());
     jv[jss::TxnSignature] =
         strHex(Slice{ sig.data(), sig.size() });
 }

--- a/src/ripple/test/mao/impl/Net_test.cpp
+++ b/src/ripple/test/mao/impl/Net_test.cpp
@@ -20,6 +20,8 @@
 #include <BeastConfig.h>
 #include <ripple/basics/Log.h>
 #include <ripple/test/mao/Net.h>
+#include <ripple/test/jtx.h>
+#include <ripple/test/ManualTimeKeeper.h>
 #include <ripple/net/HTTPClient.h>
 #include <ripple/net/RPCCall.h>
 #include <beast/unit_test/suite.h>
@@ -38,21 +40,13 @@ struct TestApp
     {
         auto config = std::make_unique<Config>();
         setupConfigForUnitTests(*config);
-        config->RUN_STANDALONE = true;
-        (*config)["server"].append("port_peer");
-        (*config)["port_peer"].set("ip", "127.0.0.1");
-        (*config)["port_peer"].set("port", "8080");
-        (*config)["port_peer"].set("protocol", "peer");
-        (*config)["server"].append("port_admin");
-        (*config)["port_admin"].set("ip", "127.0.0.1");
-        (*config)["port_admin"].set("port", "8081");
-        (*config)["port_admin"].set("protocol", "http");
-        (*config)["port_admin"].set("admin", "127.0.0.1");
         // Hack so we dont have to call Config::setup
         HTTPClient::initializeSSLContext(*config);
         auto logs = std::make_unique<Logs>();
-        instance = make_Application(
-            std::move(config), std::move(logs));
+        auto timeKeeper = std::make_unique<ManualTimeKeeper>();
+        timeKeeper_ = timeKeeper.get();
+        instance = make_Application(std::move(config),
+            std::move(logs), std::move(timeKeeper));
         instance->setup();
         thread_ = std::thread(
             [&]() { instance->run(); });
@@ -106,6 +100,7 @@ private:
         collect(v, args...);
     }
 
+    ManualTimeKeeper* timeKeeper_;
     std::unique_ptr<Application> instance;
     std::thread thread_;
     std::mutex mutex_;

--- a/src/ripple/unity/test.cpp
+++ b/src/ripple/unity/test.cpp
@@ -48,3 +48,4 @@
 #include <ripple/test/mao/impl/Net.cpp>
 #include <ripple/test/mao/impl/Net_test.cpp>
 
+#include <ripple/test/impl/ManualTimeKeeper.cpp>


### PR DESCRIPTION
These changes eliminate the Env's OpenLedger member and make transactions go through the Application associated with each instance of the Env, making the unit tests follow a code path closer to the production code path.

Reviewers: @miguelportilla @seelabs 