### PR TITLE
[TRIVIAL] Add consensus tests to CMake (RIPD-1482)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,11 @@ foreach(curdir
         basics
         beast
         conditions
+        consensus
         core
+        csf
         json
+        jtx
         ledger
         nodestore
         overlay
@@ -304,9 +307,7 @@ foreach(curdir
         resource
         rpc
         server
-        shamap
-        jtx
-        csf)
+        shamap)
     file(GLOB_RECURSE cursrcs src/test/${curdir}/*.cpp)
     list(APPEND test_srcs "${cursrcs}")
 endforeach()


### PR DESCRIPTION
@mellery451 noticed that the consensus unit tests were missing from the non-unity CMake builds. 