### PR TITLE
Correctly mark validations as full or partial

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -201,7 +201,7 @@ checkConsensus (
         }
     }
 
-    // Have we, together with the nodes on our UNL list, reached the treshold
+    // Have we, together with the nodes on our UNL list, reached the threshold
     // to declare consensus?
     if (checkConsensusReached (currentAgree, currentProposers, proposing))
     {

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1623,6 +1623,7 @@ void NetworkOPsImp::pubValidation (STValidation::ref val)
             val->getSignerPublic());
         jvObj [jss::ledger_hash]           = to_string (val->getLedgerHash ());
         jvObj [jss::signature]             = strHex (val->getSignature ());
+        jvObj [jss::full]                  = val->isFull();
 
         auto const seq = *(*val)[~sfLedgerSequence];
 

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -57,7 +57,7 @@ STValidation::STValidation (
     mNodeID = calcNodeID(publicKey);
     assert (mNodeID.isNonZero ());
 
-    if (!isFull)
+    if (isFull)
         setFlag (kFullFlag);
 }
 


### PR DESCRIPTION
* Correctly set kFullFlag in STValidation constructor
* Include validation type (full or partial) in subscription stream