### PR TITLE
Fix handleLCL consensus bug

### DIFF
--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -867,15 +867,18 @@ Consensus<Derived, Traits>::timerEntry (NetClock::time_point const& now)
     {
         using namespace std::chrono;
 
+        // checkLCL may change state_, so it needs to run prior to the
+        // switch (state_) below
+        if(state_ == State::open || state_ == State::establish)
+            checkLCL ();
+
         switch (state_)
         {
         case State::open:
-            checkLCL ();
             statePreClose ();
             break;
 
         case State::establish:
-            checkLCL ();
             stateEstablish ();
             break;
 


### PR DESCRIPTION
`Consensus::checkLCL` can change the internal consensus `state_` but it was being called inside `timerEntry` after `switch(state_)`.  In rare cases, this could end up calling `stateEstablish` even when the `state_` was open.