### PR TITLE
Disallow re-use of "became unfunded" offers & deferred payments numerical stability

### DIFF
--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -66,9 +66,13 @@ flow (
     boost::optional<STAmount> const& sendMax,
     beast::Journal j)
 {
-
-    Issue const srcIssue =
-        sendMax ? sendMax->issue () : Issue (deliver.issue ().currency, src);
+    Issue const srcIssue = [&] {
+        if (sendMax)
+            return sendMax->issue ();
+        if (!isXRP (deliver.issue ().currency))
+            return Issue (deliver.issue ().currency, src);
+        return xrpIssue ();
+    }();
 
     Issue const dstIssue = deliver.issue ();
 

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -68,7 +68,7 @@ private:
 
     boost::optional<Cache> cache_;
 
-    // Offers that were not used in the reverse pass because they because
+    // Offers that were not used in the reverse pass because they became
     // unfunded in a step preceding it
     boost::container::flat_set<uint256> becameUnfunded_;
 public:
@@ -268,7 +268,7 @@ forEachOffer (
     }
 
     becameUnfundedOffers = std::move(offers.becameUnfunded());
-    return {offers.permUnfunded (), counter.count()};
+    return {offers.permToRemove (), counter.count()};
 }
 
 template <class TIn, class TOut>

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -68,8 +68,8 @@ private:
 
     boost::optional<Cache> cache_;
 
-    // Offers that were not used in the reverse pass because they becaue unfunded
-    // in a step preceeding it
+    // Offers that were not used in the reverse pass because they because
+    // unfunded in a step preceding it
     boost::container::flat_set<uint256> becameUnfunded_;
 public:
     BookStep (Issue const& in,

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -114,6 +114,9 @@ public:
     virtual bool equalOut (EitherAmount const& lhs,
         EitherAmount const& rhs) const = 0;
 
+    virtual bool equalIn (EitherAmount const& lhs,
+                           EitherAmount const& rhs) const = 0;
+
     /**
        Check that the step can correctly execute in the forward direction
 
@@ -249,6 +252,12 @@ struct StepImp : public Step
     equalOut (EitherAmount const& lhs, EitherAmount const& rhs) const override
     {
         return get<TOut> (lhs) == get<TOut> (rhs);
+    }
+
+    bool
+    equalIn (EitherAmount const& lhs, EitherAmount const& rhs) const override
+    {
+        return get<TIn> (lhs) == get<TIn> (rhs);
     }
 };
 

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -28,8 +28,7 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/optional.hpp>
 
-namespace ripple
-{
+namespace ripple {
 class PaymentSandbox;
 class ReadView;
 class ApplyView;
@@ -56,10 +55,9 @@ class ApplyView;
    quality directory.
 
    A step may not have enough liquidity to transform the entire requested
-   amount. Both
-   `fwd` and `rev` return a pair of amounts (one for input amount, one for
-   output amount)
-   that show how much of the requested amount the step was actually able use.
+   amount. Both `fwd` and `rev` return a pair of amounts (one for input amount,
+   one for output amount) that show how much of the requested amount the step
+   was actually able use.
  */
 class Step
 {
@@ -318,8 +316,7 @@ struct StrandContext
         beast::Journal j);
 };
 
-namespace test
-{
+namespace test {
 // Needed for testing
 bool directStepEqual (Step const& step,
     AccountID const& src,

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -57,7 +57,7 @@ class ApplyView;
    A step may not have enough liquidity to transform the entire requested
    amount. Both `fwd` and `rev` return a pair of amounts (one for input amount,
    one for output amount) that show how much of the requested amount the step
-   was actually able use.
+   was actually able to use.
  */
 class Step
 {
@@ -122,7 +122,7 @@ public:
        @param afView view the the state of balances before the strand runs
        this determines if an offer becomes unfunded or is found unfunded
        @param in requested step input
-       @return first element is true is step is valid, second element is out
+       @return first element is true if step is valid, second element is out
        amount
     */
     virtual std::pair<bool, EitherAmount> validFwd (PaymentSandbox& sb,

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -302,6 +302,8 @@ public:
         // Swap, don't move, so we keep the reserve in next_
         cur_.clear ();
         std::swap (cur_, next_);
+        // BookSteps keep a blacklist of offers that need to be cleared between
+        // iterations
         for(auto& strand : cur_)
             for(auto& step : *strand)
                 step->restart ();

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -291,6 +291,9 @@ public:
         // Swap, don't move, so we keep the reserve in next_
         cur_.clear ();
         std::swap (cur_, next_);
+        for(auto& strand : cur_)
+            for(auto& step : *strand)
+                step->restart ();
     }
 
     void

--- a/src/ripple/app/tx/impl/Offer.h
+++ b/src/ripple/app/tx/impl/Offer.h
@@ -123,6 +123,11 @@ public:
         return to_string (m_entry->getIndex());
     }
 
+    uint256 const& key () const
+    {
+        return m_entry->key();
+    }
+
     Issue issueIn () const;
     Issue issueOut () const;
 };

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -193,6 +193,7 @@ TOfferStreamBase<TIn, TOut>::step ()
             }
             else
             {
+                becameUnfundedOffer (entry);
                 JLOG(j_.trace()) <<
                     "Removing became unfunded offer " << entry->getIndex();
             }
@@ -217,6 +218,12 @@ template<class TIn, class TOut>
 void FlowOfferStream<TIn, TOut>::permRmOffer (std::shared_ptr<SLE> const& sle)
 {
     toRemove_.insert (sle->key());
+}
+
+template<class TIn, class TOut>
+void FlowOfferStream<TIn, TOut>::becameUnfundedOffer (std::shared_ptr<SLE> const& sle)
+{
+    becameUnfunded_.insert (sle->key());
 }
 
 template class FlowOfferStream<STAmount, STAmount>;

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -217,7 +217,7 @@ OfferStream::permRmOffer (std::shared_ptr<SLE> const& sle)
 template<class TIn, class TOut>
 void FlowOfferStream<TIn, TOut>::permRmOffer (std::shared_ptr<SLE> const& sle)
 {
-    toRemove_.insert (sle->key());
+    permToRemove_.insert (sle->key());
 }
 
 template<class TIn, class TOut>

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -169,7 +169,7 @@ template <class TIn, class TOut>
 class FlowOfferStream : public TOfferStreamBase<TIn, TOut>
 {
 private:
-    boost::container::flat_set<uint256> toRemove_;
+    boost::container::flat_set<uint256> permToRemove_;
     boost::container::flat_set<uint256> becameUnfunded_;
 protected:
     void
@@ -181,9 +181,9 @@ protected:
 public:
     using TOfferStreamBase<TIn, TOut>::TOfferStreamBase;
 
-    boost::container::flat_set<uint256> const& permUnfunded () const
+    boost::container::flat_set<uint256> const& permToRemove () const
     {
-        return toRemove_;
+        return permToRemove_;
     };
 
     boost::container::flat_set<uint256> const& becameUnfunded () const

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -85,6 +85,10 @@ protected:
     virtual
     void
     permRmOffer (std::shared_ptr<SLE> const& sle) = 0;
+
+    virtual
+    void
+    becameUnfundedOffer (std::shared_ptr<SLE> const& sle){};
 public:
     TOfferStreamBase (ApplyView& view, ApplyView& cancelView,
         Book const& book, NetClock::time_point when,
@@ -166,16 +170,29 @@ class FlowOfferStream : public TOfferStreamBase<TIn, TOut>
 {
 private:
     boost::container::flat_set<uint256> toRemove_;
+    boost::container::flat_set<uint256> becameUnfunded_;
 protected:
     void
     permRmOffer (std::shared_ptr<SLE> const& sle) override;
 
+    void
+    becameUnfundedOffer (std::shared_ptr<SLE> const& sle) override;
+
 public:
     using TOfferStreamBase<TIn, TOut>::TOfferStreamBase;
 
-    boost::container::flat_set<uint256> const& toRemove () const
+    boost::container::flat_set<uint256> const& permUnfunded () const
     {
         return toRemove_;
+    };
+
+    boost::container::flat_set<uint256> const& becameUnfunded () const
+    {
+        return becameUnfunded_;
+    };
+    boost::container::flat_set<uint256>& becameUnfunded ()
+    {
+        return becameUnfunded_;
     };
 };
 }

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -201,11 +201,11 @@ public:
 
     // Called when a credit is made to an account
     // This is required to support PaymentSandbox
-    virtual
-    void
+    virtual void
     creditHook (AccountID const& from,
         AccountID const& to,
-            STAmount const& amount)
+        STAmount const& amount,
+        STAmount const& preCreditBalance)
     {
     }
 };

--- a/src/ripple/ledger/PaymentSandbox.h
+++ b/src/ripple/ledger/PaymentSandbox.h
@@ -36,18 +36,18 @@ namespace detail {
 class DeferredCredits
 {
 public:
-    struct adjustment
+    struct Adjustment
     {
-        adjustment (STAmount const& d, STAmount const& c, STAmount const& b)
-            : debits (d), credits (c), orgBalance (b) {}
+        Adjustment (STAmount const& d, STAmount const& c, STAmount const& b)
+            : debits (d), credits (c), origBalance (b) {}
         STAmount debits;
         STAmount credits;
-        STAmount orgBalance;
+        STAmount origBalance;
     };
 
     // Get the adjustments for the balance between main and other.
     // Returns the debits, credits and the original balance
-    boost::optional<adjustment> adjustments (
+    boost::optional<Adjustment> adjustments (
         AccountID const& main,
         AccountID const& other,
         Currency const& currency) const;
@@ -55,7 +55,7 @@ public:
     void credit (AccountID const& sender,
         AccountID const& receiver,
         STAmount const& amount,
-        STAmount const& preCreditBalance);
+        STAmount const& preCreditSenderBalance);
 
     void apply (DeferredCredits& to);
 
@@ -69,9 +69,9 @@ private:
         AccountID, AccountID, Currency>;
     struct Value
     {
-        STAmount lowAccCredits;
-        STAmount highAccCredits;
-        STAmount lowAccOrgBalance;
+        STAmount lowAcctCredits;
+        STAmount highAcctCredits;
+        STAmount lowAcctOrigBalance;
     };
 
     static

--- a/src/ripple/ledger/PaymentSandbox.h
+++ b/src/ripple/ledger/PaymentSandbox.h
@@ -58,11 +58,6 @@ public:
         STAmount const& preCreditSenderBalance);
 
     void apply (DeferredCredits& to);
-
-    // VFALCO Is this needed?
-    // DEPRECATED
-    void clear ();
-
 private:
     // lowAccount, highAccount
     using Key = std::tuple<

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,6 +328,7 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
+NetClock::time_point const& flowV2SoTime ();
 bool flowV2Switchover (NetClock::time_point const closeTime);
 
 } // ripple

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -137,13 +137,15 @@ PaymentSandbox::balanceHook (AccountID const& account,
     AccountID const& issuer,
         STAmount const& amount) const
 {
-    // There are two algorithms here. The first takes the current amount and
-    // subtracts the recorded credits. The second algorithm remembers the origional
-    // balance, and subtracts the debits. The second algorithm should be more numerically
-    // stable than the first. Consider a large credit with a small initial balance.
-    // The first algorithm computes (B+C)-C (where B+C will the the amount passed in).
-    // The second algorithm return B. When B and C differ by large magnitudes, (B+C)-C may
-    // not equal B.
+    /*
+    There are two algorithms here. The first takes the current amount and
+    subtracts the recorded credits. The second algorithm remembers the original
+    balance, and subtracts the debits. The second algorithm should be more
+    numerically stable than the first. Consider a large credit with a small
+    initial balance. The first algorithm computes (B+C)-C (where B+C will the
+    the amount passed in). The second algorithm return B. When B and C differ by
+    large magnitudes, (B+C)-C may not equal B.
+    */
 
     auto const currency = amount.getCurrency ();
     auto const switchover = flowV2Switchover (info ().parentCloseTime);

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -125,11 +125,6 @@ void DeferredCredits::apply(
     }
 }
 
-void DeferredCredits::clear ()
-{
-    map_.clear ();
-}
-
 } // detail
 
 STAmount

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -19,16 +19,19 @@
 
 #include <BeastConfig.h>
 #include <ripple/ledger/PaymentSandbox.h>
+#include <ripple/ledger/View.h>
+
+#include <boost/optional.hpp>
+
 #include <cassert>
 
 namespace ripple {
 
 namespace detail {
 
-auto
-DeferredCredits::makeKey (AccountID const& a1,
-    AccountID const& a2, Currency const& c) ->
-        Key
+auto DeferredCredits::makeKey (AccountID const& a1,
+    AccountID const& a2,
+    Currency const& c) -> Key
 {
     if (a1 < a2)
         return std::make_tuple(a1, a2, c);
@@ -36,12 +39,12 @@ DeferredCredits::makeKey (AccountID const& a1,
         return std::make_tuple(a2, a1, c);
 }
 
-void DeferredCredits::credit (AccountID const& sender,
-                              AccountID const& receiver,
-                              STAmount const& amount)
+void
+DeferredCredits::credit (AccountID const& sender,
+    AccountID const& receiver,
+    STAmount const& amount,
+    STAmount const& preCreditBalanceSender)
 {
-    using std::get;
-
     assert (sender != receiver);
     assert (!amount.negative());
 
@@ -53,52 +56,55 @@ void DeferredCredits::credit (AccountID const& sender,
 
         if (sender < receiver)
         {
-            get<1> (v) = amount;
-            get<0> (v) = amount.zeroed ();
+            v.highAccCredits = amount;
+            v.lowAccCredits = amount.zeroed ();
+            v.lowAccOrgBalance = preCreditBalanceSender;
         }
         else
         {
-            get<1> (v) = amount.zeroed ();
-            get<0> (v) = amount;
+            v.highAccCredits = amount.zeroed ();
+            v.lowAccCredits = amount;
+            v.lowAccOrgBalance = -preCreditBalanceSender;
         }
 
         map_[k] = v;
     }
     else
     {
+        // only record the balance the first time, do not record it here
         auto& v = i->second;
         if (sender < receiver)
-            get<1> (v) += amount;
+            v.highAccCredits += amount;
         else
-            get<0> (v) += amount;
+            v.lowAccCredits += amount;
     }
 }
 
-// Get the adjusted balance of main for the
-// balance between main and other.
-STAmount DeferredCredits::adjustedBalance (AccountID const& main,
-                                           AccountID const& other,
-                                           STAmount const& curBalance) const
+// Get the adjustments for the balance between main and other.
+auto
+DeferredCredits::adjustments (AccountID const& main,
+    AccountID const& other,
+    Currency const& currency) const -> boost::optional<adjustment>
 {
-    using std::get;
-    STAmount result (curBalance);
+    boost::optional<adjustment> result;
 
-    Key const k = makeKey (main, other, curBalance.getCurrency ());
+    Key const k = makeKey (main, other, currency);
     auto i = map_.find (k);
-    if (i != map_.end ())
-    {
-        auto const& v = i->second;
-        if (main < other)
-        {
-            result -= get<0> (v);
-        }
-        else
-        {
-            result -= get<1> (v);
-        }
-    }
+    if (i == map_.end ())
+        return result;
 
-    return result;
+    auto const& v = i->second;
+
+    if (main < other)
+    {
+        result.emplace (v.highAccCredits, v.lowAccCredits, v.lowAccOrgBalance);
+        return result;
+    }
+    else
+    {
+        result.emplace (v.lowAccCredits, v.highAccCredits, -v.lowAccOrgBalance);
+        return result;
+    }
 }
 
 void DeferredCredits::apply(
@@ -110,9 +116,11 @@ void DeferredCredits::apply(
             to.map_.emplace(p);
         if (! r.second)
         {
-            using std::get;
-            get<0>(r.first->second) += get<0>(p.second);
-            get<1>(r.first->second) += get<1>(p.second);
+            auto& toVal = r.first->second;
+            auto const& fromVal = p.second;
+            toVal.lowAccCredits += fromVal.lowAccCredits;
+            toVal.highAccCredits += fromVal.highAccCredits;
+            // Do not update the org balance, it's already correct
         }
     }
 }
@@ -129,19 +137,54 @@ PaymentSandbox::balanceHook (AccountID const& account,
     AccountID const& issuer,
         STAmount const& amount) const
 {
-    if (ps_)
-        return tab_.adjustedBalance (
-            account, issuer, ps_->balanceHook (account, issuer, amount));
-    return tab_.adjustedBalance(
-        account, issuer, amount);
+    // There are two algorithms here. The first takes the current amount and
+    // subtracts the recorded credits. The second algorithm remembers the origional
+    // balance, and subtracts the debits. The second algorithm should be more numerically
+    // stable than the first. Consider a large credit with a small initial balance.
+    // The first algorithm computes (B+C)-C (where B+C will the the amount passed in).
+    // The second algorithm return B. When B and C differ by large magnitudes, (B+C)-C may
+    // not equal B.
+
+    auto const currency = amount.getCurrency ();
+    auto const switchover = flowV2Switchover (info ().parentCloseTime);
+
+    auto adjustedAmt = amount;
+    if (switchover)
+    {
+        auto delta = amount.zeroed ();
+        auto lastBal = amount;
+        for (auto curSB = this; curSB; curSB = curSB->ps_)
+        {
+            if (auto adj = curSB->tab_.adjustments (account, issuer, currency))
+            {
+                delta += adj->debits;
+                lastBal = adj->orgBalance;
+            }
+        }
+        adjustedAmt = std::min(amount, lastBal - delta);
+    }
+    else
+    {
+        for (auto curSB = this; curSB; curSB = curSB->ps_)
+        {
+            if (auto adj = curSB->tab_.adjustments (account, issuer, currency))
+            {
+                adjustedAmt -= adj->credits;
+            }
+        }
+    }
+
+    assert (!isXRP(issuer) || adjustedAmt >= beast::zero);
+    return adjustedAmt;
 }
 
 void
 PaymentSandbox::creditHook (AccountID const& from,
     AccountID const& to,
-        STAmount const& amount)
+        STAmount const& amount,
+            STAmount const& preCreditBalance)
 {
-    tab_.credit(from, to, amount);
+    tab_.credit (from, to, amount, preCreditBalance);
 }
 
 void


### PR DESCRIPTION
Computing the liquidity of a strand works by walking a strand in reverse
to find the amount needed to feed into the strand to deliver the desired
output. If a step is unable to deliver the desired output, it is a
limiting step. The view is thrown out (resetting the balances, offers,
and deferred credits table), the limiting step is re-executed, and the
algorithm continues until the first step is reached. Then the steps from
one past the limiting step to the end are executed.

The algorithm above does not work if the liquidity decreases then
re-executing the steps. This can happen if an offer that was made
unfunded is now funded (the quality would go up, but the liquidity would
go down at the new quality). Disallowing the re-use of "became unfunded"
offers prevents the above scenario.

Deferred credits numerical stability is improved. The deferred credits algorithm took the current
balance and subtracted the recorded credits. Conceptually, this is the
same as taking the original balance, adding all the credits,
subtracting all the debits, and subtracting all the credits. The new
algorithm records the original balance and subtracts the debits. This
prevents errors that occur when the original balance and the recorded
credits have large differences in magnitude.

Additionally, XRP credits were recorded incorrectly in the deferred
credits table (the line was between the sender and receiver, rather than
the root account).

@scottschurr @nbougalis 

