### PR TITLE
Don't show progess bar on npm install in TravisCI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,5 +83,5 @@ test_script:
   - build\\rippled --unittest
 
   # Run the integration tests
-  - npm install
+  - npm install --progress=false
   - npm test

--- a/bin/ci/ubuntu/build-and-test.sh
+++ b/bin/ci/ubuntu/build-and-test.sh
@@ -37,5 +37,5 @@ else
 fi
 
 # Run NPM tests
-npm install
+npm install --progress=false
 npm test --rippled=$RIPPLED_PATH

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ test:
     # gdb segfaults
     # - cat script.gdb | gdb --ex 'set print thread-events off' --return-child-result --args build/clang.debug/rippled --unittest
     - build/clang.debug/rippled --unittest
-    - npm install
+    - npm install --progress=false
     # Use build/(gcc|clang).debug/rippled
     - |
       echo "exports.default_server_config = {\"rippled_path\" : \"$HOME/rippled/build/clang.debug/rippled\"};" > test/config.js


### PR DESCRIPTION
See https://github.com/npm/npm/issues/11283 for more discussion on this.

I don't assume that you are looking at progress bars in Travis anyways, so even if they use fewer resources, there would not be much point to displaying them at all.