### PR TITLE
Travis CI: Use clang 3.5 over 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ packages: &gcc5_pkgs
   - gdb
 
 packages: &clang36_pkgs
-  - clang-3.6
+  - clang-3.5
   - g++-5
   - python-software-properties
   - protobuf-compiler
@@ -50,14 +50,14 @@ matrix:
       addons: *ao_gcc5
 
     - compiler: clang
-      env: GCC_VER=5 TARGET=debug CLANG_VER=3.6
+      env: GCC_VER=5 TARGET=debug CLANG_VER=3.5
       addons: &ao_clang36
         apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
+          sources: ['ubuntu-toolchain-r-test']
           packages: *clang36_pkgs
 
     - compiler: clang
-      env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.6
+      env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.5
       addons: *ao_clang36
 
 cache:

--- a/bin/ci/ubuntu/install-dependencies.sh
+++ b/bin/ci/ubuntu/install-dependencies.sh
@@ -9,19 +9,22 @@ do
   test -x $( type -p ${g}-$GCC_VER )
   ln -sv $(type -p ${g}-$GCC_VER) $HOME/bin/${g}
 done
-for c in clang clang++
-do
+if [ -n "${CLANG_VER:-}" ]
+then
+  for c in clang clang++
+  do
     test -x $( type -p ${c}-$CLANG_VER )
     ln -sv $(type -p ${c}-$CLANG_VER) $HOME/bin/${c}
-done
-export PATH=$PWD/bin:$PATH
+  done
+fi
+export PATH=$HOME/bin:$PATH
 
 # What versions are we ACTUALLY running?
 if [ -x $HOME/bin/g++ ]; then
     $HOME/bin/g++ -v
 fi
-if [ -x $HOME/bin/clang ]; then
-    $HOME/bin/clang -v
+if [ -x "$(type -p clang)" ]; then
+    clang -v
 fi
 # Avoid `spurious errors` caused by ~/.npm permission issues
 # Does it already exist? Who owns? What permissions?

--- a/bin/ci/ubuntu/install-dependencies.sh
+++ b/bin/ci/ubuntu/install-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -u
 # Exit if anything fails.
-set -e
+set -ev
 # Override gcc version to $GCC_VER.
 # Put an appropriate symlink at the front of the path.
 mkdir -v $HOME/bin


### PR DESCRIPTION
Testing Travis CI before assigning to anyone.