### PR TITLE
Correct handling of unauthorized offers (RIPD-1481)

### DIFF
--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -523,8 +523,10 @@ BookStep<TIn, TOut, TDerived>::forEachOffer (
                 continue;
 
         // Make sure offer owner has authorization to own IOUs from issuer.
-        // An account can always own their own IOUs.
-        if (flowCross && (offer.owner() != offer.issueIn().account))
+        // An account can always own XRP or their own IOUs.
+        if (flowCross &&
+            (!isXRP (offer.issueIn().currency)) &&
+            (offer.owner() != offer.issueIn().account))
         {
             auto const& issuerID = offer.issueIn().account;
             auto const issuer = afView.read (keylet::account (issuerID));
@@ -533,10 +535,10 @@ BookStep<TIn, TOut, TDerived>::forEachOffer (
                 // Issuer requires authorization.  See if offer owner has that.
                 auto const& ownerID = offer.owner();
                 auto const authFlag =
-                    ownerID > issuerID ? lsfHighAuth : lsfLowAuth;
+                    issuerID > ownerID ? lsfHighAuth : lsfLowAuth;
 
                 auto const line = afView.read (keylet::line (
-                    ownerID, issuerID, offer.issueOut().currency));
+                    ownerID, issuerID, offer.issueIn().currency));
 
                 if (!line || (((*line)[sfFlags] & authFlag) == 0))
                 {

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -234,6 +234,13 @@ CreateOffer::checkAcceptAsset(ReadView const& view,
             : tecNO_ISSUER;
     }
 
+    // This code is attached to the FlowCross amendment as a matter of
+    // convenience.  The change is not significant enough to deserve its
+    // own amendment.
+    if (view.rules().enabled(featureFlowCross) && (issue.account == id))
+        // An account can always accept its own issuance.
+        return tesSUCCESS;
+
     if ((*issuerAccount)[sfFlags] & lsfRequireAuth)
     {
         auto const trustLine = view.read(


### PR DESCRIPTION
This pull request addresses a bug in FlowCross that was identified while running Ripple Connect smoke tests.  The pull request also addresses an additional bug identified while the original bug was being researched.

The pull request comes in four commits:

1. The first commit fixes the bug identified by the Ripple Connect smoke test.  It also fixes the original bad unit test that let the bug slip through.
2. The second commit adds a jtx unit test from @bachase that would have caught the bad behavior exhibited by the bug.
3. The third commit adds a jtx unit test, also from @bachase, that performs the same operations as the Ripple Connect smoke test that failed.  Having this test in jtx form test makes the problem much easier to diagnose.  Also, since jtx tests are run regularly, having such a jtx test would have caught the bug much earlier.
4. The fourth commit addresses an additional bug uncovered while researching the original bug.  It turns out that an issuing account with `RequireAuth` set on the account cannot create an offer to buy its own currency.  This is a non-critical bug, since it blocks an operation that apparently no one wants to do (or we would have heard about it).  The commit includes both a fix and a unit test for the fix.  If we decide that we don't want to fix then the commit is easy to remove without affecting the other commits.

Reviewers: @bachase and @seelabs, since they have the most familiarity with the primary bug being addressed.  I'd also like @nbougalis and @JoelKatz to weigh in on whether or not we should include the last commit.