### PR TITLE
Sign-and-submit: Test escalated fee autofill (RIPD-1188)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3615,6 +3615,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\jtx\impl\signandsubmit.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\test\jtx\impl\tag.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -3668,6 +3672,8 @@
     <ClInclude Include="..\..\src\ripple\test\jtx\seq.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\sig.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\signandsubmit.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\tag.h">
     </ClInclude>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -4071,6 +4071,9 @@
     <ClCompile Include="..\..\src\ripple\test\jtx\impl\sig.cpp">
       <Filter>ripple\test\jtx\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\test\jtx\impl\signandsubmit.cpp">
+      <Filter>ripple\test\jtx\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\test\jtx\impl\tag.cpp">
       <Filter>ripple\test\jtx\impl</Filter>
     </ClCompile>
@@ -4135,6 +4138,9 @@
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\sig.h">
+      <Filter>ripple\test\jtx</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\test\jtx\signandsubmit.h">
       <Filter>ripple\test\jtx</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\test\jtx\tag.h">

--- a/src/ripple/test/jtx.h
+++ b/src/ripple/test/jtx.h
@@ -47,6 +47,7 @@
 #include <ripple/test/jtx/sendmax.h>
 #include <ripple/test/jtx/seq.h>
 #include <ripple/test/jtx/sig.h>
+#include <ripple/test/jtx/signandsubmit.h>
 #include <ripple/test/jtx/tag.h>
 #include <ripple/test/jtx/tags.h>
 #include <ripple/test/jtx/ter.h>

--- a/src/ripple/test/jtx/Env.h
+++ b/src/ripple/test/jtx/Env.h
@@ -351,7 +351,12 @@ public:
         JTx jt(std::forward<JsonValue>(jv));
         invoke(jt, fN...);
         autofill(jt);
-        jt.stx = st(jt);
+        /* If the JTx is using sign_and_submit, chances are
+        it is not complete, and the STTx will fail anyway,
+        so save the effort.
+        */
+        if (!jt.sign_and_submit)
+            jt.stx = st(jt);
         return jt;
     }
 
@@ -432,6 +437,20 @@ public:
     */
     std::shared_ptr<STObject const>
     meta();
+
+    /** Return the tx data for the last JTx.
+
+        Effects:
+
+            The tx data for the last transaction
+            ID, if any, is returned. No side
+            effects.
+
+        @note Only necessary for JTx submitted
+            with the signandsubmit() funclet.
+    */
+    std::shared_ptr<STTx const>
+    tx();
 
 private:
     void

--- a/src/ripple/test/jtx/JTx.h
+++ b/src/ripple/test/jtx/JTx.h
@@ -46,6 +46,7 @@ struct JTx
     bool fill_fee = true;
     bool fill_seq = true;
     bool fill_sig = true;
+    Json::Value sign_and_submit;
     std::shared_ptr<STTx const> stx;
     std::function<void(Env&, JTx&)> signer;
 

--- a/src/ripple/test/jtx/impl/Env_test.cpp
+++ b/src/ripple/test/jtx/impl/Env_test.cpp
@@ -22,6 +22,7 @@
 #include <ripple/test/jtx.h>
 #include <ripple/json/to_string.h>
 #include <ripple/protocol/Feature.h>
+#include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/beast/hash/uhash.h>
 #include <ripple/beast/unit_test.h>
@@ -578,6 +579,54 @@ public:
         env (jt);
     }
 
+    void testSignAndSubmit()
+    {
+        using namespace jtx;
+        Env env(*this);
+
+        auto const alice = Account("alice");
+        env.fund(XRP(10000), alice);
+
+        {
+            env(noop(alice), fee(none), seq(none), signandsubmit());
+
+            // Make sure we get the right account back.
+            auto tx = env.tx();
+            if (expect(tx))
+            {
+                expect(tx->getAccountID(sfAccount) == alice.id());
+                expect(tx->getTxnType() == ttACCOUNT_SET);
+            }
+        }
+
+        {
+            auto params = Json::Value("ignored");
+            env(noop(alice), fee(none), seq(none),
+                signandsubmit(params));
+
+            // Make sure we get the right account back.
+            auto tx = env.tx();
+            if (expect(tx))
+            {
+                expect(tx->getAccountID(sfAccount) == alice.id());
+                expect(tx->getTxnType() == ttACCOUNT_SET);
+            }
+        }
+
+        {
+            auto params = Json::Value(Json::objectValue);
+            // Force the factor low enough to fail
+            params[jss::fee_mult_max] = 1;
+            params[jss::fee_div_max] = 2;
+            // RPC errors result in temINVALID
+            env(noop(alice), fee(none), seq(none),
+                signandsubmit(params), ter(temINVALID));
+
+            auto tx = env.tx();
+            expect(!tx);
+        }
+    }
+
     void
     run()
     {
@@ -598,6 +647,7 @@ public:
         testClose();
         testPath();
         testResignSigned();
+        testSignAndSubmit();
     }
 };
 

--- a/src/ripple/test/jtx/impl/signandsubmit.cpp
+++ b/src/ripple/test/jtx/impl/signandsubmit.cpp
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/test/jtx/signandsubmit.h>
+#include <ripple/test/jtx/utility.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+void
+signandsubmit::operator()(Env&, JTx& jt) const
+{
+    jt.fill_sig = false;
+    jt.sign_and_submit = submitParams;
+}
+
+} // jtx
+} // test
+} // ripple

--- a/src/ripple/test/jtx/signandsubmit.h
+++ b/src/ripple/test/jtx/signandsubmit.h
@@ -1,0 +1,69 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TEST_JTX_SIGNANDSUBMIT_H_INCLUDED
+#define RIPPLE_TEST_JTX_SIGNANDSUBMIT_H_INCLUDED
+
+#include <ripple/test/jtx/Env.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+/** Use sign-and-submit mode submission
+    @note Does not support multisign.
+*/
+class signandsubmit
+{
+private:
+    Json::Value submitParams;
+
+public:
+    /** Default constructor uses command line interface:
+        secret + tx_json
+    */
+    signandsubmit()
+        : submitParams(true)
+    {
+    }
+
+    /** Non default constructor, if the `params` are
+        an object will pass those `params` along to the
+        general RPC interface. Anything else will
+        fall back to default command line interface.
+
+        @note `tx_json` will be overridden with the JTx value.
+            `secret` will be autofilled if not included.
+    */
+    signandsubmit(Json::Value const& params)
+        : submitParams(params)
+    {
+        if (!params || !params.isObject())
+            submitParams = true;
+    }
+
+    void
+    operator()(Env&, JTx& jt) const;
+};
+
+} // jtx
+} // test
+} // ripple
+
+#endif

--- a/src/ripple/unity/test.cpp
+++ b/src/ripple/unity/test.cpp
@@ -39,6 +39,7 @@
 #include <ripple/test/jtx/impl/sendmax.cpp>
 #include <ripple/test/jtx/impl/seq.cpp>
 #include <ripple/test/jtx/impl/sig.cpp>
+#include <ripple/test/jtx/impl/signandsubmit.cpp>
 #include <ripple/test/jtx/impl/tag.cpp>
 #include <ripple/test/jtx/impl/ticket.cpp>
 #include <ripple/test/jtx/impl/trust.cpp>


### PR DESCRIPTION
Intended to be merged as 2 distinct commits. The first adds the needed support to `JTx`, the second reproduces the regression found last week.