### PR TITLE
Fix #1999

### DIFF
--- a/src/ripple/site_scons/scons_to_ninja.py
+++ b/src/ripple/site_scons/scons_to_ninja.py
@@ -60,6 +60,12 @@ rule cmd
 # hard links here (with -l) for speed.
 rule install
   command = rm -f $out && cp -l $in $out
+
+build build/proto/ripple.pb.h: cmd src/ripple/proto/ripple.proto
+  cmd = protoc -Isrc/ripple/proto --cpp_out=build/proto src/ripple/proto/ripple.proto
+
+build build/proto/ripple.pb.cc: cmd src/ripple/proto/ripple.proto
+  cmd = protoc -Isrc/ripple/proto --cpp_out=build/proto src/ripple/proto/ripple.proto
 """)
     for node in node_list:
       dest_path = node.get_path()


### PR DESCRIPTION
The scons_to_ninja file has problems with parsing the way SCons compiles protocol buffers. This is a workaround that directly writes the build rules in the generated ninja file instead of generating them dynamically.

There's probably a better/proper way to do it that likely involves changes to the Protoc handler in SCons. This works for the time being and maybe CMake anyways will in the future be able to emit proper ninja files in case you decide to migrate away from SCons.