### PR TITLE
Migrate thread safety to RCLConsensus (RIPD-1389)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1099,6 +1099,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\misc\impl\ValidatorKeys.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\misc\impl\ValidatorList.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
@@ -1130,6 +1134,8 @@
     <ClInclude Include="..\..\src\ripple\app\misc\Transaction.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\app\misc\TxQ.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\app\misc\ValidatorKeys.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\app\misc\ValidatorList.h">
     </ClInclude>
@@ -1864,6 +1870,8 @@
     <ClInclude Include="..\..\src\ripple\consensus\ConsensusParms.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\ConsensusProposal.h">
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\consensus\ConsensusTypes.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\DisputedTx.h">
     </ClInclude>
@@ -4320,6 +4328,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\test\app\TxQ_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\app\ValidatorKeys_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -1635,6 +1635,9 @@
     <ClCompile Include="..\..\src\ripple\app\misc\impl\TxQ.cpp">
       <Filter>ripple\app\misc\impl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\app\misc\impl\ValidatorKeys.cpp">
+      <Filter>ripple\app\misc\impl</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ripple\app\misc\impl\ValidatorList.cpp">
       <Filter>ripple\app\misc\impl</Filter>
     </ClCompile>
@@ -1669,6 +1672,9 @@
       <Filter>ripple\app\misc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\app\misc\TxQ.h">
+      <Filter>ripple\app\misc</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\app\misc\ValidatorKeys.h">
       <Filter>ripple\app\misc</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\app\misc\ValidatorList.h">
@@ -2509,6 +2515,9 @@
       <Filter>ripple\consensus</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\ConsensusProposal.h">
+      <Filter>ripple\consensus</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ripple\consensus\ConsensusTypes.h">
       <Filter>ripple\consensus</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\DisputedTx.h">
@@ -5119,6 +5128,9 @@
       <Filter>test\app</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\app\TxQ_test.cpp">
+      <Filter>test\app</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\app\ValidatorKeys_test.cpp">
       <Filter>test\app</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\app\ValidatorList_test.cpp">

--- a/docs/consensus.qbk
+++ b/docs/consensus.qbk
@@ -480,69 +480,87 @@ struct Ledger
   //... implementation specific
 };
 ```
-[heading Generic Consensus Interface]
 
-Following the
-[@https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern CRTP]
-idiom, generic =Consensus= relies on a deriving class implementing a set of
-helpers and callbacks that encapsulate implementation specific details of the
-algorithm. Below are excerpts of the generic consensus implementation and of
-helper types that will interact with the concrete implementing class.
-
+[heading PeerProposal] The =PeerProposal= type represents the signed position taken
+by a peer during consensus. The only type requirement is owning an instance of a
+generic =ConsensusProposal=.
 ```
-
 // Represents our proposed position or a peer's proposed position
+// and is provided with the generic code
 template <class NodeID_t, class LedgerID_t, class Position_t> class ConsensusProposal;
 
+struct PeerPosition
+{
+  ConsensusProposal<
+      NodeID_t,
+      typename Ledger::ID,
+      typename TxSet::ID> const &
+  proposal() const;
+
+  // ... implementation specific
+};
+```
+[heading Generic Consensus Interface]
+
+The generic =Consensus= relies on =Adaptor= template class to implement a set
+of helper functions that plug the consensus algorithm into a specific application.
+The =Adaptor= class also defines the types above needed by the algorithm. Below
+are excerpts of the generic consensus implementation and of helper types that will
+interact with the concrete implementing class.
+
+```
 // Represents a transction under dispute this round
 template <class Tx_t, class NodeID_t> class DisputedTx;
 
-template <class Derived, class Traits> class Consensus
+// Represents how the node participates in Consensus this round
+enum class ConsensusMode { proposing, observing, wrongLedger, switchedLedger};
+
+// Measure duration of phases of consensus
+class ConsensusTimer
 {
-protected:
-    enum class Mode { proposing, observing, wrongLedger, switchedLedger};
-
-    // Measure duration of phases of consensus
-    class Stopwatch
-    {
-    public:
-        std::chrono::milliseconds read() const;
-        // details omitted ...
-    };
-
-    // Initial ledger close times, not rounded by closeTimeResolution
-    // Used to gauge degree of synchronization between a node and its peers
-    struct CloseTimes
-    {
-        std::map<NetClock::time_point, int> peers;
-        NetClock::time_point self;
-    };
-
-    // Encapsulates the result of consensus.
-    struct Result
-    {
-        //! The set of transactions consensus agrees go in the ledger
-        TxSet_t set;
-
-        //! Our proposed position on transactions/close time
-        Proposal_t position;
-
-        //! Transactions which are under dispute with our peers
-        using Dispute_t = DisputedTx<Tx_t, NodeID_t>;
-        hash_map<typename Tx_t::ID, Dispute_t> disputes;
-
-        // Set of TxSet ids we have already compared/created disputes
-        hash_set<typename TxSet_t::ID> compares;
-
-        // Measures the duration of the establish phase for this consensus round
-        Stopwatch roundTime;
-
-        // Indicates state in which consensus ended.  Once in the accept phase
-        // will be either Yes or MovedOn
-        ConsensusState state = ConsensusState::No;
-    };
-
 public:
+    std::chrono::milliseconds read() const;
+    // details omitted ...
+};
+
+// Initial ledger close times, not rounded by closeTimeResolution
+// Used to gauge degree of synchronization between a node and its peers
+struct ConsensusCloseTimes
+{
+    std::map<NetClock::time_point, int> peers;
+    NetClock::time_point self;
+};
+
+// Encapsulates the result of consensus.
+template <class Adaptor>
+struct ConsensusResult
+{
+    //! The set of transactions consensus agrees go in the ledger
+    Adaptor::TxSet_t set;
+
+    //! Our proposed position on transactions/close time
+    ConsensusProposal<...> position;
+
+    //! Transactions which are under dispute with our peers
+    hash_map<Adaptor::Tx_t::ID, DisputedTx<...>> disputes;
+
+    // Set of TxSet ids we have already compared/created disputes
+    hash_set<typename Adaptor::TxSet_t::ID> compares;
+
+    // Measures the duration of the establish phase for this consensus round
+    ConsensusTimer roundTime;
+
+    // Indicates state in which consensus ended.  Once in the accept phase
+    // will be either Yes or MovedOn
+    ConsensusState state = ConsensusState::No;
+};
+
+template <class Adaptor>
+class Consensus
+{
+public:
+    Consensus(clock_type, Adaptor &, beast::journal);
+
     // Kick-off the next round of consensus.
     void startRound(
         NetClock::time_point const& now,
@@ -568,25 +586,19 @@ public:
 The stub below shows the set of callback/helper functions required in the implementing class.
 
 ```
-struct Traits
+struct Adaptor
 {
-  using Ledger_t = Ledger;
-  using TxSet_t = TxSet;
-  using NodeID_t = ...; // Integer-like std::uint32_t to uniquely identify a node
+    using Ledger_t = Ledger;
+    using TxSet_t = TxSet;
+    using PeerProposal_t = PeerProposal;
+    using NodeID_t = ...; // Integer-like std::uint32_t to uniquely identify a node
 
-};
 
-class ConsensusImp : public Consensus<ConsensusImp, Traits>
-{
     // Attempt to acquire a specific ledger from the network.
     boost::optional<Ledger> acquireLedger(Ledger::ID const & ledgerID);
 
     // Acquire the transaction set associated with a proposed position.
     boost::optional<TxSet> acquireTxSet(TxSet::ID const & setID);
-
-    // Get peers' proposed positions. Returns an iterable
-    // with value_type convertable to ConsensusPosition<...>
-    auto const & proposals(Ledger::ID const & ledgerID);
 
     // Whether any transactions are in the open ledger
     bool hasOpenTransactions() const;
@@ -602,24 +614,27 @@ class ConsensusImp : public Consensus<ConsensusImp, Traits>
     // application thinks consensus should use as the prior ledger.
     Ledger::ID getPrevLedger(Ledger::ID const & prevLedgerID,
                     Ledger const & prevLedger,
-                    Mode mode);
+                    ConsensusMode mode);
 
+    // Called when consensus operating mode changes
+    void onModeChange(ConsensuMode before, ConsensusMode after);
+    
     // Called when ledger closes.  Implementation should generate an initial Result
     // with position based on the current open ledger's transactions.
-    Result onClose(Ledger const &, Ledger const & prev, Mode mode);
+    ConsensusResult onClose(Ledger const &, Ledger const & prev, ConsensusMode mode);
 
     // Called when ledger is accepted by consensus
-    void onAccept(Result const & result,
+    void onAccept(ConsensusResult const & result,
       RCLCxLedger const & prevLedger,
       NetClock::duration closeResolution,
-      CloseTimes const & rawCloseTimes,
-      Mode const & mode);
+      ConsensusCloseTimes const & rawCloseTimes,
+      ConsensusMode const & mode);
 
     // Propose the position to peers.
     void propose(ConsensusProposal<...> const & pos);
 
     // Relay a received peer proposal on to other peer's.
-    void relay(ConsensusProposal<...> const & pos);
+    void relay(PeerPosition_t const & pos);
 
     // Relay a disputed transaction to peers
     void relay(TxSet::Tx const & tx);

--- a/docs/source.dox
+++ b/docs/source.dox
@@ -111,6 +111,7 @@ INPUT                  = \
     ../src/test/jtx/WSClient.h \
     ../src/ripple/consensus/Consensus.h \
     ../src/ripple/consensus/ConsensusProposal.h \
+    ../src/ripple/consensus/ConsensusTypes.h \
     ../src/ripple/consensus/DisputedTx.h \
     ../src/ripple/consensus/LedgerTiming.h \
     ../src/ripple/consensus/Validations.h \

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -34,34 +34,332 @@
 #include <ripple/protocol/RippleLedgerHash.h>
 #include <ripple/protocol/STValidation.h>
 #include <ripple/shamap/SHAMap.h>
+#include <atomic>
+#include <mutex>
 
 namespace ripple {
 
 class InboundTransactions;
 class LocalTxs;
 class LedgerMaster;
+class ValidatorKeys;
 
-//! Types used to adapt consensus for RCL
-struct RCLCxTraits
-{
-    //! Ledger type presented to Consensus
-    using Ledger_t = RCLCxLedger;
-    //! Peer identifier type used in Consensus
-    using NodeID_t = NodeID;
-    //! TxSet type presented to Consensus
-    using TxSet_t = RCLTxSet;
-};
-
-/** Adapts the generic Consensus algorithm for use by RCL.
-
-    @note The enabled_shared_from_this base allows the application to properly
-    create a shared instance of RCLConsensus for use in the accept logic..
+/** Manages the generic consensus algorithm for use by the RCL.
 */
-class RCLConsensus final : public Consensus<RCLConsensus, RCLCxTraits>,
-                           public std::enable_shared_from_this<RCLConsensus>,
-                           public CountedObject<RCLConsensus>
+class RCLConsensus
 {
-    using Base = Consensus<RCLConsensus, RCLCxTraits>;
+    // Implements the Adaptor template interface required by Consensus.
+    class Adaptor
+    {
+        Application& app_;
+        std::unique_ptr<FeeVote> feeVote_;
+        LedgerMaster& ledgerMaster_;
+        LocalTxs& localTxs_;
+        InboundTransactions& inboundTransactions_;
+        beast::Journal j_;
+
+        NodeID const nodeID_;
+        PublicKey const valPublic_;
+        SecretKey const valSecret_;
+
+        // Ledger we most recently needed to acquire
+        LedgerHash acquiringLedger_;
+        ConsensusParms parms_;
+
+        // The timestamp of the last validation we used
+        NetClock::time_point lastValidationTime_;
+
+        // These members are queried via public accesors and are atomic for
+        // thread safety.
+        std::atomic<bool> validating_{false};
+        std::atomic<std::size_t> prevProposers_{0};
+        std::atomic<std::chrono::milliseconds> prevRoundTime_{
+            std::chrono::milliseconds{0}};
+        std::atomic<ConsensusMode> mode_{ConsensusMode::observing};
+
+    public:
+        using Ledger_t = RCLCxLedger;
+        using NodeID_t = NodeID;
+        using TxSet_t = RCLTxSet;
+        using PeerPosition_t = RCLCxPeerPos;
+
+        using Result = ConsensusResult<Adaptor>;
+
+        Adaptor(
+            Application& app,
+            std::unique_ptr<FeeVote>&& feeVote,
+            LedgerMaster& ledgerMaster,
+            LocalTxs& localTxs,
+            InboundTransactions& inboundTransactions,
+            ValidatorKeys const & validatorKeys,
+            beast::Journal journal);
+
+        bool
+        validating() const
+        {
+            return validating_;
+        }
+
+        std::size_t
+        prevProposers() const
+        {
+            return prevProposers_;
+        }
+
+        std::chrono::milliseconds
+        prevRoundTime() const
+        {
+            return prevRoundTime_;
+        }
+
+        ConsensusMode
+        mode() const
+        {
+            return mode_;
+        }
+
+        /** Called before kicking off a new consensus round.
+
+            @param prevLedger Ledger that will be prior ledger for next round
+            @return Whether we enter the round proposing
+        */
+        bool
+        preStartRound(RCLCxLedger const & prevLedger);
+
+        /** Consensus simulation parameters
+         */
+        ConsensusParms const&
+        parms() const
+        {
+            return parms_;
+        }
+
+    private:
+        //---------------------------------------------------------------------
+        // The following members implement the generic Consensus requirements
+        // and are marked private to indicate ONLY Consensus<Adaptor> will call
+        // them (via friendship). Since they are callled only from Consenus<Adaptor>
+        // methods and since RCLConsensus::consensus_ should only be accessed
+        // under lock, these will only be called under lock.
+        //
+        // In general, the idea is that there is only ONE thread that is running
+        // consensus code at anytime. The only special case is the dispatched
+        // onAccept call, which does not take a lock and relies on Consensus not
+        // changing state until a future call to startRound.
+        friend class Consensus<Adaptor>;
+
+        /** Attempt to acquire a specific ledger.
+
+            If not available, asynchronously acquires from the network.
+
+            @param ledger The ID/hash of the ledger acquire
+            @return Optional ledger, will be seated if we locally had the ledger
+        */
+        boost::optional<RCLCxLedger>
+        acquireLedger(LedgerHash const& ledger);
+
+        /** Relay the given proposal to all peers
+
+            @param peerPos The peer position to relay.
+         */
+        void
+        relay(RCLCxPeerPos const& peerPos);
+
+        /** Relay disputed transacction to peers.
+
+            Only relay if the provided transaction hasn't been shared recently.
+
+            @param tx The disputed transaction to relay.
+        */
+        void
+        relay(RCLCxTx const& tx);
+
+        /** Acquire the transaction set associated with a proposal.
+
+            If the transaction set is not available locally, will attempt
+            acquire it from the network.
+
+            @param setId The transaction set ID associated with the proposal
+            @return Optional set of transactions, seated if available.
+       */
+        boost::optional<RCLTxSet>
+        acquireTxSet(RCLTxSet::ID const& setId);
+
+        /** Whether the open ledger has any transactions
+         */
+        bool
+        hasOpenTransactions() const;
+
+        /** Number of proposers that have vallidated the given ledger
+
+            @param h The hash of the ledger of interest
+            @return the number of proposers that validated a ledger
+        */
+        std::size_t
+        proposersValidated(LedgerHash const& h) const;
+
+        /** Number of proposers that have validated a ledger descended from
+           requested ledger.
+
+            @param h The hash of the ledger of interest.
+            @return The number of validating peers that have validated a ledger
+                    succeeding the one provided.
+        */
+        std::size_t
+        proposersFinished(LedgerHash const& h) const;
+
+        /** Propose the given position to my peers.
+
+            @param proposal Our proposed position
+        */
+        void
+        propose(RCLCxPeerPos::Proposal const& proposal);
+
+        /** Relay the given tx set to peers.
+
+            @param set The TxSet to share.
+        */
+        void
+        relay(RCLTxSet const& set);
+
+        /** Get the ID of the previous ledger/last closed ledger(LCL) on the
+           network
+
+            @param ledgerID ID of previous ledger used by consensus
+            @param ledger Previous ledger consensus has available
+            @param mode Current consensus mode
+            @return The id of the last closed network
+
+            @note ledgerID may not match ledger.id() if we haven't acquired
+                  the ledger matching ledgerID from the network
+         */
+        uint256
+        getPrevLedger(
+            uint256 ledgerID,
+            RCLCxLedger const& ledger,
+            ConsensusMode mode);
+
+        void
+        onModeChange(ConsensusMode before, ConsensusMode after)
+        {
+            mode_ = after;
+        }
+
+        /** Close the open ledger and return initial consensus position.
+
+           @param ledger the ledger we are changing to
+           @param closeTime When consensus closed the ledger
+           @param mode Current consensus mode
+           @return Tentative consensus result
+        */
+        Result
+        onClose(
+            RCLCxLedger const& ledger,
+            NetClock::time_point const& closeTime,
+            ConsensusMode mode);
+
+        /** Process the accepted ledger.
+
+            @param result The result of consensus
+            @param prevLedger The closed ledger consensus worked from
+            @param closeResolution The resolution used in agreeing on an
+                                   effective closeTime
+            @param rawCloseTimes The unrounded closetimes of ourself and our
+                                 peers
+            @param mode Our participating mode at the time consensus was
+                        declared
+            @param consensusJson Json representation of consensus state
+        */
+        void
+        onAccept(
+            Result const& result,
+            RCLCxLedger const& prevLedger,
+            NetClock::duration const& closeResolution,
+            ConsensusCloseTimes const& rawCloseTimes,
+            ConsensusMode const& mode,
+            Json::Value&& consensusJson);
+
+        /** Process the accepted ledger that was a result of simulation/force
+            accept.
+
+            @ref onAccept
+        */
+        void
+        onForceAccept(
+            Result const& result,
+            RCLCxLedger const& prevLedger,
+            NetClock::duration const& closeResolution,
+            ConsensusCloseTimes const& rawCloseTimes,
+            ConsensusMode const& mode,
+            Json::Value&& consensusJson);
+
+        /** Notify peers of a consensus state change
+
+            @param ne Event type for notification
+            @param ledger The ledger at the time of the state change
+            @param haveCorrectLCL Whether we believ we have the correct LCL.
+        */
+        void
+        notify(
+            protocol::NodeEvent ne,
+            RCLCxLedger const& ledger,
+            bool haveCorrectLCL);
+
+        /** Accept a new ledger based on the given transactions.
+
+            @ref onAccept
+         */
+        void
+        doAccept(
+            Result const& result,
+            RCLCxLedger const& prevLedger,
+            NetClock::duration closeResolution,
+            ConsensusCloseTimes const& rawCloseTimes,
+            ConsensusMode const& mode,
+            Json::Value&& consensusJson);
+
+        /** Build the new last closed ledger.
+
+            Accept the given the provided set of consensus transactions and
+            build the last closed ledger. Since consensus just agrees on which
+            transactions to apply, but not whether they make it into the closed
+            ledger, this function also populates retriableTxs with those that
+            can be retried in the next round.
+
+            @param previousLedger Prior ledger building upon
+            @param set The set of transactions to apply to the ledger
+            @param closeTime The the ledger closed
+            @param closeTimeCorrect Whether consensus agreed on close time
+            @param closeResolution Resolution used to determine consensus close
+                                   time
+            @param roundTime Duration of this consensus rorund
+            @param retriableTxs Populate with transactions to retry in next
+                                round
+            @return The newly built ledger
+      */
+        RCLCxLedger
+        buildLCL(
+            RCLCxLedger const& previousLedger,
+            RCLTxSet const& set,
+            NetClock::time_point closeTime,
+            bool closeTimeCorrect,
+            NetClock::duration closeResolution,
+            std::chrono::milliseconds roundTime,
+            CanonicalTXSet& retriableTxs);
+
+        /** Validate the given ledger and share with peers as necessary
+
+            @param ledger The ledger to validate
+            @param proposing Whether we were proposing transactions while
+                             generating this ledger.  If we are not proposing,
+                             a validation can still be sent to inform peers that
+                             we know we aren't fully participating in consensus
+                             but are still around and trying to catch up.
+        */
+        void
+        validate(RCLCxLedger const& ledger, bool proposing);
+
+    };
 
 public:
     //! Constructor
@@ -71,7 +369,8 @@ public:
         LedgerMaster& ledgerMaster,
         LocalTxs& localTxs,
         InboundTransactions& inboundTransactions,
-        typename Base::clock_type const& clock,
+        Consensus<Adaptor>::clock_type const& clock,
+        ValidatorKeys const & validatorKeys,
         beast::Journal journal);
 
     RCLConsensus(RCLConsensus const&) = delete;
@@ -79,310 +378,96 @@ public:
     RCLConsensus&
     operator=(RCLConsensus const&) = delete;
 
-    static char const*
-    getCountedObjectName()
-    {
-        return "Consensus";
-    }
-
-    /** Save the given consensus proposed by a peer with nodeID for later
-        use in consensus.
-
-        @param peerPos Proposed peer position
-        @param nodeID ID of peer
-    */
-    void
-    storeProposal(RCLCxPeerPos::ref peerPos, NodeID const& nodeID);
-
     //! Whether we are validating consensus ledgers.
     bool
     validating() const
     {
-        return validating_;
+        return adaptor_.validating();
     }
 
-    bool
-    haveCorrectLCL() const
+    //! Get the number of proposing peers that participated in the previous
+    //! round.
+    std::size_t
+    prevProposers() const
     {
-        return mode() != Mode::wrongLedger;
+        return adaptor_.prevProposers();
     }
 
-    bool
-    proposing() const
-    {
-        return mode() == Mode::proposing;
-    }
+    /** Get duration of the previous round.
 
-    /** Get the Json state of the consensus process.
+        The duration of the round is the establish phase, measured from closing
+        the open ledger to accepting the consensus result.
 
-        Called by the consensus_info RPC.
-
-        @param full True if verbose response desired.
-        @return     The Json state.
+        @return Last round duration in milliseconds
     */
+    std::chrono::milliseconds
+    prevRoundTime() const
+    {
+        return adaptor_.prevRoundTime();
+    }
+
+    //! @see Consensus::mode
+    ConsensusMode
+    mode() const
+    {
+        return adaptor_.mode();
+    }
+
+    //! @see Consensus::getJson
     Json::Value
     getJson(bool full) const;
 
-    //! See Consensus::startRound
+    //! @see Consensus::startRound
     void
     startRound(
         NetClock::time_point const& now,
         RCLCxLedger::ID const& prevLgrId,
         RCLCxLedger const& prevLgr);
 
-    //! See Consensus::timerEntry
+    //! @see Consensus::timerEntry
     void
     timerEntry(NetClock::time_point const& now);
 
-    //! See Consensus::gotTxSet
+    //! @see Consensus::gotTxSet
     void
     gotTxSet(NetClock::time_point const& now, RCLTxSet const& txSet);
 
-    /** Returns validation public key */
-    PublicKey const&
-    getValidationPublicKey() const;
+    // @see Consensus::prevLedgerID
+    RCLCxLedger::ID
+    prevLedgerID() const
+    {
+        ScopedLockType _{mutex_};
+        return consensus_.prevLedgerID();
+    }
 
-    /** Set validation private and public key pair. */
+    //! @see Consensus::simulate
     void
-    setValidationKeys(SecretKey const& valSecret, PublicKey const& valPublic);
+    simulate(
+        NetClock::time_point const& now,
+        boost::optional<std::chrono::milliseconds> consensusDelay);
+
+    //! @see Consensus::proposal
+    bool
+    peerProposal(
+        NetClock::time_point const& now,
+        RCLCxPeerPos const& newProposal);
+
+    ConsensusParms const &
+    parms() const
+    {
+        return adaptor_.parms();
+    }
 
 private:
-    friend class Consensus<RCLConsensus, RCLCxTraits>;
+    // Since Consensus does not provide intrinsic thread-safety, this mutex
+    // guards all calls to consensus_. adaptor_ uses atomics internally
+    // to allow concurrent access of its data members that have getters.
+    mutable std::recursive_mutex mutex_;
+    using ScopedLockType = std::lock_guard <std::recursive_mutex>;
 
-    //-------------------------------------------------------------------------
-    // Consensus type requirements.
-
-    /** Attempt to acquire a specific ledger.
-
-        If not available, asynchronously acquires from the network.
-
-        @param ledger The ID/hash of the ledger acquire
-        @return Optional ledger, will be seated if we locally had the ledger
-     */
-    boost::optional<RCLCxLedger>
-    acquireLedger(LedgerHash const& ledger);
-
-    /** Get peers' proposed positions.
-        @param prevLedger The base ledger which proposals are based on
-        @return The set of proposals
-    */
-    std::vector<RCLCxPeerPos>
-    proposals(LedgerHash const& prevLedger);
-
-    /** Relay the given proposal to all peers
-
-        @param peerPos The peer position to relay.
-     */
-    void
-    relay(RCLCxPeerPos const& peerPos);
-
-    /** Relay disputed transacction to peers.
-
-        Only relay if the provided transaction hasn't been shared recently.
-
-        @param tx The disputed transaction to relay.
-    */
-    void
-    relay(RCLCxTx const& tx);
-
-    /** Acquire the transaction set associated with a proposal.
-
-        If the transaction set is not available locally, will attempt acquire it
-        from the network.
-
-        @param setId The transaction set ID associated with the proposal
-        @return Optional set of transactions, seated if available.
-   */
-    boost::optional<RCLTxSet>
-    acquireTxSet(RCLTxSet::ID const& setId);
-
-    /** Whether the open ledger has any transactions
-     */
-    bool
-    hasOpenTransactions() const;
-
-    /** Number of proposers that have vallidated the given ledger
-
-        @param h The hash of the ledger of interest
-        @return the number of proposers that validated a ledger
-    */
-    std::size_t
-    proposersValidated(LedgerHash const& h) const;
-
-    /** Number of proposers that have validated a ledger descended from
-       requested ledger.
-
-        @param h The hash of the ledger of interest.
-        @return The number of validating peers that have validated a ledger
-                succeeding the one provided.
-    */
-    std::size_t
-    proposersFinished(LedgerHash const& h) const;
-
-    /** Propose the given position to my peers.
-
-        @param proposal Our proposed position
-    */
-    void
-    propose(RCLCxPeerPos::Proposal const& proposal);
-
-    /** Relay the given tx set to peers.
-
-        @param set The TxSet to share.
-    */
-    void
-    relay(RCLTxSet const& set);
-
-    /** Get the ID of the previous ledger/last closed ledger(LCL) on the network
-
-        @param ledgerID ID of previous ledger used by consensus
-        @param ledger Previous ledger consensus has available
-        @param mode Current consensus mode
-        @return The id of the last closed network
-
-        @note ledgerID may not match ledger.id() if we haven't acquired
-              the ledger matching ledgerID from the network
-     */
-    uint256
-    getPrevLedger(
-        uint256 ledgerID,
-        RCLCxLedger const& ledger,
-        Mode mode);
-
-    /** Close the open ledger and return initial consensus position.
-
-       @param ledger the ledger we are changing to
-       @param closeTime When consensus closed the ledger
-       @param mode Current consensus mode
-       @return Tentative consensus result
-    */
-    Result
-    onClose(
-        RCLCxLedger const& ledger,
-        NetClock::time_point const& closeTime,
-        Mode mode);
-
-    /** Process the accepted ledger.
-
-        Accepting a ledger may be expensive, so this function can dispatch
-        that call to another thread if desired.
-
-        @param result The result of consensus
-        @param prevLedger The closed ledger consensus worked from
-        @param closeResolution The resolution used in agreeing on an effective
-                               closeTiem
-        @param rawCloseTimes The unrounded closetimes of ourself and our peers
-        @param mode Our participating mode at the time consensus was declared
-    */
-    void
-    onAccept(
-        Result const& result,
-        RCLCxLedger const& prevLedger,
-        NetClock::duration const & closeResolution,
-        CloseTimes const& rawCloseTimes,
-        Mode const& mode);
-
-    /** Process the accepted ledger that was a result of simulation/force
-       accept.
-
-        @ref onAccept
-    */
-    void
-    onForceAccept(
-        Result const& result,
-        RCLCxLedger const& prevLedger,
-        NetClock::duration const &closeResolution,
-        CloseTimes const& rawCloseTimes,
-        Mode const& mode);
-
-    //!-------------------------------------------------------------------------
-    // Additional members (not directly required by Consensus interface)
-    /** Notify peers of a consensus state change
-
-        @param ne Event type for notification
-        @param ledger The ledger at the time of the state change
-        @param haveCorrectLCL Whether we believ we have the correct LCL.
-    */
-    void
-    notify(
-        protocol::NodeEvent ne,
-        RCLCxLedger const& ledger,
-        bool haveCorrectLCL);
-
-    /** Accept a new ledger based on the given transactions.
-
-        @ref onAccept
-     */
-    void
-    doAccept(
-        Result const& result,
-        RCLCxLedger const& prevLedger,
-        NetClock::duration closeResolution,
-        CloseTimes const& rawCloseTimes,
-        Mode const& mode);
-
-    /** Build the new last closed ledger.
-
-        Accept the given the provided set of consensus transactions and build
-        the last closed ledger. Since consensus just agrees on which
-        transactions to apply, but not whether they make it into the closed
-        ledger, this function also populates retriableTxs with those that can
-        be retried in the next round.
-
-        @param previousLedger Prior ledger building upon
-        @param set The set of transactions to apply to the ledger
-        @param closeTime The the ledger closed
-        @param closeTimeCorrect Whether consensus agreed on close time
-        @param closeResolution Resolution used to determine consensus close time
-        @param roundTime Duration of this consensus rorund
-        @param retriableTxs Populate with transactions to retry in next round
-        @return The newly built ledger
-  */
-    RCLCxLedger
-    buildLCL(
-        RCLCxLedger const& previousLedger,
-        RCLTxSet const& set,
-        NetClock::time_point closeTime,
-        bool closeTimeCorrect,
-        NetClock::duration closeResolution,
-        std::chrono::milliseconds roundTime,
-        CanonicalTXSet& retriableTxs);
-
-    /** Validate the given ledger and share with peers as necessary
-
-        @param ledger The ledger to validate
-        @param proposing Whether we were proposing transactions while generating
-                         this ledger.  If we are not proposing, a validation
-                         can still be sent to inform peers that we know we
-                         aren't fully participating in consensus but are still
-                         around and trying to catch up.
-    */
-    void
-    validate(RCLCxLedger const& ledger, bool proposing);
-
-    //!-------------------------------------------------------------------------
-    Application& app_;
-    std::unique_ptr<FeeVote> feeVote_;
-    LedgerMaster& ledgerMaster_;
-    LocalTxs& localTxs_;
-    InboundTransactions& inboundTransactions_;
+    Adaptor adaptor_;
+    Consensus<Adaptor> consensus_;
     beast::Journal j_;
-
-    NodeID nodeID_;
-    PublicKey valPublic_;
-    SecretKey valSecret_;
-    LedgerHash acquiringLedger_;
-
-    // The timestamp of the last validation we used, in network time. This is
-    // only used for our own validations.
-    NetClock::time_point lastValidationTime_;
-
-    using PeerPositions = hash_map<NodeID, std::deque<RCLCxPeerPos::pointer>>;
-    PeerPositions peerPositions_;
-    std::mutex peerPositionsLock_;
-
-    bool validating_ = false;
-    bool simulating_ = false;
 };
 }
 

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -150,6 +150,10 @@ public:
     std::pair<PublicKey, SecretKey> const&
     nodeIdentity () = 0;
 
+    virtual
+    PublicKey const &
+    getValidationPublicKey() const  = 0;
+
     virtual Resource::Manager&      getResourceManager () = 0;
     virtual PathRequests&           getPathRequests () = 0;
     virtual SHAMapStore&            getSHAMapStore () = 0;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -36,6 +36,7 @@
 #include <ripple/app/misc/LoadFeeTrack.h>
 #include <ripple/app/misc/Transaction.h>
 #include <ripple/app/misc/TxQ.h>
+#include <ripple/app/misc/ValidatorKeys.h>
 #include <ripple/app/misc/ValidatorList.h>
 #include <ripple/app/misc/impl/AccountTxPaging.h>
 #include <ripple/app/tx/apply.h>
@@ -187,7 +188,7 @@ public:
         Application& app, clock_type& clock, bool standalone,
             std::size_t network_quorum, bool start_valid, JobQueue& job_queue,
                 LedgerMaster& ledgerMaster, Stoppable& parent,
-                    beast::Journal journal)
+                ValidatorKeys const & validatorKeys, beast::Journal journal)
         : NetworkOPs (parent)
         , app_ (app)
         , m_clock (clock)
@@ -198,14 +199,15 @@ public:
         , m_amendmentBlocked (false)
         , m_heartbeatTimer (this)
         , m_clusterTimer (this)
-        , mConsensus (std::make_shared<RCLConsensus>(app,
+        , mConsensus (app,
             make_FeeVote(setup_FeeVote (app_.config().section ("voting")),
                                         app_.logs().journal("FeeVote")),
             ledgerMaster,
             *m_localTX,
             app.getInboundTransactions(),
             stopwatch(),
-            app_.logs().journal("LedgerConsensus")))
+            validatorKeys,
+            app_.logs().journal("LedgerConsensus"))
         , m_ledgerMaster (ledgerMaster)
         , m_job_queue (job_queue)
         , m_standalone (standalone)
@@ -296,7 +298,7 @@ public:
 
     // Ledger proposal/close functions.
     void processTrustedProposal (
-        RCLCxPeerPos::pointer proposal,
+        RCLCxPeerPos proposal,
         std::shared_ptr<protocol::TMProposeSet> set,
         NodeID const &node) override;
 
@@ -323,7 +325,6 @@ private:
         std::shared_ptr<Ledger const> const& newLCL);
     bool checkLastClosedLedger (
         const Overlay::PeerSequence&, uint256& networkClosed);
-    void tryStartConsensus ();
 
 public:
     bool beginConsensus (uint256 const& networkClosed) override;
@@ -360,15 +361,7 @@ public:
     }
     void setAmendmentBlocked () override;
     void consensusViewChange () override;
-    PublicKey const& getValidationPublicKey () const override
-    {
-        return mConsensus->getValidationPublicKey ();
-    }
-    void setValidationKeys (
-        SecretKey const& valSecret, PublicKey const& valPublic) override
-    {
-        mConsensus->setValidationKeys (valSecret, valPublic);
-    }
+
     Json::Value getConsensusInfo () override;
     Json::Value getServerInfo (bool human, bool admin) override;
     void clearLedgerFetch () override;
@@ -549,7 +542,7 @@ private:
     DeadlineTimer m_clusterTimer;
     JobCounter jobCounter_;
 
-    std::shared_ptr<RCLConsensus> mConsensus;
+    RCLConsensus mConsensus;
 
     LedgerMaster& m_ledgerMaster;
     std::shared_ptr<InboundLedger> mAcquiringLedger;
@@ -651,7 +644,7 @@ void NetworkOPsImp::setStateTimer ()
 
 void NetworkOPsImp::setHeartbeatTimer ()
 {
-    m_heartbeatTimer.setExpiration (mConsensus->parms().ledgerGRANULARITY);
+    m_heartbeatTimer.setExpiration (mConsensus.parms().ledgerGRANULARITY);
 }
 
 void NetworkOPsImp::setClusterTimer ()
@@ -697,7 +690,7 @@ void NetworkOPsImp::processHeartbeatTimer ()
                     << "Node count (" << numPeers << ") "
                     << "has fallen below quorum (" << m_network_quorum << ").";
             }
-            // We do not call mConsensus->timerEntry until there
+            // We do not call mConsensus.timerEntry until there
             // are enough peers providing meaningful inputs to consensus
             setHeartbeatTimer ();
 
@@ -720,7 +713,7 @@ void NetworkOPsImp::processHeartbeatTimer ()
 
     }
 
-    mConsensus->timerEntry (app_.timeKeeper().closeTime());
+    mConsensus.timerEntry (app_.timeKeeper().closeTime());
 
     setHeartbeatTimer ();
 }
@@ -775,13 +768,17 @@ void NetworkOPsImp::processClusterTimer ()
 
 std::string NetworkOPsImp::strOperatingMode () const
 {
-    if (mMode == omFULL && mConsensus->haveCorrectLCL())
+    if (mMode == omFULL)
     {
-        if (mConsensus->proposing ())
-            return "proposing";
+        auto const mode = mConsensus.mode();
+        if (mode != ConsensusMode::wrongLedger)
+        {
+            if (mode == ConsensusMode::proposing)
+                return "proposing";
 
-        if (mConsensus->validating ())
-            return "validating";
+            if (mConsensus.validating())
+                return "validating";
+        }
     }
 
     return states_[mMode];
@@ -1252,46 +1249,6 @@ public:
     }
 };
 
-void NetworkOPsImp::tryStartConsensus ()
-{
-    uint256 networkClosed;
-    bool ledgerChange = checkLastClosedLedger (
-        app_.overlay ().getActivePeers (), networkClosed);
-
-    if (networkClosed.isZero ())
-        return;
-
-    // WRITEME: Unless we are in omFULL and in the process of doing a consensus,
-    // we must count how many nodes share our LCL, how many nodes disagree with
-    // our LCL, and how many validations our LCL has. We also want to check
-    // timing to make sure there shouldn't be a newer LCL. We need this
-    // information to do the next three tests.
-
-    if (((mMode == omCONNECTED) || (mMode == omSYNCING)) && !ledgerChange)
-    {
-        // Count number of peers that agree with us and UNL nodes whose
-        // validations we have for LCL.  If the ledger is good enough, go to
-        // omTRACKING - TODO
-        if (!mNeedNetworkLedger)
-            setMode (omTRACKING);
-    }
-
-    if (((mMode == omCONNECTED) || (mMode == omTRACKING)) && !ledgerChange)
-    {
-        // check if the ledger is good enough to go to omFULL
-        // Note: Do not go to omFULL if we don't have the previous ledger
-        // check if the ledger is bad enough to go to omCONNECTED -- TODO
-        auto current = m_ledgerMaster.getCurrentLedger();
-        if (app_.timeKeeper().now() <
-            (current->info().parentCloseTime + 2* current->info().closeTimeResolution))
-        {
-            setMode (omFULL);
-        }
-    }
-
-    beginConsensus (networkClosed);
-}
-
 bool NetworkOPsImp::checkLastClosedLedger (
     const Overlay::PeerSequence& peerList, uint256& networkClosed)
 {
@@ -1527,7 +1484,7 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
     app_.validators().onConsensusStart (
         app_.getValidations().getCurrentPublicKeys ());
 
-    mConsensus->startRound (
+    mConsensus.startRound (
         app_.timeKeeper().closeTime(),
         networkClosed,
         prevLedger);
@@ -1538,19 +1495,19 @@ bool NetworkOPsImp::beginConsensus (uint256 const& networkClosed)
 
 uint256 NetworkOPsImp::getConsensusLCL ()
 {
-    return mConsensus->prevLedgerID ();
+    return mConsensus.prevLedgerID ();
 }
 
 void NetworkOPsImp::processTrustedProposal (
-    RCLCxPeerPos::pointer peerPos,
+    RCLCxPeerPos peerPos,
     std::shared_ptr<protocol::TMProposeSet> set,
     NodeID const& node)
 {
-    mConsensus->storeProposal (peerPos, node);
-
-    if (mConsensus->peerProposal (
-        app_.timeKeeper().closeTime(), peerPos->proposal()))
-        app_.overlay().relay(*set, peerPos->getSuppressionID());
+    if (mConsensus.peerProposal(
+            app_.timeKeeper().closeTime(), peerPos))
+    {
+        app_.overlay().relay(*set, peerPos.suppressionID());
+    }
     else
         JLOG(m_journal.info()) << "Not relaying trusted proposal";
 }
@@ -1573,7 +1530,7 @@ NetworkOPsImp::mapComplete (
 
     // We acquired it because consensus asked us to
     if (fromAcquire)
-        mConsensus->gotTxSet (
+        mConsensus.gotTxSet (
             app_.timeKeeper().closeTime(),
             RCLTxSet{map});
 }
@@ -1591,7 +1548,42 @@ void NetworkOPsImp::endConsensus ()
         }
     }
 
-    tryStartConsensus();
+    uint256 networkClosed;
+    bool ledgerChange = checkLastClosedLedger (
+        app_.overlay ().getActivePeers (), networkClosed);
+
+    if (networkClosed.isZero ())
+        return;
+
+    // WRITEME: Unless we are in omFULL and in the process of doing a consensus,
+    // we must count how many nodes share our LCL, how many nodes disagree with
+    // our LCL, and how many validations our LCL has. We also want to check
+    // timing to make sure there shouldn't be a newer LCL. We need this
+    // information to do the next three tests.
+
+    if (((mMode == omCONNECTED) || (mMode == omSYNCING)) && !ledgerChange)
+    {
+        // Count number of peers that agree with us and UNL nodes whose
+        // validations we have for LCL.  If the ledger is good enough, go to
+        // omTRACKING - TODO
+        if (!mNeedNetworkLedger)
+            setMode (omTRACKING);
+    }
+
+    if (((mMode == omCONNECTED) || (mMode == omTRACKING)) && !ledgerChange)
+    {
+        // check if the ledger is good enough to go to omFULL
+        // Note: Do not go to omFULL if we don't have the previous ledger
+        // check if the ledger is bad enough to go to omCONNECTED -- TODO
+        auto current = m_ledgerMaster.getCurrentLedger();
+        if (app_.timeKeeper().now() <
+            (current->info().parentCloseTime + 2* current->info().closeTimeResolution))
+        {
+            setMode (omFULL);
+        }
+    }
+
+    beginConsensus (networkClosed);
 }
 
 void NetworkOPsImp::consensusViewChange ()
@@ -2125,7 +2117,7 @@ bool NetworkOPsImp::recvValidation (
 
 Json::Value NetworkOPsImp::getConsensusInfo ()
 {
-    return mConsensus->getJson (true);
+    return mConsensus.getJson (true);
 }
 
 Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
@@ -2151,7 +2143,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
 
     if (admin)
     {
-        if (getValidationPublicKey().size ())
+        if (!app_.getValidationPublicKey().empty())
         {
             info[jss::pubkey_validator] = toBase58 (
                 TokenType::TOKEN_NODE_PUBLIC,
@@ -2181,23 +2173,23 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
     info[jss::peers] = Json::UInt (app_.overlay ().size ());
 
     Json::Value lastClose = Json::objectValue;
-    lastClose[jss::proposers] = Json::UInt(mConsensus->prevProposers());
+    lastClose[jss::proposers] = Json::UInt(mConsensus.prevProposers());
 
     if (human)
     {
         lastClose[jss::converge_time_s] =
             std::chrono::duration<double>{
-                mConsensus->prevRoundTime()}.count();
+                mConsensus.prevRoundTime()}.count();
     }
     else
     {
         lastClose[jss::converge_time] =
-                Json::Int (mConsensus->prevRoundTime().count());
+                Json::Int (mConsensus.prevRoundTime().count());
     }
 
     info[jss::last_close] = lastClose;
 
-    //  info[jss::consensus] = mConsensus->getJson();
+    //  info[jss::consensus] = mConsensus.getJson();
 
     if (admin)
         info[jss::load] = m_job_queue.getJson ();
@@ -2771,7 +2763,7 @@ std::uint32_t NetworkOPsImp::acceptLedger (
     // FIXME Could we improve on this and remove the need for a specialized
     // API in Consensus?
     beginConsensus (m_ledgerMaster.getClosedLedger()->info().hash);
-    mConsensus->simulate (app_.timeKeeper().closeTime(), consensusDelay);
+    mConsensus.simulate (app_.timeKeeper().closeTime(), consensusDelay);
     return m_ledgerMaster.getCurrentLedger ()->info().seq;
 }
 
@@ -3368,10 +3360,10 @@ std::unique_ptr<NetworkOPs>
 make_NetworkOPs (Application& app, NetworkOPs::clock_type& clock, bool standalone,
     std::size_t network_quorum, bool startvalid,
     JobQueue& job_queue, LedgerMaster& ledgerMaster,
-    Stoppable& parent, beast::Journal journal)
+    Stoppable& parent, ValidatorKeys const & validatorKeys, beast::Journal journal)
 {
     return std::make_unique<NetworkOPsImp> (app, clock, standalone, network_quorum,
-        startvalid, job_queue, ledgerMaster, parent, journal);
+        startvalid, job_queue, ledgerMaster, parent, validatorKeys, journal);
 }
 
 } // ripple

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -41,6 +41,7 @@ namespace ripple {
 class Peer;
 class LedgerMaster;
 class Transaction;
+class ValidatorKeys;
 
 // This is the primary interface into the "client" portion of the program.
 // Code that wants to do normal operations on the network such as
@@ -150,7 +151,7 @@ public:
     //--------------------------------------------------------------------------
 
     // ledger proposal/close functions
-    virtual void processTrustedProposal (RCLCxPeerPos::pointer peerPos,
+    virtual void processTrustedProposal (RCLCxPeerPos peerPos,
         std::shared_ptr<protocol::TMProposeSet> set,
             NodeID const& node) = 0;
 
@@ -174,9 +175,6 @@ public:
     virtual bool isAmendmentBlocked () = 0;
     virtual void setAmendmentBlocked () = 0;
     virtual void consensusViewChange () = 0;
-    virtual PublicKey const& getValidationPublicKey () const = 0;
-    virtual void setValidationKeys (
-        SecretKey const& valSecret, PublicKey const& valPublic) = 0;
 
     virtual Json::Value getConsensusInfo () = 0;
     virtual Json::Value getServerInfo (bool human, bool admin) = 0;
@@ -242,7 +240,7 @@ std::unique_ptr<NetworkOPs>
 make_NetworkOPs (Application& app, NetworkOPs::clock_type& clock, bool standalone,
     std::size_t network_quorum, bool start_valid,
     JobQueue& job_queue, LedgerMaster& ledgerMaster,
-    Stoppable& parent, beast::Journal journal);
+    Stoppable& parent, ValidatorKeys const & validatorKeys, beast::Journal journal);
 
 } // ripple
 

--- a/src/ripple/app/misc/ValidatorKeys.h
+++ b/src/ripple/app/misc/ValidatorKeys.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012-2017 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -17,20 +17,38 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
+#ifndef RIPPLE_APP_MISC_VALIDATOR_KEYS_H_INCLUDED
+#define RIPPLE_APP_MISC_VALIDATOR_KEYS_H_INCLUDED
 
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <ripple/beast/utility/Journal.h>
+#include <ripple/protocol/PublicKey.h>
+#include <ripple/protocol/SecretKey.h>
+#include <string>
 
-#include <ripple/app/misc/impl/AccountTxPaging.cpp>
-#include <ripple/app/misc/impl/AmendmentTable.cpp>
-#include <ripple/app/misc/impl/LoadFeeTrack.cpp>
-#include <ripple/app/misc/impl/Manifest.cpp>
-#include <ripple/app/misc/impl/Transaction.cpp>
-#include <ripple/app/misc/impl/TxQ.cpp>
-#include <ripple/app/misc/impl/ValidatorList.cpp>
-#include <ripple/app/misc/impl/ValidatorSite.cpp>
-#include <ripple/app/misc/impl/ValidatorKeys.cpp>
+namespace ripple {
+
+class Config;
+
+/** Validator keys and manifest as set in configuration file.  Values will be
+    empty if not configured as a validator or not configured with a manifest.
+*/
+class ValidatorKeys
+{
+public:
+    PublicKey publicKey;
+    SecretKey secretKey;
+    std::string manifest;
+    ValidatorKeys(Config const& config, beast::Journal j);
+
+    bool configInvalid() const
+    {
+        return configInvalid_;
+    }
+
+private:
+    bool configInvalid_ = false; //< Set to true if config was invalid
+};
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/app/misc/impl/ValidatorKeys.cpp
+++ b/src/ripple/app/misc/impl/ValidatorKeys.cpp
@@ -1,0 +1,73 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/misc/ValidatorKeys.h>
+
+#include <ripple/app/misc/Manifest.h>
+#include <ripple/basics/Log.h>
+#include <ripple/core/Config.h>
+#include <ripple/core/ConfigSections.h>
+
+namespace ripple {
+ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
+{
+    if (config.exists(SECTION_VALIDATOR_TOKEN) &&
+        config.exists(SECTION_VALIDATION_SEED))
+    {
+        configInvalid_ = true;
+        JLOG(j.fatal()) << "Cannot specify both [" SECTION_VALIDATION_SEED
+                           "] and [" SECTION_VALIDATOR_TOKEN "]";
+        return;
+    }
+
+    if (config.exists(SECTION_VALIDATOR_TOKEN))
+    {
+        if (auto const token = ValidatorToken::make_ValidatorToken(
+                config.section(SECTION_VALIDATOR_TOKEN).lines()))
+        {
+            secretKey = token->validationSecret;
+            publicKey = derivePublicKey(KeyType::secp256k1, secretKey);
+            manifest = std::move(token->manifest);
+        }
+        else
+        {
+            configInvalid_ = true;
+            JLOG(j.fatal())
+                << "Invalid token specified in [" SECTION_VALIDATOR_TOKEN "]";
+        }
+    }
+    else if (config.exists(SECTION_VALIDATION_SEED))
+    {
+        auto const seed = parseBase58<Seed>(
+            config.section(SECTION_VALIDATION_SEED).lines().front());
+        if (!seed)
+        {
+            configInvalid_ = true;
+            JLOG(j.fatal()) <<
+                "Invalid seed specified in [" SECTION_VALIDATION_SEED "]";
+        }
+        else
+        {
+            secretKey = generateSecretKey(KeyType::secp256k1, *seed);
+            publicKey = derivePublicKey(KeyType::secp256k1, secretKey);
+        }
+    }
+}
+}  // namespace ripple

--- a/src/ripple/consensus/Consensus.cpp
+++ b/src/ripple/consensus/Consensus.cpp
@@ -102,7 +102,7 @@ checkConsensusReached(
 
     std::size_t currentPercentage = (agreeing * 100) / total;
 
-    return currentPercentage > minConsensusPct;
+    return currentPercentage >= minConsensusPct;
 }
 
 ConsensusState

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -25,6 +25,7 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/consensus/ConsensusProposal.h>
 #include <ripple/consensus/ConsensusParms.h>
+#include <ripple/consensus/ConsensusTypes.h>
 #include <ripple/consensus/LedgerTiming.h>
 #include <ripple/consensus/DisputedTx.h>
 #include <ripple/json/json_writer.h>
@@ -62,14 +63,6 @@ shouldCloseLedger(
     std::chrono::milliseconds idleInterval,
     ConsensusParms const & parms,
     beast::Journal j);
-
-
-/** Whether we have or don't have a consensus */
-enum class ConsensusState {
-    No,       //!< We do not have consensus
-    MovedOn,  //!< The network has consensus without us
-    Yes       //!< We have consensus along with the network
-};
 
 /** Determine whether the network reached consensus and whether we joined.
 
@@ -109,7 +102,8 @@ checkConsensus(
   The basic flow:
 
     1. A call to `startRound` places the node in the `Open` phase.  In this
-       phase, the node is waiting for transactions to include in its open ledger.
+       phase, the node is waiting for transactions to include in its open
+       ledger.
     2. Successive calls to `timerEntry` check if the node can close the ledger.
        Once the node `Close`s the open ledger, it transitions to the
        `Establish` phase.  In this phase, the node shares/receives peer
@@ -122,13 +116,17 @@ checkConsensus(
        ledger with the network, does some book-keeping, then makes a call to
        `startRound` to start the cycle again.
 
-  This class uses CRTP to allow adapting Consensus for specific applications.
+  This class uses a generic interface to allow adapting Consensus for specific
+  applications. The Adaptor template implements a set of helper functions that
+  plug the consensus algorithm into a specific application.  It also identifies
+  the types that play important roles in Consensus (transactions, ledgers, ...).
+  The code stubs below outline the interface and type requirements.  The traits
+  types must be copy constructible and assignable.
 
-  The Derived template argument is used to embed consensus within the
-  larger application framework. The Traits template identifies types that
-  play important roles in Consensus (transactions, ledgers, etc.) and which must
-  conform to the generic interface outlined below. The Traits types must be copy
-  constructible and assignable.
+  @warning The generic implementation is not thread safe and the public methods
+  are not intended to be run concurrently.  When in a concurrent environment,
+  the application is responsible for ensuring thread-safety.  Simply locking
+  whenever touching the Consensus instance is one option.
 
   @code
   // A single transaction
@@ -189,24 +187,35 @@ checkConsensus(
     Json::Value getJson() const;
   };
 
-  struct Traits
+  // Wraps a peer's ConsensusProposal
+  struct PeerPosition
   {
-    using Ledger_t = Ledger;
-    using NodeID_t = std::uint32_t;
-    using TxSet_t = TxSet;
-  }
+    ConsensusProposal<
+        std::uint32_t, //NodeID,
+        typename Ledger::ID,
+        typename TxSet::ID> const &
+    proposal() const;
 
-  class ConsensusImp : public Consensus<ConsensusImp, Traits>
+  };
+
+
+  class Adaptor
   {
+  public:
+      //-----------------------------------------------------------------------
+      // Define consensus types
+      using Ledger_t = Ledger;
+      using NodeID_t = std::uint32_t;
+      using TxSet_t = TxSet;
+      using PeerPosition_t = PeerPosition;
+
+      //-----------------------------------------------------------------------
+      //
       // Attempt to acquire a specific ledger.
       boost::optional<Ledger> acquireLedger(Ledger::ID const & ledgerID);
 
       // Acquire the transaction set associated with a proposed position.
       boost::optional<TxSet> acquireTxSet(TxSet::ID const & setID);
-
-      // Get peers' proposed positions. Returns an iterable
-      // with value_type convertable to ConsensusPosition<...>
-      auto const & proposals(Ledger::ID const & ledgerID);
 
       // Whether any transactions are in the open ledger
       bool hasOpenTransactions() const;
@@ -224,6 +233,8 @@ checkConsensus(
                       Ledger const & prevLedger,
                       Mode mode);
 
+      // Called whenever consensus operating mode changes
+      void onModeChange(ConsensusMode before, ConsensusMode after);
 
       // Called when ledger closes
       Result onClose(Ledger const &, Ledger const & prev, Mode mode);
@@ -247,9 +258,7 @@ checkConsensus(
       void propose(ConsensusProposal<...> const & pos);
 
       // Relay a received peer proposal on to other peer's.
-      // The argument type should be convertible to ConsensusProposal<...>
-      // but may be a different type.
-      void relay(implementation_defined const & pos);
+      void relay(PeerPosition_t const & prop);
 
       // Relay a disputed transaction to peers
       void relay(Txn const & tx);
@@ -257,159 +266,53 @@ checkConsensus(
       // Share given transaction set with peers
       void relay(TxSet const &s);
 
+      // Consensus timing parameters and constants
+      ConsensusParms const &
+      parms() const;
   };
   @endcode
 
-  @tparam Derived The deriving class which adapts the Consensus algorithm.
-  @tparam Traits Provides definitions of types used in Consensus.
+  @tparam Adaptor Defines types and provides helper functions needed to adapt
+                  Consensus to the larger application.
 */
-template <class Derived, class Traits>
+template <class Adaptor>
 class Consensus
 {
-    //! Phases of consensensus:
-    //!        "close"             "accept"
-    //!   open ------- > establish ---------> accepted
-    //!     ^               |                    |
-    //!     |---------------|                    |
-    //!     ^                     "startRound"   |
-    //!     |------------------------------------|
-    //!
-    //! The typical transition goes from open to establish to accepted and
-    //! then a call to startRound begins the process anew.
-    //! However, if a wrong prior ledger is detected and recovered
-    //! during the establish or accept phase, consensus will internally go back
-    //! to open (see handleWrongLedger).
-    enum class Phase {
-        //! We haven't closed our ledger yet, but others might have
-        open,
-
-        //! Establishing consensus by exchanging proposals with our peers
-        establish,
-
-        //! We have accepted a new last closed ledger and are waiting on a call
-        //! to startRound to begin the next consensus round.  No changes
-        //! to consensus phase occur while in this phase.
-        accepted,
-    };
-
-    using Ledger_t = typename Traits::Ledger_t;
-    using TxSet_t = typename Traits::TxSet_t;
-    using NodeID_t = typename Traits::NodeID_t;
+    using Ledger_t = typename Adaptor::Ledger_t;
+    using TxSet_t = typename Adaptor::TxSet_t;
+    using NodeID_t = typename Adaptor::NodeID_t;
     using Tx_t = typename TxSet_t::Tx;
+    using PeerPosition_t = typename Adaptor::PeerPosition_t;
     using Proposal_t = ConsensusProposal<
         NodeID_t,
         typename Ledger_t::ID,
         typename TxSet_t::ID>;
 
-protected:
-    //! How we participating in Consensus
-    //!    proposing               observing
-    //!       \                       /
-    //|        \---> wrongLedger <---/
-    //!                   ^
-    //!                   |
-    //!                   |
-    //!                   v
-    //!              switchedLedger
-    //! We enter the round proposing or observing. If we detect we
-    //! are working on the wrong prior ledger, we go to
-    //! wrongLedger and attempt to acquire the right one (ref
-    //! handleWrongLedger). Once we acquire the right one, we go to
-    //! switchedLedger.  If we again detect the wrongLedger before this round
-    //! ends, we go back to wrongLedger until we acquire the right one.
-    enum class Mode {
-        //! We a normal participant in consensus and propose our position
-        proposing,
-        //! We are observing peer positions, but not proposing our position
-        observing,
-        //! We have the wrong ledger and are attempting to acquire it
-        wrongLedger,
-        //! We switched ledger since we started this consensus round but are now
-        //! running on what we believe is the correct ledger.  This mode is as
-        //! if we entered the round observing, but is used to indicate we did
-        //! have the wrongLedger at some point.
-        switchedLedger
-    };
+    using Result = ConsensusResult<Adaptor>;
 
-    //! Measure duration of phases of consensus
-    class Stopwatch
+    // Helper class to ensure adaptor is notified whenver the ConsensusMode
+    // changes
+    class MonitoredMode
     {
-        using time_point = std::chrono::steady_clock::time_point;
-        time_point start_;
-        std::chrono::milliseconds dur_;
+        ConsensusMode mode_;
 
     public:
-        std::chrono::milliseconds
-        read() const
+        MonitoredMode(ConsensusMode m) : mode_{m}
         {
-            return dur_;
+        }
+        ConsensusMode
+        get() const
+        {
+            return mode_;
         }
 
         void
-        tick(std::chrono::milliseconds fixed)
+        set(ConsensusMode mode, Adaptor& a)
         {
-            dur_ += fixed;
-        }
-
-        void
-        reset(time_point tp)
-        {
-            start_ = tp;
-            dur_ = std::chrono::milliseconds{0};
-        }
-
-        void
-        tick(time_point tp)
-        {
-            using namespace std::chrono;
-            dur_ = duration_cast<milliseconds>(tp - start_);
+            a.onModeChange(mode_, mode);
+            mode_ = mode;
         }
     };
-
-    //! Initial ledger close times, not rounded by closeTimeResolution
-    struct CloseTimes
-    {
-        // Close time estimates, keep ordered for predictable traverse
-        std::map<NetClock::time_point, int> peers;
-        NetClock::time_point self;
-    };
-
-    /** Enacpsulates the result of consensus.
-
-        While in the establish phase, represents our work in progress consensus
-        result.  In the accept phase, represents our final consensus result
-        for this round.
-    */
-    struct Result
-    {
-        using Dispute_t = DisputedTx<Tx_t, NodeID_t>;
-
-        Result(TxSet_t&& s, Proposal_t&& p)
-            : set{std::move(s)}, position{std::move(p)}
-        {
-            assert(set.id() == position.position());
-        }
-
-        //! The set of transactions consensus agrees go in the ledger
-        TxSet_t set;
-
-        //! Our proposed position on transactions/close time
-        Proposal_t position;
-
-        //! Transactions which are under dispute with our peers
-        hash_map<typename Tx_t::ID, Dispute_t> disputes;
-
-        // Set of TxSet ids we have already compared/created disputes
-        hash_set<typename TxSet_t::ID> compares;
-
-        // Measures the duration of the establish phase for this consensus round
-        Stopwatch roundTime;
-
-        // Indicates state in which consensus ended.  Once in the accept phase
-        // will be either Yes or MovedOn
-        ConsensusState state = ConsensusState::No;
-    };
-
 public:
     //! Clock type for measuring time within the consensus code
     using clock_type = beast::abstract_clock<std::chrono::steady_clock>;
@@ -419,10 +322,10 @@ public:
     /** Constructor.
 
         @param clock The clock used to internally sample consensus progress
-        @param p Consensus parameters to use
+        @param adaptor The instance of the adaptor class
         @param j The journal to log debug output
     */
-    Consensus(clock_type const& clock, ConsensusParms const & p, beast::Journal j);
+    Consensus(clock_type const& clock, Adaptor& adaptor, beast::Journal j);
 
     /** Kick-off the next round of consensus.
 
@@ -452,7 +355,7 @@ public:
     bool
     peerProposal(
         NetClock::time_point const& now,
-        Proposal_t const& newProposal);
+        PeerPosition_t const& newProposal);
 
     /** Call periodically to drive consensus forward.
 
@@ -500,37 +403,7 @@ public:
     typename Ledger_t::ID
     prevLedgerID() const
     {
-        std::lock_guard<std::recursive_mutex> _(*lock_);
         return prevLedgerID_;
-    }
-
-    //! Get the number of proposing peers that participated in the previous
-    //! round.
-    std::size_t
-    prevProposers() const
-    {
-        return prevProposers_;
-    }
-
-    /** Get duration of the previous round.
-
-        The duration of the round is the establish phase, measured from closing
-        the open ledger to accepting the consensus result.
-
-        @return Last round duration in milliseconds
-    */
-    std::chrono::milliseconds
-    prevRoundTime() const
-    {
-        return prevRoundTime_;
-    }
-
-    /** Get the current consensus mode.
-     */
-    Mode
-    mode() const
-    {
-        return mode_;
     }
 
     /** Get the Json state of the consensus process.
@@ -543,31 +416,13 @@ public:
     Json::Value
     getJson(bool full) const;
 
-    /** Get the consensus parameters
-    */
-    ConsensusParms const &
-    parms() const
-    {
-        return parms_;
-    }
-protected:
-
-    // Prevent deleting derived instance through base pointer
-    ~Consensus() = default;
-
-    /** Revoke our outstanding proposal, if any, and cease proposing
-        until this round ends.
-    */
-    void
-    leaveConsensus();
-
 private:
     void
     startRoundInternal(
         NetClock::time_point const& now,
         typename Ledger_t::ID const& prevLedgerID,
         Ledger_t const& prevLedger,
-        Mode mode);
+        ConsensusMode mode);
 
     // Change our view of the previous ledger
     void
@@ -586,6 +441,13 @@ private:
     */
     void
     playbackProposals();
+
+    /** Handle a replayed or a new peer proposal.
+    */
+    bool
+    peerProposalInternal(
+        NetClock::time_point const& now,
+        PeerPosition_t const& newProposal);
 
     /** Handle pre-close phase.
 
@@ -627,24 +489,16 @@ private:
     void
     updateDisputes(NodeID_t const& node, TxSet_t const& other);
 
-    Derived&
-    impl()
-    {
-        return *static_cast<Derived*>(this);
-    }
-
-    static std::string
-    to_string(Phase p);
-
-    static std::string
-    to_string(Mode m);
+    // Revoke our outstanding proposal, if any, and cease proposing
+    // until this round ends.
+    void
+    leaveConsensus();
 
 private:
-    // TODO: Move this to clients
-    std::unique_ptr<std::recursive_mutex> lock_;
+    Adaptor& adaptor_;
 
-    Phase phase_ = Phase::accepted;
-    Mode mode_ = Mode::observing;
+    ConsensusPhase phase_{ConsensusPhase::accepted};
+    MonitoredMode mode_{ConsensusMode::observing};
     bool firstRound_ = true;
     bool haveCloseTimeConsensus_ = false;
 
@@ -655,7 +509,7 @@ private:
     int convergePercent_{0};
 
     // How long has this round been open
-    Stopwatch openTime_;
+    ConsensusTimer openTime_;
 
     NetClock::duration closeResolution_ = ledgerDefaultTimeResolution;
 
@@ -682,11 +536,17 @@ private:
     hash_map<typename TxSet_t::ID, const TxSet_t> acquired_;
 
     boost::optional<Result> result_;
-    CloseTimes rawCloseTimes_;
+    ConsensusCloseTimes rawCloseTimes_;
+
     //-------------------------------------------------------------------------
     // Peer related consensus data
-    // Convergence tracking, trusted peers indexed by hash of public key
-    hash_map<NodeID_t, Proposal_t> peerProposals_;
+
+    // Peer proposed positions for the current round
+    hash_map<NodeID_t, PeerPosition_t> currPeerPositions_;
+
+    // Recently received peer positions, available when transitioning between
+    // ledgers or roundss
+    hash_map<NodeID_t, std::deque<PeerPosition_t>> recentPeerPositions_;
 
     // The number of proposers who participated in the last consensus round
     std::size_t prevProposers_ = 0;
@@ -694,40 +554,34 @@ private:
     // nodes that have bowed out of this consensus process
     hash_set<NodeID_t> deadNodes_;
 
-    // Parameters that control consensus algorithm
-    ConsensusParms const parms_;
-
     // Journal for debugging
     beast::Journal j_;
 };
 
-template <class Derived, class Traits>
-Consensus<Derived, Traits>::Consensus(
+template <class Adaptor>
+Consensus<Adaptor>::Consensus(
     clock_type const& clock,
-    ConsensusParms const & p,
+    Adaptor& adaptor,
     beast::Journal journal)
-    : lock_{std::make_unique<std::recursive_mutex>()}
-    , clock_{clock}
-    , prevRoundTime_{p.ledgerIDLE_INTERVAL}
-    , parms_(p)
+    : adaptor_(adaptor)
+    , clock_(clock)
     , j_{journal}
 {
     JLOG(j_.debug()) << "Creating consensus object";
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::startRound(
+Consensus<Adaptor>::startRound(
     NetClock::time_point const& now,
     typename Ledger_t::ID const& prevLedgerID,
     Ledger_t prevLedger,
     bool proposing)
 {
-    std::lock_guard<std::recursive_mutex> _(*lock_);
-
     if (firstRound_)
     {
         // take our initial view of closeTime_ from the seed ledger
+        prevRoundTime_ = adaptor_.parms().ledgerIDLE_INTERVAL;
         prevCloseTime_ = prevLedger.closeTime();
         firstRound_ = false;
     }
@@ -736,41 +590,38 @@ Consensus<Derived, Traits>::startRound(
         prevCloseTime_ = rawCloseTimes_.self;
     }
 
-    Mode startMode = proposing ? Mode::proposing : Mode::observing;
+    ConsensusMode startMode =
+        proposing ? ConsensusMode::proposing : ConsensusMode::observing;
 
     // We were handed the wrong ledger
     if (prevLedger.id() != prevLedgerID)
     {
         // try to acquire the correct one
-        if(auto newLedger = impl().acquireLedger(prevLedgerID))
+        if (auto newLedger = adaptor_.acquireLedger(prevLedgerID))
         {
             prevLedger = *newLedger;
         }
-        else // Unable to acquire the correct ledger
+        else  // Unable to acquire the correct ledger
         {
-            startMode = Mode::wrongLedger;
+            startMode = ConsensusMode::wrongLedger;
             JLOG(j_.info())
                 << "Entering consensus with: " << previousLedger_.id();
             JLOG(j_.info()) << "Correct LCL is: " << prevLedgerID;
         }
     }
 
-    startRoundInternal(
-        now,
-        prevLedgerID,
-        prevLedger,
-        startMode);
+    startRoundInternal(now, prevLedgerID, prevLedger, startMode);
 }
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::startRoundInternal(
+Consensus<Adaptor>::startRoundInternal(
     NetClock::time_point const& now,
     typename Ledger_t::ID const& prevLedgerID,
     Ledger_t const& prevLedger,
-    Mode mode)
+    ConsensusMode mode)
 {
-    phase_ = Phase::open;
-    mode_ = mode;
+    phase_ = ConsensusPhase::open;
+    mode_.set(mode, adaptor_);
     now_ = now;
     prevLedgerID_ = prevLedgerID;
     previousLedger_ = prevLedger;
@@ -778,7 +629,7 @@ Consensus<Derived, Traits>::startRoundInternal(
     convergePercent_ = 0;
     haveCloseTimeConsensus_ = false;
     openTime_.reset(clock_.now());
-    peerProposals_.clear();
+    currPeerPositions_.clear();
     acquired_.clear();
     rawCloseTimes_.peers.clear();
     rawCloseTimes_.self = {};
@@ -790,7 +641,7 @@ Consensus<Derived, Traits>::startRoundInternal(
         previousLedger_.seq() + 1);
 
     playbackProposals();
-    if (peerProposals_.size() > (prevProposers_ / 2))
+    if (currPeerPositions_.size() > (prevProposers_ / 2))
     {
         // We may be falling behind, don't wait for the timer
         // consider closing the ledger immediately
@@ -798,25 +649,45 @@ Consensus<Derived, Traits>::startRoundInternal(
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 bool
-Consensus<Derived, Traits>::peerProposal(
+Consensus<Adaptor>::peerProposal(
     NetClock::time_point const& now,
-    Proposal_t const& newProposal)
+    PeerPosition_t const& newPeerPos)
 {
-    auto const peerID = newProposal.nodeID();
+    NodeID_t const& peerID = newPeerPos.proposal().nodeID();
 
-    std::lock_guard<std::recursive_mutex> _(*lock_);
+    // Always need to store recent positions
+    {
+        auto& props = recentPeerPositions_[peerID];
 
-    // Nothing to do if we are currently working on a ledger
-    if (phase_ == Phase::accepted)
+        if (props.size() >= 10)
+            props.pop_front();
+
+        props.push_back(newPeerPos);
+    }
+    return peerProposalInternal(now, newPeerPos);
+}
+
+template <class Adaptor>
+bool
+Consensus<Adaptor>::peerProposalInternal(
+    NetClock::time_point const& now,
+    PeerPosition_t const& newPeerPos)
+{
+    // Nothing to do for now if we are currently working on a ledger
+    if (phase_ == ConsensusPhase::accepted)
         return false;
 
     now_ = now;
 
-    if (newProposal.prevLedger() != prevLedgerID_)
+    Proposal_t const& newPeerProp = newPeerPos.proposal();
+
+    NodeID_t const& peerID = newPeerProp.nodeID();
+
+    if (newPeerProp.prevLedger() != prevLedgerID_)
     {
-        JLOG(j_.debug()) << "Got proposal for " << newProposal.prevLedger()
+        JLOG(j_.debug()) << "Got proposal for " << newPeerProp.prevLedger()
                          << " but we are on " << prevLedgerID_;
         return false;
     }
@@ -830,18 +701,18 @@ Consensus<Derived, Traits>::peerProposal(
 
     {
         // update current position
-        auto currentPosition = peerProposals_.find(peerID);
+        auto peerPosIt = currPeerPositions_.find(peerID);
 
-        if (currentPosition != peerProposals_.end())
+        if (peerPosIt != currPeerPositions_.end())
         {
-            if (newProposal.proposeSeq() <=
-                currentPosition->second.proposeSeq())
+            if (newPeerProp.proposeSeq() <=
+                peerPosIt->second.proposal().proposeSeq())
             {
                 return false;
             }
         }
 
-        if (newProposal.isBowOut())
+        if (newPeerProp.isBowOut())
         {
             using std::to_string;
 
@@ -851,59 +722,57 @@ Consensus<Derived, Traits>::peerProposal(
                 for (auto& it : result_->disputes)
                     it.second.unVote(peerID);
             }
-            if (currentPosition != peerProposals_.end())
-                peerProposals_.erase(peerID);
+            if (peerPosIt != currPeerPositions_.end())
+                currPeerPositions_.erase(peerID);
             deadNodes_.insert(peerID);
 
             return true;
         }
 
-        if (currentPosition != peerProposals_.end())
-            currentPosition->second = newProposal;
+        if (peerPosIt != currPeerPositions_.end())
+            peerPosIt->second = newPeerPos;
         else
-            peerProposals_.emplace(peerID, newProposal);
+            currPeerPositions_.emplace(peerID, newPeerPos);
     }
 
-    if (newProposal.isInitial())
+    if (newPeerProp.isInitial())
     {
         // Record the close time estimate
         JLOG(j_.trace()) << "Peer reports close time as "
-                         << newProposal.closeTime().time_since_epoch().count();
-        ++rawCloseTimes_.peers[newProposal.closeTime()];
+                         << newPeerProp.closeTime().time_since_epoch().count();
+        ++rawCloseTimes_.peers[newPeerProp.closeTime()];
     }
 
-    JLOG(j_.trace()) << "Processing peer proposal " << newProposal.proposeSeq()
-                     << "/" << newProposal.position();
+    JLOG(j_.trace()) << "Processing peer proposal " << newPeerProp.proposeSeq()
+                     << "/" << newPeerProp.position();
 
     {
-        auto ait = acquired_.find(newProposal.position());
+        auto const ait = acquired_.find(newPeerProp.position());
         if (ait == acquired_.end())
         {
             // acquireTxSet will return the set if it is available, or
             // spawn a request for it and return none/nullptr.  It will call
             // gotTxSet once it arrives
-            if (auto set = impl().acquireTxSet(newProposal.position()))
+            if (auto set = adaptor_.acquireTxSet(newPeerProp.position()))
                 gotTxSet(now_, *set);
             else
                 JLOG(j_.debug()) << "Don't have tx set for peer";
         }
         else if (result_)
         {
-            updateDisputes(newProposal.nodeID(), ait->second);
+            updateDisputes(newPeerProp.nodeID(), ait->second);
         }
     }
 
     return true;
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::timerEntry(NetClock::time_point const& now)
+Consensus<Adaptor>::timerEntry(NetClock::time_point const& now)
 {
-    std::lock_guard<std::recursive_mutex> _(*lock_);
-
     // Nothing to do if we are currently working on a ledger
-    if (phase_ == Phase::accepted)
+    if (phase_ == ConsensusPhase::accepted)
         return;
 
     now_ = now;
@@ -911,26 +780,24 @@ Consensus<Derived, Traits>::timerEntry(NetClock::time_point const& now)
     // Check we are on the proper ledger (this may change phase_)
     checkLedger();
 
-    if(phase_ == Phase::open)
+    if (phase_ == ConsensusPhase::open)
     {
         phaseOpen();
     }
-    else if (phase_ == Phase::establish)
+    else if (phase_ == ConsensusPhase::establish)
     {
         phaseEstablish();
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::gotTxSet(
+Consensus<Adaptor>::gotTxSet(
     NetClock::time_point const& now,
     TxSet_t const& txSet)
 {
-    std::lock_guard<std::recursive_mutex> _(*lock_);
-
     // Nothing to do if we've finished work on a ledger
-    if (phase_ == Phase::accepted)
+    if (phase_ == ConsensusPhase::accepted)
         return;
 
     now_ = now;
@@ -952,11 +819,11 @@ Consensus<Derived, Traits>::gotTxSet(
         // so this txSet must differ
         assert(id != result_->position.position());
         bool any = false;
-        for (auto const& p : peerProposals_)
+        for (auto const& it : currPeerPositions_)
         {
-            if (p.second.position() == id)
+            if (it.second.proposal().position() == id)
             {
-                updateDisputes(p.first, txSet);
+                updateDisputes(it.first, txSet);
                 any = true;
             }
         }
@@ -969,40 +836,42 @@ Consensus<Derived, Traits>::gotTxSet(
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::simulate(
+Consensus<Adaptor>::simulate(
     NetClock::time_point const& now,
     boost::optional<std::chrono::milliseconds> consensusDelay)
 {
-    std::lock_guard<std::recursive_mutex> _(*lock_);
-
     JLOG(j_.info()) << "Simulating consensus";
     now_ = now;
     closeLedger();
     result_->roundTime.tick(consensusDelay.value_or(100ms));
-    prevProposers_ = peerProposals_.size();
+    result_->proposers = prevProposers_ = currPeerPositions_.size();
     prevRoundTime_ = result_->roundTime.read();
-    phase_ = Phase::accepted;
-    impl().onForceAccept(
-        *result_, previousLedger_, closeResolution_, rawCloseTimes_, mode_);
+    phase_ = ConsensusPhase::accepted;
+    adaptor_.onForceAccept(
+        *result_,
+        previousLedger_,
+        closeResolution_,
+        rawCloseTimes_,
+        mode_.get(),
+        getJson(true));
     JLOG(j_.info()) << "Simulation complete";
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 Json::Value
-Consensus<Derived, Traits>::getJson(bool full) const
+Consensus<Adaptor>::getJson(bool full) const
 {
     using std::to_string;
     using Int = Json::Value::Int;
 
     Json::Value ret(Json::objectValue);
-    std::lock_guard<std::recursive_mutex> _(*lock_);
 
-    ret["proposing"] = (mode_ == Mode::proposing);
-    ret["proposers"] = static_cast<int>(peerProposals_.size());
+    ret["proposing"] = (mode_.get() == ConsensusMode::proposing);
+    ret["proposers"] = static_cast<int>(currPeerPositions_.size());
 
-    if (mode_ != Mode::wrongLedger)
+    if (mode_.get() != ConsensusMode::wrongLedger)
     {
         ret["synched"] = true;
         ret["ledger_seq"] = previousLedger_.seq() + 1;
@@ -1011,7 +880,7 @@ Consensus<Derived, Traits>::getJson(bool full) const
     else
         ret["synched"] = false;
 
-    ret["phase"] = Consensus::to_string(phase_);
+    ret["phase"] = to_string(phase_);
 
     if (result_ && !result_->disputes.empty() && !full)
         ret["disputes"] = static_cast<Int>(result_->disputes.size());
@@ -1030,11 +899,11 @@ Consensus<Derived, Traits>::getJson(bool full) const
         ret["previous_proposers"] = static_cast<Int>(prevProposers_);
         ret["previous_mseconds"] = static_cast<Int>(prevRoundTime_.count());
 
-        if (!peerProposals_.empty())
+        if (!currPeerPositions_.empty())
         {
             Json::Value ppj(Json::objectValue);
 
-            for (auto& pp : peerProposals_)
+            for (auto const& pp : currPeerPositions_)
             {
                 ppj[to_string(pp.first)] = pp.second.getJson();
             }
@@ -1044,7 +913,7 @@ Consensus<Derived, Traits>::getJson(bool full) const
         if (!acquired_.empty())
         {
             Json::Value acq(Json::arrayValue);
-            for (auto& at : acquired_)
+            for (auto const& at : acquired_)
             {
                 acq.append(to_string(at.first));
             }
@@ -1054,7 +923,7 @@ Consensus<Derived, Traits>::getJson(bool full) const
         if (result_ && !result_->disputes.empty())
         {
             Json::Value dsj(Json::objectValue);
-            for (auto& dt : result_->disputes)
+            for (auto const& dt : result_->disputes)
             {
                 dsj[to_string(dt.first)] = dt.second.getJson();
             }
@@ -1064,7 +933,7 @@ Consensus<Derived, Traits>::getJson(bool full) const
         if (!rawCloseTimes_.peers.empty())
         {
             Json::Value ctj(Json::objectValue);
-            for (auto& ct : rawCloseTimes_.peers)
+            for (auto const& ct : rawCloseTimes_.peers)
             {
                 ctj[std::to_string(ct.first.time_since_epoch().count())] =
                     ct.second;
@@ -1087,10 +956,9 @@ Consensus<Derived, Traits>::getJson(bool full) const
 }
 
 // Handle a change in the prior ledger during a consensus round
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::handleWrongLedger(
-    typename Ledger_t::ID const& lgrId)
+Consensus<Adaptor>::handleWrongLedger(typename Ledger_t::ID const& lgrId)
 {
     assert(lgrId != prevLedgerID_ || previousLedger_.id() != lgrId);
 
@@ -1109,7 +977,7 @@ Consensus<Derived, Traits>::handleWrongLedger(
             result_->compares.clear();
         }
 
-        peerProposals_.clear();
+        currPeerPositions_.clear();
         rawCloseTimes_.peers.clear();
         deadNodes_.clear();
 
@@ -1121,65 +989,75 @@ Consensus<Derived, Traits>::handleWrongLedger(
         return;
 
     // we need to switch the ledger we're working from
-    if (auto newLedger = impl().acquireLedger(prevLedgerID_))
+    if (auto newLedger = adaptor_.acquireLedger(prevLedgerID_))
     {
         JLOG(j_.info()) << "Have the consensus ledger " << prevLedgerID_;
-        startRoundInternal(now_, lgrId, *newLedger, Mode::switchedLedger);
+        startRoundInternal(
+            now_, lgrId, *newLedger, ConsensusMode::switchedLedger);
     }
     else
     {
-        mode_ = Mode::wrongLedger;
+        mode_.set(ConsensusMode::wrongLedger, adaptor_);
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::checkLedger()
+Consensus<Adaptor>::checkLedger()
 {
-    auto netLgr = impl().getPrevLedger(prevLedgerID_, previousLedger_, mode_);
+    auto netLgr =
+        adaptor_.getPrevLedger(prevLedgerID_, previousLedger_, mode_.get());
 
     if (netLgr != prevLedgerID_)
     {
         JLOG(j_.warn()) << "View of consensus changed during "
                         << to_string(phase_) << " status=" << to_string(phase_)
                         << ", "
-                        << " mode=" << to_string(mode_);
+                        << " mode=" << to_string(mode_.get());
         JLOG(j_.warn()) << prevLedgerID_ << " to " << netLgr;
         JLOG(j_.warn()) << previousLedger_.getJson();
+        JLOG(j_.debug()) << "State on consensus change " << getJson(true);
         handleWrongLedger(netLgr);
     }
     else if (previousLedger_.id() != prevLedgerID_)
         handleWrongLedger(netLgr);
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::playbackProposals()
+Consensus<Adaptor>::playbackProposals()
 {
-    for (auto const& p : impl().proposals(prevLedgerID_))
+    for (auto const& it : recentPeerPositions_)
     {
-        if (peerProposal(now_, p))
-            impl().relay(p);
+        for (auto const& pos : it.second)
+        {
+            if (pos.proposal().prevLedger() == prevLedgerID_)
+            {
+                if (peerProposalInternal(now_, pos))
+                    adaptor_.relay(pos);
+            }
+        }
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::phaseOpen()
+Consensus<Adaptor>::phaseOpen()
 {
     using namespace std::chrono;
 
     // it is shortly before ledger close time
-    bool anyTransactions = impl().hasOpenTransactions();
-    auto proposersClosed = peerProposals_.size();
-    auto proposersValidated = impl().proposersValidated(prevLedgerID_);
+    bool anyTransactions = adaptor_.hasOpenTransactions();
+    auto proposersClosed = currPeerPositions_.size();
+    auto proposersValidated = adaptor_.proposersValidated(prevLedgerID_);
 
     openTime_.tick(clock_.now());
 
     // This computes how long since last ledger's close time
     milliseconds sinceClose;
     {
-        bool previousCloseCorrect = (mode_ != Mode::wrongLedger) &&
+        bool previousCloseCorrect =
+            (mode_.get() != ConsensusMode::wrongLedger) &&
             previousLedger_.closeAgree() &&
             (previousLedger_.closeTime() !=
              (previousLedger_.parentCloseTime() + 1s));
@@ -1195,7 +1073,7 @@ Consensus<Derived, Traits>::phaseOpen()
     }
 
     auto const idleInterval = std::max<milliseconds>(
-        parms_.ledgerIDLE_INTERVAL,
+        adaptor_.parms().ledgerIDLE_INTERVAL,
         2 * previousLedger_.closeTimeResolution());
 
     // Decide if we should close the ledger
@@ -1208,28 +1086,31 @@ Consensus<Derived, Traits>::phaseOpen()
             sinceClose,
             openTime_.read(),
             idleInterval,
-            parms_,
+            adaptor_.parms(),
             j_))
     {
         closeLedger();
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::phaseEstablish()
+Consensus<Adaptor>::phaseEstablish()
 {
     // can only establish consensus if we already took a stance
     assert(result_);
 
     using namespace std::chrono;
+    ConsensusParms const & parms = adaptor_.parms();
+
     result_->roundTime.tick(clock_.now());
+    result_->proposers = currPeerPositions_.size();
 
     convergePercent_ = result_->roundTime.read() * 100 /
-        std::max<milliseconds>(prevRoundTime_, parms_.avMIN_CONSENSUS_TIME);
+        std::max<milliseconds>(prevRoundTime_, parms.avMIN_CONSENSUS_TIME);
 
     // Give everyone a chance to take an initial position
-    if (result_->roundTime.read() < parms_.ledgerMIN_CONSENSUS)
+    if (result_->roundTime.read() < parms.ledgerMIN_CONSENSUS)
         return;
 
     updateOurPositions();
@@ -1244,40 +1125,45 @@ Consensus<Derived, Traits>::phaseEstablish()
         return;
     }
 
-    JLOG(j_.info()) << "Converge cutoff (" << peerProposals_.size()
+    JLOG(j_.info()) << "Converge cutoff (" << currPeerPositions_.size()
                     << " participants)";
-    prevProposers_ = peerProposals_.size();
+    prevProposers_ = currPeerPositions_.size();
     prevRoundTime_ = result_->roundTime.read();
-    phase_ = Phase::accepted;
-    impl().onAccept(
-        *result_, previousLedger_, closeResolution_, rawCloseTimes_, mode_);
+    phase_ = ConsensusPhase::accepted;
+    adaptor_.onAccept(
+        *result_,
+        previousLedger_,
+        closeResolution_,
+        rawCloseTimes_,
+        mode_.get(),
+        getJson(true));
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::closeLedger()
+Consensus<Adaptor>::closeLedger()
 {
     // We should not be closing if we already have a position
     assert(!result_);
 
-    phase_ = Phase::establish;
+    phase_ = ConsensusPhase::establish;
     rawCloseTimes_.self = now_;
 
-    result_.emplace(impl().onClose(previousLedger_, now_, mode_));
+    result_.emplace(adaptor_.onClose(previousLedger_, now_, mode_.get()));
     result_->roundTime.reset(clock_.now());
     // Share the newly created transaction set if we haven't already
     // received it from a peer
     if (acquired_.emplace(result_->set.id(), result_->set).second)
-        impl().relay(result_->set);
+        adaptor_.relay(result_->set);
 
-    if (mode_ == Mode::proposing)
-        impl().propose(result_->position);
+    if (mode_.get() == ConsensusMode::proposing)
+        adaptor_.propose(result_->position);
 
     // Create disputes with any peer positions we have transactions for
-    for (auto const& p : peerProposals_)
+    for (auto const& pit : currPeerPositions_)
     {
-        auto pos = p.second.position();
-        auto it = acquired_.find(pos);
+        auto const& pos = pit.second.proposal().position();
+        auto const it = acquired_.find(pos);
         if (it != acquired_.end())
         {
             createDisputes(it->second);
@@ -1305,37 +1191,39 @@ participantsNeeded(int participants, int percent)
     return (result == 0) ? 1 : result;
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::updateOurPositions()
+Consensus<Adaptor>::updateOurPositions()
 {
     // We must have a position if we are updating it
     assert(result_);
+    ConsensusParms const & parms = adaptor_.parms();
 
     // Compute a cutoff time
-    auto const peerCutoff = now_ - parms_.proposeFRESHNESS;
-    auto const ourCutoff = now_ - parms_.proposeINTERVAL;
+    auto const peerCutoff = now_ - parms.proposeFRESHNESS;
+    auto const ourCutoff = now_ - parms.proposeINTERVAL;
 
     // Verify freshness of peer positions and compute close times
     std::map<NetClock::time_point, int> effCloseTimes;
     {
-        auto it = peerProposals_.begin();
-        while (it != peerProposals_.end())
+        auto it = currPeerPositions_.begin();
+        while (it != currPeerPositions_.end())
         {
-            if (it->second.isStale(peerCutoff))
+            Proposal_t const& peerProp = it->second.proposal();
+            if (peerProp.isStale(peerCutoff))
             {
                 // peer's proposal is stale, so remove it
-                auto const& peerID = it->second.nodeID();
+                NodeID_t const& peerID = peerProp.nodeID();
                 JLOG(j_.warn()) << "Removing stale proposal from " << peerID;
                 for (auto& dt : result_->disputes)
                     dt.second.unVote(peerID);
-                it = peerProposals_.erase(it);
+                it = currPeerPositions_.erase(it);
             }
             else
             {
                 // proposal is still fresh
                 ++effCloseTimes[effCloseTime(
-                    it->second.closeTime(),
+                    peerProp.closeTime(),
                     closeResolution_,
                     previousLedger_.closeTime())];
                 ++it;
@@ -1354,7 +1242,9 @@ Consensus<Derived, Traits>::updateOurPositions()
             // Because the threshold for inclusion increases,
             //  time can change our position on a dispute
             if (it.second.updateVote(
-                    convergePercent_, (mode_ == Mode::proposing), parms_))
+                    convergePercent_,
+                    mode_.get()== ConsensusMode::proposing,
+                    parms))
             {
                 if (!mutableSet)
                     mutableSet.emplace(result_->set);
@@ -1379,7 +1269,7 @@ Consensus<Derived, Traits>::updateOurPositions()
     NetClock::time_point consensusCloseTime = {};
     haveCloseTimeConsensus_ = false;
 
-    if (peerProposals_.empty())
+    if (currPeerPositions_.empty())
     {
         // no other times
         haveCloseTimeConsensus_ = true;
@@ -1392,17 +1282,17 @@ Consensus<Derived, Traits>::updateOurPositions()
     {
         int neededWeight;
 
-        if (convergePercent_ < parms_.avMID_CONSENSUS_TIME)
-            neededWeight = parms_.avINIT_CONSENSUS_PCT;
-        else if (convergePercent_ < parms_.avLATE_CONSENSUS_TIME)
-            neededWeight = parms_.avMID_CONSENSUS_PCT;
-        else if (convergePercent_ < parms_.avSTUCK_CONSENSUS_TIME)
-            neededWeight = parms_.avLATE_CONSENSUS_PCT;
+        if (convergePercent_ < parms.avMID_CONSENSUS_TIME)
+            neededWeight = parms.avINIT_CONSENSUS_PCT;
+        else if (convergePercent_ < parms.avLATE_CONSENSUS_TIME)
+            neededWeight = parms.avMID_CONSENSUS_PCT;
+        else if (convergePercent_ < parms.avSTUCK_CONSENSUS_TIME)
+            neededWeight = parms.avLATE_CONSENSUS_PCT;
         else
-            neededWeight = parms_.avSTUCK_CONSENSUS_PCT;
+            neededWeight = parms.avSTUCK_CONSENSUS_PCT;
 
-        int participants = peerProposals_.size();
-        if (mode_ == Mode::proposing)
+        int participants = currPeerPositions_.size();
+        if (mode_.get() == ConsensusMode::proposing)
         {
             ++effCloseTimes[effCloseTime(
                 result_->position.closeTime(),
@@ -1416,9 +1306,9 @@ Consensus<Derived, Traits>::updateOurPositions()
 
         // Threshold to declare consensus
         int const threshConsensus =
-            participantsNeeded(participants, parms_.avCT_CONSENSUS_PCT);
+            participantsNeeded(participants, parms.avCT_CONSENSUS_PCT);
 
-        JLOG(j_.info()) << "Proposers:" << peerProposals_.size()
+        JLOG(j_.info()) << "Proposers:" << currPeerPositions_.size()
                         << " nw:" << neededWeight << " thrV:" << threshVote
                         << " thrC:" << threshConsensus;
 
@@ -1444,8 +1334,9 @@ Consensus<Derived, Traits>::updateOurPositions()
         {
             JLOG(j_.debug())
                 << "No CT consensus:"
-                << " Proposers:" << peerProposals_.size()
-                << " Mode:" << to_string(mode_) << " Thresh:" << threshConsensus
+                << " Proposers:" << currPeerPositions_.size()
+                << " Mode:" << to_string(mode_.get())
+                << " Thresh:" << threshConsensus
                 << " Pos:" << consensusCloseTime.time_since_epoch().count();
         }
     }
@@ -1479,26 +1370,26 @@ Consensus<Derived, Traits>::updateOurPositions()
         if (acquired_.emplace(newID, result_->set).second)
         {
             if (!result_->position.isBowOut())
-                impl().relay(result_->set);
+                adaptor_.relay(result_->set);
 
-            for (auto const& p : peerProposals_)
+            for (auto const& it : currPeerPositions_)
             {
-                if (p.second.position() == newID)
-                {
-                    updateDisputes(p.first, result_->set);
-                }
+                Proposal_t const& p = it.second.proposal();
+                if (p.position() == newID)
+                    updateDisputes(it.first, result_->set);
             }
         }
 
         // Share our new position if we are still participating this round
-        if (!result_->position.isBowOut() && (mode_ == Mode::proposing))
-            impl().propose(result_->position);
+        if (!result_->position.isBowOut() &&
+            (mode_.get() == ConsensusMode::proposing))
+            adaptor_.propose(result_->position);
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 bool
-Consensus<Derived, Traits>::haveConsensus()
+Consensus<Adaptor>::haveConsensus()
 {
     // Must have a stance if we are checking for consensus
     assert(result_);
@@ -1509,9 +1400,10 @@ Consensus<Derived, Traits>::haveConsensus()
     auto ourPosition = result_->position.position();
 
     // Count number of agreements/disagreements with our position
-    for (auto& it : peerProposals_)
+    for (auto const& it : currPeerPositions_)
     {
-        if (it.second.position() == ourPosition)
+        Proposal_t const& peerProp = it.second.proposal();
+        if (peerProp.position() == ourPosition)
         {
             ++agree;
         }
@@ -1520,11 +1412,11 @@ Consensus<Derived, Traits>::haveConsensus()
             using std::to_string;
 
             JLOG(j_.debug()) << to_string(it.first) << " has "
-                             << to_string(it.second.position());
+                             << to_string(peerProp.position());
             ++disagree;
         }
     }
-    auto currentFinished = impl().proposersFinished(prevLedgerID_);
+    auto currentFinished = adaptor_.proposersFinished(prevLedgerID_);
 
     JLOG(j_.debug()) << "Checking for TX consensus: agree=" << agree
                      << ", disagree=" << disagree;
@@ -1537,8 +1429,8 @@ Consensus<Derived, Traits>::haveConsensus()
         currentFinished,
         prevRoundTime_,
         result_->roundTime.read(),
-        parms_,
-        mode_ == Mode::proposing,
+        adaptor_.parms(),
+        mode_.get() == ConsensusMode::proposing,
         j_);
 
     if (result_->state == ConsensusState::No)
@@ -1555,26 +1447,26 @@ Consensus<Derived, Traits>::haveConsensus()
     return true;
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::leaveConsensus()
+Consensus<Adaptor>::leaveConsensus()
 {
-    if (mode_ == Mode::proposing)
+    if (mode_.get() == ConsensusMode::proposing)
     {
         if (result_ && !result_->position.isBowOut())
         {
             result_->position.bowOut(now_);
-            impl().propose(result_->position);
+            adaptor_.propose(result_->position);
         }
 
-        mode_ = Mode::observing;
+        mode_.set(ConsensusMode::observing, adaptor_);
         JLOG(j_.info()) << "Bowing out of consensus";
     }
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::createDisputes(TxSet_t const& o)
+Consensus<Adaptor>::createDisputes(TxSet_t const& o)
 {
     // Cannot create disputes without our stance
     assert(result_);
@@ -1613,25 +1505,23 @@ Consensus<Derived, Traits>::createDisputes(TxSet_t const& o)
         typename Result::Dispute_t dtx{tx, result_->set.exists(txID), j_};
 
         // Update all of the available peer's votes on the disputed transaction
-        for (auto& pit : peerProposals_)
+        for (auto const& pit : currPeerPositions_)
         {
-            auto cit(acquired_.find(pit.second.position()));
-
+            Proposal_t const& peerProp = pit.second.proposal();
+            auto const cit = acquired_.find(peerProp.position());
             if (cit != acquired_.end())
                 dtx.setVote(pit.first, cit->second.exists(txID));
         }
-        impl().relay(dtx.tx());
+        adaptor_.relay(dtx.tx());
 
         result_->disputes.emplace(txID, std::move(dtx));
     }
     JLOG(j_.debug()) << dc << " differences found";
 }
 
-template <class Derived, class Traits>
+template <class Adaptor>
 void
-Consensus<Derived, Traits>::updateDisputes(
-    NodeID_t const& node,
-    TxSet_t const& other)
+Consensus<Adaptor>::updateDisputes(NodeID_t const& node, TxSet_t const& other)
 {
     // Cannot updateDisputes without our stance
     assert(result_);
@@ -1648,41 +1538,6 @@ Consensus<Derived, Traits>::updateDisputes(
     }
 }
 
-template <class Derived, class Traits>
-std::string
-Consensus<Derived, Traits>::to_string(Phase p)
-{
-    switch (p)
-    {
-        case Phase::open:
-            return "open";
-        case Phase::establish:
-            return "establish";
-        case Phase::accepted:
-            return "accepted";
-        default:
-            return "unknown";
-    }
-}
-
-template <class Derived, class Traits>
-std::string
-Consensus<Derived, Traits>::to_string(Mode m)
-{
-    switch (m)
-    {
-        case Mode::proposing:
-            return "proposing";
-        case Mode::observing:
-            return "observing";
-        case Mode::wrongLedger:
-            return "wrongLedger";
-        case Mode::switchedLedger:
-            return "switchedLedger";
-        default:
-            return "unknown";
-    }
-}
-}  // ripple
+}  // namespace ripple
 
 #endif

--- a/src/ripple/consensus/ConsensusTypes.h
+++ b/src/ripple/consensus/ConsensusTypes.h
@@ -1,0 +1,242 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_CONSENSUS_CONSENSUS_TYPES_H_INCLUDED
+#define RIPPLE_CONSENSUS_CONSENSUS_TYPES_H_INCLUDED
+
+#include <ripple/basics/chrono.h>
+#include <ripple/consensus/ConsensusProposal.h>
+#include <ripple/consensus/DisputedTx.h>
+#include <chrono>
+#include <map>
+
+namespace ripple {
+
+/** Represents how a node currently participates in Consensus.
+
+    A node participates in consensus in varying modes, depending on how
+    the node was configured by its operator and how well it stays in sync
+    with the network during consensus.
+
+    @code
+      proposing               observing
+         \                       /
+          \---> wrongLedger <---/
+                     ^
+                     |
+                     |
+                     v
+                switchedLedger
+   @endcode
+
+   We enter the round proposing or observing. If we detect we are working
+   on the wrong prior ledger, we go to wrongLedger and attempt to acquire
+   the right one. Once we acquire the right one, we go to the switchedLedger
+   mode.  It is possible we fall behind again and find there is a new better
+   ledger, moving back and forth between wrongLedger and switchLedger as
+   we attempt to catch up.
+*/
+enum class ConsensusMode {
+    //! We are normal participant in consensus and propose our position
+    proposing,
+    //! We are observing peer positions, but not proposing our position
+    observing,
+    //! We have the wrong ledger and are attempting to acquire it
+    wrongLedger,
+    //! We switched ledgers since we started this consensus round but are now
+    //! running on what we believe is the correct ledger.  This mode is as
+    //! if we entered the round observing, but is used to indicate we did
+    //! have the wrongLedger at some point.
+    switchedLedger
+};
+
+inline std::string
+to_string(ConsensusMode m)
+{
+    switch (m)
+    {
+        case ConsensusMode::proposing:
+            return "proposing";
+        case ConsensusMode::observing:
+            return "observing";
+        case ConsensusMode::wrongLedger:
+            return "wrongLedger";
+        case ConsensusMode::switchedLedger:
+            return "switchedLedger";
+        default:
+            return "unknown";
+    }
+}
+
+/** Phases of consensus for a single ledger round.
+
+    @code
+          "close"             "accept"
+     open ------- > establish ---------> accepted
+       ^               |                    |
+       |---------------|                    |
+       ^                     "startRound"   |
+       |------------------------------------|
+   @endcode
+
+   The typical transition goes from open to establish to accepted and
+   then a call to startRound begins the process anew. However, if a wrong prior
+   ledger is detected and recovered during the establish or accept phase,
+   consensus will internally go back to open (see Consensus::handleWrongLedger).
+*/
+enum class ConsensusPhase {
+    //! We haven't closed our ledger yet, but others might have
+    open,
+
+    //! Establishing consensus by exchanging proposals with our peers
+    establish,
+
+    //! We have accepted a new last closed ledger and are waiting on a call
+    //! to startRound to begin the next consensus round.  No changes
+    //! to consensus phase occur while in this phase.
+    accepted,
+};
+
+inline std::string
+to_string(ConsensusPhase p)
+{
+    switch (p)
+    {
+        case ConsensusPhase::open:
+            return "open";
+        case ConsensusPhase::establish:
+            return "establish";
+        case ConsensusPhase::accepted:
+            return "accepted";
+        default:
+            return "unknown";
+    }
+}
+
+/** Measures the duration of phases of consensus
+ */
+class ConsensusTimer
+{
+    using time_point = std::chrono::steady_clock::time_point;
+    time_point start_;
+    std::chrono::milliseconds dur_;
+
+public:
+    std::chrono::milliseconds
+    read() const
+    {
+        return dur_;
+    }
+
+    void
+    tick(std::chrono::milliseconds fixed)
+    {
+        dur_ += fixed;
+    }
+
+    void
+    reset(time_point tp)
+    {
+        start_ = tp;
+        dur_ = std::chrono::milliseconds{0};
+    }
+
+    void
+    tick(time_point tp)
+    {
+        using namespace std::chrono;
+        dur_ = duration_cast<milliseconds>(tp - start_);
+    }
+};
+
+/** Stores the set of initial close times
+
+    The initial consensus proposal from each peer has that peer's view of
+    when the ledger closed.  This object stores all those close times for
+    analysis of clock drift between peerss.
+*/
+struct ConsensusCloseTimes
+{
+    //! Close time estimates, keep ordered for predictable traverse
+    std::map<NetClock::time_point, int> peers;
+
+    //! Our close time estimate
+    NetClock::time_point self;
+};
+
+/** Whether we have or don't have a consensus */
+enum class ConsensusState {
+    No,       //!< We do not have consensus
+    MovedOn,  //!< The network has consensus without us
+    Yes       //!< We have consensus along with the network
+};
+
+/** Encapsulates the result of consensus.
+
+    Stores all relevant data for the outcome of consensus on a single
+   ledger.
+
+    @tparam Traits Traits class defining the concrete consensus types used
+                   by the application.
+*/
+template <class Traits>
+struct ConsensusResult
+{
+    using Ledger_t = typename Traits::Ledger_t;
+    using TxSet_t = typename Traits::TxSet_t;
+    using NodeID_t = typename Traits::NodeID_t;
+
+    using Tx_t = typename TxSet_t::Tx;
+    using Proposal_t = ConsensusProposal<
+        NodeID_t,
+        typename Ledger_t::ID,
+        typename TxSet_t::ID>;
+    using Dispute_t = DisputedTx<Tx_t, NodeID_t>;
+
+    ConsensusResult(TxSet_t&& s, Proposal_t&& p)
+        : set{std::move(s)}, position{std::move(p)}
+    {
+        assert(set.id() == position.position());
+    }
+
+    //! The set of transactions consensus agrees go in the ledger
+    TxSet_t set;
+
+    //! Our proposed position on transactions/close time
+    Proposal_t position;
+
+    //! Transactions which are under dispute with our peers
+    hash_map<typename Tx_t::ID, Dispute_t> disputes;
+
+    // Set of TxSet ids we have already compared/created disputes
+    hash_set<typename TxSet_t::ID> compares;
+
+    // Measures the duration of the establish phase for this consensus round
+    ConsensusTimer roundTime;
+
+    // Indicates state in which consensus ended.  Once in the accept phase
+    // will be either Yes or MovedOn
+    ConsensusState state = ConsensusState::No;
+
+    // The number of peers proposing during the round
+    std::size_t proposers = 0;
+};
+}  // namespace ripple
+
+#endif

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -451,7 +451,7 @@ private:
     void
     checkPropose (Job& job,
         std::shared_ptr<protocol::TMProposeSet> const& packet,
-            RCLCxPeerPos::pointer peerPos);
+            RCLCxPeerPos peerPos);
 
     void
     checkValidation (STValidation::pointer val,

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -87,6 +87,12 @@ public:
         return size_;
     }
 
+    bool
+    empty() const noexcept
+    {
+        return size_ == 0;
+    }
+
     Slice
     slice() const noexcept
     {

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -1,0 +1,150 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/misc/ValidatorKeys.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/core/Config.h>
+#include <ripple/core/ConfigSections.h>
+#include <string>
+
+namespace ripple {
+namespace test {
+
+class ValidatorKeys_test : public beast::unit_test::suite
+{
+    // Used with [validation_seed]
+    const std::string seed = "shUwVw52ofnCUX5m7kPTKzJdr4HEH";
+
+    // Used with [validation_token]
+    const std::string tokenSecretStr =
+        "paQmjZ37pKKPMrgadBLsuf9ab7Y7EUNzh27LQrZqoexpAs31nJi";
+
+    const std::vector<std::string> tokenBlob = {
+        "    "
+        "eyJ2YWxpZGF0aW9uX3NlY3JldF9rZXkiOiI5ZWQ0NWY4NjYyNDFjYzE4YTI3NDdiNT\n",
+        " \tQzODdjMDYyNTkwNzk3MmY0ZTcxOTAyMzFmYWE5Mzc0NTdmYTlkYWY2IiwibWFuaWZl "
+        "    \n",
+        "\tc3QiOiJKQUFBQUFGeEllMUZ0d21pbXZHdEgyaUNjTUpxQzlnVkZLaWxHZncxL3ZDeE"
+        "\n",
+        "\t "
+        "hYWExwbGMyR25NaEFrRTFhZ3FYeEJ3RHdEYklENk9NU1l1TTBGREFscEFnTms4U0tG\t  "
+        "\t\n",
+        "bjdNTzJmZGtjd1JRSWhBT25ndTlzQUtxWFlvdUorbDJWMFcrc0FPa1ZCK1pSUzZQU2\n",
+        "hsSkFmVXNYZkFpQnNWSkdlc2FhZE9KYy9hQVpva1MxdnltR21WcmxIUEtXWDNZeXd1\n",
+        "NmluOEhBU1FLUHVnQkQ2N2tNYVJGR3ZtcEFUSGxHS0pkdkRGbFdQWXk1QXFEZWRGdj\n",
+        "VUSmEydzBpMjFlcTNNWXl3TFZKWm5GT3I3QzBrdzJBaVR6U0NqSXpkaXRROD0ifQ==\n"};
+
+    const std::string tokenManifest =
+        "JAAAAAFxIe1FtwmimvGtH2iCcMJqC9gVFKilGfw1/vCxHXXLplc2GnMhAkE1agqXxBwD"
+        "wDbID6OMSYuM0FDAlpAgNk8SKFn7MO2fdkcwRQIhAOngu9sAKqXYouJ+l2V0W+sAOkVB"
+        "+ZRS6PShlJAfUsXfAiBsVJGesaadOJc/aAZokS1vymGmVrlHPKWX3Yywu6in8HASQKPu"
+        "gBD67kMaRFGvmpATHlGKJdvDFlWPYy5AqDedFv5TJa2w0i21eq3MYywLVJZnFOr7C0kw"
+        "2AiTzSCjIzditQ8=";
+
+public:
+    void
+    run() override
+    {
+        beast::Journal j;
+
+        // Keys when using [validation_seed]
+        auto const seedSecretKey =
+            generateSecretKey(KeyType::secp256k1, *parseBase58<Seed>(seed));
+        auto const seedPublicKey =
+            derivePublicKey(KeyType::secp256k1, seedSecretKey);
+
+        // Keys when using [validation_token]
+        auto const tokenSecretKey = *parseBase58<SecretKey>(
+            TokenType::TOKEN_NODE_PRIVATE, tokenSecretStr);
+
+        auto const tokenPublicKey =
+            derivePublicKey(KeyType::secp256k1, tokenSecretKey);
+
+        {
+            // No config -> no key but valid
+            Config c;
+            ValidatorKeys k{c, j};
+            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(k.manifest.empty());
+            BEAST_EXPECT(!k.configInvalid());
+
+        }
+        {
+            // validation seed section -> empty manifest and valid seeds
+            Config c;
+            c.section(SECTION_VALIDATION_SEED).append(seed);
+
+            ValidatorKeys k{c, j};
+            BEAST_EXPECT(k.publicKey == seedPublicKey);
+            BEAST_EXPECT(k.secretKey == seedSecretKey);
+            BEAST_EXPECT(k.manifest.empty());
+            BEAST_EXPECT(!k.configInvalid());
+        }
+
+        {
+            // validation seed bad seed -> invalid
+            Config c;
+            c.section(SECTION_VALIDATION_SEED).append("badseed");
+
+            ValidatorKeys k{c, j};
+            BEAST_EXPECT(k.configInvalid());
+            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(k.manifest.empty());
+        }
+
+        {
+            // validator token
+            Config c;
+            c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
+            ValidatorKeys k{c, j};
+
+            BEAST_EXPECT(k.publicKey == tokenPublicKey);
+            BEAST_EXPECT(k.secretKey == tokenSecretKey);
+            BEAST_EXPECT(k.manifest == tokenManifest);
+            BEAST_EXPECT(!k.configInvalid());
+        }
+        {
+            // invalid validator token
+            Config c;
+            c.section(SECTION_VALIDATOR_TOKEN).append("badtoken");
+            ValidatorKeys k{c, j};
+            BEAST_EXPECT(k.configInvalid());
+            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(k.manifest.empty());
+        }
+
+        {
+            // Cannot specify both
+            Config c;
+            c.section(SECTION_VALIDATION_SEED).append(seed);
+            c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
+            ValidatorKeys k{c, j};
+
+            BEAST_EXPECT(k.configInvalid());
+            BEAST_EXPECT(k.publicKey.size() == 0);
+            BEAST_EXPECT(k.manifest.empty());
+        }
+
+    }
+};  // namespace test
+
+BEAST_DEFINE_TESTSUITE(ValidatorKeys, app, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/unity/app_test_unity.cpp
+++ b/src/test/unity/app_test_unity.cpp
@@ -45,6 +45,7 @@
 #include <test/app/Transaction_ordering_test.cpp>
 #include <test/app/TrustAndBalance_test.cpp>
 #include <test/app/TxQ_test.cpp>
+#include <test/app/ValidatorKeys_test.cpp>
 #include <test/app/ValidatorList_test.cpp>
 #include <test/app/ValidatorSite_test.cpp>
 #include <test/app/SetTrust_test.cpp>


### PR DESCRIPTION
This PR includes changes that move consensus thread safety logic from the generic implementation in `Consensus` into the RCL adapted version `RCLConsensus`.  This has the advantage of placing the concurrency responsibilities in one spot in the code and additionally improves the performance of the consensus simulation framework by eliminating the uneeded concurrency overhead.  The two primary changes are:

1. Switch from a CRTP design to an `Adaptor` design for generic `Consensus`.  Previously, CRTP was used to allow the specializing class to call into the generic `Consensus` code while servicing some of its required callback members (e.g. `onClose` could call some other member of `Consensus`).  The `Adaptor` design makes the communication from `Consensus` to the specializations in `Adaptor` more explicit by passing any dependencies as arguments to the callback functions. 

2.  Move the thread safety logic from `Consensus` to `RCLConsensus`.   I now use `atomic`s to hold status related information at the `RCLConsensus` level to avoid acquiring a mutex just to read a value.  There is still room for improving the design, particularly when dispatching the `onAccept` call to the job queue, but I think this is still better.  Although not necessary, I still use a `recursive_mutex` instead of a regular `mutex` in `RCLConsensus` to protect any future refactoring from breaking things.

This is the last planned substantial refactor of the consensus code before focusing fully on the simulation framework.

Doc preview: http://bachase.github.io/ripd1389/