### PR TITLE
Improve websocket send performance (RIPD-1158)

### DIFF
--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -283,13 +283,11 @@ ServerHandlerImp::onWSMessage(
         {
             auto const jr =
                 this->processSession(session, jc, jv);
-            beast::streambuf sb;
-            Json::stream(jr,
-                [&sb](auto const p, auto const n)
-                {
-                    sb.commit(boost::asio::buffer_copy(
-                        sb.prepare(n), boost::asio::buffer(p, n)));
-                });
+            auto const s = to_string(jr);
+            auto const n = s.length();
+            beast::streambuf sb(n);
+            sb.commit(boost::asio::buffer_copy(
+                sb.prepare(n), boost::asio::buffer(s.c_str(), n)));
             session->send(std::make_shared<
                 StreambufWSMsg<decltype(sb)>>(std::move(sb)));
             session->complete();

--- a/src/ripple/server/impl/ServerHandlerImp.cpp
+++ b/src/ripple/server/impl/ServerHandlerImp.cpp
@@ -284,7 +284,7 @@ ServerHandlerImp::onWSMessage(
             auto const jr =
                 this->processSession(session, jc, jv);
             auto const s = to_string(jr);
-            auto const n = s.length();
+            auto const n = s.size();
             beast::streambuf sb(n);
             sb.commit(boost::asio::buffer_copy(
                 sb.prepare(n), boost::asio::buffer(s.c_str(), n)));


### PR DESCRIPTION
As per Nicholas's performance suggestion, replaced Json::stream with to_string and pre-allocated the streambuf.