### PR TITLE
Remove _FORTIFY_SOURCES from build:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,12 +527,6 @@ if (NOT WIN32)
 
   if (is_gcc)
     add_compile_options(-Wno-unused-but-set-variable -Wno-unused-local-typedefs)
-    # Generator expressions are not supported in add_definitions, use set_property instead
-    set_property(
-      DIRECTORY
-      APPEND
-      PROPERTY COMPILE_DEFINITIONS
-      $<$<OR:$<CONFIG:Debug>,$<CONFIG:DebugClassic>>:_FORTIFY_SOURCE=2>)
     add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:DebugClassic>>:-O0>)
   endif (is_gcc)
 else(NOT WIN32)

--- a/SConstruct
+++ b/SConstruct
@@ -651,9 +651,6 @@ def config_env(toolchain, variant, env):
             # extra error checking into the code (e.g. std::vector will throw
             # for out-of-bounds conditions)
             if is_debug_variant(variant):
-                env.Append(CPPDEFINES={
-                    '_FORTIFY_SOURCE': 2
-                    })
                 env.Append(CCFLAGS=[
                     '-O0'
                     ])


### PR DESCRIPTION
This option is silently ignorned at -O0 on ubuntu. On fedora, we get a warning that `requires compiling with optimization (-O)`.

I see two options:

1) Increase the optimization level to `-O1` when debugging
2) Remove `_FORTIFY_SOURCES`

I'm opting for (2). We have been building this way since at least Oct/2014 and the clang sanitizers serve a similar function.