### PR TITLE
Provide BOOST_ROOT to CMake docs target (RIPD-1364)

### DIFF
--- a/Builds/CMake/CMakeFuncs.cmake
+++ b/Builds/CMake/CMakeFuncs.cmake
@@ -269,11 +269,11 @@ endmacro()
 
 # Params: Boost components to search for.
 macro(use_boost)
+    if ((NOT DEFINED BOOST_ROOT) AND (DEFINED ENV{BOOST_ROOT}))
+        set(BOOST_ROOT $ENV{BOOST_ROOT})
+    endif()
     if(WIN32 OR CYGWIN)
         # Workaround for MSVC having two boost versions - x86 and x64 on same PC in stage folders
-        if ((NOT DEFINED BOOST_ROOT) AND (DEFINED ENV{BOOST_ROOT}))
-            set(BOOST_ROOT $ENV{BOOST_ROOT})
-        endif()
         if(DEFINED BOOST_ROOT)
             if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND IS_DIRECTORY ${BOOST_ROOT}/stage64/lib)
                 set(Boost_LIBRARY_DIR ${BOOST_ROOT}/stage64/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,15 +439,45 @@ set_property(TARGET ${other_target} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD true)
 find_program(
   B2_EXE
   NAMES b2
-  PATHS ENV BOOST_ROOT
+  HINTS ${BOOST_ROOT}
+  PATHS ${BOOST_ROOT}
   DOC "Location of the b2 build executable from Boost")
-if(${B2_EXE} STREQUAL "b2-NOTFOUND")
+if(${B2_EXE} STREQUAL "B2_EXE-NOTFOUND")
   message(WARNING
     "Boost b2 executable not found. docs target will not be buildable")
+elseif(NOT BOOST_ROOT)
+    if(Boost_INCLUDE_DIRS)
+        set(BOOST_ROOT ${Boost_INCLUDE_DIRS})
+    else()
+        get_filename_component(BOOST_ROOT ${B2_EXE} DIRECTORY)
+    endif()
 endif()
+# The value for BOOST_ROOT will be determined based on
+#   1) The environment BOOST_ROOT
+#   2) The Boost_INCLUDE_DIRS found by `get_boost`
+#   3) The folder the `b2` executable is found in.
+# If those checks don't yield the correct path, BOOST_ROOT
+# can be defined on the cmake command line:
+#    cmake <path> -DBOOST_ROOT=<boost_path>
+if(BOOST_ROOT)
+    set(B2_PARAMS "-sBOOST_ROOT=${BOOST_ROOT}")
+endif()
+
+# Find bash to help Windows avoid file association problems
+find_program(
+    BASH_EXE
+    NAMES bash sh
+    DOC "Location of the bash shell executable"
+    )
+if(${BASH_EXE} STREQUAL "BASH_EXE-NOTFOUND")
+    message(WARNING
+        "Unable to find bash executable. docs target may not be buildable")
+    set(BASH_EXE "")
+endif()
+
 add_custom_target(docs
-  COMMAND "./makeqbk.sh"
-  COMMAND ${B2_EXE}
+  COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH} " ${BASH_EXE} ./makeqbk.sh
+  COMMAND ${B2_EXE} ${B2_PARAMS}
   BYPRODUCTS "${CMAKE_SOURCE_DIR}/docs/html/index.html"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/docs"
   SOURCES "${doc_srcs}"

--- a/docs/source.dox
+++ b/docs/source.dox
@@ -106,9 +106,9 @@ INPUT                  = \
 \
     ../src/ripple/protocol/STObject.h \
     ../src/ripple/protocol/JsonFields.h \
-    ../src/ripple/test/AbstractClient.h \
-    ../src/ripple/test/JSONRPCClient.h \
-    ../src/ripple/test/WSClient.h \
+    ../src/test/support/AbstractClient.h \
+    ../src/test/support/JSONRPCClient.h \
+    ../src/test/support/WSClient.h \
 
 
 INPUT_ENCODING         = UTF-8


### PR DESCRIPTION
* Should make building docs with CMake incrementally easier and more
reliable.

I've named more reviewers than usual, because they are known to have different environments than I do, and I'd like to see if this is any easier. These changes only affect the [CMake](https://www.cmake.org) build.

If you don't already have a CMake build folder set up:
```
mkdir build/cmake # or whatever name you'd prefer
pushd build/cmake
cmake ../.. #  -G"Visual Studio 14 2015 Win64" if on Windows
popd
```
Once you have the folder set up, try to build the docs
```
cmake --build <cmake build folder> --target docs
```
Please report back your results and any problems you run into along the way.