### PR TITLE
Specify syntax version for ripple.proto file

### DIFF
--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package protocol;
 
 enum MessageType


### PR DESCRIPTION
This hides warnings by the protobuf compiler about the syntax version not being specified.