### PR TITLE
Make Config extensible via lambda (RIPD-1247):

### DIFF
--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -183,6 +183,13 @@ public:
 public:
     Config() = default;
 
+    template <class... Args>
+    Config(std::function< void(Config *) > init, Args&&... args)
+        : Config(std::forward<Args>(args)...)
+    {
+        init(this);
+    }
+
     int getSize (SizedItemName) const;
     /* Be very careful to make sure these bool params
         are in the right order. */

--- a/src/test/app/Regression_test.cpp
+++ b/src/test/app/Regression_test.cpp
@@ -164,15 +164,11 @@ struct Regression_test : public beast::unit_test::suite
     {
         testcase("Autofilled fee should use the escalated fee");
         using namespace jtx;
-        Env env(*this, []()
+        Env env(*this, std::make_unique<Config>([](Config * cf)
             {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                auto& section = p->section("transaction_queue");
-                section.set("minimum_txn_in_ledger_standalone", "3");
-                return p;
-            }(),
-            features(featureFeeEscalation));
+                cf->section("transaction_queue")
+                    .set("minimum_txn_in_ledger_standalone", "3");
+            }, defaultConf), features(featureFeeEscalation));
         Env_ss envs(env);
 
         auto const alice = Account("alice");

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -79,6 +79,10 @@ features (uint256 const& key, Args const&... args)
     return {{key, args...}};
 }
 
+extern std::function<void(Config*)> defaultConf;
+extern std::function<void(Config*)> nonAdminConf;
+extern std::function<void(Config*)> validatorConf;
+
 //------------------------------------------------------------------------------
 
 /** A transaction testing environment. */
@@ -152,12 +156,9 @@ public:
     template <class... Args>
     Env (beast::unit_test::suite& suite_,
             Args&&... args)
-        : Env(suite_, []()
-            {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                return p;
-            }(), std::forward<Args>(args)...)
+        : Env(suite_,
+            std::make_unique<Config>(defaultConf),
+            std::forward<Args>(args)...)
     {
     }
 

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -83,6 +83,30 @@ setupConfigForUnitTests (Config& cfg)
 
 namespace jtx {
 
+std::function<void(Config*)> defaultConf = [] (Config * cf)
+{
+    setupConfigForUnitTests(*cf);
+};
+
+std::function<void(Config*)> nonAdminConf = [] (Config * cf)
+{
+    setupConfigForUnitTests(*cf);
+    (*cf)["port_rpc"].set("admin","");
+    (*cf)["port_ws"].set("admin","");
+};
+
+std::function<void(Config*)> validatorConf = [] (Config * cf)
+{
+    setupConfigForUnitTests(*cf);
+    // If the config has valid validation keys then we run as a validator.
+    auto const seed = parseBase58<Seed>("shUwVw52ofnCUX5m7kPTKzJdr4HEH");
+    if (!seed)
+        Throw<std::runtime_error> ("Invalid seed specified");
+    cf->VALIDATION_PRIV = generateSecretKey (KeyType::secp256k1, *seed);
+    cf->VALIDATION_PUB =
+        derivePublicKey (KeyType::secp256k1, cf->VALIDATION_PRIV);
+};
+
 class SuiteSink : public beast::Journal::Sink
 {
     std::string partition_;

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -26,22 +26,6 @@ namespace test {
 class AccountOffers_test : public beast::unit_test::suite
 {
 public:
-    static
-    std::unique_ptr<Config>
-    makeConfig(bool setup_admin)
-    {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
-        // the default config has admin active
-        // ...we remove them if setup_admin is false
-        if (! setup_admin)
-        {
-            (*p)["port_rpc"].set("admin","");
-            (*p)["port_ws"].set("admin","");
-        }
-        return p;
-    }
-
     // test helper
     static bool checkArraySize(Json::Value const& val, unsigned int size)
     {
@@ -60,7 +44,7 @@ public:
     void testNonAdminMinLimit()
     {
         using namespace jtx;
-        Env env(*this, makeConfig(false));
+        Env env {*this, std::make_unique<Config>(nonAdminConf)};
         Account const gw ("G1");
         auto const USD_gw  = gw["USD"];
         Account const bob ("bob");
@@ -100,7 +84,8 @@ public:
     void testSequential(bool as_admin)
     {
         using namespace jtx;
-        Env env(*this, makeConfig(as_admin));
+        Env env {*this, std::make_unique<Config>(
+            as_admin ? defaultConf : nonAdminConf)};
         Account const gw ("G1");
         auto const USD_gw  = gw["USD"];
         Account const bob ("bob");

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1411,16 +1411,8 @@ public:
     {
         testcase("BookOffer Limits");
         using namespace jtx;
-        Env env(*this, [asAdmin]() {
-            auto p = std::make_unique<Config>();
-            setupConfigForUnitTests(*p);
-            if(! asAdmin)
-            {
-                (*p)["port_rpc"].set("admin","");
-                (*p)["port_ws"].set("admin","");
-            }
-            return p;
-        }());
+        Env env {*this, std::make_unique<Config>(
+            asAdmin ? defaultConf : nonAdminConf)};
         Account gw {"gw"};
         env.fund(XRP(200000), gw);
         env.close();

--- a/src/test/rpc/JSONRPC_test.cpp
+++ b/src/test/rpc/JSONRPC_test.cpp
@@ -1934,15 +1934,13 @@ public:
 
     void testAutoFillEscalatedFees ()
     {
-        test::jtx::Env env(*this, []()
+        using namespace test::jtx;
+        Env env {*this, std::make_unique<Config>( [](Config* cf)
             {
-                auto p = std::make_unique<Config>();
-                test::setupConfigForUnitTests(*p);
-                auto& section = p->section("transaction_queue");
-                section.set("minimum_txn_in_ledger_standalone", "3");
-                return p;
-            }(),
-            test::jtx::features(featureFeeEscalation));
+                cf->section("transaction_queue")
+                    .set("minimum_txn_in_ledger_standalone", "3");
+            }, defaultConf),
+            test::jtx::features(featureFeeEscalation)};
         LoadFeeTrack const& feeTrack = env.app().getFeeTrack();
 
         {

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -26,23 +26,6 @@ namespace ripple {
 class LedgerData_test : public beast::unit_test::suite
 {
 public:
-
-    static
-    std::unique_ptr<Config>
-    makeConfig(bool setup_admin)
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        // the default config has admin active
-        // ...we remove them if setup_admin is false
-        if (! setup_admin)
-        {
-            (*p)["port_rpc"].set("admin","");
-            (*p)["port_ws"].set("admin","");
-        }
-        return p;
-    }
-
     // test helper
     static bool checkArraySize(Json::Value const& val, unsigned int size)
     {
@@ -61,7 +44,8 @@ public:
     void testCurrentLedgerToLimits(bool as_admin)
     {
         using namespace test::jtx;
-        Env env {*this, makeConfig(as_admin)};
+        Env env {*this, std::make_unique<Config>(
+            as_admin ? defaultConf : nonAdminConf)};
         Account const gw {"gateway"};
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -104,7 +88,7 @@ public:
     void testCurrentLedgerBinary()
     {
         using namespace test::jtx;
-        Env env { *this, makeConfig(false) };
+        Env env { *this, std::make_unique<Config>(nonAdminConf) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -192,7 +176,7 @@ public:
     void testMarkerFollow()
     {
         using namespace test::jtx;
-        Env env { *this, makeConfig(false) };
+        Env env { *this, std::make_unique<Config>(nonAdminConf) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -27,17 +27,6 @@ namespace ripple {
 
 class LedgerRPC_test : public beast::unit_test::suite
 {
-    static
-    std::unique_ptr<Config>
-    makeNonAdminConfig()
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        (*p)["port_rpc"].set("admin","");
-        (*p)["port_ws"].set("admin","");
-        return p;
-    }
-
     void
     checkErrorValue(
         Json::Value const& jv,
@@ -184,7 +173,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         testcase("Ledger Request, Full Option Without Admin");
         using namespace test::jtx;
 
-        Env env { *this, makeNonAdminConfig() };
+        Env env { *this, std::make_unique<Config>(nonAdminConf) };
 
         env.close();
 

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -31,18 +31,6 @@ namespace RPC {
 class LedgerRequestRPC_test : public beast::unit_test::suite
 {
 public:
-
-    static
-    std::unique_ptr<Config>
-    makeNonAdminConfig()
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        (*p)["port_rpc"].set("admin","");
-        (*p)["port_ws"].set("admin","");
-        return p;
-    }
-
     void testLedgerRequest()
     {
         using namespace test::jtx;
@@ -288,7 +276,7 @@ public:
     void testNonAdmin()
     {
         using namespace test::jtx;
-        Env env { *this, makeNonAdminConfig() };
+        Env env { *this, std::make_unique<Config>(nonAdminConf) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);

--- a/src/test/rpc/RPCOverload_test.cpp
+++ b/src/test/rpc/RPCOverload_test.cpp
@@ -32,14 +32,7 @@ public:
     {
         testcase << "Overload " << (useWS ? "WS" : "HTTP") << " RPC client";
         using namespace jtx;
-        Env env(*this, []()
-            {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                (*p)["port_rpc"].set("admin","");
-                (*p)["port_ws"].set("admin","");
-                return p;
-            }());
+        Env env {*this, std::make_unique<Config>(nonAdminConf)};
 
         Account const alice {"alice"};
         Account const bob {"bob"};

--- a/src/test/rpc/ServerInfo_test.cpp
+++ b/src/test/rpc/ServerInfo_test.cpp
@@ -21,8 +21,7 @@
 #include <ripple/protocol/JsonFields.h>
 #include <test/jtx.h>
 #include <ripple/beast/unit_test.h>
-
-#include <boost/format.hpp>
+#include <ripple/core/ConfigSections.h>
 
 namespace ripple {
 
@@ -34,39 +33,17 @@ static auto const master_key =
     "nHUYwQk8AyQ8pW9p4SvrWC2hosvaoii9X54uGLDYGBtEFwWFHsJK";
 static auto const signing_key =
     "n9LHPLA36SBky1YjbaVEApQQ3s9XcpazCgfAG7jsqBb1ugDAosbm";
-// Format manifest string to test trim()
 static auto const manifest =
-    "    JAAAAAFxIe2cDLvm5IqpeGFlMTD98HCqv7+GE54anRD/zbvGNYtOsXMhAuUTyasIhvj2KPfN\n"
-    " \tRbmmIBnqNUzidgkKb244eP794ZpMdkYwRAIgNVq8SYP7js0C/GAGMKVYXiCGUTIL7OKPSBLS     \n"
-    "\t7LTyrL4CIE+s4Tsn/FrrYj0nMEV1Mvf7PMRYCxtEERD3PG/etTJ3cBJAbwWWofHqg9IACoYV\n"
-    "\t +n9ulZHSVRajo55EkZYw0XUXDw8zcI4gD58suOSLZTG/dXtZp17huIyHgxHbR2YeYjQpCw==\t  \t";
+    "JAAAAAFxIe2cDLvm5IqpeGFlMTD98HCqv7+GE54anRD/zbvGNYtOsXMhAuUTyasIhvj2KPfN"
+    "RbmmIBnqNUzidgkKb244eP794ZpMdkYwRAIgNVq8SYP7js0C/GAGMKVYXiCGUTIL7OKPSBLS"
+    "7LTyrL4CIE+s4Tsn/FrrYj0nMEV1Mvf7PMRYCxtEERD3PG/etTJ3cBJAbwWWofHqg9IACoYV"
+    "+n9ulZHSVRajo55EkZYw0XUXDw8zcI4gD58suOSLZTG/dXtZp17huIyHgxHbR2YeYjQpCw==";
 static auto sequence = 1;
 }
 
 class ServerInfo_test : public beast::unit_test::suite
 {
 public:
-    static
-    std::unique_ptr<Config>
-    makeValidatorConfig()
-    {
-        auto p = std::make_unique<Config>();
-        boost::format toLoad(R"rippleConfig(
-[validation_manifest]
-%1%
-
-[validation_seed]
-%2%
-)rippleConfig");
-
-        p->loadFromString (boost::str (
-            toLoad % validator::manifest % validator::seed));
-
-        setupConfigForUnitTests(*p);
-
-        return p;
-    }
-
     void testServerInfo()
     {
         using namespace test::jtx;
@@ -79,7 +56,20 @@ public:
             BEAST_EXPECT(result[jss::result].isMember(jss::info));
         }
         {
-            Env env(*this, makeValidatorConfig());
+            // validator configuration using a seed (a different seed than
+            // the one used in jtx::validatorConf)
+            Env env { *this, std::make_unique<Config>([&](Config* cf)
+                {
+                    auto const seed = parseBase58<Seed>(validator::seed);
+                    if (!seed)
+                        Throw<std::runtime_error> ("Invalid seed specified");
+                    cf->VALIDATION_PRIV =
+                        generateSecretKey (KeyType::secp256k1, *seed);
+                    cf->VALIDATION_PUB =
+                        derivePublicKey (KeyType::secp256k1, cf->VALIDATION_PRIV);
+                    cf->legacy(SECTION_VALIDATION_MANIFEST, validator::manifest);
+                }, defaultConf) };
+
             auto const result = env.rpc("server_info", "1");
             BEAST_EXPECT(!result[jss::result].isMember (jss::error));
             BEAST_EXPECT(result[jss::status] == "success");

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -274,13 +274,11 @@ class ServerStatus_test :
     {
         testcase("WS client to http server fails");
         using namespace jtx;
-        Env env(*this, []()
+        Env env {*this, std::make_unique<Config>([](Config* cf)
             {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                p->section("port_ws").set("protocol", "http,https");
-                return p;
-            }());
+                cf->section("port_ws").set("protocol", "http,https");
+            },
+            defaultConf)};
 
         //non-secure request
         {
@@ -308,14 +306,12 @@ class ServerStatus_test :
     {
         testcase("Status request");
         using namespace jtx;
-        Env env(*this, []()
+        Env env {*this, std::make_unique<Config>([](Config* cf)
             {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                p->section("port_rpc").set("protocol", "ws2,wss2");
-                p->section("port_ws").set("protocol", "http");
-                return p;
-            }());
+                cf->section("port_rpc").set("protocol", "ws2,wss2");
+                cf->section("port_ws").set("protocol", "http");
+            },
+            defaultConf)};
 
         //non-secure request
         {
@@ -345,13 +341,11 @@ class ServerStatus_test :
         using namespace jtx;
         using namespace boost::asio;
         using namespace beast::http;
-        Env env(*this, []()
+        Env env {*this, std::make_unique<Config>([](Config* cf)
             {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                p->section("port_ws").set("protocol", "ws2");
-                return p;
-            }());
+                cf->section("port_ws").set("protocol", "ws2");
+            },
+            defaultConf)};
 
         auto const port = env.app().config()["port_ws"].
             get<std::uint16_t>("port");


### PR DESCRIPTION
Add constructor for Config that allows lambdas to be passed for further
manipulation of the Config object. Update a number of tests to use the
new constructor and simplify the common nonAdmin config option.