### PR TITLE
TxQ full queue RPC info (RIPD-1404):

### DIFF
--- a/src/ripple/app/ledger/LedgerToJson.h
+++ b/src/ripple/app/ledger/LedgerToJson.h
@@ -21,6 +21,7 @@
 #define RIPPLE_APP_LEDGER_LEDGERTOJSON_H_INCLUDED
 
 #include <ripple/app/ledger/Ledger.h>
+#include <ripple/app/misc/TxQ.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/STTx.h>
@@ -36,12 +37,27 @@ struct LedgerFill
     {
     }
 
+    LedgerFill(ReadView const& l, int o,
+        std::vector<TxQ::TxDetails> q)
+        : ledger(l)
+        , options(o)
+        , txQueue(q)
+    {
+    }
+
     enum Options {
-        dumpTxrp = 1, dumpState = 2, expand = 4, full = 8, binary = 16,
-        ownerFunds = 32};
+        dumpTxrp = 1,
+        dumpState = 2,
+        expand = 4,
+        full = 8,
+        binary = 16,
+        ownerFunds = 32,
+        dumpQueue = 64
+    };
 
     ReadView const& ledger;
     int options;
+    std::vector<TxQ::TxDetails> txQueue;
 };
 
 /** Given a Ledger and options, fill a Json::Object or Json::Value with a
@@ -49,7 +65,6 @@ struct LedgerFill
  */
 
 void addJson(Json::Value&, LedgerFill const&);
-void addJson(Json::Object&, LedgerFill const&);
 
 /** Return a new Json::Value representing the ledger with given options.*/
 Json::Value getJson (LedgerFill const&);

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/app/ledger/LedgerToJson.h>
+#include <ripple/app/misc/TxQ.h>
 #include <ripple/basics/base_uint.h>
 
 namespace ripple {
@@ -50,7 +51,7 @@ void fillJson(Object& json, bool closed, LedgerInfo const& info, bool bFull)
     {
         json[jss::closed] = true;
     }
-    else if (!bFull)
+    else if (! bFull)
     {
         json[jss::closed] = false;
         return;
@@ -95,6 +96,50 @@ void fillJsonBinary(Object& json, bool closed, LedgerInfo const& info)
     }
 }
 
+Json::Value fillJsonTx (LedgerFill const& fill,
+    bool bBinary, bool bExpanded,
+        std::pair<std::shared_ptr<STTx const>,
+            std::shared_ptr<STObject const>> const i)
+{
+    if (! bExpanded)
+    {
+        return to_string(i.first->getTransactionID());
+    }
+    else
+    {
+        Json::Value txJson{ Json::objectValue };
+        if (bBinary)
+        {
+            txJson[jss::tx_blob] = serializeHex(*i.first);
+            if (i.second)
+                txJson[jss::meta] = serializeHex(*i.second);
+        }
+        else
+        {
+            copyFrom(txJson, i.first->getJson(0));
+            if (i.second)
+                txJson[jss::metaData] = i.second->getJson(0);
+        }
+
+        if ((fill.options & LedgerFill::ownerFunds) &&
+            i.first->getTxnType() == ttOFFER_CREATE)
+        {
+            auto const account = i.first->getAccountID(sfAccount);
+            auto const amount = i.first->getFieldAmount(sfTakerGets);
+
+            // If the offer create is not self funded then add the
+            // owner balance
+            if (account != amount.getIssuer())
+            {
+                auto const ownerFunds = accountFunds(fill.ledger,
+                    account, amount, fhIGNORE_FREEZE, beast::Journal());
+                txJson[jss::owner_funds] = ownerFunds.getText ();
+            }
+        }
+        return txJson;
+    }
+}
+
 template <class Object>
 void fillJsonTx (Object& json, LedgerFill const& fill)
 {
@@ -106,42 +151,7 @@ void fillJsonTx (Object& json, LedgerFill const& fill)
     {
         for (auto& i: fill.ledger.txs)
         {
-            if (! bExpanded)
-            {
-                txns.append(to_string(i.first->getTransactionID()));
-            }
-            else
-            {
-                auto&& txJson = appendObject(txns);
-                if (bBinary)
-                {
-                    txJson[jss::tx_blob] = serializeHex(*i.first);
-                    if (i.second)
-                        txJson[jss::meta] = serializeHex(*i.second);
-                }
-                else
-                {
-                    copyFrom(txJson, i.first->getJson(0));
-                    if (i.second)
-                        txJson[jss::metaData] = i.second->getJson(0);
-                }
-
-                if ((fill.options & LedgerFill::ownerFunds) &&
-                    i.first->getTxnType() == ttOFFER_CREATE)
-                {
-                    auto const account = i.first->getAccountID(sfAccount);
-                    auto const amount = i.first->getFieldAmount(sfTakerGets);
-
-                    // If the offer create is not self funded then add the
-                    // owner balance
-                    if (account != amount.getIssuer())
-                    {
-                        auto const ownerFunds = accountFunds(fill.ledger,
-                            account, amount, fhIGNORE_FREEZE, beast::Journal());
-                        txJson[jss::owner_funds] = ownerFunds.getText ();
-                    }
-                }
-            }
+            txns.append(fillJsonTx(fill, bBinary, bExpanded, i));
         }
     }
     catch (std::exception const&)
@@ -174,15 +184,52 @@ void fillJsonState(Object& json, LedgerFill const& fill)
 }
 
 template <class Object>
+void fillJsonQueue(Object& json, LedgerFill const& fill)
+{
+    auto const& ledger = fill.ledger;
+    auto&& queueData = Json::setArray(json, jss::queue_data);
+    auto bBinary = isBinary(fill);
+    auto bExpanded = isExpanded(fill);
+
+    for (auto const& tx : fill.txQueue)
+    {
+        auto&& txJson = appendObject(queueData);
+        txJson[jss::fee_level] = to_string(tx.feeLevel);
+        if (tx.lastValid)
+            txJson[jss::LastLedgerSequence] = *tx.lastValid;
+        if (tx.consequences)
+        {
+            txJson[jss::fee] = to_string(
+                tx.consequences->fee);
+            auto spend = tx.consequences->potentialSpend +
+                tx.consequences->fee;
+            txJson[jss::max_spend_drops] = to_string(spend);
+            auto authChanged = tx.consequences->category ==
+                TxConsequences::blocker;
+            txJson[jss::auth_change] = authChanged;
+        }
+
+        txJson[jss::account] = to_string(tx.account);
+        txJson["retries_remaining"] = tx.retriesRemaining;
+        txJson["preflight_result"] = transToken(tx.preflightResult);
+        if (tx.lastResult)
+            txJson["last_result"] = transToken(*tx.lastResult);
+
+        txJson[jss::tx] = fillJsonTx(fill, bBinary, bExpanded,
+            std::make_pair(tx.txn, nullptr));
+    }
+}
+
+template <class Object>
 void fillJson (Object& json, LedgerFill const& fill)
 {
     // TODO: what happens if bBinary and bExtracted are both set?
     // Is there a way to report this back?
     auto bFull = isFull(fill);
     if (isBinary(fill))
-        fillJsonBinary(json, !fill.ledger.open(), fill.ledger.info());
+        fillJsonBinary(json, ! fill.ledger.open(), fill.ledger.info());
     else
-        fillJson(json, !fill.ledger.open(), fill.ledger.info(), bFull);
+        fillJson(json, ! fill.ledger.open(), fill.ledger.info(), bFull);
 
     if (bFull || fill.options & LedgerFill::dumpTxrp)
         fillJsonTx(json, fill);
@@ -193,17 +240,13 @@ void fillJson (Object& json, LedgerFill const& fill)
 
 } // namespace
 
-void addJson (Json::Object& json, LedgerFill const& fill)
-{
-    auto&& object = Json::addObject (json, jss::ledger);
-    fillJson (object, fill);
-}
-
 void addJson (Json::Value& json, LedgerFill const& fill)
 {
     auto&& object = Json::addObject (json, jss::ledger);
     fillJson (object, fill);
 
+    if ((fill.options & LedgerFill::dumpQueue) && !fill.txQueue.empty())
+        fillJsonQueue(json, fill);
 }
 
 Json::Value getJson (LedgerFill const& fill)

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -96,6 +96,15 @@ public:
         boost::optional<TxConsequences const> consequences;
     };
 
+    struct TxDetails : AccountTxDetails
+    {
+        AccountID account;
+        std::shared_ptr<STTx const> txn;
+        int retriesRemaining;
+        TER preflightResult;
+        boost::optional<TER> lastResult;
+    };
+
     TxQ(Setup const& setup,
         beast::Journal j);
 
@@ -149,8 +158,18 @@ public:
         amendment is not enabled, OR if the account has no transactions
         in the queue.
     */
-    boost::optional<std::map<TxSeq, AccountTxDetails>>
+    std::map<TxSeq, AccountTxDetails const>
     getAccountTxs(AccountID const& account, ReadView const& view) const;
+
+    /** Returns information about all transactions currently
+        in the queue.
+
+        @returns Uninitialized @ref optional if the FeeEscalation
+        amendment is not enabled, OR if there are no transactions
+        in the queue.
+    */
+    std::vector<TxDetails>
+    getTxs(ReadView const& view) const;
 
     /** Packages up fee metrics for the `fee` RPC command.
     */
@@ -267,6 +286,7 @@ private:
         int retriesRemaining;
         TxSeq const sequence;
         ApplyFlags const flags;
+        boost::optional<TER> lastResult;
         // Invariant: pfresult is never allowed to be empty. The
         // boost::optional is leveraged to allow `emplace`d
         // construction and replacement without a copy

--- a/src/ripple/rpc/RPCHandler.h
+++ b/src/ripple/rpc/RPCHandler.h
@@ -33,9 +33,6 @@ struct Context;
 /** Execute an RPC command and store the results in a Json::Value. */
 Status doCommand (RPC::Context&, Json::Value&);
 
-/** Execute an RPC command and store the results in an std::string. */
-void executeRPC (RPC::Context&, std::string&);
-
 Role roleRequired (std::string const& method );
 
 } // RPC

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -117,11 +117,11 @@ Json::Value doAccountInfo (RPC::Context& context)
 
             auto const txs = context.app.getTxQ().getAccountTxs(
                 accountID, *ledger);
-            if (txs && !txs->empty())
+            if (!txs.empty())
             {
-                jvQueueData[jss::txn_count] = static_cast<Json::UInt>(txs->size());
-                jvQueueData[jss::lowest_sequence] = txs->begin()->first;
-                jvQueueData[jss::highest_sequence] = txs->rbegin()->first;
+                jvQueueData[jss::txn_count] = static_cast<Json::UInt>(txs.size());
+                jvQueueData[jss::lowest_sequence] = txs.begin()->first;
+                jvQueueData[jss::highest_sequence] = txs.rbegin()->first;
 
                 auto& jvQueueTx = jvQueueData[jss::transactions];
                 jvQueueTx = Json::arrayValue;
@@ -129,7 +129,7 @@ Json::Value doAccountInfo (RPC::Context& context)
                 boost::optional<bool> anyAuthChanged(false);
                 boost::optional<XRPAmount> totalSpend(0);
 
-                for (auto const& tx : *txs)
+                for (auto const& tx : txs)
                 {
                     Json::Value jvTx = Json::objectValue;
 

--- a/src/ripple/rpc/handlers/LedgerHandler.h
+++ b/src/ripple/rpc/handlers/LedgerHandler.h
@@ -73,6 +73,7 @@ public:
 private:
     Context& context_;
     std::shared_ptr<ReadView const> ledger_;
+    std::vector<TxQ::TxDetails> queueTxs_;
     Json::Value result_;
     int options_ = 0;
 };
@@ -88,7 +89,7 @@ void LedgerHandler::writeResult (Object& value)
     if (ledger_)
     {
         Json::copyFrom (value, result_);
-        addJson (value, {*ledger_, options_});
+        addJson (value, {*ledger_, options_, queueTxs_});
     }
     else
     {

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -92,7 +92,6 @@ class HandlerTable {
         h.valueMethod_ = &handle<Json::Value, HandlerImpl>;
         h.role_ = HandlerImpl::role();
         h.condition_ = HandlerImpl::condition();
-        h.objectMethod_ = &handle<Json::Object, HandlerImpl>;
 
         table_[HandlerImpl::name()] = h;
     };

--- a/src/ripple/rpc/impl/Handler.h
+++ b/src/ripple/rpc/impl/Handler.h
@@ -48,7 +48,6 @@ struct Handler
     Method<Json::Value> valueMethod_;
     Role role_;
     RPC::Condition condition_;
-    Method<Json::Object> objectMethod_;
 };
 
 const Handler* getHandler (std::string const&);

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -265,36 +265,6 @@ Status doCommand (
     return rpcUNKNOWN_COMMAND;
 }
 
-/** Execute an RPC command and store the results in a string. */
-void executeRPC (
-    RPC::Context& context, std::string& output)
-{
-    boost::optional <Handler const&> handler;
-    if (auto error = fillHandler (context, handler))
-    {
-        auto wo = Json::stringWriterObject (output);
-        auto&& sub = Json::addObject (*wo, jss::result);
-        inject_error (error, sub);
-    }
-    else if (auto method = handler->objectMethod_)
-    {
-        auto wo = Json::stringWriterObject (output);
-        getResult (context, method, *wo, handler->name_);
-    }
-    else if (auto method = handler->valueMethod_)
-    {
-        auto object = Json::Value (Json::objectValue);
-        getResult (context, method, object, handler->name_);
-        output = to_string (object);
-    }
-    else
-    {
-        // Can't ever get here.
-        assert (false);
-        Throw<std::logic_error> ("RPC handler with no method");
-    }
-}
-
 Role roleRequired (std::string const& method)
 {
     auto handler = RPC::getHandler(method);

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -434,14 +434,13 @@ transactionPreProcessImpl (
                 *ledger);
             // If the account has any txs in the TxQ, skip those sequence
             // numbers (accounting for possible gaps).
-            if(queued)
-                for(auto const& tx : *queued)
-                {
-                    if (tx.first == seq)
-                        ++seq;
-                    else if (tx.first > seq)
-                        break;
-                }
+            for(auto const& tx : queued)
+            {
+                if (tx.first == seq)
+                    ++seq;
+                else if (tx.first > seq)
+                    break;
+            }
             tx_json[jss::Sequence] = seq;
         }
 

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -18,7 +18,9 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/app/misc/TxQ.h>
 #include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 #include <test/jtx.h>
 #include <ripple/beast/unit_test.h>
@@ -119,6 +121,15 @@ class LedgerRPC_test : public beast::unit_test::suite
             // unrecognized string arg -- error
             auto const jrr = env.rpc("ledger", "arbitrary_text") [jss::result];
             checkErrorValue(jrr, "lgrNotFound", "ledgerNotFound");
+        }
+
+        {
+            // Request queue for closed ledger
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = "validated";
+            jvParams[jss::queue] = true;
+            auto const jrr = env.rpc ( "json", "ledger", to_string(jvParams) ) [jss::result];
+            checkErrorValue(jrr, "invalidParams", "Invalid parameters.");
         }
 
     }
@@ -451,6 +462,207 @@ class LedgerRPC_test : public beast::unit_test::suite
 
     }
 
+    void testNoQueue()
+    {
+        testcase("Ledger with queueing disabled");
+        using namespace test::jtx;
+        Env env{ *this };
+
+        Json::Value jv;
+        jv[jss::ledger_index] = "current";
+        jv[jss::queue] = true;
+        jv[jss::expand] = true;
+
+        auto jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        BEAST_EXPECT(! jrr.isMember(jss::queue_data));
+    }
+
+    void testQueue()
+    {
+        testcase("Ledger with Queued Transactions");
+        using namespace test::jtx;
+        Env env{ *this, []()
+            {
+                auto p = std::make_unique<Config>();
+                test::setupConfigForUnitTests(*p);
+                auto& section = p->section("transaction_queue");
+                section.set("minimum_txn_in_ledger_standalone", "3");
+                return p;
+            }(),
+            features(featureFeeEscalation) };
+
+        Json::Value jv;
+        jv[jss::ledger_index] = "current";
+        jv[jss::queue] = true;
+        jv[jss::expand] = true;
+
+        Account const alice{ "alice" };
+        Account const bob{ "bob" };
+        Account const charlie{ "charlie" };
+        Account const daria{ "daria" };
+        env.fund(XRP(10000), alice);
+        env.fund(XRP(10000), bob);
+        env.close();
+        env.fund(XRP(10000), charlie);
+        env.fund(XRP(10000), daria);
+        env.close();
+
+        auto jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        BEAST_EXPECT(! jrr.isMember(jss::queue_data));
+
+        // Fill the open ledger
+        for (;;)
+        {
+            auto metrics = env.app().getTxQ().getMetrics(*env.current());
+            if (! BEAST_EXPECT(metrics))
+                break;
+            if (metrics->expFeeLevel > metrics->minFeeLevel)
+                break;
+            env(noop(alice));
+        }
+
+        BEAST_EXPECT(env.current()->info().seq == 5);
+        // Put some txs in the queue
+        // Alice
+        auto aliceSeq = env.seq(alice);
+        env(pay(alice, "george", XRP(1000)), json(R"({"LastLedgerSequence":7})"),
+            ter(terQUEUED));
+        env(offer(alice, XRP(50000), alice["USD"](5000)), seq(aliceSeq + 1),
+            ter(terQUEUED));
+        env(noop(alice), seq(aliceSeq + 2), ter(terQUEUED));
+        // Bob
+        auto batch = [&env](Account a)
+        {
+            auto aSeq = env.seq(a);
+            // Enough fee to get in front of alice in the queue
+            for (int i = 0; i < 10; ++i)
+            {
+                env(noop(a), fee(1000 + i), seq(aSeq + i), ter(terQUEUED));
+            }
+        };
+        batch(bob);
+        // Charlie
+        batch(charlie);
+        // Daria
+        batch(daria);
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        BEAST_EXPECT(jrr[jss::queue_data].size() == 33);
+
+        // Close enough ledgers so that alice's first tx expires.
+        env.close();
+        env.close();
+        env.close();
+        BEAST_EXPECT(env.current()->info().seq == 8);
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        BEAST_EXPECT(jrr[jss::queue_data].size() == 11);
+
+        env.close();
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        std::string txid1;
+        std::string txid2;
+        if (BEAST_EXPECT(jrr[jss::queue_data].size() == 2))
+        {
+            auto const& txj = jrr[jss::queue_data][0u];
+            BEAST_EXPECT(txj[jss::account] == alice.human());
+            BEAST_EXPECT(txj[jss::fee_level] == "256");
+            BEAST_EXPECT(txj["preflight_result"] == "tesSUCCESS");
+            BEAST_EXPECT(txj["retries_remaining"] == 10);
+            BEAST_EXPECT(txj.isMember(jss::tx));
+            auto const& tx = txj[jss::tx];
+            BEAST_EXPECT(tx[jss::Account] == alice.human());
+            BEAST_EXPECT(tx[jss::TransactionType] == "OfferCreate");
+            txid1 = tx[jss::hash].asString();
+        }
+
+        env.close();
+
+        jv[jss::expand] = false;
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        if (BEAST_EXPECT(jrr[jss::queue_data].size() == 2))
+        {
+            auto const& txj = jrr[jss::queue_data][0u];
+            BEAST_EXPECT(txj[jss::account] == alice.human());
+            BEAST_EXPECT(txj[jss::fee_level] == "256");
+            BEAST_EXPECT(txj["preflight_result"] == "tesSUCCESS");
+            BEAST_EXPECT(txj["retries_remaining"] == 9);
+            BEAST_EXPECT(txj["last_result"] == "terPRE_SEQ");
+            BEAST_EXPECT(txj.isMember(jss::tx));
+            BEAST_EXPECT(txj[jss::tx] == txid1);
+        }
+
+        env.close();
+
+        jv[jss::expand] = true;
+        jv[jss::binary] = true;
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        if (BEAST_EXPECT(jrr[jss::queue_data].size() == 2))
+        {
+            auto const& txj = jrr[jss::queue_data][0u];
+            BEAST_EXPECT(txj[jss::account] == alice.human());
+            BEAST_EXPECT(txj[jss::fee_level] == "256");
+            BEAST_EXPECT(txj["preflight_result"] == "tesSUCCESS");
+            BEAST_EXPECT(txj["retries_remaining"] == 8);
+            BEAST_EXPECT(txj["last_result"] == "terPRE_SEQ");
+            BEAST_EXPECT(txj.isMember(jss::tx));
+            BEAST_EXPECT(txj[jss::tx].isMember(jss::tx_blob));
+
+            auto const& txj2 = jrr[jss::queue_data][1u];
+            BEAST_EXPECT(txj2[jss::account] == alice.human());
+            BEAST_EXPECT(txj2[jss::fee_level] == "256");
+            BEAST_EXPECT(txj2["preflight_result"] == "tesSUCCESS");
+            BEAST_EXPECT(txj2["retries_remaining"] == 10);
+            BEAST_EXPECT(! txj2.isMember("last_result"));
+            BEAST_EXPECT(txj2.isMember(jss::tx));
+            BEAST_EXPECT(txj2[jss::tx].isMember(jss::tx_blob));
+        }
+
+        for (int i = 0; i != 9; ++i)
+        {
+            env.close();
+        }
+
+        jv[jss::expand] = false;
+        jv[jss::binary] = false;
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        if (BEAST_EXPECT(jrr[jss::queue_data].size() == 1))
+        {
+            auto const& txj = jrr[jss::queue_data][0u];
+            BEAST_EXPECT(txj[jss::account] == alice.human());
+            BEAST_EXPECT(txj[jss::fee_level] == "256");
+            BEAST_EXPECT(txj["preflight_result"] == "tesSUCCESS");
+            BEAST_EXPECT(txj["retries_remaining"] == 1);
+            BEAST_EXPECT(txj["last_result"] == "terPRE_SEQ");
+            BEAST_EXPECT(txj.isMember(jss::tx));
+            BEAST_EXPECT(txj[jss::tx] != txid1);
+            txid2 = txj[jss::tx].asString();
+        }
+
+        jv[jss::full] = true;
+
+        jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
+        if (BEAST_EXPECT(jrr[jss::queue_data].size() == 1))
+        {
+            auto const& txj = jrr[jss::queue_data][0u];
+            BEAST_EXPECT(txj[jss::account] == alice.human());
+            BEAST_EXPECT(txj[jss::fee_level] == "256");
+            BEAST_EXPECT(txj["preflight_result"] == "tesSUCCESS");
+            BEAST_EXPECT(txj["retries_remaining"] == 1);
+            BEAST_EXPECT(txj["last_result"] == "terPRE_SEQ");
+            BEAST_EXPECT(txj.isMember(jss::tx));
+            auto const& tx = txj[jss::tx];
+            BEAST_EXPECT(tx[jss::Account] == alice.human());
+            BEAST_EXPECT(tx[jss::TransactionType] == "AccountSet");
+            BEAST_EXPECT(tx[jss::hash] == txid2);
+        }
+
+    }
+
 public:
     void run ()
     {
@@ -465,6 +677,8 @@ public:
         testNotFoundAccountRoot();
         testAccountRootFromIndex();
         testLookupLedger();
+        testNoQueue();
+        testQueue();
     }
 };
 


### PR DESCRIPTION
* RPC `ledger` command returns all queue entries in "queue_data"
  when requesting open ledger, and including boolean "queue: true".
  * Includes queue state. e.g.: fee_level, retries, last_result, tx.
  * Respects "expand" and "binary" parameters for the txs.
* Remove some unused code.