### PR TITLE
Add a flag to the ledger for SHAMapV2

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4632,6 +4632,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\ledger\SHAMapV2_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\ledger\SkipList_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5400,6 +5400,9 @@
     <ClCompile Include="..\..\src\test\ledger\PendingSaves_test.cpp">
       <Filter>test\ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\ledger\SHAMapV2_test.cpp">
+      <Filter>test\ledger</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\ledger\SkipList_test.cpp">
       <Filter>test\ledger</Filter>
     </ClCompile>

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -416,12 +416,21 @@ public:
 
 // ledger close flags
 static
-std::uint32_t const sLCF_NoConsensusTime = 1;
+std::uint32_t const sLCF_NoConsensusTime = 0x01;
+
+static
+std::uint32_t const sLCF_SHAMapV2 = 0x02;
 
 inline
 bool getCloseAgree (LedgerInfo const& info)
 {
     return (info.closeFlags & sLCF_NoConsensusTime) == 0;
+}
+
+inline
+bool getSHAMapV2 (LedgerInfo const& info)
+{
+    return (info.closeFlags & sLCF_SHAMapV2) != 0;
 }
 
 void addRaw (LedgerInfo const&, Serializer&);

--- a/src/test/ledger/SHAMapV2_test.cpp
+++ b/src/test/ledger/SHAMapV2_test.cpp
@@ -19,6 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/test/jtx.h>
 #include <ripple/beast/unit_test.h>
 
 namespace ripple {

--- a/src/test/ledger/SHAMapV2_test.cpp
+++ b/src/test/ledger/SHAMapV2_test.cpp
@@ -1,0 +1,70 @@
+//-----------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2015 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/beast/unit_test.h>
+
+namespace ripple {
+namespace test {
+
+// Test that converting a ledger to SHAMapV2
+// works as expected
+
+class SHAMapV2_test : public beast::unit_test::suite
+{
+    void
+    testSHAMapV2()
+    {
+        jtx::Env env(*this);
+        Config config;
+
+        auto ledger =
+            std::make_shared<Ledger>(create_genesis, config, env.app().family());
+        BEAST_EXPECT(! getSHAMapV2 (ledger->info()));
+        BEAST_EXPECT(ledger->stateMap().get_version() == SHAMap::version{1});
+        BEAST_EXPECT(ledger->txMap().get_version() == SHAMap::version{1});
+
+        ledger =
+            std::make_shared<Ledger>(*ledger, NetClock::time_point{});
+        BEAST_EXPECT(! getSHAMapV2 (ledger->info()));
+        BEAST_EXPECT(ledger->stateMap().get_version() == SHAMap::version{1});
+        BEAST_EXPECT(ledger->txMap().get_version() == SHAMap::version{1});
+
+        ledger->make_v2();
+        BEAST_EXPECT(getSHAMapV2 (ledger->info()));
+        BEAST_EXPECT(ledger->stateMap().get_version() == SHAMap::version{2});
+        BEAST_EXPECT(ledger->txMap().get_version() == SHAMap::version{2});
+
+        ledger = std::make_shared<Ledger>(*ledger, NetClock::time_point{});
+        BEAST_EXPECT(getSHAMapV2 (ledger->info()));
+        BEAST_EXPECT(ledger->stateMap().get_version() == SHAMap::version{2});
+        BEAST_EXPECT(ledger->txMap().get_version() == SHAMap::version{2});
+    }
+
+    void run()
+    {
+        testSHAMapV2();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(SHAMapV2,ledger,ripple);
+
+}  // test
+}  // ripple

--- a/src/unity/ledger_test_unity.cpp
+++ b/src/unity/ledger_test_unity.cpp
@@ -22,5 +22,6 @@
 #include <test/ledger/Directory_test.cpp>
 #include <test/ledger/PaymentSandbox_test.cpp>
 #include <test/ledger/PendingSaves_test.cpp>
+#include <test/ledger/SHAMapV2_test.cpp>
 #include <test/ledger/SkipList_test.cpp>
 #include <test/ledger/View_test.cpp>


### PR DESCRIPTION
This will allow code that looks at the ledger header to know what version the SHAMap uses. This is helpful for code that rebuilds ledger binary structures from the leaves.

A unit test for ledger version cutover is included. We had unit tests for the SHAMap-level code but none for the corresponding ledger code.