### PR TITLE
Add batch support for both RPC and Websocket.

### DIFF
--- a/src/ripple/app/ledger/LedgerProposal.cpp
+++ b/src/ripple/app/ledger/LedgerProposal.cpp
@@ -109,7 +109,7 @@ void LedgerProposal::bowOut (NetClock::time_point now)
 
 Json::Value LedgerProposal::getJson () const
 {
-    Json::Value ret = Json::objectValue;
+    Json::Value ret{Json::objectValue};
     ret[jss::previous_ledger] = to_string (mPreviousLedger);
 
     if (mProposeSeq != seqLeave)

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2019,7 +2019,7 @@ Json::Value NetworkOPsImp::getConsensusInfo ()
 
 Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 {
-    Json::Value info = Json::objectValue;
+    Json::Value info{Json::objectValue};
 
     // hostid: unique string describing the machine
     if (human)
@@ -2052,7 +2052,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
                     s += beast::rfc2616::trim(line);
                 if (auto mo = make_Manifest (beast::detail::base64_decode(s)))
                 {
-                    Json::Value valManifest = Json::objectValue;
+                    Json::Value valManifest{Json::objectValue};
                     valManifest [jss::master_key] = toBase58 (
                         TokenType::TOKEN_NODE_PUBLIC,
                         mo->masterKey);
@@ -2092,7 +2092,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
     info[jss::peers] = Json::UInt (app_.overlay ().size ());
 
-    Json::Value lastClose = Json::objectValue;
+    Json::Value lastClose{Json::objectValue};
     lastClose[jss::proposers] = mConsensus->getLastCloseProposers();
 
     if (human)
@@ -3232,7 +3232,7 @@ Json::Value NetworkOPsImp::StateAccounting::json() const
     counters[mode].dur += std::chrono::duration_cast<
         std::chrono::microseconds>(std::chrono::system_clock::now() - start);
 
-    Json::Value ret = Json::objectValue;
+    Json::Value ret{Json::objectValue};
 
     for (std::underlying_type_t<OperatingMode> i = omDISCONNECTED;
         i <= omFULL; ++i)

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -574,7 +574,7 @@ AmendmentTableImpl::getJson (int)
 Json::Value
 AmendmentTableImpl::getJson (uint256 const& amendmentID)
 {
-    Json::Value ret = Json::objectValue;
+    Json::Value ret{Json::objectValue};
     Json::Value& jAmendment = (ret[to_string (amendmentID)] = Json::objectValue);
 
     {

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -632,7 +632,7 @@ Json::Value PathRequest::doUpdate(
             return jvStatus;
     }
 
-    Json::Value newStatus = Json::objectValue;
+    Json::Value newStatus{Json::objectValue};
 
     if (hasCompletion ())
     {
@@ -687,7 +687,7 @@ Json::Value PathRequest::doUpdate(
     JLOG(m_journal.debug()) << iIdentifier
         << " processing at level " << iLevel;
 
-    Json::Value jvArray = Json::arrayValue;
+    Json::Value jvArray{Json::arrayValue};
     if (findPaths(cache, iLevel, jvArray))
     {
         bLastSuccess = jvArray.size() != 0;

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -244,7 +244,7 @@ JobQueue::getJson (int c)
 
     ret["threads"] = m_workers.getNumberOfThreads ();
 
-    Json::Value priorities = Json::arrayValue;
+    Json::Value priorities{Json::arrayValue};
 
     std::lock_guard <std::mutex> lock (m_mutex);
 

--- a/src/ripple/json/impl/json_value.cpp
+++ b/src/ripple/json/impl/json_value.cpp
@@ -193,6 +193,12 @@ Value::CZString::isStaticString () const
  * memset( this, 0, sizeof(Value) )
  * This optimization is used in ValueInternalMap fast allocator.
  */
+Value::Value ()
+    : type_ ( nullValue )
+    , allocated_ ( 0 )
+{
+}
+
 Value::Value ( ValueType type )
     : type_ ( type )
     , allocated_ ( 0 )
@@ -502,6 +508,76 @@ bool operator== (const Value& x, const Value& y)
     }
 
     return 0;  // unreachable
+}
+
+bool
+operator== (const Value& x, ValueType y)
+{
+    return x == Value{y};
+}
+
+bool
+operator== (const Value& x, Int y)
+{
+    if (x.type_ != intValue)
+    {
+        if (x.type_ == uintValue)
+            return !integerCmp(y, x.value_.uint_);
+        return false;
+    }
+    return x.value_.int_ == y;
+}
+
+bool
+operator== (const Value& x, UInt y)
+{
+    if (x.type_ != uintValue)
+    {
+        if (x.type_ == intValue)
+            return !integerCmp(x.value_.int_, y);
+        return false;
+    }
+   return x.value_.uint_ == y;
+ }
+
+bool
+operator== (const Value& x, double y)
+{
+    if (x.type_ != realValue)
+        return false;
+    return x.value_.real_ == y;
+}
+
+bool
+operator== (const Value& x, const char* y)
+{
+    if (x.type_ != stringValue)
+        return false;
+    return std::string(x.value_.string_) == std::string(y);
+}
+
+bool
+operator== (const Value& x, StaticString const& y)
+{
+    if (x.type_ != stringValue)
+        return false;
+    return std::string(x.value_.string_) == y;
+}
+
+bool
+operator== (const Value& x, std::string const& y)
+{
+    if (x.type_ != stringValue)
+        return false;
+    return x.value_.string_ == y;
+}
+
+bool
+operator== (const Value& x, bool y)
+{
+    if (x.type_ != booleanValue)
+        return false;
+    return x.value_.bool_ == y;
 }
 
 const char*

--- a/src/ripple/json/impl/json_value.cpp
+++ b/src/ripple/json/impl/json_value.cpp
@@ -553,7 +553,7 @@ operator== (const Value& x, const char* y)
 {
     if (x.type_ != stringValue)
         return false;
-    return std::string(x.value_.string_) == std::string(y);
+    return std::string(x.value_.string_) == y;
 }
 
 bool

--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -211,11 +211,12 @@ public:
     Json::Value obj_value(Json::objectValue); // {}
     \endcode
          */
-    Value ( ValueType type = nullValue );
-    Value ( Int value );
-    Value ( UInt value );
-    Value ( double value );
-    Value ( const char* value );
+    Value ();
+    explicit Value ( ValueType type );
+    explicit Value ( Int value );
+    explicit Value ( UInt value );
+    explicit Value ( double value );
+    explicit Value ( const char* value );
     Value ( const char* beginValue, const char* endValue );
     /** \brief Constructs a value from a static string.
 
@@ -227,9 +228,9 @@ public:
      * Json::Value aValue( StaticString("some text") );
      * \endcode
      */
-    Value ( const StaticString& value );
-    Value ( std::string const& value );
-    Value ( bool value );
+    explicit Value ( const StaticString& value );
+    explicit Value ( std::string const& value );
+    explicit Value ( bool value );
     Value ( const Value& other );
     ~Value ();
 
@@ -237,6 +238,15 @@ public:
 
     Value ( Value&& other ) noexcept;
     Value& operator= ( Value&& other ) noexcept;
+
+    Value& operator=(ValueType type) {return *this = Value{type};}
+    Value& operator=(Int value) {return *this = Value{value};}
+    Value& operator=(UInt value) {return *this = Value{value};}
+    Value& operator=(double value) {return *this = Value{value};}
+    Value& operator=(const char* value) {return *this = Value{value};}
+    Value& operator=(const StaticString& value) {return *this = Value{value};}
+    Value& operator=(std::string const& value) {return *this = Value{value};}
+    Value& operator=(bool value) {return *this = Value{value};}
 
     /// Swap values.
     /// \note Currently, comments are intentionally not swapped, for
@@ -308,6 +318,15 @@ public:
     /// Equivalent to jsonvalue[jsonvalue.size()] = value;
     Value& append ( const Value& value );
 
+    Value& append(ValueType type) {return append(Value{type});}
+    Value& append(Int value) {return append(Value{value});}
+    Value& append(UInt value) {return append(Value{value});}
+    Value& append(double value) {return append(Value{value});}
+    Value& append(const char* value) {return append(Value{value});}
+    Value& append(const StaticString& value) {return append(Value{value});}
+    Value& append(std::string const& value) {return append(Value{value});}
+    Value& append(bool value) {return append(Value{value});}
+
     /// Access an object value by name, create a null member if it does not exist.
     Value& operator[] ( const char* key );
     /// Access an object value by name, returns null if there is no member with that name.
@@ -373,6 +392,15 @@ public:
     friend bool operator== (const Value&, const Value&);
     friend bool operator< (const Value&, const Value&);
 
+    friend bool operator== (const Value&, ValueType);
+    friend bool operator== (const Value&, Int);
+    friend bool operator== (const Value&, UInt);
+    friend bool operator== (const Value&, double);
+    friend bool operator== (const Value&, const char*);
+    friend bool operator== (const Value&, StaticString const&);
+    friend bool operator== (const Value&, std::string const&);
+    friend bool operator== (const Value&, bool);
+
 private:
     Value& resolveReference ( const char* key,
                               bool isStatic );
@@ -393,10 +421,74 @@ private:
 
 bool operator== (const Value&, const Value&);
 
+inline bool operator==(ValueType x, const Value& y) {return y == x;}
+inline bool operator==(Int x, const Value& y) {return y == x;}
+inline bool operator==(UInt x, const Value& y) {return y == x;}
+inline bool operator==(double x, const Value& y) {return y == x;}
+inline bool operator==(StaticString const& x, const Value& y) {return y == x;}
+inline bool operator==(std::string x, const Value& y) {return y == x;}
+inline bool operator==(bool x, const Value& y) {return y == x;}
+
 inline
 bool operator!= (const Value& x, const Value& y)
 {
     return ! (x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, ValueType y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, Int y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, UInt y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, double y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, const char* y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, const StaticString& y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, const std::string& y)
+{
+    return !(x == y);
+}
+
+inline
+bool
+operator!= (const Value& x, bool y)
+{
+    return !(x == y);
 }
 
 bool operator< (const Value&, const Value&);
@@ -406,6 +498,14 @@ bool operator<= (const Value& x, const Value& y)
 {
     return ! (y < x);
 }
+
+inline bool operator!=(ValueType x, const Value& y) {return y != x;}
+inline bool operator!=(Int x, const Value& y) {return y != x;}
+inline bool operator!=(UInt x, const Value& y) {return y != x;}
+inline bool operator!=(double x, const Value& y) {return y != x;}
+inline bool operator!=(StaticString const& x, const Value& y) {return y != x;}
+inline bool operator!=(std::string x, const Value& y) {return y != x;}
+inline bool operator!=(bool x, const Value& y) {return y != x;}
 
 inline
 bool operator> (const Value& x, const Value& y)
@@ -418,6 +518,35 @@ bool operator>= (const Value& x, const Value& y)
 {
     return ! (x < y);
 }
+
+inline
+bool
+operator< (const Value& x, double y)
+{
+    return x < Json::Value{y};
+}
+
+inline
+bool
+operator> (const Value& x, double y)
+{
+    return x > Json::Value{y};
+}
+
+inline
+bool
+operator<= (const Value& x, Int y)
+{
+    return x <= Json::Value{y};
+}
+
+inline
+bool
+operator>= (const Value& x, Int y)
+{
+    return x >= Json::Value{y};
+}
+
 
 /** \brief Experimental do not use: Allocator to customize member name and string value memory management done by Value.
  *

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1032,6 +1032,9 @@ public:
             // Request-response methods
             // - Returns an error, or the request.
             // - To modify the method, provide a new method in the request.
+            // - From the Json 2.0 spec:  http://www.jsonrpc.org/specification
+            //      Method names that begin with rpc are reserved for system extensions,
+            //      and MUST NOT be used for anything else.
             {   "account_currencies",   &RPCParser::parseAccountCurrencies,     1,  2   },
             {   "account_info",         &RPCParser::parseAccountItems,          1,  2   },
             {   "account_lines",        &RPCParser::parseAccountLines,          1,  5   },

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1363,7 +1363,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMStatusChange> const& m)
     app_.getOPs().pubPeerStatus (
         [=]() -> Json::Value
         {
-            Json::Value j = Json::objectValue;
+            Json::Value j{Json::objectValue};
 
             if (m->has_newstatus ())
             {

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -814,9 +814,9 @@ amountFromJson (SField const& name, Json::Value const& v)
     }
     else if (v.isArray ())
     {
-        value = v.get (Json::UInt (0), 0);
-        currency = v.get (Json::UInt (1), Json::nullValue);
-        issuer = v.get (Json::UInt (2), Json::nullValue);
+        value = v.get (Json::UInt (0), Json::Value{0});
+        currency = v.get (Json::UInt (1), Json::Value{});
+        issuer = v.get (Json::UInt (2), Json::Value{});
     }
     else if (v.isString ())
     {

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -145,7 +145,7 @@ std::string STArray::getText () const
 
 Json::Value STArray::getJson (int p) const
 {
-    Json::Value v = Json::arrayValue;
+    Json::Value v{Json::arrayValue};
     int index = 1;
     for (auto const& object: v_)
     {

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -98,7 +98,7 @@ STBase::getText() const
 Json::Value
 STBase::getJson (int /*options*/) const
 {
-    return getText();
+    return Json::Value{getText()};
 }
 
 void

--- a/src/ripple/protocol/impl/STInteger.cpp
+++ b/src/ripple/protocol/impl/STInteger.cpp
@@ -68,13 +68,13 @@ STUInt8::getJson (int) const
         std::string token, human;
 
         if (transResultInfo (static_cast<TER> (value_), token, human))
-            return token;
+            return Json::Value{token};
 
         JLOG (debugLog().error())
             << "Unknown result code in metadata: " << value_;
     }
 
-    return value_;
+    return Json::Value{value_};
 }
 
 //------------------------------------------------------------------------------
@@ -127,7 +127,7 @@ STUInt16::getJson (int) const
             static_cast <LedgerEntryType> (value_));
 
         if (item != nullptr)
-            return item->getName ();
+            return Json::Value{item->getName()};
     }
 
     if (getFName () == sfTransactionType)
@@ -136,10 +136,10 @@ STUInt16::getJson (int) const
             static_cast <TxType> (value_));
 
         if (item != nullptr)
-            return item->getName ();
+            return Json::Value{item->getName()};
     }
 
-    return value_;
+    return Json::Value{value_};
 }
 
 //------------------------------------------------------------------------------
@@ -168,7 +168,7 @@ template <>
 Json::Value
 STUInt32::getJson (int) const
 {
-    return value_;
+    return Json::Value{value_};
 }
 
 //------------------------------------------------------------------------------
@@ -197,7 +197,7 @@ template <>
 Json::Value
 STUInt64::getJson (int) const
 {
-    return strHex (value_);
+    return Json::Value{strHex(value_)};
 }
 
 } // ripple

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -99,7 +99,7 @@ Json::Value doAccountInfo (RPC::Context& context)
         {
             // We put the SignerList in an array because of an anticipated
             // future when we support multiple signer lists on one account.
-            Json::Value jvSignerList = Json::arrayValue;
+            Json::Value jvSignerList{Json::arrayValue};
 
             // This code will need to be revisited if in the future we support
             // multiple SignerLists on one account.
@@ -113,7 +113,7 @@ Json::Value doAccountInfo (RPC::Context& context)
         // Return queue info if that is requested
         if (queue)
         {
-            Json::Value jvQueueData = Json::objectValue;
+            Json::Value jvQueueData{Json::objectValue};
 
             auto const txs = context.app.getTxQ().getAccountTxs(
                 accountID, context.app.config(), *ledger);
@@ -131,7 +131,7 @@ Json::Value doAccountInfo (RPC::Context& context)
 
                 for (auto const& tx : *txs)
                 {
-                    Json::Value jvTx = Json::objectValue;
+                    Json::Value jvTx{Json::objectValue};
 
                     jvTx[jss::seq] = tx.first;
                     jvTx[jss::fee_level] = to_string(tx.second.feeLevel);

--- a/src/ripple/rpc/handlers/CanDelete.cpp
+++ b/src/ripple/rpc/handlers/CanDelete.cpp
@@ -40,7 +40,7 @@ Json::Value doCanDelete (RPC::Context& context)
 
     if (context.params.isMember(jss::can_delete))
     {
-        Json::Value canDelete  = context.params.get(jss::can_delete, 0);
+        Json::Value canDelete  = context.params.get(jss::can_delete, Json::Value{0});
         std::uint32_t canDeleteSeq = 0;
 
         if (canDelete.isUInt())

--- a/src/ripple/rpc/handlers/Connect.cpp
+++ b/src/ripple/rpc/handlers/Connect.cpp
@@ -39,7 +39,7 @@ Json::Value doConnect (RPC::Context& context)
 {
     auto lock = make_lock(context.app.getMasterMutex());
     if (context.app.config().standalone())
-        return "cannot connect in standalone mode";
+        return Json::Value{"cannot connect in standalone mode"};
 
     if (!context.params.isMember (jss::ip))
         return RPC::missing_field_error (jss::ip);

--- a/src/ripple/rpc/handlers/Feature1.cpp
+++ b/src/ripple/rpc/handlers/Feature1.cpp
@@ -55,7 +55,7 @@ Json::Value doFeature (RPC::Context& context)
                 m.second.time_since_epoch().count();
         }
 
-        Json::Value jvReply = Json::objectValue;
+        Json::Value jvReply{Json::objectValue};
         jvReply[jss::features] = features;
         return jvReply;
     }

--- a/src/ripple/rpc/handlers/LogLevel.cpp
+++ b/src/ripple/rpc/handlers/LogLevel.cpp
@@ -62,7 +62,7 @@ Json::Value doLogLevel (RPC::Context& context)
     {
         // set base log threshold
         context.app.logs().threshold(severity);
-        return Json::objectValue;
+        return Json::Value{Json::objectValue};
     }
 
     // log_level partition severity base?
@@ -76,7 +76,7 @@ Json::Value doLogLevel (RPC::Context& context)
         else
             context.app.logs().get(partition).threshold(severity);
 
-        return Json::objectValue;
+        return Json::Value{Json::objectValue};
     }
 
     return rpcError (rpcINVALID_PARAMS);

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -70,7 +70,7 @@ Json::Value doNoRippleCheck (RPC::Context& context)
         if (role == "gateway")
             roleGateway = true;
         else if (role != "user")
-        return RPC::invalid_field_message ("role");
+        return Json::Value{RPC::invalid_field_message ("role")};
     }
 
     unsigned int limit;

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -54,7 +54,7 @@ accountFromString(
     if (auto accountID = accountFromStringStrict (strIdent))
     {
         result = *accountID;
-        return Json::objectValue;
+        return Json::Value{Json::objectValue};
     }
 
     if (bStrict)
@@ -75,7 +75,7 @@ accountFromString(
         *seed);
 
     result = calcAccountID (keypair.first);
-    return Json::objectValue;
+    return Json::Value{Json::objectValue};
 }
 
 bool

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -569,7 +569,7 @@ ServerHandlerImp::processRequest (Port const& port,
     }
     else
     {
-        role = requestRole(required, port, Json::objectValue,
+        role = requestRole(required, port, Json::Value{Json::objectValue},
             remoteIPAddress, user);
     }
 

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -390,6 +390,14 @@ ServerHandlerImp::onStopped (Server&)
     stopped();
 }
 
+static
+void
+extract_params(Json::Value& jv, Json::Value const& params)
+{
+    for (auto i = params.begin(); i != params.end(); ++i)
+        jv[i.key().asString()] = *i;
+}
+
 //------------------------------------------------------------------------------
 
 Json::Value
@@ -540,185 +548,194 @@ ServerHandlerImp::processRequest (Port const& port,
 {
     auto rpcJ = app_.journal ("RPC");
 
-    Json::Value jsonRPC;
+    Json::Value jsonOrig;
     {
         Json::Reader reader;
         if ((request.size () > RPC::Tuning::maxRequestSize) ||
-            ! reader.parse (request, jsonRPC) ||
-            ! jsonRPC ||
-            ! jsonRPC.isObject ())
+            ! reader.parse (request, jsonOrig) ||
+            ! jsonOrig ||
+            ! (jsonOrig.isObject() || jsonOrig.isArray()))
         {
             HTTPReply (400, "Unable to parse request", output, rpcJ);
             return;
         }
     }
 
-    /* ---------------------------------------------------------------------- */
-    // Determine role/usage so we can charge for invalid requests
-    Json::Value const& method = jsonRPC [jss::method];
+    auto size = jsonOrig.isArray() ? jsonOrig.size() : 1;
+    for (unsigned i = 0; i < size; ++i)
+    {
+        Json::Value const& jsonRPC = jsonOrig.isArray() ? jsonOrig[i] : jsonOrig;
+        /* ---------------------------------------------------------------------- */
+        // Determine role/usage so we can charge for invalid requests
+        Json::Value const& method = jsonRPC [jss::method];
 
-    auto role = Role::FORBID;
-    auto required = RPC::roleRequired(method.asString());
-    if (jsonRPC.isMember(jss::params) &&
-        jsonRPC[jss::params].isArray() &&
-        jsonRPC[jss::params].size() > 0 &&
-        jsonRPC[jss::params][Json::UInt(0)].isObject())
-    {
-        role = requestRole(required, port, jsonRPC[jss::params][Json::UInt(0)],
-            remoteIPAddress, user);
-    }
-    else
-    {
-        role = requestRole(required, port, Json::Value{Json::objectValue},
-            remoteIPAddress, user);
-    }
-
-    Resource::Consumer usage;
-    if (isUnlimited(role))
-    {
-        usage = m_resourceManager.newUnlimitedEndpoint(
-            remoteIPAddress.to_string());
-    }
-    else
-    {
-        usage = m_resourceManager.newInboundEndpoint(remoteIPAddress);
-        if (usage.disconnect())
+        auto role = Role::FORBID;
+        auto required = RPC::roleRequired(method.asString());
+        if (jsonRPC.isMember(jss::params) &&
+            jsonRPC[jss::params].isArray() &&
+            jsonRPC[jss::params].size() > 0 &&
+            jsonRPC[jss::params][Json::UInt(0)].isObject())
         {
-            HTTPReply(503, "Server is overloaded", output, rpcJ);
+            role = requestRole(required, port, jsonRPC[jss::params][Json::UInt(0)],
+                remoteIPAddress, user);
+        }
+        else
+        {
+            role = requestRole(required, port, Json::Value{Json::objectValue},
+                remoteIPAddress, user);
+        }
+
+        Resource::Consumer usage;
+        if (isUnlimited(role))
+        {
+            usage = m_resourceManager.newUnlimitedEndpoint(
+                remoteIPAddress.to_string());
+        }
+        else
+        {
+            usage = m_resourceManager.newInboundEndpoint(remoteIPAddress);
+            if (usage.disconnect())
+            {
+                HTTPReply(503, "Server is overloaded", output, rpcJ);
+                return;
+            }
+        }
+
+        if (role == Role::FORBID)
+        {
+            usage.charge(Resource::feeInvalidRPC);
+            HTTPReply (403, "Forbidden", output, rpcJ);
             return;
         }
-    }
 
-    if (role == Role::FORBID)
-    {
-        usage.charge(Resource::feeInvalidRPC);
-        HTTPReply (403, "Forbidden", output, rpcJ);
-        return;
-    }
+        if (! method)
+        {
+            usage.charge(Resource::feeInvalidRPC);
+            HTTPReply (400, "Null method", output, rpcJ);
+            return;
+        }
 
-    if (! method)
-    {
-        usage.charge(Resource::feeInvalidRPC);
-        HTTPReply (400, "Null method", output, rpcJ);
-        return;
-    }
+        if (! method.isString ())
+        {
+            usage.charge(Resource::feeInvalidRPC);
+            HTTPReply (400, "method is not string", output, rpcJ);
+            return;
+        }
 
-    if (! method.isString ())
-    {
-        usage.charge(Resource::feeInvalidRPC);
-        HTTPReply (400, "method is not string", output, rpcJ);
-        return;
-    }
+        std::string strMethod = method.asString ();
+        if (strMethod.empty())
+        {
+            usage.charge(Resource::feeInvalidRPC);
+            HTTPReply (400, "method is empty", output, rpcJ);
+            return;
+        }
 
-    std::string strMethod = method.asString ();
-    if (strMethod.empty())
-    {
-        usage.charge(Resource::feeInvalidRPC);
-        HTTPReply (400, "method is empty", output, rpcJ);
-        return;
-    }
+        // Extract request parameters from the request Json as `params`.
+        //
+        // If the field "params" is empty, `params` is an empty object.
+        //
+        // Otherwise, that field must be an array of length 1 (why?)
+        // and we take that first entry and validate that it's an object.
+        Json::Value params = jsonRPC [jss::params];
 
-    // Extract request parameters from the request Json as `params`.
-    //
-    // If the field "params" is empty, `params` is an empty object.
-    //
-    // Otherwise, that field must be an array of length 1 (why?)
-    // and we take that first entry and validate that it's an object.
-    Json::Value params = jsonRPC [jss::params];
+        if (! params)
+            params = Json::Value (Json::objectValue);
 
-    if (! params)
-        params = Json::Value (Json::objectValue);
-
-    else if (!params.isArray () || params.size() != 1)
-    {
-        usage.charge(Resource::feeInvalidRPC);
-        HTTPReply (400, "params unparseable", output, rpcJ);
-        return;
-    }
-    else
-    {
-        params = std::move (params[0u]);
-        if (!params.isObject())
+        else if (!params.isArray () || params.size() != 1)
         {
             usage.charge(Resource::feeInvalidRPC);
             HTTPReply (400, "params unparseable", output, rpcJ);
             return;
         }
-    }
-
-    /**
-     * Clear header-assigned values if not positively identified from a
-     * secure_gateway.
-     */
-    if (role != Role::IDENTIFIED)
-    {
-        forwardedFor.clear();
-        user.clear();
-    }
-
-    JLOG(m_journal.debug()) << "Query: " << strMethod << params;
-
-    // Provide the JSON-RPC method as the field "command" in the request.
-    params[jss::command] = strMethod;
-    JLOG (m_journal.trace())
-        << "doRpcCommand:" << strMethod << ":" << params;
-
-    Resource::Charge loadType = Resource::feeReferenceRPC;
-    auto const start (std::chrono::high_resolution_clock::now ());
-
-    RPC::Context context {m_journal, params, app_, loadType, m_networkOPs,
-        app_.getLedgerMaster(), usage, role, coro, InfoSub::pointer(),
-        {user, forwardedFor}};
-    Json::Value result;
-    RPC::doCommand (context, result);
-
-    // Always report "status".  On an error report the request as received.
-    if (result.isMember (jss::error))
-    {
-        result[jss::status] = jss::error;
-        result[jss::request] = params;
-        JLOG (m_journal.debug())  <<
-            "rpcError: " << result [jss::error] <<
-            ": " << result [jss::error_message];
-    }
-    else
-    {
-        result[jss::status]  = jss::success;
-    }
-
-    usage.charge (loadType);
-    if (usage.warn())
-        result[jss::warning] = jss::load;
-
-    Json::Value reply (Json::objectValue);
-    reply[jss::result] = std::move (result);
-    if (jsonRPC.isMember(jss::jsonrpc))
-        reply[jss::jsonrpc] = jsonRPC[jss::jsonrpc];
-    if (jsonRPC.isMember(jss::ripplerpc))
-        reply[jss::ripplerpc] = jsonRPC[jss::ripplerpc];
-    if (jsonRPC.isMember(jss::id))
-        reply[jss::id] = jsonRPC[jss::id];
-    auto response = to_string (reply);
-
-    rpc_time_.notify (static_cast <beast::insight::Event::value_type> (
-        std::chrono::duration_cast <std::chrono::milliseconds> (
-            std::chrono::high_resolution_clock::now () - start)));
-    ++rpc_requests_;
-    rpc_size_.notify (static_cast <beast::insight::Event::value_type> (
-        response.size ()));
-
-    response += '\n';
-
-    if (auto stream = m_journal.debug())
-    {
-        static const int maxSize = 10000;
-        if (response.size() <= maxSize)
-            stream << "Reply: " << response;
         else
-            stream << "Reply: " << response.substr (0, maxSize);
-    }
+        {
+            params = std::move (params[0u]);
+            if (!params.isObject())
+            {
+                usage.charge(Resource::feeInvalidRPC);
+                HTTPReply (400, "params unparseable", output, rpcJ);
+                return;
+            }
+        }
 
-    HTTPReply (200, response, output, rpcJ);
+        /**
+         * Clear header-assigned values if not positively identified from a
+         * secure_gateway.
+         */
+        if (role != Role::IDENTIFIED)
+        {
+            forwardedFor.clear();
+            user.clear();
+        }
+
+        JLOG(m_journal.debug()) << "Query: " << strMethod << params;
+
+        // Provide the JSON-RPC method as the field "command" in the request.
+        params[jss::command] = strMethod;
+        JLOG (m_journal.trace())
+            << "doRpcCommand:" << strMethod << ":" << params;
+
+        Resource::Charge loadType = Resource::feeReferenceRPC;
+        auto const start (std::chrono::high_resolution_clock::now ());
+
+        RPC::Context context {m_journal, params, app_, loadType, m_networkOPs,
+            app_.getLedgerMaster(), usage, role, coro, InfoSub::pointer(),
+            {user, forwardedFor}};
+        Json::Value result;
+        RPC::doCommand (context, result);
+
+        // Always report "status".  On an error report the request as received.
+        bool on_error = false;
+        if (result.isMember (jss::error))
+        {
+            result[jss::status] = jss::error;
+            result[jss::request] = params;
+            JLOG (m_journal.debug())  <<
+                "rpcError: " << result [jss::error] <<
+                ": " << result [jss::error_message];
+            on_error = true;
+        }
+        else
+        {
+            result[jss::status]  = jss::success;
+        }
+
+        usage.charge (loadType);
+        if (usage.warn())
+            result[jss::warning] = jss::load;
+
+        Json::Value reply (Json::objectValue);
+        reply[jss::result] = std::move (result);
+        if (jsonRPC.isMember(jss::jsonrpc))
+            reply[jss::jsonrpc] = jsonRPC[jss::jsonrpc];
+        if (jsonRPC.isMember(jss::ripplerpc))
+            reply[jss::ripplerpc] = jsonRPC[jss::ripplerpc];
+        if (jsonRPC.isMember(jss::id))
+            reply[jss::id] = jsonRPC[jss::id];
+        auto response = to_string (reply);
+
+        rpc_time_.notify (static_cast <beast::insight::Event::value_type> (
+            std::chrono::duration_cast <std::chrono::milliseconds> (
+                std::chrono::high_resolution_clock::now () - start)));
+        ++rpc_requests_;
+        rpc_size_.notify (static_cast <beast::insight::Event::value_type> (
+            response.size ()));
+
+        response += '\n';
+
+        if (auto stream = m_journal.debug())
+        {
+            static const int maxSize = 10000;
+            if (response.size() <= maxSize)
+                stream << "Reply: " << response;
+            else
+                stream << "Reply: " << response.substr (0, maxSize);
+        }
+
+        HTTPReply (200, response, output, rpcJ);
+        if (on_error)
+            return;
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -395,14 +395,6 @@ ServerHandlerImp::onStopped (Server&)
     stopped();
 }
 
-static
-void
-extract_params(Json::Value& jv, Json::Value const& params)
-{
-    for (auto i = params.begin(); i != params.end(); ++i)
-        jv[i.key().asString()] = *i;
-}
-
 //------------------------------------------------------------------------------
 
 Json::Value

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -846,7 +846,7 @@ static Json::Value checkMultiSignFields (Json::Value const& jvRequest)
     Json::Value const& tx_json (jvRequest [jss::tx_json]);
 
     if (!tx_json.isObject())
-        return RPC::invalid_field_message (jss::tx_json);
+        return Json::Value{RPC::invalid_field_message(jss::tx_json)};
 
     // There are a couple of additional fields we need to check before
     // we serialize.  If we serialize first then we generate less useful

--- a/src/test/app/AccountTxPaging_test.cpp
+++ b/src/test/app/AccountTxPaging_test.cpp
@@ -41,7 +41,7 @@ class AccountTxPaging_test : public beast::unit_test::suite
         int ledger_max,
         int limit,
         bool forward,
-        Json::Value const& marker = Json::nullValue)
+        Json::Value const& marker = Json::Value{})
     {
         Json::Value jvc;
         jvc[jss::account] = account.human();

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -152,14 +152,14 @@ equal(STAmount const& sa1, STAmount const& sa2)
 Json::Value
 rpf(jtx::Account const& src, jtx::Account const& dst, std::uint32_t num_src)
 {
-    Json::Value jv = Json::objectValue;
+    Json::Value jv{Json::objectValue};
     jv[jss::command] = "ripple_path_find";
     jv[jss::source_account] = toBase58(src);
 
     if (num_src > 0)
     {
         auto& sc = (jv[jss::source_currencies] = Json::arrayValue);
-        Json::Value j = Json::objectValue;
+        Json::Value j{Json::objectValue};
         while (num_src--)
         {
             j[jss::currency] = std::to_string(num_src + 100);
@@ -234,7 +234,7 @@ public:
         RPC::Context context {beast::Journal(), {}, app, loadType,
             app.getOPs(), app.getLedgerMaster(), c, Role::USER, {}};
 
-        Json::Value params = Json::objectValue;
+        Json::Value params{Json::objectValue};
         params[jss::command] = "ripple_path_find";
         params[jss::source_account] = toBase58 (src);
         params[jss::destination_account] = toBase58 (dst);
@@ -244,7 +244,7 @@ public:
         if(saSrcCurrency)
         {
             auto& sc = params[jss::source_currencies] = Json::arrayValue;
-            Json::Value j = Json::objectValue;
+            Json::Value j{Json::objectValue};
             j[jss::currency] = to_string(saSrcCurrency.value());
             sc.append(j);
         }

--- a/src/test/json/json_value_test.cpp
+++ b/src/test/json/json_value_test.cpp
@@ -217,6 +217,17 @@ struct json_value_test : beast::unit_test::suite
         testGreaterThan ("big");
     }
 
+    void
+    test_dearray()
+    {
+        Json::Value a{Json::arrayValue};
+        Json::Value b;
+        b["key"] = "value";
+        a[0u] = b;
+        a = std::move(a[0u]);
+        BEAST_EXPECT(a == b);
+    }
+
     void run ()
     {
         test_bool ();
@@ -225,6 +236,7 @@ struct json_value_test : beast::unit_test::suite
         test_copy ();
         test_move ();
         test_comparisons ();
+        test_dearray();
     }
 };
 

--- a/src/test/jtx/AbstractClient.h
+++ b/src/test/jtx/AbstractClient.h
@@ -52,7 +52,11 @@ public:
     virtual
     Json::Value
     invoke(std::string const& cmd,
-        Json::Value const& params = {}) = 0;
+        Json::Value const& params) = 0;
+
+    virtual
+    Json::Value
+    invoke(Json::Value const& cmd) = 0;
 
     /// Get RPC 1.0 or RPC 2.0
     virtual unsigned version() const = 0;

--- a/src/test/jtx/AbstractClient.h
+++ b/src/test/jtx/AbstractClient.h
@@ -54,6 +54,16 @@ public:
     invoke(std::string const& cmd,
         Json::Value const& params) = 0;
 
+    /** Submit a command synchronously.
+
+        The arguments to the function and the returned JSON
+        are in a normalized format, the same whether the client
+        is using the JSON-RPC over HTTP/S or WebSocket transport.
+
+        @param cmd The command to execute as a 2.0 Json 
+                   request object.
+        @return The server response in normalized format.
+    */
     virtual
     Json::Value
     invoke(Json::Value const& cmd) = 0;

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -402,7 +402,7 @@ public:
         This calls postconditions.
     */
     void
-    sign_and_submit(JTx const& jt, Json::Value params = Json::nullValue);
+    sign_and_submit(JTx const& jt, Json::Value params = Json::Value{});
 
     /** Check expected postconditions
         of JTx submission.

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -206,6 +206,9 @@ public:
     Json::Value
     rpc(std::string const& cmd, Args&&... args);
 
+    Json::Value
+    rpc(Json::Value const& cmd);
+
     /** Returns the current ledger.
 
         This is a non-modifiable snapshot of the

--- a/src/test/jtx/Env_ss.h
+++ b/src/test/jtx/Env_ss.h
@@ -49,7 +49,7 @@ private:
         {
         }
 
-        void operator()(Json::Value const& params = Json::nullValue)
+        void operator()(Json::Value const& params = Json::Value{})
         {
             env_.sign_and_submit(jt_, params);
         }

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -549,6 +549,13 @@ Env::do_rpc(std::vector<std::string> const& args)
     return response;
 }
 
+Json::Value
+Env::rpc(Json::Value const& cmd)
+{
+    auto response = client().invoke(cmd);
+    return response;
+}
+
 } // jtx
 
 } // test

--- a/src/test/jtx/impl/JSONRPCClient.cpp
+++ b/src/test/jtx/impl/JSONRPCClient.cpp
@@ -106,7 +106,6 @@ public:
     {
         using namespace beast::http;
         using namespace boost::asio;
-        using namespace std::string_literals;
 
         request<string_body> req;
         req.method = "POST";
@@ -152,7 +151,6 @@ public:
     {
         using namespace beast::http;
         using namespace boost::asio;
-        using namespace std::string_literals;
 
         request<string_body> req;
         req.method = "POST";

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -208,7 +208,116 @@ public:
     Json::Value
     invoke(Json::Value const& cmd) override
     {
-        return {};
+        using boost::asio::buffer;
+        using namespace std::chrono_literals;
+        Json::Value request;
+        if (cmd.isArray())
+        {
+            auto const num_requests = cmd.size();
+            for (unsigned i = 0; i < num_requests; ++i)
+            {
+                Json::Value const& cmdi = cmd[i];
+
+                if (cmdi.isMember(jss::params))
+                {
+                    auto const& params = cmdi[jss::params][0u];
+                    for (auto j = params.begin(); j != params.end(); ++j)
+                        request[i][j.key().asString()] = *j;
+                }
+                for (auto j = cmdi.begin(); j != cmdi.end(); ++j)
+                {
+                    if (j.key().asString() != "params")
+                        request[i][j.key().asString()] = *j;
+                }
+            }
+        }
+        else
+        {
+            if (cmd.isMember(jss::params))
+            {
+                auto const& params = cmd[jss::params][0u];
+                for (auto i = params.begin(); i != params.end(); ++i)
+                    request[i.key().asString()] = *i;
+            }
+            for (auto i = cmd.begin(); i != cmd.end(); ++i)
+            {
+                if (i.key().asString() != "params")
+                    request[i.key().asString()] = *i;
+            }
+        }
+
+        {
+            auto const s = to_string(request);
+            ws_.write_frame(true, buffer(s));
+        }
+
+        Json::Value response;
+        if (cmd.isArray())
+        {
+            for (unsigned i = 0; i < cmd.size(); ++i)
+            {
+                auto jv = findMsg(5s,
+                    [&](Json::Value const& jv)
+                    {
+                        return jv[jss::type] == Json::Value{jss::response};
+                    });
+                if (jv)
+                {
+                    // Normalize JSON output
+                    jv->removeMember(jss::type);
+                    if ((*jv).isMember(jss::status) &&
+                        (*jv)[jss::status] == Json::Value{jss::error})
+                    {
+                        response[i][jss::result] = *jv;
+                        if ((*jv).isMember(jss::error))
+                            response[i][jss::error] = (*jv)[jss::error];
+                        response[i][jss::status] = jss::error;
+                    }
+                    else if ((*jv).isMember(jss::status) &&
+                        (*jv).isMember(jss::result))
+                    {
+                            (*jv)[jss::result][jss::status] =
+                                (*jv)[jss::status];
+                    }
+                    response[i] = *jv;
+                    if (response[i].isMember(jss::error))
+                        break;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        else
+        {
+            auto jv = findMsg(5s,
+                [&](Json::Value const& jv)
+                {
+                    return jv[jss::type] == Json::Value{jss::response};
+                });
+            if (jv)
+            {
+                // Normalize JSON output
+                jv->removeMember(jss::type);
+                if ((*jv).isMember(jss::status) &&
+                    (*jv)[jss::status] == Json::Value{jss::error})
+                {
+                    response[jss::result] = *jv;
+                    if ((*jv).isMember(jss::error))
+                        response[jss::error] = (*jv)[jss::error];
+                    response[jss::status] = jss::error;
+                }
+                else if ((*jv).isMember(jss::status) &&
+                    (*jv).isMember(jss::result))
+                {
+                        (*jv)[jss::result][jss::status] =
+                            (*jv)[jss::status];
+                }
+                response = *jv;
+            }
+        }
+        return response;
     }
 
     boost::optional<Json::Value>

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -205,6 +205,12 @@ public:
         return {};
     }
 
+    Json::Value
+    invoke(Json::Value const& cmd) override
+    {
+        return {};
+    }
+
     boost::optional<Json::Value>
     getMsg(std::chrono::milliseconds const& timeout) override
     {

--- a/src/test/rpc/GatewayBalances_test.cpp
+++ b/src/test/rpc/GatewayBalances_test.cpp
@@ -92,6 +92,63 @@ public:
             expect(jv.isMember(jss::ripplerpc) && jv[jss::ripplerpc] == "2.0");
             expect(jv.isMember(jss::id) && jv[jss::id] == 5);
         }
+        {
+            Json::Value request;
+            request[0u][jss::jsonrpc] = "2.0";
+            request[0u][jss::ripplerpc] = "2.0";
+            request[0u][jss::id] = 5;
+            request[0u][jss::method] = "gateway_balances";
+            request[0u][jss::params][0u][jss::account] = alice.human();
+            request[0u][jss::params][0u][jss::hotwallet] = hw.human();
+
+            request[1u][jss::jsonrpc] = "2.0";
+            request[1u][jss::ripplerpc] = "2.0";
+            request[1u][jss::id] = 6;
+            request[1u][jss::method] = "gateway_balances";
+            request[1u][jss::params][0u][jss::account] = alice.human();
+            request[1u][jss::params][0u][jss::hotwallet] = hw.human();
+
+            auto response = wsc->invoke(request);
+            expect(response.isArray());
+            expect(response.size() == 2);
+            auto const& r0 = response[0u][jss::id] == 5 ? response[0u] : response[1u];
+            auto const& r1 = response[1u][jss::id] == 6 ? response[1u] : response[0u];
+
+            expect(r0[jss::id] == 5);
+            expect(r0.isMember(jss::result));
+            expect(r0[jss::result].isMember("account"));
+            expect(r0[jss::result][jss::status] == "success");
+
+            expect(r1[jss::id] == 6);
+            expect(r1.isMember(jss::result));
+            expect(r1[jss::result].isMember("account"));
+            expect(r1[jss::result][jss::status] == "success");
+        }
+        {
+            wsc = makeWSClient(env.app().config());
+            Json::Value request;
+            request[0u][jss::jsonrpc] = "2.0";
+            request[0u][jss::ripplerpc] = "2.0";
+            request[0u][jss::id] = 5;
+            request[0u][jss::method] = "gateway_blances";
+            request[0u][jss::params][0u][jss::account] = alice.human();
+            request[0u][jss::params][0u][jss::hotwallet] = hw.human();
+
+            request[1u][jss::jsonrpc] = "2.0";
+            request[1u][jss::ripplerpc] = "2.0";
+            request[1u][jss::id] = 6;
+            request[1u][jss::method] = "gateway_balances";
+            request[1u][jss::params][0u][jss::account] = alice.human();
+            request[1u][jss::params][0u][jss::hotwallet] = hw.human();
+
+            auto response = wsc->invoke(request);
+            expect(response.isArray());
+            expect(response.size() == 1);
+            auto const& r0 = response[0u];
+
+            expect(r0[jss::id] == 5);
+            expect(r0.isMember(jss::error));
+        }
 
         auto const& result = jv[jss::result];
         expect(result[jss::account] == alice.human());

--- a/src/test/rpc/KeyGeneration_test.cpp
+++ b/src/test/rpc/KeyGeneration_test.cpp
@@ -92,7 +92,7 @@ public:
 
         expectEquals (result[jss::key_type],
             params.isMember (jss::key_type) ? params[jss::key_type]
-                                            : "secp256k1");
+                                            : Json::Value{"secp256k1"});
 
         std::string seed = result[jss::master_seed].asString();
 
@@ -115,7 +115,7 @@ public:
         expectEquals (result[jss::public_key_hex], s.public_key_hex);
         expectEquals (result[jss::key_type],
             params.isMember (jss::key_type) ? params[jss::key_type]
-                                            : "secp256k1");
+                                            : Json::Value{"secp256k1"});
     }
 
     void testSeed (boost::optional<std::string> const& keyType,

--- a/src/test/rpc/RPCOverload_test.cpp
+++ b/src/test/rpc/RPCOverload_test.cpp
@@ -49,7 +49,7 @@ public:
               makeWSClient(env.app().config())
             : makeJSONRPCClient(env.app().config());
 
-        Json::Value tx = Json::objectValue;
+        Json::Value tx{Json::objectValue};
         tx[jss::tx_json] = pay(alice, bob, XRP(1));
         tx[jss::secret] = toBase58(generateSeed("alice"));
 

--- a/src/test/rpc/RobustTransaction_test.cpp
+++ b/src/test/rpc/RobustTransaction_test.cpp
@@ -113,7 +113,7 @@ public:
             env.app().getJobQueue().rendezvous();
 
             // Finalize transactions
-            jv = wsc->invoke("ledger_accept");
+            jv = wsc->invoke("ledger_accept", {});
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
@@ -253,7 +253,7 @@ public:
                 "tesSUCCESS");
 
             // Finalize transaction
-            jv = wsc->invoke("ledger_accept");
+            jv = wsc->invoke("ledger_accept", {});
             if (wsc->version() == 2)
             {
                 BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
@@ -286,7 +286,7 @@ public:
             // Close ledgers
             for(auto i = 0; i < 8; ++i)
             {
-                auto jv = wsc->invoke("ledger_accept");
+                auto jv = wsc->invoke("ledger_accept", {});
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");
@@ -343,7 +343,7 @@ public:
             // Close ledgers
             for (auto i = 0; i < 2; ++i)
             {
-                auto jv = wsc->invoke("ledger_accept");
+                auto jv = wsc->invoke("ledger_accept", {});
                 if (wsc->version() == 2)
                 {
                     BEAST_EXPECT(jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0");

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -235,14 +235,14 @@ class ServerStatus_test :
     {
         Json::Value jrr;
 
-        Json::Value jp = Json::objectValue;
+        Json::Value jp{Json::objectValue};
         if(! user.empty())
         {
             jp["admin_user"] = user;
             if(subobject)
             {
                 //special case of bad password..passed as object
-                Json::Value jpi = Json::objectValue;
+                Json::Value jpi{Json::objectValue};
                 jpi["admin_password"] = password;
                 jp["admin_password"] = jpi;
             }


### PR DESCRIPTION
I have added the functionality that when a request in a batch fails, it stops processing the rest of the times in the batch.

I've also organized the commits such that we can easily accept or reject this functionality for RPC and Websockets separately.