### PR TITLE
Correct a check during RsaSha256 fulfillment loading:

### DIFF
--- a/src/ripple/conditions/impl/RsaSha256.cpp
+++ b/src/ripple/conditions/impl/RsaSha256.cpp
@@ -160,6 +160,12 @@ parsePayloadHelper(
     std::memcpy (signature.alloc (len), start, len);
     std::advance (start, len);
 
+    // Per 4.4.2 of the RFC we must check whether the
+    // signature and modulus consist of the same number
+    // of octets:
+    if (signature.size() != modulus.size())
+        return false;
+
     // Enforce constraints from the RFC:
     BigNum sig (BN_bin2bn (
         signature.data(), signature.size(), nullptr));
@@ -178,13 +184,8 @@ parsePayloadHelper(
     if (!checkModulusLength (modBytes))
         return false;
 
-    // Per 4.4.2 of the RFC we must check whether the
-    // signature and modulus consist of the same number
-    // of octets and that the signature is numerically
-    // less than the modulus:
-    if (BN_num_bytes (sig.get()) != modBytes)
-        return false;
-
+    // Per 4.4.2 of the RFC we must check that the signature
+    // is numerically less than the modulus:
     return BN_cmp (sig.get(), mod.get()) < 0;
 }
 


### PR DESCRIPTION
The specification requires that we verify that the signature and modulus of an RSA-SHA256 fulfillment are both the same length (specifically that they have "the same number of octets") referring to the encoded length.

We were, instead, checking the number of bytes that the signature and modulus had after decoding.