### PR TITLE
Correctly handle connections that fail security checks (RIPD-1114):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3469,6 +3469,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\server\Session.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\server\SimpleWriter.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\server\tests\Server_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3927,6 +3927,9 @@
     <ClInclude Include="..\..\src\ripple\server\Session.h">
       <Filter>ripple\server</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\server\SimpleWriter.h">
+      <Filter>ripple\server</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\server\tests\Server_test.cpp">
       <Filter>ripple\server\tests</Filter>
     </ClCompile>

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -276,6 +276,11 @@ private:
     makeRedirectResponse (PeerFinder::Slot::ptr const& slot,
         http_request_type const& request, address_type remote_address);
 
+    std::shared_ptr<Writer>
+    makeErrorResponse (PeerFinder::Slot::ptr const& slot,
+        http_request_type const& request, address_type remote_address,
+        std::string msg);
+
     bool
     processRequest (http_request_type const& req,
         Handoff& handoff);

--- a/src/ripple/server/SimpleWriter.h
+++ b/src/ripple/server/SimpleWriter.h
@@ -21,30 +21,29 @@
 #define RIPPLE_SERVER_SIMPLEWRITER_H_INCLUDED
 
 #include <ripple/server/Writer.h>
-#include <beast/asio/streambuf.h>
-#include <beast/http/message.h>
+#include <ripple/beast/deprecated_http.h>
+#include <beast/streambuf.hpp>
 #include <utility>
 
 namespace ripple {
-namespace HTTP {
 
 /** Writer that sends a simple HTTP response with a message body. */
 class SimpleWriter : public Writer
 {
 private:
-    beast::http::message message_;
-    beast::asio::streambuf streambuf_;
+    beast::deprecated_http::message message_;
+    beast::streambuf streambuf_;
     std::string body_;
     bool prepared_ = false;
 
 public:
     explicit
-    SimpleWriter(beast::http::message&& message)
-        : message_(std::forward<beast::http::message>(message))
+    SimpleWriter(beast::deprecated_http::message&& message)
+        : message_(std::forward<beast::deprecated_http::message>(message))
     {
     }
 
-    beast::http::message&
+    beast::deprecated_http::message&
     message()
     {
         return message_;
@@ -95,14 +94,13 @@ private:
     {
         prepared_ = true;
         message_.headers.erase("Content-Length");
-        message_.headers.append("Content-Length",
+        message_.headers.insert("Content-Length",
             std::to_string(body_.size()));
         write(streambuf_, message_);
-        write(streambuf_, body_;
+        beast::http::detail::write(streambuf_, body_);
     }
 };
 
-}
 }
 
 #endif


### PR DESCRIPTION
* Return error code 400 to the peer along with a descriptive message
* Release the slot and decrement IP connection counters.