### PR TITLE
Reduce LEDGER_MIN_CONSENSUS

### DIFF
--- a/src/ripple/app/ledger/LedgerTiming.h
+++ b/src/ripple/app/ledger/LedgerTiming.h
@@ -170,7 +170,7 @@ auto constexpr VALIDATION_VALID_LOCAL = 3min;
 auto constexpr VALIDATION_VALID_EARLY = 3min;
 
 // The number of seconds we wait minimum to ensure participation
-auto constexpr LEDGER_MIN_CONSENSUS = 2s;
+auto constexpr LEDGER_MIN_CONSENSUS = 1950ms;
 
 // Minimum number of seconds to wait to ensure others have computed the LCL
 auto constexpr LEDGER_MIN_CLOSE = 2s;


### PR DESCRIPTION
Make LEDGER_MIN_CONSENSUS slightly smaller and not a multiple of
LEDGER_GRANULARITY to avoid fluctuations in the heartbeat timer needlessly
delaying consensus.

Changes made in collaboration with @wilsonianb and @scottschurr.