### PR TITLE
Return correct error code during unfunded offer crossing

### DIFF
--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -575,10 +575,9 @@ CreateOffer::step_account (OfferStream& stream, Taker const& taker, Logs& logs)
     return false;
 }
 
-// Fill offer as much as possible by consuming offers already on the books,
-// and adjusting account balances accordingly.
-//
-// Charges fees on top to taker.
+// Fill as much of the offer as possible by consuming offers
+// already on the books. Return the status and the amount of
+// the offer to left unfilled.
 std::pair<TER, Amounts>
 CreateOffer::cross (
     ApplyView& view,
@@ -592,6 +591,20 @@ CreateOffer::cross (
     Taker taker (cross_type_, view, account_, taker_amount,
         ctx_.tx.getFlags(), beast::Journal (takerSink));
 
+    // If the taker is unfunded before we begin crossing
+    // there's nothing to do - just return an error.
+    //
+    // We check this in preclaim, but when selling XRP
+    // charged fees can cause a user's available balance
+    // to go to 0 (by causing it to dip below the reserve)
+    // so we check this case again.
+    if (taker.unfunded ())
+    {
+        JLOG (j_.debug) <<
+            "Not crossing: taker is unfunded.";
+        return { tecUNFUNDED_OFFER, taker_amount };
+    }
+
     try
     {
         if (cross_type_ == CrossType::IouToIou)
@@ -601,8 +614,9 @@ CreateOffer::cross (
     }
     catch (std::exception const& e)
     {
-        j_.error << "Exception during offer crossing: " << e.what ();
-        return std::make_pair (tecINTERNAL, taker.remaining_offer ());
+        JLOG (j_.error) <<
+            "Exception during offer crossing: " << e.what ();
+        return { tecINTERNAL, taker.remaining_offer () };
     }
 }
 
@@ -794,7 +808,7 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
     // entire operation should be aborted, with only fees paid.
     if (bFillOrKill)
     {
-        j_.trace << "Fill or Kill: offer killed";
+        JLOG (j_.trace) << "Fill or Kill: offer killed";
         return { tesSUCCESS, false };
     }
 
@@ -802,7 +816,7 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
     // placed - it gets cancelled and the operation succeeds.
     if (bImmediateOrCancel)
     {
-        j_.trace << "Immediate or cancel: offer cancelled";
+        JLOG (j_.trace) << "Immediate or cancel: offer cancelled";
         return { tesSUCCESS, true };
     }
 
@@ -847,7 +861,7 @@ CreateOffer::applyGuts (ApplyView& view, ApplyView& view_cancel)
         // Update owner count.
         adjustOwnerCount(view, sleCreator, 1, viewJ);
 
-        if (j_.trace) j_.trace <<
+        JLOG (j_.trace) <<
             "adding to book: " << to_string (saTakerPays.issue ()) <<
             " : " << to_string (saTakerGets.issue ());
 

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -88,7 +88,7 @@ CreateOffer::preflight (PreflightContext const& ctx)
     if (saTakerPays.native () && saTakerGets.native ())
     {
         JLOG(j.debug) <<
-            "Malformed offer: XRP for XRP";
+            "Malformed offer: redundant (XRP for XRP)";
         return temBAD_OFFER;
     }
     if (saTakerPays <= zero || saTakerGets <= zero)
@@ -107,14 +107,14 @@ CreateOffer::preflight (PreflightContext const& ctx)
     if (uPaysCurrency == uGetsCurrency && uPaysIssuerID == uGetsIssuerID)
     {
         JLOG(j.debug) <<
-            "Malformed offer: redundant offer";
+            "Malformed offer: redundant (IOU for IOU)";
         return temREDUNDANT;
     }
     // We don't allow a non-native currency to use the currency code XRP.
     if (badCurrency() == uPaysCurrency || badCurrency() == uGetsCurrency)
     {
         JLOG(j.debug) <<
-            "Malformed offer: Bad currency.";
+            "Malformed offer: bad currency";
         return temBAD_CURRENCY;
     }
 

--- a/src/ripple/app/tx/impl/Taker.cpp
+++ b/src/ripple/app/tx/impl/Taker.cpp
@@ -112,6 +112,16 @@ BasicTaker::effective_rate (
 }
 
 bool
+BasicTaker::unfunded () const
+{
+    if (get_funds (account(), remaining_.in) > zero)
+        return false;
+
+    journal_.debug << "Unfunded: taker is out of funds.";
+    return true;
+}
+
+bool
 BasicTaker::done () const
 {
     // We are done if we have consumed all the input currency
@@ -130,7 +140,7 @@ BasicTaker::done () const
     }
 
     // We are done if the taker is out of funds
-    if (get_funds (account(), remaining_.in) <= zero)
+    if (unfunded ())
     {
         journal_.debug << "Done: taker out of funds.";
         return true;
@@ -147,7 +157,7 @@ BasicTaker::remaining_offer () const
         return Amounts (remaining_.in.zeroed(), remaining_.out.zeroed());
 
     // Avoid math altogether if we didn't cross.
-   if (original_ == remaining_)
+    if (original_ == remaining_)
        return original_;
 
     if (sell_)
@@ -379,8 +389,6 @@ BasicTaker::flow_iou_to_iou (
 BasicTaker::Flow
 BasicTaker::do_cross (Amounts offer, Quality quality, AccountID const& owner)
 {
-    assert (!done ());
-
     auto const owner_funds = get_funds (owner, offer.out);
     auto const taker_funds = get_funds (account (), offer.in);
 
@@ -419,8 +427,6 @@ BasicTaker::do_cross (
     Amounts offer1, Quality quality1, AccountID const& owner1,
     Amounts offer2, Quality quality2, AccountID const& owner2)
 {
-    assert (!done ());
-
     assert (!offer1.in.native ());
     assert (offer1.out.native ());
     assert (offer2.in.native ());

--- a/src/ripple/app/tx/impl/Taker.h
+++ b/src/ripple/app/tx/impl/Taker.h
@@ -208,6 +208,10 @@ public:
         return issue_out_;
     }
 
+    /** Returns `true` if the taker has run out of funds. */
+    bool
+    unfunded () const;
+
     /** Returns `true` if order crossing should not continue.
         Order processing is stopped if the taker's order quantities have
         been reached, or if the taker has run out of input funds.


### PR DESCRIPTION
**Primary Change - Transaction-Breaking**
When placing an offer that sells XRP, if the account balance was low enough that paying the transaction fee would drop the balance below the reserve, the transaction should return `tecUNFUNDED_OFFER`.

The existing implementation returned a `tesSUCCESS` instead. Although the net result is the same as far as the transaction's effects (the offer is not placed on the books and the transaction fee is charged)
the incorrect result code made deciphering transaction metadata difficult.

Add unit test that verifies the new behavior.

**Secondary Change**
Add unit tests that exercise more functionality in the `OfferCreate` transactor, including the **`Fill or Kill`** and **`Immediate or Cancel`** modes and the handling of offer creation when the reserve threshold changes during offer processing.

Reviews: @JoelKatz, @vinniefalco, @ximinez 