### PR TITLE
Reduce JobQueue interface

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -838,7 +838,7 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
 void NetworkOPsImp::processTransaction (std::shared_ptr<Transaction>& transaction,
         bool bUnlimited, bool bLocal, FailHard failType)
 {
-    auto ev = m_job_queue.getLoadEventAP (jtTXN_PROC, "ProcessTXN");
+    auto ev = m_job_queue.makeLoadEvent (jtTXN_PROC, "ProcessTXN");
     auto const newFlags = app_.getHashRouter ().getFlags (transaction->getID ());
 
     if ((newFlags & SF_BAD) != 0)

--- a/src/ripple/app/misc/Validations.cpp
+++ b/src/ripple/app/misc/Validations.cpp
@@ -464,7 +464,7 @@ private:
 
     void doWrite ()
     {
-        auto event = app_.getJobQueue ().getLoadEventAP (jtDISK, "ValidationWrite");
+        auto event = app_.getJobQueue ().makeLoadEvent (jtDISK, "ValidationWrite");
 
         std::string insVal ("INSERT INTO Validations "
             "(InitialSeq, LedgerSeq, LedgerHash,NodePubKey,SignTime,RawData) "

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -56,7 +56,7 @@ void PathRequests::updateAll (std::shared_ptr <ReadView const> const& inLedger,
                               Job::CancelCallback shouldCancel)
 {
     auto event =
-        app_.getJobQueue().getLoadEventAP(
+        app_.getJobQueue().makeLoadEvent(
             jtPATH_FIND, "PathRequest::updateAll");
 
     std::vector<PathRequest::wptr> requests;

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -171,10 +171,6 @@ Pathfinder::Pathfinder (
     assert (! uSrcIssuer || isXRP(uSrcCurrency) == isXRP(uSrcIssuer.get()));
 }
 
-Pathfinder::~Pathfinder()
-{
-}
-
 bool Pathfinder::findPaths (int searchLevel)
 {
     if (mDstAmount == zero)
@@ -205,7 +201,7 @@ bool Pathfinder::findPaths (int searchLevel)
         return true;
     }
 
-    m_loadEvent = app_.getJobQueue ().getLoadEvent (
+    m_loadEvent = app_.getJobQueue ().makeLoadEvent (
         jtPATH_FIND, "FindPath");
     auto currencyIsXRP = isXRP (mSrcCurrency);
 

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -47,7 +47,9 @@ public:
         STAmount const& dstAmount,
         boost::optional<STAmount> const& srcAmount,
         Application& app);
-    ~Pathfinder();
+    Pathfinder (Pathfinder const&) = delete;
+    Pathfinder& operator= (Pathfinder const&) = delete;
+    ~Pathfinder() = default;
 
     static void initPathTable ();
 
@@ -181,7 +183,7 @@ private:
     bool convert_all_;
 
     std::shared_ptr <ReadView const> mLedger;
-    std::shared_ptr<LoadEvent> m_loadEvent;
+    std::unique_ptr<LoadEvent> m_loadEvent;
     std::shared_ptr<RippleLineCache> mRLCache;
 
     STPathElement mSource;

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -161,23 +161,14 @@ public:
     */
     int getJobCountGE (JobType t) const;
 
-    /** Shut down the job queue without completing pending jobs.
-    */
-    void shutdown ();
-
     /** Set the number of thread serving the job queue to precisely this number.
     */
     void setThreadCount (int c, bool const standaloneMode);
 
-    // VFALCO TODO Rename these to newLoadEventMeasurement or something similar
-    //             since they create the object.
-    std::shared_ptr<LoadEvent>
-    getLoadEvent (JobType t, std::string const& name);
-
-    // VFALCO TODO Why do we need two versions, one which returns a shared
-    //             pointer and the other which returns an autoptr?
+    /** Return a scoped LoadEvent.
+    */
     std::unique_ptr <LoadEvent>
-    getLoadEventAP (JobType t, std::string const& name);
+    makeLoadEvent (JobType t, std::string const& name);
 
     /** Add multiple load events.
     */

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -152,14 +152,6 @@ JobQueue::getJobCountGE (JobType t) const
 }
 
 void
-JobQueue::shutdown ()
-{
-    JLOG(m_journal.info()) <<  "Job queue shutting down";
-
-    m_workers.pauseAllThreadsAndWait ();
-}
-
-void
 JobQueue::setThreadCount (int c, bool const standaloneMode)
 {
     if (standaloneMode)
@@ -178,21 +170,8 @@ JobQueue::setThreadCount (int c, bool const standaloneMode)
     m_workers.setNumberOfThreads (c);
 }
 
-std::shared_ptr<LoadEvent>
-JobQueue::getLoadEvent (JobType t, std::string const& name)
-{
-    JobDataMap::iterator iter (m_jobData.find (t));
-    assert (iter != m_jobData.end ());
-
-    if (iter == m_jobData.end ())
-        return std::shared_ptr<LoadEvent> ();
-
-    return std::make_shared<LoadEvent> (
-        std::ref (iter-> second.load ()), name, true);
-}
-
 std::unique_ptr<LoadEvent>
-JobQueue::getLoadEventAP (JobType t, std::string const& name)
+JobQueue::makeLoadEvent (JobType t, std::string const& name)
 {
     JobDataMap::iterator iter (m_jobData.find (t));
     assert (iter != m_jobData.end ());

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -824,7 +824,7 @@ PeerImp::onMessageBegin (std::uint16_t type,
     std::shared_ptr <::google::protobuf::Message> const& m,
     std::size_t size)
 {
-    load_event_ = app_.getJobQueue ().getLoadEventAP (
+    load_event_ = app_.getJobQueue ().makeLoadEvent (
         jtPEER, protocolMessageName(type));
     fee_ = Resource::feeLightPeer;
     overlay_.reportTraffic (TrafficCount::categorize (*m, type, true),

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -193,7 +193,7 @@ Status callMethod (
 {
     try
     {
-        auto v = context.app.getJobQueue().getLoadEventAP(
+        auto v = context.app.getJobQueue().makeLoadEvent(
             jtGENERIC, "cmd:" + name);
         return method (context, result);
     }


### PR DESCRIPTION
I was working in `JobQueue` for other reasons and ran across a small cleanup.  The `JobQueue::shutdown()` method is unused and untested, so I removed it.  There were two `JobQueue::getLoadEvent*` methods, one of which returned a `std::unique_ptr` and the other returned a `std::shared_ptr`.  The lone caller of the `shared_ptr` interface only needed a `unique_ptr`.  So I removed the `shared_ptr` interface and renamed the `unique_ptr` method.