### PR TITLE
Extend View.cpp unit test coverage.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -421,8 +421,8 @@ def get_libs(lib, static):
             else:
                 static_libs.append(l)
         return (static_libs, dynamic_libs)
-    except:
-        raise Exception('pkg-config failed for ' + lib)
+    except Exception as e:
+        raise Exception('pkg-config failed for ' + lib + ' Exception: ' + str(e))
 
 def add_sanitizer (toolchain, env):
     san = GetOption('sanitize')

--- a/SConstruct
+++ b/SConstruct
@@ -422,7 +422,7 @@ def get_libs(lib, static):
                 static_libs.append(l)
         return (static_libs, dynamic_libs)
     except Exception as e:
-        raise Exception('pkg-config failed for ' + lib + ' Exception: ' + str(e))
+        raise Exception('pkg-config failed for ' + lib + '; Exception: ' + str(e))
 
 def add_sanitizer (toolchain, env):
     san = GetOption('sanitize')


### PR DESCRIPTION
A couple of notes on this pull request:

One of the unit tests in particular uses an unusual technique (https://github.com/scottschurr/rippled/blob/9c91b0a676f97380e0e03f69c01eea03c9df4b02/src/ripple/ledger/tests/View_test.cpp#L667-L728).  It holds onto `shared_ptr`s of ledgers past the lifetime of the `Env` that created the ledgers.  This seems to work fine within the confines of this unit test.  I made a cursory examination of one of these orphan ledgers using the debugger and did not spot anything suspicious.  But I can remove that test if folks decide the technique is too risky.

The `GetAmendments` and `DirIsEmpty` tests are slow.  So I put them each in their own test suites.

Additionally, @seelabs consulted with me and suggested a small addition to SConstruct.  That addition is small enough that we felt it could be combined with this pull request.

Reviewers: @nbougalis, @seelabs