### PR TITLE
Multiple transactions per account in TxQ (RIPD-1048):

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -418,16 +418,77 @@
 #
 #       The queue will be limited to this <number> of average ledgers'
 #       worth of transactions. If the queue fills up, the transactions
-#       with the lowest fees will be dropped from the queue any time a
-#       transaction with a higher fee level is added. Default: 20.
+#       with the lowest fee levels will be dropped from the queue any
+#       time a transaction with a higher fee level is added.
+#       Default: 20.
 #
 #   retry_sequence_percent = <number>
 #
-#       If a client resubmits a transaction, the new transaction's fee
-#       must be more than <number> percent higher than the original
-#       transaction's fee, or meet the current open ledger fee to be
-#       considered. Default: 125.
+#       If a client replaces a transaction in the queue (same sequence
+#       number as a transaction already in the queue), the new
+#       transaction's fee must be more than <number> percent higher
+#       than the original transaction's fee, or meet the current open
+#       ledger fee to be considered. Default: 25.
 #
+#   multi_txn_percent = <number>
+#
+#       If a client submits multiple transactions (different sequence
+#       numbers), later transactions must pay a fee at least <number>
+#       percent higher than the transaction with the previous sequence
+#       number.
+#       Default: -90.
+#
+#   minimum_escalation_multiplier = <number>
+#
+#       At ledger close time, the median fee level of the transactions
+#       in that ledger is used as a multiplier in escalation
+#       calculations of the next ledger. This minimum value ensures that
+#       the escalation is significant. Default: 500.
+#
+#   minimum_txn_in_ledger = <number>
+#
+#       Minimum number of transactions that must be allowed into the
+#       ledger at the minimum required fee before the required fee
+#       escalates. Default: 5.
+#
+#   minimum_txn_in_ledger_standalone = <number>
+#
+#       Like minimum_txn_in_ledger when rippled is running in standalone
+#       mode. Default: 1000.
+#
+#   target_txn_in_ledger = <number>
+#
+#       Number of transactions allowed into the ledger at the minimum
+#       required fee that the queue will "work toward" as long as
+#       consensus stays healthy. The limit will grow quickly until it
+#       reaches or exceeds this number. After that the limit may still
+#       change, but will stay above the target. If consensus is not
+#       healthy, the limit will be clamped to this value or lower.
+#       Default: 50.
+#
+#   maximum_txn_in_ledger = <number>
+#
+#       (Optional) Maximum number of transactions that will be allowed
+#       into the ledger at the minimum required fee before the required
+#       fee escalates. Default: no maximum.
+#
+#   maximum_txn_per_account = <number>
+#
+#       Maximum number of transactions that one account can have in the
+#       queue at any given time. Default: 10.
+#
+#   minimum_last_ledger_buffer = <number>
+#
+#       If a transaction has a LastLedgerSequence, it must be at least
+#       this much larger than the current open ledger sequence number.
+#       Default: 2.
+#
+#   zero_basefee_transaction_feelevel = <number>
+#
+#       So we don't deal with infinite fee levels, treat any transaction
+#       with a 0 base fee (ie. SetRegularKey password recovery) as
+#       having this fee level.
+#       Default: 256000.
 #
 #
 #-------------------------------------------------------------------------------

--- a/src/ripple/app/tests/SusPay_test.cpp
+++ b/src/ripple/app/tests/SusPay_test.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/test/jtx.h>
+#include <ripple/app/tx/applySteps.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
@@ -343,15 +344,66 @@ struct SusPay_test : public beast::unit_test::suite
     {
         using namespace jtx;
         using namespace std::chrono;
-        using S = seconds;
         Env env(*this, features(featureSusPay));
         auto T = [&env](NetClock::duration const& d)
             { return env.now() + d; };
         env.fund(XRP(5000), "alice", "bob", "carol");
         auto const c = cond("receipt");
-        env(condpay("alice", "carol", XRP(1000), c.first, T(S{1})));
+        env(condpay("alice", "carol", XRP(1000), c.first, T(1s)));
         auto const m = env.meta();
         expect((*m)[sfTransactionResult] == tesSUCCESS);
+    }
+
+    void testConsequences()
+    {
+        using namespace jtx;
+        using namespace std::chrono;
+        Env env(*this, features(featureSusPay));
+        auto T = [&env](NetClock::duration const& d)
+        {
+            return env.now() + d;
+        };
+        env.memoize("alice");
+        env.memoize("bob");
+        env.memoize("carol");
+        auto const c = cond("receipt");
+        {
+            auto const jtx = env.jt(
+                condpay("alice", "carol", XRP(1000), c.first, T(1s)),
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(1000));
+        }
+
+        {
+            auto const jtx = env.jt(cancel("bob", "alice", 3),
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(0));
+        }
+
+        {
+            auto const jtx = env.jt(
+                finish("bob", "alice", 3, c.first, c.second),
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(0));
+        }
     }
 
     void run() override
@@ -362,6 +414,7 @@ struct SusPay_test : public beast::unit_test::suite
         testLockup();
         testCondPay();
         testMeta();
+        testConsequences();
     }
 };
 

--- a/src/ripple/app/tests/TxQ_test.cpp
+++ b/src/ripple/app/tests/TxQ_test.cpp
@@ -23,11 +23,13 @@
 #include <ripple/app/tx/apply.h>
 #include <ripple/core/LoadFeeTrack.h>
 #include <ripple/basics/Log.h>
+#include <ripple/basics/mulDiv.h>
 #include <ripple/basics/TestSuite.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/test/jtx.h>
+#include <ripple/test/jtx/ticket.h>
 
 namespace ripple {
 namespace test {
@@ -42,9 +44,13 @@ class TxQ_test : public beast::unit_test::suite
         std::size_t expectedInLedger,
         std::size_t expectedPerLedger,
         std::uint64_t expectedMinFeeLevel,
-        std::uint64_t expectedMedFeeLevel)
+        std::uint64_t expectedMedFeeLevel = 500)
     {
-        auto metrics = env.app().getTxQ().getMetrics(*env.current());
+        auto optMetrics = env.app().getTxQ().getMetrics(env.app(),
+            *env.current());
+        if (!expect(optMetrics))
+            return;
+        auto& metrics = *optMetrics;
         expect(metrics.referenceFeeLevel == 256, "referenceFeeLevel");
         expect(metrics.txCount == expectedCount, "txCount");
         expect(metrics.txQMaxSize == expectedMaxCount, "txQMaxSize");
@@ -60,9 +66,38 @@ class TxQ_test : public beast::unit_test::suite
         expect(metrics.expFeeLevel == expectedCurFeeLevel, "expFeeLevel");
     }
 
+    void
+    fillQueue(
+        jtx::Env& env,
+        jtx::Account const& account)
+    {
+        auto metrics = env.app().getTxQ().getMetrics(env.app(),
+            *env.current());
+        if (!expect(metrics))
+            return;
+        for (int i = metrics->txInLedger; i <= metrics->txPerLedger; ++i)
+            env(noop(account));
+    }
+
+    auto
+    openLedgerFee(jtx::Env& env)
+    {
+        using namespace jtx;
+
+        auto const& view = *env.current();
+        auto metrics = env.app().getTxQ().getMetrics(env.app(),
+            view);
+        if (!expect(metrics))
+            return fee(none);
+
+        // Don't care about the overflow flag
+        return fee(mulDiv(metrics->expFeeLevel,
+            view.fees().base, metrics->referenceFeeLevel).second + 1);
+    }
+
     static
     std::unique_ptr<Config>
-    makeConfig()
+    makeConfig(std::map<std::string, std::string> extra = {})
     {
         auto p = std::make_unique<Config>();
         setupConfigForUnitTests(*p);
@@ -70,8 +105,13 @@ class TxQ_test : public beast::unit_test::suite
         section.set("ledgers_in_queue", "2");
         section.set("min_ledgers_to_compute_size_limit", "3");
         section.set("max_ledger_counts_to_store", "100");
-        section.set("retry_sequence_percent", "125");
-        return p;
+        section.set("retry_sequence_percent", "25");
+        section.set("zero_basefee_transaction_feelevel", "100000000000");
+        for (auto const& value : extra)
+        {
+            section.set(value.first, value.second);
+        }
+        return std::move(p);
     }
 
 public:
@@ -80,10 +120,9 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig(), features(featureFeeEscalation));
-
+        Env env(*this, makeConfig({ {"minimum_txn_in_ledger_standalone", "3"} }),
+            features(featureFeeEscalation));
         auto& txq = env.app().getTxQ();
-        txq.setMinimumTx(3);
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -98,44 +137,37 @@ public:
 
         expect(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256, 500);
+        checkMetrics(env, 0, boost::none, 0, 3, 256);
 
         // Create several accounts while the fee is cheap so they all apply.
         env.fund(XRP(50000), noripple(alice, bob, charlie, daria));
-        checkMetrics(env, 0, boost::none, 4, 3, 256, 500);
+        checkMetrics(env, 0, boost::none, 4, 3, 256);
 
         // Alice - price starts exploding: held
         env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 4, 3, 256, 500);
-
-        auto openLedgerFee =
-            [&]()
-            {
-                return fee(txq.openLedgerFee(*env.current()));
-            };
+        checkMetrics(env, 1, boost::none, 4, 3, 256);
 
         // Bob with really high fee - applies
-        env(noop(bob), openLedgerFee());
-        checkMetrics(env, 1, boost::none, 5, 3, 256, 500);
+        env(noop(bob), openLedgerFee(env));
+        checkMetrics(env, 1, boost::none, 5, 3, 256);
 
         // Daria with low fee: hold
         env(noop(daria), fee(1000), queued);
-        checkMetrics(env, 2, boost::none, 5, 3, 256, 500);
+        checkMetrics(env, 2, boost::none, 5, 3, 256);
 
         env.close();
         // Verify that the held transactions got applied
-        auto lastMedian = 500;
-        checkMetrics(env, 0, 10, 2, 5, 256, lastMedian);
+        checkMetrics(env, 0, 10, 2, 5, 256);
 
         //////////////////////////////////////////////////////////////
 
         // Make some more accounts. We'll need them later to abuse the queue.
         env.fund(XRP(50000), noripple(elmo, fred, gwen, hank));
-        checkMetrics(env, 0, 10, 6, 5, 256, lastMedian);
+        checkMetrics(env, 0, 10, 6, 5, 256);
 
         // Now get a bunch of transactions held.
         env(noop(alice), fee(12), queued);
-        checkMetrics(env, 1, 10, 6, 5, 256, lastMedian);
+        checkMetrics(env, 1, 10, 6, 5, 256);
 
         env(noop(bob), fee(10), queued); // won't clear the queue
         env(noop(charlie), fee(20), queued);
@@ -144,12 +176,11 @@ public:
         env(noop(fred), fee(19), queued);
         env(noop(gwen), fee(16), queued);
         env(noop(hank), fee(18), queued);
-        checkMetrics(env, 8, 10, 6, 5, 256, lastMedian);
+        checkMetrics(env, 8, 10, 6, 5, 256);
 
         env.close();
         // Verify that the held transactions got applied
-        lastMedian = 500;
-        checkMetrics(env, 1, 12, 7, 6, 256, lastMedian);
+        checkMetrics(env, 1, 12, 7, 6, 256);
 
         // Bob's transaction is still stuck in the queue.
 
@@ -158,73 +189,70 @@ public:
         // Hank sends another txn
         env(noop(hank), fee(10), queued);
         // But he's not going to leave it in the queue
-        checkMetrics(env, 2, 12, 7, 6, 256, lastMedian);
+        checkMetrics(env, 2, 12, 7, 6, 256);
 
         // Hank sees his txn  got held and bumps the fee,
         // but doesn't even bump it enough to requeue
         env(noop(hank), fee(11), ter(telINSUF_FEE_P));
-        checkMetrics(env, 2, 12, 7, 6, 256, lastMedian);
+        checkMetrics(env, 2, 12, 7, 6, 256);
 
         // Hank sees his txn got held and bumps the fee,
         // enough to requeue, but doesn't bump it enough to
         // apply to the ledger
         env(noop(hank), fee(6000), queued);
         // But he's not going to leave it in the queue
-        checkMetrics(env, 2, 12, 7, 6, 256, lastMedian);
+        checkMetrics(env, 2, 12, 7, 6, 256);
 
         // Hank sees his txn got held and bumps the fee,
         // high enough to get into the open ledger, because
         // he doesn't want to wait.
-        env(noop(hank), openLedgerFee());
-        checkMetrics(env, 1, 12, 8, 6, 256, lastMedian);
+        env(noop(hank), openLedgerFee(env));
+        checkMetrics(env, 1, 12, 8, 6, 256);
 
         // Hank then sends another, less important txn
         // (In addition to the metrics, this will verify that
         //  the original txn got removed.)
         env(noop(hank), fee(6000), queued);
-        checkMetrics(env, 2, 12, 8, 6, 256, lastMedian);
+        checkMetrics(env, 2, 12, 8, 6, 256);
 
         env.close();
 
         // Verify that bob and hank's txns were applied
-        lastMedian = 500;
-        checkMetrics(env, 0, 16, 2, 8, 256, lastMedian);
+        checkMetrics(env, 0, 16, 2, 8, 256);
 
         // Close again with a simulated time leap to
         // reset the escalation limit down to minimum
-        lastMedian = 76928;
         env.close(env.now() + 5s, 10000ms);
-        checkMetrics(env, 0, 16, 0, 3, 256, lastMedian);
+        checkMetrics(env, 0, 16, 0, 3, 256, 76928);
         // Then close once more without the time leap
         // to reset the queue maxsize down to minimum
-        lastMedian = 500;
         env.close();
-        checkMetrics(env, 0, 6, 0, 3, 256, lastMedian);
+        checkMetrics(env, 0, 6, 0, 3, 256);
 
         //////////////////////////////////////////////////////////////
 
-        // At this point, the queue should have a limit of 6.
         // Stuff the ledger and queue so we can verify that
         // stuff gets kicked out.
         env(noop(hank));
         env(noop(gwen));
         env(noop(fred));
         env(noop(elmo));
-        checkMetrics(env, 0, 6, 4, 3, 256, lastMedian);
+        checkMetrics(env, 0, 6, 4, 3, 256);
 
         // Use explicit fees so we can control which txn
         // will get dropped
-        env(noop(alice), fee(20), queued);
-        env(noop(hank), fee(19), queued);
-        env(noop(gwen), fee(18), queued);
-        env(noop(fred), fee(17), queued);
-        env(noop(elmo), fee(16), queued);
         // This one gets into the queue, but gets dropped when the
         // higher fee one is added later.
         env(noop(daria), fee(15), queued);
+        // These stay in the queue.
+        env(noop(elmo), fee(16), queued);
+        env(noop(fred), fee(17), queued);
+        env(noop(gwen), fee(18), queued);
+        env(noop(hank), fee(19), queued);
+        env(noop(alice), fee(20), queued);
 
         // Queue is full now.
-        checkMetrics(env, 6, 6, 4, 3, 385, lastMedian);
+        checkMetrics(env, 6, 6, 4, 3, 385);
 
         // Try to add another transaction with the default (low) fee,
         // it should fail because the queue is full.
@@ -236,19 +264,17 @@ public:
         env(noop(charlie), fee(100), queued);
 
         // Queue is still full, of course, but the min fee has gone up
-        checkMetrics(env, 6, 6, 4, 3, 410, lastMedian);
+        checkMetrics(env, 6, 6, 4, 3, 410);
 
         // Close out the ledger, the transactions are accepted, the
         // queue is cleared, then the localTxs are retried. At this
         // point, daria's transaction that was dropped from the queue
         // is put back in. Neat.
         env.close();
-        lastMedian = 500;
-        checkMetrics(env, 2, 8, 5, 4, 256, lastMedian);
+        checkMetrics(env, 2, 8, 5, 4, 256);
 
-        lastMedian = 500;
         env.close();
-        checkMetrics(env, 0, 10, 2, 5, 256, lastMedian);
+        checkMetrics(env, 0, 10, 2, 5, 256);
 
         //////////////////////////////////////////////////////////////
         // Cleanup:
@@ -257,24 +283,23 @@ public:
         // we can be sure that there's one in the queue when the
         // test ends and the TxQ is destructed.
 
-        auto metrics = txq.getMetrics(*env.current());
-        expect(metrics.txCount == 0, "txCount");
-        auto txnsNeeded = metrics.txPerLedger - metrics.txInLedger;
+        auto metrics = txq.getMetrics(env.app(), *env.current());
+        expect(metrics->txCount == 0, "txCount");
 
         // Stuff the ledger.
-        for (int i = 0; i <= txnsNeeded; ++i)
+        for (int i = metrics->txInLedger; i <= metrics->txPerLedger; ++i)
         {
             env(noop(env.master));
         }
 
         // Queue one straightforward transaction
         env(noop(env.master), fee(20), queued);
-        ++metrics.txCount;
+        ++metrics->txCount;
 
-        checkMetrics(env, metrics.txCount,
-            metrics.txQMaxSize, metrics.txPerLedger + 1,
-            metrics.txPerLedger,
-            256, lastMedian);
+        checkMetrics(env, metrics->txCount,
+            metrics->txQMaxSize, metrics->txPerLedger + 1,
+            metrics->txPerLedger,
+            256);
     }
 
     void testLocalTxRetry()
@@ -282,10 +307,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig(), features(featureFeeEscalation));
-
-        auto& txq = env.app().getTxQ();
-        txq.setMinimumTx(2);
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
+            features(featureFeeEscalation));
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -295,47 +318,44 @@ public:
 
         expect(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 0, 2, 256);
 
         // Create several accounts while the fee is cheap so they all apply.
         env.fund(XRP(50000), noripple(alice, bob, charlie));
-        checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 3, 2, 256);
 
-        // Alice - price starts exploding: held
-        env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
-
-        // Alice - Alice is already in the queue, so can't hold.
-        env(noop(alice), seq(env.seq(alice) + 1),
-            ter(telINSUF_FEE_P));
-        checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
-
-        auto openLedgerFee =
-            [&]()
-            {
-                return fee(txq.openLedgerFee(*env.current()));
-            };
-        // Alice's next transaction -
-        // fails because the item in the TxQ hasn't applied.
-        env(noop(alice), openLedgerFee(),
+        // Future transaction for Alice - fails
+        env(noop(alice), openLedgerFee(env),
             seq(env.seq(alice) + 1), ter(terPRE_SEQ));
-        checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 3, 2, 256);
+
+        // Current transaction for Alice: held
+        env(noop(alice), queued);
+        checkMetrics(env, 1, boost::none, 3, 2, 256);
+
+        // Alice - sequence is too far ahead, so won't queue.
+        env(noop(alice), seq(env.seq(alice) + 2),
+            ter(terPRE_SEQ));
+        checkMetrics(env, 1, boost::none, 3, 2, 256);
 
         // Bob with really high fee - applies
-        env(noop(bob), openLedgerFee());
-        checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
+        env(noop(bob), openLedgerFee(env));
+        checkMetrics(env, 1, boost::none, 4, 2, 256);
 
         // Daria with low fee: hold
         env(noop(charlie), fee(1000), queued);
-        checkMetrics(env, 2, boost::none, 4, 2, 256, 500);
+        checkMetrics(env, 2, boost::none, 4, 2, 256);
+
+        // Alice with normal fee: hold
+        env(noop(alice), seq(env.seq(alice) + 1),
+            queued);
+        checkMetrics(env, 3, boost::none, 4, 2, 256);
 
         env.close();
         // Verify that the held transactions got applied
-        auto lastMedian = 500;
-        // One of alice's bad transactions applied from the
-        // Local Txs. Since they both have the same seq,
-        // one succeeds, one fails. We don't care which.
-        checkMetrics(env, 0, 8, 3, 4, 256, lastMedian);
+        // Alice's bad transaction applied from the
+        // Local Txs.
+        checkMetrics(env, 0, 8, 4, 4, 256);
     }
 
     void testLastLedgerSeq()
@@ -343,10 +363,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig(), features(featureFeeEscalation));
-
-        auto& txq = env.app().getTxQ();
-        txq.setMinimumTx(2);
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
+            features(featureFeeEscalation));
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -357,7 +375,7 @@ public:
 
         auto queued = ter(terQUEUED);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 0, 2, 256);
 
         // Fund across several ledgers so the TxQ metrics stay restricted.
         env.fund(XRP(1000), noripple(alice, bob));
@@ -367,14 +385,18 @@ public:
         env.fund(XRP(1000), noripple(edgar, felicia));
         env.close(env.now() + 5s, 10000ms);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 0, 2, 256);
         env(noop(bob));
         env(noop(charlie));
         env(noop(daria));
-        checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 3, 2, 256);
 
-        // Queue an item with a LastLedgerSeq.
+        expect(env.current()->info().seq == 6);
+        // Fail to queue an item with a low LastLedgerSeq
         env(noop(alice), json(R"({"LastLedgerSequence":7})"),
+            ter(telINSUF_FEE_P));
+        // Queue an item with a sufficient LastLedgerSeq.
+        env(noop(alice), json(R"({"LastLedgerSequence":8})"),
             queued);
         // Queue items with higher fees to force the previous
         // txn to wait.
@@ -382,10 +404,10 @@ public:
         env(noop(charlie), fee(20), queued);
         env(noop(daria), fee(20), queued);
         env(noop(edgar), fee(20), queued);
-        checkMetrics(env, 5, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 5, boost::none, 3, 2, 256);
 
         env.close();
-        checkMetrics(env, 1, 6, 4, 3, 256, 500);
+        checkMetrics(env, 1, 6, 4, 3, 256);
 
         // Keep alice's transaction waiting.
         env(noop(bob), fee(20), queued);
@@ -393,12 +415,35 @@ public:
         env(noop(daria), fee(20), queued);
         env(noop(edgar), fee(20), queued);
         env(noop(felicia), fee(20), queued);
-        checkMetrics(env, 6, 6, 4, 3, 257, 500);
+        checkMetrics(env, 6, 6, 4, 3, 257);
+
+        env.close();
+        // alice's transaction is still hanging around
+        checkMetrics(env, 1, 8, 5, 4, 256, 512);
+        expect(env.seq(alice) == 1);
+
+        // Keep alice's transaction waiting.
+        env(noop(bob), fee(20), queued);
+        env(noop(charlie), fee(20), queued);
+        env(noop(daria), fee(20), queued);
+        env(noop(daria), fee(20), seq(env.seq(daria) + 1),
+            queued);
+        env(noop(edgar), fee(20), queued);
+        env(noop(felicia), fee(20), queued);
+        env(noop(felicia), fee(20), seq(env.seq(felicia) + 1),
+            queued);
+        checkMetrics(env, 8, 8, 5, 4, 257, 512);
 
         env.close();
         // alice's transaction expired without getting
-        // into the ledger, so the queue is now empty.
-        checkMetrics(env, 0, 8, 5, 4, 256, 512);
+        // into the ledger, so her transaction is gone,
+        // though one of felicia's is still in the queue.
+        checkMetrics(env, 1, 10, 6, 5, 256, 512);
+        expect(env.seq(alice) == 1);
+
+        env.close();
+        // And now the queue is empty
+        checkMetrics(env, 0, 12, 1, 6, 256, 512);
         expect(env.seq(alice) == 1);
     }
 
@@ -407,49 +452,107 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig(), features(featureFeeEscalation));
-
-        auto& txq = env.app().getTxQ();
-        txq.setMinimumTx(2);
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
+            features(featureFeeEscalation));
 
         auto alice = Account("alice");
         auto bob = Account("bob");
+        auto carol = Account("carol");
 
         auto queued = ter(terQUEUED);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 0, 2, 256);
 
-        // Fund these accounts and close the ledger without
-        // involving the queue, so that stats aren't affected.
+        // Fund across several ledgers so the TxQ metrics stay restricted.
         env.fund(XRP(1000), noripple(alice, bob));
+        env.close(env.now() + 5s, 10000ms);
+        env.fund(XRP(1000), noripple(carol));
         env.close(env.now() + 5s, 10000ms);
 
         // Fill the ledger
         env(noop(alice));
         env(noop(alice));
         env(noop(alice));
-        checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 3, 2, 256);
 
         env(noop(bob), queued);
-        checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 1, boost::none, 3, 2, 256);
 
         // Even though this transaction has a 0 fee,
         // SetRegularKey::calculateBaseFee indicates this is
         // a "free" transaction, so it has an "infinite" fee
         // level and goes into the open ledger.
         env(regkey(alice, bob), fee(0));
-        checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
+        checkMetrics(env, 1, boost::none, 4, 2, 256);
+
+        // Close out this ledger so we can get a maxsize
+        env.close();
+        checkMetrics(env, 0, 8, 1, 4, 256);
+
+        fillQueue(env, bob);
+        checkMetrics(env, 0, 8, 5, 4, 256);
+
+        auto feeBob = 30;
+        auto seqBob = env.seq(bob);
+        for (int i = 0; i < 4; ++i)
+        {
+            env(noop(bob), fee(feeBob),
+                seq(seqBob), queued);
+            feeBob = (feeBob + 1) * 125 / 100;
+            ++seqBob;
+        }
+        checkMetrics(env, 4, 8, 5, 4, 256);
 
         // This transaction also has an "infinite" fee level,
-        // but since bob has a txn in the queue, and multiple
-        // transactions aren't yet supported, this one fails
-        // with terPRE_SEQ (notably, *not* telINSUF_FEE_P).
-        // This implicitly relies on preclaim succeeding and
-        // canBeHeld failing under the hood.
+        // but since bob has txns in the queue, it gets queued.
         env(regkey(bob, alice), fee(0),
-            seq(env.seq(bob) + 1), ter(terPRE_SEQ));
-        checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
+            seq(seqBob), queued);
+        ++seqBob;
+        checkMetrics(env, 5, 8, 5, 4, 256);
 
+        // Unfortunately bob can't get any more txns into
+        // the queue, because of the multiTxnPercent.
+        // TANSTAAFL
+        env(noop(bob), fee(XRP(100)),
+            seq(seqBob), ter(telINSUF_FEE_P));
+
+        // Carol fills the queue, but can't kick out any
+        // transactions.
+        auto feeCarol = feeBob;
+        auto seqCarol = env.seq(carol);
+        for (int i = 0; i < 3; ++i)
+        {
+            env(noop(carol), fee(feeCarol),
+                seq(seqCarol), queued);
+            feeCarol = (feeCarol + 1) * 125 / 100;
+            ++seqCarol;
+        }
+        checkMetrics(env, 8, 8, 5, 4, 3 * 256 + 1);
+
+        // Carol doesn't submit high enough to beat Bob's
+        // average fee. (Which is ~144,115,188,075,855,907
+        // because of the zero fee txn.)
+        env(noop(carol), fee(feeCarol),
+            seq(seqCarol), ter(telINSUF_FEE_P));
+
+        env.close();
+        // Some of Bob's transactions stay in the queue,
+        // and Carol's low fee tx is reapplied from the
+        // Local Txs.
+        checkMetrics(env, 3, 10, 6, 5, 256);
+        expect(env.seq(bob) == seqBob - 2);
+        expect(env.seq(carol) == seqCarol);
+
+
+        env.close();
+        checkMetrics(env, 0, 12, 4, 6, 256, 1600);
+        expect(env.seq(bob) == seqBob + 1);
+        expect(env.seq(carol) == seqCarol + 1);
+
+        env.close();
+        checkMetrics(env, 0, 12, 0, 6, 256, 2739);
+        expect(env.seq(bob) == seqBob + 1);
+        expect(env.seq(carol) == seqCarol + 1);
     }
 
     void testPreclaimFailures()
@@ -480,29 +583,27 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig(), features(featureFeeEscalation));
-
-        auto& txq = env.app().getTxQ();
-        txq.setMinimumTx(2);
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
+            features(featureFeeEscalation));
 
         auto alice = Account("alice");
         auto bob = Account("bob");
 
         auto queued = ter(terQUEUED);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 0, 2, 256);
 
         env.fund(XRP(1000), noripple(alice, bob));
 
-        checkMetrics(env, 0, boost::none, 2, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 2, 2, 256);
 
         // Fill the ledger
         env(noop(alice));
-        checkMetrics(env, 0, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 0, boost::none, 3, 2, 256);
 
         // Put a transaction in the queue
         env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 3, 2, 256, 500);
+        checkMetrics(env, 1, boost::none, 3, 2, 256);
 
         // Now cheat, and bypass the queue.
         {
@@ -524,13 +625,910 @@ public:
                 );
             env.postconditions(jt, ter, didApply);
         }
-        checkMetrics(env, 1, boost::none, 4, 2, 256, 500);
+        checkMetrics(env, 1, boost::none, 4, 2, 256);
 
         env.close();
         // Alice's queued transaction failed in TxQ::accept
         // with tefPAST_SEQ
-        checkMetrics(env, 0, 8, 0, 4, 256, 500);
+        checkMetrics(env, 0, 8, 0, 4, 256);
+    }
 
+    void testMultiTxnPerAccount()
+    {
+        using namespace jtx;
+
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
+            features(featureFeeEscalation));
+
+        auto alice = Account("alice");
+        auto bob = Account("bob");
+        auto charlie = Account("charlie");
+        auto daria = Account("daria");
+
+        auto queued = ter(terQUEUED);
+
+        expect(env.current()->fees().base == 10);
+
+        checkMetrics(env, 0, boost::none, 0, 3, 256);
+
+        // Create several accounts while the fee is cheap so they all apply.
+        env.fund(XRP(50000), noripple(alice, bob, charlie, daria));
+        checkMetrics(env, 0, boost::none, 4, 3, 256);
+
+        // Alice - price starts exploding: held
+        env(noop(alice), queued);
+        checkMetrics(env, 1, boost::none, 4, 3, 256);
+
+        auto aliceSeq = env.seq(alice);
+        auto bobSeq = env.seq(bob);
+        auto charlieSeq = env.seq(charlie);
+
+        // Alice - try to queue a second transaction, but leave a gap
+        env(noop(alice), seq(aliceSeq + 2), fee(100),
+            ter(terPRE_SEQ));
+        checkMetrics(env, 1, boost::none, 4, 3, 256);
+
+        // Alice - queue a second transaction. Yay.
+        env(noop(alice), seq(aliceSeq + 1), fee(13),
+            queued);
+        checkMetrics(env, 2, boost::none, 4, 3, 256);
+
+        // Alice - queue a third transaction. Yay.
+        env(noop(alice), seq(aliceSeq + 2), fee(17),
+            queued);
+        checkMetrics(env, 3, boost::none, 4, 3, 256);
+
+        // Bob - queue a transaction
+        env(noop(bob), queued);
+        checkMetrics(env, 4, boost::none, 4, 3, 256);
+
+        // Bob - queue a second transaction
+        env(noop(bob), seq(bobSeq + 1), fee(50),
+            queued);
+        checkMetrics(env, 5, boost::none, 4, 3, 256);
+
+        // Charlie - queue a transaction, with a higher fee
+        // than default
+        env(noop(charlie), fee(15), queued);
+        checkMetrics(env, 6, boost::none, 4, 3, 256);
+
+        expect(env.seq(alice) == aliceSeq);
+        expect(env.seq(bob) == bobSeq);
+        expect(env.seq(charlie) == charlieSeq);
+
+        env.close();
+        // Verify that all of but one of the queued transactions
+        // got applied.
+        checkMetrics(env, 1, 8, 5, 4, 256);
+
+        // Verify that the stuck transaction is Bob's second.
+        // Even though it had a higher fee than Alice's and
+        // Charlie's, it didn't get attempted until the fee escalated.
+        expect(env.seq(alice) == aliceSeq + 3);
+        expect(env.seq(bob) == bobSeq + 1);
+        expect(env.seq(charlie) == charlieSeq + 1);
+
+        // Alice - fill up the queue
+        std::int64_t aliceFee = 10;
+        aliceSeq = env.seq(alice);
+        auto lastLedgerSeq = env.current()->info().seq + 2;
+        for (auto i = 0; i < 7; i++)
+        {
+            env(noop(alice), seq(aliceSeq),
+                json(jss::LastLedgerSequence, lastLedgerSeq + i),
+                    fee(aliceFee), queued);
+            aliceFee = (aliceFee + 1) * 125 / 100;
+            ++aliceSeq;
+        }
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Alice attempts to add another item to the queue,
+        // but you can't force your own earlier txn off the
+        // queue.
+        env(noop(alice), seq(aliceSeq),
+            json(jss::LastLedgerSequence, lastLedgerSeq + 7),
+                fee(aliceFee), ter(telCAN_NOT_QUEUE));
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Charlie - try to add another item to the queue,
+        // which fails because fee is lower than Alice's
+        // queued average.
+        env(noop(charlie), fee(24), ter(telINSUF_FEE_P));
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Charlie - add another item to the queue, which
+        // causes Alice's last txn to drop
+        env(noop(charlie), fee(30), queued);
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Alice - now attempt to add one more to the queue,
+        // which fails because the last tx was dropped, so
+        // there is no complete chain.
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), ter(terPRE_SEQ));
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Alice wants this tx more than the dropped tx,
+        // so resubmits with higher fee, but the queue
+        // is full, and her account is the cheapest.
+        env(noop(alice), seq(aliceSeq - 1),
+            fee(aliceFee), ter(telCAN_NOT_QUEUE));
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Try to replace a middle item in the queue
+        // without enough fee.
+        aliceSeq = env.seq(alice) + 2;
+        aliceFee = 21;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), ter(telINSUF_FEE_P));
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Replace a middle item from the queue successfully
+        ++aliceFee;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), queued);
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Try to replace the next item in the queue
+        // without enough fee.
+        ++aliceSeq;
+        aliceFee = aliceFee * 125 / 100;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), ter(telINSUF_FEE_P));
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        // Replace a middle item from the queue successfully
+        ++aliceFee;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), queued);
+        checkMetrics(env, 8, 8, 5, 4, 257);
+
+        env.close();
+        // Alice's transactions processed, along with
+        // Charlie's, and the lost one is replayed and
+        // added back to the queue.
+        checkMetrics(env, 4, 10, 6, 5, 256);
+
+        aliceSeq = env.seq(alice) + 1;
+
+        // Try to replace that item with a transaction that will
+        // bankrupt Alice. Fails, because an account can't have
+        // more than the minimum reserve in flight before the
+        // last queued transaction
+        aliceFee = env.le(alice)->getFieldAmount(sfBalance).xrp().drops()
+            - (121);
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), ter(telCAN_NOT_QUEUE));
+        checkMetrics(env, 4, 10, 6, 5, 256);
+
+        // Try to spend more than Alice can afford with all the other txs.
+        aliceSeq += 2;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), ter(terINSUF_FEE_B));
+        checkMetrics(env, 4, 10, 6, 5, 256);
+
+        // Replace the last queued item with a transaction that will
+        // bankrupt Alice
+        --aliceFee;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), queued);
+        checkMetrics(env, 4, 10, 6, 5, 256);
+
+        // Alice - Attempt to queue a last transaction, but it
+        // fails because the fee in flight is too high, before
+        // the fee is checked against the balance
+        aliceFee /= 5;
+        ++aliceSeq;
+        env(noop(alice), seq(aliceSeq),
+            fee(aliceFee), ter(telCAN_NOT_QUEUE));
+        checkMetrics(env, 4, 10, 6, 5, 256);
+
+        env.close();
+        // All of Alice's transactions applied.
+        checkMetrics(env, 0, 12, 4, 6, 256, 640);
+
+        env.close();
+        checkMetrics(env, 0, 12, 0, 6, 256, 1203);
+
+        // Alice is broke
+        env.require(balance(alice, XRP(0)));
+        env(noop(alice), ter(terINSUF_FEE_B));
+    }
+
+    void testTieBreaking()
+    {
+        using namespace jtx;
+        using namespace std::chrono;
+
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "4" } }),
+            features(featureFeeEscalation));
+
+        auto alice = Account("alice");
+        auto bob = Account("bob");
+        auto charlie = Account("charlie");
+        auto daria = Account("daria");
+        auto elmo = Account("elmo");
+        auto fred = Account("fred");
+        auto gwen = Account("gwen");
+        auto hank = Account("hank");
+
+        auto queued = ter(terQUEUED);
+
+        expect(env.current()->fees().base == 10);
+
+        checkMetrics(env, 0, boost::none, 0, 4, 256);
+
+        // Create several accounts while the fee is cheap so they all apply.
+        env.fund(XRP(50000), noripple(alice, bob, charlie, daria));
+        checkMetrics(env, 0, boost::none, 4, 4, 256);
+
+        env.close();
+        checkMetrics(env, 0, 8, 0, 4, 256);
+
+        env.fund(XRP(50000), noripple(elmo, fred, gwen, hank));
+        checkMetrics(env, 0, 8, 4, 4, 256);
+
+        env.close();
+        checkMetrics(env, 0, 8, 0, 4, 256);
+
+        //////////////////////////////////////////////////////////////
+
+        // Stuff the ledger and queue so we can verify that
+        // stuff gets kicked out.
+        env(noop(gwen));
+        env(noop(hank));
+        env(noop(gwen));
+        env(noop(fred));
+        env(noop(elmo));
+        checkMetrics(env, 0, 8, 5, 4, 256);
+
+        auto aliceSeq = env.seq(alice);
+        auto bobSeq = env.seq(bob);
+        auto charlieSeq = env.seq(charlie);
+        auto dariaSeq = env.seq(daria);
+        auto elmoSeq = env.seq(elmo);
+        auto fredSeq = env.seq(fred);
+        auto gwenSeq = env.seq(gwen);
+        auto hankSeq = env.seq(hank);
+
+        // This time, use identical fees.
+        env(noop(alice), fee(15), queued);
+        env(noop(bob), fee(15), queued);
+        env(noop(charlie), fee(15), queued);
+        env(noop(daria), fee(15), queued);
+        env(noop(elmo), fee(15), queued);
+        env(noop(fred), fee(15), queued);
+        env(noop(gwen), fee(15), queued);
+        // This one gets into the queue, but gets dropped when the
+        // higher fee one is added later.
+        env(noop(hank), fee(15), queued);
+
+        // Queue is full now. Minimum fee now reflects the
+        // lowest fee in the queue.
+        checkMetrics(env, 8, 8, 5, 4, 385);
+
+        // Try to add another transaction with the default (low) fee,
+        // it should fail because it can't replace the one already
+        // there.
+        env(noop(charlie), ter(telINSUF_FEE_P));
+
+        // Add another transaction, with a higher fee,
+        // Not high enough to get into the ledger, but high
+        // enough to get into the queue (and kick somebody out)
+        env(noop(charlie), fee(100), seq(charlieSeq + 1), queued);
+
+        // Queue is still full.
+        checkMetrics(env, 8, 8, 5, 4, 385);
+
+        // alice, bob, charlie, daria, and elmo's txs
+        // are processed out of the queue into the ledger,
+        // leaving fred and gwen's txs. hank's tx is
+        // retried from localTxs, and put back into the
+        // queue.
+        env.close();
+        checkMetrics(env, 3, 10, 6, 5, 256);
+
+        expect(aliceSeq + 1 == env.seq(alice));
+        expect(bobSeq + 1 == env.seq(bob));
+        expect(charlieSeq + 2 == env.seq(charlie));
+        expect(dariaSeq + 1 == env.seq(daria));
+        expect(elmoSeq + 1 == env.seq(elmo));
+        expect(fredSeq == env.seq(fred));
+        expect(gwenSeq == env.seq(gwen));
+        expect(hankSeq == env.seq(hank));
+
+        aliceSeq = env.seq(alice);
+        bobSeq = env.seq(bob);
+        charlieSeq = env.seq(charlie);
+        dariaSeq = env.seq(daria);
+        elmoSeq = env.seq(elmo);
+
+        // Fill up the queue again
+        env(noop(alice), fee(15), queued);
+        env(noop(alice), seq(aliceSeq + 1), fee(15), queued);
+        env(noop(alice), seq(aliceSeq + 2), fee(15), queued);
+        env(noop(bob), fee(15), queued);
+        env(noop(charlie), fee(15), queued);
+        env(noop(daria), fee(15), queued);
+        // This one gets into the queue, but gets dropped when the
+        // higher fee one is added later.
+        env(noop(elmo), fee(15), queued);
+        checkMetrics(env, 10, 10, 6, 5, 385);
+
+        // Add another transaction, with a higher fee,
+        // Not high enough to get into the ledger, but high
+        // enough to get into the queue (and kick somebody out)
+        env(noop(alice), fee(100), seq(aliceSeq + 3), queued);
+
+        env.close();
+        checkMetrics(env, 4, 12, 7, 6, 256);
+
+        expect(fredSeq + 1 == env.seq(fred));
+        expect(gwenSeq + 1 == env.seq(gwen));
+        expect(hankSeq + 1 == env.seq(hank));
+        expect(aliceSeq + 4 == env.seq(alice));
+        expect(bobSeq == env.seq(bob));
+        expect(charlieSeq == env.seq(charlie));
+        expect(dariaSeq == env.seq(daria));
+        expect(elmoSeq == env.seq(elmo));
+    }
+
+    void testDisabled()
+    {
+        using namespace jtx;
+
+        Env env(*this);
+
+        auto alice = Account("alice");
+
+        expect(!env.app().getTxQ().getMetrics(env.app(),
+            *env.current()));
+
+        env.fund(XRP(50000), noripple(alice));
+
+        // If the queue was enabled, most of these would
+        // return terQUEUED. (The required fee for the last
+        // would be 10 * 500 * 11^2 / 5^2 = 24,200.)
+        for (int i = 0; i < 10; ++i)
+            env(noop(alice), fee(30));
+
+        env.close();
+        expect(!env.app().getTxQ().getMetrics(env.app(),
+            *env.current()));
+    }
+
+    void testAcctTxnID()
+    {
+        using namespace jtx;
+
+        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "1" } }),
+            features(featureFeeEscalation));
+
+        auto alice = Account("alice");
+
+        auto queued = ter(terQUEUED);
+
+        expect(env.current()->fees().base == 10);
+
+        checkMetrics(env, 0, boost::none, 0, 1, 256);
+
+        env.fund(XRP(50000), noripple(alice));
+        checkMetrics(env, 0, boost::none, 1, 1, 256);
+
+        env(fset(alice, asfAccountTxnID));
+        checkMetrics(env, 0, boost::none, 2, 1, 256);
+
+        // Immediately after the fset, the sfAccountTxnID field
+        // is still uninitialized, so preflight succeeds here,
+        // and this txn fails because it can't be stored in the queue.
+        env(noop(alice), json(R"({"AccountTxnID": "0"})"),
+            ter(telINSUF_FEE_P));
+
+        checkMetrics(env, 0, boost::none, 2, 1, 256);
+        env.close();
+        // The failed transaction is retried from LocalTx
+        // and succeeds.
+        checkMetrics(env, 0, 4, 1, 2, 256);
+
+        env(noop(alice));
+        checkMetrics(env, 0, 4, 2, 2, 256);
+
+        env(noop(alice), json(R"({"AccountTxnID": "0"})"),
+            ter(tefWRONG_PRIOR));
+    }
+
+    void testMaximum()
+    {
+        using namespace jtx;
+
+        Env env(*this, makeConfig(
+            { {"minimum_txn_in_ledger_standalone", "2"},
+                {"target_txn_in_ledger", "4"},
+                    {"maximum_txn_in_ledger", "5"} }),
+                        features(featureFeeEscalation));
+
+        auto alice = Account("alice");
+        auto queued = ter(terQUEUED);
+
+        checkMetrics(env, 0, boost::none, 0, 2, 256);
+
+        env.fund(XRP(50000), noripple(alice));
+        checkMetrics(env, 0, boost::none, 1, 2, 256);
+
+        for (int i = 0; i < 10; ++i)
+            env(noop(alice), openLedgerFee(env));
+
+        checkMetrics(env, 0, boost::none, 11, 2, 256);
+
+        env.close();
+        // If not for the maximum, the per ledger would be 11.
+        checkMetrics(env, 0, 10, 0, 5, 256, 800025);
+
+    }
+
+    void testUnexpectedBalanceChange()
+    {
+        using namespace jtx;
+
+        Env env(*this,
+            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
+                features(featureFeeEscalation));
+
+        auto alice = Account("alice");
+        auto bob = Account("bob");
+
+        auto queued = ter(terQUEUED);
+
+        expect(env.current()->fees().base == 10);
+
+        checkMetrics(env, 0, boost::none, 0, 3, 256);
+
+        env.fund(XRP(50000), noripple(alice, bob));
+        checkMetrics(env, 0, boost::none, 2, 3, 256);
+        auto USD = bob["USD"];
+
+        env(offer(alice, USD(5000), XRP(50000)), require(owners(alice, 1)));
+        checkMetrics(env, 0, boost::none, 3, 3, 256);
+
+        env.close();
+        checkMetrics(env, 0, 6, 0, 3, 256);
+
+        // Fill up the ledger
+        fillQueue(env, alice);
+        checkMetrics(env, 0, 6, 4, 3, 256);
+
+        // Queue up a couple of transactions, plus one
+        // really expensive one.
+        auto aliceSeq = env.seq(alice);
+        env(noop(alice), seq(aliceSeq++), queued);
+        env(noop(alice), seq(aliceSeq++), queued);
+        env(noop(alice), seq(aliceSeq++), queued);
+        env(noop(alice), fee(XRP(1000)),
+            seq(aliceSeq), queued);
+        checkMetrics(env, 4, 6, 4, 3, 256);
+
+        // This offer should take Alice's offer
+        // up to Alice's reserve.
+        env(offer(bob, XRP(50000), USD(5000)),
+            openLedgerFee(env), require(balance("alice", XRP(250)),
+                owners(alice, 1), lines(alice, 1)));
+        checkMetrics(env, 4, 6, 5, 3, 256);
+
+        // Try adding a new transaction.
+        // Too many fees in flight.
+        env(noop(alice), fee(XRP(2000)), seq(aliceSeq+1),
+            ter(telCAN_NOT_QUEUE));
+        checkMetrics(env, 4, 6, 5, 3, 256);
+
+        // Close the ledger. All of Alice's transactions
+        // take a fee, except the last one.
+        env.close();
+        checkMetrics(env, 1, 10, 3, 5, 256);
+        env.require(balance(alice, XRP(250) - drops(30)));
+
+        // Still can't add a new transaction for Alice,
+        // no matter the fee.
+        env(noop(alice), fee(XRP(2000)), seq(aliceSeq + 1),
+            ter(telCAN_NOT_QUEUE));
+        checkMetrics(env, 1, 10, 3, 5, 256);
+
+        /* At this point, Alice's transaction is indefinitely
+            stuck in the queue. Eventually it will either
+            expire, get forced off the end by more valuable
+            transactions, get replaced by Alice, or Alice
+            will get more XRP, and it'll process.
+        */
+
+        for (int i = 0; i < 9; ++i)
+        {
+            env.close();
+            checkMetrics(env, 1, 10, 0, 5, 256);
+        }
+
+        // And Alice's transaction expires (via the retry limit,
+        // not LastLedgerSequence).
+        env.close();
+        checkMetrics(env, 0, 10, 0, 5, 256);
+    }
+
+    void testBlockers()
+    {
+        using namespace jtx;
+
+        Env env(*this,
+            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
+            features(featureFeeEscalation), features(featureMultiSign));
+
+        auto alice = Account("alice");
+        auto bob = Account("bob");
+        auto charlie = Account("charlie");
+        auto daria = Account("daria");
+
+        auto queued = ter(terQUEUED);
+
+        expect(env.current()->fees().base == 10);
+
+        checkMetrics(env, 0, boost::none, 0, 3, 256);
+
+        env.fund(XRP(50000), noripple(alice, bob));
+        env.memoize(charlie);
+        env.memoize(daria);
+        checkMetrics(env, 0, boost::none, 2, 3, 256);
+
+        // Fill up the open ledger
+        env(noop(alice));
+        // Set a regular key just to clear the password spent flag
+        env(regkey(alice, charlie));
+        checkMetrics(env, 0, boost::none, 4, 3, 256);
+
+        // Put some "normal" txs in the queue
+        auto aliceSeq = env.seq(alice);
+        env(noop(alice), queued);
+        env(noop(alice), seq(aliceSeq + 1), queued);
+        env(noop(alice), seq(aliceSeq + 2), queued);
+
+        // Can't replace the first tx with a blocker
+        env(fset(alice, asfAccountTxnID), fee(20), ter(telINSUF_FEE_P));
+        // Can't replace the second / middle tx with a blocker
+        env(regkey(alice, bob), seq(aliceSeq + 1), fee(20),
+            ter(telCAN_NOT_QUEUE));
+        env(signers(alice, 2, { {bob}, {charlie}, {daria} }), fee(20),
+            seq(aliceSeq + 1), ter(telCAN_NOT_QUEUE));
+        // CAN replace the last tx with a blocker
+        env(signers(alice, 2, { { bob },{ charlie },{ daria } }), fee(20),
+            seq(aliceSeq + 2), queued);
+        env(regkey(alice, bob), seq(aliceSeq + 2), fee(30),
+            queued);
+
+        // Can't queue up any more transactions after the blocker
+        env(noop(alice), seq(aliceSeq + 3), ter(telCAN_NOT_QUEUE));
+
+        // Other accounts are not affected
+        env(noop(bob), queued);
+
+        // Can replace the txs before the blocker
+        env(noop(alice), fee(14), queued);
+
+        // Can replace the blocker itself
+        env(noop(alice), seq(aliceSeq + 2), fee(40), queued);
+
+        // And now there's no block.
+        env(noop(alice), seq(aliceSeq + 3), queued);
+    }
+
+    void testInFlightBalance()
+    {
+        using namespace jtx;
+
+        Env env(*this,
+            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
+            features(featureFeeEscalation), features(featureTickets));
+
+        auto alice = Account("alice");
+        auto charlie = Account("charlie");
+        auto gw = Account("gw");
+
+        auto queued = ter(terQUEUED);
+
+        expect(env.current()->fees().base == 10);
+        expect(env.current()->fees().reserve == 200 * 1000000);
+        expect(env.current()->fees().increment == 50 * 1000000);
+
+        checkMetrics(env, 0, boost::none, 0, 3, 256);
+
+        env.fund(XRP(50000), noripple(alice, charlie), gw);
+        checkMetrics(env, 0, boost::none, 4, 3, 256);
+
+        auto USD = gw["USD"];
+        auto BUX = gw["BUX"];
+
+        //////////////////////////////////////////
+        // Offer with high XRP out blocks later txs
+        auto aliceSeq = env.seq(alice);
+        auto aliceBal = env.balance(alice);
+
+        env.require(balance(alice, XRP(50000)),
+            owners(alice, 0));
+
+        // If this offer crosses, all of alice's
+        // XRP will be taken (except the reserve).
+        env(offer(alice, BUX(5000), XRP(50000)),
+            queued);
+
+        // So even a noop will look like alice
+        // doesn't have the balance to pay the fee
+        env(noop(alice), seq(aliceSeq + 1), ter(terINSUF_FEE_B));
+        checkMetrics(env, 1, boost::none, 4, 3, 256);
+
+        env.close();
+        checkMetrics(env, 0, 8, 2, 4, 256);
+
+        // But once we close the ledger, we find alice
+        // has plenty of XRP, because the offer didn't
+        // cross (of course).
+        env.require(balance(alice, aliceBal - drops(20)),
+            owners(alice, 1));
+
+        //////////////////////////////////////////
+        // Offer with low XRP out allows later txs
+        fillQueue(env, alice);
+        checkMetrics(env, 0, 8, 5, 4, 256);
+        aliceSeq = env.seq(alice);
+        aliceBal = env.balance(alice);
+
+        // If this offer crosses, just a bit
+        // of alice's XRP will be taken.
+        env(offer(alice, BUX(50), XRP(500)),
+            queued);
+
+        // And later transactions are just fine
+        env(noop(alice), seq(aliceSeq + 1), queued);
+        checkMetrics(env, 2, 8, 5, 4, 256);
+
+        env.close();
+        checkMetrics(env, 0, 10, 2, 5, 256);
+
+        // But once we close the ledger, we find alice
+        // has plenty of XRP, because the offer didn't
+        // cross (of course).
+        env.require(balance(alice, aliceBal - drops(20)),
+            owners(alice, 2));
+
+        //////////////////////////////////////////
+        // Large XRP payment blocks later txs
+        fillQueue(env, alice);
+        checkMetrics(env, 0, 10, 6, 5, 256);
+
+        aliceSeq = env.seq(alice);
+        aliceBal = env.balance(alice);
+
+        // If this payment succeeds, alice will
+        // send her entire balance to charlie
+        // (minus the reserve).
+        env(pay(alice, charlie, XRP(50000)),
+            queued);
+
+        // So even a noop will look like alice
+        // doesn't have the balance to pay the fee
+        env(noop(alice), seq(aliceSeq + 1), ter(terINSUF_FEE_B));
+        checkMetrics(env, 1, 10, 6, 5, 256);
+
+        env.close();
+        checkMetrics(env, 0, 12, 2, 6, 256);
+
+        // But once we close the ledger, we find alice
+        // still has most of her balance, because the
+        // payment was unfunded!
+        env.require(balance(alice, aliceBal - drops(20)),
+            owners(alice, 2));
+
+        //////////////////////////////////////////
+        // Small XRP payment allows later txs
+        fillQueue(env, alice);
+        checkMetrics(env, 0, 12, 7, 6, 256);
+
+        aliceSeq = env.seq(alice);
+        aliceBal = env.balance(alice);
+
+        // If this payment succeeds, alice will
+        // send just a bit of balance to charlie
+        env(pay(alice, charlie, XRP(500)),
+            queued);
+
+        // And later transactions are just fine
+        env(noop(alice), seq(aliceSeq + 1), queued);
+        checkMetrics(env, 2, 12, 7, 6, 256);
+
+        env.close();
+        checkMetrics(env, 0, 14, 2, 7, 256);
+
+        // The payment succeeds
+        env.require(balance(alice, aliceBal - XRP(500) - drops(20)),
+            owners(alice, 2));
+
+        //////////////////////////////////////////
+        // Large IOU payment allows later txs
+        auto const amount = USD(500000);
+        env(trust(alice, USD(50000000)));
+        env(trust(charlie, USD(50000000)));
+        checkMetrics(env, 0, 14, 4, 7, 256);
+        // Close so we don't have to deal
+        // with tx ordering in consensus.
+        env.close();
+
+        env(pay(gw, alice, amount));
+        checkMetrics(env, 0, 14, 1, 7, 256);
+        // Close so we don't have to deal
+        // with tx ordering in consensus.
+        env.close();
+
+        fillQueue(env, alice);
+        checkMetrics(env, 0, 14, 8, 7, 256);
+
+        aliceSeq = env.seq(alice);
+        aliceBal = env.balance(alice);
+        auto aliceUSD = env.balance(alice, USD);
+
+        // If this payment succeeds, alice will
+        // send her entire USD balance to charlie.
+        env(pay(alice, charlie, amount),
+            queued);
+
+        // But that's fine, because it doesn't affect
+        // alice's XRP balance (other than the fee, of course).
+        env(noop(alice), seq(aliceSeq + 1), queued);
+        checkMetrics(env, 2, 14, 8, 7, 256);
+
+        env.close();
+        checkMetrics(env, 0, 16, 2, 8, 256);
+
+        // So once we close the ledger, alice has her
+        // XRP balance, but her USD balance went to charlie.
+        env.require(balance(alice, aliceBal - drops(20)),
+            balance(alice, USD(0)),
+            balance(charlie, aliceUSD),
+            owners(alice, 3),
+            owners(charlie, 1));
+
+        //////////////////////////////////////////
+        // Large XRP to IOU payment blocks later txs.
+
+        env(offer(gw, XRP(500000), USD(50000)));
+        // Close so we don't have to deal
+        // with tx ordering in consensus.
+        env.close();
+
+        fillQueue(env, charlie);
+        checkMetrics(env, 0, 16, 9, 8, 256);
+
+        aliceSeq = env.seq(alice);
+        aliceBal = env.balance(alice);
+        auto charlieUSD = env.balance(charlie, USD);
+
+        // If this payment succeeds, and uses the
+        // entire sendMax, alice will send her
+        // entire XRP balance to charlie in the
+        // form of USD.
+        expect(XRP(60000) > aliceBal);
+        env(pay(alice, charlie, USD(1000)),
+            sendmax(XRP(60000)), queued);
+
+        // So even a noop will look like alice
+        // doesn't have the balance to pay the fee
+        env(noop(alice), seq(aliceSeq + 1), ter(terINSUF_FEE_B));
+        checkMetrics(env, 1, 16, 9, 8, 256);
+
+        env.close();
+        checkMetrics(env, 0, 18, 2, 9, 256);
+
+        // So once we close the ledger, alice sent a payment
+        // to charlie using only a portion of her XRP balance
+        env.require(balance(alice, aliceBal - XRP(10000) - drops(20)),
+            balance(alice, USD(0)),
+            balance(charlie, charlieUSD + USD(1000)),
+            owners(alice, 3),
+            owners(charlie, 1));
+
+        //////////////////////////////////////////
+        // Small XRP to IOU payment allows later txs.
+
+        fillQueue(env, charlie);
+        checkMetrics(env, 0, 18, 10, 9, 256);
+
+        aliceSeq = env.seq(alice);
+        aliceBal = env.balance(alice);
+        charlieUSD = env.balance(charlie, USD);
+
+        // If this payment succeeds, and uses the
+        // entire sendMax, alice will only send
+        // a portion of her XRP balance to charlie
+        // in the form of USD.
+        expect(aliceBal > XRP(6001));
+        env(pay(alice, charlie, USD(500)),
+            sendmax(XRP(6000)), queued);
+
+        // And later transactions are just fine
+        env(noop(alice), seq(aliceSeq + 1), queued);
+        checkMetrics(env, 2, 18, 10, 9, 256);
+
+        env.close();
+        checkMetrics(env, 0, 20, 2, 10, 256);
+
+        // So once we close the ledger, alice sent a payment
+        // to charlie using only a portion of her XRP balance
+        env.require(balance(alice, aliceBal - XRP(5000) - drops(20)),
+            balance(alice, USD(0)),
+            balance(charlie, charlieUSD + USD(500)),
+            owners(alice, 3),
+            owners(charlie, 1));
+    }
+
+    void testConsequences()
+    {
+        using namespace jtx;
+        using namespace std::chrono;
+        Env env(*this, features(featureTickets));
+        auto const alice = Account("alice");
+        env.memoize(alice);
+        env.memoize("bob");
+        env.memoize("carol");
+        {
+            Json::Value cancelOffer;
+            cancelOffer[jss::Account] = alice.human();
+            cancelOffer[jss::OfferSequence] = 3;
+            cancelOffer[jss::TransactionType] = "OfferCancel";
+            auto const jtx = env.jt(cancelOffer,
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(0));
+        }
+
+        {
+            auto USD = alice["USD"];
+
+            auto const jtx = env.jt(trust("carol", USD(50000000)),
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(0));
+        }
+
+        {
+            auto const jtx = env.jt(ticket::create(alice, "bob", 60),
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(0));
+        }
+
+        {
+            Json::Value cancelTicket;
+            cancelTicket[jss::Account] = alice.human();
+            cancelTicket["TicketID"] = to_string(uint256());
+            cancelTicket[jss::TransactionType] = "TicketCancel";
+            auto const jtx = env.jt(cancelTicket,
+                seq(1), fee(10));
+            auto const pf = preflight(env.app(), env.current()->rules(),
+                *jtx.stx, tapNONE, env.journal);
+            expect(pf.ter == tesSUCCESS);
+            auto const conseq = calculateConsequences(pf);
+            expect(conseq.category == TxConsequences::normal);
+            expect(conseq.fee == drops(10));
+            expect(conseq.potentialSpend == XRP(0));
+        }
     }
 
     void run()
@@ -541,6 +1539,15 @@ public:
         testZeroFeeTxn();
         testPreclaimFailures();
         testQueuedFailure();
+        testMultiTxnPerAccount();
+        testTieBreaking();
+        testDisabled();
+        testAcctTxnID();
+        testMaximum();
+        testUnexpectedBalanceChange();
+        testBlockers();
+        testInFlightBalance();
+        testConsequences();
     }
 };
 

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -92,6 +92,37 @@ public:
     PreclaimResult& operator=(PreclaimResult const&) = delete;
 };
 
+struct TxConsequences
+{
+    enum Category
+    {
+        // Moves currency around, creates offers, etc.
+        normal = 0,
+        // Affects the ability of subsequent transactions
+        // to claim a fee. Eg. SetRegularKey
+        blocker
+    };
+
+    Category const category;
+    XRPAmount const fee;
+    // Does NOT include the fee.
+    XRPAmount const potentialSpend;
+
+    TxConsequences(Category const category_,
+        XRPAmount const fee_, XRPAmount const spend_)
+        : category(category_)
+        , fee(fee_)
+        , potentialSpend(spend_)
+    {
+    }
+
+    TxConsequences(TxConsequences const&) = default;
+    TxConsequences& operator=(TxConsequences const&) = delete;
+    TxConsequences(TxConsequences&&) = default;
+    TxConsequences& operator=(TxConsequences&&) = delete;
+
+};
+
 /** Gate a transaction based on static information.
 
     The transaction is checked against all possible
@@ -142,6 +173,13 @@ preclaim(PreflightResult const& preflightResult,
 std::uint64_t
 calculateBaseFee(Application& app, ReadView const& view,
     STTx const& tx, beast::Journal j);
+
+/** Determine the XRP balance consequences if a transaction
+    consumes the maximum XRP allowed.
+*/
+TxConsequences
+calculateConsequences(PreflightResult const& preflightResult);
+
 /** Apply a prechecked transaction to an OpenView.
 
     See also: apply()

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -32,6 +32,15 @@
 
 namespace ripple {
 
+XRPAmount
+CreateOffer::calculateMaxSpend(STTx const& tx)
+{
+    auto const& saTakerGets = tx[sfTakerGets];
+
+    return saTakerGets.native() ?
+        saTakerGets.xrp() : beast::zero;
+}
+
 TER
 CreateOffer::preflight (PreflightContext const& ctx)
 {

--- a/src/ripple/app/tx/impl/CreateOffer.h
+++ b/src/ripple/app/tx/impl/CreateOffer.h
@@ -47,6 +47,10 @@ public:
     }
 
     static
+    XRPAmount
+    calculateMaxSpend(STTx const& tx);
+
+    static
     TER
     preflight (PreflightContext const& ctx);
 

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -30,6 +30,20 @@ namespace ripple {
 
 // See https://ripple.com/wiki/Transaction_Format#Payment_.280.29
 
+XRPAmount
+Payment::calculateMaxSpend(STTx const& tx)
+{
+    if (tx.isFieldPresent(sfSendMax))
+    {
+        auto const& sendMax = tx[sfSendMax];
+        return sendMax.native() ? sendMax.xrp() : beast::zero;
+    }
+    /* If there's no sfSendMax in XRP, and the sfAmount isn't
+    in XRP, then the transaction can not send XRP. */
+    auto const& saDstAmount = tx.getFieldAmount(sfAmount);
+    return saDstAmount.native() ? saDstAmount.xrp() : beast::zero;
+}
+
 TER
 Payment::preflight (PreflightContext const& ctx)
 {

--- a/src/ripple/app/tx/impl/Payment.h
+++ b/src/ripple/app/tx/impl/Payment.h
@@ -45,6 +45,10 @@ public:
     }
 
     static
+    XRPAmount
+    calculateMaxSpend(STTx const& tx);
+
+    static
     TER
     preflight (PreflightContext const& ctx);
 

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -29,6 +29,25 @@
 
 namespace ripple {
 
+bool
+SetAccount::affectsSubsequentTransactionAuth(STTx const& tx)
+{
+    auto const uTxFlags = tx.getFlags();
+    if(uTxFlags & (tfRequireAuth | tfOptionalAuth))
+        return true;
+
+    auto const uSetFlag = tx[~sfSetFlag];
+    if(uSetFlag && (*uSetFlag == asfRequireAuth ||
+        *uSetFlag == asfDisableMaster ||
+            *uSetFlag == asfAccountTxnID))
+                return true;
+
+    auto const uClearFlag = tx[~sfClearFlag];
+    return uClearFlag && (*uClearFlag == asfRequireAuth ||
+        *uClearFlag == asfDisableMaster ||
+            *uClearFlag == asfAccountTxnID);
+}
+
 TER
 SetAccount::preflight (PreflightContext const& ctx)
 {

--- a/src/ripple/app/tx/impl/SetAccount.h
+++ b/src/ripple/app/tx/impl/SetAccount.h
@@ -42,6 +42,10 @@ public:
     }
 
     static
+    bool
+    affectsSubsequentTransactionAuth(STTx const& tx);
+
+    static
     TER
     preflight (PreflightContext const& ctx);
 

--- a/src/ripple/app/tx/impl/SetRegularKey.h
+++ b/src/ripple/app/tx/impl/SetRegularKey.h
@@ -37,6 +37,13 @@ public:
     }
 
     static
+    bool
+    affectsSubsequentTransactionAuth(STTx const& tx)
+    {
+        return true;
+    }
+
+    static
     TER
     preflight (PreflightContext const& ctx);
 

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -54,6 +54,13 @@ public:
     }
 
     static
+    bool
+    affectsSubsequentTransactionAuth(STTx const& tx)
+    {
+        return true;
+    }
+
+    static
     TER
     preflight (PreflightContext const& ctx);
 

--- a/src/ripple/app/tx/impl/SusPay.cpp
+++ b/src/ripple/app/tx/impl/SusPay.cpp
@@ -128,6 +128,12 @@ namespace ripple {
 
 //------------------------------------------------------------------------------
 
+XRPAmount
+SusPayCreate::calculateMaxSpend(STTx const& tx)
+{
+    return tx[sfAmount].xrp();
+}
+
 TER
 SusPayCreate::preflight (PreflightContext const& ctx)
 {

--- a/src/ripple/app/tx/impl/SusPay.h
+++ b/src/ripple/app/tx/impl/SusPay.h
@@ -35,6 +35,10 @@ public:
     }
 
     static
+    XRPAmount
+    calculateMaxSpend(STTx const& tx);
+
+    static
     TER
     preflight (PreflightContext const& ctx);
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -70,6 +70,9 @@ public:
     PreclaimContext& operator=(PreclaimContext const&) = delete;
 };
 
+struct TxConsequences;
+struct PreflightResult;
+
 class Transactor
 {
 protected:
@@ -125,6 +128,21 @@ public:
     std::uint64_t
     calculateBaseFee (
         PreclaimContext const& ctx);
+
+    static
+    bool
+    affectsSubsequentTransactionAuth(STTx const& tx)
+    {
+        return false;
+    }
+
+    static
+    XRPAmount
+    calculateFeePaid(STTx const& tx);
+
+    static
+    XRPAmount
+    calculateMaxSpend(STTx const& tx);
 
     static
     TER

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -122,7 +122,7 @@ public:
     std::string                 START_LEDGER;
 
     // Network parameters
-    int                         TRANSACTION_FEE_BASE = 10;   // The number of fee units a reference transaction costs
+    int const                   TRANSACTION_FEE_BASE = 10;   // The number of fee units a reference transaction costs
 
     /** Operate in stand-alone mode.
 

--- a/src/ripple/core/LoadFeeTrack.h
+++ b/src/ripple/core/LoadFeeTrack.h
@@ -96,8 +96,6 @@ public:
     }
 
 
-    Json::Value getJson (std::uint64_t baseFee, std::uint32_t referenceFeeUnits) const;
-
     void setClusterFee (std::uint32_t fee)
     {
         ScopedLockType sl (mLock);

--- a/src/ripple/core/impl/LoadFeeTrack.cpp
+++ b/src/ripple/core/impl/LoadFeeTrack.cpp
@@ -102,29 +102,6 @@ LoadFeeTrack::scaleFeeLoad (std::uint64_t fee, std::uint64_t baseFee,
     return fee;
 }
 
-Json::Value
-LoadFeeTrack::getJson (std::uint64_t baseFee,
-    std::uint32_t referenceFeeUnits) const
-{
-    Json::Value j (Json::objectValue);
-
-    {
-        ScopedLockType sl (mLock);
-
-        // base_fee = The cost to send a "reference" transaction under
-        // no load, in millionths of a Ripple
-        j[jss::base_fee] = Json::Value::UInt (baseFee);
-
-        // load_fee = The cost to send a "reference" transaction now,
-        // in millionths of a Ripple
-        j[jss::load_fee] = Json::Value::UInt (
-            mulDivThrow(baseFee, std::max(mLocalTxnLoadFee,
-                mRemoteTxnLoadFee), lftNormalFee));
-    }
-
-    return j;
-}
-
 bool
 LoadFeeTrack::raiseLocalFee ()
 {

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -32,10 +32,6 @@ enum ApplyFlags
     // Signature already checked
     tapNO_CHECK_SIGN    = 0x01,
 
-    // We expect the transaction to have a later
-    // sequence number than the account in the ledger
-    tapPOST_SEQ         = 0x04,
-
     // This is not the transaction's last pass
     // Transaction can be retried, soft failures allowed
     tapRETRY            = 0x20,

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -43,6 +43,7 @@ JSS ( DeliverMin );                 // in: TransactionSign
 JSS ( Fee );                        // in/out: TransactionSign; field.
 JSS ( Flags );                      // in/out: TransactionSign; field.
 JSS ( Invalid );                    //
+JSS ( LastLedgerSequence );         // in: TransactionSign; field
 JSS ( LimitAmount );                // field.
 JSS ( OfferSequence );              // field.
 JSS ( Paths );                      // in/out: TransactionSign
@@ -231,6 +232,9 @@ JSS ( load );                       // out: NetworkOPs, PeerImp
 JSS ( load_base );                  // out: NetworkOPs
 JSS ( load_factor );                // out: NetworkOPs
 JSS ( load_factor_cluster );        // out: NetworkOPs
+JSS ( load_factor_fee_escalation ); // out: NetworkOPs
+JSS ( load_factor_fee_queue );      // out: NetworkOPs
+JSS ( load_factor_fee_reference );  // out: NetworkOPs
 JSS ( load_factor_local );          // out: NetworkOPs
 JSS ( load_factor_net );            // out: NetworkOPs
 JSS ( load_fee );                   // out: LoadFeeTrackImp

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -45,6 +45,7 @@ enum TER
     telFAILED_PROCESSING,
     telINSUF_FEE_P,
     telNO_DST_PARTIAL,
+    telCAN_NOT_QUEUE,
 
     // -299 .. -200: M Malformed (bad signature)
     // Causes:

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -89,6 +89,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { telFAILED_PROCESSING,      { "telFAILED_PROCESSING",     "Failed to correctly process transaction."                                      } },
         { telINSUF_FEE_P,            { "telINSUF_FEE_P",           "Fee insufficient."                                                             } },
         { telNO_DST_PARTIAL,         { "telNO_DST_PARTIAL",        "Partial payment to create account not allowed."                                } },
+        { telCAN_NOT_QUEUE,          { "telCAN_NOT_QUEUE",         "Can not queue at this time." } },
 
         { temMALFORMED,              { "temMALFORMED",             "Malformed transaction."                                                        } },
         { temBAD_AMOUNT,             { "temBAD_AMOUNT",            "Can only send positive amounts."                                               } },
@@ -132,7 +133,7 @@ bool transResultInfo (TER code, std::string& token, std::string& text)
         { terNO_LINE,                { "terNO_LINE",               "No such line."                                                                 } },
         { terPRE_SEQ,                { "terPRE_SEQ",               "Missing/inapplicable prior transaction."                                       } },
         { terOWNERS,                 { "terOWNERS",                "Non-zero owner count."                                                         } },
-        { terQUEUED,                 { "terQUEUED",                "Held until fee drops."                                                         } },
+        { terQUEUED,                 { "terQUEUED",                "Held until escalated fee drops."                                                         } },
 
         { tesSUCCESS,                { "tesSUCCESS",               "The transaction was applied. Only final in a validated ledger."                } },
     };


### PR DESCRIPTION
* Tweak account XRP balance and sequence if needed before preclaim.
* Limit total fees in flight to minimum reserve / account balance.
* Limit queuing multiple transactions after transactions that affect authentication.
* Full queue: new txn can only kick out a tx if the fee is higher than that account's average fee.
* Queued tx retry limit prevents indefinitely stuck txns.
* Return escalation factors in server_info and _state when escalated.
* Update documentation.
* Update experimental config to only include the % increase.
* Convert TxQ metric magic numbers to experimental config.


Reviewers: @JoelKatz @miguelportilla 

Of special note:
* I created a new `TER` code: `telCAN_NOT_QUEUE` to indicate when a tx may be fine, but violates one of the queue's rules.
* Some of the decisions were made just because I had to make a decision. I welcome discussion and suggestions for anything you disagree with.
