### PR TITLE
Use beast::temp_dir in tests (RIPD-1414):

### DIFF
--- a/src/ripple/beast/utility/temp_dir.h
+++ b/src/ripple/beast/utility/temp_dir.h
@@ -57,7 +57,10 @@ public:
     /// Destroy a temporary directory.
     ~temp_dir()
     {
-        boost::filesystem::remove_all (path_);
+        // use non-throwing calls in the destructor
+        boost::system::error_code ec;
+        boost::filesystem::remove_all(path_, ec);
+        // TODO: warn/notify if ec set ?
     }
 
     /// Get the native path for the temporary directory

--- a/src/test/app/LedgerLoad_test.cpp
+++ b/src/test/app/LedgerLoad_test.cpp
@@ -18,54 +18,49 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/beast/unit_test.h>
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
-#include <ripple/beast/unit_test.h>
+#include <ripple/beast/utility/temp_dir.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/SField.h>
-#include <boost/scope_exit.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <fstream>
 
 namespace ripple {
 
 class LedgerLoad_test : public beast::unit_test::suite
 {
-    Json::Value jvLedger_;
-    Json::Value jvHashes_;
-    boost::filesystem::path ledgerFile_;
-    boost::filesystem::path dbPath_;
-
-    auto ledgerConfig(std::string const& ledger, Config::StartUpType type)
+    auto static ledgerConfig(
+        std::unique_ptr<Config> cfg,
+        std::string const& dbPath,
+        std::string const& ledger,
+        Config::StartUpType type)
     {
-        assert(! dbPath_.empty());
-        auto p = test::jtx::envconfig();
-        p->START_LEDGER = ledger;
-        p->START_UP = type;
-        p->legacy("database_path", dbPath_.string());
-        return p;
+        cfg->START_LEDGER = ledger;
+        cfg->START_UP = type;
+        assert(! dbPath.empty());
+        cfg->legacy("database_path", dbPath);
+        return cfg;
     }
 
     // setup for test cases
-    void
-    setupLedger()
+    struct SetupData
+    {
+        std::string const dbPath;
+        std::string ledgerFile;
+        Json::Value ledger;
+        Json::Value hashes;
+    };
+
+    SetupData
+    setupLedger(beast::temp_dir const& td)
     {
         using namespace test::jtx;
+        SetupData retval = {td.path()};
 
-        boost::system::error_code ec;
-        // create a temporary path to write ledger files in
-        dbPath_  = boost::filesystem::temp_directory_path(ec);
-        if(! BEAST_EXPECTS(!ec, ec.message()))
-            return;
-        dbPath_ /= boost::filesystem::unique_path("%%%%-%%%%-%%%%-%%%%", ec);
-        if(! BEAST_EXPECTS(!ec, ec.message()))
-            return;
-        boost::filesystem::create_directories(dbPath_, ec);
-        if(! BEAST_EXPECTS(!ec, ec.message()))
-            return;
-
-        ledgerFile_ = dbPath_ / "ledgerdata.json";
+        retval.ledgerFile = td.file("ledgerdata.json");
 
         Env env {*this};
         Account prev;
@@ -85,62 +80,72 @@ class LedgerLoad_test : public beast::unit_test::suite
             prev = std::move(acct);
         }
 
-        jvLedger_ = env.rpc ("ledger", "current", "full") [jss::result];
-        BEAST_EXPECT(jvLedger_[jss::ledger][jss::accountState].size() == 101);
+        retval.ledger = env.rpc ("ledger", "current", "full") [jss::result];
+        BEAST_EXPECT(retval.ledger[jss::ledger][jss::accountState].size() == 101);
 
-        for(auto const& it : jvLedger_[jss::ledger][jss::accountState])
-        {
-            if(it[sfLedgerEntryType.fieldName] == "LedgerHashes")
+        retval.hashes = [&] {
+            for(auto const& it : retval.ledger[jss::ledger][jss::accountState])
             {
-                jvHashes_ = it[sfHashes.fieldName];
+                if(it[sfLedgerEntryType.fieldName] == "LedgerHashes")
+                    return it[sfHashes.fieldName];
             }
-        }
-        BEAST_EXPECT(jvHashes_.size() == 41);
+            return Json::Value {};
+        }();
+
+        BEAST_EXPECT(retval.hashes.size() == 41);
 
         //write this ledger data to a file.
-        std::ofstream o (ledgerFile_.string(), std::ios::out | std::ios::trunc);
-        o << to_string(jvLedger_);
+        std::ofstream o (retval.ledgerFile, std::ios::out | std::ios::trunc);
+        o << to_string(retval.ledger);
         o.close();
+        return retval;
     }
 
     void
-    testLoad ()
+    testLoad (SetupData const& sd)
     {
         testcase ("Load a saved ledger");
         using namespace test::jtx;
 
         // create a new env with the ledger file specified for startup
-        Env env(*this, ledgerConfig(ledgerFile_.string(), Config::LOAD_FILE));
+        Env env(*this,
+            envconfig( ledgerConfig,
+                sd.dbPath, sd.ledgerFile, Config::LOAD_FILE));
         auto jrb = env.rpc ( "ledger", "current", "full") [jss::result];
         BEAST_EXPECT(
-            jvLedger_[jss::ledger][jss::accountState].size() ==
+            sd.ledger[jss::ledger][jss::accountState].size() ==
             jrb[jss::ledger][jss::accountState].size());
     }
 
     void
-    testBadFiles ()
+    testBadFiles (SetupData const& sd)
     {
         testcase ("Load ledger: Bad Files");
         using namespace test::jtx;
         using namespace boost::filesystem;
 
         // empty path
-        except ([this]
+        except ([&]
         {
-            Env env(*this, ledgerConfig("", Config::LOAD_FILE));
+            Env env(*this,
+                envconfig( ledgerConfig,
+                    sd.dbPath, "", Config::LOAD_FILE));
         });
 
         // file does not exist
-        except ([this]
+        except ([&]
         {
-            Env env(*this, ledgerConfig("badfile.json", Config::LOAD_FILE));
+            Env env(*this,
+                envconfig( ledgerConfig,
+                    sd.dbPath, "badfile.json", Config::LOAD_FILE));
         });
 
         // make a corrupted version of the ledger file (last 10 bytes removed).
         boost::system::error_code ec;
-        auto ledgerFileCorrupt = dbPath_ / "ledgerdata_bad.json";
+        auto ledgerFileCorrupt =
+            boost::filesystem::path{sd.dbPath} / "ledgerdata_bad.json";
         copy_file(
-            ledgerFile_,
+            sd.ledgerFile,
             ledgerFileCorrupt,
             copy_option::overwrite_if_exists,
             ec);
@@ -153,73 +158,77 @@ class LedgerLoad_test : public beast::unit_test::suite
         if(! BEAST_EXPECTS(!ec, ec.message()))
             return;
 
-        except ([this, &ledgerFileCorrupt]
+        except ([&]
         {
-            Env env(*this, ledgerConfig(ledgerFileCorrupt.string(), Config::LOAD_FILE));
+            Env env(*this,
+                envconfig( ledgerConfig,
+                    sd.dbPath, ledgerFileCorrupt.string(), Config::LOAD_FILE));
         });
     }
 
     void
-    testLoadByHash ()
+    testLoadByHash (SetupData const& sd)
     {
         testcase ("Load by hash");
         using namespace test::jtx;
 
         // create a new env with the ledger hash specified for startup
-        auto ledgerHash = to_string(jvHashes_[jvHashes_.size()-1]);
+        auto ledgerHash = to_string(sd.hashes[sd.hashes.size()-1]);
         boost::erase_all(ledgerHash, "\"");
-        Env env(*this, ledgerConfig(ledgerHash, Config::LOAD));
+        Env env(*this,
+            envconfig( ledgerConfig,
+                sd.dbPath, ledgerHash, Config::LOAD));
         auto jrb = env.rpc ( "ledger", "current", "full") [jss::result];
         BEAST_EXPECT(jrb[jss::ledger][jss::accountState].size() == 97);
         BEAST_EXPECT(
             jrb[jss::ledger][jss::accountState].size() <=
-            jvLedger_[jss::ledger][jss::accountState].size());
+            sd.ledger[jss::ledger][jss::accountState].size());
     }
 
     void
-    testLoadLatest ()
+    testLoadLatest (SetupData const& sd)
     {
         testcase ("Load by keyword");
         using namespace test::jtx;
 
         // create a new env with the ledger "latest" specified for startup
-        Env env(*this, ledgerConfig("latest", Config::LOAD));
+        Env env(*this,
+            envconfig( ledgerConfig,
+                sd.dbPath, "latest", Config::LOAD));
         auto jrb = env.rpc ( "ledger", "current", "full") [jss::result];
         BEAST_EXPECT(
-            jvLedger_[jss::ledger][jss::accountState].size() ==
+            sd.ledger[jss::ledger][jss::accountState].size() ==
             jrb[jss::ledger][jss::accountState].size());
     }
 
     void
-    testLoadIndex ()
+    testLoadIndex (SetupData const& sd)
     {
         testcase ("Load by index");
         using namespace test::jtx;
 
         // create a new env with specific ledger index at startup
-        Env env(*this, ledgerConfig("43", Config::LOAD));
+        Env env(*this,
+            envconfig( ledgerConfig,
+                sd.dbPath, "43", Config::LOAD));
         auto jrb = env.rpc ( "ledger", "current", "full") [jss::result];
         BEAST_EXPECT(
-            jvLedger_[jss::ledger][jss::accountState].size() ==
+            sd.ledger[jss::ledger][jss::accountState].size() ==
             jrb[jss::ledger][jss::accountState].size());
     }
 
 public:
     void run ()
     {
-        setupLedger();
-        BOOST_SCOPE_EXIT( this_ ) {
-            boost::system::error_code ec;
-            boost::filesystem::remove_all(this_->dbPath_, ec);
-            this_->expect(!ec, ec.message(), __FILE__, __LINE__);
-        } BOOST_SCOPE_EXIT_END
+        beast::temp_dir td;
+        auto sd = setupLedger(td);
 
         // test cases
-        testLoad ();
-        testBadFiles ();
-        testLoadByHash ();
-        testLoadLatest ();
-        testLoadIndex ();
+        testLoad (sd);
+        testBadFiles (sd);
+        testLoadByHash (sd);
+        testLoadLatest (sd);
+        testLoadIndex (sd);
     }
 };
 


### PR DESCRIPTION
Use non-throwing fs function in temp_dir destructor. Eliminate only use
of BOOST_SCOPE_EXIT.