### PR TITLE
Disallow  strands where steps may unfund offers in other steps & deferred payments numerical stability

### DIFF
--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -66,9 +66,13 @@ flow (
     boost::optional<STAmount> const& sendMax,
     beast::Journal j)
 {
-
-    Issue const srcIssue =
-        sendMax ? sendMax->issue () : Issue (deliver.issue ().currency, src);
+    Issue const srcIssue = [&] {
+        if (sendMax)
+            return sendMax->issue ();
+        if (!isXRP (deliver.issue ().currency))
+            return Issue (deliver.issue ().currency, src);
+        return xrpIssue ();
+    }();
 
     Issue const dstIssue = deliver.issue ();
 

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -102,6 +102,12 @@ public:
         return EitherAmount (cache_->out);
     }
 
+    boost::optional<Book>
+    bookStepBook () const override
+    {
+        return book_;
+    }
+
     std::pair<TIn, TOut>
     revImp (
         PaymentSandbox& sb,
@@ -258,7 +264,7 @@ forEachOffer (
             break;
     }
 
-    return {offers.toRemove (), counter.count()};
+    return {offers.permToRemove (), counter.count()};
 }
 
 template <class TIn, class TOut>
@@ -546,11 +552,14 @@ BookStep<TIn, TOut>::check(StrandContext const& ctx) const
         JLOG (j_.debug()) << "Book: currency is inconsistent with issuer." << *this;
         return temBAD_PATH;
     }
-    if (!ctx.seenBooks.insert (book_).second)
+
+    if (!ctx.seenBookOuts.insert (book_.out).second ||
+        ctx.seenDirectIssues[0].count (book_.out))
     {
         JLOG (j_.debug()) << "BookStep: loop detected: " << *this;
         return temBAD_PATH_LOOP;
     }
+
     return tesSUCCESS;
 }
 

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -553,6 +553,8 @@ BookStep<TIn, TOut>::check(StrandContext const& ctx) const
         return temBAD_PATH;
     }
 
+    // Do not allow two books to output the same issue. This may cause offers on
+    // one step to unfund offers in another step.
     if (!ctx.seenBookOuts.insert (book_.out).second ||
         ctx.seenDirectIssues[0].count (book_.out))
     {

--- a/src/ripple/app/paths/impl/PaySteps.cpp
+++ b/src/ripple/app/paths/impl/PaySteps.cpp
@@ -226,14 +226,14 @@ toStrand (
     */
     std::array<boost::container::flat_set<Issue>, 2> seenDirectIssues;
     // A strand may not include the same offer book more than once
-    boost::container::flat_set<Book> seenBooks;
+    boost::container::flat_set<Issue> seenBookOuts;
     seenDirectIssues[0].reserve (pes.size());
     seenDirectIssues[1].reserve (pes.size());
-    seenBooks.reserve (pes.size());
+    seenBookOuts.reserve (pes.size());
     auto ctx = [&](bool isLast = false)
     {
         return StrandContext{view, result, strandSrc, strandDst, isLast,
-            seenDirectIssues, seenBooks, j};
+            seenDirectIssues, seenBookOuts, j};
     };
 
     for (int i = 0; i < pes.size () - 1; ++i)
@@ -456,7 +456,7 @@ StrandContext::StrandContext (
     AccountID strandDst_,
     bool isLast_,
     std::array<boost::container::flat_set<Issue>, 2>& seenDirectIssues_,
-    boost::container::flat_set<Book>& seenBooks_,
+    boost::container::flat_set<Issue>& seenBookOuts_,
     beast::Journal j_)
         : view (view_)
         , strandSrc (strandSrc_)
@@ -467,7 +467,7 @@ StrandContext::StrandContext (
         , prevStep (!strand_.empty () ? strand_.back ().get ()
                      : nullptr)
         , seenDirectIssues(seenDirectIssues_)
-        , seenBooks(seenBooks_)
+        , seenBookOuts(seenBookOuts_)
         , j (j_)
 {
 }

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -186,7 +186,8 @@ flow (
                 if (strand[i]->dry (r.second) ||
                     !strand[i]->equalIn (r.first, stepIn))
                 {
-                    // limiting step forward
+                    // The limits should already have been found, so executing a strand forward
+                    // from the limiting step should not find a new limit
                     JLOG (j.fatal()) << "Re-executed forward pass failed";
                     assert (0);
                     return {telFAILED_PROCESSING, std::move (ofrsToRm)};

--- a/src/ripple/app/tests/Offer.test.cpp
+++ b/src/ripple/app/tests/Offer.test.cpp
@@ -41,6 +41,15 @@ class Offer_test : public beast::unit_test::suite
         return env.current()->info().parentCloseTime.time_since_epoch().count();
     }
 
+    static auto
+    xrpMinusFee (jtx::Env const& env, std::int64_t xrpAmount)
+        -> jtx::PrettyAmount
+    {
+        using namespace jtx;
+        auto feeDrops = env.current ()->fees ().base;
+        return drops (dropsPerXRP<std::int64_t>::value * xrpAmount - feeDrops);
+    };
+
 public:
     void testRmFundedOffer ()
     {
@@ -343,15 +352,6 @@ public:
 
             env (pay (alice, carol, USD2 (50)), path (~USD1, bob),
                 sendmax (XRP (50)), txflags (tfNoRippleDirect));
-
-            auto xrpMinusFee = [](jtx::Env const& env,
-                std::int64_t xrpAmount) -> jtx::PrettyAmount
-            {
-                using namespace jtx;
-                auto feeDrops = env.current ()->fees ().base;
-                return drops (
-                    dropsPerXRP<std::int64_t>::value * xrpAmount - feeDrops);
-            };
 
             env.require (balance (alice, xrpMinusFee (env, 10000 - 50)));
             env.require (balance (bob, USD1 (100)));

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -216,7 +216,7 @@ OfferStream::permRmOffer (std::shared_ptr<SLE> const& sle)
 template<class TIn, class TOut>
 void FlowOfferStream<TIn, TOut>::permRmOffer (std::shared_ptr<SLE> const& sle)
 {
-    toRemove_.insert (sle->key());
+    permToRemove_.insert (sle->key());
 }
 
 template class FlowOfferStream<STAmount, STAmount>;

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -85,6 +85,7 @@ protected:
     virtual
     void
     permRmOffer (std::shared_ptr<SLE> const& sle) = 0;
+
 public:
     TOfferStreamBase (ApplyView& view, ApplyView& cancelView,
         Book const& book, NetClock::time_point when,
@@ -149,11 +150,11 @@ public:
     The `view_' ` `ApplyView` accumulates changes to the ledger.
     The `cancelView_` is used to determine if an offer is found
     unfunded or became unfunded.
-    The `toRemove` collection identifies offers that should be
+    The `permToRemove` collection identifies offers that should be
     removed even if the strand associated with this OfferStream
     is not applied.
 
-    Certain invalid offers are added to the `toRemove` collection:
+    Certain invalid offers are added to the `permToRemove` collection:
     - Offers with missing ledger entries
     - Offers that expired
     - Offers found unfunded:
@@ -165,7 +166,7 @@ template <class TIn, class TOut>
 class FlowOfferStream : public TOfferStreamBase<TIn, TOut>
 {
 private:
-    boost::container::flat_set<uint256> toRemove_;
+    boost::container::flat_set<uint256> permToRemove_;
 protected:
     void
     permRmOffer (std::shared_ptr<SLE> const& sle) override;
@@ -173,9 +174,9 @@ protected:
 public:
     using TOfferStreamBase<TIn, TOut>::TOfferStreamBase;
 
-    boost::container::flat_set<uint256> const& toRemove () const
+    boost::container::flat_set<uint256> const& permToRemove () const
     {
-        return toRemove_;
+        return permToRemove_;
     };
 };
 }

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -201,11 +201,11 @@ public:
 
     // Called when a credit is made to an account
     // This is required to support PaymentSandbox
-    virtual
-    void
+    virtual void
     creditHook (AccountID const& from,
         AccountID const& to,
-            STAmount const& amount)
+        STAmount const& amount,
+        STAmount const& preCreditBalance)
     {
     }
 };

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,6 +328,7 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
+NetClock::time_point const& flowV2SoTime ();
 bool flowV2Switchover (NetClock::time_point const closeTime);
 
 } // ripple

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -133,13 +133,14 @@ PaymentSandbox::balanceHook (AccountID const& account,
         STAmount const& amount) const
 {
     /*
-    There are two algorithms here. The first takes the current amount and
-    subtracts the recorded credits. The second algorithm remembers the original
-    balance, and subtracts the debits. The second algorithm should be more
-    numerically stable than the first. Consider a large credit with a small
-    initial balance. The first algorithm computes (B+C)-C (where B+C will the
-    the amount passed in). The second algorithm return B. When B and C differ by
-    large magnitudes, (B+C)-C may not equal B.
+    There are two algorithms here. The pre-switchover algorithm takes the
+    current amount and subtracts the recorded credits. The post-switchover
+    algorithm remembers the original balance, and subtracts the debits. The
+    post-switchover algorithm should be more numerically stable. Consider a
+    large credit with a small initial balance. The pre-switchover algorithm
+    computes (B+C)-C (where B+C will the the amount passed in). The
+    post-switchover algorithm returns B. When B and C differ by large
+    magnitudes, (B+C)-C may not equal B.
     */
 
     auto const currency = amount.getCurrency ();

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -19,16 +19,19 @@
 
 #include <BeastConfig.h>
 #include <ripple/ledger/PaymentSandbox.h>
+#include <ripple/ledger/View.h>
+
+#include <boost/optional.hpp>
+
 #include <cassert>
 
 namespace ripple {
 
 namespace detail {
 
-auto
-DeferredCredits::makeKey (AccountID const& a1,
-    AccountID const& a2, Currency const& c) ->
-        Key
+auto DeferredCredits::makeKey (AccountID const& a1,
+    AccountID const& a2,
+    Currency const& c) -> Key
 {
     if (a1 < a2)
         return std::make_tuple(a1, a2, c);
@@ -36,12 +39,12 @@ DeferredCredits::makeKey (AccountID const& a1,
         return std::make_tuple(a2, a1, c);
 }
 
-void DeferredCredits::credit (AccountID const& sender,
-                              AccountID const& receiver,
-                              STAmount const& amount)
+void
+DeferredCredits::credit (AccountID const& sender,
+    AccountID const& receiver,
+    STAmount const& amount,
+    STAmount const& preCreditSenderBalance)
 {
-    using std::get;
-
     assert (sender != receiver);
     assert (!amount.negative());
 
@@ -53,52 +56,55 @@ void DeferredCredits::credit (AccountID const& sender,
 
         if (sender < receiver)
         {
-            get<1> (v) = amount;
-            get<0> (v) = amount.zeroed ();
+            v.highAcctCredits = amount;
+            v.lowAcctCredits = amount.zeroed ();
+            v.lowAcctOrigBalance = preCreditSenderBalance;
         }
         else
         {
-            get<1> (v) = amount.zeroed ();
-            get<0> (v) = amount;
+            v.highAcctCredits = amount.zeroed ();
+            v.lowAcctCredits = amount;
+            v.lowAcctOrigBalance = -preCreditSenderBalance;
         }
 
         map_[k] = v;
     }
     else
     {
+        // only record the balance the first time, do not record it here
         auto& v = i->second;
         if (sender < receiver)
-            get<1> (v) += amount;
+            v.highAcctCredits += amount;
         else
-            get<0> (v) += amount;
+            v.lowAcctCredits += amount;
     }
 }
 
-// Get the adjusted balance of main for the
-// balance between main and other.
-STAmount DeferredCredits::adjustedBalance (AccountID const& main,
-                                           AccountID const& other,
-                                           STAmount const& curBalance) const
+// Get the adjustments for the balance between main and other.
+auto
+DeferredCredits::adjustments (AccountID const& main,
+    AccountID const& other,
+    Currency const& currency) const -> boost::optional<Adjustment>
 {
-    using std::get;
-    STAmount result (curBalance);
+    boost::optional<Adjustment> result;
 
-    Key const k = makeKey (main, other, curBalance.getCurrency ());
+    Key const k = makeKey (main, other, currency);
     auto i = map_.find (k);
-    if (i != map_.end ())
-    {
-        auto const& v = i->second;
-        if (main < other)
-        {
-            result -= get<0> (v);
-        }
-        else
-        {
-            result -= get<1> (v);
-        }
-    }
+    if (i == map_.end ())
+        return result;
 
-    return result;
+    auto const& v = i->second;
+
+    if (main < other)
+    {
+        result.emplace (v.highAcctCredits, v.lowAcctCredits, v.lowAcctOrigBalance);
+        return result;
+    }
+    else
+    {
+        result.emplace (v.lowAcctCredits, v.highAcctCredits, -v.lowAcctOrigBalance);
+        return result;
+    }
 }
 
 void DeferredCredits::apply(
@@ -110,16 +116,13 @@ void DeferredCredits::apply(
             to.map_.emplace(p);
         if (! r.second)
         {
-            using std::get;
-            get<0>(r.first->second) += get<0>(p.second);
-            get<1>(r.first->second) += get<1>(p.second);
+            auto& toVal = r.first->second;
+            auto const& fromVal = p.second;
+            toVal.lowAcctCredits += fromVal.lowAcctCredits;
+            toVal.highAcctCredits += fromVal.highAcctCredits;
+            // Do not update the orig balance, it's already correct
         }
     }
-}
-
-void DeferredCredits::clear ()
-{
-    map_.clear ();
 }
 
 } // detail
@@ -129,19 +132,56 @@ PaymentSandbox::balanceHook (AccountID const& account,
     AccountID const& issuer,
         STAmount const& amount) const
 {
-    if (ps_)
-        return tab_.adjustedBalance (
-            account, issuer, ps_->balanceHook (account, issuer, amount));
-    return tab_.adjustedBalance(
-        account, issuer, amount);
+    /*
+    There are two algorithms here. The first takes the current amount and
+    subtracts the recorded credits. The second algorithm remembers the original
+    balance, and subtracts the debits. The second algorithm should be more
+    numerically stable than the first. Consider a large credit with a small
+    initial balance. The first algorithm computes (B+C)-C (where B+C will the
+    the amount passed in). The second algorithm return B. When B and C differ by
+    large magnitudes, (B+C)-C may not equal B.
+    */
+
+    auto const currency = amount.getCurrency ();
+    auto const switchover = flowV2Switchover (info ().parentCloseTime);
+
+    auto adjustedAmt = amount;
+    if (switchover)
+    {
+        auto delta = amount.zeroed ();
+        auto lastBal = amount;
+        for (auto curSB = this; curSB; curSB = curSB->ps_)
+        {
+            if (auto adj = curSB->tab_.adjustments (account, issuer, currency))
+            {
+                delta += adj->debits;
+                lastBal = adj->origBalance;
+            }
+        }
+        adjustedAmt = std::min(amount, lastBal - delta);
+    }
+    else
+    {
+        for (auto curSB = this; curSB; curSB = curSB->ps_)
+        {
+            if (auto adj = curSB->tab_.adjustments (account, issuer, currency))
+            {
+                adjustedAmt -= adj->credits;
+            }
+        }
+    }
+
+    assert (!isXRP(issuer) || adjustedAmt >= beast::zero);
+    return adjustedAmt;
 }
 
 void
 PaymentSandbox::creditHook (AccountID const& from,
     AccountID const& to,
-        STAmount const& amount)
+        STAmount const& amount,
+            STAmount const& preCreditBalance)
 {
-    tab_.credit(from, to, amount);
+    tab_.credit (from, to, amount, preCreditBalance);
 }
 
 void


### PR DESCRIPTION
Computing the liquidity of a strand works by walking a strand in reverse
to find the amount needed to feed into the strand to deliver the desired
output. If a step is unable to deliver the desired output, it is a
limiting step. The view is thrown out (resetting the balances, offers,
and deferred credits table), the limiting step is re-executed, and the
algorithm continues until the first step is reached. Then the steps from
one past the limiting step to the end are executed.

The algorithm above does not work if the liquidity decreases then
re-executing the steps. This can happen if an offer that was made
unfunded is now funded (the quality would go up, but the liquidity would
go down at the new quality). Disallowing strands where steps may unfund
offers in other steps prevents the above scenario.

Deferred credits numerical stability is improved. The deferred credits algorithm took the current
balance and subtracted the recorded credits. Conceptually, this is the
same as taking the original balance, adding all the credits,
subtracting all the debits, and subtracting all the credits. The new
algorithm records the original balance and subtracts the debits. This
prevents errors that occur when the original balance and the recorded
credits have large differences in magnitude.

Additionally, XRP credits were recorded incorrectly in the deferred
credits table (the line was between the sender and receiver, rather than
the root account).

@scottschurr @nbougalis
