### PR TITLE
Remove Env::disable_testing() stub

### DIFF
--- a/src/ripple/app/tests/MultiSign.test.cpp
+++ b/src/ripple/app/tests/MultiSign.test.cpp
@@ -196,9 +196,7 @@ public:
         env.fund(XRP(1000), alice);
         env.close();
 
-        // Make sure multisign is disabled in production.
         // NOTE: These six tests will fail when multisign is default enabled.
-        env.disable_testing();
         env(signers(alice, 1, {{bogie, 1}}), ter(temDISABLED));
         env.close();
         env.require (owners (alice, 0));

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -289,13 +289,6 @@ public:
         trace_ = 0;
     }
 
-    /** Turn off testing. */
-    void
-    disable_testing()
-    {
-        testing_ = false;
-    }
-
     /** Turn off signature checks. */
     void
     disable_sigs()
@@ -540,7 +533,6 @@ public:
 
 protected:
     int trace_ = 0;
-    bool testing_ = true;
     TestStopwatch stopwatch_;
     uint256 txid_;
     TER ter_ = tesSUCCESS;


### PR DESCRIPTION
I wandered across this little bit of left over code recently.  I think it can be safely removed.

Reviewers: @vinniefalco

