### PR TITLE
Clear old Validations during online delete (RIPD-870):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1544,6 +1544,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tests\SHAMapStore_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tests\SusPay_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2127,6 +2127,9 @@
     <ClCompile Include="..\..\src\ripple\app\tests\SetAuth_test.cpp">
       <Filter>ripple\app\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\tests\SHAMapStore_test.cpp">
+      <Filter>ripple\app\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\tests\SusPay_test.cpp">
       <Filter>ripple\app\tests</Filter>
     </ClCompile>

--- a/src/ripple/app/misc/SHAMapStore.h
+++ b/src/ripple/app/misc/SHAMapStore.h
@@ -41,6 +41,7 @@ class SHAMapStore
 public:
     struct Setup
     {
+        bool standalone = false;
         std::uint32_t deleteInterval = 0;
         bool advisoryDelete = false;
         std::uint32_t ledgerHistory = 0;

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -179,9 +179,9 @@ SHAMapStoreImp::SHAMapStoreImp (
     , scheduler_ (scheduler)
     , journal_ (journal)
     , nodeStoreJournal_ (nodeStoreJournal)
+    , rotating_(false)
     , transactionMaster_ (transactionMaster)
     , canDelete_ (std::numeric_limits <LedgerIndex>::max())
-    , rotating_(false)
 {
     if (setup_.deleteInterval)
     {

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -272,7 +272,6 @@ void
 SHAMapStoreImp::run()
 {
     LedgerIndex lastRotated = state_db_.getState().lastRotated;
-    Ledger::pointer validatedLedger;
     netOPs_ = &app_.getOPs();
     ledgerMaster_ = &app_.getLedgerMaster();
     fullBelowCache_ = &app_.family().fullbelow();
@@ -286,7 +285,7 @@ SHAMapStoreImp::run()
     while (1)
     {
         healthy_ = true;
-        validatedLedger.reset();
+        Ledger::pointer validatedLedger;
         rotating_ = false;
 
         {

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -593,13 +593,14 @@ SHAMapStoreImp::clearPrior (LedgerIndex lastRotated)
             R"sql(
             DELETE FROM Validations WHERE LedgerHash IN
             (
-            SELECT v.LedgerHash
-            FROM Validations v
-            LEFT OUTER JOIN Ledgers l
-            ON v.LedgerHash = l.LedgerHash
-            WHERE l.LedgerHash is NULL
-            LIMIT )sql" + std::to_string (deleteBatch)
-            + ");");
+                SELECT v.LedgerHash
+                FROM Validations v
+                LEFT OUTER JOIN Ledgers l
+                ON v.LedgerHash = l.LedgerHash
+                WHERE l.LedgerHash is NULL
+                LIMIT )sql" +
+                std::to_string (deleteBatch) +
+            ");");
 
         JLOG (journal_.debug) << "start: " << deleteQuery << " of "
                               << deleteBatch << " rows.";
@@ -610,11 +611,11 @@ SHAMapStoreImp::clearPrior (LedgerIndex lastRotated)
             auto db = ledgerDb_->checkoutDb ();
             return (db->prepare << deleteQuery);
         }();
+        if (health())
+            return;
         do
         {
             {
-                // Note: We may not need to lock the db before executing the statement, but I
-                // couldn't find documentation that said it was safe, so locking
                 auto db = ledgerDb_->checkoutDb ();
                 st.execute (true);
                 rowsAffected = st.get_affected_rows ();

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -80,7 +80,9 @@ private:
     // check health/stop status as records are copied
     std::uint64_t const checkHealthInterval_ = 1000;
     // minimum # of ledgers to maintain for health of network
-    std::uint32_t minimumDeletionInterval_ = 256;
+    std::uint32_t const minimumDeletionInterval_ = 256;
+    // minimum # of ledgers required for standalone mode.
+    std::uint32_t const minimumDeletionIntervalSA_ = 8;
 
     Setup setup_;
     NodeStore::Scheduler& scheduler_;
@@ -94,7 +96,7 @@ private:
     mutable std::condition_variable cond_;
     mutable std::mutex mutex_;
     Ledger::pointer newLedger_;
-    Ledger::pointer validatedLedger_;
+    std::atomic<bool> rotating_;
     TransactionMaster& transactionMaster_;
     std::atomic <LedgerIndex> canDelete_;
     // these do not exist upon SHAMapStore creation, but do exist
@@ -105,6 +107,12 @@ private:
     TreeNodeCache* treeNodeCache_ = nullptr;
     DatabaseCon* transactionDb_ = nullptr;
     DatabaseCon* ledgerDb_ = nullptr;
+
+public:
+    bool rotating() const
+    {
+        return rotating_;
+    }
 
 public:
     SHAMapStoreImp (Application& app,
@@ -206,9 +214,11 @@ private:
      */
     void clearSql (DatabaseCon& database, LedgerIndex lastRotated,
                    std::string const& minQuery, std::string const& deleteQuery);
+    void clearSql(DatabaseCon& database, std::string const& deleteQuery);
     void clearCaches (LedgerIndex validatedSeq);
     void freshenCaches();
     void clearPrior (LedgerIndex lastRotated);
+private:
 
     // If rippled is not healthy, defer rotate-delete.
     // If already unhealthy, do not change state on further check.

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -214,11 +214,9 @@ private:
      */
     void clearSql (DatabaseCon& database, LedgerIndex lastRotated,
                    std::string const& minQuery, std::string const& deleteQuery);
-    void clearSql(DatabaseCon& database, std::string const& deleteQuery);
     void clearCaches (LedgerIndex validatedSeq);
     void freshenCaches();
     void clearPrior (LedgerIndex lastRotated);
-private:
 
     // If rippled is not healthy, defer rotate-delete.
     // If already unhealthy, do not change state on further check.

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -80,9 +80,9 @@ private:
     // check health/stop status as records are copied
     std::uint64_t const checkHealthInterval_ = 1000;
     // minimum # of ledgers to maintain for health of network
-    std::uint32_t const minimumDeletionInterval_ = 256;
+    static std::uint32_t const minimumDeletionInterval_ = 256;
     // minimum # of ledgers required for standalone mode.
-    std::uint32_t const minimumDeletionIntervalSA_ = 8;
+    static std::uint32_t const minimumDeletionIntervalSA_ = 8;
 
     Setup setup_;
     NodeStore::Scheduler& scheduler_;

--- a/src/ripple/app/tests/SHAMapStore_test.cpp
+++ b/src/ripple/app/tests/SHAMapStore_test.cpp
@@ -28,7 +28,7 @@ namespace test {
 
 class SHAMapStore_test : public beast::unit_test::suite
 {
-    static auto constexpr deleteInterval = 8;
+    static auto const deleteInterval = 8;
 
     static
     std::unique_ptr<Config>
@@ -136,12 +136,10 @@ class SHAMapStore_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
 
-        auto store = dynamic_cast<SHAMapStoreImp*>(
-            &env.app().getSHAMapStore());
-        expect(store);
+        auto& store = env.app().getSHAMapStore();
 
         int ledgerSeq = 3;
-        while (!store->getLastRotated())
+        while (!store.getLastRotated())
         {
             env.close();
             std::this_thread::sleep_for(100ms);

--- a/src/ripple/app/tests/SHAMapStore_test.cpp
+++ b/src/ripple/app/tests/SHAMapStore_test.cpp
@@ -1,0 +1,575 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/app/misc/SHAMapStoreImp.h>
+#include <ripple/core/ConfigSections.h>
+#include <ripple/test/jtx.h>
+
+namespace ripple {
+namespace test {
+
+class SHAMapStore_test : public beast::unit_test::suite
+{
+    static auto constexpr deleteInterval = 8;
+
+    static
+    std::unique_ptr<Config>
+    makeConfig()
+    {
+        auto p = std::make_unique<Config>();
+        setupConfigForUnitTests(*p);
+        p->LEDGER_HISTORY = deleteInterval;
+        auto& section = p->section(ConfigSection::nodeDatabase());
+        section.set("online_delete", to_string(deleteInterval));
+        //section.set("age_threshold", "60");
+        return p;
+    }
+
+    static
+    std::unique_ptr<Config>
+    makeConfigAdvisory()
+    {
+        auto p = makeConfig();
+        auto& section = p->section(ConfigSection::nodeDatabase());
+        section.set("advisory_delete", "1");
+        return p;
+    }
+
+    bool goodLedger(Json::Value const& json, std::string ledgerID)
+    {
+        return json.isMember(jss::result)
+            && !RPC::contains_error(json[jss::result])
+            && json[jss::result][jss::ledger][jss::ledger_index] == ledgerID;
+    }
+
+    bool bad(Json::Value const& json, error_code_i error = rpcLGR_NOT_FOUND)
+    {
+        return json.isMember(jss::result)
+            && RPC::contains_error(json[jss::result])
+            && json[jss::result][jss::error_code] == error;
+    }
+
+    std::string getHash(Json::Value const& json)
+    {
+        expect(json.isMember(jss::result) &&
+            json[jss::result].isMember(jss::ledger) &&
+            json[jss::result][jss::ledger].isMember(jss::hash) &&
+            json[jss::result][jss::ledger][jss::hash].isString());
+        return json[jss::result][jss::ledger][jss::hash].asString();
+    }
+
+    void validationCheck(jtx::Env& env, int const expected)
+    {
+        auto db = env.app().getLedgerDB().checkoutDb();
+
+        int actual;
+        *db << "SELECT count(*) AS rows FROM Validations;",
+            soci::into(actual);
+
+        expect(actual == expected);
+
+    }
+
+    void ledgerCheck(jtx::Env& env, int const rows,
+        int const first)
+    {
+        auto db = env.app().getLedgerDB().checkoutDb();
+
+        int actualRows, actualFirst, actualLast;
+        *db << "SELECT count(*) AS rows, "
+            "min(LedgerSeq) as first, "
+            "max(LedgerSeq) as last "
+            "FROM Ledgers;",
+            soci::into(actualRows),
+            soci::into(actualFirst),
+            soci::into(actualLast);
+
+        expect(actualRows == rows);
+        expect(actualFirst == first);
+        expect(actualLast == first + rows - 1);
+
+    }
+
+    void transactionCheck(jtx::Env& env, int const rows)
+    {
+        auto db = env.app().getTxnDB().checkoutDb();
+
+        int actualRows;
+        *db << "SELECT count(*) AS rows "
+            "FROM Transactions;",
+            soci::into(actualRows);
+
+        expect(actualRows == rows);
+    }
+
+    void accountTransactionCheck(jtx::Env& env, int const rows)
+    {
+        auto db = env.app().getTxnDB().checkoutDb();
+
+        int actualRows;
+        *db << "SELECT count(*) AS rows "
+            "FROM AccountTransactions;",
+            soci::into(actualRows);
+
+        expect(actualRows == rows);
+    }
+
+    int waitForReady(jtx::Env& env)
+    {
+        using namespace std::chrono_literals;
+
+        auto store = dynamic_cast<SHAMapStoreImp*>(
+            &env.app().getSHAMapStore());
+        expect(store);
+
+        int ledgerSeq = 3;
+        while (!store->getLastRotated())
+        {
+            env.close();
+            std::this_thread::sleep_for(100ms);
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq++)));
+        }
+        return ledgerSeq;
+    }
+
+public:
+    void testClear()
+    {
+        using namespace std::chrono_literals;
+
+        testcase("clearPrior");
+        using namespace jtx;
+
+        Env env(*this, makeConfig());
+
+        auto store = dynamic_cast<SHAMapStoreImp*>(
+            &env.app().getSHAMapStore());
+        expect(store);
+        env.fund(XRP(10000), noripple("alice"));
+
+        validationCheck(env, 0);
+        ledgerCheck(env, 1, 2);
+        transactionCheck(env, 0);
+        accountTransactionCheck(env, 0);
+
+        std::map<std::uint32_t, Json::Value const> ledgers;
+
+        auto ledgerTmp = env.rpc("ledger", "0");
+        expect(bad(ledgerTmp));
+
+        ledgers.emplace(std::make_pair(1, env.rpc("ledger", "1")));
+        expect(goodLedger(ledgers[1], "1"));
+
+        ledgers.emplace(std::make_pair(2, env.rpc("ledger", "2")));
+        expect(goodLedger(ledgers[2], "2"));
+
+        ledgerTmp = env.rpc("ledger", "current");
+        expect(goodLedger(ledgerTmp, "3"));
+
+        ledgerTmp = env.rpc("ledger", "4");
+        expect(bad(ledgerTmp));
+
+        ledgerTmp = env.rpc("ledger", "100");
+        expect(bad(ledgerTmp));
+
+        for (auto i = 4; i < deleteInterval + 4; ++i)
+        {
+            env.fund(XRP(10000), noripple("test" + to_string(i)));
+            env.close();
+
+            ledgerTmp = env.rpc("ledger", "current");
+            expect(goodLedger(ledgerTmp, to_string(i)));
+        }
+        assert(store->getLastRotated() == 3);
+
+        for (auto i = 3; i < deleteInterval + 3; ++i)
+        {
+            ledgers.emplace(std::make_pair(i,
+                env.rpc("ledger", to_string(i))));
+            expect(goodLedger(ledgers[i], to_string(i)) &&
+                getHash(ledgers[i]).length());
+        }
+
+        validationCheck(env, 0);
+        ledgerCheck(env, deleteInterval + 1, 2);
+        transactionCheck(env, deleteInterval + 1);
+        accountTransactionCheck(env, 2*(deleteInterval + 1));
+
+        {
+            // Since standalone doesn't _do_ validations, manually
+            // insert some into the table. Create some with the
+            // hashes from our real ledgers, and some with fake
+            // hashes to represent validations that never ended up
+            // in a validated ledger.
+            char lh[65];
+            memset(lh, 'a', 64);
+            lh[64] = '\0';
+            std::vector<std::string> ledgerHashes({
+                lh
+            });
+            for (auto const& lgr : ledgers)
+            {
+                ledgerHashes.emplace_back(getHash(lgr.second));
+            }
+            for (auto i = 0; i < 10; ++i)
+            {
+                ++lh[30];
+                ledgerHashes.emplace_back(lh);
+            }
+
+            auto db = env.app().getLedgerDB().checkoutDb();
+
+            *db << "INSERT INTO Validations "
+                "(LedgerHash) "
+                "VALUES "
+                "(:ledgerHash);",
+                soci::use(ledgerHashes);
+        }
+
+        validationCheck(env, deleteInterval + 13);
+        ledgerCheck(env, deleteInterval + 1, 2);
+        transactionCheck(env, deleteInterval + 1);
+        accountTransactionCheck(env, 2 * (deleteInterval + 1));
+
+        {
+            // Closing one more ledger triggers a rotate
+            env.close();
+
+            auto ledger = env.rpc("ledger", "current");
+            expect(goodLedger(ledger, to_string(deleteInterval + 4)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        expect(store->getLastRotated() == deleteInterval + 3);
+        auto const lastRotated = store->getLastRotated();
+
+        // That took care of the fake hashes
+        validationCheck(env, deleteInterval);
+        ledgerCheck(env, deleteInterval + 1, 3);
+        transactionCheck(env, deleteInterval + 1);
+        accountTransactionCheck(env, 2 * (deleteInterval + 1));
+
+        for (auto i = lastRotated - 1; i < lastRotated + deleteInterval - 1; ++i)
+        {
+            validationCheck(env, deleteInterval + i + 1 - lastRotated);
+
+            env.close();
+
+            ledgerTmp = env.rpc("ledger", "current");
+            expect(goodLedger(ledgerTmp, to_string(i + 3)));
+
+            ledgers.emplace(std::make_pair(i,
+                env.rpc("ledger", to_string(i))));
+            expect(goodLedger(ledgers[i], to_string(i)) &&
+                getHash(ledgers[i]).length());
+
+            std::vector<std::string> ledgerHashes({
+                getHash(ledgers[i])
+            });
+            auto db = env.app().getLedgerDB().checkoutDb();
+
+            *db << "INSERT INTO Validations "
+                "(LedgerHash) "
+                "VALUES "
+                "(:ledgerHash);",
+                soci::use(ledgerHashes);
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        expect(store->getLastRotated() == deleteInterval + lastRotated);
+
+        validationCheck(env, deleteInterval - 1);
+        ledgerCheck(env, deleteInterval + 1, lastRotated);
+        transactionCheck(env, 0);
+        accountTransactionCheck(env, 0);
+
+    }
+
+    void testAutomatic()
+    {
+        testcase("automatic online_delete");
+        using namespace jtx;
+        using namespace std::chrono_literals;
+
+        Env env(*this, makeConfig());
+        auto store = dynamic_cast<SHAMapStoreImp*>(
+            &env.app().getSHAMapStore());
+        expect(store);
+
+        auto ledgerSeq = waitForReady(env);
+        auto lastRotated = ledgerSeq - 1;
+        expect(store->getLastRotated() == lastRotated,
+            to_string(store->getLastRotated()));
+        expect(lastRotated != 2);
+
+        // Because advisory_delete is unset,
+        // "can_delete" is disabled.
+        auto const canDelete = env.rpc("can_delete");
+        expect(bad(canDelete, rpcNOT_ENABLED));
+
+        // Close ledgers without triggering a rotate
+        for (; ledgerSeq < lastRotated + deleteInterval; ++ledgerSeq)
+        {
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq)));
+        }
+
+        while(store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        // The database will always have back to ledger 2,
+        // regardless of lastRotated.
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - 2, 2);
+        expect(lastRotated == store->getLastRotated());
+
+        {
+            // Closing one more ledger triggers a rotate
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq++)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - lastRotated, lastRotated);
+        expect(lastRotated != store->getLastRotated());
+
+        lastRotated = store->getLastRotated();
+
+        // Close enough ledgers to trigger another rotate
+        for (; ledgerSeq < lastRotated + deleteInterval + 1; ++ledgerSeq)
+        {
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, deleteInterval + 1, lastRotated);
+        expect(lastRotated != store->getLastRotated());
+    }
+
+    void testCanDelete()
+    {
+        testcase("online_delete with advisory_delete");
+        using namespace jtx;
+        using namespace std::chrono_literals;
+
+        // Same config with advisory_delete enabled
+        Env env(*this, makeConfigAdvisory());
+        auto store = dynamic_cast<SHAMapStoreImp*>(
+            &env.app().getSHAMapStore());
+        expect(store);
+
+        auto ledgerSeq = waitForReady(env);
+        auto lastRotated = ledgerSeq - 1;
+        expect(store->getLastRotated() == lastRotated,
+            to_string(store->getLastRotated()));
+        expect(lastRotated != 2);
+
+        auto canDelete = env.rpc("can_delete");
+        expect(!RPC::contains_error(canDelete[jss::result]));
+        expect(canDelete[jss::result][jss::can_delete] == 0);
+
+        canDelete = env.rpc("can_delete", "never");
+        expect(!RPC::contains_error(canDelete[jss::result]));
+        expect(canDelete[jss::result][jss::can_delete] == 0);
+
+        auto const firstBatch = deleteInterval + ledgerSeq;
+        for (; ledgerSeq < firstBatch; ++ledgerSeq)
+        {
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - 2, 2);
+        expect(lastRotated == store->getLastRotated());
+
+        // This does not kick off a cleanup
+        canDelete = env.rpc("can_delete", to_string(
+            ledgerSeq + deleteInterval / 2));
+        expect(!RPC::contains_error(canDelete[jss::result]));
+        expect(canDelete[jss::result][jss::can_delete] ==
+            ledgerSeq + deleteInterval / 2);
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - 2, 2);
+        expect(store->getLastRotated() == lastRotated);
+
+        {
+            // This kicks off a cleanup, but it stays small.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq++)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - lastRotated, lastRotated);
+
+        expect(store->getLastRotated() == ledgerSeq - 1);
+        lastRotated = ledgerSeq - 1;
+
+        for (; ledgerSeq < lastRotated + deleteInterval; ++ledgerSeq)
+        {
+            // No cleanups in this loop.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        expect(store->getLastRotated() == lastRotated);
+
+        {
+            // This kicks off another cleanup.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq++)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - firstBatch, firstBatch);
+
+        expect(store->getLastRotated() == ledgerSeq - 1);
+        lastRotated = ledgerSeq - 1;
+
+        // This does not kick off a cleanup
+        canDelete = env.rpc("can_delete", "always");
+        expect(!RPC::contains_error(canDelete[jss::result]));
+        expect(canDelete[jss::result][jss::can_delete] ==
+            std::numeric_limits <unsigned int>::max());
+
+        for (; ledgerSeq < lastRotated + deleteInterval; ++ledgerSeq)
+        {
+            // No cleanups in this loop.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        expect(store->getLastRotated() == lastRotated);
+
+        {
+            // This kicks off another cleanup.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq++)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - lastRotated, lastRotated);
+
+        expect(store->getLastRotated() == ledgerSeq - 1);
+        lastRotated = ledgerSeq - 1;
+
+        // This does not kick off a cleanup
+        canDelete = env.rpc("can_delete", "now");
+        expect(!RPC::contains_error(canDelete[jss::result]));
+        expect(canDelete[jss::result][jss::can_delete] == ledgerSeq - 1);
+
+        for (; ledgerSeq < lastRotated + deleteInterval; ++ledgerSeq)
+        {
+            // No cleanups in this loop.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        expect(store->getLastRotated() == lastRotated);
+
+        {
+            // This kicks off another cleanup.
+            env.close();
+
+            auto ledger = env.rpc("ledger", "validated");
+            expect(goodLedger(ledger, to_string(ledgerSeq++)));
+        }
+
+        while (store->rotating())
+            std::this_thread::sleep_for(1ms);
+
+        validationCheck(env, 0);
+        ledgerCheck(env, ledgerSeq - lastRotated, lastRotated);
+
+        expect(store->getLastRotated() == ledgerSeq - 1);
+        lastRotated = ledgerSeq - 1;
+    }
+
+    void run()
+    {
+        testClear();
+        testAutomatic();
+        testCanDelete();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(SHAMapStore,app,ripple);
+
+}
+}

--- a/src/ripple/rpc/handlers/CanDelete.cpp
+++ b/src/ripple/rpc/handlers/CanDelete.cpp
@@ -70,10 +70,11 @@ Json::Value doCanDelete (RPC::Context& context)
             {
                 canDeleteSeq = context.app.getSHAMapStore().getLastRotated();
                 if (!canDeleteSeq)
-                    return RPC::make_error (rpcNOT_READY);            }
-                else if (canDeleteStr.size() == 64 &&
-                    canDeleteStr.find_first_not_of("0123456789abcdef") ==
-                    std::string::npos)
+                    return RPC::make_error (rpcNOT_READY);
+            }
+            else if (canDeleteStr.size() == 64 &&
+                canDeleteStr.find_first_not_of("0123456789abcdef") ==
+                std::string::npos)
             {
                 auto ledger = context.ledgerMaster.getLedgerByHash (
                     from_hex_text<uint256>(canDeleteStr));

--- a/src/ripple/unity/app_tests.cpp
+++ b/src/ripple/unity/app_tests.cpp
@@ -29,6 +29,7 @@
 #include <ripple/app/tests/Offer.test.cpp>
 #include <ripple/app/tests/Path_test.cpp>
 #include <ripple/app/tests/Regression_test.cpp>
+#include <ripple/app/tests/SHAMapStore_test.cpp>
 #include <ripple/app/tests/SusPay_test.cpp>
 #include <ripple/app/tests/SetAuth_test.cpp>
 #include <ripple/app/tests/OversizeMeta_test.cpp>


### PR DESCRIPTION
* Lower online delete minimum for standalone mode.
* Clean up logging.
* Unit tests of online_delete.

My "large data set" testing procedure started with the existing installation on my dogfood box, running as a validator. Notably, ledger.db was over 13Gb, with about 22,000,000 rows in the `Validations` table. I configured `online_delete=150000`  and waited for online delete to kick in and finish cleaning up the `Ledgers` table. Based on observations of the debug and trace messages in the log and `server_info` output, the clean up has been able to average 4-5 queries per second (cleaning up about 100 rows each) without obviously interfering with other processing. The state does periodically change, causing the online delete to abort until rippled gets caught up, but that happens with the other queries, too, and the time it takes it pretty comparable, which leads to to believe that those changes are either independent of the query, or that this new query is at least no worse than the existing queries.

My initial cleanup is going to take at least 15 hours (22000000 rows / (400 rows/sec) / (3600sec/hour)), so I'll leave this branch running and keep observing for any other issues.

Each separate run of the query is pretty fast, despite the large data set for a few reasons.

1. The `Ledgers` clean up runs first, so the `Validations` clean up only needs to find rows that are not in `Ledgers`.
2. The inner query takes advantage of indexes on both tables to find mismatches (via the `LEFT OUTER JOIN`).
3. The `LIMIT` is applied on the inner query without any ordering so it'll end as soon as 100 mismatched rows are found.
4. And the 100 row dataset is small enough that the outer `DELETE` can act on it quickly as well.

One side effect of writing the query this way is that more than 100 rows can be deleted per pass -- if more than one row has the same `LedgerHash` -- but by letting it go free like that, the query can actually run more quickly than if we try to force it to exactly 100.

Reviewers: @mtrippled @seelabs 