### PR TITLE
Add virtual destructor to Logs

### DIFF
--- a/src/ripple/basics/Log.h
+++ b/src/ripple/basics/Log.h
@@ -159,6 +159,8 @@ public:
     Logs (Logs const&) = delete;
     Logs& operator= (Logs const&) = delete;
 
+    virtual ~Logs() = default;
+
     bool
     open (boost::filesystem::path const& pathToLogFile);
 

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -128,6 +128,8 @@ public:
     {
     }
 
+    ~SuiteLogs() override = default;
+
     std::unique_ptr<beast::Journal::Sink>
     makeSink(std::string const& partition,
         beast::Journal::Severity startingLevel) override


### PR DESCRIPTION
This is a trivial PR to add a virtual destructor to Logs.

@scottschurr @HowardHinnant 