### PR TITLE
Fix secured Websocket closing.

### DIFF
--- a/src/ripple/websocket/AutoSocket.h
+++ b/src/ripple/websocket/AutoSocket.h
@@ -38,7 +38,7 @@ class AutoSocket
 public:
     using ssl_socket   = boost::asio::ssl::stream<boost::asio::ip::tcp::socket>;
     using endpoint_type     = boost::asio::ip::tcp::socket::endpoint_type;
-    using socket_ptr        = std::shared_ptr<ssl_socket>;
+    using socket_ptr        = std::unique_ptr<ssl_socket>;
     using plain_socket      = ssl_socket::next_layer_type;
     using lowest_layer_type = ssl_socket::lowest_layer_type;
     using handshake_type    = ssl_socket::handshake_type;
@@ -55,7 +55,7 @@ public:
         , mBuffer ((plainOnly || secureOnly) ? 0 : 4)
         , j_ (ripple::debugJournal())
     {
-        mSocket = std::make_shared<ssl_socket> (s, c);
+        mSocket = std::make_unique<ssl_socket> (s, c);
     }
 
     AutoSocket (

--- a/src/ripple/websocket/Handler.h
+++ b/src/ripple/websocket/Handler.h
@@ -278,7 +278,7 @@ public:
                 return;
             }
 
-            ptr = it->second;
+            ptr = std::move (it->second);
             // prevent the ConnectionImpl from being destroyed until we release
             // the lock
             mMap.erase (it);
@@ -298,7 +298,10 @@ public:
         app_.getJobQueue ().addJob (
             jtCLIENT,
             "WSClient::destroy",
-            [ptr] (Job&) { ConnectionImpl <WebSocket>::destroy(ptr); });
+            [p = std::move(ptr)] (Job&)
+            {
+                ConnectionImpl <WebSocket>::destroy(std::move (p));
+            });
     }
 
     void message_job(std::string const& name, connection_ptr const& cpClient)

--- a/src/websocketpp_02/src/connection.hpp
+++ b/src/websocketpp_02/src/connection.hpp
@@ -1404,6 +1404,8 @@ public:
 
             log_close_result();
         }
+        else
+            m_state = session::state::CLOSED;
 
         // finally remove this connection from the endpoint's list. This will
         // remove the last shared pointer to the connection held by WS++. If we

--- a/src/websocketpp_02/src/roles/server.hpp
+++ b/src/websocketpp_02/src/roles/server.hpp
@@ -914,7 +914,8 @@ void server<endpoint>::connection<connection_type>::handle_write_response(
         return;
     }
 
-    if (m_response.get_status_code() != http::status_code::SWITCHING_PROTOCOLS) {
+    if (m_response.get_status_code() != http::status_code::SWITCHING_PROTOCOLS ||
+        m_connection.m_state == session::state::CLOSED) {
         if (m_version == -1) {
             // if this was not a websocket connection, we have written
             // the expected response and the connection can be closed.

--- a/src/websocketpp_02/src/sockets/autotls.hpp
+++ b/src/websocketpp_02/src/sockets/autotls.hpp
@@ -133,18 +133,15 @@ public:
             callback(error);
         }
 
-        // note, this function for some reason shouldn't/doesn't need to be
-        // called for plain HTTP connections. not sure why.
+        // Only SSL conections actually need to be shut down
         bool shutdown() {
             boost::system::error_code ignored_ec;
 
             m_socket_ptr->async_shutdown( // Don't block on connection shutdown DJS
                 std::bind(
-		            &autotls<endpoint_type>::handle_shutdown,
+                    &autotls<endpoint_type>::handle_shutdown,
                     m_socket_ptr,
-                    beast::asio::placeholders::error
-				)
-			);
+                    beast::asio::placeholders::error));
 
             if (ignored_ec) {
                 return false;


### PR DESCRIPTION
Websocketpp was incorrectly handling close before or during protocol negotiation. This issue addresses lingering CLOSE_WAIT file descriptors.

Reviewers: @JoelKatz @vinniefalco 