### PR TITLE
Validations::flush() doesn't use JobQueue (RIPD-1356):

### DIFF
--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -479,6 +479,8 @@ private:
         doWrite (sl);
     }
 
+    // NOTE: doWrite() must be called with mLock *locked*.  The passed
+    // ScopedLockType& acts as a reminder to future maintainers.
     void doWrite (ScopedLockType& sl)
     {
         std::string const insVal ("INSERT INTO Validations "


### PR DESCRIPTION
In general, using the `JobQueue` during shutdown is risk prone.  `Validations::flush()` no longer uses the `JobQueue` for its database write at shutdown.  It performs the write directly without changing threads.

Currently the only place that calls `Validations::flush()` is `ApplicationImp::onStop()` during shutdown.

I've tested this change by doing start / sync / wait-60-seconds / stop in a loop 50 times.  It's held up so far.  I intend to do several hundred more loops over the weekend.