### PR TITLE
Fix video link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ![Ripple](/images/ripple.png)
 
 # What is Ripple?
-Ripple is a network of computers which use the [Ripple consensus algorithm]
-(https://www.youtube.com/watch?v=pj1QVb1vlC0) to atomically settle and record
+Ripple is a network of computers which use the [Ripple consensus algorithm](https://www.youtube.com/watch?v=pj1QVb1vlC0) to atomically settle and record
 transactions on a secure distributed database, the Ripple Consensus Ledger
 (RCL). Because of its distributed nature, the RCL offers transaction immutability
 without a central operator. The RCL contains a built-in currency exchange and its


### PR DESCRIPTION
Markdown does not allow a line break or other whitespace between [] and () when creating a link.