### PR TITLE
[TRIVIAL] Fix broken Intellisense (MSVC)

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -577,11 +577,13 @@ static std::array<char const*, 5> const stateNames {{
     "tracking",
     "full"}};
 
+#ifndef __INTELLISENSE__
 static_assert (NetworkOPs::omDISCONNECTED == 0, "");
 static_assert (NetworkOPs::omCONNECTED == 1, "");
 static_assert (NetworkOPs::omSYNCING == 2, "");
 static_assert (NetworkOPs::omTRACKING == 3, "");
 static_assert (NetworkOPs::omFULL == 4, "");
+#endif
 
 std::array<char const*, 5> const NetworkOPsImp::states_ = stateNames;
 

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -564,9 +564,11 @@ inline std::ostream& operator<< (
     return out << to_string (u);
 }
 
+#ifndef __INTELLISENSE__
 static_assert(sizeof(uint128) == 128/8, "There should be no padding bytes");
 static_assert(sizeof(uint160) == 160/8, "There should be no padding bytes");
 static_assert(sizeof(uint256) == 256/8, "There should be no padding bytes");
+#endif
 
 } // rippled
 

--- a/src/ripple/basics/random.h
+++ b/src/ripple/basics/random.h
@@ -34,6 +34,7 @@
 
 namespace ripple {
 
+#ifndef __INTELLISENSE__
 static_assert (
     std::is_integral <beast::xor_shift_engine::result_type>::value &&
     std::is_unsigned <beast::xor_shift_engine::result_type>::value,
@@ -43,6 +44,7 @@ static_assert (
     std::numeric_limits<beast::xor_shift_engine::result_type>::max() >=
     std::numeric_limits<std::uint64_t>::max(),
         "The Ripple default PRNG engine return must be at least 64 bits wide.");
+#endif
 
 namespace detail {
 

--- a/src/ripple/beast/core/SystemStats.cpp
+++ b/src/ripple/beast/core/SystemStats.cpp
@@ -28,6 +28,7 @@
 // Some basic tests, to keep an eye on things and make sure these types work ok
 // on all platforms.
 
+#ifndef __INTELLISENSE__
 static_assert (sizeof (std::intptr_t) == sizeof (void*), "std::intptr_t must be the same size as void*");
 
 static_assert (sizeof (std::int8_t) == 1,   "std::int8_t must be exactly 1 byte!");
@@ -39,6 +40,7 @@ static_assert (sizeof (std::uint8_t) == 1,  "std::uint8_t must be exactly 1 byte
 static_assert (sizeof (std::uint16_t) == 2, "std::uint16_t must be exactly 2 bytes!");
 static_assert (sizeof (std::uint32_t) == 4, "std::uint32_t must be exactly 4 bytes!");
 static_assert (sizeof (std::uint64_t) == 8, "std::uint64_t must be exactly 8 bytes!");
+#endif
 
 namespace beast
 {

--- a/src/ripple/beast/hash/endian.h
+++ b/src/ripple/beast/hash/endian.h
@@ -40,12 +40,14 @@ enum class endian
 #endif
 };
 
+#ifndef __INTELLISENSE__
 static_assert(endian::native == endian::little ||
               endian::native == endian::big,
               "endian::native shall be one of endian::little or endian::big");
 
 static_assert(endian::big != endian::little,
               "endian::big and endian::little shall have different values");
+#endif
 
 } // beast
 

--- a/src/ripple/beast/hash/meta.h
+++ b/src/ripple/beast/hash/meta.h
@@ -39,8 +39,10 @@ struct static_and<>
 {
 };
 
+#ifndef __INTELLISENSE__
 static_assert( static_and<true, true, true>::value, "");
 static_assert(!static_and<true, false, true>::value, "");
+#endif
 
 template <std::size_t ...>
 struct static_sum;
@@ -58,7 +60,9 @@ struct static_sum<>
 {
 };
 
+#ifndef __INTELLISENSE__
 static_assert(static_sum<5, 2, 17, 0>::value == 24, "");
+#endif
 
 template <class T, class U>
 struct enable_if_lvalue

--- a/src/ripple/beast/utility/Journal.h
+++ b/src/ripple/beast/utility/Journal.h
@@ -109,12 +109,14 @@ public:
         bool m_console;
     };
 
+#ifndef __INTELLISENSE__
 static_assert(std::is_default_constructible<Sink>::value == false, "");
 static_assert(std::is_copy_constructible<Sink>::value == false, "");
 static_assert(std::is_move_constructible<Sink>::value == false, "");
 static_assert(std::is_copy_assignable<Sink>::value == false, "");
 static_assert(std::is_move_assignable<Sink>::value == false, "");
 static_assert(std::is_nothrow_destructible<Sink>::value == true, "");
+#endif
 
     /** Returns a Sink which does nothing. */
     static Sink& getNullSink ();
@@ -161,12 +163,14 @@ private:
         std::ostringstream mutable m_ostream;
     };
 
+#ifndef __INTELLISENSE__
 static_assert(std::is_default_constructible<ScopedStream>::value == false, "");
 static_assert(std::is_copy_constructible<ScopedStream>::value == true, "");
 static_assert(std::is_move_constructible<ScopedStream>::value == true, "");
 static_assert(std::is_copy_assignable<ScopedStream>::value == false, "");
 static_assert(std::is_move_assignable<ScopedStream>::value == false, "");
 static_assert(std::is_nothrow_destructible<ScopedStream>::value == true, "");
+#endif
 
     //--------------------------------------------------------------------------
 public:
@@ -237,12 +241,14 @@ public:
         Severity m_level;
     };
 
+#ifndef __INTELLISENSE__
 static_assert(std::is_default_constructible<Stream>::value == true, "");
 static_assert(std::is_copy_constructible<Stream>::value == true, "");
 static_assert(std::is_move_constructible<Stream>::value == true, "");
 static_assert(std::is_copy_assignable<Stream>::value == false, "");
 static_assert(std::is_move_assignable<Stream>::value == false, "");
 static_assert(std::is_nothrow_destructible<Stream>::value == true, "");
+#endif
 
     //--------------------------------------------------------------------------
 
@@ -322,12 +328,14 @@ static_assert(std::is_nothrow_destructible<Stream>::value == true, "");
     /** @} */
 };
 
+#ifndef __INTELLISENSE__
 static_assert(std::is_default_constructible<Journal>::value == true, "");
 static_assert(std::is_copy_constructible<Journal>::value == true, "");
 static_assert(std::is_move_constructible<Journal>::value == true, "");
 static_assert(std::is_copy_assignable<Journal>::value == false, "");
 static_assert(std::is_move_assignable<Journal>::value == false, "");
 static_assert(std::is_nothrow_destructible<Journal>::value == true, "");
+#endif
 
 //------------------------------------------------------------------------------
 

--- a/src/test/basics/hardened_hash_test.cpp
+++ b/src/test/basics/hardened_hash_test.cpp
@@ -170,8 +170,10 @@ public:
 
 using sha256_t = unsigned_integer <256, std::size_t>;
 
+#ifndef __INTELLISENSE__
 static_assert (sha256_t::bits == 256,
     "sha256_t must have 256 bits");
+#endif
 
 } // ripple
 

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -28,6 +28,7 @@
 namespace ripple {
 namespace tests {
 
+#ifndef __INTELLISENSE__
 static_assert( std::is_nothrow_destructible <SHAMap>{}, "");
 static_assert(!std::is_default_constructible<SHAMap>{}, "");
 static_assert(!std::is_copy_constructible   <SHAMap>{}, "");
@@ -97,6 +98,7 @@ static_assert(!std::is_copy_constructible   <SHAMapTreeNode>{}, "");
 static_assert(!std::is_copy_assignable      <SHAMapTreeNode>{}, "");
 static_assert(!std::is_move_constructible   <SHAMapTreeNode>{}, "");
 static_assert(!std::is_move_assignable      <SHAMapTreeNode>{}, "");
+#endif
 
 inline bool operator== (SHAMapItem const& a, SHAMapItem const& b) { return a.key() == b.key(); }
 inline bool operator!= (SHAMapItem const& a, SHAMapItem const& b) { return a.key() != b.key(); }


### PR DESCRIPTION
* MSVC Intellisense will ignore all file-level `static_asserts`.

See also: https://github.com/vinniefalco/Beast/commit/7db3c6eacf9a68b1c40b1eb270f8d384430e9e53. Because there are other file-level `static_asserts` in Beast and nudb, this may not fix _all_ Intellisense problems until those dependencies are updated, too.