### PR TITLE
Access base_uint through public members (RIPD-898):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1441,6 +1441,10 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\basics\TestSuite.h">
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\basics\tests\base_uint.test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\basics\tests\CheckLibraryVersions.test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -1923,6 +1923,9 @@
     <ClInclude Include="..\..\src\ripple\basics\TestSuite.h">
       <Filter>ripple\basics</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\ripple\basics\tests\base_uint.test.cpp">
+      <Filter>ripple\basics\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\basics\tests\CheckLibraryVersions.test.cpp">
       <Filter>ripple\basics\tests</Filter>
     </ClCompile>

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -50,17 +50,14 @@ class base_uint
     static_assert (Bits >= 64,
         "The length of a base_uint in bits must be at least 64.");
 
-    static_assert(sizeof(unsigned int) == 32 / CHAR_BIT,
-        "Expecting 32-bit unsigned ints");
-
 protected:
     enum { WIDTH = Bits / 32 };
 
     // This is really big-endian in byte order.
-    // We sometimes use unsigned int for speed.
+    // We sometimes use std::uint32_t for speed.
 
     // NIKB TODO: migrate to std::array
-    unsigned int pn[WIDTH];
+    std::uint32_t pn[WIDTH];
 
 public:
     //--------------------------------------------------------------------------
@@ -271,7 +268,7 @@ public:
     {
         for (int i = WIDTH - 1; i >= 0; --i)
         {
-            std::uint32_t prev = pn[i];
+            auto prev = pn[i];
             pn[i] = hostToBigend (bigendToHost (pn[i]) - 1);
 
             if (prev != 0)

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -50,6 +50,9 @@ class base_uint
     static_assert (Bits >= 64,
         "The length of a base_uint in bits must be at least 64.");
 
+    static_assert(sizeof(unsigned int) == 32 / CHAR_BIT,
+        "Expecting 32-bit unsigned ints");
+
 protected:
     enum { WIDTH = Bits / 32 };
 
@@ -320,6 +323,7 @@ public:
     {
         unsigned char* pOut  = begin ();
 
+        assert(sizeof(pn) == bytes);
         for (int i = 0; i < sizeof (pn); ++i)
         {
             auto hi = charUnHex(*psz++);
@@ -406,9 +410,9 @@ public:
         return SetHexExact (str.c_str ());
     }
 
-    unsigned int size () const
+    constexpr static std::size_t size ()
     {
-        return sizeof (pn);
+        return bytes;
     }
 
     base_uint<Bits, Tag>& operator=(Zero)

--- a/src/ripple/basics/tests/base_uint.test.cpp
+++ b/src/ripple/basics/tests/base_uint.test.cpp
@@ -1,0 +1,114 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/basics/base_uint.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/digest.h>
+
+namespace ripple {
+namespace test {
+
+struct base_uint_test : beast::unit_test::suite
+{
+    using test96 = base_uint<96>;
+
+    template<class bt>
+    void checkHash(bt const& t, std::string const& hash)
+    {
+        auto h = sha512Half(t);
+        expect(to_string(h) == hash);
+    }
+
+    void run()
+    {
+        Blob raw{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        expect(test96::bytes == raw.size());
+
+        test96 u(raw);
+        expect(raw.size() == u.size());
+        expect(to_string(u) == "0102030405060708090A0B0C");
+        expect(*u.data() == 1);
+        expect(u.signum() == 1);
+        expect(!!u);
+        expect(!u.isZero());
+        expect(u.isNonZero());
+        unsigned char t = 0;
+        for (auto& d : u)
+        {
+            expect(d == ++t);
+        }
+        checkHash(u, "25996DBE31A04FF03E4E63C9C647AC6D459475E2845529238F3D08F4A37EBC54");
+
+        test96 v(~u);
+        expect(to_string(v) == "FEFDFCFBFAF9F8F7F6F5F4F3");
+        expect(*v.data() == 0xfe);
+        expect(v.signum() == 1);
+        expect(!!v);
+        expect(!v.isZero());
+        expect(v.isNonZero());
+        t = 0xff;
+        for (auto& d : v)
+        {
+            expect(d == --t);
+        }
+        checkHash(v, "019A8C0B8307FD822A1346546200328DB40B4565793FD4799B83D780BDB634CE");
+
+        expect(compare(u, v) < 0);
+        expect(compare(v, u) > 0);
+
+        v = u;
+        expect(v == u);
+
+        test96 z(beast::zero);
+        expect(to_string(z) == "000000000000000000000000");
+        expect(*z.data() == 0);
+        expect(*z.begin() == 0);
+        expect(*std::prev(z.end(), 1) == 0);
+        expect(z.signum() == 0);
+        expect(!z);
+        expect(z.isZero());
+        expect(!z.isNonZero());
+        for (auto& d : z)
+        {
+            expect(d == 0);
+        }
+        checkHash(z, "666A9A1A7542E895A9F447D1C3E0FFD679BBF6346E0C43F5C7A733C46F5E56C2");
+
+        test96 n(z);
+        n++;
+        expect(n == test96(1));
+        n--;
+        expect(n == beast::zero);
+        expect(n == z);
+        n--;
+        expect(to_string(n) == "FFFFFFFFFFFFFFFFFFFFFFFF");
+        n = beast::zero;
+        expect(n == z);
+
+        auto hash = sha512Half(u, v, z, n);
+        expect(to_string(hash) ==
+            "55CAB39C72F2572057114B4732210605AA22C6E89243FBB5F9943130D813F902");
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(base_uint, ripple_basics, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/ripple/crypto/impl/GenerateDeterministicKey.cpp
+++ b/src/ripple/crypto/impl/GenerateDeterministicKey.cpp
@@ -95,7 +95,7 @@ static bignum generateRootDeterministicKey (uint128 const& seed)
         copy_uint32 (buf.begin() + 16, seq++);
         auto root = sha512Half(buf);
         std::fill (buf.begin(), buf.end(), 0); // security erase
-        privKey.assign ((unsigned char const*) &root, sizeof (root));
+        privKey.assign ((unsigned char const*)root.data(), root.size());
         root.zero(); // security erase
     }
     while (privKey.is_zero() || privKey >= secp256k1curve.order);
@@ -154,7 +154,7 @@ static bignum makeHash (Blob const& pubGen, int seq, bignum const& order)
         copy_uint32 (buf.begin() + 37, subSeq++);
         auto root = sha512Half_s(buf);
         std::fill(buf.begin(), buf.end(), 0); // security erase
-        result.assign ((unsigned char const*) &root, sizeof (root));
+        result.assign ((unsigned char const*)root.data(), root.size());
     }
     while (result.is_zero()  ||  result >= order);
 

--- a/src/ripple/crypto/impl/GenerateDeterministicKey.cpp
+++ b/src/ripple/crypto/impl/GenerateDeterministicKey.cpp
@@ -95,7 +95,7 @@ static bignum generateRootDeterministicKey (uint128 const& seed)
         copy_uint32 (buf.begin() + 16, seq++);
         auto root = sha512Half(buf);
         std::fill (buf.begin(), buf.end(), 0); // security erase
-        privKey.assign ((unsigned char const*)root.data(), root.size());
+        privKey.assign (root.data(), root.size());
         root.zero(); // security erase
     }
     while (privKey.is_zero() || privKey >= secp256k1curve.order);
@@ -154,7 +154,7 @@ static bignum makeHash (Blob const& pubGen, int seq, bignum const& order)
         copy_uint32 (buf.begin() + 37, subSeq++);
         auto root = sha512Half_s(buf);
         std::fill(buf.begin(), buf.end(), 0); // security erase
-        result.assign ((unsigned char const*)root.data(), root.size());
+        result.assign (root.data(), root.size());
     }
     while (result.is_zero()  ||  result >= order);
 

--- a/src/ripple/protocol/Serializer.h
+++ b/src/ripple/protocol/Serializer.h
@@ -107,6 +107,8 @@ public:
 
     int addVL (Blob const& vector);
     int addVL (Slice const& slice);
+    template<class FwdIt>
+    int addVL (FwdIt begin, FwdIt end, int len);
     int addVL (const void* ptr, int len);
 
     // disassemble functions
@@ -279,6 +281,20 @@ private:
     static int encodeLengthLength (int length); // length to encode length
     int addEncoded (int length);
 };
+
+template<class FwdIt>
+int Serializer::addVL(FwdIt begin, FwdIt end, int len)
+{
+    int ret = addEncoded(len);
+    if (len)
+        for (; begin != end; ++begin)
+        {
+            addRaw(begin->data(), begin->size());
+            len -= begin->size();
+        }
+    assert(len == 0);
+    return ret;
+}
 
 //------------------------------------------------------------------------------
 

--- a/src/ripple/protocol/Serializer.h
+++ b/src/ripple/protocol/Serializer.h
@@ -107,8 +107,8 @@ public:
 
     int addVL (Blob const& vector);
     int addVL (Slice const& slice);
-    template<class FwdIt>
-    int addVL (FwdIt begin, FwdIt end, int len);
+    template<class Iter>
+    int addVL (Iter begin, Iter end, int len);
     int addVL (const void* ptr, int len);
 
     // disassemble functions
@@ -282,16 +282,17 @@ private:
     int addEncoded (int length);
 };
 
-template<class FwdIt>
-int Serializer::addVL(FwdIt begin, FwdIt end, int len)
+template<class Iter>
+int Serializer::addVL(Iter begin, Iter end, int len)
 {
     int ret = addEncoded(len);
-    if (len)
-        for (; begin != end; ++begin)
-        {
-            addRaw(begin->data(), begin->size());
-            len -= begin->size();
-        }
+    for (; begin != end; ++begin)
+    {
+        addRaw(begin->data(), begin->size());
+#ifndef NDEBUG
+        len -= begin->size();
+#endif
+    }
     assert(len == 0);
     return ret;
 }

--- a/src/ripple/protocol/impl/AccountID.cpp
+++ b/src/ripple/protocol/impl/AccountID.cpp
@@ -147,7 +147,7 @@ calcAccountID (PublicKey const& pk)
     auto const d = static_cast<
         ripesha_hasher::result_type>(rsh);
     AccountID id;
-    static_assert(sizeof(d) == sizeof(id), "");
+    static_assert(sizeof(d) == id.size(), "");
     std::memcpy(id.data(), d.data(), d.size());
     return id;
 }

--- a/src/ripple/protocol/impl/STVector256.cpp
+++ b/src/ripple/protocol/impl/STVector256.cpp
@@ -48,7 +48,7 @@ STVector256::add (Serializer& s) const
 {
     assert (fName->isBinary ());
     assert (fName->fieldType == STI_VECTOR256);
-    s.addVL (mValue.empty () ? nullptr : mValue[0].begin (), mValue.size () * (256 / 8));
+    s.addVL (mValue.begin(), mValue.end(), mValue.size () * (256 / 8));
 }
 
 bool

--- a/src/ripple/protocol/tests/STObject.test.cpp
+++ b/src/ripple/protocol/tests/STObject.test.cpp
@@ -203,7 +203,7 @@ public:
             auto const& uints1 = object1.getFieldV256(sfTestV256);
             auto const& uints3 = object3.getFieldV256(sfTestV256);
 
-            expect(uints1 == uints3);
+            expect(uints1 == uints3, "STObject vector mismatch");
         }
     }
 

--- a/src/ripple/shamap/SHAMapTreeNode.h
+++ b/src/ripple/shamap/SHAMapTreeNode.h
@@ -147,7 +147,7 @@ class SHAMapInnerNodeV2;
 class SHAMapInnerNode
     : public SHAMapAbstractNode
 {
-    SHAMapHash                      mHashes[16];
+    std::array<SHAMapHash, 16>          mHashes;
     std::shared_ptr<SHAMapAbstractNode> mChildren[16];
     int                             mIsBranch = 0;
     std::uint32_t                   mFullBelowGen = 0;

--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -60,7 +60,7 @@ SHAMapInnerNodeV2::clone(std::uint32_t seq) const
     p->mHash = mHash;
     p->mIsBranch = mIsBranch;
     p->mFullBelowGen = mFullBelowGen;
-    std::memcpy(p->mHashes, mHashes, sizeof(mHashes));
+    p->mHashes = mHashes;
     p->common_ = common_;
     p->depth_ = depth_;
     std::unique_lock <std::mutex> lock(childLock);

--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -368,8 +368,8 @@ SHAMapInnerNode::updateHash()
         sha512_half_hasher h;
         using beast::hash_append;
         hash_append(h, HashPrefix::innerNode);
-        for (int i = 0; i < mHashes.size(); ++i)
-            hash_append(h, mHashes[i]);
+        for(auto const& hh : mHashes)
+            hash_append(h, hh);
         nh = static_cast<typename
             sha512_half_hasher::result_type>(h);
     }
@@ -441,8 +441,8 @@ SHAMapInnerNode::addRaw(Serializer& s, SHANodeFormat format) const
         {
             s.add32 (HashPrefix::innerNode);
 
-            for (int i = 0; i < mHashes.size(); ++i)
-                s.add256 (mHashes[i].as_uint256());
+            for (auto const& hh : mHashes)
+                s.add256 (hh.as_uint256());
         }
         else  // format == snfWIRE
         {
@@ -460,8 +460,8 @@ SHAMapInnerNode::addRaw(Serializer& s, SHANodeFormat format) const
             }
             else
             {
-                for (int i = 0; i < mHashes.size(); ++i)
-                    s.add256 (mHashes[i].as_uint256());
+                for (auto const& hh : mHashes)
+                    s.add256 (hh.as_uint256());
 
                 s.add8 (2);
             }

--- a/src/ripple/shamap/impl/SHAMapTreeNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapTreeNode.cpp
@@ -43,8 +43,7 @@ SHAMapInnerNode::clone(std::uint32_t seq) const
     p->mHash = mHash;
     p->mIsBranch = mIsBranch;
     p->mFullBelowGen = mFullBelowGen;
-    for (int i = 0; i < sizeof(mHashes) / sizeof(mHashes[0]); ++i)
-        p->mHashes[i] = mHashes[i];
+    p->mHashes = mHashes;
     std::unique_lock <std::mutex> lock(childLock);
     for (int i = 0; i < 16; ++i)
     {
@@ -369,7 +368,7 @@ SHAMapInnerNode::updateHash()
         sha512_half_hasher h;
         using beast::hash_append;
         hash_append(h, HashPrefix::innerNode);
-        for (int i = 0; i < sizeof(mHashes) / sizeof(mHashes[0]); ++i)
+        for (int i = 0; i < mHashes.size(); ++i)
             hash_append(h, mHashes[i]);
         nh = static_cast<typename
             sha512_half_hasher::result_type>(h);
@@ -442,7 +441,7 @@ SHAMapInnerNode::addRaw(Serializer& s, SHANodeFormat format) const
         {
             s.add32 (HashPrefix::innerNode);
 
-            for (int i = 0; i < 16; ++i)
+            for (int i = 0; i < mHashes.size(); ++i)
                 s.add256 (mHashes[i].as_uint256());
         }
         else  // format == snfWIRE
@@ -450,7 +449,7 @@ SHAMapInnerNode::addRaw(Serializer& s, SHANodeFormat format) const
             if (getBranchCount () < 12)
             {
                 // compressed node
-                for (int i = 0; i < 16; ++i)
+                for (int i = 0; i < mHashes.size(); ++i)
                     if (!isEmptyBranch (i))
                     {
                         s.add256 (mHashes[i].as_uint256());
@@ -461,7 +460,7 @@ SHAMapInnerNode::addRaw(Serializer& s, SHANodeFormat format) const
             }
             else
             {
-                for (int i = 0; i < 16; ++i)
+                for (int i = 0; i < mHashes.size(); ++i)
                     s.add256 (mHashes[i].as_uint256());
 
                 s.add8 (2);
@@ -610,7 +609,7 @@ std::string
 SHAMapInnerNode::getString(const SHAMapNodeID & id) const
 {
     std::string ret = SHAMapAbstractNode::getString(id);
-    for (int i = 0; i < 16; ++i)
+    for (int i = 0; i < mHashes.size(); ++i)
     {
         if (!isEmptyBranch (i))
         {

--- a/src/ripple/unity/basics.cpp
+++ b/src/ripple/unity/basics.cpp
@@ -36,6 +36,7 @@
 #include <ripple/basics/impl/Time.cpp>
 #include <ripple/basics/impl/UptimeTimer.cpp>
 
+#include <ripple/basics/tests/base_uint.test.cpp>
 #include <ripple/basics/tests/CheckLibraryVersions.test.cpp>
 #include <ripple/basics/tests/mulDiv.test.cpp>
 #include <ripple/basics/tests/contract.test.cpp>


### PR DESCRIPTION
* Updates many (but probably not all) locations that access base_uint private storage.
* More calls to access base_uint through members.
* Use an iterator to write Serializer collections.

I am not 100% confident that this is a complete solution, because we don't have 100% test coverage, and because `base_uint` is pretty ubiquitous, so I could have easily missed something vital. I didn't make any changes to the structure of `base_uint` itself, so there's no real risk of harm. However, there is an experimental branch at https://github.com/ximinez/rippled/commits/baseuint-x which replaces the `unsigned int[]` with a `std::unique_ptr<unsigned int[]>`, and still passes tests. That change isn't going anywhere - it's only to demonstrate that the automated tests still pass when `base_uint` is not structured as a POD type.

Reviewers: @vinniefalco, @seelabs 