### PR TITLE
Improve reporting of delivered_amount

### DIFF
--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -163,7 +163,7 @@ Json::Value doAccountTx (RPC::Context& context)
                 {
                     auto meta = it.second->getJson (1);
                     addPaymentDeliveredAmount (meta, context, it.first, it.second);
-                    jvObj[jss::meta] = meta;
+                    jvObj[jss::meta] = std::move(meta);
 
                     std::uint32_t uLedgerIndex = it.second->getLgrSeq ();
 

--- a/src/ripple/rpc/handlers/AccountTxOld.cpp
+++ b/src/ripple/rpc/handlers/AccountTxOld.cpp
@@ -29,6 +29,7 @@
 #include <ripple/resource/Fees.h>
 #include <ripple/rpc/Context.h>
 #include <ripple/rpc/impl/LookupLedger.h>
+#include <ripple/rpc/impl/Utilities.h>
 #include <ripple/server/Role.h>
 
 namespace ripple {
@@ -183,7 +184,10 @@ Json::Value doAccountTxOld (RPC::Context& context)
                 {
                     std::uint32_t uLedgerIndex = it->second->getLgrSeq ();
 
-                    jvObj[jss::meta]           = it->second->getJson (0);
+                    auto meta = it->second->getJson(0);
+                    addPaymentDeliveredAmount(meta, context, it->first, it->second);
+                    jvObj[jss::meta] = std::move(meta);
+
                     jvObj[jss::validated]
                             = bValidated
                             && uValidatedMin <= uLedgerIndex

--- a/src/ripple/rpc/impl/Utilities.cpp
+++ b/src/ripple/rpc/impl/Utilities.cpp
@@ -42,20 +42,29 @@ addPaymentDeliveredAmount (
 {
     // We only want to add a "delivered_amount" field if the transaction
     // succeeded - otherwise nothing could have been delivered.
-    if (!transaction || transaction->getResult () != tesSUCCESS)
+    if (! transaction)
         return;
 
     auto serializedTx = transaction->getSTransaction ();
-
-    if (!serializedTx || serializedTx->getTxnType () != ttPAYMENT)
+    if (! serializedTx || serializedTx->getTxnType () != ttPAYMENT)
         return;
 
-    // If the transaction explicitly specifies a DeliveredAmount in the
-    // metadata then we use it.
-    if (transactionMeta && transactionMeta->hasDeliveredAmount ())
+    if (transactionMeta)
     {
-        meta[jss::delivered_amount] =
-            transactionMeta->getDeliveredAmount ().getJson (1);
+        if (transactionMeta->getResultTER() != tesSUCCESS)
+            return;
+
+        // If the transaction explicitly specifies a DeliveredAmount in the
+        // metadata then we use it.
+        if (transactionMeta->hasDeliveredAmount ())
+        {
+            meta[jss::delivered_amount] =
+                transactionMeta->getDeliveredAmount ().getJson (1);
+            return;
+        }
+    }
+    else if (transaction->getResult() != tesSUCCESS)
+    {
         return;
     }
 


### PR DESCRIPTION
Robust reporting of delivered_amount:
* Use the result from the metadata, to determine if a particular transaction succeeded.
* Report delivered_amount for legacy `account_tx` queries.

Reviewers: @JoelKatz @nbougalis 