### PR TITLE
[TRIVIAL] Verify that returned RPC codes are known

### DIFF
--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -116,6 +116,7 @@ public:
         add (rpcTXN_NOT_FOUND,         "txnNotFound",       "Transaction not found.");
         add (rpcUNKNOWN_COMMAND,       "unknownCmd",        "Unknown method.");
         add (rpcWRONG_SEED,            "wrongSeed",         "The regular key does not point as the master key.");
+        add (rpcSENDMAX_MALFORMED,     "sendMaxMalformed",  "SendMax amount malformed.");
     }
 
     ErrorInfo const& get (error_code_i code) const

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -121,6 +121,7 @@ public:
     ErrorInfo const& get (error_code_i code) const
     {
         Map::const_iterator const iter (m_map.find (code));
+        assert (iter != m_map.end());
         if (iter != m_map.end())
             return iter->second;
         return m_unknown;


### PR DESCRIPTION
Assert that all RPC error codes that are returned are known in debug builds.