### PR TITLE
Add missing include and rm unneeded test

### DIFF
--- a/src/ripple/beast/clock/basic_seconds_clock.h
+++ b/src/ripple/beast/clock/basic_seconds_clock.h
@@ -63,8 +63,7 @@ public:
     seconds_clock_thread ()
         : stop_ (false)
     {
-        thread_ = thread (std::bind(
-            &seconds_clock_thread::run, this));
+        thread_ = thread (&seconds_clock_thread::run, this);
     }
 
     ~seconds_clock_thread ()

--- a/src/test/beast/IPEndpoint_test.cpp
+++ b/src/test/beast/IPEndpoint_test.cpp
@@ -116,7 +116,6 @@ public:
       BEAST_EXPECT(v4[2]==0);
       BEAST_EXPECT(v4[3]==1);
 
-      BEAST_EXPECT((!((0xff)<<16)) == 0x00000000);
       BEAST_EXPECT((~((0xff)<<16)) == 0xff00ffff);
 
       v4[1] = 10;


### PR DESCRIPTION
These changes are required to allow gcc 7 to cleanly compile rippled