### PR TITLE
Add RPC filters for Escrow an PayChan (RIPD-1414)

### DIFF
--- a/src/ripple/app/ledger/LedgerToJson.h
+++ b/src/ripple/app/ledger/LedgerToJson.h
@@ -31,17 +31,12 @@ namespace ripple {
 
 struct LedgerFill
 {
-    LedgerFill (ReadView const& l, int o = 0)
+    LedgerFill (ReadView const& l, int o = 0, std::vector<TxQ::TxDetails> q = {},
+                LedgerEntryType t = ltINVALID)
         : ledger (l)
         , options (o)
-    {
-    }
-
-    LedgerFill(ReadView const& l, int o,
-        std::vector<TxQ::TxDetails> q)
-        : ledger(l)
-        , options(o)
-        , txQueue(q)
+        , txQueue(std::move(q))
+        , type (t)
     {
     }
 
@@ -58,6 +53,7 @@ struct LedgerFill
     ReadView const& ledger;
     int options;
     std::vector<TxQ::TxDetails> txQueue;
+    LedgerEntryType type;
 };
 
 /** Given a Ledger and options, fill a Json::Object or Json::Value with a

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -170,16 +170,19 @@ void fillJsonState(Object& json, LedgerFill const& fill)
 
     for(auto const& sle : ledger.sles)
     {
-        if (binary)
+        if (fill.type == ltINVALID || sle->getType () == fill.type)
         {
-            auto&& obj = appendObject(array);
-            obj[jss::hash] = to_string(sle->key());
-            obj[jss::tx_blob] = serializeHex(*sle);
+            if (binary)
+            {
+                auto&& obj = appendObject(array);
+                obj[jss::hash] = to_string(sle->key());
+                obj[jss::tx_blob] = serializeHex(*sle);
+            }
+            else if (expanded)
+                array.append(sle->getJson(0));
+            else
+                array.append(to_string(sle->key()));
         }
-        else if (expanded)
-            array.append(sle->getJson(0));
-        else
-            array.append(to_string(sle->key()));
     }
 }
 

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -159,6 +159,7 @@ JSS ( error );                      // out: error
 JSS ( error_code );                 // out: error
 JSS ( error_exception );            // out: Submit
 JSS ( error_message );              // out: error
+JSS ( escrow );                     // in: LedgerEntry
 JSS ( expand );                     // in: handler/Ledger
 JSS ( expected_ledger_size );       // out: TxQ
 JSS ( expiration );                 // out: AccountOffers, AccountChannels
@@ -314,6 +315,7 @@ JSS ( password );                   // in: Subscribe
 JSS ( paths );                      // in: RipplePathFind
 JSS ( paths_canonical );            // out: RipplePathFind
 JSS ( paths_computed );             // out: PathRequest, RipplePathFind
+JSS ( payment_channel );            // in: LedgerEntry
 JSS ( peer );                       // in: AccountLines
 JSS ( peer_authorized );            // out: AccountLines
 JSS ( peer_id );                    // out: RCLCxPeerPos

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_LEDGERFORMATS_H_INCLUDED
 
 #include <ripple/protocol/KnownFormats.h>
+#include <ripple/rpc/Status.h>
 
 namespace ripple {
 
@@ -162,6 +163,9 @@ public:
 private:
     void addCommonFields (Item& item);
 };
+
+std::pair<RPC::Status, LedgerEntryType>
+    chooseLedgerEntryType(Json::Value const& params);
 
 } // ripple
 

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -18,7 +18,12 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/LedgerFormats.h>
+#include <algorithm>
+#include <array>
+#include <utility>
 
 namespace ripple {
 
@@ -163,6 +168,51 @@ LedgerFormats::getInstance ()
 {
     static LedgerFormats instance;
     return instance;
+}
+
+std::pair<RPC::Status, LedgerEntryType>
+chooseLedgerEntryType(Json::Value const& params)
+{
+    std::pair<RPC::Status, LedgerEntryType> result{RPC::Status::OK, ltINVALID};
+    if (params.isMember(jss::type))
+    {
+        static
+        std::array<std::pair<char const *, LedgerEntryType>, 9> const types
+            {{
+                { jss::account,     ltACCOUNT_ROOT  },
+                { jss::amendments,  ltAMENDMENTS    },
+                { jss::directory,   ltDIR_NODE      },
+                { jss::fee,         ltFEE_SETTINGS  },
+                { jss::hashes,      ltLEDGER_HASHES },
+                { jss::offer,       ltOFFER         },
+                { jss::signer_list, ltSIGNER_LIST   },
+                { jss::state,       ltRIPPLE_STATE  },
+                { jss::ticket,      ltTICKET        }
+            }};
+
+        auto const& p = params[jss::type];
+        if (!p.isString())
+        {
+            result.first = RPC::Status{rpcINVALID_PARAMS,
+                                       "Invalid field 'type', not string."};
+            assert(result.first.type() == RPC::Status::Type::error_code_i);
+            return result;
+        }
+
+        auto const filter = p.asString ();
+        auto iter = std::find_if (types.begin (), types.end (),
+            [&filter](decltype (types.front ())& t)
+                { return t.first == filter; });
+        if (iter == types.end ())
+        {
+            result.first = RPC::Status{rpcINVALID_PARAMS,
+                                       "Invalid field 'type'."};
+            assert(result.first.type() == RPC::Status::Type::error_code_i);
+            return result;
+        }
+        result.second = iter->second;
+    }
+    return result;
 }
 
 } // ripple

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -177,17 +177,19 @@ chooseLedgerEntryType(Json::Value const& params)
     if (params.isMember(jss::type))
     {
         static
-        std::array<std::pair<char const *, LedgerEntryType>, 9> const types
+        std::array<std::pair<char const *, LedgerEntryType>, 11> const types
             {{
-                { jss::account,     ltACCOUNT_ROOT  },
-                { jss::amendments,  ltAMENDMENTS    },
-                { jss::directory,   ltDIR_NODE      },
-                { jss::fee,         ltFEE_SETTINGS  },
-                { jss::hashes,      ltLEDGER_HASHES },
-                { jss::offer,       ltOFFER         },
-                { jss::signer_list, ltSIGNER_LIST   },
-                { jss::state,       ltRIPPLE_STATE  },
-                { jss::ticket,      ltTICKET        }
+                { jss::account,         ltACCOUNT_ROOT  },
+                { jss::amendments,      ltAMENDMENTS    },
+                { jss::directory,       ltDIR_NODE      },
+                { jss::fee,             ltFEE_SETTINGS  },
+                { jss::hashes,          ltLEDGER_HASHES },
+                { jss::offer,           ltOFFER         },
+                { jss::signer_list,     ltSIGNER_LIST   },
+                { jss::state,           ltRIPPLE_STATE  },
+                { jss::ticket,          ltTICKET        },
+                { jss::escrow,          ltESCROW        },
+                { jss::payment_channel, ltPAYCHAN       }
             }};
 
         auto const& p = params[jss::type];

--- a/src/ripple/rpc/Status.h
+++ b/src/ripple/rpc/Status.h
@@ -43,7 +43,7 @@ public:
     using Code = int;
     using Strings = std::vector <std::string>;
 
-    static const Code OK = 0;
+    static constexpr Code OK = 0;
 
     Status () = default;
 

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -25,6 +25,7 @@
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/JsonFields.h>
+#include <ripple/protocol/LedgerFormats.h>
 #include <ripple/resource/Fees.h>
 #include <ripple/rpc/Context.h>
 #include <ripple/rpc/impl/RPCHelpers.h>
@@ -72,36 +73,12 @@ Json::Value doAccountObjects (RPC::Context& context)
     if (! ledger->exists(keylet::account (accountID)))
         return rpcError (rpcACT_NOT_FOUND);
 
-    auto type = ltINVALID;
-    if (params.isMember (jss::type))
+    auto type = chooseLedgerEntryType(params);
+    if (type.first)
     {
-        static
-        std::array<std::pair<char const *, LedgerEntryType>, 9> const
-        types
-        {{
-            { jss::account, ltACCOUNT_ROOT },
-            { jss::amendments, ltAMENDMENTS },
-            { jss::directory, ltDIR_NODE },
-            { jss::fee, ltFEE_SETTINGS },
-            { jss::hashes, ltLEDGER_HASHES },
-            { jss::offer, ltOFFER },
-            { jss::signer_list, ltSIGNER_LIST },
-            { jss::state, ltRIPPLE_STATE },
-            { jss::ticket, ltTICKET }
-        }};
-
-        auto const& p = params[jss::type];
-        if (! p.isString ())
-            return RPC::expected_field_error (jss::type, "string");
-
-        auto const filter = p.asString ();
-        auto iter = std::find_if (types.begin (), types.end (),
-            [&filter](decltype (types.front ())& t)
-                { return t.first == filter; });
-        if (iter == types.end ())
-            return RPC::invalid_field_error (jss::type);
-
-        type = iter->second;
+        result.clear();
+        type.first.inject(result);
+        return result;
     }
 
     unsigned int limit;
@@ -131,7 +108,7 @@ Json::Value doAccountObjects (RPC::Context& context)
             return RPC::invalid_field_error (jss::marker);
     }
 
-    if (! RPC::getAccountObjects (*ledger, accountID, type,
+    if (! RPC::getAccountObjects (*ledger, accountID, type.second,
         dirIndex, entryIndex, limit, result))
     {
         result[jss::account_objects] = Json::arrayValue;

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -55,6 +55,10 @@ Status LedgerHandler::check()
     bool const binary = params[jss::binary].asBool();
     bool const owner_funds = params[jss::owner_funds].asBool();
     bool const queue = params[jss::queue].asBool();
+    auto type = chooseLedgerEntryType(params);
+    if (type.first)
+        return type.first;
+    type_ = type.second;
 
     options_ = (full ? LedgerFill::full : 0)
             | (expand ? LedgerFill::expand : 0)

--- a/src/ripple/rpc/handlers/LedgerHandler.h
+++ b/src/ripple/rpc/handlers/LedgerHandler.h
@@ -76,6 +76,7 @@ private:
     std::vector<TxQ::TxDetails> queueTxs_;
     Json::Value result_;
     int options_ = 0;
+    LedgerEntryType type_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,7 +90,7 @@ void LedgerHandler::writeResult (Object& value)
     if (ledger_)
     {
         Json::copyFrom (value, result_);
-        addJson (value, {*ledger_, options_, queueTxs_});
+        addJson (value, {*ledger_, options_, queueTxs_, type_});
     }
     else
     {

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -139,7 +139,6 @@ error_code_i fillHandler (Context& context,
 
     JLOG (context.j.trace()) << "COMMAND:" << strCommand;
     JLOG (context.j.trace()) << "REQUEST:" << context.params;
-
     auto handler = getHandler(strCommand);
 
     if (!handler)

--- a/src/ripple/rpc/impl/Status.cpp
+++ b/src/ripple/rpc/impl/Status.cpp
@@ -23,6 +23,8 @@
 namespace ripple {
 namespace RPC {
 
+constexpr Status::Code Status::OK;
+
 std::string Status::codeString () const
 {
     if (!*this)

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -266,8 +266,10 @@ public:
     {
         // Put a bunch of different LedgerEntryTypes into a ledger
         using namespace test::jtx;
+        using namespace std::chrono;
         Env env { *this, envconfig(validator, ""),
-                   features(featureMultiSign, featureTickets) };
+                   features(featureMultiSign, featureTickets,
+                           featureEscrow, featurePayChan) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -290,109 +292,126 @@ public:
             if (!majorities.empty())
                 break;
         }
-        env(signers(Account{"bob0"}, 1, {{Account{"bob1"}, 1}, {Account{"bob2"}, 1}}));
+        env(signers(Account{"bob0"}, 1,
+                {{Account{"bob1"}, 1}, {Account{"bob2"}, 1}}));
         env(ticket::create(env.master));
+
+        {
+            Json::Value jv;
+            jv[jss::TransactionType] = "EscrowCreate";
+            jv[jss::Flags] = tfUniversal;
+            jv[jss::Account] = Account{"bob5"}.human();
+            jv[jss::Destination] = Account{"bob6"}.human();
+            jv[jss::Amount] = XRP(50).value().getJson(0);
+            jv["FinishAfter"] =
+                NetClock::time_point{env.now() + 10s}
+                    .time_since_epoch().count();
+            env(jv);
+        }
+
+        {
+            Json::Value jv;
+            jv[jss::TransactionType] = "PaymentChannelCreate";
+            jv[jss::Flags] = tfUniversal;
+            jv[jss::Account] = Account{"bob6"}.human ();
+            jv[jss::Destination] = Account{"bob7"}.human ();
+            jv[jss::Amount] = XRP(100).value().getJson (0);
+            jv["SettleDelay"] = NetClock::duration{10s}.count();
+            jv["PublicKey"] = strHex (Account{"bob6"}.pk().slice ());
+            jv["CancelAfter"] =
+                NetClock::time_point{env.now() + 300s}
+                    .time_since_epoch().count();
+            env(jv);
+        }
+
         env.close();
 
+
         // Now fetch each type
+        auto makeRequest = [&env](Json::StaticString t)
+        {
+            Json::Value jvParams;
+            jvParams[jss::ledger_index] = "current";
+            jvParams[jss::type] = t;
+            return env.rpc ( "json", "ledger_data",
+                boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        };
 
         {  // jvParams[jss::type] = "account";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "account";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::account);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 12) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "AccountRoot" );
         }
 
         {  // jvParams[jss::type] = "amendments";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "amendments";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::amendments);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "Amendments" );
         }
 
         {  // jvParams[jss::type] = "directory";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "directory";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
-        BEAST_EXPECT( checkArraySize(jrr[jss::state], 5) );
+        auto const jrr = makeRequest(jss::directory);
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 7) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "DirectoryNode" );
         }
 
         {  // jvParams[jss::type] = "fee";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "fee";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::fee);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "FeeSettings" );
         }
 
         {  // jvParams[jss::type] = "hashes";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "hashes";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::hashes);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 2) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "LedgerHashes" );
         }
 
         {  // jvParams[jss::type] = "offer";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "offer";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::offer);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "Offer" );
         }
 
         {  // jvParams[jss::type] = "signer_list";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "signer_list";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::signer_list);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "SignerList" );
         }
 
         {  // jvParams[jss::type] = "state";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "state";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::state);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "RippleState" );
         }
 
         {  // jvParams[jss::type] = "ticket";
-        Json::Value jvParams;
-        jvParams[jss::ledger_index] = "current";
-        jvParams[jss::type] = "ticket";
-        auto const jrr = env.rpc ( "json", "ledger_data",
-            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        auto const jrr = makeRequest(jss::ticket);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
             BEAST_EXPECT( j["LedgerEntryType"] == "Ticket" );
+        }
+
+        {  // jvParams[jss::type] = "escrow";
+        auto const jrr = makeRequest(jss::escrow);
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "Escrow" );
+        }
+
+        {  // jvParams[jss::type] = "payment_channel";
+        auto const jrr = makeRequest(jss::payment_channel);
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "PayChannel" );
         }
 
         {  // jvParams[jss::type] = "misspelling";

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -58,7 +58,6 @@ public:
         }
         env.close();
 
-        // no limit specified
         // with no limit specified, we get the max_limit if the total number of
         // accounts is greater than max, which it is here
         Json::Value jvParams;
@@ -101,7 +100,6 @@ public:
         }
         env.close();
 
-        // no limit specified
         // with no limit specified, we should get all of our fund entries
         // plus three more related to the gateway setup
         Json::Value jvParams;
@@ -189,7 +187,6 @@ public:
         }
         env.close();
 
-        // no limit specified
         // with no limit specified, we should get all of our fund entries
         // plus three more related to the gateway setup
         Json::Value jvParams;
@@ -281,7 +278,6 @@ public:
         }
         env.close();
 
-        // no limit specified
         // with no limit specified, we should get all of our fund entries
         // plus three more related to the gateway setup
         Json::Value jvParams;

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -303,7 +303,7 @@ public:
             jv[jss::Account] = Account{"bob5"}.human();
             jv[jss::Destination] = Account{"bob6"}.human();
             jv[jss::Amount] = XRP(50).value().getJson(0);
-            jv["FinishAfter"] =
+            jv[sfFinishAfter.fieldName] =
                 NetClock::time_point{env.now() + 10s}
                     .time_since_epoch().count();
             env(jv);
@@ -316,9 +316,9 @@ public:
             jv[jss::Account] = Account{"bob6"}.human ();
             jv[jss::Destination] = Account{"bob7"}.human ();
             jv[jss::Amount] = XRP(100).value().getJson (0);
-            jv["SettleDelay"] = NetClock::duration{10s}.count();
-            jv["PublicKey"] = strHex (Account{"bob6"}.pk().slice ());
-            jv["CancelAfter"] =
+            jv[jss::SettleDelay] = NetClock::duration{10s}.count();
+            jv[sfPublicKey.fieldName] = strHex (Account{"bob6"}.pk().slice ());
+            jv[sfCancelAfter.fieldName] =
                 NetClock::time_point{env.now() + 300s}
                     .time_since_epoch().count();
             env(jv);

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/basics/StringUtilities.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/JsonFields.h>
 #include <test/jtx.h>
 
@@ -263,8 +264,10 @@ public:
 
     void testLedgerType()
     {
+        // Put a bunch of different LedgerEntryTypes into a ledger
         using namespace test::jtx;
-        Env env { *this, envconfig(no_admin) };
+        Env env { *this, envconfig(validator, ""),
+                   features(featureMultiSign, featureTickets) };
         Account const gw { "gateway" };
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
@@ -276,20 +279,132 @@ public:
             Account const bob { std::string("bob") + std::to_string(i) };
             env.fund(XRP(1000), bob);
         }
+        env(offer(Account{"bob0"}, USD(100), XRP(100)));
+        env.trust(Account{"bob2"}["USD"](100), Account{"bob3"});
+
+        auto majorities = getMajorityAmendments(*env.closed());
+        for (int i = 0; i <= 256; ++i)
+        {
+            env.close();
+            majorities = getMajorityAmendments(*env.closed());
+            if (!majorities.empty())
+                break;
+        }
+        env(signers(Account{"bob0"}, 1, {{Account{"bob1"}, 1}, {Account{"bob2"}, 1}}));
+        env(ticket::create(env.master));
         env.close();
 
-        // with no limit specified, we should get all of our fund entries
-        // plus three more related to the gateway setup
+        // Now fetch each type
+
+        {  // jvParams[jss::type] = "account";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "account";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 12) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "AccountRoot" );
+        }
+
+        {  // jvParams[jss::type] = "amendments";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "amendments";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "Amendments" );
+        }
+
+        {  // jvParams[jss::type] = "directory";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "directory";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 5) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "DirectoryNode" );
+        }
+
+        {  // jvParams[jss::type] = "fee";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "fee";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "FeeSettings" );
+        }
+
+        {  // jvParams[jss::type] = "hashes";
         Json::Value jvParams;
         jvParams[jss::ledger_index] = "current";
         jvParams[jss::type] = "hashes";
         auto const jrr = env.rpc ( "json", "ledger_data",
             boost::lexical_cast<std::string>(jvParams)) [jss::result];
-        BEAST_EXPECT(
-            jrr[jss::ledger_current_index].isIntegral() &&
-            jrr[jss::ledger_current_index].asInt() > 0);
-        BEAST_EXPECT( ! jrr.isMember(jss::marker) );
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 2) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "LedgerHashes" );
+        }
+
+        {  // jvParams[jss::type] = "offer";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "offer";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "Offer" );
+        }
+
+        {  // jvParams[jss::type] = "signer_list";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "signer_list";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "SignerList" );
+        }
+
+        {  // jvParams[jss::type] = "state";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "state";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "RippleState" );
+        }
+
+        {  // jvParams[jss::type] = "ticket";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "ticket";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == "Ticket" );
+        }
+
+        {  // jvParams[jss::type] = "misspelling";
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = "current";
+        jvParams[jss::type] = "misspelling";
+        auto const jrr = env.rpc ( "json", "ledger_data",
+            boost::lexical_cast<std::string>(jvParams)) [jss::result];
+        BEAST_EXPECT( jrr.isMember("error") );
+        BEAST_EXPECT( jrr["error"] == "invalidParams" );
+        BEAST_EXPECT( jrr["error_message"] == "Invalid field 'type'." );
+        }
     }
 
     void run()

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -652,6 +652,28 @@ class LedgerRPC_test : public beast::unit_test::suite
 
     }
 
+    void testLedgerAccountsType()
+    {
+        testcase("Ledger Request, Accounts Option");
+        using namespace test::jtx;
+
+        Env env {*this};
+
+        env.close();
+
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = 3u;
+        jvParams[jss::accounts] = true;
+        jvParams[jss::expand] = true;
+        jvParams[jss::type] = "hashes";
+        auto const jrr = env.rpc ( "json", "ledger", to_string(jvParams) ) [jss::result];
+        BEAST_EXPECT(jrr[jss::ledger].isMember(jss::accountState));
+        BEAST_EXPECT(jrr[jss::ledger][jss::accountState].isArray());
+        BEAST_EXPECT(jrr[jss::ledger][jss::accountState].size() == 1u);
+        BEAST_EXPECT(jrr[jss::ledger][jss::accountState][0u]["LedgerEntryType"]
+                                                          == "LedgerHashes");
+    }
+
 public:
     void run ()
     {
@@ -668,6 +690,7 @@ public:
         testLookupLedger();
         testNoQueue();
         testQueue();
+        testLedgerAccountsType();
     }
 };
 

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -661,6 +661,8 @@ class LedgerRPC_test : public beast::unit_test::suite
 
         env.close();
 
+        std::string index;
+        {
         Json::Value jvParams;
         jvParams[jss::ledger_index] = 3u;
         jvParams[jss::accounts] = true;
@@ -672,6 +674,20 @@ class LedgerRPC_test : public beast::unit_test::suite
         BEAST_EXPECT(jrr[jss::ledger][jss::accountState].size() == 1u);
         BEAST_EXPECT(jrr[jss::ledger][jss::accountState][0u]["LedgerEntryType"]
                                                           == "LedgerHashes");
+        index = jrr[jss::ledger][jss::accountState][0u]["index"].asString();
+        }
+        {
+        Json::Value jvParams;
+        jvParams[jss::ledger_index] = 3u;
+        jvParams[jss::accounts] = true;
+        jvParams[jss::expand] = false;
+        jvParams[jss::type] = "hashes";
+        auto const jrr = env.rpc ( "json", "ledger", to_string(jvParams) ) [jss::result];
+        BEAST_EXPECT(jrr[jss::ledger].isMember(jss::accountState));
+        BEAST_EXPECT(jrr[jss::ledger][jss::accountState].isArray());
+        BEAST_EXPECT(jrr[jss::ledger][jss::accountState].size() == 1u);
+        BEAST_EXPECT(jrr[jss::ledger][jss::accountState][0u] == index);
+        }
     }
 
 public:


### PR DESCRIPTION
This adds two ledger entry types to RPC filter options. It is built on top of refactoring by @HowardHinnant in https://github.com/ripple/rippled/pull/2066 - this should be merged *after* that PR. 