### PR TITLE
Add Journal friend functions for stream access:

### DIFF
--- a/src/beast/beast/utility/Journal.h
+++ b/src/beast/beast/utility/Journal.h
@@ -24,6 +24,26 @@
 
 namespace beast {
 
+/** A namespace for easy access to logging severity values. */
+namespace severities
+{
+    /** Severity level / threshold of a Journal message. */
+    enum Severity
+    {
+        kAll = 0,
+
+        kTrace = kAll,
+        kDebug,
+        kInfo,
+        kWarning,
+        kError,
+        kFatal,
+
+        kDisabled,
+        kNone = kDisabled
+    };
+}
+
 /** A generic endpoint for log messages.
 
     The Journal has a few simple goals:
@@ -40,20 +60,17 @@ class Journal
 {
 public:
     /** Severity level / threshold of a Journal message. */
-    enum Severity
-    {
-        kAll = 0,
+    using Severity = severities::Severity;
 
-        kTrace = kAll,
-        kDebug,
-        kInfo,
-        kWarning,
-        kError,
-        kFatal,
-
-        kDisabled,
-        kNone = kDisabled
-    };
+    static constexpr Severity kAll      = severities::kAll;
+    static constexpr Severity kTrace    = severities::kTrace;
+    static constexpr Severity kDebug    = severities::kDebug;
+    static constexpr Severity kInfo     = severities::kInfo;
+    static constexpr Severity kWarning  = severities::kWarning;
+    static constexpr Severity kError    = severities::kError;
+    static constexpr Severity kFatal    = severities::kFatal;
+    static constexpr Severity kDisabled = severities::kDisabled;
+    static constexpr Severity kNone     = severities::kNone;
 
     class Sink;
 
@@ -151,7 +168,7 @@ private:
     class TScopedStream
     {
     public:
-        static_assert (LEVEL < kDisabled, "Invalid streaming LEVEL");
+        static_assert (LEVEL < severities::kDisabled, "Invalid streaming LEVEL");
 
         TScopedStream() = delete;
         TScopedStream (TScopedStream const& other);
@@ -180,7 +197,7 @@ private:
     class TScopedStreamProxy
     {
     public:
-        static_assert (LEVEL < kDisabled, "Invalid streaming LEVEL");
+        static_assert (LEVEL < severities::kDisabled, "Invalid streaming LEVEL");
 
         TScopedStreamProxy() = delete;
         TScopedStreamProxy (TScopedStreamProxy const&) = default;
@@ -319,56 +336,56 @@ public:
     */
     /** @{ */
     friend
-    TScopedStreamProxy<kTrace>
+    TScopedStreamProxy<severities::kTrace>
     trace(Journal const& j)
     {
-        return TScopedStreamProxy<kTrace>(j);
+        return TScopedStreamProxy<severities::kTrace>(j);
     }
 
     friend
-    TScopedStreamProxy<kDebug>
+    TScopedStreamProxy<severities::kDebug>
     debug(Journal const& j)
     {
-        return TScopedStreamProxy<kDebug>(j);
+        return TScopedStreamProxy<severities::kDebug>(j);
     }
 
     friend
-    TScopedStreamProxy<kInfo>
+    TScopedStreamProxy<severities::kInfo>
     info(Journal const& j)
     {
-        return TScopedStreamProxy<kInfo>(j);
+        return TScopedStreamProxy<severities::kInfo>(j);
     }
 
     friend
-    TScopedStreamProxy<kWarning>
+    TScopedStreamProxy<severities::kWarning>
     warn(Journal const& j)
     {
-        return TScopedStreamProxy<kWarning>(j);
+        return TScopedStreamProxy<severities::kWarning>(j);
     }
 
     friend
-    TScopedStreamProxy<kError>
+    TScopedStreamProxy<severities::kError>
     error(Journal const& j)
     {
-        return TScopedStreamProxy<kError>(j);
+        return TScopedStreamProxy<severities::kError>(j);
     }
 
     friend
-    TScopedStreamProxy<kFatal>
+    TScopedStreamProxy<severities::kFatal>
     fatal(Journal const& j)
     {
-        return TScopedStreamProxy<kFatal>(j);
+        return TScopedStreamProxy<severities::kFatal>(j);
     }
     /** @} */
 };
 
 // Make the friend functions visible at namespace scope.
-Journal::TScopedStreamProxy<Journal::kTrace>   trace(Journal const& j);
-Journal::TScopedStreamProxy<Journal::kDebug>   debug(Journal const& j);
-Journal::TScopedStreamProxy<Journal::kInfo>    info (Journal const& j);
-Journal::TScopedStreamProxy<Journal::kWarning> warn (Journal const& j);
-Journal::TScopedStreamProxy<Journal::kError>   error(Journal const& j);
-Journal::TScopedStreamProxy<Journal::kFatal>   fatal(Journal const& j);
+Journal::TScopedStreamProxy<severities::kTrace>   trace(Journal const& j);
+Journal::TScopedStreamProxy<severities::kDebug>   debug(Journal const& j);
+Journal::TScopedStreamProxy<severities::kInfo>    info (Journal const& j);
+Journal::TScopedStreamProxy<severities::kWarning> warn (Journal const& j);
+Journal::TScopedStreamProxy<severities::kError>   error(Journal const& j);
+Journal::TScopedStreamProxy<severities::kFatal>   fatal(Journal const& j);
 
 //------------------------------------------------------------------------------
 

--- a/src/beast/beast/utility/Journal.h
+++ b/src/beast/beast/utility/Journal.h
@@ -107,7 +107,7 @@ public:
 
     class Stream;
 private:
-    /** Scoped ostream-based container for writing messages to a Journal. */
+    /* Scoped ostream-based container for writing messages to a Journal. */
     class ScopedStream
     {
     public:
@@ -146,7 +146,7 @@ private:
 
 //------------------------------------------------------------------------------
 private:
-    /** Templated TScopedStream. */
+    /* Templated TScopedStream. */
     template <Severity LEVEL>
     class TScopedStream
     {
@@ -175,7 +175,7 @@ private:
 
 //------------------------------------------------------------------------------
 private:
-    /** Templated TScopedStreamProxy. */
+    /* Templated TScopedStreamProxy. */
     template <Severity LEVEL>
     class TScopedStreamProxy
     {
@@ -191,8 +191,8 @@ private:
 
         TScopedStreamProxy& operator= (TScopedStreamProxy const&) = delete;
 
-        /** Returns `true` if m_sink logs anything at this stream's severity. */
-        /** @{ */
+        /* Returns `true` if m_sink logs anything at this stream's severity. */
+        /* @{ */
         bool active() const
         {
             return m_sink.active (LEVEL);
@@ -203,16 +203,16 @@ private:
         {
             return active();
         }
-        /** @} */
+        /* @} */
 
-        /** Postpone creating an actual TScopedStream until streaming. */
-        /** @{ */
+        /* Postpone creating an actual TScopedStream until streaming. */
+        /* @{ */
         TScopedStream<LEVEL> operator<< (
             std::ostream& manip (std::ostream&)) const;
 
         template <typename T>
         TScopedStream<LEVEL> operator<< (T const& t) const;
-        /** @} */
+        /* @} */
 
     private:
         Sink& m_sink;
@@ -361,6 +361,14 @@ public:
     }
     /** @} */
 };
+
+// Make the friend functions visible at namespace scope.
+Journal::TScopedStreamProxy<Journal::kTrace>   trace(Journal const& j);
+Journal::TScopedStreamProxy<Journal::kDebug>   debug(Journal const& j);
+Journal::TScopedStreamProxy<Journal::kInfo>    info (Journal const& j);
+Journal::TScopedStreamProxy<Journal::kWarning> warn (Journal const& j);
+Journal::TScopedStreamProxy<Journal::kError>   error(Journal const& j);
+Journal::TScopedStreamProxy<Journal::kFatal>   fatal(Journal const& j);
 
 //------------------------------------------------------------------------------
 

--- a/src/beast/beast/utility/impl/Journal.cpp
+++ b/src/beast/beast/utility/impl/Journal.cpp
@@ -29,12 +29,12 @@ class NullJournalSink : public Journal::Sink
 {
 public:
     NullJournalSink ()
-    : Sink (Journal::kDisabled, false)
+    : Sink (severities::kDisabled, false)
     { }
 
     ~NullJournalSink() override = default;
 
-    bool active (Journal::Severity) const override
+    bool active (severities::Severity) const override
     {
         return false;
     }
@@ -48,16 +48,16 @@ public:
     {
     }
 
-    Journal::Severity threshold() const override
+    severities::Severity threshold() const override
     {
-        return Journal::kDisabled;
+        return severities::kDisabled;
     }
 
-    void threshold (Journal::Severity) override
+    void threshold (severities::Severity) override
     {
     }
 
-    void write (Journal::Severity, std::string const&) override
+    void write (severities::Severity, std::string const&) override
     {
     }
 };
@@ -152,7 +152,7 @@ std::ostream& Journal::ScopedStream::operator<< (std::ostream& manip (std::ostre
 
 Journal::Stream::Stream ()
     : m_sink (&getNullSink ())
-    , m_level (kDisabled)
+    , m_level (severities::kDisabled)
 {
 }
 
@@ -160,7 +160,7 @@ Journal::Stream::Stream (Sink& sink, Severity level)
     : m_sink (&sink)
     , m_level (level)
 {
-    assert (level != kDisabled);
+    assert (level != severities::kDisabled);
 }
 
 Journal::Stream::Stream (Stream const& other)
@@ -174,7 +174,7 @@ Journal::Sink& Journal::Stream::sink () const
     return *m_sink;
 }
 
-Journal::Severity Journal::Stream::severity () const
+severities::Severity Journal::Stream::severity () const
 {
     return m_level;
 }
@@ -196,23 +196,23 @@ Journal::ScopedStream Journal::Stream::operator<< (
 
 Journal::Journal ()
     : m_sink  (&getNullSink())
-    , trace   (stream (kTrace))
-    , debug   (stream (kDebug))
-    , info    (stream (kInfo))
-    , warning (stream (kWarning))
-    , error   (stream (kError))
-    , fatal   (stream (kFatal))
+    , trace   (stream (severities::kTrace))
+    , debug   (stream (severities::kDebug))
+    , info    (stream (severities::kInfo))
+    , warning (stream (severities::kWarning))
+    , error   (stream (severities::kError))
+    , fatal   (stream (severities::kFatal))
 {
 }
 
 Journal::Journal (Sink& sink)
     : m_sink  (&sink)
-    , trace   (stream (kTrace))
-    , debug   (stream (kDebug))
-    , info    (stream (kInfo))
-    , warning (stream (kWarning))
-    , error   (stream (kError))
-    , fatal   (stream (kFatal))
+    , trace   (stream (severities::kTrace))
+    , debug   (stream (severities::kDebug))
+    , info    (stream (severities::kInfo))
+    , warning (stream (severities::kWarning))
+    , error   (stream (severities::kError))
+    , fatal   (stream (severities::kFatal))
 {
 }
 

--- a/src/beast/beast/utility/impl/Journal.cpp
+++ b/src/beast/beast/utility/impl/Journal.cpp
@@ -109,13 +109,6 @@ void Journal::Sink::threshold (Severity thresh)
 
 //------------------------------------------------------------------------------
 
-Journal::ScopedStream::ScopedStream (Stream const& stream)
-    : m_sink (stream.sink ())
-    , m_level (stream.severity ())
-{
-    init ();
-}
-
 Journal::ScopedStream::ScopedStream (ScopedStream const& other)
     : m_sink (other.m_sink)
     , m_level (other.m_level)
@@ -123,13 +116,11 @@ Journal::ScopedStream::ScopedStream (ScopedStream const& other)
     init ();
 }
 
-Journal::ScopedStream::ScopedStream (
-    Stream const& stream, std::ostream& manip (std::ostream&))
-    : m_sink (stream.sink ())
-    , m_level (stream.severity ())
+Journal::ScopedStream::ScopedStream (Sink& sink, Severity level)
+    : m_sink (sink)
+    , m_level (level)
 {
     init ();
-    m_ostream << manip;
 }
 
 Journal::ScopedStream::~ScopedStream ()
@@ -155,11 +146,6 @@ void Journal::ScopedStream::init ()
 std::ostream& Journal::ScopedStream::operator<< (std::ostream& manip (std::ostream&)) const
 {
     return m_ostream << manip;
-}
-
-std::ostringstream& Journal::ScopedStream::ostream () const
-{
-    return m_ostream;
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -31,7 +31,7 @@ namespace path {
 // Between offer nodes, the fee charged may vary.  Therefore, process one
 // inbound offer at a time.  Propagate the inbound offer's requirements to the
 // previous node.  The previous node adjusts the amount output and the amount
-// spent on fees.  Continue processing until the request is satisified as long
+// spent on fees.  Continue processing until the request is satisfied as long
 // as the rate does not increase past the initial rate.
 
 // To deliver from an order book, when computing
@@ -50,7 +50,7 @@ TER PathCursor::deliverNodeReverseImpl (
     // only on first increment, then it could be a limit on the forward pass.
     saOutAct.clear (saOutReq);
 
-    JLOG (j_.trace)
+    JLOG (trace(j_))
         << "deliverNodeReverse>"
         << " saOutAct=" << saOutAct
         << " saOutReq=" << saOutReq
@@ -69,7 +69,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 CALC_NODE_DELIVER_MAX_LOOPS_MQ :
                 CALC_NODE_DELIVER_MAX_LOOPS))
         {
-            JLOG (j_.warning) << "loop count exceeded";
+            JLOG (warn(j_)) << "loop count exceeded";
             return telFAILED_PROCESSING;
         }
 
@@ -88,7 +88,7 @@ TER PathCursor::deliverNodeReverseImpl (
             ? STAmount::saOne         // No fee.
             : node().transferRate_;   // Transfer rate of issuer.
 
-        JLOG (j_.trace)
+        JLOG (trace(j_))
             << "deliverNodeReverse:"
             << " offerOwnerAccount_="
             << node().offerOwnerAccount_
@@ -108,7 +108,7 @@ TER PathCursor::deliverNodeReverseImpl (
             // Set initial rate.
             node().saRateMax = saOutFeeRate;
 
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: Set initial rate:"
                 << " node().saRateMax=" << node().saRateMax
                 << " saOutFeeRate=" << saOutFeeRate;
@@ -116,7 +116,7 @@ TER PathCursor::deliverNodeReverseImpl (
         else if (saOutFeeRate > node().saRateMax)
         {
             // Offer exceeds initial rate.
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: Offer exceeds initial rate:"
                 << " node().saRateMax=" << node().saRateMax
                 << " saOutFeeRate=" << saOutFeeRate;
@@ -137,7 +137,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
             node().saRateMax   = saOutFeeRate;
 
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: Reducing rate:"
                 << " node().saRateMax=" << node().saRateMax;
         }
@@ -162,7 +162,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
         // Offer out with fees.
 
-        JLOG (j_.trace)
+        JLOG (trace(j_))
             << "deliverNodeReverse:"
             << " saOutReq=" << saOutReq
             << " saOutAct=" << saOutAct
@@ -183,7 +183,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saOutPlusFees.issue (), true);
             saOutPassAct = std::min (saOutPassReq, fee);
 
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: Total exceeds fees:"
                 << " saOutPassAct=" << saOutPassAct
                 << " saOutPlusFees=" << saOutPlusFees
@@ -195,7 +195,7 @@ TER PathCursor::deliverNodeReverseImpl (
             saOutPassAct, node().saOfrRate, node().saTakerPays.issue (), true);
         if (*stAmountCalcSwitchover == false && ! outputFee)
         {
-            JLOG (j_.fatal)
+            JLOG (fatal(j_))
                 << "underflow computing outputFee "
                 << "saOutPassAct: " << saOutPassAct
                 << " saOfrRate: " << node ().saOfrRate;
@@ -204,7 +204,7 @@ TER PathCursor::deliverNodeReverseImpl (
         STAmount saInPassReq = std::min (node().saTakerPays, outputFee);
         STAmount saInPassAct;
 
-        JLOG (j_.trace)
+        JLOG (trace(j_))
             << "deliverNodeReverse:"
             << " outputFee=" << outputFee
             << " saInPassReq=" << saInPassReq
@@ -215,7 +215,7 @@ TER PathCursor::deliverNodeReverseImpl (
         if (!saInPassReq) // FIXME: This is bogus
         {
             // After rounding did not want anything.
-            JLOG (j_.debug)
+            JLOG (debug(j_))
                 << "deliverNodeReverse: micro offer is unfunded.";
 
             node().bEntryAdvance   = true;
@@ -238,7 +238,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
             saInPassAct = saInPassReq;
 
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: account --> OFFER --> ? :"
                 << " saInPassAct=" << saInPassAct;
         }
@@ -253,7 +253,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saInPassReq,
                 saInPassAct);
 
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: offer --> OFFER --> ? :"
                 << " saInPassAct=" << saInPassAct;
         }
@@ -271,7 +271,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saOutPassAct.issue (), true);
             saOutPlusFees   = std::min (node().saOfferFunds, outputFees);
 
-            JLOG (j_.trace)
+            JLOG (trace(j_))
                 << "deliverNodeReverse: adjusted:"
                 << " saOutPassAct=" << saOutPassAct
                 << " saOutPlusFees=" << saOutPlusFees;
@@ -304,7 +304,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
         if (saTakerPaysNew < zero || saTakerGetsNew < zero)
         {
-            JLOG (j_.warning)
+            JLOG (warn(j_))
                 << "deliverNodeReverse: NEGATIVE:"
                 << " node().saTakerPaysNew=" << saTakerPaysNew
                 << " node().saTakerGetsNew=" << saTakerGetsNew;
@@ -321,7 +321,7 @@ TER PathCursor::deliverNodeReverseImpl (
         if (saOutPassAct == node().saTakerGets)
         {
             // Offer became unfunded.
-            JLOG (j_.debug)
+            JLOG (debug(j_))
                 << "deliverNodeReverse: offer became unfunded.";
 
             node().bEntryAdvance   = true;
@@ -339,7 +339,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
     if (saOutAct > saOutReq)
     {
-        JLOG (j_.warning)
+        JLOG (warn(j_))
             << "deliverNodeReverse: TOO MUCH:"
             << " saOutAct=" << saOutAct
             << " saOutReq=" << saOutReq;
@@ -352,7 +352,7 @@ TER PathCursor::deliverNodeReverseImpl (
     // Unable to meet request, consider path dry.
     // Design invariant: if nothing was actually delivered, return tecPATH_DRY.
 
-    JLOG (j_.trace)
+    JLOG (trace(j_))
         << "deliverNodeReverse<"
         << " saOutAct=" << saOutAct
         << " saOutReq=" << saOutReq

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -352,9 +352,6 @@ public:
     /** Creates or updates an existing Element based on a new message. */
     void insert (Endpoint const& ep);
 
-    /** Produce diagnostic output. */
-    void dump (beast::Journal::ScopedStream& ss) const;
-
     /** Output statistics. */
     void onWrite (beast::PropertyStream::Map& map);
 };
@@ -442,21 +439,6 @@ void Livecache <Allocator>::insert (Endpoint const& ep)
         if (m_journal.trace) m_journal.trace << beast::leftw (18) <<
             "Livecache refresh " << ep.address <<
             " at hops " << ep.hops;
-    }
-}
-
-template <class Allocator>
-void
-Livecache <Allocator>::dump (beast::Journal::ScopedStream& ss) const
-{
-    ss << std::endl << std::endl <<
-        "Livecache (size " << m_cache.size() << ")";
-    for (auto const& entry : m_cache)
-    {
-        auto const& e (entry.second);
-        ss << std::endl <<
-            e.endpoint.address << ", " <<
-            e.endpoint.hops << " hops";
     }
 }
 


### PR DESCRIPTION
`beast::Journal` is heavier weight than we would wish.  It carries around 6 `Journal::Stream` objects for convenient streaming.  If we can get rid of the convenience objects while leaving streaming just as convenient, we can significantly reduce the cost of passing a `Journal` by value.

This pull request is an attempt to meet the easy-streaming requirements.  Streaming at various Severities can be done by calling a function and passing in a reference to a `Journal`.  This is the new way:
```
    JLOG(info(j_)) << "A long time ago...";
```
And this is the old way:
```
    JLOG(j_.info) << "...in a galaxy far, far away...";
```
In this pull request I've converted one file, DeliverNodeReverse.cpp, over to use the new approach.  So you can see what the new approach to logging would look like in the wild.

This pull request leaves both interfaces in place.  If we choose to use the new approach, I will make a pass through the code base to switch all uses to the new approach.  After that is done, in a yet later pull request, I will remove `Journal` code that supports the old approach, in particular the 6 `Journal::Stream` public members.  We only achieve the real goal after that third pull request.

Argument Dependent Lookup is an important part of this design, so I'm asking for a couple of very C++ savvy reviewers: @HowardHinnant, @vinniefalco.

Additionally, since changes to logging affect the entire team, I'd like to give everyone the chance to weigh in on the new approach in case there are any objections or suggestions for improvements. @JoelKatz, @ximinez, @miguelportilla, @nbougalis, @seelabs.  