### PR TITLE
Prevent low likelihood Database job queue crash

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -23,7 +23,6 @@
 #include <ripple/app/main/DBInit.h>
 #include <ripple/app/main/BasicApp.h>
 #include <ripple/app/main/Tuning.h>
-#include <ripple/app/ledger/AcceptedLedger.h>
 #include <ripple/app/ledger/InboundLedgers.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/ledger/LedgerToJson.h>
@@ -32,59 +31,29 @@
 #include <ripple/app/ledger/PendingSaves.h>
 #include <ripple/app/ledger/InboundTransactions.h>
 #include <ripple/app/ledger/TransactionMaster.h>
-#include <ripple/app/main/CollectorManager.h>
 #include <ripple/app/main/LoadManager.h>
 #include <ripple/app/main/NodeIdentity.h>
 #include <ripple/app/main/NodeStoreScheduler.h>
 #include <ripple/app/misc/AmendmentTable.h>
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/LoadFeeTrack.h>
-#include <ripple/app/misc/Manifest.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/SHAMapStore.h>
 #include <ripple/app/misc/TxQ.h>
-#include <ripple/app/misc/Validations.h>
-#include <ripple/app/misc/ValidatorList.h>
 #include <ripple/app/misc/ValidatorSite.h>
-#include <ripple/app/paths/Pathfinder.h>
 #include <ripple/app/paths/PathRequests.h>
 #include <ripple/app/tx/apply.h>
-#include <ripple/basics/contract.h>
-#include <ripple/basics/Log.h>
 #include <ripple/basics/ResolverAsio.h>
 #include <ripple/basics/Sustain.h>
-#include <ripple/basics/chrono.h>
 #include <ripple/json/json_reader.h>
-#include <ripple/json/to_string.h>
-#include <ripple/core/ConfigSections.h>
 #include <ripple/core/DeadlineTimer.h>
-#include <ripple/core/TimeKeeper.h>
-#include <ripple/ledger/CachedSLEs.h>
-#include <ripple/nodestore/Database.h>
 #include <ripple/nodestore/DummyScheduler.h>
-#include <ripple/nodestore/Manager.h>
 #include <ripple/overlay/Cluster.h>
 #include <ripple/overlay/make_Overlay.h>
-#include <ripple/protocol/Indexes.h>
-#include <ripple/protocol/PublicKey.h>
-#include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/STParsedJSON.h>
-#include <ripple/protocol/types.h>
-#include <ripple/resource/Charge.h>
-#include <ripple/resource/Consumer.h>
 #include <ripple/resource/Fees.h>
-#include <ripple/rpc/Context.h>
-#include <ripple/rpc/RPCHandler.h>
-#include <ripple/shamap/Family.h>
-#include <ripple/crypto/csprng.h>
 #include <ripple/beast/asio/io_latency_probe.h>
 #include <ripple/beast/core/LexicalCast.h>
-#include <beast/core/detail/ci_char_traits.hpp>
-#include <boost/asio/signal_set.hpp>
-#include <boost/optional.hpp>
-#include <atomic>
-#include <chrono>
-#include <fstream>
 
 namespace ripple {
 
@@ -325,7 +294,6 @@ public:
 
     NodeStoreScheduler m_nodeStoreScheduler;
     std::unique_ptr <SHAMapStore> m_shaMapStore;
-    std::unique_ptr <NodeStore::Database> m_nodeStore;
     PendingSaves pendingSaves_;
     AccountIDCache accountIDCache_;
     boost::optional<OpenLedger> openLedger_;
@@ -333,7 +301,6 @@ public:
     // These are not Stoppable-derived
     NodeCache m_tempNodeCache;
     std::unique_ptr <CollectorManager> m_collectorManager;
-    detail::AppFamily family_;
     CachedSLEs cachedSLEs_;
     std::pair<PublicKey, SecretKey> nodeIdentity_;
 
@@ -341,6 +308,8 @@ public:
 
     // These are Stoppable-related
     std::unique_ptr <JobQueue> m_jobQueue;
+    std::unique_ptr <NodeStore::Database> m_nodeStore;
+    detail::AppFamily family_;
     // VFALCO TODO Make OrderBookDB abstract
     OrderBookDB m_orderBookDB;
     std::unique_ptr <PathRequests> m_pathRequests;
@@ -415,8 +384,6 @@ public:
             logs_->journal ("SHAMapStore"), logs_->journal ("NodeObject"),
             m_txMaster, *config_))
 
-        , m_nodeStore (m_shaMapStore->makeDatabase ("NodeStore.main", 4))
-
         , accountIDCache_(128000)
 
         , m_tempNodeCache ("NodeCache", 16384, 90, stopwatch(),
@@ -424,8 +391,6 @@ public:
 
         , m_collectorManager (CollectorManager::New (
             config_->section (SECTION_INSIGHT), logs_->journal("Collector")))
-
-        , family_ (*this, *m_nodeStore, *m_collectorManager)
 
         , cachedSLEs_ (std::chrono::minutes(1), stopwatch())
 
@@ -442,6 +407,10 @@ public:
         //
         // Anything which calls addJob must be a descendant of the JobQueue
         //
+        , m_nodeStore (
+            m_shaMapStore->makeDatabase ("NodeStore.main", 4, *m_jobQueue))
+
+        , family_ (*this, *m_nodeStore, *m_collectorManager)
 
         , m_orderBookDB (*this, *m_jobQueue)
 
@@ -1955,9 +1924,9 @@ bool ApplicationImp::updateTables ()
         auto j = logs_->journal("NodeObject");
         NodeStore::DummyScheduler scheduler;
         std::unique_ptr <NodeStore::Database> source =
-            NodeStore::Manager::instance().make_Database ("NodeStore.import", scheduler,
-                j, 0,
-                config_->section(ConfigSection::importNodeDatabase ()));
+            NodeStore::Manager::instance().make_Database ("NodeStore.import",
+                scheduler, 0, *m_jobQueue,
+                config_->section(ConfigSection::importNodeDatabase ()), j);
 
         JLOG (j.warn())
             << "Node import from '" << source->getName () << "' to '"

--- a/src/ripple/app/misc/SHAMapStore.h
+++ b/src/ripple/app/misc/SHAMapStore.h
@@ -21,9 +21,7 @@
 #define RIPPLE_APP_MISC_SHAMAPSTORE_H_INCLUDED
 
 #include <ripple/app/ledger/Ledger.h>
-#include <ripple/core/Config.h>
 #include <ripple/nodestore/Manager.h>
-#include <ripple/nodestore/Scheduler.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/core/Stoppable.h>
 
@@ -62,7 +60,8 @@ public:
     virtual std::uint32_t clampFetchDepth (std::uint32_t fetch_depth) const = 0;
 
     virtual std::unique_ptr <NodeStore::Database> makeDatabase (
-            std::string const& name, std::int32_t readThreads) = 0;
+            std::string const& name,
+            std::int32_t readThreads, Stoppable& parent) = 0;
 
     /** Highest ledger that may be deleted. */
     virtual LedgerIndex setCanDelete (LedgerIndex canDelete) = 0;

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -21,17 +21,16 @@
 #define RIPPLE_APP_MISC_SHAMAPSTOREIMP_H_INCLUDED
 
 #include <ripple/app/misc/SHAMapStore.h>
-#include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/core/DatabaseCon.h>
-#include <ripple/core/SociDB.h>
-#include <ripple/nodestore/impl/Tuning.h>
 #include <ripple/nodestore/DatabaseRotating.h>
-#include <iostream>
 #include <condition_variable>
 #include <thread>
 
 
 namespace ripple {
+
+class NetworkOPs;
 
 class SHAMapStoreImp : public SHAMapStore
 {
@@ -134,7 +133,8 @@ public:
     }
 
     std::unique_ptr <NodeStore::Database> makeDatabase (
-            std::string const&name, std::int32_t readThreads) override;
+            std::string const&name,
+            std::int32_t readThreads, Stoppable& parent) override;
 
     LedgerIndex
     setCanDelete (LedgerIndex seq) override
@@ -191,7 +191,7 @@ private:
      */
     std::unique_ptr <NodeStore::DatabaseRotating>
     makeDatabaseRotating (std::string const&name,
-            std::int32_t readThreads,
+            std::int32_t readThreads, Stoppable& parent,
             std::shared_ptr <NodeStore::Backend> writableBackend,
             std::shared_ptr <NodeStore::Backend> archiveBackend) const;
 

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -22,19 +22,12 @@
 
 #include <ripple/basics/LocalValue.h>
 #include <ripple/basics/win32_workaround.h>
-#include <ripple/core/Job.h>
 #include <ripple/core/JobTypes.h>
 #include <ripple/core/JobTypeData.h>
+#include <ripple/core/Stoppable.h>
 #include <ripple/core/impl/Workers.h>
 #include <ripple/json/json_value.h>
-#include <ripple/beast/insight/Collector.h>
-#include <ripple/core/Stoppable.h>
 #include <boost/coroutine/all.hpp>
-#include <boost/function.hpp>
-#include <condition_variable>
-#include <mutex>
-#include <set>
-#include <thread>
 
 namespace ripple {
 

--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -44,7 +44,7 @@ class RootStoppable;
     provides a set of behaviors for ensuring that the start and stop of a
     composite application-style object is well defined.
 
-    Upon the initialization of the composite object these steps are peformed:
+    Upon the initialization of the composite object these steps are performed:
 
     1.  Construct sub-components.
 
@@ -339,14 +339,15 @@ private:
     /*  Notify a root stoppable and children to stop, without waiting.
         Has no effect if the stoppable was already notified.
 
+        Returns true on the first call to stopAsync(), false otherwise.
+
         Thread safety:
             Safe to call from any thread at any time.
     */
-    void stopAsync(beast::Journal j);
+    bool stopAsync(beast::Journal j);
 
     std::atomic<bool> m_prepared;
-    bool m_calledStop;
-    std::atomic<bool> m_calledStopAsync;
+    std::atomic<bool> m_calledStop;
     std::mutex m_;
     std::condition_variable c_;
 };
@@ -362,7 +363,7 @@ RootStoppable::alertable_sleep_for(
     std::unique_lock<std::mutex> lock(m_);
     if (m_calledStop)
         return true;
-    return c_.wait_for(lock, d, [this]{return m_calledStop;});
+    return c_.wait_for(lock, d, [this]{return m_calledStop.load();});
 }
 
 template <class Rep, class Period>

--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -172,11 +172,11 @@ class RootStoppable;
 class Stoppable
 {
 protected:
-    Stoppable (char const* name, RootStoppable& root);
+    Stoppable (std::string name, RootStoppable& root);
 
 public:
     /** Create the Stoppable. */
-    Stoppable (char const* name, Stoppable& parent);
+    Stoppable (std::string name, Stoppable& parent);
 
     /** Destroy the Stoppable. */
     virtual ~Stoppable ();
@@ -294,7 +294,7 @@ private:
 class RootStoppable : public Stoppable
 {
 public:
-    explicit RootStoppable (char const* name);
+    explicit RootStoppable (std::string name);
 
     ~RootStoppable () = default;
 
@@ -339,7 +339,7 @@ private:
     /*  Notify a root stoppable and children to stop, without waiting.
         Has no effect if the stoppable was already notified.
 
-        Returns true on the first call to stopAsync(), false otherwise.
+        Returns true on the first call to this method, false otherwise.
 
         Thread safety:
             Safe to call from any thread at any time.

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -19,15 +19,7 @@
 
 #include <BeastConfig.h>
 #include <ripple/core/JobQueue.h>
-#include <ripple/core/JobTypes.h>
-#include <ripple/core/JobTypeInfo.h>
-#include <ripple/core/JobTypeData.h>
-#include <ripple/beast/clock/chrono_util.h>
-#include <chrono>
-#include <memory>
-#include <mutex>
-#include <set>
-#include <thread>
+#include <ripple/basics/contract.h>
 
 namespace ripple {
 
@@ -93,6 +85,8 @@ JobQueue::addJob (JobType type, std::string const& name,
     assert (type == jtCLIENT || m_workers.getNumberOfThreads () > 0);
 
     {
+        std::lock_guard <std::mutex> lock (m_mutex);
+
         // If this goes off it means that a child didn't follow
         // the Stoppable API rules. A job may only be added if:
         //
@@ -104,15 +98,10 @@ JobQueue::addJob (JobType type, std::string const& name,
         //          OR
         //      * Not all children are stopped
         //
-        std::lock_guard <std::mutex> lock (m_mutex);
         assert (! isStopped() && (
             m_processCount>0 ||
             ! m_jobSet.empty () ||
             ! areChildrenStopped()));
-    }
-
-    {
-        std::lock_guard <std::mutex> lock (m_mutex);
 
         std::pair <std::set <Job>::iterator, bool> result (
             m_jobSet.insert (Job (type, name, ++m_lastJob,
@@ -218,6 +207,9 @@ void
 JobQueue::addLoadEvents (JobType t, int count,
     std::chrono::milliseconds elapsed)
 {
+    if (isStopped())
+        LogicError ("JobQueue::addLoadEvents() called after JobQueue stopped");
+
     JobDataMap::iterator iter (m_jobData.find (t));
     assert (iter != m_jobData.end ());
     iter->second.load().addSamples (count, elapsed);

--- a/src/ripple/core/impl/Stoppable.cpp
+++ b/src/ripple/core/impl/Stoppable.cpp
@@ -22,8 +22,8 @@
 
 namespace ripple {
 
-Stoppable::Stoppable (char const* name, RootStoppable& root)
-    : m_name (name)
+Stoppable::Stoppable (std::string name, RootStoppable& root)
+    : m_name (std::move (name))
     , m_root (root)
     , m_child (this)
     , m_started (false)
@@ -32,8 +32,8 @@ Stoppable::Stoppable (char const* name, RootStoppable& root)
 {
 }
 
-Stoppable::Stoppable (char const* name, Stoppable& parent)
-    : m_name (name)
+Stoppable::Stoppable (std::string name, Stoppable& parent)
+    : m_name (std::move (name))
     , m_root (parent.m_root)
     , m_child (this)
     , m_started (false)
@@ -157,8 +157,8 @@ void Stoppable::stopRecursive (beast::Journal j)
 
 //------------------------------------------------------------------------------
 
-RootStoppable::RootStoppable (char const* name)
-    : Stoppable (name, *this)
+RootStoppable::RootStoppable (std::string name)
+    : Stoppable (std::move (name), *this)
     , m_prepared (false)
     , m_calledStop (false)
 {

--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -20,9 +20,10 @@
 #ifndef RIPPLE_NODESTORE_DATABASE_H_INCLUDED
 #define RIPPLE_NODESTORE_DATABASE_H_INCLUDED
 
+#include <ripple/basics/TaggedCache.h>
+#include <ripple/core/Stoppable.h>
 #include <ripple/nodestore/NodeObject.h>
 #include <ripple/nodestore/Backend.h>
-#include <ripple/basics/TaggedCache.h>
 
 namespace ripple {
 namespace NodeStore {
@@ -40,9 +41,20 @@ namespace NodeStore {
 
     @see NodeObject
 */
-class Database
+class Database : public Stoppable
 {
 public:
+    Database() = delete;
+
+    /** Construct the node store.
+
+        @param name The Stoppable name for this Database.
+        @param parent The parent Stoppable.
+    */
+    Database (std::string name, Stoppable& parent)
+        : Stoppable (std::move (name), parent)
+    { }
+
     /** Destroy the node store.
         All pending operations are completed, pending writes flushed,
         and files closed before this returns.
@@ -54,11 +66,6 @@ public:
         or paths used by the underlying backend.
     */
     virtual std::string getName () const = 0;
-
-    /** Close the database.
-        This allows the caller to catch exceptions.
-    */
-    virtual void close() = 0;
 
     /** Fetch an object.
         If the object is known to be not in the database, isn't found in the

--- a/src/ripple/nodestore/Manager.h
+++ b/src/ripple/nodestore/Manager.h
@@ -22,9 +22,6 @@
 
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/DatabaseRotating.h>
-#include <ripple/basics/BasicConfig.h>
-#include <ripple/basics/Log.h>
-#include <ripple/beast/utility/Journal.h>
 
 namespace ripple {
 namespace NodeStore {
@@ -87,16 +84,18 @@ public:
     virtual
     std::unique_ptr <Database>
     make_Database (std::string const& name, Scheduler& scheduler,
-        beast::Journal journal, int readThreads,
-            Section const& backendParameters) = 0;
+        int readThreads, Stoppable& parent,
+            Section const& backendParameters,
+                beast::Journal journal) = 0;
 
     virtual
     std::unique_ptr <DatabaseRotating>
     make_DatabaseRotating (std::string const& name,
         Scheduler& scheduler, std::int32_t readThreads,
-            std::shared_ptr <Backend> writableBackend,
-                std::shared_ptr <Backend> archiveBackend,
-                    beast::Journal journal) = 0;
+            Stoppable& parent,
+                std::shared_ptr <Backend> writableBackend,
+                    std::shared_ptr <Backend> archiveBackend,
+                        beast::Journal journal) = 0;
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -50,6 +50,7 @@ public:
     DatabaseRotatingImp (std::string const& name,
                  Scheduler& scheduler,
                  int readThreads,
+                 Stoppable& parent,
                  std::shared_ptr <Backend> writableBackend,
                  std::shared_ptr <Backend> archiveBackend,
                  beast::Journal journal)
@@ -57,6 +58,7 @@ public:
                 name,
                 scheduler,
                 readThreads,
+                parent,
                 std::unique_ptr <Backend>(),
                 journal)
             , writableBackend_ (writableBackend)
@@ -91,13 +93,6 @@ public:
     std::string getName() const override
     {
         return getWritableBackend()->getName();
-    }
-
-    void
-    close() override
-    {
-        // VFALCO TODO How do we close everything?
-        assert(false);
     }
 
     std::int32_t getWriteLoad() const override

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -63,6 +63,12 @@ public:
             , archiveBackend_ (archiveBackend)
     {}
 
+    ~DatabaseRotatingImp () override
+    {
+        // Stop threads before data members are destroyed.
+        DatabaseImp::stopThreads ();
+    }
+
     std::shared_ptr <Backend> const& getWritableBackend() const override
     {
         std::lock_guard <std::mutex> lock (rotateMutex_);

--- a/src/ripple/nodestore/impl/ManagerImp.cpp
+++ b/src/ripple/nodestore/impl/ManagerImp.cpp
@@ -18,14 +18,8 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/basics/contract.h>
 #include <ripple/nodestore/impl/ManagerImp.h>
-#include <ripple/nodestore/impl/DatabaseImp.h>
 #include <ripple/nodestore/impl/DatabaseRotatingImp.h>
-#include <ripple/basics/StringUtilities.h>
-#include <beast/core/detail/ci_char_traits.hpp>
-#include <memory>
-#include <stdexcept>
 
 namespace ripple {
 namespace NodeStore {
@@ -90,14 +84,16 @@ std::unique_ptr <Database>
 ManagerImp::make_Database (
     std::string const& name,
     Scheduler& scheduler,
-    beast::Journal journal,
     int readThreads,
-    Section const& backendParameters)
+    Stoppable& parent,
+    Section const& backendParameters,
+    beast::Journal journal)
 {
     return std::make_unique <DatabaseImp> (
         name,
         scheduler,
         readThreads,
+        parent,
         make_Backend (
             backendParameters,
             scheduler,
@@ -110,6 +106,7 @@ ManagerImp::make_DatabaseRotating (
         std::string const& name,
         Scheduler& scheduler,
         std::int32_t readThreads,
+        Stoppable& parent,
         std::shared_ptr <Backend> writableBackend,
         std::shared_ptr <Backend> archiveBackend,
         beast::Journal journal)
@@ -118,6 +115,7 @@ ManagerImp::make_DatabaseRotating (
         name,
         scheduler,
         readThreads,
+        parent,
         writableBackend,
         archiveBackend,
         journal);

--- a/src/ripple/nodestore/impl/ManagerImp.h
+++ b/src/ripple/nodestore/impl/ManagerImp.h
@@ -21,8 +21,6 @@
 #define RIPPLE_NODESTORE_MANAGERIMP_H_INCLUDED
 
 #include <ripple/nodestore/Manager.h>
-#include <mutex>
-#include <vector>
 
 namespace ripple {
 namespace NodeStore {
@@ -65,15 +63,17 @@ public:
     make_Database (
         std::string const& name,
         Scheduler& scheduler,
-        beast::Journal journal,
         int readThreads,
-        Section const& backendParameters) override;
+        Stoppable& parent,
+        Section const& backendParameters,
+        beast::Journal journal) override;
 
     std::unique_ptr <DatabaseRotating>
     make_DatabaseRotating (
         std::string const& name,
         Scheduler& scheduler,
         std::int32_t readThreads,
+        Stoppable& parent,
         std::shared_ptr <Backend> writableBackend,
         std::shared_ptr <Backend> archiveBackend,
         beast::Journal journal) override;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -970,17 +970,32 @@ OverlayImpl::remove (Child& child)
 void
 OverlayImpl::stop()
 {
-    std::lock_guard<decltype(mutex_)> lock(mutex_);
-    if (work_)
+    // Calling list_[].second->stop() may cause list_ to be modified
+    // (OverlayImpl::remove() may be called on this same thread).  So
+    // iterating directly over list_ to call child->stop() could lead to
+    // undefined behavior.
+    //
+    // Therefore we copy all of the weak/shared ptrs out of list_ before we
+    // start calling stop() on them.  That guarantees OverlayImpl::remove()
+    // won't be called until vector<> children leaves scope.
+    std::vector<std::shared_ptr<Child>> children;
     {
+        std::lock_guard<decltype(mutex_)> lock(mutex_);
+        if (!work_)
+            return;
         work_ = boost::none;
-        for (auto& _ : list_)
+
+        children.reserve (list_.size());
+        for (auto const& element : list_)
         {
-            auto const child = _.second.lock();
-            // Happens when the child is about to be destroyed
-            if (child != nullptr)
-                child->stop();
+            children.emplace_back (element.second.lock());
         }
+    } // lock released
+
+    for (auto const& child : children)
+    {
+        if (child != nullptr)
+            child->stop();
     }
 }
 

--- a/src/test/core/Stoppable_test.cpp
+++ b/src/test/core/Stoppable_test.cpp
@@ -436,6 +436,13 @@ class Stoppable_test
             Stoppable::stopped();
             test_.expect(--test_.count == 0, "Root::onChildrenStopped called out of order");
         }
+
+        void secondStop()
+        {
+            // Calling stop() a second time should have no negative
+            // consequences.
+            stop({});
+        }
     };
 
 public:
@@ -444,6 +451,7 @@ public:
         {
             Root rt(*this);
             rt.run();
+            rt.secondStop();
         }
         pass();
     }

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -22,7 +22,6 @@
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/beast/utility/temp_dir.h>
-#include <algorithm>
 
 namespace ripple {
 namespace NodeStore {
@@ -34,6 +33,7 @@ public:
         std::string const& srcBackendType, std::int64_t seedValue)
     {
         DummyScheduler scheduler;
+        RootStoppable parent ("TestRootStoppable");
 
         beast::temp_dir node_db;
         Section srcParams;
@@ -49,7 +49,7 @@ public:
         // Write to source db
         {
             std::unique_ptr <Database> src = Manager::instance().make_Database (
-                "test", scheduler, j, 2, srcParams);
+                "test", scheduler, 2, parent, srcParams, j);
             storeBatch (*src, batch);
         }
 
@@ -58,7 +58,7 @@ public:
         {
             // Re-open the db
             std::unique_ptr <Database> src = Manager::instance().make_Database (
-                "test", scheduler, j, 2, srcParams);
+                "test", scheduler, 2, parent, srcParams, j);
 
             // Set up the destination database
             beast::temp_dir dest_db;
@@ -67,7 +67,7 @@ public:
             destParams.set ("path", dest_db.path());
 
             std::unique_ptr <Database> dest = Manager::instance().make_Database (
-                "test", scheduler, j, 2, destParams);
+                "test", scheduler, 2, parent, destParams, j);
 
             testcase ("import into '" + destBackendType +
                 "' from '" + srcBackendType + "'");
@@ -93,6 +93,7 @@ public:
                         int numObjectsToTest = 2000)
     {
         DummyScheduler scheduler;
+        RootStoppable parent ("TestRootStoppable");
 
         std::string s = "NodeStore backend '" + type + "'";
 
@@ -114,7 +115,7 @@ public:
         {
             // Open the database
             std::unique_ptr <Database> db = Manager::instance().make_Database (
-                "test", scheduler, j, 2, nodeParams);
+                "test", scheduler, 2, parent, nodeParams, j);
 
             // Write the batch
             storeBatch (*db, batch);
@@ -143,7 +144,7 @@ public:
             {
                 // Re-open the database without the ephemeral DB
                 std::unique_ptr <Database> db = Manager::instance().make_Database (
-                    "test", scheduler, j, 2, nodeParams);
+                    "test", scheduler, 2, parent, nodeParams, j);
 
                 // Read it back in
                 Batch copy;

--- a/src/test/shamap/common.h
+++ b/src/test/shamap/common.h
@@ -21,17 +21,10 @@
 #define RIPPLE_SHAMAP_TESTS_COMMON_H_INCLUDED
 
 #include <BeastConfig.h>
-#include <ripple/basics/contract.h>
 #include <ripple/basics/chrono.h>
-#include <ripple/shamap/Family.h>
-#include <ripple/shamap/FullBelowCache.h>
-#include <ripple/shamap/TreeNodeCache.h>
-#include <ripple/shamap/SHAMap.h>
-#include <ripple/basics/StringUtilities.h>
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/nodestore/Manager.h>
-#include <ripple/beast/utility/Journal.h>
-#include <ripple/beast/clock/manual_clock.h>
+#include <ripple/shamap/Family.h>
 
 namespace ripple {
 namespace tests {
@@ -43,6 +36,7 @@ private:
     NodeStore::DummyScheduler scheduler_;
     TreeNodeCache treecache_;
     FullBelowCache fullbelow_;
+    RootStoppable parent_;
     std::unique_ptr<NodeStore::Database> db_;
     beast::Journal j_;
 
@@ -50,13 +44,14 @@ public:
     TestFamily (beast::Journal j)
         : treecache_ ("TreeNodeCache", 65536, 60, clock_, j)
         , fullbelow_ ("full_below", clock_)
+        , parent_ ("TestRootStoppable")
         , j_ (j)
     {
         Section testSection;
         testSection.set("type", "memory");
         testSection.set("Path", "SHAMap_test");
         db_ = NodeStore::Manager::instance ().make_Database (
-            "test", scheduler_, j, 1, testSection);
+            "test", scheduler_, 1, parent_, testSection, j);
     }
 
     beast::manual_clock <std::chrono::steady_clock>


### PR DESCRIPTION
The first three commits have already passed review, so they do not need to be audited.  However they are small, so there's not a lot of savings there.  The interesting commit is the top-most one.

Regarding the top-most commit, the `DatabaseImp` has threads that asynchronously call `JobQueue` to perform database reads.  Formerly these threads had the same lifespan as `DatabaseImp`, which was until the end-of-life of `ApplicationImp`.  During shutdown these threads could call `JobQueue` after `JobQueue` had already stopped.  Or, even worse, occasionally call `JobQueue` after `JobQueue`'s destructor had run.

To avoid these shutdown conditions, `Database` is made a `Stoppable`, with `JobQueue` as its parent.  When `Database` stops, it shuts down `DatabaseImp`'s asynchronous read threads.  This prevents `Database` from accessing `JobQueue` after `JobQueue` has stopped, but allows `Database` to perform stores for the remainder of shutdown.

During development it was noted that the `Database::close()` method was never called.  So that method is removed from `Database` and all derived classes.

`Stoppable` is also adjusted so it can be constructed using either a `char const*` or a `std::string`.

For those files touched for other reasons, unneeded `#includes` are removed.

I ran over 10,000 15 second start / stop cycles of rippled over the weekend with theses changes and had no crashes or hangs.  I also verified (using the debugger) that `DatabaseImp::storeInternal()` can still succeed when `DatabaseImp::isStopped` is `true`.

Reviewers: @JoelKatz, @mellery451