### PR TITLE
Server overlay improvements

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -211,9 +211,11 @@ PeerImp::send (Message::pointer const& m)
         large_sendq_ = 0;
     }
     else if ((sendq_size % Tuning::sendQueueLogFreq) == 0)
+    {
         JLOG (journal_.debug()) <<
-            (name_.empty() ? to_string(remote_address_) : name_) <<
+            (name_.empty() ? remote_address_.to_string() : name_) <<
                 " sendq: " << sendq_size;
+    }
 
     send_queue_.push(m);
 
@@ -447,7 +449,8 @@ PeerImp::fail(std::string const& reason)
     if (socket_.is_open())
     {
         JLOG (journal_.warn()) <<
-            (name_.empty() ? to_string(remote_address_) : name_) << " failed: " << reason;
+            (name_.empty() ? remote_address_.to_string() : name_) <<
+                " failed: " << reason;
     }
     close();
 }

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -210,6 +210,10 @@ PeerImp::send (Message::pointer const& m)
         // a small senq periodically
         large_sendq_ = 0;
     }
+    else if ((sendq_size % Tuning::sendQueueLogFreq) == 0)
+        JLOG (journal_.debug()) <<
+            (name_.empty() ? to_string(remote_address_) : name_) <<
+                " sendq: " << sendq_size;
 
     send_queue_.push(m);
 
@@ -442,7 +446,8 @@ PeerImp::fail(std::string const& reason)
                 shared_from_this(), reason));
     if (socket_.is_open())
     {
-        JLOG (journal_.warn()) << reason;
+        JLOG (journal_.warn()) <<
+            (name_.empty() ? to_string(remote_address_) : name_) << " failed: " << reason;
     }
     close();
 }

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -73,7 +73,7 @@ enum
     targetSendQueue     =   128,
 
     /** How often to log send queue size */
-    sendQueueLogFreq    =    16,
+    sendQueueLogFreq    =    64,
 };
 
 } // Tuning

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -52,13 +52,13 @@ enum
 
     /** How many milliseconds to consider high latency
         on a peer connection */
-    peerHighLatency     =  250,
+    peerHighLatency     =  300,
 
     /** How often we check connections (seconds) */
-    checkSeconds        =   10,
+    checkSeconds        =   32,
 
     /** How often we latency/sendq probe connections */
-    timerSeconds        =    4,
+    timerSeconds        =    8,
 
     /** How many timer intervals a sendq has to stay large before we disconnect */
     sendqIntervals      =    4,
@@ -67,10 +67,13 @@ enum
     noPing              =   10,
 
     /** How many messages on a send queue before we refuse queries */
-    dropSendQueue       =    8,
+    dropSendQueue       =   192,
 
     /** How many messages we consider reasonable sustained on a send queue */
-    targetSendQueue     =   16,
+    targetSendQueue     =   128,
+
+    /** How often to log send queue size */
+    sendQueueLogFreq    =    16,
 };
 
 } // Tuning

--- a/src/ripple/peerfinder/impl/Bootcache.cpp
+++ b/src/ripple/peerfinder/impl/Bootcache.cpp
@@ -225,7 +225,7 @@ Bootcache::onWrite (beast::PropertyStream::Map& map)
     for (auto iter = m_map.right.begin(); iter != m_map.right.end(); ++iter)
     {
         beast::PropertyStream::Map entry (entries);
-        entry["endpoint"] = to_string (iter->get_left());
+        entry["endpoint"] = iter->get_left().to_string();
         entry["valence"] = std::int32_t (iter->get_right().valence());
     }
 }

--- a/src/ripple/peerfinder/impl/Bootcache.h
+++ b/src/ripple/peerfinder/impl/Bootcache.h
@@ -110,6 +110,8 @@ private:
     bool m_needsUpdate;
 
 public:
+    static constexpr int staticValence = 32;
+
     using iterator = boost::transform_iterator <Transform,
         map_type::right_map::const_iterator>;
 
@@ -140,8 +142,11 @@ public:
     /** Load the persisted data from the Store into the container. */
     void load ();
 
-    /** Add the address to the cache. */
+    /** Add a newly-learned address to the cache. */
     bool insert (beast::IP::Endpoint const& endpoint);
+
+    /** Add a staticallyconfigured address to the cache. */
+    bool insertStatic (beast::IP::Endpoint const& endpoint);
 
     /** Called when an outbound connection handshake completes. */
     void on_success (beast::IP::Endpoint const& endpoint);

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -990,7 +990,7 @@ public:
         std::lock_guard<std::recursive_mutex> _(lock_);
         for (auto addr : list)
         {
-            if (bootcache_.insert (addr))
+            if (bootcache_.insertStatic (addr))
                 ++count;
         }
         return count;


### PR DESCRIPTION
We've seen some instability in the overlay network due to the increased load we've been seeing. This pull requests includes two major changes aimed at that problem and a few minor changes as well:

1) Peers configured into the boot cache are given a minimum priority when deciding which outbound connections to make. This helps to keep more connections to reliable peers and improves resistance to Sybil attacks.

2) The sendq tuning has been changed drastically. Measurements show that peers often hiccup to send queue sizes of a few hundred messages but then recover. This causes us to keep the connections much longer if they hiccup and also to wait longer before we start refusing to respond to their ledger queries.

Minor changes:

Periodically log the sizes of large peer send queues.
Improve logging of server disconnect reasons
Improve bootcache reporting in print output