### PR TITLE
Update RPC handler role/usage (RIPD-557):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4608,6 +4608,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\rpc\RPCOverload_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\rpc\ServerInfo_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5247,6 +5247,9 @@
     <ClCompile Include="..\..\src\test\rpc\RobustTransaction_test.cpp">
       <Filter>test\rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\rpc\RPCOverload_test.cpp">
+      <Filter>test\rpc</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\rpc\ServerInfo_test.cpp">
       <Filter>test\rpc</Filter>
     </ClCompile>

--- a/src/ripple/server/impl/JSONRPCUtil.cpp
+++ b/src/ripple/server/impl/JSONRPCUtil.cpp
@@ -94,6 +94,7 @@ void HTTPReply (
     case 403: output ("HTTP/1.1 403 Forbidden\r\n"); break;
     case 404: output ("HTTP/1.1 404 Not Found\r\n"); break;
     case 500: output ("HTTP/1.1 500 Internal Server Error\r\n"); break;
+    case 503: output ("HTTP/1.1 503 Server is overloaded\r\n"); break;
     }
 
     output (getHTTPHeaderTimestamp ());

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -294,10 +294,12 @@ public:
         env.fund(XRP(100000), gw);
         env.close();
 
-        auto const result = env.rpc ( "ledger_request", "1" ) [jss::result];
-        BEAST_EXPECT(result[jss::error]         == "noPermission");
-        BEAST_EXPECT(result[jss::status]        == "error");
-        BEAST_EXPECT(result[jss::error_message] == "You don't have permission for this command.");
+        auto const result = env.rpc ( "ledger_request", "1" )  [jss::result];
+        // The current HTTP/S ServerHandler returns an HTTP 403 error code here
+        // rather than a noPermission JSON error.  The JSONRPCClient just eats that
+        // error and returns an null result.
+        BEAST_EXPECT(result.type() == Json::nullValue);
+
     }
 
     void run ()

--- a/src/test/rpc/RPCOverload_test.cpp
+++ b/src/test/rpc/RPCOverload_test.cpp
@@ -1,0 +1,90 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/protocol/JsonFields.h>
+#include <test/support/WSClient.h>
+#include <test/support/JSONRPCClient.h>
+#include <test/support/jtx.h>
+#include <ripple/beast/unit_test.h>
+
+namespace ripple {
+namespace test {
+
+class RPCOverload_test : public beast::unit_test::suite
+{
+public:
+    void testOverload(bool useWS)
+    {
+        testcase << "Overload " << (useWS ? "WS" : "HTTP") << " RPC client";
+        using namespace jtx;
+        Env env(*this, []()
+            {
+                auto p = std::make_unique<Config>();
+                setupConfigForUnitTests(*p);
+                (*p)["port_rpc"].set("admin","");
+                (*p)["port_ws"].set("admin","");
+                return p;
+            }());
+
+        Account const alice {"alice"};
+        Account const bob {"bob"};
+        env.fund (XRP (10000), alice, bob);
+
+        std::unique_ptr<AbstractClient> client = useWS ?
+              makeWSClient(env.app().config())
+            : makeJSONRPCClient(env.app().config());
+
+        Json::Value tx = Json::objectValue;
+        tx[jss::tx_json] = pay(alice, bob, XRP(1));
+        tx[jss::secret] = toBase58(generateSeed("alice"));
+
+        // Ask the server to repeatedly sign this transaction
+        // Signing is a resource heavy transaction, so we want the server
+        // to warn and eventually boot us.
+        bool warned = false, booted = false;
+        for(int i = 0 ; i < 500 && !booted; ++i)
+        {
+            auto jv = client->invoke("sign", tx);
+            if(!useWS)
+                jv = jv[jss::result];
+            // When booted, we just get a null json response
+            if(jv.isNull())
+                booted = true;
+            else
+                BEAST_EXPECT(jv.isMember(jss::status)
+                             && (jv[jss::status] == "success"));
+
+            if(jv.isMember(jss::warning))
+                warned = jv[jss::warning] == jss::load;
+        }
+        BEAST_EXPECT(warned && booted);
+    }
+
+
+
+    void run() override
+    {
+        testOverload(false /* http */);
+        testOverload(true /* ws */);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(RPCOverload,app,ripple);
+
+} // test
+} // ripple

--- a/src/test/unity/rpc_test_unity.cpp
+++ b/src/test/unity/rpc_test_unity.cpp
@@ -33,6 +33,7 @@
 #include <test/rpc/LedgerRequestRPC_test.cpp>
 #include <test/rpc/NoRipple_test.cpp>
 #include <test/rpc/RobustTransaction_test.cpp>
+#include <test/rpc/RPCOverload_test.cpp>
 #include <test/rpc/ServerInfo_test.cpp>
 #include <test/rpc/Status_test.cpp>
 #include <test/rpc/Subscribe_test.cpp>


### PR DESCRIPTION
* Properly use the RPC method to determine required role for HTTP/S RPC calls.
* Charge for malformed RPC calls over HTTP/S

Already reviewed by @vinniefalco and @miguelportilla 