### PR TITLE
Add "seed" to JSONRPC unit tests (RIPD-1099):

### DIFF
--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -71,17 +71,17 @@ enum CommentPlacement
 class StaticString
 {
 public:
-    explicit StaticString ( const char* czstring )
+    constexpr explicit StaticString ( const char* czstring )
         : str_ ( czstring )
     {
     }
 
-    operator const char* () const
+    constexpr operator const char* () const
     {
         return str_;
     }
 
-    const char* c_str () const
+    constexpr const char* c_str () const
     {
         return str_;
     }

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -27,7 +27,7 @@ namespace jss {
 
 // JSON static strings
 
-#define JSS(x) const ::Json::StaticString x ( #x )
+#define JSS(x) constexpr ::Json::StaticString x ( #x )
 
 /* The "StaticString" field names are used instead of string literals to
    optimize the performance of accessing members of Json::Value objects.


### PR DESCRIPTION
There was a bug in version 0.30.1 where signing with an ed25519
key and a corrupt seed would cause the "sign" and "sign_for"
commands to return an unexpected error.  That bug was fixed in
the 0.31.0 release.

These unit tests verify the fix.  The error message for a corrupt
seed is also slightly improved.

Reviewers: @nbougalis, @ximinez