### PR TITLE
Travis install clang from tar file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 
 env:
   global:
+    - LLVM_VERSION=3.8.0
     # Maintenance note: to move to a new version
     # of boost, update both BOOST_ROOT and BOOST_URL.
     # Note that for simplicity, BOOST_ROOT's final
@@ -14,18 +15,6 @@ env:
 
 packages: &gcc5_pkgs
   - gcc-5
-  - g++-5
-  - python-software-properties
-  - protobuf-compiler
-  - libprotobuf-dev
-  - libssl-dev
-  - libstdc++6
-  - binutils-gold
-  # Provides a backtrace if the unittests crash
-  - gdb
-
-packages: &clang36_pkgs
-  - clang-3.6
   - g++-5
   - python-software-properties
   - protobuf-compiler
@@ -50,25 +39,17 @@ matrix:
       addons: *ao_gcc5
 
     - compiler: clang
-      env: GCC_VER=5 TARGET=debug CLANG_VER=3.6
-      addons: &ao_clang36
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
-          packages: *clang36_pkgs
+      env: GCC_VER=5 TARGET=debug CLANG_VER=3.8 PATH=$PWD/llvm-$LLVM_VERSION/bin:$PATH
+      addons: *ao_gcc5
 
     - compiler: clang
-      env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.6
-      addons: *ao_clang36
-
-  # Temporary workaround while the llvm apt repository is down.
-  # TODO: REMOVE THIS if/when clang builds become reliable again.
-  allow_failures:
-    - env: GCC_VER=5 TARGET=debug CLANG_VER=3.6
-    - env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.6
+      env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.8 PATH=$PWD/llvm-$LLVM_VERSION/bin:$PATH
+      addons: *ao_gcc5
 
 cache:
   directories:
   - $BOOST_ROOT
+  - llvm-$LLVM_VERSION
 
 before_install:
   - bin/ci/ubuntu/install-dependencies.sh

--- a/bin/ci/ubuntu/install-dependencies.sh
+++ b/bin/ci/ubuntu/install-dependencies.sh
@@ -9,20 +9,27 @@ do
   test -x $( type -p ${g}-$GCC_VER )
   ln -sv $(type -p ${g}-$GCC_VER) $HOME/bin/${g}
 done
-for c in clang clang++
-do
-    test -x $( type -p ${c}-$CLANG_VER )
-    ln -sv $(type -p ${c}-$CLANG_VER) $HOME/bin/${c}
-done
-export PATH=$PWD/bin:$PATH
+
+if [[ -n ${CLANG_VER:-} ]]; then
+    # There are cases where the directory exists, but the exe is not available.
+    # Use this workaround for now.
+    if [[ ! -x llvm-${LLVM_VERSION}/bin/llvm-config ]] && [[ -d llvm-${LLVM_VERSION} ]]; then
+        rm -fr llvm-${LLVM_VERSION}
+    fi
+    if [[ ! -d llvm-${LLVM_VERSION} ]]; then
+        mkdir llvm-${LLVM_VERSION}
+        LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz"
+        wget -O - ${LLVM_URL} | tar -Jxvf - --strip 1 -C llvm-${LLVM_VERSION}
+    fi
+    llvm-${LLVM_VERSION}/bin/llvm-config --version;
+    export LLVM_CONFIG="llvm-${LLVM_VERSION}/bin/llvm-config";
+fi
 
 # What versions are we ACTUALLY running?
 if [ -x $HOME/bin/g++ ]; then
     $HOME/bin/g++ -v
 fi
-if [ -x $HOME/bin/clang ]; then
-    $HOME/bin/clang -v
-fi
+
 # Avoid `spurious errors` caused by ~/.npm permission issues
 # Does it already exist? Who owns? What permissions?
 ls -lah ~/.npm || mkdir ~/.npm

--- a/bin/sh/install-boost.sh
+++ b/bin/sh/install-boost.sh
@@ -7,6 +7,7 @@
 # When testing you can force a boost build by clearing travis caches:
 # https://travis-ci.org/ripple/rippled/caches
 set -e
+
 if [ ! -d "$BOOST_ROOT/lib" ]
 then
   wget $BOOST_URL -O /tmp/boost.tar.gz
@@ -15,7 +16,8 @@ then
   tar xzf /tmp/boost.tar.gz
   cd $BOOST_ROOT && \
     ./bootstrap.sh --prefix=$BOOST_ROOT && \
-    ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 && ./b2 -d0 define=_GLIBCXX_USE_CXX11_ABI=0 install
+    ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 -j${NUM_PROCESSORS:-2} &&\
+    ./b2 -d0 define=_GLIBCXX_USE_CXX11_ABI=0 install
 else
   echo "Using cached boost at $BOOST_ROOT"
 fi


### PR DESCRIPTION
The llvm apt repos are offline. This is a workaround to install clang directly from a tar file.