### PR TITLE
Make sure we shut the door properly

### DIFF
--- a/src/ripple/server/impl/Door.h
+++ b/src/ripple/server/impl/Door.h
@@ -376,7 +376,8 @@ do_accept(boost::asio::yield_context do_yield)
             JLOG(j_.error()) <<
                 "accept: " << ec.message();
         }
-        if (ec == boost::asio::error::operation_aborted)
+        if ((ec == boost::asio::error::operation_aborted) ||
+            ! acceptor_.is_open())
             break;
         if (ec)
             continue;


### PR DESCRIPTION
A rare race condition could cause ripple to fail to shut down and instead spin producing a "Bad file descriptor" error. This closes the race condition by ensuring the door thread shuts down even if the attempt to close the door does not interrupt a pending async_accept operation.

Bug reported by ops, logging 250,000 errors per second!