### PR TITLE
Separate Scheduler from BasicNetwork

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4475,6 +4475,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\csf\Peer.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\test\csf\Scheduler.h">
+    </ClInclude>
+    <ClCompile Include="..\..\src\test\csf\Scheduler_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\test\csf\Sim.h">
     </ClInclude>
     <ClInclude Include="..\..\src\test\csf\Tx.h">

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5214,6 +5214,12 @@
     <ClInclude Include="..\..\src\test\csf\Peer.h">
       <Filter>test\csf</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\test\csf\Scheduler.h">
+      <Filter>test\csf</Filter>
+    </ClInclude>
+    <ClCompile Include="..\..\src\test\csf\Scheduler_test.cpp">
+      <Filter>test\csf</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\test\csf\Sim.h">
       <Filter>test\csf</Filter>
     </ClInclude>

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -45,7 +45,7 @@ public:
         p.start();
         p.submit(Tx{1});
 
-        s.net.step();
+        s.scheduler.step();
 
         // Inspect that the proper ledger was created
         BEAST_EXPECT(p.prevLedgerID().seq == 1);
@@ -441,11 +441,11 @@ public:
             for (auto& p : sim.peers)
             {
                 p.start();
-                sim.net.step_for(stagger);
+                sim.scheduler.step_for(stagger);
             }
 
             // run until all peers have accepted all transactions
-            sim.net.step_while([&]() {
+            sim.scheduler.step_while([&]() {
                 for (auto& p : sim.peers)
                 {
                     if (p.prevLedgerID().txs.size() != 1)

--- a/src/test/csf.h
+++ b/src/test/csf.h
@@ -17,10 +17,10 @@
 */
 //==============================================================================
 
-#include <test/csf/Tx.h>
-#include <test/csf/Ledger.h>
 #include <test/csf/BasicNetwork.h>
+#include <test/csf/Ledger.h>
 #include <test/csf/Peer.h>
-#include <test/csf/UNL.h>
+#include <test/csf/Scheduler.h>
 #include <test/csf/Sim.h>
-#include <test/csf/Peer.h>
+#include <test/csf/Tx.h>
+#include <test/csf/UNL.h>

--- a/src/test/csf/BasicNetwork.h
+++ b/src/test/csf/BasicNetwork.h
@@ -20,21 +20,15 @@
 #ifndef RIPPLE_TEST_CSF_BASICNETWORK_H_INCLUDED
 #define RIPPLE_TEST_CSF_BASICNETWORK_H_INCLUDED
 
-#include <ripple/basics/qalloc.h>
-#include <ripple/beast/clock/manual_clock.h>
 #include <ripple/beast/hash/hash_append.h>
 #include <ripple/beast/hash/uhash.h>
 #include <boost/container/flat_map.hpp>
-#include <boost/intrusive/list.hpp>
-#include <boost/intrusive/set.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <cassert>
 #include <cstdint>
 #include <deque>
-#include <iomanip>
-#include <memory>
+#include <test/csf/Scheduler.h>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -66,14 +60,10 @@ namespace csf {
     If a Peer is disconnected, all messages pending delivery
     at either end of the associated connection are discarded.
 
-    A timer may be set for a Peer. When the timer expires,
-    a caller provided lambda is invoked. Timers may be canceled
-    using a token returned when the timer is created.
-
-    After creating the Peer set, constructing the network,
-    and establishing connections, the caller uses one or more
-    of the step, step_one, step_for, step_until and step_while
-    functions to iterate the network,
+    When creating the Peer set, the caller needs to provide a Scheduler object
+    for managing the the timing and delivery of messages. After constructing
+    the network, and establishing connections, the caller uses the scheduler's
+    step_* functions to iterate the network,
 
     Peer Requirements:
 
@@ -91,6 +81,7 @@ namespace csf {
         u < v           bool        LessThanComparable
         std::hash<P>    class       std::hash is defined for P
         ! u             bool        true if u is not-a-peer
+
 */
 template <class Peer>
 class BasicNetwork
@@ -98,148 +89,13 @@ class BasicNetwork
 public:
     using peer_type = Peer;
 
-    using clock_type = beast::manual_clock<std::chrono::steady_clock>;
+    using clock_type = Scheduler::clock_type;
 
     using duration = typename clock_type::duration;
 
     using time_point = typename clock_type::time_point;
 
 private:
-    struct by_to_tag
-    {
-    };
-    struct by_from_tag
-    {
-    };
-    struct by_when_tag
-    {
-    };
-
-    using by_to_hook = boost::intrusive::list_base_hook<
-        boost::intrusive::link_mode<boost::intrusive::normal_link>,
-        boost::intrusive::tag<by_to_tag>>;
-
-    using by_from_hook = boost::intrusive::list_base_hook<
-        boost::intrusive::link_mode<boost::intrusive::normal_link>,
-        boost::intrusive::tag<by_from_tag>>;
-
-    using by_when_hook = boost::intrusive::set_base_hook<
-        boost::intrusive::link_mode<boost::intrusive::normal_link>>;
-
-    struct msg : by_to_hook, by_from_hook, by_when_hook
-    {
-        Peer to;
-        Peer from;
-        time_point when;
-
-        msg(msg const&) = delete;
-        msg&
-        operator=(msg const&) = delete;
-        virtual ~msg() = default;
-        virtual void
-        operator()() const = 0;
-
-        msg(Peer const& from_, Peer const& to_, time_point when_)
-            : to(to_), from(from_), when(when_)
-        {
-        }
-
-        bool
-        operator<(msg const& other) const
-        {
-            return when < other.when;
-        }
-    };
-
-    template <class Handler>
-    class msg_impl : public msg
-    {
-    private:
-        Handler const h_;
-
-    public:
-        msg_impl(msg_impl const&) = delete;
-        msg_impl&
-        operator=(msg_impl const&) = delete;
-
-        msg_impl(
-            Peer const& from_,
-            Peer const& to_,
-            time_point when_,
-            Handler&& h)
-            : msg(from_, to_, when_), h_(std::move(h))
-        {
-        }
-
-        msg_impl(
-            Peer const& from_,
-            Peer const& to_,
-            time_point when_,
-            Handler const& h)
-            : msg(from_, to_, when_), h_(h)
-        {
-        }
-
-        void
-        operator()() const override
-        {
-            h_();
-        }
-    };
-
-    class queue_type
-    {
-    private:
-        using by_to_list = typename boost::intrusive::make_list<
-            msg,
-            boost::intrusive::base_hook<by_to_hook>,
-            boost::intrusive::constant_time_size<false>>::type;
-
-        using by_from_list = typename boost::intrusive::make_list<
-            msg,
-            boost::intrusive::base_hook<by_from_hook>,
-            boost::intrusive::constant_time_size<false>>::type;
-
-        using by_when_set = typename boost::intrusive::make_multiset<
-            msg,
-            boost::intrusive::constant_time_size<false>>::type;
-
-        qalloc alloc_;
-        by_when_set by_when_;
-        std::unordered_map<Peer, by_to_list> by_to_;
-        std::unordered_map<Peer, by_from_list> by_from_;
-
-    public:
-        using iterator = typename by_when_set::iterator;
-
-        queue_type(queue_type const&) = delete;
-        queue_type&
-        operator=(queue_type const&) = delete;
-
-        explicit queue_type(qalloc const& alloc);
-
-        ~queue_type();
-
-        bool
-        empty() const;
-
-        iterator
-        begin();
-
-        iterator
-        end();
-
-        template <class Handler>
-        typename by_when_set::iterator
-        emplace(Peer const& from, Peer const& to, time_point when, Handler&& h);
-
-        void
-        erase(iterator iter);
-
-        void
-        remove(Peer const& from, Peer const& to);
-    };
-
     struct link_type
     {
         bool inbound;
@@ -255,11 +111,7 @@ private:
 
     class link_transform;
 
-    qalloc alloc_;
-    queue_type queue_;
-    // VFALCO This is an ugly wart, aged containers
-    //        want a non-const reference to a clock.
-    clock_type mutable clock_;
+    Scheduler& scheduler;
     std::unordered_map<Peer, links_type> links_;
 
 public:
@@ -267,22 +119,7 @@ public:
     BasicNetwork&
     operator=(BasicNetwork const&) = delete;
 
-    BasicNetwork();
-
-    /** Return the allocator. */
-    qalloc const&
-    alloc() const;
-
-    /** Return the clock. */
-    clock_type&
-    clock() const;
-
-    /** Return the current network time.
-
-        @note The epoch is unspecified
-    */
-    time_point
-    now() const;
+    BasicNetwork(Scheduler& s);
 
     /** Connect two peers.
 
@@ -327,6 +164,15 @@ public:
     bool
     disconnect(Peer const& peer1, Peer const& peer2);
 
+    /** Check if peers are connected.
+
+        This checks that peer1 has an outbound connection to peer2.
+
+        @return `true` if peer1 is connected to peer2 and peer1 != peer2
+    */
+    bool
+    connected(Peer const& peer1, Peer const& peer2);
+
     /** Return the range of active links.
 
         @return A random access range.
@@ -356,43 +202,6 @@ public:
     void
     send(Peer const& from, Peer const& to, Function&& f);
 
-    // Used to cancel timers
-    struct cancel_token;
-
-    /** Deliver a timer notification.
-
-        Effects:
-
-            When the network time is reached,
-            the function will be called with
-            no arguments.
-    */
-    template <class Function>
-    cancel_token
-    timer(time_point const& when, Function&& f);
-
-    /** Deliver a timer notification.
-
-        Effects:
-
-            When the specified time has elapsed,
-            the function will be called with
-            no arguments.
-    */
-    template <class Function>
-    cancel_token
-    timer(duration const& delay, Function&& f);
-
-    /** Cancel a timer.
-
-        Preconditions:
-
-            `token` was the return value of a call
-            timer() which has not yet been invoked.
-    */
-    void
-    cancel(cancel_token const& token);
-
     /** Perform breadth-first search.
 
         Function will be called with this signature:
@@ -405,180 +214,9 @@ public:
     template <class Function>
     void
     bfs(Peer const& start, Function&& f);
-
-    /** Run the network for up to one message.
-
-        Effects:
-
-            The clock is advanced to the time
-            of the last delivered message.
-
-        @return `true` if a message was processed.
-    */
-    bool
-    step_one();
-
-    /** Run the network until no messages remain.
-
-        Effects:
-
-            The clock is advanced to the time
-            of the last delivered message.
-
-        @return `true` if any message was processed.
-    */
-    bool
-    step();
-
-    /** Run the network while a condition is true.
-
-        Function takes no arguments and will be called
-        repeatedly after each message is processed to
-        decide whether to continue.
-
-        Effects:
-
-            The clock is advanced to the time
-            of the last delivered message.
-
-        @return `true` if any message was processed.
-    */
-    template <class Function>
-    bool
-    step_while(Function&& func);
-
-    /** Run the network until the specified time.
-
-        Effects:
-
-            The clock is advanced to the
-            specified time.
-
-        @return `true` if any messages remain.
-    */
-    bool
-    step_until(time_point const& until);
-
-    /** Run the network until time has elapsed.
-
-        Effects:
-
-            The clock is advanced by the
-            specified duration.
-
-        @return `true` if any messages remain.
-    */
-    template <class Period, class Rep>
-    bool
-    step_for(std::chrono::duration<Period, Rep> const& amount);
 };
 
 //------------------------------------------------------------------------------
-
-template <class Peer>
-BasicNetwork<Peer>::queue_type::queue_type(qalloc const& alloc)
-    : alloc_(alloc)
-{
-}
-
-template <class Peer>
-BasicNetwork<Peer>::queue_type::~queue_type()
-{
-    for (auto iter = by_when_.begin(); iter != by_when_.end();)
-    {
-        auto m = &*iter;
-        ++iter;
-        m->~msg();
-        alloc_.dealloc(m, 1);
-    }
-}
-
-template <class Peer>
-inline bool
-BasicNetwork<Peer>::queue_type::empty() const
-{
-    return by_when_.empty();
-}
-
-template <class Peer>
-inline auto
-BasicNetwork<Peer>::queue_type::begin() -> iterator
-{
-    return by_when_.begin();
-}
-
-template <class Peer>
-inline auto
-BasicNetwork<Peer>::queue_type::end() -> iterator
-{
-    return by_when_.end();
-}
-
-template <class Peer>
-template <class Handler>
-auto
-BasicNetwork<Peer>::queue_type::emplace(
-    Peer const& from,
-    Peer const& to,
-    time_point when,
-    Handler&& h) -> typename by_when_set::iterator
-{
-    using msg_type = msg_impl<std::decay_t<Handler>>;
-    auto const p = alloc_.alloc<msg_type>(1);
-    auto& m = *new (p) msg_type(from, to, when, std::forward<Handler>(h));
-    if (to)
-        by_to_[to].push_back(m);
-    if (from)
-        by_from_[from].push_back(m);
-    return by_when_.insert(m);
-}
-
-template <class Peer>
-void
-BasicNetwork<Peer>::queue_type::erase(iterator iter)
-{
-    auto& m = *iter;
-    if (iter->to)
-    {
-        auto& list = by_to_[iter->to];
-        list.erase(list.iterator_to(m));
-    }
-    if (iter->from)
-    {
-        auto& list = by_from_[iter->from];
-        list.erase(list.iterator_to(m));
-    }
-    by_when_.erase(iter);
-    m.~msg();
-    alloc_.dealloc(&m, 1);
-}
-
-template <class Peer>
-void
-BasicNetwork<Peer>::queue_type::remove(Peer const& from, Peer const& to)
-{
-    {
-        auto& list = by_to_[to];
-        for (auto iter = list.begin(); iter != list.end();)
-        {
-            auto& m = *iter++;
-            if (m.from == from)
-                erase(by_when_.iterator_to(m));
-        }
-    }
-    {
-        auto& list = by_to_[from];
-        for (auto iter = list.begin(); iter != list.end();)
-        {
-            auto& m = *iter++;
-            if (m.from == to)
-                erase(by_when_.iterator_to(m));
-        }
-    }
-}
-
-//------------------------------------------------------------------------------
-
 template <class Peer>
 class BasicNetwork<Peer>::link_transform
 {
@@ -635,52 +273,9 @@ public:
 };
 
 //------------------------------------------------------------------------------
-
 template <class Peer>
-struct BasicNetwork<Peer>::cancel_token
+BasicNetwork<Peer>::BasicNetwork(Scheduler& s) : scheduler(s)
 {
-private:
-    typename queue_type::iterator iter_;
-
-public:
-    cancel_token() = delete;
-    cancel_token(cancel_token const&) = default;
-    cancel_token&
-    operator=(cancel_token const&) = default;
-
-private:
-    friend class BasicNetwork;
-    cancel_token(typename queue_type::iterator iter) : iter_(iter)
-    {
-    }
-};
-
-//------------------------------------------------------------------------------
-
-template <class Peer>
-BasicNetwork<Peer>::BasicNetwork() : queue_(alloc_)
-{
-}
-
-template <class Peer>
-inline qalloc const&
-BasicNetwork<Peer>::alloc() const
-{
-    return alloc_;
-}
-
-template <class Peer>
-inline auto
-BasicNetwork<Peer>::clock() const -> clock_type&
-{
-    return clock_;
-}
-
-template <class Peer>
-inline auto
-BasicNetwork<Peer>::now() const -> time_point
-{
-    return clock_.now();
 }
 
 template <class Peer>
@@ -703,6 +298,15 @@ BasicNetwork<Peer>::connect(
 
 template <class Peer>
 bool
+BasicNetwork<Peer>::connected(Peer const& from, Peer const& to)
+{
+    auto& froms = links_[from];
+    auto it = froms.find(to);
+    return it != froms.end() && !it->second.inbound;
+}
+
+template <class Peer>
+bool
 BasicNetwork<Peer>::disconnect(Peer const& peer1, Peer const& peer2)
 {
     if (links_[peer1].erase(peer2) == 0)
@@ -710,7 +314,14 @@ BasicNetwork<Peer>::disconnect(Peer const& peer1, Peer const& peer2)
     auto const n = links_[peer2].erase(peer1);
     (void)n;
     assert(n);
-    queue_.remove(peer1, peer2);
+    auto it = scheduler.queue_.begin();
+    while (it != scheduler.queue_.end())
+    {
+        if (it->drop())
+            it = scheduler.queue_.erase(it);
+        else
+            ++it;
+    }
     return true;
 }
 
@@ -728,103 +339,13 @@ template <class Function>
 inline void
 BasicNetwork<Peer>::send(Peer const& from, Peer const& to, Function&& f)
 {
-    using namespace std;
     auto const iter = links_[from].find(to);
-    queue_.emplace(
-        from, to, clock_.now() + iter->second.delay, forward<Function>(f));
-}
 
-template <class Peer>
-template <class Function>
-inline auto
-BasicNetwork<Peer>::timer(time_point const& when, Function&& f) -> cancel_token
-{
-    using namespace std;
-    return queue_.emplace(nullptr, nullptr, when, forward<Function>(f));
-}
-
-template <class Peer>
-template <class Function>
-inline auto
-BasicNetwork<Peer>::timer(duration const& delay, Function&& f) -> cancel_token
-{
-    return timer(clock_.now() + delay, std::forward<Function>(f));
-}
-
-template <class Peer>
-inline void
-BasicNetwork<Peer>::cancel(cancel_token const& token)
-{
-    queue_.erase(token.iter_);
-}
-
-template <class Peer>
-bool
-BasicNetwork<Peer>::step_one()
-{
-    if (queue_.empty())
-        return false;
-    auto const iter = queue_.begin();
-    clock_.set(iter->when);
-    (*iter)();
-    queue_.erase(iter);
-    return true;
-}
-
-template <class Peer>
-bool
-BasicNetwork<Peer>::step()
-{
-    if (!step_one())
-        return false;
-    for (;;)
-        if (!step_one())
-            break;
-    return true;
-}
-
-template <class Peer>
-template <class Function>
-bool
-BasicNetwork<Peer>::step_while(Function&& f)
-{
-    bool ran = false;
-    while (f() && step_one())
-        ran = true;
-    return ran;
-}
-
-template <class Peer>
-bool
-BasicNetwork<Peer>::step_until(time_point const& until)
-{
-    // VFALCO This routine needs optimizing
-    if (queue_.empty())
-    {
-        clock_.set(until);
-        return false;
-    }
-    auto iter = queue_.begin();
-    if (iter->when > until)
-    {
-        clock_.set(until);
-        return true;
-    }
-    do
-    {
-        step_one();
-        iter = queue_.begin();
-    } while (iter != queue_.end() && iter->when <= until);
-    clock_.set(until);
-    return iter != queue_.end();
-}
-
-template <class Peer>
-template <class Period, class Rep>
-inline bool
-BasicNetwork<Peer>::step_for(std::chrono::duration<Period, Rep> const& amount)
-{
-    return step_until(now() + amount);
+    // Schedule with droppable condition on disconnect
+    scheduler.queue_.emplace(
+        scheduler.now() + iter->second.delay,
+        std::forward<Function>(f),
+        [from, to, this] { return !connected(from, to); });
 }
 
 template <class Peer>
@@ -853,8 +374,8 @@ BasicNetwork<Peer>::bfs(Peer const& start, Function&& f)
     }
 }
 
-}  // csf
-}  // test
-}  // ripple
+}  // namespace csf
+}  // namespace test
+}  // namespace ripple
 
 #endif

--- a/src/test/csf/BasicNetwork_test.cpp
+++ b/src/test/csf/BasicNetwork_test.cpp
@@ -21,6 +21,7 @@
 #include <ripple/beast/unit_test.h>
 #include <set>
 #include <test/csf/BasicNetwork.h>
+#include <test/csf/Scheduler.h>
 #include <vector>
 
 namespace ripple {
@@ -43,10 +44,10 @@ public:
 
         template <class Net>
         void
-        start(Net& net)
+        start(csf::Scheduler& scheduler, Net& net)
         {
             using namespace std::chrono_literals;
-            auto t = net.timer(1s, [&] { set.insert(0); });
+            auto t = scheduler.in(1s, [&] { set.insert(0); });
             if (id == 0)
             {
                 for (auto const& link : net.links(this))
@@ -56,7 +57,7 @@ public:
             }
             else
             {
-                net.cancel(t);
+                scheduler.cancel(t);
             }
         }
 
@@ -77,14 +78,15 @@ public:
     };
 
     void
-    run() override
+    testNetwork()
     {
         using namespace std::chrono_literals;
         std::vector<Peer> pv;
         pv.emplace_back(0);
         pv.emplace_back(1);
         pv.emplace_back(2);
-        csf::BasicNetwork<Peer*> net;
+        csf::Scheduler scheduler;
+        csf::BasicNetwork<Peer*> net(scheduler);
         BEAST_EXPECT(!net.connect(&pv[0], &pv[0]));
         BEAST_EXPECT(net.connect(&pv[0], &pv[1], 1s));
         BEAST_EXPECT(net.connect(&pv[1], &pv[2], 1s));
@@ -94,12 +96,12 @@ public:
             &pv[0], [&](auto d, Peer*) { diameter = std::max(d, diameter); });
         BEAST_EXPECT(diameter == 2);
         for (auto& peer : pv)
-            peer.start(net);
-        BEAST_EXPECT(net.step_for(0s));
-        BEAST_EXPECT(net.step_for(1s));
-        BEAST_EXPECT(net.step());
-        BEAST_EXPECT(!net.step());
-        BEAST_EXPECT(!net.step_for(1s));
+            peer.start(scheduler, net);
+        BEAST_EXPECT(scheduler.step_for(0s));
+        BEAST_EXPECT(scheduler.step_for(1s));
+        BEAST_EXPECT(scheduler.step());
+        BEAST_EXPECT(!scheduler.step());
+        BEAST_EXPECT(!scheduler.step_for(1s));
         net.send(&pv[0], &pv[1], [] {});
         net.send(&pv[1], &pv[0], [] {});
         BEAST_EXPECT(net.disconnect(&pv[0], &pv[1]));
@@ -114,11 +116,41 @@ public:
         BEAST_EXPECT(pv[0].set == std::set<int>({0, 2, 4}));
         BEAST_EXPECT(pv[1].set == std::set<int>({1, 3}));
         BEAST_EXPECT(pv[2].set == std::set<int>({2, 4}));
-        net.timer(0s, [] {});
+    }
+
+    void
+    testDisconnect()
+    {
+        using namespace std::chrono_literals;
+        csf::Scheduler scheduler;
+        csf::BasicNetwork<int> net(scheduler);
+        BEAST_EXPECT(net.connect(0, 1, 1s));
+        BEAST_EXPECT(net.connect(0, 2, 2s));
+
+        std::set<int> delivered;
+        net.send(0, 1, [&]() { delivered.insert(1); });
+        net.send(0, 2, [&]() { delivered.insert(2); });
+
+        scheduler.in(1000ms, [&]() { BEAST_EXPECT(net.disconnect(0, 2)); });
+        scheduler.in(1100ms, [&]() { BEAST_EXPECT(net.connect(0, 2)); });
+
+        scheduler.step();
+
+        // only the first message is delivered because the disconnect at 1 s
+        // purges all pending messages from 0 to 2
+        BEAST_EXPECT(delivered == std::set<int>({1}));
+    }
+
+    void
+    run() override
+    {
+        testNetwork();
+        testDisconnect();
+
     }
 };
 
 BEAST_DEFINE_TESTSUITE(BasicNetwork, test, ripple);
 
-}  // test
-}  // ripple
+}  // namespace test
+}  // namespace ripple

--- a/src/test/csf/Scheduler.h
+++ b/src/test/csf/Scheduler.h
@@ -1,0 +1,497 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TEST_CSF_SCHEDULER_H_INCLUDED
+#define RIPPLE_TEST_CSF_SCHEDULER_H_INCLUDED
+
+#include <ripple/basics/qalloc.h>
+#include <ripple/beast/clock/manual_clock.h>
+#include <boost/intrusive/set.hpp>
+#include <type_traits>
+#include <utility>
+
+namespace ripple {
+namespace test {
+namespace csf {
+
+/** Simulated discrete-event scheduler.
+
+    Simulates the behavior of events using a single common clock.
+
+    An event is modeled using a lambda function and is scheduled to occur at a
+    specific time. Events may be canceled using a token returned when the
+    event is scheduled.
+
+    The caller uses one or more of the step, step_one, step_for, step_until and
+    step_while functions to process scheduled events.
+
+    This class is meant to be used in conjunction with BasicNetwork to allow
+    simulating event processing and messaging.
+*/
+class Scheduler
+{
+public:
+    using clock_type = beast::manual_clock<std::chrono::steady_clock>;
+
+    using duration = typename clock_type::duration;
+
+    using time_point = typename clock_type::time_point;
+
+private:
+    // Allow BasicNetwork the ability to schedule events with drop conditions
+    template <class T>
+    friend class BasicNetwork;
+
+    using by_when_hook = boost::intrusive::set_base_hook<
+        boost::intrusive::link_mode<boost::intrusive::normal_link>>;
+
+    struct event : by_when_hook
+    {
+        time_point when;
+
+        event(event const&) = delete;
+        event&
+        operator=(event const&) = delete;
+
+        virtual ~event() = default;
+
+        // Called to perform the event
+        virtual void
+        operator()() const = 0;
+
+        // Called to determine if event should be dropped before its processing
+        // time.  This is primarily a hook for BasicNetwork to prune events
+        // when a link between nodes is disconnected
+        virtual bool
+        drop() const = 0;
+
+        event(time_point when_) : when(when_)
+        {
+        }
+
+        bool
+        operator<(event const& other) const
+        {
+            return when < other.when;
+        }
+    };
+
+    template <class Handler, class Dropped>
+    class event_impl : public event
+    {
+    private:
+        Handler const h_;
+        Dropped const d_;
+
+    public:
+        event_impl(event_impl const&) = delete;
+
+        event_impl&
+        operator=(event_impl const&) = delete;
+
+        template <class DeducedHandler, class DeducedDropped>
+        event_impl(time_point when_, DeducedHandler&& h, DeducedDropped&& d)
+            : event(when_)
+            , h_(std::forward<DeducedHandler>(h))
+            , d_(std::forward<DeducedDropped>(d))
+        {
+        }
+
+        void
+        operator()() const override
+        {
+            h_();
+        }
+
+        bool
+        drop() const override
+        {
+            return d_();
+        }
+    };
+
+    class queue_type
+    {
+    private:
+        using by_when_set = typename boost::intrusive::make_multiset<
+            event,
+            boost::intrusive::constant_time_size<false>>::type;
+
+        qalloc alloc_;
+        by_when_set by_when_;
+
+    public:
+        using iterator = typename by_when_set::iterator;
+
+        queue_type(queue_type const&) = delete;
+        queue_type&
+        operator=(queue_type const&) = delete;
+
+        explicit queue_type(qalloc const& alloc);
+
+        ~queue_type();
+
+        bool
+        empty() const;
+
+        iterator
+        begin();
+
+        iterator
+        end();
+
+        template <class Handler>
+        typename by_when_set::iterator
+        emplace(time_point when, Handler&& h);
+
+        template <class Handler, class Dropped>
+        typename by_when_set::iterator
+        emplace(time_point when, Handler&& h, Dropped&& d);
+
+        iterator
+        erase(iterator iter);
+    };
+
+    qalloc alloc_;
+    queue_type queue_;
+    clock_type clock_;
+
+public:
+    Scheduler(Scheduler const&) = delete;
+    Scheduler&
+    operator=(Scheduler const&) = delete;
+
+    Scheduler();
+
+    /** Return the allocator. */
+    qalloc const&
+    alloc() const;
+
+    /** Return the clock. */
+    clock_type const&
+    clock() const;
+
+    /** Return the current network time.
+
+        @note The epoch is unspecified
+    */
+    time_point
+    now() const;
+
+    // Used to cancel timers
+    struct cancel_token;
+
+    /** Schedule an event at a specific time
+
+        Effects:
+
+            When the network time is reached,
+            the function will be called with
+            no arguments.
+    */
+    template <class Function>
+    cancel_token
+    at(time_point const& when, Function&& f);
+
+    /** Schedule an event after a specified duration passes
+
+        Effects:
+
+            When the specified time has elapsed,
+            the function will be called with
+            no arguments.
+    */
+    template <class Function>
+    cancel_token
+    in(duration const& delay, Function&& f);
+
+    /** Cancel a timer.
+
+        Preconditions:
+
+            `token` was the return value of a call
+            timer() which has not yet been invoked.
+    */
+    void
+    cancel(cancel_token const& token);
+
+    /** Run the scheduler for up to one event.
+
+        Effects:
+
+            The clock is advanced to the time
+            of the last delivered event.
+
+        @return `true` if a event was processed.
+    */
+    bool
+    step_one();
+
+    /** Run the scheduler until no events remain.
+
+        Effects:
+
+            The clock is advanced to the time
+            of the last event.
+
+        @return `true` if any event was processed.
+    */
+    bool
+    step();
+
+    /** Run the scheduler while a condition is true.
+
+        Function takes no arguments and will be called
+        repeatedly after each event is processed to
+        decide whether to continue.
+
+        Effects:
+
+            The clock is advanced to the time
+            of the last delivered event.
+
+        @return `true` if any event was processed.
+    */
+    template <class Function>
+    bool
+    step_while(Function&& func);
+
+    /** Run the scheduler until the specified time.
+
+        Effects:
+
+            The clock is advanced to the
+            specified time.
+
+        @return `true` if any event remain.
+    */
+    bool
+    step_until(time_point const& until);
+
+    /** Run the scheduler until time has elapsed.
+
+        Effects:
+
+            The clock is advanced by the
+            specified duration.
+
+        @return `true` if any event remain.
+    */
+    template <class Period, class Rep>
+    bool
+    step_for(std::chrono::duration<Period, Rep> const& amount);
+};
+
+//------------------------------------------------------------------------------
+
+inline Scheduler::queue_type::queue_type(qalloc const& alloc) : alloc_(alloc)
+{
+}
+
+inline Scheduler::queue_type::~queue_type()
+{
+    for (auto iter = by_when_.begin(); iter != by_when_.end();)
+    {
+        auto e = &*iter;
+        ++iter;
+        e->~event();
+        alloc_.dealloc(e, 1);
+    }
+}
+
+inline bool
+Scheduler::queue_type::empty() const
+{
+    return by_when_.empty();
+}
+
+inline auto
+Scheduler::queue_type::begin() -> iterator
+{
+    return by_when_.begin();
+}
+
+inline auto
+Scheduler::queue_type::end() -> iterator
+{
+    return by_when_.end();
+}
+
+template <class Handler, class Dropped>
+inline auto
+Scheduler::queue_type::emplace(time_point when, Handler&& h, Dropped&& d) ->
+    typename by_when_set::iterator
+{
+    using event_type = event_impl<std::decay_t<Handler>, std::decay_t<Dropped>>;
+    auto const p = alloc_.alloc<event_type>(1);
+    auto& e = *new (p) event_type(
+        when, std::forward<Handler>(h), std::forward<Dropped>(d));
+    return by_when_.insert(e);
+}
+
+template <class Handler>
+inline auto
+Scheduler::queue_type::emplace(time_point when, Handler&& h) ->
+    typename by_when_set::iterator
+{
+    // Never droppable by default
+    return emplace(when, std::forward<Handler>(h), [] { return false; });
+}
+
+inline auto
+Scheduler::queue_type::erase(iterator iter) -> typename by_when_set::iterator
+{
+    auto& e = *iter;
+    auto next = by_when_.erase(iter);
+    e.~event();
+    alloc_.dealloc(&e, 1);
+    return next;
+}
+
+//-----------------------------------------------------------------------------
+struct Scheduler::cancel_token
+{
+private:
+    typename queue_type::iterator iter_;
+
+public:
+    cancel_token() = delete;
+    cancel_token(cancel_token const&) = default;
+    cancel_token&
+    operator=(cancel_token const&) = default;
+
+private:
+    friend class Scheduler;
+    cancel_token(typename queue_type::iterator iter) : iter_(iter)
+    {
+    }
+};
+
+//------------------------------------------------------------------------------
+inline Scheduler::Scheduler() : queue_(alloc_)
+{
+}
+
+inline qalloc const&
+Scheduler::alloc() const
+{
+    return alloc_;
+}
+
+inline auto
+Scheduler::clock() const -> clock_type const&
+{
+    return clock_;
+}
+
+inline auto
+Scheduler::now() const -> time_point
+{
+    return clock_.now();
+}
+
+template <class Function>
+inline auto
+Scheduler::at(time_point const& when, Function&& f) -> cancel_token
+{
+    return queue_.emplace(when, std::forward<Function>(f));
+}
+
+template <class Function>
+inline auto
+Scheduler::in(duration const& delay, Function&& f) -> cancel_token
+{
+    return at(clock_.now() + delay, std::forward<Function>(f));
+}
+
+inline void
+Scheduler::cancel(cancel_token const& token)
+{
+    queue_.erase(token.iter_);
+}
+
+inline bool
+Scheduler::step_one()
+{
+    if (queue_.empty())
+        return false;
+    auto const iter = queue_.begin();
+    clock_.set(iter->when);
+    (*iter)();
+    queue_.erase(iter);
+    return true;
+}
+
+inline bool
+Scheduler::step()
+{
+    if (!step_one())
+        return false;
+    for (;;)
+        if (!step_one())
+            break;
+    return true;
+}
+
+template <class Function>
+inline bool
+Scheduler::step_while(Function&& f)
+{
+    bool ran = false;
+    while (f() && step_one())
+        ran = true;
+    return ran;
+}
+
+inline bool
+Scheduler::step_until(time_point const& until)
+{
+    // VFALCO This routine needs optimizing
+    if (queue_.empty())
+    {
+        clock_.set(until);
+        return false;
+    }
+    auto iter = queue_.begin();
+    if (iter->when > until)
+    {
+        clock_.set(until);
+        return true;
+    }
+    do
+    {
+        step_one();
+        iter = queue_.begin();
+    } while (iter != queue_.end() && iter->when <= until);
+    clock_.set(until);
+    return iter != queue_.end();
+}
+
+template <class Period, class Rep>
+inline bool
+Scheduler::step_for(std::chrono::duration<Period, Rep> const& amount)
+{
+    return step_until(now() + amount);
+}
+
+}  // namespace csf
+}  // namespace test
+}  // namespace ripple
+
+#endif

--- a/src/test/csf/Scheduler_test.cpp
+++ b/src/test/csf/Scheduler_test.cpp
@@ -1,0 +1,89 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/beast/unit_test.h>
+#include <test/csf/Scheduler.h>
+#include <set>
+
+namespace ripple {
+namespace test {
+
+class Scheduler_test : public beast::unit_test::suite
+{
+public:
+
+    void
+    run() override
+    {
+        using namespace std::chrono_literals;
+        csf::Scheduler scheduler;
+        std::set<int> seen;
+
+        scheduler.in(1s, [&]{ seen.insert(1);});
+        scheduler.in(2s, [&]{ seen.insert(2);});
+        auto token = scheduler.in(3s, [&]{ seen.insert(3);});
+        scheduler.at(scheduler.now() + 4s, [&]{ seen.insert(4);});
+        scheduler.at(scheduler.now() + 8s, [&]{ seen.insert(8);});
+
+        auto start = scheduler.now();
+
+        // Process first event
+        BEAST_EXPECT(seen.empty());
+        BEAST_EXPECT(scheduler.step_one());
+        BEAST_EXPECT(seen == std::set<int>({1}));
+        BEAST_EXPECT(scheduler.now() == (start + 1s));
+
+        // No processing if stepping until current time
+        BEAST_EXPECT(scheduler.step_until(scheduler.now()));
+        BEAST_EXPECT(seen == std::set<int>({1}));
+        BEAST_EXPECT(scheduler.now() == (start + 1s));
+
+        // Process next event
+        BEAST_EXPECT(scheduler.step_for(1s));
+        BEAST_EXPECT(seen == std::set<int>({1,2}));
+        BEAST_EXPECT(scheduler.now() == (start + 2s));
+
+        // Don't process cancelled event, but advance clock
+        scheduler.cancel(token);
+        BEAST_EXPECT(scheduler.step_for(1s));
+        BEAST_EXPECT(seen == std::set<int>({1,2}));
+        BEAST_EXPECT(scheduler.now() == (start + 3s));
+
+        // Process until 3 seen ints
+        BEAST_EXPECT(scheduler.step_while([&]() { return seen.size() < 3; }));
+        BEAST_EXPECT(seen == std::set<int>({1,2,4}));
+        BEAST_EXPECT(scheduler.now() == (start + 4s));
+
+        // Process the rest
+        BEAST_EXPECT(scheduler.step());
+        BEAST_EXPECT(seen == std::set<int>({1,2,4,8}));
+        BEAST_EXPECT(scheduler.now() == (start + 8s));
+
+        // Process the rest again doesn't advance
+        BEAST_EXPECT(!scheduler.step());
+        BEAST_EXPECT(seen == std::set<int>({1,2,4,8}));
+        BEAST_EXPECT(scheduler.now() == (start + 8s));
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Scheduler, test, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/csf/Sim.h
+++ b/src/test/csf/Sim.h
@@ -21,6 +21,7 @@
 #define RIPPLE_TEST_CSF_SIM_H_INCLUDED
 
 #include <test/csf/BasicNetwork.h>
+#include <test/csf/Scheduler.h>
 #include <test/csf/UNL.h>
 
 namespace ripple {
@@ -51,10 +52,11 @@ public:
     */
     template <class Topology>
     Sim(TrustGraph const& g, Topology const& top)
+        : net{scheduler}
     {
         peers.reserve(g.numPeers());
         for (int i = 0; i < g.numPeers(); ++i)
-            peers.emplace_back(i, net, g.unl(i));
+            peers.emplace_back(i, scheduler, net, g.unl(i));
 
         for (int i = 0; i < peers.size(); ++i)
         {
@@ -88,10 +90,11 @@ public:
             p.targetLedgers = p.completedLedgers + ledgers;
             p.start();
         }
-        net.step();
+        scheduler.step();
     }
 
     std::vector<Peer> peers;
+    Scheduler scheduler;
     BasicNetwork<Peer*> net;
 };
 

--- a/src/test/unity/csf_unity.cpp
+++ b/src/test/unity/csf_unity.cpp
@@ -20,4 +20,5 @@
 #include <BeastConfig.h>
 
 #include <test/csf/BasicNetwork_test.cpp>
+#include <test/csf/Scheduler_test.cpp>
 #include <test/csf/impl/UNL.cpp>


### PR DESCRIPTION
The existing BasicNetwork class is used in the consensus simulation framework to simulate sending messages between peers in the network *and* to schedule events to occur at certain times during the simulation.  This changeset breaks out that scheduling functionality into a standalone `Scheduler` class so that other simulation components can be independent of `BasicNetwork`.