### PR TITLE
Lightweight journal

### DIFF
--- a/src/beast/beast/insight/impl/StatsDCollector.cpp
+++ b/src/beast/beast/insight/impl/StatsDCollector.cpp
@@ -326,8 +326,8 @@ public:
 
         if (ec)
         {
-            m_journal.error <<
-                "async_send failed: " << ec.message();
+            if (auto stream = m_journal.error())
+                stream << "async_send failed: " << ec.message();
             return;
         }
     }
@@ -414,8 +414,8 @@ public:
 
         if (ec)
         {
-            m_journal.error <<
-                "on_timer failed: " << ec.message();
+            if (auto stream = m_journal.error())
+                stream << "on_timer failed: " << ec.message();
             return;
         }
 
@@ -435,8 +435,8 @@ public:
 
         if (m_socket.connect (to_endpoint (m_address), ec))
         {
-            m_journal.error <<
-                "Connect failed: " << ec.message();
+            if (auto stream = m_journal.error())
+                stream << "Connect failed: " << ec.message();
             return;
         }
 

--- a/src/beast/beast/threads/impl/Stoppable.cpp
+++ b/src/beast/beast/threads/impl/Stoppable.cpp
@@ -117,7 +117,8 @@ void Stoppable::stopAsyncRecursive (Journal j)
 
 #ifdef NDEBUG
     if (ms >= 10)
-        j.fatal << m_name << "::onStop took " << ms << "ms";
+        if (auto stream = j.fatal())
+            stream << m_name << "::onStop took " << ms << "ms";
 #else
     (void)ms;
 #endif
@@ -145,7 +146,8 @@ void Stoppable::stopRecursive (Journal j)
     bool const timedOut (! m_stoppedEvent.wait (1 * 1000)); // milliseconds
     if (timedOut)
     {
-        j.error << "Waiting for '" << m_name << "' to stop";
+        if (auto stream = j.error())
+            stream << "Waiting for '" << m_name << "' to stop";
         m_stoppedEvent.wait ();
     }
 
@@ -193,7 +195,8 @@ void RootStoppable::stop (Journal j)
         std::lock_guard<std::mutex> lock(m_);
         if (m_calledStop)
         {
-            j.warning << "Stoppable::stop called again";
+            if (auto stream = j.warn())
+                stream << "Stoppable::stop called again";
             return;
         }
         m_calledStop = true;

--- a/src/beast/beast/utility/WrappedSink.h
+++ b/src/beast/beast/utility/WrappedSink.h
@@ -57,7 +57,7 @@ public:
     }
 
     bool
-    active (beast::Journal::Severity level) const override
+    active (beast::severities::Severity level) const override
     {
         return sink_.active (level);
     }
@@ -73,18 +73,18 @@ public:
         sink_.console (output);
     }
 
-    beast::Journal::Severity
+    beast::severities::Severity
     threshold() const override
     {
         return sink_.threshold();
     }
 
-    void threshold (beast::Journal::Severity thresh) override
+    void threshold (beast::severities::Severity thresh) override
     {
         sink_.threshold (thresh);
     }
 
-    void write (beast::Journal::Severity level, std::string const& text) override
+    void write (beast::severities::Severity level, std::string const& text) override
     {
         using beast::Journal;
         sink_.write (level, prefix_ + text);

--- a/src/beast/beast/utility/impl/Journal.cpp
+++ b/src/beast/beast/utility/impl/Journal.cpp
@@ -29,12 +29,12 @@ class NullJournalSink : public Journal::Sink
 {
 public:
     NullJournalSink ()
-    : Sink (Journal::kDisabled, false)
+    : Sink (severities::kDisabled, false)
     { }
 
     ~NullJournalSink() override = default;
 
-    bool active (Journal::Severity) const override
+    bool active (severities::Severity) const override
     {
         return false;
     }
@@ -48,16 +48,16 @@ public:
     {
     }
 
-    Journal::Severity threshold() const override
+    severities::Severity threshold() const override
     {
-        return Journal::kDisabled;
+        return severities::kDisabled;
     }
 
-    void threshold (Journal::Severity) override
+    void threshold (severities::Severity) override
     {
     }
 
-    void write (Journal::Severity, std::string const&) override
+    void write (severities::Severity, std::string const&) override
     {
     }
 };
@@ -97,7 +97,7 @@ void Journal::Sink::console (bool output)
     m_console = output;
 }
 
-Journal::Severity Journal::Sink::threshold () const
+severities::Severity Journal::Sink::threshold () const
 {
     return thresh_;
 }
@@ -109,26 +109,20 @@ void Journal::Sink::threshold (Severity thresh)
 
 //------------------------------------------------------------------------------
 
-Journal::ScopedStream::ScopedStream (Stream const& stream)
-    : m_sink (stream.sink ())
-    , m_level (stream.severity ())
+Journal::ScopedStream::ScopedStream (Sink& sink, Severity level)
+    : m_sink (sink)
+    , m_level (level)
 {
-    init ();
-}
-
-Journal::ScopedStream::ScopedStream (ScopedStream const& other)
-    : m_sink (other.m_sink)
-    , m_level (other.m_level)
-{
-    init ();
+    // Modifiers applied from all ctors
+    m_ostream
+        << std::boolalpha
+        << std::showbase;
 }
 
 Journal::ScopedStream::ScopedStream (
     Stream const& stream, std::ostream& manip (std::ostream&))
-    : m_sink (stream.sink ())
-    , m_level (stream.severity ())
+    : ScopedStream (stream.sink(), stream.level())
 {
-    init ();
     m_ostream << manip;
 }
 
@@ -144,61 +138,12 @@ Journal::ScopedStream::~ScopedStream ()
     }
 }
 
-void Journal::ScopedStream::init ()
-{
-    // Modifiers applied from all ctors
-    m_ostream
-        << std::boolalpha
-        << std::showbase;
-}
-
 std::ostream& Journal::ScopedStream::operator<< (std::ostream& manip (std::ostream&)) const
 {
     return m_ostream << manip;
 }
 
-std::ostringstream& Journal::ScopedStream::ostream () const
-{
-    return m_ostream;
-}
-
 //------------------------------------------------------------------------------
-
-Journal::Stream::Stream ()
-    : m_sink (&getNullSink ())
-    , m_level (kDisabled)
-{
-}
-
-Journal::Stream::Stream (Sink& sink, Severity level)
-    : m_sink (&sink)
-    , m_level (level)
-{
-    assert (level != kDisabled);
-}
-
-Journal::Stream::Stream (Stream const& other)
-    : m_sink (other.m_sink)
-    , m_level (other.m_level)
-{
-}
-
-Journal::Sink& Journal::Stream::sink () const
-{
-    return *m_sink;
-}
-
-Journal::Severity Journal::Stream::severity () const
-{
-    return m_level;
-}
-
-Journal::Stream& Journal::Stream::operator= (Stream const& other)
-{
-    m_sink = other.m_sink;
-    m_level = other.m_level;
-    return *this;
-}
 
 Journal::ScopedStream Journal::Stream::operator<< (
     std::ostream& manip (std::ostream&)) const
@@ -206,52 +151,5 @@ Journal::ScopedStream Journal::Stream::operator<< (
     return ScopedStream (*this, manip);
 }
 
-//------------------------------------------------------------------------------
+} // beast
 
-Journal::Journal ()
-    : m_sink  (&getNullSink())
-    , trace   (stream (kTrace))
-    , debug   (stream (kDebug))
-    , info    (stream (kInfo))
-    , warning (stream (kWarning))
-    , error   (stream (kError))
-    , fatal   (stream (kFatal))
-{
-}
-
-Journal::Journal (Sink& sink)
-    : m_sink  (&sink)
-    , trace   (stream (kTrace))
-    , debug   (stream (kDebug))
-    , info    (stream (kInfo))
-    , warning (stream (kWarning))
-    , error   (stream (kError))
-    , fatal   (stream (kFatal))
-{
-}
-
-Journal::Journal (Journal const& other)
-    : Journal  (*other.m_sink)
-{
-}
-
-Journal::~Journal ()
-{
-}
-
-Journal::Sink& Journal::sink() const
-{
-    return *m_sink;
-}
-
-Journal::Stream Journal::stream (Severity level) const
-{
-    return Stream (*m_sink, level);
-}
-
-bool Journal::active (Severity level) const
-{
-    return m_sink->active (level);
-}
-
-}

--- a/src/beast/beast/utility/tests/Journal.test.cpp
+++ b/src/beast/beast/utility/tests/Journal.test.cpp
@@ -32,7 +32,7 @@ public:
 
     public:
         TestSink()
-            : Sink (Journal::kWarning, false)
+            : Sink (severities::kWarning, false)
             , m_count(0)
         {
         }
@@ -50,7 +50,7 @@ public:
         }
 
         void
-        write (Journal::Severity level, std::string const&) override
+        write (severities::Severity level, std::string const&) override
         {
             if (level >= threshold())
                 ++m_count;
@@ -61,38 +61,39 @@ public:
     {
         TestSink sink;
 
-        sink.threshold(Journal::kInfo);
+        using namespace beast::severities;
+        sink.threshold(kInfo);
 
         Journal j(sink);
 
-        j.trace << " ";
+        j.trace() << " ";
         expect(sink.count() == 0);
-        j.debug << " ";
+        j.debug() << " ";
         expect(sink.count() == 0);
-        j.info << " ";
+        j.info() << " ";
         expect(sink.count() == 1);
-        j.warning << " ";
+        j.warn() << " ";
         expect(sink.count() == 2);
-        j.error << " ";
+        j.error() << " ";
         expect(sink.count() == 3);
-        j.fatal << " ";
+        j.fatal() << " ";
         expect(sink.count() == 4);
 
         sink.reset();
 
-        sink.threshold(Journal::kDebug);
+        sink.threshold(kDebug);
 
-        j.trace << " ";
+        j.trace() << " ";
         expect(sink.count() == 0);
-        j.debug << " ";
+        j.debug() << " ";
         expect(sink.count() == 1);
-        j.info << " ";
+        j.info() << " ";
         expect(sink.count() == 2);
-        j.warning << " ";
+        j.warn() << " ";
         expect(sink.count() == 3);
-        j.error << " ";
+        j.error() << " ";
         expect(sink.count() == 4);
-        j.fatal << " ";
+        j.fatal() << " ";
         expect(sink.count() == 5);
     }
 };

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -50,7 +50,7 @@ void ConsensusTransSetSF::gotNode (
     if ((type == SHAMapTreeNode::tnTRANSACTION_NM) && (nodeData.size () > 16))
     {
         // this is a transaction, and we didn't have it
-        JLOG (j_.debug)
+        JLOG (j_.debug())
                 << "Node on our acquiring TX set is TXN we may not have";
 
         try
@@ -69,7 +69,7 @@ void ConsensusTransSetSF::gotNode (
         }
         catch (std::exception const&)
         {
-            JLOG (j_.warning)
+            JLOG (j_.warn())
                     << "Fetched invalid transaction in proposed set";
         }
     }
@@ -86,7 +86,7 @@ bool ConsensusTransSetSF::haveNode (
     if (txn)
     {
         // this is a transaction, and we have it
-        JLOG (j_.trace)
+        JLOG (j_.trace())
                 << "Node in our acquiring TX set is TXN we have";
         Serializer s;
         s.add32 (HashPrefix::transactionID);

--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -154,13 +154,13 @@ log_one(
 
     if (metaData != nullptr)
     {
-        JLOG (j.debug) << "MISMATCH on TX " << tx <<
+        JLOG (j.debug()) << "MISMATCH on TX " << tx <<
             ": " << msg << " is missing this transaction:\n" <<
             metaData->getJson (0);
     }
     else
     {
-        JLOG (j.debug) << "MISMATCH on TX " << tx <<
+        JLOG (j.debug()) << "MISMATCH on TX " << tx <<
             ": " << msg << " is missing this transaction.";
     }
 }
@@ -201,7 +201,7 @@ log_metadata_difference(
 
         if (!result_diff && !index_diff && !nodes_diff)
         {
-            JLOG (j.error) << "MISMATCH on TX " << tx <<
+            JLOG (j.error()) << "MISMATCH on TX " << tx <<
                 ": No apparent mismatches detected!";
             return;
         }
@@ -210,31 +210,31 @@ log_metadata_difference(
         {
             if (result_diff && index_diff)
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different result and index!";
-                JLOG (j.debug) << " Built:" <<
+                JLOG (j.debug()) << " Built:" <<
                     " Result: " << builtMetaData->getResult () <<
                     " Index: " << builtMetaData->getIndex ();
-                JLOG (j.debug) << " Valid:" <<
+                JLOG (j.debug()) << " Valid:" <<
                     " Result: " << validMetaData->getResult () <<
                     " Index: " << validMetaData->getIndex ();
             }
             else if (result_diff)
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different result!";
-                JLOG (j.debug) << " Built:" <<
+                JLOG (j.debug()) << " Built:" <<
                     " Result: " << builtMetaData->getResult ();
-                JLOG (j.debug) << " Valid:" <<
+                JLOG (j.debug()) << " Valid:" <<
                     " Result: " << validMetaData->getResult ();
             }
             else if (index_diff)
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different index!";
-                JLOG (j.debug) << " Built:" <<
+                JLOG (j.debug()) << " Built:" <<
                     " Index: " << builtMetaData->getIndex ();
-                JLOG (j.debug) << " Valid:" <<
+                JLOG (j.debug()) << " Valid:" <<
                     " Index: " << validMetaData->getIndex ();
             }
         }
@@ -242,55 +242,55 @@ log_metadata_difference(
         {
             if (result_diff && index_diff)
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different result, index and nodes!";
-                JLOG (j.debug) << " Built:\n" <<
+                JLOG (j.debug()) << " Built:\n" <<
                     builtMetaData->getJson (0);
-                JLOG (j.debug) << " Valid:\n" <<
+                JLOG (j.debug()) << " Valid:\n" <<
                     validMetaData->getJson (0);
             }
             else if (result_diff)
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different result and nodes!";
-                JLOG (j.debug) << " Built:" <<
+                JLOG (j.debug()) << " Built:" <<
                     " Result: " << builtMetaData->getResult () <<
                     " Nodes:\n" << builtNodes.getJson (0);
-                JLOG (j.debug) << " Valid:" <<
+                JLOG (j.debug()) << " Valid:" <<
                     " Result: " << validMetaData->getResult () <<
                     " Nodes:\n" << validNodes.getJson (0);
             }
             else if (index_diff)
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different index and nodes!";
-                JLOG (j.debug) << " Built:" <<
+                JLOG (j.debug()) << " Built:" <<
                     " Index: " << builtMetaData->getIndex () <<
                     " Nodes:\n" << builtNodes.getJson (0);
-                JLOG (j.debug) << " Valid:" <<
+                JLOG (j.debug()) << " Valid:" <<
                     " Index: " << validMetaData->getIndex () <<
                     " Nodes:\n" << validNodes.getJson (0);
             }
             else // nodes_diff
             {
-                JLOG (j.debug) << "MISMATCH on TX " << tx <<
+                JLOG (j.debug()) << "MISMATCH on TX " << tx <<
                     ": Different nodes!";
-                JLOG (j.debug) << " Built:" <<
+                JLOG (j.debug()) << " Built:" <<
                     " Nodes:\n" << builtNodes.getJson (0);
-                JLOG (j.debug) << " Valid:" <<
+                JLOG (j.debug()) << " Valid:" <<
                     " Nodes:\n" << validNodes.getJson (0);
             }
         }
     }
     else if (validMetaData != nullptr)
     {
-        JLOG (j.error) << "MISMATCH on TX " << tx <<
+        JLOG (j.error()) << "MISMATCH on TX " << tx <<
             ": Metadata Difference (built has none)\n" <<
             validMetaData->getJson (0);
     }
     else // builtMetaData != nullptr
     {
-        JLOG (j.error) << "MISMATCH on TX " << tx <<
+        JLOG (j.error()) << "MISMATCH on TX " << tx <<
             ": Metadata Difference (valid has none)\n" <<
             builtMetaData->getJson (0);
     }
@@ -325,7 +325,7 @@ void LedgerHistory::handleMismatch (
 
     if (!builtLedger || !validLedger)
     {
-        JLOG (j_.error) << "MISMATCH cannot be analyzed:" <<
+        JLOG (j_.error()) << "MISMATCH cannot be analyzed:" <<
             " builtLedger: " << to_string (built) << " -> " << builtLedger <<
             " validLedger: " << to_string (valid) << " -> " << validLedger;
         return;
@@ -333,11 +333,11 @@ void LedgerHistory::handleMismatch (
 
     assert (builtLedger->info().seq == validLedger->info().seq);
 
-    if (j_.debug)
+    if (auto stream = j_.debug())
     {
-        j_.debug << "Built: " << getJson (*builtLedger);
-        j_.debug << "Valid: " << getJson (*validLedger);
-        j_.debug << "Consensus: " << consensus;
+        stream << "Built: " << getJson (*builtLedger);
+        stream << "Valid: " << getJson (*validLedger);
+        stream << "Consensus: " << consensus;
     }
 
     // Determine the mismatch reason, distinguishing Byzantine
@@ -346,14 +346,14 @@ void LedgerHistory::handleMismatch (
     // Disagreement over prior ledger indicates sync issue
     if (builtLedger->info().parentHash != validLedger->info().parentHash)
     {
-        JLOG (j_.error) << "MISMATCH on prior ledger";
+        JLOG (j_.error()) << "MISMATCH on prior ledger";
         return;
     }
 
     // Disagreement over close time indicates Byzantine failure
     if (builtLedger->info().closeTime != validLedger->info().closeTime)
     {
-        JLOG (j_.error) << "MISMATCH on close time";
+        JLOG (j_.error()) << "MISMATCH on close time";
         return;
     }
 
@@ -362,16 +362,16 @@ void LedgerHistory::handleMismatch (
     auto const validTx = leaves(validLedger->txMap());
 
     if (builtTx == validTx)
-        JLOG (j_.error) <<
+        JLOG (j_.error()) <<
             "MISMATCH with same " << builtTx.size() <<
             " transactions";
     else
-        JLOG (j_.error) << "MISMATCH with " <<
+        JLOG (j_.error()) << "MISMATCH with " <<
             builtTx.size() << " built and " <<
             validTx.size() << " valid transactions.";
 
-    JLOG (j_.error) << "built\n" << getJson(*builtLedger);
-    JLOG (j_.error) << "valid\n" << getJson(*validLedger);
+    JLOG (j_.error()) << "built\n" << getJson(*builtLedger);
+    JLOG (j_.error()) << "valid\n" << getJson(*validLedger);
 
     // Log all differences between built and valid ledgers
     auto b = builtTx.begin();
@@ -425,7 +425,7 @@ void LedgerHistory::builtLedger (
     {
         if (entry->validated.get() != hash)
         {
-            JLOG (j_.error) << "MISMATCH: seq=" << index
+            JLOG (j_.error()) << "MISMATCH: seq=" << index
                 << " validated:" << entry->validated.get()
                 << " then:" << hash;
             handleMismatch (hash, entry->validated.get(), consensus);
@@ -433,7 +433,7 @@ void LedgerHistory::builtLedger (
         else
         {
             // We validated a ledger and then built it locally
-            JLOG (j_.debug) << "MATCH: seq=" << index << " late";
+            JLOG (j_.debug()) << "MATCH: seq=" << index << " late";
         }
     }
 
@@ -458,7 +458,7 @@ void LedgerHistory::validatedLedger (
     {
         if (entry->built.get() != hash)
         {
-            JLOG (j_.error) << "MISMATCH: seq=" << index
+            JLOG (j_.error()) << "MISMATCH: seq=" << index
                 << " built:" << entry->built.get()
                 << " then:" << hash;
             handleMismatch (entry->built.get(), hash, entry->consensus.get());
@@ -466,7 +466,7 @@ void LedgerHistory::validatedLedger (
         else
         {
             // We built a ledger locally and then validated it
-            JLOG (j_.debug) << "MATCH: seq=" << index;
+            JLOG (j_.debug()) << "MATCH: seq=" << index;
         }
     }
 

--- a/src/ripple/app/ledger/OpenLedger.h
+++ b/src/ripple/app/ledger/OpenLedger.h
@@ -226,7 +226,7 @@ OpenLedger::apply (Application& app, OpenView& view,
         }
         catch(std::exception const&)
         {
-            JLOG(j.error) <<
+            JLOG(j.error()) <<
                 "Caught exception";
         }
     }

--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -60,7 +60,7 @@ void OrderBookDB::setup(
                 return;
         }
 
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "Advancing from " << mSeq << " to " << seq;
 
         mSeq = seq;
@@ -86,7 +86,7 @@ void OrderBookDB::update(
     OrderBookDB::IssueToOrderBook sourceMap;
     hash_set< Issue > XRPBooks;
 
-    JLOG (j_.debug) << "OrderBookDB::update>";
+    JLOG (j_.debug()) << "OrderBookDB::update>";
 
     if (app_.config().PATH_SEARCH_MAX == 0)
     {
@@ -130,14 +130,14 @@ void OrderBookDB::update(
     }
     catch (const SHAMapMissingNode&)
     {
-        JLOG (j_.info)
+        JLOG (j_.info())
             << "OrderBookDB::update encountered a missing node";
         std::lock_guard <std::recursive_mutex> sl (mLock);
         mSeq = 0;
         return;
     }
 
-    JLOG (j_.debug)
+    JLOG (j_.debug())
         << "OrderBookDB::update< " << books << " books found";
     {
         std::lock_guard <std::recursive_mutex> sl (mLock);
@@ -284,7 +284,7 @@ void OrderBookDB::processTxn (
             }
             catch (std::exception const&)
             {
-                JLOG (j_.info)
+                JLOG (j_.info())
                     << "Fields not found in OrderBookDB::processTxn";
             }
         }

--- a/src/ripple/app/ledger/impl/DisputedTx.cpp
+++ b/src/ripple/app/ledger/impl/DisputedTx.cpp
@@ -35,13 +35,13 @@ void DisputedTx::setVote (NodeID const& peer, bool votesYes)
     {
         if (votesYes)
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                     << "Peer " << peer << " votes YES on " << mTransactionID;
             ++mYays;
         }
         else
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                     << "Peer " << peer << " votes NO on " << mTransactionID;
             ++mNays;
         }
@@ -49,7 +49,7 @@ void DisputedTx::setVote (NodeID const& peer, bool votesYes)
     // changes vote to yes
     else if (votesYes && !res.first->second)
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
                 << "Peer " << peer << " now votes YES on " << mTransactionID;
         --mNays;
         ++mYays;
@@ -58,7 +58,7 @@ void DisputedTx::setVote (NodeID const& peer, bool votesYes)
     // changes vote to no
     else if (!votesYes && res.first->second)
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
                 << "Peer " << peer << " now votes NO on " << mTransactionID;
         ++mNays;
         --mYays;
@@ -124,18 +124,18 @@ bool DisputedTx::updateVote (int percentTime, bool proposing)
 
     if (newPosition == mOurVote)
     {
-        JLOG (j_.info)
+        JLOG (j_.info())
                 << "No change (" << (mOurVote ? "YES" : "NO") << ") : weight "
                 << weight << ", percent " << percentTime;
-        JLOG (j_.debug) << getJson ();
+        JLOG (j_.debug()) << getJson ();
         return false;
     }
 
     mOurVote = newPosition;
-    JLOG (j_.debug)
+    JLOG (j_.debug())
             << "We now vote " << (mOurVote ? "YES" : "NO")
             << " on " << mTransactionID;
-    JLOG (j_.debug) << getJson ();
+    JLOG (j_.debug()) << getJson ();
     return true;
 }
 

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -159,7 +159,7 @@ public:
     {
         protocol::TMLedgerData& packet = *packet_ptr;
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "Got data (" << packet.nodes ().size ()
             << ") for acquiring ledger: " << hash;
 
@@ -167,7 +167,7 @@ public:
 
         if (!ledger)
         {
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "Got data for ledger we're no longer acquiring";
 
             // If it's state node data, stash it because it still might be
@@ -401,7 +401,7 @@ public:
 
         }
 
-        JLOG (j_.debug) <<
+        JLOG (j_.debug()) <<
             "Swept " << stuffToSweep.size () <<
             " out of " << total << " inbound ledgers.";
     }

--- a/src/ripple/app/ledger/impl/InboundTransactions.cpp
+++ b/src/ripple/app/ledger/impl/InboundTransactions.cpp
@@ -146,7 +146,7 @@ public:
     {
         protocol::TMLedgerData& packet = *packet_ptr;
 
-        JLOG (app_.journal("InboundLedger").trace) <<
+        JLOG (app_.journal("InboundLedger").trace()) <<
             "Got data (" << packet.nodes ().size () << ") "
             "for acquiring ledger: " << hash;
 

--- a/src/ripple/app/ledger/impl/LedgerCleaner.cpp
+++ b/src/ripple/app/ledger/impl/LedgerCleaner.cpp
@@ -110,7 +110,7 @@ public:
 
     void onStop () override
     {
-        JLOG (j_.info) << "Stopping";
+        JLOG (j_.info()) << "Stopping";
         {
             std::lock_guard<std::mutex> lock (mutex_);
             shouldExit_ = true;
@@ -237,13 +237,13 @@ public:
 private:
     void init ()
     {
-        JLOG (j_.debug) << "Initializing";
+        JLOG (j_.debug()) << "Initializing";
     }
 
     void run ()
     {
         beast::Thread::setCurrentThreadName ("LedgerCleaner");
-        JLOG (j_.debug) << "Started";
+        JLOG (j_.debug()) << "Started";
 
         init();
 
@@ -280,7 +280,7 @@ private:
         }
         catch (SHAMapMissingNode &)
         {
-            JLOG (j_.warning) <<
+            JLOG (j_.warn()) <<
                 "Node missing from ledger " << ledger->info().seq;
             app_.getInboundLedgers().acquire (
                 ledger->info().hash, ledger->info().seq,
@@ -306,7 +306,7 @@ private:
             ledgerHash, ledgerIndex, InboundLedger::fcGENERIC);
         if (!nodeLedger)
         {
-            JLOG (j_.debug) << "Ledger " << ledgerIndex << " not available";
+            JLOG (j_.debug()) << "Ledger " << ledgerIndex << " not available";
             app_.getLedgerMaster().clearLedger (ledgerIndex);
             app_.getInboundLedgers().acquire(
                 ledgerHash, ledgerIndex, InboundLedger::fcGENERIC);
@@ -319,21 +319,21 @@ private:
             (dbLedger->info().parentHash != nodeLedger->info().parentHash))
         {
             // Ideally we'd also check for more than one ledger with that index
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Ledger " << ledgerIndex << " mismatches SQL DB";
             doTxns = true;
         }
 
         if(! app_.getLedgerMaster().fixIndex(ledgerIndex, ledgerHash))
         {
-            JLOG (j_.debug) << "ledger " << ledgerIndex
+            JLOG (j_.debug()) << "ledger " << ledgerIndex
                             << " had wrong entry in history";
             doTxns = true;
         }
 
         if (doNodes && !nodeLedger->walkLedger(app_.journal ("Ledger")))
         {
-            JLOG (j_.debug) << "Ledger " << ledgerIndex << " is missing nodes";
+            JLOG (j_.debug()) << "Ledger " << ledgerIndex << " is missing nodes";
             app_.getLedgerMaster().clearLedger (ledgerIndex);
             app_.getInboundLedgers().acquire(
                 ledgerHash, ledgerIndex, InboundLedger::fcGENERIC);
@@ -342,7 +342,7 @@ private:
 
         if (doTxns && !pendSaveValidated(app_, nodeLedger, true, false))
         {
-            JLOG (j_.debug) << "Failed to save ledger " << ledgerIndex;
+            JLOG (j_.debug()) << "Failed to save ledger " << ledgerIndex;
             return false;
         }
 
@@ -365,7 +365,7 @@ private:
             referenceLedger = app_.getLedgerMaster().getValidatedLedger();
             if (!referenceLedger)
             {
-                JLOG (j_.warning) << "No validated ledger";
+                JLOG (j_.warn()) << "No validated ledger";
                 return ledgerHash; // Nothing we can do. No validated ledger.
             }
         }
@@ -398,7 +398,7 @@ private:
             }
         }
         else
-            JLOG (j_.warning) << "Validated ledger is prior to target ledger";
+            JLOG (j_.warn()) << "Validated ledger is prior to target ledger";
 
         return ledgerHash;
     }
@@ -423,7 +423,7 @@ private:
 
             while (app_.getFeeTrack().isLoadedLocal())
             {
-                JLOG (j_.debug) << "Waiting for load to subside";
+                JLOG (j_.debug()) << "Waiting for load to subside";
                 std::this_thread::sleep_for(std::chrono::seconds(5));
                 if (shouldExit())
                     return;
@@ -448,13 +448,13 @@ private:
             bool fail = false;
             if (ledgerHash.isZero())
             {
-                JLOG (j_.info) << "Unable to get hash for ledger "
+                JLOG (j_.info()) << "Unable to get hash for ledger "
                                << ledgerIndex;
                 fail = true;
             }
             else if (!doLedger(ledgerIndex, ledgerHash, doNodes, doTxns))
             {
-                JLOG (j_.info) << "Failed to process ledger " << ledgerIndex;
+                JLOG (j_.info()) << "Failed to process ledger " << ledgerIndex;
                 fail = true;
             }
 

--- a/src/ripple/app/ledger/impl/OpenLedger.cpp
+++ b/src/ripple/app/ledger/impl/OpenLedger.cpp
@@ -81,7 +81,7 @@ OpenLedger::accept(Application& app, Rules const& rules,
                 std::string const& suffix,
                     modify_type const& f)
 {
-    JLOG(j_.trace) <<
+    JLOG(j_.trace()) <<
         "accept ledger " << ledger->seq() << " " << suffix;
     auto next = create(rules, ledger);
     if (retriesFirst)

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -60,11 +60,11 @@ void TransactionAcquire::done ()
 
     if (mFailed)
     {
-        JLOG (j_.warning) << "Failed to acquire TX set " << mHash;
+        JLOG (j_.warn()) << "Failed to acquire TX set " << mHash;
     }
     else
     {
-        JLOG (j_.debug) << "Acquired TX set " << mHash;
+        JLOG (j_.debug()) << "Acquired TX set " << mHash;
         mMap->setImmutable ();
 
         uint256 const& hash (mHash);
@@ -111,18 +111,18 @@ void TransactionAcquire::trigger (Peer::ptr const& peer)
 {
     if (mComplete)
     {
-        JLOG (j_.info) << "trigger after complete";
+        JLOG (j_.info()) << "trigger after complete";
         return;
     }
     if (mFailed)
     {
-        JLOG (j_.info) << "trigger after fail";
+        JLOG (j_.info()) << "trigger after fail";
         return;
     }
 
     if (!mHaveRoot)
     {
-        JLOG (j_.trace) << "TransactionAcquire::trigger " << (peer ? "havePeer" : "noPeer") << " no root";
+        JLOG (j_.trace()) << "TransactionAcquire::trigger " << (peer ? "havePeer" : "noPeer") << " no root";
         protocol::TMGetLedger tmGL;
         tmGL.set_ledgerhash (mHash.begin (), mHash.size ());
         tmGL.set_itype (protocol::liTS_CANDIDATE);
@@ -177,13 +177,13 @@ SHAMapAddNode TransactionAcquire::takeNodes (const std::list<SHAMapNodeID>& node
 
     if (mComplete)
     {
-        JLOG (j_.trace) << "TX set complete";
+        JLOG (j_.trace()) << "TX set complete";
         return SHAMapAddNode ();
     }
 
     if (mFailed)
     {
-        JLOG (j_.trace) << "TX set failed";
+        JLOG (j_.trace()) << "TX set failed";
         return SHAMapAddNode ();
     }
 
@@ -201,18 +201,18 @@ SHAMapAddNode TransactionAcquire::takeNodes (const std::list<SHAMapNodeID>& node
             if (nodeIDit->isRoot ())
             {
                 if (mHaveRoot)
-                    JLOG (j_.debug) << "Got root TXS node, already have it";
+                    JLOG (j_.debug()) << "Got root TXS node, already have it";
                 else if (!mMap->addRootNode (SHAMapHash{getHash ()},
                                              *nodeDatait, snfWIRE, nullptr).isGood())
                 {
-                    JLOG (j_.warning) << "TX acquire got bad root node";
+                    JLOG (j_.warn()) << "TX acquire got bad root node";
                 }
                 else
                     mHaveRoot = true;
             }
             else if (!mMap->addKnownNode (*nodeIDit, *nodeDatait, &sf).isGood())
             {
-                JLOG (j_.warning) << "TX acquire got bad non-root node";
+                JLOG (j_.warn()) << "TX acquire got bad non-root node";
                 return SHAMapAddNode::invalid ();
             }
 
@@ -226,7 +226,7 @@ SHAMapAddNode TransactionAcquire::takeNodes (const std::list<SHAMapNodeID>& node
     }
     catch (std::exception const&)
     {
-        JLOG (j_.error) << "Peer sends us junky transaction node data";
+        JLOG (j_.error()) << "Peer sends us junky transaction node data";
         return SHAMapAddNode::invalid ();
     }
 }

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -53,7 +53,7 @@ LoadManager::~LoadManager ()
     catch (std::exception const& ex)
     {
         // Swallow the exception in a destructor.
-        JLOG(journal_.warning) << "std::exception in ~LoadManager.  "
+        JLOG(journal_.warn()) << "std::exception in ~LoadManager.  "
             << ex.what();
     }
 }
@@ -83,7 +83,7 @@ void LoadManager::onPrepare ()
 
 void LoadManager::onStart ()
 {
-    JLOG(journal_.debug) << "Starting";
+    JLOG(journal_.debug()) << "Starting";
     assert (! thread_.joinable());
 
     thread_ = std::thread {&LoadManager::run, this};
@@ -93,7 +93,7 @@ void LoadManager::onStop ()
 {
     if (thread_.joinable())
     {
-        JLOG(journal_.debug) << "Stopping";
+        JLOG(journal_.debug()) << "Stopping";
         {
             std::lock_guard<std::mutex> sl (mutex_);
             stop_ = true;
@@ -148,7 +148,7 @@ void LoadManager::run ()
                 // Report the deadlocked condition every 10 seconds
                 if ((timeSpentDeadlocked % reportingIntervalSeconds) == 0)
                 {
-                    JLOG(journal_.warning)
+                    JLOG(journal_.warn())
                         << "Server stalled for "
                         << timeSpentDeadlocked << " seconds.";
                 }
@@ -164,7 +164,7 @@ void LoadManager::run ()
         bool change = false;
         if (app_.getJobQueue ().isOverloaded ())
         {
-            JLOG(journal_.info) << app_.getJobQueue ().getJson (0);
+            JLOG(journal_.info()) << app_.getJobQueue ().getJson (0);
             change = app_.getFeeTrack ().raiseLocalFee ();
         }
         else
@@ -185,7 +185,7 @@ void LoadManager::run ()
         if ((duration < std::chrono::seconds (0)) ||
             (duration > std::chrono::seconds (1)))
         {
-            JLOG(journal_.warning) << "time jump";
+            JLOG(journal_.warn()) << "time jump";
             t = clock_type::now();
         }
         else

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -420,12 +420,13 @@ int run (int argc, char** argv)
     }
 
     // Construct the logs object at the configured severity
-    beast::Journal::Severity thresh = beast::Journal::kInfo;
+    using namespace beast::severities;
+    Severity thresh = kInfo;
 
     if (vm.count ("quiet"))
-        thresh = beast::Journal::kFatal;
+        thresh = kFatal;
     else if (vm.count ("verbose"))
-        thresh = beast::Journal::kTrace;
+        thresh = kTrace;
 
     auto logs = std::make_unique<Logs>(thresh);
 

--- a/src/ripple/app/misc/FeeVoteImpl.cpp
+++ b/src/ripple/app/misc/FeeVoteImpl.cpp
@@ -122,7 +122,7 @@ FeeVoteImpl::doValidation(
 {
     if (lastClosedLedger->fees().base != target_.reference_fee)
     {
-        if (journal_.info) journal_.info <<
+        JLOG(journal_.info()) <<
             "Voting for base fee of " << target_.reference_fee;
 
         baseValidation.setFieldU64 (sfBaseFee, target_.reference_fee);
@@ -130,7 +130,7 @@ FeeVoteImpl::doValidation(
 
     if (lastClosedLedger->fees().accountReserve(0) != target_.account_reserve)
     {
-        if (journal_.info) journal_.info <<
+        JLOG(journal_.info()) <<
             "Voting for base resrve of " << target_.account_reserve;
 
         baseValidation.setFieldU32(sfReserveBase, target_.account_reserve);
@@ -138,7 +138,7 @@ FeeVoteImpl::doValidation(
 
     if (lastClosedLedger->fees().increment != target_.owner_reserve)
     {
-        if (journal_.info) journal_.info <<
+        JLOG(journal_.info()) <<
             "Voting for reserve increment of " << target_.owner_reserve;
 
         baseValidation.setFieldU32 (sfReserveIncrement,
@@ -211,7 +211,7 @@ FeeVoteImpl::doVoting(
             (baseReserve != lastClosedLedger->fees().accountReserve(0)) ||
             (incReserve != lastClosedLedger->fees().increment))
     {
-        if (journal_.warning) journal_.warning <<
+        JLOG(journal_.warn()) <<
             "We are voting for a fee change: " << baseFee <<
             "/" << baseReserve <<
             "/" << incReserve;
@@ -229,8 +229,8 @@ FeeVoteImpl::doVoting(
 
         uint256 txID = feeTx.getTransactionID ();
 
-        if (journal_.warning)
-            journal_.warning << "Vote: " << txID;
+        JLOG(journal_.warn()) <<
+            "Vote: " << txID;
 
         Serializer s;
         feeTx.add (s);
@@ -239,7 +239,7 @@ FeeVoteImpl::doVoting(
 
         if (!initialPosition->addGiveItem (tItem, true, false))
         {
-            if (journal_.warning) journal_.warning <<
+            JLOG(journal_.warn()) <<
                 "Ledger already had fee change";
         }
     }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -654,7 +654,7 @@ void NetworkOPsImp::processHeartbeatTimer ()
             if (mMode != omDISCONNECTED)
             {
                 setMode (omDISCONNECTED);
-                JLOG(m_journal.warning)
+                JLOG(m_journal.warn())
                     << "Node count (" << numPeers << ") "
                     << "has fallen below quorum (" << m_network_quorum << ").";
             }
@@ -667,7 +667,7 @@ void NetworkOPsImp::processHeartbeatTimer ()
         if (mMode == omDISCONNECTED)
         {
             setMode (omCONNECTED);
-            JLOG(m_journal.info)
+            JLOG(m_journal.info())
                 << "Node count (" << numPeers << ") is sufficient.";
         }
 
@@ -697,7 +697,7 @@ void NetworkOPsImp::processClusterTimer ()
 
     if (!update)
     {
-        JLOG(m_journal.debug) << "Too soon to send cluster update";
+        JLOG(m_journal.debug()) << "Too soon to send cluster update";
         return;
     }
 
@@ -762,13 +762,13 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
 
     if ((flags & SF_RETRY) != 0)
     {
-        JLOG(m_journal.warning) << "Redundant transactions submitted";
+        JLOG(m_journal.warn()) << "Redundant transactions submitted";
         return;
     }
 
     if ((flags & SF_BAD) != 0)
     {
-        JLOG(m_journal.warning) << "Submitted transaction cached bad";
+        JLOG(m_journal.warn()) << "Submitted transaction cached bad";
         return;
     }
 
@@ -781,7 +781,7 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
 
         if (validity.first != Validity::Valid)
         {
-            JLOG(m_journal.warning) <<
+            JLOG(m_journal.warn()) <<
                 "Submitted transaction invalid: " <<
                 validity.second;
             return;
@@ -789,7 +789,7 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
     }
     catch (std::exception const&)
     {
-        JLOG(m_journal.warning) << "Exception checking transaction" << txid;
+        JLOG(m_journal.warn()) << "Exception checking transaction" << txid;
 
         return;
     }
@@ -832,7 +832,7 @@ void NetworkOPsImp::processTransaction (std::shared_ptr<Transaction>& transactio
     // Not concerned with local checks at this point.
     if (validity.first == Validity::SigBad)
     {
-        JLOG(m_journal.info) << "Transaction has bad signature: " <<
+        JLOG(m_journal.info()) << "Transaction has bad signature: " <<
             validity.second;
         transaction->setStatus(INVALID);
         transaction->setResult(temBAD_SIGNATURE);
@@ -979,7 +979,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
 
                 if (transResultInfo (e.result, token, human))
                 {
-                    JLOG(m_journal.info) << "TransactionResult: "
+                    JLOG(m_journal.info()) << "TransactionResult: "
                             << token << ": " << human;
                 }
             }
@@ -989,7 +989,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
 
             if (e.result == tesSUCCESS)
             {
-                JLOG(m_journal.debug)
+                JLOG(m_journal.debug())
                     << "Transaction is now included in open ledger";
                 e.transaction->setStatus (INCLUDED);
 
@@ -1009,12 +1009,12 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
             else if (e.result == tefPAST_SEQ)
             {
                 // duplicate or conflict
-                JLOG(m_journal.info) << "Transaction is obsolete";
+                JLOG(m_journal.info()) << "Transaction is obsolete";
                 e.transaction->setStatus (OBSOLETE);
             }
             else if (e.result == terQUEUED)
             {
-                JLOG(m_journal.info) << "Transaction is likely to claim a " <<
+                JLOG(m_journal.info()) << "Transaction is likely to claim a " <<
                     "fee, but is queued until fee drops";
                 e.transaction->setStatus(HELD);
                 // Add to held transactions, because it could get
@@ -1031,7 +1031,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                 else
                 {
                     // transaction should be held
-                    JLOG(m_journal.debug)
+                    JLOG(m_journal.debug())
                         << "Transaction should be held: " << e.result;
                     e.transaction->setStatus (HELD);
                     m_ledgerMaster.addHeldTransaction (e.transaction);
@@ -1039,7 +1039,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
             }
             else
             {
-                JLOG(m_journal.debug)
+                JLOG(m_journal.debug())
                     << "Status other than success " << e.result;
                 e.transaction->setStatus (INVALID);
             }
@@ -1250,7 +1250,7 @@ bool NetworkOPsImp::checkLastClosedLedger (
     // our last closed ledger? Or do sufficient nodes agree? And do we have no
     // better ledger available?  If so, we are either tracking or full.
 
-    JLOG(m_journal.trace) << "NetworkOPsImp::checkLastClosedLedger";
+    JLOG(m_journal.trace()) << "NetworkOPsImp::checkLastClosedLedger";
 
     auto const ourClosed = m_ledgerMaster.getClosedLedger ();
 
@@ -1259,8 +1259,8 @@ bool NetworkOPsImp::checkLastClosedLedger (
 
     uint256 closedLedger = ourClosed->info().hash;
     uint256 prevClosedLedger = ourClosed->info().parentHash;
-    JLOG(m_journal.trace) << "OurClosed:  " << closedLedger;
-    JLOG(m_journal.trace) << "PrevClosed: " << prevClosedLedger;
+    JLOG(m_journal.trace()) << "OurClosed:  " << closedLedger;
+    JLOG(m_journal.trace()) << "PrevClosed: " << prevClosedLedger;
 
     hash_map<uint256, ValidationCount> ledgers;
     {
@@ -1321,19 +1321,19 @@ bool NetworkOPsImp::checkLastClosedLedger (
 
     for (auto const& it: ledgers)
     {
-        JLOG(m_journal.debug) << "L: " << it.first
+        JLOG(m_journal.debug()) << "L: " << it.first
                               << " t=" << it.second.trustedValidations
                               << ", n=" << it.second.nodesUsing;
 
         // Temporary logging to make sure tiebreaking isn't broken
         if (it.second.trustedValidations > 0)
-            JLOG(m_journal.trace)
+            JLOG(m_journal.trace())
                 << "  TieBreakTV: " << it.second.highValidation;
         else
         {
             if (it.second.nodesUsing > 0)
             {
-                JLOG(m_journal.trace)
+                JLOG(m_journal.trace())
                     << "  TieBreakNU: " << it.second.highNodeUsing;
             }
         }
@@ -1349,7 +1349,7 @@ bool NetworkOPsImp::checkLastClosedLedger (
     if (switchLedgers && (closedLedger == prevClosedLedger))
     {
         // don't switch to our own previous ledger
-        JLOG(m_journal.info) << "We won't switch to our own previous ledger";
+        JLOG(m_journal.info()) << "We won't switch to our own previous ledger";
         networkClosed = ourClosed->info().hash;
         switchLedgers = false;
     }
@@ -1366,7 +1366,7 @@ bool NetworkOPsImp::checkLastClosedLedger (
             closedLedger, 0, InboundLedger::fcCONSENSUS);
 
     if (consensus &&
-        ! m_ledgerMaster.isCompatible (*consensus, m_journal.debug,
+        ! m_ledgerMaster.isCompatible (*consensus, m_journal.debug(),
             "Not switching"))
     {
         // Don't switch to a ledger not on the validated chain
@@ -1374,9 +1374,9 @@ bool NetworkOPsImp::checkLastClosedLedger (
         return false;
     }
 
-    JLOG(m_journal.warning) << "We are not running on the consensus ledger";
-    JLOG(m_journal.info) << "Our LCL: " << getJson (*ourClosed);
-    JLOG(m_journal.info) << "Net LCL " << closedLedger;
+    JLOG(m_journal.warn()) << "We are not running on the consensus ledger";
+    JLOG(m_journal.info()) << "Our LCL: " << getJson (*ourClosed);
+    JLOG(m_journal.info()) << "Net LCL " << closedLedger;
 
     if ((mMode == omTRACKING) || (mMode == omFULL))
         setMode (omCONNECTED);
@@ -1398,7 +1398,7 @@ void NetworkOPsImp::switchLastClosedLedger (
     std::shared_ptr<Ledger const> const& newLCL)
 {
     // set the newLCL as our last closed ledger -- this is abnormal code
-    JLOG(m_journal.error) <<
+    JLOG(m_journal.error()) <<
         "JUMP last closed ledger to " << newLCL->info().hash;
 
     clearNeedNetworkLedger ();
@@ -1453,7 +1453,7 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
 
     auto closingInfo = m_ledgerMaster.getCurrentLedger()->info();
 
-    JLOG(m_journal.info) <<
+    JLOG(m_journal.info()) <<
         "Consensus time for #" << closingInfo.seq <<
         " with LCL " << closingInfo.parentHash;
 
@@ -1465,7 +1465,7 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
         // this shouldn't happen unless we jump ledgers
         if (mMode == omFULL)
         {
-            JLOG(m_journal.warning) << "Don't have LCL, going to tracking";
+            JLOG(m_journal.warn()) << "Don't have LCL, going to tracking";
             setMode (omTRACKING);
         }
 
@@ -1482,7 +1482,7 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
         prevLedger,
         closingInfo.closeTime);
 
-    JLOG(m_journal.debug) << "Initiating consensus engine";
+    JLOG(m_journal.debug()) << "Initiating consensus engine";
     return true;
 }
 
@@ -1502,7 +1502,7 @@ void NetworkOPsImp::processTrustedProposal (
         if (mLedgerConsensus->peerPosition (proposal))
             app_.overlay().relay(*set, proposal->getSuppressionID());
         else
-            JLOG(m_journal.info) << "Not relaying trusted proposal";
+            JLOG(m_journal.info()) << "Not relaying trusted proposal";
     }
 }
 
@@ -1524,7 +1524,7 @@ void NetworkOPsImp::endConsensus (bool correctLCL)
     {
         if (it && (it->getClosedLedgerHash () == deadLedger))
         {
-            JLOG(m_journal.trace) << "Killing obsolete peer status";
+            JLOG(m_journal.trace()) << "Killing obsolete peer status";
             it->cycleStatus ();
         }
     }
@@ -1695,7 +1695,7 @@ void NetworkOPsImp::setMode (OperatingMode om)
 
     accounting_.mode (om);
 
-    JLOG(m_journal.info) << "STATE->" << strOperatingMode ();
+    JLOG(m_journal.info()) << "STATE->" << strOperatingMode ();
     pubServer ();
 }
 
@@ -1780,7 +1780,7 @@ NetworkOPsImp::transactionsSQL (
                     % beast::lexicalCastThrow <std::string> (offset)
                     % beast::lexicalCastThrow <std::string> (numberOfResults)
                    );
-    JLOG(m_journal.trace) << "txSQL query: " << sql;
+    JLOG(m_journal.trace()) << "txSQL query: " << sql;
     return sql;
 }
 
@@ -1834,7 +1834,7 @@ NetworkOPs::AccountTxs NetworkOPsImp::getAccountTxs (
                 auto const seq = rangeCheckedCast<std::uint32_t>(
                     ledgerSeq.value_or (0));
 
-                JLOG(m_journal.warning) <<
+                JLOG(m_journal.warn()) <<
                     "Recovering ledger " << seq <<
                     ", txn " << txn->getID();
 
@@ -1961,7 +1961,7 @@ NetworkOPsImp::getTxsAccountB (
 bool NetworkOPsImp::recvValidation (
     STValidation::ref val, std::string const& source)
 {
-    JLOG(m_journal.debug) << "recvValidation " << val->getLedgerHash ()
+    JLOG(m_journal.debug()) << "recvValidation " << val->getLedgerHash ()
                           << " from " << source;
     pubValidation (val);
     return app_.getValidations ().addValidation (val, source);
@@ -2186,7 +2186,7 @@ void NetworkOPsImp::pubProposedTransaction (
     }
     AcceptedLedgerTx alt (lpCurrent, stTxn, terResult,
         app_.accountIDCache(), app_.logs());
-    JLOG(m_journal.trace) << "pubProposed: " << alt.getJson ();
+    JLOG(m_journal.trace()) << "pubProposed: " << alt.getJson ();
     pubAccountTransaction (lpCurrent, alt, false);
 }
 
@@ -2251,7 +2251,7 @@ void NetworkOPsImp::pubLedger (
     // Don't lock since pubAcceptedTransaction is locking.
     for (auto const& vt : alpAccepted->getMap ())
     {
-        JLOG(m_journal.trace) << "pubAccepted: " << vt.second->getJson ();
+        JLOG(m_journal.trace()) << "pubAccepted: " << vt.second->getJson ();
         pubValidatedTransaction (lpAccepted, *vt.second);
     }
 }
@@ -2429,7 +2429,7 @@ void NetworkOPsImp::pubAccountTransaction (
             }
         }
     }
-    JLOG(m_journal.trace) << "pubAccountTransaction:" <<
+    JLOG(m_journal.trace()) << "pubAccountTransaction:" <<
         " iProposed=" << iProposed <<
         " iAccepted=" << iAccepted;
 
@@ -2458,7 +2458,7 @@ void NetworkOPsImp::subAccount (
 
     for (auto const& naAccountID : vnaAccountIDs)
     {
-        JLOG(m_journal.trace) <<
+        JLOG(m_journal.trace()) <<
             "subAccount: account: " << toBase58(naAccountID);
 
         isrListener->insertSubAccountInfo (naAccountID, rt);
@@ -2748,12 +2748,12 @@ void NetworkOPsImp::getBookPage (
     const uint256   uBookEnd    = getQualityNext (uBookBase);
     uint256         uTipIndex   = uBookBase;
 
-    if (m_journal.trace)
+    if (auto stream = m_journal.trace())
     {
-        m_journal.trace << "getBookPage:" << book;
-        m_journal.trace << "getBookPage: uBookBase=" << uBookBase;
-        m_journal.trace << "getBookPage: uBookEnd=" << uBookEnd;
-        m_journal.trace << "getBookPage: uTipIndex=" << uTipIndex;
+        stream << "getBookPage:" << book;
+        stream << "getBookPage: uBookBase=" << uBookBase;
+        stream << "getBookPage: uBookEnd=" << uBookEnd;
+        stream << "getBookPage: uTipIndex=" << uTipIndex;
     }
 
     ReadView const& view = *lpLedger;
@@ -2783,7 +2783,7 @@ void NetworkOPsImp::getBookPage (
         {
             bDirectAdvance  = false;
 
-            JLOG(m_journal.trace) << "getBookPage: bDirectAdvance";
+            JLOG(m_journal.trace()) << "getBookPage: bDirectAdvance";
 
             auto const ledgerIndex = view.succ(uTipIndex, uBookEnd);
             if (ledgerIndex)
@@ -2793,7 +2793,7 @@ void NetworkOPsImp::getBookPage (
 
             if (!sleOfferDir)
             {
-                JLOG(m_journal.trace) << "getBookPage: bDone";
+                JLOG(m_journal.trace()) << "getBookPage: bDone";
                 bDone           = true;
             }
             else
@@ -2804,9 +2804,9 @@ void NetworkOPsImp::getBookPage (
                 cdirFirst (view,
                     uTipIndex, sleOfferDir, uBookEntry, offerIndex, viewJ);
 
-                JLOG(m_journal.trace)
+                JLOG(m_journal.trace())
                     << "getBookPage:   uTipIndex=" << uTipIndex;
-                JLOG(m_journal.trace)
+                JLOG(m_journal.trace())
                     << "getBookPage: offerIndex=" << offerIndex;
             }
         }
@@ -2930,7 +2930,7 @@ void NetworkOPsImp::getBookPage (
             }
             else
             {
-                JLOG(m_journal.warning) << "Missing offer";
+                JLOG(m_journal.warn()) << "Missing offer";
             }
 
             if (! cdirNext(view,
@@ -2940,7 +2940,7 @@ void NetworkOPsImp::getBookPage (
             }
             else
             {
-                JLOG(m_journal.trace)
+                JLOG(m_journal.trace())
                     << "getBookPage: offerIndex=" << offerIndex;
             }
         }

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -318,7 +318,7 @@ SHAMapStoreImp::run()
         if (validatedSeq >= lastRotated + setup_.deleteInterval
                 && canDelete_ >= lastRotated - 1)
         {
-            JLOG(journal_.debug) << "rotating  validatedSeq " << validatedSeq
+            JLOG(journal_.debug()) << "rotating  validatedSeq " << validatedSeq
                     << " lastRotated " << lastRotated << " deleteInterval "
                     << setup_.deleteInterval << " canDelete_ " << canDelete_;
 
@@ -352,7 +352,7 @@ SHAMapStoreImp::run()
                     false)->visitNodes (
                     std::bind (&SHAMapStoreImp::copyNode, this,
                     std::ref(nodeCount), std::placeholders::_1));
-            JLOG(journal_.debug) << "copied ledger " << validatedSeq
+            JLOG(journal_.debug()) << "copied ledger " << validatedSeq
                     << " nodecount " << nodeCount;
             switch (health())
             {
@@ -367,7 +367,7 @@ SHAMapStoreImp::run()
             }
 
             freshenCaches();
-            JLOG(journal_.debug) << validatedSeq << " freshened caches";
+            JLOG(journal_.debug()) << validatedSeq << " freshened caches";
             switch (health())
             {
                 case Health::stopping:
@@ -382,7 +382,7 @@ SHAMapStoreImp::run()
 
             std::shared_ptr <NodeStore::Backend> newBackend =
                     makeBackendRotating();
-            JLOG(journal_.debug) << validatedSeq << " new backend "
+            JLOG(journal_.debug()) << validatedSeq << " new backend "
                     << newBackend->getName();
             std::shared_ptr <NodeStore::Backend> oldBackend;
 
@@ -410,7 +410,7 @@ SHAMapStoreImp::run()
                 clearCaches (validatedSeq);
                 oldBackend = database_->rotateBackends (newBackend);
             }
-            JLOG(journal_.debug) << "finished rotation " << validatedSeq;
+            JLOG(journal_.debug()) << "finished rotation " << validatedSeq;
 
             oldBackend->setDeletePath();
         }
@@ -534,7 +534,7 @@ SHAMapStoreImp::clearSql (DatabaseCon& database,
 
     boost::format formattedDeleteQuery (deleteQuery);
 
-    JLOG(journal_.debug) <<
+    JLOG(journal_.debug()) <<
         "start: " << deleteQuery << " from " << min << " to " << lastRotated;
     while (min < lastRotated)
     {
@@ -549,7 +549,7 @@ SHAMapStoreImp::clearSql (DatabaseCon& database,
             std::this_thread::sleep_for (
                     std::chrono::milliseconds (setup_.backOff));
     }
-    JLOG(journal_.debug) << "finished: " << deleteQuery;
+    JLOG(journal_.debug()) << "finished: " << deleteQuery;
     return true;
 }
 
@@ -660,7 +660,7 @@ SHAMapStoreImp::clearPrior (LedgerIndex lastRotated)
                     std::to_string (deleteBatch) +
                 ");");
 
-            JLOG(journal_.debug) << "start: " << deleteQuery << " of "
+            JLOG(journal_.debug()) << "start: " << deleteQuery << " of "
                 << deleteBatch << " rows.";
             long long totalRowsAffected = 0;
             long long rowsAffected;
@@ -681,7 +681,7 @@ SHAMapStoreImp::clearPrior (LedgerIndex lastRotated)
                     totalRowsAffected += rowsAffected;
                     auto const ms = duration_cast<milliseconds>(
                         high_resolution_clock::now() - start).count();
-                    JLOG(journal_.trace) << "step: deleted " << rowsAffected
+                    JLOG(journal_.trace()) << "step: deleted " << rowsAffected
                         << " rows in " << ms << "ms.";
                 }
                 if (health())
@@ -691,7 +691,7 @@ SHAMapStoreImp::clearPrior (LedgerIndex lastRotated)
                         std::chrono::milliseconds(setup_.backOff));
             }
             while (rowsAffected && rowsAffected >= continueLimit);
-            JLOG(journal_.debug) << "finished: " << deleteQuery << ". Deleted "
+            JLOG(journal_.debug()) << "finished: " << deleteQuery << ". Deleted "
                 << totalRowsAffected << " rows.";
         }
     }
@@ -728,7 +728,7 @@ SHAMapStoreImp::health()
     auto age = ledgerMaster_->getValidatedLedgerAge();
     if (mode != NetworkOPs::omFULL || age.count() >= setup_.ageThreshold)
     {
-        JLOG(journal_.warning) << "Not deleting. state: " << mode
+        JLOG(journal_.warn()) << "Not deleting. state: " << mode
                                << " age " << age.count()
                                << " age threshold " << setup_.ageThreshold;
         healthy_ = false;

--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -96,7 +96,7 @@ private:
 
         if (!val->isTrusted ())
         {
-            JLOG (j_.trace) <<
+            JLOG (j_.trace()) <<
                 "Node " << toBase58 (TokenType::TOKEN_NODE_PUBLIC, signer) <<
                 " not in UNL st=" << val->getSignTime().time_since_epoch().count() <<
                 ", hash=" << val->getLedgerHash () <<
@@ -141,7 +141,7 @@ private:
             }
         }
 
-        JLOG (j_.debug) <<
+        JLOG (j_.debug()) <<
             "Val for " << hash <<
             " from " << toBase58 (TokenType::TOKEN_NODE_PUBLIC, signer) <<
             " added " << (val->isTrusted () ? "trusted/" : "UNtrusted/") <<
@@ -207,7 +207,7 @@ private:
 
                 if (isTrusted && currentOnly && ! current (it.second))
                 {
-                    JLOG (j_.trace) << "VC: Untrusted due to time " << ledger;
+                    JLOG (j_.trace()) << "VC: Untrusted due to time " << ledger;
                     isTrusted = false;
                 }
 
@@ -218,7 +218,7 @@ private:
             }
         }
 
-        JLOG (j_.trace) << "VC: " << ledger << "t:" << trusted << " u:" << untrusted;
+        JLOG (j_.trace()) << "VC: " << ledger << "t:" << trusted << " u:" << untrusted;
     }
 
     void getValidationTypes (uint256 const& ledger, int& full, int& partial) override
@@ -241,7 +241,7 @@ private:
             }
         }
 
-        JLOG (j_.trace) << "VC: " << ledger << "f:" << full << " p:" << partial;
+        JLOG (j_.trace()) << "VC: " << ledger << "f:" << full << " p:" << partial;
     }
 
     int getTrustedValidationCount (uint256 const& ledger) override
@@ -387,7 +387,7 @@ private:
                          (valPriorLedger && (it->second->getLedgerHash () == priorLedger))))
                 {
                     countPreferred = true;
-                    JLOG (j_.trace) << "Counting for " << currentLedger << " not " << it->second->getLedgerHash ();
+                    JLOG (j_.trace()) << "Counting for " << currentLedger << " not " << it->second->getLedgerHash ();
                 }
 
                 ValidationCounter& p = countPreferred ? ret[currentLedger] : ret[it->second->getLedgerHash ()];
@@ -424,7 +424,7 @@ private:
     {
         bool anyNew = false;
 
-        JLOG (j_.info) << "Flushing validations";
+        JLOG (j_.info()) << "Flushing validations";
         ScopedLockType sl (mLock);
         for (auto& it: mCurrentValidations)
         {
@@ -444,7 +444,7 @@ private:
             std::this_thread::sleep_for (std::chrono::milliseconds (100));
         }
 
-        JLOG (j_.debug) << "Validations flushed";
+        JLOG (j_.debug()) << "Validations flushed";
     }
 
     void condWrite ()

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -229,7 +229,7 @@ AmendmentTableImpl::AmendmentTableImpl (
     {
         if (auto s = add (a.first))
         {
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Amendment " << a.first << " is supported.";
 
             if (!a.second.empty ())
@@ -243,7 +243,7 @@ AmendmentTableImpl::AmendmentTableImpl (
     {
         if (auto s = add (a.first))
         {
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Amendment " << a.first << " is enabled.";
 
             if (!a.second.empty ())
@@ -259,7 +259,7 @@ AmendmentTableImpl::AmendmentTableImpl (
         // Unknown amendments are effectively vetoed already
         if (auto s = get (a.first))
         {
-            JLOG (j_.info) <<
+            JLOG (j_.info()) <<
                 "Amendment " << a.first << " is vetoed.";
 
             if (!a.second.empty ())
@@ -403,7 +403,7 @@ AmendmentTableImpl::doVoting (
     majorityAmendments_t const& majorityAmendments,
     ValidationSet const& valSet)
 {
-    JLOG (j_.trace) <<
+    JLOG (j_.trace()) <<
         "voting at " << closeTime.time_since_epoch().count() <<
         ": " << enabledAmendments.size() <<
         ", " << majorityAmendments.size() <<
@@ -432,7 +432,7 @@ AmendmentTableImpl::doVoting (
     vote->mThreshold = std::max(1,
         (vote->mTrustedValidations * majorityFraction_) / 256);
 
-    JLOG (j_.debug) <<
+    JLOG (j_.debug()) <<
         "Received " << vote->mTrustedValidations <<
         " trusted validations, threshold is: " << vote->mThreshold;
 
@@ -459,7 +459,7 @@ AmendmentTableImpl::doVoting (
 
             if (enabledAmendments.count (entry.first) != 0)
             {
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     entry.first << ": amendment already enabled";
             }
             else  if (hasValMajority &&
@@ -467,7 +467,7 @@ AmendmentTableImpl::doVoting (
                 ! entry.second.vetoed)
             {
                 // Ledger says no majority, validators say yes
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     entry.first << ": amendment got majority";
                 actions[entry.first] = tfGotMajority;
             }
@@ -475,7 +475,7 @@ AmendmentTableImpl::doVoting (
                 (majorityTime != NetClock::time_point{}))
             {
                 // Ledger says majority, validators say no
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     entry.first << ": amendment lost majority";
                 actions[entry.first] = tfLostMajority;
             }
@@ -484,7 +484,7 @@ AmendmentTableImpl::doVoting (
                 ! entry.second.vetoed)
             {
                 // Ledger says majority held
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     entry.first << ": amendment majority held";
                 actions[entry.first] = 0;
             }

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -98,7 +98,7 @@ FeeMetrics::updateFeeMetrics(Application& app,
     std::sort(feeLevels.begin(), feeLevels.end());
     auto const size = feeLevels.size();
 
-    JLOG(j_.debug) << "Ledger " << view.info().seq <<
+    JLOG(j_.debug()) << "Ledger " << view.info().seq <<
         " has " << size << " transactions. " <<
         "Ledgers are processing " <<
         (timeLeap ? "slowly" : "as expected") <<
@@ -137,7 +137,7 @@ FeeMetrics::updateFeeMetrics(Application& app,
         escalationMultiplier = std::max(escalationMultiplier,
             minimumMultiplier_);
     }
-    JLOG(j_.debug) << "Expected transactions updated to " <<
+    JLOG(j_.debug()) << "Expected transactions updated to " <<
         txnsExpected << " and multiplier updated to " <<
         escalationMultiplier;
 
@@ -375,7 +375,7 @@ TxQ::apply(Application& app, OpenView& view,
             auto requiredRetryLevel = mulDiv(
                 existingCandidate->feeLevel,
                 setup_.retrySequencePercent, 100).second;
-            JLOG(j_.trace) << "Found transaction in queue for account " <<
+            JLOG(j_.trace()) << "Found transaction in queue for account " <<
                 account << " with sequence number " << sequence <<
                 " new txn fee level is " << feeLevelPaid <<
                 ", old txn fee level is " <<
@@ -390,7 +390,7 @@ TxQ::apply(Application& app, OpenView& view,
                 // the prior txn could not get into the open ledger,
                 //  but this one can.
                 // Remove the queued transaction and continue
-                JLOG(j_.trace) <<
+                JLOG(j_.trace()) <<
                     "Removing transaction from queue " <<
                     existingCandidate->txID <<
                     " in favor of " << transactionID;
@@ -404,7 +404,7 @@ TxQ::apply(Application& app, OpenView& view,
             else
             {
                 // Drop the current transaction
-                JLOG(j_.trace) <<
+                JLOG(j_.trace()) <<
                     "Ignoring transaction " <<
                     transactionID <<
                     " in favor of queued " <<
@@ -414,7 +414,7 @@ TxQ::apply(Application& app, OpenView& view,
         }
     }
 
-    JLOG(j_.trace) << "Transaction " <<
+    JLOG(j_.trace()) << "Transaction " <<
         transactionID <<
         " from account " << account <<
         " has fee level of " << feeLevelPaid <<
@@ -427,7 +427,7 @@ TxQ::apply(Application& app, OpenView& view,
     {
         // Transaction fee is sufficient to go in open ledger immediately
 
-        JLOG(j_.trace) << "Applying transaction " <<
+        JLOG(j_.trace()) << "Applying transaction " <<
             transactionID <<
             " to open ledger.";
         ripple::TER txnResult;
@@ -435,7 +435,7 @@ TxQ::apply(Application& app, OpenView& view,
 
         std::tie(txnResult, didApply) = doApply(pcresult, app, view);
 
-        JLOG(j_.trace) << "Transaction " <<
+        JLOG(j_.trace()) << "Transaction " <<
             transactionID <<
                 (didApply ? " applied successfully with " :
                     " failed with ") <<
@@ -447,7 +447,7 @@ TxQ::apply(Application& app, OpenView& view,
     if (! canBeHeld(tx))
     {
         // Bail, transaction cannot be held
-        JLOG(j_.trace) << "Transaction " <<
+        JLOG(j_.trace()) << "Transaction " <<
             transactionID <<
             " can not be held";
         return { feeLevelPaid >= requiredFeeLevel ?
@@ -463,7 +463,7 @@ TxQ::apply(Application& app, OpenView& view,
         {
             // The queue is full, and this transaction is more
             // valuable, so kick out the cheapest transaction.
-            JLOG(j_.warning) <<
+            JLOG(j_.warn()) <<
                 "Removing end item from queue with fee of" <<
                 lastRIter->feeLevel << " in favor of " <<
                 transactionID << " with fee of " <<
@@ -472,7 +472,7 @@ TxQ::apply(Application& app, OpenView& view,
         }
         else
         {
-            JLOG(j_.warning) << "Queue is full, and transaction " <<
+            JLOG(j_.warn()) << "Queue is full, and transaction " <<
                 transactionID <<
                 " fee is lower than end item";
             return { telINSUF_FEE_P, false };
@@ -496,7 +496,7 @@ TxQ::apply(Application& app, OpenView& view,
     { tx, transactionID, feeLevelPaid, flags, pfresult });
     // Then index it into the byFee lookup.
     byFee_.insert(candidate);
-    JLOG(j_.debug) << "Added transaction " << candidate.txID <<
+    JLOG(j_.debug()) << "Added transaction " << candidate.txID <<
         " from " << op << " account " << candidate.account <<
         " to queue.";
 
@@ -584,7 +584,7 @@ TxQ::accept(Application& app,
     {
         auto const requiredFeeLevel = feeMetrics_.scaleFeeLevel(view);
         auto const feeLevelPaid = candidateIter->feeLevel;
-        JLOG(j_.trace) << "Queued transaction " <<
+        JLOG(j_.trace()) << "Queued transaction " <<
             candidateIter->txID << " from account " <<
             candidateIter->account << " has fee level of " <<
             feeLevelPaid << " needs at least " <<
@@ -593,7 +593,7 @@ TxQ::accept(Application& app,
         {
             auto firstTxn = candidateIter->txn;
 
-            JLOG(j_.trace) << "Applying queued transaction " <<
+            JLOG(j_.trace()) << "Applying queued transaction " <<
                 candidateIter->txID << " to open ledger.";
 
             // If the rules or flags change, preflight again
@@ -618,7 +618,7 @@ TxQ::accept(Application& app,
             if (didApply)
             {
                 // Remove the candidate from the queue
-                JLOG(j_.debug) << "Queued transaction " <<
+                JLOG(j_.debug()) << "Queued transaction " <<
                     candidateIter->txID <<
                     " applied successfully. Remove from queue.";
 
@@ -628,14 +628,14 @@ TxQ::accept(Application& app,
             else if (isTefFailure(txnResult) || isTemMalformed(txnResult) ||
                 isTelLocal(txnResult))
             {
-                JLOG(j_.debug) << "Queued transaction " <<
+                JLOG(j_.debug()) << "Queued transaction " <<
                     candidateIter->txID << " failed with " <<
                     transToken(txnResult) << ". Remove from queue.";
                 candidateIter = erase(candidateIter);
             }
             else
             {
-                JLOG(j_.debug) << "Transaction " <<
+                JLOG(j_.debug()) << "Transaction " <<
                     candidateIter->txID << " failed with " <<
                     transToken(txnResult) << ". Leave in queue.";
                 candidateIter++;

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -63,7 +63,7 @@ ValidatorList::insertEphemeralKey (
 
     if (permanent_.find (identity) != permanent_.end())
     {
-        JLOG (j_.error) <<
+        JLOG (j_.error()) <<
             toBase58 (TokenType::TOKEN_NODE_PUBLIC, identity) <<
             ": ephemeral key exists in permanent table!";
         return false;
@@ -89,7 +89,7 @@ ValidatorList::insertPermanentKey (
 
     if (ephemeral_.find (identity) != ephemeral_.end())
     {
-        JLOG (j_.error) <<
+        JLOG (j_.error()) <<
             toBase58 (TokenType::TOKEN_NODE_PUBLIC, identity) <<
             ": permanent key exists in ephemeral table!";
         return false;
@@ -141,21 +141,21 @@ ValidatorList::load (
         ")?"                      // end optional comment block
     );
 
-    JLOG (j_.debug) <<
+    JLOG (j_.debug()) <<
         "Loading configured validators";
 
     std::size_t count = 0;
 
     for (auto const& n : validators.values ())
     {
-        JLOG (j_.trace) <<
+        JLOG (j_.trace()) <<
             "Processing '" << n << "'";
 
         boost::smatch match;
 
         if (!boost::regex_match (n, match, re))
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "Malformed entry: '" << n << "'";
             return false;
         }
@@ -165,14 +165,14 @@ ValidatorList::load (
 
         if (!id)
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "Invalid node identity: " << match[1];
             return false;
         }
 
         if (trusted (*id))
         {
-            JLOG (j_.warning) <<
+            JLOG (j_.warn()) <<
                 "Duplicate node identity: " << match[1];
             continue;
         }
@@ -181,7 +181,7 @@ ValidatorList::load (
             ++count;
     }
 
-    JLOG (j_.debug) <<
+    JLOG (j_.debug()) <<
         "Loaded " << count << " entries";
 
     return true;

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -72,7 +72,7 @@ void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
     bool newRequests = app_.getLedgerMaster().isNewPathRequest();
     bool mustBreak = false;
 
-    JLOG (mJournal.trace) <<
+    JLOG (mJournal.trace()) <<
         "updateAll seq=" << cache->getLedger()->seq() <<
         ", " << requests.size() << " requests";
 
@@ -176,7 +176,7 @@ void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
     }
     while (!shouldCancel ());
 
-    JLOG (mJournal.debug) <<
+    JLOG (mJournal.debug()) <<
         "updateAll complete: " << processed << " processed and " <<
         removed << " removed";
 }

--- a/src/ripple/app/paths/PathState.cpp
+++ b/src/ripple/app/paths/PathState.cpp
@@ -55,7 +55,7 @@ void PathState::reset(STAmount const& in, STAmount const& out)
 
     if (inReq() > zero && inAct() >= inReq())
     {
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             <<  "rippleCalc: DONE:"
             << " inAct()=" << inAct()
             << " inReq()=" << inReq();
@@ -66,7 +66,7 @@ void PathState::reset(STAmount const& in, STAmount const& out)
 
     if (outAct() >= outReq())
     {
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             << "rippleCalc: ALREADY DONE:"
             << " saOutAct=" << outAct()
             << " saOutReq=" << outReq();
@@ -113,7 +113,7 @@ TER PathState::pushImpliedNodes (
 {
     TER resultCode = tesSUCCESS;
 
-     JLOG (j_.trace) << "pushImpliedNodes>" <<
+     JLOG (j_.trace()) << "pushImpliedNodes>" <<
          " " << account <<
          " " << currency <<
          " " << issuer;
@@ -152,7 +152,7 @@ TER PathState::pushImpliedNodes (
             STPathElement::typeAll, issuer, currency, issuer);
     }
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "pushImpliedNodes< : " << transToken (resultCode);
 
     return resultCode;
@@ -190,7 +190,7 @@ TER PathState::pushNode (
 
     TER resultCode = tesSUCCESS;
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
          << "pushNode> " << iType << ": "
          << (hasAccount ? to_string(account) : std::string("-")) << " "
          << (hasCurrency ? to_string(currency) : std::string("-")) << "/"
@@ -206,18 +206,18 @@ TER PathState::pushNode (
     if (iType & ~STPathElement::typeAll)
     {
         // Of course, this could never happen.
-        JLOG (j_.debug) << "pushNode: bad bits.";
+        JLOG (j_.debug()) << "pushNode: bad bits.";
         resultCode = temBAD_PATH;
     }
     else if (hasIssuer && isXRP (node.issue_))
     {
-        JLOG (j_.debug) << "pushNode: issuer specified for XRP.";
+        JLOG (j_.debug()) << "pushNode: issuer specified for XRP.";
 
         resultCode = temBAD_PATH;
     }
     else if (hasIssuer && !issuer)
     {
-        JLOG (j_.debug) << "pushNode: specified bad issuer.";
+        JLOG (j_.debug()) << "pushNode: specified bad issuer.";
 
         resultCode = temBAD_PATH;
     }
@@ -225,7 +225,7 @@ TER PathState::pushNode (
     {
         // You can't default everything to the previous node as you would make
         // no progress.
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "pushNode: offer must specify at least currency or issuer.";
         resultCode = temBAD_PATH;
     }
@@ -249,14 +249,14 @@ TER PathState::pushNode (
         }
         else if (!account)
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "pushNode: specified bad account.";
             resultCode = temBAD_PATH;
         }
         else
         {
             // Add required intermediate nodes to deliver to current account.
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "pushNode: imply for account.";
 
             resultCode = pushImpliedNodes (
@@ -279,18 +279,18 @@ TER PathState::pushNode (
                 // specific currency.
                 if (!sleRippleState)
                 {
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                             << "pushNode: No credit line between "
                             << backNode.account_ << " and " << node.account_
                             << " for " << node.issue_.currency << "." ;
 
-                    JLOG (j_.trace) << getJson ();
+                    JLOG (j_.trace()) << getJson ();
 
                     resultCode   = terNO_LINE;
                 }
                 else
                 {
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                             << "pushNode: Credit line found between "
                             << backNode.account_ << " and " << node.account_
                             << " for " << node.issue_.currency << "." ;
@@ -302,7 +302,7 @@ TER PathState::pushNode (
 
                     if (!sleBck)
                     {
-                        JLOG (j_.warning)
+                        JLOG (j_.warn())
                             << "pushNode: delay: can't receive IOUs from "
                             << "non-existent issuer: " << backNode.account_;
 
@@ -313,7 +313,7 @@ TER PathState::pushNode (
                                   (bHigh ? lsfHighAuth : lsfLowAuth)) &&
                              sleRippleState->getFieldAmount(sfBalance) == zero)
                     {
-                        JLOG (j_.warning)
+                        JLOG (j_.warn())
                                 << "pushNode: delay: can't receive IOUs from "
                                 << "issuer without auth.";
 
@@ -335,7 +335,7 @@ TER PathState::pushNode (
                                 node.issue_.currency);
                             if (-saOwed >= saLimit)
                             {
-                                JLOG (j_.debug) <<
+                                JLOG (j_.debug()) <<
                                     "pushNode: dry:" <<
                                     " saOwed=" << saOwed <<
                                     " saLimit=" << saLimit;
@@ -372,19 +372,19 @@ TER PathState::pushNode (
 
         if (!isConsistent (node.issue_))
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "pushNode: currency is inconsistent with issuer.";
 
             resultCode = temBAD_PATH;
         }
         else if (backNode.issue_ == node.issue_)
         {
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "pushNode: bad path: offer to same currency and issuer";
             resultCode = temBAD_PATH;
         }
         else {
-            JLOG (j_.trace) << "pushNode: imply for offer.";
+            JLOG (j_.trace()) << "pushNode: imply for offer.";
 
             // Insert intermediary issuer account if needed.
             resultCode   = pushImpliedNodes (
@@ -397,7 +397,7 @@ TER PathState::pushNode (
             nodes_.push_back (node);
     }
 
-    JLOG (j_.trace) << "pushNode< : " << transToken (resultCode);
+    JLOG (j_.trace()) << "pushNode< : " << transToken (resultCode);
     return resultCode;
 }
 
@@ -433,7 +433,7 @@ TER PathState::expandPath (
         = isXRP(uMaxCurrencyID) ? xrpAccount() : uSenderID;
     // Sender is always issuer for non-XRP.
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "expandPath> " << spSourcePath.getJson (0);
 
     terStatus = tesSUCCESS;
@@ -442,7 +442,7 @@ TER PathState::expandPath (
     if ((isXRP (uMaxCurrencyID) && !isXRP (uMaxIssuerID))
         || (isXRP (currencyOutID) && !isXRP (issuerOutID)))
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "expandPath> issuer with XRP";
         terStatus   = temBAD_PATH;
     }
@@ -463,7 +463,7 @@ TER PathState::expandPath (
             uSenderIssuerID);
     }
 
-    JLOG (j_.debug)
+    JLOG (j_.debug())
         << "expandPath: pushed:"
         << " account=" << uSenderID
         << " currency=" << uMaxCurrencyID
@@ -492,7 +492,7 @@ TER PathState::expandPath (
                 : AccountID(issuerOutID)                      // Use implied node.
                 : xrpAccount();
 
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "expandPath: implied check:"
             << " uMaxIssuerID=" << uMaxIssuerID
             << " uSenderIssuerID=" << uSenderIssuerID
@@ -508,7 +508,7 @@ TER PathState::expandPath (
             || uMaxIssuerID != nextAccountID)
             // Next is not implied issuer
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "expandPath: sender implied:"
                 << " account=" << uMaxIssuerID
                 << " currency=" << uMaxCurrencyID
@@ -530,7 +530,7 @@ TER PathState::expandPath (
     {
         if (terStatus == tesSUCCESS)
         {
-            JLOG (j_.trace) << "expandPath: element in path";
+            JLOG (j_.trace()) << "expandPath: element in path";
             terStatus = pushNode (
                 speElement.getNodeType (), speElement.getAccountID (),
                 speElement.getCurrency (), speElement.getIssuerID ());
@@ -549,7 +549,7 @@ TER PathState::expandPath (
             || backNode.account_ != issuerOutID)       // Need implied issuer
         {
             // Add implied account.
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "expandPath: receiver implied:"
                 << " account=" << issuerOutID
                 << " currency=" << currencyOutID
@@ -592,7 +592,7 @@ TER PathState::expandPath (
             if (!umForward.insert ({accountIssue, index++}).second)
             {
                 // Failed to insert. Have a loop.
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     "expandPath: loop detected: " << getJson ();
 
                 terStatus = temBAD_PATH_LOOP;
@@ -601,7 +601,7 @@ TER PathState::expandPath (
         }
     }
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "expandPath:"
         << " in=" << uMaxCurrencyID
         << "/" << uMaxIssuerID
@@ -697,7 +697,7 @@ TER PathState::checkNoRipple (
         sleOut->getFieldU32 (sfFlags) &
             ((secondAccount > thirdAccount) ? lsfHighNoRipple : lsfLowNoRipple))
     {
-        JLOG (j_.info)
+        JLOG (j_.info())
             << "Path violates noRipple constraint between "
             << firstAccount << ", "
             << secondAccount << " and "

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -179,7 +179,7 @@ bool Pathfinder::findPaths (int searchLevel)
     if (mDstAmount == zero)
     {
         // No need to send zero money.
-        JLOG (j_.debug) << "Destination amount was zero.";
+        JLOG (j_.debug()) << "Destination amount was zero.";
         mLedger.reset ();
         return false;
 
@@ -192,7 +192,7 @@ bool Pathfinder::findPaths (int searchLevel)
         mSrcCurrency == mDstAmount.getCurrency ())
     {
         // No need to send to same account with same currency.
-        JLOG (j_.debug) << "Tried to send to same issuer";
+        JLOG (j_.debug()) << "Tried to send to same issuer";
         mLedger.reset ();
         return false;
     }
@@ -215,7 +215,7 @@ bool Pathfinder::findPaths (int searchLevel)
     mSource = STPathElement (account, mSrcCurrency, issuer);
     auto issuerString = mSrcIssuer
             ? to_string (*mSrcIssuer) : std::string ("none");
-    JLOG (j_.trace)
+    JLOG (j_.trace())
             << "findPaths>"
             << " mSrcAccount=" << mSrcAccount
             << " mDstAccount=" << mDstAccount
@@ -225,7 +225,7 @@ bool Pathfinder::findPaths (int searchLevel)
 
     if (!mLedger)
     {
-        JLOG (j_.debug) << "findPaths< no ledger";
+        JLOG (j_.debug()) << "findPaths< no ledger";
         return false;
     }
 
@@ -235,14 +235,14 @@ bool Pathfinder::findPaths (int searchLevel)
     if (! mLedger->exists (keylet::account(mSrcAccount)))
     {
         // We can't even start without a source account.
-        JLOG (j_.debug) << "invalid source account";
+        JLOG (j_.debug()) << "invalid source account";
         return false;
     }
 
     if ((mEffectiveDst != mDstAccount) &&
         ! mLedger->exists (keylet::account(mEffectiveDst)))
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "Non-existent gateway";
         return false;
     }
@@ -253,7 +253,7 @@ bool Pathfinder::findPaths (int searchLevel)
         // account.
         if (!bDstXrp)
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                     << "New account not being funded in XRP ";
             return false;
         }
@@ -261,7 +261,7 @@ bool Pathfinder::findPaths (int searchLevel)
         auto const reserve = STAmount (mLedger->fees().accountReserve (0));
         if (mDstAmount < reserve)
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                     << "New account not getting enough funding: "
                     << mDstAmount << " < " << reserve;
             return false;
@@ -274,31 +274,31 @@ bool Pathfinder::findPaths (int searchLevel)
     if (bSrcXrp && bDstXrp)
     {
         // XRP -> XRP
-        JLOG (j_.debug) << "XRP to XRP payment";
+        JLOG (j_.debug()) << "XRP to XRP payment";
         paymentType = pt_XRP_to_XRP;
     }
     else if (bSrcXrp)
     {
         // XRP -> non-XRP
-        JLOG (j_.debug) << "XRP to non-XRP payment";
+        JLOG (j_.debug()) << "XRP to non-XRP payment";
         paymentType = pt_XRP_to_nonXRP;
     }
     else if (bDstXrp)
     {
         // non-XRP -> XRP
-        JLOG (j_.debug) << "non-XRP to XRP payment";
+        JLOG (j_.debug()) << "non-XRP to XRP payment";
         paymentType = pt_nonXRP_to_XRP;
     }
     else if (mSrcCurrency == mDstAmount.getCurrency ())
     {
         // non-XRP -> non-XRP - Same currency
-        JLOG (j_.debug) << "non-XRP to non-XRP - same currency";
+        JLOG (j_.debug()) << "non-XRP to non-XRP - same currency";
         paymentType = pt_nonXRP_to_same;
     }
     else
     {
         // non-XRP to non-XRP - Different currency
-        JLOG (j_.debug) << "non-XRP to non-XRP - cross currency";
+        JLOG (j_.debug()) << "non-XRP to non-XRP - cross currency";
         paymentType = pt_nonXRP_to_nonXRP;
     }
 
@@ -317,7 +317,7 @@ bool Pathfinder::findPaths (int searchLevel)
         }
     }
 
-    JLOG (j_.debug)
+    JLOG (j_.debug())
             << mCompletePaths.size () << " complete paths found";
 
     // Even if we find no paths, default paths may work, and we don't check them
@@ -385,7 +385,7 @@ TER Pathfinder::getPathLiquidity (
     }
     catch (std::exception const& e)
     {
-        JLOG (j_.info) <<
+        JLOG (j_.info()) <<
             "checkpath: exception (" << e.what() << ") " <<
             path.getJson (0);
         return tefEXCEPTION;
@@ -429,19 +429,19 @@ void Pathfinder::computePathRanks (int maxPaths)
 
         if (rc.result () == tesSUCCESS)
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                     << "Default path contributes: " << rc.actualAmountIn;
             mRemainingAmount -= rc.actualAmountOut;
         }
         else
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "Default path fails: " << transToken (rc.result ());
         }
     }
     catch (std::exception const&)
     {
-        JLOG (j_.debug) << "Default path causes exception";
+        JLOG (j_.debug()) << "Default path causes exception";
     }
 
     rankPaths (maxPaths, mCompletePaths, mPathRanks);
@@ -513,14 +513,14 @@ void Pathfinder::rankPaths (
                 currentPath, saMinDstAmount, liquidity, uQuality);
             if (resultCode != tesSUCCESS)
             {
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     "findPaths: dropping : " <<
                     transToken (resultCode) <<
                     ": " << currentPath.getJson (0);
             }
             else
             {
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     "findPaths: quality: " << uQuality <<
                     ": " << currentPath.getJson (0);
 
@@ -562,7 +562,7 @@ Pathfinder::getBestPaths (
     STPathSet const& extraPaths,
     AccountID const& srcIssuer)
 {
-    JLOG (j_.debug) << "findPaths: " <<
+    JLOG (j_.debug()) << "findPaths: " <<
         mCompletePaths.size() << " paths and " <<
         extraPaths.size () << " extras";
 
@@ -659,12 +659,12 @@ Pathfinder::getBestPaths (
         {
             // We found an extra path that can move the whole amount.
             fullLiquidityPath = (startsWithIssuer ? removeIssuer (path) : path);
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Found extra full path: " << fullLiquidityPath.getJson (0);
         }
         else
         {
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Skipping a non-filling path: " << path.getJson (0);
         }
     }
@@ -672,12 +672,12 @@ Pathfinder::getBestPaths (
     if (remaining > zero)
     {
         assert (fullLiquidityPath.empty ());
-        JLOG (j_.info) <<
+        JLOG (j_.info()) <<
             "Paths could not send " << remaining << " of " << mDstAmount;
     }
     else
     {
-        JLOG (j_.debug) <<
+        JLOG (j_.debug()) <<
             "findPaths: RESULTS: " << bestPaths.getJson (0);
     }
     return bestPaths;
@@ -764,7 +764,7 @@ void Pathfinder::addLinks (
     STPathSet& incompletePaths,     // The set of partial paths we add to
     int addFlags)
 {
-    JLOG (j_.debug)
+    JLOG (j_.debug())
         << "addLink< on " << currentPaths.size ()
         << " source(s), flags=" << addFlags;
     for (auto const& path: currentPaths)
@@ -790,7 +790,7 @@ STPathSet& Pathfinder::addPathsForType (PathType const& pathType)
     STPathSet const& parentPaths = addPathsForType (parentPathType);
     STPathSet& pathsOut = mPaths[pathType];
 
-    JLOG (j_.debug)
+    JLOG (j_.debug())
         << "getPaths< adding onto '"
         << pathTypeToString (parentPathType) << "' to get '"
         << pathTypeToString (pathType) << "'";
@@ -833,12 +833,12 @@ STPathSet& Pathfinder::addPathsForType (PathType const& pathType)
 
     if (mCompletePaths.size () != initialSize)
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << (mCompletePaths.size () - initialSize)
             << " complete paths added";
     }
 
-    JLOG (j_.debug)
+    JLOG (j_.debug())
         << "getPaths> " << pathsOut.size () << " partial paths found";
     return pathsOut;
 }
@@ -908,9 +908,9 @@ void Pathfinder::addLink (
     // rather than the ultimate destination?
     bool const hasEffectiveDestination = mEffectiveDst != mDstAccount;
 
-    JLOG (j_.trace) << "addLink< flags="
+    JLOG (j_.trace()) << "addLink< flags="
                                    << addFlags << " onXRP=" << bOnXRP;
-    JLOG (j_.trace) << currentPath.getJson (0);
+    JLOG (j_.trace()) << currentPath.getJson (0);
 
     if (addFlags & afADD_ACCOUNTS)
     {
@@ -919,7 +919,7 @@ void Pathfinder::addLink (
         {
             if (mDstAmount.native () && !currentPath.empty ())
             { // non-default path to XRP destination
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "complete path found ax: " << currentPath.getJson(0);
                 addUniquePath (mCompletePaths, currentPath);
             }
@@ -950,7 +950,7 @@ void Pathfinder::addLink (
                     auto* rs = dynamic_cast<RippleState const *> (item.get ());
                     if (!rs)
                     {
-                        JLOG (j_.error)
+                        JLOG (j_.error())
                                 << "Couldn't decipher RippleState";
                         continue;
                     }
@@ -992,7 +992,7 @@ void Pathfinder::addLink (
                                 // this is a complete path
                                 if (!currentPath.empty ())
                                 {
-                                    JLOG (j_.trace)
+                                    JLOG (j_.trace())
                                             << "complete path found ae: "
                                             << currentPath.getJson (0);
                                     addUniquePath
@@ -1056,7 +1056,7 @@ void Pathfinder::addLink (
             }
             else
             {
-                JLOG (j_.warning)
+                JLOG (j_.warn())
                     << "Path ends on non-existent issuer";
             }
         }
@@ -1083,7 +1083,7 @@ void Pathfinder::addLink (
             bool bDestOnly = (addFlags & afOB_LAST) != 0;
             auto books = app_.getOrderBookDB ().getBooksByTakerPays(
                 {uEndCurrency, uEndIssuer});
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << books.size () << " books found from this currency/issuer";
 
             for (auto const& book : books)
@@ -1112,7 +1112,7 @@ void Pathfinder::addLink (
                         {
                             // destination is XRP, add account and path is
                             // complete
-                            JLOG (j_.trace)
+                            JLOG (j_.trace())
                                 << "complete path found bx: "
                                 << currentPath.getJson(0);
                             addUniquePath (mCompletePaths, newPath);
@@ -1155,7 +1155,7 @@ void Pathfinder::addLink (
                         else if (book->getIssuerOut() == mEffectiveDst &&
                             book->getCurrencyOut() == mDstAmount.getCurrency())
                         { // with the destination account, this path is complete
-                            JLOG (j_.trace)
+                            JLOG (j_.trace())
                                 << "complete path found ba: "
                                 << currentPath.getJson(0);
                             addUniquePath (mCompletePaths, newPath);

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -117,7 +117,7 @@ bool RippleCalc::addPathState(STPath const& path, TER& resultCode)
 
     pathState->setIndex (pathStateList_.size ());
 
-    JLOG (j_.debug)
+    JLOG (j_.debug())
         << "rippleCalc: Build direct:"
         << " status: " << transToken (pathState->status());
 
@@ -147,7 +147,7 @@ bool RippleCalc::addPathState(STPath const& path, TER& resultCode)
 // <-- TER: Only returns tepPATH_PARTIAL if partialPaymentAllowed.
 TER RippleCalc::rippleCalculate ()
 {
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "rippleCalc>"
         << " saMaxAmountReq_:" << saMaxAmountReq_
         << " saDstAmountReq_:" << saDstAmountReq_;
@@ -166,7 +166,7 @@ TER RippleCalc::rippleCalculate ()
     }
     else if (spsPaths_.empty ())
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "rippleCalc: Invalid transaction:"
             << "No paths and direct ripple not allowed.";
 
@@ -177,7 +177,7 @@ TER RippleCalc::rippleCalculate ()
     // nodes.
     // XXX Might also make a XRP bridge by default.
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "rippleCalc: Paths in set: " << spsPaths_.size ();
 
     // Now expand the path state.
@@ -230,7 +230,7 @@ TER RippleCalc::rippleCalculate ()
                 pc.nextIncrement ();
 
                 // Compute increment.
-                JLOG (j_.debug)
+                JLOG (j_.debug())
                     << "rippleCalc: AFTER:"
                     << " mIndex=" << pathState->index()
                     << " uQuality=" << pathState->quality()
@@ -247,7 +247,7 @@ TER RippleCalc::rippleCalculate ()
                     // Path is not dry, but moved no funds
                     // This should never happen. Consider the path dry
 
-                    JLOG (j_.warning)
+                    JLOG (j_.warn())
                         << "rippleCalc: Non-dry path moves no funds";
 
                     assert (false);
@@ -259,7 +259,7 @@ TER RippleCalc::rippleCalculate ()
                 {
                     if (!pathState->inPass() || !pathState->outPass())
                     {
-                        JLOG (j_.debug)
+                        JLOG (j_.debug())
                             << "rippleCalc: better:"
                             << " uQuality="
                             << amountFromRate (pathState->quality())
@@ -279,7 +279,7 @@ TER RippleCalc::rippleCalculate ()
                                 *pathStateList_[iBest], *pathState)))
                         // Current is better than set.
                     {
-                        JLOG (j_.debug)
+                        JLOG (j_.debug())
                             << "rippleCalc: better:"
                             << " mIndex=" << pathState->index()
                             << " uQuality=" << pathState->quality()
@@ -296,16 +296,16 @@ TER RippleCalc::rippleCalculate ()
 
         ++iPass;
 
-        if (j_.debug)
+        if (auto stream = j_.debug())
         {
-            j_.debug
+            stream
                 << "rippleCalc: Summary:"
                 << " Pass: " << iPass
                 << " Dry: " << iDry
                 << " Paths: " << pathStateList_.size ();
             for (auto pathState: pathStateList_)
             {
-                j_.debug
+                stream
                     << "rippleCalc: "
                     << "Summary: " << pathState->index()
                     << " rate: "
@@ -320,7 +320,7 @@ TER RippleCalc::rippleCalculate ()
             // Apply best path.
             auto pathState = pathStateList_[iBest];
 
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "rippleCalc: best:"
                 << " uQuality="
                 << amountFromRate (pathState->quality())
@@ -354,7 +354,7 @@ TER RippleCalc::rippleCalculate ()
             }
             else if (actualAmountOut_ > saDstAmountReq_)
             {
-                JLOG (j_.fatal)
+                JLOG (j_.fatal())
                     << "rippleCalc: TOO MUCH:"
                     << " actualAmountOut_:" << actualAmountOut_
                     << " saDstAmountReq_:" << saDstAmountReq_;
@@ -376,7 +376,7 @@ TER RippleCalc::rippleCalculate ()
                 {
                     // This payment is taking too many passes
 
-                    JLOG (j_.error)
+                    JLOG (j_.error())
                        << "rippleCalc: pass limit";
 
                     resultCode = telFAILED_PROCESSING;

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -46,7 +46,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
 
     // Taker is the active party against an offer in the ledger - the entity
     // that is taking advantage of an offer in the order book.
-    JLOG (j_.trace)
+    JLOG (j_.trace())
             << "advanceNode: TakerPays:"
             << node().saTakerPays << " TakerGets:" << node().saTakerGets;
 
@@ -63,7 +63,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
         //
         if (++loopCount > NODE_ADVANCE_MAX_LOOPS)
         {
-            JLOG (j_.warning) << "Loop count exceeded";
+            JLOG (j_.warn()) << "Loop count exceeded";
             return tefEXCEPTION;
         }
 
@@ -78,13 +78,13 @@ TER PathCursor::advanceNode (bool const bReverse) const
             {
                 // We didn't run off the end of this order book and found
                 // another quality directory.
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "advanceNode: Quality advance: node.directory.current="
                     << node().directory.current;
             }
             else if (bReverse)
             {
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "advanceNode: No more offers.";
 
                 node().offerIndex_ = 0;
@@ -94,7 +94,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
             {
                 // No more offers. Should be done rather than fall off end of
                 // book.
-                JLOG (j_.warning)
+                JLOG (j_.warn())
                     << "advanceNode: Unreachable: "
                     << "Fell off end of order book.";
                 // FIXME: why?
@@ -112,7 +112,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
             node().uEntry = 0;
             node().bEntryAdvance   = true;
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "advanceNode: directory dirty: node.saOfrRate="
                 << node().saOfrRate;
         }
@@ -135,13 +135,13 @@ TER PathCursor::advanceNode (bool const bReverse) const
                     fhZERO_IF_FROZEN, viewJ);
                 node().bFundsDirty = false;
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "advanceNode: funds dirty: node().saOfrRate="
                     << node().saOfrRate;
             }
             else
             {
-                JLOG (j_.trace) << "advanceNode: as is";
+                JLOG (j_.trace()) << "advanceNode: as is";
             }
         }
         else if (!dirNext (view(),
@@ -157,7 +157,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
             {
                 // We are allowed to process multiple qualities if this is the
                 // only path.
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "advanceNode: next quality";
                 node().directory.advanceNeeded  = true;  // Process next quality.
             }
@@ -167,7 +167,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                 // going forwards - this should be impossible!
                 // TODO(tom): these warnings occur in production!  They
                 // shouldn't.
-                JLOG (j_.warning)
+                JLOG (j_.warn())
                     << "advanceNode: unreachable: ran out of offers";
                 return telFAILED_PROCESSING;
             }
@@ -187,7 +187,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
             {
                 // Corrupt directory that points to an entry that doesn't exist.
                 // This has happened in production.
-                JLOG (j_.warning) <<
+                JLOG (j_.warn()) <<
                     "Missing offer in directory";
                 node().bEntryAdvance = true;
             }
@@ -203,7 +203,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                 AccountIssue const accountIssue (
                     node().offerOwnerAccount_, node().issue_);
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "advanceNode: offerOwnerAccount_="
                     << to_string (node().offerOwnerAccount_)
                     << " node.saTakerPays=" << node().saTakerPays
@@ -215,7 +215,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                             view().parentCloseTime().time_since_epoch().count()))
                 {
                     // Offer is expired.
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                         << "advanceNode: expired offer";
                     rippleCalc_.permanentlyUnfundedOffers_.insert(
                         node().offerIndex_);
@@ -231,7 +231,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                     {
                         // Past internal error, offer had bad amounts.
                         // This has occurred in production.
-                        JLOG (j_.warning)
+                        JLOG (j_.warn())
                             << "advanceNode: PAST INTERNAL ERROR"
                             << " REVERSE: OFFER NON-POSITIVE:"
                             << " node.saTakerPays=" << node().saTakerPays
@@ -247,7 +247,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                         // Past internal error, offer was found failed to place
                         // this in permanentlyUnfundedOffers_.
                         // Just skip it. It will be deleted.
-                        JLOG (j_.debug)
+                        JLOG (j_.debug())
                             << "advanceNode: PAST INTERNAL ERROR "
                             << " FORWARD CONFIRM: OFFER NON-POSITIVE:"
                             << " node.saTakerPays=" << node().saTakerPays
@@ -258,7 +258,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                     {
                         // Reverse should have previously put bad offer in list.
                         // An internal error previously left a bad offer.
-                        JLOG (j_.warning)
+                        JLOG (j_.warn())
                             << "advanceNode: INTERNAL ERROR"
 
                             <<" FORWARD NEWLY FOUND: OFFER NON-POSITIVE:"
@@ -295,7 +295,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                 {
                     // Temporarily unfunded. Another node uses this source,
                     // ignore in this offer.
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                         << "advanceNode: temporarily unfunded offer"
                         << " (forward)";
                     continue;
@@ -315,7 +315,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                 {
                     // Temporarily unfunded. Another node uses this source,
                     // ignore in this offer.
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                         << "advanceNode: temporarily unfunded offer"
                         <<" (reverse)";
                     continue;
@@ -337,7 +337,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                 if (node().saOfferFunds <= zero)
                 {
                     // Offer is unfunded.
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                         << "advanceNode: unfunded offer";
 
                     if (bReverse && !bFoundReverse && !bFoundPast)
@@ -363,7 +363,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                     && !bFoundReverse)  // New to pass.
                 {
                     // Consider source mentioned by current path state.
-                    JLOG (j_.trace)
+                    JLOG (j_.trace())
                         << "advanceNode: remember="
                         <<  node().offerOwnerAccount_
                         << "/"
@@ -382,12 +382,12 @@ TER PathCursor::advanceNode (bool const bReverse) const
 
     if (resultCode == tesSUCCESS)
     {
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "advanceNode: node.offerIndex_=" << node().offerIndex_;
     }
     else
     {
-        JLOG (j_.debug)
+        JLOG (j_.debug())
             << "advanceNode: resultCode=" << transToken (resultCode);
     }
 

--- a/src/ripple/app/paths/cursor/DeliverNodeForward.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeForward.cpp
@@ -59,7 +59,7 @@ TER PathCursor::deliverNodeForward (
                 CALC_NODE_DELIVER_MAX_LOOPS_MQ :
                 CALC_NODE_DELIVER_MAX_LOOPS))
         {
-            JLOG (j_.warning)
+            JLOG (j_.warn())
                 << "deliverNodeForward: max loops cndf";
             return telFAILED_PROCESSING;
         }
@@ -75,7 +75,7 @@ TER PathCursor::deliverNodeForward (
         }
         else if (!node().offerIndex_)
         {
-            JLOG (j_.warning)
+            JLOG (j_.warn())
                 << "deliverNodeForward: INTERNAL ERROR: Ran out of offers.";
             return telFAILED_PROCESSING;
         }
@@ -138,7 +138,7 @@ TER PathCursor::deliverNodeForward (
             // Will be determined by adjusted saInPassAct.
             STAmount saInPassFees;
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeForward:"
                 << " nodeIndex_=" << nodeIndex_
                 << " saOutFunded=" << saOutFunded
@@ -157,7 +157,7 @@ TER PathCursor::deliverNodeForward (
             // FIXME: We remove an offer if WE didn't want anything out of it?
             if (!node().saTakerPays || saInSum <= zero)
             {
-                JLOG (j_.debug)
+                JLOG (j_.debug())
                     << "deliverNodeForward: Microscopic offer unfunded.";
 
                 // After math offer is effectively unfunded.
@@ -169,7 +169,7 @@ TER PathCursor::deliverNodeForward (
             if (!saInFunded)
             {
                 // Previous check should catch this.
-                JLOG (j_.warning)
+                JLOG (j_.warn())
                     << "deliverNodeForward: UNREACHABLE REACHED";
 
                 // After math offer is effectively unfunded.
@@ -188,7 +188,7 @@ TER PathCursor::deliverNodeForward (
                 saOutPassAct = saOutPassMax;
                 saInPassFees = saInPassFeesMax;
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "deliverNodeForward: ? --> OFFER --> account:"
                     << " offerOwnerAccount_="
                     << node().offerOwnerAccount_
@@ -262,13 +262,13 @@ TER PathCursor::deliverNodeForward (
                     outPassTotal,
                     viewJ);
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "deliverNodeForward: ? --> OFFER --> offer:"
                     << " saOutPassAct=" << saOutPassAct
                     << " saOutPassFees=" << saOutPassFees;
             }
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeForward: "
                 << " nodeIndex_=" << nodeIndex_
                 << " node().saTakerGets=" << node().saTakerGets
@@ -310,7 +310,7 @@ TER PathCursor::deliverNodeForward (
 
             if (saTakerPaysNew < zero || saTakerGetsNew < zero)
             {
-                JLOG (j_.warning)
+                JLOG (j_.warn())
                     << "deliverNodeForward: NEGATIVE:"
                     << " saTakerPaysNew=" << saTakerPaysNew
                     << " saTakerGetsNew=" << saTakerGetsNew;
@@ -328,7 +328,7 @@ TER PathCursor::deliverNodeForward (
             {
                 // Offer became unfunded.
 
-                JLOG (j_.debug)
+                JLOG (j_.debug())
                     << "deliverNodeForward: unfunded:"
                     << " saOutPassAct=" << saOutPassAct
                     << " saOutFunded=" << saOutFunded;
@@ -340,7 +340,7 @@ TER PathCursor::deliverNodeForward (
             {
                 if (saOutPassAct >= saOutFunded)
                 {
-                    JLOG (j_.warning)
+                    JLOG (j_.warn())
                         << "deliverNodeForward: TOO MUCH:"
                         << " saOutPassAct=" << saOutPassAct
                         << " saOutFunded=" << saOutFunded;
@@ -358,7 +358,7 @@ TER PathCursor::deliverNodeForward (
         }
     }
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "deliverNodeForward<"
         << " nodeIndex_=" << nodeIndex_
         << " saInAct=" << saInAct

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -50,7 +50,7 @@ TER PathCursor::deliverNodeReverseImpl (
     // only on first increment, then it could be a limit on the forward pass.
     saOutAct.clear (saOutReq);
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "deliverNodeReverse>"
         << " saOutAct=" << saOutAct
         << " saOutReq=" << saOutReq
@@ -69,7 +69,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 CALC_NODE_DELIVER_MAX_LOOPS_MQ :
                 CALC_NODE_DELIVER_MAX_LOOPS))
         {
-            JLOG (j_.warning) << "loop count exceeded";
+            JLOG (j_.warn()) << "loop count exceeded";
             return telFAILED_PROCESSING;
         }
 
@@ -88,7 +88,7 @@ TER PathCursor::deliverNodeReverseImpl (
             ? STAmount::saOne         // No fee.
             : node().transferRate_;   // Transfer rate of issuer.
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "deliverNodeReverse:"
             << " offerOwnerAccount_="
             << node().offerOwnerAccount_
@@ -108,7 +108,7 @@ TER PathCursor::deliverNodeReverseImpl (
             // Set initial rate.
             node().saRateMax = saOutFeeRate;
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: Set initial rate:"
                 << " node().saRateMax=" << node().saRateMax
                 << " saOutFeeRate=" << saOutFeeRate;
@@ -116,7 +116,7 @@ TER PathCursor::deliverNodeReverseImpl (
         else if (saOutFeeRate > node().saRateMax)
         {
             // Offer exceeds initial rate.
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: Offer exceeds initial rate:"
                 << " node().saRateMax=" << node().saRateMax
                 << " saOutFeeRate=" << saOutFeeRate;
@@ -137,7 +137,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
             node().saRateMax   = saOutFeeRate;
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: Reducing rate:"
                 << " node().saRateMax=" << node().saRateMax;
         }
@@ -162,7 +162,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
         // Offer out with fees.
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "deliverNodeReverse:"
             << " saOutReq=" << saOutReq
             << " saOutAct=" << saOutAct
@@ -183,7 +183,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saOutPlusFees.issue (), true);
             saOutPassAct = std::min (saOutPassReq, fee);
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: Total exceeds fees:"
                 << " saOutPassAct=" << saOutPassAct
                 << " saOutPlusFees=" << saOutPlusFees
@@ -195,7 +195,7 @@ TER PathCursor::deliverNodeReverseImpl (
             saOutPassAct, node().saOfrRate, node().saTakerPays.issue (), true);
         if (*stAmountCalcSwitchover == false && ! outputFee)
         {
-            JLOG (j_.fatal)
+            JLOG (j_.fatal())
                 << "underflow computing outputFee "
                 << "saOutPassAct: " << saOutPassAct
                 << " saOfrRate: " << node ().saOfrRate;
@@ -204,7 +204,7 @@ TER PathCursor::deliverNodeReverseImpl (
         STAmount saInPassReq = std::min (node().saTakerPays, outputFee);
         STAmount saInPassAct;
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "deliverNodeReverse:"
             << " outputFee=" << outputFee
             << " saInPassReq=" << saInPassReq
@@ -215,7 +215,7 @@ TER PathCursor::deliverNodeReverseImpl (
         if (!saInPassReq) // FIXME: This is bogus
         {
             // After rounding did not want anything.
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "deliverNodeReverse: micro offer is unfunded.";
 
             node().bEntryAdvance   = true;
@@ -238,7 +238,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
             saInPassAct = saInPassReq;
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: account --> OFFER --> ? :"
                 << " saInPassAct=" << saInPassAct;
         }
@@ -253,7 +253,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saInPassReq,
                 saInPassAct);
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: offer --> OFFER --> ? :"
                 << " saInPassAct=" << saInPassAct;
         }
@@ -271,7 +271,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saOutPassAct.issue (), true);
             saOutPlusFees   = std::min (node().saOfferFunds, outputFees);
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "deliverNodeReverse: adjusted:"
                 << " saOutPassAct=" << saOutPassAct
                 << " saOutPlusFees=" << saOutPlusFees;
@@ -304,7 +304,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
         if (saTakerPaysNew < zero || saTakerGetsNew < zero)
         {
-            JLOG (j_.warning)
+            JLOG (j_.warn())
                 << "deliverNodeReverse: NEGATIVE:"
                 << " node().saTakerPaysNew=" << saTakerPaysNew
                 << " node().saTakerGetsNew=" << saTakerGetsNew;
@@ -321,7 +321,7 @@ TER PathCursor::deliverNodeReverseImpl (
         if (saOutPassAct == node().saTakerGets)
         {
             // Offer became unfunded.
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "deliverNodeReverse: offer became unfunded.";
 
             node().bEntryAdvance   = true;
@@ -339,7 +339,7 @@ TER PathCursor::deliverNodeReverseImpl (
 
     if (saOutAct > saOutReq)
     {
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             << "deliverNodeReverse: TOO MUCH:"
             << " saOutAct=" << saOutAct
             << " saOutReq=" << saOutReq;
@@ -352,7 +352,7 @@ TER PathCursor::deliverNodeReverseImpl (
     // Unable to meet request, consider path dry.
     // Design invariant: if nothing was actually delivered, return tecPATH_DRY.
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "deliverNodeReverse<"
         << " saOutAct=" << saOutAct
         << " saOutReq=" << saOutReq

--- a/src/ripple/app/paths/cursor/ForwardLiquidityForAccount.cpp
+++ b/src/ripple/app/paths/cursor/ForwardLiquidityForAccount.cpp
@@ -80,7 +80,7 @@ TER PathCursor::forwardLiquidityForAccount () const
     // For !previousNode().isAccount()
     auto saPrvDeliverAct = previousNode().saFwdDeliver.zeroed ();
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "forwardLiquidityForAccount> "
         << "nodeIndex_=" << nodeIndex_ << "/" << lastNodeIndex
         << " previousNode.saFwdRedeem:" << previousNode().saFwdRedeem
@@ -127,7 +127,7 @@ TER PathCursor::forwardLiquidityForAccount () const
 
             pathState_.setInPass (pathState_.inPass() + node().saFwdIssue);
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "forwardLiquidityForAccount: ^ --> "
                 << "ACCOUNT --> account :"
                 << " saInReq=" << pathState_.inReq()
@@ -140,7 +140,7 @@ TER PathCursor::forwardLiquidityForAccount () const
         else if (nodeIndex_ == lastNodeIndex)
         {
             // account --> ACCOUNT --> $
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "forwardLiquidityForAccount: account --> "
                 << "ACCOUNT --> $ :"
                 << " previousAccountID="
@@ -182,7 +182,7 @@ TER PathCursor::forwardLiquidityForAccount () const
         else
         {
             // account --> ACCOUNT --> account
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "forwardLiquidityForAccount: account --> "
                 << "ACCOUNT --> account";
 
@@ -286,7 +286,7 @@ TER PathCursor::forwardLiquidityForAccount () const
         if (nodeIndex_)
         {
             // Non-XRP, current node is the issuer.
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "forwardLiquidityForAccount: account --> "
                 << "ACCOUNT --> offer";
 
@@ -375,7 +375,7 @@ TER PathCursor::forwardLiquidityForAccount () const
                 // We could be delivering to multiple accounts, so we don't know
                 // which ripple balance will be adjusted.  Assume just issuing.
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "forwardLiquidityForAccount: ^ --> "
                     << "ACCOUNT -- !XRP --> offer";
 
@@ -385,7 +385,7 @@ TER PathCursor::forwardLiquidityForAccount () const
             }
             else
             {
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "forwardLiquidityForAccount: ^ --> "
                     << "ACCOUNT -- XRP --> offer";
 
@@ -400,7 +400,7 @@ TER PathCursor::forwardLiquidityForAccount () const
         if (nodeIndex_ == lastNodeIndex)
         {
             // offer --> ACCOUNT --> $
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "forwardLiquidityForAccount: offer --> "
                 << "ACCOUNT --> $ : "
                 << previousNode().saFwdDeliver;
@@ -414,7 +414,7 @@ TER PathCursor::forwardLiquidityForAccount () const
         else
         {
             // offer --> ACCOUNT --> account
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "forwardLiquidityForAccount: offer --> "
                 << "ACCOUNT --> account";
 
@@ -470,7 +470,7 @@ TER PathCursor::forwardLiquidityForAccount () const
     {
         // offer --> ACCOUNT --> offer
         // deliver/redeem -> deliver/issue.
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "forwardLiquidityForAccount: offer --> ACCOUNT --> offer";
 
         node().saFwdDeliver.clear (node().saRevDeliver);

--- a/src/ripple/app/paths/cursor/Liquidity.cpp
+++ b/src/ripple/app/paths/cursor/Liquidity.cpp
@@ -34,14 +34,14 @@ TER PathCursor::liquidity () const
 
     for (pc.nodeIndex_ = pc.nodeSize(); pc.nodeIndex_--; )
     {
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "reverseLiquidity>"
             << " nodeIndex=" << pc.nodeIndex_
             << ".issue_.account=" << to_string (pc.node().issue_.account);
 
         resultCode  = pc.reverseLiquidity();
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "reverseLiquidity< "
             << "nodeIndex=" << pc.nodeIndex_
             << " resultCode=" << transToken (resultCode)
@@ -53,7 +53,7 @@ TER PathCursor::liquidity () const
     }
 
     // VFALCO-FIXME this generates errors
-    // JLOG (j_.trace)
+    // JLOG (j_.trace())
     //     << "nextIncrement: Path after reverse: " << pathState_.getJson ();
 
     if (resultCode != tesSUCCESS)
@@ -63,14 +63,14 @@ TER PathCursor::liquidity () const
 
     for (pc.nodeIndex_ = 0; pc.nodeIndex_ < pc.nodeSize(); ++pc.nodeIndex_)
     {
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "forwardLiquidity> nodeIndex=" << nodeIndex_;
 
         resultCode = pc.forwardLiquidity();
         if (resultCode != tesSUCCESS)
             return resultCode;
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "forwardLiquidity<"
             << " nodeIndex:" << pc.nodeIndex_
             << " resultCode:" << resultCode;

--- a/src/ripple/app/paths/cursor/NextIncrement.cpp
+++ b/src/ripple/app/paths/cursor/NextIncrement.cpp
@@ -46,7 +46,7 @@ void PathCursor::nextIncrement () const
     {
         if (pathState_.isDry())
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                 << "nextIncrement: success on dry path:"
                 << " outPass=" << pathState_.outPass()
                 << " inPass=" << pathState_.inPass();

--- a/src/ripple/app/paths/cursor/ReverseLiquidity.cpp
+++ b/src/ripple/app/paths/cursor/ReverseLiquidity.cpp
@@ -65,7 +65,7 @@ TER PathCursor::reverseLiquidity () const
     // Otherwise the node is an Offer.
     if (isXRP (nextNode().account_))
     {
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "reverseLiquidityForOffer: "
             << "OFFER --> offer: nodeIndex_=" << nodeIndex_;
         return tesSUCCESS;
@@ -78,7 +78,7 @@ TER PathCursor::reverseLiquidity () const
     // Next is an account node, resolve current offer node's deliver.
     STAmount saDeliverAct;
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "reverseLiquidityForOffer: OFFER --> account:"
         << " nodeIndex_=" << nodeIndex_
         << " saRevDeliver=" << node().saRevDeliver;

--- a/src/ripple/app/paths/cursor/ReverseLiquidityForAccount.cpp
+++ b/src/ripple/app/paths/cursor/ReverseLiquidityForAccount.cpp
@@ -105,7 +105,7 @@ TER PathCursor::reverseLiquidityForAccount () const
             node().issue_.currency)
         : STAmount (node().issue_);
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "reverseLiquidityForAccount>"
         << " nodeIndex_=" << nodeIndex_ << "/" << lastNodeIndex
         << " previousAccountID=" << previousAccountID
@@ -143,7 +143,7 @@ TER PathCursor::reverseLiquidityForAccount () const
     // For !nextNodeIsAccount
     auto saCurDeliverAct  = node().saRevDeliver.zeroed();
 
-    JLOG (j_.trace)
+    JLOG (j_.trace())
         << "reverseLiquidityForAccount:"
         << " saPrvRedeemReq:" << saPrvRedeemReq
         << " saPrvIssueReq:" << saPrvIssueReq
@@ -154,7 +154,7 @@ TER PathCursor::reverseLiquidityForAccount () const
         << " saNxtOwed:" << saNxtOwed;
 
     // VFALCO-FIXME this generates errors
-    //JLOG (j_.trace) << pathState_.getJson ();
+    //JLOG (j_.trace()) << pathState_.getJson ();
 
     // Current redeem req can't be more than IOUs on hand.
     assert (!node().saRevRedeem || -saNxtOwed >= node().saRevRedeem);
@@ -187,7 +187,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                 saPrvLimit + saPrvOwed);
             auto saCurWantedAct = saCurWantedReq.zeroed ();
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "reverseLiquidityForAccount: account --> "
                 << "ACCOUNT --> $ :"
                 << " saCurWantedReq=" << saCurWantedReq;
@@ -202,7 +202,7 @@ TER PathCursor::reverseLiquidityForAccount () const
 
                 uRateMax = STAmount::uRateOne;
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "reverseLiquidityForAccount: Redeem at 1:1"
                     << " saPrvRedeemReq=" << saPrvRedeemReq
                     << " (available) previousNode.saRevRedeem="
@@ -235,7 +235,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     saCurWantedAct,
                     uRateMax);
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "reverseLiquidityForAccount: Issuing: Rate: "
                     << "quality in : 1.0"
                     << " previousNode.saRevIssue:" << previousNode().saRevIssue
@@ -274,7 +274,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     saCurRedeemAct,
                     uRateMax);
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "reverseLiquidityForAccount: "
                     << "Rate : 1.0 : quality out"
                     << " previousNode.saRevRedeem:" << previousNode().saRevRedeem
@@ -298,7 +298,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     saCurRedeemAct,
                     uRateMax);
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "reverseLiquidityForAccount: "
                     << "Rate: quality in : quality out:"
                     << " previousNode.saRevIssue:" << previousNode().saRevIssue
@@ -324,7 +324,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     saCurIssueAct,
                     uRateMax);
 
-                JLOG (j_.debug)
+                JLOG (j_.debug())
                     << "reverseLiquidityForAccount: "
                     << "Rate : 1.0 : transfer_rate:"
                     << " previousNode.saRevRedeem:" << previousNode().saRevRedeem
@@ -352,7 +352,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     saCurIssueAct,
                     uRateMax);
 
-                JLOG (j_.trace)
+                JLOG (j_.trace())
                     << "reverseLiquidityForAccount: "
                     << "Rate: quality in : 1.0:"
                     << " previousNode.saRevIssue:" << previousNode().saRevIssue
@@ -365,7 +365,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                 terResult = tecPATH_DRY;
             }
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "reverseLiquidityForAccount: "
                 << "^|account --> ACCOUNT --> account :"
                 << " node.saRevRedeem:" << node().saRevRedeem
@@ -380,7 +380,7 @@ TER PathCursor::reverseLiquidityForAccount () const
         // account --> ACCOUNT --> offer
         // Note: deliver is always issue as ACCOUNT is the issuer for the offer
         // input.
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "reverseLiquidityForAccount: "
             << "account --> ACCOUNT --> offer";
 
@@ -434,7 +434,7 @@ TER PathCursor::reverseLiquidityForAccount () const
             terResult   = tecPATH_DRY;
         }
 
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "reverseLiquidityForAccount: "
             << " node.saRevDeliver:" << node().saRevDeliver
             << " saCurDeliverAct:" << saCurDeliverAct
@@ -453,7 +453,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     pathState_.outReq() - pathState_.outAct();
             STAmount saCurWantedAct = saCurWantedReq.zeroed();
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "reverseLiquidityForAccount: "
                 << "offer --> ACCOUNT --> $ :"
                 << " saCurWantedReq:" << saCurWantedReq
@@ -463,7 +463,7 @@ TER PathCursor::reverseLiquidityForAccount () const
             if (saCurWantedReq <= zero)
             {
                 assert(false);
-                JLOG (j_.fatal) << "CurWantReq was not positive";
+                JLOG (j_.fatal()) << "CurWantReq was not positive";
                 return tefEXCEPTION;
             }
 
@@ -497,7 +497,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                 terResult   = tecPATH_DRY;
             }
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "reverseLiquidityForAccount:"
                 << " previousNode().saRevDeliver:" << previousNode().saRevDeliver
                 << " saPrvDeliverReq:" << saPrvDeliverReq
@@ -508,7 +508,7 @@ TER PathCursor::reverseLiquidityForAccount () const
         {
             // offer --> ACCOUNT --> account
             // Note: offer is always delivering(redeeming) as account is issuer.
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "reverseLiquidityForAccount: "
                 << "offer --> ACCOUNT --> account :"
                 << " node.saRevRedeem:" << node().saRevRedeem
@@ -554,7 +554,7 @@ TER PathCursor::reverseLiquidityForAccount () const
                     uRateMax);
             }
 
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "reverseLiquidityForAccount:"
                 << " saCurRedeemAct:" << saCurRedeemAct
                 << " node.saRevRedeem:" << node().saRevRedeem
@@ -572,7 +572,7 @@ TER PathCursor::reverseLiquidityForAccount () const
     {
         // offer --> ACCOUNT --> offer
         // deliver/redeem -> deliver/issue.
-        JLOG (j_.trace)
+        JLOG (j_.trace())
             << "reverseLiquidityForAccount: offer --> ACCOUNT --> offer";
 
         // Rate : 1.0 : transfer_rate

--- a/src/ripple/app/paths/cursor/RippleLiquidity.cpp
+++ b/src/ripple/app/paths/cursor/RippleLiquidity.cpp
@@ -57,7 +57,7 @@ void rippleLiquidity (
     STAmount& saCurAct,  // <-> out limit including achieved so far: <-- <= -->
     std::uint64_t& uRateMax)
 {
-    JLOG (rippleCalc.j_.trace)
+    JLOG (rippleCalc.j_.trace())
         << "rippleLiquidity>"
         << " uQualityIn=" << uQualityIn
         << " uQualityOut=" << uQualityOut
@@ -84,7 +84,7 @@ void rippleLiquidity (
     // How much could possibly flow through the current node?
     const STAmount  saCur = saCurReq - saCurAct;
 
-    JLOG (rippleCalc.j_.trace)
+    JLOG (rippleCalc.j_.trace())
         << "rippleLiquidity: "
         << " bPrvUnlimited=" << bPrvUnlimited
         << " saPrv=" << saPrv
@@ -97,7 +97,7 @@ void rippleLiquidity (
     if (uQualityIn >= uQualityOut)
     {
         // You're getting better quality than you asked for, so no fee.
-        JLOG (rippleCalc.j_.trace) << "rippleLiquidity: No fees";
+        JLOG (rippleCalc.j_.trace()) << "rippleLiquidity: No fees";
 
         // Only process if the current rate, 1:1, is not worse than the previous
         // rate, uRateMax - otherwise there is no flow.
@@ -127,7 +127,7 @@ void rippleLiquidity (
     else
     {
         // If the quality is worse than the previous
-        JLOG (rippleCalc.j_.trace) << "rippleLiquidity: Fee";
+        JLOG (rippleCalc.j_.trace()) << "rippleLiquidity: Fee";
 
         std::uint64_t uRate = getRate (
             STAmount (uQualityOut), STAmount (uQualityIn));
@@ -146,7 +146,7 @@ void rippleLiquidity (
             STAmount saCurIn = divRound (
                 numerator, uQualityIn, {currency, uCurIssuerID}, true);
 
-            JLOG (rippleCalc.j_.trace)
+            JLOG (rippleCalc.j_.trace())
                 << "rippleLiquidity:"
                 << " bPrvUnlimited=" << bPrvUnlimited
                 << " saPrv=" << saPrv
@@ -157,7 +157,7 @@ void rippleLiquidity (
                 // All of current. Some amount of previous.
                 saCurAct += saCur;
                 saPrvAct += saCurIn;
-                JLOG (rippleCalc.j_.trace)
+                JLOG (rippleCalc.j_.trace())
                     << "rippleLiquidity:3c:"
                     << " saCurReq=" << saCurReq
                     << " saPrvAct=" << saPrvAct;
@@ -178,7 +178,7 @@ void rippleLiquidity (
                 STAmount saCurOut = divRound (
                     numerator, uQualityOut, issue, true);
 
-                JLOG (rippleCalc.j_.trace)
+                JLOG (rippleCalc.j_.trace())
                     << "rippleLiquidity:4: saCurReq=" << saCurReq;
 
                 saCurAct += saCurOut;
@@ -189,7 +189,7 @@ void rippleLiquidity (
         }
     }
 
-    JLOG (rippleCalc.j_.trace)
+    JLOG (rippleCalc.j_.trace())
         << "rippleLiquidity<"
         << " uQualityIn=" << uQualityIn
         << " uQualityOut=" << uQualityOut

--- a/src/ripple/app/tx/impl/CancelOffer.cpp
+++ b/src/ripple/app/tx/impl/CancelOffer.cpp
@@ -36,7 +36,7 @@ CancelOffer::preflight (PreflightContext const& ctx)
 
     if (uTxFlags & tfUniversalMask)
     {
-        JLOG(ctx.j.trace) << "Malformed transaction: " <<
+        JLOG(ctx.j.trace()) << "Malformed transaction: " <<
             "Invalid flags set.";
         return temINVALID_FLAG;
     }
@@ -44,7 +44,7 @@ CancelOffer::preflight (PreflightContext const& ctx)
     auto const seq = ctx.tx.getFieldU32 (sfOfferSequence);
     if (! seq)
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "CancelOffer::preflight: missing sequence";
         return temBAD_SEQUENCE;
     }
@@ -65,7 +65,7 @@ CancelOffer::preclaim(PreclaimContext const& ctx)
 
     if ((*sle)[sfSequence] <= offerSequence)
     {
-        ctx.j.trace << "Malformed transaction: " <<
+        JLOG(ctx.j.trace()) << "Malformed transaction: " <<
             "Sequence " << offerSequence << " is invalid.";
         return temBAD_SEQUENCE;
     }
@@ -90,11 +90,11 @@ CancelOffer::doApply ()
 
     if (sleOffer)
     {
-        JLOG(j_.debug) << "Trying to cancel offer #" << offerSequence;
+        JLOG(j_.debug()) << "Trying to cancel offer #" << offerSequence;
         return offerDelete (view(), sleOffer, ctx_.app.journal("View"));
     }
 
-    JLOG(j_.debug) << "Offer #" << offerSequence << " can't be found.";
+    JLOG(j_.debug()) << "Offer #" << offerSequence << " can't be found.";
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -38,7 +38,7 @@ Change::preflight (PreflightContext const& ctx)
     auto account = ctx.tx.getAccountID(sfAccount);
     if (account != zero)
     {
-        JLOG(ctx.j.warning) << "Change: Bad source id";
+        JLOG(ctx.j.warn()) << "Change: Bad source id";
         return temBAD_SRC_ACCOUNT;
     }
 
@@ -46,7 +46,7 @@ Change::preflight (PreflightContext const& ctx)
     auto const fee = ctx.tx.getFieldAmount (sfFee);
     if (!fee.native () || fee != beast::zero)
     {
-        JLOG(ctx.j.warning) << "Change: invalid fee";
+        JLOG(ctx.j.warn()) << "Change: invalid fee";
         return temBAD_FEE;
     }
 
@@ -54,13 +54,13 @@ Change::preflight (PreflightContext const& ctx)
         !ctx.tx.getSignature ().empty () ||
         ctx.tx.isFieldPresent (sfSigners))
     {
-        JLOG(ctx.j.warning) << "Change: Bad signature";
+        JLOG(ctx.j.warn()) << "Change: Bad signature";
         return temBAD_SIGNATURE;
     }
 
     if (ctx.tx.getSequence () != 0 || ctx.tx.isFieldPresent (sfPreviousTxnID))
     {
-        JLOG(ctx.j.warning) << "Change: Bad sequence";
+        JLOG(ctx.j.warn()) << "Change: Bad sequence";
         return temBAD_SEQUENCE;
     }
 
@@ -74,7 +74,7 @@ Change::preclaim(PreclaimContext const &ctx)
     // this block can be moved to preflight.
     if (ctx.view.open())
     {
-        ctx.j.warning << "Change transaction against open ledger";
+        JLOG(ctx.j.warn()) << "Change transaction against open ledger";
         return temINVALID;
     }
 
@@ -170,7 +170,7 @@ Change::applyAmendment()
 
         if (!ctx_.app.getAmendmentTable ().isSupported (amendment))
         {
-            JLOG (j_.warning) <<
+            JLOG (j_.warn()) <<
                 "Unsupported amendment " << amendment <<
                 " received a majority.";
         }
@@ -185,7 +185,7 @@ Change::applyAmendment()
 
         if (!ctx_.app.getAmendmentTable ().isSupported (amendment))
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "Unsupported amendment " << amendment <<
                 " activated: server blocked.";
             ctx_.app.getOPs ().setAmendmentBlocked ();
@@ -226,7 +226,7 @@ Change::applyFee()
 
     view().update (feeObject);
 
-    j_.warning << "Fees have been changed";
+    JLOG(j_.warn()) << "Fees have been changed";
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -41,7 +41,7 @@ CreateTicket::preflight (PreflightContext const& ctx)
     {
         if (ctx.tx.getFieldU32 (sfExpiration) == 0)
         {
-            JLOG(ctx.j.warning) <<
+            JLOG(ctx.j.warn()) <<
                 "Malformed transaction: bad expiration";
             return temBAD_EXPIRATION;
         }
@@ -61,7 +61,7 @@ CreateTicket::doApply ()
     {
         auto const reserve = view().fees().accountReserve(
             sle->getFieldU32(sfOwnerCount) + 1);
-        
+
         if (mPriorBalance < reserve)
             return tecINSUFFICIENT_RESERVE;
     }
@@ -115,7 +115,7 @@ CreateTicket::doApply ()
         describer,
         viewJ);
 
-    if (j_.trace) j_.trace <<
+    JLOG(j_.trace()) <<
         "Creating ticket " << to_string (sleTicket->getIndex ()) <<
         ": " << transHuman (result);
 

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -49,7 +49,7 @@ OfferStream::erase (ApplyView& view)
 
     if (p == nullptr)
     {
-        JLOG(j_.error) <<
+        JLOG(j_.error()) <<
             "Missing directory " << tip_.dir() <<
             " for offer " << tip_.index();
         return;
@@ -60,7 +60,7 @@ OfferStream::erase (ApplyView& view)
 
     if (it == v.end())
     {
-        JLOG(j_.error) <<
+        JLOG(j_.error()) <<
             "Missing offer " << tip_.index() <<
             " for directory " << tip_.dir();
         return;
@@ -70,7 +70,7 @@ OfferStream::erase (ApplyView& view)
     p->setFieldV256 (sfIndexes, v);
     view.update (p);
 
-    JLOG(j_.trace) <<
+    JLOG(j_.trace()) <<
         "Missing offer " << tip_.index() <<
         " removed from directory " << tip_.dir();
 }
@@ -109,7 +109,7 @@ OfferStream::step (Logs& l)
         if (entry->isFieldPresent (sfExpiration) &&
             tp{d{(*entry)[sfExpiration]}} <= expire_)
         {
-            JLOG(j_.trace) <<
+            JLOG(j_.trace()) <<
                 "Removing expired offer " << entry->getIndex();
             offerDelete (cancelView_,
                 cancelView_.peek(keylet::offer(entry->key())), viewJ);
@@ -123,7 +123,7 @@ OfferStream::step (Logs& l)
         // Remove if either amount is zero
         if (amount.empty())
         {
-            JLOG(j_.warning) <<
+            JLOG(j_.warn()) <<
                 "Removing bad offer " << entry->getIndex();
             offerDelete (cancelView_,
                 cancelView_.peek(keylet::offer(entry->key())), viewJ);
@@ -148,12 +148,12 @@ OfferStream::step (Logs& l)
             {
                 offerDelete (cancelView_, cancelView_.peek(
                     keylet::offer(entry->key())), viewJ);
-                JLOG(j_.trace) <<
+                JLOG(j_.trace()) <<
                     "Removing unfunded offer " << entry->getIndex();
             }
             else
             {
-                JLOG(j_.trace) <<
+                JLOG(j_.trace()) <<
                     "Removing became unfunded offer " << entry->getIndex();
             }
             offer_ = Offer{};

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -23,6 +23,7 @@
 #include <ripple/app/tx/impl/BookTip.h>
 #include <ripple/app/tx/impl/Offer.h>
 #include <ripple/basics/chrono.h>
+#include <ripple/basics/Log.h>
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Quality.h>
 #include <beast/utility/Journal.h>
@@ -69,7 +70,7 @@ public:
         {
             if (count_ >= limit_)
             {
-                j_.debug << "Exceeded " << limit_ << " step limit.";
+                JLOG(j_.debug()) << "Exceeded " << limit_ << " step limit.";
                 return false;
             }
             count_++;

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -42,7 +42,7 @@ Payment::preflight (PreflightContext const& ctx)
 
     if (uTxFlags & tfPaymentMask)
     {
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "Invalid flags set.";
         return temINVALID_FLAG;
     }
@@ -81,25 +81,25 @@ Payment::preflight (PreflightContext const& ctx)
 
     if (!uDstAccountID)
     {
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "Payment destination account not specified.";
         return temDST_NEEDED;
     }
     if (bMax && maxSourceAmount <= zero)
     {
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "bad max amount: " << maxSourceAmount.getFullText ();
         return temBAD_AMOUNT;
     }
     if (saDstAmount <= zero)
     {
-        JLOG(j.trace) << "Malformed transaction: "<<
+        JLOG(j.trace()) << "Malformed transaction: "<<
             "bad dst amount: " << saDstAmount.getFullText ();
         return temBAD_AMOUNT;
     }
     if (badCurrency() == uSrcCurrency || badCurrency() == uDstCurrency)
     {
-        JLOG(j.trace) <<"Malformed transaction: " <<
+        JLOG(j.trace()) <<"Malformed transaction: " <<
             "Bad currency.";
         return temBAD_CURRENCY;
     }
@@ -107,7 +107,7 @@ Payment::preflight (PreflightContext const& ctx)
     {
         // You're signing yourself a payment.
         // If bPaths is true, you might be trying some arbitrage.
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "Redundant payment from " << to_string (account) <<
             " to self without path for " << to_string (uDstCurrency);
         return temREDUNDANT;
@@ -115,35 +115,35 @@ Payment::preflight (PreflightContext const& ctx)
     if (bXRPDirect && bMax)
     {
         // Consistent but redundant transaction.
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "SendMax specified for XRP to XRP.";
         return temBAD_SEND_XRP_MAX;
     }
     if (bXRPDirect && bPaths)
     {
         // XRP is sent without paths.
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "Paths specified for XRP to XRP.";
         return temBAD_SEND_XRP_PATHS;
     }
     if (bXRPDirect && partialPaymentAllowed)
     {
         // Consistent but redundant transaction.
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "Partial payment specified for XRP to XRP.";
         return temBAD_SEND_XRP_PARTIAL;
     }
     if (bXRPDirect && limitQuality)
     {
         // Consistent but redundant transaction.
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "Limit quality specified for XRP to XRP.";
         return temBAD_SEND_XRP_LIMIT;
     }
     if (bXRPDirect && !defaultPathsAllowed)
     {
         // Consistent but redundant transaction.
-        JLOG(j.trace) << "Malformed transaction: " <<
+        JLOG(j.trace()) << "Malformed transaction: " <<
             "No ripple direct specified for XRP to XRP.";
         return temBAD_SEND_XRP_NO_DIRECT;
     }
@@ -153,7 +153,7 @@ Payment::preflight (PreflightContext const& ctx)
     {
         if (! partialPaymentAllowed)
         {
-            JLOG(j.trace) << "Malformed transaction: Partial payment not "
+            JLOG(j.trace()) << "Malformed transaction: Partial payment not "
                 "specified for " << jss::DeliverMin.c_str() << ".";
             return temBAD_AMOUNT;
         }
@@ -161,21 +161,21 @@ Payment::preflight (PreflightContext const& ctx)
         auto const dMin = *deliverMin;
         if (!isLegalNet(dMin) || dMin <= zero)
         {
-            JLOG(j.trace) << "Malformed transaction: Invalid " <<
+            JLOG(j.trace()) << "Malformed transaction: Invalid " <<
                 jss::DeliverMin.c_str() << " amount. " <<
                     dMin.getFullText();
             return temBAD_AMOUNT;
         }
         if (dMin.issue() != saDstAmount.issue())
         {
-            JLOG(j.trace) <<  "Malformed transaction: Dst issue differs "
+            JLOG(j.trace()) <<  "Malformed transaction: Dst issue differs "
                 "from " << jss::DeliverMin.c_str() << ". " <<
                     dMin.getFullText();
             return temBAD_AMOUNT;
         }
         if (dMin > saDstAmount)
         {
-            JLOG(j.trace) << "Malformed transaction: Dst amount less than " <<
+            JLOG(j.trace()) << "Malformed transaction: Dst amount less than " <<
                 jss::DeliverMin.c_str() << ". " <<
                     dMin.getFullText();
             return temBAD_AMOUNT;
@@ -205,7 +205,7 @@ Payment::preclaim(PreclaimContext const& ctx)
         // Destination account does not exist.
         if (!saDstAmount.native())
         {
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "Delay transaction: Destination account does not exist.";
 
             // Another transaction could create the account and then this
@@ -217,7 +217,7 @@ Payment::preclaim(PreclaimContext const& ctx)
         {
             // You cannot fund an account with a partial payment.
             // Make retry work smaller, by rejecting this.
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "Delay transaction: Partial payment not allowed to create account.";
 
 
@@ -229,7 +229,7 @@ Payment::preclaim(PreclaimContext const& ctx)
         {
             // accountReserve is the minimum amount that an account can have.
             // Reserve is not scaled by load.
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "Delay transaction: Destination account does not exist. " <<
                 "Insufficent payment to create account.";
 
@@ -247,7 +247,7 @@ Payment::preclaim(PreclaimContext const& ctx)
 
         // We didn't make this test for a newly-formed account because there's
         // no way for this field to be set.
-        JLOG(ctx.j.trace) << "Malformed transaction: DestinationTag required.";
+        JLOG(ctx.j.trace()) << "Malformed transaction: DestinationTag required.";
 
         return tecDST_TAG_NEEDED;
     }
@@ -306,7 +306,7 @@ Payment::doApply ()
             saDstAmount.mantissa(), saDstAmount.exponent (),
             saDstAmount < zero);
 
-    JLOG(j_.trace) <<
+    JLOG(j_.trace()) <<
         "maxSourceAmount=" << maxSourceAmount.getFullText () <<
         " saDstAmount=" << saDstAmount.getFullText ();
 
@@ -413,7 +413,7 @@ Payment::doApply ()
         {
             // Vote no. However the transaction might succeed, if applied in
             // a different order.
-            JLOG(j_.trace) << "Delay transaction: Insufficient funds: " <<
+            JLOG(j_.trace()) << "Delay transaction: Insufficient funds: " <<
                 " " << to_string (mPriorBalance) <<
                 " / " << to_string (saDstAmount.xrp () + mmm) <<
                 " (" << to_string (reserve) << ")";

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -43,7 +43,7 @@ SetAccount::preflight (PreflightContext const& ctx)
 
     if (uTxFlags & tfAccountSetMask)
     {
-        JLOG(j.trace) << "Malformed transaction: Invalid flags set.";
+        JLOG(j.trace()) << "Malformed transaction: Invalid flags set.";
         return temINVALID_FLAG;
     }
 
@@ -52,7 +52,7 @@ SetAccount::preflight (PreflightContext const& ctx)
 
     if ((uSetFlag != 0) && (uSetFlag == uClearFlag))
     {
-        JLOG(j.trace) << "Malformed transaction: Set and clear same flag.";
+        JLOG(j.trace()) << "Malformed transaction: Set and clear same flag.";
         return temINVALID_FLAG;
     }
 
@@ -64,7 +64,7 @@ SetAccount::preflight (PreflightContext const& ctx)
 
     if (bSetRequireAuth && bClearRequireAuth)
     {
-        JLOG(j.trace) << "Malformed transaction: Contradictory flags set.";
+        JLOG(j.trace()) << "Malformed transaction: Contradictory flags set.";
         return temINVALID_FLAG;
     }
 
@@ -76,7 +76,7 @@ SetAccount::preflight (PreflightContext const& ctx)
 
     if (bSetRequireDest && bClearRequireDest)
     {
-        JLOG(j.trace) << "Malformed transaction: Contradictory flags set.";
+        JLOG(j.trace()) << "Malformed transaction: Contradictory flags set.";
         return temINVALID_FLAG;
     }
 
@@ -88,7 +88,7 @@ SetAccount::preflight (PreflightContext const& ctx)
 
     if (bSetDisallowXRP && bClearDisallowXRP)
     {
-        JLOG(j.trace) << "Malformed transaction: Contradictory flags set.";
+        JLOG(j.trace()) << "Malformed transaction: Contradictory flags set.";
         return temINVALID_FLAG;
     }
 
@@ -99,7 +99,7 @@ SetAccount::preflight (PreflightContext const& ctx)
 
         if (uRate && (uRate < QUALITY_ONE))
         {
-            JLOG(j.trace) << "Malformed transaction: Bad transfer rate.";
+            JLOG(j.trace()) << "Malformed transaction: Bad transfer rate.";
             return temBAD_TRANSFER_RATE;
         }
     }
@@ -107,14 +107,14 @@ SetAccount::preflight (PreflightContext const& ctx)
     auto const messageKey = tx[~sfMessageKey];
     if (messageKey && messageKey->size() > PUBLIC_BYTES_MAX)
     {
-        JLOG(j.trace) << "message key too long";
+        JLOG(j.trace()) << "message key too long";
         return telBAD_PUBLIC_KEY;
     }
 
     auto const domain = tx[~sfDomain];
     if (domain&& domain->size() > DOMAIN_BYTES_MAX)
     {
-        JLOG(j.trace) << "domain too long";
+        JLOG(j.trace()) << "domain too long";
         return telBAD_DOMAIN;
     }
 
@@ -146,7 +146,7 @@ SetAccount::preclaim(PreclaimContext const& ctx)
         if (!dirIsEmpty(ctx.view,
             keylet::ownerDir(id)))
         {
-            JLOG(ctx.j.trace) << "Retry: Owner directory not empty.";
+            JLOG(ctx.j.trace()) << "Retry: Owner directory not empty.";
             return (ctx.flags & tapRETRY) ? terOWNERS : tecOWNERS;
         }
     }
@@ -195,13 +195,13 @@ SetAccount::doApply ()
     //
     if (bSetRequireAuth && !(uFlagsIn & lsfRequireAuth))
     {
-        JLOG(j_.trace) << "Set RequireAuth.";
+        JLOG(j_.trace()) << "Set RequireAuth.";
         uFlagsOut |= lsfRequireAuth;
     }
 
     if (bClearRequireAuth && (uFlagsIn & lsfRequireAuth))
     {
-        JLOG(j_.trace) << "Clear RequireAuth.";
+        JLOG(j_.trace()) << "Clear RequireAuth.";
         uFlagsOut &= ~lsfRequireAuth;
     }
 
@@ -210,13 +210,13 @@ SetAccount::doApply ()
     //
     if (bSetRequireDest && !(uFlagsIn & lsfRequireDestTag))
     {
-        JLOG(j_.trace) << "Set lsfRequireDestTag.";
+        JLOG(j_.trace()) << "Set lsfRequireDestTag.";
         uFlagsOut |= lsfRequireDestTag;
     }
 
     if (bClearRequireDest && (uFlagsIn & lsfRequireDestTag))
     {
-        JLOG(j_.trace) << "Clear lsfRequireDestTag.";
+        JLOG(j_.trace()) << "Clear lsfRequireDestTag.";
         uFlagsOut &= ~lsfRequireDestTag;
     }
 
@@ -225,13 +225,13 @@ SetAccount::doApply ()
     //
     if (bSetDisallowXRP && !(uFlagsIn & lsfDisallowXRP))
     {
-        JLOG(j_.trace) << "Set lsfDisallowXRP.";
+        JLOG(j_.trace()) << "Set lsfDisallowXRP.";
         uFlagsOut |= lsfDisallowXRP;
     }
 
     if (bClearDisallowXRP && (uFlagsIn & lsfDisallowXRP))
     {
-        JLOG(j_.trace) << "Clear lsfDisallowXRP.";
+        JLOG(j_.trace()) << "Clear lsfDisallowXRP.";
         uFlagsOut &= ~lsfDisallowXRP;
     }
 
@@ -242,7 +242,7 @@ SetAccount::doApply ()
     {
         if (!sigWithMaster)
         {
-            JLOG(j_.trace) << "Must use master key to disable master key.";
+            JLOG(j_.trace()) << "Must use master key to disable master key.";
             return tecNEED_MASTER_KEY;
         }
 
@@ -259,13 +259,13 @@ SetAccount::doApply ()
             return tecNO_REGULAR_KEY;
         }
 
-        JLOG(j_.trace) << "Set lsfDisableMaster.";
+        JLOG(j_.trace()) << "Set lsfDisableMaster.";
         uFlagsOut |= lsfDisableMaster;
     }
 
     if ((uClearFlag == asfDisableMaster) && (uFlagsIn & lsfDisableMaster))
     {
-        JLOG(j_.trace) << "Clear lsfDisableMaster.";
+        JLOG(j_.trace()) << "Clear lsfDisableMaster.";
         uFlagsOut &= ~lsfDisableMaster;
     }
 
@@ -288,18 +288,18 @@ SetAccount::doApply ()
     {
         if (!sigWithMaster && !(uFlagsIn & lsfDisableMaster))
         {
-            JLOG(j_.trace) << "Can't use regular key to set NoFreeze.";
+            JLOG(j_.trace()) << "Can't use regular key to set NoFreeze.";
             return tecNEED_MASTER_KEY;
         }
 
-        JLOG(j_.trace) << "Set NoFreeze flag";
+        JLOG(j_.trace()) << "Set NoFreeze flag";
         uFlagsOut |= lsfNoFreeze;
     }
 
     // Anyone may set global freeze
     if (uSetFlag == asfGlobalFreeze)
     {
-        JLOG(j_.trace) << "Set GlobalFreeze flag";
+        JLOG(j_.trace()) << "Set GlobalFreeze flag";
         uFlagsOut |= lsfGlobalFreeze;
     }
 
@@ -309,7 +309,7 @@ SetAccount::doApply ()
     if ((uSetFlag != asfGlobalFreeze) && (uClearFlag == asfGlobalFreeze) &&
         ((uFlagsOut & lsfNoFreeze) == 0))
     {
-        JLOG(j_.trace) << "Clear GlobalFreeze flag";
+        JLOG(j_.trace()) << "Clear GlobalFreeze flag";
         uFlagsOut &= ~lsfGlobalFreeze;
     }
 
@@ -318,13 +318,13 @@ SetAccount::doApply ()
     //
     if ((uSetFlag == asfAccountTxnID) && !sle->isFieldPresent (sfAccountTxnID))
     {
-        JLOG(j_.trace) << "Set AccountTxnID";
+        JLOG(j_.trace()) << "Set AccountTxnID";
         sle->makeFieldPresent (sfAccountTxnID);
         }
 
     if ((uClearFlag == asfAccountTxnID) && sle->isFieldPresent (sfAccountTxnID))
     {
-        JLOG(j_.trace) << "Clear AccountTxnID";
+        JLOG(j_.trace()) << "Clear AccountTxnID";
         sle->makeFieldAbsent (sfAccountTxnID);
     }
 
@@ -337,12 +337,12 @@ SetAccount::doApply ()
 
         if (!uHash)
         {
-            JLOG(j_.trace) << "unset email hash";
+            JLOG(j_.trace()) << "unset email hash";
             sle->makeFieldAbsent (sfEmailHash);
         }
         else
         {
-            JLOG(j_.trace) << "set email hash";
+            JLOG(j_.trace()) << "set email hash";
             sle->setFieldH128 (sfEmailHash, uHash);
         }
     }
@@ -356,12 +356,12 @@ SetAccount::doApply ()
 
         if (!uHash)
         {
-            JLOG(j_.trace) << "unset wallet locator";
+            JLOG(j_.trace()) << "unset wallet locator";
             sle->makeFieldAbsent (sfWalletLocator);
         }
         else
         {
-            JLOG(j_.trace) << "set wallet locator";
+            JLOG(j_.trace()) << "set wallet locator";
             sle->setFieldH256 (sfWalletLocator, uHash);
         }
     }
@@ -375,12 +375,12 @@ SetAccount::doApply ()
 
         if (messageKey.empty ())
         {
-            JLOG(j_.debug) << "set message key";
+            JLOG(j_.debug()) << "set message key";
             sle->makeFieldAbsent (sfMessageKey);
         }
         else
         {
-            JLOG(j_.debug) << "set message key";
+            JLOG(j_.debug()) << "set message key";
             sle->setFieldVL (sfMessageKey, messageKey);
         }
     }
@@ -394,12 +394,12 @@ SetAccount::doApply ()
 
         if (domain.empty ())
         {
-            JLOG(j_.trace) << "unset domain";
+            JLOG(j_.trace()) << "unset domain";
             sle->makeFieldAbsent (sfDomain);
         }
         else
         {
-            JLOG(j_.trace) << "set domain";
+            JLOG(j_.trace()) << "set domain";
             sle->setFieldVL (sfDomain, domain);
         }
     }
@@ -413,12 +413,12 @@ SetAccount::doApply ()
 
         if (uRate == 0 || uRate == QUALITY_ONE)
         {
-            JLOG(j_.trace) << "unset transfer rate";
+            JLOG(j_.trace()) << "unset transfer rate";
             sle->makeFieldAbsent (sfTransferRate);
         }
         else if (uRate > QUALITY_ONE)
         {
-            JLOG(j_.trace) << "set transfer rate";
+            JLOG(j_.trace()) << "set transfer rate";
             sle->setFieldU32 (sfTransferRate, uRate);
         }
     }

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -60,7 +60,7 @@ SetRegularKey::preflight (PreflightContext const& ctx)
 
     if (uTxFlags & tfUniversalMask)
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "Malformed transaction: Invalid flags set.";
 
         return temINVALID_FLAG;

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -88,7 +88,7 @@ SetSignerList::preflight (PreflightContext const& ctx)
     if (std::get<3>(result) == unknown)
     {
         // Neither a set nor a destroy.  Malformed.
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "Malformed transaction: Invalid signer set list format.";
         return temMALFORMED;
     }
@@ -156,7 +156,7 @@ SetSignerList::validateQuorumAndSignerEntries (
         if ((signerCount < STTx::minMultiSigners)
             || (signerCount > STTx::maxMultiSigners))
         {
-            JLOG(j.trace) << "Too many or too few signers in signer list.";
+            JLOG(j.trace()) << "Too many or too few signers in signer list.";
             return temMALFORMED;
         }
     }
@@ -166,7 +166,7 @@ SetSignerList::validateQuorumAndSignerEntries (
     if (std::adjacent_find (
         signers.begin (), signers.end ()) != signers.end ())
     {
-        JLOG(j.trace) << "Duplicate signers in signer list";
+        JLOG(j.trace()) << "Duplicate signers in signer list";
         return temBAD_SIGNER;
     }
 
@@ -178,7 +178,7 @@ SetSignerList::validateQuorumAndSignerEntries (
         std::uint32_t const weight = signer.weight;
         if (weight <= 0)
         {
-            JLOG(j.trace) << "Every signer must have a positive weight.";
+            JLOG(j.trace()) << "Every signer must have a positive weight.";
             return temBAD_WEIGHT;
         }
 
@@ -186,7 +186,7 @@ SetSignerList::validateQuorumAndSignerEntries (
 
         if (signer.account == account)
         {
-            JLOG(j.trace) << "A signer may not self reference account.";
+            JLOG(j.trace()) << "A signer may not self reference account.";
             return temBAD_SIGNER;
         }
 
@@ -195,7 +195,7 @@ SetSignerList::validateQuorumAndSignerEntries (
     }
     if ((quorum <= 0) || (allSignersWeight < quorum))
     {
-        JLOG(j.trace) << "Quorum is unreachable";
+        JLOG(j.trace()) << "Quorum is unreachable";
         return temBAD_QUORUM;
     }
     return tesSUCCESS;
@@ -241,7 +241,7 @@ SetSignerList::replaceSignerList ()
     TER result = dirAdd(ctx_.view (), hint, ownerDirKeylet.key,
         signerListKeylet.key, describeOwnerDir (account_), viewJ);
 
-    JLOG(j_.trace) << "Create signer list for account " <<
+    JLOG(j_.trace()) << "Create signer list for account " <<
         toBase58(account_) << ": " << transHuman (result);
 
     if (result != tesSUCCESS)

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -42,7 +42,7 @@ SetTrust::preflight (PreflightContext const& ctx)
 
     if (uTxFlags & tfTrustSetMask)
     {
-        JLOG(j.trace) <<
+        JLOG(j.trace()) <<
             "Malformed transaction: Invalid flags set.";
         return temINVALID_FLAG;
     }
@@ -54,7 +54,7 @@ SetTrust::preflight (PreflightContext const& ctx)
 
     if (saLimitAmount.native ())
     {
-        JLOG(j.trace) <<
+        JLOG(j.trace()) <<
             "Malformed transaction: specifies native limit " <<
             saLimitAmount.getFullText ();
         return temBAD_LIMIT;
@@ -62,14 +62,14 @@ SetTrust::preflight (PreflightContext const& ctx)
 
     if (badCurrency() == saLimitAmount.getCurrency ())
     {
-        JLOG(j.trace) <<
+        JLOG(j.trace()) <<
             "Malformed transaction: specifies XRP as IOU";
         return temBAD_CURRENCY;
     }
 
     if (saLimitAmount < zero)
     {
-        JLOG(j.trace) <<
+        JLOG(j.trace()) <<
             "Malformed transaction: Negative credit limit.";
         return temBAD_LIMIT;
     }
@@ -79,7 +79,7 @@ SetTrust::preflight (PreflightContext const& ctx)
 
     if (!issuer || issuer == noAccount())
     {
-        JLOG(j.trace) <<
+        JLOG(j.trace()) <<
             "Malformed transaction: no destination account.";
         return temDST_NEEDED;
     }
@@ -101,7 +101,7 @@ SetTrust::preclaim(PreclaimContext const& ctx)
 
     if (bSetAuth && !(sle->getFieldU32(sfFlags) & lsfRequireAuth))
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "Retry: Auth not required.";
         return tefNO_AUTH_REQUIRED;
     }
@@ -121,7 +121,7 @@ SetTrust::preclaim(PreclaimContext const& ctx)
 
         if (!sleDelete)
         {
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "Malformed transaction: Can not extend credit to self.";
             return temDST_IS_SRC;
         }
@@ -191,7 +191,7 @@ SetTrust::doApply ()
         SLE::pointer sleDelete = view().peek (
             keylet::line(account_, uDstAccountID, currency));
 
-        JLOG(j_.warning) <<
+        JLOG(j_.warn()) <<
             "Clearing redundant line.";
 
         return trustDelete (view(),
@@ -203,7 +203,7 @@ SetTrust::doApply ()
 
     if (!sleDst)
     {
-        JLOG(j_.trace) <<
+        JLOG(j_.trace()) <<
             "Delay transaction: Destination account does not exist.";
         return tecNO_DST;
     }
@@ -412,7 +412,7 @@ SetTrust::doApply ()
         // Reserve is not scaled by load.
         else if (bReserveIncrease && mPriorBalance < reserveCreate)
         {
-            JLOG(j_.trace) <<
+            JLOG(j_.trace()) <<
                 "Delay transaction: Insufficent reserve to add trust line.";
 
             // Another transaction could provide XRP to the account and then
@@ -423,7 +423,7 @@ SetTrust::doApply ()
         {
             view().update (sleRippleState);
 
-            JLOG(j_.trace) << "Modify ripple line";
+            JLOG(j_.trace()) << "Modify ripple line";
         }
     }
     // Line does not exist.
@@ -432,13 +432,13 @@ SetTrust::doApply ()
         (! bQualityOut || ! uQualityOut) &&         // Not setting quality out or setting default quality out.
         (! (view().rules().enabled(featureTrustSetAuth, ctx_.app.config().features)) || ! bSetAuth))
     {
-        JLOG(j_.trace) <<
+        JLOG(j_.trace()) <<
             "Redundant: Setting non-existent ripple line to defaults.";
         return tecNO_LINE_REDUNDANT;
     }
     else if (mPriorBalance < reserveCreate) // Reserve is not scaled by load.
     {
-        JLOG(j_.trace) <<
+        JLOG(j_.trace()) <<
             "Delay transaction: Line does not exist. Insufficent reserve to create line.";
 
         // Another transaction could create the account and then this transaction would succeed.
@@ -452,7 +452,7 @@ SetTrust::doApply ()
         uint256 index (getRippleStateIndex (
             account_, uDstAccountID, currency));
 
-        JLOG(j_.trace) <<
+        JLOG(j_.trace()) <<
             "doTrustSet: Creating ripple line: " <<
             to_string (index);
 

--- a/src/ripple/app/tx/impl/SignerEntries.cpp
+++ b/src/ripple/app/tx/impl/SignerEntries.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/tx/impl/SignerEntries.h>
+#include <ripple/basics/Log.h>
 #include <ripple/protocol/STObject.h>
 #include <ripple/protocol/STArray.h>
 #include <cstdint>
@@ -33,7 +34,7 @@ SignerEntries::deserialize (
 
     if (!obj.isFieldPresent (sfSignerEntries))
     {
-        if (journal.trace) journal.trace <<
+        JLOG(journal.trace()) <<
             "Malformed " << annotation << ": Need signer entry array.";
         s.second = temMALFORMED;
         return s;
@@ -48,7 +49,7 @@ SignerEntries::deserialize (
         // Validate the SignerEntry.
         if (sEntry.getFName () != sfSignerEntry)
         {
-            journal.trace <<
+            JLOG(journal.trace()) <<
                 "Malformed " << annotation << ": Expected SignerEntry.";
             s.second = temMALFORMED;
             return s;

--- a/src/ripple/app/tx/impl/Taker.cpp
+++ b/src/ripple/app/tx/impl/Taker.cpp
@@ -118,7 +118,7 @@ BasicTaker::unfunded () const
     if (get_funds (account(), remaining_.in) > zero)
         return false;
 
-    JLOG(journal_.debug) << "Unfunded: taker is out of funds.";
+    JLOG(journal_.debug()) << "Unfunded: taker is out of funds.";
     return true;
 }
 
@@ -128,7 +128,7 @@ BasicTaker::done () const
     // We are done if we have consumed all the input currency
     if (remaining_.in <= zero)
     {
-        JLOG(journal_.debug) << "Done: all the input currency has been consumed.";
+        JLOG(journal_.debug()) << "Done: all the input currency has been consumed.";
         return true;
     }
 
@@ -136,14 +136,14 @@ BasicTaker::done () const
     // desired amount of output currency
     if (!sell_ && (remaining_.out <= zero))
     {
-        JLOG(journal_.debug) << "Done: the desired amount has been received.";
+        JLOG(journal_.debug()) << "Done: the desired amount has been received.";
         return true;
     }
 
     // We are done if the taker is out of funds
     if (unfunded ())
     {
-        JLOG(journal_.debug) << "Done: taker out of funds.";
+        JLOG(journal_.debug()) << "Done: taker out of funds.";
         return true;
     }
 
@@ -205,21 +205,22 @@ qual_mul (STAmount const& amount, Quality const& quality, STAmount const& output
 void
 BasicTaker::log_flow (char const* description, Flow const& flow)
 {
-    if (!journal_.debug)
+    auto stream = journal_.debug();
+    if (!stream)
         return;
 
-    journal_.debug << description;
+    stream << description;
 
     if (isXRP (issue_in ()))
-        journal_.debug << "   order in: " << format_amount (flow.order.in);
+        stream << "   order in: " << format_amount (flow.order.in);
     else
-        journal_.debug << "   order in: " << format_amount (flow.order.in) <<
+        stream << "   order in: " << format_amount (flow.order.in) <<
             " (issuer: " << format_amount (flow.issuers.in) << ")";
 
     if (isXRP (issue_out ()))
-        journal_.debug << "  order out: " << format_amount (flow.order.out);
+        stream << "  order out: " << format_amount (flow.order.out);
     else
-        journal_.debug << "  order out: " << format_amount (flow.order.out) <<
+        stream << "  order out: " << format_amount (flow.order.out) <<
             " (issuer: " << format_amount (flow.issuers.out) << ")";
 }
 
@@ -439,7 +440,7 @@ BasicTaker::do_cross (
 
     if (account () == owner1)
     {
-        JLOG(journal_.trace) << "The taker owns the first leg of a bridge.";
+        JLOG(journal_.trace()) << "The taker owns the first leg of a bridge.";
         leg1_in_funds = std::max (leg1_in_funds, offer1.in);
     }
 
@@ -449,7 +450,7 @@ BasicTaker::do_cross (
 
     if (account () == owner2)
     {
-        JLOG(journal_.trace) << "The taker owns the second leg of a bridge.";
+        JLOG(journal_.trace()) << "The taker owns the second leg of a bridge.";
         leg2_out_funds = std::max (leg2_out_funds, offer2.out);
     }
 
@@ -465,17 +466,17 @@ BasicTaker::do_cross (
 
     if (owner1 == owner2)
     {
-        JLOG(journal_.trace) <<
+        JLOG(journal_.trace()) <<
             "The bridge endpoints are owned by the same account.";
         xrp_funds = std::max (offer1.out, offer2.in);
     }
 
-    if (journal_.debug)
+    if (auto stream = journal_.debug())
     {
-        journal_.debug << "Available bridge funds:";
-        journal_.debug << "  leg1 in: " << format_amount (leg1_in_funds);
-        journal_.debug << " leg2 out: " << format_amount (leg2_out_funds);
-        journal_.debug << "      xrp: " << format_amount (xrp_funds);
+        stream << "Available bridge funds:";
+        stream << "  leg1 in: " << format_amount (leg1_in_funds);
+        stream << " leg2 out: " << format_amount (leg2_out_funds);
+        stream << "      xrp: " << format_amount (xrp_funds);
     }
 
     auto const leg1_rate = in_rate (owner1, account ());
@@ -540,23 +541,23 @@ Taker::Taker (CrossType cross_type, ApplyView& view,
     assert (issue_in () == offer.in.issue ());
     assert (issue_out () == offer.out.issue ());
 
-    if (journal_.debug)
+    if (auto stream = journal_.debug())
     {
-        journal_.debug << "Crossing as: " << to_string (account);
+        stream << "Crossing as: " << to_string (account);
 
         if (isXRP (issue_in ()))
-            journal_.debug << "   Offer in: " << format_amount (offer.in);
+            stream << "   Offer in: " << format_amount (offer.in);
         else
-            journal_.debug << "   Offer in: " << format_amount (offer.in) <<
+            stream << "   Offer in: " << format_amount (offer.in) <<
                 " (issuer: " << issue_in ().account << ")";
 
         if (isXRP (issue_out ()))
-            journal_.debug << "  Offer out: " << format_amount (offer.out);
+            stream << "  Offer out: " << format_amount (offer.out);
         else
-            journal_.debug << "  Offer out: " << format_amount (offer.out) <<
+            stream << "  Offer out: " << format_amount (offer.out) <<
                 " (issuer: " << issue_out ().account << ")";
 
-        journal_.debug <<
+        stream <<
             "    Balance: " << format_amount (get_funds (account, offer.in));
     }
 }
@@ -570,14 +571,14 @@ Taker::consume_offer (Offer const& offer, Amounts const& order)
     if (order.out < zero)
         Throw<std::logic_error> ("flow with negative output.");
 
-    JLOG(journal_.debug) << "Consuming from offer " << offer;
+    JLOG(journal_.debug()) << "Consuming from offer " << offer;
 
-    if (journal_.trace)
+    if (auto stream = journal_.trace())
     {
         auto const& available = offer.amount ();
 
-        journal_.trace << "   in:" << format_amount (available.in);
-        journal_.trace << "  out:" << format_amount(available.out);
+        stream << "   in:" << format_amount (available.in);
+        stream << "  out:" << format_amount(available.out);
     }
 
     offer.consume (view_, order);

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -42,7 +42,7 @@ preflight0(PreflightContext const& ctx)
 
     if (txID == beast::zero)
     {
-        JLOG(ctx.j.warning) <<
+        JLOG(ctx.j.warn()) <<
             "applyTransaction: transaction id may not be zero";
         return temINVALID;
     }
@@ -61,7 +61,7 @@ preflight1 (PreflightContext const& ctx)
     auto const id = ctx.tx.getAccountID(sfAccount);
     if (id == zero)
     {
-        JLOG(ctx.j.warning) << "preflight1: bad account id";
+        JLOG(ctx.j.warn()) << "preflight1: bad account id";
         return temBAD_SRC_ACCOUNT;
     }
 
@@ -69,7 +69,7 @@ preflight1 (PreflightContext const& ctx)
     auto const fee = ctx.tx.getFieldAmount (sfFee);
     if (!fee.native () || fee.negative () || !isLegalAmount (fee.xrp ()))
     {
-        JLOG(ctx.j.debug) << "preflight1: invalid fee";
+        JLOG(ctx.j.debug()) << "preflight1: invalid fee";
         return temBAD_FEE;
     }
 
@@ -77,7 +77,7 @@ preflight1 (PreflightContext const& ctx)
 
     if (!spk.empty () && !publicKeyType (makeSlice (spk)))
     {
-        JLOG(ctx.j.debug) << "preflight1: invalid signing key";
+        JLOG(ctx.j.debug()) << "preflight1: invalid signing key";
         return temBAD_SIGNATURE;
     }
 
@@ -94,7 +94,7 @@ preflight2 (PreflightContext const& ctx)
             ctx.tx, ctx.rules, ctx.app.config());
         if (sigValid.first == Validity::SigBad)
        {
-            JLOG(ctx.j.debug) <<
+            JLOG(ctx.j.debug()) <<
                 "preflight2: bad signature. " << sigValid.second;
             return temINVALID;
         }
@@ -165,7 +165,7 @@ Transactor::checkFee (PreclaimContext const& ctx, std::uint64_t baseFee)
     // Only check fee is sufficient when the ledger is open.
     if (ctx.view.open() && feePaid < feeDue)
     {
-        JLOG(ctx.j.trace) << "Insufficient fee paid: " <<
+        JLOG(ctx.j.trace()) << "Insufficient fee paid: " <<
             to_string (feePaid) << "/" << to_string (feeDue);
         return telINSUF_FEE_P;
     }
@@ -180,7 +180,7 @@ Transactor::checkFee (PreclaimContext const& ctx, std::uint64_t baseFee)
 
     if (balance < feePaid)
     {
-        JLOG(ctx.j.trace) << "Insufficient balance:" <<
+        JLOG(ctx.j.trace()) << "Insufficient balance:" <<
             " balance=" << to_string(balance) <<
             " paid=" << to_string(feePaid);
 
@@ -224,7 +224,7 @@ Transactor::checkSeq (PreclaimContext const& ctx)
 
     if (!sle)
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "applyTransaction: delay: source account does not exist " <<
             toBase58(ctx.tx.getAccountID(sfAccount));
         return terNO_ACCOUNT;
@@ -242,7 +242,7 @@ Transactor::checkSeq (PreclaimContext const& ctx)
                 return tesSUCCESS;
             }
 
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "applyTransaction: has future sequence number " <<
                 "a_seq=" << a_seq << " t_seq=" << t_seq;
             return terPRE_SEQ;
@@ -251,7 +251,7 @@ Transactor::checkSeq (PreclaimContext const& ctx)
         if (ctx.view.txExists(ctx.tx.getTransactionID ()))
             return tefALREADY;
 
-        JLOG(ctx.j.trace) << "applyTransaction: has past sequence number " <<
+        JLOG(ctx.j.trace()) << "applyTransaction: has past sequence number " <<
             "a_seq=" << a_seq << " t_seq=" << t_seq;
         return tefPAST_SEQ;
     }
@@ -349,7 +349,7 @@ Transactor::checkSingleSign (PreclaimContext const& ctx)
     auto const spk = ctx.tx.getSigningPubKey();
     if (!publicKeyType (makeSlice (spk)))
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "checkSingleSign: signing public key type is unknown";
         return tefBAD_AUTH; // FIXME: should be better error!
     }
@@ -370,13 +370,13 @@ Transactor::checkSingleSign (PreclaimContext const& ctx)
     }
     else if (hasAuthKey)
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "checkSingleSign: Not authorized to use account.";
         return tefBAD_AUTH;
     }
     else
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "checkSingleSign: Not authorized to use account.";
         return tefBAD_AUTH_MASTER;
     }
@@ -393,7 +393,7 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
     // If the signer list doesn't exist the account is not multi-signing.
     if (!sleAccountSigners)
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "applyTransaction: Invalid: Not a multi-signing account.";
         return tefNOT_MULTI_SIGNING;
     }
@@ -428,7 +428,7 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
         {
             if (++iter == accountSigners.first.end ())
             {
-                JLOG(ctx.j.trace) <<
+                JLOG(ctx.j.trace()) <<
                     "applyTransaction: Invalid SigningAccount.Account.";
                 return tefBAD_SIGNATURE;
             }
@@ -436,7 +436,7 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
         if (iter->account != txSignerAcctID)
         {
             // The SigningAccount is not in the SignerEntries.
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "applyTransaction: Invalid SigningAccount.Account.";
             return tefBAD_SIGNATURE;
         }
@@ -448,7 +448,7 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
 
         if (!publicKeyType (makeSlice(spk)))
         {
-            JLOG(ctx.j.trace) <<
+            JLOG(ctx.j.trace()) <<
                 "checkMultiSign: signing public key type is unknown";
             return tefBAD_SIGNATURE;
         }
@@ -495,7 +495,7 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
 
                 if (signerAccountFlags & lsfDisableMaster)
                 {
-                    JLOG(ctx.j.trace) <<
+                    JLOG(ctx.j.trace()) <<
                         "applyTransaction: Signer:Account lsfDisableMaster.";
                     return tefMASTER_DISABLED;
                 }
@@ -507,21 +507,21 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
             // Public key must hash to the account's regular key.
             if (!sleTxSignerRoot)
             {
-                JLOG(ctx.j.trace) <<
+                JLOG(ctx.j.trace()) <<
                     "applyTransaction: Non-phantom signer lacks account root.";
                 return tefBAD_SIGNATURE;
             }
 
             if (!sleTxSignerRoot->isFieldPresent (sfRegularKey))
             {
-                JLOG(ctx.j.trace) <<
+                JLOG(ctx.j.trace()) <<
                     "applyTransaction: Account lacks RegularKey.";
                 return tefBAD_SIGNATURE;
             }
             if (signingAcctIDFromPubKey !=
                 sleTxSignerRoot->getAccountID (sfRegularKey))
             {
-                JLOG(ctx.j.trace) <<
+                JLOG(ctx.j.trace()) <<
                     "applyTransaction: Account doesn't match RegularKey.";
                 return tefBAD_SIGNATURE;
             }
@@ -533,7 +533,7 @@ TER Transactor::checkMultiSign (PreclaimContext const& ctx)
     // Cannot perform transaction if quorum is not met.
     if (weightSum < sleAccountSigners->getFieldU32 (sfSignerQuorum))
     {
-        JLOG(ctx.j.trace) <<
+        JLOG(ctx.j.trace()) <<
             "applyTransaction: Signers failed to meet quorum.";
         return tefBAD_QUORUM;
     }
@@ -566,7 +566,7 @@ void removeUnfundedOffers (ApplyView& view, std::vector<uint256> const& offers, 
 std::pair<TER, bool>
 Transactor::operator()()
 {
-    JLOG(j_.trace) <<
+    JLOG(j_.trace()) <<
         "applyTransaction>";
 
     auto const txID = ctx_.tx.getTransactionID ();
@@ -580,10 +580,10 @@ Transactor::operator()()
 
         if (! s2.isEquivalent(ctx_.tx))
         {
-            JLOG(j_.fatal) <<
+            JLOG(j_.fatal()) <<
                 "Transaction serdes mismatch";
-            JLOG(j_.info) << to_string(ctx_.tx.getJson (0));
-            JLOG(j_.fatal) << s2.getJson (0);
+            JLOG(j_.info()) << to_string(ctx_.tx.getJson (0));
+            JLOG(j_.fatal()) << s2.getJson (0);
             assert (false);
         }
     }
@@ -597,14 +597,14 @@ Transactor::operator()()
     // and it can't be passed in from a preclaim.
     assert(terResult != temUNKNOWN);
 
-    if (j_.debug)
+    if (auto stream = j_.debug())
     {
         std::string strToken;
         std::string strHuman;
 
         transResultInfo (terResult, strToken, strHuman);
 
-        j_.debug <<
+        stream <<
             "applyTransaction: terResult=" << strToken <<
             " : " << terResult <<
             " : " << strHuman;
@@ -620,7 +620,7 @@ Transactor::operator()()
         (isTecClaim (terResult) && !(view().flags() & tapRETRY)))
     {
         // only claim the transaction fee
-        JLOG(j_.debug) <<
+        JLOG(j_.debug()) <<
             "Reprocessing tx " << txID << " to only claim fee";
 
         std::vector<uint256> removedOffers;
@@ -675,7 +675,7 @@ Transactor::operator()()
     }
     else if (!didApply)
     {
-        JLOG(j_.debug) << "Not applying transaction " << txID;
+        JLOG(j_.debug()) << "Not applying transaction " << txID;
     }
 
     if (didApply)
@@ -691,7 +691,7 @@ Transactor::operator()()
             if (fee < zero)
             {
                 // VFALCO Log to journal here
-                // JLOG(journal.fatal) << "invalid fee";
+                // JLOG(journal.fatal()) << "invalid fee";
                 Throw<std::logic_error> ("amount is negative!");
             }
 
@@ -704,7 +704,7 @@ Transactor::operator()()
         // at view() past this point.
     }
 
-    JLOG(j_.trace) <<
+    JLOG(j_.trace()) <<
         "apply: " << transToken(terResult) <<
         ", " << (didApply ? "true" : "false");
 

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -195,7 +195,7 @@ preflight(Application& app, Rules const& rules,
     }
     catch (std::exception const& e)
     {
-        JLOG(j.fatal) <<
+        JLOG(j.fatal()) <<
             "apply: " << e.what();
         return{ pfctx, tefEXCEPTION };
     }
@@ -228,7 +228,7 @@ preclaim (PreflightResult const& preflightResult,
     }
     catch (std::exception const& e)
     {
-        JLOG(ctx->j.fatal) <<
+        JLOG(ctx->j.fatal()) <<
             "apply: " << e.what();
         return{ *ctx, tefEXCEPTION, 0 };
     }
@@ -267,7 +267,7 @@ doApply(PreclaimResult const& preclaimResult,
     }
     catch (std::exception const& e)
     {
-        JLOG(preclaimResult.j.fatal) <<
+        JLOG(preclaimResult.j.fatal()) <<
             "apply: " << e.what();
         return { tefEXCEPTION, false };
     }

--- a/src/ripple/basics/Log.h
+++ b/src/ripple/basics/Log.h
@@ -31,7 +31,7 @@
 
 namespace ripple {
 
-// DEPRECATED use beast::Journal::Severity instead
+// DEPRECATED use beast::severities::Severity instead
 enum LogSeverity
 {
     lsINVALID   = -1,   // used to indicate an invalid severity
@@ -57,13 +57,13 @@ private:
 
     public:
         Sink (std::string const& partition,
-            beast::Journal::Severity thresh, Logs& logs);
+            beast::severities::Severity thresh, Logs& logs);
 
         Sink (Sink const&) = delete;
         Sink& operator= (Sink const&) = delete;
 
         void
-        write (beast::Journal::Severity level,
+        write (beast::severities::Severity level,
                std::string const& text) override;
     };
 
@@ -149,12 +149,12 @@ private:
     std::map <std::string,
         std::unique_ptr<beast::Journal::Sink>,
             beast::ci_less> sinks_;
-    beast::Journal::Severity thresh_;
+    beast::severities::Severity thresh_;
     File file_;
     bool silent_ = false;
 
 public:
-    Logs(beast::Journal::Severity level);
+    Logs(beast::severities::Severity level);
 
     Logs (Logs const&) = delete;
     Logs& operator= (Logs const&) = delete;
@@ -173,17 +173,17 @@ public:
     beast::Journal
     journal (std::string const& name);
 
-    beast::Journal::Severity
+    beast::severities::Severity
     threshold() const;
 
     void
-    threshold (beast::Journal::Severity thresh);
+    threshold (beast::severities::Severity thresh);
 
     std::vector<std::pair<std::string, std::string>>
     partition_severities() const;
 
     void
-    write (beast::Journal::Severity level, std::string const& partition,
+    write (beast::severities::Severity level, std::string const& partition,
         std::string const& text, bool console);
 
     std::string
@@ -203,15 +203,15 @@ public:
     virtual
     std::unique_ptr<beast::Journal::Sink>
     makeSink(std::string const& partition,
-        beast::Journal::Severity startingLevel);
+        beast::severities::Severity startingLevel);
 
 public:
     static
     LogSeverity
-    fromSeverity (beast::Journal::Severity level);
+    fromSeverity (beast::severities::Severity level);
 
     static
-    beast::Journal::Severity
+    beast::severities::Severity
     toSeverity (LogSeverity level);
 
     static
@@ -237,7 +237,7 @@ private:
     static
     void
     format (std::string& output, std::string const& message,
-        beast::Journal::Severity severity, std::string const& partition);
+        beast::severities::Severity severity, std::string const& partition);
 };
 
 // Wraps a Journal::Stream to skip evaluation of

--- a/src/ripple/basics/TaggedCache.h
+++ b/src/ripple/basics/TaggedCache.h
@@ -21,6 +21,7 @@
 #define RIPPLE_BASICS_TAGGEDCACHE_H_INCLUDED
 
 #include <ripple/basics/hardened_hash.h>
+#include <ripple/basics/Log.h>
 #include <ripple/basics/UnorderedContainers.h>
 #include <beast/chrono/abstract_clock.h>
 #include <beast/Insight.h>
@@ -108,7 +109,7 @@ public:
         if (s > 0)
             m_cache.rehash (static_cast<std::size_t> ((s + (s >> 2)) / m_cache.max_load_factor () + 1));
 
-        if (m_journal.debug) m_journal.debug <<
+        JLOG(m_journal.debug()) <<
             m_name << " target size set to " << s;
     }
 
@@ -122,7 +123,7 @@ public:
     {
         lock_guard lock (m_mutex);
         m_target_age = std::chrono::seconds (s);
-        if (m_journal.debug) m_journal.debug <<
+        JLOG(m_journal.debug()) <<
             m_name << " target age set to " << m_target_age.count();
     }
 
@@ -191,7 +192,7 @@ public:
                 if (when_expire > (now - minimumAge))
                     when_expire = now - minimumAge;
 
-                if (m_journal.trace) m_journal.trace <<
+                JLOG(m_journal.trace()) <<
                     m_name << " is growing fast " << m_cache.size () << " of " << m_target_size <<
                         " aging at " << (now - when_expire).count() << " of " << m_target_age.count();
             }
@@ -242,9 +243,12 @@ public:
             }
         }
 
-        if (m_journal.trace && (mapRemovals || cacheRemovals)) m_journal.trace <<
-            m_name << ": cache = " << m_cache.size () << "-" << cacheRemovals <<
-                ", map-=" << mapRemovals;
+        if (mapRemovals || cacheRemovals)
+        {
+            JLOG(m_journal.trace()) <<
+                m_name << ": cache = " << m_cache.size () <<
+                "-" << cacheRemovals << ", map-=" << mapRemovals;
+        }
 
         // At this point stuffToSweep will go out of scope outside the lock
         // and decrement the reference count on each strong pointer.

--- a/src/ripple/basics/impl/Log.cpp
+++ b/src/ripple/basics/impl/Log.cpp
@@ -28,7 +28,7 @@
 namespace ripple {
 
 Logs::Sink::Sink (std::string const& partition,
-    beast::Journal::Severity thresh, Logs& logs)
+    beast::severities::Severity thresh, Logs& logs)
     : beast::Journal::Sink (thresh, false)
     , logs_(logs)
     , partition_(partition)
@@ -36,7 +36,7 @@ Logs::Sink::Sink (std::string const& partition,
 }
 
 void
-Logs::Sink::write (beast::Journal::Severity level, std::string const& text)
+Logs::Sink::write (beast::severities::Severity level, std::string const& text)
 {
     if (level < threshold())
         return;
@@ -111,7 +111,7 @@ void Logs::File::writeln (char const* text)
 
 //------------------------------------------------------------------------------
 
-Logs::Logs(beast::Journal::Severity thresh)
+Logs::Logs(beast::severities::Severity thresh)
     : thresh_ (thresh) // default severity
 {
 }
@@ -143,14 +143,14 @@ Logs::journal (std::string const& name)
     return beast::Journal (get(name));
 }
 
-beast::Journal::Severity
+beast::severities::Severity
 Logs::threshold() const
 {
     return thresh_;
 }
 
 void
-Logs::threshold (beast::Journal::Severity thresh)
+Logs::threshold (beast::severities::Severity thresh)
 {
     std::lock_guard <std::mutex> lock (mutex_);
     thresh_ = thresh;
@@ -171,7 +171,7 @@ Logs::partition_severities() const
 }
 
 void
-Logs::write (beast::Journal::Severity level, std::string const& partition,
+Logs::write (beast::severities::Severity level, std::string const& partition,
     std::string const& text, bool console)
 {
     std::string s;
@@ -197,51 +197,51 @@ Logs::rotate()
 
 std::unique_ptr<beast::Journal::Sink>
 Logs::makeSink(std::string const& name,
-    beast::Journal::Severity threshold)
+    beast::severities::Severity threshold)
 {
     return std::make_unique<Sink>(
         name, threshold, *this);
 }
 
 LogSeverity
-Logs::fromSeverity (beast::Journal::Severity level)
+Logs::fromSeverity (beast::severities::Severity level)
 {
-    using beast::Journal;
+    using namespace beast::severities;
     switch (level)
     {
-    case Journal::kTrace:   return lsTRACE;
-    case Journal::kDebug:   return lsDEBUG;
-    case Journal::kInfo:    return lsINFO;
-    case Journal::kWarning: return lsWARNING;
-    case Journal::kError:   return lsERROR;
+    case kTrace:   return lsTRACE;
+    case kDebug:   return lsDEBUG;
+    case kInfo:    return lsINFO;
+    case kWarning: return lsWARNING;
+    case kError:   return lsERROR;
 
     default:
         assert(false);
-    case Journal::kFatal:
+    case kFatal:
         break;
     }
 
     return lsFATAL;
 }
 
-beast::Journal::Severity
+beast::severities::Severity
 Logs::toSeverity (LogSeverity level)
 {
-    using beast::Journal;
+    using namespace beast::severities;
     switch (level)
     {
-    case lsTRACE:   return Journal::kTrace;
-    case lsDEBUG:   return Journal::kDebug;
-    case lsINFO:    return Journal::kInfo;
-    case lsWARNING: return Journal::kWarning;
-    case lsERROR:   return Journal::kError;
+    case lsTRACE:   return kTrace;
+    case lsDEBUG:   return kDebug;
+    case lsINFO:    return kInfo;
+    case lsWARNING: return kWarning;
+    case lsERROR:   return kError;
     default:
         assert(false);
     case lsFATAL:
         break;
     }
 
-    return Journal::kFatal;
+    return kFatal;
 }
 
 std::string
@@ -307,7 +307,7 @@ Logs::scrub (std::string s)
 
 void
 Logs::format (std::string& output, std::string const& message,
-    beast::Journal::Severity severity, std::string const& partition)
+    beast::severities::Severity severity, std::string const& partition)
 {
     output.reserve (message.size() + partition.size() + 100);
 
@@ -318,16 +318,17 @@ Logs::format (std::string& output, std::string const& message,
     if (! partition.empty ())
         output += partition + ":";
 
+    using namespace beast::severities;
     switch (severity)
     {
-    case beast::Journal::kTrace:    output += "TRC "; break;
-    case beast::Journal::kDebug:    output += "DBG "; break;
-    case beast::Journal::kInfo:     output += "NFO "; break;
-    case beast::Journal::kWarning:  output += "WRN "; break;
-    case beast::Journal::kError:    output += "ERR "; break;
+    case kTrace:    output += "TRC "; break;
+    case kDebug:    output += "DBG "; break;
+    case kInfo:     output += "NFO "; break;
+    case kWarning:  output += "WRN "; break;
+    case kError:    output += "ERR "; break;
     default:
         assert(false);
-    case beast::Journal::kFatal:    output += "FTL "; break;
+    case kFatal:    output += "FTL "; break;
     }
 
     output += scrub (message);

--- a/src/ripple/basics/impl/ResolverAsio.cpp
+++ b/src/ripple/basics/impl/ResolverAsio.cpp
@@ -121,7 +121,7 @@ public:
                 &ResolverAsioImpl::do_stop,
                     this, CompletionCounter (this))));
 
-            JLOG(m_journal.debug) << "Queued a stop request";
+            JLOG(m_journal.debug()) << "Queued a stop request";
         }
     }
 
@@ -129,9 +129,9 @@ public:
     {
         stop_async ();
 
-        JLOG(m_journal.debug) << "Waiting to stop";
+        JLOG(m_journal.debug()) << "Waiting to stop";
         m_stop_complete.wait();
-        JLOG(m_journal.debug) << "Stopped";
+        JLOG(m_journal.debug()) << "Stopped";
     }
 
     void resolve (
@@ -256,7 +256,7 @@ public:
 
         if (hp.first.empty ())
         {
-            JLOG(m_journal.error) <<
+            JLOG(m_journal.error()) <<
                 "Unable to parse '" << name << "'";
 
             m_io_service.post (m_strand.wrap (std::bind (
@@ -285,7 +285,7 @@ public:
         {
             m_work.emplace_back (names, handler);
 
-            JLOG(m_journal.debug) <<
+            JLOG(m_journal.debug()) <<
                 "Queued new job with " << names.size() <<
                 " tasks. " << m_work.size() << " jobs outstanding.";
 

--- a/src/ripple/core/SociDB.h
+++ b/src/ripple/core/SociDB.h
@@ -52,7 +52,7 @@ T rangeCheckedCast (C c)
          std::numeric_limits<C>::is_signed &&
          c < std::numeric_limits<T>::lowest ()))
     {
-        JLOG (debugJournal().error) << "rangeCheckedCast domain error:"
+        JLOG (debugJournal().error()) << "rangeCheckedCast domain error:"
           << " value = " << c
           << " min = " << std::numeric_limits<T>::lowest ()
           << " max: " << std::numeric_limits<T>::max ();

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -120,7 +120,7 @@ bool getSingleSection (IniFileSections& secSource,
     }
     else if (pmtEntries)
     {
-        JLOG (j.warning) << boost::str (
+        JLOG (j.warn()) << boost::str (
             boost::format ("Section [%s]: requires 1 line not %d lines.") %
             strSection % pmtEntries->size ());
     }
@@ -442,7 +442,7 @@ void Config::loadFromString (std::string const& fileContents)
 
         if (validatorsFile.empty ())
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "[" SECTION_VALIDATORS_FILE "]" <<
                 ": " << strTemp <<
                 " is not a valid path";
@@ -450,7 +450,7 @@ void Config::loadFromString (std::string const& fileContents)
         }
         else if (!boost::filesystem::exists (validatorsFile))
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "[" SECTION_VALIDATORS_FILE "]" <<
                 ": the file " << validatorsFile <<
                 " does not exist";
@@ -458,7 +458,7 @@ void Config::loadFromString (std::string const& fileContents)
         }
         else if (!boost::filesystem::is_regular_file (validatorsFile))
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "[" SECTION_VALIDATORS_FILE "]" <<
                 ": the file " << validatorsFile <<
                 " is not a regular file";
@@ -498,7 +498,7 @@ void Config::loadFromString (std::string const& fileContents)
 
         if (!entries)
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "[" SECTION_VALIDATORS_FILE "]" <<
                 ": the file " << validatorsFile <<
                 " does not contain a [" SECTION_VALIDATORS <<

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -166,7 +166,7 @@ JobQueue::getJobCountGE (JobType t) const
 void
 JobQueue::shutdown ()
 {
-    JLOG(m_journal.info) <<  "Job queue shutting down";
+    JLOG(m_journal.info()) <<  "Job queue shutting down";
 
     m_workers.pauseAllThreadsAndWait ();
 }
@@ -183,7 +183,7 @@ JobQueue::setThreadCount (int c, bool const standaloneMode)
         c = static_cast<int>(std::thread::hardware_concurrency());
         c = 2 + std::min (c, 4); // I/O will bottleneck
 
-        JLOG(m_journal.info) << "Auto-tuning to " << c <<
+        JLOG(m_journal.info()) << "Auto-tuning to " << c <<
                             " validation/transaction/proposal threads";
     }
 
@@ -463,7 +463,7 @@ JobQueue::processTask ()
             type = job.getType();
             JobTypeData& data(getJobTypeData(type));
             beast::Thread::setCurrentThreadName (data.name ());
-            JLOG(m_journal.trace) << "Doing " << data.name () << " job";
+            JLOG(m_journal.trace()) << "Doing " << data.name () << " job";
             on_dequeue (job.getType (), start_time - job.queue_time ());
             job.doJob ();
         }

--- a/src/ripple/core/impl/LoadFeeTrack.cpp
+++ b/src/ripple/core/impl/LoadFeeTrack.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/basics/contract.h>
+#include <ripple/basics/Log.h>
 #include <ripple/basics/mulDiv.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/core/Config.h>
@@ -147,7 +148,7 @@ LoadFeeTrack::raiseLocalFee ()
     if (origFee == mLocalTxnLoadFee)
         return false;
 
-    m_journal.debug << "Local load fee raised from " <<
+    JLOG(m_journal.debug()) << "Local load fee raised from " <<
         origFee << " to " << mLocalTxnLoadFee;
     return true;
 }
@@ -168,7 +169,7 @@ LoadFeeTrack::lowerLocalFee ()
     if (origFee == mLocalTxnLoadFee)
         return false;
 
-    m_journal.debug << "Local load fee lowered from " <<
+    JLOG(m_journal.debug()) << "Local load fee lowered from " <<
         origFee << " to " << mLocalTxnLoadFee;
     return true;
 }

--- a/src/ripple/core/impl/LoadMonitor.cpp
+++ b/src/ripple/core/impl/LoadMonitor.cpp
@@ -147,7 +147,7 @@ void LoadMonitor::addLoadSample (LoadEvent const& sample)
 
     if (latency.inSeconds() > 0.5)
     {
-        auto& mj = latency.inSeconds() > 1.0 ? j_.warning : j_.info;
+        auto mj = latency.inSeconds() > 1.0 ? j_.warn() : j_.info();
         JLOG (mj)
             << "Job: " << name << " ExecutionTime: " << printElapsed (sample.getSecondsRunning()) <<
             " WaitingTime: " << printElapsed (sample.getSecondsWaiting());

--- a/src/ripple/core/impl/SNTPClock.cpp
+++ b/src/ripple/core/impl/SNTPClock.cpp
@@ -141,7 +141,7 @@ public:
 
         if (it == servers.end ())
         {
-            JLOG(j_.info) <<
+            JLOG(j_.info()) <<
                 "SNTP: no server specified";
             return;
         }
@@ -207,7 +207,7 @@ public:
             return;
         if (ec)
         {
-            JLOG(j_.error) <<
+            JLOG(j_.error()) <<
                 "SNTPClock::onTimer: " << ec.message();
             return;
         }
@@ -235,18 +235,18 @@ public:
 
         if (! ec)
         {
-            JLOG(j_.trace) <<
+            JLOG(j_.trace()) <<
                 "SNTP: Packet from " << ep_;
             std::lock_guard<std::mutex> lock (mutex_);
             auto const query = queries_.find (ep_);
             if (query == queries_.end ())
             {
-                JLOG(j_.debug) <<
+                JLOG(j_.debug()) <<
                     "SNTP: Reply from " << ep_ << " found without matching query";
             }
             else if (query->second.replied)
             {
-                JLOG(j_.debug) <<
+                JLOG(j_.debug()) <<
                     "SNTP: Duplicate response from " << ep_;
             }
             else
@@ -255,12 +255,12 @@ public:
 
                 if (time (nullptr) > (query->second.sent + 1))
                 {
-                    JLOG(j_.warning) <<
+                    JLOG(j_.warn()) <<
                         "SNTP: Late response from " << ep_;
                 }
                 else if (bytes_xferd < 48)
                 {
-                    JLOG(j_.warning) <<
+                    JLOG(j_.warn()) <<
                         "SNTP: Short reply from " << ep_ <<
                             " (" << bytes_xferd << ") " << buf_.size ();
                 }
@@ -268,7 +268,7 @@ public:
                         &buf_[0])[NTP_OFF_ORGTS_FRAC] !=
                             query->second.nonce)
                 {
-                    JLOG(j_.warning) <<
+                    JLOG(j_.warn()) <<
                         "SNTP: Reply from " << ep_ << "had wrong nonce";
                 }
                 else
@@ -311,7 +311,7 @@ public:
 
         if (best == servers_.end ())
         {
-            JLOG(j_.trace) <<
+            JLOG(j_.trace()) <<
                 "SNTP: No server to query";
             return false;
         }
@@ -320,7 +320,7 @@ public:
 
         if ((best->second != time_t(-1)) && ((best->second + NTP_MIN_QUERY) >= now))
         {
-            JLOG(j_.trace) <<
+            JLOG(j_.trace()) <<
                 "SNTP: All servers recently queried";
             return false;
         }
@@ -333,7 +333,7 @@ public:
             &SNTPClientImp::resolveComplete, this,
                 beast::asio::placeholders::error,
                     beast::asio::placeholders::iterator));
-        JLOG(j_.trace) <<
+        JLOG(j_.trace()) <<
             "SNTPClock: Resolve pending for " << best->first;
         return true;
     }
@@ -346,7 +346,7 @@ public:
             return;
         if (ec)
         {
-            JLOG(j_.trace) <<
+            JLOG(j_.trace()) <<
                 "SNTPClock::resolveComplete: " << ec.message();
             return;
         }
@@ -371,7 +371,7 @@ public:
             if ((query.sent == now) || ((query.sent + 1) == now))
             {
                 // This can happen if the same IP address is reached through multiple names
-                JLOG(j_.trace) <<
+                JLOG(j_.trace()) <<
                     "SNTP: Redundant query suppressed";
                 return;
             }
@@ -395,7 +395,7 @@ public:
 
         if (ec)
         {
-            JLOG(j_.warning) <<
+            JLOG(j_.warn()) <<
                 "SNTPClock::onSend: " << ec.message();
             return;
         }
@@ -412,14 +412,14 @@ public:
 
         if ((info >> 30) == 3)
         {
-            JLOG(j_.info) <<
+            JLOG(j_.info()) <<
                 "SNTP: Alarm condition " << ep_;
             return;
         }
 
         if ((stratum == 0) || (stratum > 14))
         {
-            JLOG(j_.info) <<
+            JLOG(j_.info()) <<
                 "SNTP: Unreasonable stratum (" << stratum << ") from " << ep_;
             return;
         }
@@ -453,7 +453,7 @@ public:
 
         if (timev || offset_)
         {
-            JLOG(j_.trace) << "SNTP: Offset is " << timev <<
+            JLOG(j_.trace()) << "SNTP: Offset is " << timev <<
                 ", new system offset is " << offset_;
         }
     }

--- a/src/ripple/core/impl/SociDB.cpp
+++ b/src/ripple/core/impl/SociDB.cpp
@@ -238,13 +238,13 @@ private:
         auto fname = sqlite3_db_filename (&conn_, "main");
         if (ret != SQLITE_OK)
         {
-            auto& jm = (ret == SQLITE_LOCKED) ? j_.trace : j_.warning;
+            auto jm = (ret == SQLITE_LOCKED) ? j_.trace() : j_.warn();
             JLOG (jm)
                 << "WAL(" << fname << "): error " << ret;
         }
         else
         {
-            JLOG (j_.trace)
+            JLOG (j_.trace())
                 << "WAL(" << fname << "): frames="
                 << log << ", written=" << ckpt;
         }

--- a/src/ripple/core/impl/TimeKeeper.cpp
+++ b/src/ripple/core/impl/TimeKeeper.cpp
@@ -94,13 +94,13 @@ public:
         {
             if (std::abs (closeOffset_.count()) < 60)
             {
-                JLOG(j_.info) <<
+                JLOG(j_.info()) <<
                     "TimeKeeper: Close time offset now " <<
                         closeOffset_.count();
             }
             else
             {
-                JLOG(j_.warning) <<
+                JLOG(j_.warn()) <<
                     "TimeKeeper: Large close time offset = " <<
                         closeOffset_.count();
             }

--- a/src/ripple/ledger/impl/ApplyStateTable.cpp
+++ b/src/ripple/ledger/impl/ApplyStateTable.cpp
@@ -247,7 +247,7 @@ ApplyStateTable::apply (OpenView& to,
 
         // VFALCO For diagnostics do we want to show
         //        metadata even when the base view is open?
-        JLOG(j.trace) <<
+        JLOG(j.trace()) <<
             "metadata " << meta.getJson (0);
     }
     to.rawTxInsert(
@@ -565,7 +565,7 @@ ApplyStateTable::getForMod (ReadView const& base,
             {
                 // VFALCO We need to think about throwing
                 //        an exception or calling LogicError
-                JLOG(j.fatal) <<
+                JLOG(j.fatal()) <<
                     "Trying to thread to deleted node";
                 return nullptr;
             }
@@ -581,7 +581,7 @@ ApplyStateTable::getForMod (ReadView const& base,
     {
         // VFALCO We need to think about throwing
         //        an exception or calling LogicError
-        JLOG(j.fatal) <<
+        JLOG(j.fatal()) <<
             "ApplyStateTable::getForMod: key not found";
         return nullptr;
     }
@@ -602,7 +602,7 @@ ApplyStateTable::threadTx (ReadView const& base,
     {
         // VFALCO We need to think about throwing
         //        an exception or calling LogicError
-        JLOG(j.fatal) <<
+        JLOG(j.fatal()) <<
             "Threading to non-existent account: " <<
                 toBase58(to);
         return;

--- a/src/ripple/ledger/impl/TxMeta.cpp
+++ b/src/ripple/ledger/impl/TxMeta.cpp
@@ -157,7 +157,7 @@ TxMeta::getAffectedAccounts() const
                         }
                         else
                         {
-                            JLOG (j_.fatal) << "limit is not amount " << field.getJson (0);
+                            JLOG (j_.fatal()) << "limit is not amount " << field.getJson (0);
                         }
                     }
                 }

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -119,7 +119,7 @@ accountHolds (ReadView const& view,
             amount.clear ();
         else
             amount = balance - reserve;
-        JLOG (j.trace) << "accountHolds:" <<
+        JLOG (j.trace()) << "accountHolds:" <<
             " account=" << to_string (account) <<
             " amount=" << amount.getFullText () <<
             " balance=" << to_string (balance) <<
@@ -149,7 +149,7 @@ accountHolds (ReadView const& view,
             }
             amount.setIssuer (issuer);
         }
-        JLOG (j.trace) << "accountHolds:" <<
+        JLOG (j.trace()) << "accountHolds:" <<
             " account=" << to_string (account) <<
             " amount=" << amount.getFullText ();
     }
@@ -169,7 +169,7 @@ accountFunds (ReadView const& view, AccountID const& id,
         saDefault.getIssuer () == id)
     {
         saFunds = saDefault;
-        JLOG (j.trace) << "accountFunds:" <<
+        JLOG (j.trace()) << "accountFunds:" <<
             " account=" << to_string (id) <<
             " saDefault=" << saDefault.getFullText () <<
             " SELF-FUNDED";
@@ -179,7 +179,7 @@ accountFunds (ReadView const& view, AccountID const& id,
         saFunds = accountHolds(view, id,
             saDefault.getCurrency(), saDefault.getIssuer(),
                 freezeHandling, j);
-        JLOG (j.trace) << "accountFunds:" <<
+        JLOG (j.trace()) << "accountFunds:" <<
             " account=" << to_string (id) <<
             " saDefault=" << saDefault.getFullText () <<
             " saFunds=" << saFunds.getFullText ();
@@ -453,7 +453,7 @@ cdirNext (ReadView const& view,
         if (!sleNext)
         {
             // This should never happen
-            JLOG (j.fatal)
+            JLOG (j.fatal())
                     << "Corrupt directory: index:"
                     << uRootIndex << " next:" << uNodeNext;
             return false;
@@ -463,7 +463,7 @@ cdirNext (ReadView const& view,
             sleNode, uDirEntry, uEntryIndex, j);
     }
     uEntryIndex = svIndexes[uDirEntry++];
-    JLOG (j.trace) << "dirNext:" <<
+    JLOG (j.trace()) << "dirNext:" <<
         " uDirEntry=" << uDirEntry <<
         " uEntryIndex=" << uEntryIndex;
     return true;
@@ -516,7 +516,7 @@ hashOfSeq (ReadView const& ledger, LedgerIndex seq,
     // Easy cases...
     if (seq > ledger.seq())
     {
-        JLOG (journal.warning) <<
+        JLOG (journal.warn()) <<
             "Can't get seq " << seq <<
             " from " << ledger.seq() << " future";
         return boost::none;
@@ -540,21 +540,21 @@ hashOfSeq (ReadView const& ledger, LedgerIndex seq,
                 STVector256 vec = hashIndex->getFieldV256 (sfHashes);
                 if (vec.size () >= diff)
                     return vec[vec.size () - diff];
-                JLOG (journal.warning) <<
+                JLOG (journal.warn()) <<
                     "Ledger " << ledger.seq() <<
                     " missing hash for " << seq <<
                     " (" << vec.size () << "," << diff << ")";
             }
             else
             {
-                JLOG (journal.warning) <<
+                JLOG (journal.warn()) <<
                     "Ledger " << ledger.seq() <<
                     ":" << ledger.info().hash << " missing normal list";
             }
         }
         if ((seq & 0xff) != 0)
         {
-            JLOG (journal.debug) <<
+            JLOG (journal.debug()) <<
                 "Can't get seq " << seq <<
                 " from " << ledger.seq() << " past";
             return boost::none;
@@ -575,7 +575,7 @@ hashOfSeq (ReadView const& ledger, LedgerIndex seq,
         if (vec.size () > diff)
             return vec[vec.size () - diff - 1];
     }
-    JLOG (journal.warning) <<
+    JLOG (journal.warn()) <<
         "Can't get seq " << seq <<
         " from " << ledger.seq() << " error";
     return boost::none;
@@ -601,7 +601,7 @@ adjustOwnerCount (ApplyView& view,
         // Overflow is well defined on unsigned
         if (adjusted < current)
         {
-            JLOG (j.fatal) <<
+            JLOG (j.fatal()) <<
                 "Account " << sle->getAccountID(sfAccount) <<
                 " owner count exceeds max!";
             adjusted =
@@ -613,7 +613,7 @@ adjustOwnerCount (ApplyView& view,
         // Underflow is well defined on unsigned
         if (adjusted > current)
         {
-            JLOG (j.fatal) <<
+            JLOG (j.fatal()) <<
                 "Account " << sle->getAccountID (sfAccount) <<
                 " owner count set below 0!";
             adjusted = 0;
@@ -663,7 +663,7 @@ dirNext (ApplyView& view,
         if (!sleNext)
         {
             // This should never happen
-            JLOG (j.fatal)
+            JLOG (j.fatal())
                     << "Corrupt directory: index:"
                     << uRootIndex << " next:" << uNodeNext;
             return false;
@@ -673,7 +673,7 @@ dirNext (ApplyView& view,
             sleNode, uDirEntry, uEntryIndex, j);
     }
     uEntryIndex = svIndexes[uDirEntry++];
-    JLOG (j.trace) << "dirNext:" <<
+    JLOG (j.trace()) << "dirNext:" <<
         " uDirEntry=" << uDirEntry <<
         " uEntryIndex=" << uEntryIndex;
     return true;
@@ -696,7 +696,7 @@ dirAdd (ApplyView& view,
     std::function<void (SLE::ref, bool)>    fDescriber,
     beast::Journal j)
 {
-    JLOG (j.trace) << "dirAdd:" <<
+    JLOG (j.trace()) << "dirAdd:" <<
         " uRootIndex=" << to_string (uRootIndex) <<
         " uLedgerIndex=" << to_string (uLedgerIndex);
 
@@ -772,11 +772,11 @@ dirAdd (ApplyView& view,
     svIndexes.push_back (uLedgerIndex); // Append entry.
     sleNode->setFieldV256 (sfIndexes, svIndexes);   // Save entry.
 
-    JLOG (j.trace) <<
+    JLOG (j.trace()) <<
         "dirAdd:   creating: root: " << to_string (uRootIndex);
-    JLOG (j.trace) <<
+    JLOG (j.trace()) <<
         "dirAdd:  appending: Entry: " << to_string (uLedgerIndex);
-    JLOG (j.trace) <<
+    JLOG (j.trace()) <<
         "dirAdd:  appending: Node: " << strHex (uNodeDir);
 
     return tesSUCCESS;
@@ -799,7 +799,7 @@ dirDelete (ApplyView& view,
 
     if (!sleNode)
     {
-        JLOG (j.warning) << "dirDelete: no such node:" <<
+        JLOG (j.warn()) << "dirDelete: no such node:" <<
             " uRootIndex=" << to_string (uRootIndex) <<
             " uNodeDir=" << strHex (uNodeDir) <<
             " uLedgerIndex=" << to_string (uLedgerIndex);
@@ -831,7 +831,7 @@ dirDelete (ApplyView& view,
         if (!bSoft)
         {
             assert (false);
-            JLOG (j.warning) << "dirDelete: no such entry";
+            JLOG (j.warn()) << "dirDelete: no such entry";
             return tefBAD_LEDGER;
         }
 
@@ -921,13 +921,13 @@ dirDelete (ApplyView& view,
             assert (slePrevious);
             if (!slePrevious)
             {
-                JLOG (j.warning) << "dirDelete: previous node is missing";
+                JLOG (j.warn()) << "dirDelete: previous node is missing";
                 return tefBAD_LEDGER;
             }
             assert (sleNext);
             if (!sleNext)
             {
-                JLOG (j.warning) << "dirDelete: next node is missing";
+                JLOG (j.warn()) << "dirDelete: next node is missing";
                 return tefBAD_LEDGER;
             }
 
@@ -989,7 +989,7 @@ trustCreate (ApplyView& view,
     std::uint32_t uQualityOut,
     beast::Journal j)
 {
-    JLOG (j.trace)
+    JLOG (j.trace())
         << "trustCreate: " << to_string (uSrcAccountID) << ", "
         << to_string (uDstAccountID) << ", " << saBalance.getFullText ();
 
@@ -1104,7 +1104,7 @@ trustDelete (ApplyView& view,
     std::uint64_t uHighNode   = sleRippleState->getFieldU64 (sfHighNode);
     TER         terResult;
 
-    JLOG (j.trace)
+    JLOG (j.trace())
         << "trustDelete: Deleting ripple line: low";
     terResult   = dirDelete(view,
         false,
@@ -1117,7 +1117,7 @@ trustDelete (ApplyView& view,
 
     if (tesSUCCESS == terResult)
     {
-        JLOG (j.trace)
+        JLOG (j.trace())
                 << "trustDelete: Deleting ripple line: high";
         terResult   = dirDelete (view,
             false,
@@ -1129,7 +1129,7 @@ trustDelete (ApplyView& view,
             j);
     }
 
-    JLOG (j.trace) << "trustDelete: Deleting ripple line: state";
+    JLOG (j.trace()) << "trustDelete: Deleting ripple line: state";
     view.erase(sleRippleState);
 
     return terResult;
@@ -1204,7 +1204,7 @@ rippleCredit (ApplyView& view,
 
         saBalance.setIssuer (noAccount());
 
-        JLOG (j.debug) << "rippleCredit: "
+        JLOG (j.debug()) << "rippleCredit: "
             "create line: " << to_string (uSenderID) <<
             " -> " << to_string (uReceiverID) <<
             " : " << saAmount.getFullText ();
@@ -1243,7 +1243,7 @@ rippleCredit (ApplyView& view,
 
         saBalance   -= saAmount;
 
-        JLOG (j.trace) << "rippleCredit: " <<
+        JLOG (j.trace()) << "rippleCredit: " <<
             to_string (uSenderID) <<
             " -> " << to_string (uReceiverID) <<
             " : before=" << saBefore.getFullText () <<
@@ -1332,7 +1332,7 @@ rippleTransferFee (ReadView const& view,
                 saAmount, amountFromRate (uTransitRate), saAmount.issue ());
             STAmount saTransferFee = saTransferTotal - saAmount;
 
-            JLOG (j.debug) << "rippleTransferFee:" <<
+            JLOG (j.debug()) << "rippleTransferFee:" <<
                 " saTransferFee=" << saTransferFee.getFullText ();
 
             return saTransferFee;
@@ -1375,7 +1375,7 @@ rippleSend (ApplyView& view,
 
         saActual.setIssuer (issuer); // XXX Make sure this done in + above.
 
-        JLOG (j.debug) << "rippleSend> " <<
+        JLOG (j.debug()) << "rippleSend> " <<
             to_string (uSenderID) <<
             " - > " << to_string (uReceiverID) <<
             " : deliver=" << saAmount.getFullText () <<
@@ -1408,7 +1408,7 @@ accountSend (ApplyView& view,
     {
         STAmount saActual;
 
-        JLOG (j.trace) << "accountSend: " <<
+        JLOG (j.trace()) << "accountSend: " <<
             to_string (uSenderID) << " -> " << to_string (uReceiverID) <<
             " : " << saAmount.getFullText ();
 
@@ -1433,7 +1433,7 @@ accountSend (ApplyView& view,
         ? view.peek (keylet::account(uReceiverID))
         : SLE::pointer ();
 
-    if (j.trace)
+    if (auto stream = j.trace())
     {
         std::string sender_bal ("-");
         std::string receiver_bal ("-");
@@ -1444,7 +1444,7 @@ accountSend (ApplyView& view,
         if (receiver)
             receiver_bal = receiver->getFieldAmount (sfBalance).getFullText ();
 
-       j.trace << "accountSend> " <<
+       stream << "accountSend> " <<
             to_string (uSenderID) << " (" << sender_bal <<
             ") -> " << to_string (uReceiverID) << " (" << receiver_bal <<
             ") : " << saAmount.getFullText ();
@@ -1477,7 +1477,7 @@ accountSend (ApplyView& view,
         view.update (receiver);
     }
 
-    if (j.trace)
+    if (auto stream = j.trace())
     {
         std::string sender_bal ("-");
         std::string receiver_bal ("-");
@@ -1488,7 +1488,7 @@ accountSend (ApplyView& view,
         if (receiver)
             receiver_bal = receiver->getFieldAmount (sfBalance).getFullText ();
 
-        j.trace << "accountSend< " <<
+        stream << "accountSend< " <<
             to_string (uSenderID) << " (" << sender_bal <<
             ") -> " << to_string (uReceiverID) << " (" << receiver_bal <<
             ") : " << saAmount.getFullText ();
@@ -1563,7 +1563,7 @@ issueIOU (ApplyView& view,
     // Can't send to self!
     assert (issue.account != account);
 
-    JLOG (j.trace) << "issueIOU: " <<
+    JLOG (j.trace()) << "issueIOU: " <<
         to_string (account) << ": " <<
         amount.getFullText ();
 
@@ -1637,7 +1637,7 @@ redeemIOU (ApplyView& view,
     // Can't send to self!
     assert (issue.account != account);
 
-    JLOG (j.trace) << "redeemIOU: " <<
+    JLOG (j.trace()) << "redeemIOU: " <<
         to_string (account) << ": " <<
         amount.getFullText ();
 
@@ -1651,7 +1651,7 @@ redeemIOU (ApplyView& view,
         // In order to hold an IOU, a trust line *MUST* exist to track the
         // balance. If it doesn't, then something is very wrong. Don't try
         // to continue.
-        JLOG (j.fatal) << "redeemIOU: " <<
+        JLOG (j.fatal()) << "redeemIOU: " <<
             to_string (account) << " attempts to redeem " <<
             amount.getFullText () << " but no trust line exists!";
 
@@ -1707,7 +1707,7 @@ transferXRP (ApplyView& view,
     SLE::pointer sender = view.peek (keylet::account(from));
     SLE::pointer receiver = view.peek (keylet::account(to));
 
-    JLOG (j.trace) << "transferXRP: " <<
+    JLOG (j.trace()) << "transferXRP: " <<
         to_string (from) <<  " -> " << to_string (to) <<
         ") : " << amount.getFullText ();
 

--- a/src/ripple/ledger/tests/View_test.cpp
+++ b/src/ripple/ledger/tests/View_test.cpp
@@ -724,7 +724,7 @@ class View_test
         auto const rdViewB4 = eB.closed();
 
         // Check for compatibility.
-        auto jStream = eA.journal.stream(beast::Journal::kError);
+        auto jStream = eA.journal.error();
         expect (  areCompatible (*rdViewA3, *rdViewA4, jStream, ""));
         expect (  areCompatible (*rdViewA4, *rdViewA3, jStream, ""));
         expect (  areCompatible (*rdViewA4, *rdViewA4, jStream, ""));

--- a/src/ripple/net/impl/HTTPClient.cpp
+++ b/src/ripple/net/impl/HTTPClient.cpp
@@ -178,7 +178,7 @@ public:
 
     void httpsNext ()
     {
-        JLOG (j_.trace) << "Fetch: " << mDeqSites[0];
+        JLOG (j_.trace()) << "Fetch: " << mDeqSites[0];
 
         auto query = std::make_shared<boost::asio::ip::tcp::resolver::query>(
                 mDeqSites[0],
@@ -188,7 +188,7 @@ public:
 
         mDeadline.expires_from_now (mTimeout, mShutdown);
 
-        JLOG (j_.trace) << "expires_from_now: " << mShutdown.message ();
+        JLOG (j_.trace()) << "expires_from_now: " << mShutdown.message ();
 
         if (!mShutdown)
         {
@@ -201,7 +201,7 @@ public:
 
         if (!mShutdown)
         {
-            JLOG (j_.trace) << "Resolving: " << mDeqSites[0];
+            JLOG (j_.trace()) << "Resolving: " << mDeqSites[0];
 
             mResolver.async_resolve (*mQuery,
                                      std::bind (
@@ -220,20 +220,20 @@ public:
         if (ecResult == boost::asio::error::operation_aborted)
         {
             // Timer canceled because deadline no longer needed.
-            JLOG (j_.trace) << "Deadline cancelled.";
+            JLOG (j_.trace()) << "Deadline cancelled.";
 
             // Aborter is done.
         }
         else if (ecResult)
         {
-            JLOG (j_.trace) << "Deadline error: " << mDeqSites[0] << ": " << ecResult.message ();
+            JLOG (j_.trace()) << "Deadline error: " << mDeqSites[0] << ": " << ecResult.message ();
 
             // Can't do anything sound.
             abort ();
         }
         else
         {
-            JLOG (j_.trace) << "Deadline arrived.";
+            JLOG (j_.trace()) << "Deadline arrived.";
 
             // Mark us as shutting down.
             // XXX Use our own error code.
@@ -257,7 +257,7 @@ public:
     {
         if (ecResult)
         {
-            JLOG (j_.trace) << "Shutdown error: " << mDeqSites[0] << ": " << ecResult.message ();
+            JLOG (j_.trace()) << "Shutdown error: " << mDeqSites[0] << ": " << ecResult.message ();
         }
     }
 
@@ -271,13 +271,13 @@ public:
 
         if (mShutdown)
         {
-            JLOG (j_.trace) << "Resolve error: " << mDeqSites[0] << ": " << mShutdown.message ();
+            JLOG (j_.trace()) << "Resolve error: " << mDeqSites[0] << ": " << mShutdown.message ();
 
             invokeComplete (mShutdown);
         }
         else
         {
-            JLOG (j_.trace) << "Resolve complete.";
+            JLOG (j_.trace()) << "Resolve complete.";
 
             boost::asio::async_connect (
                 mSocket.lowest_layer (),
@@ -296,12 +296,12 @@ public:
 
         if (mShutdown)
         {
-            JLOG (j_.trace) << "Connect error: " << mShutdown.message ();
+            JLOG (j_.trace()) << "Connect error: " << mShutdown.message ();
         }
 
         if (!mShutdown)
         {
-            JLOG (j_.trace) << "Connected.";
+            JLOG (j_.trace()) << "Connected.";
 
             if (httpClientSSLContext->sslVerify ())
             {
@@ -309,7 +309,7 @@ public:
 
                 if (mShutdown)
                 {
-                    JLOG (j_.trace) << "set_verify_callback: " << mDeqSites[0] << ": " << mShutdown.message ();
+                    JLOG (j_.trace()) << "set_verify_callback: " << mDeqSites[0] << ": " << mShutdown.message ();
                 }
             }
         }
@@ -340,13 +340,13 @@ public:
 
         if (mShutdown)
         {
-            JLOG (j_.trace) << "Handshake error:" << mShutdown.message ();
+            JLOG (j_.trace()) << "Handshake error:" << mShutdown.message ();
 
             invokeComplete (mShutdown);
         }
         else
         {
-            JLOG (j_.trace) << "Session started.";
+            JLOG (j_.trace()) << "Session started.";
 
             mBuild (mRequest, mDeqSites[0]);
 
@@ -366,13 +366,13 @@ public:
 
         if (mShutdown)
         {
-            JLOG (j_.trace) << "Write error: " << mShutdown.message ();
+            JLOG (j_.trace()) << "Write error: " << mShutdown.message ();
 
             invokeComplete (mShutdown);
         }
         else
         {
-            JLOG (j_.trace) << "Wrote.";
+            JLOG (j_.trace()) << "Wrote.";
 
             mSocket.async_read_until (
                 mHeader,
@@ -387,7 +387,7 @@ public:
     void handleHeader (const boost::system::error_code& ecResult, std::size_t bytes_transferred)
     {
         std::string     strHeader ((std::istreambuf_iterator<char> (&mHeader)), std::istreambuf_iterator<char> ());
-        JLOG (j_.trace) << "Header: \"" << strHeader << "\"";
+        JLOG (j_.trace()) << "Header: \"" << strHeader << "\"";
 
         static boost::regex reStatus ("\\`HTTP/1\\S+ (\\d{3}) .*\\'");          // HTTP/1.1 200 OK
         static boost::regex reSize ("\\`.*\\r\\nContent-Length:\\s+([0-9]+).*\\'");
@@ -400,7 +400,7 @@ public:
         if (!bMatch)
         {
             // XXX Use our own error code.
-            JLOG (j_.trace) << "No status code";
+            JLOG (j_.trace()) << "No status code";
             invokeComplete (boost::system::error_code (boost::system::errc::bad_address, boost::system::system_category ()));
             return;
         }
@@ -447,7 +447,7 @@ public:
 
         if (mShutdown && mShutdown != boost::asio::error::eof)
         {
-            JLOG (j_.trace) << "Read error: " << mShutdown.message ();
+            JLOG (j_.trace()) << "Read error: " << mShutdown.message ();
 
             invokeComplete (mShutdown);
         }
@@ -455,7 +455,7 @@ public:
         {
             if (mShutdown)
             {
-                JLOG (j_.trace) << "Complete.";
+                JLOG (j_.trace()) << "Complete.";
             }
             else
             {
@@ -475,10 +475,10 @@ public:
 
         if (ecCancel)
         {
-            JLOG (j_.trace) << "invokeComplete: Deadline cancel error: " << ecCancel.message ();
+            JLOG (j_.trace()) << "invokeComplete: Deadline cancel error: " << ecCancel.message ();
         }
 
-        JLOG (j_.debug) << "invokeComplete: Deadline popping: " << mDeqSites.size ();
+        JLOG (j_.debug()) << "invokeComplete: Deadline popping: " << mDeqSites.size ();
 
         if (!mDeqSites.empty ())
         {

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -478,8 +478,8 @@ private:
         Json::Reader    reader;
         Json::Value     jvRequest;
 
-        JLOG (j_.trace) << "RPC method: " << jvParams[0u];
-        JLOG (j_.trace) << "RPC json: " << jvParams[1u];
+        JLOG (j_.trace()) << "RPC method: " << jvParams[0u];
+        JLOG (j_.trace()) << "RPC json: " << jvParams[1u];
 
         if (reader.parse (jvParams[1u].asString (), jvRequest))
         {
@@ -635,7 +635,7 @@ private:
         Json::Value     jvRequest;
         bool            bLedger     = 2 == jvParams.size ();
 
-        JLOG (j_.trace) << "RPC json: " << jvParams[0u];
+        JLOG (j_.trace()) << "RPC json: " << jvParams[0u];
 
         if (reader.parse (jvParams[0u].asString (), jvRequest))
         {
@@ -893,10 +893,10 @@ public:
     // <-- { method: xyz, params: [... ] } or { error: ..., ... }
     Json::Value parseCommand (std::string strMethod, Json::Value jvParams, bool allowAnyCommand)
     {
-        if (j_.trace)
+        if (auto stream = j_.trace())
         {
-            j_.trace << "Method: '" << strMethod << "'";
-            j_.trace << "Params: " << jvParams;
+            stream << "Method: '" << strMethod << "'";
+            stream << "Params: " << jvParams;
         }
 
         struct Command
@@ -983,7 +983,7 @@ public:
                 if ((command.minParams >= 0 && count < command.minParams) ||
                     (command.maxParams >= 0 && count > command.maxParams))
                 {
-                    JLOG (j_.debug) <<
+                    JLOG (j_.debug()) <<
                         "Wrong number of parameters for " << command.name <<
                         " minimum=" << command.minParams <<
                         " maximum=" << command.maxParams <<
@@ -1054,7 +1054,7 @@ struct RPCCallImp
                 Throw<std::runtime_error> ("no response from server");
 
             // Parse reply
-            JLOG (j.debug) << "RPC reply: " << strData << std::endl;
+            JLOG (j.debug()) << "RPC reply: " << strData << std::endl;
 
             Json::Reader    reader;
             Json::Value     jvReply;
@@ -1080,7 +1080,7 @@ struct RPCCallImp
         const std::map<std::string, std::string>& mHeaders, std::string const& strPath,
             boost::asio::streambuf& sb, std::string const& strHost, beast::Journal j)
     {
-        JLOG (j.debug) << "requestRPC: strPath='" << strPath << "'";
+        JLOG (j.debug()) << "requestRPC: strPath='" << strPath << "'";
 
         std::ostream    osRequest (&sb);
         osRequest <<
@@ -1114,7 +1114,7 @@ rpcCmdLineToJson (std::vector<std::string> const& args,
 
     jvRequest   = rpParser.parseCommand (args[0], jvRpcParams, true);
 
-    JLOG (j.trace) << "RPC Request: " << jvRequest << std::endl;
+    JLOG (j.trace()) << "RPC Request: " << jvRequest << std::endl;
 
     return jvRequest;
 }

--- a/src/ripple/net/impl/RPCSub.cpp
+++ b/src/ripple/net/impl/RPCSub.cpp
@@ -61,7 +61,7 @@ public:
         if (mPort < 0)
             mPort   = mSSL ? 443 : 80;
 
-        JLOG (j_.info) <<
+        JLOG (j_.info()) <<
             "RPCCall::fromNetwork sub: ip=" << mIp <<
             " port=" << mPort <<
             " ssl= "<< (mSSL ? "yes" : "no") <<
@@ -79,11 +79,11 @@ public:
         if (mDeque.size () >= eventQueueMax)
         {
             // Drop the previous event.
-            JLOG (j_.warning) << "RPCCall::fromNetwork drop";
+            JLOG (j_.warn()) << "RPCCall::fromNetwork drop";
             mDeque.pop_back ();
         }
 
-        auto& jm = broadcast ? j_.debug : j_.info;
+        auto jm = broadcast ? j_.debug() : j_.info();
         JLOG (jm) <<
             "RPCCall::fromNetwork push: " << jvObj;
 
@@ -94,7 +94,7 @@ public:
             // Start a sending thread.
             mSending    = true;
 
-            JLOG (j_.info) << "RPCCall::fromNetwork start";
+            JLOG (j_.info()) << "RPCCall::fromNetwork start";
 
             m_jobQueue.addJob (
                 jtCLIENT, "RPCSub::sendThread", [this] (Job&) {
@@ -154,7 +154,7 @@ private:
                 // XXX Might not need this in a try.
                 try
                 {
-                    JLOG (j_.info) << "RPCCall::fromNetwork: " << mIp;
+                    JLOG (j_.info()) << "RPCCall::fromNetwork: " << mIp;
 
                     RPCCall::fromNetwork (
                         m_io_service,
@@ -168,7 +168,7 @@ private:
                 }
                 catch (const std::exception& e)
                 {
-                    JLOG (j_.info) << "RPCCall::fromNetwork exception: " << e.what ();
+                    JLOG (j_.info()) << "RPCCall::fromNetwork exception: " << e.what ();
                 }
             }
         }

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -248,7 +248,7 @@ public:
             {
                 status = Status (customCode + getStatus.code());
 
-                m_journal.error << getStatus.ToString ();
+                JLOG(m_journal.error()) << getStatus.ToString ();
             }
         }
 
@@ -322,7 +322,7 @@ public:
                 else
                 {
                     // Uh oh, corrupted data!
-                    if (m_journal.fatal) m_journal.fatal <<
+                    JLOG(m_journal.fatal()) <<
                         "Corrupt NodeObject #" <<
                         from_hex_text<uint256>(it->key ().data ());
                 }
@@ -331,7 +331,7 @@ public:
             {
                 // VFALCO NOTE What does it mean to find an
                 //             incorrectly sized key? Corruption?
-                if (m_journal.fatal) m_journal.fatal <<
+                JLOG(m_journal.fatal()) <<
                     "Bad key size = " << it->key ().size ();
             }
         }

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -247,7 +247,7 @@ public:
             {
                 status = Status (customCode + getStatus.code());
 
-                m_journal.error << getStatus.ToString ();
+                JLOG(m_journal.error()) << getStatus.ToString ();
             }
         }
 
@@ -324,7 +324,7 @@ public:
                 else
                 {
                     // Uh oh, corrupted data!
-                    if (m_journal.fatal) m_journal.fatal <<
+                    JLOG(m_journal.fatal()) <<
                         "Corrupt NodeObject #" <<
                         from_hex_text<uint256>(it->key ().data ());
                 }
@@ -333,7 +333,7 @@ public:
             {
                 // VFALCO NOTE What does it mean to find an
                 //             incorrectly sized key? Corruption?
-                if (m_journal.fatal) m_journal.fatal <<
+                JLOG(m_journal.fatal()) <<
                     "Bad key size = " << it->key ().size ();
             }
         }

--- a/src/ripple/nodestore/impl/DatabaseImp.h
+++ b/src/ripple/nodestore/impl/DatabaseImp.h
@@ -226,7 +226,7 @@ public:
 
             // Since this was a 'hard' fetch, we will log it.
             //
-            if (m_journal.trace) m_journal.trace <<
+            JLOG(m_journal.trace()) <<
                 "HOS: " << hash << " fetch: in db";
         }
 
@@ -257,12 +257,12 @@ public:
         case dataCorrupt:
             // VFALCO TODO Deal with encountering corrupt data!
             //
-            if (m_journal.fatal) m_journal.fatal <<
+            JLOG(m_journal.fatal()) <<
                 "Corrupt NodeObject #" << hash;
             break;
 
         default:
-            if (m_journal.warning) m_journal.warning <<
+            JLOG(m_journal.warn()) <<
                 "Unknown status=" << status;
             break;
         }

--- a/src/ripple/overlay/impl/Cluster.cpp
+++ b/src/ripple/overlay/impl/Cluster.cpp
@@ -115,7 +115,7 @@ Cluster::load (Section const& nodes)
 
         if (!boost::regex_match (n, match, re))
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "Malformed entry: '" << n << "'";
             return false;
         }
@@ -125,14 +125,14 @@ Cluster::load (Section const& nodes)
 
         if (!id)
         {
-            JLOG (j_.error) <<
+            JLOG (j_.error()) <<
                 "Invalid node identity: " << match[1];
             return false;
         }
 
         if (member (*id))
         {
-            JLOG (j_.warning) <<
+            JLOG (j_.warn()) <<
                 "Duplicate node identity: " << match[1];
             continue;
         }

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -109,7 +109,7 @@ OverlayImpl::Timer::on_timer (error_code ec)
     {
         if (ec && ec != boost::asio::error::operation_aborted)
         {
-            JLOG(overlay_.journal_.error) << "on_timer: " << ec.message();
+            JLOG(overlay_.journal_.error()) << "on_timer: " << ec.message();
         }
         return;
     }
@@ -186,13 +186,13 @@ OverlayImpl::onHandoff (std::unique_ptr <beast::asio::ssl_bundle>&& ssl_bundle,
 
     handoff.moved = true;
 
-    JLOG(journal.debug) << "Peer connection upgrade from " << remote_endpoint;
+    JLOG(journal.debug()) << "Peer connection upgrade from " << remote_endpoint;
 
     error_code ec;
     auto const local_endpoint (ssl_bundle->socket.local_endpoint(ec));
     if (ec)
     {
-        JLOG(journal.debug) << remote_endpoint << " failed: " << ec.message();
+        JLOG(journal.debug()) << remote_endpoint << " failed: " << ec.message();
         return handoff;
     }
 
@@ -255,7 +255,7 @@ OverlayImpl::onHandoff (std::unique_ptr <beast::asio::ssl_bundle>&& ssl_bundle,
     if (result != PeerFinder::Result::success)
     {
         m_peerFinder->on_closed(slot);
-        JLOG(journal.debug) <<
+        JLOG(journal.debug()) <<
             "Peer " << remote_endpoint << " redirected, slots full";
         handoff.moved = false;
         handoff.response = makeRedirectResponse(slot, request,
@@ -346,14 +346,14 @@ OverlayImpl::connect (beast::IP::Endpoint const& remote_endpoint)
     auto usage = resourceManager().newOutboundEndpoint (remote_endpoint);
     if (usage.disconnect())
     {
-        JLOG(journal_.info) << "Over resource limit: " << remote_endpoint;
+        JLOG(journal_.info()) << "Over resource limit: " << remote_endpoint;
         return;
     }
 
     auto const slot = peerFinder().new_outbound_slot(remote_endpoint);
     if (slot == nullptr)
     {
-        JLOG(journal_.debug) << "Connect: No slot for " << remote_endpoint;
+        JLOG(journal_.debug()) << "Connect: No slot for " << remote_endpoint;
         return;
     }
 
@@ -393,7 +393,7 @@ OverlayImpl::add_active (std::shared_ptr<PeerImp> const& peer)
 
     list_.emplace(peer.get(), peer);
 
-    JLOG(journal_.debug) <<
+    JLOG(journal_.debug()) <<
         "activated " << peer->getRemoteAddress() <<
         " (" << peer->id() << ":" <<
         toBase58 (
@@ -463,7 +463,7 @@ OverlayImpl::setupValidatorKeyManifests (BasicConfig const& config,
     }
     else
     {
-        JLOG(journal_.debug) << "No [validation_manifest] section in config";
+        JLOG(journal_.debug()) << "No [validation_manifest] section in config";
     }
 
     manifestCache_.load (
@@ -628,7 +628,7 @@ OverlayImpl::activate (std::shared_ptr<PeerImp> const& peer)
         (void) result.second;
     }
 
-    JLOG(journal_.debug) <<
+    JLOG(journal_.debug()) <<
         "activated " << peer->getRemoteAddress() <<
         " (" << peer->id() <<
         ":" << toBase58 (
@@ -655,7 +655,7 @@ OverlayImpl::onManifests (
     auto const n = m->list_size();
     auto const& journal = from->pjournal();
 
-    JLOG(journal.debug) << "TMManifest, " << n << (n == 1 ? " item" : " items");
+    JLOG(journal.debug()) << "TMManifest, " << n << (n == 1 ? " item" : " items");
 
     bool const history = m->history ();
     for (std::size_t i = 0; i < n; ++i)
@@ -713,12 +713,12 @@ OverlayImpl::onManifests (
             }
             else
             {
-                JLOG(journal.info) << "Bad manifest #" << i + 1;
+                JLOG(journal.info()) << "Bad manifest #" << i + 1;
             }
         }
         else
         {
-            JLOG(journal.warning) << "Malformed manifest #" << i + 1;
+            JLOG(journal.warn()) << "Malformed manifest #" << i + 1;
             continue;
         }
     }

--- a/src/ripple/overlay/impl/PeerSet.cpp
+++ b/src/ripple/overlay/impl/PeerSet.cpp
@@ -85,7 +85,7 @@ void PeerSet::invokeOnTimer ()
     if (!isProgress())
     {
         ++mTimeouts;
-        JLOG (m_journal.debug) << "Timeout(" << mTimeouts
+        JLOG (m_journal.debug()) << "Timeout(" << mTimeouts
             << ") pc=" << mPeers.size () << " acquiring " << mHash;
         onTimer (false, sl);
     }
@@ -127,7 +127,7 @@ void PeerSet::timerEntry (
 
             if (jc > 4)
             {
-                JLOG (j.debug) << "Deferring PeerSet timer due to load";
+                JLOG (j.debug()) << "Deferring PeerSet timer due to load";
                 ptr->setTimer ();
             }
             else

--- a/src/ripple/overlay/impl/TMHello.cpp
+++ b/src/ripple/overlay/impl/TMHello.cpp
@@ -71,14 +71,14 @@ makeSharedValue (SSL* ssl, beast::Journal journal)
     auto const cookie1 = hashLastMessage(ssl, SSL_get_finished);
     if (!cookie1)
     {
-        JLOG (journal.error) << "Cookie generation: local setup not complete";
+        JLOG (journal.error()) << "Cookie generation: local setup not complete";
         return boost::none;
     }
 
     auto const cookie2 = hashLastMessage(ssl, SSL_get_peer_finished);
     if (!cookie2)
     {
-        JLOG (journal.error) << "Cookie generation: peer setup not complete";
+        JLOG (journal.error()) << "Cookie generation: peer setup not complete";
         return boost::none;
     }
 
@@ -88,7 +88,7 @@ makeSharedValue (SSL* ssl, beast::Journal journal)
     // is 0. Don't allow this.
     if (result == zero)
     {
-        JLOG(journal.error) << "Cookie generation: identical finished messages";
+        JLOG(journal.error()) << "Cookie generation: identical finished messages";
         return boost::none;
     }
 
@@ -359,26 +359,26 @@ verifyHello (protocol::TMHello const& h,
 
         if (h.nettime () > maxTime)
         {
-            JLOG(journal.info) <<
+            JLOG(journal.info()) <<
                 "Clock for is off by +" << h.nettime() - ourTime;
             return boost::none;
         }
 
         if (h.nettime () < minTime)
         {
-            JLOG(journal.info) <<
+            JLOG(journal.info()) <<
                 "Clock is off by -" << ourTime - h.nettime();
             return boost::none;
         }
 
-        JLOG(journal.trace) <<
+        JLOG(journal.trace()) <<
             "Connect: time offset " <<
             static_cast<std::int64_t>(ourTime) - h.nettime();
     }
 
     if (h.protoversionmin () > to_packed (BuildInfo::getCurrentProtocol()))
     {
-        JLOG(journal.info) <<
+        JLOG(journal.info()) <<
             "Hello: Disconnect: Protocol mismatch [" <<
             "Peer expects " << to_string (
                 BuildInfo::make_protocol(h.protoversion())) <<
@@ -392,14 +392,14 @@ verifyHello (protocol::TMHello const& h,
 
     if (! publicKey)
     {
-        journal.info <<
+        JLOG(journal.info()) <<
             "Hello: Disconnect: Bad node public key.";
         return boost::none;
     }
 
     if (*publicKey == app.nodeIdentity().first)
     {
-        JLOG(journal.info) <<
+        JLOG(journal.info()) <<
             "Hello: Disconnect: Self connection.";
         return boost::none;
     }
@@ -408,7 +408,7 @@ verifyHello (protocol::TMHello const& h,
         makeSlice (h.nodeproof()), false))
     {
         // Unable to verify they have private key for claimed public key.
-        JLOG(journal.info) <<
+        JLOG(journal.info()) <<
             "Hello: Disconnect: Failed to verify session.";
         return boost::none;
     }
@@ -420,7 +420,7 @@ verifyHello (protocol::TMHello const& h,
     {
         // Remote asked us to confirm connection is from
         // correct IP
-        JLOG(journal.info) <<
+        JLOG(journal.info()) <<
             "Hello: Disconnect: Peer IP is " <<
             beast::IP::to_string (remote.to_v4())
             << " not " <<
@@ -434,7 +434,7 @@ verifyHello (protocol::TMHello const& h,
     {
         // We know our public IP and peer reports connection
         // from some other IP
-        JLOG(journal.info) <<
+        JLOG(journal.info()) <<
             "Hello: Disconnect: Our IP is " <<
             beast::IP::to_string (public_ip.to_v4())
             << " not " <<

--- a/src/ripple/peerfinder/impl/Bootcache.cpp
+++ b/src/ripple/peerfinder/impl/Bootcache.cpp
@@ -21,6 +21,7 @@
 #include <ripple/peerfinder/impl/Bootcache.h>
 #include <ripple/peerfinder/impl/iosformat.h>
 #include <ripple/peerfinder/impl/Tuning.h>
+#include <ripple/basics/Log.h>
 
 namespace ripple {
 namespace PeerFinder {
@@ -98,15 +99,15 @@ Bootcache::load ()
                 value_type (endpoint, valence)));
             if (! result.second)
             {
-                if (this->m_journal.error)
-                    this->m_journal.error << beast::leftw (18) <<
+                JLOG(this->m_journal.error())
+                    << beast::leftw (18) <<
                     "Bootcache discard " << endpoint;
             }
         }));
 
     if (n > 0)
     {
-        if (m_journal.info) m_journal.info << beast::leftw (18) <<
+        JLOG(m_journal.info()) << beast::leftw (18) <<
             "Bootcache loaded " << n <<
                 ((n > 1) ? " addresses" : " address");
         prune ();
@@ -120,7 +121,7 @@ Bootcache::insert (beast::IP::Endpoint const& endpoint)
         value_type (endpoint, 0)));
     if (result.second)
     {
-        if (m_journal.trace) m_journal.trace << beast::leftw (18) <<
+        JLOG(m_journal.trace()) << beast::leftw (18) <<
             "Bootcache insert " << endpoint;
         prune ();
         flagForUpdate();
@@ -149,7 +150,7 @@ Bootcache::on_success (beast::IP::Endpoint const& endpoint)
         assert (result.second);
     }
     Entry const& entry (result.first->right);
-    if (m_journal.info) m_journal.info << beast::leftw (18) <<
+    JLOG(m_journal.info()) << beast::leftw (18) <<
         "Bootcache connect " << endpoint <<
         " with " << entry.valence() <<
         ((entry.valence() > 1) ? " successes" : " success");
@@ -178,7 +179,7 @@ Bootcache::on_failure (beast::IP::Endpoint const& endpoint)
     }
     Entry const& entry (result.first->right);
     auto const n (std::abs (entry.valence()));
-    if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
+    JLOG(m_journal.debug()) << beast::leftw (18) <<
         "Bootcache failed " << endpoint <<
         " with " << n <<
         ((n > 1) ? " attempts" : " attempt");
@@ -220,13 +221,13 @@ Bootcache::prune ()
         --iter;
         beast::IP::Endpoint const& endpoint (iter->get_left());
         Entry const& entry (iter->get_right());
-        if (m_journal.trace) m_journal.trace << beast::leftw (18) <<
+        JLOG(m_journal.trace()) << beast::leftw (18) <<
             "Bootcache pruned" << endpoint <<
             " at valence " << entry.valence();
         iter = m_map.right.erase (iter);
     }
 
-    if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
+    JLOG(m_journal.debug()) << beast::leftw (18) <<
         "Bootcache pruned " << pruned << " entries total";
 }
 

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PEERFINDER_LIVECACHE_H_INCLUDED
 #define RIPPLE_PEERFINDER_LIVECACHE_H_INCLUDED
 
+#include <ripple/basics/Log.h>
 #include <ripple/peerfinder/PeerfinderManager.h>
 #include <ripple/peerfinder/impl/iosformat.h>
 #include <ripple/peerfinder/impl/Tuning.h>
@@ -352,9 +353,6 @@ public:
     /** Creates or updates an existing Element based on a new message. */
     void insert (Endpoint const& ep);
 
-    /** Produce diagnostic output. */
-    void dump (beast::Journal::ScopedStream& ss) const;
-
     /** Output statistics. */
     void onWrite (beast::PropertyStream::Map& map);
 };
@@ -389,7 +387,7 @@ Livecache <Allocator>::expire()
     }
     if (n > 0)
     {
-        if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
+        JLOG(m_journal.debug()) << beast::leftw (18) <<
             "Livecache expired " << n <<
             ((n > 1) ? " entries" : " entry");
     }
@@ -411,7 +409,7 @@ void Livecache <Allocator>::insert (Endpoint const& ep)
     if (result.second)
     {
         hops.insert (e);
-        if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
+        JLOG(m_journal.debug()) << beast::leftw (18) <<
             "Livecache insert " << ep.address <<
             " at hops " << ep.hops;
         return;
@@ -421,7 +419,7 @@ void Livecache <Allocator>::insert (Endpoint const& ep)
         // Drop duplicates at higher hops
         std::size_t const excess (
             ep.hops - e.endpoint.hops);
-        if (m_journal.trace) m_journal.trace << beast::leftw(18) <<
+        JLOG(m_journal.trace()) << beast::leftw(18) <<
             "Livecache drop " << ep.address <<
             " at hops +" << excess;
         return;
@@ -433,30 +431,15 @@ void Livecache <Allocator>::insert (Endpoint const& ep)
     if (ep.hops < e.endpoint.hops)
     {
         hops.reinsert (e, ep.hops);
-        if (m_journal.debug) m_journal.debug << beast::leftw (18) <<
+        JLOG(m_journal.debug()) << beast::leftw (18) <<
             "Livecache update " << ep.address <<
             " at hops " << ep.hops;
     }
     else
     {
-        if (m_journal.trace) m_journal.trace << beast::leftw (18) <<
+        JLOG(m_journal.trace()) << beast::leftw (18) <<
             "Livecache refresh " << ep.address <<
             " at hops " << ep.hops;
-    }
-}
-
-template <class Allocator>
-void
-Livecache <Allocator>::dump (beast::Journal::ScopedStream& ss) const
-{
-    ss << std::endl << std::endl <<
-        "Livecache (size " << m_cache.size() << ")";
-    for (auto const& entry : m_cache)
-    {
-        auto const& e (entry.second);
-        ss << std::endl <<
-            e.endpoint.address << ", " <<
-            e.endpoint.hops << " hops";
     }
 }
 

--- a/src/ripple/peerfinder/impl/StoreSqdb.h
+++ b/src/ripple/peerfinder/impl/StoreSqdb.h
@@ -55,7 +55,7 @@ public:
     {
         sociConfig.open (m_session);
 
-        JLOG(m_journal.info) <<
+        JLOG(m_journal.info()) <<
             "Opening database at '" << sociConfig.connectionString () << "'";
 
         init ();
@@ -91,7 +91,7 @@ public:
             }
             else
             {
-                JLOG(m_journal.error) <<
+                JLOG(m_journal.error()) <<
                     "Bad address string '" << s << "' in Bootcache table";
             }
         }
@@ -152,14 +152,14 @@ public:
 
             version = vO.value_or (0);
 
-            JLOG(m_journal.info) <<
+            JLOG(m_journal.info()) <<
                 "Opened version " << version << " database";
         }
 
         {
             if (version < currentSchemaVersion)
             {
-                JLOG(m_journal.info) <<
+                JLOG(m_journal.info()) <<
                     "Updating database to version " << currentSchemaVersion;
             }
             else if (version > currentSchemaVersion)
@@ -223,7 +223,7 @@ public:
                     }
                     else
                     {
-                        JLOG(m_journal.error) <<
+                        JLOG(m_journal.error()) <<
                             "Bad address string '" << s << "' in Bootcache table";
                     }
                 }

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -915,7 +915,7 @@ amountFromJsonNoThrow (STAmount& result, Json::Value const& jvSource)
     }
     catch (const std::exception& e)
     {
-        JLOG (debugJournal().debug) <<
+        JLOG (debugJournal().debug()) <<
             "amountFromJsonNoThrow: caught: " << e.what ();
     }
     return false;

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -76,7 +76,7 @@ STArray::STArray (SerialIter& sit, SField const& f)
 
         if ((type == STI_OBJECT) && (field == 1))
         {
-            JLOG (debugJournal().warning) <<
+            JLOG (debugJournal().warn()) <<
                 "Encountered array with end of object marker";
             Throw<std::runtime_error> ("Illegal terminator in array");
         }
@@ -85,14 +85,14 @@ STArray::STArray (SerialIter& sit, SField const& f)
 
         if (fn.isInvalid ())
         {
-            JLOG (debugJournal().trace) <<
+            JLOG (debugJournal().trace()) <<
                 "Unknown field: " << type << "/" << field;
             Throw<std::runtime_error> ("Unknown field");
         }
 
         if (fn.fieldType != STI_OBJECT)
         {
-            JLOG (debugJournal().trace) <<
+            JLOG (debugJournal().trace()) <<
                 "Array contains non-object";
             Throw<std::runtime_error> ("Non-object in array");
         }

--- a/src/ripple/protocol/impl/STInteger.cpp
+++ b/src/ripple/protocol/impl/STInteger.cpp
@@ -52,7 +52,7 @@ STUInt8::getText () const
         if (transResultInfo (static_cast<TER> (value_), token, human))
             return human;
 
-        JLOG (debugJournal().warning)
+        JLOG (debugJournal().warn())
             << "Unknown result code in metadata: " << value_;
     }
 
@@ -70,7 +70,7 @@ STUInt8::getJson (int) const
         if (transResultInfo (static_cast<TER> (value_), token, human))
             return token;
 
-        JLOG (debugJournal().warning)
+        JLOG (debugJournal().warn())
             << "Unknown result code in metadata: " << value_;
     }
 

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -78,7 +78,7 @@ void STLedgerEntry::setSLEType ()
     type_ = mFormat->getType ();
     if (!setType (mFormat->elements))
     {
-        if (auto j = debugJournal().warning)
+        if (auto j = debugJournal().warn())
         {
             j << "Ledger entry not valid for type " << mFormat->getName ();
             j << "Object: " << getJson (0);
@@ -141,7 +141,7 @@ bool STLedgerEntry::thread (uint256 const& txID, std::uint32_t ledgerSeq,
 {
     uint256 oldPrevTxID = getFieldH256 (sfPreviousTxnID);
 
-    JLOG (debugJournal().trace)
+    JLOG (debugJournal().trace())
         << "Thread Tx:" << txID << " prev:" << oldPrevTxID;
 
     if (oldPrevTxID == txID)

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -113,7 +113,7 @@ bool STObject::setType (const SOTemplate& type)
         {
             if ((e->flags == SOE_DEFAULT) && iter->get().isDefault())
             {
-                JLOG (debugJournal().warning)
+                JLOG (debugJournal().warn())
                     << "setType(" << getFName().getName()
                     << "): explicit default " << e->e_field.fieldName;
                 valid = false;
@@ -125,7 +125,7 @@ bool STObject::setType (const SOTemplate& type)
         {
             if (e->flags == SOE_REQUIRED)
             {
-                JLOG (debugJournal().warning)
+                JLOG (debugJournal().warn())
                     << "setType(" << getFName().getName()
                     << "): missing " << e->e_field.fieldName;
                 valid = false;
@@ -138,7 +138,7 @@ bool STObject::setType (const SOTemplate& type)
         // Anything left over in the object must be discardable
         if (! e->getFName().isDiscardable())
         {
-            JLOG (debugJournal().warning)
+            JLOG (debugJournal().warn())
                 << "setType(" << getFName().getName()
                 << "): non-discardable leftover " << e->getFName().getName ();
             valid = false;
@@ -208,7 +208,7 @@ bool STObject::set (SerialIter& sit, int depth)
 
         if ((type == STI_ARRAY) && (field == 1))
         {
-            JLOG (debugJournal().warning)
+            JLOG (debugJournal().warn())
                 << "Encountered object with end of array marker";
             Throw<std::runtime_error> ("Illegal terminator in object");
         }
@@ -221,7 +221,7 @@ bool STObject::set (SerialIter& sit, int depth)
 
             if (fn.isInvalid ())
             {
-                JLOG (debugJournal().warning)
+                JLOG (debugJournal().warn())
                     << "Unknown field: field_type=" << type
                     << ", field_name=" << field;
                 Throw<std::runtime_error> ("Unknown field");

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -64,7 +64,7 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
         {
             if (path.empty ())
             {
-                JLOG (debugJournal().info)
+                JLOG (debugJournal().info())
                     << "Empty path in pathset";
                 Throw<std::runtime_error> ("empty path");
             }
@@ -77,7 +77,7 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
         }
         else if (iType & ~STPathElement::typeAll)
         {
-            JLOG (debugJournal().info)
+            JLOG (debugJournal().info())
                 << "Bad path element " << iType << " in pathset";
             Throw<std::runtime_error> ("bad path element");
         }

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -35,7 +35,7 @@ STValidation::STValidation (SerialIter& sit, bool checkSignature)
 
     if  (checkSignature && !isValid ())
     {
-        JLOG (debugJournal().trace)
+        JLOG (debugJournal().trace())
             << "Invalid validation" << getJson (0);
         Throw<std::runtime_error> ("Invalid validation");
     }
@@ -113,7 +113,7 @@ bool STValidation::isValid (uint256 const& signingHash) const
     }
     catch (std::exception const&)
     {
-        JLOG (debugJournal().info)
+        JLOG (debugJournal().info())
             << "Exception validating validation";
         return false;
     }

--- a/src/ripple/resource/impl/Logic.h
+++ b/src/ripple/resource/impl/Logic.h
@@ -132,7 +132,7 @@ public:
             }
         }
 
-        JLOG(m_journal.debug) <<
+        JLOG(m_journal.debug()) <<
             "New inbound endpoint " << *entry;
 
         return Consumer (*this, *entry);
@@ -161,7 +161,7 @@ public:
             }
         }
 
-        JLOG(m_journal.debug) <<
+        JLOG(m_journal.debug()) <<
             "New outbound endpoint " << *entry;
 
         return Consumer (*this, *entry);
@@ -195,7 +195,7 @@ public:
             }
         }
 
-        JLOG(m_journal.debug) <<
+        JLOG(m_journal.debug()) <<
             "New unlimited endpoint " << *entry;
 
         return Consumer (*this, *entry);
@@ -347,7 +347,7 @@ public:
         {
             if (iter->whenExpires <= elapsed)
             {
-                JLOG(m_journal.debug) << "Expired " << *iter;
+                JLOG(m_journal.debug()) << "Expired " << *iter;
                 auto table_iter =
                     table_.find (*iter->key);
                 ++iter;
@@ -413,7 +413,7 @@ public:
         std::lock_guard<std::recursive_mutex> _(lock_);
         if (--entry.refcount == 0)
         {
-            JLOG(m_journal.debug) <<
+            JLOG(m_journal.debug()) <<
                 "Inactive " << entry;
 
             switch (entry.key->kind)
@@ -444,7 +444,7 @@ public:
         std::lock_guard<std::recursive_mutex> _(lock_);
         clock_type::time_point const now (m_clock.now());
         int const balance (entry.add (fee.cost(), now));
-        JLOG(m_journal.trace) <<
+        JLOG(m_journal.trace()) <<
             "Charging " << entry << " for " << fee;
         return disposition (balance);
     }
@@ -466,7 +466,7 @@ public:
         }
         if (notify)
         {
-            JLOG(m_journal.info) << "Load warning: " << entry;
+            JLOG(m_journal.info()) << "Load warning: " << entry;
             ++m_stats.warn;
         }
         return notify;
@@ -483,7 +483,7 @@ public:
         int const balance (entry.balance (now));
         if (balance >= dropThreshold)
         {
-            JLOG(m_journal.warning) <<
+            JLOG(m_journal.warn()) <<
                 "Consumer entry " << entry <<
                 " dropped with balance " << balance <<
                 " at or above drop threshold " << dropThreshold;

--- a/src/ripple/resource/tests/Logic.test.cpp
+++ b/src/ripple/resource/tests/Logic.test.cpp
@@ -207,12 +207,12 @@ public:
             beast::IP::Endpoint address (beast::IP::Endpoint::from_string ("192.0.2.1"));
             Consumer c (logic.newInboundEndpoint (address));
             Charge fee (1000);
-            j.info <<
+            JLOG(j.info()) <<
                 "Charging " << c.to_string() << " " << fee << " per second";
             c.charge (fee);
             for (int i = 0; i < 128; ++i)
             {
-                j.info <<
+                JLOG(j.info()) <<
                     "Time= " << logic.clock().now().time_since_epoch().count() <<
                     ", Balance = " << c.balance();
                 logic.advance();
@@ -223,12 +223,12 @@ public:
             beast::IP::Endpoint address (beast::IP::Endpoint::from_string ("192.0.2.2"));
             Consumer c (logic.newInboundEndpoint (address));
             Charge fee (1000);
-            j.info <<
+            JLOG(j.info()) <<
                 "Charging " << c.to_string() << " " << fee << " per second";
             for (int i = 0; i < 128; ++i)
             {
                 c.charge (fee);
-                j.info <<
+                JLOG(j.info()) <<
                     "Time= " << logic.clock().now().time_since_epoch().count() <<
                     ", Balance = " << c.balance();
                 logic.advance();

--- a/src/ripple/rpc/handlers/BookOffers.cpp
+++ b/src/ripple/rpc/handlers/BookOffers.cpp
@@ -79,7 +79,7 @@ Json::Value doBookOffers (RPC::Context& context)
 
     if (!to_currency (pay_currency, taker_pays [jss::currency].asString ()))
     {
-        JLOG (context.j.info) << "Bad taker_pays currency.";
+        JLOG (context.j.info()) << "Bad taker_pays currency.";
         return RPC::make_error (rpcSRC_CUR_MALFORMED,
             "Invalid field 'taker_pays.currency', bad currency.");
     }
@@ -88,7 +88,7 @@ Json::Value doBookOffers (RPC::Context& context)
 
     if (!to_currency (get_currency, taker_gets [jss::currency].asString ()))
     {
-        JLOG (context.j.info) << "Bad taker_gets currency.";
+        JLOG (context.j.info()) << "Bad taker_gets currency.";
         return RPC::make_error (rpcDST_AMT_MALFORMED,
             "Invalid field 'taker_gets.currency', bad currency.");
     }
@@ -168,7 +168,7 @@ Json::Value doBookOffers (RPC::Context& context)
 
     if (pay_currency == get_currency && pay_issuer == get_issuer)
     {
-        JLOG (context.j.info) << "taker_gets same as taker_pays.";
+        JLOG (context.j.info()) << "taker_gets same as taker_pays.";
         return RPC::make_error (rpcBAD_MARKET);
     }
 

--- a/src/ripple/rpc/handlers/Internal.cpp
+++ b/src/ripple/rpc/handlers/Internal.cpp
@@ -45,10 +45,10 @@ Json::Value doInternal (RPC::Context& context)
     {
         if (name == h->name_)
         {
-            JLOG (context.j.warning)
+            JLOG (context.j.warn())
                 << "Internal command " << name << ": " << params;
             Json::Value ret = h->handler_ (params);
-            JLOG (context.j.warning)
+            JLOG (context.j.warn())
                 << "Internal command returns: " << ret;
             return ret;
         }

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -147,7 +147,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
             && (!saDstAmount.getIssuer () ||
                 noAccount() == saDstAmount.getIssuer ())))
     {
-        JLOG (context.j.info) << "Bad destination_amount.";
+        JLOG (context.j.info()) << "Bad destination_amount.";
         jvResult    = rpcError (rpcINVALID_PARAMS);
     }
     else if (
@@ -158,7 +158,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
         // Don't allow empty currencies.
     )
     {
-        JLOG (context.j.info) << "Bad source_currencies.";
+        JLOG (context.j.info()) << "Bad source_currencies.";
         jvResult    = rpcError (rpcINVALID_PARAMS);
     }
     else
@@ -258,7 +258,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
         jvResult[jss::alternatives] = pathFindResult.second;
     }
 
-    JLOG (context.j.debug)
+    JLOG (context.j.debug())
             << "ripple_path_find< " << jvResult;
 
     return jvResult;
@@ -311,7 +311,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
             || !to_currency(
             uSrcCurrencyID, jvSource[jss::currency].asString()))
         {
-            JLOG (j.info) << "Bad currency.";
+            JLOG (j.info()) << "Bad currency.";
             return std::make_pair(false, rpcError(rpcSRC_CUR_MALFORMED));
         }
 
@@ -325,7 +325,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
             (uSrcIssuerID.isZero() != uSrcCurrencyID.isZero()) ||
             (noAccount() == uSrcIssuerID)))
         {
-            JLOG (j.info) << "Bad issuer.";
+            JLOG (j.info()) << "Bad issuer.";
             return std::make_pair(false, rpcError(rpcSRC_ISR_MALFORMED));
         }
 
@@ -363,7 +363,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
                 return std::make_pair(false, paths.error);
 
             spsComputed = paths.object->getFieldPathSet(sfPaths);
-            JLOG (j.trace) << "ripple_path_find: Paths: " <<
+            JLOG (j.trace()) << "ripple_path_find: Paths: " <<
                 spsComputed.getJson(0);
         }
 
@@ -371,7 +371,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
             currency_map, issue.currency, saDstAmount, level, app);
         if (! pathfinder)
         {
-            JLOG (j.warning) << "ripple_path_find: No paths found.";
+            JLOG (j.warn()) << "ripple_path_find: No paths found.";
             continue;
         }
 
@@ -406,7 +406,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
             app.logs(),
             &rcInput);
 
-        JLOG(j.info)
+        JLOG(j.info())
             << "ripple_path_find:"
             << " saMaxAmount=" << saMaxAmount
             << " saDstAmount=" << saDstAmount
@@ -418,7 +418,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
             (rc.result() == terNO_LINE || rc.result() == tecPATH_PARTIAL))
         {
             auto jpr = app.journal("PathRequest");
-            JLOG(jpr.debug)
+            JLOG(jpr.debug())
                 << "Trying with an extra path element";
             ps.push_back(fullLiquidityPath);
             sandbox.emplace(&*cache->getLedger(), tapNONE);
@@ -432,7 +432,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
                 raSrc,          // --> Account sending from.
                 ps,             // --> Path set.
                 app.logs());
-            JLOG(jpr.debug)
+            JLOG(jpr.debug())
                 << "Extra path element gives "
                 << transHuman(rc.result());
         }
@@ -461,7 +461,7 @@ ripplePathFind (std::shared_ptr<RippleLineCache> const& cache,
             std::string strToken;
             std::string strHuman;
             transResultInfo(rc.result(), strToken, strHuman);
-            JLOG (j.debug)
+            JLOG (j.debug())
                 << "ripple_path_find: "
                 << strToken << " "
                 << strHuman << " "

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -42,7 +42,7 @@ Json::Value doSubscribe (RPC::Context& context)
     if (! context.infoSub && ! context.params.isMember(jss::url))
     {
         // Must be a JSON-RPC call.
-        JLOG(context.j.info) << "doSubscribe: RPC subscribe requires a url";
+        JLOG(context.j.info()) << "doSubscribe: RPC subscribe requires a url";
         return rpcError (rpcINVALID_PARAMS);
     }
 
@@ -68,7 +68,7 @@ Json::Value doSubscribe (RPC::Context& context)
         ispSub = context.netOps.findRpcSub(strUrl);
         if (! ispSub)
         {
-            JLOG (context.j.debug)
+            JLOG (context.j.debug())
                 << "doSubscribe: building: " << strUrl;
 
             auto rspSub = make_RPCSub (context.app.getOPs (),
@@ -79,7 +79,7 @@ Json::Value doSubscribe (RPC::Context& context)
         }
         else
         {
-            JLOG (context.j.trace)
+            JLOG (context.j.trace())
                 << "doSubscribe: reusing: " << strUrl;
 
             if (auto rpcSub = std::dynamic_pointer_cast<RPCSub> (ispSub))
@@ -104,7 +104,7 @@ Json::Value doSubscribe (RPC::Context& context)
     {
         if (! context.params[jss::streams].isArray ())
         {
-            JLOG (context.j.info)
+            JLOG (context.j.info())
                 << "doSubscribe: streams requires an array.";
             return rpcError (rpcINVALID_PARAMS);
         }
@@ -176,7 +176,7 @@ Json::Value doSubscribe (RPC::Context& context)
         if (ids.empty())
             return rpcError(rpcACT_MALFORMED);
         context.netOps.subAccount(ispSub, ids, false);
-        JLOG(context.j.debug) << "doSubscribe: accounts: " << ids.size();
+        JLOG(context.j.debug()) << "doSubscribe: accounts: " << ids.size();
     }
 
     if (context.params.isMember(jss::books))
@@ -201,7 +201,7 @@ Json::Value doSubscribe (RPC::Context& context)
             if (! taker_pays.isMember (jss::currency) || ! to_currency (
                     book.in.currency, taker_pays[jss::currency].asString ()))
             {
-                JLOG (context.j.info) << "Bad taker_pays currency.";
+                JLOG (context.j.info()) << "Bad taker_pays currency.";
                 return rpcError (rpcSRC_CUR_MALFORMED);
             }
 
@@ -214,7 +214,7 @@ Json::Value doSubscribe (RPC::Context& context)
                      || (!book.in.currency != !book.in.account)
                      || noAccount() == book.in.account)
             {
-                JLOG (context.j.info) << "Bad taker_pays issuer.";
+                JLOG (context.j.info()) << "Bad taker_pays issuer.";
                 return rpcError (rpcSRC_ISR_MALFORMED);
             }
 
@@ -222,7 +222,7 @@ Json::Value doSubscribe (RPC::Context& context)
             if (! taker_gets.isMember (jss::currency) || !to_currency (
                 book.out.currency, taker_gets[jss::currency].asString ()))
             {
-                JLOG (context.j.info) << "Bad taker_pays currency.";
+                JLOG (context.j.info()) << "Bad taker_pays currency.";
                 return rpcError (rpcSRC_CUR_MALFORMED);
             }
 
@@ -235,14 +235,14 @@ Json::Value doSubscribe (RPC::Context& context)
                      || (!book.out.currency != !book.out.account)
                      || noAccount() == book.out.account)
             {
-                JLOG (context.j.info) << "Bad taker_gets issuer.";
+                JLOG (context.j.info()) << "Bad taker_gets issuer.";
                 return rpcError (rpcDST_ISR_MALFORMED);
             }
 
             if (book.in.currency == book.out.currency
                     && book.in.account == book.out.account)
             {
-                JLOG (context.j.info)
+                JLOG (context.j.info())
                     << "taker_gets same as taker_pays.";
                 return rpcError (rpcBAD_MARKET);
             }
@@ -259,7 +259,7 @@ Json::Value doSubscribe (RPC::Context& context)
 
             if (!isConsistent (book))
             {
-                JLOG (context.j.warning) << "Bad market: " << book;
+                JLOG (context.j.warn()) << "Bad market: " << book;
                 return rpcError (rpcBAD_MARKET);
             }
 

--- a/src/ripple/rpc/handlers/Unsubscribe.cpp
+++ b/src/ripple/rpc/handlers/Unsubscribe.cpp
@@ -155,7 +155,7 @@ Json::Value doUnsubscribe (RPC::Context& context)
                 || !to_currency (
                     book.in.currency, taker_pays[jss::currency].asString ()))
             {
-                JLOG (context.j.info) << "Bad taker_pays currency.";
+                JLOG (context.j.info()) << "Bad taker_pays currency.";
                 return rpcError (rpcSRC_CUR_MALFORMED);
             }
             // Parse optional issuer.
@@ -167,7 +167,7 @@ Json::Value doUnsubscribe (RPC::Context& context)
                      || !isConsistent (book.in)
                      || noAccount() == book.in.account)
             {
-                JLOG (context.j.info) << "Bad taker_pays issuer.";
+                JLOG (context.j.info()) << "Bad taker_pays issuer.";
 
                 return rpcError (rpcSRC_ISR_MALFORMED);
             }
@@ -177,7 +177,7 @@ Json::Value doUnsubscribe (RPC::Context& context)
                     || !to_currency (book.out.currency,
                                      taker_gets[jss::currency].asString ()))
             {
-                JLOG (context.j.info) << "Bad taker_pays currency.";
+                JLOG (context.j.info()) << "Bad taker_pays currency.";
 
                 return rpcError (rpcSRC_CUR_MALFORMED);
             }
@@ -190,14 +190,14 @@ Json::Value doUnsubscribe (RPC::Context& context)
                      || !isConsistent (book.out)
                      || noAccount() == book.out.account)
             {
-                JLOG (context.j.info) << "Bad taker_gets issuer.";
+                JLOG (context.j.info()) << "Bad taker_gets issuer.";
 
                 return rpcError (rpcDST_ISR_MALFORMED);
             }
 
             if (book.in == book.out)
             {
-                JLOG (context.j.info)
+                JLOG (context.j.info())
                     << "taker_gets same as taker_pays.";
                 return rpcError (rpcBAD_MARKET);
             }

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -180,8 +180,9 @@ bool isValidated (LedgerMaster& ledgerMaster, ReadView const& ledger,
     }
     catch (SHAMapMissingNode const&)
     {
-        JLOG (app.journal ("RPCHandler").warning)
-                << "Missing SHANode " << std::to_string (seq);
+        auto stream = app.journal ("RPCHandler").warn();
+        JLOG (stream)
+            << "Missing SHANode " << std::to_string (seq);
         return false;
     }
 

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -119,7 +119,7 @@ error_code_i fillHandler (Context& context,
         int jc = context.app.getJobQueue ().getJobCountGE (jtCLIENT);
         if (jc > Tuning::maxJobQueueClients)
         {
-            JLOG (context.j.debug) << "Too busy for command: " << jc;
+            JLOG (context.j.debug()) << "Too busy for command: " << jc;
             return rpcTOO_BUSY;
         }
     }
@@ -129,8 +129,8 @@ error_code_i fillHandler (Context& context,
 
     std::string strCommand  = context.params[jss::command].asString ();
 
-    JLOG (context.j.trace) << "COMMAND:" << strCommand;
-    JLOG (context.j.trace) << "REQUEST:" << context.params;
+    JLOG (context.j.trace()) << "COMMAND:" << strCommand;
+    JLOG (context.j.trace()) << "REQUEST:" << context.params;
 
     auto handler = getHandler(strCommand);
 
@@ -143,7 +143,7 @@ error_code_i fillHandler (Context& context,
     if ((handler->condition_ & NEEDS_NETWORK_CONNECTION) &&
         (context.netOps.getOperatingMode () < NetworkOPs::omSYNCING))
     {
-        JLOG (context.j.info)
+        JLOG (context.j.info())
             << "Insufficient network mode for RPC: "
             << context.netOps.strOperatingMode ();
 
@@ -164,7 +164,7 @@ error_code_i fillHandler (Context& context,
 
         if (cID + 10 < vID)
         {
-            JLOG (context.j.debug) << "Current ledger ID(" << cID <<
+            JLOG (context.j.debug()) << "Current ledger ID(" << cID <<
                 ") is less than validated ledger ID(" << vID << ")";
             return rpcNO_CURRENT;
         }
@@ -192,7 +192,7 @@ Status callMethod (
     }
     catch (std::exception& e)
     {
-        JLOG (context.j.info) << "Caught throw: " << e.what ();
+        JLOG (context.j.info()) << "Caught throw: " << e.what ();
 
         if (context.loadType == Resource::feeReferenceRPC)
             context.loadType = Resource::feeExceptionRPC;
@@ -209,7 +209,7 @@ void getResult (
     auto&& result = Json::addObject (object, jss::result);
     if (auto status = callMethod (context, method, name, result))
     {
-        JLOG (context.j.debug) << "rpcError: " << status.toString();
+        JLOG (context.j.debug()) << "rpcError: " << status.toString();
         result[jss::status] = jss::error;
         result[jss::request] = context.params;
     }
@@ -236,13 +236,13 @@ Status doCommand (
         if (! context.headers.user.empty() ||
             ! context.headers.forwardedFor.empty())
         {
-            context.j.debug << "start command: " << handler->name_ <<
+            JLOG(context.j.debug()) << "start command: " << handler->name_ <<
                 ", X-User: " << context.headers.user << ", X-Forwarded-For: " <<
                     context.headers.forwardedFor;
 
             auto ret = callMethod (context, method, handler->name_, result);
 
-            context.j.debug << "finish command: " << handler->name_ <<
+            JLOG(context.j.debug()) << "finish command: " << handler->name_ <<
                 ", X-User: " << context.headers.user << ", X-Forwarded-For: " <<
                     context.headers.forwardedFor;
 

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -218,7 +218,7 @@ static Json::Value checkPayment(
             }
 
             auto j = app.journal ("RPCHandler");
-            JLOG (j.debug)
+            JLOG (j.debug())
                 << "transactionSign: build_path: "
                 << result.getJson (0);
 
@@ -378,7 +378,7 @@ transactionPreProcessImpl (
     if (verify && !sle)
     {
         // If not offline and did not find account, error.
-        JLOG (j.debug)
+        JLOG (j.debug())
             << "transactionSign: Failed to find source account "
             << "in current ledger: "
             << toBase58(srcAddressID);
@@ -417,7 +417,7 @@ transactionPreProcessImpl (
         {
             if (! sle)
             {
-                JLOG (j.debug)
+                JLOG (j.debug())
                 << "transactionSign: Failed to find source account "
                 << "in current ledger: "
                 << toBase58(srcAddressID);
@@ -441,7 +441,7 @@ transactionPreProcessImpl (
             // XXX Ignore transactions for accounts not created.
             return rpcError (rpcSRC_ACT_NOT_FOUND);
 
-        JLOG (j.trace)
+        JLOG (j.trace())
             << "verify: " << toBase58(calcAccountID(keypair.first))
             << " : " << toBase58(srcAddressID);
 
@@ -704,7 +704,7 @@ Json::Value transactionSign (
     using namespace detail;
 
     auto j = app.journal ("RPCHandler");
-    JLOG (j.debug) << "transactionSign: " << jvRequest;
+    JLOG (j.debug()) << "transactionSign: " << jvRequest;
 
     // Add and amend fields based on the transaction type.
     SigningForParams signForParams;
@@ -739,7 +739,7 @@ Json::Value transactionSubmit (
     using namespace detail;
 
     auto j = app.journal ("RPCHandler");
-    JLOG (j.debug) << "transactionSubmit: " << jvRequest;
+    JLOG (j.debug()) << "transactionSubmit: " << jvRequest;
 
 
     // Add and amend fields based on the transaction type.
@@ -861,7 +861,7 @@ Json::Value transactionSignFor (
     std::shared_ptr<ReadView const> const& ledger)
 {
     auto j = app.journal ("RPCHandler");
-    JLOG (j.debug) << "transactionSignFor: " << jvRequest;
+    JLOG (j.debug()) << "transactionSignFor: " << jvRequest;
 
     // Verify presence of the signer's account field.
     const char accountField[] = "account";
@@ -972,7 +972,7 @@ Json::Value transactionSubmitMultiSigned (
     ProcessTransactionFn const& processTransaction)
 {
     auto j = app.journal ("RPCHandler");
-    JLOG (j.debug)
+    JLOG (j.debug())
         << "transactionSubmitMultiSigned: " << jvRequest;
 
     // When multi-signing, the "Sequence" and "SigningPubKey" fields must
@@ -1001,7 +1001,7 @@ Json::Value transactionSubmitMultiSigned (
     if (!sle)
     {
         // If did not find account, error.
-        JLOG (j.debug)
+        JLOG (j.debug())
             << "transactionSubmitMultiSigned: Failed to find source account "
             << "in current ledger: "
             << toBase58(srcAddressID);

--- a/src/ripple/server/impl/BaseHTTPPeer.h
+++ b/src/ripple/server/impl/BaseHTTPPeer.h
@@ -236,7 +236,7 @@ BaseHTTPPeer<Impl>::BaseHTTPPeer (Port const& port, Handler& handler,
     static std::atomic <int> sid;
     nid_ = ++sid;
     id_ = std::string("#") + std::to_string(nid_) + " ";
-    JLOG(journal_.trace) << id_ <<
+    JLOG(journal_.trace()) << id_ <<
         "accept:    " << remote_address_.address();
     when_ = clock_type::now();
 }
@@ -245,7 +245,7 @@ template <class Impl>
 BaseHTTPPeer<Impl>::~BaseHTTPPeer()
 {
     handler_.onClose(session(), ec_);
-    JLOG(journal_.trace) << id_ <<
+    JLOG(journal_.trace()) << id_ <<
         "destroyed: " << request_count_ <<
             ((request_count_ == 1) ? " request" : " requests");
 }
@@ -271,7 +271,7 @@ BaseHTTPPeer<Impl>::fail (error_code ec, char const* what)
     if (! ec_ && ec != boost::asio::error::operation_aborted)
     {
         ec_ = ec;
-        JLOG(journal_.trace) << id_ <<
+        JLOG(journal_.trace()) << id_ <<
             std::string(what) << ": " << ec.message();
         impl().stream_.lowest_layer().close (ec);
     }

--- a/src/ripple/server/impl/Door.cpp
+++ b/src/ripple/server/impl/Door.cpp
@@ -155,7 +155,7 @@ Door::Detector::do_detect (boost::asio::yield_context yield)
     }
     if (ec != boost::asio::error::operation_aborted)
     {
-        JLOG(j_.trace) <<
+        JLOG(j_.trace()) <<
             "Error detecting ssl: " << ec.message() <<
                 " from " << remote_address_;
     }
@@ -185,7 +185,7 @@ Door::Door (Handler& handler, boost::asio::io_service& io_service,
     acceptor_.open(local_address.protocol(), ec);
     if (ec)
     {
-        JLOG(j_.error) <<
+        JLOG(j_.error()) <<
             "Open port '" << port.name << "' failed:" << ec.message();
         Throw<std::exception> ();
     }
@@ -194,7 +194,7 @@ Door::Door (Handler& handler, boost::asio::io_service& io_service,
         boost::asio::ip::tcp::acceptor::reuse_address(true), ec);
     if (ec)
     {
-        JLOG(j_.error) <<
+        JLOG(j_.error()) <<
             "Option for port '" << port.name << "' failed:" << ec.message();
         Throw<std::exception> ();
     }
@@ -202,7 +202,7 @@ Door::Door (Handler& handler, boost::asio::io_service& io_service,
     acceptor_.bind(local_address, ec);
     if (ec)
     {
-        JLOG(j_.error) <<
+        JLOG(j_.error()) <<
             "Bind port '" << port.name << "' failed:" << ec.message();
         Throw<std::exception> ();
     }
@@ -210,12 +210,12 @@ Door::Door (Handler& handler, boost::asio::io_service& io_service,
     acceptor_.listen(boost::asio::socket_base::max_connections, ec);
     if (ec)
     {
-        JLOG(j_.error) <<
+        JLOG(j_.error()) <<
             "Listen on port '" << port.name << "' failed:" << ec.message();
         Throw<std::exception> ();
     }
 
-    JLOG(j_.info) <<
+    JLOG(j_.info()) <<
         "Opened " << port;
 }
 
@@ -267,8 +267,10 @@ Door::do_accept (boost::asio::yield_context yield)
         socket_type socket (acceptor_.get_io_service());
         acceptor_.async_accept (socket, remote_address, yield[ec]);
         if (ec && ec != boost::asio::error::operation_aborted)
-            if (j_.error) j_.error <<
+        {
+            JLOG(j_.error()) <<
                 "accept: " << ec.message();
+        }
         if (ec == boost::asio::error::operation_aborted)
             break;
         if (ec)

--- a/src/ripple/server/impl/JSONRPCUtil.cpp
+++ b/src/ripple/server/impl/JSONRPCUtil.cpp
@@ -46,7 +46,7 @@ std::string getHTTPHeaderTimestamp ()
 void HTTPReply (
     int nStatus, std::string const& content, Json::Output const& output, beast::Journal j)
 {
-    JLOG (j.trace)
+    JLOG (j.trace())
         << "HTTP Reply " << nStatus << " " << content;
 
     if (nStatus == 401)

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -355,11 +355,11 @@ ServerHandlerImp::processRequest (Port const& port,
 
     Resource::Charge loadType = Resource::feeReferenceRPC;
 
-    JLOG(m_journal.debug) << "Query: " << strMethod << params;
+    JLOG(m_journal.debug()) << "Query: " << strMethod << params;
 
     // Provide the JSON-RPC method as the field "command" in the request.
     params[jss::command] = strMethod;
-    JLOG (m_journal.trace)
+    JLOG (m_journal.trace())
         << "doRpcCommand:" << strMethod << ":" << params;
 
     auto const start (std::chrono::high_resolution_clock::now ());
@@ -375,7 +375,7 @@ ServerHandlerImp::processRequest (Port const& port,
     {
         result[jss::status] = jss::error;
         result[jss::request] = params;
-        JLOG (m_journal.debug)  <<
+        JLOG (m_journal.debug())  <<
             "rpcError: " << result [jss::error] <<
             ": " << result [jss::error_message];
     }
@@ -398,13 +398,13 @@ ServerHandlerImp::processRequest (Port const& port,
     response += '\n';
     usage.charge (loadType);
 
-    if (m_journal.debug.active())
+    if (auto stream = m_journal.debug())
     {
         static const int maxSize = 10000;
         if (response.size() <= maxSize)
-            m_journal.debug << "Reply: " << response;
+            stream << "Reply: " << response;
         else
-            m_journal.debug << "Reply: " << response.substr (0, maxSize);
+            stream << "Reply: " << response.substr (0, maxSize);
     }
 
     HTTPReply (200, response, output, rpcJ);

--- a/src/ripple/server/tests/Server_test.cpp
+++ b/src/ripple/server/tests/Server_test.cpp
@@ -77,13 +77,13 @@ public:
 
     public:
         TestSink (beast::unit_test::suite& suite)
-            : Sink (beast::Journal::kWarning, false)
+            : Sink (beast::severities::kWarning, false)
             , suite_ (suite)
         {
         }
 
         void
-        write (beast::Journal::Severity level,
+        write (beast::severities::Severity level,
             std::string const& text) override
         {
             if (level < threshold())
@@ -279,7 +279,7 @@ public:
     {
         TestSink sink {*this};
         TestThread thread;
-        sink.threshold (beast::Journal::Severity::kAll);
+        sink.threshold (beast::severities::Severity::kAll);
         beast::Journal journal {sink};
         TestHandler handler;
         auto s = make_Server (handler,

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -104,7 +104,7 @@ SHAMap::dirtyUp (SharedPtrNodeStack& stack,
         node->setChild (branch, child);
 
     #ifdef ST_DEBUG
-        JLOG(journal_.trace) <<
+        JLOG(journal_.trace()) <<
             "dirtyUp sets branch " << branch << " to " << prevHash;
     #endif
         child = std::move (node);
@@ -163,7 +163,7 @@ SHAMap::fetchNodeFromDB (SHAMapHash const& hash) const
             }
             catch (std::exception const&)
             {
-                JLOG(journal_.warning) <<
+                JLOG(journal_.warn()) <<
                     "Invalid DB node " << hash;
                 return std::shared_ptr<SHAMapTreeNode> ();
             }
@@ -802,7 +802,7 @@ SHAMap::updateGiveItem (std::shared_ptr<SHAMapItem const> const& item,
     if (!node->setItem (item, !isTransaction ? SHAMapTreeNode::tnACCOUNT_STATE :
                         (hasMeta ? SHAMapTreeNode::tnTRANSACTION_MD : SHAMapTreeNode::tnTRANSACTION_NM)))
     {
-        JLOG(journal_.trace) <<
+        JLOG(journal_.trace()) <<
             "SHAMap setItem, no change";
         return true;
     }
@@ -816,21 +816,21 @@ bool SHAMap::fetchRoot (SHAMapHash const& hash, SHAMapSyncFilter* filter)
     if (hash == root_->getNodeHash ())
         return true;
 
-    if (journal_.trace)
+    if (auto stream = journal_.trace())
     {
         if (type_ == SHAMapType::TRANSACTION)
         {
-            journal_.trace
+            stream
                 << "Fetch root TXN node " << hash;
         }
         else if (type_ == SHAMapType::STATE)
         {
-            journal_.trace <<
+            stream <<
                 "Fetch root STATE node " << hash;
         }
         else
         {
-            journal_.trace <<
+            stream <<
                 "Fetch root SHAMap node " << hash;
         }
     }
@@ -1031,7 +1031,7 @@ SHAMap::walkSubTree (bool doWrite, NodeObjectType t, std::uint32_t seq)
 void SHAMap::dump (bool hash) const
 {
     int leafCount = 0;
-    JLOG(journal_.info) << " MAP Contains";
+    JLOG(journal_.info()) << " MAP Contains";
 
     std::stack <std::pair <SHAMapAbstractNode*, SHAMapNodeID> > stack;
     stack.push ({root_.get (), SHAMapNodeID ()});
@@ -1042,10 +1042,10 @@ void SHAMap::dump (bool hash) const
         auto nodeID = stack.top().second;
         stack.pop();
 
-        JLOG(journal_.info) << node->getString (nodeID);
+        JLOG(journal_.info()) << node->getString (nodeID);
         if (hash)
         {
-           JLOG(journal_.info) << "Hash: " << node->getNodeHash();
+           JLOG(journal_.info()) << "Hash: " << node->getNodeHash();
         }
 
         if (node->isInner ())
@@ -1069,7 +1069,7 @@ void SHAMap::dump (bool hash) const
     }
     while (!stack.empty ());
 
-    JLOG(journal_.info) << leafCount << " resident leaves";
+    JLOG(journal_.info()) << leafCount << " resident leaves";
 }
 
 std::shared_ptr<SHAMapAbstractNode> SHAMap::getCache (SHAMapHash const& hash) const

--- a/src/ripple/shamap/impl/SHAMapNodeID.cpp
+++ b/src/ripple/shamap/impl/SHAMapNodeID.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/shamap/SHAMapNodeID.h>
 #include <ripple/crypto/csprng.h>
+#include <ripple/basics/Log.h>
 #include <beast/module/core/text/LexicalCast.h>
 #include <boost/format.hpp>
 #include <cassert>
@@ -144,7 +145,7 @@ int SHAMapNodeID::selectBranch (uint256 const& hash) const
 
 void SHAMapNodeID::dump (beast::Journal journal) const
 {
-    if (journal.debug) journal.debug <<
+    JLOG(journal.debug()) <<
         getString ();
 }
 

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -130,7 +130,7 @@ SHAMap::getMissingNodes(std::size_t max, SHAMapSyncFilter* filter)
         if (generation == 0)
             clearSynching();
         else
-            JLOG(journal_.warning) << "synching empty tree";
+            JLOG(journal_.warn()) << "synching empty tree";
         return ret;
     }
 
@@ -292,7 +292,7 @@ SHAMap::getMissingNodes(std::size_t max, SHAMapSyncFilter* filter)
 
         if ((count > 50) || (elapsed.count() > 50))
         {
-            JLOG(journal_.debug) << "getMissingNodes reads " <<
+            JLOG(journal_.debug()) << "getMissingNodes reads " <<
                 count << " nodes (" << hits << " hits) in "
                 << elapsed.count() << " + " << process_time.count()  << " ms";
         }
@@ -345,14 +345,14 @@ bool SHAMap::getNodeFat (SHAMapNodeID wanted,
 
     if (!node || (nodeID != wanted))
     {
-        JLOG(journal_.warning) <<
+        JLOG(journal_.warn()) <<
             "peer requested node that is not in the map: " << wanted;
         return false;
     }
 
     if (node->isInner() && static_cast<SHAMapInnerNode*>(node)->isEmpty())
     {
-        JLOG(journal_.warning) << "peer requests empty node";
+        JLOG(journal_.warn()) << "peer requests empty node";
         return false;
     }
 
@@ -423,7 +423,7 @@ SHAMapAddNode SHAMap::addRootNode (SHAMapHash const& hash, Blob const& rootNode,
     // we already have a root_ node
     if (root_->getNodeHash ().isNonZero ())
     {
-        JLOG(journal_.trace) << "got root node, already have one";
+        JLOG(journal_.trace()) << "got root node, already have one";
         assert (root_->getNodeHash () == hash);
         return SHAMapAddNode::duplicate ();
     }
@@ -462,7 +462,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
 
     if (!isSynching ())
     {
-        JLOG(journal_.trace) << "AddKnownNode while not synching";
+        JLOG(journal_.trace()) << "AddKnownNode while not synching";
         return SHAMapAddNode::duplicate ();
     }
 
@@ -479,7 +479,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
         auto inner = static_cast<SHAMapInnerNode*>(iNode);
         if (inner->isEmptyBranch (branch))
         {
-            JLOG(journal_.warning) << "Add known node for empty branch" << node;
+            JLOG(journal_.warn()) << "Add known node for empty branch" << node;
             return SHAMapAddNode::invalid ();
         }
 
@@ -495,9 +495,9 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
             if (iNodeID != node)
             {
                 // Either this node is broken or we didn't request it (yet)
-                JLOG(journal_.warning) << "unable to hook node " << node;
-                JLOG(journal_.info) << " stuck at " << iNodeID;
-                JLOG(journal_.info) <<
+                JLOG(journal_.warn()) << "unable to hook node " << node;
+                JLOG(journal_.info()) << " stuck at " << iNodeID;
+                JLOG(journal_.info()) <<
                     "got depth=" << node.getDepth () <<
                         ", walked to= " << iNodeID.getDepth ();
                 return SHAMapAddNode::invalid ();
@@ -508,7 +508,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
 
             if (!newNode || !newNode->isValid() || childHash != newNode->getNodeHash ())
             {
-                JLOG(journal_.warning) << "Corrupt node received";
+                JLOG(journal_.warn()) << "Corrupt node received";
                 return SHAMapAddNode::invalid ();
             }
 
@@ -536,7 +536,7 @@ SHAMap::addKnownNode (const SHAMapNodeID& node, Blob const& rawNode,
         }
     }
 
-    JLOG(journal_.trace) << "got node, already had it (late)";
+    JLOG(journal_.trace()) << "got node, already had it (late)";
     return SHAMapAddNode::duplicate ();
 }
 
@@ -556,12 +556,12 @@ bool SHAMap::deepCompare (SHAMap& other) const
 
         if (!node || !otherNode)
         {
-            JLOG(journal_.info) << "unable to fetch node";
+            JLOG(journal_.info()) << "unable to fetch node";
             return false;
         }
         else if (otherNode->getNodeHash () != node->getNodeHash ())
         {
-            JLOG(journal_.warning) << "node hash mismatch";
+            JLOG(journal_.warn()) << "node hash mismatch";
             return false;
         }
 
@@ -598,7 +598,7 @@ bool SHAMap::deepCompare (SHAMap& other) const
                     auto otherNext = other.descend(other_inner, i);
                     if (!next || !otherNext)
                     {
-                        JLOG(journal_.warning) << "unable to fetch inner node";
+                        JLOG(journal_.warn()) << "unable to fetch inner node";
                         return false;
                     }
                     stack.push ({next, otherNext});

--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -182,7 +182,7 @@ SHAMapAbstractNode::make(Blob const& rawNode, std::uint32_t seq, SHANodeFormat f
     {
         if (rawNode.size () < 4)
         {
-            JLOG (j.info) << "size < 4";
+            JLOG (j.info()) << "size < 4";
             Throw<std::runtime_error> ("invalid P node");
         }
 
@@ -215,7 +215,7 @@ SHAMapAbstractNode::make(Blob const& rawNode, std::uint32_t seq, SHANodeFormat f
 
             if (u.isZero ())
             {
-                JLOG (j.info) << "invalid PLN node";
+                JLOG (j.info()) << "invalid PLN node";
                 Throw<std::runtime_error> ("invalid PLN node");
             }
 
@@ -258,7 +258,7 @@ SHAMapAbstractNode::make(Blob const& rawNode, std::uint32_t seq, SHANodeFormat f
         }
         else
         {
-            JLOG (j.info) << "Unknown node prefix " << std::hex << prefix << std::dec;
+            JLOG (j.info()) << "Unknown node prefix " << std::hex << prefix << std::dec;
             Throw<std::runtime_error> ("invalid node prefix");
         }
     }
@@ -466,7 +466,7 @@ int SHAMapInnerNode::getBranchCount () const
 void
 SHAMapAbstractNode::dump(const SHAMapNodeID & id, beast::Journal journal)
 {
-    if (journal.debug) journal.debug <<
+    JLOG(journal.debug()) <<
         "SHAMapTreeNode(" << id.getNodeID () << ")";
 }
 

--- a/src/ripple/shamap/tests/FetchPack.test.cpp
+++ b/src/ripple/shamap/tests/FetchPack.test.cpp
@@ -72,7 +72,7 @@ public:
             Map::iterator it = mMap.find (nodeHash);
             if (it == mMap.end ())
             {
-                mJournal.fatal << "Test filter missing node";
+                JLOG(mJournal.fatal()) << "Test filter missing node";
                 return false;
             }
             nodeData = it->second;

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -92,7 +92,7 @@ class SuiteSink : public beast::Journal::Sink
 
 public:
     SuiteSink(std::string const& partition,
-            beast::Journal::Severity threshold,
+            beast::severities::Severity threshold,
             beast::unit_test::suite& suite)
         : Sink (threshold, false)
         , partition_(partition + " ")
@@ -101,25 +101,26 @@ public:
     }
 
     // For unit testing, always generate logging text.
-    bool active(beast::Journal::Severity level) const override
+    bool active(beast::severities::Severity level) const override
     {
         return true;
     }
 
     void
-    write(beast::Journal::Severity level,
+    write(beast::severities::Severity level,
         std::string const& text) override
     {
+        using namespace beast::severities;
         std::string s;
         switch(level)
         {
-        case beast::Journal::kTrace:    s = "TRC:"; break;
-        case beast::Journal::kDebug:    s = "DBG:"; break;
-        case beast::Journal::kInfo:     s = "INF:"; break;
-        case beast::Journal::kWarning:  s = "WRN:"; break;
-        case beast::Journal::kError:    s = "ERR:"; break;
+        case kTrace:    s = "TRC:"; break;
+        case kDebug:    s = "DBG:"; break;
+        case kInfo:     s = "INF:"; break;
+        case kWarning:  s = "WRN:"; break;
+        case kError:    s = "ERR:"; break;
         default:
-        case beast::Journal::kFatal:    s = "FTL:"; break;
+        case kFatal:    s = "FTL:"; break;
         }
 
         // Only write the string if the level at least equals the threshold.
@@ -135,7 +136,7 @@ class SuiteLogs : public Logs
 public:
     explicit
     SuiteLogs(beast::unit_test::suite& suite)
-        : Logs (beast::Journal::kError)
+        : Logs (beast::severities::kError)
         , suite_(suite)
     {
     }
@@ -144,7 +145,7 @@ public:
 
     std::unique_ptr<beast::Journal::Sink>
     makeSink(std::string const& partition,
-        beast::Journal::Severity threshold) override
+        beast::severities::Severity threshold) override
     {
         return std::make_unique<SuiteSink>(partition, threshold, suite_);
     }
@@ -170,7 +171,7 @@ Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
     owned = make_Application(std::move(config),
         std::move(logs), std::move(timeKeeper_));
     app = owned.get();
-    app->logs().threshold(beast::Journal::kError);
+    app->logs().threshold(beast::severities::kError);
     app->setup();
     timeKeeper->set(
         app->getLedgerMaster().getClosedLedger()->info().closeTime);

--- a/src/ripple/websocket/AutoSocket.h
+++ b/src/ripple/websocket/AutoSocket.h
@@ -131,7 +131,7 @@ public:
         if (boost::asio::ssl::rfc2818_verification (domain) (preverified, ctx))
             return true;
 
-        JLOG (j.warning) <<
+        JLOG (j.warn()) <<
             "Outbound SSL connection to " << domain <<
             " fails certificate verification";
         return false;
@@ -319,7 +319,7 @@ protected:
 
         if (ec)
         {
-            JLOG (j_.warning) <<
+            JLOG (j_.warn()) <<
                 "Handle autodetect error: " << ec;
             cbFunc (ec);
         }
@@ -332,14 +332,14 @@ protected:
                   || ((mBuffer[3] < 127) && (mBuffer[3] > 31))))
         {
             // not ssl
-            JLOG (j_.trace) << "non-SSL";
+            JLOG (j_.trace()) << "non-SSL";
             mSecure = false;
             cbFunc (ec);
         }
         else
         {
             // ssl
-            JLOG (j_.trace) << "SSL";
+            JLOG (j_.trace()) << "SSL";
             mSecure = true;
             mSocket->async_handshake (ssl_socket::server, cbFunc);
         }

--- a/src/ripple/websocket/Connection.h
+++ b/src/ripple/websocket/Connection.h
@@ -160,7 +160,7 @@ ConnectionImpl <WebSocket>::ConnectionImpl (
 
     if (! m_forwardedFor.empty() || ! m_user.empty())
     {
-        j_.debug << "connect secure_gateway X-Forwarded-For: " <<
+        JLOG(j_.debug()) << "connect secure_gateway X-Forwarded-For: " <<
             m_forwardedFor << ", X-User: " << m_user;
     }
 }
@@ -175,7 +175,7 @@ template <class WebSocket>
 void ConnectionImpl <WebSocket>::rcvMessage (
     message_ptr const& msg, bool& msgRejected, bool& runQueue)
 {
-    JLOG(j_.debug) <<
+    JLOG(j_.debug()) <<
         "WebSocket: received " << msg->get_payload();
 
     ScopedLockType sl (m_receiveQueueMutex);
@@ -337,7 +337,7 @@ void ConnectionImpl <WebSocket>::preDestroy ()
 {
     if (! m_forwardedFor.empty() || ! m_user.empty())
     {
-        j_.debug << "disconnect secure_gateway X-Forwarded-For: " <<
+        JLOG(j_.debug()) << "disconnect secure_gateway X-Forwarded-For: " <<
             m_forwardedFor << ", X-User: " << m_user;
     }
 
@@ -355,7 +355,7 @@ void ConnectionImpl <WebSocket>::preDestroy ()
 template <class WebSocket>
 void ConnectionImpl <WebSocket>::send (Json::Value const& jvObj, bool broadcast)
 {
-    JLOG (j_.debug) <<
+    JLOG (j_.debug()) <<
         "WebSocket: sending " << to_string (jvObj);
     connection_ptr ptr = m_connection.lock ();
     if (ptr)
@@ -365,7 +365,7 @@ void ConnectionImpl <WebSocket>::send (Json::Value const& jvObj, bool broadcast)
 template <class WebSocket>
 void ConnectionImpl <WebSocket>::disconnect ()
 {
-    JLOG (j_.debug) <<
+    JLOG (j_.debug()) <<
         "WebSocket: disconnecting";
     connection_ptr ptr = m_connection.lock ();
 

--- a/src/ripple/websocket/Handler.h
+++ b/src/ripple/websocket/Handler.h
@@ -125,7 +125,7 @@ public:
     {
         try
         {
-            auto& jm = broadcast ? j_.trace : j_.debug;
+            auto jm = broadcast ? j_.trace() : j_.debug();
             JLOG (jm)
                     << "Ws:: Sending '" << strMessage << "'";
 
@@ -162,7 +162,7 @@ public:
             cpClient->terminate ({});
             try
             {
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     "Ws:: ping_out(" <<
                     // TODO(tom): re-enable this logging.
                     // cpClient->get_socket ().remote_endpoint ().to_string ()
@@ -213,7 +213,7 @@ public:
 
             assert (result.second);
             (void) result.second;
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Ws:: on_open(" << remoteEndpoint << ")";
         }
         catch (std::exception const&)
@@ -235,7 +235,7 @@ public:
         }
         try
         {
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
            "Ws:: on_pong(" << cpClient->get_socket ().remote_endpoint() << ")";
         }
         catch (std::exception const&)
@@ -267,7 +267,7 @@ public:
             {
                 try
                 {
-                    JLOG (j_.debug) <<
+                    JLOG (j_.debug()) <<
                         "Ws:: " << reason << "(" <<
                            cpClient->get_socket ().remote_endpoint() <<
                            ") not found";
@@ -286,7 +286,7 @@ public:
         ptr->preDestroy (); // Must be done before we return
         try
         {
-            JLOG (j_.debug) <<
+            JLOG (j_.debug()) <<
                 "Ws:: " << reason << "(" <<
                    cpClient->get_socket ().remote_endpoint () << ") found";
         }
@@ -331,7 +331,7 @@ public:
         {
             try
             {
-                JLOG (j_.debug) <<
+                JLOG (j_.debug()) <<
                     "Ws:: Rejected(" <<
                     cpClient->get_socket().remote_endpoint() <<
                     ") '" << mpMessage->get_payload () << "'";
@@ -388,7 +388,7 @@ public:
 
         try
         {
-            JLOG (j_.debug)
+            JLOG (j_.debug())
                     << "Ws:: Receiving("
                     << cpClient->get_socket ().remote_endpoint ()
                     << ") '" << message << "'";

--- a/src/ripple/websocket/Server.h
+++ b/src/ripple/websocket/Server.h
@@ -61,7 +61,7 @@ private:
     {
         beast::Thread::setCurrentThreadName ("WebSocket");
 
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             << "Websocket: listening on " << desc_.port;
 
         listen();
@@ -70,17 +70,17 @@ private:
             endpoint_.reset();
         }
 
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             << "Websocket: finished listening on " << desc_.port;
 
         stopped ();
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             << "Websocket: stopped on " << desc_.port;
     }
 
     void onStart () override
     {
-        JLOG (j_.warning)
+        JLOG (j_.warn())
                 << "Websocket: creating endpoint " << desc_.port;
 
         {
@@ -103,7 +103,7 @@ private:
 
     void onStop () override
     {
-        JLOG (j_.warning)
+        JLOG (j_.warn())
             << "Websocket: onStop " << desc_.port;
 
         auto endpoint = [&]

--- a/src/ripple/websocket/WebSocket02.cpp
+++ b/src/ripple/websocket/WebSocket02.cpp
@@ -112,12 +112,12 @@ void Server <WebSocket02>::listen()
             }
             catch (std::exception const& e)
             {
-                JLOG (j_.warning) << "websocketpp exception: "
+                JLOG (j_.warn()) << "websocketpp exception: "
                                              << e.what ();
                 static const int maxRetries = 10;
                 if (maxRetries && i >= maxRetries)
                 {
-                    JLOG (j_.warning)
+                    JLOG (j_.warn())
                             << "websocketpp exceeded max retries: " << i;
                     break;
                 }


### PR DESCRIPTION
This is a fairly mechanical pull request, but it touches a lot of code.  Users of `beast::Journal` must now call member functions, instead of invoking public data members, to access `Streams` at various `Severity` thresholds.  At the beginning of this exercise each `Journal` object carries a reference and 6 small classes as data members.  At the end of the exercise a `Journal` object carries a single reference as its only data member.  So `Journal` becomes a much better choice for pass-by-value.

To make the new member functions as efficient as the old code, at least in release builds, the `Journal::ScopedStream`, `Journal::Stream`, and `Journal` classes were re-worked a bit with close attention to what should be in-lined and what should not.  I looked at the clang optimized disassembly to guide me in these decisions. It was important that the `active()` check in a `JLOG` could be completed with a single call to a virtual function.  No additional constructors or destructors are called, at least in optimized code.

Some of the preferred names for the member functions collided with the names of the public data members, so the rename had to be done in several steps:

 1. Introduce the `Journal` member functions using less desirable names.
 2. Switch all users of the `Journal` data members to call the new member functions.
 3. Remove the data members and provide `Journal` member functions with better names.
 4. Switch all callers of the less desirable names to call the better names.
 5. Remove the member functions with less desirable names from `Journal`.

Much of the renaming was done with python scripts.  But some of the renaming was manual.  The manual renaming allowed me to check for cases where `JLOG` (or some equivalent construct) was not being used.  Those cases are fixed.

I'd like for the reviewers to think about how we should push the end result into develop.  For the pull request I kept the automated changes separate from the manual changes.  For the final commit I'd be happy to `[FOLD]` any or all of the commits.  Let me know what you think.

I'm not assigning reviewers because I'm hoping for volunteers.  A lot has changed, but much of it is mechanical.