### PR TITLE
Simplify calculation of transfer fee

### DIFF
--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -94,12 +94,6 @@ std::uint32_t
 rippleTransferRate (ReadView const& view,
     AccountID const& issuer);
 
-std::uint32_t
-rippleTransferRate (ReadView const& view,
-    AccountID const& uSenderID,
-        AccountID const& uReceiverID,
-            AccountID const& issuer);
-
 /** Returns `true` if the directory is empty
     @param key The key of the directory
 */

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -294,20 +294,6 @@ rippleTransferRate (ReadView const& view,
     return quality;
 }
 
-std::uint32_t
-rippleTransferRate (ReadView const& view,
-    AccountID const& uSenderID,
-        AccountID const& uReceiverID,
-            AccountID const& issuer)
-{
-    // If calculating the transfer rate from
-    // or to the issuer of the currency no
-    // fees are assessed.
-    return (uSenderID == issuer || uReceiverID == issuer)
-           ? QUALITY_ONE
-           : rippleTransferRate(view, issuer);
-}
-
 bool
 areCompatible (ReadView const& validLedger, ReadView const& testLedger,
     beast::Journal::Stream& s, const char* reason)
@@ -1313,39 +1299,9 @@ rippleCredit (ApplyView& view,
     return terResult;
 }
 
-// Calculate the fee needed to transfer IOU assets between two parties.
-static
-STAmount
-rippleTransferFee (ReadView const& view,
-    AccountID const& from,
-    AccountID const& to,
-    AccountID const& issuer,
-    STAmount const& saAmount,
-    beast::Journal j)
-{
-    if (from != issuer && to != issuer)
-    {
-        std::uint32_t uTransitRate = rippleTransferRate (view, issuer);
-
-        if (QUALITY_ONE != uTransitRate)
-        {
-            STAmount saTransferTotal = multiply (
-                saAmount, amountFromRate (uTransitRate), saAmount.issue ());
-            STAmount saTransferFee = saTransferTotal - saAmount;
-
-            JLOG (j.debug) << "rippleTransferFee:" <<
-                " saTransferFee=" << saTransferFee.getFullText ();
-
-            return saTransferFee;
-        }
-    }
-
-    return saAmount.zeroed();
-}
-
 // Send regardless of limits.
 // --> saAmount: Amount/currency/issuer to deliver to reciever.
-// <-- saActual: Amount actually cost.  Sender pay's fees.
+// <-- saActual: Amount actually cost.  Sender pays fees.
 static
 TER
 rippleSend (ApplyView& view,
@@ -1353,7 +1309,6 @@ rippleSend (ApplyView& view,
     STAmount const& saAmount, STAmount& saActual, beast::Journal j)
 {
     auto const issuer   = saAmount.getIssuer ();
-    TER             terResult;
 
     assert (!isXRP (uSenderID) && !isXRP (uReceiverID));
     assert (uSenderID != uReceiverID);
@@ -1362,32 +1317,36 @@ rippleSend (ApplyView& view,
     {
         // Direct send: redeeming IOUs and/or sending own IOUs.
         rippleCredit (view, uSenderID, uReceiverID, saAmount, false, j);
-        saActual    = saAmount;
-        terResult   = tesSUCCESS;
+        saActual = saAmount;
+        return tesSUCCESS;
     }
-    else
+
+    // Sending 3rd party IOUs: transit.
+
+    // First, calculate the amount to transfer accounting
+    // for any transfer fees:
     {
-        // Sending 3rd party IOUs: transit.
+        auto const rate = rippleTransferRate (view, issuer);
 
-        STAmount saTransitFee = rippleTransferFee (view,
-            uSenderID, uReceiverID, issuer, saAmount, j);
-
-        saActual = !saTransitFee ? saAmount : saAmount + saTransitFee;
-
-        saActual.setIssuer (issuer); // XXX Make sure this done in + above.
-
-        JLOG (j.debug) << "rippleSend> " <<
-            to_string (uSenderID) <<
-            " - > " << to_string (uReceiverID) <<
-            " : deliver=" << saAmount.getFullText () <<
-            " fee=" << saTransitFee.getFullText () <<
-            " cost=" << saActual.getFullText ();
-
-        terResult   = rippleCredit (view, issuer, uReceiverID, saAmount, true, j);
-
-        if (tesSUCCESS == terResult)
-            terResult   = rippleCredit (view, uSenderID, issuer, saActual, true, j);
+        if (QUALITY_ONE == rate)
+            saActual = saAmount;
+        else
+            saActual = multiply (
+                saAmount,
+                amountFromRate (rate),
+                saAmount.issue ());
     }
+
+    JLOG (j.debug) << "rippleSend> " <<
+        to_string (uSenderID) <<
+        " - > " << to_string (uReceiverID) <<
+        " : deliver=" << saAmount.getFullText () <<
+        " cost=" << saActual.getFullText ();
+
+    TER terResult = rippleCredit (view, issuer, uReceiverID, saAmount, true, j);
+
+    if (tesSUCCESS == terResult)
+        terResult = rippleCredit (view, uSenderID, issuer, saActual, true, j);
 
     return terResult;
 }


### PR DESCRIPTION
This is a simplification to the way we handle the transfer fee: it eliminates a couple of function calls, and avoids subtracting an amount only to then readd it and expecting to get back the original minuend.

We may want to just reject this, pending Scott D's refactor - I leave that up to you.

Reviews: @JoelKatz, @seelabs 