### PR TITLE
Use canonical method to access base fee in unit tests.

### DIFF
--- a/src/ripple/app/tests/MultiSign.test.cpp
+++ b/src/ripple/app/tests/MultiSign.test.cpp
@@ -143,7 +143,7 @@ public:
         env.require (owners (alice, 4));
 
         // This should work.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         std::uint32_t aliceSeq = env.seq (alice);
         env(noop(alice), msig(bogie, demon), fee(3 * baseFee));
         env.close();
@@ -234,7 +234,7 @@ public:
         env.require (owners (alice, 0));
 
         std::uint32_t aliceSeq = env.seq (alice);
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         env(noop(alice), msig(bogie), fee(2 * baseFee), ter(temINVALID));
         env.close();
         expect (env.seq(alice) == aliceSeq);
@@ -259,7 +259,7 @@ public:
         env.require (owners (alice, 10));
 
         // This should work.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         std::uint32_t aliceSeq = env.seq (alice);
         env(noop(alice), msig(bogie), fee(2 * baseFee));
         env.close();
@@ -342,7 +342,7 @@ public:
         env.require (owners (alice, 4));
 
         // Attempt a multisigned transaction that meets the quorum.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         aliceSeq = env.seq (alice);
         env(noop(alice), msig(cheri), fee(2 * baseFee));
         env.close();
@@ -395,7 +395,7 @@ public:
         env.close();
 
         // Attempt a multisigned transaction that meets the quorum.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         std::uint32_t aliceSeq = env.seq (alice);
         env(noop(alice), msig(msig::Reg{cheri, cher}), fee(2 * baseFee));
         env.close();
@@ -462,7 +462,7 @@ public:
         env.require (owners (alice, 6));
 
         // Each type of signer should succeed individually.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         std::uint32_t aliceSeq = env.seq (alice);
         env(noop(alice), msig(becky), fee(2 * baseFee));
         env.close();
@@ -586,7 +586,7 @@ public:
         env(regkey (alice, disabled), sig(alie));
 
         // L0; A lone signer list cannot be removed.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         env(signers(alice, jtx::none), msig(bogie),
             fee(2 * baseFee), ter(tecNO_ALTERNATIVE_KEY));
 
@@ -672,7 +672,7 @@ public:
         env.require (owners (alice, 4));
 
         // Multisign a ttPAYMENT.
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         std::uint32_t aliceSeq = env.seq (alice);
         env(pay(alice, env.master, XRP(1)),
             msig(becky, bogie), fee(3 * baseFee));

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -361,7 +361,7 @@ public:
             { { "bob", 1 }, { "carol", 2 } }));
         env(noop("alice"));
 
-        auto const baseFee = env.app().config().FEE_DEFAULT;
+        auto const baseFee = env.current()->fees().base;
         env(noop("alice"), msig("bob"), fee(2 * baseFee));
         env(noop("alice"), msig("carol"), fee(2 * baseFee));
         env(noop("alice"), msig("bob", "carol"), fee(3 * baseFee));
@@ -569,7 +569,7 @@ public:
         env.fund(XRP(10000), "alice");
         auto const baseFee = env.current()->fees().base;
         std::uint32_t const aliceSeq = env.seq ("alice");
-        
+
         // Sign jsonNoop.
         Json::Value jsonNoop = env.json (
             noop ("alice"), fee(baseFee), seq(aliceSeq), sig("alice"));


### PR DESCRIPTION
In a previous code review I learned the canonical way to access the base fee inside of a unit test.  This change corrects those places I could find that were not using the canonical method.

Reviewers: @ximinez @vinniefalco