### PR TITLE
Simplify Env Config Customization (RIPD-1247):

### DIFF
--- a/src/test/app/Regression_test.cpp
+++ b/src/test/app/Regression_test.cpp
@@ -164,15 +164,9 @@ struct Regression_test : public beast::unit_test::suite
     {
         testcase("Autofilled fee should use the escalated fee");
         using namespace jtx;
-        Env env(*this, []()
-            {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                auto& section = p->section("transaction_queue");
-                section.set("minimum_txn_in_ledger_standalone", "3");
-                return p;
-            }(),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        env.config().section("transaction_queue")
+            .set("minimum_txn_in_ledger_standalone", "3");
         Env_ss envs(env);
 
         auto const alice = Account("alice");

--- a/src/test/app/SHAMapStore_test.cpp
+++ b/src/test/app/SHAMapStore_test.cpp
@@ -33,27 +33,13 @@ class SHAMapStore_test : public beast::unit_test::suite
 {
     static auto const deleteInterval = 8;
 
-    static
-    std::unique_ptr<Config>
-    makeConfig()
+    void
+    modConfigForOnlineDelete(Config& cfg)
     {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
-        p->LEDGER_HISTORY = deleteInterval;
-        auto& section = p->section(ConfigSection::nodeDatabase());
+        cfg.LEDGER_HISTORY = deleteInterval;
+        auto& section = cfg.section(ConfigSection::nodeDatabase());
         section.set("online_delete", to_string(deleteInterval));
         //section.set("age_threshold", "60");
-        return p;
-    }
-
-    static
-    std::unique_ptr<Config>
-    makeConfigAdvisory()
-    {
-        auto p = makeConfig();
-        auto& section = p->section(ConfigSection::nodeDatabase());
-        section.set("advisory_delete", "1");
-        return p;
     }
 
     bool goodLedger(jtx::Env& env, Json::Value const& json,
@@ -211,7 +197,8 @@ public:
         testcase("clearPrior");
         using namespace jtx;
 
-        Env env(*this, makeConfig());
+        Env env {*this};
+        modConfigForOnlineDelete(env.config());
 
         auto& store = env.app().getSHAMapStore();
         env.fund(XRP(10000), noripple("alice"));
@@ -397,7 +384,8 @@ public:
         using namespace jtx;
         using namespace std::chrono_literals;
 
-        Env env(*this, makeConfig());
+        Env env {*this};
+        modConfigForOnlineDelete(env.config());
         auto& store = env.app().getSHAMapStore();
 
         auto ledgerSeq = waitForReady(env);
@@ -466,7 +454,11 @@ public:
         using namespace std::chrono_literals;
 
         // Same config with advisory_delete enabled
-        Env env(*this, makeConfigAdvisory());
+        Env env {*this};
+        modConfigForOnlineDelete(env.config());
+        // also change advisory_delete in the config
+        env.config().section(ConfigSection::nodeDatabase())
+            .set("advisory_delete", "1");
         auto& store = env.app().getSHAMapStore();
 
         auto ledgerSeq = waitForReady(env);

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -97,12 +97,10 @@ class TxQ_test : public beast::unit_test::suite
     }
 
     static
-    std::unique_ptr<Config>
-    makeConfig(std::map<std::string, std::string> extra = {})
+    void
+    modConfig(Config& cfg, std::map<std::string, std::string> extra = {})
     {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
-        auto& section = p->section("transaction_queue");
+        auto& section = cfg.section("transaction_queue");
         section.set("ledgers_in_queue", "2");
         section.set("min_ledgers_to_compute_size_limit", "3");
         section.set("max_ledger_counts_to_store", "100");
@@ -110,7 +108,6 @@ class TxQ_test : public beast::unit_test::suite
         section.set("zero_basefee_transaction_feelevel", "100000000000");
         for (auto const& value : extra)
             section.set(value.first, value.second);
-        return p;
     }
 
     void
@@ -161,8 +158,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig({ {"minimum_txn_in_ledger_standalone", "3"} }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{"minimum_txn_in_ledger_standalone", "3"}});
         auto& txq = env.app().getTxQ();
 
         auto alice = Account("alice");
@@ -348,8 +345,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "2" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -404,8 +401,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "2" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -520,8 +517,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "2" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -627,7 +624,8 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig(), features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config());
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -651,8 +649,8 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "2" } }),
-            features(featureFeeEscalation));
+        Env env{*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "2" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -705,8 +703,8 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -935,8 +933,8 @@ public:
         using namespace jtx;
         using namespace std::chrono;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "4" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "4" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -1096,8 +1094,8 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "1" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "1" }});
 
         auto alice = Account("alice");
 
@@ -1136,11 +1134,11 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this, makeConfig(
-            { {"minimum_txn_in_ledger_standalone", "2"},
-                {"target_txn_in_ledger", "4"},
-                    {"maximum_txn_in_ledger", "5"} }),
-                        features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {
+            {"minimum_txn_in_ledger_standalone", "2"},
+            {"target_txn_in_ledger", "4"},
+            {"maximum_txn_in_ledger", "5"}});
 
         auto alice = Account("alice");
         auto queued = ter(terQUEUED);
@@ -1165,9 +1163,8 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this,
-            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
-                features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -1253,9 +1250,9 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this,
-            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
-            features(featureFeeEscalation), features(featureMultiSign));
+        Env env {*this,
+            features(featureFeeEscalation), features(featureMultiSign)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
 
         auto alice = Account("alice");
         auto bob = Account("bob");
@@ -1319,8 +1316,8 @@ public:
         using namespace jtx;
 
         Env env(*this,
-            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
             features(featureFeeEscalation), features(featureTickets));
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
 
         auto alice = Account("alice");
         auto charlie = Account("charlie");
@@ -1720,9 +1717,11 @@ public:
         */
         using namespace jtx;
 
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "1" },
-            {"ledgers_in_queue", "10"}, {"maximum_txn_per_account", "20"} }),
-                features(featureFeeEscalation));
+        Env env(*this, features(featureFeeEscalation));
+        modConfig(env.config(), {
+            { "minimum_txn_in_ledger_standalone", "1" },
+            {"ledgers_in_queue", "10"},
+            {"maximum_txn_per_account", "20"}});
 
         // Alice will recreate the scenario. Bob will block.
         auto const alice = Account("alice");
@@ -1796,8 +1795,8 @@ public:
     {
         testcase("Autofilled sequence should account for TxQ");
         using namespace jtx;
-        Env env(*this, makeConfig({ {"minimum_txn_in_ledger_standalone", "6"} }),
-            features(featureFeeEscalation));
+        Env env(*this, features(featureFeeEscalation));
+        modConfig(env.config(), {{"minimum_txn_in_ledger_standalone", "6"}});
         Env_ss envs(env);
         auto const& txQ = env.app().getTxQ();
 
@@ -1941,8 +1940,8 @@ public:
     void testAccountInfo()
     {
         using namespace jtx;
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
         Env_ss envs(env);
 
         Account const alice{ "alice" };
@@ -2211,8 +2210,8 @@ public:
     void testServerInfo()
     {
         using namespace jtx;
-        Env env(*this, makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
         Env_ss envs(env);
 
         Account const alice{ "alice" };
@@ -2434,9 +2433,8 @@ public:
     {
         using namespace jtx;
 
-        Env env(*this,
-            makeConfig({ { "minimum_txn_in_ledger_standalone", "3" } }),
-            features(featureFeeEscalation));
+        Env env {*this, features(featureFeeEscalation)};
+        modConfig(env.config(), {{ "minimum_txn_in_ledger_standalone", "3" }});
         auto alice = Account("alice");
         auto bob = Account("bob");
 

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -187,6 +187,34 @@ Env::AppBundle::~AppBundle()
 
 //------------------------------------------------------------------------------
 
+admin_t const no_admin_cfg {false};
+admin_t const admin_cfg {true};
+validator_t const validator_cfg {};
+
+
+/// @brief modify the configuration to be a validator by adding
+/// PUB/PRIV validator keys
+///
+/// @param const <unused> tag type for dispatching
+void
+Env::construct_arg (validator_t const&)
+{
+    // If the config has valid validation keys then we run as a validator.
+    auto const seed = parseBase58<Seed>("shUwVw52ofnCUX5m7kPTKzJdr4HEH");
+    if (!seed)
+        Throw<std::runtime_error> ("Invalid seed specified");
+    config().VALIDATION_PRIV = generateSecretKey (KeyType::secp256k1, *seed);
+    config().VALIDATION_PUB =
+        derivePublicKey (KeyType::secp256k1, config().VALIDATION_PRIV);
+}
+
+void
+Env::construct_arg (admin_t const& a)
+{
+    config()["port_rpc"].set("admin", a.is_admin ? "127.0.0.1" : "");
+    config()["port_ws"].set("admin", a.is_admin ? "127.0.0.1" : "");
+}
+
 std::shared_ptr<ReadView const>
 Env::closed()
 {

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -26,22 +26,6 @@ namespace test {
 class AccountOffers_test : public beast::unit_test::suite
 {
 public:
-    static
-    std::unique_ptr<Config>
-    makeConfig(bool setup_admin)
-    {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
-        // the default config has admin active
-        // ...we remove them if setup_admin is false
-        if (! setup_admin)
-        {
-            (*p)["port_rpc"].set("admin","");
-            (*p)["port_ws"].set("admin","");
-        }
-        return p;
-    }
-
     // test helper
     static bool checkArraySize(Json::Value const& val, unsigned int size)
     {
@@ -60,7 +44,7 @@ public:
     void testNonAdminMinLimit()
     {
         using namespace jtx;
-        Env env(*this, makeConfig(false));
+        Env env(*this, no_admin_cfg);
         Account const gw ("G1");
         auto const USD_gw  = gw["USD"];
         Account const bob ("bob");
@@ -100,7 +84,8 @@ public:
     void testSequential(bool as_admin)
     {
         using namespace jtx;
-        Env env(*this, makeConfig(as_admin));
+        Env env {*this, as_admin ? admin_cfg : no_admin_cfg};
+
         Account const gw ("G1");
         auto const USD_gw  = gw["USD"];
         Account const bob ("bob");

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1411,16 +1411,7 @@ public:
     {
         testcase("BookOffer Limits");
         using namespace jtx;
-        Env env(*this, [asAdmin]() {
-            auto p = std::make_unique<Config>();
-            setupConfigForUnitTests(*p);
-            if(! asAdmin)
-            {
-                (*p)["port_rpc"].set("admin","");
-                (*p)["port_ws"].set("admin","");
-            }
-            return p;
-        }());
+        Env env {*this, asAdmin ? admin_cfg : no_admin_cfg};
         Account gw {"gw"};
         env.fund(XRP(200000), gw);
         env.close();

--- a/src/test/rpc/JSONRPC_test.cpp
+++ b/src/test/rpc/JSONRPC_test.cpp
@@ -1934,15 +1934,11 @@ public:
 
     void testAutoFillEscalatedFees ()
     {
-        test::jtx::Env env(*this, []()
-            {
-                auto p = std::make_unique<Config>();
-                test::setupConfigForUnitTests(*p);
-                auto& section = p->section("transaction_queue");
-                section.set("minimum_txn_in_ledger_standalone", "3");
-                return p;
-            }(),
-            test::jtx::features(featureFeeEscalation));
+        using namespace test::jtx;
+        test::jtx::Env env {*this, features(featureFeeEscalation)};
+        env.config().section("transaction_queue")
+            .set("minimum_txn_in_ledger_standalone", "3");
+
         LoadFeeTrack const& feeTrack = env.app().getFeeTrack();
 
         {

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -27,22 +27,6 @@ class LedgerData_test : public beast::unit_test::suite
 {
 public:
 
-    static
-    std::unique_ptr<Config>
-    makeConfig(bool setup_admin)
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        // the default config has admin active
-        // ...we remove them if setup_admin is false
-        if (! setup_admin)
-        {
-            (*p)["port_rpc"].set("admin","");
-            (*p)["port_ws"].set("admin","");
-        }
-        return p;
-    }
-
     // test helper
     static bool checkArraySize(Json::Value const& val, unsigned int size)
     {
@@ -61,7 +45,7 @@ public:
     void testCurrentLedgerToLimits(bool as_admin)
     {
         using namespace test::jtx;
-        Env env {*this, makeConfig(as_admin)};
+        Env env {*this, as_admin ? admin_cfg : no_admin_cfg};
         Account const gw {"gateway"};
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -104,7 +88,7 @@ public:
     void testCurrentLedgerBinary()
     {
         using namespace test::jtx;
-        Env env { *this, makeConfig(false) };
+        Env env { *this, no_admin_cfg };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -192,7 +176,7 @@ public:
     void testMarkerFollow()
     {
         using namespace test::jtx;
-        Env env { *this, makeConfig(false) };
+        Env env { *this, no_admin_cfg};
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -27,17 +27,6 @@ namespace ripple {
 
 class LedgerRPC_test : public beast::unit_test::suite
 {
-    static
-    std::unique_ptr<Config>
-    makeNonAdminConfig()
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        (*p)["port_rpc"].set("admin","");
-        (*p)["port_ws"].set("admin","");
-        return p;
-    }
-
     void
     checkErrorValue(
         Json::Value const& jv,
@@ -184,7 +173,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         testcase("Ledger Request, Full Option Without Admin");
         using namespace test::jtx;
 
-        Env env { *this, makeNonAdminConfig() };
+        Env env { *this, no_admin_cfg };
 
         env.close();
 

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -32,17 +32,6 @@ class LedgerRequestRPC_test : public beast::unit_test::suite
 {
 public:
 
-    static
-    std::unique_ptr<Config>
-    makeNonAdminConfig()
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        (*p)["port_rpc"].set("admin","");
-        (*p)["port_ws"].set("admin","");
-        return p;
-    }
-
     void testLedgerRequest()
     {
         using namespace test::jtx;
@@ -288,7 +277,7 @@ public:
     void testNonAdmin()
     {
         using namespace test::jtx;
-        Env env { *this, makeNonAdminConfig() };
+        Env env {*this, no_admin_cfg};
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);

--- a/src/test/rpc/RPCOverload_test.cpp
+++ b/src/test/rpc/RPCOverload_test.cpp
@@ -32,14 +32,7 @@ public:
     {
         testcase << "Overload " << (useWS ? "WS" : "HTTP") << " RPC client";
         using namespace jtx;
-        Env env(*this, []()
-            {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                (*p)["port_rpc"].set("admin","");
-                (*p)["port_ws"].set("admin","");
-                return p;
-            }());
+        Env env {*this, no_admin_cfg};
 
         Account const alice {"alice"};
         Account const bob {"bob"};

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -311,42 +311,11 @@ public:
         BEAST_EXPECT(jv[jss::status] == "success");
     }
 
-    static
-    std::unique_ptr<Config>
-    makeValidatorConfig(
-        std::string const& valPrivateKey, std::string const& valPublicKey)
-    {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
-
-        // If the config has valid validation keys then we run as a validator.
-        auto const sk = parseBase58<SecretKey>(
-            TOKEN_NODE_PRIVATE,
-            valPrivateKey);
-        if (!sk)
-            Throw<std::runtime_error> ("Invalid validation private key");
-        p->VALIDATION_PRIV = *sk;
-
-        auto const pk = parseBase58<PublicKey>(
-            TOKEN_NODE_PUBLIC,
-            valPublicKey);
-        if (!pk)
-            Throw<std::runtime_error> ("Invalid validation public key");
-        p->VALIDATION_PUB = *pk;
-
-        return p;
-    }
-
     void testValidations()
     {
         using namespace jtx;
 
-        // Public key must be derived from the private key
-        const std::string valPrivateKey =
-            "paEdUCVVCNnv4aYBepid9Xh3NaAr9xWRw2vh351piFJrxQwvExd";
-        const std::string valPublicKey =
-            "n9MvFGjgv1kYkm7bLbb2QUwSqgzrQkYMYHXtrzN8W28Jfp2mVihq";
-        Env env(*this, makeValidatorConfig(valPrivateKey, valPublicKey));
+        Env env {*this, validator_cfg};
         auto wsc = makeWSClient(env.app().config());
         Json::Value stream;
 
@@ -373,7 +342,9 @@ public:
                 [&](auto const& jv)
                 {
                     return jv[jss::type] == "validationReceived" &&
-                        jv[jss::validation_public_key] == valPublicKey &&
+                        jv[jss::validation_public_key].asString() ==
+                            toBase58 (TokenType::TOKEN_NODE_PUBLIC,
+                                env.app().config().VALIDATION_PUB) &&
                         jv[jss::ledger_hash] ==
                             to_string(env.closed()->info().hash) &&
                         jv[jss::ledger_index] ==


### PR DESCRIPTION
Defer creation of Env AppBundle object so that callers can selectively
modify the config before it is used to start the Application. Add Env
construct_arg variants that simplify the config modification for
non-admin ports and validator mode.