### PR TITLE
jtx::sign needs to use addWithoutSigningFields()

### DIFF
--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -562,7 +562,7 @@ public:
     }
 
     // Test that jtx can re-sign a transaction that's already been signed.
-    void testSig()
+    void testResignSigned()
     {
         using namespace jtx;
         Env env(*this);
@@ -598,7 +598,7 @@ public:
         testAdvance();
         testClose();
         testPath();
-        testSig();
+        testResignSigned();
     }
 };
 

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -561,6 +561,21 @@ public:
                 );
     }
 
+    void testSig()
+    {
+        using namespace jtx;
+        Env env(*this);
+
+        env.fund(XRP(10000), "alice");
+        auto const baseFee = env.app().config().FEE_DEFAULT;
+        std::uint32_t const aliceSeq = env.seq ("alice");
+        
+        Json::Value jsonNoop = env.json (
+            noop ("alice"), fee(baseFee), seq(aliceSeq), sig("alice"));
+        JTx jt = env.jt (jsonNoop);
+        env (jt);
+    }
+
     void
     run()
     {
@@ -580,6 +595,7 @@ public:
         testAdvance();
         testClose();
         testPath();
+        testSig();
     }
 };
 

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -568,7 +568,7 @@ public:
         Env env(*this);
 
         env.fund(XRP(10000), "alice");
-        auto const baseFee = env.open()->fees().base;;
+        auto const baseFee = env.open()->fees().base;
         std::uint32_t const aliceSeq = env.seq ("alice");
         
         // Sign jsonNoop.

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -561,17 +561,20 @@ public:
                 );
     }
 
+    // Test that jtx can re-sign a transaction that's already been signed.
     void testSig()
     {
         using namespace jtx;
         Env env(*this);
 
         env.fund(XRP(10000), "alice");
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.open()->fees().base;;
         std::uint32_t const aliceSeq = env.seq ("alice");
         
+        // Sign jsonNoop.
         Json::Value jsonNoop = env.json (
             noop ("alice"), fee(baseFee), seq(aliceSeq), sig("alice"));
+        // Re-sign jsonNoop.
         JTx jt = env.jt (jsonNoop);
         env (jt);
     }

--- a/src/ripple/test/jtx/impl/utility.cpp
+++ b/src/ripple/test/jtx/impl/utility.cpp
@@ -50,7 +50,7 @@ sign (Json::Value& jv,
         strHex(account.pk().slice());
     Serializer ss;
     ss.add32 (HashPrefix::txSign);
-    parse(jv).add(ss);
+    parse(jv).addWithoutSigningFields(ss);
     auto const sig = ripple::sign(
         *publicKeyType(account.pk().slice()),
             account.sk(), ss.slice());


### PR DESCRIPTION
When jtx is generating a signature it can't include signing fields if they are present.  In typical usage jtx does not have any signing fields in place when the signature was generated, so it wasn't an issue.  But for special debugging cases those fields may be already in position.  This change supports both the standard usage model and special debugging cases.  A unit test is included to demonstrate the failing case.

reviewers: @vinniefalco, @ximinez