### PR TITLE
Unit test for free trust lines (RIPD-911)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ Builds/VisualStudio2015/*.sdf
 
 # MSVC
 *.pdb
+.vs/

--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4384,6 +4384,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\app\SetTrust_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\app\SHAMapStore_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5190,6 +5190,9 @@
     <ClCompile Include="..\..\src\test\app\SetRegularKey_test.cpp">
       <Filter>test\app</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\app\SetTrust_test.cpp">
+      <Filter>test\app</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\app\SHAMapStore_test.cpp">
       <Filter>test\app</Filter>
     </ClCompile>

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -1,0 +1,68 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#include <ripple/test/jtx.h>
+
+namespace ripple {
+namespace test {
+
+class SetTrust_test : public beast::unit_test::suite
+{
+public:
+    void testFreeTrustlines()
+    {
+        testcase("Allow 2 free trust lines before requiring reserve");
+
+        using namespace jtx;
+        Env env(*this);
+
+        auto const gwA = Account{ "gatewayA" };
+        auto const gwB = Account{ "gatewayB" };
+        auto const gwC = Account{ "gatewayC" };
+        auto const alice = Account{ "alice" };
+
+        auto const txFee = env.current()->fees().base;
+        auto const baseReserve = env.current()->fees().accountReserve(0);
+        auto const threelineReserve = env.current()->fees().accountReserve(3);
+
+        env.fund(XRP(10000), gwA, gwB, gwC);
+
+        // Fund alice with ...
+        env.fund(baseReserve /* enough to hold an account */
+            + drops(3*txFee) /* and to pay for 3 transactions */, alice);
+
+        env(trust(alice, gwA["USD"](100)), require(lines(alice,1)));
+        env(trust(alice, gwB["USD"](100)), require(lines(alice,2)));
+
+        // Alice does not have enough for the third trust line
+        env(trust(alice, gwC["USD"](100)), ter(tecNO_LINE_INSUF_RESERVE), require(lines(alice,2)));
+
+        // Fund Alice additional amount to cover
+        env(pay(env.master, alice, STAmount{ threelineReserve - baseReserve }));
+        env(trust(alice, gwC["USD"](100)), require(lines(alice,3)));
+    }
+
+
+    void run()
+    {
+        testFreeTrustlines();
+    }
+};
+BEAST_DEFINE_TESTSUITE(SetTrust, app, ripple);
+} // test
+} // ripple

--- a/src/unity/app_test_unity.cpp
+++ b/src/unity/app_test_unity.cpp
@@ -40,3 +40,4 @@
 #include <test/app/Transaction_ordering_test.cpp>
 #include <test/app/TxQ_test.cpp>
 #include <test/app/ValidatorList_test.cpp>
+#include <test/app/SetTrust_test.cpp>


### PR DESCRIPTION
Unit test to ensure two free trust lines can be added for an account without extra reserve.