### PR TITLE
Stricter validation of JSON input (RIPD-1100):

### DIFF
--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -71,17 +71,17 @@ enum CommentPlacement
 class StaticString
 {
 public:
-    explicit StaticString ( const char* czstring )
+    constexpr explicit StaticString ( const char* czstring )
         : str_ ( czstring )
     {
     }
 
-    operator const char* () const
+    constexpr operator const char* () const
     {
         return str_;
     }
 
-    const char* c_str () const
+    constexpr const char* c_str () const
     {
         return str_;
     }

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -27,7 +27,7 @@ namespace jss {
 
 // JSON static strings
 
-#define JSS(x) const ::Json::StaticString x ( #x )
+#define JSS(x) constexpr ::Json::StaticString x ( #x )
 
 /* The "StaticString" field names are used instead of string literals to
    optimize the performance of accessing members of Json::Value objects.

--- a/src/ripple/rpc/KeypairForSignature.h
+++ b/src/ripple/rpc/KeypairForSignature.h
@@ -24,12 +24,14 @@
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/Seed.h>
+#include <boost/optional.hpp>
+#include <utility>
 
 namespace ripple {
 namespace RPC {
 
 boost::optional<Seed>
-getSeedFromRPC (Json::Value const& params);
+getSeedFromRPC (Json::Value const& params, Json::Value& error);
 
 std::pair<PublicKey, SecretKey>
 keypairForSignature (Json::Value const& params, Json::Value& error);

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -77,6 +77,12 @@ Json::Value walletPropose (Json::Value const& params)
 
     if (params.isMember (jss::key_type))
     {
+        if (! params[jss::key_type].isString())
+        {
+            return RPC::expected_field_error (
+                jss::key_type, "string");
+        }
+
         keyType = keyTypeFromString (
             params[jss::key_type].asString());
 
@@ -88,10 +94,10 @@ Json::Value walletPropose (Json::Value const& params)
         params.isMember (jss::seed) ||
         params.isMember (jss::seed_hex))
     {
-        seed = RPC::getSeedFromRPC (params);
-
+        Json::Value err;
+        seed = RPC::getSeedFromRPC (params, err);
         if (!seed)
-            return rpcError(rpcBAD_SEED);
+            return err;
     }
     else
     {

--- a/src/ripple/rpc/tests/JSONRPC.test.cpp
+++ b/src/ripple/rpc/tests/JSONRPC.test.cpp
@@ -575,8 +575,8 @@ R"({
     }
 })",
 {
-"Invalid field 'seed'.",
-"Invalid field 'seed'.",
+"Disallowed seed.",
+"Disallowed seed.",
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}},
 
@@ -929,9 +929,9 @@ R"({
     }
 })",
 {
-"Invalid field 'seed'.",
-"Invalid field 'seed'.",
-"Invalid field 'seed'.",
+"Disallowed seed.",
+"Disallowed seed.",
+"Disallowed seed.",
 "Missing field 'tx_json.Signers'."}},
 
 { "Missing 'Account' in sign_for.",


### PR DESCRIPTION
Passing in objects, arrays or non-string objects previously generated
nondescript errors. Improve the error messages returned to clients.

Add unit tests to ensure that incorrect inputs are reliably detected
and generate descriptive and accurate errors.

Reviews: @scottschurr, @mDuo13