### PR TITLE
Add optional consensus hash field

### DIFF
--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -416,6 +416,7 @@ extern SF_U256 const sfAmendment;
 extern SF_U256 const sfTicketID;
 extern SF_U256 const sfDigest;
 extern SF_U256 const sfPayChannel;
+extern SF_U256 const sfConsensusHash;
 
 // currency amount (common)
 extern SF_Amount const sfAmount;

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -169,6 +169,7 @@ SF_U256 const sfAmendment     = make::one<SF_U256::type>(&sfAmendment,     STI_H
 SF_U256 const sfTicketID      = make::one<SF_U256::type>(&sfTicketID,      STI_HASH256, 20, "TicketID");
 SF_U256 const sfDigest        = make::one<SF_U256::type>(&sfDigest,        STI_HASH256, 21, "Digest");
 SF_U256 const sfPayChannel    = make::one<SF_U256::type>(&sfPayChannel,    STI_HASH256, 22, "Channel");
+SF_U256 const sfConsensusHash = make::one<SF_U256::type>(&sfConsensusHash, STI_HASH256, 23, "ConsensusHash");
 
 // currency amount (common)
 SF_Amount const sfAmount      = make::one<SF_Amount::type>(&sfAmount,      STI_AMOUNT,  1, "Amount");

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -161,10 +161,11 @@ SOTemplate const& STValidation::getFormat ()
             format.push_back (SOElement (sfSigningTime,     SOE_REQUIRED));
             format.push_back (SOElement (sfSigningPubKey,   SOE_REQUIRED));
             format.push_back (SOElement (sfSignature,       SOE_OPTIONAL));
+            format.push_back (SOElement (sfConsensusHash,   SOE_OPTIONAL));
         }
     };
 
-    static FormatHolder holder;
+    static const FormatHolder holder;
 
     return holder.format;
 }


### PR DESCRIPTION
Adds an optional field to `STValidation` for storing the hash of the consensus set.  This field will be populated in the future once all non amendment-blocked servers are running this code.  Sharing the consensus set hash in validations will help classify the source of different validated ledgers.