### PR TITLE
Improve TxQ edge-case handling logic (RIPD-1200):

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1300,8 +1300,8 @@ void LedgerConsensusImp::addDisputedTransaction (
         }
     }
 
-    // If we didn't relay this transaction recently, relay it
-    if (app_.getHashRouter ().setFlags (txID, SF_RELAYED))
+    // If we didn't relay this transaction recently, relay it to all peers
+    if (app_.getHashRouter ().shouldRelay (txID))
     {
         protocol::TMTransaction msg;
         msg.set_rawtransaction (& (tx.front ()), tx.size ());

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1059,10 +1059,10 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                 (e.failType != FailHard::yes) && e.local) ||
                     (e.result == terQUEUED))
             {
-                std::set<Peer::id_t> peers;
+                auto const toSkip = app_.getHashRouter().shouldRelay(
+                    e.transaction->getID());
 
-                if (app_.getHashRouter().swapSet (
-                        e.transaction->getID(), peers, SF_RELAYED))
+                if (toSkip)
                 {
                     protocol::TMTransaction tx;
                     Serializer s;
@@ -1075,7 +1075,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                     // FIXME: This should be when we received it
                     app_.overlay().foreach (send_if_not (
                         std::make_shared<Message> (tx, protocol::mtTRANSACTION),
-                        peer_in_set(peers)));
+                        peer_in_set(*toSkip)));
                 }
             }
         }

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -308,7 +308,7 @@ TxQ::canBeHeld(STTx const& tx, OpenView const& view,
             an early one fail or get dropped.
         */
         canBeHeld = accountIter == byAccount_.end() ||
-            !replacementIter ||
+            replacementIter ||
                 accountIter->second.getTxnCount() <
                     setup_.maximumTxnPerAccount;
     }
@@ -521,9 +521,10 @@ TxQ::apply(Application& app, OpenView& view,
                 */
                 if (std::next(existingIter) != txQAcct.transactions.end())
                 {
-                    // Only the last tx in the queue should have
-                    // !consequences, and this can't be the last tx.
-                    assert(existingIter->second.consequences);
+                    // Normally, only the last tx in the queue will have
+                    // !consequences, but an expired transaction can be
+                    // replaced, and that replacement won't have it set,
+                    // and that's ok.
                     if (!existingIter->second.consequences)
                         existingIter->second.consequences.emplace(
                             calculateConsequences(


### PR DESCRIPTION
* HashRouter: Track relay expiration separately from item lifespan.
  * Renamed `swapSet` to `prepRelay`.
  * Cleaned up `HashRouter` member names and removed unused code.
  * Remove `SF_RELAYED` flag.
* Fix TxQ edge case replacing dropped transactions.
* Fix TxQ bug in maximumTxnPerAccount check.

@seelabs found the dropped transactions issue. @JoelKatz suggested the HashRouter changes.