### PR TITLE
Add timer start param to Application [RIPD 1405]

### DIFF
--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -97,7 +97,7 @@ public:
     virtual ~Application () = default;
 
     virtual bool setup() = 0;
-    virtual void doStart() = 0;
+    virtual void doStart(bool withTimers) = 0;
     virtual void run() = 0;
     virtual bool isShutdown () = 0;
     virtual void signalStop () = 0;

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -461,7 +461,7 @@ int run (int argc, char** argv)
         }
 
         // Start the server
-        app->doStart();
+        app->doStart(true /*start timers*/);
 
         // Block until we get a stop RPC.
         app->run();

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -171,7 +171,7 @@ Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
         Throw<std::runtime_error> ("Env::AppBundle: setup failed");
     timeKeeper->set(
         app->getLedgerMaster().getClosedLedger()->info().closeTime);
-    app->doStart();
+    app->doStart(false /*don't start timers*/);
     thread = std::thread(
         [&](){ app->run(); });
 


### PR DESCRIPTION
Modify doStart Application method to specify whether or not to start the
DeadlineTimers. Specify inactive timers for jtx::Env Applications and
active timers for standard Applications.