### PR TITLE
Remove redundant call to clearNeedNetworkLedger

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1391,8 +1391,6 @@ bool NetworkOPsImp::checkLastClosedLedger (
 
     if (consensus)
     {
-        clearNeedNetworkLedger ();
-
         // FIXME: If this rewinds the ledger sequence, or has the same sequence, we
         // should update the status on any stored transactions in the invalidated
         // ledgers.


### PR DESCRIPTION
    if (consensus)
    {
      clearNeedNetworkLedger ();//_first run_--------------------------------

        // FIXME: If this rewinds the ledger sequence, or has the same sequence, we
        // should update the status on any stored transactions in the invalidated
        // ledgers.
        switchLastClosedLedger (consensus);//double run in this function --------
    }
    return true;

void NetworkOPsImp::switchLastClosedLedger (
    std::shared_ptr<Ledger const> const& newLCL)
{
    clearNeedNetworkLedger ();//double run -----------------------------------