### PR TITLE
Improve automatic tuning of thread pool:

### DIFF
--- a/src/ripple/app/main/BasicApp.cpp
+++ b/src/ripple/app/main/BasicApp.cpp
@@ -39,6 +39,6 @@ BasicApp::BasicApp(std::size_t numberOfThreads)
 BasicApp::~BasicApp()
 {
     work_ = boost::none;
-    for (auto& _ : threads_)
-        _.join();
+    for (auto& t : threads_)
+        t.join();
 }

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -160,7 +160,7 @@ public:
     // Node storage configuration
     std::uint32_t                      LEDGER_HISTORY = 256;
     std::uint32_t                      FETCH_DEPTH = 1000000000;
-    int                         NODE_SIZE = 0;
+    unsigned int                       NODE_SIZE = 0;
 
     bool                        SSL_VERIFY = true;
     std::string                 SSL_VERIFY_FILE;

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -108,7 +108,7 @@ public:
     using JobFunction = std::function <void(Job&)>;
 
     JobQueue (beast::insight::Collector::ptr const& collector,
-        Stoppable& parent, beast::Journal journal, Logs& logs);
+        Stoppable& parent, unsigned int threads, beast::Journal journal, Logs& logs);
     ~JobQueue ();
 
     /** Adds a job to the JobQueue.
@@ -163,7 +163,7 @@ public:
 
     /** Set the number of thread serving the job queue to precisely this number.
     */
-    void setThreadCount (int c, bool const standaloneMode);
+    void setThreadCount (int c);
 
     /** Return a scoped LoadEvent.
     */

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -336,14 +336,7 @@ void Config::loadFromString (std::string const& fileContents)
         else if (beast::detail::ci_equal(strTemp, "huge"))
             NODE_SIZE = 4;
         else
-        {
-            NODE_SIZE = beast::lexicalCastThrow <int> (strTemp);
-
-            if (NODE_SIZE < 0)
-                NODE_SIZE = 0;
-            else if (NODE_SIZE > 4)
-                NODE_SIZE = 4;
-        }
+            NODE_SIZE = std::min(4u, beast::lexicalCastThrow<unsigned int>(strTemp));
     }
 
     if (getSingleSection (secConfig, SECTION_ELB_SUPPORT, strTemp, j_))

--- a/src/test/app/Transaction_ordering_test.cpp
+++ b/src/test/app/Transaction_ordering_test.cpp
@@ -63,7 +63,7 @@ struct Transaction_ordering_test : public beast::unit_test::suite
         using namespace jtx;
 
         Env env(*this);
-        env.app().getJobQueue().setThreadCount(0, false);
+        env.app().getJobQueue().setThreadCount(4);
         auto const alice = Account("alice");
         env.fund(XRP(1000), noripple(alice));
 
@@ -96,7 +96,7 @@ struct Transaction_ordering_test : public beast::unit_test::suite
         using namespace jtx;
 
         Env env(*this);
-        env.app().getJobQueue().setThreadCount(0, false);
+        env.app().getJobQueue().setThreadCount(4);
         auto const alice = Account("alice");
         env.fund(XRP(1000), noripple(alice));
 

--- a/src/test/core/Coroutine_test.cpp
+++ b/src/test/core/Coroutine_test.cpp
@@ -66,7 +66,7 @@ public:
         using namespace jtx;
         Env env(*this);
         auto& jq = env.app().getJobQueue();
-        jq.setThreadCount(0, false);
+        jq.setThreadCount(4);
         gate g1, g2;
         std::shared_ptr<JobQueue::Coro> c;
         jq.postCoro(jtCLIENT, "Coroutine-Test",
@@ -90,7 +90,7 @@ public:
         using namespace jtx;
         Env env(*this);
         auto& jq = env.app().getJobQueue();
-        jq.setThreadCount(0, false);
+        jq.setThreadCount(4);
         gate g;
         jq.postCoro(jtCLIENT, "Coroutine-Test",
             [&](auto const& c)
@@ -109,7 +109,7 @@ public:
         using namespace jtx;
         Env env(*this);
         auto& jq = env.app().getJobQueue();
-        jq.setThreadCount(0, true);
+        jq.setThreadCount(1);
         static int const N = 4;
         std::array<std::shared_ptr<JobQueue::Coro>, N> a;
 


### PR DESCRIPTION
The job queue can automatically tune the number of threads that
it creates based on the number of processors or processor cores
that are available.

The existing tuning was very conservative, limiting the maximum
number of threads to only 6.

Adjust the new algorithm to allow a larger number of threads to
be created by factoring the "node_size" specified in the config
file as well as the number of available processor cores.

Sample differences in the number of threads configured, with
1, 2, 4, 8 and 16 cores:

With 1 core:

| Node Size | Old Thread Count | New Thread Count |
|-----------|------------------|------------------|
| `tiny` | 3 | 4 |
| `small` | 3 | 4 |
| `medium` | 3 | 4 |
| `large` | 3 | 4 |
| `huge` | 3 | 4 |

With 2 cores:

| Node Size | Old Thread Count | New Thread Count |
|-----------|------------------|------------------|
| `tiny` | 4 | 4 |
| `small` | 4 | 4 |
| `medium` | 4 | 4 |
| `large` | 4 | 4 |
| `huge` | 4 | 4 |

With 4 cores:

| Node Size | Old Thread Count | New Thread Count |
|-----------|------------------|------------------|
| `tiny` | 6 | 4 |
| `small` | 6 | 6 |
| `medium` | 6 | 6 |
| `large` | 6 | 6 |
| `huge` | 6 | 6 |

With 8 cores:

| Node Size | Old Thread Count | New Thread Count |
|-----------|------------------|------------------|
| `tiny` | 6 | 4 |
| `small` | 6 | 8 |
| `medium` | 6 | 10 |
| `large` | 6 | 10 |
| `huge` | 6 | 10 |

With 16 cores:

| Node Size | Old Thread Count | New Thread Count |
|-----------|------------------|------------------|
| `tiny` | 6 | 4 |
| `small` | 6 | 8 |
| `medium` | 6 | 12 |
| `large` | 6 | 16 |
| `huge` | 6 | 18 |