### PR TITLE
Disable tx sig checking at the Application level:

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -343,6 +343,8 @@ public:
     boost::asio::signal_set m_signals;
     beast::WaitableEvent m_stop;
 
+    std::atomic<bool> checkSigs_;
+
     std::unique_ptr <ResolverAsio> m_resolver;
 
     io_latency_sampler m_io_latency_sampler;
@@ -474,6 +476,8 @@ public:
 
         , m_signals (get_io_service())
 
+        , checkSigs_(true)
+
         , m_resolver (ResolverAsio::New (get_io_service(), logs_->journal("Resolver")))
 
         , m_io_latency_sampler (m_collectorManager->collector()->make_event ("ios_latency"),
@@ -510,6 +514,8 @@ public:
     void run() override;
     bool isShutdown() override;
     void signalStop() override;
+    bool checkSigs() const override;
+    void checkSigs(bool) override;
 
     //--------------------------------------------------------------------------
 
@@ -1138,6 +1144,16 @@ ApplicationImp::isShutdown()
 {
     // from Stoppable mixin
     return isStopped();
+}
+
+bool ApplicationImp::checkSigs() const
+{
+    return checkSigs_;
+}
+
+void ApplicationImp::checkSigs(bool check)
+{
+    checkSigs_ = check;
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -97,6 +97,8 @@ public:
     virtual void run() = 0;
     virtual bool isShutdown () = 0;
     virtual void signalStop () = 0;
+    virtual bool checkSigs() const = 0;
+    virtual void checkSigs(bool) = 0;
 
     //
     // ---

--- a/src/ripple/app/tests/OversizeMeta_test.cpp
+++ b/src/ripple/app/tests/OversizeMeta_test.cpp
@@ -54,13 +54,28 @@ public:
     }
 
     void
-    run()
+    run() override
     {
         test(10000);
     }
 };
 
 BEAST_DEFINE_TESTSUITE_MANUAL(PlumpBook,tx,ripple);
+
+//------------------------------------------------------------------------------
+
+// Ensure that unsigned transactions succeed during automatic test runs.
+class ThinBook_test : public PlumpBook_test
+{
+public:
+    void
+        run() override
+    {
+        test(1);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(ThinBook, tx, ripple);
 
 //------------------------------------------------------------------------------
 

--- a/src/ripple/rpc/handlers/Submit.cpp
+++ b/src/ripple/rpc/handlers/Submit.cpp
@@ -82,7 +82,11 @@ Json::Value doSubmit (RPC::Context& context)
         return jvResult;
     }
 
+
     {
+        if (!context.app.checkSigs())
+            forceValidity(context.app.getHashRouter(),
+                stpTrans->getTransactionID(), Validity::SigGoodOnly);
         auto validity = checkValidity(context.app.getHashRouter(),
             *stpTrans, context.ledgerMaster.getCurrentLedger()->rules(),
                 context.app.config());

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -546,6 +546,9 @@ transactionConstructImpl (std::shared_ptr<STTx const> const& stpTrans,
 
             // Check the signature if that's called for.
             auto sttxNew = std::make_shared<STTx const> (sit);
+            if (!app.checkSigs())
+                forceValidity(app.getHashRouter(),
+                    sttxNew->getTransactionID(), Validity::SigGoodOnly);
             if (checkValidity(app.getHashRouter(),
                 *sttxNew, rules, app.config()).first != Validity::Valid)
             {

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -299,7 +299,7 @@ public:
     void
     disable_sigs()
     {
-        nosig_ = true;
+        app().checkSigs(false);
     }
 
     /** Associate AccountID with account. */
@@ -540,7 +540,6 @@ public:
 protected:
     int trace_ = 0;
     bool testing_ = true;
-    bool nosig_ = false;
     TestStopwatch stopwatch_;
     uint256 txid_;
     TER ter_ = tesSUCCESS;
@@ -564,9 +563,6 @@ protected:
     */
     std::shared_ptr<STTx const>
     st (JTx const& jt);
-
-    ApplyFlags
-    applyFlags() const;
 
     inline
     void

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -305,7 +305,9 @@ Env::postconditions(JTx const& jt, TER ter, bool didApply)
 {
     if (jt.ter && ! test.expect(ter == *jt.ter,
         "apply: " + transToken(ter) +
-            " (" + transHuman(ter) + ")"))
+            " (" + transHuman(ter) + ") != " +
+                transToken(*jt.ter) + " (" +
+                    transHuman(*jt.ter) + ")"))
     {
         test.log << pretty(jt.jv);
         // Don't check postconditions if
@@ -340,7 +342,7 @@ Env::autofill_sig (JTx& jt)
         return;
     auto const account =
         lookup(jv[jss::Account].asString());
-    if (nosig_)
+    if (!app().checkSigs())
     {
         jv[jss::SigningPubKey] =
             strHex(account.pk().slice());
@@ -404,15 +406,6 @@ Env::st (JTx const& jt)
     {
     }
     return nullptr;
-}
-
-ApplyFlags
-Env::applyFlags() const
-{
-    ApplyFlags flags = tapNONE;
-    if (nosig_)
-        flags = flags | tapNO_CHECK_SIGN;
-    return flags;
 }
 
 Json::Value


### PR DESCRIPTION
* Only skip sig checking on the RPC/Websocket interface.
* Used by Env tests which submit unsigned transactions.

Rewrite of closed #1501, so same reviewers: @nbougalis @vinniefalco 