### PR TITLE
Cleanup, refactor, and improve GetMissingNodes

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -1160,7 +1160,8 @@ void LedgerConsensusImp<Traits>::leaveConsensus ()
     if (ourPosition_ && ! ourPosition_->isBowOut ())
     {
         ourPosition_->bowOut(app_.timeKeeper().closeTime());
-        propose();
+        if (proposing_)
+            propose();
     }
     proposing_ = false;
 }

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1078,7 +1078,7 @@ LedgerMaster::findNewLedgersToPublish ()
             }
 
             // Can we try to acquire the ledger we need?
-            if (! ledger && (++acqCount < 4))
+            if (! ledger && (++acqCount < ledger_fetch_size_))
                 ledger = app_.getInboundLedgers ().acquire(
                     *hash, seq, InboundLedger::fcGENERIC);
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -537,7 +537,7 @@ int Config::getSize (SizedItemName item) const
 
         { siSweepInterval,      {   10,     30,     60,     90,         120     } },
 
-        { siLedgerFetch,        {   2,      2,      3,      3,          3       } },
+        { siLedgerFetch,        {   2,      3,      5,      5,          8       } },
 
         { siNodeCacheSize,      {   16384,  32768,  131072, 262144,     524288  } },
         { siNodeCacheAge,       {   60,     90,     120,    900,        1800    } },
@@ -551,9 +551,9 @@ int Config::getSize (SizedItemName item) const
         { siLedgerSize,         {   32,     128,    256,    384,        768     } },
         { siLedgerAge,          {   30,     90,     180,    240,        900     } },
 
-        { siHashNodeDBCache,    {   4,      12,     24,     64,         128      } },
-        { siTxnDBCache,         {   4,      12,     24,     64,         128      } },
-        { siLgrDBCache,         {   4,      8,      16,     32,         128      } },
+        { siHashNodeDBCache,    {   4,      12,     24,     64,         128     } },
+        { siTxnDBCache,         {   4,      12,     24,     64,         128     } },
+        { siLgrDBCache,         {   4,      8,      16,     32,         128     } },
     };
 
     for (int i = 0; i < (sizeof (sizeTable) / sizeof (SizedItem)); ++i)


### PR DESCRIPTION
Split SHAMap::getMissingNodes into three functions, cleanup and improve comments. Algorithmic improvements include avoiding the need to restart from the root.

In my quick benchmarks:
Time to coldstart with no database and get to full sync: 7% faster
Time to resynch to network ledger after synch is lost: 15% faster
Fetch speed of historical ledgers: 166% faster

The first patch (Make ledger fetch tuning saner) uses the configured fetch limit in one case where we had a limit hard coded in. It also bumps the limits a bit for the larger node sizes.

The second patch fixes a bug that could cause a non-validator to crash in rare cases were it opted to bow out the middle of consensus. The code attempted to send a proposal unconditionally which will fail if we're not a validator because we don't have a valid signing key.