### PR TITLE
Return unfunded and expired offers when flow fails

### DIFF
--- a/src/ripple/app/paths/RippleCalc.h
+++ b/src/ripple/app/paths/RippleCalc.h
@@ -26,6 +26,8 @@
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/TER.h>
 
+#include <boost/container/flat_set.hpp>
+
 namespace ripple {
 class Config;
 namespace path {
@@ -53,6 +55,12 @@ public:
         // The computed output amount.
         STAmount actualAmountOut;
 
+        // Collection of offers found expired or unfunded. When a payment
+        // succeeds, unfunded and expired offers are removed. When a payment
+        // fails, they are not removed. This vector contains the offers that
+        // could have been removed but were not because the payment fails. It is
+        // useful for offer crossing, which does remove the offers.
+        boost::container::flat_set<uint256> removableOffers;
     private:
         TER calculationResult_ = temUNKNOWN;
 
@@ -105,7 +113,7 @@ public:
     // unfunded offers in a deterministic order (hence the ordered container).
     //
     // Offers that were found unfunded.
-    std::set<uint256> permanentlyUnfundedOffers_;
+    boost::container::flat_set<uint256> permanentlyUnfundedOffers_;
 
     // First time working in reverse a funding source was mentioned.  Source may
     // only be used there.

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -26,6 +26,8 @@
 #include <ripple/protocol/IOUAmount.h>
 #include <ripple/protocol/Quality.h>
 
+#include <boost/container/flat_set.hpp>
+
 #include <numeric>
 #include <sstream>
 
@@ -111,14 +113,14 @@ class DirectStepI : public StepImp<IOUAmount, IOUAmount, DirectStepI>
     revImp (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         IOUAmount const& out);
 
     std::pair<IOUAmount, IOUAmount>
     fwdImp (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         IOUAmount const& in);
 
     std::pair<bool, EitherAmount>
@@ -195,7 +197,7 @@ std::pair<IOUAmount, IOUAmount>
 DirectStepI::revImp (
     PaymentSandbox& sb,
     ApplyView& /*afView*/,
-    std::vector<uint256>& /*ofrsToRm*/,
+    boost::container::flat_set<uint256>& /*ofrsToRm*/,
     IOUAmount const& out)
 {
     cache_.reset ();
@@ -313,7 +315,7 @@ std::pair<IOUAmount, IOUAmount>
 DirectStepI::fwdImp (
     PaymentSandbox& sb,
     ApplyView& /*afView*/,
-    std::vector<uint256>& /*ofrsToRm*/,
+    boost::container::flat_set<uint256>& /*ofrsToRm*/,
     IOUAmount const& in)
 {
     assert (cache_);
@@ -409,7 +411,7 @@ DirectStepI::validFwd (
 
     try
     {
-        std::vector<uint256> dummy;
+        boost::container::flat_set<uint256> dummy;
         fwdImp (sb, afView, dummy, in.iou);  // changes cache
     }
     catch (FlowException const&)

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -79,7 +79,7 @@ class Step
     rev (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         EitherAmount const& out) = 0;
 
     /**
@@ -98,7 +98,7 @@ class Step
     fwd (
         PaymentSandbox&,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         EitherAmount const& in) = 0;
 
     virtual
@@ -238,7 +238,7 @@ struct StepImp : public Step
     rev (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         EitherAmount const& out) override
     {
         auto const r =
@@ -252,7 +252,7 @@ struct StepImp : public Step
     fwd (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         EitherAmount const& in) override
     {
         auto const r =

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -28,6 +28,7 @@
 #include <ripple/protocol/Quality.h>
 #include <ripple/protocol/XRPAmount.h>
 
+#include <boost/container/flat_set.hpp>
 
 #include <numeric>
 #include <sstream>
@@ -83,14 +84,14 @@ class XRPEndpointStep : public StepImp<XRPAmount, XRPAmount, XRPEndpointStep>
     revImp (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         XRPAmount const& out);
 
     std::pair<XRPAmount, XRPAmount>
     fwdImp (
         PaymentSandbox& sb,
         ApplyView& afView,
-        std::vector<uint256>& ofrsToRm,
+        boost::container::flat_set<uint256>& ofrsToRm,
         XRPAmount const& in);
 
     std::pair<bool, EitherAmount>
@@ -154,7 +155,7 @@ std::pair<XRPAmount, XRPAmount>
 XRPEndpointStep::revImp (
     PaymentSandbox& sb,
     ApplyView& afView,
-    std::vector<uint256>& ofrsToRm,
+    boost::container::flat_set<uint256>& ofrsToRm,
     XRPAmount const& out)
 {
     auto const balance = xrpLiquid (sb, acc_);
@@ -174,7 +175,7 @@ std::pair<XRPAmount, XRPAmount>
 XRPEndpointStep::fwdImp (
     PaymentSandbox& sb,
     ApplyView& afView,
-    std::vector<uint256>& ofrsToRm,
+    boost::container::flat_set<uint256>& ofrsToRm,
     XRPAmount const& in)
 {
     assert (cache_);

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -216,7 +216,7 @@ OfferStream::permRmOffer (std::shared_ptr<SLE> const& sle)
 template<class TIn, class TOut>
 void FlowOfferStream<TIn, TOut>::permRmOffer (std::shared_ptr<SLE> const& sle)
 {
-    toRemove_.push_back (sle->key());
+    toRemove_.insert (sle->key());
 }
 
 template class FlowOfferStream<STAmount, STAmount>;

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -28,6 +28,8 @@
 #include <ripple/protocol/Quality.h>
 #include <beast/utility/Journal.h>
 
+#include <boost/container/flat_set.hpp>
+
 namespace ripple {
 
 template<class TIn, class TOut>
@@ -163,7 +165,7 @@ template <class TIn, class TOut>
 class FlowOfferStream : public TOfferStreamBase<TIn, TOut>
 {
 private:
-    std::vector<uint256> toRemove_;
+    boost::container::flat_set<uint256> toRemove_;
 protected:
     void
     permRmOffer (std::shared_ptr<SLE> const& sle) override;
@@ -171,7 +173,7 @@ protected:
 public:
     using TOfferStreamBase<TIn, TOut>::TOfferStreamBase;
 
-    std::vector<uint256> const& toRemove () const
+    boost::container::flat_set<uint256> const& toRemove () const
     {
         return toRemove_;
     };


### PR DESCRIPTION
Payments do not remove unfunded and expired offers when a payment fails. However, offer crossing is now using the payment engine and needs to know what offers were found in a removable state, even on failure.

@scottschurr @ximinez 