### PR TITLE
Make wallet_propose seed generation consistent:

### DIFF
--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -82,30 +82,21 @@ Json::Value walletPropose (Json::Value const& params)
 
         if (keyType == KeyType::invalid)
             return rpcError(rpcINVALID_PARAMS);
-
-        if (params.isMember (jss::passphrase) ||
-            params.isMember (jss::seed) ||
-            params.isMember (jss::seed_hex))
-        {
-            seed = RPC::getSeedFromRPC (params);
-        }
-        else
-        {
-            seed = randomSeed ();
-        }
     }
-    else if (params.isMember (jss::passphrase))
+
+    if (params.isMember (jss::passphrase) ||
+        params.isMember (jss::seed) ||
+        params.isMember (jss::seed_hex))
     {
-        seed = parseGenericSeed (
-            params[jss::passphrase].asString());
+        seed = RPC::getSeedFromRPC (params);
+
+        if (!seed)
+            return rpcError(rpcBAD_SEED);
     }
     else
     {
         seed = randomSeed ();
     }
-
-    if (!seed)
-        return rpcError(rpcBAD_SEED);
 
     auto const publicKey = generateKeyPair (keyType, *seed).first;
 

--- a/src/ripple/rpc/impl/KeypairForSignature.cpp
+++ b/src/ripple/rpc/impl/KeypairForSignature.cpp
@@ -30,9 +30,6 @@ namespace RPC {
 boost::optional<Seed>
 getSeedFromRPC (Json::Value const& params)
 {
-    // This function is only called when `key_type` is present.
-    assert (params.isMember (jss::key_type));
-
     bool const hasPassphrase = params.isMember (jss::passphrase);
     bool const hasSeed       = params.isMember (jss::seed);
     bool const hasHexSeed    = params.isMember (jss::seed_hex);
@@ -48,7 +45,7 @@ getSeedFromRPC (Json::Value const& params)
             return parseBase58<Seed> (params[jss::seed].asString());
 
         if (hasPassphrase)
-            return generateSeed (params[jss::passphrase].asString());
+            return parseGenericSeed (params[jss::passphrase].asString());
 
         if (hasHexSeed)
         {


### PR DESCRIPTION
Allow 'seed' or 'seed_hex' if 'key_type' is not specified.
Use legacy passphrase seed generation if 'key_type' is specified.

@nbougalis @vinniefalco 