### PR TITLE
Fix inbound ledger add peers logic

### DIFF
--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -399,7 +399,7 @@ void InboundLedger::onTimer (bool wasProgress, ScopedLockType&)
 void InboundLedger::addPeers ()
 {
     app_.overlay().selectPeers (*this,
-        (getPeerCount() > 0) ? peerCountStart : peerCountAdd,
+        (getPeerCount() == 0) ? peerCountStart : peerCountAdd,
         ScoreHasLedger (getHash(), mSeq));
 }
 


### PR DESCRIPTION
Corrected the logic that determines how many peers we query for ledger acquisitions on start up and timeouts.