### PR TITLE
Improve watchdog restart logic:

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -331,7 +331,7 @@ int run (int argc, char** argv)
         std::string logMe = DoSustain ();
 
         if (!logMe.empty ())
-            std::cerr << logMe;
+            std::cerr << logMe << std::endl;
     }
 
     // Run the unit tests if requested.


### PR DESCRIPTION
Stop attempting to restart the server after five consecutive restarts fail to remain operational for at least ten seconds.

Reviews: @vinniefalco, @JoelKatz