### PR TITLE
Add zlib to libs when finding openssl

### DIFF
--- a/Builds/CMake/CMakeFuncs.cmake
+++ b/Builds/CMake/CMakeFuncs.cmake
@@ -388,6 +388,11 @@ macro(use_openssl openssl_min)
     endif()
 
     find_package(OpenSSL)
+    # depending on how openssl is built, it might depend
+    # on zlib. In fact, the openssl find package should
+    # figure this out for us, but it does not currently...
+    # so let's add zlib ourselves to the lib list
+    find_package(ZLIB)
 
     if (static)
       set(CMAKE_FIND_LIBRARY_SUFFIXES tmp)
@@ -395,6 +400,7 @@ macro(use_openssl openssl_min)
 
     if (OPENSSL_FOUND)
       include_directories(${OPENSSL_INCLUDE_DIR})
+      list(APPEND OPENSSL_LIBRARIES ${ZLIB_LIBRARIES})
     else()
       message(FATAL_ERROR "OpenSSL not found")
     endif()

--- a/src/test/beast/beast_asio_error_test.cpp
+++ b/src/test/beast/beast_asio_error_test.cpp
@@ -33,7 +33,12 @@ public:
                 boost::system::error_code (335544539,
                     boost::asio::error::get_ssl_category ());
             std::string const s = beast::error_message_with_ssl(ec);
+
+#ifdef SSL_R_SHORT_READ
             BEAST_EXPECT(s == " (20,0,219) error:140000DB:SSL routines:SSL routines:short read");
+#else
+            BEAST_EXPECT(s == " (20,0,219) error:140000DB:SSL routines:SSL routines:reason(219)");
+#endif
         }
     }
 };


### PR DESCRIPTION
FIXES: (RIPD-1496):

if openssl is configured with compression support AND you link
to the static lib, you are going to need to link to zlib. Fundamentally
the CMake finder should take care of this (as described in
https://gitlab.kitware.com/cmake/cmake/issues/16885), but we
work around it here by adding zlib explicitly.