### PR TITLE
Get quorum and trusted master validator keys from validators.txt:

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -513,14 +513,6 @@
 #
 #
 #
-# [validation_quorum]
-#
-#   Sets the minimum number of trusted validations a ledger must have before
-#   the server considers it fully validated. Note that if you are validating,
-#   your validation counts.
-#
-#
-#
 # [ledger_history]
 #
 #   The number of past ledgers to acquire on server startup and the minimum to
@@ -562,29 +554,21 @@
 #
 #
 #
-# [validators]
-#
-#   List of the validation public keys of nodes to always accept as validators.
-#   A comment may, optionally, be associated with each entry, separated by
-#   whitespace from the validation public key.
-#
-#   Examples:
-#    n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5
-#    n9MqiExBcoG19UXwoLjBJnhsxEhAZMuWwJDRdkyDz1EkEkwzQTNt John Doe
-#
-#
-#
 # [validators_file]
 #
-#   Path to a file that contains the validation public keys of nodes to always
-#   accept as validators. A comment may, optionally, be associated with each
-#   entry, separated by whitespace from the validation public key.
+#   Path or name of a file that contains the validation public keys of nodes
+#   to always accept as validators as well as the minimum number of validators
+#   needed to accept consensus.
 #
-#   The contents of the file should include a [validators] entry, followed by
-#   a list of validation public keys of nodes to always accept as validators,
-#   one per line, optionally followed by a comment separated by whitespace:
+#   The contents of the file should include a [validators] and a
+#   [validation_quorum] entry. [validators] should be followed by
+#   a list of validation public keys of nodes, one per line, optionally
+#   followed by a comment separated by whitespace.
+#   [validation_quorum] should be followed by a number.
 #
-#   Specify the file by specifying its full path.
+#   Specify the file by its name or path.
+#   Unless an absolute path is specified, it will be considered relative to
+#   the folder in which the rippled.cfg file is located.
 #
 #   Examples:
 #    /home/ripple/validators.txt
@@ -597,6 +581,9 @@
 #    n9L81uNCaPgtUJfaHh89gmdvXKAmSt5Gdsw2g1iPWaPkAHW5Nm4C RL3
 #    n9KiYM9CgngLvtRCQHZwgC2gjpdaZcCcbt3VboxiNFcKuwFVujzS RL4
 #    n9LdgEtkmGB9E2h3K4Vp7iGUaKuq23Zr32ehxiU8FWY7xoxbWTSA RL5
+#
+#    [validation_quorum]
+#    3
 #
 #
 # [path_search]
@@ -987,22 +974,11 @@ pool.ntp.org
 [ips]
 r.ripple.com 51235
 
-# Public keys of the validators that this rippled instance trusts.  The latest
-# list of validators can be obtained from https://ripple.com/ripple.txt
-#
-# See also https://wiki.ripple.com/Ripple.txt
-#
-[validators]
-n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7    RL1
-n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj    RL2
-n9L81uNCaPgtUJfaHh89gmdvXKAmSt5Gdsw2g1iPWaPkAHW5Nm4C    RL3
-n9KiYM9CgngLvtRCQHZwgC2gjpdaZcCcbt3VboxiNFcKuwFVujzS    RL4
-n9LdgEtkmGB9E2h3K4Vp7iGUaKuq23Zr32ehxiU8FWY7xoxbWTSA    RL5
-
-# The number of validators rippled needs to accept a consensus.
-# Don't change this unless you know what you're doing.
-[validation_quorum]
-3
+# File containing validation quorum and trusted validator keys.
+# Unless an absolute path is specified, it will be considered relative to the
+# folder in which the rippled.cfg file is located.
+[validators_file]
+validators.txt
 
 # Turn down default logging to save disk space in the long run.
 # Valid values here are trace, debug, info, warning, error, and fatal

--- a/doc/validators-example.txt
+++ b/doc/validators-example.txt
@@ -8,20 +8,41 @@
 # Blank lines and lines starting with a '#' are ignored.
 # All other lines should be hankos or domain names.
 #
-# [validators]:
-#   List of nodes to accept as validators specified by public key or domain.
 #
-#   For domains, rippled will probe for https web servers at the specified
-#   domain in the following order: ripple.DOMAIN, www.DOMAIN, DOMAIN
 #
-#   Examples: redstem.com
-#             n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5
-#             n9MqiExBcoG19UXwoLjBJnhsxEhAZMuWwJDRdkyDz1EkEkwzQTNt John Doe
+# [validators]
+#
+#   List of the validation public keys of nodes to always accept as validators.
+#   A comment may, optionally, be associated with each entry, separated by
+#   whitespace from the validation public key.
+#
+#   The latest list of recommended validators can be obtained from
+#   https://ripple.com/ripple.txt
+#
+#   See also https://wiki.ripple.com/Ripple.txt
+#
+#   Examples:
+#    n9KorY8QtTdRx7TVDpwnG9NvyxsDwHUKUEeDLY3AkiGncVaSXZi5
+#    n9MqiExBcoG19UXwoLjBJnhsxEhAZMuWwJDRdkyDz1EkEkwzQTNt John Doe
+#
+#
+#
+# [validation_quorum]
+#
+#   Sets the minimum number of trusted validations a ledger must have before
+#   the server considers it fully validated. Note that if you are validating,
+#   your validation counts.
 #
 
+# Public keys of the validators that this rippled instance trusts.
 [validators]
 n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7 RL1
 n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj RL2
 n9L81uNCaPgtUJfaHh89gmdvXKAmSt5Gdsw2g1iPWaPkAHW5Nm4C RL3
 n9KiYM9CgngLvtRCQHZwgC2gjpdaZcCcbt3VboxiNFcKuwFVujzS RL4
 n9LdgEtkmGB9E2h3K4Vp7iGUaKuq23Zr32ehxiU8FWY7xoxbWTSA RL5
+
+# The number of validators rippled needs to accept a consensus.
+# Don't change this unless you know what you're doing.
+[validation_quorum]
+3

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -64,6 +64,8 @@ struct ConfigSection
 #define SECTION_VALIDATION_SEED         "validation_seed"
 #define SECTION_WEBSOCKET_PING_FREQ     "websocket_ping_frequency"
 #define SECTION_VALIDATORS              "validators"
+#define SECTION_VALIDATOR_KEYS          "validator_keys"
+#define SECTION_VALIDATION_MANIFEST     "validation_manifest"
 #define SECTION_VETO_AMENDMENTS         "veto_amendments"
 
 } // ripple

--- a/src/ripple/overlay/impl/Manifest.cpp
+++ b/src/ripple/overlay/impl/Manifest.cpp
@@ -420,13 +420,7 @@ void ManifestCache::load (
 
             if (trusted(mo->masterKey) || unl.trusted(mo->masterKey))
             {
-                auto const result = applyManifest (
-                    std::move(*mo), unl, journal);
-                if (result != ManifestDisposition::accepted)
-                {
-                    Throw<std::runtime_error> (
-                        "Trusted manifest in db was not accepted");
-                }
+                applyManifest (std::move(*mo), unl, journal);
             }
             else
             {

--- a/src/ripple/overlay/impl/Manifest.cpp
+++ b/src/ripple/overlay/impl/Manifest.cpp
@@ -198,6 +198,12 @@ ManifestCache::configManifest (
         Throw<std::runtime_error> ("Unverifiable manifest in config");
     }
 
+    // Trust our own master public key
+    if (!trusted(m.masterKey) && !unl.trusted (m.masterKey))
+    {
+        addTrustedKey (m.masterKey, "");
+    }
+
     auto const result = applyManifest (std::move(m), unl, journal);
 
     if (result != ManifestDisposition::accepted)
@@ -412,15 +418,21 @@ void ManifestCache::load (
                 Throw<std::runtime_error> ("Unverifiable manifest in db");
             }
 
-            // Remove master public key from permanent trusted key list
-            if (unl.trusted(mo->masterKey))
-                unl.removePermanentKey (mo->masterKey);
-
-            // add trusted key
-            map_[mo->masterKey];
-
-            // OK if not accepted (may have been loaded from the config file)
-            applyManifest (std::move(*mo), unl, journal);
+            if (trusted(mo->masterKey) || unl.trusted(mo->masterKey))
+            {
+                auto const result = applyManifest (
+                    std::move(*mo), unl, journal);
+                if (result != ManifestDisposition::accepted)
+                {
+                    Throw<std::runtime_error> (
+                        "Trusted manifest in db was not accepted");
+                }
+            }
+            else
+            {
+                JLOG(journal.info())
+                   << "Manifest in db is no longer trusted";
+            }
         }
         else
         {

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/core/ConfigSections.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
@@ -483,15 +484,15 @@ OverlayImpl::setupValidatorKeyManifests (BasicConfig const& config,
                                          DatabaseCon& db)
 {
     auto const loaded = manifestCache_.loadValidatorKeys (
-        config.section ("validator_keys"),
+        config.section (SECTION_VALIDATOR_KEYS),
         journal_);
 
     if (!loaded)
         Throw<std::runtime_error> (
-            "Unable to load keys from [validator_keys]");
+            "Unable to load keys from [" SECTION_VALIDATOR_KEYS "]");
 
     auto const validation_manifest =
-        config.section ("validation_manifest");
+        config.section (SECTION_VALIDATION_MANIFEST);
 
     if (! validation_manifest.lines().empty())
     {
@@ -513,7 +514,8 @@ OverlayImpl::setupValidatorKeyManifests (BasicConfig const& config,
     }
     else
     {
-        JLOG(journal_.debug()) << "No [validation_manifest] section in config";
+        JLOG(journal_.debug()) << "No [" SECTION_VALIDATION_MANIFEST <<
+            "] section in config";
     }
 
     manifestCache_.load (


### PR DESCRIPTION
* Remove [validators] and [validation_quorum] from rippled-example.cfg
* Add [validation_quorum] to validators-example.txt
* Do not require validators.txt to be a regular file
* Trust own master public key from configured manifest
* Do not load untrusted manifest public keys from database

Trusted validators are loaded from [validators] and [validator_keys]
sections from both rippled.cfg and validators.txt

Quorum is loaded from [validation_quorum] section in validators.txt
only if it is not configured in rippled.cfg

Reviewers: @ximinez @nbougalis 