### PR TITLE
Forward manifests from new peer (RIPD-1325):

### DIFF
--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -709,7 +709,6 @@ OverlayImpl::onManifests (
 
     JLOG(journal.debug()) << "TMManifest, " << n << (n == 1 ? " item" : " items");
 
-    bool const history = m->history ();
     for (std::size_t i = 0; i < n; ++i)
     {
         auto& s = m->list ().Get (i).stobject ();
@@ -741,18 +740,7 @@ OverlayImpl::onManifests (
                 convert (serialized, rawData);
                 *db << sql, soci::use (rawData);
                 tr.commit ();
-            }
 
-            if (history)
-            {
-                // Historical manifests are sent on initial peer connections.
-                // They do not need to be forwarded to other peers.
-                hashRouter.shouldRelay (hash);
-                continue;
-            }
-
-            if (result == ManifestDisposition::accepted)
-            {
                 protocol::TMManifests o;
                 o.add_list ()->set_stobject (s);
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -702,7 +702,6 @@ PeerImp::doProtocolStart()
     onReadMessage(error_code(), 0);
 
     protocol::TMManifests tm;
-    tm.set_history (true);
 
     overlay_.manifestCache ().for_each_manifest (
         [&tm](size_t s){tm.mutable_list()->Reserve(s);},

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -44,9 +44,9 @@ message TMManifest
 message TMManifests
 {
     repeated TMManifest list = 1;
+
     // The manifests sent when a peer first connects to another peer are `history`.
-    // The receiving peer does not forward them.
-    optional bool history = 2 [default = false];
+    optional bool history = 2 [deprecated=true];
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Previously, manifests sent to new peers were marked as history so that
they would not be forwarded. However, this prevented a starting up
node's new manifest from being forwarded beyond its directly connected
peers. Stale or invalid manifests are still not forwarded.