### PR TITLE
Do not submit Env tx through RPC for non-default conditions:

### DIFF
--- a/src/ripple/app/tests/OversizeMeta_test.cpp
+++ b/src/ripple/app/tests/OversizeMeta_test.cpp
@@ -54,13 +54,28 @@ public:
     }
 
     void
-    run()
+    run() override
     {
         test(10000);
     }
 };
 
 BEAST_DEFINE_TESTSUITE_MANUAL(PlumpBook,tx,ripple);
+
+//------------------------------------------------------------------------------
+
+// Ensure that unsigned transactions succeed during automatic test runs.
+class ThinBook_test : public PlumpBook_test
+{
+public:
+    void
+        run() override
+    {
+        test(1);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(ThinBook, tx, ripple);
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
* Fixes tests which use unsigned transactions.

This might be a little controversial, because it uses the same pattern I used in `Env::close()` where it goes through RPC for the default behavior, and calls into the `app()` for unusual behavior, and which @vinniefalco [didn't like so much](https://github.com/ripple/rippled/pull/1471/files#r49459268).

I also included an automatic stripped down version of the `PlumpBook` manual test to ensure it works and gets covered.

Reviewers: @nbougalis @vinniefalco 