### PR TITLE
Remove superfluous assert

### DIFF
--- a/src/ripple/basics/BasicConfig.h
+++ b/src/ripple/basics/BasicConfig.h
@@ -88,7 +88,6 @@ public:
             lines_.emplace_back (std::move (value));
         else
         {
-            assert (lines_.size () == 1);
             lines_[0] = std::move (value);
         }
     }

--- a/src/ripple/basics/BasicConfig.h
+++ b/src/ripple/basics/BasicConfig.h
@@ -87,9 +87,7 @@ public:
         if (lines_.empty ())
             lines_.emplace_back (std::move (value));
         else
-        {
             lines_[0] = std::move (value);
-        }
     }
 
     /**
@@ -101,9 +99,7 @@ public:
     std::string
     legacy () const
     {
-        if (lines_.empty ())
-            return "";
-        else if (lines_.size () > 1)
+        if (lines_.size () > 1)
             Throw<std::runtime_error> (
                 "A legacy value must have exactly one line. Section: " + name_);
         return lines_[0];

--- a/src/ripple/basics/BasicConfig.h
+++ b/src/ripple/basics/BasicConfig.h
@@ -99,6 +99,8 @@ public:
     std::string
     legacy () const
     {
+        if (lines_.empty ())
+            return "";
         if (lines_.size () > 1)
             Throw<std::runtime_error> (
                 "A legacy value must have exactly one line. Section: " + name_);


### PR DESCRIPTION
The size of lines_ gets checked at runtime in the legacy() function below.

A different solution might be to promote this to a runtime error, since it would throw a little bit later (when the getter is invoked) anyways.