### PR TITLE
Prefer paths with more liquidity when qualities are equal

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1049,6 +1049,8 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\app\paths\impl\FlowDebugInfo.h">
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\paths\impl\PaySteps.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -1524,6 +1524,9 @@
     <ClCompile Include="..\..\src\ripple\app\paths\impl\DirectStep.cpp">
       <Filter>ripple\app\paths\impl</Filter>
     </ClCompile>
+    <ClInclude Include="..\..\src\ripple\app\paths\impl\FlowDebugInfo.h">
+      <Filter>ripple\app\paths\impl</Filter>
+    </ClInclude>
     <ClCompile Include="..\..\src\ripple\app\paths\impl\PaySteps.cpp">
       <Filter>ripple\app\paths\impl</Filter>
     </ClCompile>

--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -65,7 +65,8 @@ flow (
     bool ownerPaysTransferFee,
     boost::optional<Quality> const& limitQuality,
     boost::optional<STAmount> const& sendMax,
-    beast::Journal j)
+    beast::Journal j,
+    path::detail::FlowDebugInfo* flowDebugInfo)
 {
     Issue const srcIssue = [&] {
         if (sendMax)
@@ -123,7 +124,7 @@ flow (
         return finishFlow (sb, srcIssue, dstIssue,
             flow<XRPAmount, XRPAmount> (
                 sb, strands, asDeliver.xrp, defaultPaths, partialPayment,
-                limitQuality, sendMax, j));
+                limitQuality, sendMax, j, flowDebugInfo));
     }
 
     if (srcIsXRP && !dstIsXRP)
@@ -131,7 +132,7 @@ flow (
         return finishFlow (sb, srcIssue, dstIssue,
             flow<XRPAmount, IOUAmount> (
                 sb, strands, asDeliver.iou, defaultPaths, partialPayment,
-                limitQuality, sendMax, j));
+                limitQuality, sendMax, j, flowDebugInfo));
     }
 
     if (!srcIsXRP && dstIsXRP)
@@ -139,14 +140,14 @@ flow (
         return finishFlow (sb, srcIssue, dstIssue,
             flow<IOUAmount, XRPAmount> (
                 sb, strands, asDeliver.xrp, defaultPaths, partialPayment,
-                limitQuality, sendMax, j));
+                limitQuality, sendMax, j, flowDebugInfo));
     }
 
     assert (!srcIsXRP && !dstIsXRP);
     return finishFlow (sb, srcIssue, dstIssue,
         flow<IOUAmount, IOUAmount> (
             sb, strands, asDeliver.iou, defaultPaths, partialPayment,
-            limitQuality, sendMax, j));
+            limitQuality, sendMax, j, flowDebugInfo));
 
 }
 

--- a/src/ripple/app/paths/Flow.h
+++ b/src/ripple/app/paths/Flow.h
@@ -27,6 +27,12 @@
 namespace ripple
 {
 
+namespace path {
+namespace detail{
+struct FlowDebugInfo;
+}
+}
+
 /**
   Make a payment from the src account to the dst account
 
@@ -54,7 +60,8 @@ flow (PaymentSandbox& view,
     bool ownerPaysTransferFee,
     boost::optional<Quality> const& limitQuality,
     boost::optional<STAmount> const& sendMax,
-    beast::Journal j);
+    beast::Journal j,
+    path::detail::FlowDebugInfo* flowDebugInfo=nullptr);
 
 }  // ripple
 

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -76,7 +76,6 @@ RippleCalc::Output RippleCalc::rippleCalculate (
         view.rules ().enabled (featureCompareFlowV1V2, config.features);
 
     bool const useFlowV1Output =
-        !flowV2Switchover (view.info ().parentCloseTime) &&
         !view.rules ().enabled (featureFlowV2, config.features);
     bool const callFlowV1 = useFlowV1Output || compareFlowV1V2;
     bool const callFlowV2 = !useFlowV1Output || compareFlowV1V2;
@@ -331,7 +330,7 @@ TER RippleCalc::rippleCalculate (detail::FlowDebugInfo* flowDebugInfo)
     boost::container::flat_set<uint256> unfundedOffersFromBestPaths;
 
     int iPass = 0;
-    auto const dcSwitch = dcSwitchover(view.info().parentCloseTime);
+    auto const dcSwitch = amendmentRIPD1141(view.info().parentCloseTime);
 
     while (resultCode == temUNCERTAIN)
     {

--- a/src/ripple/app/paths/RippleCalc.h
+++ b/src/ripple/app/paths/RippleCalc.h
@@ -32,6 +32,10 @@ namespace ripple {
 class Config;
 namespace path {
 
+namespace detail {
+struct FlowDebugInfo;
+}
+
 /** RippleCalc calculates the quality of a payment path.
 
     Quality is the amount of input required to produce a given output along a
@@ -145,7 +149,7 @@ private:
     }
 
     /** Compute liquidity through these path sets. */
-    TER rippleCalculate ();
+    TER rippleCalculate (detail::FlowDebugInfo* flowDebugInfo=nullptr);
 
     /** Add a single PathState.  Returns true on success.*/
     bool addPathState(STPath const&, TER&);

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -27,7 +27,7 @@ namespace path {
 
 TER PathCursor::advanceNode (STAmount const& amount, bool reverse, bool callerHasLiquidity) const
 {
-    bool const multi = dcSwitchover (view ().info ().parentCloseTime)
+    bool const multi = amendmentRIPD1141 (view ().info ().parentCloseTime)
         ? (multiQuality_ || (!callerHasLiquidity && amount == zero))
         : (multiQuality_ || amount == zero);
 

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -255,7 +255,7 @@ TER PathCursor::deliverNodeReverseImpl (
                 saInPassAct,
                 saOutAct > zero);
 
-            if (dcSwitchover(view().info().parentCloseTime))
+            if (amendmentRIPD1141(view().info().parentCloseTime))
             {
                 // The recursive call is dry this time, but we have liquidity
                 // from previous calls

--- a/src/ripple/app/paths/impl/AmountSpec.h
+++ b/src/ripple/app/paths/impl/AmountSpec.h
@@ -183,6 +183,15 @@ toAmountSpec (STAmount const& amt)
 }
 
 inline
+EitherAmount
+toEitherAmount (STAmount const& amt)
+{
+    if (isXRP (amt))
+        return EitherAmount{amt.xrp()};
+    return EitherAmount{amt.iou()};
+}
+
+inline
 AmountSpec
 toAmountSpec (
     EitherAmount const& ea,

--- a/src/ripple/app/paths/impl/FlowDebugInfo.h
+++ b/src/ripple/app/paths/impl/FlowDebugInfo.h
@@ -1,0 +1,372 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_PATH_IMPL_FLOWDEBUGINFO_H_INCLUDED
+#define RIPPLE_PATH_IMPL_FLOWDEBUGINFO_H_INCLUDED
+
+#include <ripple/app/paths/impl/AmountSpec.h>
+#include <ripple/ledger/PaymentSandbox.h>
+#include <ripple/protocol/IOUAmount.h>
+#include <ripple/protocol/XRPAmount.h>
+
+#include <boost/container/flat_map.hpp>
+#include <boost/optional.hpp>
+
+#include <chrono>
+#include <sstream>
+
+namespace ripple
+{
+namespace path
+{
+namespace detail
+{
+// Track performance information of a single payment
+struct FlowDebugInfo
+{
+    using clock = std::chrono::high_resolution_clock;
+    using time_point = clock::time_point;
+    boost::container::flat_map<std::string, std::pair<time_point, time_point>>
+        timePoints;
+    boost::container::flat_map<std::string, std::size_t> counts;
+
+    struct PassInfo
+    {
+        PassInfo () = delete;
+        PassInfo (bool nativeIn_, bool nativeOut_)
+            : nativeIn (nativeIn_), nativeOut (nativeOut_)
+        {
+        }
+        bool const nativeIn;
+        bool const nativeOut;
+        std::vector<EitherAmount> in;
+        std::vector<EitherAmount> out;
+        std::vector<size_t> numActive;
+
+        std::vector<std::vector<EitherAmount>> liquiditySrcIn;
+        std::vector<std::vector<EitherAmount>> liquiditySrcOut;
+
+        void
+        reserve (size_t s)
+        {
+            in.reserve (s);
+            out.reserve (s);
+            liquiditySrcIn.reserve(s);
+            liquiditySrcOut.reserve(s);
+            numActive.reserve (s);
+        }
+
+        size_t
+        size () const
+        {
+            return in.size ();
+        }
+
+        void
+        push_back (EitherAmount const& in_amt,
+            EitherAmount const& out_amt,
+            std::size_t active)
+        {
+            in.push_back (in_amt);
+            out.push_back (out_amt);
+            numActive.push_back (active);
+        }
+
+        void
+        pushLiquiditySrc (EitherAmount const& in, EitherAmount const& out)
+        {
+            assert(!liquiditySrcIn.empty());
+            liquiditySrcIn.back().push_back(in);
+            liquiditySrcOut.back().push_back(out);
+        }
+
+        void
+        newLiquidityPass()
+        {
+            auto const s = liquiditySrcIn.size();
+            size_t const r = !numActive.empty() ? numActive.back() : 16;
+            liquiditySrcIn.resize(s+1);
+            liquiditySrcIn.back().reserve(r);
+            liquiditySrcOut.resize(s+1);
+            liquiditySrcOut.back().reserve(r);
+        }
+    };
+
+    PassInfo passInfo;
+
+    FlowDebugInfo () = delete;
+    FlowDebugInfo (bool nativeIn, bool nativeOut)
+        : passInfo (nativeIn, nativeOut)
+    {
+        timePoints.reserve (16);
+        counts.reserve (16);
+        passInfo.reserve (64);
+    }
+
+    auto
+    duration (std::string const& tag) const
+    {
+        auto i = timePoints.find (tag);
+        if (i == timePoints.end ())
+        {
+            assert (0);
+            return std::chrono::duration<double>(0);
+        }
+        auto const& t = i->second;
+        return std::chrono::duration_cast<std::chrono::duration<double>> (
+            t.second - t.first);
+    }
+
+    std::size_t
+    count (std::string const& tag) const
+    {
+        auto i = counts.find (tag);
+        if (i == counts.end ())
+            return 0;
+        return i->second;
+    }
+
+    // Time the duration of the existence of the result
+    auto
+    timeBlock (std::string name)
+    {
+        struct Stopper
+        {
+            std::string tag;
+            FlowDebugInfo* info;
+            Stopper (std::string name, FlowDebugInfo& pi)
+                : tag (std::move (name)), info (&pi)
+            {
+                auto const start = FlowDebugInfo::clock::now ();
+                info->timePoints.emplace (tag, std::make_pair (start, start));
+            }
+            ~Stopper ()
+            {
+                auto const end = FlowDebugInfo::clock::now ();
+                info->timePoints[tag].second = end;
+            }
+        };
+        return Stopper (std::move (name), *this);
+    }
+
+    void
+    inc (std::string const& tag)
+    {
+        auto i = counts.find (tag);
+        if (i == counts.end ())
+        {
+            counts[tag] = 1;
+        }
+        ++i->second;
+    }
+
+    void
+    setCount (std::string const& tag, std::size_t c)
+    {
+        counts[tag] = c;
+    }
+
+    std::size_t
+    passCount () const
+    {
+        return passInfo.size ();
+    }
+
+    void
+    pushPass (EitherAmount const& in,
+        EitherAmount const& out,
+        std::size_t activeStrands)
+    {
+        passInfo.push_back (in, out, activeStrands);
+    }
+
+    void
+    pushLiquiditySrc (EitherAmount const& in, EitherAmount const& out)
+    {
+        passInfo.pushLiquiditySrc (in, out);
+    }
+
+    void
+    newLiquidityPass ()
+    {
+        passInfo.newLiquidityPass ();
+    }
+
+    std::string
+    to_string (bool writePassInfo) const
+    {
+        std::ostringstream ostr;
+
+        auto const d = duration ("main");
+
+        ostr << "duration: " << d.count () << ", pass_count: " << passCount ();
+
+        if (writePassInfo)
+        {
+            auto write_list = [&ostr](auto const& vals, auto&& fun, char delim=';') {
+                ostr << '[';
+                if (!vals.empty ())
+                {
+                    ostr << fun (vals[0]);
+                    for (size_t i = 1, e = vals.size (); i < e; ++i)
+                        ostr << delim << fun (vals[i]);
+                }
+                ostr << ']';
+            };
+            auto writeXrpAmtList = [&ostr, &write_list](
+                std::vector<EitherAmount> const& amts, char delim=';') {
+                auto get_val = [](EitherAmount const& a) -> std::string {
+                    return ripple::to_string (a.xrp);
+                };
+                write_list (amts, get_val, delim);
+            };
+            auto writeIouAmtList = [&ostr, &write_list](
+                std::vector<EitherAmount> const& amts, char delim=';') {
+                auto get_val = [](EitherAmount const& a) -> std::string {
+                    return ripple::to_string (a.iou);
+                };
+                write_list (amts, get_val, delim);
+            };
+            auto writeIntList = [&ostr, &write_list](
+                std::vector<size_t> const& vals, char delim=';') {
+                auto get_val = [](
+                    size_t const& v) -> size_t const& { return v; };
+                write_list (vals, get_val);
+            };
+            auto writeNestedIouAmtList = [&ostr, &writeIouAmtList](
+                std::vector<std::vector<EitherAmount>> const& amts) {
+                ostr << '[';
+                if (!amts.empty ())
+                {
+                    writeIouAmtList(amts[0], '|');
+                    for (size_t i = 1, e = amts.size (); i < e; ++i)
+                    {
+                        ostr << ';';
+                        writeIouAmtList(amts[i], '|');
+                    }
+                }
+                ostr << ']';
+            };
+            auto writeNestedXrpAmtList = [&ostr, &writeXrpAmtList](
+                std::vector<std::vector<EitherAmount>> const& amts) {
+                ostr << '[';
+                if (!amts.empty ())
+                {
+                    writeXrpAmtList(amts[0], '|');
+                    for (size_t i = 1, e = amts.size (); i < e; ++i)
+                    {
+                        ostr << ';';
+                        writeXrpAmtList(amts[i], '|');
+                    }
+                }
+                ostr << ']';
+            };
+
+            ostr << ", in_pass: ";
+            if (passInfo.nativeIn)
+                writeXrpAmtList (passInfo.in);
+            else
+                writeIouAmtList (passInfo.in);
+            ostr << ", out_pass: ";
+            if (passInfo.nativeOut)
+                writeXrpAmtList (passInfo.out);
+            else
+                writeIouAmtList (passInfo.out);
+            ostr << ", num_active: ";
+            writeIntList (passInfo.numActive);
+            if (!passInfo.liquiditySrcIn.empty () &&
+                !passInfo.liquiditySrcIn.back ().empty ())
+            {
+                ostr << ", l_src_in: ";
+                if (passInfo.nativeIn)
+                    writeNestedXrpAmtList (passInfo.liquiditySrcIn);
+                else
+                    writeNestedIouAmtList (passInfo.liquiditySrcIn);
+                ostr << ", l_src_out: ";
+                if (passInfo.nativeOut)
+                    writeNestedXrpAmtList (passInfo.liquiditySrcOut);
+                else
+                    writeNestedIouAmtList (passInfo.liquiditySrcOut);
+            }
+        }
+
+        return ostr.str ();
+    }
+};
+
+inline
+void
+writeDiffElement (std::ostringstream& ostr,
+    std::pair<std::tuple<AccountID, AccountID, Currency>, STAmount> const& elem)
+{
+    using namespace std;
+    auto const k = elem.first;
+    auto const v = elem.second;
+    ostr << '[' << get<0> (k) << '|' << get<1> (k) << '|' << get<2> (k) << '|'
+         << v << ']';
+};
+
+template<class Iter>
+void
+writeDiffs (std::ostringstream& ostr, Iter begin, Iter end)
+{
+    ostr << '[';
+    if (begin != end)
+    {
+        writeDiffElement (ostr, *begin);
+        ++begin;
+    }
+    for (; begin != end; ++begin)
+    {
+        ostr << ';';
+        writeDiffElement (ostr, *begin);
+    }
+    ostr << ']';
+};
+
+using BalanceDiffs = std::pair<
+    std::map<std::tuple<AccountID, AccountID, Currency>, STAmount>,
+    XRPAmount>;
+
+inline
+BalanceDiffs
+balanceDiffs(PaymentSandbox const& sb, ReadView const& rv)
+{
+    return {sb.balanceChanges (rv), sb.xrpDestroyed ()};
+}
+
+inline
+std::string
+balanceDiffsToString (boost::optional<BalanceDiffs> const& bd)
+{
+    if (!bd)
+        return std::string{};
+    auto const& diffs = bd->first;
+    auto const& xrpDestroyed = bd->second;
+    std::ostringstream ostr;
+    ostr << ", xrpDestroyed: " << to_string (xrpDestroyed);
+    ostr << ", balanceDiffs: ";
+    writeDiffs (ostr, diffs.begin (), diffs.end ());
+    return ostr.str ();
+};
+
+}  // detail
+}  // path
+}  // ripple
+#endif

--- a/src/ripple/app/paths/impl/PaySteps.cpp
+++ b/src/ripple/app/paths/impl/PaySteps.cpp
@@ -176,7 +176,9 @@ toStrand (
         STPathElement::typeAll, src, curIssue.currency, curIssue.account);
 
     boost::optional<STPathElement> sendMaxPE;
-    if (sendMaxIssue && sendMaxIssue->account != src)
+    if (sendMaxIssue && sendMaxIssue->account != src &&
+        (path.empty () || !path[0].isAccount () ||
+            path[0].getAccountID () != sendMaxIssue->account))
         sendMaxPE.emplace (sendMaxIssue->account, boost::none, boost::none);
 
     STPathElement const lastNode (dst, boost::none, boost::none);

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -468,7 +468,8 @@ flow (PaymentSandbox const& baseView,
 
             activeStrands.push (strand);
 
-            if (!best || q > best->quality)
+            if (!best || best->quality < q ||
+                (best->quality == q && best->out < f.out))
                 best.emplace (f.in, f.out, std::move (*f.sandbox), *strand, q);
         }
 

--- a/src/ripple/app/tests/Flow_test.cpp
+++ b/src/ripple/app/tests/Flow_test.cpp
@@ -913,7 +913,7 @@ struct Flow_test : public beast::unit_test::suite
         Account const bob ("bob");
         Account const carol ("carol");
 
-        auto const closeTime = dcSoTime() +
+        auto const closeTime = amendmentRIPD1141SoTime() +
                 100 * env.closed ()->info ().closeTimeResolution;
         env.close (closeTime);
 
@@ -977,30 +977,27 @@ struct Flow_test : public beast::unit_test::suite
 
         auto const timeDelta = Env{*this}.closed ()->info ().closeTimeResolution;
 
-        for(auto const& t :{dcSoTime(), flowV2SoTime()}){
-            for(auto const& d: {-timeDelta*100, +timeDelta*100}){
-                auto const closeTime = t+d;
-                Env env (*this);
-                env.close (closeTime);
+        for(auto const& d: {-timeDelta*100, +timeDelta*100}){
+            auto const closeTime = amendmentRIPD1141SoTime () + d;
+            Env env (*this);
+            env.close (closeTime);
 
-                env.fund (XRP(10000), alice, bob, carol, gw);
+            env.fund (XRP(10000), alice, bob, carol, gw);
 
-                env.trust (USD(100), alice, bob, carol);
-                env (pay (gw, bob, USD (100)));
-                env (offer (bob, XRP (50), USD (50)));
-                env (offer (bob, XRP (100), USD (50)));
+            env.trust (USD(100), alice, bob, carol);
+            env (pay (gw, bob, USD (100)));
+            env (offer (bob, XRP (50), USD (50)));
+            env (offer (bob, XRP (100), USD (50)));
 
-                auto expectedResult =
-                    closeTime < dcSoTime () ? tecPATH_DRY : tesSUCCESS;
-                env (pay (alice, carol, USD (100)), path (~USD), sendmax (XRP (100)),
-                    txflags (tfNoRippleDirect | tfPartialPayment | tfLimitQuality),
-                    ter (expectedResult));
+            auto expectedResult =
+                closeTime < amendmentRIPD1141SoTime () ? tecPATH_DRY : tesSUCCESS;
+            env (pay (alice, carol, USD (100)), path (~USD), sendmax (XRP (100)),
+                txflags (tfNoRippleDirect | tfPartialPayment | tfLimitQuality),
+                ter (expectedResult));
 
-                if (expectedResult == tesSUCCESS)
-                    env.require (balance (carol, USD (50)));
-            }
+            if (expectedResult == tesSUCCESS)
+                env.require (balance (carol, USD (50)));
         }
-
     }
 
     // Helper function that returns the reserve on an account based on
@@ -1045,7 +1042,7 @@ struct Flow_test : public beast::unit_test::suite
         Env env (*this, features (featureFlowV2));
 
         auto const closeTime =
-            flowV2SoTime () + 100 * env.closed ()->info ().closeTimeResolution;
+            amendmentRIPD1141SoTime () + 100 * env.closed ()->info ().closeTimeResolution;
         env.close (closeTime);
 
         env.fund (XRP (1000000), gw1, gw2);
@@ -1119,7 +1116,7 @@ struct Flow_test : public beast::unit_test::suite
         Env env (*this, features (featureFlowV2));
 
         auto const closeTime =
-            flowV2SoTime () + 100 * env.closed ()->info ().closeTimeResolution;
+            amendmentRIPD1141SoTime () + 100 * env.closed ()->info ().closeTimeResolution;
         env.close (closeTime);
 
         env.fund (XRP (1000000), gw1, gw2);

--- a/src/ripple/app/tests/Flow_test.cpp
+++ b/src/ripple/app/tests/Flow_test.cpp
@@ -363,6 +363,17 @@ struct Flow_test : public beast::unit_test::suite
             expect (r.first == tesSUCCESS);
             expect (equal (r.second, D{alice, gw, usdC}));
         }
+        {
+            // Check path with sendMax and node with correct sendMax already set
+            Env env (*this, features(featureFlowV2), features(featureOwnerPaysFee));
+            env.fund (XRP (10000), alice, bob, gw);
+            env.trust (USD (1000), alice, bob);
+            env.trust (EUR (1000), alice, bob);
+            env (pay (gw, alice, EUR (100)));
+            auto const path = STPath ({STPathElement (STPathElement::typeAll,
+                EUR.account, EUR.currency, EUR.account)});
+            test (env, USD, EUR.issue(), path, tesSUCCESS);
+        }
     }
     void testDirectStep ()
     {

--- a/src/ripple/ledger/PaymentSandbox.h
+++ b/src/ripple/ledger/PaymentSandbox.h
@@ -188,6 +188,15 @@ public:
     apply (PaymentSandbox& to);
     /** @} */
 
+    // Return a map of balance changes on trust lines. The low account is the
+    // first account in the key. If the two accounts are equal, the map contains
+    // the total changes in currency regardless of issuer. This is useful to get
+    // the total change in XRP balances.
+    std::map<std::tuple<AccountID, AccountID, Currency>, STAmount>
+    balanceChanges (ReadView const& view) const;
+
+    XRPAmount xrpDestroyed () const;
+
 private:
     detail::DeferredCredits tab_;
     PaymentSandbox const* ps_ = nullptr;

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -340,11 +340,11 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
-NetClock::time_point const& flowV2SoTime ();
-bool flowV2Switchover (NetClock::time_point const closeTime);
+NetClock::time_point const& amendmentRIPD1141SoTime ();
+bool amendmentRIPD1141 (NetClock::time_point const closeTime);
 
-NetClock::time_point const& dcSoTime ();
-bool dcSwitchover (NetClock::time_point const closeTime);
+NetClock::time_point const& amendmentRIPD1141SoTime ();
+bool amendmentRIPD1141 (NetClock::time_point const closeTime);
 
 
 } // ripple

--- a/src/ripple/ledger/detail/ApplyStateTable.h
+++ b/src/ripple/ledger/detail/ApplyStateTable.h
@@ -96,7 +96,7 @@ public:
             uint256 const& key,
             bool isDelete,
             std::shared_ptr <SLE const> const& before,
-            std::shared_ptr <SLE const> const& after)> const& func);
+            std::shared_ptr <SLE const> const& after)> const& func) const;
 
     void
     erase (ReadView const& base,
@@ -120,6 +120,12 @@ public:
 
     void
     destroyXRP (XRPAmount const& fee);
+
+    // For debugging
+    XRPAmount const& dropsDestroyed () const
+    {
+        return dropsDestroyed_;
+    }
 
 private:
     using Mods = hash_map<key_type,

--- a/src/ripple/ledger/impl/ApplyStateTable.cpp
+++ b/src/ripple/ledger/impl/ApplyStateTable.cpp
@@ -78,7 +78,7 @@ ApplyStateTable::visit (ReadView const& to,
         uint256 const& key,
         bool isDelete,
         std::shared_ptr <SLE const> const& before,
-        std::shared_ptr <SLE const> const& after)> const& func)
+        std::shared_ptr <SLE const> const& after)> const& func) const
 {
     for (auto& item : items_)
     {

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -18,9 +18,11 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/app/paths/impl/AmountSpec.h>
 #include <ripple/ledger/PaymentSandbox.h>
 #include <ripple/ledger/View.h>
-
+#include <ripple/protocol/SField.h>
+#include <ripple/protocol/STAccount.h>
 #include <boost/optional.hpp>
 
 #include <cassert>
@@ -258,6 +260,132 @@ PaymentSandbox::apply (PaymentSandbox& to)
     assert(ps_ == &to);
     items_.apply(to);
     tab_.apply(to.tab_);
+}
+
+std::map<std::tuple<AccountID, AccountID, Currency>, STAmount>
+PaymentSandbox::balanceChanges (ReadView const& view) const
+{
+    using key = std::tuple<AccountID, AccountID, Currency>;
+    // Map of delta trust lines. As a special case, when both ends of the trust
+    // line are the same currency, then it's delta currency for that issuer. To
+    // get the change in XRP balance, Account == root, issuer == root, currency == XRP
+    std::map<key, STAmount> result;
+
+    // populate a dictionary with low/high/currency/delta. This can be
+    // compared with the other versions payment code.
+    auto each = [&result](uint256 const& key, bool isDelete,
+        std::shared_ptr<SLE const> const& before,
+        std::shared_ptr<SLE const> const& after) {
+
+        STAmount oldBalance;
+        STAmount newBalance;
+        AccountID lowID;
+        AccountID highID;
+
+        // before is read from prev view
+        if (isDelete)
+        {
+            if (!before)
+                return;
+
+            auto const bt = before->getType ();
+            switch(bt)
+            {
+                case ltACCOUNT_ROOT:
+                    lowID = xrpAccount();
+                    highID = (*before)[sfAccount];
+                    oldBalance = (*before)[sfBalance];
+                    newBalance = oldBalance.zeroed();
+                    break;
+                case ltRIPPLE_STATE:
+                    lowID = (*before)[sfLowLimit].getIssuer();
+                    highID = (*before)[sfHighLimit].getIssuer();
+                    oldBalance = (*before)[sfBalance];
+                    newBalance = oldBalance.zeroed();
+                    break;
+                case ltOFFER:
+                    // TBD
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (!before)
+        {
+            // insert
+            auto const at = after->getType ();
+            switch(at)
+            {
+                case ltACCOUNT_ROOT:
+                    lowID = xrpAccount();
+                    highID = (*after)[sfAccount];
+                    newBalance = (*after)[sfBalance];
+                    oldBalance = newBalance.zeroed();
+                    break;
+                case ltRIPPLE_STATE:
+                    lowID = (*after)[sfLowLimit].getIssuer();
+                    highID = (*after)[sfHighLimit].getIssuer();
+                    newBalance = (*after)[sfBalance];
+                    oldBalance = newBalance.zeroed();
+                    break;
+                case ltOFFER:
+                    // TBD
+                    break;
+                default:
+                    break;
+            }
+        }
+        else
+        {
+            // modify
+            auto const at = after->getType ();
+            assert (at == before->getType ());
+            switch(at)
+            {
+                case ltACCOUNT_ROOT:
+                    lowID = xrpAccount();
+                    highID = (*after)[sfAccount];
+                    oldBalance = (*before)[sfBalance];
+                    newBalance = (*after)[sfBalance];
+                    break;
+                case ltRIPPLE_STATE:
+                    lowID = (*after)[sfLowLimit].getIssuer();
+                    highID = (*after)[sfHighLimit].getIssuer();
+                    oldBalance = (*before)[sfBalance];
+                    newBalance = (*after)[sfBalance];
+                    break;
+                case ltOFFER:
+                    // TBD
+                    break;
+                default:
+                    break;
+            }
+        }
+        // The following are now set, put them in the map
+        auto delta = newBalance - oldBalance;
+        auto const cur = newBalance.getCurrency();
+        result[std::make_tuple(lowID, highID, cur)] = delta;
+        auto r = result.emplace(std::make_tuple(lowID, lowID, cur), delta);
+        if (r.second)
+        {
+            r.first->second += delta;
+        }
+
+        delta.negate();
+        r = result.emplace(std::make_tuple(highID, highID, cur), delta);
+        if (r.second)
+        {
+            r.first->second += delta;
+        }
+    };
+    items_.visit (view, each);
+    return result;
+}
+
+XRPAmount PaymentSandbox::xrpDestroyed () const
+{
+    return items_.dropsDestroyed ();
 }
 
 }  // ripple

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -179,7 +179,7 @@ PaymentSandbox::balanceHook (AccountID const& account,
     */
 
     auto const currency = amount.getCurrency ();
-    auto const switchover = flowV2Switchover (info ().parentCloseTime);
+    auto const switchover = amendmentRIPD1141 (info ().parentCloseTime);
 
     auto adjustedAmt = amount;
     if (switchover)

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -31,7 +31,7 @@
 
 namespace ripple {
 
-NetClock::time_point const& flowV2SoTime ()
+NetClock::time_point const& amendmentRIPD1141SoTime ()
 {
     using namespace std::chrono_literals;
     // Wed May 26, 2016 07:00:00am PDT
@@ -39,22 +39,9 @@ NetClock::time_point const& flowV2SoTime ()
     return soTime;
 }
 
-bool flowV2Switchover (NetClock::time_point const closeTime)
+bool amendmentRIPD1141 (NetClock::time_point const closeTime)
 {
-    return closeTime > flowV2SoTime();
-}
-
-NetClock::time_point const& dcSoTime ()
-{
-    using namespace std::chrono_literals;
-    // Mon May 23, 2016 10:00:00am PDT
-    static NetClock::time_point const soTime{517338000s};
-    return soTime;
-}
-
-bool dcSwitchover (NetClock::time_point const closeTime)
-{
-    return closeTime > dcSoTime();
+    return closeTime > amendmentRIPD1141SoTime();
 }
 
 // VFALCO NOTE A copy of the other one for now
@@ -134,7 +121,7 @@ accountHolds (ReadView const& view,
     if (isXRP(currency))
     {
         // XRP: return balance minus reserve
-        if (dcSwitchover (view.info ().parentCloseTime))
+        if (amendmentRIPD1141 (view.info ().parentCloseTime))
         {
             auto const sle = view.read(
                 keylet::account(account));
@@ -1429,7 +1416,7 @@ rippleSend (ApplyView& view,
 
     // Calculate the amount to transfer accounting
     // for any transfer fees:
-    if (!flowV2Switchover (view.info ().parentCloseTime))
+    if (!amendmentRIPD1141 (view.info ().parentCloseTime))
     {
         STAmount const saTransitFee = rippleTransferFee (
             view, uSenderID, uReceiverID, issuer, saAmount, j);
@@ -1485,7 +1472,7 @@ accountSend (ApplyView& view,
         return rippleSend (view, uSenderID, uReceiverID, saAmount, saActual, j);
     }
 
-    auto const fv2Switch = flowV2Switchover (view.info ().parentCloseTime);
+    auto const fv2Switch = amendmentRIPD1141 (view.info ().parentCloseTime);
     if (!fv2Switch)
     {
         auto const dummyBalance = saAmount.zeroed();

--- a/src/ripple/ledger/tests/PaymentSandbox_test.cpp
+++ b/src/ripple/ledger/tests/PaymentSandbox_test.cpp
@@ -280,12 +280,12 @@ class PaymentSandbox_test : public beast::unit_test::suite
         for (auto timeDelta : {-env.closed ()->info ().closeTimeResolution,
                  env.closed ()->info ().closeTimeResolution})
         {
-            auto const closeTime = flowV2SoTime () + timeDelta;
+            auto const closeTime = amendmentRIPD1141SoTime () + timeDelta;
             env.close (closeTime);
             ApplyViewImpl av (&*env.current (), tapNONE);
             PaymentSandbox pv (&av);
             pv.creditHook (gw, alice, hugeAmt, -tinyAmt);
-            if (closeTime > flowV2SoTime ())
+            if (closeTime > amendmentRIPD1141SoTime ())
                 expect (pv.balanceHook (alice, gw, hugeAmt) == tinyAmt);
             else
                 expect (pv.balanceHook (alice, gw, hugeAmt) != tinyAmt);
@@ -315,7 +315,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
         Account const alice ("alice");
         env.fund (reserve(env, 1), alice);
 
-        auto const closeTime = dcSoTime () +
+        auto const closeTime = amendmentRIPD1141SoTime () +
                 100 * env.closed ()->info ().closeTimeResolution;
         env.close (closeTime);
         ApplyViewImpl av (&*env.current (), tapNONE);

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -41,6 +41,7 @@ extern uint256 const featureTrustSetAuth;
 extern uint256 const featureFeeEscalation;
 extern uint256 const featureFlowV2;
 extern uint256 const featureOwnerPaysFee;
+extern uint256 const featureCompareFlowV1V2;
 
 } // ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -52,5 +52,6 @@ uint256 const featureTrustSetAuth = feature("TrustSetAuth");
 uint256 const featureFeeEscalation = feature("FeeEscalation");
 uint256 const featureFlowV2 = feature("FlowV2");
 uint256 const featureOwnerPaysFee = feature("OwnerPaysFee");
+uint256 const featureCompareFlowV1V2 = feature("CompareFlowV1V2");
 
 } // ripple


### PR DESCRIPTION
This PR has three changes:

1) When evaluating path qualities in flow V2, prefer paths with more liquidity when qualities are equal.

2) Added debugging probes that help me compare flow v1 and flow v2 differences. I intend to take out these debugging probes when we remove flow v1. I also added a feature to enable these comparisons, so they are off by default

3) I took flow V2 off a date switch, it will be enabled with an amendment only