### PR TITLE
NetworkOPs isn't stopped() until its Jobs are done (RIPD-1356)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1943,6 +1943,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\core\Job.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\core\JobCounter.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\core\JobQueue.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\core\JobTypeData.h">
@@ -4406,6 +4408,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\test\core\DeadlineTimer_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\core\JobCounter_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2529,6 +2529,9 @@
     <ClInclude Include="..\..\src\ripple\core\Job.h">
       <Filter>ripple\core</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\core\JobCounter.h">
+      <Filter>ripple\core</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\core\JobQueue.h">
       <Filter>ripple\core</Filter>
     </ClInclude>
@@ -5143,6 +5146,9 @@
       <Filter>test\core</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\core\DeadlineTimer_test.cpp">
+      <Filter>test\core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\core\JobCounter_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">

--- a/src/ripple/core/JobCounter.h
+++ b/src/ripple/core/JobCounter.h
@@ -1,0 +1,191 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_CORE_JOB_COUNTER_H_INCLUDED
+#define RIPPLE_CORE_JOB_COUNTER_H_INCLUDED
+
+#include <ripple/core/Job.h>
+#include <boost/optional.hpp>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <type_traits>
+
+namespace ripple {
+
+// A class that does reference counting for Jobs.  The reference counting
+// allows a Stoppable to assure that all child Jobs in the JobQueue are
+// completed before the Stoppable declares itself stopped().
+class JobCounter
+{
+private:
+    std::mutex mutable mutex_ {};
+    std::condition_variable allJobsDoneCond_ {};  // guard with mutex_
+    bool waitForJobs_ {false};                    // guard with mutex_
+    std::atomic<int> jobCount_ {0};
+
+    // Increment the count.
+    JobCounter& operator++()
+    {
+        ++jobCount_;
+        return *this;
+    }
+
+    // Decrement the count.  If we're stopping and the count drops to zero
+    // notify allJobsDoneCond_.
+    JobCounter&  operator--()
+    {
+        // Even though jobCount_ is atomic, we decrement its value under a
+        // lock.  This removes a small timing window that occurs if the
+        // waiting thread is handling a spurious wakeup when jobCount_
+        // drops to zero.
+        std::lock_guard<std::mutex> lock {mutex_};
+
+        // Update jobCount_.  Notify if we're stopping and all jobs are done.
+        if ((--jobCount_ == 0) && waitForJobs_)
+            allJobsDoneCond_.notify_all();
+        return *this;
+    }
+
+    // A private template class that helps count the number of Jobs
+    // in flight.  This allows Stoppables to hold off declaring stopped()
+    // until all their JobQueue Jobs are dispatched.
+    template <typename JobHandler>
+    class CountedJob
+    {
+    private:
+        JobCounter& counter_;
+        JobHandler handler_;
+
+        static_assert (
+            std::is_same<decltype(
+                handler_(std::declval<Job&>())), void>::value,
+                "JobHandler must be callable with Job&");
+
+    public:
+        CountedJob() = delete;
+
+        CountedJob (CountedJob const& rhs)
+        : counter_ (rhs.counter_)
+        , handler_ (rhs.handler_)
+        {
+            ++counter_;
+        }
+
+        CountedJob (CountedJob&& rhs)
+        : counter_ (rhs.counter_)
+        , handler_ (std::move (rhs.handler_))
+        {
+            ++counter_;
+        }
+
+        CountedJob (JobCounter& counter, JobHandler&& handler)
+        : counter_ (counter)
+        , handler_ (std::move (handler))
+        {
+            ++counter_;
+        }
+
+        CountedJob& operator=(CountedJob const& rhs) = delete;
+        CountedJob& operator=(CountedJob&& rhs) = delete;
+
+        ~CountedJob()
+        {
+            --counter_;
+        }
+
+        void operator ()(Job& job)
+        {
+            return handler_ (job);
+        }
+    };
+
+public:
+    JobCounter() = default;
+    // Not copyable or movable.  Outstanding counts would be hard to sort out.
+    JobCounter (JobCounter const&) = delete;
+
+    JobCounter& operator=(JobCounter const&) = delete;
+
+    /** Destructor verifies all in-flight jobs are complete. */
+    ~JobCounter()
+    {
+        join();
+    }
+
+    /** Returns once all counted in-flight Jobs are destroyed. */
+    void join()
+    {
+        std::unique_lock<std::mutex> lock {mutex_};
+        waitForJobs_ = true;
+        if (jobCount_ > 0)
+        {
+            allJobsDoneCond_.wait (
+                lock, [this] { return jobCount_ == 0; });
+        }
+    }
+
+    /** Wrap the passed lambda with a reference counter.
+
+        @param handler Lambda that accepts a Job& parameter and returns void.
+        @return If join() has been called returns boost::none.  Otherwise
+                returns a boost::optional that wraps handler with a
+                reference counter.
+    */
+    template <class JobHandler>
+    boost::optional<CountedJob<JobHandler>>
+    wrap (JobHandler&& handler)
+    {
+        // The current intention is that wrap() may only be called with an
+        // rvalue lambda.  That can be adjusted in the future if needed,
+        // but the following static_assert covers current expectations.
+        static_assert (std::is_rvalue_reference<decltype (handler)>::value,
+            "JobCounter::wrap() only supports rvalue lambdas.");
+
+        boost::optional<CountedJob<JobHandler>> ret;
+
+        std::lock_guard<std::mutex> lock {mutex_};
+        if (! waitForJobs_)
+            ret.emplace (*this, std::move (handler));
+
+        return ret;
+    }
+
+    /** Current number of Jobs outstanding.  Only useful for testing. */
+    int count() const
+    {
+        return jobCount_;
+    }
+
+    /** Returns true if this has been joined.
+
+        Even if true is returned, counted Jobs may still be in flight.
+        However if (joined() && (count() == 0)) there should be no more
+        counted Jobs in flight.
+    */
+    bool joined() const
+    {
+        std::lock_guard<std::mutex> lock {mutex_};
+        return waitForJobs_;
+    }
+};
+
+} // ripple
+
+#endif // RIPPLE_CORE_JOB_COUNTER_H_INCLUDED

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -22,6 +22,7 @@
 
 #include <ripple/basics/LocalValue.h>
 #include <ripple/basics/win32_workaround.h>
+#include <ripple/core/JobCounter.h>
 #include <ripple/core/JobTypes.h>
 #include <ripple/core/JobTypeData.h>
 #include <ripple/core/Stoppable.h>
@@ -110,7 +111,34 @@ public:
         Stoppable& parent, beast::Journal journal, Logs& logs);
     ~JobQueue ();
 
+    /** Adds a job to the JobQueue.
+
+        @param t The type of job.
+        @param name Name of the job.
+        @param func std::function with signature void (Job&).  Called when the job is executed.
+    */
     void addJob (JobType type, std::string const& name, JobFunction const& func);
+
+    /** Adds a counted job to the JobQueue.
+
+        @param t The type of job.
+        @param name Name of the job.
+        @param counter JobCounter for counting the Job.
+        @param jobHandler Lambda with signature void (Job&).  Called when the job is executed.
+
+        @return true if JobHandler added, false if JobCounter is already joined.
+    */
+    template <typename JobHandler>
+    bool addCountedJob (JobType type,
+        std::string const& name, JobCounter& counter, JobHandler&& jobHandler)
+    {
+        if (auto optionalCountedJob = counter.wrap (std::move (jobHandler)))
+        {
+            addJob (type, name, std::move (*optionalCountedJob));
+            return true;
+        }
+        return false;
+    }
 
     /** Creates a coroutine and adds a job to the queue which will run it.
 

--- a/src/test/core/JobCounter_test.cpp
+++ b/src/test/core/JobCounter_test.cpp
@@ -1,0 +1,122 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/core/JobCounter.h>
+#include <ripple/beast/unit_test.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace ripple {
+
+//------------------------------------------------------------------------------
+
+class JobCounter_test : public beast::unit_test::suite
+{
+    void testWrap()
+    {
+        // Verify reference counting.
+        JobCounter jobCounter;
+        BEAST_EXPECT (jobCounter.count() == 0);
+        {
+            auto wrapped1 = jobCounter.wrap ([] (Job&) {});
+            BEAST_EXPECT (jobCounter.count() == 1);
+
+            // wrapped1 should be callable with a Job.
+            {
+                Job j;
+                (*wrapped1)(j);
+            }
+            {
+                // Copy should increase reference count.
+                auto wrapped2 (wrapped1);
+                BEAST_EXPECT (jobCounter.count() == 2);
+                {
+                    // Move should increase reference count.
+                    auto wrapped3 (std::move(wrapped2));
+                    BEAST_EXPECT (jobCounter.count() == 3);
+                    {
+                        // An additional Job also increases count.
+                        auto wrapped4 = jobCounter.wrap ([] (Job&) {});
+                        BEAST_EXPECT (jobCounter.count() == 4);
+                    }
+                    BEAST_EXPECT (jobCounter.count() == 3);
+                }
+                BEAST_EXPECT (jobCounter.count() == 2);
+            }
+            BEAST_EXPECT (jobCounter.count() == 1);
+        }
+        BEAST_EXPECT (jobCounter.count() == 0);
+
+        // Join with 0 count should not stall.
+        jobCounter.join();
+
+        // Wrapping a Job after join() should return boost::none.
+        BEAST_EXPECT (jobCounter.wrap ([] (Job&) {}) == boost::none);
+    }
+
+    void testWaitOnJoin()
+    {
+        // Verify reference counting.
+        JobCounter jobCounter;
+        BEAST_EXPECT (jobCounter.count() == 0);
+
+        auto job = (jobCounter.wrap ([] (Job&) {}));
+        BEAST_EXPECT (jobCounter.count() == 1);
+
+        // Calling join() now should stall, so do it on a different thread.
+        std::atomic<bool> threadExited {false};
+        std::thread localThread ([&jobCounter, &threadExited] ()
+        {
+            // Should stall after calling join.
+            jobCounter.join();
+            threadExited.store (true);
+        });
+
+        // Wait for the thread to call jobCounter.join().
+        while (! jobCounter.joined());
+
+        // The thread should still be active after waiting a millisecond.
+        // This is not a guarantee that join() stalled the thread, but it
+        // improves confidence.
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for (1ms);
+        BEAST_EXPECT (threadExited == false);
+
+        // Destroy the Job and expect the thread to exit (asynchronously).
+        job = boost::none;
+        BEAST_EXPECT (jobCounter.count() == 0);
+
+        // Wait for the thread to exit.
+        while (threadExited == false);
+        localThread.join();
+    }
+
+public:
+    void run()
+    {
+        testWrap();
+        testWaitOnJoin();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(JobCounter, core, ripple);
+
+}

--- a/src/test/unity/core_test_unity.cpp
+++ b/src/test/unity/core_test_unity.cpp
@@ -21,6 +21,7 @@
 #include <test/core/Config_test.cpp>
 #include <test/core/Coroutine_test.cpp>
 #include <test/core/DeadlineTimer_test.cpp>
+#include <test/core/JobCounter_test.cpp>
 #include <test/core/SociDB_test.cpp>
 #include <test/core/Stoppable_test.cpp>
 #include <test/core/TerminateHandler_test.cpp>


### PR DESCRIPTION
Background: I was working on replacing uses of `DeadlineTimer` with `boost::asio::steady_timer`.  A coworker asked, "How do you know that those `Job`s are completed before `NetworkOPs` declares itself `stopped()`?"  I investigated.  The answer was that I didn't.  `NetworkOPs` could still have `Job`s in flight in the `JobQueue` when it declared itself `stopped()`.  This problem has been around for a while, but it didn't seem right to ignore it.  So I set out to address it.

To address the stopping-with-`Job`s-in-flight problem, a new `JobCounter` class is introduced.  The `JobCounter` keeps a reference count of `Job`s in flight to the `JobQueue`.  When `NetworkOPs` needs to stop, in addition to other work, it calls `JobCounter::join()`, which waits until all counted `Job`s in flight have been destroyed before returning.  This ensures that all `NetworkOPs` `Job`s are completed before `NetworkOPs` declares itself `stopped()`.

Also, once a `JobCounter` is `join()`ed, it refuses to produce more counted `Job`s for the `JobQueue`.  So, once all old `Job`s in flight are done, then `NetworkOPs` will add no additional `Job`s to the `JobQueue`.

Other classes besides `NetworkOPs` should also be able to use `JobCounter` (notably `Overlay`, `LedgerMaster`, and `Application`).  `NetworkOPs` is a first test case.

Also unneeded #includes were removed from files touched for other reasons.

Reviewers: @miguelportilla for JobQueue expertise, @HowardHinnant for reference counting correctness.