### PR TITLE
[Trivial] Resolve warnings for boost 1.61 and gcc 6.1

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -457,7 +457,7 @@ def add_boost_and_protobuf(toolchain, env):
             os.path.join(BOOST_ROOT, 'stage', 'lib'),
             ])
         env['BOOST_ROOT'] = BOOST_ROOT
-        if toolchain == 'gcc':
+        if toolchain in ['gcc', 'clang']:
             env.Append(CCFLAGS=['-isystem' + env['BOOST_ROOT']])
         else:
             env.Append(CPPPATH=[

--- a/src/ripple/ledger/impl/TxMeta.cpp
+++ b/src/ripple/ledger/impl/TxMeta.cpp
@@ -170,7 +170,6 @@ TxMeta::getAffectedAccounts() const
 
 STObject& TxMeta::getAffectedNode (SLE::ref node, SField const& type)
 {
-    assert (&type);
     uint256 index = node->getIndex ();
     for (auto& n : mNodes)
     {


### PR DESCRIPTION
Add boost to system path when compiling with clang.
Remove check for null for a var that can never be null.

@HowardHinnant @miguelportilla 