### PR TITLE
Refactor treatment of Ledger (RIPD-1089)

### DIFF
--- a/src/ripple/app/ledger/AcceptedLedgerTx.cpp
+++ b/src/ripple/app/ledger/AcceptedLedgerTx.cpp
@@ -41,7 +41,7 @@ AcceptedLedgerTx::AcceptedLedgerTx (
     , accountCache_ (accountCache)
     , logs_ (logs)
 {
-    assert (! ledger->info().open);
+    assert (! ledger->open());
 
     mResult = mMeta->getResultTER ();
 
@@ -65,7 +65,7 @@ AcceptedLedgerTx::AcceptedLedgerTx (
     , accountCache_ (accountCache)
     , logs_ (logs)
 {
-    assert (ledger->info().open);
+    assert (ledger->open());
     buildJson ();
 }
 

--- a/src/ripple/app/ledger/Consensus.h
+++ b/src/ripple/app/ledger/Consensus.h
@@ -77,7 +77,7 @@ public:
     startRound (
         LedgerConsensus& consensus,
         LedgerHash const &prevLCLHash,
-        Ledger::ref previousLedger,
+        std::shared_ptr<Ledger const> const& previousLedger,
         NetClock::time_point closeTime) = 0;
 
     /** Specified the network time when the last ledger closed */

--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -66,7 +66,8 @@ public:
     {
         return mHaveHeader;
     }
-    Ledger::ref getLedger () const
+    std::shared_ptr<Ledger> const&
+    getLedger() const
     {
         return mLedger;
     }
@@ -131,7 +132,7 @@ private:
     bool takeAsRootNode (Blob const& data, SHAMapAddNode&);
 
 private:
-    Ledger::pointer    mLedger;
+    std::shared_ptr<Ledger> mLedger;
     bool               mHaveHeader;
     bool               mHaveState;
     bool               mHaveTransactions;

--- a/src/ripple/app/ledger/InboundLedgers.h
+++ b/src/ripple/app/ledger/InboundLedgers.h
@@ -40,7 +40,9 @@ public:
 
     // VFALCO TODO Should this be called findOrAdd ?
     //
-    virtual Ledger::pointer acquire (uint256 const& hash,
+    virtual
+    std::shared_ptr<Ledger>
+    acquire (uint256 const& hash,
         std::uint32_t seq, InboundLedger::fcReason) = 0;
 
     virtual std::shared_ptr<InboundLedger> find (LedgerHash const& hash) = 0;

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -179,6 +179,7 @@ Ledger::Ledger (create_genesis_t, Config const& config, Family& family)
     info_.seq = 1;
     info_.drops = SYSTEM_CURRENCY_START;
     info_.closeTimeResolution = ledgerDefaultTimeResolution;
+
     static auto const id = calcAccountID(
         generateKeyPair(KeyType::secp256k1,
             generateSeed("masterpassphrase")).first);
@@ -189,7 +190,6 @@ Ledger::Ledger (create_genesis_t, Config const& config, Family& family)
     rawInsert(sle);
     stateMap_->flushDirty (hotACCOUNT_NODE, info_.seq);
     updateHash();
-    setClosed();
     setImmutable(config);
     setup(config);
 }
@@ -210,8 +210,8 @@ Ledger::Ledger (uint256 const& parentHash,
     : mImmutable (true)
     , txMap_ (std::make_shared <SHAMap> (
         SHAMapType::TRANSACTION, transHash, family))
-    , stateMap_ (std::make_shared <SHAMap> (SHAMapType::STATE, accountHash,
-        family))
+    , stateMap_ (std::make_shared <SHAMap> (
+        SHAMapType::STATE, accountHash, family))
 {
     info_.seq = ledgerSeq;
     info_.parentCloseTime = parentCloseTime;
@@ -222,6 +222,7 @@ Ledger::Ledger (uint256 const& parentHash,
     info_.parentHash = parentHash;
     info_.closeTimeResolution = closeResolution;
     info_.closeFlags = closeFlags;
+
     loaded = true;
 
     if (info_.txHash.isNonZero () &&
@@ -251,20 +252,8 @@ Ledger::Ledger (uint256 const& parentHash,
     }
 }
 
-// Create a new ledger that's a snapshot of this one
-Ledger::Ledger (Ledger const& ledger,
-                bool isMutable)
-    : mImmutable (!isMutable)
-    , txMap_ (ledger.txMap_->snapShot (isMutable))
-    , stateMap_ (ledger.stateMap_->snapShot (isMutable))
-    , fees_ (ledger.fees_)
-    , info_ (ledger.info_)
-{
-    updateHash ();
-}
-
-// Create a new open ledger that follows this one
-Ledger::Ledger (open_ledger_t, Ledger const& prevLedger,
+// Create a new ledger that follows this one
+Ledger::Ledger (Ledger const& prevLedger,
     NetClock::time_point closeTime)
     : mImmutable (false)
     , txMap_ (std::make_shared <SHAMap> (SHAMapType::TRANSACTION,
@@ -273,14 +262,13 @@ Ledger::Ledger (open_ledger_t, Ledger const& prevLedger,
     , fees_(prevLedger.fees_)
     , rules_(prevLedger.rules_)
 {
-    info_.open = true;
     info_.seq = prevLedger.info_.seq + 1;
     info_.parentCloseTime =
         prevLedger.info_.closeTime;
     info_.hash = prevLedger.info().hash + uint256(1);
     info_.drops = prevLedger.info().drops;
     info_.closeTimeResolution = prevLedger.info_.closeTimeResolution;
-    info_.parentHash = prevLedger.getHash ();
+    info_.parentHash = prevLedger.info().hash;
     info_.closeTimeResolution = getNextLedgerTimeResolution(
         prevLedger.info_.closeTimeResolution,
         getCloseAgree(prevLedger.info()), info_.seq);
@@ -374,39 +362,13 @@ void Ledger::updateHash()
     mValidHash = true;
 }
 
-void Ledger::setRaw (SerialIter& sit, bool hasPrefix, Family& family)
-{
-    if (hasPrefix)
-        sit.get32 ();
-
-    info_.seq = sit.get32 ();
-    info_.drops = sit.get64 ();
-    info_.parentHash = sit.get256 ();
-    info_.txHash = sit.get256 ();
-    info_.accountHash = sit.get256 ();
-    info_.parentCloseTime = NetClock::time_point{NetClock::duration{sit.get32()}};
-    info_.closeTime = NetClock::time_point{NetClock::duration{sit.get32()}};
-    info_.closeTimeResolution = NetClock::duration{sit.get8()};
-    info_.closeFlags = sit.get8 ();
-    updateHash ();
-    txMap_ = std::make_shared<SHAMap> (SHAMapType::TRANSACTION, info_.txHash,
-        family);
-    stateMap_ = std::make_shared<SHAMap> (SHAMapType::STATE, info_.accountHash,
-        family);
-}
-
-void Ledger::addRaw (Serializer& s) const
-{
-    ripple::addRaw(info_, s);
-}
-
 void
 Ledger::setAccepted(NetClock::time_point closeTime,
                     NetClock::duration closeResolution,
                     bool correctCloseTime, Config const& config)
 {
     // Used when we witnessed the consensus.
-    assert (closed());
+    assert (!open());
 
     info_.closeTime = closeTime;
     info_.closeTimeResolution = closeResolution;
@@ -453,28 +415,13 @@ deserializeTxPlusMeta (SHAMapItem const& item)
     return result;
 }
 
-void Ledger::setAcquiring (void)
+void Ledger::setAcquiring ()
 {
     if (!txMap_ || !stateMap_)
         Throw<std::runtime_error> ("invalid map");
 
     txMap_->setSynching ();
     stateMap_->setSynching ();
-}
-
-bool Ledger::isAcquiring (void) const
-{
-    return isAcquiringTx () || isAcquiringAS ();
-}
-
-bool Ledger::isAcquiringTx (void) const
-{
-    return txMap_->isSynching ();
-}
-
-bool Ledger::isAcquiringAS (void) const
-{
-    return stateMap_->isSynching ();
 }
 
 //------------------------------------------------------------------------------
@@ -555,18 +502,16 @@ auto
 Ledger::txsBegin() const ->
     std::unique_ptr<txs_type::iter_base>
 {
-    return std::make_unique<
-        txs_iter_impl>(closed(),
-            txMap_->begin(), *this);
+    return std::make_unique<txs_iter_impl>(
+        !open(), txMap_->begin(), *this);
 }
 
 auto
 Ledger::txsEnd() const ->
     std::unique_ptr<txs_type::iter_base>
 {
-    return std::make_unique<
-        txs_iter_impl>(closed(),
-            txMap_->end(), *this);
+    return std::make_unique<txs_iter_impl>(
+        !open(), txMap_->end(), *this);
 }
 
 bool
@@ -584,7 +529,7 @@ Ledger::txRead(
         txMap_->peekItem(key);
     if (! item)
         return {};
-    if (closed())
+    if (!open())
     {
         auto result =
             deserializeTxPlusMeta(*item);
@@ -649,30 +594,18 @@ Ledger::rawTxInsert (uint256 const& key,
         > const& txn, std::shared_ptr<
             Serializer const> const& metaData)
 {
-    assert (static_cast<bool>(metaData) != info_.open);
+    assert (metaData);
 
-    if (metaData)
-    {
-        // low-level - just add to table
-        Serializer s(txn->getDataLength () +
-            metaData->getDataLength () + 16);
-        s.addVL (txn->peekData ());
-        s.addVL (metaData->peekData ());
-        auto item = std::make_shared<
-            SHAMapItem const> (key, std::move(s));
-        if (! txMap().addGiveItem
-                (std::move(item), true, true))
-            LogicError("duplicate_tx: " + to_string(key));
-    }
-    else
-    {
-        // low-level - just add to table
-        auto item = std::make_shared<
-            SHAMapItem const>(key, txn->peekData());
-        if (! txMap().addGiveItem(
-                std::move(item), true, false))
-            LogicError("duplicate_tx: " + to_string(key));
-    }
+    // low-level - just add to table
+    Serializer s(txn->getDataLength () +
+        metaData->getDataLength () + 16);
+    s.addVL (txn->peekData ());
+    s.addVL (metaData->peekData ());
+    auto item = std::make_shared<
+        SHAMapItem const> (key, std::move(s));
+    if (! txMap().addGiveItem
+            (std::move(item), true, true))
+        LogicError("duplicate_tx: " + to_string(key));
 }
 
 bool
@@ -910,8 +843,31 @@ void Ledger::updateSkipList ()
         rawReplace(sle);
 }
 
+void Ledger::setRaw (SerialIter& sit, bool hasPrefix, Family& family)
+{
+    if (hasPrefix)
+        sit.get32 ();
+
+    info_.seq = sit.get32 ();
+    info_.drops = sit.get64 ();
+    info_.parentHash = sit.get256 ();
+    info_.txHash = sit.get256 ();
+    info_.accountHash = sit.get256 ();
+    info_.parentCloseTime = NetClock::time_point{NetClock::duration{sit.get32()}};
+    info_.closeTime = NetClock::time_point{NetClock::duration{sit.get32()}};
+    info_.closeTimeResolution = NetClock::duration{sit.get8()};
+    info_.closeFlags = sit.get8 ();
+    updateHash ();
+    txMap_ = std::make_shared<SHAMap> (SHAMapType::TRANSACTION, info_.txHash,
+        family);
+    stateMap_ = std::make_shared<SHAMap> (SHAMapType::STATE, info_.accountHash,
+        family);
+}
+
 static bool saveValidatedLedger (
-    Application& app, std::shared_ptr<Ledger> const& ledger, bool current)
+    Application& app,
+    std::shared_ptr<Ledger const> const& ledger,
+    bool current)
 {
     auto j = app.journal ("Ledger");
 
@@ -969,7 +925,7 @@ static bool saveValidatedLedger (
     {
         Serializer s (128);
         s.add32 (HashPrefix::ledgerMaster);
-        ledger->addRaw (s);
+        addRaw(ledger->info(), s);
         app.getNodeStore ().store (
             hotLEDGER, std::move (s.modData ()), ledger->info().hash);
     }
@@ -1099,8 +1055,11 @@ static bool saveValidatedLedger (
 /** Save, or arrange to save, a fully-validated ledger
     Returns false on error
 */
-bool pendSaveValidated (Application& app,
-    std::shared_ptr<Ledger> const& ledger, bool isSynchronous, bool isCurrent)
+bool pendSaveValidated (
+    Application& app,
+    std::shared_ptr<Ledger const> const& ledger,
+    bool isSynchronous,
+    bool isCurrent)
 {
     if (! app.getHashRouter ().setFlags (ledger->info().hash, SF_SAVED))
     {
@@ -1221,10 +1180,9 @@ Ledger::getNeededAccountStateHashes (
  *        (typically a where clause).
  * @return The ledger, ledger sequence, and ledger hash.
  */
-std::tuple<Ledger::pointer, std::uint32_t, uint256>
+std::tuple<std::shared_ptr<Ledger>, std::uint32_t, uint256>
 loadLedgerHelper(std::string const& sqlSuffix, Application& app)
 {
-    Ledger::pointer ledger;
     uint256 ledgerHash{};
     std::uint32_t ledgerSeq{0};
 
@@ -1258,7 +1216,10 @@ loadLedgerHelper(std::string const& sqlSuffix, Application& app)
     if (!db->got_data ())
     {
         JLOG (app.journal("Ledger").debug) << "Ledger not found: " << sqlSuffix;
-        return std::make_tuple (Ledger::pointer (), ledgerSeq, ledgerHash);
+        return std::make_tuple (
+            std::shared_ptr<Ledger>(),
+            ledgerSeq,
+            ledgerHash);
     }
 
     ledgerSeq =
@@ -1277,45 +1238,49 @@ loadLedgerHelper(std::string const& sqlSuffix, Application& app)
     using time_point = NetClock::time_point;
     using duration = NetClock::duration;
     bool loaded = false;
-    ledger = std::make_shared<Ledger>(prevHash,
-                                      transHash,
-                                      accountHash,
-                                      totDrops.value_or(0),
-                                      time_point{duration{closingTime.value_or(0)}},
-                                      time_point{duration{prevClosingTime.value_or(0)}},
-                                      closeFlags.value_or(0),
-                                      duration{closeResolution.value_or(0)},
-                                      ledgerSeq,
-                                      loaded,
-                                      app.config(),
-                                      app.family(),
-                                      app.journal("Ledger"));
+
+    auto ledger = std::make_shared<Ledger>(
+        prevHash,
+        transHash,
+        accountHash,
+        totDrops.value_or(0),
+        time_point{duration{closingTime.value_or(0)}},
+        time_point{duration{prevClosingTime.value_or(0)}},
+        closeFlags.value_or(0),
+        duration{closeResolution.value_or(0)},
+        ledgerSeq,
+        loaded,
+        app.config(),
+        app.family(),
+        app.journal("Ledger"));
 
     if (!loaded)
-        return std::make_tuple (Ledger::pointer (), ledgerSeq, ledgerHash);
+        ledger.reset();
 
     return std::make_tuple (ledger, ledgerSeq, ledgerHash);
 }
 
 static
-void finishLoadByIndexOrHash(Ledger::pointer& ledger, Config const& config, beast::Journal j)
+void finishLoadByIndexOrHash(
+    std::shared_ptr<Ledger> const& ledger,
+    Config const& config,
+    beast::Journal j)
 {
     if (!ledger)
         return;
 
-    ledger->setClosed ();
     ledger->setImmutable (config);
 
     JLOG (j.trace)
-        << "Loaded ledger: " << to_string (ledger->getHash ());
+        << "Loaded ledger: " << to_string (ledger->info().hash);
 
     ledger->setFull ();
 }
 
-Ledger::pointer
+std::shared_ptr<Ledger>
 loadByIndex (std::uint32_t ledgerIndex, Application& app)
 {
-    Ledger::pointer ledger;
+    std::shared_ptr<Ledger> ledger;
     {
         std::ostringstream s;
         s << "WHERE LedgerSeq = " << ledgerIndex;
@@ -1323,14 +1288,15 @@ loadByIndex (std::uint32_t ledgerIndex, Application& app)
             loadLedgerHelper (s.str (), app);
     }
 
-    finishLoadByIndexOrHash (ledger, app.config(), app.journal ("Ledger"));
+    finishLoadByIndexOrHash (ledger, app.config(),
+        app.journal ("Ledger"));
     return ledger;
 }
 
-Ledger::pointer
+std::shared_ptr<Ledger>
 loadByHash (uint256 const& ledgerHash, Application& app)
 {
-    Ledger::pointer ledger;
+    std::shared_ptr<Ledger> ledger;
     {
         std::ostringstream s;
         s << "WHERE LedgerHash = '" << ledgerHash << "'";
@@ -1338,9 +1304,10 @@ loadByHash (uint256 const& ledgerHash, Application& app)
             loadLedgerHelper (s.str (), app);
     }
 
-    finishLoadByIndexOrHash (ledger, app.config(), app.journal ("Ledger"));
+    finishLoadByIndexOrHash (ledger, app.config(),
+        app.journal ("Ledger"));
 
-    assert (!ledger || ledger->getHash () == ledgerHash);
+    assert (!ledger || ledger->info().hash == ledgerHash);
 
     return ledger;
 }

--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -56,7 +56,7 @@ public:
 
     virtual void startRound (
         LedgerHash const& prevLCLHash,
-        Ledger::ref prevLedger,
+        std::shared_ptr<Ledger const> const& prevLedger,
         NetClock::time_point closeTime,
         int previousProposers,
         std::chrono::milliseconds previousConvergeTime) = 0;
@@ -90,7 +90,7 @@ void applyTransactions (
     Application& app,
     SHAMap const* set,
     OpenView& view,
-    Ledger::ref checkLedger,
+    ReadView const& checkLedger,
     CanonicalTXSet& retriableTransactions,
     ApplyFlags flags);
 

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -40,7 +40,8 @@ public:
     /** Track a ledger
         @return `true` if the ledger was already tracked
     */
-    bool addLedger (Ledger::pointer ledger, bool validated);
+    bool insert (std::shared_ptr<Ledger const> ledger,
+        bool validated);
 
     /** Get the ledgers_by_hash cache hit rate
         @return the hit rate
@@ -50,22 +51,19 @@ public:
         return m_ledgers_by_hash.getHitRate ();
     }
 
-    /** Get a ledger given its squence number
-        @param ledgerIndex The sequence number of the desired ledger
-    */
-    Ledger::pointer getLedgerBySeq (LedgerIndex ledgerIndex);
+    /** Get a ledger given its squence number */
+    std::shared_ptr<Ledger const>
+    getLedgerBySeq (LedgerIndex ledgerIndex);
+
+    /** Retrieve a ledger given its hash */
+    std::shared_ptr<Ledger const>
+    getLedgerByHash (LedgerHash const& ledgerHash);
 
     /** Get a ledger's hash given its sequence number
         @param ledgerIndex The sequence number of the desired ledger
         @return The hash of the specified ledger
     */
     LedgerHash getLedgerHash (LedgerIndex ledgerIndex);
-
-    /** Retrieve a ledger given its hash
-        @param ledgerHash The hash of the requested ledger
-        @return The ledger requested
-    */
-    Ledger::pointer getLedgerByHash (LedgerHash const& ledgerHash);
 
     /** Set the history cache's paramters
         @param size The target size of the cache
@@ -81,13 +79,14 @@ public:
         m_consensus_validated.sweep ();
     }
 
-    /** Report that we have locally built a particular ledger
-    */
-    void builtLedger (Ledger::ref, Json::Value);
+    /** Report that we have locally built a particular ledger */
+    void builtLedger (
+        std::shared_ptr<Ledger const> const&,
+        Json::Value);
 
-    /** Report that we have validated a particular ledger
-    */
-    void validatedLedger (Ledger::ref);
+    /** Report that we have validated a particular ledger */
+    void validatedLedger (
+        std::shared_ptr<Ledger const> const&);
 
     /** Repair a hash to index mapping
         @param ledgerIndex The index whose mapping is to be repaired
@@ -113,7 +112,7 @@ private:
     beast::insight::Collector::ptr collector_;
     beast::insight::Counter mismatch_counter_;
 
-    using LedgersByHash = TaggedCache <LedgerHash, Ledger>;
+    using LedgersByHash = TaggedCache <LedgerHash, Ledger const>;
 
     LedgersByHash m_ledgers_by_hash;
 

--- a/src/ripple/app/ledger/LocalTxs.h
+++ b/src/ripple/app/ledger/LocalTxs.h
@@ -20,8 +20,8 @@
 #ifndef RIPPLE_APP_LEDGER_LOCALTXS_H_INCLUDED
 #define RIPPLE_APP_LEDGER_LOCALTXS_H_INCLUDED
 
-#include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/misc/CanonicalTXSet.h>
+#include <ripple/ledger/ReadView.h>
 #include <memory>
 
 namespace ripple {
@@ -42,7 +42,7 @@ public:
     virtual CanonicalTXSet getTxSet () = 0;
 
     // Remove obsolete transactions based on a new fully-valid ledger
-    virtual void sweep (Ledger::ref validLedger) = 0;
+    virtual void sweep (ReadView const& view) = 0;
 
     virtual std::size_t size () = 0;
 };

--- a/src/ripple/app/ledger/impl/ConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/ConsensusImp.cpp
@@ -78,7 +78,7 @@ void
 ConsensusImp::startRound (
     LedgerConsensus& consensus,
     LedgerHash const &prevLCLHash,
-    Ledger::ref previousLedger,
+    std::shared_ptr<Ledger const> const& previousLedger,
     NetClock::time_point closeTime)
 {
     consensus.startRound (

--- a/src/ripple/app/ledger/impl/ConsensusImp.h
+++ b/src/ripple/app/ledger/impl/ConsensusImp.h
@@ -63,7 +63,7 @@ public:
     startRound (
         LedgerConsensus& ledgerConsensus,
         LedgerHash const& prevLCLHash,
-        Ledger::ref previousLedger,
+        std::shared_ptr<Ledger const> const& previousLedger,
         NetClock::time_point closeTime) override;
 
     void

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -142,7 +142,6 @@ void InboundLedger::init (ScopedLockType& collectionLock)
     {
         JLOG (m_journal.debug) <<
             "Acquiring ledger we already have locally: " << getHash ();
-        mLedger->setClosed ();
         mLedger->setImmutable (app_.config());
 
         if (mReason != fcHISTORY)
@@ -192,7 +191,7 @@ bool InboundLedger::tryLocal ()
                 true, app_.config(), app_.family());
         }
 
-        if (mLedger->getHash () != mHash)
+        if (mLedger->info().hash != mHash)
         {
             // We know for a fact the ledger can never be acquired
             JLOG (m_journal.warning) <<
@@ -264,7 +263,6 @@ bool InboundLedger::tryLocal ()
         JLOG (m_journal.debug) <<
             "Had everything locally";
         mComplete = true;
-        mLedger->setClosed ();
         mLedger->setImmutable (app_.config());
     }
 
@@ -357,7 +355,6 @@ void InboundLedger::done ()
 
     if (isComplete () && !isFailed () && mLedger)
     {
-        mLedger->setClosed ();
         mLedger->setImmutable (app_.config());
         if (mReason != fcHISTORY)
             app_.getLedgerMaster ().storeLedger (mLedger);
@@ -735,10 +732,10 @@ bool InboundLedger::takeHeader (std::string const& data)
         data.data(), data.size(), false,
         app_.config(), app_.family());
 
-    if (mLedger->getHash () != mHash)
+    if (mLedger->info().hash != mHash)
     {
         JLOG (m_journal.warning) <<
-            "Acquire hash mismatch: " << mLedger->getHash () <<
+            "Acquire hash mismatch: " << mLedger->info().hash <<
             "!=" << mHash;
         mLedger.reset ();
         return false;

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -64,8 +64,11 @@ public:
     {
     }
 
-    Ledger::pointer acquire (
-        uint256 const& hash, std::uint32_t seq, InboundLedger::fcReason reason)
+    std::shared_ptr<Ledger>
+    acquire (
+        uint256 const& hash,
+        std::uint32_t seq,
+        InboundLedger::fcReason reason)
     {
         assert (hash.isNonZero ());
         bool isNew = true;

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.h
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.h
@@ -105,7 +105,7 @@ public:
     */
     void startRound (
         LedgerHash const& prevLCLHash,
-        Ledger::ref prevLedger,
+        std::shared_ptr<Ledger const> const& prevLedger,
         NetClock::time_point closeTime,
         int previousProposers,
         std::chrono::milliseconds previousConvergeTime) override;
@@ -256,7 +256,7 @@ private:
                      typically neACCEPTED_LEDGER or neCLOSING_LEDGER.
       @param ledger  The ledger associated with the event.
     */
-    void statusChange (protocol::NodeEvent event, Ledger& ledger);
+    void statusChange (protocol::NodeEvent event, ReadView const& ledger);
 
     /** Take an initial position on what we think the consensus should be
         based on the transactions that made it into our open ledger
@@ -316,7 +316,7 @@ private:
     uint256 mPrevLedgerHash;
     uint256 mAcquiringLedger;
 
-    Ledger::pointer mPreviousLedger;
+    std::shared_ptr<Ledger const> mPreviousLedger;
     LedgerProposal::pointer mOurPosition;
     PublicKey mValPublic;
     SecretKey mValSecret;

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -40,13 +40,13 @@ bool isBinary(LedgerFill const& fill)
 }
 
 template <class Object>
-void fillJson(Object& json, LedgerInfo const& info, bool bFull)
+void fillJson(Object& json, bool closed, LedgerInfo const& info, bool bFull)
 {
     json[jss::parent_hash]  = to_string (info.parentHash);
     json[jss::ledger_index] = to_string (info.seq);
     json[jss::seqNum]       = to_string (info.seq);      // DEPRECATED
 
-    if (! info.open)
+    if (closed)
     {
         json[jss::closed] = true;
     }
@@ -64,7 +64,7 @@ void fillJson(Object& json, LedgerInfo const& info, bool bFull)
     // These next three are DEPRECATED.
     json[jss::hash] = to_string (info.hash);
     json[jss::totalCoins] = to_string (info.drops);
-    json[jss::accepted] = ! info.open;
+    json[jss::accepted] = closed;
     json[jss::close_flags] = info.closeFlags;
 
     // Always show fields that contribute to the ledger hash
@@ -165,7 +165,7 @@ void fillJson (Object& json, LedgerFill const& fill)
     // TODO: what happens if bBinary and bExtracted are both set?
     // Is there a way to report this back?
     auto bFull = isFull(fill);
-    fillJson(json, fill.ledger.info(), bFull);
+    fillJson(json, !fill.ledger.open(), fill.ledger.info(), bFull);
 
     if (bFull || fill.options & LedgerFill::dumpTxrp)
         fillJsonTx(json, fill);

--- a/src/ripple/app/misc/FeeVote.h
+++ b/src/ripple/app/misc/FeeVote.h
@@ -20,7 +20,8 @@
 #ifndef RIPPLE_APP_MISC_FEEVOTE_H_INCLUDED
 #define RIPPLE_APP_MISC_FEEVOTE_H_INCLUDED
 
-#include <ripple/app/ledger/Ledger.h>
+#include <ripple/ledger/ReadView.h>
+#include <ripple/shamap/SHAMap.h>
 #include <ripple/app/misc/Validations.h>
 #include <ripple/basics/BasicConfig.h>
 #include <ripple/protocol/SystemParameters.h>
@@ -60,7 +61,7 @@ public:
     */
     virtual
     void
-    doValidation (Ledger::ref lastClosedLedger,
+    doValidation (std::shared_ptr<ReadView const> const& lastClosedLedger,
         STObject& baseValidation) = 0;
 
     /** Cast our local vote on the fee.
@@ -70,8 +71,9 @@ public:
     */
     virtual
     void
-    doVoting (Ledger::ref lastClosedLedger, ValidationSet const& parentValidations,
-        std::shared_ptr<SHAMap> const& initialPosition) = 0;
+    doVoting (std::shared_ptr<ReadView const> const& lastClosedLedger,
+        ValidationSet const& parentValidations,
+            std::shared_ptr<SHAMap> const& initialPosition) = 0;
 };
 
 /** Build FeeVote::Setup from a config section. */

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -98,11 +98,11 @@ public:
     FeeVoteImpl (Setup const& setup, beast::Journal journal);
 
     void
-    doValidation (Ledger::ref lastClosedLedger,
+    doValidation (std::shared_ptr<ReadView const> const& lastClosedLedger,
         STObject& baseValidation) override;
 
     void
-    doVoting (Ledger::ref lastClosedLedger,
+    doVoting (std::shared_ptr<ReadView const> const& lastClosedLedger,
         ValidationSet const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition) override;
 };
@@ -116,8 +116,9 @@ FeeVoteImpl::FeeVoteImpl (Setup const& setup, beast::Journal journal)
 }
 
 void
-FeeVoteImpl::doValidation (Ledger::ref lastClosedLedger,
-    STObject& baseValidation)
+FeeVoteImpl::doValidation(
+    std::shared_ptr<ReadView const> const& lastClosedLedger,
+        STObject& baseValidation)
 {
     if (lastClosedLedger->fees().base != target_.reference_fee)
     {
@@ -146,9 +147,10 @@ FeeVoteImpl::doValidation (Ledger::ref lastClosedLedger,
 }
 
 void
-FeeVoteImpl::doVoting (Ledger::ref lastClosedLedger,
-    ValidationSet const& set,
-    std::shared_ptr<SHAMap> const& initialPosition)
+FeeVoteImpl::doVoting(
+    std::shared_ptr<ReadView const> const& lastClosedLedger,
+        ValidationSet const& set,
+            std::shared_ptr<SHAMap> const& initialPosition)
 {
     // LCL must be flag ledger
     assert ((lastClosedLedger->info().seq % 256) == 0);

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -24,6 +24,7 @@
 #include <ripple/protocol/STValidation.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/ledger/LedgerProposal.h>
+#include <ripple/ledger/ReadView.h>
 #include <ripple/net/InfoSub.h>
 #include <memory>
 #include <beast/threads/Stoppable.h>
@@ -197,7 +198,7 @@ public:
 
     virtual void reportFeeChange () = 0;
 
-    virtual void updateLocalTx (Ledger::ref newValidLedger) = 0;
+    virtual void updateLocalTx (ReadView const& newValidLedger) = 0;
     virtual std::size_t getLocalTxCount () = 0;
 
     // client information retrieval functions
@@ -229,7 +230,8 @@ public:
     //
     // Monitoring: publisher side
     //
-    virtual void pubLedger (Ledger::ref lpAccepted) = 0;
+    virtual void pubLedger (
+        std::shared_ptr<ReadView const> const& lpAccepted) = 0;
     virtual void pubProposedTransaction (
         std::shared_ptr<ReadView const> const& lpCurrent,
         std::shared_ptr<STTx const> const& stTxn, TER terResult) = 0;

--- a/src/ripple/app/misc/SHAMapStore.h
+++ b/src/ripple/app/misc/SHAMapStore.h
@@ -54,7 +54,7 @@ public:
     SHAMapStore (Stoppable& parent) : Stoppable ("SHAMapStore", parent) {}
 
     /** Called by LedgerMaster every time a ledger validates. */
-    virtual void onLedgerClosed (Ledger::pointer validatedLedger) = 0;
+    virtual void onLedgerClosed(std::shared_ptr<Ledger const> const& ledger) = 0;
 
     virtual std::uint32_t clampFetchDepth (std::uint32_t fetch_depth) const = 0;
 

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -241,11 +241,12 @@ SHAMapStoreImp::makeDatabase (std::string const& name,
 }
 
 void
-SHAMapStoreImp::onLedgerClosed (Ledger::pointer validatedLedger)
+SHAMapStoreImp::onLedgerClosed(
+    std::shared_ptr<Ledger const> const& ledger)
 {
     {
         std::lock_guard <std::mutex> lock (mutex_);
-        newLedger_ = validatedLedger;
+        newLedger_ = ledger;
     }
     cond_.notify_one();
 }

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -93,8 +93,8 @@ private:
     bool healthy_ = true;
     mutable std::condition_variable cond_;
     mutable std::mutex mutex_;
-    Ledger::pointer newLedger_;
-    Ledger::pointer validatedLedger_;
+    std::shared_ptr<Ledger const> newLedger_;
+    std::shared_ptr<Ledger const> validatedLedger_;
     TransactionMaster& transactionMaster_;
     std::atomic <LedgerIndex> canDelete_;
     // these do not exist upon SHAMapStore creation, but do exist
@@ -158,7 +158,7 @@ public:
         return canDelete_;
     }
 
-    void onLedgerClosed (Ledger::pointer validatedLedger) override;
+    void onLedgerClosed (std::shared_ptr<Ledger const> const& ledger) override;
 
 private:
     // callback for visitNodes

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -57,9 +57,8 @@ convertBlobsToTxResult (
 void
 saveLedgerAsync (Application& app, std::uint32_t seq)
 {
-    Ledger::pointer ledger = app.getLedgerMaster().getLedgerBySeq(seq);
-    if (ledger)
-        pendSaveValidated(app, ledger, false, false);
+    if (auto l = app.getLedgerMaster().getLedgerBySeq(seq))
+        pendSaveValidated(app, l, false, false);
 }
 
 void

--- a/src/ripple/app/tests/Regression_test.cpp
+++ b/src/ripple/app/tests/Regression_test.cpp
@@ -58,9 +58,8 @@ struct Regression_test : public beast::unit_test::suite
         auto const aliceAmount = XRP(aliceXRP);
 
         auto next = std::make_shared<Ledger>(
-            open_ledger, *closed,
+            *closed,
             env.app().timeKeeper().closeTime());
-        next->setClosed();
         {
             // Fund alice
             auto const jt = env.jt(pay(env.master, "alice", aliceAmount));

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -683,7 +683,7 @@ Transactor::operator()()
         // Transaction succeeded fully or (retries are
         // not allowed and the transaction could claim a fee)
 
-        if(view().closed())
+        if(!view().open())
         {
             // Charge whatever fee they specified.
 

--- a/src/ripple/ledger/CachedView.h
+++ b/src/ripple/ledger/CachedView.h
@@ -65,6 +65,12 @@ public:
     std::shared_ptr<SLE const>
     read (Keylet const& k) const override;
 
+    bool
+    open() const override
+    {
+        return base_.open();
+    }
+
     LedgerInfo const&
     info() const override
     {

--- a/src/ripple/ledger/OpenView.h
+++ b/src/ripple/ledger/OpenView.h
@@ -66,6 +66,7 @@ private:
     ReadView const* base_;
     detail::RawStateTable items_;
     std::shared_ptr<void const> hold_;
+    bool open_ = true;
 
 public:
     OpenView() = delete;
@@ -133,6 +134,13 @@ public:
     */
     OpenView (ReadView const* base,
         std::shared_ptr<void const> hold = nullptr);
+
+    /** Returns true if this reflects an open ledger. */
+    bool
+    open() const override
+    {
+        return open_;
+    }
 
     /** Return the number of tx inserted since creation.
 

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -75,7 +75,6 @@ struct LedgerInfo
     // For all ledgers
     //
 
-    bool open = true;
     LedgerIndex seq = 0;
     NetClock::time_point parentCloseTime = {};
 
@@ -233,18 +232,9 @@ public:
     info() const = 0;
 
     /** Returns true if this reflects an open ledger. */
+    virtual
     bool
-    open() const
-    {
-        return info().open;
-    }
-
-    /** Returns true if this reflects a closed ledger. */
-    bool
-    closed() const
-    {
-        return ! info().open;
-    }
+    open() const = 0;
 
     /** Returns the close time of the previous ledger. */
     NetClock::time_point

--- a/src/ripple/ledger/detail/ApplyViewBase.h
+++ b/src/ripple/ledger/detail/ApplyViewBase.h
@@ -46,6 +46,8 @@ public:
         ReadView const* base, ApplyFlags flags);
 
     // ReadView
+    bool
+    open() const override;
 
     LedgerInfo const&
     info() const override;

--- a/src/ripple/ledger/impl/ApplyStateTable.cpp
+++ b/src/ripple/ledger/impl/ApplyStateTable.cpp
@@ -116,7 +116,7 @@ ApplyStateTable::apply (OpenView& to,
         std::make_shared<Serializer>();
     tx.add(*sTx);
     std::shared_ptr<Serializer> sMeta;
-    if (to.closed())
+    if (!to.open())
     {
         TxMeta meta(j);
         // VFALCO Shouldn't TxMeta ctor do this?

--- a/src/ripple/ledger/impl/ApplyViewBase.cpp
+++ b/src/ripple/ledger/impl/ApplyViewBase.cpp
@@ -33,6 +33,12 @@ ApplyViewBase::ApplyViewBase(
 
 //---
 
+bool
+ApplyViewBase::open() const
+{
+    return base_->open();
+}
+
 LedgerInfo const&
 ApplyViewBase::info() const
 {

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -94,7 +94,6 @@ OpenView::OpenView (open_ledger_t,
     , base_ (base)
     , hold_ (std::move(hold))
 {
-    info_.open = true;
     info_.validated = false;
     info_.accepted = false;
     info_.seq = base_->info().seq + 1;
@@ -108,6 +107,7 @@ OpenView::OpenView (ReadView const* base,
     , info_ (base->info())
     , base_ (base)
     , hold_ (std::move(hold))
+    , open_ (base->open())
 {
 }
 
@@ -192,18 +192,16 @@ auto
 OpenView::txsBegin() const ->
     std::unique_ptr<txs_type::iter_base>
 {
-    return std::make_unique<
-        txs_iter_impl>(
-            closed(), txs_.cbegin());
+    return std::make_unique<txs_iter_impl>(
+        !open(), txs_.cbegin());
 }
 
 auto
 OpenView::txsEnd() const ->
     std::unique_ptr<txs_type::iter_base>
 {
-    return std::make_unique<
-        txs_iter_impl>(
-            closed(), txs_.cend());
+    return std::make_unique<txs_iter_impl>(
+        !open(), txs_.cend());
 }
 
 bool

--- a/src/ripple/ledger/tests/SkipList_test.cpp
+++ b/src/ripple/ledger/tests/SkipList_test.cpp
@@ -43,10 +43,9 @@ class SkipList_test : public beast::unit_test::suite
             for (auto i = 0; i < 1023; ++i)
             {
                 auto next = std::make_shared<Ledger>(
-                    open_ledger, *prev,
+                    *prev,
                     env.app().timeKeeper().closeTime());
                 next->updateSkipList();
-                next->setClosed();
                 history.push_back(next);
                 prev = next;
             }

--- a/src/ripple/ledger/tests/View_test.cpp
+++ b/src/ripple/ledger/tests/View_test.cpp
@@ -155,7 +155,7 @@ class View_test
                 create_genesis, config, env.app().family());
         auto const ledger =
             std::make_shared<Ledger>(
-                open_ledger, *genesis,
+                *genesis,
                 env.app().timeKeeper().closeTime());
         wipe(*ledger);
         ReadView& v = *ledger;
@@ -419,7 +419,7 @@ class View_test
             std::make_shared<Ledger> (
                 create_genesis, config, env.app().family());
         auto const ledger = std::make_shared<Ledger>(
-            open_ledger, *genesis,
+            *genesis,
             env.app().timeKeeper().closeTime());
         auto setup123 = [&ledger, this]()
         {
@@ -761,7 +761,7 @@ class View_test
                     create_genesis, config, env.app().family());
             auto const ledger =
                 std::make_shared<Ledger>(
-                    open_ledger, *genesis,
+                    *genesis,
                     env.app().timeKeeper().closeTime());
             wipe(*ledger);
             ledger->rawInsert(sle(1));

--- a/src/ripple/overlay/impl/TMHello.cpp
+++ b/src/ripple/overlay/impl/TMHello.cpp
@@ -140,9 +140,11 @@ buildHello (
 
     auto const closedLedger = app.getLedgerMaster().getClosedLedger();
 
-    if (closedLedger && !closedLedger->info().open)
+    assert(! closedLedger->open());
+    // VFALCO There should ALWAYS be a closed ledger
+    if (closedLedger)
     {
-        uint256 hash = closedLedger->getHash ();
+        uint256 hash = closedLedger->info().hash;
         h.set_ledgerclosed (hash.begin (), hash.size ());
         hash = closedLedger->info().parentHash;
         h.set_ledgerprevious (hash.begin (), hash.size ());

--- a/src/ripple/rpc/handlers/LedgerClosed.cpp
+++ b/src/ripple/rpc/handlers/LedgerClosed.cpp
@@ -33,7 +33,7 @@ Json::Value doLedgerClosed (RPC::Context& context)
 
     Json::Value jvResult;
     jvResult[jss::ledger_index] = ledger->info().seq;
-    jvResult[jss::ledger_hash] = to_string (ledger->getHash ());
+    jvResult[jss::ledger_hash] = to_string (ledger->info().hash);
 
     return jvResult;
 }

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -138,7 +138,7 @@ Json::Value doTx (RPC::Context& context)
 
         if (okay)
             ret[jss::validated] = isValidated (
-                context, lgr->info().seq, lgr->getHash ());
+                context, lgr->info().seq, lgr->info().hash);
     }
 
     return ret;

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -111,19 +111,19 @@ Status ledgerFromRequest (T& ledger, Context& context)
             if (ledger == nullptr)
                 return {rpcNO_NETWORK, "InsufficientNetworkMode"};
 
-            assert (! ledger->info().open);
+            assert (! ledger->open());
         }
         else
         {
             if (index.empty () || index == "current")
             {
                 ledger = ledgerMaster.getCurrentLedger ();
-                assert (ledger->info().open);
+                assert (ledger->open());
             }
             else if (index == "closed")
             {
                 ledger = ledgerMaster.getClosedLedger ();
-                assert (! ledger->info().open);
+                assert (! ledger->open());
             }
             else
             {
@@ -148,7 +148,7 @@ Status ledgerFromRequest (T& ledger, Context& context)
 bool isValidated (LedgerMaster& ledgerMaster, ReadView const& ledger,
     Application& app)
 {
-    if (ledger.info().open)
+    if (ledger.open())
         return false;
 
     if (ledger.info().validated)
@@ -220,7 +220,7 @@ Status lookupLedger (
 
     auto& info = ledger->info();
 
-    if (!info.open)
+    if (!ledger->open())
     {
         result[jss::ledger_hash] = to_string (info.hash);
         result[jss::ledger_index] = info.seq;

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -82,7 +82,7 @@ private:
     Family&                         f_;
     beast::Journal                  journal_;
     std::uint32_t                   seq_;
-    std::uint32_t                   ledgerSeq_; // sequence number of ledger this is part of
+    std::uint32_t                   ledgerSeq_ = 0; // sequence number of ledger this is part of
     std::shared_ptr<SHAMapAbstractNode> root_;
     SHAMapState                     state_;
     SHAMapType                      type_;
@@ -131,7 +131,14 @@ public:
     // Returns a new map that's a snapshot of this one.
     // Handles copy on write for mutable snapshots.
     std::shared_ptr<SHAMap> snapShot (bool isMutable) const;
+
+    /*  Sets metadata associated with the SHAMap
+
+        Marked `const` because the data is not part of
+        the map contents.
+    */
     void setLedgerSeq (std::uint32_t lseq);
+
     bool fetchRoot (SHAMapHash const& hash, SHAMapSyncFilter * filter);
 
     // normal hash access functions
@@ -198,7 +205,7 @@ public:
 
     using fetchPackEntry_t = std::pair <uint256, Blob>;
 
-    void getFetchPack (SHAMap * have, bool includeLeaves, int max,
+    void getFetchPack (SHAMap const* have, bool includeLeaves, int max,
         std::function<void (SHAMapHash const&, const Blob&)>) const;
 
     void setUnbacked ();
@@ -211,7 +218,7 @@ private:
     using DeltaRef = std::pair<std::shared_ptr<SHAMapItem const> const&,
                                std::shared_ptr<SHAMapItem const> const&>;
 
-    void visitDifferences(SHAMap* have, std::function<bool(SHAMapAbstractNode&)>) const;
+    void visitDifferences(SHAMap const* have, std::function<bool(SHAMapAbstractNode&)>) const;
     int unshare ();
 
      // tree node cache operations

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -31,7 +31,6 @@ SHAMap::SHAMap (
     : f_ (f)
     , journal_(f.journal())
     , seq_ (seq)
-    , ledgerSeq_ (0)
     , state_ (SHAMapState::Modifying)
     , type_ (t)
 {
@@ -47,7 +46,6 @@ SHAMap::SHAMap (
     : f_ (f)
     , journal_(f.journal())
     , seq_ (1)
-    , ledgerSeq_ (0)
     , state_ (SHAMapState::Synching)
     , type_ (t)
 {

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -671,7 +671,7 @@ SHAMap::hasLeafNode (uint256 const& tag, SHAMapHash const& targetNodeHash) const
 Note: a caller should set includeLeaves to false for transaction trees.
 There's no point in including the leaves of transaction trees.
 */
-void SHAMap::getFetchPack (SHAMap* have, bool includeLeaves, int max,
+void SHAMap::getFetchPack (SHAMap const* have, bool includeLeaves, int max,
                            std::function<void (SHAMapHash const&, const Blob&)> func) const
 {
     visitDifferences (have,
@@ -691,7 +691,7 @@ void SHAMap::getFetchPack (SHAMap* have, bool includeLeaves, int max,
 }
 
 void
-SHAMap::visitDifferences(SHAMap* have,
+SHAMap::visitDifferences(SHAMap const* have,
                          std::function<bool (SHAMapAbstractNode&)> func) const
 {
     // Visit every node in this SHAMap that is not present


### PR DESCRIPTION
Use `const` Ledger when the context does not require the ability to change a ledger and avoid publishing ledgers to history while still in flux.