### PR TITLE
Add support for Beast Websockets (RIPD-1097)

### DIFF
--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -118,6 +118,7 @@ public:
     };
 
 public:
+    InfoSub (Source& source);
     InfoSub (Source& source, Consumer consumer);
 
     virtual ~InfoSub ();
@@ -156,6 +157,14 @@ private:
     hash_set <AccountID> normalSubscriptions_;
     std::shared_ptr <PathRequest> mPathRequest;
     std::uint64_t                 mSeq;
+
+    static
+    int
+    assign_id()
+    {
+        static std::atomic<std::uint64_t> id(0);
+        return ++id;
+    }
 };
 
 } // ripple

--- a/src/ripple/net/impl/InfoSub.cpp
+++ b/src/ripple/net/impl/InfoSub.cpp
@@ -43,12 +43,17 @@ InfoSub::Source::Source (char const* name, Stoppable& parent)
 
 //------------------------------------------------------------------------------
 
-InfoSub::InfoSub (Source& source, Consumer consumer)
-    : m_consumer (consumer)
-    , m_source (source)
+InfoSub::InfoSub(Source& source)
+    : m_source(source)
+    , mSeq(assign_id())
 {
-    static std::atomic <int> s_seq_id (0);
-    mSeq = ++s_seq_id;
+}
+
+InfoSub::InfoSub(Source& source, Consumer consumer)
+    : m_consumer(consumer)
+    , m_source(source)
+    , mSeq(assign_id())
+{
 }
 
 InfoSub::~InfoSub ()

--- a/src/ripple/server/WSSession.h
+++ b/src/ripple/server/WSSession.h
@@ -112,8 +112,16 @@ struct WSSession
     std::shared_ptr<void> appDefined;
 
     virtual
+    void
+    run() = 0;
+
+    virtual
     Port const&
     port() const = 0;
+
+    virtual
+    http_request_type const&
+    request() const = 0;
 
     virtual
     boost::asio::ip::tcp::endpoint const&
@@ -127,6 +135,14 @@ struct WSSession
     virtual
     void
     close() = 0;
+
+    /** Indicate that the response is complete.
+        The handler should call this when it has completed writing
+        the response.
+    */
+    virtual
+    void
+    complete() = 0;
 };
 
 } // ripple

--- a/src/ripple/server/impl/BaseHTTPPeer.h
+++ b/src/ripple/server/impl/BaseHTTPPeer.h
@@ -67,7 +67,6 @@ protected:
 
         // Max seconds without completing a message
         timeoutSeconds = 30
-
     };
 
     struct buffer
@@ -105,7 +104,6 @@ protected:
     bool complete_ = false;
     boost::system::error_code ec_;
 
-    clock_type::time_point when_;
     int request_count_ = 0;
     std::size_t bytes_in_ = 0;
     std::size_t bytes_out_ = 0;
@@ -233,7 +231,6 @@ BaseHTTPPeer<Impl>::BaseHTTPPeer (Port const& port, Handler& handler,
     id_ = std::string("#") + std::to_string(nid_) + " ";
     JLOG(journal_.trace()) << id_ <<
         "accept:    " << remote_address_.address();
-    when_ = clock_type::now();
 }
 
 template <class Impl>

--- a/src/ripple/server/impl/PlainHTTPPeer.h
+++ b/src/ripple/server/impl/PlainHTTPPeer.h
@@ -99,7 +99,6 @@ PlainHTTPPeer::websocketUpgrade()
         port_, handler_, remote_address_,
             std::move(message_), std::move(stream_),
                 journal_);
-    ws->run();
     return ws;
 }
 

--- a/src/ripple/server/impl/Port.cpp
+++ b/src/ripple/server/impl/Port.cpp
@@ -23,6 +23,7 @@
 
 namespace ripple {
 
+// Detects legacy websockets only.
 bool
 Port::websockets() const
 {
@@ -33,7 +34,9 @@ bool
 Port::secure() const
 {
     return protocol.count("peer") > 0 ||
-        protocol.count("https") > 0 || protocol.count("wss") > 0;
+        protocol.count("https") > 0 ||
+        protocol.count("wss") > 0 ||
+        protocol.count("wss2") > 0;
 }
 
 std::string

--- a/src/ripple/server/impl/SSLHTTPPeer.h
+++ b/src/ripple/server/impl/SSLHTTPPeer.h
@@ -104,7 +104,6 @@ SSLHTTPPeer::websocketUpgrade()
         port_, handler_, remote_address_,
             std::move(message_), std::move(ssl_bundle_),
                 journal_);
-    ws->run();
     return ws;
 }
 
@@ -118,10 +117,11 @@ SSLHTTPPeer::do_handshake (yield_context yield)
         stream_type::server, read_buf_.data(), yield[ec]));
     cancel_timer();
     if (ec)
-        return fail (ec, "handshake");
+        return fail(ec, "handshake");
     bool const http =
         port().protocol.count("peer") > 0 ||
-        //|| port().protocol.count("wss") > 0
+        //port().protocol.count("wss") > 0 ||
+        port().protocol.count("wss2") > 0 ||
         port().protocol.count("https") > 0;
     if (http)
     {


### PR DESCRIPTION
Most of the work appears in ServerHandler, where new Beast Websockets, secured and plain, coexist with HTTP requests and handle messages in a similar fashion.

Reviewers: @nbougalis @seelabs 