### PR TITLE
Ensure fee change transactions have a unique transaction ID

### DIFF
--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -202,6 +202,7 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
     std::uint32_t const baseReserve = baseReserveVote.getVotes ();
     std::uint32_t const incReserve = incReserveVote.getVotes ();
     std::uint32_t const feeUnits = target_.reference_fee_units;
+    auto const seq = lastClosedLedger->info().seq + 1;
 
     // add transactions to our position
     if ((baseFee != lastClosedLedger->fees().base) ||
@@ -214,9 +215,10 @@ FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
             "/" << incReserve;
 
         STTx feeTx (ttFEE,
-            [baseFee,baseReserve,incReserve,feeUnits](auto& obj)
+            [seq,baseFee,baseReserve,incReserve,feeUnits](auto& obj)
             {
                 obj[sfAccount] = AccountID();
+                obj[sfLedgerSequence] = seq;
                 obj[sfBaseFee] = baseFee;
                 obj[sfReserveBase] = baseReserve;
                 obj[sfReserveIncrement] = incReserve;

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -86,7 +86,7 @@ TxFormats::TxFormats ()
         SOElement (sfOfferSequence,       SOE_REQUIRED);
 
     add ("EnableAmendment", ttAMENDMENT)
-        << SOElement (sfLedgerSequence,      SOE_OPTIONAL)
+        << SOElement (sfLedgerSequence,      SOE_REQUIRED)
         << SOElement (sfAmendment,           SOE_REQUIRED)
         ;
 


### PR DESCRIPTION
Include the ledger sequence number in fee change transactions to ensure each such transaction has a unique transaction ID. We have already made a ledger sequence optional in fee change transactions, so existing rippled's will understand these transactions without difficulty.

We tolerate the absence of a ledger sequence in fee change transactions so that past fee change transactions remain parseable. Since no live amendment transactions have yet happened, there is no need to tolerate an absent ledger sequence there. The code already put the ledger sequence number in amendment transactions, though it's not strictly needed since the same amendment is never supposed to be enabled twice anyway.