### PR TITLE
Do not close socket on a foreign thread:

### DIFF
--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -114,10 +114,12 @@ class WSClientImpl : public WSClient
 
     void cleanup()
     {
-        error_code ec;
-		if(!peerClosed_)
-        	ws_.close({}, ec);
-        stream_.close(ec);
+        ios_.post(strand_.wrap([this] {
+            error_code ec;
+            if (!peerClosed_)
+                ws_.close({}, ec);
+            stream_.close(ec);
+        }));
         work_ = boost::none;
         thread_.join();
     }

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1058,8 +1058,7 @@ public:
         BEAST_EXPECT(jrNextOffer[sfOwnerNode.fieldName] == "0000000000000000");
         BEAST_EXPECT(jrNextOffer[sfSequence.fieldName] == 3);
         BEAST_EXPECT(jrNextOffer[jss::TakerGets] == USD(5).value().getJson(0));
-        BEAST_EXPECT(jrNextOffer[jss::TakerPays] ==
-			XRP(2000).value().getJson(0));
+        BEAST_EXPECT(jrNextOffer[jss::TakerPays] == XRP(2000).value().getJson(0));
         BEAST_EXPECT(jrNextOffer[jss::owner_funds] == "50");
         BEAST_EXPECT(jrNextOffer[jss::quality] == "400000000");
 


### PR DESCRIPTION
* Closing a socket in WSClient's cleanup method was not thread safe. Force the
close to happen on the WSClient's strand.