### PR TITLE
Change advisory delete interaction with acquire (RIPD-1112)

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -264,7 +264,6 @@ private:
     bool shouldAcquire(
         std::uint32_t const currentLedger,
         std::uint32_t const ledgerHistory,
-        std::uint32_t const ledgerHistoryIndex,
         std::uint32_t const candidateLedger) const;
 
     std::vector<std::shared_ptr<Ledger const>>

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1557,15 +1557,13 @@ bool
 LedgerMaster::shouldAcquire (
     std::uint32_t const currentLedger,
     std::uint32_t const ledgerHistory,
-    std::uint32_t const ledgerHistoryIndex,
     std::uint32_t const candidateLedger) const
 {
     // If the ledger could be the current ledger acquire it.
     // Otherwise, acquire it only if it's within our range of
-    // desired history and we wouldn't delete it if we had it.
+    // desired history
     bool ret = (candidateLedger >= currentLedger) ||
-        ((candidateLedger >= ledgerHistoryIndex) &&
-        ((currentLedger - candidateLedger) <= ledgerHistory));
+        ((currentLedger - candidateLedger) <= ledgerHistory);
 
     JLOG (m_journal.trace())
         << "Missing ledger "
@@ -1602,8 +1600,7 @@ void LedgerMaster::doAdvance ()
                 JLOG (m_journal.trace())
                     << "tryAdvance discovered missing " << missing;
                 if ((missing != RangeSet::absent) && (missing > 0) &&
-                    shouldAcquire (mValidLedgerSeq, ledger_history_,
-                        app_.getSHAMapStore ().getCanDelete (), missing) &&
+                    shouldAcquire (mValidLedgerSeq, ledger_history_, missing) &&
                     ((mFillInProgress == 0) || (missing > mFillInProgress)))
                 {
                     JLOG (m_journal.trace())

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -150,12 +150,16 @@ public:
         return setup_.advisoryDelete;
     }
 
+    // All ledgers prior to this one were deleted
+    // in the last rotation
     LedgerIndex
     getLastRotated() override
     {
         return state_db_.getState().lastRotated;
     }
 
+    // All ledgers after this are unprotected and online delete
+    // may delete them if appropriate
     LedgerIndex
     getCanDelete() override
     {


### PR DESCRIPTION
The previous commit addressing RIPD-1112 could interact with advisory delete and cause some history not to be acquired even configured to acquire.

This disconnects the advisory delete and historical ledger acquire logic. Advisory delete no longer affects which ledgers are acquired at all. There is no need to avoid acquiring ledgers we would have deleted, the online delete logic already takes that into account.

We need to make sure people (particularly OPs) understands that advisory delete will no longer affect acquire behavior. The previous RIPD-1112 patch disabled that behavior without fully realizing it. This interaction is what was causing the excessive history consumption and not fully understanding it was causing the lack of history fetching that resulted in this patch.