### PR TITLE
Copy rules from parent ledger

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -271,6 +271,7 @@ Ledger::Ledger (open_ledger_t, Ledger const& prevLedger,
         prevLedger.stateMap_->family()))
     , stateMap_ (prevLedger.stateMap_->snapShot (true))
     , fees_(prevLedger.fees_)
+    , rules_(prevLedger.rules_)
 {
     info_.open = true;
     info_.seq = prevLedger.info_.seq + 1;


### PR DESCRIPTION
`Ledger` ctor for `open_ledger` is initialized based off of `prevLedger`, but the `Rules` object is not initialized. In `LedgerConsensusImp::accept`, this causes the `newLCL` to always be built with an empty set of rules, which are not updated until `setAccepted`, which is called *after* transactions are applied, and the `TxQ` attempts to update its metrics.

This change simply initializes the rules with those from the `prevLedger`.

Reviewers: @nbougalis, @JoelKatz