### PR TITLE
RPC fee command checks open ledger rules (RIPD-1183):

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1151,6 +1151,7 @@ TxQ::doRPC(Application& app) const
 
     auto const view = app.openLedger().current();
     auto const metrics = getMetrics(app, *view);
+    assert(metrics);
     if (!metrics)
         return{};
 

--- a/src/ripple/app/tests/TxQ_test.cpp
+++ b/src/ripple/app/tests/TxQ_test.cpp
@@ -25,6 +25,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/mulDiv.h>
 #include <ripple/basics/TestSuite.h>
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/STTx.h>
@@ -1529,6 +1530,42 @@ public:
         }
     }
 
+    void testRPC()
+    {
+        using namespace jtx;
+        {
+            Env env(*this, features(featureFeeEscalation));
+
+            auto fee = env.rpc("fee");
+
+            if (expect(fee.isMember(jss::result) &&
+                !RPC::contains_error(fee[jss::result])))
+            {
+                auto const& result = fee[jss::result];
+                expect(result.isMember(jss::drops) &&
+                    result.isMember(jss::levels) &&
+                    result.isMember(jss::current_ledger_size) &&
+                    result.isMember(jss::current_queue_size) &&
+                    result.isMember(jss::expected_ledger_size));
+            }
+        }
+
+        {
+            Env env(*this);
+
+            auto fee = env.rpc("fee");
+
+            if(expect(fee.isMember(jss::result) &&
+                RPC::contains_error(fee[jss::result])))
+            {
+                auto const& result = fee[jss::result];
+                expect(result.isMember(jss::error) &&
+                    result[jss::error] ==
+                        RPC::get_error_info(rpcNOT_ENABLED).token);
+            }
+        }
+    }
+
     void run()
     {
         testQueue();
@@ -1546,6 +1583,7 @@ public:
         testBlockers();
         testInFlightBalance();
         testConsequences();
+        testRPC();
     }
 };
 

--- a/src/ripple/app/tests/TxQ_test.cpp
+++ b/src/ripple/app/tests/TxQ_test.cpp
@@ -1542,11 +1542,11 @@ public:
                 !RPC::contains_error(fee[jss::result])))
             {
                 auto const& result = fee[jss::result];
-                expect(result.isMember(jss::drops) &&
-                    result.isMember(jss::levels) &&
-                    result.isMember(jss::current_ledger_size) &&
-                    result.isMember(jss::current_queue_size) &&
-                    result.isMember(jss::expected_ledger_size));
+                expect(result.isMember(jss::drops));
+                expect(result.isMember(jss::levels));
+                expect(result.isMember(jss::current_ledger_size));
+                expect(result.isMember(jss::current_queue_size));
+                expect(result.isMember(jss::expected_ledger_size));
             }
         }
 

--- a/src/ripple/rpc/handlers/Fee1.cpp
+++ b/src/ripple/rpc/handlers/Fee1.cpp
@@ -31,9 +31,8 @@ namespace ripple
     {
         // Bail if fee escalation is not enabled.
         auto const view = context.app.openLedger().current();
-        if (!view || !view->rules().
-            enabled(featureFeeEscalation,
-                context.app.config().features))
+        if (!view || !view->rules().enabled(
+            featureFeeEscalation, context.app.config().features))
         {
             RPC::inject_error(rpcNOT_ENABLED, context.params);
             return context.params;


### PR DESCRIPTION
* Matches internal getMetric() to avoid races.

(Also a good chance to write more unit tests and increase code coverage a little bit.)

Reviewers: @vinniefalco @HowardHinnant 