### PR TITLE
NPM ports to C++ unit tests (RIPD-1076, RIPD-1077, RIPD-1079)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3288,6 +3288,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\Subscribe.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\tests\TestOutputSuite.test.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\server\Handler.h">

--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3436,6 +3436,14 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\impl\WSClient.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\impl\WSClient_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\test\JSONRPCClient.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx.h">
@@ -3612,6 +3620,8 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\test\mao\Net.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\WSClient.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\unity\app_ledger.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
@@ -3769,6 +3779,10 @@
       <ExcludedFromBuild>True</ExcludedFromBuild>
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\websocket\WebSocket02.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\wsproto\basic_socket.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\wsproto\wsproto.h">
     </ClInclude>
     <ClCompile Include="..\..\src\rocksdb2\db\builder.cc">
       <ExcludedFromBuild>True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3272,6 +3272,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\Book.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\JSONRPC.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3288,6 +3288,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\RobustTransaction.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\Status.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -406,6 +406,9 @@
     <Filter Include="ripple\websocket">
       <UniqueIdentifier>{44780F86-42D3-2F2B-0846-5AEE2CA6D7FE}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ripple\wsproto">
+      <UniqueIdentifier>{1D54E820-ADC9-94FB-19E7-653EFDE4CBE9}</UniqueIdentifier>
+    </Filter>
     <Filter Include="rocksdb2">
       <UniqueIdentifier>{15B4B65A-0F03-7BA9-38CD-42A5712392CB}</UniqueIdentifier>
     </Filter>
@@ -3930,6 +3933,12 @@
     <ClCompile Include="..\..\src\ripple\test\impl\ManualTimeKeeper.cpp">
       <Filter>ripple\test\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\impl\WSClient.cpp">
+      <Filter>ripple\test\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\impl\WSClient_test.cpp">
+      <Filter>ripple\test\impl</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\test\JSONRPCClient.h">
       <Filter>ripple\test</Filter>
     </ClInclude>
@@ -4116,6 +4125,9 @@
     <ClInclude Include="..\..\src\ripple\test\mao\Net.h">
       <Filter>ripple\test\mao</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\WSClient.h">
+      <Filter>ripple\test</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\unity\app_ledger.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
@@ -4250,6 +4262,12 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\websocket\WebSocket02.h">
       <Filter>ripple\websocket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\wsproto\basic_socket.h">
+      <Filter>ripple\wsproto</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\wsproto\wsproto.h">
+      <Filter>ripple\wsproto</Filter>
     </ClInclude>
     <ClCompile Include="..\..\src\rocksdb2\db\builder.cc">
       <Filter>rocksdb2\db</Filter>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3771,6 +3771,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\tests\LedgerRequestRPC.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\RobustTransaction.test.cpp">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\Status.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3771,6 +3771,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\tests\Status.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\Subscribe.test.cpp">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\tests\TestOutputSuite.test.h">
       <Filter>ripple\rpc\tests</Filter>
     </ClInclude>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3759,6 +3759,9 @@
     <ClCompile Include="..\..\src\ripple\rpc\tests\AccountLinesRPC.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\tests\Book.test.cpp">
+      <Filter>ripple\rpc\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\rpc\tests\JSONRPC.test.cpp">
       <Filter>ripple\rpc\tests</Filter>
     </ClCompile>

--- a/src/ripple/app/ledger/BookListeners.cpp
+++ b/src/ripple/app/ledger/BookListeners.cpp
@@ -38,8 +38,6 @@ void BookListeners::removeSubscriber (std::uint64_t seq)
 
 void BookListeners::publish (Json::Value const& jvObj)
 {
-    std::string sObj = to_string (jvObj);
-
     std::lock_guard <std::recursive_mutex> sl (mLock);
     auto it = mListeners.cbegin ();
 
@@ -49,7 +47,7 @@ void BookListeners::publish (Json::Value const& jvObj)
 
         if (p)
         {
-            p->send (jvObj, sObj, true);
+            p->send (jvObj, true);
             ++it;
         }
         else

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1571,9 +1571,6 @@ void NetworkOPsImp::pubServer ()
         jvObj [jss::load_factor]   =
                 (mLastLoadFactor = app_.getFeeTrack ().getLoadFactor ());
 
-        std::string sObj = to_string (jvObj);
-
-
         for (auto i = mSubServer.begin (); i != mSubServer.end (); )
         {
             InfoSub::pointer p = i->second.lock ();
@@ -1583,7 +1580,7 @@ void NetworkOPsImp::pubServer ()
             //             sending of JSON data.
             if (p)
             {
-                p->send (jvObj, sObj, true);
+                p->send (jvObj, true);
                 ++i;
             }
             else
@@ -2316,8 +2313,6 @@ void NetworkOPsImp::pubValidatedTransaction (
         *alTx.getTxn (), alTx.getResult (), true, alAccepted);
     jvObj[jss::meta] = alTx.getMeta ()->getJson (0);
 
-    std::string sObj = to_string (jvObj);
-
     {
         ScopedLockType sl (mSubLock);
 
@@ -2328,7 +2323,7 @@ void NetworkOPsImp::pubValidatedTransaction (
 
             if (p)
             {
-                p->send (jvObj, sObj, true);
+                p->send (jvObj, true);
                 ++it;
             }
             else
@@ -2343,7 +2338,7 @@ void NetworkOPsImp::pubValidatedTransaction (
 
             if (p)
             {
-                p->send (jvObj, sObj, true);
+                p->send (jvObj, true);
                 ++it;
             }
             else
@@ -2430,12 +2425,8 @@ void NetworkOPsImp::pubAccountTransaction (
         if (alTx.isApplied ())
             jvObj[jss::meta] = alTx.getMeta ()->getJson (0);
 
-        std::string sObj = to_string (jvObj);
-
         for (InfoSub::ref isrListener : notify)
-        {
-            isrListener->send (jvObj, sObj, true);
-        }
+            isrListener->send (jvObj, true);
     }
 }
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -920,6 +920,7 @@ void NetworkOPsImp::transactionBatch()
 
 void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
 {
+    std::vector<TransactionStatus> submit_held;
     std::vector<TransactionStatus> transactions;
     mTransactions.swap (transactions);
     assert (! transactions.empty());
@@ -996,7 +997,13 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                 for (auto const& tx : m_ledgerMaster.pruneHeldTransactions(
                     txCur->getAccountID(sfAccount), txCur->getSequence() + 1))
                 {
-                    submitTransaction(tx);
+                    std::string reason;
+                    auto const trans = sterilize(*tx);
+                    auto t = std::make_shared<Transaction>(
+                        trans, reason, app_);
+                    submit_held.emplace_back(
+                        t, false, false, FailHard::no);
+                    t->setApplying();
                 }
             }
             else if (e.result == tefPAST_SEQ)
@@ -1074,6 +1081,15 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
 
     for (TransactionStatus& e : transactions)
         e.transaction->clearApplying();
+
+    if (! submit_held.empty())
+    {
+        if (mTransactions.empty())
+            mTransactions.swap(submit_held);
+        else
+            for (auto& e : submit_held)
+                mTransactions.push_back(std::move(e));
+    }
 
     mCond.notify_all();
 

--- a/src/ripple/core/JobCoro.h
+++ b/src/ripple/core/JobCoro.h
@@ -39,6 +39,7 @@ struct JobCoro_create_t { };
 
 } // detail
 
+/** Coroutines must run to completion. */
 class JobCoro : public std::enable_shared_from_this<JobCoro>
 {
 private:
@@ -52,12 +53,21 @@ private:
     std::condition_variable cv_;
     boost::coroutines::asymmetric_coroutine<void>::pull_type coro_;
     boost::coroutines::asymmetric_coroutine<void>::push_type* yield_;
+#ifndef NDEBUG
+    bool finished_ = false;
+#endif
 
 public:
     // Private: Used in the implementation
     template <class F>
     JobCoro(detail::JobCoro_create_t, JobQueue&, JobType,
         std::string const&, F&&);
+
+    // Not copy-constructible or assignable
+    JobCoro(JobCoro const&) = delete;
+    JobCoro& operator= (JobCoro const&) = delete;
+
+    ~JobCoro();
 
     /** Suspend coroutine execution.
         Effects:

--- a/src/ripple/core/JobCoro.ipp
+++ b/src/ripple/core/JobCoro.ipp
@@ -34,7 +34,7 @@ JobCoro::JobCoro(detail::JobCoro_create_t, JobQueue& jq, JobType type,
         (boost::coroutines::asymmetric_coroutine<void>::push_type& do_yield)
         {
             yield_ = &do_yield;
-            (*yield_)();
+            yield();
             fn(shared_from_this());
         }, boost::coroutines::attributes (1024 * 1024))
 {
@@ -44,6 +44,10 @@ inline
 void
 JobCoro::yield() const
 {
+    {
+        std::lock_guard<std::mutex> lock(jq_.m_mutex);
+        ++jq_.nSuspend_;
+    }
     (*yield_)();
 }
 
@@ -60,6 +64,10 @@ JobCoro::post()
     jq_.addJob(type_, name_,
         [this, sp = shared_from_this()](Job&)
         {
+            {
+                std::lock_guard<std::mutex> lock(jq_.m_mutex);
+                --jq_.nSuspend_;
+            }
             auto saved = detail::getLocalValues().release();
             detail::getLocalValues().reset(&lvs_);
             std::lock_guard<std::mutex> lock(mutex_);

--- a/src/ripple/core/JobCoro.ipp
+++ b/src/ripple/core/JobCoro.ipp
@@ -36,8 +36,17 @@ JobCoro::JobCoro(detail::JobCoro_create_t, JobQueue& jq, JobType type,
             yield_ = &do_yield;
             yield();
             fn(shared_from_this());
+#ifndef NDEBUG
+            finished_ = true;
+#endif
         }, boost::coroutines::attributes (1024 * 1024))
 {
+}
+
+inline
+JobCoro::~JobCoro()
+{
+    assert(finished_);
 }
 
 inline

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -28,8 +28,9 @@
 #include <beast/threads/Stoppable.h>
 #include <beast/module/core/thread/Workers.h>
 #include <boost/function.hpp>
-#include <thread>
+#include <condition_variable>
 #include <set>
+#include <thread>
 
 namespace ripple {
 
@@ -95,6 +96,10 @@ public:
     // Cannot be const because LoadMonitor has no const methods.
     Json::Value getJson (int c = 0);
 
+    /** Block until no tasks running. */
+    void
+    rendezvous();
+
 private:
     using JobDataMap = std::map <JobType, JobTypeData>;
 
@@ -115,6 +120,8 @@ private:
     beast::insight::Collector::ptr m_collector;
     beast::insight::Gauge job_count;
     beast::insight::Hook hook;
+
+    std::condition_variable cv_;
 
     static JobTypes const& getJobTypes()
     {

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -92,10 +92,6 @@ public:
     // Cannot be const because LoadMonitor has no const methods.
     bool isOverloaded ();
 
-    /** Get the Job corresponding to a thread.  If no thread, use the current
-        thread. */
-    Job* getJobForThread(std::thread::id const& id = {}) const;
-
     // Cannot be const because LoadMonitor has no const methods.
     Json::Value getJson (int c = 0);
 
@@ -108,8 +104,6 @@ private:
     std::set <Job> m_jobSet;
     JobDataMap m_jobData;
     JobTypeData m_invalidJobData;
-
-    std::map <std::thread::id, Job*> m_threadIds;
 
     // The number of jobs currently in processTask()
     int m_processCount;

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -36,6 +36,8 @@ namespace ripple {
 
 class Logs;
 
+/** A pool of threads to perform work.
+*/
 class JobQueue
     : public beast::Stoppable
     , private beast::Workers::Callback
@@ -101,6 +103,8 @@ public:
     rendezvous();
 
 private:
+    friend class JobCoro;
+
     using JobDataMap = std::map <JobType, JobTypeData>;
 
     beast::Journal m_journal;
@@ -112,6 +116,9 @@ private:
 
     // The number of jobs currently in processTask()
     int m_processCount;
+
+    // The number of suspended coroutines
+    int nSuspend_ = 0;
 
     beast::Workers m_workers;
     Job::CancelCallback m_cancelCallback;

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -180,7 +180,7 @@ private:
     //
     // Invariants:
     //  <none>
-    void finishJob (Job const& job);
+    void finishJob (JobType type);
 
     template <class Rep, class Period>
     void on_dequeue (JobType type,

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -37,6 +37,14 @@ namespace ripple {
 class Logs;
 
 /** A pool of threads to perform work.
+
+    A job posted will always run to completion.
+    
+    Coroutines that are suspended must be resumed,
+    and run to completion.
+
+    When the JobQueue stops, it waits for all jobs
+    and coroutines to finish.
 */
 class JobQueue
     : public beast::Stoppable
@@ -139,6 +147,8 @@ private:
     void collect();
     JobTypeData& getJobTypeData (JobType type);
 
+    void onStop() override;
+
     // Signals the service stopped if the stopped condition is met.
     void checkStopped (std::lock_guard <std::mutex> const& lock);
 
@@ -210,18 +220,11 @@ private:
     //  <none>
     void processTask () override;
 
-    // Returns `true` if all jobs of this type should be skipped when
-    // the JobQueue receives a stop notification. If the job type isn't
-    // skipped, the Job will be called and the job must call Job::shouldCancel
-    // to determine if a long running or non-mandatory operation should be canceled.
-    bool skipOnStop (JobType type);
-
     // Returns the limit of running jobs for the given job type.
     // For jobs with no limit, we return the largest int. Hopefully that
     // will be enough.
     int getJobLimit (JobType type);
 
-    void onStop () override;
     void onChildrenStopped () override;
 };
 

--- a/src/ripple/core/JobTypeInfo.h
+++ b/src/ripple/core/JobTypeInfo.h
@@ -33,9 +33,6 @@ private:
     /** The limit on the number of running jobs for this job type. */
     int const m_limit;
 
-    /** Can be skipped */
-    bool const m_skip;
-
     /** Special jobs are not dispatched via the job queue */
     bool const m_special;
 
@@ -48,11 +45,10 @@ public:
     JobTypeInfo () = delete;
 
     JobTypeInfo (JobType type, std::string name, int limit,
-            bool skip, bool special, std::uint64_t avgLatency, std::uint64_t peakLatency)
+            bool special, std::uint64_t avgLatency, std::uint64_t peakLatency)
         : m_type (type)
         , m_name (name)
         , m_limit (limit)
-        , m_skip (skip)
         , m_special (special)
         , m_avgLatency (avgLatency)
         , m_peakLatency (peakLatency)
@@ -73,11 +69,6 @@ public:
     int limit () const
     {
         return m_limit;
-    }
-
-    bool skip () const
-    {
-        return m_skip;
     }
 
     bool special () const

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -34,144 +34,47 @@ public:
     using const_iterator = Map::const_iterator;
 
     JobTypes ()
-        : m_unknown (jtINVALID, "invalid", 0, true, true, 0, 0)
+        : m_unknown (jtINVALID, "invalid", 0, true, 0, 0)
     {
         int maxLimit = std::numeric_limits <int>::max ();
 
-        // Make a fetch pack for a peer
-        add (jtPACK,          "makeFetchPack",
-            1,        true,   false, 0,     0);
+add(    jtPACK,          "makeFetchPack",           1,        false, 0,     0);
+add(    jtPUBOLDLEDGER,  "publishAcqLedger",        2,        false, 10000, 15000);
+add(    jtVALIDATION_ut, "untrustedValidation",     maxLimit, false, 2000,  5000);
+add(    jtTRANSACTION_l, "localTransaction",        maxLimit, false, 100,   500);
+add(    jtLEDGER_REQ,    "ledgerRequest",           2,        false, 0,     0);
+add(    jtPROPOSAL_ut,   "untrustedProposal",       maxLimit, false, 500,   1250);
+add(    jtLEDGER_DATA,   "ledgerData",              2,        false, 0,     0);
+add(    jtCLIENT,        "clientCommand",           maxLimit, false, 2000,  5000);
+add(    jtRPC,           "RPC",                     maxLimit, false, 0,     0);
+add(    jtUPDATE_PF,     "updatePaths",             maxLimit, false, 0,     0);
+add(    jtTRANSACTION,   "transaction",             maxLimit, false, 250,   1000);
+add(    jtBATCH,         "batch",                   maxLimit, false, 250,   1000);
+add(    jtUNL,           "unl",                     1,        false, 0,     0);
+add(    jtADVANCE,       "advanceLedger",           maxLimit, false, 0,     0);
+add(    jtPUBLEDGER,     "publishNewLedger",        maxLimit, false, 3000,  4500);
+add(    jtTXN_DATA,      "fetchTxnData",            1,        false, 0,     0);
+add(    jtWAL,           "writeAhead",              maxLimit, false, 1000,  2500);
+add(    jtVALIDATION_t,  "trustedValidation",       maxLimit, false, 500,  1500);
+add(    jtWRITE,         "writeObjects",            maxLimit, false, 1750,  2500);
+add(    jtACCEPT,        "acceptLedger",            maxLimit, false, 0,     0);
+add(    jtPROPOSAL_t,    "trustedProposal",         maxLimit, false, 100,   500);
+add(    jtSWEEP,         "sweep",                   maxLimit, false, 0,     0);
+add(    jtNETOP_CLUSTER, "clusterReport",           1,        false, 9999,  9999);
+add(    jtNETOP_TIMER,   "heartbeat",               1,        false, 999,   999);
+add(    jtADMIN,         "administration",          maxLimit, false, 0,     0);
 
-        // An old ledger has been accepted
-        add (jtPUBOLDLEDGER,  "publishAcqLedger",
-            2,        true,   false, 10000, 15000);
-
-        // A validation from an untrusted source
-        add (jtVALIDATION_ut, "untrustedValidation",
-            maxLimit, true,   false, 2000,  5000);
-
-        // A local transaction
-        add (jtTRANSACTION_l, "localTransaction",
-            maxLimit, true,   false, 100,   500);
-
-        // A request for ledger/txnset data from another server
-        add (jtLEDGER_REQ,    "ledgerRequest",
-            2,        true,   false,    0,     0);
-
-        // A proposal from an untrusted source
-        add (jtPROPOSAL_ut,   "untrustedProposal",
-            maxLimit, true,   false, 500,   1250);
-
-        // Received data for a ledger we're acquiring
-        add (jtLEDGER_DATA,   "ledgerData",
-            2,        true,   false, 0,     0);
-
-        // A websocket command from the client
-        add (jtCLIENT,        "clientCommand",
-            maxLimit, true,   false, 2000,  5000);
-
-        // A websocket command from the client
-        add (jtRPC,           "RPC",
-            maxLimit, false,  false, 0,     0);
-
-        // Update pathfinding requests
-        add (jtUPDATE_PF,     "updatePaths",
-            maxLimit, true,   false, 0,     0);
-
-        // A transaction received from the network
-        add (jtTRANSACTION,   "transaction",
-            maxLimit, true,   false, 250,   1000);
-
-        // Apply batched transactions
-        add (jtBATCH,          "batch",
-            maxLimit, true,   false, 250,   1000);
-
-        // A Score or Fetch of the UNL (DEPRECATED)
-        add (jtUNL,           "unl",
-            1,        true,   false, 0,     0);
-
-        // Advance validated/acquired ledgers
-        add (jtADVANCE,       "advanceLedger",
-            maxLimit, true,   false, 0,     0);
-
-        // Publish a fully-accepted ledger
-        add (jtPUBLEDGER,     "publishNewLedger",
-            maxLimit, true,   false, 3000,  4500);
-
-        // Fetch a proposed set
-        add (jtTXN_DATA,      "fetchTxnData",
-            1,        true,   false, 0,     0);
-
-        // Write-ahead logging
-        add (jtWAL,           "writeAhead",
-            maxLimit, false,  false, 1000,  2500);
-
-        // A validation from a trusted source
-        add (jtVALIDATION_t,  "trustedValidation",
-            maxLimit, true,   false, 500,  1500);
-
-        // Write out hashed objects
-        add (jtWRITE,         "writeObjects",
-            maxLimit, false,  false, 1750,  2500);
-
-        // Accept a consensus ledger
-        add (jtACCEPT,        "acceptLedger",
-            maxLimit, false,  false, 0,     0);
-
-        // A proposal from a trusted source
-        add (jtPROPOSAL_t,    "trustedProposal",
-            maxLimit, false,  false, 100,   500);
-
-        // Sweep for stale structures
-        add (jtSWEEP,         "sweep",
-            maxLimit, true,   false, 0,     0);
-
-        // NetworkOPs cluster peer report
-        add (jtNETOP_CLUSTER, "clusterReport",
-            1,        true,   false, 9999,  9999);
-
-        // NetworkOPs net timer processing
-        add (jtNETOP_TIMER,   "heartbeat",
-            1,        true,   false, 999,   999);
-
-        // An administrative operation
-        add (jtADMIN,         "administration",
-            maxLimit, true,   false, 0,     0);
-
-        // The rest are special job types that are not dispatched
-        // by the job pool. The "limit" and "skip" attributes are
-        // not applicable to these types of jobs.
-
-        add (jtPEER,          "peerCommand",
-            0,        false,  true,  200,   2500);
-
-        add (jtDISK,          "diskAccess",
-            0,        false,  true,  500,   1000);
-
-        add (jtTXN_PROC,      "processTransaction",
-            0,        false,  true,  0,     0);
-
-        add (jtOB_SETUP,      "orderBookSetup",
-            0,        false,  true,  0,     0);
-
-        add (jtPATH_FIND,     "pathFind",
-            0,        false,  true,  0,     0);
-
-        add (jtHO_READ,       "nodeRead",
-            0,        false,  true,  0,     0);
-
-        add (jtHO_WRITE,      "nodeWrite",
-            0,        false,  true,  0,     0);
-
-        add (jtGENERIC,       "generic",
-            0,        false,  true,  0,     0);
-
-        add (jtNS_SYNC_READ,  "SyncReadNode",
-            0,        false,  true,  0,     0);
-        add (jtNS_ASYNC_READ, "AsyncReadNode",
-            0,        false,  true,  0,     0);
-        add (jtNS_WRITE,      "WriteNode",
-            0,        false,  true,  0,     0);
+add(    jtPEER,          "peerCommand",             0,        true,  200,   2500);
+add(    jtDISK,          "diskAccess",              0,        true,  500,   1000);
+add(    jtTXN_PROC,      "processTransaction",      0,        true,  0,     0);
+add(    jtOB_SETUP,      "orderBookSetup",          0,        true,  0,     0);
+add(    jtPATH_FIND,     "pathFind",                0,        true,  0,     0);
+add(    jtHO_READ,       "nodeRead",                0,        true,  0,     0);
+add(    jtHO_WRITE,      "nodeWrite",               0,        true,  0,     0);
+add(    jtGENERIC,       "generic",                 0,        true,  0,     0);
+add(    jtNS_SYNC_READ,  "SyncReadNode",            0,        true,  0,     0);
+add(    jtNS_ASYNC_READ, "AsyncReadNode",           0,        true,  0,     0);
+add(    jtNS_WRITE,      "WriteNode",               0,        true,  0,     0);
 
     }
 
@@ -213,14 +116,14 @@ public:
 
 private:
     void add(JobType jt, std::string name, int limit,
-        bool skip, bool special, std::uint64_t avgLatency, std::uint64_t peakLatency)
+        bool special, std::uint64_t avgLatency, std::uint64_t peakLatency)
     {
         assert (m_map.find (jt) == m_map.end ());
 
         std::pair<Map::iterator,bool> result (m_map.emplace (
             std::piecewise_construct,
             std::forward_as_tuple (jt),
-            std::forward_as_tuple (jt, name, limit, skip, special,
+            std::forward_as_tuple (jt, name, limit, special,
                 avgLatency, peakLatency)));
 
         assert (result.second == true);

--- a/src/ripple/core/impl/Job.cpp
+++ b/src/ripple/core/impl/Job.cpp
@@ -80,6 +80,10 @@ void Job::doJob ()
     m_loadEvent->reName (mName);
 
     mJob (*this);
+
+    // Destroy the lambda, otherwise we won't include
+    // its duration in the time measurement
+    mJob = std::function<void(Job&)>();
 }
 
 void Job::rename (std::string const& newName)

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -305,16 +305,6 @@ JobQueue::getJson (int c)
     return ret;
 }
 
-Job*
-JobQueue::getJobForThread (std::thread::id const& id) const
-{
-    auto tid = (id == std::thread::id()) ? std::this_thread::get_id() : id;
-
-    std::lock_guard <std::mutex> lock (m_mutex);
-    auto i = m_threadIds.find (tid);
-    return (i == m_threadIds.end()) ? nullptr : i->second;
-}
-
 JobTypeData&
 JobQueue::getJobTypeData (JobType type)
 {
@@ -400,8 +390,6 @@ JobQueue::getNextJob (Job& job)
     job = *iter;
     m_jobSet.erase (iter);
 
-    m_threadIds[std::this_thread::get_id()] = &job;
-
     --data.waiting;
     ++data.running;
 }
@@ -422,10 +410,6 @@ JobQueue::finishJob (JobType type)
         m_workers.addTask ();
     }
 
-    if (! m_threadIds.erase (std::this_thread::get_id()))
-    {
-        assert (false);
-    }
     --data.running;
 }
 

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -305,6 +305,17 @@ JobQueue::getJson (int c)
     return ret;
 }
 
+void
+JobQueue::rendezvous()
+{
+    std::unique_lock<std::mutex> lock(m_mutex);
+    cv_.wait(lock, [&]
+    {
+        return m_processCount == 0 &&
+            m_jobSet.empty();
+    });
+}
+
 JobTypeData&
 JobQueue::getJobTypeData (JobType type)
 {
@@ -476,11 +487,12 @@ JobQueue::processTask ()
 
     {
         std::lock_guard <std::mutex> lock (m_mutex);
-        finishJob (type);
-        --m_processCount;
         // Job should be destroyed before calling checkStopped
         // otherwise destructors with side effects can access
         // parent objects that are already destroyed.
+        finishJob (type);
+        if(--m_processCount == 0 && m_jobSet.empty())
+            cv_.notify_all();
         checkStopped (lock);
     }
 

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -339,11 +339,13 @@ JobQueue::checkStopped (std::lock_guard <std::mutex> const& lock)
     //  2. All Stoppable children have stopped
     //  3. There are no executing calls to processTask
     //  4. There are no remaining Jobs in the job set
+    //  5. There are no suspended coroutines
     //
     if (isStopping() &&
         areChildrenStopped() &&
         (m_processCount == 0) &&
-        m_jobSet.empty())
+        m_jobSet.empty() &&
+        nSuspend_ == 0)
     {
         stopped();
     }

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -407,14 +407,11 @@ JobQueue::getNextJob (Job& job)
 }
 
 void
-JobQueue::finishJob (Job const& job)
+JobQueue::finishJob (JobType type)
 {
-    JobType const type = job.getType ();
+    assert(type != jtINVALID);
 
-    assert (m_jobSet.find (job) == m_jobSet.end ());
-    assert (type != jtINVALID);
-
-    JobTypeData& data (getJobTypeData (type));
+    JobTypeData& data = getJobTypeData (type);
 
     // Queue a deferred task if possible
     if (data.deferred > 0)
@@ -457,40 +454,49 @@ void JobQueue::on_execute (JobType type,
 void
 JobQueue::processTask ()
 {
-    Job job;
+    JobType type;
+
+    {
+        Job job;
+
+        {
+            std::lock_guard <std::mutex> lock (m_mutex);
+            getNextJob (job);
+            ++m_processCount;
+        }
+
+        JobTypeData& data (getJobTypeData (job.getType ()));
+
+        // Skip the job if we are stopping and the
+        // skipOnStop flag is set for the job type
+        //
+        if (!isStopping() || !data.info.skip ())
+        {
+            beast::Thread::setCurrentThreadName (data.name ());
+            JLOG(m_journal.trace) << "Doing " << data.name () << " job";
+
+            Job::clock_type::time_point const start_time (
+                Job::clock_type::now());
+
+            on_dequeue (job.getType (), start_time - job.queue_time ());
+            job.doJob ();
+            on_execute (job.getType (), Job::clock_type::now() - start_time);
+        }
+        else
+        {
+            JLOG(m_journal.trace) << "Skipping processTask ('" << data.name () << "')";
+        }
+
+        type = job.getType();
+    }
 
     {
         std::lock_guard <std::mutex> lock (m_mutex);
-        getNextJob (job);
-        ++m_processCount;
-    }
-
-    JobTypeData& data (getJobTypeData (job.getType ()));
-
-    // Skip the job if we are stopping and the
-    // skipOnStop flag is set for the job type
-    //
-    if (!isStopping() || !data.info.skip ())
-    {
-        beast::Thread::setCurrentThreadName (data.name ());
-        JLOG(m_journal.trace) << "Doing " << data.name () << " job";
-
-        Job::clock_type::time_point const start_time (
-            Job::clock_type::now());
-
-        on_dequeue (job.getType (), start_time - job.queue_time ());
-        job.doJob ();
-        on_execute (job.getType (), Job::clock_type::now() - start_time);
-    }
-    else
-    {
-        JLOG(m_journal.trace) << "Skipping processTask ('" << data.name () << "')";
-    }
-
-    {
-        std::lock_guard <std::mutex> lock (m_mutex);
-        finishJob (job);
+        finishJob (type);
         --m_processCount;
+        // Job should be destroyed before calling checkStopped
+        // otherwise destructors with side effects can access
+        // parent objects that are already destroyed.
         checkStopped (lock);
     }
 

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -112,16 +112,6 @@ JobQueue::addJob (JobType type, std::string const& name,
             ! areChildrenStopped()));
     }
 
-    // Don't even add it to the queue if we're stopping
-    // and the job type is marked for skipOnStop.
-    //
-    if (isStopping() && skipOnStop (type))
-    {
-        JLOG(m_journal.debug) <<
-            "Skipping addJob ('" << name << "')";
-        return;
-    }
-
     {
         std::lock_guard <std::mutex> lock (m_mutex);
 
@@ -331,6 +321,13 @@ JobQueue::getJobTypeData (JobType type)
 }
 
 void
+JobQueue::onStop()
+{
+    // onStop must be defined and empty here,
+    // otherwise the base class will do the wrong thing.
+}
+
+void
 JobQueue::checkStopped (std::lock_guard <std::mutex> const& lock)
 {
     // We are stopped when all of the following are true:
@@ -454,37 +451,23 @@ JobQueue::processTask ()
     JobType type;
 
     {
-        Job job;
-
+        Job::clock_type::time_point const start_time (
+            Job::clock_type::now());
         {
-            std::lock_guard <std::mutex> lock (m_mutex);
-            getNextJob (job);
-            ++m_processCount;
-        }
-
-        JobTypeData& data (getJobTypeData (job.getType ()));
-
-        // Skip the job if we are stopping and the
-        // skipOnStop flag is set for the job type
-        //
-        if (!isStopping() || !data.info.skip ())
-        {
+            Job job;
+            {
+                std::lock_guard <std::mutex> lock (m_mutex);
+                getNextJob (job);
+                ++m_processCount;
+            }
+            type = job.getType();
+            JobTypeData& data(getJobTypeData(type));
             beast::Thread::setCurrentThreadName (data.name ());
             JLOG(m_journal.trace) << "Doing " << data.name () << " job";
-
-            Job::clock_type::time_point const start_time (
-                Job::clock_type::now());
-
             on_dequeue (job.getType (), start_time - job.queue_time ());
             job.doJob ();
-            on_execute (job.getType (), Job::clock_type::now() - start_time);
         }
-        else
-        {
-            JLOG(m_journal.trace) << "Skipping processTask ('" << data.name () << "')";
-        }
-
-        type = job.getType();
+        on_execute(type, Job::clock_type::now() - start_time);
     }
 
     {
@@ -502,15 +485,6 @@ JobQueue::processTask ()
     // to the associated LoadEvent object (in the Job) may be destroyed.
 }
 
-bool
-JobQueue::skipOnStop (JobType type)
-{
-    JobTypeInfo const& j (getJobTypes ().get (type));
-    assert (j.type () != jtINVALID);
-
-    return j.skip ();
-}
-
 int
 JobQueue::getJobLimit (JobType type)
 {
@@ -518,59 +492,6 @@ JobQueue::getJobLimit (JobType type)
     assert (j.type () != jtINVALID);
 
     return j.limit ();
-}
-
-void
-JobQueue::onStop ()
-{
-    // VFALCO NOTE I wanted to remove all the jobs that are skippable
-    //             but then the Workers count of tasks to process
-    //             goes wrong.
-
-    /*
-    {
-        std::lock_guard <std::mutex> lock (m_mutex);
-
-        // Remove all jobs whose type is skipOnStop
-        using JobDataMap = hash_map <JobType, std::size_t>;
-        JobDataMap counts;
-        bool const report (m_journal.debug.active());
-
-        for (std::set <Job>::const_iterator iter (m_jobSet.begin());
-            iter != m_jobSet.end();)
-        {
-            if (skipOnStop (iter->getType()))
-            {
-                if (report)
-                {
-                    std::pair <JobDataMap::iterator, bool> result (
-                        counts.insert (std::make_pair (iter->getType(), 1)));
-                    if (! result.second)
-                        ++(result.first->second);
-                }
-
-                iter = m_jobSet.erase (iter);
-            }
-            else
-            {
-                ++iter;
-            }
-        }
-
-        if (report)
-        {
-            beast::Journal::ScopedStream s (m_journal.debug);
-
-            for (JobDataMap::const_iterator iter (counts.begin());
-                iter != counts.end(); ++iter)
-            {
-                s << std::endl <<
-                    "Removed " << iter->second <<
-                    " skiponStop jobs of type " << Job::toString (iter->first);
-            }
-        }
-    }
-    */
 }
 
 void

--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -126,10 +126,6 @@ public:
 
     virtual void send (Json::Value const& jvObj, bool broadcast) = 0;
 
-    // virtual so that a derived class can optimize this case
-    virtual void send (
-        Json::Value const& jvObj, std::string const& sObj, bool broadcast);
-
     std::uint64_t getSeq ();
 
     void onSendEmpty ();

--- a/src/ripple/net/impl/InfoSub.cpp
+++ b/src/ripple/net/impl/InfoSub.cpp
@@ -77,12 +77,6 @@ Resource::Consumer& InfoSub::getConsumer()
     return m_consumer;
 }
 
-void InfoSub::send (
-    Json::Value const& jvObj, std::string const& sObj, bool broadcast)
-{
-    send (jvObj, broadcast);
-}
-
 std::uint64_t InfoSub::getSeq ()
 {
     return mSeq;

--- a/src/ripple/rpc/handlers/Unsubscribe.cpp
+++ b/src/ripple/rpc/handlers/Unsubscribe.cpp
@@ -136,16 +136,14 @@ Json::Value doUnsubscribe (RPC::Context& context)
 
         for (auto& jv: context.params[jss::books])
         {
-            if (!jv.isObject ()
-                    || !jv.isMember (jss::taker_pays)
-                    || !jv.isMember (jss::taker_gets)
-                    || !jv[jss::taker_pays].isObject ()
-                    || !jv[jss::taker_gets].isObject ())
-                return rpcError (rpcINVALID_PARAMS);
-
-            bool bBoth = (jv.isMember (jss::both) && jv[jss::both].asBool ()) ||
-                    (jv.isMember (jss::both_sides) && jv[jss::both_sides].asBool ());
-            // both_sides is deprecated.
+            if (! jv.isObject() ||
+                ! jv.isMember(jss::taker_pays) ||
+                ! jv.isMember(jss::taker_gets) ||
+                ! jv[jss::taker_pays].isObject() ||
+                ! jv[jss::taker_gets].isObject())
+            {
+                return rpcError(rpcINVALID_PARAMS);
+            }
 
             Json::Value taker_pays = jv[jss::taker_pays];
             Json::Value taker_gets = jv[jss::taker_gets];
@@ -206,8 +204,12 @@ Json::Value doUnsubscribe (RPC::Context& context)
 
             context.netOps.unsubBook (ispSub->getSeq (), book);
 
-            if (bBoth)
-                context.netOps.unsubBook (ispSub->getSeq (), book);
+            // both_sides is deprecated.
+            if ((jv.isMember(jss::both) && jv[jss::both].asBool()) ||
+                (jv.isMember(jss::both_sides) && jv[jss::both_sides].asBool()))
+            {
+                context.netOps.unsubBook(ispSub->getSeq(), reversed(book));
+            }
         }
     }
 

--- a/src/ripple/rpc/tests/Book.test.cpp
+++ b/src/ripple/rpc/tests/Book.test.cpp
@@ -1,0 +1,823 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/test/WSClient.h>
+#include <ripple/test/jtx.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+namespace test {
+
+class Book_test : public beast::unit_test::suite
+{
+public:
+    void
+    testOneSideEmptyBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::offers) &&
+                jv[jss::result][jss::offers].size() == 0);
+            expect(! jv[jss::result].isMember(jss::asks));
+            expect(! jv[jss::result].isMember(jss::bids));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 1)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 2)));
+            env.close();
+            expect(! wsc->getMsg(10ms));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testOneSideOffersInBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        // Create an ask: TakerPays 500, TakerGets 100/USD
+        env(offer("alice", XRP(500), USD(100)),
+            require(owners("alice", 1)));
+
+        // Create a bid: TakerPays 100/USD, TakerGets 200
+        env(offer("alice", USD(100), XRP(200)),
+            require(owners("alice", 2)));
+        env.close();
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::offers) &&
+                jv[jss::result][jss::offers].size() == 1);
+            expect(jv[jss::result][jss::offers][0u][jss::TakerGets] ==
+                XRP(200).value().getJson(0));
+            expect(jv[jss::result][jss::offers][0u][jss::TakerPays] ==
+                USD(100).value().getJson(0));
+            expect(! jv[jss::result].isMember(jss::asks));
+            expect(! jv[jss::result].isMember(jss::bids));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 3)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 4)));
+            env.close();
+            expect(! wsc->getMsg(10ms));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testBothSidesEmptyBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::both] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::asks) &&
+                jv[jss::result][jss::asks].size() == 0);
+            expect(jv[jss::result].isMember(jss::bids) &&
+                jv[jss::result][jss::bids].size() == 0);
+            expect(! jv[jss::result].isMember(jss::offers));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 1)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 2)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == XRP(75).value().getJson(0) &&
+                            t[jss::TakerPays] == USD(100).value().getJson(0);
+                }));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testBothSidesOffersInBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        // Create an ask: TakerPays 500, TakerGets 100/USD
+        env(offer("alice", XRP(500), USD(100)),
+            require(owners("alice", 1)));
+
+        // Create a bid: TakerPays 100/USD, TakerGets 200
+        env(offer("alice", USD(100), XRP(200)),
+            require(owners("alice", 2)));
+        env.close();
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::both] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::asks) &&
+                jv[jss::result][jss::asks].size() == 1);
+            expect(jv[jss::result].isMember(jss::bids) &&
+                jv[jss::result][jss::bids].size() == 1);
+            expect(jv[jss::result][jss::asks][0u][jss::TakerGets] ==
+                USD(100).value().getJson(0));
+            expect(jv[jss::result][jss::asks][0u][jss::TakerPays] ==
+                XRP(500).value().getJson(0));
+            expect(jv[jss::result][jss::bids][0u][jss::TakerGets] ==
+                XRP(200).value().getJson(0));
+            expect(jv[jss::result][jss::bids][0u][jss::TakerPays] ==
+                USD(100).value().getJson(0));
+            expect(! jv[jss::result].isMember(jss::offers));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 3)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 4)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == XRP(75).value().getJson(0) &&
+                            t[jss::TakerPays] == USD(100).value().getJson(0);
+                }));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testMultipleBooksOneSideEmptyBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto CNY = Account("alice")["CNY"];
+        auto JPY = Account("alice")["JPY"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::taker_gets][jss::currency] = "CNY";
+                j[jss::taker_gets][jss::issuer] = Account("alice").human();
+                j[jss::taker_pays][jss::currency] = "JPY";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::offers) &&
+                jv[jss::result][jss::offers].size() == 0);
+            expect(! jv[jss::result].isMember(jss::asks));
+            expect(! jv[jss::result].isMember(jss::bids));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 1)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 2)));
+            env.close();
+            expect(! wsc->getMsg(10ms));
+        }
+
+        {
+            // Create an ask: TakerPays 700/CNY, TakerGets 100/JPY
+            env(offer("alice", CNY(700), JPY(100)),
+                require(owners("alice", 3)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == JPY(100).value().getJson(0) &&
+                            t[jss::TakerPays] == CNY(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/JPY, TakerGets 75/CNY
+            env(offer("alice", JPY(100), CNY(75)),
+                require(owners("alice", 4)));
+            env.close();
+            expect(! wsc->getMsg(10ms));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testMultipleBooksOneSideOffersInBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto CNY = Account("alice")["CNY"];
+        auto JPY = Account("alice")["JPY"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        // Create an ask: TakerPays 500, TakerGets 100/USD
+        env(offer("alice", XRP(500), USD(100)),
+            require(owners("alice", 1)));
+
+        // Create an ask: TakerPays 500/CNY, TakerGets 100/JPY
+        env(offer("alice", CNY(500), JPY(100)),
+            require(owners("alice", 2)));
+
+        // Create a bid: TakerPays 100/USD, TakerGets 200
+        env(offer("alice", USD(100), XRP(200)),
+            require(owners("alice", 3)));
+
+        // Create a bid: TakerPays 100/JPY, TakerGets 200/CNY
+        env(offer("alice", JPY(100), CNY(200)),
+            require(owners("alice", 4)));
+        env.close();
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::taker_gets][jss::currency] = "CNY";
+                j[jss::taker_gets][jss::issuer] = Account("alice").human();
+                j[jss::taker_pays][jss::currency] = "JPY";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::offers) &&
+                jv[jss::result][jss::offers].size() == 2);
+            expect(jv[jss::result][jss::offers][0u][jss::TakerGets] ==
+                XRP(200).value().getJson(0));
+            expect(jv[jss::result][jss::offers][0u][jss::TakerPays] ==
+                USD(100).value().getJson(0));
+            expect(jv[jss::result][jss::offers][1u][jss::TakerGets] ==
+                CNY(200).value().getJson(0));
+            expect(jv[jss::result][jss::offers][1u][jss::TakerPays] ==
+                JPY(100).value().getJson(0));
+            expect(! jv[jss::result].isMember(jss::asks));
+            expect(! jv[jss::result].isMember(jss::bids));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 5)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 6)));
+            env.close();
+            expect(! wsc->getMsg(10ms));
+        }
+
+        {
+            // Create an ask: TakerPays 700/CNY, TakerGets 100/JPY
+            env(offer("alice", CNY(700), JPY(100)),
+                require(owners("alice", 7)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == JPY(100).value().getJson(0) &&
+                            t[jss::TakerPays] == CNY(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/JPY, TakerGets 75/CNY
+            env(offer("alice", JPY(100), CNY(75)),
+                require(owners("alice", 8)));
+            env.close();
+            expect(! wsc->getMsg(10ms));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testMultipleBooksBothSidesEmptyBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto CNY = Account("alice")["CNY"];
+        auto JPY = Account("alice")["JPY"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::both] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::both] = true;
+                j[jss::taker_gets][jss::currency] = "CNY";
+                j[jss::taker_gets][jss::issuer] = Account("alice").human();
+                j[jss::taker_pays][jss::currency] = "JPY";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::asks) &&
+                jv[jss::result][jss::asks].size() == 0);
+            expect(jv[jss::result].isMember(jss::bids) &&
+                jv[jss::result][jss::bids].size() == 0);
+            expect(! jv[jss::result].isMember(jss::offers));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 1)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 2)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == XRP(75).value().getJson(0) &&
+                            t[jss::TakerPays] == USD(100).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create an ask: TakerPays 700/CNY, TakerGets 100/JPY
+            env(offer("alice", CNY(700), JPY(100)),
+                require(owners("alice", 3)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == JPY(100).value().getJson(0) &&
+                            t[jss::TakerPays] == CNY(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/JPY, TakerGets 75/CNY
+            env(offer("alice", JPY(100), CNY(75)),
+                require(owners("alice", 4)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == CNY(75).value().getJson(0) &&
+                            t[jss::TakerPays] == JPY(100).value().getJson(0);
+                }));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    testMultipleBooksBothSidesOffersInBook()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        auto USD = Account("alice")["USD"];
+        auto CNY = Account("alice")["CNY"];
+        auto JPY = Account("alice")["JPY"];
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value books;
+
+        // Create an ask: TakerPays 500, TakerGets 100/USD
+        env(offer("alice", XRP(500), USD(100)),
+            require(owners("alice", 1)));
+
+        // Create an ask: TakerPays 500/CNY, TakerGets 100/JPY
+        env(offer("alice", CNY(500), JPY(100)),
+            require(owners("alice", 2)));
+
+        // Create a bid: TakerPays 100/USD, TakerGets 200
+        env(offer("alice", USD(100), XRP(200)),
+            require(owners("alice", 3)));
+
+        // Create a bid: TakerPays 100/JPY, TakerGets 200/CNY
+        env(offer("alice", JPY(100), CNY(200)),
+            require(owners("alice", 4)));
+        env.close();
+
+        {
+            // RPC subscribe to books stream
+            books[jss::books] = Json::arrayValue;
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::both] = true;
+                j[jss::taker_gets][jss::currency] = "XRP";
+                j[jss::taker_pays][jss::currency] = "USD";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+            // RPC subscribe to books stream
+            {
+                auto &j = books[jss::books].append(Json::objectValue);
+                j[jss::snapshot] = true;
+                j[jss::both] = true;
+                j[jss::taker_gets][jss::currency] = "CNY";
+                j[jss::taker_gets][jss::issuer] = Account("alice").human();
+                j[jss::taker_pays][jss::currency] = "JPY";
+                j[jss::taker_pays][jss::issuer] = Account("alice").human();
+            }
+
+            auto jv = wsc->invoke("subscribe", books);
+            expect(jv[jss::status] == "success");
+            expect(jv[jss::result].isMember(jss::asks) &&
+                jv[jss::result][jss::asks].size() == 2);
+            expect(jv[jss::result].isMember(jss::bids) &&
+                jv[jss::result][jss::bids].size() == 2);
+            expect(jv[jss::result][jss::asks][0u][jss::TakerGets] ==
+                USD(100).value().getJson(0));
+            expect(jv[jss::result][jss::asks][0u][jss::TakerPays] ==
+                XRP(500).value().getJson(0));
+            expect(jv[jss::result][jss::asks][1u][jss::TakerGets] ==
+                JPY(100).value().getJson(0));
+            expect(jv[jss::result][jss::asks][1u][jss::TakerPays] ==
+                CNY(500).value().getJson(0));
+            expect(jv[jss::result][jss::bids][0u][jss::TakerGets] ==
+                XRP(200).value().getJson(0));
+            expect(jv[jss::result][jss::bids][0u][jss::TakerPays] ==
+                USD(100).value().getJson(0));
+            expect(jv[jss::result][jss::bids][1u][jss::TakerGets] ==
+                CNY(200).value().getJson(0));
+            expect(jv[jss::result][jss::bids][1u][jss::TakerPays] ==
+                JPY(100).value().getJson(0));
+            expect(! jv[jss::result].isMember(jss::offers));
+        }
+
+        {
+            // Create an ask: TakerPays 700, TakerGets 100/USD
+            env(offer("alice", XRP(700), USD(100)),
+                require(owners("alice", 5)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == USD(100).value().getJson(0) &&
+                            t[jss::TakerPays] == XRP(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/USD, TakerGets 75
+            env(offer("alice", USD(100), XRP(75)),
+                require(owners("alice", 6)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == XRP(75).value().getJson(0) &&
+                            t[jss::TakerPays] == USD(100).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create an ask: TakerPays 700/CNY, TakerGets 100/JPY
+            env(offer("alice", CNY(700), JPY(100)),
+                require(owners("alice", 7)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == JPY(100).value().getJson(0) &&
+                            t[jss::TakerPays] == CNY(700).value().getJson(0);
+                }));
+        }
+
+        {
+            // Create a bid: TakerPays 100/JPY, TakerGets 75/CNY
+            env(offer("alice", JPY(100), CNY(75)),
+                require(owners("alice", 8)));
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& t = jv[jss::transaction];
+                    return t[jss::TransactionType] == "OfferCreate" &&
+                        t[jss::TakerGets] == CNY(75).value().getJson(0) &&
+                            t[jss::TakerPays] == JPY(100).value().getJson(0);
+                }));
+        }
+
+        // RPC unsubscribe
+        expect(wsc->invoke("unsubscribe",
+            books)[jss::status] == "success");
+    }
+
+    void
+    run() override
+    {
+        testOneSideEmptyBook();
+        testOneSideOffersInBook();
+
+        testBothSidesEmptyBook();
+        testBothSidesOffersInBook();
+
+        testMultipleBooksOneSideEmptyBook();
+        testMultipleBooksOneSideOffersInBook();
+
+        testMultipleBooksBothSidesEmptyBook();
+        testMultipleBooksBothSidesOffersInBook();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Book,app,ripple);
+
+} // test
+} // ripple

--- a/src/ripple/rpc/tests/RobustTransaction.test.cpp
+++ b/src/ripple/rpc/tests/RobustTransaction.test.cpp
@@ -1,0 +1,321 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/core/JobQueue.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/test/jtx.h>
+#include <ripple/test/WSClient.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+namespace test {
+
+class RobustTransaction_test : public beast::unit_test::suite
+{
+public:
+    void
+    testSequenceRealignment()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice", "bob");
+        env.close();
+        auto wsc = makeWSClient(env.app().config());
+
+        {
+            // RPC subscribe to transactions stream
+            Json::Value jv;
+            jv[jss::streams] = Json::arrayValue;
+            jv[jss::streams].append("transactions");
+            jv = wsc->invoke("subscribe", jv);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            // Submit past ledger sequence transaction
+            Json::Value payment;
+            payment[jss::secret] = toBase58(generateSeed("alice"));
+            payment[jss::tx_json] = pay("alice", "bob", XRP(1));
+            payment[jss::tx_json][sfLastLedgerSequence.fieldName] = 1;
+            auto jv = wsc->invoke("submit", payment);
+            expect(jv[jss::result][jss::engine_result] ==
+                "tefMAX_LEDGER");
+
+            // Submit past sequence transaction
+            payment[jss::tx_json] = pay("alice", "bob", XRP(1));
+            payment[jss::tx_json][sfSequence.fieldName] =
+                env.seq("alice") - 1;
+            jv = wsc->invoke("submit", payment);
+            expect(jv[jss::result][jss::engine_result] ==
+                "tefPAST_SEQ");
+
+            // Submit future sequence transaction
+            payment[jss::tx_json][sfSequence.fieldName] =
+                env.seq("alice") + 1;
+            jv = wsc->invoke("submit", payment);
+            expect(jv[jss::result][jss::engine_result] ==
+                "terPRE_SEQ");
+
+            // Submit transaction to bridge the sequence gap
+            payment[jss::tx_json][sfSequence.fieldName] =
+                env.seq("alice");
+            jv = wsc->invoke("submit", payment);
+            expect(jv[jss::result][jss::engine_result] ==
+                "tesSUCCESS");
+
+            // Wait for the jobqueue to process everything
+            env.app().getJobQueue().rendezvous();
+
+            // Finalize transactions
+            jv = wsc->invoke("ledger_accept");
+            expect(jv[jss::result].isMember(
+                jss::ledger_current_index));
+        }
+
+        {
+            // Check balances
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& ff = jv[jss::meta]["AffectedNodes"]
+                        [1u]["ModifiedNode"]["FinalFields"];
+                    return ff[jss::Account] == Account("bob").human() &&
+                        ff["Balance"] == "10001000000";
+                }));
+
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    auto const& ff = jv[jss::meta]["AffectedNodes"]
+                        [1u]["ModifiedNode"]["FinalFields"];
+                    return ff[jss::Account] == Account("bob").human() &&
+                        ff["Balance"] == "10002000000";
+                }));
+        }
+    }
+
+    /*
+    Submit a normal payment. Client disconnects after the proposed
+    transaction result is received.
+
+    Client reconnects in the future. During this time it is presumed that the
+    transaction should have succeeded.
+
+    Upon reconnection, recent account transaction history is loaded.
+    The submitted transaction should be detected, and the transaction should
+    ultimately succeed.
+    */
+    void
+    testReconnect()
+    {
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice", "bob");
+        env.close();
+        auto wsc = makeWSClient(env.app().config());
+
+        {
+            // Submit normal payment
+            Json::Value jv;
+            jv[jss::secret] = toBase58(generateSeed("alice"));
+            jv[jss::tx_json] = pay("alice", "bob", XRP(1));
+            jv = wsc->invoke("submit", jv);
+            expect(jv[jss::result][jss::engine_result] ==
+                "tesSUCCESS");
+
+            // Disconnect
+            wsc.reset();
+
+            // Server finalizes transaction
+            env.close();
+        }
+
+        {
+            // RPC account_tx
+            Json::Value jv;
+            jv[jss::account] = Account("bob").human();
+            jv[jss::ledger_index_min] = -1;
+            jv[jss::ledger_index_max] = -1;
+            wsc = makeWSClient(env.app().config());
+            jv = wsc->invoke("account_tx", jv);
+
+            // Check balance
+            auto ff = jv[jss::result][jss::transactions][0u][jss::meta]
+                ["AffectedNodes"][1u]["ModifiedNode"]["FinalFields"];
+            expect(ff[jss::Account] ==
+                Account("bob").human());
+            expect(ff["Balance"] == "10001000000");
+        }
+    }
+
+    void
+    testReconnectAfterWait()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice", "bob");
+        env.close();
+        auto wsc = makeWSClient(env.app().config());
+
+        {
+            // Submit normal payment
+            Json::Value jv;
+            jv[jss::secret] = toBase58(generateSeed("alice"));
+            jv[jss::tx_json] = pay("alice", "bob", XRP(1));
+            jv = wsc->invoke("submit", jv);
+            expect(jv[jss::result][jss::engine_result] ==
+                "tesSUCCESS");
+
+            // Finalize transaction
+            jv = wsc->invoke("ledger_accept");
+            expect(jv[jss::result].isMember(
+                jss::ledger_current_index));
+
+            // Wait for the jobqueue to process everything
+            env.app().getJobQueue().rendezvous();
+        }
+
+        {
+            // RPC subscribe to ledger stream
+            Json::Value jv;
+            jv[jss::streams] = Json::arrayValue;
+            jv[jss::streams].append("ledger");
+            jv = wsc->invoke("subscribe", jv);
+            expect(jv[jss::status] == "success");
+
+            // Close ledgers
+            for(auto i = 0; i < 8; ++i)
+            {
+                expect(wsc->invoke("ledger_accept")[jss::result].
+                    isMember(jss::ledger_current_index));
+
+                // Wait for the jobqueue to process everything
+                env.app().getJobQueue().rendezvous();
+
+                expect(wsc->findMsg(5s,
+                    [&](auto const& jv)
+                    {
+                        return jv[jss::type] == "ledgerClosed";
+                    }));
+            }
+        }
+
+        {
+            // Disconnect, reconnect
+            wsc = makeWSClient(env.app().config());
+
+            // RPC subscribe to ledger stream
+            Json::Value jv;
+            jv[jss::streams] = Json::arrayValue;
+            jv[jss::streams].append("ledger");
+            jv = wsc->invoke("subscribe", jv);
+            expect(jv[jss::status] == "success");
+
+            // Close ledgers
+            for (auto i = 0; i < 2; ++i)
+            {
+                expect(wsc->invoke("ledger_accept")[jss::result].
+                    isMember(jss::ledger_current_index));
+
+                // Wait for the jobqueue to process everything
+                env.app().getJobQueue().rendezvous();
+
+                expect(wsc->findMsg(5s,
+                    [&](auto const& jv)
+                    {
+                        return jv[jss::type] == "ledgerClosed";
+                    }));
+            }
+        }
+
+        {
+            // RPC account_tx
+            Json::Value jv;
+            jv[jss::account] = Account("bob").human();
+            jv[jss::ledger_index_min] = -1;
+            jv[jss::ledger_index_max] = -1;
+            wsc = makeWSClient(env.app().config());
+            jv = wsc->invoke("account_tx", jv);
+
+            // Check balance
+            auto ff = jv[jss::result][jss::transactions][0u][jss::meta]
+                ["AffectedNodes"][1u]["ModifiedNode"]["FinalFields"];
+            expect(ff[jss::Account] ==
+                Account("bob").human());
+            expect(ff["Balance"] == "10001000000");
+        }
+    }
+
+    void
+    testAccountsProposed()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        env.fund(XRP(10000), "alice");
+        env.close();
+        auto wsc = makeWSClient(env.app().config());
+
+        {
+            // RPC subscribe to accounts_proposed stream
+            Json::Value jv;
+            jv[jss::accounts_proposed] = Json::arrayValue;
+            jv[jss::accounts_proposed].append(
+                Account("alice").human());
+            jv = wsc->invoke("subscribe", jv);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            // Submit account_set transaction
+            Json::Value jv;
+            jv[jss::secret] = toBase58(generateSeed("alice"));
+            jv[jss::tx_json] = fset("alice", 0);
+            jv[jss::tx_json][jss::Fee] = 10;
+            jv = wsc->invoke("submit", jv);
+            expect(jv[jss::result][jss::engine_result] ==
+                "tesSUCCESS");
+        }
+
+        {
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::transaction][jss::TransactionType] ==
+                        "AccountSet";
+                }));
+        }
+    }
+
+    void
+    run() override
+    {
+        testSequenceRealignment();
+        testReconnect();
+        testReconnectAfterWait();
+        testAccountsProposed();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(RobustTransaction,app,ripple);
+
+} // test
+} // ripple

--- a/src/ripple/rpc/tests/Subscribe.test.cpp
+++ b/src/ripple/rpc/tests/Subscribe.test.cpp
@@ -1,0 +1,285 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/core/LoadFeeTrack.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/test/WSClient.h>
+#include <ripple/test/jtx.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+namespace test {
+
+class Subscribe_test : public beast::unit_test::suite
+{
+public:
+    void testServer()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value stream;
+
+        {
+            // RPC subscribe to server stream
+            stream[jss::streams] = Json::arrayValue;
+            stream[jss::streams].append("server");
+            auto jv = wsc->invoke("subscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            // Raise fee to cause an update
+            for(int i = 0; i < 5; ++i)
+                env.app().getFeeTrack().raiseLocalFee();
+            env.app().getOPs().reportFeeChange();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::type] == "serverStatus";
+                }));
+        }
+
+        {
+            // RPC unsubscribe
+            auto jv = wsc->invoke("unsubscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            // Raise fee to cause an update
+            for (int i = 0; i < 5; ++i)
+                env.app().getFeeTrack().raiseLocalFee();
+            env.app().getOPs().reportFeeChange();
+
+            // Check stream update
+            expect(! wsc->getMsg(10ms));
+        }
+    }
+
+    void testLedger()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value stream;
+
+        {
+            // RPC subscribe to ledger stream
+            stream[jss::streams] = Json::arrayValue;
+            stream[jss::streams].append("ledger");
+            auto jv = wsc->invoke("subscribe", stream);
+            expect(jv[jss::result][jss::ledger_index] == 2);
+        }
+
+        {
+            // Accept a ledger
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::ledger_index] == 3;
+                }));
+        }
+
+        {
+            // Accept another ledger
+            env.close();
+
+            // Check stream update
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::ledger_index] == 4;
+                }));
+        }
+
+        // RPC unsubscribe
+        auto jv = wsc->invoke("unsubscribe", stream);
+        expect(jv[jss::status] == "success");
+    }
+
+    void testTransactions()
+    {
+        using namespace std::chrono_literals;
+        using namespace jtx;
+        Env env(*this);
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value stream;
+
+        {
+            // RPC subscribe to transactions stream
+            stream[jss::streams] = Json::arrayValue;
+            stream[jss::streams].append("transactions");
+            auto jv = wsc->invoke("subscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            env.fund(XRP(10000), "alice");
+            env.close();
+
+            // Check stream update for payment transaction
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::meta]["AffectedNodes"][1u]
+                        ["CreatedNode"]["NewFields"][jss::Account] ==
+                            Account("alice").human();
+                }));
+
+            // Check stream update for accountset transaction
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::meta]["AffectedNodes"][0u]
+                        ["ModifiedNode"]["FinalFields"][jss::Account] ==
+                            Account("alice").human();
+                }));
+
+            env.fund(XRP(10000), "bob");
+            env.close();
+
+            // Check stream update for payment transaction
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::meta]["AffectedNodes"][1u]
+                        ["CreatedNode"]["NewFields"][jss::Account] ==
+                            Account("bob").human();
+                }));
+
+            // Check stream update for accountset transaction
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::meta]["AffectedNodes"][0u]
+                        ["ModifiedNode"]["FinalFields"][jss::Account] ==
+                            Account("bob").human();
+                }));
+        }
+
+        {
+            // RPC unsubscribe
+            auto jv = wsc->invoke("unsubscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            // RPC subscribe to accounts stream
+            stream = Json::objectValue;
+            stream[jss::accounts] = Json::arrayValue;
+            stream[jss::accounts].append(Account("alice").human());
+            auto jv = wsc->invoke("subscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        {
+            // Transaction that does not affect stream
+            env.fund(XRP(10000), "carol");
+            env.close();
+            expect(! wsc->getMsg(10ms));
+
+            // Transactions concerning alice
+            env.trust(Account("bob")["USD"](100), "alice");
+            env.close();
+
+            // Check stream updates
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::meta]["AffectedNodes"][1u]
+                        ["ModifiedNode"]["FinalFields"][jss::Account] ==
+                            Account("alice").human();
+                }));
+
+            expect(wsc->findMsg(5s,
+                [&](auto const& jv)
+                {
+                    return jv[jss::meta]["AffectedNodes"][1u]
+                        ["CreatedNode"]["NewFields"]["LowLimit"]
+                            [jss::issuer] == Account("alice").human();
+                }));
+        }
+
+        // RPC unsubscribe
+        auto jv = wsc->invoke("unsubscribe", stream);
+        expect(jv[jss::status] == "success");
+    }
+
+    void testManifests()
+    {
+        using namespace jtx;
+        Env env(*this);
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value stream;
+
+        {
+            // RPC subscribe to manifests stream
+            stream[jss::streams] = Json::arrayValue;
+            stream[jss::streams].append("manifests");
+            auto jv = wsc->invoke("subscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        // RPC unsubscribe
+        auto jv = wsc->invoke("unsubscribe", stream);
+        expect(jv[jss::status] == "success");
+    }
+
+    void testValidations()
+    {
+        using namespace jtx;
+        Env env(*this);
+        auto wsc = makeWSClient(env.app().config());
+        Json::Value stream;
+
+        {
+            // RPC subscribe to validations stream
+            stream[jss::streams] = Json::arrayValue;
+            stream[jss::streams].append("validations");
+            auto jv = wsc->invoke("subscribe", stream);
+            expect(jv[jss::status] == "success");
+        }
+
+        // RPC unsubscribe
+        auto jv = wsc->invoke("unsubscribe", stream);
+        expect(jv[jss::status] == "success");
+    }
+
+    void run() override
+    {
+        testServer();
+        testLedger();
+        testTransactions();
+        testManifests();
+        testValidations();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Subscribe,app,ripple);
+
+} // test
+} // ripple

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -237,8 +237,6 @@ ServerHandlerImp::processRequest (Port const& port,
         std::string forwardedFor, std::string user)
 {
     auto rpcJ = app_.journal ("RPC");
-    // Move off the webserver thread onto the JobQueue.
-    assert (app_.getJobQueue().getJobForThread());
 
     Json::Value jsonRPC;
     {

--- a/src/ripple/test/WSClient.h
+++ b/src/ripple/test/WSClient.h
@@ -1,0 +1,55 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TEST_WSCLIENT_H_INCLUDED
+#define RIPPLE_TEST_WSCLIENT_H_INCLUDED
+
+#include <ripple/test/AbstractClient.h>
+#include <ripple/core/Config.h>
+#include <boost/optional.hpp>
+#include <chrono>
+#include <memory>
+
+namespace ripple {
+namespace test {
+
+class WSClient : public AbstractClient
+{
+public:
+    /** Retrieve a message. */
+    virtual
+    boost::optional<Json::Value>
+    getMsg(std::chrono::milliseconds const& timeout =
+        std::chrono::milliseconds{0}) = 0;
+
+    /** Retrieve a message that meets the predicate criteria. */
+    virtual
+    boost::optional<Json::Value>
+    findMsg(std::chrono::milliseconds const& timeout,
+        std::function<bool(Json::Value const&)> pred) = 0;
+};
+
+/** Returns a client operating through WebSockets/S. */
+std::unique_ptr<WSClient>
+makeWSClient(Config const& cfg);
+
+} // test
+} // ripple
+
+#endif

--- a/src/ripple/test/impl/WSClient.cpp
+++ b/src/ripple/test/impl/WSClient.cpp
@@ -1,0 +1,313 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/test/WSClient.h>
+#include <ripple/test/jtx.h>
+#include <ripple/json/json_reader.h>
+#include <ripple/json/to_string.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/server/Port.h>
+#include <ripple/wsproto/wsproto.h>
+#include <condition_variable>
+
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+namespace test {
+
+class WSClientImpl : public WSClient
+{
+    using error_code = boost::system::error_code;
+
+    struct msg
+    {
+        Json::Value jv;
+
+        explicit
+        msg(Json::Value&& jv_)
+            : jv(jv_)
+        {
+        }
+    };
+
+    class read_frame_op
+    {
+        struct data
+        {
+            WSClientImpl& wsc;
+            wsproto::frame_header fh;
+            boost::asio::streambuf sb;
+
+            data(WSClientImpl& wsc_)
+                : wsc(wsc_)
+            {
+            }
+
+            ~data()
+            {
+                wsc.on_read_done();
+            }
+        };
+
+        std::shared_ptr<data> d_;
+
+    public:
+        read_frame_op(read_frame_op const&) = default;
+        read_frame_op(read_frame_op&&) = default;
+
+        explicit
+        read_frame_op(WSClientImpl& wsc)
+            : d_(std::make_shared<data>(wsc))
+        {
+            read_one();
+        }
+
+        void read_one()
+        {
+            // hack
+            d_->sb.consume(d_->sb.size());
+            d_->wsc.ws_.async_read_fh(
+                d_->fh, std::move(*this));
+        }
+
+        void operator()(error_code const& ec)
+        {
+            if(ec)
+                return d_->wsc.on_read_frame(
+                    ec, d_->fh, 0, d_->sb.data(),
+                        std::move(*this));
+            d_->wsc.ws_.async_read(d_->fh,
+                d_->sb.prepare(d_->fh.len), std::move(*this));
+        }
+
+        void operator()(error_code const& ec,
+            wsproto::frame_header const& fh,
+                std::size_t bytes_transferred)
+        {
+            if(ec)
+                return d_->wsc.on_read_frame(
+                    ec, d_->fh, 0, d_->sb.data(),
+                        std::move(*this));
+            if(d_->fh.mask)
+            {
+                // TODO: apply key mask to payload
+            }
+            d_->sb.commit(bytes_transferred);
+            return d_->wsc.on_read_frame(
+                ec, d_->fh, bytes_transferred, d_->sb.data(),
+                    std::move(*this));
+       }
+    };
+
+    static
+    boost::asio::ip::tcp::endpoint
+    getEndpoint(BasicConfig const& cfg)
+    {
+        auto& log = std::cerr;
+        ParsedPort common;
+        parse_Port (common, cfg["server"], log);
+        for (auto const& name : cfg.section("server").values())
+        {
+            if (! cfg.exists(name))
+                continue;
+            ParsedPort pp;
+            parse_Port(pp, cfg[name], log);
+            if(pp.protocol.count("ws") == 0)
+                continue;
+            using boost::asio::ip::address_v4;
+            if(*pp.ip == address_v4{0x00000000})
+                *pp.ip = address_v4{0x7f000001};
+            return { *pp.ip, *pp.port };
+        }
+        throw std::runtime_error("Missing WebSocket port");
+    }
+
+    template <class ConstBuffers>
+    static
+    std::string
+    buffer_string (ConstBuffers const& b)
+    {
+        using namespace boost::asio;
+        std::string s;
+        s.resize(buffer_size(b));
+        buffer_copy(buffer(&s[0], s.size()), b);
+        return s;
+    }
+
+    boost::asio::io_service ios_;
+    boost::optional<
+        boost::asio::io_service::work> work_;
+    std::thread thread_;
+    boost::asio::ip::tcp::socket stream_;
+    wsproto::basic_socket<boost::asio::ip::tcp::socket&> ws_;
+
+    // synchronize destructor
+    bool b0_ = false;
+    std::mutex m0_;
+    std::condition_variable cv0_;
+
+    // sychronize message queue
+    std::mutex m_;
+    std::condition_variable cv_;
+    std::list<std::shared_ptr<msg>> msgs_;
+
+public:
+    explicit
+    WSClientImpl(Config const& cfg)
+        : work_(ios_)
+        , thread_([&]{ ios_.run(); })
+        , stream_(ios_)
+        , ws_(stream_)
+    {
+        using namespace boost::asio;
+        stream_.connect(getEndpoint(cfg));
+        error_code ec;
+        ws_.connect(ec);
+        if(ec)
+            throw ec;
+        read_frame_op{*this};
+    }
+
+    ~WSClientImpl() override
+    {
+        stream_.close();
+        {
+            std::unique_lock<std::mutex> lock(m0_);
+            cv0_.wait(lock, [&]{ return b0_; });
+        }
+        work_ = boost::none;
+        thread_.join();
+
+        //stream_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
+        //stream_.close();
+    }
+
+    Json::Value
+    invoke(std::string const& cmd,
+        Json::Value const& params) override
+    {
+        using namespace boost::asio;
+        using namespace std::chrono_literals;
+
+        {
+            Json::Value jp;
+            if(params)
+               jp = params;
+            jp["command"] = cmd;
+            auto const s = to_string(jp);
+            ws_.write(buffer(s));
+        }
+
+        auto jv = findMsg(5s,
+            [&](Json::Value const& jv)
+            {
+                return jv[jss::type] == jss::response;
+            });
+        if (jv)
+            return *jv;
+        return {};
+    }
+
+    boost::optional<Json::Value>
+    getMsg(std::chrono::milliseconds const& timeout) override
+    {
+        std::shared_ptr<msg> m;
+        {
+            std::unique_lock<std::mutex> lock(m_);
+            if(! cv_.wait_for(lock, timeout,
+                    [&]{ return ! msgs_.empty(); }))
+                return boost::none;
+            m = std::move(msgs_.back());
+            msgs_.pop_back();
+        }
+        return std::move(m->jv);
+    }
+
+    boost::optional<Json::Value>
+    findMsg(std::chrono::milliseconds const& timeout,
+        std::function<bool(Json::Value const&)> pred) override
+    {
+        std::shared_ptr<msg> m;
+        {
+            std::unique_lock<std::mutex> lock(m_);
+            if(! cv_.wait_for(lock, timeout,
+                [&]
+                {
+                    for (auto it = msgs_.begin();
+                        it != msgs_.end(); ++it)
+                    {
+                        if (pred((*it)->jv))
+                        {
+                            m = std::move(*it);
+                            msgs_.erase(it);
+                            return true;
+                        }
+                    }
+                    return false;
+                }))
+            {
+                return boost::none;
+            }
+        }
+        return std::move(m->jv);
+    }
+
+private:
+    template<class ConstBuffers>
+    void
+    on_read_frame(error_code const& ec,
+        wsproto::frame_header const& fh,
+            std::size_t bytes_transferred,
+                ConstBuffers const& b,
+                    read_frame_op&& op)
+    {
+        if(bytes_transferred == 0)
+            return;
+        Json::Value jv;
+        Json::Reader jr;
+        jr.parse(buffer_string(b), jv);
+        auto m = std::make_shared<msg>(
+            std::move(jv));
+        {
+            std::lock_guard<std::mutex> lock(m_);
+            msgs_.push_front(m);
+            cv_.notify_all();
+        }
+        op.read_one();
+    }
+
+    // Called when the read op terminates
+    void
+    on_read_done()
+    {
+        std::lock_guard<std::mutex> lock(m_);
+        b0_ = true;
+        cv0_.notify_all();
+    }
+};
+
+std::unique_ptr<WSClient>
+makeWSClient(Config const& cfg)
+{
+    return std::make_unique<WSClientImpl>(cfg);
+}
+
+} // test
+} // ripple

--- a/src/ripple/test/impl/WSClient_test.cpp
+++ b/src/ripple/test/impl/WSClient_test.cpp
@@ -1,0 +1,63 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/test/WSClient.h>
+#include <ripple/test/jtx.h>
+#include <beast/unit_test/suite.h>
+
+namespace ripple {
+namespace test {
+
+class WSClient_test : public beast::unit_test::suite
+{
+public:
+    void run() override
+    {
+        using namespace jtx;
+        Env env(*this);
+        auto wsc = makeWSClient(env.app().config());
+        {
+            Json::Value jv;
+            jv["streams"] = Json::arrayValue;
+            jv["streams"].append("ledger");
+            //jv["streams"].append("server");
+            //jv["streams"].append("transactions");
+            //jv["streams"].append("transactions_proposed");
+            log << pretty(wsc->invoke("subscribe", jv));
+        }
+        env.fund(XRP(10000), "alice");
+        env.close();
+        /*
+        env.fund(XRP(10000), "dan", "eric", "fred");
+        env.close();
+        env.fund(XRP(10000), "george", "harold", "iris");
+        env.close();
+        */
+        auto jv = wsc->getMsg(std::chrono::seconds(1));
+        if(jv)
+            log << pretty(*jv);
+        pass();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(WSClient,test,ripple);
+
+} // test
+} // ripple

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -184,6 +184,9 @@ Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
 Env::AppBundle::~AppBundle()
 {
     client.reset();
+    // Make sure all jobs finish, otherwise tests
+    // might not get the coverage they expect.
+    app->getJobQueue().rendezvous();
     app->signalStop();
     thread.join();
 }

--- a/src/ripple/test/jtx/jtx_json.h
+++ b/src/ripple/test/jtx/jtx_json.h
@@ -49,6 +49,12 @@ public:
         jv_[key] = value;
     }
 
+    template <class T>
+    json (std::string const& key, T const& value)
+    {
+        jv_[key] = value;
+    }
+
     void
     operator()(Env&, JTx& jt) const;
 };

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -101,6 +101,7 @@
 
 #include <ripple/rpc/tests/AccountInfo_test.cpp>
 #include <ripple/rpc/tests/AccountLinesRPC.test.cpp>
+#include <ripple/rpc/tests/Book.test.cpp>
 #include <ripple/rpc/tests/JSONRPC.test.cpp>
 #include <ripple/rpc/tests/LedgerRequestRPC.test.cpp>
 #include <ripple/rpc/tests/KeyGeneration.test.cpp>

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -105,3 +105,4 @@
 #include <ripple/rpc/tests/LedgerRequestRPC.test.cpp>
 #include <ripple/rpc/tests/KeyGeneration.test.cpp>
 #include <ripple/rpc/tests/Status.test.cpp>
+#include <ripple/rpc/tests/Subscribe.test.cpp>

--- a/src/ripple/unity/rpcx.cpp
+++ b/src/ripple/unity/rpcx.cpp
@@ -105,5 +105,6 @@
 #include <ripple/rpc/tests/JSONRPC.test.cpp>
 #include <ripple/rpc/tests/LedgerRequestRPC.test.cpp>
 #include <ripple/rpc/tests/KeyGeneration.test.cpp>
+#include <ripple/rpc/tests/RobustTransaction.test.cpp>
 #include <ripple/rpc/tests/Status.test.cpp>
 #include <ripple/rpc/tests/Subscribe.test.cpp>

--- a/src/ripple/unity/test.cpp
+++ b/src/ripple/unity/test.cpp
@@ -50,3 +50,5 @@
 #include <ripple/test/impl/BasicNetwork_test.cpp>
 #include <ripple/test/impl/JSONRPCClient.cpp>
 #include <ripple/test/impl/ManualTimeKeeper.cpp>
+#include <ripple/test/impl/WSClient.cpp>
+#include <ripple/test/impl/WSClient_test.cpp>

--- a/src/ripple/websocket/Connection.h
+++ b/src/ripple/websocket/Connection.h
@@ -175,8 +175,9 @@ template <class WebSocket>
 void ConnectionImpl <WebSocket>::rcvMessage (
     message_ptr const& msg, bool& msgRejected, bool& runQueue)
 {
-    JLOG (j_.warning)
-            << "WebSocket: rcvMessage";
+    JLOG(j_.debug) <<
+        "WebSocket: received " << msg->get_payload();
+
     ScopedLockType sl (m_receiveQueueMutex);
 
     if (m_isDead)
@@ -354,10 +355,9 @@ void ConnectionImpl <WebSocket>::preDestroy ()
 template <class WebSocket>
 void ConnectionImpl <WebSocket>::send (Json::Value const& jvObj, bool broadcast)
 {
-    JLOG (j_.warning)
-            << "WebSocket: sending '" << to_string (jvObj);
+    JLOG (j_.debug) <<
+        "WebSocket: sending " << to_string (jvObj);
     connection_ptr ptr = m_connection.lock ();
-
     if (ptr)
         m_handler.send (ptr, jvObj, broadcast);
 }
@@ -365,8 +365,8 @@ void ConnectionImpl <WebSocket>::send (Json::Value const& jvObj, bool broadcast)
 template <class WebSocket>
 void ConnectionImpl <WebSocket>::disconnect ()
 {
-    JLOG (j_.warning)
-            << "WebSocket: disconnecting";
+    JLOG (j_.debug) <<
+        "WebSocket: disconnecting";
     connection_ptr ptr = m_connection.lock ();
 
     if (ptr)

--- a/src/ripple/websocket/Handler.h
+++ b/src/ripple/websocket/Handler.h
@@ -365,6 +365,8 @@ public:
         //
         for (int i = 0; i < 3; ++i)
         {
+            if(app_.getJobQueue().isStopping())
+                return;
             boost::optional <std::string> msg = ptr->getMessage ();
             if (! msg)
                 return;

--- a/src/ripple/wsproto/basic_socket.h
+++ b/src/ripple/wsproto/basic_socket.h
@@ -1,0 +1,595 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_WSPROTO_BASIC_SOCKET_H_INCLUDED
+#define RIPPLE_WSPROTO_BASIC_SOCKET_H_INCLUDED
+
+#include <BeastConfig.h>
+#include <beast/http/parser.h>
+#include <beast/is_call_possible.h>
+#include <boost/asio.hpp>
+#include <boost/asio/detail/handler_alloc_helpers.hpp>
+#include <boost/asio/detail/handler_cont_helpers.hpp>
+#include <boost/asio/detail/handler_invoke_helpers.hpp>
+#include <boost/optional.hpp>
+#include <array>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <thread>
+#include <type_traits>
+
+//------------------------------------------------------------------------------
+
+#if 0//BOOST_VERSION >= 105800
+
+#include <boost/endian/arithmetic.hpp>
+template <class Int>
+Int native_to_big(Int n);
+{
+    return boost::endian::native_to_big<Int>(n);
+}
+
+template <class Int>
+Int big_to_native(Int b)
+{
+    return boost::endian::big_to_native<Int>(b);
+}
+
+#else
+
+template <class Int>
+Int native_to_big(Int n);
+
+template <class Int>
+Int big_to_native(Int b);
+
+template<>
+inline
+std::uint16_t
+native_to_big<std::uint16_t>(std::uint16_t n)
+{
+    std::uint8_t* p =
+        reinterpret_cast<std::uint8_t*>(&n);
+    std::swap(p[0], p[1]);
+    return n;
+}
+
+template<>
+inline
+std::uint64_t
+native_to_big<std::uint64_t>(std::uint64_t n)
+{
+    return 0;
+}
+
+template<>
+inline
+std::uint16_t
+big_to_native<uint16_t>(std::uint16_t b)
+{
+    std::uint8_t* p =
+        reinterpret_cast<std::uint8_t*>(&b);
+    std::swap(p[0], p[1]);
+    return b;
+}
+
+template<>
+inline
+std::uint64_t
+big_to_native<uint64_t>(std::uint64_t b)
+{
+    return 0;
+}
+
+#endif
+
+//------------------------------------------------------------------------------
+
+namespace wsproto {
+
+struct frame_header
+{
+    int op;
+    bool fin;
+    bool mask;
+    bool rsv1;
+    bool rsv2;
+    bool rsv3;
+    std::uint64_t len;
+    std::array<std::uint8_t, 4> key;
+
+    // next offset in key, [0-4)
+    int offset = 0;
+};
+
+namespace detail {
+
+// decode first 2 bytes of frame header
+// return: number of additional bytes needed
+template<class = void>
+std::size_t
+decode_fh1(frame_header& fh, std::uint8_t const* p)
+{
+    std::size_t need;
+    fh.len = p[1] & 0x7f;
+    switch(fh.len)
+    {
+        case 126: need = 2; break;
+        case 127: need = 8; break;
+        default:
+            need = 0;
+    }
+    if((fh.mask = (p[1] & 0x80)))
+        need += 4;
+    fh.op   = p[0] & 0x0f;
+    fh.fin  = p[0] & 0x80;
+    fh.rsv1 = p[0] & 0x40;
+    fh.rsv2 = p[0] & 0x20;
+    fh.rsv3 = p[0] & 0x10;
+    fh.offset = 0;
+    return need;
+}
+
+// decode remainder of frame header
+template<class = void>
+void
+decode_fh2(frame_header& fh, std::uint8_t const* p)
+{
+    switch(fh.len)
+    {
+    case 126:
+        fh.len =
+            (std::uint64_t(p[0])<<8) + p[1];
+        p += 2;
+        break;
+    case 127:
+        fh.len = 0;
+        for(int i = 0; i < 8; ++i)
+            fh.len = (fh.len << 8) + p[i];
+        p += 8;
+        break;
+    default:
+        break;
+    }
+    if(fh.mask)
+        std::memcpy(fh.key.data(), p, 4);
+}
+
+template<
+    class StreamBuf,
+    class ConstBuffers>
+void
+write_frame_payload(StreamBuf& sb, ConstBuffers const& cb)
+{
+    using namespace boost::asio;
+    sb.commit(buffer_copy(
+        sb.prepare(buffer_size(cb)), cb));
+}
+
+template<
+    class StreamBuf,
+    class ConstBuffers
+>
+void
+write_frame(StreamBuf& sb, ConstBuffers const& cb)
+{
+    using namespace boost::asio;
+    int  const op   = 1;
+    bool const fin  = true;
+    bool const mask = false;
+    std::array<std::uint8_t, 10> b;
+    b[0] = (fin ? 0x80 : 0x00) | op;
+    b[1] = mask ? 0x80 : 0x00;
+    auto const len = buffer_size(cb);
+    if (len <= 125)
+    {
+        b[1] |= len;
+        sb.commit(buffer_copy(
+            sb.prepare(2), buffer(&b[0], 2)));
+    }
+    else if (len <= 65535)
+    {
+        b[1] |= 126;
+        std::uint16_t& d = *reinterpret_cast<
+            std::uint16_t*>(&b[2]);
+        d = native_to_big<std::uint16_t>(len);
+        sb.commit(buffer_copy(
+            sb.prepare(4), buffer(&b[0], 4)));
+    }
+    else
+    {
+        b[1] |= 127;
+        std::uint64_t& d = *reinterpret_cast<
+            std::uint64_t*>(&b[2]);
+        d = native_to_big<std::uint64_t>(len);
+        sb.commit(buffer_copy(
+            sb.prepare(10), buffer(&b[0], 10)));
+    }
+    if(mask)
+    {
+    }
+    write_frame_payload(sb, cb);
+}
+
+//------------------------------------------------------------------------------
+
+// establish client connection
+template<class Stream, class Handler>
+class connect_op
+{
+    using error_code = boost::system::error_code;
+
+    struct data
+    {
+        Stream& s;
+        Handler h;
+        
+        data(Stream& s_, Handler&& h_)
+            : s(s_)
+            , h(std::forward<Handler>(h_))
+        {
+        }
+    };
+
+    std::shared_ptr<data> d_;
+
+public:
+    connect_op(Stream& s_, Handler&& h_)
+        : d_(std::make_shared<data>(
+            s_, std::forward<Handler>(h_)))
+    {
+    }
+};
+
+// read a frame header
+template<class Stream, class Handler>
+class read_fh_op
+{
+    using error_code = boost::system::error_code;
+
+    struct data
+    {
+        Stream& s;
+        frame_header& fh;
+        Handler h;
+        int state = 0;
+        std::array<std::uint8_t, 12> buf;
+
+        data(Stream& s_, frame_header& fh_,
+                Handler&& h_)
+            : s(s_)
+            , fh(fh_)
+            , h(std::forward<Handler>(h_))
+        {
+        }
+    };
+
+    std::shared_ptr<data> d_;
+
+public:
+    read_fh_op(read_fh_op&&) = default;
+    read_fh_op(read_fh_op const&) = default;
+
+    read_fh_op(Stream& s, frame_header& fh,
+            Handler&& h)
+        : d_(std::make_shared<data>(s, fh,
+            std::forward<Handler>(h)))
+    {
+        using namespace boost::asio;
+        async_read(d_->s, mutable_buffers_1(
+            d_->buf.data(), 2), std::move(*this));
+    }
+
+    void operator()(error_code const& ec,
+        std::size_t bytes_transferred)
+    {
+        using namespace boost::asio;
+        if(ec == error::operation_aborted)
+            return;
+        if(! ec)
+        {
+            if(d_->state == 0)
+            {
+                d_->state = 1;
+                async_read(d_->s, mutable_buffers_1(
+                    d_->buf.data(), detail::decode_fh1(
+                        d_->fh, d_->buf.data())),
+                            std::move(*this));
+                return;
+            }
+            detail::decode_fh2(
+                d_->fh, d_->buf.data());
+        }
+        return d_->s.get_io_service().wrap(
+            std::move(d_->h))(ec);
+    }
+
+    friend
+    auto asio_handler_allocate(
+        std::size_t size, read_fh_op* op)
+    {
+        return boost_asio_handler_alloc_helpers::
+            allocate(size, op->d_->h);
+    }
+
+    friend
+    auto asio_handler_deallocate(
+        void* p, std::size_t size,
+            read_fh_op* op)
+    {
+        return boost_asio_handler_alloc_helpers::
+            deallocate(p, size, op->d_->h);
+    }
+
+    friend
+    auto asio_handler_is_continuation(
+        read_fh_op* op)
+    {
+        return (op->d_->state != 0) ? true :
+            boost_asio_handler_cont_helpers::
+                is_continuation(op->d_->h);
+    }
+
+    template <class Function>
+    friend
+    auto asio_handler_invoke(
+        Function&& f, read_fh_op* op)
+    {
+        return boost_asio_handler_invoke_helpers::
+            invoke(f, op->d_->h);
+    }
+};
+
+// read a frame body
+template<class Stream,
+    class MutableBuffers, class Handler>
+struct read_op
+{
+    using error_code = boost::system::error_code;
+
+    struct data
+    {
+        Stream& s;
+        frame_header fh;
+        MutableBuffers b;
+        Handler h;
+
+        data(Stream& s_, frame_header const& fh_,
+                MutableBuffers const& b_, Handler&& h_)
+            : s(s_)
+            , fh(fh_)
+            , b(b_)
+            , h(std::forward<Handler>(h_))
+        {
+        }
+    };
+
+    std::shared_ptr<data> d_;
+
+public:
+    read_op(read_op&&) = default;
+    read_op(read_op const&) = default;
+
+    read_op(Stream& s, frame_header const& fh,
+            MutableBuffers const& b, Handler&& h)
+        : d_(std::make_shared<data>(s, fh, b,
+            std::forward<Handler>(h)))
+    {
+        using namespace boost::asio;
+        async_read(d_->s, d_->b,
+            std::move(*this));
+    }
+
+    void operator()(error_code const& ec,
+        std::size_t bytes_transferred)
+    {
+        using namespace boost::asio;
+        if(ec == error::operation_aborted)
+            return;
+        if(d_->fh.mask)
+        {
+            // apply mask key
+            // adjust d_->fh.offset
+        }
+        return d_->s.get_io_service().wrap(
+            std::move(d_->h))(ec, std::move(d_->fh),
+                bytes_transferred);
+    }
+
+    friend
+    auto asio_handler_allocate(
+        std::size_t size, read_op* op)
+    {
+        return boost_asio_handler_alloc_helpers::
+                allocate(size, op->d_->h);
+    }
+
+    friend
+    auto asio_handler_deallocate(
+        void* p, std::size_t size,
+            read_op* op)
+    {
+        return boost_asio_handler_alloc_helpers::
+            deallocate(p, size, op->d_->h);
+    }
+
+    friend
+    auto asio_handler_is_continuation(
+        read_op* op)
+    {
+        return boost_asio_handler_cont_helpers::
+            is_continuation(op->d_->h);
+    }
+
+    template <class Function>
+    friend
+    auto asio_handler_invoke(
+        Function&& f, read_op* op)
+    {
+        return boost_asio_handler_invoke_helpers::
+            invoke(f, op->d_->h);
+    }
+};
+
+} // detail
+
+//------------------------------------------------------------------------------
+
+template <
+    class Stream,
+    class Allocator = std::allocator<char>
+>
+class basic_socket
+{
+private:
+    static_assert(! std::is_const<Stream>::value, "");
+
+    using error_code = boost::system::error_code;
+
+    Stream s_;
+    boost::asio::io_service::strand st_;
+
+public:
+    using next_layer_type =
+        std::remove_reference_t<Stream>;
+
+    using lowest_layer_type =
+        typename next_layer_type::lowest_layer_type;
+
+    basic_socket(basic_socket&&) = default;
+    basic_socket(basic_socket const&) = delete;
+    basic_socket& operator= (basic_socket const&) = delete;
+    basic_socket& operator= (basic_socket&&) = delete;
+
+    template <class... Args>
+    explicit
+    basic_socket(Args&&... args)
+        : s_(std::forward<Args>(args)...)
+        , st_(s_.get_io_service())
+    {
+    }
+
+    ~basic_socket()
+    {
+    }
+
+    boost::asio::io_service&
+    get_io_service()
+    {
+        return s_.lowest_layer().get_io_service();
+    }
+
+    next_layer_type&
+    next_layer()
+    {
+        return s_;
+    }
+
+    next_layer_type const&
+    next_layer() const
+    {
+        return s_;
+    }
+
+    lowest_layer_type&
+    lowest_layer()
+    {
+        return s_.lowest_layer();
+    }
+
+    lowest_layer_type const&
+    lowest_layer() const
+    {
+        return s_.lowest_layer();
+    }
+
+public:
+    /** Request a WebSocket upgrade.
+        Requirements:
+            Stream is connected.
+    */
+    void
+    connect(error_code& ec)
+    {
+        using namespace boost::asio;
+        boost::asio::write(s_, buffer(
+            "GET / HTTP/1.1\r\n"
+            "Host: 127.0.0.1\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "\r\n"), ec);
+        if(ec)
+            return;
+        streambuf sb;
+        read_until(s_, sb, "\r\n\r\n");
+        using namespace beast;
+        http::body b;
+        http::message m;
+        http::parser p(m, b, false);
+        auto const result = p.write(sb.data());
+        if (result.first || ! p.complete())
+            throw std::runtime_error(result.first.message());
+        sb.consume(result.second);
+    }
+
+    // write a text message
+    template <class ConstBuffers>
+    void
+    write(ConstBuffers const& cb)
+    {
+        boost::asio::streambuf sb;
+        wsproto::detail::write_frame(sb, cb);
+        boost::asio::write(s_, sb.data());
+    }
+
+public:
+    // read a frame header asynchronously
+    template<class Handler>
+    void
+    async_read_fh(frame_header& fh, Handler&& h)
+    {
+        static_assert(beast::is_call_possible<Handler,
+            void(error_code)>::value,
+                "Type does not meet the handler requirements");
+        detail::read_fh_op<Stream, Handler>{
+            s_, fh, std::forward<Handler>(h)};
+    }
+
+    // read a frame body asynchronously
+    // requires buffer_size(b) == fh.len
+    template<class MutableBuffers, class Handler>
+    void
+    async_read(frame_header const& fh,
+        MutableBuffers const& b, Handler&& h)
+    {
+        static_assert(beast::is_call_possible<Handler,
+            void(error_code)>::value,
+                "Type does not meet the handler requirements");
+        detail::read_op<Stream, MutableBuffers, Handler>{
+            s_, fh, b, std::forward<Handler>(h)};
+    }
+};
+
+} // wsproto
+
+#endif

--- a/src/ripple/wsproto/wsproto.h
+++ b/src/ripple/wsproto/wsproto.h
@@ -1,0 +1,25 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_WSPROTO_H_INCLUDED
+#define RIPPLE_WSPROTO_H_INCLUDED
+
+#include <ripple/wsproto/basic_socket.h>
+
+#endif

--- a/test/subscribe-book-test.js
+++ b/test/subscribe-book-test.js
@@ -650,4 +650,3 @@ suite("Subscribe book tests", function() {
   });
 
 });
-


### PR DESCRIPTION
These C++ unit tests use the new WSClient class to submit asynchronous RPC subscription commands.

- Ported NPM test jsonrpc-test.js to Subscribe.test.cpp.
- Ported NPM test robust-transaction-test.js to RobustTransaction.test.cpp.
    - Test 'submission timeout' was omitted as the test is invalid.
    - Test 'set LastLedgerSequence' was omitted as it is already included in the first test.
- Ported NPM test subscribe-book-test.js to Book.test.cpp
- Minor cleanup to the RPC subscribe and unsubscribe code.
- Improved held transaction submission in NetworkOPsImp::apply by removing redundant validity checks.

Reviewers: @JoelKatz @ximinez