### PR TITLE
Pathfinding cleanups:

### DIFF
--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -276,7 +276,7 @@ PathRequest::doCreate (
         }
     }
 
-    return { valid, status };
+    return { valid, std::move(status) };
 }
 
 int PathRequest::parseJson (Json::Value const& jvParams)

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -241,12 +241,13 @@ bool PathRequest::isValid (RippleLineCache::ref crCache)
     If there's an error, we need to be sure to return it to the caller
     in all cases.
 */
-Json::Value PathRequest::doCreate (
+std::pair<bool, Json::Value>
+PathRequest::doCreate (
     RippleLineCache::ref& cache,
-    Json::Value const& value,
-    bool& valid)
+    Json::Value const& value)
 {
     Json::Value status;
+    bool valid;
 
     if (parseJson (value) != PFR_PJ_INVALID)
     {
@@ -264,10 +265,10 @@ Json::Value PathRequest::doCreate (
     {
         if (valid)
         {
-            m_journal.debug << iIdentifier
-                            << " valid: " << toBase58(*raSrcAccount);
-            m_journal.debug << iIdentifier
-                            << " Deliver: " << saDstAmount.getFullText ();
+            m_journal.debug << iIdentifier <<
+                " valid: " << toBase58(*raSrcAccount);
+            m_journal.debug << iIdentifier <<
+                " deliver: " << saDstAmount.getFullText ();
         }
         else
         {
@@ -275,7 +276,7 @@ Json::Value PathRequest::doCreate (
         }
     }
 
-    return status;
+    return { valid, status };
 }
 
 int PathRequest::parseJson (Json::Value const& jvParams)

--- a/src/ripple/app/paths/PathRequest.h
+++ b/src/ripple/app/paths/PathRequest.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <utility>
 
 namespace ripple {
 
@@ -79,10 +80,10 @@ public:
     void        updateComplete ();
     Json::Value getStatus ();
 
-    Json::Value doCreate (
+    std::pair<bool, Json::Value> doCreate (
         const RippleLineCache::pointer&,
-        Json::Value const&,
-        bool&);
+        Json::Value const&);
+
     Json::Value doClose (Json::Value const&);
     Json::Value doStatus (Json::Value const&);
 

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -21,6 +21,7 @@
 #include <ripple/app/paths/PathRequests.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/basics/Log.h>
 #include <ripple/core/JobQueue.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/resource/Fees.h>
@@ -53,60 +54,64 @@ RippleLineCache::pointer PathRequests::getLineCache (
 void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
                               Job::CancelCallback shouldCancel)
 {
-    std::vector<PathRequest::wptr> requests;
+    auto event =
+        app_.getJobQueue().getLoadEventAP(
+            jtPATH_FIND, "PathRequest::updateAll");
 
-    LoadEvent::autoptr event (app_.getJobQueue().getLoadEventAP(jtPATH_FIND, "PathRequest::updateAll"));
+    std::vector<PathRequest::wptr> requests;
+    RippleLineCache::pointer cache;
 
     // Get the ledger and cache we should be using
-    RippleLineCache::pointer cache;
     {
         ScopedLockType sl (mLock);
-        requests = mRequests;
+        requests = requests_;
         cache = getLineCache (inLedger, true);
     }
 
     bool newRequests = app_.getLedgerMaster().isNewPathRequest();
     bool mustBreak = false;
 
-    mJournal.trace << "updateAll seq=" << cache->getLedger()->seq() << ", " <<
-        requests.size() << " requests";
+    JLOG (mJournal.trace) <<
+        "updateAll seq=" << cache->getLedger()->seq() <<
+        ", " << requests.size() << " requests";
+
     int processed = 0, removed = 0;
 
     do
     {
-        for (auto& wRequest : requests)
+        for (auto const& wr : requests)
         {
             if (shouldCancel())
                 break;
 
+            auto request = wr.lock ();
             bool remove = true;
-            PathRequest::pointer pRequest = wRequest.lock ();
 
-            if (pRequest)
+            if (request)
             {
-                if (!pRequest->needsUpdate (newRequests, cache->getLedger()->seq()))
+                if (!request->needsUpdate (newRequests, cache->getLedger()->seq()))
                     remove = false;
                 else
                 {
-                    InfoSub::pointer ipSub = pRequest->getSubscriber ();
-                    if (ipSub)
+                    if (auto ipSub = request->getSubscriber ())
                     {
-                        ipSub->getConsumer ().charge (Resource::feePathFindUpdate);
+                        ipSub->getConsumer ().charge (
+                            Resource::feePathFindUpdate);
                         if (!ipSub->getConsumer ().warn ())
                         {
-                            Json::Value update = pRequest->doUpdate (cache, false);
-                            pRequest->updateComplete ();
+                            Json::Value update = request->doUpdate (cache, false);
+                            request->updateComplete ();
                             update[jss::type] = "path_find";
                             ipSub->send (update, false);
                             remove = false;
                             ++processed;
                         }
                     }
-                    else if (pRequest->hasCompletion ())
+                    else if (request->hasCompletion ())
                     {
                         // One-shot request with completion function
-                        pRequest->doUpdate (cache, false);
-                        pRequest->updateComplete();
+                        request->doUpdate (cache, false);
+                        request->updateComplete();
                         ++processed;
                     }
                 }
@@ -119,22 +124,26 @@ void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
                 // Remove any dangling weak pointers or weak
                 // pointers that refer to this path request.
                 auto ret = std::remove_if (
-                    mRequests.begin(), mRequests.end(),
-                    [&removed,&pRequest](auto const& wl)
+                    requests_.begin(), requests_.end(),
+                    [&removed,&request](auto const& wl)
                     {
                         auto r = wl.lock();
 
-                        if (r && r != pRequest)
+                        if (r && r != request)
                             return false;
                         ++removed;
                         return true;
                     });
 
-                mRequests.erase (ret, mRequests.end());
+                requests_.erase (ret, requests_.end());
             }
 
-            mustBreak = !newRequests && app_.getLedgerMaster().isNewPathRequest();
-            if (mustBreak) // We weren't handling new requests and then there was a new request
+            mustBreak = !newRequests &&
+                app_.getLedgerMaster().isNewPathRequest();
+
+            // We weren't handling new requests and then
+            // there was a new request
+            if (mustBreak)
                 break;
 
         }
@@ -148,47 +157,47 @@ void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
             newRequests = app_.getLedgerMaster().isNewPathRequest();
         }
         else
-        { // check if there are any new requests, otherwise we are done
+        { // if there are no new requests, we are done
             newRequests = app_.getLedgerMaster().isNewPathRequest();
-            if (!newRequests) // We did a full pass and there are no new requests
-                return;
+            if (!newRequests)
+                break;
         }
 
         {
             // Get the latest requests, cache, and ledger for next pass
             ScopedLockType sl (mLock);
 
-            if (mRequests.empty())
+            if (requests_.empty())
                 break;
-            requests = mRequests;
-
+            requests = requests_;
             cache = getLineCache (cache->getLedger(), false);
         }
-
     }
     while (!shouldCancel ());
 
-    mJournal.debug << "updateAll complete " << processed << " process and " <<
+    JLOG (mJournal.debug) <<
+        "updateAll complete: " << processed << " processed and " <<
         removed << " removed";
 }
 
-void PathRequests::insertPathRequest (PathRequest::pointer const& req)
+void PathRequests::insertPathRequest (
+    PathRequest::pointer const& req)
 {
     ScopedLockType sl (mLock);
 
     // Insert after any older unserviced requests but before
     // any serviced requests
     auto ret = std::find_if (
-        mRequests.begin(), mRequests.end(),
+        requests_.begin(), requests_.end(),
         [](auto const& wl)
         {
             auto r = wl.lock();
 
-            // This request has been handled, we come before it
+            // We come before handled requests
             return r && !r->isNew();
         });
 
-    mRequests.insert (ret, PathRequest::wptr (req));
+    requests_.emplace (ret, req);
 }
 
 // Make a new-style path_find request

--- a/src/ripple/app/paths/PathRequests.h
+++ b/src/ripple/app/paths/PathRequests.h
@@ -26,6 +26,7 @@
 #include <ripple/core/Job.h>
 #include <atomic>
 #include <mutex>
+#include <vector>
 
 namespace ripple {
 
@@ -79,7 +80,7 @@ private:
     beast::insight::Event            mFull;
 
     // Track all requests
-    std::vector<PathRequest::wptr>   mRequests;
+    std::vector<PathRequest::wptr> requests_;
 
     // Use a RippleLineCache
     RippleLineCache::pointer         mLineCache;


### PR DESCRIPTION
* Return std::pair instead of returning by reference
* Use std algorithms when possible
* Use auto and C++14 lambdas

@JoelKatz, @seelabs