### PR TITLE
Transfer fees

### DIFF
--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -62,6 +62,7 @@ flow (
     STPathSet const& paths,
     bool defaultPaths,
     bool partialPayment,
+    bool ownerPaysTransferFee,
     boost::optional<Quality> const& limitQuality,
     boost::optional<STAmount> const& sendMax,
     beast::Journal j)
@@ -83,7 +84,7 @@ flow (
     // convert the paths to a collection of strands. Each strand is the collection
     // of account->account steps and book steps that may be used in this payment.
     auto sr = toStrands (sb, src, dst, dstIssue, sendMaxIssue, paths,
-        defaultPaths, j);
+        defaultPaths, ownerPaysTransferFee, j);
 
     if (sr.first != tesSUCCESS)
     {

--- a/src/ripple/app/paths/Flow.h
+++ b/src/ripple/app/paths/Flow.h
@@ -51,6 +51,7 @@ flow (PaymentSandbox& view,
     STPathSet const& paths,
     bool defaultPaths,
     bool partialPayment,
+    bool ownerPaysTransferFee,
     boost::optional<Quality> const& limitQuality,
     boost::optional<STAmount> const& sendMax,
     beast::Journal j);

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -121,6 +121,18 @@ public:
     }
 
     /**
+       If this step is a DirectStepI and the src redeems to the dst, return true,
+       otherwise return false.
+       If this step is a BookStep, return false if the owner pays the transfer fee,
+       otherwise return true.
+    */
+    virtual bool
+    redeems (ReadView const& sb, bool fwd) const
+    {
+        return false;
+    }
+
+    /**
        If this step is a BookStep, return the book.
     */
     virtual boost::optional<Book>
@@ -226,6 +238,7 @@ toStrand (
     Issue const& deliver,
     boost::optional<Issue> const& sendMaxIssue,
     STPath const& path,
+    bool ownerPaysTransferFee,
     beast::Journal j);
 
 /**
@@ -253,6 +266,7 @@ toStrands (ReadView const& sb,
     boost::optional<Issue> const& sendMax,
     STPathSet const& paths,
     bool addDefaultPath,
+    bool ownerPaysTransferFee,
     beast::Journal j);
 
 template <class TIn, class TOut, class TDerived>
@@ -338,6 +352,7 @@ struct StrandContext
     AccountID const strandDst;
     bool const isFirst;
     bool const isLast = false;
+    bool ownerPaysTransferFee;
     size_t const strandSize;
     // The previous step in the strand. Needed to check the no ripple constraint
     Step const* const prevStep = nullptr;
@@ -357,6 +372,7 @@ struct StrandContext
         AccountID strandSrc_,
         AccountID strandDst_,
         bool isLast_,
+        bool ownerPaysTransferFee_,
         std::array<boost::container::flat_set<Issue>, 2>& seenDirectIssues_,
         boost::container::flat_set<Issue>& seenBookOuts_,
         beast::Journal j);

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -138,7 +138,7 @@ flow (
                     limitStepOut = r.second;
 
                     if (strand[i]->dry (r.second) ||
-                        get<TInAmt> (r.first) != get<TInAmt> (*maxIn))
+                        get<TInAmt> (r.first) != *maxIn)
                     {
                         // Something is very wrong
                         // throwing out the sandbox can only increase liquidity

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -34,8 +34,8 @@ namespace ripple {
 NetClock::time_point const& flowV2SoTime ()
 {
     using namespace std::chrono_literals;
-    // Mon March 28, 2016 10:00:00am PST
-    static NetClock::time_point const soTime{512503200s};
+    // Wed May 25, 2016 10:00:00am PDT
+    static NetClock::time_point const soTime{517510800s};
     return soTime;
 }
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -40,6 +40,7 @@ extern uint256 const featureSusPay;
 extern uint256 const featureTrustSetAuth;
 extern uint256 const featureFeeEscalation;
 extern uint256 const featureFlowV2;
+extern uint256 const featureOwnerPaysFee;
 
 } // ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -51,5 +51,6 @@ uint256 const featureSusPay = feature("SusPay");
 uint256 const featureTrustSetAuth = feature("TrustSetAuth");
 uint256 const featureFeeEscalation = feature("FeeEscalation");
 uint256 const featureFlowV2 = feature("FlowV2");
+uint256 const featureOwnerPaysFee = feature("OwnerPaysFee");
 
 } // ripple


### PR DESCRIPTION
There are three major changes in this PR:

1) Transfer fees are only changed when transferring an IOU (an account redeems to a gateway and that gateway issues). Flow V2 was charging the transfer fee whenever an account issued, even when no IOU was transfered.

2) In an offer book, the offer owner pays the transfer fee, not the payment sender.

3) A strands output in the forward pass is limited by the amount requested in the reverse pass. Please review this commit carefully, as it mixes amounts from both the forward and reverse pass.

@scottschurr @nbougalis 