### PR TITLE
Standalone mode always uses temp DB files (RIPD-1129):

### DIFF
--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -70,7 +70,7 @@ void OrderBookDB::setup(
     {
         // nothing to do
     }
-    else if (app_.config().RUN_STANDALONE)
+    else if (app_.config().standalone())
         update(ledger);
     else
         app_.getJobQueue().addJob(

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1433,7 +1433,7 @@ void LedgerConsensusImp::takeInitialPosition (
             SHAMapItem (tx.first->getTransactionID(), std::move (s)), true, false);
     }
 
-    if ((app_.config().RUN_STANDALONE || (mProposing && mHaveCorrectLCL))
+    if ((app_.config().standalone() || (mProposing && mHaveCorrectLCL))
             && ((mPreviousLedger->info().seq % 256) == 0))
     {
         // previous ledger was flag ledger, add pseudo-transactions

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -86,7 +86,7 @@ LedgerMaster::LedgerMaster (Application& app, Stopwatch& stopwatch,
     , mValidLedgerSign (0)
     , mValidLedgerSeq (0)
     , mBuildingLedgerSeq (0)
-    , standalone_ (app_.config().RUN_STANDALONE)
+    , standalone_ (app_.config().standalone())
     , fetch_depth_ (app_.getSHAMapStore ().clampFetchDepth (
         app_.config().FETCH_DEPTH))
     , ledger_history_ (app_.config().LEDGER_HISTORY)
@@ -209,7 +209,7 @@ LedgerMaster::setValidLedger(
 {
     std::vector <NetClock::time_point> times;
 
-    if (! app_.config().RUN_STANDALONE)
+    if (! standalone_)
     {
         times = app_.getValidations().getValidationTimes(
             l->info().hash);

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -466,7 +466,7 @@ public:
             logs_->journal("TaggedCache"))
 
         , m_networkOPs (make_NetworkOPs (*this, stopwatch(),
-            config_->RUN_STANDALONE, config_->NETWORK_QUORUM, config_->START_VALID,
+            config_->standalone(), config_->NETWORK_QUORUM, config_->START_VALID,
             *m_jobQueue, *m_ledgerMaster, *m_jobQueue,
             logs_->journal("NetworkOPs")))
 
@@ -882,7 +882,7 @@ public:
         {
             // VFALCO TODO Move all this into doSweep
 
-            if (! config_->RUN_STANDALONE)
+            if (! config_->standalone())
             {
                 boost::filesystem::space_info space =
                         boost::filesystem::space (config_->legacy ("database_path"));
@@ -951,7 +951,7 @@ private:
 void ApplicationImp::setup()
 {
     // VFALCO NOTE: 0 means use heuristics to determine the thread count.
-    m_jobQueue->setThreadCount (0, config_->RUN_STANDALONE);
+    m_jobQueue->setThreadCount (0, config_->standalone());
 
     // We want to intercept and wait for CTRL-C to terminate the process
     m_signals.add (SIGINT);
@@ -976,9 +976,9 @@ void ApplicationImp::setup()
             logs_->threshold (kDebug);
     }
 
-    logs_->silent (config_->SILENT);
+    logs_->silent (config_->silent());
 
-    if (!config_->RUN_STANDALONE)
+    if (!config_->standalone())
         timeKeeper_->run(config_->SNTP_SERVERS);
 
     if (!initSqliteDbs ())
@@ -998,8 +998,7 @@ void ApplicationImp::setup()
     mTxnDB->setupCheckpointing (m_jobQueue.get(), logs());
     mLedgerDB->setupCheckpointing (m_jobQueue.get(), logs());
 
-    if (!config_->RUN_STANDALONE)
-        updateTables ();
+    updateTables ();
 
     // Configure the amendments the server supports
     {
@@ -1049,7 +1048,7 @@ void ApplicationImp::setup()
     else if (startUp == Config::NETWORK)
     {
         // This should probably become the default once we have a stable network.
-        if (!config_->RUN_STANDALONE)
+        if (!config_->standalone())
             m_networkOPs->needNetworkLedger ();
 
         startGenesisLedger ();
@@ -1075,7 +1074,7 @@ void ApplicationImp::setup()
         Throw<std::exception>();
     }
 
-    if (validators_->size () == 0 && !config_->RUN_STANDALONE)
+    if (validators_->size () == 0 && !config_->standalone())
     {
         JLOG(m_journal.warn()) << "No validators are configured.";
     }
@@ -1095,7 +1094,7 @@ void ApplicationImp::setup()
     //             foolishly calls overlay(). When this is fixed we can
     //             move the instantiation inside a conditional:
     //
-    //             if (!config_.RUN_STANDALONE)
+    //             if (!config_.standalone())
     m_overlay = make_Overlay (*this, setup_Overlay(*config_), *m_jobQueue,
         *serverHandler_, *m_resourceManager, *m_resolver, get_io_service(),
         *config_);
@@ -1135,7 +1134,7 @@ void ApplicationImp::setup()
     //----------------------------------------------------------------------
 
     // Begin connecting to network.
-    if (!config_->RUN_STANDALONE)
+    if (!config_->standalone())
     {
         // Should this message be here, conceptually? In theory this sort
         // of message, if displayed, should be displayed from PeerFinder.
@@ -1167,7 +1166,7 @@ ApplicationImp::doStart()
 void
 ApplicationImp::run()
 {
-    if (!config_->RUN_STANDALONE)
+    if (!config_->standalone())
     {
         // VFALCO NOTE This seems unnecessary. If we properly refactor the load
         //             manager then the deadlock detector can just always be "armed"

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -122,7 +122,7 @@ void startServer (Application& app)
         {
             Json::Value const& jvCommand    = app.config().RPC_STARTUP[i];
 
-            if (!app.config().QUIET)
+            if (!app.config().quiet())
                 std::cerr << "Startup RPC: " << jvCommand << std::endl;
 
             Resource::Charge loadType = Resource::feeReferenceRPC;
@@ -133,7 +133,7 @@ void startServer (Application& app)
             Json::Value jvResult;
             RPC::doCommand (context, jvResult);
 
-            if (!app.config().QUIET)
+            if (!app.config().quiet())
                 std::cerr << "Result: " << jvResult << std::endl;
         }
     }
@@ -318,16 +318,8 @@ int run (int argc, char** argv)
             vm["conf"].as<std::string> () : std::string();
 
     // config file, quiet flag.
-    config->setup (configFile, bool (vm.count ("quiet")));
-
-    if (vm.count ("silent"))
-        config->SILENT = true;
-
-    if (vm.count ("standalone"))
-    {
-        config->RUN_STANDALONE = true;
-        config->LEDGER_HISTORY = 0;
-    }
+    config->setup (configFile, bool (vm.count ("quiet")),
+        bool(vm.count("silent")), bool(vm.count("standalone")));
 
     {
         // Stir any previously saved entropy into the pool:
@@ -456,7 +448,7 @@ int run (int argc, char** argv)
         if (!adjustDescriptorLimit(1024, logs->journal("Application")))
             return -1;
 
-        if (HaveSustain() && !vm.count ("fg") && !config->RUN_STANDALONE)
+        if (HaveSustain() && !vm.count ("fg") && !config->standalone())
         {
             auto const ret = DoSustain ();
 

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -804,7 +804,7 @@ setup_SHAMapStore (Config const& c)
 {
     SHAMapStore::Setup setup;
 
-    setup.standalone = c.RUN_STANDALONE;
+    setup.standalone = c.standalone();
 
     // Get existing settings and add some default values if not specified:
     setup.nodeDatabase = c.section (ConfigSection::nodeDatabase ());

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1214,7 +1214,7 @@ setup_TxQ(Config const& config)
     set(setup.zeroBaseFeeTransactionFeeLevel,
         "zero_basefee_transaction_feelevel", section);
 
-    setup.standAlone = config.RUN_STANDALONE;
+    setup.standAlone = config.standalone();
     return setup;
 }
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -98,10 +98,21 @@ private:
     void load ();
     beast::Journal j_;
 
-public:
-    bool doImport = false;
     bool QUIET = false;          // Minimize logging verbosity.
     bool SILENT = false;         // No output to console after startup.
+    /** Operate in stand-alone mode.
+
+        In stand alone mode:
+
+        - Peer connections are not attempted or accepted
+        - The ledger is not advanced automatically.
+        - If no ledger is loaded, the default ledger with the root
+          account is created.
+    */
+    bool                        RUN_STANDALONE = false;
+
+public:
+    bool doImport = false;
     bool ELB_SUPPORT = false;
 
     std::vector<std::string>    IPS;                    // Peer IPs from rippled.cfg.
@@ -125,17 +136,6 @@ public:
 
     // Network parameters
     int const                   TRANSACTION_FEE_BASE = 10;   // The number of fee units a reference transaction costs
-
-    /** Operate in stand-alone mode.
-
-        In stand alone mode:
-
-        - Peer connections are not attempted or accepted
-        - The ledger is not advanced automatically.
-        - If no ledger is loaded, the default ledger with the root
-          account is created.
-    */
-    bool                        RUN_STANDALONE = false;
 
     // Note: The following parameters do not relate to the UNL or trust at all
     std::size_t                 NETWORK_QUORUM = 0;         // Minimum number of nodes to consider the network present
@@ -188,7 +188,12 @@ public:
     Config() = default;
 
     int getSize (SizedItemName) const;
-    void setup (std::string const& strConf, bool bQuiet);
+    /* Be very careful to make sure these bool params
+        are in the right order. */
+    void setup (std::string const& strConf, bool bQuiet,
+        bool bSilent, bool bStandalone);
+    void setupControl (bool bQuiet,
+        bool bSilent, bool bStandalone);
 
     /**
      *  Load the conig from the contents of the sting.
@@ -196,6 +201,10 @@ public:
      *  @param fileContents String representing the config contents.
      */
     void loadFromString (std::string const& fileContents);
+
+    bool quiet() const { return QUIET; }
+    bool silent() const { return SILENT; }
+    bool standalone() const { return RUN_STANDALONE; }
 };
 
 } // ripple

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -62,7 +62,7 @@ DatabaseCon::Setup setup_DatabaseCon (Config const& c)
     DatabaseCon::Setup setup;
 
     setup.startUp = c.START_UP;
-    setup.standAlone = c.RUN_STANDALONE;
+    setup.standAlone = c.standalone();
     setup.dataDir = c.legacy ("database_path");
     if (!setup.standAlone && setup.dataDir.empty())
     {

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1208,7 +1208,7 @@ rpcClient(std::vector<std::string> const& args,
                         ? jvRequest["method"].asString () : args[0],
                     jvParams,                               // Parsed, execute.
                     setup.client.secure != 0,                // Use SSL
-                    config.QUIET,
+                    config.quiet(),
                     logs,
                     std::bind (RPCCallImp::callRPCHandler, &jvOutput,
                                std::placeholders::_1));

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -548,7 +548,7 @@ OverlayImpl::onPrepare()
     // if it's a private peer or we are running as standalone
     // automatic connections would defeat the purpose.
     config.autoConnect =
-        !app_.config().RUN_STANDALONE &&
+        !app_.config().standalone() &&
         !app_.config().PEER_PRIVATE;
     config.listeningPort = port;
     config.features = "";
@@ -591,7 +591,7 @@ OverlayImpl::onPrepare()
         });
 
     // Add the ips_fixed from the rippled.cfg file
-    if (! app_.config().RUN_STANDALONE && !app_.config().IPS_FIXED.empty ())
+    if (! app_.config().standalone() && !app_.config().IPS_FIXED.empty ())
     {
         m_resolver.resolve (app_.config().IPS_FIXED,
             [this](

--- a/src/ripple/rpc/handlers/Connect.cpp
+++ b/src/ripple/rpc/handlers/Connect.cpp
@@ -38,7 +38,7 @@ namespace ripple {
 Json::Value doConnect (RPC::Context& context)
 {
     auto lock = make_lock(context.app.getMasterMutex());
-    if (context.app.config().RUN_STANDALONE)
+    if (context.app.config().standalone())
         return "cannot connect in standalone mode";
 
     if (!context.params.isMember (jss::ip))

--- a/src/ripple/rpc/handlers/LedgerAccept.cpp
+++ b/src/ripple/rpc/handlers/LedgerAccept.cpp
@@ -36,7 +36,7 @@ Json::Value doLedgerAccept (RPC::Context& context)
     auto lock = make_lock(context.app.getMasterMutex());
     Json::Value jvResult;
 
-    if (!context.app.config().RUN_STANDALONE)
+    if (!context.app.config().standalone())
     {
         jvResult[jss::error] = "notStandAlone";
     }

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -60,7 +60,7 @@ Json::Value doRipplePathFind (RPC::Context& context)
     std::shared_ptr <ReadView const> lpLedger;
     Json::Value jvResult;
 
-    if (! context.app.config().RUN_STANDALONE &&
+    if (! context.app.config().standalone() &&
         ! context.params.isMember(jss::ledger) &&
         ! context.params.isMember(jss::ledger_index) &&
         ! context.params.isMember(jss::ledger_hash))

--- a/src/ripple/rpc/impl/LookupLedger.cpp
+++ b/src/ripple/rpc/impl/LookupLedger.cpp
@@ -93,7 +93,7 @@ Status ledgerFromRequest (T& ledger, Context& context)
             return {rpcLGR_NOT_FOUND, "ledgerNotFound"};
 
         if (ledger->info().seq > ledgerMaster.getValidLedgerIndex() &&
-            isValidatedOld(ledgerMaster, context.app.config().RUN_STANDALONE))
+            isValidatedOld(ledgerMaster, context.app.config().standalone()))
         {
             ledger.reset();
             return {rpcNO_NETWORK, "InsufficientNetworkMode"};
@@ -101,7 +101,7 @@ Status ledgerFromRequest (T& ledger, Context& context)
     }
     else
     {
-        if (isValidatedOld (ledgerMaster, context.app.config().RUN_STANDALONE))
+        if (isValidatedOld (ledgerMaster, context.app.config().standalone()))
             return {rpcNO_NETWORK, "InsufficientNetworkMode"};
 
         auto const index = indexValue.asString ();

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -150,7 +150,7 @@ error_code_i fillHandler (Context& context,
         return rpcNO_NETWORK;
     }
 
-    if (!context.app.config().RUN_STANDALONE &&
+    if (!context.app.config().standalone() &&
         handler->condition_ & NEEDS_CURRENT_LEDGER)
     {
         if (context.ledgerMaster.getValidatedLedgerAge () >

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -280,7 +280,7 @@ checkTxJsonFields (
     }
 
     // Check for current ledger.
-    if (verify && !config.RUN_STANDALONE &&
+    if (verify && !config.standalone() &&
         (validatedLedgerAge > Tuning::maxValidatedLedgerAge))
     {
         ret.first = rpcError (rpcNO_CURRENT);

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -770,7 +770,7 @@ parse_Ports (
         result.push_back(to_Port(parsed, log));
     }
 
-    if (config.RUN_STANDALONE)
+    if (config.standalone())
     {
         auto it = result.begin ();
 

--- a/src/ripple/test/jtx/impl/Env.cpp
+++ b/src/ripple/test/jtx/impl/Env.cpp
@@ -62,9 +62,7 @@ setupConfigForUnitTests (Config& cfg)
     cfg.overwrite (ConfigSection::nodeDatabase (), "path", "main");
     cfg.deprecatedClearSection (ConfigSection::importNodeDatabase ());
     cfg.legacy("database_path", "");
-    cfg.RUN_STANDALONE = true;
-    cfg.QUIET = true;
-    cfg.SILENT = true;
+    cfg.setupControl(true, true, true);
     cfg["server"].append("port_peer");
     cfg["port_peer"].set("ip", "127.0.0.1");
     cfg["port_peer"].set("port", "8080");


### PR DESCRIPTION
Reusing the closed commit, but using a much simpler solution. Will use temp folders in standalone mode if a path is not defined in the config. Will also update database tables regardless of mode, which does not seem to affect test runtime at all.

Reviewers: @nbougalis @sublimator (since he created the ticket)

