### PR TITLE
Stricter checking on integer json inputs.

### DIFF
--- a/src/ripple/rpc/handlers/LedgerRequest.cpp
+++ b/src/ripple/rpc/handlers/LedgerRequest.cpp
@@ -57,7 +57,7 @@ Json::Value doLedgerRequest (RPC::Context& context)
     else
     {
         auto const& jsonIndex = context.params[jss::ledger_index];
-        if (!jsonIndex.isNumeric ())
+        if (!jsonIndex.isInt())
             return RPC::invalid_field_error (jss::ledger_index);
 
         // We need a validated ledger to get the hash from the sequence

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -640,19 +640,19 @@ Json::Value checkFee (
     int div = Tuning::defaultAutoFillFeeDivisor;
     if (request.isMember (jss::fee_mult_max))
     {
-        if (request[jss::fee_mult_max].isNumeric ())
+        if (request[jss::fee_mult_max].isInt())
         {
             mult = request[jss::fee_mult_max].asInt();
         }
         else
         {
             return RPC::make_error (rpcHIGH_FEE,
-                RPC::expected_field_message (jss::fee_mult_max, "a number"));
+                RPC::expected_field_message (jss::fee_mult_max, "an integer"));
         }
     }
     if (request.isMember(jss::fee_div_max))
     {
-        if (request[jss::fee_div_max].isNumeric())
+        if (request[jss::fee_div_max].isInt())
         {
             div = request[jss::fee_div_max].asInt();
             if (div == 0)
@@ -662,7 +662,7 @@ Json::Value checkFee (
         else
         {
             return RPC::make_error(rpcHIGH_FEE,
-                RPC::expected_field_message(jss::fee_div_max, "a number"));
+                RPC::expected_field_message(jss::fee_div_max, "an integer"));
         }
     }
 

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -222,8 +222,8 @@ R"({
     }
 })",
 {
-"Invalid field 'fee_mult_max', not a number.",
-"Invalid field 'fee_mult_max', not a number.",
+"Invalid field 'fee_mult_max', not an integer.",
+"Invalid field 'fee_mult_max', not an integer.",
 "Missing field 'tx_json.Fee'.",
 "Missing field 'tx_json.SigningPubKey'."}},
 
@@ -243,8 +243,8 @@ R"({
     }
 })",
 {
-"Invalid field 'fee_div_max', not a number.",
-"Invalid field 'fee_div_max', not a number.",
+"Invalid field 'fee_div_max', not an integer.",
+"Invalid field 'fee_div_max', not an integer.",
 "Missing field 'tx_json.Fee'.",
 "Missing field 'tx_json.SigningPubKey'."}},
 


### PR DESCRIPTION
Nearly trivial. It doesn't change the API, but it is stricter about checking input values passed through the API.

Reviewers: @miguelportilla @seelabs 