### PR TITLE
Convert DeadlineTimer to std::thread: (RIPD-1189):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4584,6 +4584,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\core\DeadlineTimer_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5364,6 +5364,9 @@
     <ClCompile Include="..\..\src\test\core\Coroutine_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\core\DeadlineTimer_test.cpp">
+      <Filter>test\core</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -81,6 +81,7 @@
 #include <boost/asio/signal_set.hpp>
 #include <boost/optional.hpp>
 #include <atomic>
+#include <chrono>
 #include <fstream>
 
 namespace ripple {
@@ -809,8 +810,9 @@ public:
         JLOG(m_journal.info())
             << "Application starting. Version is " << BuildInfo::getVersionString();
 
-        m_sweepTimer.setExpiration (10);
-        m_entropyTimer.setRecurringExpiration (300);
+        using namespace std::chrono_literals;
+        m_sweepTimer.setExpiration (10s);
+        m_entropyTimer.setRecurringExpiration (300s);
 
         m_io_latency_sampler.start();
 
@@ -910,7 +912,8 @@ public:
         cachedSLEs_.expire();
 
         // VFALCO NOTE does the call to sweep() happen on another thread?
-        m_sweepTimer.setExpiration (config_->getSize (siSweepInterval));
+        m_sweepTimer.setExpiration (
+            std::chrono::seconds {config_->getSize (siSweepInterval)});
     }
 
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -812,7 +812,7 @@ public:
 
         using namespace std::chrono_literals;
         m_sweepTimer.setExpiration (10s);
-        m_entropyTimer.setRecurringExpiration (300s);
+        m_entropyTimer.setRecurringExpiration (5min);
 
         m_io_latency_sampler.start();
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -628,7 +628,8 @@ void NetworkOPsImp::setHeartbeatTimer ()
 
 void NetworkOPsImp::setClusterTimer ()
 {
-    m_clusterTimer.setExpiration (10.0);
+    using namespace std::chrono_literals;
+    m_clusterTimer.setExpiration (10s);
 }
 
 void NetworkOPsImp::onDeadlineTimer (DeadlineTimer& timer)

--- a/src/ripple/core/DeadlineTimer.h
+++ b/src/ripple/core/DeadlineTimer.h
@@ -20,7 +20,6 @@
 #ifndef RIPPLE_CORE_DEADLINETIMER_H_INCLUDED
 #define RIPPLE_CORE_DEADLINETIMER_H_INCLUDED
 
-#include <ripple/beast/core/RelativeTime.h>
 #include <ripple/beast/core/List.h>
 #include <chrono>
 
@@ -67,30 +66,19 @@ public:
         If the timer is already active, this will reset it.
         @note If the timer is already active, the old one might go off
               before this function returns.
-        @param secondsUntilDeadline The number of seconds until the timer
-                                    will send a notification. This must be
-                                    greater than zero.
+        @param delay duration until the timer will send a notification.
+                     This must be greater than zero.
     */
-    /** @{ */
-    void setExpiration (double secondsUntilDeadline);
-
-    template <class Rep, class Period>
-    void setExpiration (std::chrono::duration <Rep, Period> const& amount)
-    {
-        setExpiration (std::chrono::duration_cast <
-            std::chrono::duration <double>> (amount).count ());
-    }
-    /** @} */
+    void setExpiration (std::chrono::milliseconds delay);
 
     /** Set the timer to go off repeatedly with the specified frequency.
         If the timer is already active, this will reset it.
         @note If the timer is already active, the old one might go off
               before this function returns.
-        @param secondsUntilDeadline The number of seconds until the timer
-                                    will send a notification. This must be
-                                    greater than zero.
+        @param interval duration until the timer will send a notification.
+                        This must be greater than zero.
     */
-    void setRecurringExpiration (double secondsUntilDeadline);
+    void setRecurringExpiration (std::chrono::milliseconds interval);
 
     /** Equality comparison.
         Timers are equal if they have the same address.
@@ -111,8 +99,8 @@ private:
 
     Listener* const m_listener;
     bool m_isActive;
-    beast::RelativeTime m_notificationTime;
-    double m_secondsRecurring; // non zero if recurring
+    std::chrono::steady_clock::time_point notificationTime_;
+    std::chrono::milliseconds recurring_; // > 0ms if recurring.
 };
 
 }

--- a/src/ripple/core/DeadlineTimer.h
+++ b/src/ripple/core/DeadlineTimer.h
@@ -49,8 +49,9 @@ public:
         virtual void onDeadlineTimer (DeadlineTimer&) = 0;
     };
 
-public:
     /** Create a deadline timer with the specified listener attached.
+
+        @param listener pointer to Listener that is called at the deadline.
     */
     explicit DeadlineTimer (Listener* listener);
 
@@ -75,7 +76,7 @@ public:
     */
     void setExpiration (duration delay);
 
-    /** Set the timer to go off repeatedly with the specified frequency.
+    /** Set the timer to go off repeatedly with the specified period.
         If the timer is already active, this will reset it.
         @note If the timer is already active, the old one might go off
               before this function returns.

--- a/src/ripple/core/DeadlineTimer.h
+++ b/src/ripple/core/DeadlineTimer.h
@@ -31,6 +31,10 @@ class DeadlineTimer
     : public beast::List <DeadlineTimer>::Node
 {
 public:
+    using clock = std::chrono::steady_clock;
+    using duration = std::chrono::milliseconds;
+    using time_point = std::chrono::time_point<clock, duration>;
+
     /** Listener for a deadline timer.
 
         The listener is called on an auxiliary thread. It is suggested
@@ -42,7 +46,7 @@ public:
     class Listener
     {
     public:
-        virtual void onDeadlineTimer (DeadlineTimer&) { }
+        virtual void onDeadlineTimer (DeadlineTimer&) = 0;
     };
 
 public:
@@ -69,7 +73,7 @@ public:
         @param delay duration until the timer will send a notification.
                      This must be greater than zero.
     */
-    void setExpiration (std::chrono::milliseconds delay);
+    void setExpiration (duration delay);
 
     /** Set the timer to go off repeatedly with the specified frequency.
         If the timer is already active, this will reset it.
@@ -78,7 +82,7 @@ public:
         @param interval duration until the timer will send a notification.
                         This must be greater than zero.
     */
-    void setRecurringExpiration (std::chrono::milliseconds interval);
+    void setRecurringExpiration (duration interval);
 
     /** Equality comparison.
         Timers are equal if they have the same address.
@@ -99,8 +103,9 @@ private:
 
     Listener* const m_listener;
     bool m_isActive;
-    std::chrono::steady_clock::time_point notificationTime_;
-    std::chrono::milliseconds recurring_; // > 0ms if recurring.
+
+    time_point notificationTime_;
+    duration recurring_; // > 0ms if recurring.
 };
 
 }

--- a/src/ripple/core/impl/DeadlineTimer.cpp
+++ b/src/ripple/core/impl/DeadlineTimer.cpp
@@ -20,34 +20,35 @@
 #include <BeastConfig.h>
 #include <ripple/core/DeadlineTimer.h>
 #include <ripple/core/ThreadEntry.h>
-#include <ripple/beast/clock/chrono_util.h>
-#include <ripple/beast/core/Thread.h>
-#include <algorithm>
 #include <cassert>
+#include <condition_variable>
 #include <mutex>
+#include <thread>
 
 namespace ripple {
 
 class DeadlineTimer::Manager
-    : protected beast::Thread
 {
 private:
     using Items = beast::List <DeadlineTimer>;
 
-public:
-    Manager () : beast::Thread ("DeadlineTimer::Manager")
+    Manager ()
     {
-        startThread ();
+        thread_ = std::thread {&Manager::run, this};
     }
 
     ~Manager ()
     {
-        signalThreadShouldExit ();
-        notify ();
-        waitForThreadToExit ();
+        {
+            std::lock_guard<std::recursive_mutex> lock (mutex_);
+            shouldExit_ = true;
+            wakeup_.notify_one();
+        }
+        thread_.join();
         assert (m_items.empty ());
     }
 
+public:
     static
     Manager&
     instance()
@@ -66,7 +67,7 @@ public:
         using namespace std::chrono_literals;
         assert (recurring >= 0ms);
 
-        std::lock_guard <std::recursive_mutex> lock {m_mutex};
+        std::lock_guard <std::recursive_mutex> lock {mutex_};
 
         if (timer.m_isActive)
         {
@@ -81,7 +82,7 @@ public:
         insertSorted (timer);
         timer.m_isActive = true;
 
-        notify ();
+        wakeup_.notify_one();
     }
 
     // Okay to call this on an inactive timer.
@@ -89,7 +90,7 @@ public:
     //
     void deactivate (DeadlineTimer& timer)
     {
-        std::lock_guard <std::recursive_mutex> lock {m_mutex};
+        std::lock_guard <std::recursive_mutex> lock {mutex_};
 
         if (timer.m_isActive)
         {
@@ -97,11 +98,11 @@ public:
 
             timer.m_isActive = false;
 
-            notify ();
+            wakeup_.notify_one();
         }
     }
 
-    void run () override
+    void run ()
     {
         threadEntry (
             this, &Manager::runImpl, "DeadlineTimer::Manager::run()");
@@ -110,20 +111,21 @@ public:
     void runImpl ()
     {
         using namespace std::chrono;
-        while (! threadShouldExit ())
+        bool shouldExit = true;
+
+        do
         {
-            auto const currentTime = time_point_cast<duration>(clock::now());
-
-            auto nextDeadline = currentTime;
-            DeadlineTimer* timer {nullptr};
-
             {
-                std::lock_guard <std::recursive_mutex> lock {m_mutex};
+                auto const currentTime =
+                    time_point_cast<duration>(clock::now());
+                auto nextDeadline = currentTime;
+
+                std::unique_lock <std::recursive_mutex> lock {mutex_};
 
                 // See if a timer expired
-                if (! m_items.empty ())
+                if (!shouldExit_ && !m_items.empty ())
                 {
-                    timer = &m_items.front ();
+                    DeadlineTimer* const timer = &m_items.front ();
 
                     // Has this timer expired?
                     if (timer->notificationTime_ <= currentTime)
@@ -148,7 +150,10 @@ public:
                             timer->m_isActive = false;
                         }
 
-                        // NOTE!  Called *inside* lock!
+                        // Given the current code structure this call must
+                        // happen inside the lock.  Once the lock is released
+                        // the timer might be canceled and it would be invalid
+                        // to call timer->m_listener.
                         timer->m_listener->onDeadlineTimer (*timer);
 
                         // re-loop
@@ -156,44 +161,37 @@ public:
                     }
                     else
                     {
+                        // Timer has not yet expired.
                         nextDeadline = timer->notificationTime_;
 
                         // Can't be zero and come into the else clause.
                         assert (nextDeadline > currentTime);
-
-                        // Don't call the listener
-                        timer = nullptr;
                     }
                 }
-            }
 
-            // Note that we have released the lock here.
+                if (!shouldExit_)
+                {
+                    if (nextDeadline > currentTime)
+                        // Wake up at the next deadline or next notify.
+                        // Cast to clock::duration to work around VS-2015 bug.
+                        // Harmless on other platforms.
+                        wakeup_.wait_until (lock,
+                            time_point_cast<clock::duration>(nextDeadline));
 
-            if (nextDeadline > currentTime)
-            {
-                // Wait until interrupt or next timer.
-                //
-                auto const waitCountMilliSeconds = nextDeadline - currentTime;
-                static_assert(
-                    std::ratio_equal<decltype(waitCountMilliSeconds)::period,
-                    std::milli>::value,
-                    "Call to wait() requires units of milliseconds.");
+                    else if (nextDeadline == currentTime)
+                        // There is no deadline.  Wake up at the next notify.
+                        wakeup_.wait (lock);
 
-                wait (static_cast<int>(waitCountMilliSeconds.count()));
-            }
-            else if (nextDeadline == currentTime)
-            {
-                // Wait until interrupt
-                //
-                wait ();
-            }
-            else
-            {
-                // Do not wait. This can happen if the recurring timer duration
-                // is extremely short, or if a listener wastes too much time in
-                // their callback.
-            }
-        }
+                    else;
+                        // Do not wait. This can happen if the recurring
+                        // timer duration is extremely short or if a listener
+                        // burns lots of time in their callback.
+                }
+                // shouldExit is used outside the lock.
+                shouldExit = shouldExit_;
+            } // Note that we release the lock here.
+
+        } while (!shouldExit);
     }
 
     // Caller is responsible for locking
@@ -227,7 +225,11 @@ public:
     }
 
 private:
-    std::recursive_mutex m_mutex;
+    std::recursive_mutex mutex_;
+    std::condition_variable_any wakeup_;  // Works with std::recursive_mutex.
+    std::thread thread_;
+    bool shouldExit_ {false};
+
     Items m_items;
 };
 

--- a/src/ripple/core/impl/DeadlineTimer.cpp
+++ b/src/ripple/core/impl/DeadlineTimer.cpp
@@ -20,6 +20,7 @@
 #include <BeastConfig.h>
 #include <ripple/core/DeadlineTimer.h>
 #include <ripple/core/ThreadEntry.h>
+#include <ripple/beast/clock/chrono_util.h>
 #include <ripple/beast/core/Thread.h>
 #include <algorithm>
 #include <cassert>
@@ -59,11 +60,13 @@ public:
     // However, an extra notification may still happen due to concurrency.
     //
     void activate (DeadlineTimer& timer,
-        double secondsRecurring, beast::RelativeTime const& when)
+        std::chrono::milliseconds recurring,
+        std::chrono::steady_clock::time_point when)
     {
-        assert (secondsRecurring >= 0);
+        using namespace std::chrono_literals;
+        assert (recurring >= 0ms);
 
-        std::lock_guard <std::recursive_mutex> lock (m_mutex);
+        std::lock_guard <std::recursive_mutex> lock {m_mutex};
 
         if (timer.m_isActive)
         {
@@ -72,8 +75,8 @@ public:
             timer.m_isActive = false;
         }
 
-        timer.m_secondsRecurring = secondsRecurring;
-        timer.m_notificationTime = when;
+        timer.recurring_ = recurring;
+        timer.notificationTime_ = when;
 
         insertSorted (timer);
         timer.m_isActive = true;
@@ -86,7 +89,7 @@ public:
     //
     void deactivate (DeadlineTimer& timer)
     {
-        std::lock_guard <std::recursive_mutex> lock (m_mutex);
+        std::lock_guard <std::recursive_mutex> lock {m_mutex};
 
         if (timer.m_isActive)
         {
@@ -106,16 +109,16 @@ public:
 
     void runImpl ()
     {
+        using namespace std::chrono_literals;
         while (! threadShouldExit ())
         {
-            beast::RelativeTime const currentTime (
-                beast::RelativeTime::fromStartup ());
+            auto const currentTime = std::chrono::steady_clock::now();
 
-            double seconds (0);
-            DeadlineTimer* timer (nullptr);
+            auto nextDeadline = currentTime;
+            DeadlineTimer* timer {nullptr};
 
             {
-                std::lock_guard <std::recursive_mutex> lock (m_mutex);
+                std::lock_guard <std::recursive_mutex> lock {m_mutex};
 
                 // See if a timer expired
                 if (! m_items.empty ())
@@ -123,18 +126,18 @@ public:
                     timer = &m_items.front ();
 
                     // Has this timer expired?
-                    if (timer->m_notificationTime <= currentTime)
+                    if (timer->notificationTime_ <= currentTime)
                     {
                         // Expired, remove it from the list.
                         assert (timer->m_isActive);
                         m_items.pop_front ();
 
                         // Is the timer recurring?
-                        if (timer->m_secondsRecurring > 0)
+                        if (timer->recurring_ > 0ms)
                         {
                             // Yes so set the timer again.
-                            timer->m_notificationTime =
-                                currentTime + timer->m_secondsRecurring;
+                            timer->notificationTime_ =
+                                currentTime + timer->recurring_;
 
                             // Put it back into the list as active
                             insertSorted (*timer);
@@ -145,18 +148,18 @@ public:
                             timer->m_isActive = false;
                         }
 
+                        // NOTE!  Called *inside* lock!
                         timer->m_listener->onDeadlineTimer (*timer);
 
                         // re-loop
-                        seconds = -1;
+                        nextDeadline = currentTime - 1s;
                     }
                     else
                     {
-                        seconds = (
-                            timer->m_notificationTime - currentTime).inSeconds ();
+                        nextDeadline = timer->notificationTime_;
 
                         // Can't be zero and come into the else clause.
-                        assert (seconds != 0);
+                        assert (nextDeadline > currentTime);
 
                         // Don't call the listener
                         timer = nullptr;
@@ -166,16 +169,18 @@ public:
 
             // Note that we have released the lock here.
 
-            if (seconds > 0)
+            if (nextDeadline > currentTime)
             {
                 // Wait until interrupt or next timer.
                 //
-                int const milliSeconds (std::max (
-                    static_cast <int> (seconds * 1000 + 0.5), 1));
-                assert (milliSeconds > 0);
-                wait (milliSeconds);
+                int const waitCountMilliSeconds {std::max (
+                    ceil<std::chrono::duration<int, std::milli>> (
+                        nextDeadline - currentTime).count(), 1)};
+
+                assert (waitCountMilliSeconds > 0);
+                wait (waitCountMilliSeconds);
             }
-            else if (seconds == 0)
+            else if (nextDeadline == currentTime)
             {
                 // Wait until interrupt
                 //
@@ -195,11 +200,11 @@ public:
     {
         if (! m_items.empty ())
         {
-            Items::iterator before = m_items.begin ();
+            Items::iterator before {m_items.begin()};
 
             for (;;)
             {
-                if (before->m_notificationTime >= timer.m_notificationTime)
+                if (before->notificationTime_ >= timer.notificationTime_)
                 {
                     m_items.insert (before, timer);
                     break;
@@ -243,24 +248,24 @@ void DeadlineTimer::cancel ()
     Manager::instance().deactivate (*this);
 }
 
-void DeadlineTimer::setExpiration (double secondsUntilDeadline)
+void DeadlineTimer::setExpiration (std::chrono::milliseconds delay)
 {
-    assert (secondsUntilDeadline != 0);
+    using namespace std::chrono_literals;
+    assert (delay > 0ms);
 
-    beast::RelativeTime const when (
-        beast::RelativeTime::fromStartup() + secondsUntilDeadline);
+    auto const when = std::chrono::steady_clock::now() + delay;
 
-    Manager::instance().activate (*this, 0, when);
+    Manager::instance().activate (*this, 0ms, when);
 }
 
-void DeadlineTimer::setRecurringExpiration (double secondsUntilDeadline)
+void DeadlineTimer::setRecurringExpiration (std::chrono::milliseconds interval)
 {
-    assert (secondsUntilDeadline != 0);
+    using namespace std::chrono_literals;
+    assert (interval > 0ms);
 
-    beast::RelativeTime const when (
-        beast::RelativeTime::fromStartup() + secondsUntilDeadline);
+    auto const when = std::chrono::steady_clock::now() + interval;
 
-    Manager::instance().activate (*this, secondsUntilDeadline, when);
+    Manager::instance().activate (*this, interval, when);
 }
 
-} // beast
+} // ripple

--- a/src/test/core/DeadlineTimer_test.cpp
+++ b/src/test/core/DeadlineTimer_test.cpp
@@ -1,0 +1,123 @@
+//------------------------------------------------------------------------------
+/*
+This file is part of rippled: https://github.com/ripple/rippled
+Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose  with  or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/core/DeadlineTimer.h>
+#include <ripple/beast/unit_test.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace ripple {
+
+//------------------------------------------------------------------------------
+
+class DeadlineTimer_test : public beast::unit_test::suite
+{
+public:
+    struct TestCallback : DeadlineTimer::Listener
+    {
+        TestCallback() = default;
+
+        void onDeadlineTimer (DeadlineTimer&) override
+        {
+            ++count;
+        }
+
+        std::atomic<int> count {0};
+    };
+
+    void testExpiration()
+    {
+        using clock = DeadlineTimer::clock;
+
+        using namespace std::chrono_literals;
+        using namespace std::this_thread;
+
+        TestCallback cb;
+        DeadlineTimer dt {&cb};
+
+        // There are parts of this test that are somewhat race conditional.
+        // The test is designed to avoid spurious failures, rather than
+        // fail occasionally but randomly, whereever possible.  So there may
+        // be occasional gratuitous passes.  Unfortunately, since it is a
+        // time-based test, there may also be occasional spurious failures
+        // on low-powered continuous integration platforms.
+        {
+            testcase("Expiration");
+
+            // Set a deadline timer that should only fire once in 5ms.
+            cb.count = 0;
+            auto const startTime = clock::now();
+            dt.setExpiration (5ms);
+
+             // Make sure the timer didn't fire immediately.
+            int const count = cb.count.load();
+            if (clock::now() < startTime + 4ms)
+            {
+                BEAST_EXPECT (count == 0);
+            }
+
+            // Wait until the timer should have fired and check that it did.
+            // In fact, we wait long enough that if it were to fire multiple
+            // times we'd see that.
+            sleep_until (startTime + 50ms);
+            BEAST_EXPECT (cb.count.load() == 1);
+        }
+        {
+            testcase("RecurringExpiration");
+
+            // Set a deadline timer that should fire once every 5ms.
+            cb.count = 0;
+            auto const startTime = clock::now();
+            dt.setRecurringExpiration (5ms);
+
+             // Make sure the timer didn't fire immediately.
+            {
+                int const count = cb.count.load();
+                if (clock::now() < startTime + 4ms)
+                {
+                    BEAST_EXPECT (count == 0);
+                }
+            }
+
+            // Wait until the timer should have fired several times and
+            // check that it did.
+            sleep_until (startTime + 100ms);
+            {
+                auto const count = cb.count.load();
+                BEAST_EXPECT ((count > 1) && (count < 21));
+            }
+
+            // Cancel the recurring timer and it should not fire any more.
+            dt.cancel();
+            auto const count = cb.count.load();
+            sleep_for (50ms);
+            BEAST_EXPECT (count == cb.count.load());
+        }
+    }
+
+    void run()
+    {
+        testExpiration();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(DeadlineTimer, core, ripple);
+
+}

--- a/src/unity/core_test_unity.cpp
+++ b/src/unity/core_test_unity.cpp
@@ -20,6 +20,7 @@
 
 #include <test/core/Config_test.cpp>
 #include <test/core/Coroutine_test.cpp>
+#include <test/core/DeadlineTimer_test.cpp>
 #include <test/core/SociDB_test.cpp>
 #include <test/core/Stoppable_test.cpp>
 #include <test/core/Workers_test.cpp>


### PR DESCRIPTION
Standard library time facilities are primarily `chrono`-based, so it made sense to convert `DeadlineTimer` to `chrono` first.  Also added a brief unit test for good measure.