### PR TITLE
Check amendment block status and update with ledgers:

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4931,6 +4931,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\rpc\AmendmentBlocked_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\rpc\Book_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5646,6 +5646,9 @@
     <ClCompile Include="..\..\src\test\rpc\AccountSet_test.cpp">
       <Filter>test\rpc</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\rpc\AmendmentBlocked_test.cpp">
+      <Filter>test\rpc</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\rpc\Book_test.cpp">
       <Filter>test\rpc</Filter>
     </ClCompile>

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -910,9 +910,12 @@ RCLConsensus::startRound(
     RCLCxLedger::ID const& prevLgrId,
     RCLCxLedger const& prevLgr)
 {
-    // We have a key, and we have some idea what the ledger is
+    // We have a key, we have some idea what the ledger is, and we are not
+    // amendment blocked
     validating_ =
-        !app_.getOPs().isNeedNetworkLedger() && (valPublic_.size() != 0);
+        !app_.getOPs().isNeedNetworkLedger() &&
+        (valPublic_.size() != 0) &&
+        !app_.getOPs().isAmendmentBlocked();
 
     // propose only if we're in sync with the network (and validating)
     bool proposing =

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -227,6 +227,13 @@ LedgerMaster::setValidLedger(
     app_.getSHAMapStore().onLedgerClosed (getValidatedLedger());
     mLedgerHistory.validatedLedger (l);
     app_.getAmendmentTable().doValidatedLedger (l);
+    if (!app_.getOPs().isAmendmentBlocked() &&
+        app_.getAmendmentTable().hasUnsupportedEnabled ())
+    {
+        JLOG (m_journal.error()) <<
+            "One or more unsupported amendments activated: server blocked.";
+        app_.getOPs().setAmendmentBlocked();
+    }
 }
 
 void

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -47,6 +47,14 @@ public:
     virtual bool isEnabled (uint256 const& amendment) = 0;
     virtual bool isSupported (uint256 const& amendment) = 0;
 
+    /**
+     * @brief returns true if one or more amendments on the network
+     * have been enabled that this server does not support
+     *
+     * @return true if an unsupported feature is enabled on the network
+     */
+    virtual bool hasUnsupportedEnabled () = 0;
+
     virtual Json::Value getJson (int) = 0;
 
     /** Returns a Json::objectValue. */

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -157,6 +157,9 @@ protected:
     // we haven't participated in one yet.
     std::unique_ptr <AmendmentSet> lastVote_;
 
+    // True if an unsupported amendment is enabled
+    bool unsupportedEnabled_;
+
     beast::Journal j_;
 
     // Finds or creates state
@@ -186,6 +189,8 @@ public:
 
     bool isEnabled (uint256 const& amendment) override;
     bool isSupported (uint256 const& amendment) override;
+
+    bool hasUnsupportedEnabled () override;
 
     Json::Value getJson (int) override;
     Json::Value getJson (uint256 const&) override;
@@ -222,6 +227,7 @@ AmendmentTableImpl::AmendmentTableImpl (
     : lastUpdateSeq_ (0)
     , majorityTime_ (majorityTime)
     , majorityFraction_ (majorityFraction)
+    , unsupportedEnabled_ (false)
     , j_ (journal)
 {
     assert (majorityFraction_ != 0);
@@ -340,6 +346,14 @@ AmendmentTableImpl::enable (uint256 const& amendment)
         return false;
 
     s->enabled = true;
+
+    if (! s->supported)
+    {
+        JLOG (j_.error()) <<
+            "Unsupported amendment " << amendment << " activated.";
+        unsupportedEnabled_ = true;
+    }
+
     return true;
 }
 
@@ -370,6 +384,13 @@ AmendmentTableImpl::isSupported (uint256 const& amendment)
     std::lock_guard <std::mutex> sl (mutex_);
     auto s = get (amendment);
     return s && s->supported;
+}
+
+bool
+AmendmentTableImpl::hasUnsupportedEnabled ()
+{
+    std::lock_guard <std::mutex> sl (mutex_);
+    return unsupportedEnabled_;
 }
 
 std::vector <uint256>
@@ -523,10 +544,8 @@ AmendmentTableImpl::doValidatedLedger (
     LedgerIndex ledgerSeq,
     std::set<uint256> const& enabled)
 {
-    std::lock_guard <std::mutex> sl (mutex_);
-
-    for (auto& e : amendmentMap_)
-        e.second.enabled = (enabled.count (e.first) != 0);
+    for (auto& e : enabled)
+        enable(e);
 }
 
 void

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -51,6 +51,7 @@ enum error_code_i
     rpcHIGH_FEE,
     rpcNOT_ENABLED,
     rpcNOT_READY,
+    rpcAMENDMENT_BLOCKED,
 
     // Networking
     rpcNO_CLOSED,

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -53,6 +53,7 @@ public:
         add (rpcACT_EXISTS,            "actExists",         "Account already exists.");
         add (rpcACT_MALFORMED,         "actMalformed",      "Account malformed.");
         add (rpcACT_NOT_FOUND,         "actNotFound",       "Account not found.");
+        add (rpcAMENDMENT_BLOCKED,     "amendmentBlocked",  "Amendment blocked, need upgrade.");
         add (rpcATX_DEPRECATED,        "deprecated",        "Use the new API or specify a ledger range.");
         add (rpcBAD_BLOB,              "badBlob",           "Blob must be a non-empty hex string.");
         add (rpcBAD_FEATURE,           "badFeature",        "Feature unknown or invalid.");

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -157,6 +157,13 @@ error_code_i fillHandler (Context& context,
         return rpcNO_NETWORK;
     }
 
+    if (context.app.getOPs().isAmendmentBlocked() &&
+         (handler->condition_ & NEEDS_CURRENT_LEDGER ||
+          handler->condition_ & NEEDS_CLOSED_LEDGER))
+    {
+        return rpcAMENDMENT_BLOCKED;
+    }
+
     if (!context.app.config().standalone() &&
         handler->condition_ & NEEDS_CURRENT_LEDGER)
     {

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -745,6 +745,20 @@ public:
         }
     }
 
+    void testHasUnsupported ()
+    {
+        testcase ("hasUnsupportedEnabled");
+
+        auto table = makeTable(1);
+        BEAST_EXPECT(! table->hasUnsupportedEnabled());
+
+        std::set <uint256> enabled;
+        std::for_each(m_set4.begin(), m_set4.end(),
+            [&enabled](auto const &s){ enabled.insert(amendmentId(s)); });
+        table->doValidatedLedger(1, enabled);
+        BEAST_EXPECT(table->hasUnsupportedEnabled());
+    }
+
     void run ()
     {
         testConstruct();
@@ -757,6 +771,7 @@ public:
         testDetectMajority ();
         testLostMajority ();
         testSupportedAmendments ();
+        testHasUnsupported ();
     }
 };
 

--- a/src/test/rpc/AmendmentBlocked_test.cpp
+++ b/src/test/rpc/AmendmentBlocked_test.cpp
@@ -1,0 +1,169 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/jtx.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/app/misc/NetworkOPs.h>
+#include <test/jtx/WSClient.h>
+
+namespace ripple {
+
+class AmendmentBlocked_test : public beast::unit_test::suite
+{
+    void testBlockedMethods()
+    {
+        using namespace test::jtx;
+        Env env {*this};
+        auto const gw = Account {"gateway"};
+        auto const USD = gw["USD"];
+        auto const alice = Account {"alice"};
+        auto const bob = Account {"bob"};
+        env.fund (XRP(10000), alice, bob, gw);
+        env.trust (USD(600), alice);
+        env.trust (USD(700), bob);
+        env(pay (gw, alice, USD(70)));
+        env(pay (gw, bob, USD(50)));
+        env.close();
+
+        auto wsc = test::makeWSClient(env.app().config());
+
+        auto current = env.current ();
+        // ledger_accept
+        auto jr = env.rpc ("ledger_accept") [jss::result];
+        BEAST_EXPECT (jr[jss::ledger_current_index] == current->seq ()+1);
+
+        // ledger_current
+        jr = env.rpc ("ledger_current") [jss::result];
+        BEAST_EXPECT (jr[jss::ledger_current_index] == current->seq ()+1);
+
+        // owner_info
+        jr = env.rpc ("owner_info", alice.human()) [jss::result];
+        BEAST_EXPECT (jr.isMember (jss::accepted) && jr.isMember (jss::current));
+
+        // path_find
+        Json::Value pf_req;
+        pf_req[jss::subcommand] = "create";
+        pf_req[jss::source_account] = alice.human();
+        pf_req[jss::destination_account] = bob.human();
+        pf_req[jss::destination_amount] = bob["USD"](20).value ().getJson (0);
+        jr = wsc->invoke("path_find", pf_req) [jss::result];
+        BEAST_EXPECT (jr.isMember (jss::alternatives) &&
+            jr[jss::alternatives].isArray () &&
+            jr[jss::alternatives].size () == 1);
+
+        // submit
+        auto jt = env.jt (noop (alice));
+        Serializer s;
+        jt.stx->add (s);
+        jr = env.rpc ("submit", strHex (s.slice ())) [jss::result];
+        BEAST_EXPECT (jr.isMember (jss::engine_result) &&
+            jr[jss::engine_result] == "tesSUCCESS");
+
+        // submit_multisigned
+        env(signers(bob, 1, {{alice, 1}}), sig (bob));
+        Account const ali {"ali", KeyType::secp256k1};
+        env(regkey (alice, ali));
+        env.close();
+
+        Json::Value set_tx;
+        set_tx[jss::Account] = bob.human();
+        set_tx[jss::TransactionType] = "AccountSet";
+        set_tx[jss::Fee] =
+            static_cast<uint32_t>(8 * env.current()->fees().base);
+        set_tx[jss::Sequence] = env.seq(bob);
+        set_tx[jss::SigningPubKey] = "";
+
+        Json::Value sign_for;
+        sign_for[jss::tx_json] = set_tx;
+        sign_for[jss::account] = alice.human();
+        sign_for[jss::secret]  = ali.name();
+        jr = env.rpc("json", "sign_for", to_string(sign_for)) [jss::result];
+        BEAST_EXPECT(jr[jss::status] == "success");
+
+        Json::Value ms_req;
+        ms_req[jss::tx_json] = jr[jss::tx_json];
+        jr = env.rpc("json", "submit_multisigned", to_string(ms_req))
+            [jss::result];
+        BEAST_EXPECT (jr.isMember (jss::engine_result) &&
+            jr[jss::engine_result] == "tesSUCCESS");
+
+        // make the network amendment blocked...now all the same
+        // requests should fail
+
+        env.app ().getOPs ().setAmendmentBlocked ();
+
+        // ledger_accept
+        jr = env.rpc ("ledger_accept") [jss::result];
+        BEAST_EXPECT(
+            jr.isMember (jss::error) &&
+            jr[jss::error] == "amendmentBlocked");
+        BEAST_EXPECT(jr[jss::status] == "error");
+
+        // ledger_current
+        jr = env.rpc ("ledger_current") [jss::result];
+        BEAST_EXPECT(
+            jr.isMember (jss::error) &&
+            jr[jss::error] == "amendmentBlocked");
+        BEAST_EXPECT(jr[jss::status] == "error");
+
+        // owner_info
+        jr = env.rpc ("owner_info", alice.human()) [jss::result];
+        BEAST_EXPECT(
+            jr.isMember (jss::error) &&
+            jr[jss::error] == "amendmentBlocked");
+        BEAST_EXPECT(jr[jss::status] == "error");
+
+        // path_find
+        jr = wsc->invoke("path_find", pf_req) [jss::result];
+        BEAST_EXPECT(
+            jr.isMember (jss::error) &&
+            jr[jss::error] == "amendmentBlocked");
+        BEAST_EXPECT(jr[jss::status] == "error");
+
+        // submit
+        jr = env.rpc("submit", strHex(s.slice())) [jss::result];
+        BEAST_EXPECT(
+            jr.isMember (jss::error) &&
+            jr[jss::error] == "amendmentBlocked");
+        BEAST_EXPECT(jr[jss::status] == "error");
+
+        // submit_multisigned
+        set_tx[jss::Sequence] = env.seq(bob);
+        sign_for[jss::tx_json] = set_tx;
+        jr = env.rpc("json", "sign_for", to_string(sign_for)) [jss::result];
+        BEAST_EXPECT(jr[jss::status] == "success");
+        ms_req[jss::tx_json] = jr[jss::tx_json];
+        jr = env.rpc("json", "submit_multisigned", to_string(ms_req))
+            [jss::result];
+        BEAST_EXPECT(
+            jr.isMember (jss::error) &&
+            jr[jss::error] == "amendmentBlocked");
+    }
+
+public:
+    void run()
+    {
+        testBlockedMethods();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(AmendmentBlocked,app,ripple);
+
+}
+

--- a/src/test/unity/rpc_test_unity.cpp
+++ b/src/test/unity/rpc_test_unity.cpp
@@ -24,6 +24,7 @@
 #include <test/rpc/AccountObjects_test.cpp>
 #include <test/rpc/AccountOffers_test.cpp>
 #include <test/rpc/AccountSet_test.cpp>
+#include <test/rpc/AmendmentBlocked_test.cpp>
 #include <test/rpc/Book_test.cpp>
 #include <test/rpc/Feature_test.cpp>
 #include <test/rpc/GatewayBalances_test.cpp>


### PR DESCRIPTION
Check and modify amendment blocked status with each new ledger (provided
by @wilsonianb). Honor blocked status in certain RPC commands and when
deciding whether to propose/validate.

Fixes: RIPD-1479
Fixes: RIPD-1447

Release Notes
-------------

This resolves an issue whereby an amendment blocked server would still
serve some RPC requests that are unreliable in blocked state and would
continue to publish validations.