### PR TITLE
Convert Workers to std::thread (RIPD-1189)

### DIFF
--- a/src/ripple/core/impl/Workers.cpp
+++ b/src/ripple/core/impl/Workers.cpp
@@ -165,10 +165,8 @@ Workers::Worker::~Worker ()
 
 void Workers::Worker::notify ()
 {
-    {
-        std::lock_guard <std::mutex> lock {mutex_};
-        ++wakeCount_;
-    }
+    std::lock_guard <std::mutex> lock {mutex_};
+    ++wakeCount_;
     wakeup_.notify_one();
 }
 

--- a/src/ripple/core/impl/semaphore.h
+++ b/src/ripple/core/impl/semaphore.h
@@ -54,9 +54,6 @@ public:
         m_cond.notify_one ();
     }
 
-    // Deprecated, for backward compatibility
-    void signal () { notify (); }
-
     /** Block until notify is called. */
     void wait ()
     {


### PR DESCRIPTION
I believe this change removes the last use of `beast::Thread` (other than calls to `beast::Thread::setCurrentThreadName()`).

The tests are expanded slightly.  There was a quiescent bug where if someone reduced the number of Workers there might be a double delete on shutdown.  That problem never occurred since the number of `Worker`s was never reduced.  Still, the problem is now fixed and the new tests check for that case.