### PR TITLE
Don't use JobQueue during shutdown (RIPD-1356):

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4479,6 +4479,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\core\JobQueue_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5238,6 +5238,9 @@
     <ClCompile Include="..\..\src\test\core\JobCounter_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\core\JobQueue_test.cpp">
+      <Filter>test\core</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\core\SociDB_test.cpp">
       <Filter>test\core</Filter>
     </ClCompile>

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -59,8 +59,8 @@ RCLValidationsPolicy::onStale(RCLValidation&& v)
     if (staleWriting_)
         return;
 
-    staleWriting_ = true;
-    app_.getJobQueue().addJob(
+    // addJob() may return false (Job not added) at shutdown.
+    staleWriting_  = app_.getJobQueue().addJob(
         jtWRITE, "Validations::doStaleWrite", [this](Job&) {
             auto event =
                 app_.getJobQueue().makeLoadEvent(jtDISK, "ValidationWrite");

--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -101,6 +101,15 @@ void OrderBookDB::update(
     {
         for(auto& sle : ledger->sles)
         {
+            if (isStopping())
+            {
+                JLOG (j_.info())
+                    << "OrderBookDB::update exiting due to isStopping";
+                std::lock_guard <std::recursive_mutex> sl (mLock);
+                mSeq = 0;
+                return;
+            }
+
             if (sle->getType () == ltDIR_NODE &&
                 sle->isFieldPresent (sfExchangeRate) &&
                 sle->getFieldH256 (sfRootIndex) == sle->key())

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -912,7 +912,7 @@ LedgerMaster::advanceThread()
 
     try
     {
-        doAdvance();
+        doAdvance(sl);
     }
     catch (std::exception const&)
     {
@@ -1152,6 +1152,7 @@ LedgerMaster::updatePaths (Job& job)
             {
                 JLOG (m_journal.debug())
                     << "Published ledger too old for updating paths";
+                ScopedLockType ml (m_mutex);
                 --mPathFindThread;
                 return;
             }
@@ -1186,48 +1187,51 @@ LedgerMaster::updatePaths (Job& job)
     }
 }
 
-void
+bool
 LedgerMaster::newPathRequest ()
 {
     ScopedLockType ml (m_mutex);
-    mPathFindNewRequest = true;
-
-    newPFWork("pf:newRequest");
+    mPathFindNewRequest = newPFWork("pf:newRequest", ml);
+    return mPathFindNewRequest;
 }
 
 bool
 LedgerMaster::isNewPathRequest ()
 {
     ScopedLockType ml (m_mutex);
-    if (!mPathFindNewRequest)
-        return false;
+    bool const ret = mPathFindNewRequest;
     mPathFindNewRequest = false;
-    return true;
+    return ret;
 }
 
 // If the order book is radically updated, we need to reprocess all
 // pathfinding requests.
-void
+bool
 LedgerMaster::newOrderBookDB ()
 {
     ScopedLockType ml (m_mutex);
     mPathLedger.reset();
 
-    newPFWork("pf:newOBDB");
+    return newPFWork("pf:newOBDB", ml);
 }
 
 /** A thread needs to be dispatched to handle pathfinding work of some kind.
 */
-void
-LedgerMaster::newPFWork (const char *name)
+bool
+LedgerMaster::newPFWork (const char *name, ScopedLockType&)
 {
     if (mPathFindThread < 2)
     {
-        ++mPathFindThread;
-        app_.getJobQueue().addJob (
+        if (app_.getJobQueue().addJob (
             jtUPDATE_PF, name,
-            [this] (Job& j) { updatePaths(j); });
+            [this] (Job& j) { updatePaths(j); }))
+        {
+            ++mPathFindThread;
+        }
     }
+    // If we're stopping don't give callers the expectation that their
+    // request will be fulfilled, even if it may be serviced.
+    return mPathFindThread > 0 && !isStopping();
 }
 
 std::recursive_mutex&
@@ -1513,7 +1517,7 @@ LedgerMaster::shouldAcquire (
 }
 
 // Try to publish ledgers, acquire missing ledgers
-void LedgerMaster::doAdvance ()
+void LedgerMaster::doAdvance (ScopedLockType& sl)
 {
     // TODO NIKB: simplify and unindent this a bit!
 
@@ -1700,9 +1704,8 @@ void LedgerMaster::doAdvance ()
                 }
             }
 
-            progress = true;
             app_.getOPs().clearNeedNetworkLedger();
-            newPFWork ("pf:newLedger");
+            progress = newPFWork ("pf:newLedger", sl);
         }
         if (progress)
             mAdvanceWork = true;

--- a/src/ripple/app/ledger/impl/TransactionAcquire.cpp
+++ b/src/ripple/app/ledger/impl/TransactionAcquire.cpp
@@ -82,6 +82,11 @@ void TransactionAcquire::done ()
         uint256 const& hash (mHash);
         std::shared_ptr <SHAMap> const& map (mMap);
         auto const pap = &app_;
+        // Note that, when we're in the process of shutting down, addJob()
+        // may reject the request.  If that happens then giveSet() will
+        // not be called.  That's fine.  According to David the giveSet() call
+        // just updates the consensus and related structures when we acquire
+        // a transaction set. No need to update them if we're shutting down.
         app_.getJobQueue().addJob (jtTXN_DATA, "completeAcquire",
             [pap, hash, map](Job&)
             {

--- a/src/ripple/app/main/NodeStoreScheduler.h
+++ b/src/ripple/app/main/NodeStoreScheduler.h
@@ -49,8 +49,8 @@ public:
 private:
     void doTask (NodeStore::Task& task);
 
-    JobQueue* m_jobQueue;
-    std::atomic <int> m_taskCount;
+    JobQueue* m_jobQueue {nullptr};
+    std::atomic <int> m_taskCount {0};
 };
 
 } // ripple

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -43,7 +43,6 @@
 #include <ripple/basics/UptimeTimer.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/core/DeadlineTimer.h>
-#include <ripple/core/JobCounter.h>
 #include <ripple/crypto/csprng.h>
 #include <ripple/crypto/RFC1751.h>
 #include <ripple/json/to_string.h>
@@ -216,8 +215,7 @@ public:
 
     ~NetworkOPsImp() override
     {
-        jobCounter_.join();
-        // this clear() is necessary to ensure the shared_ptrs in this map get
+        // This clear() is necessary to ensure the shared_ptrs in this map get
         // destroyed NOW because the objects in this map invoke methods on this
         // class when they are destroyed
         mRpcSubMap.clear();
@@ -493,9 +491,6 @@ public:
         m_heartbeatTimer.cancel();
         m_clusterTimer.cancel();
 
-        // Wait until all our in-flight Jobs are completed.
-        jobCounter_.join();
-
         stopped ();
     }
 
@@ -547,7 +542,6 @@ private:
 
     DeadlineTimer m_heartbeatTimer;
     DeadlineTimer m_clusterTimer;
-    JobCounter jobCounter_;
 
     std::shared_ptr<RCLConsensus> mConsensus;
 
@@ -664,14 +658,14 @@ void NetworkOPsImp::onDeadlineTimer (DeadlineTimer& timer)
 {
     if (timer == m_heartbeatTimer)
     {
-        m_job_queue.addCountedJob (
-            jtNETOP_TIMER, "NetOPs.heartbeat", jobCounter_,
+        m_job_queue.addJob (
+            jtNETOP_TIMER, "NetOPs.heartbeat",
             [this] (Job&) { processHeartbeatTimer(); });
     }
     else if (timer == m_clusterTimer)
     {
-        m_job_queue.addCountedJob (
-            jtNETOP_CLUSTER, "NetOPs.cluster", jobCounter_,
+        m_job_queue.addJob (
+            jtNETOP_CLUSTER, "NetOPs.cluster",
             [this] (Job&) { processClusterTimer(); });
     }
 }
@@ -840,8 +834,8 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
     auto tx = std::make_shared<Transaction> (
         trans, reason, app_);
 
-    m_job_queue.addCountedJob (
-        jtTRANSACTION, "submitTxn", jobCounter_,
+    m_job_queue.addJob (
+        jtTRANSACTION, "submitTxn",
         [this, tx] (Job&) {
             auto t = tx;
             processTransaction(t, false, false, FailHard::no);
@@ -907,8 +901,8 @@ void NetworkOPsImp::doTransactionAsync (std::shared_ptr<Transaction> transaction
 
     if (mDispatchState == DispatchState::none)
     {
-        if (m_job_queue.addCountedJob (
-            jtBATCH, "transactionBatch", jobCounter_,
+        if (m_job_queue.addJob (
+            jtBATCH, "transactionBatch",
             [this] (Job&) { transactionBatch(); }))
         {
             mDispatchState = DispatchState::scheduled;
@@ -942,8 +936,8 @@ void NetworkOPsImp::doTransactionSync (std::shared_ptr<Transaction> transaction,
             if (mTransactions.size())
             {
                 // More transactions need to be applied, but by another job.
-                if (m_job_queue.addCountedJob (
-                    jtBATCH, "transactionBatch", jobCounter_,
+                if (m_job_queue.addJob (
+                    jtBATCH, "transactionBatch",
                     [this] (Job&) { transactionBatch(); }))
                 {
                     mDispatchState = DispatchState::scheduled;
@@ -2474,8 +2468,8 @@ void NetworkOPsImp::reportFeeChange ()
     // only schedule the job if something has changed
     if (f != mLastFeeSummary)
     {
-        m_job_queue.addCountedJob (
-            jtCLIENT, "reportFeeChange->pubServer", jobCounter_,
+        m_job_queue.addJob (
+            jtCLIENT, "reportFeeChange->pubServer",
             [this] (Job&) { pubServer(); });
     }
 }
@@ -3312,10 +3306,6 @@ void NetworkOPsImp::getBookPage (
 
 NetworkOPs::NetworkOPs (Stoppable& parent)
     : InfoSub::Source ("NetworkOPs", parent)
-{
-}
-
-NetworkOPs::~NetworkOPs ()
 {
 }
 

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -20,14 +20,14 @@
 #ifndef RIPPLE_APP_MISC_NETWORKOPS_H_INCLUDED
 #define RIPPLE_APP_MISC_NETWORKOPS_H_INCLUDED
 
-#include <ripple/core/JobQueue.h>
-#include <ripple/protocol/STValidation.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/consensus/RCLCxPeerPos.h>
+#include <ripple/core/JobQueue.h>
+#include <ripple/core/Stoppable.h>
 #include <ripple/ledger/ReadView.h>
 #include <ripple/net/InfoSub.h>
+#include <ripple/protocol/STValidation.h>
 #include <memory>
-#include <ripple/core/Stoppable.h>
 #include <deque>
 #include <tuple>
 
@@ -95,7 +95,7 @@ public:
     }
 
 public:
-    virtual ~NetworkOPs () = 0;
+    ~NetworkOPs () override = default;
 
     //--------------------------------------------------------------------------
     //

--- a/src/ripple/app/paths/PathRequest.h
+++ b/src/ripple/app/paths/PathRequest.h
@@ -70,7 +70,7 @@ public:
         beast::Journal journal);
 
     // ripple_path_find semantics
-    // Completion function is called
+    // Completion function is called after path update is complete
     PathRequest (
         Application& app,
         std::function <void (void)> const& completion,
@@ -83,6 +83,8 @@ public:
 
     bool isNew ();
     bool needsUpdate (bool newOnly, LedgerIndex index);
+
+    // Called when the PathRequest update is complete.
     void updateComplete ();
 
     std::pair<bool, Json::Value> doCreate (

--- a/src/ripple/app/paths/PathRequests.cpp
+++ b/src/ripple/app/paths/PathRequests.cpp
@@ -23,6 +23,8 @@
 #include <ripple/app/main/Application.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/JobQueue.h>
+#include <ripple/net/RPCErr.h>
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/resource/Fees.h>
 #include <algorithm>
@@ -246,7 +248,12 @@ PathRequests::makeLegacyPathRequest(
     else
     {
         insertPathRequest (req);
-        app_.getLedgerMaster().newPathRequest();
+        if (! app_.getLedgerMaster().newPathRequest())
+        {
+            // The newPathRequest failed.  Tell the caller.
+            result.second = rpcError (rpcTOO_BUSY);
+            req.reset();
+        }
     }
 
     return std::move (result.second);

--- a/src/ripple/app/paths/PathRequests.h
+++ b/src/ripple/app/paths/PathRequests.h
@@ -33,6 +33,7 @@ namespace ripple {
 class PathRequests
 {
 public:
+    /** A collection of all PathRequest instances. */
     PathRequests (Application& app,
             beast::Journal journal, beast::insight::Collector::ptr const& collector)
         : app_ (app)
@@ -43,6 +44,11 @@ public:
         mFull = collector->make_event ("pathfind_full");
     }
 
+    /** Update all of the contained PathRequest instances.
+
+        @param ledger Ledger we are pathfinding in.
+        @param shouldCancel Invocable that returns whether to cancel.
+     */
     void updateAll (std::shared_ptr<ReadView const> const& ledger,
                     Job::CancelCallback shouldCancel);
 

--- a/src/ripple/core/Coro.ipp
+++ b/src/ripple/core/Coro.ipp
@@ -48,7 +48,9 @@ inline
 JobQueue::Coro::
 ~Coro()
 {
+#ifndef NDEBUG
     assert(finished_);
+#endif
 }
 
 inline
@@ -64,7 +66,7 @@ yield() const
 }
 
 inline
-void
+bool
 JobQueue::Coro::
 post()
 {
@@ -74,23 +76,76 @@ post()
     }
 
     // sp keeps 'this' alive
-    jq_.addJob(type_, name_,
+    if (jq_.addJob(type_, name_,
         [this, sp = shared_from_this()](Job&)
         {
-            {
-                std::lock_guard<std::mutex> lock(jq_.m_mutex);
-                --jq_.nSuspend_;
-            }
-            auto saved = detail::getLocalValues().release();
-            detail::getLocalValues().reset(&lvs_);
-            std::lock_guard<std::mutex> lock(mutex_);
-            coro_();
-            detail::getLocalValues().release();
-            detail::getLocalValues().reset(saved);
-            std::lock_guard<std::mutex> lk(mutex_run_);
-            running_ = false;
-            cv_.notify_all();
-        });
+            resume();
+        }))
+    {
+        return true;
+    }
+
+    // The coroutine will not run.  Clean up running_.
+    std::lock_guard<std::mutex> lk(mutex_run_);
+    running_ = false;
+    cv_.notify_all();
+    return false;
+}
+
+inline
+void
+JobQueue::Coro::
+resume()
+{
+    {
+        std::lock_guard<std::mutex> lk(mutex_run_);
+        running_ = true;
+    }
+    {
+        std::lock_guard<std::mutex> lock(jq_.m_mutex);
+        --jq_.nSuspend_;
+    }
+    auto saved = detail::getLocalValues().release();
+    detail::getLocalValues().reset(&lvs_);
+    std::lock_guard<std::mutex> lock(mutex_);
+    assert (coro_);
+    coro_();
+    detail::getLocalValues().release();
+    detail::getLocalValues().reset(saved);
+    std::lock_guard<std::mutex> lk(mutex_run_);
+    running_ = false;
+    cv_.notify_all();
+}
+
+inline
+bool
+JobQueue::Coro::
+runnable() const
+{
+    return static_cast<bool>(coro_);
+}
+
+inline
+void
+JobQueue::Coro::
+expectEarlyExit()
+{
+#ifndef NDEBUG
+    if (! finished_)
+#endif
+    {
+        // expectEarlyExit() must only ever be called from outside the
+        // Coro's stack.  It you're inside the stack you can simply return
+        // and be done.
+        //
+        // That said, since we're outside the Coro's stack, we need to
+        // decrement the nSuspend that the Coro's call to yield caused.
+        std::lock_guard<std::mutex> lock(jq_.m_mutex);
+        --jq_.nSuspend_;
+#ifndef NDEBUG
+        finished_ = true;
+#endif
+    }
 }
 
 inline

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -97,9 +97,31 @@ public:
               When the job runs, the coroutine's stack is restored and execution
                 continues at the beginning of coroutine function or the statement
                 after the previous call to yield.
-            Undefined behavior if called consecutively without a corresponding yield.
+            Undefined behavior if called after the coroutine has completed
+              with a return (as opposed to a yield()).
+            Undefined behavior if post() or resume() called consecutively
+              without a corresponding yield.
+
+            @return true if the Coro's job is added to the JobQueue.
         */
-        void post();
+        bool post();
+
+        /** Resume coroutine execution.
+            Effects:
+               The coroutine continues execution from where it last left off
+                 using this same thread.
+            Undefined behavior if called after the coroutine has completed
+              with a return (as opposed to a yield()).
+            Undefined behavior if resume() or post() called consecutively
+              without a corresponding yield.
+        */
+        void resume();
+
+        /** Returns true if the Coro is still runnable (has not returned). */
+        bool runnable() const;
+
+        /** Once called, the Coro allows early exit without an assert. */
+        void expectEarlyExit();
 
         /** Waits until coroutine returns from the user function. */
         void join();
@@ -113,29 +135,23 @@ public:
 
     /** Adds a job to the JobQueue.
 
-        @param t The type of job.
+        @param type The type of job.
         @param name Name of the job.
-        @param func std::function with signature void (Job&).  Called when the job is executed.
-    */
-    void addJob (JobType type, std::string const& name, JobFunction const& func);
-
-    /** Adds a counted job to the JobQueue.
-
-        @param t The type of job.
-        @param name Name of the job.
-        @param counter JobCounter for counting the Job.
         @param jobHandler Lambda with signature void (Job&).  Called when the job is executed.
 
-        @return true if JobHandler added, false if JobCounter is already joined.
+        @return true if jobHandler added to queue.
     */
-    template <typename JobHandler>
-    bool addCountedJob (JobType type,
-        std::string const& name, JobCounter& counter, JobHandler&& jobHandler)
+    template <typename JobHandler,
+        typename = std::enable_if_t<std::is_same<decltype(
+            std::declval<JobHandler&&>()(std::declval<Job&>())), void>::value>>
+    bool addJob (JobType type,
+        std::string const& name, JobHandler&& jobHandler)
     {
-        if (auto optionalCountedJob = counter.wrap (std::move (jobHandler)))
+        if (auto optionalCountedJob =
+            Stoppable::jobCounter().wrap (std::forward<JobHandler>(jobHandler)))
         {
-            addJob (type, name, std::move (*optionalCountedJob));
-            return true;
+            return addRefCountedJob (
+                type, name, std::move (*optionalCountedJob));
         }
         return false;
     }
@@ -145,9 +161,11 @@ public:
         @param t The type of job.
         @param name Name of the job.
         @param f Has a signature of void(std::shared_ptr<Coro>). Called when the job executes.
+
+        @return shared_ptr to posted Coro.  nullptr if post was not successful.
     */
     template <class F>
-    void postCoro (JobType t, std::string const& name, F&& f);
+    std::shared_ptr<Coro> postCoro (JobType t, std::string const& name, F&& f);
 
     /** Jobs waiting at this priority.
     */
@@ -226,6 +244,16 @@ private:
 
     // Signals the service stopped if the stopped condition is met.
     void checkStopped (std::lock_guard <std::mutex> const& lock);
+
+    // Adds a reference counted job to the JobQueue.
+    //
+    //    param type The type of job.
+    //    param name Name of the job.
+    //    param func std::function with signature void (Job&).  Called when the job is executed.
+    //
+    //    return true if func added to queue.
+    bool addRefCountedJob (
+        JobType type, std::string const& name, JobFunction const& func);
 
     // Signals an added Job for processing.
     //
@@ -311,15 +339,15 @@ private:
     other requests while the RPC command completes its work asynchronously.
 
     postCoro() creates a Coro object. When the Coro ctor is called, and its
-    coro_ member is initialized(a boost::coroutines::pull_type), execution
+    coro_ member is initialized (a boost::coroutines::pull_type), execution
     automatically passes to the coroutine, which we don't want at this point,
     since we are still in the handler thread context. It's important to note here
     that construction of a boost pull_type automatically passes execution to the
     coroutine. A pull_type object automatically generates a push_type that is
-    used as the as a parameter(do_yield) in the signature of the function the
+    passed as a parameter (do_yield) in the signature of the function the
     pull_type was created with. This function is immediately called during coro_
     construction and within it, Coro::yield_ is assigned the push_type
-    parameter(do_yield) address and called(yield()) so we can return execution
+    parameter (do_yield) address and called (yield()) so we can return execution
     back to the caller's stack.
 
     postCoro() then calls Coro::post(), which schedules a job on the job
@@ -368,15 +396,23 @@ private:
 namespace ripple {
 
 template <class F>
-void JobQueue::postCoro (JobType t, std::string const& name, F&& f)
+std::shared_ptr<JobQueue::Coro>
+JobQueue::postCoro (JobType t, std::string const& name, F&& f)
 {
     /*  First param is a detail type to make construction private.
         Last param is the function the coroutine runs. Signature of
         void(std::shared_ptr<Coro>).
     */
-    auto const coro = std::make_shared<Coro>(
+    auto coro = std::make_shared<Coro>(
         Coro_create_t{}, *this, t, name, std::forward<F>(f));
-    coro->post();
+    if (! coro->post())
+    {
+        // The Coro was not successfully posted.  Disable it so it's destructor
+        // can run with no negative side effects.  Then destroy it.
+        coro->expectEarlyExit();
+        coro.reset();
+    }
+    return coro;
 }
 
 }

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -67,8 +67,8 @@ JobQueue::collect ()
     job_count = m_jobSet.size ();
 }
 
-void
-JobQueue::addJob (JobType type, std::string const& name,
+bool
+JobQueue::addRefCountedJob (JobType type, std::string const& name,
     JobFunction const& func)
 {
     assert (type != jtINVALID);
@@ -76,7 +76,7 @@ JobQueue::addJob (JobType type, std::string const& name,
     auto iter (m_jobData.find (type));
     assert (iter != m_jobData.end ());
     if (iter == m_jobData.end ())
-        return;
+        return false;
 
     JobTypeData& data (iter->second);
 
@@ -108,6 +108,7 @@ JobQueue::addJob (JobType type, std::string const& name,
                 data.load (), func, m_cancelCallback)));
         queueJob (*result.first, lock);
     }
+    return true;
 }
 
 int

--- a/src/ripple/core/impl/SociDB.cpp
+++ b/src/ripple/core/impl/SociDB.cpp
@@ -226,7 +226,13 @@ private:
             running_ = true;
         }
 
-        jobQueue_.addJob (jtWAL, "WAL", [this] (Job&) { checkpoint(); });
+        // If the Job is not added to the JobQueue then we're not running_.
+        if (! jobQueue_.addJob (
+            jtWAL, "WAL", [this] (Job&) { checkpoint(); }))
+        {
+            std::lock_guard <std::mutex> lock (mutex_);
+            running_ = false;
+        }
     }
 
     void checkpoint ()

--- a/src/ripple/net/impl/RPCSub.cpp
+++ b/src/ripple/net/impl/RPCSub.cpp
@@ -93,11 +93,9 @@ public:
         if (!mSending)
         {
             // Start a sending thread.
-            mSending    = true;
-
             JLOG (j_.info()) << "RPCCall::fromNetwork start";
 
-            m_jobQueue.addJob (
+            mSending = m_jobQueue.addJob (
                 jtCLIENT, "RPCSub::sendThread", [this] (Job&) {
                     sendThread();
                 });

--- a/src/ripple/rpc/handlers/RipplePathFind.cpp
+++ b/src/ripple/rpc/handlers/RipplePathFind.cpp
@@ -55,9 +55,93 @@ Json::Value doRipplePathFind (RPC::Context& context)
         PathRequest::pointer request;
         lpLedger = context.ledgerMaster.getClosedLedger();
 
+        // It doesn't look like there's much odd happening here, but you should
+        // be aware this code runs in a JobQueue::Coro, which is a coroutine.
+        // And we may be flipping around between threads.  Here's an overview:
+        //
+        // 1. We're running doRipplePathFind() due to a call to
+        //    ripple_path_find.  doRipplePathFind() is currently running
+        //    inside of a JobQueue::Coro using a JobQueue thread.
+        //
+        // 2. doRipplePathFind's call to makeLegacyPathRequest() enqueues the
+        //    path-finding request.  That request will (probably) run at some
+        //    indeterminate future time on a (probably different) JobQueue
+        //    thread.
+        //
+        // 3. As a continuation from that path-finding JobQueue thread, the
+        //    coroutine we're currently running in (!) is posted to the
+        //    JobQueue.  Because it is a continuation, that post won't
+        //    happen until the path-finding request completes.
+        //
+        // 4. Once the continuation is enqueued, and we have reason to think
+        //    the path-finding job is likely to run, then the coroutine we're
+        //    running in yield()s.  That means it surrenders its thread in
+        //    the JobQueue.  The coroutine is suspended, but ready to run,
+        //    because it is kept resident by a shared_ptr in the
+        //    path-finding continuation.
+        //
+        // 5. If all goes well then path-finding runs on a JobQueue thread
+        //    and executes its continuation.  The continuation posts this
+        //    same coroutine (!) to the JobQueue.
+        //
+        // 6. When the JobQueue calls this coroutine, this coroutine resumes
+        //    from the line below the coro->yield() and returns the
+        //    path-finding result.
+        //
+        // With so many moving parts, what could go wrong?
+        //
+        // Just in terms of the JobQueue refusing to add jobs at shutdown
+        // there are two specific things that can go wrong.
+        //
+        // 1. The path-finding Job queued by makeLegacyPathRequest() might be
+        //    rejected (because we're shutting down).
+        //
+        //    Fortunately this problem can be addressed by looking at the
+        //    return value of makeLegacyPathRequest().  If
+        //    makeLegacyPathRequest() cannot get a thread to run the path-find
+        //    on, then it returns an empty request.
+        //
+        // 2. The path-finding job might run, but the Coro::post() might be
+        //    rejected by the JobQueue (because we're shutting down).
+        //
+        //    We handle this case by resuming (not posting) the Coro.
+        //    By resuming the Coro, we allow the Coro to run to completion
+        //    on the current thread instead of requiring that it run on a
+        //    new thread from the JobQueue.
+        //
+        // Both of these failure modes are hard to recreate in a unit test
+        // because they are so dependent on inter-thread timing.  However
+        // the failure modes can be observed by synchronously (inside the
+        // rippled source code) shutting down the application.  The code to
+        // do so looks like this:
+        //
+        //   context.app.signalStop();
+        //   while (! context.app.getJobQueue().jobCounter().joined()) { }
+        //
+        // The first line starts the process of shutting down the app.
+        // The second line waits until no more jobs can be added to the
+        // JobQueue before letting the thread continue.
+        //
+        // May 2017
         jvResult = context.app.getPathRequests().makeLegacyPathRequest (
-            request, std::bind(&JobQueue::Coro::post, context.coro),
-                context.consumer, lpLedger, context.params);
+            request,
+            [&context] () {
+                // Copying the shared_ptr keeps the coroutine alive up
+                // through the return.  Otherwise the storage under the
+                // captured reference could evaporate when we return from
+                // coroCopy->resume().  This is not strictly necessary, but
+                // will make maintenance easier.
+                std::shared_ptr<JobQueue::Coro> coroCopy {context.coro};
+                if (!coroCopy->post())
+                {
+                    // The post() failed, so we won't get a thread to let
+                    // the Coro finish.  We'll call Coro::resume() so the
+                    // Coro can finish on our thread.  Otherwise the
+                    // application will hang on shutdown.
+                    coroCopy->resume();
+                }
+            },
+            context.consumer, lpLedger, context.params);
         if (request)
         {
             context.coro->yield();

--- a/src/test/core/JobQueue_test.cpp
+++ b/src/test/core/JobQueue_test.cpp
@@ -1,0 +1,154 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/core/JobQueue.h>
+#include <ripple/beast/unit_test.h>
+#include <test/jtx/Env.h>
+
+namespace ripple {
+namespace test {
+
+//------------------------------------------------------------------------------
+
+class JobQueue_test : public beast::unit_test::suite
+{
+    void testAddJob()
+    {
+        jtx::Env env {*this};
+
+        JobQueue& jQueue = env.app().getJobQueue();
+        {
+            // addJob() should run the Job (and return true).
+            std::atomic<bool> jobRan {false};
+            BEAST_EXPECT (jQueue.addJob (jtCLIENT, "JobAddTest1",
+                [&jobRan] (Job&) { jobRan = true; }) == true);
+
+            // Wait for the Job to run.
+            while (jobRan == false);
+        }
+        {
+            // If the JobQueue's JobCounter is join()ed we should no
+            // longer be able to add Jobs (and calling addJob() should
+            // return false).
+            using namespace std::chrono_literals;
+            beast::Journal j {env.app().journal ("JobQueue_test")};
+            JobCounter& jCounter = jQueue.jobCounter();
+            jCounter.join("JobQueue_test", 1s, j);
+
+            // The Job should never run, so having the Job access this
+            // unprotected variable on the stack should be completely safe.
+            // Not recommended for the faint of heart...
+            bool unprotected;
+            BEAST_EXPECT (jQueue.addJob (jtCLIENT, "JobAddTest2",
+                [&unprotected] (Job&) { unprotected = false; }) == false);
+        }
+    }
+
+    void testPostCoro()
+    {
+        jtx::Env env {*this};
+
+        JobQueue& jQueue = env.app().getJobQueue();
+        {
+            // Test repeated post()s until the Coro completes.
+            std::atomic<int> yieldCount {0};
+            auto const coro = jQueue.postCoro (jtCLIENT, "PostCoroTest1",
+                [&yieldCount] (std::shared_ptr<JobQueue::Coro> const& coroCopy)
+                {
+                    while (++yieldCount < 4)
+                        coroCopy->yield();
+                });
+            BEAST_EXPECT (coro != nullptr);
+
+            // Wait for the Job to run and yield.
+            while (yieldCount == 0);
+
+            // Now re-post until the Coro says it is done.
+            int old = yieldCount;
+            while (coro->runnable())
+            {
+                BEAST_EXPECT (coro->post());
+                while (old == yieldCount) { }
+                coro->join();
+                BEAST_EXPECT (++old == yieldCount);
+            }
+            BEAST_EXPECT (yieldCount == 4);
+        }
+        {
+            // Test repeated resume()s until the Coro completes.
+            int yieldCount {0};
+            auto const coro = jQueue.postCoro (jtCLIENT, "PostCoroTest2",
+                [&yieldCount] (std::shared_ptr<JobQueue::Coro> const& coroCopy)
+                {
+                    while (++yieldCount < 4)
+                        coroCopy->yield();
+                });
+            if (! coro)
+            {
+                // There's no good reason we should not get a Coro, but we
+                // can't continue without one.
+                BEAST_EXPECT (false);
+                return;
+            }
+
+            // Wait for the Job to run and yield.
+            coro->join();
+
+            // Now resume until the Coro says it is done.
+            int old = yieldCount;
+            while (coro->runnable())
+            {
+                coro->resume(); // Resume runs synchronously on this thread.
+                BEAST_EXPECT (++old == yieldCount);
+            }
+            BEAST_EXPECT (yieldCount == 4);
+        }
+        {
+            // If the JobQueue's JobCounter is join()ed we should no
+            // longer be able to add a Coro (and calling postCoro() should
+            // return false).
+            using namespace std::chrono_literals;
+            beast::Journal j {env.app().journal ("JobQueue_test")};
+            JobCounter& jCounter = jQueue.jobCounter();
+            jCounter.join("JobQueue_test", 1s, j);
+
+            // The Coro should never run, so having the Coro access this
+            // unprotected variable on the stack should be completely safe.
+            // Not recommended for the faint of heart...
+            bool unprotected;
+            auto const coro = jQueue.postCoro (jtCLIENT, "PostCoroTest3",
+                [&unprotected] (std::shared_ptr<JobQueue::Coro> const&)
+                { unprotected = false; });
+            BEAST_EXPECT (coro == nullptr);
+        }
+    }
+
+public:
+    void run()
+    {
+        testAddJob();
+        testPostCoro();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(JobQueue, core, ripple);
+
+} // test
+} // ripple

--- a/src/test/unity/core_test_unity.cpp
+++ b/src/test/unity/core_test_unity.cpp
@@ -23,6 +23,7 @@
 #include <test/core/CryptoPRNG_test.cpp>
 #include <test/core/DeadlineTimer_test.cpp>
 #include <test/core/JobCounter_test.cpp>
+#include <test/core/JobQueue_test.cpp>
 #include <test/core/SociDB_test.cpp>
 #include <test/core/Stoppable_test.cpp>
 #include <test/core/TerminateHandler_test.cpp>


### PR DESCRIPTION
If the `JobQueue` is used during shutdown then those `Jobs` may access `Stoppables` after they have already stopped.  This violates the preconditions of `Stoppables` and may lead to undefined behavior.

The solution taken here is to reference count all `Jobs` in the `JobQueue`.  At stop time all `Jobs` already in the `JobQueue` are allowed to run to completion, but no further `Jobs` are allowed into the `JobQueue`.

If a `Job` is rejected from the `JobQueue` (because we are stopping), then `JobQueue::addJob()` returns false, so the caller can make any necessary adjustments.

The pull request is divided into three different commits:

1. The first commit does two things.  First, when the `JobCounter` was originally introduced I thought each `Stoppable` would have a `JobCounter`.  That ended up being impractical.  So I changed the model to having a single `JobCounter` which is held by the `RootStoppable`.  This `JobCounter` is used to guarantee that all counted `Job`s are completed before any of the `Stoppables` begin stopping.  The rest of the commit switches most calls of `JobQueue::addJob()` into `JobQueue::addCountedJob()`.  The concern here is that all calls to `addJob()` previously were assumed to always be successful.  Now the call may fail (returning `false`) once the system begins shutting down.  It seems that in _most_ cases it's okay if adding the `Job` fails while we're shutting down.  In those specific cases where we need the operation to complete then I added code to do the right thing.  As code reviewers you get to ponder whether I added the right code in all of the necessary places.

2. The second commit deals with `JobQueue::Coro`.  It turns out that `JobQueue::Coro` objects are executed by adding them as `Job`s to the `JobQueue`.  Handling a `Coro` when a `Job` might not be successfully added to the `JobQueue` ended up being a bit tricky.  So that conversion is in its own commit.  This commit converts all of the remaining `JobQueue::addJob()` calls to `JobQueue::addCountedJob()`.

3. The last commit tidies up the naming.  Since `JobQueue::addJob()` is no longer a used name, we can convert our new longer name `addCountedJob()` back to `addJob()`.  It's no longer useful to distinguish between counted and uncounted `Job`s -- all `Job`s are counted.

My biggest concern during the code review is whether I missed any places where we need recovery code if `addJob()` fails (and returns `false`).

Assignees: @miguelportilla, @bachase.  More are welcome.  The more eyes the better.