### PR TITLE
Support OpenSSL 1.1.0

### DIFF
--- a/src/ripple/beast/asio/ssl_error.h
+++ b/src/ripple/beast/asio/ssl_error.h
@@ -68,8 +68,12 @@ inline
 bool
 is_short_read(boost::system::error_code const& ec)
 {
+#ifdef SSL_R_SHORT_READ
     return (ec.category() == boost::asio::error::get_ssl_category())
         && (ERR_GET_REASON(ec.value()) == SSL_R_SHORT_READ);
+#else
+    return false;
+#endif
 }
 
 } // beast


### PR DESCRIPTION
Work around differences between OpenSSL 1.0 and 1.1 to permit compiling on distributions that use newer versions. This involves using conditional compilation to remove workarounds that are no longer needed. Fedora 26 is coming out shortly and will need this.