### PR TITLE
Exercise debugLog writes in jtx unit tests (RIPD-1393)

### DIFF
--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -160,6 +160,9 @@ Env::AppBundle::AppBundle(beast::unit_test::suite&,
 Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
     std::unique_ptr<Config> config)
 {
+    using namespace beast::severities;
+    // Use kFatal threshold to reduce noise from STObject.
+    setDebugLogSink (std::make_unique<SuiteSink>("Debug", kFatal, suite));
     auto logs = std::make_unique<SuiteLogs>(suite);
     auto timeKeeper_ =
         std::make_unique<ManualTimeKeeper>();
@@ -169,7 +172,7 @@ Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
     owned = make_Application(std::move(config),
         std::move(logs), std::move(timeKeeper_));
     app = owned.get();
-    app->logs().threshold(beast::severities::kError);
+    app->logs().threshold(kError);
     if(! app->setup())
         Throw<std::runtime_error> ("Env::AppBundle: setup failed");
     timeKeeper->set(
@@ -189,6 +192,9 @@ Env::AppBundle::~AppBundle()
     app->getJobQueue().rendezvous();
     app->signalStop();
     thread.join();
+
+    // Remove the debugLogSink before the suite goes out of scope.
+    setDebugLogSink (nullptr);
 }
 
 //------------------------------------------------------------------------------

--- a/src/test/protocol/InnerObjectFormats_test.cpp
+++ b/src/test/protocol/InnerObjectFormats_test.cpp
@@ -24,6 +24,7 @@
 #include <ripple/json/json_reader.h>             // Json::Reader
 #include <ripple/protocol/STParsedJSON.h>        // STParsedJSONObject
 #include <ripple/beast/unit_test.h>
+#include <test/jtx.h>
 
 namespace ripple {
 
@@ -174,6 +175,9 @@ public:
     void run()
     {
         using namespace InnerObjectFormatsUnitTestDetail;
+
+        // Instantiate a jtx::Env so debugLog writes are exercised.
+        test::jtx::Env env (*this);
 
         for (auto const& test : testArray)
         {

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -24,6 +24,8 @@
 #include <ripple/json/json_reader.h>
 #include <ripple/json/to_string.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx.h>
+
 #include <memory>
 #include <type_traits>
 
@@ -501,6 +503,9 @@ public:
     void
     run()
     {
+        // Instantiate a jtx::Env so debugLog writes are exercised.
+        test::jtx::Env env (*this);
+
         testFields();
         testSerialization();
         testParseJSONArray();


### PR DESCRIPTION
Motivation: recently I submitted a pull request where one of the files had 80% coverage.  That file would have had 100% coverage with this change.  That irritated me.  So here's the change.

The change makes it so invocations of `debugLog` in `jtx` tests will always generate their text but not log it unless it's `FTL`. This just means `debugLog` and `beast::Journal` will enjoy (almost) the same behavior in `jtx` tests.  Tests that do not construct a `jtx::Env` will not see the new behavior.

The behavioral difference between `debugLog()` and `beast::Journal` is in the threshold.  If I set `debugLog().threshold(kError)` (which would match `beast::Journal`) then STObject.cpp generates a lot of noise in the unit test output.  So `debugLog` has a threshold of  `kFatal`.

Reviewers: @mellery451 @ximinez
