### PR TITLE
Eliminate protocol header dependency (RIPD-1234):

### DIFF
--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -91,7 +91,7 @@ public:
     const_iterator cend()   const { return data()+bytes; }
 
     /** Value hashing function.
-        The seed prevents crafted inputs from causing degenarate parent containers.
+        The seed prevents crafted inputs from causing degenerate parent containers.
     */
     using hasher = hardened_hash <>;
 

--- a/src/test/basics/base_uint_test.cpp
+++ b/src/test/basics/base_uint_test.cpp
@@ -19,8 +19,9 @@
 
 #include <BeastConfig.h>
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/hardened_hash.h>
 #include <ripple/beast/unit_test.h>
-#include <ripple/protocol/digest.h>
+#include <boost/algorithm/string.hpp>
 
 namespace ripple {
 namespace test {
@@ -29,19 +30,16 @@ struct base_uint_test : beast::unit_test::suite
 {
     using test96 = base_uint<96>;
 
-    template<class bt>
-    void checkHash(bt const& t, std::string const& hash)
-    {
-        auto h = sha512Half(t);
-        BEAST_EXPECT(to_string(h) == hash);
-    }
-
     void run()
     {
-        Blob raw{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+        // used to verify set insertion (hashing required)
+        std::unordered_set<test96, hardened_hash<>> uset;
+
+        Blob raw { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         BEAST_EXPECT(test96::bytes == raw.size());
 
-        test96 u(raw);
+        test96 u { raw };
+        uset.insert(u);
         BEAST_EXPECT(raw.size() == u.size());
         BEAST_EXPECT(to_string(u) == "0102030405060708090A0B0C");
         BEAST_EXPECT(*u.data() == 1);
@@ -54,9 +52,9 @@ struct base_uint_test : beast::unit_test::suite
         {
             BEAST_EXPECT(d == ++t);
         }
-        checkHash(u, "25996DBE31A04FF03E4E63C9C647AC6D459475E2845529238F3D08F4A37EBC54");
 
-        test96 v(~u);
+        test96 v { ~u };
+        uset.insert(v);
         BEAST_EXPECT(to_string(v) == "FEFDFCFBFAF9F8F7F6F5F4F3");
         BEAST_EXPECT(*v.data() == 0xfe);
         BEAST_EXPECT(v.signum() == 1);
@@ -68,7 +66,6 @@ struct base_uint_test : beast::unit_test::suite
         {
             BEAST_EXPECT(d == --t);
         }
-        checkHash(v, "019A8C0B8307FD822A1346546200328DB40B4565793FD4799B83D780BDB634CE");
 
         BEAST_EXPECT(compare(u, v) < 0);
         BEAST_EXPECT(compare(v, u) > 0);
@@ -76,7 +73,8 @@ struct base_uint_test : beast::unit_test::suite
         v = u;
         BEAST_EXPECT(v == u);
 
-        test96 z(beast::zero);
+        test96 z { beast::zero };
+        uset.insert(z);
         BEAST_EXPECT(to_string(z) == "000000000000000000000000");
         BEAST_EXPECT(*z.data() == 0);
         BEAST_EXPECT(*z.begin() == 0);
@@ -89,9 +87,8 @@ struct base_uint_test : beast::unit_test::suite
         {
             BEAST_EXPECT(d == 0);
         }
-        checkHash(z, "666A9A1A7542E895A9F447D1C3E0FFD679BBF6346E0C43F5C7A733C46F5E56C2");
 
-        test96 n(z);
+        test96 n { z };
         n++;
         BEAST_EXPECT(n == test96(1));
         n--;
@@ -102,9 +99,56 @@ struct base_uint_test : beast::unit_test::suite
         n = beast::zero;
         BEAST_EXPECT(n == z);
 
-        auto hash = sha512Half(u, v, z, n);
-        BEAST_EXPECT(to_string(hash) ==
-            "55CAB39C72F2572057114B4732210605AA22C6E89243FBB5F9943130D813F902");
+        test96 x { (--test96 { z }) ^ (++test96 { z }) };
+        uset.insert(x);
+        BEAST_EXPECT(to_string(x) == "FFFFFFFFFFFFFFFFFFFFFFFE");
+
+        BEAST_EXPECT(uset.size() == 4);
+
+        // SetHex tests...
+        test96 fromHex;
+        BEAST_EXPECT(fromHex.SetHexExact(to_string(u)));
+        BEAST_EXPECT(fromHex == u);
+        fromHex = z;
+
+        // fails with extra char
+        BEAST_EXPECT(! fromHex.SetHexExact("A" + to_string(u)));
+        BEAST_EXPECT(fromHex != u);
+        fromHex = z;
+
+        // fails with extra char at end, but the value is still parsed (?)
+        BEAST_EXPECT(! fromHex.SetHexExact(to_string(u) + "A"));
+        BEAST_EXPECT(fromHex == u);
+        fromHex = z;
+
+        BEAST_EXPECT(fromHex.SetHex(to_string(u)));
+        BEAST_EXPECT(fromHex == u);
+        fromHex = z;
+
+        // leading space/0x allowed if not strict
+        BEAST_EXPECT(fromHex.SetHex("  0x" + to_string(u)));
+        BEAST_EXPECT(fromHex == u);
+        fromHex = z;
+
+        // other leading chars also allowed (ignored)
+        BEAST_EXPECT(fromHex.SetHex("FEFEFE" + to_string(u)));
+        BEAST_EXPECT(fromHex == u);
+        fromHex = z;
+
+        // invalid hex chars should fail (0 replaced with Z here)
+        BEAST_EXPECT(! fromHex.SetHex(
+            boost::algorithm::replace_all_copy(to_string(u), "0", "Z")));
+        BEAST_EXPECT(fromHex != u);
+        fromHex = z;
+
+        BEAST_EXPECT(fromHex.SetHex(to_string(u), true));
+        BEAST_EXPECT(fromHex == u);
+        fromHex = z;
+
+        // strict mode fails with leading chars
+        BEAST_EXPECT(! fromHex.SetHex("  0x" + to_string(u), true));
+        BEAST_EXPECT(fromHex != u);
+        fromHex = z;
     }
 };
 

--- a/src/test/basics/base_uint_test.cpp
+++ b/src/test/basics/base_uint_test.cpp
@@ -129,9 +129,13 @@ struct base_uint_test : beast::unit_test::suite
         n = beast::zero;
         BEAST_EXPECT(n == z);
 
-        test96 x { (--test96 { z }) ^ (++test96 { z }) };
+        test96 zp1 { z };
+        zp1++;
+        test96 zm1 { z };
+        zm1--;
+        test96 x { zm1 ^ zp1 };
         uset.insert(x);
-        BEAST_EXPECT(to_string(x) == "FFFFFFFFFFFFFFFFFFFFFFFE");
+        BEAST_EXPECTS(to_string(x) == "FFFFFFFFFFFFFFFFFFFFFFFE", to_string(x));
 
         BEAST_EXPECT(uset.size() == 4);
 

--- a/src/test/basics/base_uint_test.cpp
+++ b/src/test/basics/base_uint_test.cpp
@@ -77,7 +77,6 @@ struct base_uint_test : beast::unit_test::suite
 
         nonhash<96> h;
         hash_append(h, u);
-        test96 y;
         test96 w {std::vector<std::uint8_t>(h.data_.begin(), h.data_.end())};
         BEAST_EXPECT(w == u);
 


### PR DESCRIPTION
Eliminate checks using sha512half, add coverage for xor and SetHex.