### PR TITLE
Travis CI: Allow clang builds to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,12 @@ matrix:
       env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.6
       addons: *ao_clang36
 
+  # Temporary workaround while the llvm apt repository is down.
+  # TODO: REMOVE THIS if/when clang builds become reliable again.
+  allow_failures:
+    - env: GCC_VER=5 TARGET=debug CLANG_VER=3.6
+    - env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.6
+
 cache:
   directories:
   - $BOOST_ROOT


### PR DESCRIPTION
I want to emphasise that this does _not_ fix the ongoing issue with llvm's apt repos being unavailable. The CI clang builds will still fail. This change merely a *workaround* that allows the overall Travis job to succeed despite that. If/when clang builds become (relatively) reliable again, we should probably revert this commit.