### PR TITLE
Fix underflow issue for XRP:

### DIFF
--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -402,6 +402,7 @@ inline bool isXRP(STAmount const& amount)
 }
 
 extern LocalValue<bool> stAmountCalcSwitchover;
+extern LocalValue<bool> stAmountCalcSwitchover2;
 
 /** RAII class to set and restore the STAmount calc switchover.*/
 class STAmountSO
@@ -409,20 +410,27 @@ class STAmountSO
 public:
     explicit STAmountSO(NetClock::time_point const closeTime)
         : saved_(*stAmountCalcSwitchover)
+        , saved2_(*stAmountCalcSwitchover2)
     {
         *stAmountCalcSwitchover = closeTime > soTime;
+        *stAmountCalcSwitchover2 = closeTime > soTime2;
     }
 
     ~STAmountSO()
     {
         *stAmountCalcSwitchover = saved_;
+        *stAmountCalcSwitchover2 = saved2_;
     }
 
     // Mon Dec 28, 2015 10:00:00am PST
     static NetClock::time_point const soTime;
 
+    // Mon Mar 28, 2015 10:00:00am PST
+    static NetClock::time_point const soTime2;
+
 private:
     bool saved_;
+    bool saved2_;
 };
 
 } // ripple

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -36,8 +36,13 @@
 namespace ripple {
 
 LocalValue<bool> stAmountCalcSwitchover(true);
+LocalValue<bool> stAmountCalcSwitchover2(true);
+
 using namespace std::chrono_literals;
 const NetClock::time_point STAmountSO::soTime{504640800s};
+
+// Mon March 28, 2015 10:00:00am PST
+const NetClock::time_point STAmountSO::soTime2{512416800s};
 
 static const std::uint64_t tenTo14 = 100000000000000ull;
 static const std::uint64_t tenTo14m1 = tenTo14 - 1;
@@ -1199,10 +1204,20 @@ mulRound (STAmount const& v1, STAmount const& v2, Issue const& issue,
     // Control when bugfixes that require switchover dates are enabled
     if (roundUp && !resultNegative && !result && *stAmountCalcSwitchover)
     {
-        // return the smallest value above zero
-        amount = STAmount::cMinValue;
-        offset = STAmount::cMinOffset;
-        return STAmount(issue, amount, offset, resultNegative);
+        if (isXRP(issue) && *stAmountCalcSwitchover2)
+        {
+            // return the smallest value above zero
+            amount = 1;
+            offset = 0;
+            return STAmount(issue, amount, offset, resultNegative);
+        }
+        else
+        {
+            // return the smallest value above zero
+            amount = STAmount::cMinValue;
+            offset = STAmount::cMinOffset;
+            return STAmount(issue, amount, offset, resultNegative);
+        }
     }
     return result;
 }
@@ -1259,10 +1274,20 @@ divRound (STAmount const& num, STAmount const& den,
     // Control when bugfixes that require switchover dates are enabled
     if (roundUp && !resultNegative && !result && *stAmountCalcSwitchover)
     {
-        // return the smallest value above zero
-        amount = STAmount::cMinValue;
-        offset = STAmount::cMinOffset;
-        return STAmount (issue, amount, offset, resultNegative);
+        if (isXRP(issue) && *stAmountCalcSwitchover2)
+        {
+            // return the smallest value above zero
+            amount = 1;
+            offset = 0;
+            return STAmount(issue, amount, offset, resultNegative);
+        }
+        else
+        {
+            // return the smallest value above zero
+            amount = STAmount::cMinValue;
+            offset = STAmount::cMinOffset;
+            return STAmount(issue, amount, offset, resultNegative);
+        }
     }
     return result;
 }


### PR DESCRIPTION
When specifying that a result should be rounded up,
the code rounded up to a value suitable for a non-xrp
amount. When called with an xrp amount, if that rounded-up
value was less than one drop, the code rounded down to zero.

This could cause funded offers to be removed as unfunded.

@nbougalis @miguelportilla 