### PR TITLE
[Trivial] Enable two warnings:

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -573,7 +573,6 @@ def config_env(toolchain, variant, env):
             env.Append(CCFLAGS=[
                 '-Wno-deprecated',
                 '-Wno-deprecated-declarations',
-                '-Wno-unused-variable',
                 '-Wno-unused-function',
                 ])
         else:


### PR DESCRIPTION
* -Wsign-compare
* -Wunused-variable

Needs testing on Linux and Windows to ensure this does not introduce any warnings to the scons build.