### PR TITLE
RIPD-1365 and RIPD-1366

### DIFF
--- a/src/ripple/app/ledger/InboundLedger.h
+++ b/src/ripple/app/ledger/InboundLedger.h
@@ -65,7 +65,7 @@ public:
     // Called when another attempt is made to fetch this same ledger
     void update (std::uint32_t seq);
 
-    std::shared_ptr<Ledger> const&
+    std::shared_ptr<Ledger const>
     getLedger() const
     {
         return mLedger;

--- a/src/ripple/app/ledger/InboundLedgers.h
+++ b/src/ripple/app/ledger/InboundLedgers.h
@@ -41,7 +41,7 @@ public:
     // VFALCO TODO Should this be called findOrAdd ?
     //
     virtual
-    std::shared_ptr<Ledger>
+    std::shared_ptr<Ledger const>
     acquire (uint256 const& hash,
         std::uint32_t seq, InboundLedger::fcReason) = 0;
 

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -705,7 +705,7 @@ bool Ledger::walkLedger (beast::Journal j) const
     return missingNodes1.empty () && missingNodes2.empty ();
 }
 
-bool Ledger::assertSane (beast::Journal ledgerJ)
+bool Ledger::assertSane (beast::Journal ledgerJ) const
 {
     if (info_.hash.isNonZero () &&
             info_.accountHash.isNonZero () &&

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -303,7 +303,7 @@ public:
 
     bool walkLedger (beast::Journal j) const;
 
-    bool assertSane (beast::Journal ledgerJ);
+    bool assertSane (beast::Journal ledgerJ) const;
 
     void make_v2();
     void invariants() const;

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -64,7 +64,7 @@ public:
     {
     }
 
-    std::shared_ptr<Ledger>
+    std::shared_ptr<Ledger const>
     acquire (
         uint256 const& hash,
         std::uint32_t seq,

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1565,7 +1565,7 @@ bool ApplicationImp::loadOldLedger (
 {
     try
     {
-        std::shared_ptr<Ledger> loadLedger, replayLedger;
+        std::shared_ptr<Ledger const> loadLedger, replayLedger;
 
         if (isFileName)
         {

--- a/src/ripple/net/HTTPClient.h
+++ b/src/ripple/net/HTTPClient.h
@@ -45,7 +45,7 @@ public:
         std::deque <std::string> deqSites,
         const unsigned short port,
         std::string const& strPath,
-        std::size_t responseMax,
+        std::size_t responseMax,    // if no Content-Length header
         std::chrono::seconds timeout,
         std::function <bool (const boost::system::error_code& ecResult, int iStatus, std::string const& strData)> complete,
         beast::Journal& j);
@@ -56,7 +56,7 @@ public:
         std::string strSite,
         const unsigned short port,
         std::string const& strPath,
-        std::size_t responseMax,
+        std::size_t responseMax,    // if no Content-Length header
         std::chrono::seconds timeout,
         std::function <bool (const boost::system::error_code& ecResult, int iStatus, std::string const& strData)> complete,
         beast::Journal& j);
@@ -67,7 +67,7 @@ public:
         std::string strSite,
         const unsigned short port,
         std::function <void (boost::asio::streambuf& sb, std::string const& strHost)> build,
-        std::size_t responseMax,
+        std::size_t responseMax,    // if no Content-Length header
         std::chrono::seconds timeout,
         std::function <bool (const boost::system::error_code& ecResult, int iStatus, std::string const& strData)> complete,
         beast::Journal& j);

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1415,7 +1415,10 @@ void fromNetwork (
 
     // Send request
 
+    // Number of bytes to try to receive if no
+    // Content-Length header received
     const int RPC_REPLY_MAX_BYTES (256*1024*1024);
+
     using namespace std::chrono_literals;
     auto constexpr RPC_NOTIFY = 10min;
 

--- a/src/ripple/rpc/handlers/LedgerRequest.cpp
+++ b/src/ripple/rpc/handlers/LedgerRequest.cpp
@@ -38,6 +38,7 @@ Json::Value doLedgerRequest (RPC::Context& context)
 {
     auto const hasHash = context.params.isMember (jss::ledger_hash);
     auto const hasIndex = context.params.isMember (jss::ledger_index);
+    std::uint32_t ledgerIndex = 0;
 
     auto& ledgerMaster = context.app.getLedgerMaster();
     LedgerHash ledgerHash;
@@ -47,6 +48,8 @@ Json::Value doLedgerRequest (RPC::Context& context)
         return RPC::make_param_error(
             "Exactly one of ledger_hash and ledger_index can be set.");
     }
+
+    context.loadType = Resource::feeHighBurdenRPC;
 
     if (hasHash)
     {
@@ -65,7 +68,7 @@ Json::Value doLedgerRequest (RPC::Context& context)
             RPC::Tuning::maxValidatedLedgerAge)
             return rpcError (rpcNO_CURRENT);
 
-        auto ledgerIndex = jsonIndex.asInt();
+        ledgerIndex = jsonIndex.asInt();
         auto ledger = ledgerMaster.getValidatedLedger();
 
         if (ledgerIndex >= ledger->info().seq)
@@ -118,28 +121,29 @@ Json::Value doLedgerRequest (RPC::Context& context)
         ledgerHash = neededHash ? *neededHash : zero; // kludge
     }
 
-    auto ledger = ledgerMaster.getLedgerByHash (ledgerHash);
+    // Try to get the desired ledger
+    // Verify all nodes even if we think we have it
+    auto ledger = context.app.getInboundLedgers().acquire (
+        ledgerHash, ledgerIndex, InboundLedger::fcGENERIC);
+
+    // In standalone mode, accept the ledger from the ledger cache
+    if (! ledger && context.app.config().standalone())
+        ledger = ledgerMaster.getLedgerByHash (ledgerHash);
+
     if (ledger)
     {
-        // We already have the ledger they want
+        // We already had the entire ledger verified/acquired
         Json::Value jvResult;
         jvResult[jss::ledger_index] = ledger->info().seq;
         addJson (jvResult, {*ledger, 0});
         return jvResult;
     }
-    else
-    {
-        // Try to get the desired ledger
-        if (auto il = context.app.getInboundLedgers ().acquire (
-                ledgerHash, 0, InboundLedger::fcGENERIC))
-            return getJson (LedgerFill (*il));
 
-        if (auto il = context.app.getInboundLedgers().find (ledgerHash))
-            return il->getJson (0);
+    if (auto il = context.app.getInboundLedgers().find (ledgerHash))
+        return il->getJson (0);
 
-        return RPC::make_error (
-            rpcNOT_READY, "findCreate failed to return an inbound ledger");
-    }
+    return RPC::make_error (
+        rpcNOT_READY, "findCreate failed to return an inbound ledger");
 }
 
 } // ripple


### PR DESCRIPTION
RIPD-1365 requests that the ledger_request RPC command ensure the full ledger is present in the back end database to allow it to be used in cases where the database is believed to be incomplete or corrupt. The documentation suggested that it already did this, but it actually didn't.

RIPD-1366 requests that it be possible to retrieve a full ledger from the production rippled code with our RPC client code. The ledger exceeded the reply limit. This change removes the reply limit for responses that contain a Content-Length header. We should switch to beast's HTTP client code before removing rippled's Content-Length header (to support streaming and chunked encoding) or this problem will return.