### PR TITLE
Create new Validations columns properly

### DIFF
--- a/src/ripple/app/main/DBInit.cpp
+++ b/src/ripple/app/main/DBInit.cpp
@@ -100,13 +100,6 @@ const char* LedgerDBInit[] =
         SignTime    BIGINT UNSIGNED,                \
         RawData     BLOB                            \
     );",
-    // This will error out if the column already exists,
-    //  but DatabaseCon intentionally ignores errors.
-    "ALTER TABLE Validations                        \
-        ADD COLUMN LedgerSeq       BIGINT UNSIGNED;",
-    "ALTER TABLE Validations                        \
-        ADD COLUMN InitialSeq      BIGINT UNSIGNED;",
-
     "CREATE INDEX IF NOT EXISTS ValidationsByHash ON              \
         Validations(LedgerHash);",
     "CREATE INDEX IF NOT EXISTS ValidationsBySeq ON              \

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -664,10 +664,10 @@ SHAMapStoreImp::clearPrior (LedgerIndex lastRotated)
                 << deleteBatch << " rows.";
             long long totalRowsAffected = 0;
             long long rowsAffected;
-            soci::statement st = [&]
+            auto st = [&]
             {
                 auto db = ledgerDb_->checkoutDb();
-                return (db->prepare << deleteQuery);
+                return soci::statement(db->prepare << deleteQuery);
             }();
             if (health())
                 return;


### PR DESCRIPTION
* Thread-safe preparation of Validations cleanup query
* Followup to RIPD-870

This is a followup to #1556, which was only merged to develop 4 days ago (as of this writing). It had two problems.

1. I didn't follow the established pattern for table modifications (https://github.com/ripple/rippled/pull/1556#discussion_r54768875).
2. The Validations clean up query `prepare` was thread unsafe, causing occasional crashes.

This PR fixes both issues.

Reviewers: @vinniefalco @seelabs 