### PR TITLE
Add the config preset features to the view

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -195,6 +195,7 @@ Ledger::Ledger (
         family, SHAMap::version{1}))
     , stateMap_ (std::make_shared <SHAMap> (SHAMapType::STATE,
         family, SHAMap::version{1}))
+    , rules_{config.features}
 {
     info_.seq = 1;
     info_.drops = SYSTEM_CURRENCY_START;
@@ -233,6 +234,7 @@ Ledger::Ledger (
     , stateMap_ (std::make_shared <SHAMap> (SHAMapType::STATE,
         info.accountHash, family,
         SHAMap::version{getSHAMapV2(info) ? 2 : 1}))
+    , rules_ (config.features)
     , info_ (info)
 {
     loaded = true;
@@ -305,12 +307,14 @@ Ledger::Ledger (Ledger const& prevLedger,
 
 Ledger::Ledger (
         LedgerInfo const& info,
+        Config const& config,
         Family& family)
     : mImmutable (true)
     , txMap_ (std::make_shared <SHAMap> (SHAMapType::TRANSACTION,
         info.txHash, family, SHAMap::version{1}))
     , stateMap_ (std::make_shared <SHAMap> (SHAMapType::STATE,
         info.accountHash, family, SHAMap::version{1}))
+    , rules_{config.features}
     , info_ (info)
 {
     info_.hash = calculateLedgerHash (info_);
@@ -324,6 +328,7 @@ Ledger::Ledger (std::uint32_t ledgerSeq,
           SHAMapType::TRANSACTION, family, SHAMap::version{1}))
     , stateMap_ (std::make_shared <SHAMap> (
           SHAMapType::STATE, family, SHAMap::version{1}))
+    , rules_{config.features}
 {
     info_.seq = ledgerSeq;
     info_.closeTime = closeTime;
@@ -624,7 +629,7 @@ Ledger::setup (Config const& config)
 
     try
     {
-        rules_ = Rules(*this);
+        rules_ = Rules(*this, config.features);
     }
     catch (SHAMapMissingNode &)
     {

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -105,6 +105,7 @@ public:
 
     Ledger (
         LedgerInfo const& info,
+        Config const& config,
         Family& family);
 
     // Used for ledgers loaded from JSON files

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -255,6 +255,7 @@ bool InboundLedger::tryLocal ()
 
             mLedger = std::make_shared<Ledger> (
                 deserializeHeader (makeSlice(*data), true),
+                app_.config(),
                 app_.family());
 
             app_.getNodeStore ().store (
@@ -264,6 +265,7 @@ bool InboundLedger::tryLocal ()
         {
             mLedger = std::make_shared<Ledger>(
                 deserializeHeader (makeSlice (node->getData()), true),
+                app_.config(),
                 app_.family());
         }
 
@@ -799,6 +801,7 @@ bool InboundLedger::takeHeader (std::string const& data)
 
     mLedger = std::make_shared<Ledger>(
         deserializeHeader (makeSlice(data), false),
+        app_.config(),
         app_.family());
 
     if (mLedger->info().hash != mHash)

--- a/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
+++ b/src/ripple/app/ledger/impl/LedgerConsensusImp.cpp
@@ -817,8 +817,7 @@ void LedgerConsensusImp<Traits>::accept (TxSet_t const& set)
         auto buildLCL = std::make_shared<Ledger>(
             *previousLedger_,
             app_.timeKeeper().closeTime());
-        auto const v2_enabled = buildLCL->rules().enabled(featureSHAMapV2,
-                                                       app_.config().features);
+        auto const v2_enabled = buildLCL->rules().enabled(featureSHAMapV2);
         auto v2_transition = false;
         if (v2_enabled && !buildLCL->stateMap().is_v2())
         {
@@ -1000,9 +999,9 @@ void LedgerConsensusImp<Traits>::accept (TxSet_t const& set)
         auto const lastVal = ledgerMaster_.getValidatedLedger();
         boost::optional<Rules> rules;
         if (lastVal)
-            rules.emplace(*lastVal);
+            rules.emplace(*lastVal, app_.config().features);
         else
-            rules.emplace();
+            rules.emplace(app_.config().features);
         app_.openLedger().accept(app_, *rules,
             sharedLCL, localTx, anyDisputes, retriableTxs, tapNONE,
                 "consensus",

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1301,7 +1301,7 @@ LedgerMaster::getValidatedRules ()
     if (auto const ledger = getValidatedLedger())
         return ledger->rules();
 
-    return Rules();
+    return Rules(app_.config().features);
 }
 
 // This is the last ledger we published to clients and can lag the validated

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1426,9 +1426,9 @@ void NetworkOPsImp::switchLastClosedLedger (
             app_.getLedgerMaster().getValidatedLedger();
         boost::optional<Rules> rules;
         if (lastVal)
-            rules.emplace(*lastVal);
+            rules.emplace(*lastVal, app_.config().features);
         else
-            rules.emplace();
+            rules.emplace(app_.config().features);
         app_.openLedger().accept(app_, *rules,
             newLCL, OrderedTxs({}), false, retries,
                 tapNONE, "jump",
@@ -2115,7 +2115,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
         info[jss::load] = m_job_queue.getJson ();
 
     auto const escalationMetrics = app_.getTxQ().getMetrics(
-        app_.config(), *app_.openLedger().current());
+        *app_.openLedger().current());
 
     constexpr std::uint64_t max32 =
         std::numeric_limits<std::uint32_t>::max();

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -23,7 +23,6 @@
 #include <ripple/app/tx/applySteps.h>
 #include <ripple/ledger/OpenView.h>
 #include <ripple/ledger/ApplyView.h>
-#include <ripple/core/Config.h>
 #include <ripple/protocol/TER.h>
 #include <ripple/protocol/STTx.h>
 #include <boost/intrusive/set.hpp>
@@ -31,6 +30,7 @@
 namespace ripple {
 
 class Application;
+class Config;
 
 /**
     Transaction Queue. Used to manage transactions in conjunction with
@@ -139,7 +139,7 @@ public:
         amendment is not enabled.
     */
     boost::optional<Metrics>
-    getMetrics(Config const& config, OpenView const& view,
+    getMetrics(OpenView const& view,
         std::uint32_t txCountPadding = 0) const;
 
     /** Returns information about the transactions currently
@@ -150,8 +150,7 @@ public:
         in the queue.
     */
     boost::optional<std::map<TxSeq, AccountTxDetails>>
-    getAccountTxs(AccountID const& account, Config const& config,
-        ReadView const& view) const;
+    getAccountTxs(AccountID const& account, ReadView const& view) const;
 
     /** Packages up fee metrics for the `fee` RPC command.
     */

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -589,8 +589,7 @@ TxQ::apply(Application& app, OpenView& view,
         ApplyFlags flags, beast::Journal j)
 {
     auto const allowEscalation =
-        (view.rules().enabled(featureFeeEscalation,
-            app.config().features));
+        (view.rules().enabled(featureFeeEscalation));
     if (!allowEscalation)
     {
         return ripple::apply(app, view, *tx, flags, j);
@@ -1110,8 +1109,7 @@ TxQ::processClosedLedger(Application& app,
     OpenView const& view, bool timeLeap)
 {
     auto const allowEscalation =
-        (view.rules().enabled(featureFeeEscalation,
-            app.config().features));
+        (view.rules().enabled(featureFeeEscalation));
     if (!allowEscalation)
     {
         return;
@@ -1190,8 +1188,7 @@ TxQ::accept(Application& app,
     OpenView& view)
 {
     auto const allowEscalation =
-        (view.rules().enabled(featureFeeEscalation,
-            app.config().features));
+        (view.rules().enabled(featureFeeEscalation));
     if (!allowEscalation)
     {
         return false;
@@ -1307,13 +1304,11 @@ TxQ::accept(Application& app,
 }
 
 auto
-TxQ::getMetrics(Config const& config, OpenView const& view,
-    std::uint32_t txCountPadding) const
-        -> boost::optional<Metrics>
+TxQ::getMetrics(OpenView const& view, std::uint32_t txCountPadding) const
+    -> boost::optional<Metrics>
 {
     auto const allowEscalation =
-        (view.rules().enabled(featureFeeEscalation,
-            config.features));
+        (view.rules().enabled(featureFeeEscalation));
     if (!allowEscalation)
         return boost::none;
 
@@ -1335,13 +1330,11 @@ TxQ::getMetrics(Config const& config, OpenView const& view,
 }
 
 auto
-TxQ::getAccountTxs(AccountID const& account, Config const& config,
-    ReadView const& view) const
-        -> boost::optional<std::map<TxSeq, AccountTxDetails>>
+TxQ::getAccountTxs(AccountID const& account, ReadView const& view) const
+    -> boost::optional<std::map<TxSeq, AccountTxDetails>>
 {
     auto const allowEscalation =
-        (view.rules().enabled(featureFeeEscalation,
-            config.features));
+        (view.rules().enabled(featureFeeEscalation));
     if (!allowEscalation)
         return boost::none;
 
@@ -1372,7 +1365,7 @@ TxQ::doRPC(Application& app) const
     using std::to_string;
 
     auto const view = app.openLedger().current();
-    auto const metrics = getMetrics(app.config(), *view);
+    auto const metrics = getMetrics(*view);
 
     if (!metrics)
         return{};

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -545,7 +545,6 @@ PathRequest::findPaths (std::shared_ptr<RippleLineCache> const& cache,
             *raSrcAccount,  // --> Account sending from.
             ps,             // --> Path set.
             app_.logs(),
-            app_.config(),
             &rcInput);
 
         if (! convert_all_ &&
@@ -566,8 +565,7 @@ PathRequest::findPaths (std::shared_ptr<RippleLineCache> const& cache,
                 *raDstAccount,  // --> Account to deliver to.
                 *raSrcAccount,  // --> Account sending from.
                 ps,             // --> Path set.
-                app_.logs(),
-                app_.config());
+                app_.logs());
 
             if (rc.result() != tesSUCCESS)
             {

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -355,7 +355,6 @@ TER Pathfinder::getPathLiquidity (
             mSrcAccount,
             pathSet,
             app_.logs(),
-            app_.config(),
             &rcInput);
         // If we can't get even the minimum liquidity requested, we're done.
         if (rc.result () != tesSUCCESS)
@@ -376,7 +375,6 @@ TER Pathfinder::getPathLiquidity (
                 mSrcAccount,
                 pathSet,
                 app_.logs (),
-                app_.config (),
                 &rcInput);
 
             // If we found further liquidity, add it into the result.
@@ -428,7 +426,6 @@ void Pathfinder::computePathRanks (int maxPaths)
             mSrcAccount,
             STPathSet(),
             app_.logs (),
-            app_.config (),
             &rcInput);
 
         if (rc.result () == tesSUCCESS)

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -24,7 +24,6 @@
 #include <ripple/app/paths/cursor/PathCursor.h>
 #include <ripple/app/paths/impl/FlowDebugInfo.h>
 #include <ripple/basics/Log.h>
-#include <ripple/core/Config.h>
 #include <ripple/ledger/View.h>
 #include <ripple/protocol/Feature.h>
 
@@ -68,15 +67,14 @@ RippleCalc::Output RippleCalc::rippleCalculate (
     // explore for liquidity.
     STPathSet const& spsPaths,
     Logs& l,
-    Config const& config,
     Input const* const pInputs)
 {
     // call flow v1 and v2 so results may be compared
     bool const compareFlowV1V2 =
-        view.rules ().enabled (featureCompareFlowV1V2, config.features);
+        view.rules ().enabled (featureCompareFlowV1V2);
 
     bool const useFlowV1Output =
-        !view.rules().enabled(featureFlow, config.features);
+        !view.rules().enabled(featureFlow);
     bool const callFlowV1 = useFlowV1Output || compareFlowV1V2;
     bool const callFlowV2 = !useFlowV1Output || compareFlowV1V2;
 
@@ -140,7 +138,7 @@ RippleCalc::Output RippleCalc::rippleCalculate (
         try
         {
             bool const ownerPaysTransferFee =
-                    view.rules ().enabled (featureOwnerPaysFee, config.features);
+                    view.rules ().enabled (featureOwnerPaysFee);
             auto const timeIt = flowV2FlowDebugInfo.timeBlock ("main");
             flowV2Out = flow (flowV2SB, saDstAmountReq, uSrcAccountID,
                 uDstAccountID, spsPaths, defaultPaths, partialPayment,

--- a/src/ripple/app/paths/RippleCalc.h
+++ b/src/ripple/app/paths/RippleCalc.h
@@ -107,7 +107,6 @@ public:
         // explore for liquidity.
         STPathSet const& spsPaths,
         Logs& l,
-        Config const& config,
         Input const* const pInputs = nullptr);
 
     // The view we are currently working on

--- a/src/ripple/app/tx/impl/CancelTicket.cpp
+++ b/src/ripple/app/tx/impl/CancelTicket.cpp
@@ -29,8 +29,7 @@ namespace ripple {
 TER
 CancelTicket::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureTickets,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featureTickets))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -29,8 +29,7 @@ namespace ripple {
 TER
 CreateTicket::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureTickets,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featureTickets))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -158,7 +158,7 @@ closeChannel (
 TER
 PayChanCreate::preflight (PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled (featurePayChan, ctx.app.config ().features))
+    if (!ctx.rules.enabled (featurePayChan))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);
@@ -258,7 +258,7 @@ PayChanCreate::doApply()
 TER
 PayChanFund::preflight (PreflightContext const& ctx)
 {
-    if (!ctx.rules.enabled (featurePayChan, ctx.app.config ().features))
+    if (!ctx.rules.enabled (featurePayChan))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);
@@ -340,8 +340,7 @@ PayChanFund::doApply()
 TER
 PayChanClaim::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featurePayChan,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featurePayChan))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/Payment.cpp
+++ b/src/ripple/app/tx/impl/Payment.cpp
@@ -378,7 +378,6 @@ Payment::doApply ()
                 account_,
                 spsPaths,
                 ctx_.app.logs(),
-                ctx_.app.config(),
                 &rcInput);
             // VFALCO NOTE We might not need to apply, depending
             //             on the TER. But always applying *should*

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -127,8 +127,7 @@ SetAccount::preflight (PreflightContext const& ctx)
     // TickSize
     if (tx.isFieldPresent (sfTickSize))
     {
-        if (!ctx.rules.enabled(featureTickSize,
-            ctx.app.config().features))
+        if (!ctx.rules.enabled(featureTickSize))
             return temDISABLED;
 
         auto uTickSize = tx[sfTickSize];
@@ -291,8 +290,7 @@ SetAccount::doApply ()
             // Account has no regular key or multi-signer signer list.
 
             // Prevent transaction changes until we're ready.
-            if (view().rules().enabled(featureMultiSign,
-                    ctx_.app.config().features))
+            if (view().rules().enabled(featureMultiSign))
                 return tecNO_ALTERNATIVE_KEY;
 
             return tecNO_REGULAR_KEY;

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -73,8 +73,7 @@ SetSignerList::determineOperation(STTx const& tx,
 TER
 SetSignerList::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureMultiSign,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featureMultiSign))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -436,7 +436,7 @@ SetTrust::doApply ()
     else if (! saLimitAmount &&                          // Setting default limit.
         (! bQualityIn || ! uQualityIn) &&           // Not setting quality in or setting default quality in.
         (! bQualityOut || ! uQualityOut) &&         // Not setting quality out or setting default quality out.
-        (! (view().rules().enabled(featureTrustSetAuth, ctx_.app.config().features)) || ! bSetAuth))
+        (! (view().rules().enabled(featureTrustSetAuth)) || ! bSetAuth))
     {
         JLOG(j_.trace()) <<
             "Redundant: Setting non-existent ripple line to defaults.";

--- a/src/ripple/app/tx/impl/SusPay.cpp
+++ b/src/ripple/app/tx/impl/SusPay.cpp
@@ -143,8 +143,7 @@ SusPayCreate::calculateMaxSpend(STTx const& tx)
 TER
 SusPayCreate::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureSusPay,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featureSusPay))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);
@@ -167,8 +166,7 @@ SusPayCreate::preflight (PreflightContext const& ctx)
 
     if (auto const cb = ctx.tx[~sfCondition])
     {
-        if (! ctx.rules.enabled(featureCryptoConditions,
-                ctx.app.config().features))
+        if (! ctx.rules.enabled(featureCryptoConditions))
             return temDISABLED;
 
         using namespace ripple::cryptoconditions;
@@ -336,8 +334,7 @@ checkCondition (Slice f, Slice c)
 TER
 SusPayFinish::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureSusPay,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featureSusPay))
         return temDISABLED;
 
     {
@@ -351,8 +348,7 @@ SusPayFinish::preflight (PreflightContext const& ctx)
 
     if (cb || fb)
     {
-        if (! ctx.rules.enabled(featureCryptoConditions,
-                ctx.app.config().features))
+        if (! ctx.rules.enabled(featureCryptoConditions))
             return temDISABLED;
     }
 
@@ -516,8 +512,7 @@ SusPayFinish::doApply()
 TER
 SusPayCancel::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureSusPay,
-            ctx.app.config().features))
+    if (! ctx.rules.enabled(featureSusPay))
         return temDISABLED;
 
     auto const ret = preflight1 (ctx);

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -331,8 +331,7 @@ TER
 Transactor::checkSign (PreclaimContext const& ctx)
 {
     // Make sure multisigning is enabled before we check for multisignatures.
-    if ((ctx.view.rules().enabled(featureMultiSign,
-            ctx.app.config().features)))
+    if (ctx.view.rules().enabled(featureMultiSign))
     {
         // If the pk is empty, then we must be multi-signing.
         if (ctx.tx.getSigningPubKey().empty ())

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -40,8 +40,7 @@ checkValidity(HashRouter& router,
         Config const& config)
 {
     auto const allowMultiSign =
-        rules.enabled(featureMultiSign,
-            config.features);
+        rules.enabled(featureMultiSign);
 
     auto const id = tx.getTransactionID();
     auto const flags = router.getFlags(id);

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -125,26 +125,27 @@ public:
     Rules (Rules const&) = default;
     Rules& operator= (Rules const&) = default;
 
+    Rules() = delete;
+
     /** Construct an empty rule set.
 
         These are the rules reflected by
         the genesis ledger.
     */
-    Rules() = default;
+    explicit Rules(std::unordered_set<uint256, beast::uhash<>> const& presets);
 
     /** Construct rules from a ledger.
 
         The ledger contents are analyzed for rules
         and amendments and extracted to the object.
     */
-    explicit
-    Rules (DigestAwareReadView const& ledger);
+    explicit Rules(
+        DigestAwareReadView const& ledger,
+            std::unordered_set<uint256, beast::uhash<>> const& presets);
 
     /** Returns `true` if a feature is enabled. */
     bool
-    enabled (uint256 const& id,
-        std::unordered_set<uint256,
-            beast::uhash<>> const& presets) const;
+    enabled (uint256 const& id) const;
 
     /** Returns `true` if these rules don't match the ledger. */
     bool

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -29,10 +29,19 @@ private:
     std::unordered_set<uint256,
         hardened_hash<>> set_;
     boost::optional<uint256> digest_;
+    std::unordered_set<uint256, beast::uhash<>> const& presets_;
 
 public:
-    explicit
-    Impl (DigestAwareReadView const& ledger)
+    explicit Impl(
+            std::unordered_set<uint256, beast::uhash<>> const& presets)
+        : presets_(presets)
+    {
+    }
+
+    explicit Impl(
+        DigestAwareReadView const& ledger,
+            std::unordered_set<uint256, beast::uhash<>> const& presets)
+        : presets_(presets)
     {
         auto const k = keylet::amendments();
         digest_ = ledger.digest(k.key);
@@ -53,6 +62,8 @@ public:
     bool
     enabled (uint256 const& feature) const
     {
+        if (presets_.count(feature) > 0)
+            return true;
         return set_.count(feature) > 0;
     }
 
@@ -81,44 +92,39 @@ public:
 
 //------------------------------------------------------------------------------
 
-Rules::Rules (DigestAwareReadView const& ledger)
-    : impl_(std::make_shared<Impl>(ledger))
+Rules::Rules(
+    DigestAwareReadView const& ledger,
+        std::unordered_set<uint256, beast::uhash<>> const& presets)
+    : impl_(std::make_shared<Impl>(ledger, presets))
+{
+}
+
+Rules::Rules(std::unordered_set<uint256, beast::uhash<>> const& presets)
+    : impl_(std::make_shared<Impl>(presets))
 {
 }
 
 bool
-Rules::enabled (uint256 const& id,
-    std::unordered_set<uint256,
-        beast::uhash<>> const& presets) const
+Rules::enabled (uint256 const& id) const
 {
-    if (presets.count(id) > 0)
-        return true;
-    if (! impl_)
-        return false;
+    assert (impl_);
     return impl_->enabled(id);
 }
 
 bool
 Rules::changed (DigestAwareReadView const& ledger) const
 {
-    if (! impl_)
-        return static_cast<bool>(
-            ledger.digest(keylet::amendments().key));
+    assert (impl_);
     return impl_->changed(ledger);
 }
 
 bool
 Rules::operator== (Rules const& other) const
 {
-#if 1
+    assert(impl_ && other.impl_);
     if (impl_.get() == other.impl_.get())
         return true;
-    if (! impl_ || ! other.impl_)
-        return false;
     return *impl_ == *other.impl_;
-#else
-    return impl_.get() == other.impl_.get();
-#endif
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -116,7 +116,7 @@ Json::Value doAccountInfo (RPC::Context& context)
             Json::Value jvQueueData = Json::objectValue;
 
             auto const txs = context.app.getTxQ().getAccountTxs(
-                accountID, context.app.config(), *ledger);
+                accountID, *ledger);
             if (txs && !txs->empty())
             {
                 jvQueueData[jss::txn_count] = static_cast<Json::UInt>(txs->size());

--- a/src/ripple/rpc/handlers/Fee1.cpp
+++ b/src/ripple/rpc/handlers/Fee1.cpp
@@ -31,8 +31,7 @@ namespace ripple
     {
         // Bail if fee escalation is not enabled.
         auto const view = context.app.openLedger().current();
-        if (!view || !view->rules().enabled(
-            featureFeeEscalation, context.app.config().features))
+        if (!view || !view->rules().enabled(featureFeeEscalation))
         {
             RPC::inject_error(rpcNOT_ENABLED, context.params);
             return context.params;

--- a/src/ripple/rpc/handlers/SignFor.cpp
+++ b/src/ripple/rpc/handlers/SignFor.cpp
@@ -36,7 +36,7 @@ Json::Value doSignFor (RPC::Context& context)
 {
     // Bail if multisign is not enabled.
     if (! context.app.getLedgerMaster().getValidatedRules().
-        enabled (featureMultiSign, context.app.config().features))
+        enabled (featureMultiSign))
     {
         RPC::inject_error (rpcNOT_ENABLED, context.params);
         return context.params;

--- a/src/ripple/rpc/handlers/SubmitMultiSigned.cpp
+++ b/src/ripple/rpc/handlers/SubmitMultiSigned.cpp
@@ -35,7 +35,7 @@ Json::Value doSubmitMultiSigned (RPC::Context& context)
 {
     // Bail if multisign is not enabled.
     if (! context.app.getLedgerMaster().getValidatedRules().
-        enabled (featureMultiSign, context.app.config().features))
+        enabled (featureMultiSign))
     {
         RPC::inject_error (rpcNOT_ENABLED, context.params);
         return context.params;

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -431,7 +431,7 @@ transactionPreProcessImpl (
 
             auto seq = (*sle)[sfSequence];
             auto const queued = app.getTxQ().getAccountTxs(srcAddressID,
-                app.config(), *ledger);
+                *ledger);
             // If the account has any txs in the TxQ, skip those sequence
             // numbers (accounting for possible gaps).
             if(queued)
@@ -704,7 +704,7 @@ Json::Value checkFee (
         auto const assumeTx = request.isMember("x_assume_tx") &&
             request["x_assume_tx"].isConvertibleTo(Json::uintValue) ?
                 request["x_assume_tx"].asUInt() : 0;
-        auto const metrics = txQ.getMetrics(config, *ledger, assumeTx);
+        auto const metrics = txQ.getMetrics(*ledger, assumeTx);
         if(metrics)
         {
             auto const baseFee = ledger->fees().base;

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -48,8 +48,7 @@ class TxQ_test : public beast::unit_test::suite
         std::uint64_t expectedMinFeeLevel,
         std::uint64_t expectedMedFeeLevel = 256 * 500)
     {
-        auto optMetrics = env.app().getTxQ().getMetrics(
-            env.app().config(), *env.current());
+        auto optMetrics = env.app().getTxQ().getMetrics(*env.current());
         if (!BEAST_EXPECT(optMetrics))
             return;
         auto& metrics = *optMetrics;
@@ -72,8 +71,7 @@ class TxQ_test : public beast::unit_test::suite
         jtx::Env& env,
         jtx::Account const& account)
     {
-        auto metrics = env.app().getTxQ().getMetrics(env.app().config(),
-            *env.current());
+        auto metrics = env.app().getTxQ().getMetrics(*env.current());
         if (!BEAST_EXPECT(metrics))
             return;
         for (int i = metrics->txInLedger; i <= metrics->txPerLedger; ++i)
@@ -86,8 +84,7 @@ class TxQ_test : public beast::unit_test::suite
         using namespace jtx;
 
         auto const& view = *env.current();
-        auto metrics = env.app().getTxQ().getMetrics(env.app().config(),
-            view);
+        auto metrics = env.app().getTxQ().getMetrics(view);
         if (!BEAST_EXPECT(metrics))
             return fee(none);
 
@@ -324,7 +321,7 @@ public:
         // we can be sure that there's one in the queue when the
         // test ends and the TxQ is destructed.
 
-        auto metrics = txq.getMetrics(env.app().config(), *env.current());
+        auto metrics = txq.getMetrics(*env.current());
         BEAST_EXPECT(metrics->txCount == 0);
 
         // Stuff the ledger.
@@ -448,8 +445,7 @@ public:
         checkMetrics(env, 5, boost::none, 3, 2, 256);
         {
             auto& txQ = env.app().getTxQ();
-            auto aliceStat = txQ.getAccountTxs(alice.id(),
-                env.app().config(), *env.current());
+            auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             if (BEAST_EXPECT(aliceStat))
             {
                 BEAST_EXPECT(aliceStat->size() == 1);
@@ -459,8 +455,7 @@ public:
                 BEAST_EXPECT(!aliceStat->begin()->second.consequences);
             }
 
-            auto bobStat = txQ.getAccountTxs(bob.id(),
-                env.app().config(), *env.current());
+            auto bobStat = txQ.getAccountTxs(bob.id(), *env.current());
             if (BEAST_EXPECT(bobStat))
             {
                 BEAST_EXPECT(bobStat->size() == 1);
@@ -470,7 +465,7 @@ public:
             }
 
             auto noStat = txQ.getAccountTxs(Account::master.id(),
-                env.app().config(), *env.current());
+                *env.current());
             BEAST_EXPECT(!noStat);
         }
 
@@ -793,8 +788,7 @@ public:
         checkMetrics(env, 8, 8, 5, 4, 513);
         {
             auto& txQ = env.app().getTxQ();
-            auto aliceStat = txQ.getAccountTxs(alice.id(),
-                env.app().config(), *env.current());
+            auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             std::int64_t fee = 20;
             auto seq = env.seq(alice);
             if (BEAST_EXPECT(aliceStat))
@@ -1076,8 +1070,7 @@ public:
 
         auto alice = Account("alice");
 
-        BEAST_EXPECT(!env.app().getTxQ().getMetrics(env.app().config(),
-            *env.current()));
+        BEAST_EXPECT(!env.app().getTxQ().getMetrics(*env.current()));
 
         env.fund(XRP(50000), noripple(alice));
 
@@ -1088,8 +1081,7 @@ public:
             env(noop(alice), fee(30));
 
         env.close();
-        BEAST_EXPECT(!env.app().getTxQ().getMetrics(env.app().config(),
-            *env.current()));
+        BEAST_EXPECT(!env.app().getTxQ().getMetrics(*env.current()));
     }
 
     void testAcctTxnID()
@@ -1829,8 +1821,7 @@ public:
         }
         checkMetrics(env, 5, boost::none, 7, 6, 256);
         {
-            auto aliceStat = txQ.getAccountTxs(alice.id(),
-                env.app().config(), *env.current());
+            auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             if (BEAST_EXPECT(aliceStat))
             {
                 auto seq = aliceSeq;
@@ -1877,15 +1868,13 @@ public:
         checkMetrics(env, 4, 18, 10, 9, 256);
         {
             // Bob has nothing left in the queue.
-            auto bobStat = txQ.getAccountTxs(bob.id(),
-                env.app().config(), *env.current());
+            auto bobStat = txQ.getAccountTxs(bob.id(), *env.current());
             BEAST_EXPECT(!bobStat);
         }
         // Verify alice's tx got dropped as we BEAST_EXPECT, and that there's
         // a gap in her queued txs.
         {
-            auto aliceStat = txQ.getAccountTxs(alice.id(),
-                env.app().config(), *env.current());
+            auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             if (BEAST_EXPECT(aliceStat))
             {
                 auto seq = aliceSeq;
@@ -1907,8 +1896,7 @@ public:
         envs(noop(alice), fee(none), seq(none), ter(terQUEUED))(params);
         checkMetrics(env, 5, 18, 10, 9, 256);
         {
-            auto aliceStat = txQ.getAccountTxs(alice.id(),
-                env.app().config(), *env.current());
+            auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             if (BEAST_EXPECT(aliceStat))
             {
                 auto seq = aliceSeq;
@@ -1927,13 +1915,11 @@ public:
         checkMetrics(env, 0, 20, 5, 10, 256);
         {
             // Bob's data has been cleaned up.
-            auto bobStat = txQ.getAccountTxs(bob.id(),
-                env.app().config(), *env.current());
+            auto bobStat = txQ.getAccountTxs(bob.id(), *env.current());
             BEAST_EXPECT(!bobStat);
         }
         {
-            auto aliceStat = txQ.getAccountTxs(alice.id(),
-                env.app().config(), *env.current());
+            auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             BEAST_EXPECT(!aliceStat);
         }
     }
@@ -2450,7 +2436,7 @@ public:
                 -> std::uint64_t {
             auto totalFactor = 0;
             auto const metrics = env.app ().getTxQ ().getMetrics (
-                env.app ().config (), *env.current ());
+                *env.current ());
             if (!numToClear)
                 numToClear.emplace(metrics->txCount + 1);
             for (int i = 0; i < *numToClear; ++i)
@@ -2531,7 +2517,7 @@ public:
             // Figure out how much it would cost to cover all the
             // queued txs + itself
             auto const metrics = env.app ().getTxQ ().getMetrics (
-                env.app ().config (), *env.current ());
+                *env.current ());
             std::uint64_t const totalFee =
                 calcTotalFee (100 * 2, metrics->txCount);
             BEAST_EXPECT(totalFee == 167578);
@@ -2567,7 +2553,7 @@ public:
 
             checkMetrics(env, 2, 24, 16, 12, 256);
             auto const aliceQueue = env.app().getTxQ().getAccountTxs(
-                alice.id(), env.app().config(), *env.current());
+                alice.id(), *env.current());
             if (BEAST_EXPECT(aliceQueue))
             {
                 BEAST_EXPECT(aliceQueue->size() == 2);


### PR DESCRIPTION
When new code is added that is conditional on a feature, that code needs access to the config object. This can mean passing the config object as a parameter through several layers of calls. Adding the preset features to the view solves this problem.