### PR TITLE
Fix history acquire check (RIPD-1112)

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1560,9 +1560,12 @@ LedgerMaster::shouldAcquire (
     std::uint32_t const ledgerHistoryIndex,
     std::uint32_t const candidateLedger) const
 {
-    bool ret (candidateLedger >= currentLedger ||
-        candidateLedger > ledgerHistoryIndex ||
-        (currentLedger - candidateLedger) <= ledgerHistory);
+    // If the ledger could be the current ledger acquire it.
+    // Otherwise, acquire it only if it's within our range of
+    // desired history and we wouldn't delete it if we had it.
+    bool ret = (candidateLedger >= currentLedger) ||
+        ((candidateLedger >= ledgerHistoryIndex) &&
+        ((currentLedger - candidateLedger) <= ledgerHistory));
 
     JLOG (m_journal.trace())
         << "Missing ledger "


### PR DESCRIPTION
The various history acquire conditions were not combined properly, resulting in historical ledgers being acquired in cases where they should not be.

The online delete logic returns zero to mean "don't delete anything", not "fetch everything".