### PR TITLE
Fix scons vcxproj in OS X

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -384,7 +384,8 @@ def config_base(env):
         openssl = os.path.join(OSX_OPENSSL_ROOT, most_recent)
         env.Prepend(CPPPATH='%s/include' % openssl)
         env.Prepend(LIBPATH=['%s/lib' % openssl])
-        env.Append(CPPDEFINES=['NO_LOG_UNHANDLED_EXCEPTIONS'])
+        if not 'vcxproj' in COMMAND_LINE_TARGETS:
+            env.Append(CPPDEFINES=['NO_LOG_UNHANDLED_EXCEPTIONS'])
 
     # handle command-line arguments
     profile_jemalloc = ARGUMENTS.get('profile-jemalloc')


### PR DESCRIPTION
On OS X, the preprocessor definition NO_LOG_UNHANDLED_EXCEPTIONS was incorrectly added with the target 'vcxproj'