### PR TITLE
Specify syntax version for ripple.proto file

### DIFF
--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package protocol;
 
 enum MessageType


### PR DESCRIPTION
This change eliminates a warning about unspecified syntax version when using
a newer proto3 compiler.

This is a copy of #2001 that I will manage rebasing as needed on behalf of @MarkusTeufelberger .