### PR TITLE
Some SHAMap changes

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1384,6 +1384,7 @@ void LedgerConsensusImp::takeInitialPosition (
 {
     std::shared_ptr<SHAMap> initialSet = std::make_shared <SHAMap> (
         SHAMapType::TRANSACTION, app_.family());
+    initialSet->setUnbacked ();
 
     // Build SHAMap containing all transactions in our open ledger
     for (auto const& tx : initialLedger->txs)
@@ -1627,6 +1628,8 @@ void LedgerConsensusImp::updateOurPositions ()
 
     if (changes)
     {
+        ourPosition = ourPosition->snapShot (false);
+
         auto newHash = ourPosition->getHash ().as_uint256();
         JLOG (j_.info)
             << "Position change: CTime "

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -179,8 +179,6 @@ public:
     std::vector<uint256> getNeededHashes (int max, SHAMapSyncFilter * filter);
     SHAMapAddNode addRootNode (SHAMapHash const& hash, Blob const& rootNode,
                                SHANodeFormat format, SHAMapSyncFilter * filter);
-    SHAMapAddNode addRootNode (Blob const& rootNode, SHANodeFormat format,
-                               SHAMapSyncFilter * filter);
     SHAMapAddNode addKnownNode (SHAMapNodeID const& nodeID, Blob const& rawNode,
                                 SHAMapSyncFilter * filter);
 

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -406,46 +406,6 @@ bool SHAMap::getRootNode (Serializer& s, SHANodeFormat format) const
     return true;
 }
 
-SHAMapAddNode SHAMap::addRootNode (Blob const& rootNode,
-    SHANodeFormat format, SHAMapSyncFilter* filter)
-{
-    // we already have a root_ node
-    if (root_->getNodeHash ().isNonZero ())
-    {
-        if (journal_.trace) journal_.trace <<
-            "got root node, already have one";
-        return SHAMapAddNode::duplicate ();
-    }
-
-    assert (seq_ >= 1);
-    auto node = SHAMapAbstractNode::make(
-        rootNode, 0, format, SHAMapHash{uZero}, false, f_.journal ());
-    if (!node || !node->isValid ())
-        return SHAMapAddNode::invalid ();
-
-#ifdef BEAST_DEBUG
-    node->dump (SHAMapNodeID (), journal_);
-#endif
-
-    if (backed_)
-        canonicalize (node->getNodeHash (), node);
-
-    root_ = node;
-
-    if (root_->isLeaf())
-        clearSynching ();
-
-    if (filter)
-    {
-        Serializer s;
-        root_->addRaw (s, snfPREFIX);
-        filter->gotNode (false, SHAMapNodeID{}, root_->getNodeHash (),
-                         s.modData (), root_->getType ());
-    }
-
-    return SHAMapAddNode::useful ();
-}
-
 SHAMapAddNode SHAMap::addRootNode (SHAMapHash const& hash, Blob const& rootNode, SHANodeFormat format,
                                    SHAMapSyncFilter* filter)
 {

--- a/src/ripple/shamap/tests/SHAMap.test.cpp
+++ b/src/ripple/shamap/tests/SHAMap.test.cpp
@@ -48,7 +48,16 @@ public:
 
     void run ()
     {
-        testcase ("add/traverse");
+        run (true);
+        run (false);
+    }
+
+    void run (bool backed)
+    {
+        if (backed)
+            testcase ("add/traverse backed");
+        else
+            testcase ("add/traverse unbacked");
 
         beast::Journal const j;                            // debug journal
         tests::TestFamily f(j);
@@ -62,6 +71,9 @@ public:
         h5.SetHex ("a92891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7");
 
         SHAMap sMap (SHAMapType::FREE, f);
+        if (! backed)
+            sMap.setUnbacked ();
+
         SHAMapItem i1 (h1, IntToVUC (1)), i2 (h2, IntToVUC (2)), i3 (h3, IntToVUC (3)), i4 (h4, IntToVUC (4)), i5 (h5, IntToVUC (5));
         unexpected (!sMap.addItem (i2, true, false), "no add");
         unexpected (!sMap.addItem (i1, true, false), "no add");
@@ -86,7 +98,11 @@ public:
         ++i;
         unexpected (i != e, "bad traverse");
 
-        testcase ("snapshot");
+        if (backed)
+            testcase ("snapshot backed");
+        else
+            testcase ("snapshot unbacked");
+
         SHAMapHash mapHash = sMap.getHash ();
         std::shared_ptr<SHAMap> map2 = sMap.snapShot (false);
         unexpected (sMap.getHash () != mapHash, "bad snapshot");
@@ -95,7 +111,10 @@ public:
         unexpected (sMap.getHash () == mapHash, "bad snapshot");
         unexpected (map2->getHash () != mapHash, "bad snapshot");
 
-        testcase ("build/tear");
+        if (backed)
+            testcase ("build/tear backed");
+        else
+            testcase ("build/tear unbacked");
         {
             std::vector<uint256> keys(8);
             keys[0].SetHex ("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
@@ -118,23 +137,29 @@ public:
             hashes[7].SetHex ("DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA02BBE7230E5");
 
             SHAMap map (SHAMapType::FREE, f);
+            if (! backed)
+                map.setUnbacked ();
 
             expect (map.getHash() == zero, "bad initial empty map hash");
             for (int i = 0; i < keys.size(); ++i)
             {
                 SHAMapItem item (keys[i], IntToVUC (i));
-                map.addItem (item, true, false);
+                expect (map.addItem (item, true, false), "unable to add item");
                 expect (map.getHash().as_uint256() == hashes[i], "bad buildup map hash");
             }
             for (int i = keys.size() - 1; i >= 0; --i)
             {
                 expect (map.getHash().as_uint256() == hashes[i], "bad teardown hash");
-                map.delItem (keys[i]);
+                expect (map.delItem (keys[i]), "unable to remove item");
             }
             expect (map.getHash() == zero, "bad final empty map hash");
         }
 
-        testcase ("iterate");
+        if (backed)
+            testcase ("iterate backed");
+        else
+            testcase ("iterate unbacked");
+
         {
             std::vector<uint256> keys(8);
             keys[0].SetHex ("f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
@@ -148,6 +173,8 @@ public:
 
             tests::TestFamily f{beast::Journal{}};
             SHAMap map{SHAMapType::FREE, f};
+            if (! backed)
+                map.setUnbacked ();
             for (auto const& k : keys)
                 map.addItem(SHAMapItem{k, IntToVUC(0)}, true, false);
 

--- a/src/ripple/shamap/tests/SHAMapSync.test.cpp
+++ b/src/ripple/shamap/tests/SHAMapSync.test.cpp
@@ -129,7 +129,8 @@ public:
 
         unexpected (gotNodes.size () < 1, "NodeSize");
 
-        unexpected (!destination.addRootNode (*gotNodes.begin (), snfWIRE, nullptr).isGood(), "AddRootNode");
+        unexpected (!destination.addRootNode (source.getHash(),
+            *gotNodes.begin (), snfWIRE, nullptr).isGood(), "AddRootNode");
 
         nodeIDs.clear ();
         gotNodes.clear ();

--- a/src/ripple/shamap/tests/common.h
+++ b/src/ripple/shamap/tests/common.h
@@ -50,6 +50,7 @@ public:
     TestFamily (beast::Journal j)
         : treecache_ ("TreeNodeCache", 65536, 60, clock_, j)
         , fullbelow_ ("full_below", clock_)
+        , j_ (j)
     {
         Section testSection;
         testSection.set("type", "memory");


### PR DESCRIPTION
1) Run some key SHAMap unit tests on both backed and unbacked SHAMap's. There's also two tiny changes to those unit tests, one to forward the test family's journal to the created SHAMap's and one to check the return value of addItem/delItem.

2) Remove an obsolete version of addRootNode that was only called by a unit test. The unit test now tests the version of that function we actually use.

3) walkSubTree now sets sequence numbers to zero for both backed and unbacked SHAMap's. This ensures that subsequent hash operations don't have to rehash more than they should. Some other small cleanups to walkSubTree are included.

4) Our consensus positions should always be unbacked and immutable. Failure to set them unbacked may have resulted in some nodes being stored in the database that shouldn't have been. Failure to set them immutable was likely harmless.

@HowardHinnant should definitely review this code. Other reviewer(s) wanted.