### PR TITLE
Remove unused member variable in ApplyBaseView

### DIFF
--- a/src/ripple/ledger/detail/ApplyViewBase.h
+++ b/src/ripple/ledger/detail/ApplyViewBase.h
@@ -131,7 +131,6 @@ protected:
     ApplyFlags flags_;
     ReadView const* base_;
     detail::ApplyStateTable items_;
-    XRPAmount dropsDestroyed_ = 0;
 };
 
 } // detail


### PR DESCRIPTION
The `ApplyBaseView::dropsDestroyed_` member is currently unused, thankfully.  It looks like all information about dropsDestroyed is intended to be stored in the `ApplyBaseView::items_` member.  I'd be less worried about an unused member variable, but `ApplyBaseView` is a protected member of a base class.  Let's remove the `dropsDestroyed_` member before someone modifying a derived class makes a mistake and tries to use it.