### PR TITLE
Add sanitize build support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -73,6 +73,8 @@ The following extra options may be used:
 
     --static        On linux, link protobuf, openssl, libc++, and boost statically
 
+    --sanitize=[address, thread]  On gcc & clang, add sanitizer instrumentation
+
 GCC 5: If the gcc toolchain is used, gcc version 5 or better is required. On
     linux distros that ship with gcc 4 (ubuntu < 15.10), rippled will force gcc
     to use gcc4's ABI (there was an ABI change between versions). This allows us
@@ -121,6 +123,9 @@ import scons_to_ninja
 
 AddOption('--ninja', dest='ninja', action='store_true',
           help='generate ninja build file build.ninja')
+
+AddOption('--sanitize', dest='sanitize', choices=['address', 'thread'],
+          help='Build with sanitizer support (gcc and clang only).')
 
 AddOption('--static', dest='static', action='store_true',
           help='On linux, link protobuf, openssl, libc++, and boost statically')
@@ -428,6 +433,17 @@ def get_libs(lib, static):
     except:
         raise Exception('pkg-config failed for ' + lib)
 
+def add_sanitizer (toolchain, env):
+    san = GetOption('sanitize')
+    if not san: return
+    san_to_lib = {'address': 'asan', 'thread': 'tsan'}
+    if toolchain not in Split('clang gcc'):
+        raise Exception("Sanitizers are only supported for gcc and clang")
+    env.Append(CCFLAGS=['-fsanitize='+san, '-fno-omit-frame-pointer'])
+    env.Append(LINKFLAGS=['-fsanitize='+san])
+    add_static_libs(env, [san_to_lib[san]])
+    env.Append(CPPDEFINES=['SANITIZER='+san_to_lib[san].upper()])
+
 # Set toolchain and variant specific construction variables
 def config_env(toolchain, variant, env):
     if is_debug_variant(variant):
@@ -446,6 +462,8 @@ def config_env(toolchain, variant, env):
 
     if should_link_static() and not Beast.system.linux:
         raise Exception("Static linking is only implemented for linux.")
+
+    add_sanitizer(toolchain, env)
 
     if toolchain in Split('clang gcc'):
         if Beast.system.linux:

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -41,9 +41,21 @@ char const* getRawVersionString ()
     //
     //  http://semver.org/
     //
+
+#if defined(DEBUG) || defined(SANITIZER)
+       "+"
 #ifdef DEBUG
-        "+DEBUG"
+        "DEBUG"
+#ifdef SANITIZER
+        "."
 #endif
+#endif
+
+#ifdef SANITIZER
+        BEAST_PP_STR1_(SANITIZER)
+#endif
+#endif
+
     //--------------------------------------------------------------------------
     ;
 


### PR DESCRIPTION
Add a `--sanitize=[address,thread]` command line option to scons. 

Note: clang builds fail with the error: `error: inline assembly requires more registers than available`. I decided to leave in clang support anyway.

@nbougalis @ximinez 