### PR TITLE
Improve error message when signing fails (RIPD-1066):

### DIFF
--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -88,14 +88,17 @@ preflight1 (PreflightContext const& ctx)
 TER
 preflight2 (PreflightContext const& ctx)
 {
-    if(!( ctx.flags & tapNO_CHECK_SIGN) &&
-        checkValidity(ctx.app.getHashRouter(),
-            ctx.tx, ctx.rules, ctx.app.config()).first == Validity::SigBad)
+    if(!( ctx.flags & tapNO_CHECK_SIGN))
     {
-        JLOG(ctx.j.debug) << "preflight2: bad signature";
-        return temINVALID;
+        auto const sigValid = checkValidity(ctx.app.getHashRouter(),
+            ctx.tx, ctx.rules, ctx.app.config());
+        if (sigValid.first == Validity::SigBad)
+       {
+            JLOG(ctx.j.debug) <<
+                "preflight2: bad signature. " << sigValid.second;
+            return temINVALID;
+        }
     }
-
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -46,16 +46,16 @@ checkValidity(HashRouter& router,
     auto const flags = router.getFlags(id);
     if (flags & SF_SIGBAD)
         // Signature is known bad
-        return std::make_pair(Validity::SigBad,
-            "Transaction has bad signature.");
+        return {Validity::SigBad, "Transaction has bad signature."};
+
     if (!(flags & SF_SIGGOOD))
     {
         // Don't know signature state. Check it.
-        if (!tx.checkSign(allowMultiSign))
+        auto const sigVerify = tx.checkSign(allowMultiSign);
+        if (! sigVerify.first)
         {
             router.setFlags(id, SF_SIGBAD);
-            return std::make_pair(Validity::SigBad,
-                "Transaction has bad signature.");
+            return {Validity::SigBad, sigVerify.second};
         }
         router.setFlags(id, SF_SIGGOOD);
     }
@@ -64,22 +64,22 @@ checkValidity(HashRouter& router,
     if (flags & SF_LOCALBAD)
         // ...but the local checks
         // are known bad.
-        return std::make_pair(Validity::SigGoodOnly,
-            "Local checks failed.");
+        return {Validity::SigGoodOnly, "Local checks failed."};
+
     if (flags & SF_LOCALGOOD)
         // ...and the local checks
         // are known good.
-        return std::make_pair(Validity::Valid, "");
+        return {Validity::Valid, ""};
 
     // Do the local checks
     std::string reason;
     if (!passesLocalChecks(tx, reason))
     {
         router.setFlags(id, SF_LOCALBAD);
-        return std::make_pair(Validity::SigGoodOnly, reason);
+        return {Validity::SigGoodOnly, reason};
     }
     router.setFlags(id, SF_LOCALGOOD);
-    return std::make_pair(Validity::Valid, "");
+    return {Validity::Valid, ""};
 }
 
 void

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -127,7 +127,11 @@ public:
         PublicKey const& publicKey,
         SecretKey const& secretKey);
 
-    bool checkSign(bool allowMultiSign) const;
+    /** Check the signature.
+        @return `true` if valid signature. If invalid, the error message string.
+    */
+    std::pair<bool, std::string>
+    checkSign(bool allowMultiSign) const;
 
     // SQL Functions with metadata.
     static
@@ -144,8 +148,8 @@ public:
         std::string const& escapedMetaData) const;
 
 private:
-    bool checkSingleSign () const;
-    bool checkMultiSign () const;
+    std::pair<bool, std::string> checkSingleSign () const;
+    std::pair<bool, std::string> checkMultiSign () const;
 
     uint256 tid_;
     TxType tx_type_;

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -181,9 +181,9 @@ void STTx::sign (
     tid_ = getHash(HashPrefix::transactionID);
 }
 
-bool STTx::checkSign(bool allowMultiSign) const
+std::pair<bool, std::string> STTx::checkSign(bool allowMultiSign) const
 {
-    bool sigGood = false;
+    std::pair<bool, std::string> ret {false, ""};
     try
     {
         if (allowMultiSign)
@@ -192,18 +192,19 @@ bool STTx::checkSign(bool allowMultiSign) const
             // at the SigningPubKey.  It it's empty we must be
             // multi-signing.  Otherwise we're single-signing.
             Blob const& signingPubKey = getFieldVL (sfSigningPubKey);
-            sigGood = signingPubKey.empty () ?
+            ret = signingPubKey.empty () ?
                 checkMultiSign () : checkSingleSign ();
         }
         else
         {
-            sigGood = checkSingleSign ();
+            ret = checkSingleSign ();
         }
     }
     catch (std::exception const&)
     {
+        ret = {false, "Internal signature check failure."};
     }
-    return sigGood;
+    return ret;
 }
 
 Json::Value STTx::getJson (int) const
@@ -261,14 +262,13 @@ STTx::getMetaSQL (Serializer rawTxn,
                 % getSequence () % inLedger % status % rTxn % escapedMetaData);
 }
 
-bool
-STTx::checkSingleSign () const
+std::pair<bool, std::string> STTx::checkSingleSign () const
 {
     // We don't allow both a non-empty sfSigningPubKey and an sfSigners.
     // That would allow the transaction to be signed two ways.  So if both
     // fields are present the signature is invalid.
     if (isFieldPresent (sfSigners))
-        return false;
+        return {false, "Cannot both single- and multi-sign."};
 
     bool validSig = false;
     try
@@ -293,27 +293,29 @@ STTx::checkSingleSign () const
         // Assume it was a signature failure.
         validSig = false;
     }
-    return validSig;
+    if (validSig == false)
+        return {false, "Invalid signature."};
+
+    return {true, ""};
 }
 
-bool
-STTx::checkMultiSign () const
+std::pair<bool, std::string> STTx::checkMultiSign () const
 {
     // Make sure the MultiSigners are present.  Otherwise they are not
     // attempting multi-signing and we just have a bad SigningPubKey.
     if (!isFieldPresent (sfSigners))
-        return false;
+        return {false, "Empty SigningPubKey."};
 
     // We don't allow both an sfSigners and an sfTxnSignature.  Both fields
     // being present would indicate that the transaction is signed both ways.
     if (isFieldPresent (sfTxnSignature))
-        return false;
+        return {false, "Cannot both single- and multi-sign."};
 
     STArray const& signers {getFieldArray (sfSigners)};
 
     // There are well known bounds that the number of signers must be within.
     if (signers.size() < minMultiSigners || signers.size() > maxMultiSigners)
-        return false;
+        return {false, "Invalid Signers array size."};
 
     // We can ease the computational load inside the loop a bit by
     // pre-constructing part of the data that we hash.  Fill a Serializer
@@ -335,11 +337,15 @@ STTx::checkMultiSign () const
 
         // The account owner may not multisign for themselves.
         if (accountID == txnAccountID)
-            return false;
+            return {false, "Invalid multisigner."};
+
+        // No duplicate signers allowed.
+        if (lastAccountID == accountID)
+            return {false, "Duplicate Signers not allowed."};
 
         // Accounts must be in order by account ID.  No duplicates allowed.
-        if (lastAccountID >= accountID)
-            return false;
+        if (lastAccountID > accountID)
+            return {false, "Unsorted Signers array."};
 
         // The next signature must be greater than this one.
         lastAccountID = accountID;
@@ -371,11 +377,12 @@ STTx::checkMultiSign () const
             validSig = false;
         }
         if (!validSig)
-            return false;
+            return {false, std::string("Invalid signature on account ") +
+                toBase58(accountID)  + "."};
     }
 
     // All signatures verified.
-    return true;
+    return {true, ""};
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/tests/STTx.test.cpp
+++ b/src/ripple/protocol/tests/STTx.test.cpp
@@ -52,7 +52,7 @@ public:
             });
         j.sign (keypair.first, keypair.second);
 
-        unexpected (!j.checkSign (true), "Transaction fails signature test");
+        unexpected (!j.checkSign (true).first, "Transaction fails signature test");
 
         Serializer rawTxn;
         j.add (rawTxn);


### PR DESCRIPTION
With the addition of multisigning there are a variety of reasons a signature may fail.  We now return a more descriptive message for the reason certain signature checks fail.

Reviewers: @miguelportilla @seelabs 