### PR TITLE
Improve error message when signing fails (RIPD-1066):

### DIFF
--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -80,15 +80,17 @@ preflight1 (PreflightContext const& ctx)
 TER
 preflight2 (PreflightContext const& ctx)
 {
-    if(!( ctx.flags & tapNO_CHECK_SIGN) &&
-        checkValidity(ctx.app.getHashRouter(),
-            ctx.tx, ctx.rules, ctx.app.config(),
-                ctx.flags).first == Validity::SigBad)
+    if(!( ctx.flags & tapNO_CHECK_SIGN))
     {
-        JLOG(ctx.j.debug) << "preflight2: bad signature";
-        return temINVALID;
+        auto const sigValid = checkValidity(ctx.app.getHashRouter(),
+            ctx.tx, ctx.rules, ctx.app.config(), ctx.flags);
+        if (sigValid.first == Validity::SigBad)
+       {
+            JLOG(ctx.j.debug) <<
+                "preflight2: bad signature. " << sigValid.second;
+            return temINVALID;
+        }
     }
-
     return tesSUCCESS;
 }
 

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -123,7 +123,9 @@ public:
 
     void sign (RippleAddress const& private_key);
 
-    bool checkSign(bool allowMultiSign) const;
+    // Returned bool indicates success/failure.
+    // Returned string indicates reason for failure.
+    std::pair<bool, std::string> checkSign(bool allowMultiSign) const;
 
     // SQL Functions with metadata.
     static
@@ -140,8 +142,8 @@ public:
         std::string const& escapedMetaData) const;
 
 private:
-    bool checkSingleSign () const;
-    bool checkMultiSign () const;
+    std::pair<bool, std::string> checkSingleSign () const;
+    std::pair<bool, std::string> checkMultiSign () const;
 
     uint256 tid_;
     TxType tx_type_;

--- a/src/ripple/protocol/tests/STTx.test.cpp
+++ b/src/ripple/protocol/tests/STTx.test.cpp
@@ -47,7 +47,7 @@ public:
             });
         j.sign (privateAcct);
 
-        unexpected (!j.checkSign (true), "Transaction fails signature test");
+        unexpected (!j.checkSign (true).first, "Transaction fails signature test");
 
         Serializer rawTxn;
         j.add (rawTxn);


### PR DESCRIPTION
RIPD-1066 requests a better error message if a multisigned transaction fails because the signatures are not sorted.  This adds that message along with the plumbing to get the message out to the user (that JIRA item results from using the submit RPC command with a blob).

Reviewers: @ximinez, @vinniefalco 