### PR TITLE
Payment bug fixes

### DIFF
--- a/src/ripple/app/paths/Credit.cpp
+++ b/src/ripple/app/paths/Credit.cpp
@@ -83,15 +83,4 @@ STAmount creditBalance (
     return result;
 }
 
-IOUAmount
-creditBalance2 (
-    ReadView const& v,
-    AccountID const& acc,
-    AccountID const& iss,
-    Currency const& cur)
-{
-    return toAmount<IOUAmount> (creditBalance (v, acc, iss, cur));
-}
-
-
 } // ripple

--- a/src/ripple/app/paths/Credit.h
+++ b/src/ripple/app/paths/Credit.h
@@ -60,13 +60,6 @@ STAmount creditBalance (
     AccountID const& account,
     AccountID const& issuer,
     Currency const& currency);
-
-IOUAmount
-creditBalance2 (
-    ReadView const& v,
-    AccountID const& acc,
-    AccountID const& iss,
-    Currency const& cur);
 /** @} */
 
 } // ripple

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -291,6 +291,7 @@ TER RippleCalc::rippleCalculate ()
     boost::container::flat_set<uint256> unfundedOffersFromBestPaths;
 
     int iPass = 0;
+    auto const dcSwitch = dcSwitchover(view.info().parentCloseTime);
 
     while (resultCode == temUNCERTAIN)
     {
@@ -306,8 +307,12 @@ TER RippleCalc::rippleCalculate ()
             if (pathState->quality())
                 // Only do active paths.
             {
-                // If computing the only non-dry path, compute multi-quality.
-                multiQuality = ((pathStateList_.size () - iDry) == 1);
+                // If computing the only non-dry path, and not limiting quality,
+                // compute multi-quality.
+                multiQuality = dcSwitch
+                    ? !inputFlags.limitQuality &&
+                        ((pathStateList_.size () - iDry) == 1)
+                    : ((pathStateList_.size () - iDry) == 1);
 
                 // Update to current amount processed.
                 pathState->reset (actualAmountIn_, actualAmountOut_);

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -20,13 +20,16 @@
 #include <BeastConfig.h>
 #include <ripple/app/paths/cursor/RippleLiquidity.h>
 #include <ripple/basics/Log.h>
+#include <ripple/ledger/View.h>
 
 namespace ripple {
 namespace path {
 
-TER PathCursor::advanceNode (STAmount const& amount, bool reverse) const
+TER PathCursor::advanceNode (STAmount const& amount, bool reverse, bool callerHasLiquidity) const
 {
-    bool multi = multiQuality_ || amount == zero;
+    bool const multi = dcSwitchover (view ().info ().parentCloseTime)
+        ? (multiQuality_ || (!callerHasLiquidity && amount == zero))
+        : (multiQuality_ || amount == zero);
 
     // If the multiQuality_ is unchanged, use the PathCursor we're using now.
     if (multi == multiQuality_)

--- a/src/ripple/app/paths/cursor/DeliverNodeForward.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeForward.cpp
@@ -35,7 +35,8 @@ TER PathCursor::deliverNodeForward (
     AccountID const& uInAccountID,    // --> Input owner's account.
     STAmount const& saInReq,        // --> Amount to deliver.
     STAmount& saInAct,              // <-- Amount delivered, this invocation.
-    STAmount& saInFees) const       // <-- Fees charged, this invocation.
+    STAmount& saInFees,             // <-- Fees charged, this invocation.
+    bool callerHasLiquidity) const
 {
     TER resultCode   = tesSUCCESS;
 
@@ -66,7 +67,7 @@ TER PathCursor::deliverNodeForward (
 
         // Determine values for pass to adjust saInAct, saInFees, and
         // node().saFwdDeliver.
-        advanceNode (saInAct, false);
+        advanceNode (saInAct, false, callerHasLiquidity);
 
         // If needed, advance to next funded offer.
 
@@ -224,7 +225,8 @@ TER PathCursor::deliverNodeForward (
                     node().offerOwnerAccount_,  // --> Current holder.
                     saOutPassMax,             // --> Amount available.
                     saOutPassAct,             // <-- Amount delivered.
-                    saOutPassFees);           // <-- Fees charged.
+                    saOutPassFees,            // <-- Fees charged.
+                    saInAct > zero);
 
                 if (resultCode != tesSUCCESS)
                     break;

--- a/src/ripple/app/paths/cursor/ForwardLiquidity.cpp
+++ b/src/ripple/app/paths/cursor/ForwardLiquidity.cpp
@@ -42,7 +42,8 @@ TER PathCursor::forwardLiquidity () const
         previousNode().account_,
         previousNode().saFwdDeliver, // Previous is sending this much.
         saInAct,
-        saInFees);
+        saInFees,
+        false);
 
     assert (resultCode != tesSUCCESS ||
             previousNode().saFwdDeliver == saInAct + saInFees);

--- a/src/ripple/app/paths/cursor/PathCursor.h
+++ b/src/ripple/app/paths/cursor/PathCursor.h
@@ -79,7 +79,7 @@ private:
       <-- uOfferIndex : 0=end of list.
     */
     TER advanceNode (bool reverse) const;
-    TER advanceNode (STAmount const& amount, bool reverse) const;
+    TER advanceNode (STAmount const& amount, bool reverse, bool callerHasLiquidity) const;
 
     // To deliver from an order book, when computing
     TER deliverNodeReverse (
@@ -91,13 +91,15 @@ private:
     TER deliverNodeReverseImpl (
         AccountID const& uOutAccountID,
         STAmount const& saOutReq,
-        STAmount& saOutAct) const;
+        STAmount& saOutAct,
+        bool callerHasLiquidity) const;
 
     TER deliverNodeForward (
         AccountID const& uInAccountID,
         STAmount const& saInReq,
         STAmount& saInAct,
-        STAmount& saInFees) const;
+        STAmount& saInFees,
+        bool callerHasLiquidity) const;
 
     // VFALCO TODO Rename this to view()
     PaymentSandbox&

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -197,7 +197,8 @@ maxFlow (
     AccountID const& dst,
     Currency const& cur)
 {
-    auto const srcOwed = creditBalance2 (sb, dst, src, cur);
+    auto const srcOwed = toAmount<IOUAmount> (
+        accountHolds (sb, src, cur, dst, fhIGNORE_FREEZE, beast::Journal{}));
 
     if (srcOwed.signum () > 0)
         return {srcOwed, true};
@@ -211,7 +212,8 @@ DirectStepI::redeems (ReadView const& sb, bool fwd) const
 {
     if (!fwd)
     {
-        auto const srcOwed = creditBalance2 (sb, dst_, src_, currency_);
+        auto const srcOwed = accountHolds (
+            sb, src_, currency_, dst_, fhIGNORE_FREEZE, beast::Journal{});
         return srcOwed.signum () > 0;
     }
     else

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -204,6 +204,14 @@ public:
         STAmount const& preCreditBalance)
     {
     }
+
+    // Called when the owner count changes
+    // This is required to support PaymentSandbox
+    virtual
+    void adjustOwnerCountHook (AccountID const& account,
+        std::uint32_t cur, std::uint32_t next)
+    {};
+
 };
 
 } // ripple

--- a/src/ripple/ledger/PaymentSandbox.h
+++ b/src/ripple/ledger/PaymentSandbox.h
@@ -57,6 +57,16 @@ public:
         STAmount const& amount,
         STAmount const& preCreditSenderBalance);
 
+    void ownerCount (AccountID const& id,
+        std::uint32_t cur,
+            std::uint32_t next);
+
+    // Get the adjusted owner count. Since DeferredCredits is meant to be used
+    // in payments, and payments only decrease owner counts, return the max
+    // remembered owner count.
+    boost::optional<std::uint32_t>
+    ownerCount (AccountID const& id) const;
+
     void apply (DeferredCredits& to);
 private:
     // lowAccount, highAccount
@@ -75,7 +85,8 @@ private:
         AccountID const& a2,
             Currency const& c);
 
-    std::map<Key, Value> map_;
+    std::map<Key, Value> credits_;
+    std::map<AccountID, std::uint32_t> ownerCounts_;
 };
 
 } // detail
@@ -154,6 +165,15 @@ public:
         AccountID const& to,
             STAmount const& amount,
                 STAmount const& preCreditBalance) override;
+
+    void
+    adjustOwnerCountHook (AccountID const& account,
+        std::uint32_t cur,
+            std::uint32_t next) override;
+
+    std::uint32_t
+    ownerCountHook (AccountID const& account,
+        std::uint32_t count) const override;
 
     /** Apply changes to base view.
 

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -303,8 +303,11 @@ public:
     std::shared_ptr<SLE const>
     read (Keylet const& k) const = 0;
 
-    // Called to adjust returned balances
-    // This is required to support PaymentSandbox
+    // Accounts in a payment are not allowed to use assets acquired during that
+    // payment. The PaymentSandbox tracks the debits, credits, and owner count
+    // changes that accounts make during a payment. `balanceHook` adjusts balances
+    // so newly acquired assets are not counted toward the balance.
+    // This is required to support PaymentSandbox.
     virtual
     STAmount
     balanceHook (AccountID const& account,
@@ -312,6 +315,19 @@ public:
             STAmount const& amount) const
     {
         return amount;
+    }
+
+    // Accounts in a payment are not allowed to use assets acquired during that
+    // payment. The PaymentSandbox tracks the debits, credits, and owner count
+    // changes that accounts make during a payment. `ownerCountHook` adjusts the
+    // ownerCount so it returns the max value of the ownerCount so far.
+    // This is required to support PaymentSandbox.
+    virtual
+    std::uint32_t
+    ownerCountHook (AccountID const& account,
+        std::uint32_t count) const
+    {
+        return count;
     }
 
     // used by the implementation

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -331,6 +331,10 @@ transferXRP (ApplyView& view,
 NetClock::time_point const& flowV2SoTime ();
 bool flowV2Switchover (NetClock::time_point const closeTime);
 
+NetClock::time_point const& dcSoTime ();
+bool dcSwitchover (NetClock::time_point const closeTime);
+
+
 } // ripple
 
 #endif

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -44,6 +44,19 @@ bool flowV2Switchover (NetClock::time_point const closeTime)
     return closeTime > flowV2SoTime();
 }
 
+NetClock::time_point const& dcSoTime ()
+{
+    using namespace std::chrono_literals;
+    // Mon May 23, 2016 10:00:00am PDT
+    static NetClock::time_point const soTime{517338000s};
+    return soTime;
+}
+
+bool dcSwitchover (NetClock::time_point const closeTime)
+{
+    return closeTime > dcSoTime();
+}
+
 // VFALCO NOTE A copy of the other one for now
 /** Maximum number of entries in a directory page
     A change would be protocol-breaking.
@@ -121,51 +134,85 @@ accountHolds (ReadView const& view,
     if (isXRP(currency))
     {
         // XRP: return balance minus reserve
-        auto const sle = view.read(
-            keylet::account(account));
-        auto const reserve =
-            view.fees().accountReserve(
-                sle->getFieldU32(sfOwnerCount));
-        auto const balance =
-            sle->getFieldAmount(sfBalance).xrp ();
-        if (balance < reserve)
-            amount.clear ();
+        if (dcSwitchover (view.info ().parentCloseTime))
+        {
+            auto const sle = view.read(
+                keylet::account(account));
+            auto const ownerCount =
+                view.ownerCountHook (account, sle->getFieldU32 (sfOwnerCount));
+            auto const reserve =
+                    view.fees().accountReserve(ownerCount);
+
+            auto const fullBalance =
+                sle->getFieldAmount(sfBalance);
+
+            auto const balance = view.balanceHook(
+                account, issuer, fullBalance).xrp();
+
+            if (balance < reserve)
+                amount.clear ();
+            else
+                amount = balance - reserve;
+
+            JLOG (j.trace()) << "accountHolds:" <<
+                " account=" << to_string (account) <<
+                " amount=" << amount.getFullText () <<
+                " fullBalance=" << to_string (fullBalance.xrp()) <<
+                " balance=" << to_string (balance) <<
+                " reserve=" << to_string (reserve);
+
+            return amount;
+        }
         else
-            amount = balance - reserve;
-        JLOG (j.trace()) << "accountHolds:" <<
-            " account=" << to_string (account) <<
-            " amount=" << amount.getFullText () <<
-            " balance=" << to_string (balance) <<
-            " reserve=" << to_string (reserve);
+        {
+            // pre-switchover
+            // XRP: return balance minus reserve
+            auto const sle = view.read(
+                keylet::account(account));
+            auto const reserve =
+                    view.fees().accountReserve(
+                        sle->getFieldU32(sfOwnerCount));
+            auto const balance =
+                    sle->getFieldAmount(sfBalance).xrp ();
+            if (balance < reserve)
+                amount.clear ();
+            else
+                amount = balance - reserve;
+            JLOG (j.trace()) << "accountHolds:" <<
+                    " account=" << to_string (account) <<
+                    " amount=" << amount.getFullText () <<
+                    " balance=" << to_string (balance) <<
+                    " reserve=" << to_string (reserve);
+            return view.balanceHook(
+                account, issuer, amount);
+        }
+    }
+
+    // IOU: Return balance on trust line modulo freeze
+    auto const sle = view.read(keylet::line(
+        account, issuer, currency));
+    if (! sle)
+    {
+        amount.clear ({currency, issuer});
+    }
+    else if ((zeroIfFrozen == fhZERO_IF_FROZEN) &&
+        isFrozen(view, account, currency, issuer))
+    {
+        amount.clear (Issue (currency, issuer));
     }
     else
     {
-        // IOU: Return balance on trust line modulo freeze
-        auto const sle = view.read(keylet::line(
-            account, issuer, currency));
-        if (! sle)
+        amount = sle->getFieldAmount (sfBalance);
+        if (account > issuer)
         {
-            amount.clear ({currency, issuer});
+            // Put balance in account terms.
+            amount.negate();
         }
-        else if ((zeroIfFrozen == fhZERO_IF_FROZEN) &&
-            isFrozen(view, account, currency, issuer))
-        {
-            amount.clear (Issue (currency, issuer));
-        }
-        else
-        {
-            amount = sle->getFieldAmount (sfBalance);
-            if (account > issuer)
-            {
-                // Put balance in account terms.
-                amount.negate();
-            }
-            amount.setIssuer (issuer);
-        }
-        JLOG (j.trace()) << "accountHolds:" <<
-            " account=" << to_string (account) <<
-            " amount=" << amount.getFullText ();
+        amount.setIssuer (issuer);
     }
+    JLOG (j.trace()) << "accountHolds:" <<
+        " account=" << to_string (account) <<
+        " amount=" << amount.getFullText ();
 
     return view.balanceHook(
         account, issuer, amount);
@@ -609,13 +656,14 @@ adjustOwnerCount (ApplyView& view,
     auto const current =
         sle->getFieldU32 (sfOwnerCount);
     auto adjusted = current + amount;
+    AccountID const id = (*sle)[sfAccount];
     if (amount > 0)
     {
         // Overflow is well defined on unsigned
         if (adjusted < current)
         {
             JLOG (j.fatal()) <<
-                "Account " << sle->getAccountID(sfAccount) <<
+                "Account " << id <<
                 " owner count exceeds max!";
             adjusted =
                 std::numeric_limits<std::uint32_t>::max ();
@@ -627,12 +675,13 @@ adjustOwnerCount (ApplyView& view,
         if (adjusted > current)
         {
             JLOG (j.fatal()) <<
-                "Account " << sle->getAccountID (sfAccount) <<
+                "Account " << id <<
                 " owner count set below 0!";
             adjusted = 0;
             assert(false);
         }
     }
+    view.adjustOwnerCountHook (id, current, adjusted);
     sle->setFieldU32 (sfOwnerCount, adjusted);
     view.update(sle);
 }


### PR DESCRIPTION
This PR fixes three bugs in payments:

1) Owner count could decrease while evaluating a strand, causing different behavior in forward passes and reverses passes. The fix treats a decreased owner count like a deferred credit.

2) In some situations, deferred credits could cause an XRP balance to be calculated as negative, triggering some asserts.

3) When XRP is used as a bridge currency, a path could be falsely marked as dry. This happens when the XRP/XXX offer recursively checks the XXX/XRP offer and the XXX/XRP offer could not satisfy the request in a single call.

@scottschurr @nbougalis 