### PR TITLE
Add ledger_current_index to fee RPC result (RIPD-1300)

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1381,6 +1381,7 @@ TxQ::doRPC(Application& app) const
 
     auto& levels = ret[jss::levels] = Json::objectValue;
 
+    ret[jss::ledger_current_index] = view->info().seq;
     ret[jss::expected_ledger_size] = to_string(metrics->txPerLedger);
     ret[jss::current_ledger_size] = to_string(metrics->txInLedger);
     ret[jss::current_queue_size] = to_string(metrics->txCount);

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -1641,6 +1641,8 @@ public:
                 !RPC::contains_error(fee[jss::result])))
             {
                 auto const& result = fee[jss::result];
+                BEAST_EXPECT(result.isMember(jss::ledger_current_index)
+                    && result[jss::ledger_current_index] == 3);
                 BEAST_EXPECT(result.isMember(jss::current_ledger_size));
                 BEAST_EXPECT(result.isMember(jss::current_queue_size));
                 BEAST_EXPECT(result.isMember(jss::expected_ledger_size));
@@ -1667,6 +1669,8 @@ public:
                 !RPC::contains_error(fee[jss::result])))
             {
                 auto const& result = fee[jss::result];
+                BEAST_EXPECT(result.isMember(jss::ledger_current_index)
+                    && result[jss::ledger_current_index] == 4);
                 BEAST_EXPECT(result.isMember(jss::current_ledger_size));
                 BEAST_EXPECT(result.isMember(jss::current_queue_size));
                 BEAST_EXPECT(result.isMember(jss::expected_ledger_size));


### PR DESCRIPTION
Nearly trivial.

Example updated output of the `fee` RPC command:
```
{
   "id" : 1,
   "result" : {
      "current_ledger_size" : "16",
      "current_queue_size" : "14",
      "drops" : {
         "base_fee" : "10",
         "median_fee" : "5000",
         "minimum_fee" : "10",
         "open_ledger_fee" : "51200"
      },
      "expected_ledger_size" : "5",
      "ledger_current_index" : 26575101,
      "levels" : {
         "median_level" : "128000",
         "minimum_level" : "256",
         "open_ledger_level" : "1310720",
         "reference_level" : "256"
      },
      "max_queue_size" : "100",
      "status" : "success"
   }
}
```

No documentation preview, because no .h files were touched.