### PR TITLE
Avoid passing SHAMapNodeID's to sync filters

### DIFF
--- a/src/ripple/app/ledger/AccountStateSF.cpp
+++ b/src/ripple/app/ledger/AccountStateSF.cpp
@@ -34,7 +34,6 @@ AccountStateSF::AccountStateSF(Application& app)
 }
 
 void AccountStateSF::gotNode (bool fromFilter,
-                              SHAMapNodeID const& id,
                               SHAMapHash const& nodeHash,
                               Blob& nodeData,
                               SHAMapTreeNode::TNType) const
@@ -46,8 +45,7 @@ void AccountStateSF::gotNode (bool fromFilter,
         hotACCOUNT_NODE, std::move (nodeData), nodeHash.as_uint256());
 }
 
-bool AccountStateSF::haveNode (SHAMapNodeID const& id,
-                               SHAMapHash const& nodeHash,
+bool AccountStateSF::haveNode (SHAMapHash const& nodeHash,
                                Blob& nodeData) const
 {
     return app_.getLedgerMaster ().getFetchPack (nodeHash.as_uint256(), nodeData);

--- a/src/ripple/app/ledger/AccountStateSF.cpp
+++ b/src/ripple/app/ledger/AccountStateSF.cpp
@@ -35,7 +35,7 @@ AccountStateSF::AccountStateSF(Application& app)
 
 void AccountStateSF::gotNode (bool fromFilter,
                               SHAMapHash const& nodeHash,
-                              Blob& nodeData,
+                              Blob&& nodeData,
                               SHAMapTreeNode::TNType) const
 {
     // VFALCO SHAMapSync filters should be passed the SHAMap, the

--- a/src/ripple/app/ledger/AccountStateSF.h
+++ b/src/ripple/app/ledger/AccountStateSF.h
@@ -40,7 +40,7 @@ public:
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
                   SHAMapHash const& nodeHash,
-                  Blob& nodeData,
+                  Blob&& nodeData,
                   SHAMapTreeNode::TNType) const override;
 
     bool haveNode (SHAMapHash const& nodeHash,

--- a/src/ripple/app/ledger/AccountStateSF.h
+++ b/src/ripple/app/ledger/AccountStateSF.h
@@ -39,13 +39,11 @@ public:
 
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
-                  SHAMapNodeID const& id,
                   SHAMapHash const& nodeHash,
                   Blob& nodeData,
                   SHAMapTreeNode::TNType) const override;
 
-    bool haveNode (SHAMapNodeID const& id,
-                   SHAMapHash const& nodeHash,
+    bool haveNode (SHAMapHash const& nodeHash,
                    Blob& nodeData) const override;
 };
 

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -39,7 +39,7 @@ ConsensusTransSetSF::ConsensusTransSetSF (Application& app, NodeCache& nodeCache
 }
 
 void ConsensusTransSetSF::gotNode (
-    bool fromFilter, const SHAMapNodeID& id, SHAMapHash const& nodeHash,
+    bool fromFilter, SHAMapHash const& nodeHash,
     Blob& nodeData, SHAMapTreeNode::TNType type) const
 {
     if (fromFilter)
@@ -76,7 +76,7 @@ void ConsensusTransSetSF::gotNode (
 }
 
 bool ConsensusTransSetSF::haveNode (
-    const SHAMapNodeID& id, SHAMapHash const& nodeHash, Blob& nodeData) const
+    SHAMapHash const& nodeHash, Blob& nodeData) const
 {
     if (m_nodeCache.retrieve (nodeHash, nodeData))
         return true;

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -40,7 +40,7 @@ ConsensusTransSetSF::ConsensusTransSetSF (Application& app, NodeCache& nodeCache
 
 void ConsensusTransSetSF::gotNode (
     bool fromFilter, SHAMapHash const& nodeHash,
-    Blob& nodeData, SHAMapTreeNode::TNType type) const
+    Blob&& nodeData, SHAMapTreeNode::TNType type) const
 {
     if (fromFilter)
         return;

--- a/src/ripple/app/ledger/ConsensusTransSetSF.h
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.h
@@ -41,7 +41,7 @@ public:
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
                   SHAMapHash const& nodeHash,
-                  Blob& nodeData,
+                  Blob&& nodeData,
                   SHAMapTreeNode::TNType) const override;
 
     bool haveNode (SHAMapHash const& nodeHash,

--- a/src/ripple/app/ledger/ConsensusTransSetSF.h
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.h
@@ -40,13 +40,11 @@ public:
 
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
-                  SHAMapNodeID const& id,
                   SHAMapHash const& nodeHash,
                   Blob& nodeData,
                   SHAMapTreeNode::TNType) const override;
 
-    bool haveNode (SHAMapNodeID const& id,
-                   SHAMapHash const& nodeHash,
+    bool haveNode (SHAMapHash const& nodeHash,
                    Blob& nodeData) const override;
 
 private:

--- a/src/ripple/app/ledger/TransactionStateSF.cpp
+++ b/src/ripple/app/ledger/TransactionStateSF.cpp
@@ -35,7 +35,6 @@ TransactionStateSF::TransactionStateSF(Application& app)
 
 // VFALCO This might be better as Blob&&
 void TransactionStateSF::gotNode (bool fromFilter,
-                                  SHAMapNodeID const& id,
                                   SHAMapHash const& nodeHash,
                                   Blob& nodeData,
                                   SHAMapTreeNode::TNType type) const
@@ -50,8 +49,7 @@ void TransactionStateSF::gotNode (bool fromFilter,
             std::move (nodeData), nodeHash.as_uint256());
 }
 
-bool TransactionStateSF::haveNode (SHAMapNodeID const& id,
-                                   SHAMapHash const& nodeHash,
+bool TransactionStateSF::haveNode (SHAMapHash const& nodeHash,
                                    Blob& nodeData) const
 {
     return app_.getLedgerMaster ().getFetchPack (nodeHash.as_uint256(), nodeData);

--- a/src/ripple/app/ledger/TransactionStateSF.cpp
+++ b/src/ripple/app/ledger/TransactionStateSF.cpp
@@ -36,7 +36,7 @@ TransactionStateSF::TransactionStateSF(Application& app)
 // VFALCO This might be better as Blob&&
 void TransactionStateSF::gotNode (bool fromFilter,
                                   SHAMapHash const& nodeHash,
-                                  Blob& nodeData,
+                                  Blob&& nodeData,
                                   SHAMapTreeNode::TNType type) const
 {
     // VFALCO SHAMapSync filters should be passed the SHAMap, the

--- a/src/ripple/app/ledger/TransactionStateSF.h
+++ b/src/ripple/app/ledger/TransactionStateSF.h
@@ -41,7 +41,7 @@ public:
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
                   SHAMapHash const& nodeHash,
-                  Blob& nodeData,
+                  Blob&& nodeData,
                   SHAMapTreeNode::TNType) const override;
 
     bool haveNode (SHAMapHash const& nodeHash,

--- a/src/ripple/app/ledger/TransactionStateSF.h
+++ b/src/ripple/app/ledger/TransactionStateSF.h
@@ -40,13 +40,11 @@ public:
 
     // Note that the nodeData is overwritten by this call
     void gotNode (bool fromFilter,
-                  SHAMapNodeID const& id,
                   SHAMapHash const& nodeHash,
                   Blob& nodeData,
                   SHAMapTreeNode::TNType) const override;
 
-    bool haveNode (SHAMapNodeID const& id,
-                   SHAMapHash const& nodeHash,
+    bool haveNode (SHAMapHash const& nodeHash,
                    Blob& nodeData) const override;
 };
 

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -222,12 +222,11 @@ private:
     std::shared_ptr<SHAMapAbstractNode> fetchNodeFromDB (SHAMapHash const& hash) const;
     std::shared_ptr<SHAMapAbstractNode> fetchNodeNT (SHAMapHash const& hash) const;
     std::shared_ptr<SHAMapAbstractNode> fetchNodeNT (
-        SHAMapNodeID const& id,
         SHAMapHash const& hash,
         SHAMapSyncFilter *filter) const;
     std::shared_ptr<SHAMapAbstractNode> fetchNode (SHAMapHash const& hash) const;
     std::shared_ptr<SHAMapAbstractNode> checkFilter(SHAMapHash const& hash,
-        SHAMapNodeID const& id, SHAMapSyncFilter* filter) const;
+        SHAMapSyncFilter* filter) const;
 
     /** Update hashes up to the root */
     void dirtyUp (SharedPtrNodeStack& stack,
@@ -268,7 +267,7 @@ private:
 
     // Descend with filter
     SHAMapAbstractNode* descendAsync (SHAMapInnerNode* parent, int branch,
-        SHAMapNodeID const& childID, SHAMapSyncFilter* filter, bool& pending) const;
+        SHAMapSyncFilter* filter, bool& pending) const;
 
     std::pair <SHAMapAbstractNode*, SHAMapNodeID>
         descend (SHAMapInnerNode* parent, SHAMapNodeID const& parentID,

--- a/src/ripple/shamap/SHAMapSyncFilter.h
+++ b/src/ripple/shamap/SHAMapSyncFilter.h
@@ -37,7 +37,7 @@ public:
     // Note that the nodeData is overwritten by this call
     virtual void gotNode (bool fromFilter,
                           SHAMapHash const& nodeHash,
-                          Blob& nodeData,
+                          Blob&& nodeData,
                           SHAMapTreeNode::TNType type) const = 0;
 
     virtual bool haveNode (SHAMapHash const& nodeHash,

--- a/src/ripple/shamap/SHAMapSyncFilter.h
+++ b/src/ripple/shamap/SHAMapSyncFilter.h
@@ -36,13 +36,11 @@ public:
 
     // Note that the nodeData is overwritten by this call
     virtual void gotNode (bool fromFilter,
-                          SHAMapNodeID const& id,
                           SHAMapHash const& nodeHash,
                           Blob& nodeData,
                           SHAMapTreeNode::TNType type) const = 0;
 
-    virtual bool haveNode (SHAMapNodeID const& id,
-                           SHAMapHash const& nodeHash,
+    virtual bool haveNode (SHAMapHash const& nodeHash,
                            Blob& nodeData) const = 0;
 };
 

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -187,13 +187,13 @@ SHAMap::checkFilter(SHAMapHash const& hash, SHAMapNodeID const& id,
 {
     std::shared_ptr<SHAMapAbstractNode> node;
     Blob nodeData;
-    if (filter->haveNode (id, hash, nodeData))
+    if (filter->haveNode (hash, nodeData))
     {
         node = SHAMapAbstractNode::make(
             nodeData, 0, snfPREFIX, hash, true, f_.journal ());
         if (node)
         {
-            filter->gotNode (true, id, hash, nodeData, node->getType ());
+            filter->gotNode (true, hash, nodeData, node->getType ());
             if (backed_)
                 canonicalize (hash, node);
         }

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -193,7 +193,8 @@ SHAMap::checkFilter(SHAMapHash const& hash, SHAMapNodeID const& id,
             nodeData, 0, snfPREFIX, hash, true, f_.journal ());
         if (node)
         {
-            filter->gotNode (true, hash, nodeData, node->getType ());
+            filter->gotNode (true, hash,
+                std::move(nodeData), node->getType ());
             if (backed_)
                 canonicalize (hash, node);
         }

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -182,7 +182,7 @@ SHAMap::fetchNodeFromDB (SHAMapHash const& hash) const
 
 // See if a sync filter has a node
 std::shared_ptr<SHAMapAbstractNode>
-SHAMap::checkFilter(SHAMapHash const& hash, SHAMapNodeID const& id,
+SHAMap::checkFilter(SHAMapHash const& hash,
                     SHAMapSyncFilter* filter) const
 {
     std::shared_ptr<SHAMapAbstractNode> node;
@@ -205,7 +205,6 @@ SHAMap::checkFilter(SHAMapHash const& hash, SHAMapNodeID const& id,
 // Get a node without throwing
 // Used on maps where missing nodes are expected
 std::shared_ptr<SHAMapAbstractNode> SHAMap::fetchNodeNT(
-    SHAMapNodeID const& id,
     SHAMapHash const& hash,
     SHAMapSyncFilter* filter) const
 {
@@ -224,7 +223,7 @@ std::shared_ptr<SHAMapAbstractNode> SHAMap::fetchNodeNT(
     }
 
     if (filter)
-        node = checkFilter (hash, id, filter);
+        node = checkFilter (hash, filter);
 
     return node;
 }
@@ -325,7 +324,7 @@ SHAMap::descend (SHAMapInnerNode * parent, SHAMapNodeID const& parentID,
 
     if (!child)
     {
-        std::shared_ptr<SHAMapAbstractNode> childNode = fetchNodeNT (childID, childHash, filter);
+        std::shared_ptr<SHAMapAbstractNode> childNode = fetchNodeNT (childHash, filter);
 
         if (childNode)
         {
@@ -339,7 +338,7 @@ SHAMap::descend (SHAMapInnerNode * parent, SHAMapNodeID const& parentID,
 
 SHAMapAbstractNode*
 SHAMap::descendAsync (SHAMapInnerNode* parent, int branch,
-    SHAMapNodeID const& childID, SHAMapSyncFilter * filter, bool & pending) const
+    SHAMapSyncFilter * filter, bool & pending) const
 {
     pending = false;
 
@@ -353,7 +352,7 @@ SHAMap::descendAsync (SHAMapInnerNode* parent, int branch,
     if (!ptr)
     {
         if (filter)
-            ptr = checkFilter (hash, childID, filter);
+            ptr = checkFilter (hash, filter);
 
         if (!ptr && backed_)
         {
@@ -838,7 +837,7 @@ bool SHAMap::fetchRoot (SHAMapHash const& hash, SHAMapSyncFilter* filter)
         }
     }
 
-    auto newRoot = fetchNodeNT (SHAMapNodeID(), hash, filter);
+    auto newRoot = fetchNodeNT (hash, filter);
 
     if (newRoot)
     {

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -446,7 +446,7 @@ SHAMapAddNode SHAMap::addRootNode (SHAMapHash const& hash, Blob const& rootNode,
     {
         Serializer s;
         root_->addRaw (s, snfPREFIX);
-        filter->gotNode (false, SHAMapNodeID{}, root_->getNodeHash (),
+        filter->gotNode (false, root_->getNodeHash (),
                          s.modData (), root_->getType ());
     }
 
@@ -528,7 +528,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
             {
                 Serializer s;
                 newNode->addRaw (s, snfPREFIX);
-                filter->gotNode (false, node, childHash,
+                filter->gotNode (false, childHash,
                                  s.modData (), newNode->getType ());
             }
 

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -187,7 +187,7 @@ SHAMap::getMissingNodes(std::size_t max, SHAMapSyncFilter* filter)
                     {
                         SHAMapNodeID childID = nodeID.getChildNodeID (branch);
                         bool pending = false;
-                        auto d = descendAsync (node, branch, childID, filter, pending);
+                        auto d = descendAsync (node, branch, filter, pending);
 
                         if (!d)
                         {
@@ -268,7 +268,7 @@ SHAMap::getMissingNodes(std::size_t max, SHAMapSyncFilter* filter)
             auto const& nodeID = std::get<2>(node);
             auto const& nodeHash = parent->getChildHash (branch);
 
-            auto nodePtr = fetchNodeNT(nodeID, nodeHash, filter);
+            auto nodePtr = fetchNodeNT(nodeHash, filter);
             if (nodePtr)
             {
                 ++hits;

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -447,7 +447,7 @@ SHAMapAddNode SHAMap::addRootNode (SHAMapHash const& hash, Blob const& rootNode,
         Serializer s;
         root_->addRaw (s, snfPREFIX);
         filter->gotNode (false, root_->getNodeHash (),
-                         s.modData (), root_->getType ());
+                         std::move(s.modData ()), root_->getType ());
     }
 
     return SHAMapAddNode::useful ();
@@ -529,7 +529,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
                 Serializer s;
                 newNode->addRaw (s, snfPREFIX);
                 filter->gotNode (false, childHash,
-                                 s.modData (), newNode->getType ());
+                                 std::move(s.modData ()), newNode->getType ());
             }
 
             return SHAMapAddNode::useful ();

--- a/src/ripple/shamap/tests/FetchPack.test.cpp
+++ b/src/ripple/shamap/tests/FetchPack.test.cpp
@@ -61,13 +61,13 @@ public:
         }
 
         void gotNode (bool fromFilter,
-            SHAMapNodeID const& id, SHAMapHash const& nodeHash,
+            SHAMapHash const& nodeHash,
                 Blob& nodeData, SHAMapTreeNode::TNType type) const override
         {
         }
 
-        bool haveNode (SHAMapNodeID const& id,
-            SHAMapHash const& nodeHash, Blob& nodeData) const override
+        bool haveNode (SHAMapHash const& nodeHash,
+            Blob& nodeData) const override
         {
             Map::iterator it = mMap.find (nodeHash);
             if (it == mMap.end ())

--- a/src/ripple/shamap/tests/FetchPack.test.cpp
+++ b/src/ripple/shamap/tests/FetchPack.test.cpp
@@ -62,7 +62,7 @@ public:
 
         void gotNode (bool fromFilter,
             SHAMapHash const& nodeHash,
-                Blob& nodeData, SHAMapTreeNode::TNType type) const override
+                Blob&& nodeData, SHAMapTreeNode::TNType type) const override
         {
         }
 


### PR DESCRIPTION
In version 2 SHAMap's, we sometimes have to call a sync filter without knowing the correct node ID. Since no sync filter uses the node ID, the simplest solution is to just stop passing the node IDs to the sync filters.

This is a trivial change. It doesn't change behavior.

Howard's SHAMapV2 code does not conflict with this, and I've already made a branch with this change ahead of his.