### PR TITLE
Preliminary changes to make the consensus refactor easier

### DIFF
--- a/src/ripple/app/ledger/LedgerConsensus.h
+++ b/src/ripple/app/ledger/LedgerConsensus.h
@@ -47,8 +47,8 @@ public:
 
     virtual uint256 getLCL () = 0;
 
-    virtual void mapComplete (uint256 const& hash,
-        std::shared_ptr<SHAMap> const& map, bool acquired) = 0;
+    virtual void gotMap (uint256 const& hash,
+        std::shared_ptr<SHAMap> const& map) = 0;
 
     virtual void timerEntry () = 0;
 
@@ -73,41 +73,6 @@ public:
     virtual void simulate (
         boost::optional<std::chrono::milliseconds> consensusDelay) = 0;
 };
-
-//------------------------------------------------------------------------------
-/** Apply a set of transactions to a ledger
-
-  @param set                   The set of transactions to apply
-  @param applyLedger           The ledger to which the transactions should
-                               be applied.
-  @param checkLedger           A reference ledger for determining error
-                               messages (typically new last closed
-                                ledger).
-  @param retriableTransactions collect failed transactions in this set
-  @param openLgr               true if applyLedger is open, else false.
-*/
-void applyTransactions (
-    Application& app,
-    SHAMap const* set,
-    OpenView& view,
-    ReadView const& checkLedger,
-    CanonicalTXSet& retriableTransactions,
-    ApplyFlags flags);
-
-/** Apply a single transaction to a ledger
-  @param view                   The open view to apply to
-  @param txn                    The transaction to apply
-  @param retryAssured           True if another pass is assured
-  @param flags                  Flags for transactor
-  @return                       resultSuccess, resultFail or resultRetry
-*/
-int applyTransaction (
-    Application& app,
-    OpenView& view,
-    std::shared_ptr<STTx const> const& txn,
-    bool retryAssured,
-    ApplyFlags flags,
-    beast::Journal j);
 
 } // ripple
 

--- a/src/ripple/app/ledger/LedgerProposal.h
+++ b/src/ripple/app/ledger/LedgerProposal.h
@@ -107,10 +107,6 @@ public:
         return signature_;
     }
 
-    bool isPrevLedger (uint256 const& pl) const
-    {
-        return mPreviousLedger == pl;
-    }
     bool isInitial () const
     {
         return mProposeSeq == seqJoin;

--- a/src/ripple/app/ledger/impl/ConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/ConsensusImp.cpp
@@ -177,15 +177,22 @@ ConsensusImp::takePosition (int seq, std::shared_ptr<SHAMap> const& position)
     }
 }
 
-void
-ConsensusImp::visitStoredProposals (
-    std::function<void(LedgerProposal::ref)> const& f)
+std::vector <std::shared_ptr <LedgerProposal>>
+ConsensusImp::getStoredProposals (uint256 const& prevLedger)
 {
-    std::lock_guard <std::mutex> _(lock_);
 
-    for (auto const& it : storedProposals_)
-        for (auto const& prop : it.second)
-            f(prop);
+    std::vector <std::shared_ptr <LedgerProposal>> ret;
+
+    {
+        std::lock_guard <std::mutex> _(lock_);
+
+        for (auto const& it : storedProposals_)
+            for (auto const& prop : it.second)
+                if (prop->getPrevLedger() == prevLedger)
+                    ret.push_back (prop);
+    }
+
+    return ret;
 }
 
 //==============================================================================

--- a/src/ripple/app/ledger/impl/ConsensusImp.h
+++ b/src/ripple/app/ledger/impl/ConsensusImp.h
@@ -96,8 +96,8 @@ public:
 
     void takePosition (int seq, std::shared_ptr<SHAMap> const& position);
 
-    void
-    visitStoredProposals (std::function<void(LedgerProposal::ref)> const&);
+    std::vector <std::shared_ptr <LedgerProposal>>
+    getStoredProposals (uint256 const& previousLedger);
 
 private:
     beast::Journal journal_;

--- a/src/ripple/app/ledger/impl/LedgerTiming.cpp
+++ b/src/ripple/app/ledger/impl/LedgerTiming.cpp
@@ -73,4 +73,137 @@ roundCloseTime (
     closeTime += (closeResolution / 2);
     return closeTime - (closeTime.time_since_epoch() % closeResolution);
 }
+
+bool
+shouldCloseLedger (
+    bool anyTransactions,
+    int previousProposers,
+    int proposersClosed,
+    int proposersValidated,
+    std::chrono::milliseconds previousTime,
+    std::chrono::milliseconds currentTime, // Time since last ledger's close time
+    std::chrono::milliseconds openTime,    // Time waiting to close this ledger
+    std::chrono::seconds idleInterval,
+    beast::Journal j)
+{
+    using namespace std::chrono_literals;
+    if ((previousTime < -1s) || (previousTime > 10min) ||
+        (currentTime > 10min))
+    {
+        // These are unexpected cases, we just close the ledger
+        JLOG (j.warn()) <<
+            "shouldCloseLedger Trans=" << (anyTransactions ? "yes" : "no") <<
+            " Prop: " << previousProposers << "/" << proposersClosed <<
+            " Secs: " << currentTime.count() << " (last: " <<
+            previousTime.count() << ")";
+        return true;
+    }
+
+    if ((proposersClosed + proposersValidated) > (previousProposers / 2))
+    {
+        // If more than half of the network has closed, we close
+        JLOG (j.trace()) << "Others have closed";
+        return true;
+    }
+
+    if (!anyTransactions)
+    {
+        // Only close at the end of the idle interval
+        return currentTime >= idleInterval; // normal idle
+    }
+
+    // Preserve minimum ledger open time
+    if (openTime < LEDGER_MIN_CLOSE)
+    {
+        JLOG (j.debug()) <<
+            "Must wait minimum time before closing";
+        return false;
+    }
+
+    // Don't let this ledger close more than twice as fast as the previous
+    // ledger reached consensus so that slower validators can slow down
+    // the network
+    if (openTime < (previousTime / 2))
+    {
+        JLOG (j.debug()) <<
+            "Ledger has not been open long enough";
+        return false;
+    }
+
+    // Close the ledger
+    return true;
+}
+
+bool
+checkConsensusReached (int agreeing, int total, bool count_self)
+{
+    // If we are alone, we have a consensus
+    if (total == 0)
+        return true;
+
+    if (count_self)
+    {
+        ++agreeing;
+        ++total;
+    }
+
+    int currentPercentage = (agreeing * 100) / total;
+
+    return currentPercentage > minimumConsensusPercentage;
+}
+
+ConsensusState
+checkConsensus (
+    int previousProposers,
+    int currentProposers,
+    int currentAgree,
+    int currentFinished,
+    std::chrono::milliseconds previousAgreeTime,
+    std::chrono::milliseconds currentAgreeTime,
+    bool proposing,
+    beast::Journal j)
+{
+    JLOG (j.trace()) <<
+        "checkConsensus: prop=" << currentProposers <<
+        "/" << previousProposers <<
+        " agree=" << currentAgree << " validated=" << currentFinished <<
+        " time=" << currentAgreeTime.count() <<  "/" << previousAgreeTime.count();
+
+    if (currentAgreeTime <= LEDGER_MIN_CONSENSUS)
+        return ConsensusState::No;
+
+    if (currentProposers < (previousProposers * 3 / 4))
+    {
+        // Less than 3/4 of the last ledger's proposers are present; don't
+        // rush: we may need more time.
+        if (currentAgreeTime < (previousAgreeTime + LEDGER_MIN_CONSENSUS))
+        {
+            JLOG (j.trace()) <<
+                "too fast, not enough proposers";
+            return ConsensusState::No;
+        }
+    }
+
+    // Have we, together with the nodes on our UNL list, reached the threshold
+    // to declare consensus?
+    if (checkConsensusReached (currentAgree, currentProposers, proposing))
+    {
+        JLOG (j.debug()) << "normal consensus";
+        return ConsensusState::Yes;
+    }
+
+    // Have sufficient nodes on our UNL list moved on and reached the threshold
+    // to declare consensus?
+    if (checkConsensusReached (currentFinished, currentProposers, false))
+    {
+        JLOG (j.warn()) <<
+            "We see no consensus, but 80% of nodes have moved on";
+        return ConsensusState::MovedOn;
+    }
+
+    // no consensus yet
+    JLOG (j.trace()) << "no consensus";
+    return ConsensusState::No;
+}
+
 } // ripple

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1514,7 +1514,7 @@ void
 NetworkOPsImp::mapComplete (uint256 const& hash,
                             std::shared_ptr<SHAMap> const& map)
 {
-    mLedgerConsensus->mapComplete (hash, map, true);
+    mLedgerConsensus->gotMap (hash, map);
 }
 
 void NetworkOPsImp::endConsensus (bool correctLCL)

--- a/src/ripple/app/tx/apply.h
+++ b/src/ripple/app/tx/apply.h
@@ -95,6 +95,25 @@ apply (Application& app, OpenView& view,
     STTx const& tx, ApplyFlags flags,
         beast::Journal journal);
 
+
+/** Class for return value from applyTransaction */
+enum class ApplyResult
+{
+    Success,    // Applied to this ledger
+    Fail,       // Should not be retried in this ledger
+    Retry       // Should be retried in this ledger
+};
+
+/** Transaction application helper
+
+    Provides more detailed logging and decodes the
+    correct behavior based on the TER type
+*/
+ApplyResult
+applyTransaction(Application& app, OpenView& view,
+    STTx const& tx, bool retryAssured, ApplyFlags flags,
+    beast::Journal journal);
+
 } // ripple
 
 #endif

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/basics/Log.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/app/tx/applySteps.h>
 #include <ripple/app/misc/HashRouter.h>
@@ -112,6 +113,53 @@ apply (Application& app, OpenView& view,
     auto pfresult = preflight(app, view.rules(), tx, flags, j);
     auto pcresult = preclaim(pfresult, app, view);
     return doApply(pcresult, app, view);
+}
+
+ApplyResult
+applyTransaction (Application& app, OpenView& view,
+    STTx const& txn,
+        bool retryAssured, ApplyFlags flags,
+            beast::Journal j)
+{
+    // Returns false if the transaction has need not be retried.
+    if (retryAssured)
+        flags = flags | tapRETRY;
+
+    JLOG (j.debug()) << "TXN "
+        << txn.getTransactionID ()
+        //<< (engine.view().open() ? " open" : " closed")
+        // because of the optional in engine
+        << (retryAssured ? "/retry" : "/final");
+
+    try
+    {
+        auto const result = apply(app,
+            view, txn, flags, j);
+        if (result.second)
+        {
+            JLOG (j.debug())
+                << "Transaction applied: " << transHuman (result.first);
+            return ApplyResult::Success;
+        }
+
+        if (isTefFailure (result.first) || isTemMalformed (result.first) ||
+            isTelLocal (result.first))
+        {
+            // failure
+            JLOG (j.debug())
+                << "Transaction failure: " << transHuman (result.first);
+            return ApplyResult::Fail;
+        }
+
+        JLOG (j.debug())
+            << "Transaction retry: " << transHuman (result.first);
+        return ApplyResult::Retry;
+    }
+    catch (std::exception const&)
+    {
+        JLOG (j.warn()) << "Throws";
+        return ApplyResult::Fail;
+    }
 }
 
 } // ripple


### PR DESCRIPTION
Trying to do the entire refactor in one shot would lead to a change that could not be reviewed. So instead I'm going to submit pull requests to gradually move the deployed code over to the refactored code.

This is currently structured as one dummy commit that just adds a missing space followed by six commits that make individual changes. I've kept them separate for ease of review but they can be combined for inclusion. I strongly recommend reviewing each change on its own as each stands alone and has a distinct functional purpose.

The dummy commit has a message suitable for the folded commits.

Changes are:
* Standardize names of LedgerConsensusImp members
* Rework visitStoredProposals (to getStoredProposals)
* Clean up mapComplete (to gotMap)
* Move status helpers out of LedgerConsensusImp
* Move applyTransaction out of LedgerConsensusUmp
* Clean up applyTransactions (and simplify)