### PR TITLE
Add helper to modify Env configs (RIPD-1247)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4461,6 +4461,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\Env.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\test\jtx\envconfig.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\Env_ss.h">
     </ClInclude>
     <ClCompile Include="..\..\src\test\jtx\Env_test.cpp">
@@ -4488,6 +4490,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\test\jtx\impl\Env.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\jtx\impl\envconfig.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5199,6 +5199,9 @@
     <ClInclude Include="..\..\src\test\jtx\Env.h">
       <Filter>test\jtx</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\test\jtx\envconfig.h">
+      <Filter>test\jtx</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\Env_ss.h">
       <Filter>test\jtx</Filter>
     </ClInclude>
@@ -5224,6 +5227,9 @@
       <Filter>test\jtx\impl</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\jtx\impl\Env.cpp">
+      <Filter>test\jtx\impl</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\jtx\impl\envconfig.cpp">
       <Filter>test\jtx\impl</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\jtx\impl\fee.cpp">

--- a/src/test/app/LedgerLoad_test.cpp
+++ b/src/test/app/LedgerLoad_test.cpp
@@ -40,8 +40,7 @@ class LedgerLoad_test : public beast::unit_test::suite
     auto ledgerConfig(std::string const& ledger, Config::StartUpType type)
     {
         assert(! dbPath_.empty());
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
+        auto p = test::jtx::envconfig();
         p->START_LEDGER = ledger;
         p->START_UP = type;
         p->legacy("database_path", dbPath_.string());

--- a/src/test/app/Regression_test.cpp
+++ b/src/test/app/Regression_test.cpp
@@ -17,6 +17,7 @@
 
 #include <BeastConfig.h>
 #include <test/jtx.h>
+#include <test/jtx/envconfig.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/json/json_reader.h>
@@ -164,14 +165,12 @@ struct Regression_test : public beast::unit_test::suite
     {
         testcase("Autofilled fee should use the escalated fee");
         using namespace jtx;
-        Env env(*this, []()
+        Env env(*this, envconfig([](std::unique_ptr<Config> cfg)
             {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                auto& section = p->section("transaction_queue");
-                section.set("minimum_txn_in_ledger_standalone", "3");
-                return p;
-            }(),
+                cfg->section("transaction_queue")
+                    .set("minimum_txn_in_ledger_standalone", "3");
+                return cfg;
+            }),
             features(featureFeeEscalation));
         Env_ss envs(env);
 

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -25,6 +25,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/mulDiv.h>
 #include <test/jtx/TestSuite.h>
+#include <test/jtx/envconfig.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
@@ -98,8 +99,7 @@ class TxQ_test : public beast::unit_test::suite
     std::unique_ptr<Config>
     makeConfig(std::map<std::string, std::string> extra = {})
     {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
+        auto p = test::jtx::envconfig();
         auto& section = p->section("transaction_queue");
         section.set("ledgers_in_queue", "2");
         section.set("min_ledgers_to_compute_size_limit", "3");

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -22,6 +22,7 @@
 
 #include <test/jtx/Account.h>
 #include <test/jtx/amount.h>
+#include <test/jtx/envconfig.h>
 #include <test/jtx/JTx.h>
 #include <test/jtx/require.h>
 #include <test/jtx/tags.h>
@@ -54,13 +55,6 @@
 
 namespace ripple {
 namespace test {
-
-extern
-void
-setupConfigForUnitTests (Config& config);
-
-//------------------------------------------------------------------------------
-
 namespace jtx {
 
 /** Designate accounts as no-ripple in Env::fund */
@@ -152,12 +146,7 @@ public:
     template <class... Args>
     Env (beast::unit_test::suite& suite_,
             Args&&... args)
-        : Env(suite_, []()
-            {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                return p;
-            }(), std::forward<Args>(args)...)
+        : Env(suite_, envconfig(), std::forward<Args>(args)...)
     {
     }
 

--- a/src/test/jtx/envconfig.h
+++ b/src/test/jtx/envconfig.h
@@ -1,0 +1,111 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TEST_JTX_ENVCONFIG_H_INCLUDED
+#define RIPPLE_TEST_JTX_ENVCONFIG_H_INCLUDED
+
+#include <ripple/core/Config.h>
+
+namespace ripple {
+namespace test {
+
+/// @brief initializes a config object for use with jtx::Env
+///
+/// @param config the configuration object to be initialized
+extern
+void
+setupConfigForUnitTests (Config& config);
+
+namespace jtx {
+
+/// @brief creates and initializes a default
+/// configuration for jtx::Env
+///
+/// @return unique_ptr to Config instance
+inline
+std::unique_ptr<Config>
+envconfig()
+{
+    auto p = std::make_unique<Config>();
+    setupConfigForUnitTests(*p);
+    return p;
+}
+
+/// @brief creates and initializes a default configuration for jtx::Env and
+/// invokes the provided function/lambda with the configuration object.
+///
+/// @param modfunc callable function or lambda to modify the default config.
+/// The first argument to the function must be std::unique_ptr to
+/// ripple::Config. The function takes ownership of the unique_ptr and
+/// relinquishes ownership by returning a unique_ptr.
+///
+/// @param args additional arguments that will be passed to
+/// the config modifier function (optional)
+///
+/// @return unique_ptr to Config instance
+template <class F, class... Args>
+std::unique_ptr<Config>
+envconfig(F&& modfunc, Args&&... args)
+{
+    return modfunc(envconfig(), std::forward<Args>(args)...);
+}
+
+/// @brief adjust config so no admin ports are enabled
+///
+/// this is intended for use with envconfig, as in
+/// envconfig(no_admin)
+///
+/// @param cfg config instance to be modified
+///
+/// @return unique_ptr to Config instance
+std::unique_ptr<Config>
+no_admin(std::unique_ptr<Config>);
+
+/// @brief adjust configuration with params needed to be a validator
+///
+/// this is intended for use with envconfig, as in
+/// envconfig(validator, myseed)
+///
+/// @param cfg config instance to be modified
+/// @param seed seed string for use in secret key generation. A fixed default
+/// value will be used if this string is empty
+///
+/// @return unique_ptr to Config instance
+std::unique_ptr<Config>
+validator(std::unique_ptr<Config>, std::string const&);
+
+/// @brief adjust the default configured server ports by a specified value
+///
+/// This is intended for use with envconfig, as in
+/// envconfig(port_increment, 5)
+///
+/// @param cfg config instance to be modified
+/// @param int amount by which to increment the existing server port
+/// values in the config
+///
+/// @return unique_ptr to Config instance
+std::unique_ptr<Config>
+port_increment(std::unique_ptr<Config>, int);
+
+} // jtx
+} // test
+} // ripple
+
+#endif
+

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -35,7 +35,6 @@
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/Slice.h>
-#include <ripple/core/ConfigSections.h>
 #include <ripple/json/to_string.h>
 #include <ripple/net/HTTPClient.h>
 #include <ripple/net/RPCCall.h>
@@ -54,33 +53,6 @@
 
 namespace ripple {
 namespace test {
-
-void
-setupConfigForUnitTests (Config& cfg)
-{
-    cfg.overwrite (ConfigSection::nodeDatabase (), "type", "memory");
-    cfg.overwrite (ConfigSection::nodeDatabase (), "path", "main");
-    cfg.deprecatedClearSection (ConfigSection::importNodeDatabase ());
-    cfg.legacy("database_path", "");
-    cfg.setupControl(true, true, true);
-    cfg["server"].append("port_peer");
-    cfg["port_peer"].set("ip", "127.0.0.1");
-    cfg["port_peer"].set("port", "8080");
-    cfg["port_peer"].set("protocol", "peer");
-    cfg["server"].append("port_rpc");
-    cfg["port_rpc"].set("ip", "127.0.0.1");
-    cfg["port_rpc"].set("port", "8081");
-    cfg["port_rpc"].set("protocol", "http,ws2");
-    cfg["port_rpc"].set("admin", "127.0.0.1");
-    cfg["server"].append("port_ws");
-    cfg["port_ws"].set("ip", "127.0.0.1");
-    cfg["port_ws"].set("port", "8082");
-    cfg["port_ws"].set("protocol", "ws");
-    cfg["port_ws"].set("admin", "127.0.0.1");
-}
-
-//------------------------------------------------------------------------------
-
 namespace jtx {
 
 class SuiteSink : public beast::Journal::Sink

--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -1,0 +1,89 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/jtx/envconfig.h>
+#include <test/jtx/Env.h>
+#include <ripple/core/ConfigSections.h>
+
+namespace ripple {
+namespace test {
+
+void
+setupConfigForUnitTests (Config& cfg)
+{
+    cfg.overwrite (ConfigSection::nodeDatabase (), "type", "memory");
+    cfg.overwrite (ConfigSection::nodeDatabase (), "path", "main");
+    cfg.deprecatedClearSection (ConfigSection::importNodeDatabase ());
+    cfg.legacy("database_path", "");
+    cfg.setupControl(true, true, true);
+    cfg["server"].append("port_peer");
+    cfg["port_peer"].set("ip", "127.0.0.1");
+    cfg["port_peer"].set("port", "8080");
+    cfg["port_peer"].set("protocol", "peer");
+    cfg["server"].append("port_rpc");
+    cfg["port_rpc"].set("ip", "127.0.0.1");
+    cfg["port_rpc"].set("port", "8081");
+    cfg["port_rpc"].set("protocol", "http,ws2");
+    cfg["port_rpc"].set("admin", "127.0.0.1");
+    cfg["server"].append("port_ws");
+    cfg["port_ws"].set("ip", "127.0.0.1");
+    cfg["port_ws"].set("port", "8082");
+    cfg["port_ws"].set("protocol", "ws");
+    cfg["port_ws"].set("admin", "127.0.0.1");
+}
+
+namespace jtx {
+
+std::unique_ptr<Config>
+no_admin(std::unique_ptr<Config> cfg)
+{
+    (*cfg)["port_rpc"].set("admin","");
+    (*cfg)["port_ws"].set("admin","");
+    return cfg;
+}
+
+auto constexpr defaultseed = "shUwVw52ofnCUX5m7kPTKzJdr4HEH";
+
+std::unique_ptr<Config>
+validator(std::unique_ptr<Config> cfg, std::string const& seed)
+{
+    // If the config has valid validation keys then we run as a validator.
+    cfg->section(SECTION_VALIDATION_SEED).append(
+        std::vector<std::string>{seed.empty() ? defaultseed : seed});
+    return cfg;
+}
+
+std::unique_ptr<Config>
+port_increment(std::unique_ptr<Config> cfg, int increment)
+{
+    for (auto const sectionName : {"port_peer", "port_rpc", "port_ws"})
+    {
+        Section& s = (*cfg)[sectionName];
+        auto const port = s.get<std::int32_t>("port");
+        if (port)
+        {
+            s.set ("port", std::to_string(*port + increment));
+        }
+    }
+    return cfg;
+}
+
+} // jtx
+} // test
+} // ripple

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -26,22 +26,6 @@ namespace test {
 class AccountOffers_test : public beast::unit_test::suite
 {
 public:
-    static
-    std::unique_ptr<Config>
-    makeConfig(bool setup_admin)
-    {
-        auto p = std::make_unique<Config>();
-        setupConfigForUnitTests(*p);
-        // the default config has admin active
-        // ...we remove them if setup_admin is false
-        if (! setup_admin)
-        {
-            (*p)["port_rpc"].set("admin","");
-            (*p)["port_ws"].set("admin","");
-        }
-        return p;
-    }
-
     // test helper
     static bool checkArraySize(Json::Value const& val, unsigned int size)
     {
@@ -60,7 +44,7 @@ public:
     void testNonAdminMinLimit()
     {
         using namespace jtx;
-        Env env(*this, makeConfig(false));
+        Env env {*this, envconfig(no_admin)};
         Account const gw ("G1");
         auto const USD_gw  = gw["USD"];
         Account const bob ("bob");
@@ -97,10 +81,10 @@ public:
         BEAST_EXPECT(checkArraySize(jro_l, 10u));
     }
 
-    void testSequential(bool as_admin)
+    void testSequential(bool asAdmin)
     {
         using namespace jtx;
-        Env env(*this, makeConfig(as_admin));
+        Env env {*this, asAdmin ? envconfig() : envconfig(no_admin)};
         Account const gw ("G1");
         auto const USD_gw  = gw["USD"];
         Account const bob ("bob");
@@ -153,9 +137,9 @@ public:
             // limit parameter is NOT subject to sane defaults, but with a
             // non-admin there are pre-configured limit ranges applied. That's
             // why we have different BEAST_EXPECT()s here for the two scenarios
-            BEAST_EXPECT(checkArraySize(jro_l_1, as_admin ? 1u : 3u));
-            BEAST_EXPECT(as_admin ? checkMarker(jrr_l_1) : (! jrr_l_1.isMember(jss::marker)));
-            if (as_admin)
+            BEAST_EXPECT(checkArraySize(jro_l_1, asAdmin ? 1u : 3u));
+            BEAST_EXPECT(asAdmin ? checkMarker(jrr_l_1) : (! jrr_l_1.isMember(jss::marker)));
+            if (asAdmin)
             {
                 BEAST_EXPECT(jro[0u] == jro_l_1[0u]);
 
@@ -193,8 +177,8 @@ public:
             jvParams[jss::limit]   = 0u;
             auto const  jrr = env.rpc ("json", "account_offers", jvParams.toStyledString())[jss::result];
             auto const& jro = jrr[jss::offers];
-            BEAST_EXPECT(checkArraySize(jro, as_admin ? 0u : 3u));
-            BEAST_EXPECT(as_admin ? checkMarker(jrr) : (! jrr.isMember(jss::marker)));
+            BEAST_EXPECT(checkArraySize(jro, asAdmin ? 0u : 3u));
+            BEAST_EXPECT(asAdmin ? checkMarker(jrr) : (! jrr.isMember(jss::marker)));
         }
 
     }

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1410,16 +1410,7 @@ public:
     {
         testcase("BookOffer Limits");
         using namespace jtx;
-        Env env(*this, [asAdmin]() {
-            auto p = std::make_unique<Config>();
-            setupConfigForUnitTests(*p);
-            if(! asAdmin)
-            {
-                (*p)["port_rpc"].set("admin","");
-                (*p)["port_ws"].set("admin","");
-            }
-            return p;
-        }());
+        Env env {*this, asAdmin ? envconfig() : envconfig(no_admin)};
         Account gw {"gw"};
         env.fund(XRP(200000), gw);
         env.close();

--- a/src/test/rpc/JSONRPC_test.cpp
+++ b/src/test/rpc/JSONRPC_test.cpp
@@ -26,6 +26,7 @@
 #include <ripple/protocol/Feature.h>
 #include <ripple/rpc/impl/TransactionSign.h>
 #include <test/jtx.h>
+#include <test/jtx/envconfig.h>
 #include <ripple/beast/unit_test.h>
 
 namespace ripple {
@@ -1934,15 +1935,14 @@ public:
 
     void testAutoFillEscalatedFees ()
     {
-        test::jtx::Env env(*this, []()
+        using namespace test::jtx;
+        Env env {*this, envconfig([](std::unique_ptr<Config> cfg)
             {
-                auto p = std::make_unique<Config>();
-                test::setupConfigForUnitTests(*p);
-                auto& section = p->section("transaction_queue");
-                section.set("minimum_txn_in_ledger_standalone", "3");
-                return p;
-            }(),
-            test::jtx::features(featureFeeEscalation));
+                cfg->section("transaction_queue")
+                    .set("minimum_txn_in_ledger_standalone", "3");
+                return cfg;
+            }),
+            test::jtx::features(featureFeeEscalation)};
         LoadFeeTrack const& feeTrack = env.app().getFeeTrack();
 
         {

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -26,23 +26,6 @@ namespace ripple {
 class LedgerData_test : public beast::unit_test::suite
 {
 public:
-
-    static
-    std::unique_ptr<Config>
-    makeConfig(bool setup_admin)
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        // the default config has admin active
-        // ...we remove them if setup_admin is false
-        if (! setup_admin)
-        {
-            (*p)["port_rpc"].set("admin","");
-            (*p)["port_ws"].set("admin","");
-        }
-        return p;
-    }
-
     // test helper
     static bool checkArraySize(Json::Value const& val, unsigned int size)
     {
@@ -58,10 +41,10 @@ public:
                val[jss::marker].asString().size() > 0;
     }
 
-    void testCurrentLedgerToLimits(bool as_admin)
+    void testCurrentLedgerToLimits(bool asAdmin)
     {
         using namespace test::jtx;
-        Env env {*this, makeConfig(as_admin)};
+        Env env {*this, asAdmin ? envconfig() : envconfig(no_admin)};
         Account const gw {"gateway"};
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -97,14 +80,14 @@ public:
                 boost::lexical_cast<std::string>(jvParams)) [jss::result];
             BEAST_EXPECT(
                 checkArraySize( jrr[jss::state],
-                    (delta > 0 && !as_admin) ? max_limit : max_limit + delta ));
+                    (delta > 0 && !asAdmin) ? max_limit : max_limit + delta ));
         }
     }
 
     void testCurrentLedgerBinary()
     {
         using namespace test::jtx;
-        Env env { *this, makeConfig(false) };
+        Env env { *this, envconfig(no_admin) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -192,7 +175,7 @@ public:
     void testMarkerFollow()
     {
         using namespace test::jtx;
-        Env env { *this, makeConfig(false) };
+        Env env { *this, envconfig(no_admin) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -27,17 +27,6 @@ namespace ripple {
 
 class LedgerRPC_test : public beast::unit_test::suite
 {
-    static
-    std::unique_ptr<Config>
-    makeNonAdminConfig()
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        (*p)["port_rpc"].set("admin","");
-        (*p)["port_ws"].set("admin","");
-        return p;
-    }
-
     void
     checkErrorValue(
         Json::Value const& jv,
@@ -184,7 +173,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         testcase("Ledger Request, Full Option Without Admin");
         using namespace test::jtx;
 
-        Env env { *this, makeNonAdminConfig() };
+        Env env { *this, envconfig(no_admin) };
 
         env.close();
 

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -32,17 +32,6 @@ class LedgerRequestRPC_test : public beast::unit_test::suite
 {
 public:
 
-    static
-    std::unique_ptr<Config>
-    makeNonAdminConfig()
-    {
-        auto p = std::make_unique<Config>();
-        test::setupConfigForUnitTests(*p);
-        (*p)["port_rpc"].set("admin","");
-        (*p)["port_ws"].set("admin","");
-        return p;
-    }
-
     void testLedgerRequest()
     {
         using namespace test::jtx;
@@ -288,7 +277,7 @@ public:
     void testNonAdmin()
     {
         using namespace test::jtx;
-        Env env { *this, makeNonAdminConfig() };
+        Env env { *this, envconfig(no_admin) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);

--- a/src/test/rpc/RPCOverload_test.cpp
+++ b/src/test/rpc/RPCOverload_test.cpp
@@ -32,14 +32,7 @@ public:
     {
         testcase << "Overload " << (useWS ? "WS" : "HTTP") << " RPC client";
         using namespace jtx;
-        Env env(*this, []()
-            {
-                auto p = std::make_unique<Config>();
-                setupConfigForUnitTests(*p);
-                (*p)["port_rpc"].set("admin","");
-                (*p)["port_ws"].set("admin","");
-                return p;
-            }());
+        Env env {*this, envconfig(no_admin)};
 
         Account const alice {"alice"};
         Account const bob {"bob"};

--- a/src/test/rpc/ServerInfo_test.cpp
+++ b/src/test/rpc/ServerInfo_test.cpp
@@ -28,7 +28,7 @@ namespace ripple {
 
 namespace test {
 
-namespace validator {
+namespace validator_data {
 static auto const public_key =
     "nHBt9fsb4849WmZiCds4r5TXyBeQjqnH5kzPtqgMAQMgi39YZRPa";
 
@@ -60,7 +60,7 @@ public:
 )rippleConfig");
 
         p->loadFromString (boost::str (
-            toLoad % validator::token % validator::public_key));
+            toLoad % validator_data::token % validator_data::public_key));
 
         setupConfigForUnitTests(*p);
 
@@ -85,7 +85,7 @@ public:
             BEAST_EXPECT(result[jss::status] == "success");
             BEAST_EXPECT(result[jss::result].isMember(jss::info));
             BEAST_EXPECT(result[jss::result][jss::info]
-                [jss::pubkey_validator] == validator::public_key);
+                [jss::pubkey_validator] == validator_data::public_key);
         }
     }
 

--- a/src/test/unity/support_unity.cpp
+++ b/src/test/unity/support_unity.cpp
@@ -24,6 +24,7 @@
 #include <test/jtx/impl/balance.cpp>
 #include <test/jtx/impl/delivermin.cpp>
 #include <test/jtx/impl/Env.cpp>
+#include <test/jtx/impl/envconfig.cpp>
 #include <test/jtx/impl/fee.cpp>
 #include <test/jtx/impl/flags.cpp>
 #include <test/jtx/impl/jtx_json.cpp>


### PR DESCRIPTION
Add envconfig test helper for manipulating Env config via
callables. Create new common modifiers for non-admin config,
validator config and one for using different server port values.