### PR TITLE
Replace beast streambuf with boost variant

### DIFF
--- a/src/ripple/app/misc/detail/WorkBase.h
+++ b/src/ripple/app/misc/detail/WorkBase.h
@@ -61,7 +61,7 @@ protected:
     socket_type socket_;
     request_type req_;
     response_type res_;
-    beast::streambuf read_buf_;
+    boost::asio::streambuf read_buf_;
 
 public:
     WorkBase(

--- a/src/ripple/overlay/impl/ConnectAttempt.h
+++ b/src/ripple/overlay/impl/ConnectAttempt.h
@@ -72,7 +72,7 @@ private:
     std::unique_ptr<beast::asio::ssl_bundle> ssl_bundle_;
     beast::asio::ssl_bundle::socket_type& socket_;
     beast::asio::ssl_bundle::stream_type& stream_;
-    beast::streambuf read_buf_;
+    boost::asio::streambuf read_buf_;
     response_type response_;
     PeerFinder::Slot::ptr slot_;
     request_type req_;

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -151,11 +151,11 @@ private:
     Resource::Consumer usage_;
     Resource::Charge fee_;
     PeerFinder::Slot::ptr slot_;
-    beast::streambuf read_buffer_;
+    boost::asio::streambuf read_buffer_;
     http_request_type request_;
     http_response_type response_;
     beast::http::fields const& headers_;
-    beast::streambuf write_buffer_;
+    boost::asio::streambuf write_buffer_;
     std::queue<Message::pointer> send_queue_;
     bool gracefulClose_ = false;
     int large_sendq_ = 0;

--- a/src/ripple/rpc/impl/WSInfoSub.h
+++ b/src/ripple/rpc/impl/WSInfoSub.h
@@ -74,17 +74,15 @@ public:
         auto sp = ws_.lock();
         if(! sp)
             return;
-        beast::streambuf sb;
+        auto sb = std::make_shared<StreambufWSMsg<boost::asio::streambuf>>();
         stream(jv,
             [&](void const* data, std::size_t n)
             {
-                sb.commit(boost::asio::buffer_copy(
-                    sb.prepare(n), boost::asio::buffer(data, n)));
+                auto& buf = sb->rdbuf();
+                buf.commit(boost::asio::buffer_copy(
+                    buf.prepare(n), boost::asio::buffer(data, n)));
             });
-        auto m = std::make_shared<
-            StreambufWSMsg<decltype(sb)>>(
-                std::move(sb));
-        sp->send(m);
+        sp->send(sb);
     }
 };
 

--- a/src/ripple/rpc/json_body.h
+++ b/src/ripple/rpc/json_body.h
@@ -23,6 +23,7 @@
 #include <ripple/json/json_value.h>
 #include <beast/core/streambuf.hpp>
 #include <beast/http/message.hpp>
+#include <boost/asio/streambuf.hpp>
 
 namespace ripple {
 
@@ -33,7 +34,7 @@ struct json_body
 
     class writer
     {
-        beast::streambuf sb_;
+        boost::asio::streambuf sb_;
 
     public:
         template<bool isRequest, class Fields>

--- a/src/ripple/server/SimpleWriter.h
+++ b/src/ripple/server/SimpleWriter.h
@@ -25,6 +25,7 @@
 #include <beast/core/write_dynabuf.hpp>
 #include <beast/http/message.hpp>
 #include <beast/http/write.hpp>
+#include <boost/asio/streambuf.hpp>
 #include <utility>
 
 namespace ripple {
@@ -32,7 +33,7 @@ namespace ripple {
 /// Deprecated: Writer that serializes a HTTP/1 message
 class SimpleWriter : public Writer
 {
-    beast::streambuf sb_;
+    boost::asio::streambuf sb_;
 
 public:
     template<bool isRequest, class Body, class Headers>

--- a/src/ripple/server/WSSession.h
+++ b/src/ripple/server/WSSession.h
@@ -74,9 +74,10 @@ class StreambufWSMsg : public WSMsg
     std::size_t n_ = 0;
 
 public:
-    StreambufWSMsg(Streambuf&& sb)
-        : sb_(std::move(sb))
+    Streambuf&
+    rdbuf()
     {
+        return sb_;
     }
 
     std::pair<boost::tribool,

--- a/src/ripple/server/impl/BaseWSPeer.h
+++ b/src/ripple/server/impl/BaseWSPeer.h
@@ -49,8 +49,8 @@ private:
 
     http_request_type request_;
     beast::websocket::opcode op_;
-    beast::streambuf rb_;
-    beast::streambuf wb_;
+    boost::asio::streambuf rb_;
+    boost::asio::streambuf wb_;
     std::list<std::shared_ptr<WSMsg>> wq_;
     bool do_close_ = false;
     beast::websocket::close_reason cr_;

--- a/src/ripple/server/impl/Door.h
+++ b/src/ripple/server/impl/Door.h
@@ -225,7 +225,7 @@ do_detect(boost::asio::yield_context do_yield)
 {
     bool ssl;
     error_code ec;
-    beast::streambuf buf(16);
+    boost::asio::streambuf buf(16);
     timer_.expires_from_now(std::chrono::seconds(15));
     std::tie(ec, ssl) = detect_ssl(socket_, buf, do_yield);
     error_code unused;

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -141,7 +141,7 @@ private:
     do_peer(int id, socket_type&& sock0)
     {
         socket_type sock(std::move(sock0));
-        beast::streambuf sb;
+        boost::asio::streambuf sb;
         error_code ec;
         for(;;)
         {

--- a/src/test/jtx/impl/JSONRPCClient.cpp
+++ b/src/test/jtx/impl/JSONRPCClient.cpp
@@ -75,7 +75,7 @@ class JSONRPCClient : public AbstractClient
     boost::asio::io_service ios_;
     boost::asio::ip::tcp::socket stream_;
     beast::streambuf bin_;
-    beast::streambuf bout_;
+    boost::asio::streambuf bout_;
     unsigned rpc_version_;
 
 public:
@@ -84,7 +84,7 @@ public:
         : ep_(getEndpoint(cfg))
         , stream_(ios_)
         , rpc_version_(rpc_version)
-    {   
+    {
         stream_.connect(ep_);
     }
 

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -96,7 +96,7 @@ class WSClientImpl : public WSClient
     boost::asio::ip::tcp::socket stream_;
     beast::websocket::stream<boost::asio::ip::tcp::socket&> ws_;
     beast::websocket::opcode op_;
-    beast::streambuf rb_;
+    boost::asio::streambuf rb_;
 
     bool peerClosed_ = false;
 


### PR DESCRIPTION
The beast streambuf class internally allocates one or more buffers of up to 4KB in size each. These buffers are contained in a linked list. The debug build frequently calls a debug_check function to validate the buffer data, including its size. The slow debug sync case occurred because enough data was stored where many small buffers were created. In my tests, I measured a peak of 2400 buffers in the list. Each iteration of the list creates a temporary value_type object that is solely used to gather its buffer size. So upon each peer connection, we iterate up to 2400 items, in which each constructs a temp object that is only used to gather its size. This is inefficient, to say the least. Not allowing a customization point for the buffer_size function is an unfortunate limitation of the boost library. If such customization were allowed, finding the total buffer size would be trivially inexpensive as it is already stored by the beast class.

The boost streambuf variant allocates a single buffer that reallocates when required. This means that calls to the debug_check function are significantly faster as they find their buffer size in a single call as opposed to iterating through a linked list. Additional performance benefits may be reaped as the number of allocations in the boost class will be much less.