### PR TITLE
Catch exceptions in rippleCalc:

### DIFF
--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -149,7 +149,12 @@ RippleCalc::Output RippleCalc::rippleCalculate (
         {
             JLOG (j.error()) << "Exception from flow: " << e.what ();
             if (!useFlowV1Output)
-                Rethrow();
+            {
+                // return a tec so the tx is stored
+                path::RippleCalc::Output exceptResult;
+                exceptResult.setResult(tecINTERNAL);
+                return exceptResult;
+            }
         }
     }
 


### PR DESCRIPTION
* If rippleCalc throws, return an error instead of letting the exception escape