### PR TITLE
OpenSSL 1.1 compatibility patches

### DIFF
--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -201,6 +201,7 @@ disallowRenegotiation (SSL const* ssl, bool isNew)
     return false;
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static
 void
 info_handler (SSL const* ssl, int event, int)
@@ -211,8 +212,16 @@ info_handler (SSL const* ssl, int event, int)
             ssl->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
     }
 }
-
+#else
 static
+void
+info_handler (SSL const* ssl, int event, int)
+{
+// empty
+}
+#endif
+static
+
 std::string
 error_message (std::string const& what,
     boost::system::error_code const& ec)

--- a/src/ripple/beast/asio/ssl_error.h
+++ b/src/ripple/beast/asio/ssl_error.h
@@ -68,8 +68,12 @@ inline
 bool
 is_short_read(boost::system::error_code const& ec)
 {
+#ifdef SSL_R_SHORT_READ
     return (ec.category() == boost::asio::error::get_ssl_category())
         && (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ);
+#else
+    return false;
+#endif
 }
 
 } // beast


### PR DESCRIPTION
OpenSSL removed SSL_R_SHORT_READ upstream

See #2047 

SSL_R_SHORT_READ was removed in https://github.com/openssl/openssl/commit/45f55f6a5bdcec411ef08a6f8aae41d5d3d234ad about 2.5 years ago.

This still will not allow rippled to build with OpenSSL 1.1.0, but it fixes one of the two main error sites (the other one being src/ripple/basics/impl/make_SSLContext.cpp, see #1914).

Edit: make_SSLContext.cpp is fixed now too, there was only a single problematic function and it tries to set a deprecated flag.