### PR TITLE
Add SignerList support to account_objects (RIPD-1061):

### DIFF
--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -78,6 +78,7 @@ JSS ( affected );                   // out: AcceptedLedgerTx
 JSS ( age );                        // out: UniqueNodeList, NetworkOPs, Peers
 JSS ( alternatives );               // out: PathRequest, RipplePathFind
 JSS ( amendment_blocked );          // out: NetworkOPs
+JSS ( amendments );                 // in: AccountObjects
 JSS ( asks );                       // out: Subscribe
 JSS ( assets );                     // out: GatewayBalances
 JSS ( authorized );                 // out: AccountLines
@@ -175,6 +176,7 @@ JSS ( generator );                  // in: LedgerEntry
 JSS ( good );                       // out: RPCVersion
 JSS ( hash );                       // out: NetworkOPs, InboundLedger,
                                     //      LedgerToJson, STTx; field
+JSS ( hashes );                     // in: AccountObjects
 JSS ( have_header );                // out: InboundLedger
 JSS ( have_state );                 // out: InboundLedger
 JSS ( have_transactions );          // out: InboundLedger
@@ -338,6 +340,7 @@ JSS ( server_state );               // out: NetworkOPs
 JSS ( server_status );              // out: NetworkOPs
 JSS ( severity );                   // in: LogLevel
 JSS ( signature );                  // out: NetworkOPs
+JSS ( signer_list );                // in: AccountObjects
 JSS ( snapshot );                   // in: Subscribe
 JSS ( source_account );             // in: PathRequest, RipplePathFind
 JSS ( source_amount );              // in: PathRequest, RipplePathFind
@@ -363,6 +366,7 @@ JSS ( taker_gets_funded );          // out: NetworkOPs
 JSS ( taker_pays );                 // in: Subscribe, Unsubscribe, BookOffers
 JSS ( taker_pays_funded );          // out: NetworkOPs
 JSS ( threshold );                  // in: Blacklist
+JSS ( ticket );                     // in: AccountObjects
 JSS ( timeouts );                   // out: InboundLedger
 JSS ( traffic );                    // out: Overlay
 JSS ( totalCoins );                 // out: LedgerToJson

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -35,7 +35,6 @@
 
 #include <string>
 #include <sstream>
-#include <vector>
 
 namespace ripple {
 
@@ -80,18 +79,19 @@ Json::Value doAccountObjects (RPC::Context& context)
     if (params.isMember (jss::type))
     {
         static
-        std::vector<std::pair<std::string, LedgerEntryType>> const
+        std::array<std::pair<char const *, LedgerEntryType>, 9> const
         types
-        {
-            { "account", ltACCOUNT_ROOT },
-            { "amendments", ltAMENDMENTS },
-            { "directory", ltDIR_NODE },
-            { "fee", ltFEE_SETTINGS },
-            { "hashes", ltLEDGER_HASHES },
-            { "offer", ltOFFER },
-            { "state", ltRIPPLE_STATE },
-            { "ticket", ltTICKET }
-        };
+        {{
+            { jss::account, ltACCOUNT_ROOT },
+            { jss::amendments, ltAMENDMENTS },
+            { jss::directory, ltDIR_NODE },
+            { jss::fee, ltFEE_SETTINGS },
+            { jss::hashes, ltLEDGER_HASHES },
+            { jss::offer, ltOFFER },
+            { jss::signer_list, ltSIGNER_LIST },
+            { jss::state, ltRIPPLE_STATE },
+            { jss::ticket, ltTICKET }
+        }};
 
         auto const& p = params[jss::type];
         if (! p.isString ())


### PR DESCRIPTION
The `account_objects` RPC command allows specific types of objects to be requested.  Add SignerList as one of those supported types.

Reviewers: @miguelportilla, @seelabs 