### PR TITLE
Update source lib readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,122 +1,30 @@
-# src
+# rippled Source
 
 Some of these directories come from entire outside repositories brought in
-using git-subtree. This means that the source files are inserted directly
-into the rippled repository. They can be edited and committed just as if they
+using [git-subtree][]. This means that the source files are inserted directly
+into the `rippled` repository. They can be edited and committed just as if they
 were normal files.
+[git-subtree]: https://github.com/apenwarr/git-subtree
 
-However, if you create a commit that contains files both from a
-subtree, and from the ripple source tree please use care when designing
-the commit message, since it will appear in the subtree's individual
-repository when the changes are pushed back to the upstream.
+If you create a commit that contains files both from a subtree, and from the
+`rippled` source tree, please use care when designing the commit message, since
+it will appear in the subtree's individual repository when the changes are
+pushed back to the upstream. Better yet, do not mix files from subtrees and
+`ripple` in the same commit at all.
 
-When submitting pull request, make sure that any commits which include
-files from subtrees are isolated - i.e. do not mix files from subtrees
-and ripple in the same commit. This way, the commit message will make
-sense. We don't want to see "Fix pathfinding bug with XRP" appearing
-in the LevelDB or Beast commit log, for example.
+Source folders:
 
-About git-subtree:
-
-https://github.com/apenwarr/git-subtree <br>
-http://blogs.atlassian.com/2013/05/alternatives-to-git-submodule-git-subtree/ <br>
-
-<table align=left><tr>
-<th>dir</th>
-<th>What</th>
-</tr><tr>
-<td>beast</td>
-<td>Beast, the amazing cross-platform library.<br>
-    git@github.com:vinniefalco/Beast.git
-</td>
-</tr></table>
-
-## ./beast
-
-Beast, the amazing cross-platform library.
-
-Repository <br>
-```
-git@github.com:vinniefalco/Beast.git
-```
-Branch
-```
-master
-```
-
-## HyperLevelDB
-
-Ripple's fork of HyperLevelDB
-
-Repository <br>
-```
-git@github.com:ripple/HyperLevelDB.git
-```
-Branch
-```
-ripple-fork
-```
-
-## LevelDB
-
-Ripple's fork of LevelDB.
-
-Repository <br>
-```
-git@github.com:ripple/LevelDB.git
-```
-Branch
-```
-ripple-fork
-```
-
-## LightningDB (a.k.a. MDB)
-
-Ripple's fork of MDB, a fast memory-mapped key value database system.
-
-Repository <br>
-```
-git@github.com:ripple/LightningDB.git
-```
-Branch
-```
-ripple-fork
-```
-
-## websocket
-
-Ripple's fork of websocketpp has some incompatible changes and Ripple specific includes.
-
-Repository
-```
-git@github.com:ripple/websocketpp.git
-```
-Branch
-```
-ripple-fork
-```
-
-## protobuf
-
-Ripple's fork of protobuf. We've changed some names in order to support the
-unity-style of build (a single .cpp added to the project, instead of
-linking to a separately built static library).
-
-Repository
-```
-git@github.com:ripple/protobuf.git
-```
-Branch
-```
-master
-```
-
-**NOTE** Linux builds use the protobuf installed in /usr/lib. This will be
-fixed in a future revision.
-
-## SQLite
-
-Not technically a subtree but included here because it is a direct
-copy of the official SQLite distributions available here:
-
-http://sqlite.org/download.html
+| Folder          | Upstream Repo                                | Description |
+|:----------------|:---------------------------------------------|:------------|
+| `beast`         | https://github.com/vinniefalco/Beast         | Cross-platform library for WebSocket and HTTP built on [Boost.Asio](https://think-async.com/Asio) |
+| `ed25519-donna` | https://github.com/floodyberry/ed25519-donna | [Ed25519](http://ed25519.cr.yp.to/) digital signatures |
+| `lz4`           | https://github.com/lz4/lz4                   | LZ4 lossless compression algorithm |
+| `nudb`          | https://github.com/vinniefalco/NuDB          | Constant-time insert-only key/value database for SSD drives (Less memory usage than RocksDB.) |
+| `protobuf`      | https://github.com/google/protobuf           | Protocol buffer data interchange format. Ripple has changed some names in order to support the unity-style of build (a single .cpp added to the project, instead of linking to a separately built static library). |
+| `ripple`        | N/A                                          | **Core source code for `rippled`** |
+| `rocksdb2`      | https://github.com/facebook/rocksdb          | Fast key/value database. (Supports rotational disks better than NuDB.) |
+| `secp256k1`     | https://github.com/bitcoin-core/secp256k1    | ECDSA digital signatures using the **secp256k1** curve |
+| `snappy`        | https://github.com/google/snappy             | "Snappy" lossless compression algorithm. (Technically, the source is in `snappy/snappy`, while `snappy/` also has config options that aren't part of the upstream repository.) |
+| `soci`          | https://github.com/SOCI/soci                 | Abstraction layer for database access. |
+| `sqlite`        | https://www.sqlite.org/src                   | An embedded database engine that writes to simple files. (Technically not a subtree, just a direct copy of the [SQLite source distribution](http://sqlite.org/download.html).) |
+| `test`          | N/A                                          | **Unit tests for `rippled`** |


### PR DESCRIPTION
Resolves #2119.

I simplified the long list of included libs into a table, removed the ones that weren't there anymore, and added entries for the ones that didn't have entries.

At first I had a column for upstream branch, but it was "master" or "N/A" in all cases, so I dropped it.