### PR TITLE
Use rocksdb2 as a system dir based on clang++ version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,12 +11,13 @@ dependencies:
     - sudo apt-get purge -qq libboost1.48-dev
     - sudo apt-get install -qq libboost1.57-all-dev
     - sudo apt-get install -qq clang-3.6 gcc-5 g++-5 libobjc-5-dev libgcc-5-dev libstdc++-5-dev libclang1-3.6 libgcc1 libgomp1 libstdc++6 scons protobuf-compiler libprotobuf-dev libssl-dev exuberant-ctags
-    - lsb_release -si -sr
+    - lsb_release -a
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 99
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 99
-    - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 99 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.6
+    - sudo update-alternatives --force --install /usr/bin/clang clang /usr/bin/clang-3.6 99 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-3.6
     - gcc --version
     - clang --version
+    - clang++ --version
 test:
   pre:
     - scons clang.debug


### PR DESCRIPTION
This fixes the rocksdb2 circleci warnings. The issue was `clang` was still using version 3 (while clang++ was using version 3.6). This caused problems for our SConstruct, which assumed that `clang --version` could be used to check the version of both clang and clang++.

@scottschurr @nbougalis 