### PR TITLE
Convert DeadlineTimer to std::thread (RIPD-1189):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4584,6 +4584,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\core\DeadlineTimer_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5364,6 +5364,9 @@
     <ClCompile Include="..\..\src\test\core\Coroutine_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\core\DeadlineTimer_test.cpp">
+      <Filter>test\core</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -81,6 +81,7 @@
 #include <boost/asio/signal_set.hpp>
 #include <boost/optional.hpp>
 #include <atomic>
+#include <chrono>
 #include <fstream>
 
 namespace ripple {
@@ -809,8 +810,9 @@ public:
         JLOG(m_journal.info())
             << "Application starting. Version is " << BuildInfo::getVersionString();
 
-        m_sweepTimer.setExpiration (10);
-        m_entropyTimer.setRecurringExpiration (300);
+        using namespace std::chrono_literals;
+        m_sweepTimer.setExpiration (10s);
+        m_entropyTimer.setRecurringExpiration (5min);
 
         m_io_latency_sampler.start();
 
@@ -910,7 +912,8 @@ public:
         cachedSLEs_.expire();
 
         // VFALCO NOTE does the call to sweep() happen on another thread?
-        m_sweepTimer.setExpiration (config_->getSize (siSweepInterval));
+        m_sweepTimer.setExpiration (
+            std::chrono::seconds {config_->getSize (siSweepInterval)});
     }
 
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -628,7 +628,8 @@ void NetworkOPsImp::setHeartbeatTimer ()
 
 void NetworkOPsImp::setClusterTimer ()
 {
-    m_clusterTimer.setExpiration (10.0);
+    using namespace std::chrono_literals;
+    m_clusterTimer.setExpiration (10s);
 }
 
 void NetworkOPsImp::onDeadlineTimer (DeadlineTimer& timer)

--- a/src/ripple/core/DeadlineTimer.h
+++ b/src/ripple/core/DeadlineTimer.h
@@ -31,8 +31,9 @@ class DeadlineTimer
     : public beast::List <DeadlineTimer>::Node
 {
 public:
-    using clock = std::chrono::steady_clock;
-    using duration = std::chrono::milliseconds;
+    using clock = std::chrono::steady_clock;     ///< DeadlineTimer clock.
+    using duration = std::chrono::milliseconds;  ///< DeadlineTimer duration.
+    /** DeadlineTimer time_point. */
     using time_point = std::chrono::time_point<clock, duration>;
 
     /** Listener for a deadline timer.
@@ -46,17 +47,22 @@ public:
     class Listener
     {
     public:
+        /** Entry point called by DeadlineTimer when a deadline elapses. */
         virtual void onDeadlineTimer (DeadlineTimer&) = 0;
     };
 
-public:
     /** Create a deadline timer with the specified listener attached.
+
+        @param listener pointer to Listener that is called at the deadline.
     */
     explicit DeadlineTimer (Listener* listener);
 
+    /// @cond INTERNAL
     DeadlineTimer (DeadlineTimer const&) = delete;
     DeadlineTimer& operator= (DeadlineTimer const&) = delete;
+    /// @endcond
 
+    /** Destructor. */
     ~DeadlineTimer ();
 
     /** Cancel all notifications.
@@ -75,7 +81,7 @@ public:
     */
     void setExpiration (duration delay);
 
-    /** Set the timer to go off repeatedly with the specified frequency.
+    /** Set the timer to go off repeatedly with the specified period.
         If the timer is already active, this will reset it.
         @note If the timer is already active, the old one might go off
               before this function returns.

--- a/src/test/core/DeadlineTimer_test.cpp
+++ b/src/test/core/DeadlineTimer_test.cpp
@@ -1,0 +1,123 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/core/DeadlineTimer.h>
+#include <ripple/beast/unit_test.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace ripple {
+
+//------------------------------------------------------------------------------
+
+class DeadlineTimer_test : public beast::unit_test::suite
+{
+public:
+    struct TestCallback : DeadlineTimer::Listener
+    {
+        TestCallback() = default;
+
+        void onDeadlineTimer (DeadlineTimer&) override
+        {
+            ++count;
+        }
+
+        std::atomic<int> count {0};
+    };
+
+    void testExpiration()
+    {
+        using clock = DeadlineTimer::clock;
+
+        using namespace std::chrono_literals;
+        using namespace std::this_thread;
+
+        TestCallback cb;
+        DeadlineTimer dt {&cb};
+
+        // There are parts of this test that are somewhat race conditional.
+        // The test is designed to avoid spurious failures, rather than
+        // fail occasionally but randomly, where ever possible.  So there may
+        // be occasional gratuitous passes.  Unfortunately, since it is a
+        // time-based test, there may also be occasional spurious failures
+        // on low-powered continuous integration platforms.
+        {
+            testcase("Expiration");
+
+            // Set a deadline timer that should only fire once in 5ms.
+            cb.count = 0;
+            auto const startTime = clock::now();
+            dt.setExpiration (5ms);
+
+             // Make sure the timer didn't fire immediately.
+            int const count = cb.count.load();
+            if (clock::now() < startTime + 4ms)
+            {
+                BEAST_EXPECT (count == 0);
+            }
+
+            // Wait until the timer should have fired and check that it did.
+            // In fact, we wait long enough that if it were to fire multiple
+            // times we'd see that.
+            sleep_until (startTime + 50ms);
+            BEAST_EXPECT (cb.count.load() == 1);
+        }
+        {
+            testcase("RecurringExpiration");
+
+            // Set a deadline timer that should fire once every 5ms.
+            cb.count = 0;
+            auto const startTime = clock::now();
+            dt.setRecurringExpiration (5ms);
+
+             // Make sure the timer didn't fire immediately.
+            {
+                int const count = cb.count.load();
+                if (clock::now() < startTime + 4ms)
+                {
+                    BEAST_EXPECT (count == 0);
+                }
+            }
+
+            // Wait until the timer should have fired several times and
+            // check that it did.
+            sleep_until (startTime + 100ms);
+            {
+                auto const count = cb.count.load();
+                BEAST_EXPECT ((count > 1) && (count < 21));
+            }
+
+            // Cancel the recurring timer and it should not fire any more.
+            dt.cancel();
+            auto const count = cb.count.load();
+            sleep_for (50ms);
+            BEAST_EXPECT (count == cb.count.load());
+        }
+    }
+
+    void run()
+    {
+        testExpiration();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(DeadlineTimer, core, ripple);
+
+}

--- a/src/unity/core_test_unity.cpp
+++ b/src/unity/core_test_unity.cpp
@@ -20,6 +20,7 @@
 
 #include <test/core/Config_test.cpp>
 #include <test/core/Coroutine_test.cpp>
+#include <test/core/DeadlineTimer_test.cpp>
 #include <test/core/SociDB_test.cpp>
 #include <test/core/Stoppable_test.cpp>
 #include <test/core/Workers_test.cpp>


### PR DESCRIPTION
Since many of the `std::thread`-related timing facilities use `chrono`, it made sense to convert to `chrono` first.  Then, for good measure, add some light unit testing of `DeadlineTimer`.  Finally, convert to `std::thread`.

Doc preview: https://scottschurr.github.io
