### PR TITLE
Ignore empty CONFIG_DIR for validators file (RIPD-1221)

### DIFF
--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -440,7 +440,7 @@ void Config::loadFromString (std::string const& fileContents)
             Throw<std::runtime_error> (
                 "Invalid path specified in [" SECTION_VALIDATORS_FILE "]");
 
-        if (!validatorsFile.is_absolute())
+        if (!validatorsFile.is_absolute() && !CONFIG_DIR.empty())
             validatorsFile = CONFIG_DIR / validatorsFile;
 
         if (!boost::filesystem::exists (validatorsFile))
@@ -454,7 +454,7 @@ void Config::loadFromString (std::string const& fileContents)
                 "Invalid file specified in [" SECTION_VALIDATORS_FILE "]: " +
                 validatorsFile.string());
     }
-    else
+    else if (!CONFIG_DIR.empty())
     {
         validatorsFile = CONFIG_DIR / validatorsFileName;
 

--- a/src/ripple/core/tests/Config.test.cpp
+++ b/src/ripple/core/tests/Config.test.cpp
@@ -141,7 +141,7 @@ protected:
             remove (toRm);
         else
             test_.log << "Expected " << toRm.string ()
-                      << " to be an empty existing directory.";
+                      << " to be an empty existing directory." << std::endl;
     };
 
 public:
@@ -176,12 +176,13 @@ public:
             if (rmSubDir_)
                 rmDir (subDir_);
             else
-                test_.log << "Skipping rm dir: " << subDir_.string ();
+                test_.log << "Skipping rm dir: "
+                          << subDir_.string () << std::endl;
         }
         catch (std::exception& e)
         {
             // if we throw here, just let it die.
-            test_.log << "Error in ~ConfigGuard: " << e.what ();
+            test_.log << "Error in ~ConfigGuard: " << e.what () << std::endl;
         };
     }
 };
@@ -249,19 +250,21 @@ public:
             using namespace boost::filesystem;
             if (!boost::filesystem::exists (configFile_))
                 test_.log << "Expected " << configFile_.string ()
-                          << " to be an existing file.";
+                          << " to be an existing file." << std::endl;
             else
                 remove (configFile_.string ());
 
             if (rmDataDir_)
                 rmDir (dataDir_);
             else
-                test_.log << "Skipping rm dir: " << dataDir_.string ();
+                test_.log << "Skipping rm dir: "
+                          << dataDir_.string () << std::endl;
         }
         catch (std::exception& e)
         {
             // if we throw here, just let it die.
-            test_.log << "Error in ~RippledCfgGuard: " << e.what ();
+            test_.log << "Error in ~RippledCfgGuard: "
+                      << e.what () << std::endl;
         };
     }
 };
@@ -337,14 +340,15 @@ public:
             using namespace boost::filesystem;
             if (!boost::filesystem::exists (validatorsFile_))
                 test_.log << "Expected " << validatorsFile_.string ()
-                          << " to be an existing file.";
+                          << " to be an existing file." << std::endl;
             else
                 remove (validatorsFile_.string ());
         }
         catch (std::exception& e)
         {
             // if we throw here, just let it die.
-            test_.log << "Error in ~ValidatorsTxtGuard: " << e.what ();
+            test_.log << "Error in ~ValidatorsTxtGuard: "
+                      << e.what () << std::endl;
         };
     }
 };


### PR DESCRIPTION
Some unit tests load configs with `Config::loadFromString()` instead of `Config::setup()` where an actual rippled.cfg file path exists and `CONFIG_DIR` is defined.
The empty `CONFIG_DIR` was causing rippled to look for validators.txt at the current path, leading to test failure if a validators.txt was unexpectedly found there.