### PR TITLE
Fix access to obsolete reference in PathRequest (RIPD-1219)

### DIFF
--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -687,14 +687,17 @@ Json::Value PathRequest::doUpdate(
     JLOG(m_journal.debug()) << iIdentifier
         << " processing at level " << iLevel;
 
-    Json::Value& jvArray = (newStatus[jss::alternatives] = Json::arrayValue);
-    if (! findPaths(cache, iLevel, jvArray))
+    Json::Value jvArray = Json::arrayValue;
+    if (findPaths(cache, iLevel, jvArray))
+    {
+        bLastSuccess = jvArray.size() != 0;
+        newStatus[jss::alternatives] = std::move (jvArray);
+    }
+    else
     {
         bLastSuccess = false;
         newStatus = rpcError(rpcINTERNAL);
     }
-    else
-        bLastSuccess = jvArray.size() != 0;
 
     if (fast && quick_reply_ == steady_clock::time_point{})
     {

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -52,7 +52,7 @@ PathRequest::PathRequest (
         , jvStatus (Json::objectValue)
         , mLastIndex (0)
         , mInProgress (false)
-        , iLastLevel (0)
+        , iLevel (0)
         , bLastSuccess (false)
         , iIdentifier (id)
         , created_ (std::chrono::steady_clock::now())
@@ -76,7 +76,7 @@ PathRequest::PathRequest (
         , jvStatus (Json::objectValue)
         , mLastIndex (0)
         , mInProgress (false)
-        , iLastLevel (0)
+        , iLevel (0)
         , bLastSuccess (false)
         , iIdentifier (id)
         , created_ (std::chrono::steady_clock::now())
@@ -651,7 +651,6 @@ Json::Value PathRequest::doUpdate(
     if (jvId)
         newStatus["id"] = jvId;
 
-    int iLevel = iLastLevel;
     bool loaded = app_.getFeeTrack().isLoadedLocal();
 
     if (iLevel == 0)
@@ -690,10 +689,12 @@ Json::Value PathRequest::doUpdate(
 
     Json::Value& jvArray = (newStatus[jss::alternatives] = Json::arrayValue);
     if (! findPaths(cache, iLevel, jvArray))
+    {
+        bLastSuccess = false;
         newStatus = rpcError(rpcINTERNAL);
-
-    bLastSuccess = jvArray.size();
-    iLastLevel = iLevel;
+    }
+    else
+        bLastSuccess = jvArray.size() != 0;
 
     if (fast && quick_reply_ == steady_clock::time_point{})
     {

--- a/src/ripple/app/paths/PathRequest.h
+++ b/src/ripple/app/paths/PathRequest.h
@@ -141,7 +141,7 @@ private:
     LedgerIndex mLastIndex;
     bool mInProgress;
 
-    int iLastLevel;
+    int iLevel;
     bool bLastSuccess;
 
     int iIdentifier;


### PR DESCRIPTION
This fixes a bug where we access jvArray (to get its size) even if newStatus is replaced. This is illegal because jvArray is a reference into an entry in newStatus.

Rename iLastLevel to iLevel. There was no need for two variables.
