### PR TITLE
Improve peer iteration in overlay

### DIFF
--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -234,18 +234,15 @@ public:
     void
     for_each (UnaryFunc&& f)
     {
-        std::vector<std::weak_ptr<PeerImp>> wp;
+        std::lock_guard <decltype(mutex_)> lock (mutex_);
 
-        // We make a copy of the list of peers to avoid having
-        // `ids_` modified during iteration.
-        {
-            std::lock_guard <decltype(mutex_)> lock (mutex_);
-            wp.reserve(ids_.size());
-            for (auto& x : ids_)
-                wp.push_back(x.second);
-        }
-        
-        for(auto& w : wp)
+        std::vector<std::weak_ptr<PeerImp>> wp;
+        wp.reserve(ids_.size());
+
+        for (auto& x : ids_)
+            wp.push_back(x.second);
+
+        for (auto& w : wp)
         {
             if (auto p = w.lock())
                 f(std::move(p));

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -236,6 +236,8 @@ public:
     {
         std::lock_guard <decltype(mutex_)> lock (mutex_);
 
+        // Iterate over a copy of the peer list because peer
+        // destruction can invalidate iterators.
         std::vector<std::weak_ptr<PeerImp>> wp;
         wp.reserve(ids_.size());
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1958,7 +1958,7 @@ getPeerWithTree (OverlayImpl& ov,
     std::shared_ptr<PeerImp> ret;
     int retScore = 0;
 
-    ov.for_each([&](std::shared_ptr<PeerImp> const&& p)
+    ov.for_each([&](std::shared_ptr<PeerImp>&& p)
     {
         if (p->hasTxSet(rootHash) && p.get() != skip)
         {
@@ -1986,7 +1986,7 @@ getPeerWithLedger (OverlayImpl& ov,
     std::shared_ptr<PeerImp> ret;
     int retScore = 0;
 
-    ov.for_each([&](std::shared_ptr<PeerImp> const&& p)
+    ov.for_each([&](std::shared_ptr<PeerImp>&& p)
     {
         if (p->hasLedger(ledgerHash, ledger) &&
                 p.get() != skip)

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1958,14 +1958,14 @@ getPeerWithTree (OverlayImpl& ov,
     std::shared_ptr<PeerImp> ret;
     int retScore = 0;
 
-    ov.for_each([&](std::shared_ptr<PeerImp> const& p)
+    ov.for_each([&](std::shared_ptr<PeerImp> const&& p)
     {
         if (p->hasTxSet(rootHash) && p.get() != skip)
         {
             auto score = p->getScore (true);
             if (! ret || (score > retScore))
             {
-                ret = p;
+                ret = std::move(p);
                 retScore = score;
             }
         }
@@ -1986,7 +1986,7 @@ getPeerWithLedger (OverlayImpl& ov,
     std::shared_ptr<PeerImp> ret;
     int retScore = 0;
 
-    ov.for_each([&](std::shared_ptr<PeerImp> const& p)
+    ov.for_each([&](std::shared_ptr<PeerImp> const&& p)
     {
         if (p->hasLedger(ledgerHash, ledger) &&
                 p.get() != skip)
@@ -1994,7 +1994,7 @@ getPeerWithLedger (OverlayImpl& ov,
             auto score = p->getScore (true);
             if (! ret || (score > retScore))
             {
-                ret = p;
+                ret = std::move(p);
                 retScore = score;
             }
         }


### PR DESCRIPTION
Reviewers: it's important to verify that all the callback functions are safe to call without the overlay `mutex_` being held.
