### PR TITLE
[TRIVIAL] Use sys.exit() in Manifests.py to run as program

### DIFF
--- a/bin/python/Manifest.py
+++ b/bin/python/Manifest.py
@@ -4,4 +4,4 @@ import sys
 from ripple.util import Sign
 
 result = Sign.run_command(sys.argv[1:])
-exit(0 if result else -1)
+sys.exit(0 if result else -1)


### PR DESCRIPTION
Running `bin/python/Manifest.py` as a single-file executable (packaged with PyInstaller) currently errors with:
```
Traceback (most recent call last):
  File "Manifest.py", line 7, in <module>
NameError: name 'exit' is not defined
Failed to execute script Manifest
```
Using `sys.exit()` instead of `exit()` resolves the issue.
https://stackoverflow.com/questions/6501121/the-difference-between-exit-and-sys-exit-in-python

Reviewers: @mtrippled @seelabs 