### PR TITLE
Fix uncommon crashes and hangs on shutdown (RIPD-1392)

### DIFF
--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -44,7 +44,7 @@ class RootStoppable;
     provides a set of behaviors for ensuring that the start and stop of a
     composite application-style object is well defined.
 
-    Upon the initialization of the composite object these steps are peformed:
+    Upon the initialization of the composite object these steps are performed:
 
     1.  Construct sub-components.
 
@@ -339,14 +339,15 @@ private:
     /*  Notify a root stoppable and children to stop, without waiting.
         Has no effect if the stoppable was already notified.
 
+        Returns true on the first call to stopAsync(), false otherwise.
+
         Thread safety:
             Safe to call from any thread at any time.
     */
-    void stopAsync(beast::Journal j);
+    bool stopAsync(beast::Journal j);
 
     std::atomic<bool> m_prepared;
-    bool m_calledStop;
-    std::atomic<bool> m_calledStopAsync;
+    std::atomic<bool> m_calledStop;
     std::mutex m_;
     std::condition_variable c_;
 };
@@ -362,7 +363,7 @@ RootStoppable::alertable_sleep_for(
     std::unique_lock<std::mutex> lock(m_);
     if (m_calledStop)
         return true;
-    return c_.wait_for(lock, d, [this]{return m_calledStop;});
+    return c_.wait_for(lock, d, [this]{return m_calledStop.load();});
 }
 
 template <class Rep, class Period>

--- a/src/ripple/nodestore/impl/DatabaseImp.h
+++ b/src/ripple/nodestore/impl/DatabaseImp.h
@@ -93,17 +93,15 @@ public:
             fdlimit_ = m_backend->fdlimit();
     }
 
-    ~DatabaseImp ()
+    ~DatabaseImp () override
     {
-        {
-            std::lock_guard <std::mutex> lock (m_readLock);
-            m_readShut = true;
-            m_readCondVar.notify_all ();
-            m_readGenCondVar.notify_all ();
-        }
-
-        for (auto& e : m_readThreads)
-            e.join();
+        // NOTE!
+        // Any derived class should call the stopThreads() method in its
+        // destructor.  Otherwise, occasionally, the derived class may
+        // crash during shutdown when its members are accessed by one of
+        // these threads after the derived class is destroyed but before
+        // this base class is destroyed.
+        stopThreads();
     }
 
     std::string
@@ -448,6 +446,23 @@ public:
     int fdlimit() const override
     {
         return fdlimit_;
+    }
+
+protected:
+    void stopThreads ()
+    {
+        {
+            std::lock_guard <std::mutex> lock (m_readLock);
+            if (m_readShut) // Only stop threads once.
+                return;
+
+            m_readShut = true;
+            m_readCondVar.notify_all ();
+            m_readGenCondVar.notify_all ();
+        }
+
+        for (auto& e : m_readThreads)
+            e.join();
     }
 
 private:

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -63,6 +63,12 @@ public:
             , archiveBackend_ (archiveBackend)
     {}
 
+    ~DatabaseRotatingImp () override
+    {
+        // Stop threads before data members are destroyed.
+        DatabaseImp::stopThreads ();
+    }
+
     std::shared_ptr <Backend> const& getWritableBackend() const override
     {
         std::lock_guard <std::mutex> lock (rotateMutex_);


### PR DESCRIPTION
This pull request was motivated by @vinniefalco  asking me if a
different pull request was thread safe.  I started testing and
found other preexisting crashes or hangs on shutdown.  Before I
could test my own pull request I needed to remove the preexisting
crashes and hangs.

The test process was to start rippled on the network, let it run
for 15 seconds (not all the way to sync), and then gracefully shut
it down.  If the shutdown returned a 0 error code and did not hang
then we'd do the loop again.

When I first started the project I'd get a crash or hang
approximately once every 200 shutdowns.  With these four fixes in
place I was able to run the loop through 10,000 consecutive
shutdowns on two different computers (a total of 20,000 shutdowns)
without seeing any crashes or hangs.  So we're approximately 2
orders of magnitude better than we were, at least for that
particular loop.

I have a small concern that the fixes in `NodeStoreScheduler`
will block database writes during shutdown that previously would
go through (and occasionally crash).  My belief is that these
blocked database writes could not be relied upon previously, since
they were occurring during shutdown.  But just because I believe
that does not necessarily make it true.

Additionally, @nbougalis  raised the question whether there was a
way to easily enforce the change in `RootStoppable`.  I thought
of a clumsy way, but nothing elegant.  I'm open to suggestions.

Thanks to @nbougalis  for an early review.

Reviewers: @vinniefalco , @HowardHinnant 