### PR TITLE
CMake -Dassert=true properly enables asserts in Release:

### DIFF
--- a/Builds/CMake/CMakeFuncs.cmake
+++ b/Builds/CMake/CMakeFuncs.cmake
@@ -147,11 +147,6 @@ macro(setup_build_cache)
     set(CMAKE_CONFIGURATION_TYPES
       DebugClassic
       ReleaseClassic)
-    if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-      set(CMAKE_BUILD_TYPE DebugClassic)
-    elseif(${CMAKE_BUILD_TYPE} STREQUAL "Release")
-      set(CMAKE_BUILD_TYPE ReleaseClassic)
-    endif()
   endif()
 
   set(CMAKE_CONFIGURATION_TYPES
@@ -502,6 +497,15 @@ macro(setup_build_boilerplate)
       APPEND
       PROPERTY COMPILE_DEFINITIONS
       $<$<OR:$<BOOL:${profile}>,$<CONFIG:Release>,$<CONFIG:ReleaseClassic>>:NDEBUG>)
+  else()
+    # CMAKE_CXX_FLAGS_RELEASE is created by CMake for most / all generators
+    #  with defaults including /DNDEBUG or -DNDEBUG, and that value is stored
+    #  in the cache. Override that locally so that the cache value will be
+    #  avaiable if "assert" is ever changed.
+    STRING(REGEX REPLACE "[-/]DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+    STRING(REGEX REPLACE "[-/]DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASECLASSIC "${CMAKE_CXX_FLAGS_RELEASECLASSIC}")
+    STRING(REGEX REPLACE "[-/]DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
+    STRING(REGEX REPLACE "[-/]DNDEBUG" "" CMAKE_C_FLAGS_RELEASECLASSIC "${CMAKE_C_FLAGS_RELEASECLASSIC}")
   endif()
 
   if (NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@
 
 cmake_minimum_required(VERSION 3.1.0)
 
+# The project command can override some computed values.
+# Don't put any code above this line.
+project(rippled)
+
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   set(dir "build")
   set(cmd "cmake")
@@ -95,8 +99,6 @@ if (NOT DEFINED unity)
 endif()
 
 setup_build_cache()
-
-project(rippled)
 
 if(nonunity)
     get_cmake_property(allvars VARIABLES)


### PR DESCRIPTION
* CMake defaults CMAKE_CXX_FLAGS_RELEASE, etc. to include defining
  NDEBUG, regardless of other options set elsewhere, for most or all
  generators. This change explicitly removes that flag from the relevant
  variables.
* Also simplify the CMAKE_BUILD_TYPE setting for classic builds.

I'm not entirely happy with the commit message. I'd appreciate suggestions (or reassurance).