### PR TITLE
Make debugLog() return a beast::Journal (RIPD-1209)

### DIFF
--- a/src/ripple/basics/Log.h
+++ b/src/ripple/basics/Log.h
@@ -263,7 +263,7 @@ setDebugLogSink(
     may never be seen. Never use it for critical
     information.
 */
-beast::Journal::Stream
+beast::Journal
 debugLog();
 
 } // ripple

--- a/src/ripple/basics/impl/Log.cpp
+++ b/src/ripple/basics/impl/Log.cpp
@@ -403,10 +403,10 @@ setDebugLogSink(
     return debugSink().set(std::move(sink));
 }
 
-beast::Journal::Stream
+beast::Journal
 debugLog()
 {
-    return { debugSink().get() };
+    return beast::Journal (debugSink().get());
 }
 
 } // ripple

--- a/src/ripple/basics/impl/contract.cpp
+++ b/src/ripple/basics/impl/contract.cpp
@@ -43,14 +43,14 @@ accessViolation() noexcept
 void
 LogThrow (std::string const& title)
 {
-    JLOG(debugLog()) << title;
+    JLOG(debugLog().warn()) << title;
 }
 
 [[noreturn]]
 void
 LogicError (std::string const& s) noexcept
 {
-    JLOG(debugLog()) << s;
+    JLOG(debugLog().fatal()) << s;
     std::cerr << "Logic error: " << s << std::endl;
     detail::accessViolation();
 }

--- a/src/ripple/beast/utility/Journal.h
+++ b/src/ripple/beast/utility/Journal.h
@@ -175,17 +175,12 @@ public:
     {
     public:
         /** Create a stream which produces no output. */
-        Stream ()
+        explicit Stream ()
             : m_sink (getNullSink())
             , m_level (severities::kDisabled)
         { }
 
-        Stream (Sink& sink)
-            : m_sink (sink)
-            , m_level (sink.threshold())
-        { }
-
-        /** Create stream that writes at the given level.
+        /** Create a stream that writes at the given level.
 
             Constructor is inlined so checking active() very inexpensive.
         */

--- a/src/ripple/core/ReportUncaughtException.h
+++ b/src/ripple/core/ReportUncaughtException.h
@@ -115,7 +115,7 @@ void reportUncaughtException (
             if (! extra.empty())
                 ss << "; " << extra;
 
-            JLOG(debugLog()) << ss.str();
+            JLOG(debugLog().fatal()) << ss.str();
             std::cerr << ss.str() << std::endl;
             throw;
         };

--- a/src/ripple/core/SociDB.h
+++ b/src/ripple/core/SociDB.h
@@ -52,7 +52,7 @@ T rangeCheckedCast (C c)
          std::numeric_limits<C>::is_signed &&
          c < std::numeric_limits<T>::lowest ()))
     {
-        JLOG (debugLog()) << "rangeCheckedCast domain error:"
+        JLOG (debugLog().error()) << "rangeCheckedCast domain error:"
           << " value = " << c
           << " min = " << std::numeric_limits<T>::lowest ()
           << " max: " << std::numeric_limits<T>::max ();

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -906,7 +906,7 @@ amountFromJsonNoThrow (STAmount& result, Json::Value const& jvSource)
     }
     catch (const std::exception& e)
     {
-        JLOG (debugLog()) <<
+        JLOG (debugLog().warn()) <<
             "amountFromJsonNoThrow: caught: " << e.what ();
     }
     return false;

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -76,7 +76,7 @@ STArray::STArray (SerialIter& sit, SField const& f)
 
         if ((type == STI_OBJECT) && (field == 1))
         {
-            JLOG (debugLog()) <<
+            JLOG (debugLog().error()) <<
                 "Encountered array with end of object marker";
             Throw<std::runtime_error> ("Illegal terminator in array");
         }
@@ -85,14 +85,14 @@ STArray::STArray (SerialIter& sit, SField const& f)
 
         if (fn.isInvalid ())
         {
-            JLOG (debugLog()) <<
+            JLOG (debugLog().error()) <<
                 "Unknown field: " << type << "/" << field;
             Throw<std::runtime_error> ("Unknown field");
         }
 
         if (fn.fieldType != STI_OBJECT)
         {
-            JLOG (debugLog()) <<
+            JLOG (debugLog().error()) <<
                 "Array contains non-object";
             Throw<std::runtime_error> ("Non-object in array");
         }

--- a/src/ripple/protocol/impl/STInteger.cpp
+++ b/src/ripple/protocol/impl/STInteger.cpp
@@ -52,7 +52,7 @@ STUInt8::getText () const
         if (transResultInfo (static_cast<TER> (value_), token, human))
             return human;
 
-        JLOG (debugLog())
+        JLOG (debugLog().error())
             << "Unknown result code in metadata: " << value_;
     }
 
@@ -70,7 +70,7 @@ STUInt8::getJson (int) const
         if (transResultInfo (static_cast<TER> (value_), token, human))
             return token;
 
-        JLOG (debugLog())
+        JLOG (debugLog().error())
             << "Unknown result code in metadata: " << value_;
     }
 

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -78,7 +78,7 @@ void STLedgerEntry::setSLEType ()
     type_ = mFormat->getType ();
     if (!setType (mFormat->elements))
     {
-        if (auto j = debugLog())
+        if (auto j = debugLog().error())
         {
             j << "Ledger entry not valid for type " << mFormat->getName ();
             j << "Object: " << getJson (0);
@@ -141,7 +141,7 @@ bool STLedgerEntry::thread (uint256 const& txID, std::uint32_t ledgerSeq,
 {
     uint256 oldPrevTxID = getFieldH256 (sfPreviousTxnID);
 
-    JLOG (debugLog())
+    JLOG (debugLog().info())
         << "Thread Tx:" << txID << " prev:" << oldPrevTxID;
 
     if (oldPrevTxID == txID)

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -113,7 +113,7 @@ bool STObject::setType (const SOTemplate& type)
         {
             if ((e->flags == SOE_DEFAULT) && iter->get().isDefault())
             {
-                JLOG (debugLog())
+                JLOG (debugLog().error())
                     << "setType(" << getFName().getName()
                     << "): explicit default " << e->e_field.fieldName;
                 valid = false;
@@ -125,7 +125,7 @@ bool STObject::setType (const SOTemplate& type)
         {
             if (e->flags == SOE_REQUIRED)
             {
-                JLOG (debugLog())
+                JLOG (debugLog().error())
                     << "setType(" << getFName().getName()
                     << "): missing " << e->e_field.fieldName;
                 valid = false;
@@ -138,7 +138,7 @@ bool STObject::setType (const SOTemplate& type)
         // Anything left over in the object must be discardable
         if (! e->getFName().isDiscardable())
         {
-            JLOG (debugLog())
+            JLOG (debugLog().error())
                 << "setType(" << getFName().getName()
                 << "): non-discardable leftover " << e->getFName().getName ();
             valid = false;
@@ -208,7 +208,7 @@ bool STObject::set (SerialIter& sit, int depth)
 
         if ((type == STI_ARRAY) && (field == 1))
         {
-            JLOG (debugLog())
+            JLOG (debugLog().error())
                 << "Encountered object with end of array marker";
             Throw<std::runtime_error> ("Illegal terminator in object");
         }
@@ -221,7 +221,7 @@ bool STObject::set (SerialIter& sit, int depth)
 
             if (fn.isInvalid ())
             {
-                JLOG (debugLog())
+                JLOG (debugLog().error())
                     << "Unknown field: field_type=" << type
                     << ", field_name=" << field;
                 Throw<std::runtime_error> ("Unknown field");

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -64,7 +64,7 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
         {
             if (path.empty ())
             {
-                JLOG (debugLog())
+                JLOG (debugLog().error())
                     << "Empty path in pathset";
                 Throw<std::runtime_error> ("empty path");
             }
@@ -77,7 +77,7 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
         }
         else if (iType & ~STPathElement::typeAll)
         {
-            JLOG (debugLog())
+            JLOG (debugLog().error())
                 << "Bad path element " << iType << " in pathset";
             Throw<std::runtime_error> ("bad path element");
         }

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -35,7 +35,7 @@ STValidation::STValidation (SerialIter& sit, bool checkSignature)
 
     if  (checkSignature && !isValid ())
     {
-        JLOG (debugLog())
+        JLOG (debugLog().error())
             << "Invalid validation" << getJson (0);
         Throw<std::runtime_error> ("Invalid validation");
     }
@@ -113,7 +113,7 @@ bool STValidation::isValid (uint256 const& signingHash) const
     }
     catch (std::exception const&)
     {
-        JLOG (debugLog())
+        JLOG (debugLog().error())
             << "Exception validating validation";
         return false;
     }


### PR DESCRIPTION
Previously, writes using `debugLog()` tagged every entry with `TRC:`.  With this change users of `debugLog()` must specify the severity level they want their information logged at.  Using the `debugLog()` becomes much more similar to using a `beast::Journal`.

Since Severity levels were attached to all `debugLog()` writes, please look over the Severities to see if you agree with the new levels.

There are two separate commits so the changes to beast can have a separate commit message from the changes to rippled.