### PR TITLE
Allow random seed with specified wallet_propose key_type (RIPD-1030)

### DIFF
--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -56,7 +56,15 @@ Json::Value walletPropose (Json::Value const& params)
         if (keyType == KeyType::invalid)
             return rpcError(rpcINVALID_PARAMS);
 
-        seed = RPC::getSeedFromRPC (params);
+        if (params.isMember (jss::passphrase) || params.isMember (jss::seed) ||
+            params.isMember (jss::seed_hex))
+        {
+            seed = RPC::getSeedFromRPC (params);
+        }
+        else
+        {
+            seed = randomSeed ();
+        }
     }
     else if (params.isMember (jss::passphrase))
     {

--- a/src/ripple/rpc/tests/KeyGeneration.test.cpp
+++ b/src/ripple/rpc/tests/KeyGeneration.test.cpp
@@ -132,6 +132,9 @@ public:
 
         Json::Value params;
         params[jss::key_type] = keyType;
+
+        expect (! contains_error (walletPropose (params)));
+
         params[jss::passphrase] = common::passphrase;
 
         testSecretWallet (params, strings);


### PR DESCRIPTION
Generate a random seed for `wallet_propose` if a `key_type` is specified without a `passphrase`, `seed`, or `seed_hex`.

An `rpcBAD_SEED` error is still returned if a bad `passphrase`, `seed`, or `seed_hex` is provided or if more than one are provided (they are mutually exclusive).