### PR TITLE
Fix tx re-ordering bug in test:

### DIFF
--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -44,12 +44,11 @@ struct XRPEndpointStepInfo
     AccountID acc;
 };
 
-enum class TrustFlag { freeze, auth };
+enum class TrustFlag {freeze, auth, noripple};
 
-std::uint32_t
-trustFlag(TrustFlag f, bool useHigh)
+/*constexpr*/ std::uint32_t trustFlag (TrustFlag f, bool useHigh)
 {
-    switch (f)
+    switch(f)
     {
         case TrustFlag::freeze:
             if (useHigh)
@@ -59,8 +58,12 @@ trustFlag(TrustFlag f, bool useHigh)
             if (useHigh)
                 return lsfHighAuth;
             return lsfLowAuth;
+        case TrustFlag::noripple:
+            if (useHigh)
+                return lsfHighNoRipple;
+            return lsfLowNoRipple;
     }
-    return 0;  // Silence warning about end of non-void function
+    return 0; // Silence warning about end of non-void function
 }
 
 bool


### PR DESCRIPTION
`env.fund` requires two transactions: `pay` and `set account`. If there is a
`trust` transaction in the same set of txs, the txs may be reordered so
`pay` -> `trust` -> `set account` so the wrong `no ripple` flag would be used
on the trust line.

Adding a `close` between `env.fund` and `env.trust` resolves this problem.