### PR TITLE
Address Travis build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
     - BOOST_ROOT=$HOME/boost_1_60_0
     - BOOST_URL='http://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.tar.gz'
 
+# Travis is timing out on Trusty.  So, for now, use Precise.  July 2017
+dist: precise
+
 addons:
   apt:
     sources: ['ubuntu-toolchain-r-test']

--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3197,11 +3197,23 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\ripple\unity\app_main.cpp">
+    <ClCompile Include="..\..\src\ripple\unity\app_ledger_impl.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\app_main1.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\app_main2.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\unity\app_misc.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\app_misc_impl.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
@@ -3261,7 +3273,11 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='debug|x64'">..\..\src\rocksdb2\include;..\..\src\snappy\config;..\..\src\snappy\snappy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='release|x64'">..\..\src\rocksdb2\include;..\..\src\snappy\config;..\..\src\snappy\snappy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
-    <ClCompile Include="..\..\src\ripple\unity\overlay.cpp">
+    <ClCompile Include="..\..\src\ripple\unity\overlay1.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\overlay2.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
@@ -3287,7 +3303,11 @@
     </ClCompile>
     <ClInclude Include="..\..\src\ripple\unity\rocksdb.h">
     </ClInclude>
-    <ClCompile Include="..\..\src\ripple\unity\rpcx.cpp">
+    <ClCompile Include="..\..\src\ripple\unity\rpcx1.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\rpcx2.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
@@ -5053,7 +5073,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\unity\app_test_unity.cpp">
+    <ClCompile Include="..\..\src\test\unity\app_test_unity1.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\app_test_unity2.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
@@ -5061,7 +5085,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\unity\beast_test_unity.cpp">
+    <ClCompile Include="..\..\src\test\unity\beast_test_unity1.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\beast_test_unity2.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
@@ -5085,7 +5113,11 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\unity\jtx_unity.cpp">
+    <ClCompile Include="..\..\src\test\unity\jtx_unity1.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\jtx_unity2.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
@@ -5116,6 +5148,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\test\unity\rpc_test_unity.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\server_status_test_unity.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug.classic|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release.classic|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3822,10 +3822,19 @@
     <ClCompile Include="..\..\src\ripple\unity\app_ledger.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\ripple\unity\app_main.cpp">
+    <ClCompile Include="..\..\src\ripple\unity\app_ledger_impl.cpp">
+      <Filter>ripple\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\app_main1.cpp">
+      <Filter>ripple\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\app_main2.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\unity\app_misc.cpp">
+      <Filter>ripple\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\app_misc_impl.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\unity\app_paths.cpp">
@@ -3870,7 +3879,10 @@
     <ClCompile Include="..\..\src\ripple\unity\nodestore.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\ripple\unity\overlay.cpp">
+    <ClCompile Include="..\..\src\ripple\unity\overlay1.cpp">
+      <Filter>ripple\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\overlay2.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\unity\peerfinder.cpp">
@@ -3894,7 +3906,10 @@
     <ClInclude Include="..\..\src\ripple\unity\rocksdb.h">
       <Filter>ripple\unity</Filter>
     </ClInclude>
-    <ClCompile Include="..\..\src\ripple\unity\rpcx.cpp">
+    <ClCompile Include="..\..\src\ripple\unity\rpcx1.cpp">
+      <Filter>ripple\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\unity\rpcx2.cpp">
       <Filter>ripple\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ripple\unity\secp256k1.cpp">
@@ -5742,13 +5757,19 @@
     <ClCompile Include="..\..\src\test\shamap\SHAMap_test.cpp">
       <Filter>test\shamap</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\unity\app_test_unity.cpp">
+    <ClCompile Include="..\..\src\test\unity\app_test_unity1.cpp">
+      <Filter>test\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\app_test_unity2.cpp">
       <Filter>test\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\unity\basics_test_unity.cpp">
       <Filter>test\unity</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\unity\beast_test_unity.cpp">
+    <ClCompile Include="..\..\src\test\unity\beast_test_unity1.cpp">
+      <Filter>test\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\beast_test_unity2.cpp">
       <Filter>test\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\unity\conditions_test_unity.cpp">
@@ -5766,7 +5787,10 @@
     <ClCompile Include="..\..\src\test\unity\json_test_unity.cpp">
       <Filter>test\unity</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\unity\jtx_unity.cpp">
+    <ClCompile Include="..\..\src\test\unity\jtx_unity1.cpp">
+      <Filter>test\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\jtx_unity2.cpp">
       <Filter>test\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\unity\ledger_test_unity.cpp">
@@ -5788,6 +5812,9 @@
       <Filter>test\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\unity\rpc_test_unity.cpp">
+      <Filter>test\unity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\unity\server_status_test_unity.cpp">
       <Filter>test\unity</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\unity\server_test_unity.cpp">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,8 +187,11 @@ prepend(ripple_unity_srcs
 src/ripple/unity/
 app_consensus.cpp
 app_ledger.cpp
-app_main.cpp
+app_ledger_impl.cpp
+app_main1.cpp
+app_main2.cpp
 app_misc.cpp
+app_misc_impl.cpp
 app_paths.cpp
 app_tx.cpp
 conditions.cpp
@@ -198,19 +201,23 @@ basics.cpp
 crypto.cpp
 ledger.cpp
 net.cpp
-overlay.cpp
+overlay1.cpp
+overlay2.cpp
 peerfinder.cpp
 json.cpp
 protocol.cpp
-rpcx.cpp
+rpcx1.cpp
+rpcx2.cpp
 shamap.cpp
 server.cpp)
 
 prepend(test_unity_srcs
 src/test/unity/
-app_test_unity.cpp
+app_test_unity1.cpp
+app_test_unity2.cpp
 basics_test_unity.cpp
-beast_test_unity.cpp
+beast_test_unity1.cpp
+beast_test_unity2.cpp
 conditions_test_unity.cpp
 consensus_test_unity.cpp
 core_test_unity.cpp
@@ -222,8 +229,10 @@ protocol_test_unity.cpp
 resource_test_unity.cpp
 rpc_test_unity.cpp
 server_test_unity.cpp
+server_status_test_unity.cpp
 shamap_test_unity.cpp
-jtx_unity.cpp
+jtx_unity1.cpp
+jtx_unity2.cpp
 csf_unity.cpp)
 
 list(APPEND rippled_src_unity ${beast_unity_srcs} ${ripple_unity_srcs} ${test_unity_srcs})

--- a/SConstruct
+++ b/SConstruct
@@ -976,7 +976,7 @@ def get_classic_sources(toolchain):
     append_sources(result, *list_sources('src/test/server', '.cpp'))
     append_sources(result, *list_sources('src/test/shamap', '.cpp'))
     append_sources(result, *list_sources('src/test/jtx', '.cpp'))
-    append_sources(result, *list_sources('src/test/csf', '.cpp'))    
+    append_sources(result, *list_sources('src/test/csf', '.cpp'))
 
 
     if use_shp(toolchain):
@@ -1008,8 +1008,11 @@ def get_unity_sources(toolchain):
         'src/ripple/beast/unity/beast_utility_unity.cpp',
         'src/ripple/unity/app_consensus.cpp',
         'src/ripple/unity/app_ledger.cpp',
-        'src/ripple/unity/app_main.cpp',
+        'src/ripple/unity/app_ledger_impl.cpp',
+        'src/ripple/unity/app_main1.cpp',
+        'src/ripple/unity/app_main2.cpp',
         'src/ripple/unity/app_misc.cpp',
+        'src/ripple/unity/app_misc_impl.cpp',
         'src/ripple/unity/app_paths.cpp',
         'src/ripple/unity/app_tx.cpp',
         'src/ripple/unity/conditions.cpp',
@@ -1019,16 +1022,20 @@ def get_unity_sources(toolchain):
         'src/ripple/unity/crypto.cpp',
         'src/ripple/unity/ledger.cpp',
         'src/ripple/unity/net.cpp',
-        'src/ripple/unity/overlay.cpp',
+        'src/ripple/unity/overlay1.cpp',
+        'src/ripple/unity/overlay2.cpp',
         'src/ripple/unity/peerfinder.cpp',
         'src/ripple/unity/json.cpp',
         'src/ripple/unity/protocol.cpp',
-        'src/ripple/unity/rpcx.cpp',
+        'src/ripple/unity/rpcx1.cpp',
+        'src/ripple/unity/rpcx2.cpp',
         'src/ripple/unity/shamap.cpp',
         'src/ripple/unity/server.cpp',
-        'src/test/unity/app_test_unity.cpp',
+        'src/test/unity/app_test_unity1.cpp',
+        'src/test/unity/app_test_unity2.cpp',
         'src/test/unity/basics_test_unity.cpp',
-        'src/test/unity/beast_test_unity.cpp',
+        'src/test/unity/beast_test_unity1.cpp',
+        'src/test/unity/beast_test_unity2.cpp',
     	'src/test/unity/consensus_test_unity.cpp',
         'src/test/unity/core_test_unity.cpp',
         'src/test/unity/conditions_test_unity.cpp',
@@ -1040,8 +1047,10 @@ def get_unity_sources(toolchain):
         'src/test/unity/resource_test_unity.cpp',
         'src/test/unity/rpc_test_unity.cpp',
         'src/test/unity/server_test_unity.cpp',
+        'src/test/unity/server_status_test_unity.cpp',
         'src/test/unity/shamap_test_unity.cpp',
-        'src/test/unity/jtx_unity.cpp',
+        'src/test/unity/jtx_unity1.cpp',
+        'src/test/unity/jtx_unity2.cpp',
         'src/test/unity/csf_unity.cpp'
     )
 

--- a/bin/ci/ubuntu/build-and-test.sh
+++ b/bin/ci/ubuntu/build-and-test.sh
@@ -10,6 +10,12 @@ echo "using TARGET: $TARGET"
 
 # Ensure APP defaults to rippled if it's not set.
 : ${APP:=rippled}
+
+JOBS=${NUM_PROCESSORS:-2}
+if [[ ${TARGET} == *.nounity ]]; then
+    JOBS=$((2*${JOBS}))
+fi
+
 if [[ ${BUILD:-scons} == "cmake" ]]; then
   echo "cmake building ${APP}"
   CMAKE_TARGET=$CC.$TARGET
@@ -19,7 +25,7 @@ if [[ ${BUILD:-scons} == "cmake" ]]; then
   mkdir -p "build/${CMAKE_TARGET}"
   pushd "build/${CMAKE_TARGET}"
   cmake ../.. -Dtarget=$CMAKE_TARGET
-  cmake --build . -- -j${NUM_PROCESSORS:-2}
+  cmake --build . -- -j${JOBS}
   popd
   export APP_PATH="$PWD/build/${CMAKE_TARGET}/${APP}"
   echo "using APP_PATH: $APP_PATH"
@@ -33,7 +39,7 @@ else
   # $CC will be either `clang` or `gcc`
   # http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
   #   indicates that 2 cores are available to containers.
-  scons -j${NUM_PROCESSORS:-2} $CC.$TARGET
+  scons -j${JOBS} $CC.$TARGET
 fi
 # We can be sure we're using the build/$CC.$TARGET variant
 # (-f so never err)

--- a/bin/ci/ubuntu/install-dependencies.sh
+++ b/bin/ci/ubuntu/install-dependencies.sh
@@ -8,7 +8,7 @@ TWD=$( cd ${TWD:-${1:-${PWD:-$( pwd )}}}; pwd )
 echo "Target path is: $TWD"
 # Override gcc version to $GCC_VER.
 # Put an appropriate symlink at the front of the path.
-mkdir -v $HOME/bin
+mkdir -pv $HOME/bin
 for g in gcc g++ gcov gcc-ar gcc-nm gcc-ranlib
 do
   test -x $( type -p ${g}-$GCC_VER )

--- a/bin/sh/install-boost.sh
+++ b/bin/sh/install-boost.sh
@@ -16,7 +16,7 @@ then
   tar xzf /tmp/boost.tar.gz
   cd $BOOST_ROOT && \
     ./bootstrap.sh --prefix=$BOOST_ROOT && \
-    ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 -j${NUM_PROCESSORS:-2} &&\
+    ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 -j$((2*${NUM_PROCESSORS:-2})) &&\
     ./b2 -d0 define=_GLIBCXX_USE_CXX11_ABI=0 install
 else
   echo "Using cached boost at $BOOST_ROOT"

--- a/src/ripple/overlay/PeerSet.h
+++ b/src/ripple/overlay/PeerSet.h
@@ -21,11 +21,9 @@
 #define RIPPLE_APP_PEERS_PEERSET_H_INCLUDED
 
 #include <ripple/app/main/Application.h>
-#include <ripple/basics/Log.h>
-#include <ripple/core/Job.h>
-#include <ripple/overlay/Peer.h>
 #include <ripple/beast/clock/abstract_clock.h>
 #include <ripple/beast/utility/Journal.h>
+#include <ripple/overlay/Peer.h>
 #include <boost/asio/basic_waitable_timer.hpp>
 #include <mutex>
 #include <set>

--- a/src/ripple/overlay/impl/ConnectAttempt.cpp
+++ b/src/ripple/overlay/impl/ConnectAttempt.cpp
@@ -18,13 +18,10 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/overlay/Cluster.h>
 #include <ripple/overlay/impl/ConnectAttempt.h>
 #include <ripple/overlay/impl/PeerImp.h>
-#include <ripple/overlay/impl/Tuning.h>
+#include <ripple/overlay/Cluster.h>
 #include <ripple/json/json_reader.h>
-#include <beast/http/read.hpp>
-#include <beast/http/write.hpp>
 
 namespace ripple {
 

--- a/src/ripple/overlay/impl/ConnectAttempt.h
+++ b/src/ripple/overlay/impl/ConnectAttempt.h
@@ -22,25 +22,7 @@
 
 #include "ripple.pb.h"
 #include <ripple/overlay/impl/OverlayImpl.h>
-#include <ripple/overlay/impl/ProtocolMessage.h>
-#include <ripple/overlay/impl/TMHello.h>
 #include <ripple/overlay/impl/Tuning.h>
-#include <ripple/overlay/Message.h>
-#include <ripple/protocol/BuildInfo.h>
-#include <ripple/protocol/UintTypes.h>
-#include <ripple/beast/asio/ssl_bundle.h>
-#include <ripple/beast/net/IPAddressConversion.h>
-#include <ripple/beast/utility/WrappedSink.h>
-#include <beast/core/multi_buffer.hpp>
-#include <beast/http/empty_body.hpp>
-#include <beast/http/string_body.hpp>
-#include <beast/http/parser.hpp>
-#include <boost/asio/basic_waitable_timer.hpp>
-#include <boost/asio/buffers_iterator.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <chrono>
-#include <functional>
-#include <memory>
 
 namespace ripple {
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -21,26 +21,16 @@
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/ValidatorList.h>
-#include <ripple/core/DatabaseCon.h>
-#include <ripple/basics/contract.h>
-#include <ripple/basics/Log.h>
 #include <ripple/basics/make_SSLContext.h>
-#include <ripple/beast/rfc2616.h>
-#include <ripple/protocol/JsonFields.h>
-#include <ripple/rpc/json_body.h>
-#include <ripple/server/SimpleWriter.h>
+#include <ripple/beast/core/LexicalCast.h>
+#include <ripple/core/DatabaseCon.h>
 #include <ripple/overlay/Cluster.h>
+#include <ripple/overlay/predicates.h>
 #include <ripple/overlay/impl/ConnectAttempt.h>
-#include <ripple/overlay/impl/OverlayImpl.h>
 #include <ripple/overlay/impl/PeerImp.h>
 #include <ripple/peerfinder/make_Manager.h>
-#include <ripple/protocol/STExchange.h>
-#include <ripple/beast/core/ByteOrder.h>
-#include <beast/core/detail/base64.hpp>
-#include <ripple/beast/core/LexicalCast.h>
-#include <beast/http.hpp>
-#include <beast/core/string.hpp>
-#include <ripple/beast/utility/WrappedSink.h>
+#include <ripple/rpc/json_body.h>
+#include <ripple/server/SimpleWriter.h>
 
 #include <boost/utility/in_place_factory.hpp>
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -18,41 +18,26 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/overlay/impl/TMHello.h>
 #include <ripple/overlay/impl/PeerImp.h>
 #include <ripple/overlay/impl/Tuning.h>
+#include <ripple/app/consensus/RCLValidations.h>
 #include <ripple/app/ledger/InboundLedgers.h>
 #include <ripple/app/ledger/LedgerMaster.h>
-#include <ripple/consensus/LedgerTiming.h>
 #include <ripple/app/ledger/InboundTransactions.h>
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/LoadFeeTrack.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/Transaction.h>
-#include <ripple/app/consensus/RCLValidations.h>
 #include <ripple/app/misc/ValidatorList.h>
 #include <ripple/app/tx/apply.h>
-#include <ripple/protocol/digest.h>
 #include <ripple/basics/random.h>
-#include <ripple/basics/StringUtilities.h>
 #include <ripple/basics/UptimeTimer.h>
-#include <ripple/core/JobQueue.h>
-#include <ripple/core/TimeKeeper.h>
-#include <ripple/json/json_reader.h>
-#include <ripple/resource/Fees.h>
-#include <ripple/rpc/ServerHandler.h>
-#include <ripple/overlay/Cluster.h>
-#include <ripple/overlay/ClusterNode.h>
-#include <ripple/protocol/BuildInfo.h>
-#include <ripple/protocol/JsonFields.h>
 #include <ripple/beast/core/SemanticVersion.h>
-#include <ripple/beast/utility/weak_fn.h>
-#include <beast/core/ostream.hpp>
-#include <beast/http/write.hpp>
+#include <ripple/overlay/Cluster.h>
+#include <ripple/protocol/digest.h>
+
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/asio/io_service.hpp>
 #include <algorithm>
-#include <functional>
 #include <memory>
 #include <sstream>
 

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -21,25 +21,16 @@
 #define RIPPLE_OVERLAY_PEERIMP_H_INCLUDED
 
 #include <ripple/app/consensus/RCLCxPeerPos.h>
-#include <ripple/basics/Log.h> // deprecated
-#include <ripple/nodestore/Database.h>
-#include <ripple/overlay/predicates.h>
+#include <ripple/basics/Log.h>
+#include <ripple/beast/core/ByteOrder.h>
+#include <ripple/beast/utility/WrappedSink.h>
 #include <ripple/overlay/impl/ProtocolMessage.h>
 #include <ripple/overlay/impl/OverlayImpl.h>
-#include <ripple/resource/Fees.h>
-#include <ripple/core/Config.h>
-#include <ripple/core/Job.h>
-#include <ripple/core/LoadEvent.h>
 #include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/STValidation.h>
-#include <ripple/beast/core/ByteOrder.h>
-#include <ripple/beast/net/IPAddressConversion.h>
-#include <beast/core/multi_buffer.hpp>
-#include <ripple/beast/asio/ssl_bundle.h>
-#include <beast/http/message.hpp>
-#include <beast/http/parser.hpp>
-#include <ripple/beast/utility/WrappedSink.h>
+#include <ripple/resource/Fees.h>
+
 #include <cstdint>
 #include <deque>
 #include <queue>

--- a/src/ripple/overlay/impl/PeerSet.cpp
+++ b/src/ripple/overlay/impl/PeerSet.cpp
@@ -18,8 +18,8 @@
 //==============================================================================
 
 #include <BeastConfig.h>
-#include <ripple/app/main/Application.h>
 #include <ripple/overlay/PeerSet.h>
+#include <ripple/app/main/Application.h>
 #include <ripple/core/JobQueue.h>
 #include <ripple/overlay/Overlay.h>
 

--- a/src/ripple/overlay/impl/TMHello.cpp
+++ b/src/ripple/overlay/impl/TMHello.cpp
@@ -18,15 +18,12 @@
 //==============================================================================
 
 #include <BeastConfig.h>
+#include <ripple/overlay/impl/TMHello.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/main/Application.h>
-#include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/beast/rfc2616.h>
 #include <ripple/beast/core/LexicalCast.h>
-#include <ripple/core/TimeKeeper.h>
 #include <ripple/protocol/digest.h>
-#include <ripple/protocol/BuildInfo.h>
-#include <ripple/overlay/impl/TMHello.h>
 #include <beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 #include <algorithm>

--- a/src/ripple/overlay/impl/TMHello.h
+++ b/src/ripple/overlay/impl/TMHello.h
@@ -20,17 +20,15 @@
 #ifndef RIPPLE_OVERLAY_TMHELLO_H_INCLUDED
 #define RIPPLE_OVERLAY_TMHELLO_H_INCLUDED
 
+#include "ripple.pb.h"
 #include <ripple/app/main/Application.h>
-#include <ripple/protocol/BuildInfo.h>
-#include <ripple/protocol/PublicKey.h>
-#include <ripple/protocol/UintTypes.h>
-#include <beast/http/message.hpp>
 #include <ripple/beast/utility/Journal.h>
-#include <utility>
+#include <ripple/protocol/BuildInfo.h>
+
+#include <beast/http/message.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/optional.hpp>
-#include <boost/utility/string_ref.hpp>
-#include "ripple.pb.h"
+#include <utility>
 
 namespace ripple {
 

--- a/src/ripple/unity/app_ledger.cpp
+++ b/src/ripple/unity/app_ledger.cpp
@@ -28,14 +28,3 @@
 #include <ripple/app/ledger/LedgerHistory.cpp>
 #include <ripple/app/ledger/OrderBookDB.cpp>
 #include <ripple/app/ledger/TransactionStateSF.cpp>
-
-#include <ripple/app/ledger/impl/InboundLedger.cpp>
-#include <ripple/app/ledger/impl/InboundLedgers.cpp>
-#include <ripple/app/ledger/impl/InboundTransactions.cpp>
-#include <ripple/app/ledger/impl/LedgerCleaner.cpp>
-#include <ripple/app/ledger/impl/LedgerMaster.cpp>
-#include <ripple/app/ledger/impl/LocalTxs.cpp>
-#include <ripple/app/ledger/impl/OpenLedger.cpp>
-#include <ripple/app/ledger/impl/LedgerToJson.cpp>
-#include <ripple/app/ledger/impl/TransactionAcquire.cpp>
-#include <ripple/app/ledger/impl/TransactionMaster.cpp>

--- a/src/ripple/unity/app_ledger_impl.cpp
+++ b/src/ripple/unity/app_ledger_impl.cpp
@@ -19,12 +19,13 @@
 
 #include <BeastConfig.h>
 
-#include <ripple/app/main/BasicApp.cpp>
-#include <ripple/app/main/Amendments.cpp>
-#include <ripple/app/main/Application.cpp>
-#include <ripple/app/main/CollectorManager.cpp>
-#include <ripple/app/main/Main.cpp>
-#include <ripple/app/main/NodeIdentity.cpp>
-#include <ripple/app/main/NodeStoreScheduler.cpp>
-#include <ripple/app/main/DBInit.cpp>
-#include <ripple/app/main/LoadManager.cpp>
+#include <ripple/app/ledger/impl/InboundLedger.cpp>
+#include <ripple/app/ledger/impl/InboundLedgers.cpp>
+#include <ripple/app/ledger/impl/InboundTransactions.cpp>
+#include <ripple/app/ledger/impl/LedgerCleaner.cpp>
+#include <ripple/app/ledger/impl/LedgerMaster.cpp>
+#include <ripple/app/ledger/impl/LocalTxs.cpp>
+#include <ripple/app/ledger/impl/OpenLedger.cpp>
+#include <ripple/app/ledger/impl/LedgerToJson.cpp>
+#include <ripple/app/ledger/impl/TransactionAcquire.cpp>
+#include <ripple/app/ledger/impl/TransactionMaster.cpp>

--- a/src/ripple/unity/app_main1.cpp
+++ b/src/ripple/unity/app_main1.cpp
@@ -1,4 +1,3 @@
-
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
@@ -18,20 +17,10 @@
 */
 //==============================================================================
 
-#include <test/beast/aged_associative_container_test.cpp>
-#include <test/beast/beast_abstract_clock_test.cpp>
-#include <test/beast/beast_asio_error_test.cpp>
-#include <test/beast/beast_basic_seconds_clock_test.cpp>
-#include <test/beast/beast_CurrentThreadName_test.cpp>
-#include <test/beast/beast_Debug_test.cpp>
-#include <test/beast/beast_Journal_test.cpp>
-#include <test/beast/beast_PropertyStream_test.cpp>
-#include <test/beast/beast_tagged_integer_test.cpp>
-#include <test/beast/beast_weak_fn_test.cpp>
-#include <test/beast/beast_Zero_test.cpp>
-#include <test/beast/define_print.cpp>
-#include <test/beast/hash_append_test.cpp>
-#include <test/beast/hash_speed_test.cpp>
-#include <test/beast/IPEndpoint_test.cpp>
-#include <test/beast/LexicalCast_test.cpp>
-#include <test/beast/SemanticVersion_test.cpp>
+#include <BeastConfig.h>
+
+#include <ripple/app/main/Amendments.cpp>
+#include <ripple/app/main/Application.cpp>
+#include <ripple/app/main/BasicApp.cpp>
+#include <ripple/app/main/CollectorManager.cpp>
+#include <ripple/app/main/DBInit.cpp>

--- a/src/ripple/unity/app_main2.cpp
+++ b/src/ripple/unity/app_main2.cpp
@@ -19,8 +19,7 @@
 
 #include <BeastConfig.h>
 
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <ripple/app/main/LoadManager.cpp>
+#include <ripple/app/main/Main.cpp>
+#include <ripple/app/main/NodeIdentity.cpp>
+#include <ripple/app/main/NodeStoreScheduler.cpp>

--- a/src/ripple/unity/app_misc_impl.cpp
+++ b/src/ripple/unity/app_misc_impl.cpp
@@ -19,8 +19,12 @@
 
 #include <BeastConfig.h>
 
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <ripple/app/misc/impl/AccountTxPaging.cpp>
+#include <ripple/app/misc/impl/AmendmentTable.cpp>
+#include <ripple/app/misc/impl/LoadFeeTrack.cpp>
+#include <ripple/app/misc/impl/Manifest.cpp>
+#include <ripple/app/misc/impl/Transaction.cpp>
+#include <ripple/app/misc/impl/TxQ.cpp>
+#include <ripple/app/misc/impl/ValidatorList.cpp>
+#include <ripple/app/misc/impl/ValidatorSite.cpp>
+#include <ripple/app/misc/impl/ValidatorKeys.cpp>

--- a/src/ripple/unity/overlay1.cpp
+++ b/src/ripple/unity/overlay1.cpp
@@ -19,8 +19,7 @@
 
 #include <BeastConfig.h>
 
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <ripple/overlay/impl/Cluster.cpp>
+#include <ripple/overlay/impl/ConnectAttempt.cpp>
+#include <ripple/overlay/impl/Message.cpp>
+#include <ripple/overlay/impl/OverlayImpl.cpp>

--- a/src/ripple/unity/overlay2.cpp
+++ b/src/ripple/unity/overlay2.cpp
@@ -19,8 +19,11 @@
 
 #include <BeastConfig.h>
 
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <ripple/overlay/impl/PeerImp.cpp>
+#include <ripple/overlay/impl/PeerSet.cpp>
+#include <ripple/overlay/impl/TMHello.cpp>
+#include <ripple/overlay/impl/TrafficCount.cpp>
+
+#if DOXYGEN
+#include <ripple/overlay/README.md>
+#endif

--- a/src/ripple/unity/rpcx1.cpp
+++ b/src/ripple/unity/rpcx1.cpp
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+
+// This has to be included early to prevent an obscure MSVC compile error
+#include <boost/asio/deadline_timer.hpp>
+
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/rpc/RPCHandler.h>
+#include <ripple/rpc/handlers/Handlers.h>
+
+#include <ripple/rpc/handlers/AccountCurrenciesHandler.cpp>
+#include <ripple/rpc/handlers/AccountInfo.cpp>
+#include <ripple/rpc/handlers/AccountLines.cpp>
+#include <ripple/rpc/handlers/AccountChannels.cpp>
+#include <ripple/rpc/handlers/AccountObjects.cpp>
+#include <ripple/rpc/handlers/AccountOffers.cpp>
+#include <ripple/rpc/handlers/AccountTx.cpp>
+#include <ripple/rpc/handlers/AccountTxOld.cpp>
+#include <ripple/rpc/handlers/AccountTxSwitch.cpp>
+#include <ripple/rpc/handlers/BlackList.cpp>
+#include <ripple/rpc/handlers/BookOffers.cpp>
+#include <ripple/rpc/handlers/CanDelete.cpp>
+#include <ripple/rpc/handlers/Connect.cpp>
+#include <ripple/rpc/handlers/ConsensusInfo.cpp>
+#include <ripple/rpc/handlers/Feature1.cpp>
+#include <ripple/rpc/handlers/Fee1.cpp>
+#include <ripple/rpc/handlers/FetchInfo.cpp>
+#include <ripple/rpc/handlers/GatewayBalances.cpp>
+#include <ripple/rpc/handlers/GetCounts.cpp>
+#include <ripple/rpc/handlers/LedgerHandler.cpp>
+#include <ripple/rpc/handlers/LedgerAccept.cpp>
+#include <ripple/rpc/handlers/LedgerCleanerHandler.cpp>
+#include <ripple/rpc/handlers/LedgerClosed.cpp>
+#include <ripple/rpc/handlers/LedgerCurrent.cpp>
+#include <ripple/rpc/handlers/LedgerData.cpp>
+#include <ripple/rpc/handlers/LedgerEntry.cpp>
+#include <ripple/rpc/handlers/LedgerHeader.cpp>
+#include <ripple/rpc/handlers/LedgerRequest.cpp>
+#include <ripple/rpc/handlers/LogLevel.cpp>
+#include <ripple/rpc/handlers/LogRotate.cpp>
+#include <ripple/rpc/handlers/NoRippleCheck.cpp>
+#include <ripple/rpc/handlers/OwnerInfo.cpp>

--- a/src/ripple/unity/rpcx2.cpp
+++ b/src/ripple/unity/rpcx2.cpp
@@ -23,45 +23,9 @@
 #include <boost/asio/deadline_timer.hpp>
 
 #include <ripple/protocol/JsonFields.h>
-
 #include <ripple/rpc/RPCHandler.h>
-
-#include <ripple/rpc/impl/RPCHandler.cpp>
-#include <ripple/rpc/impl/Status.cpp>
-
 #include <ripple/rpc/handlers/Handlers.h>
-#include <ripple/rpc/handlers/AccountCurrenciesHandler.cpp>
-#include <ripple/rpc/handlers/AccountInfo.cpp>
-#include <ripple/rpc/handlers/AccountLines.cpp>
-#include <ripple/rpc/handlers/AccountChannels.cpp>
-#include <ripple/rpc/handlers/AccountObjects.cpp>
-#include <ripple/rpc/handlers/AccountOffers.cpp>
-#include <ripple/rpc/handlers/AccountTx.cpp>
-#include <ripple/rpc/handlers/AccountTxOld.cpp>
-#include <ripple/rpc/handlers/AccountTxSwitch.cpp>
-#include <ripple/rpc/handlers/BlackList.cpp>
-#include <ripple/rpc/handlers/BookOffers.cpp>
-#include <ripple/rpc/handlers/CanDelete.cpp>
-#include <ripple/rpc/handlers/Connect.cpp>
-#include <ripple/rpc/handlers/ConsensusInfo.cpp>
-#include <ripple/rpc/handlers/Feature1.cpp>
-#include <ripple/rpc/handlers/Fee1.cpp>
-#include <ripple/rpc/handlers/FetchInfo.cpp>
-#include <ripple/rpc/handlers/GatewayBalances.cpp>
-#include <ripple/rpc/handlers/GetCounts.cpp>
-#include <ripple/rpc/handlers/LedgerHandler.cpp>
-#include <ripple/rpc/handlers/LedgerAccept.cpp>
-#include <ripple/rpc/handlers/LedgerCleanerHandler.cpp>
-#include <ripple/rpc/handlers/LedgerClosed.cpp>
-#include <ripple/rpc/handlers/LedgerCurrent.cpp>
-#include <ripple/rpc/handlers/LedgerData.cpp>
-#include <ripple/rpc/handlers/LedgerEntry.cpp>
-#include <ripple/rpc/handlers/LedgerHeader.cpp>
-#include <ripple/rpc/handlers/LedgerRequest.cpp>
-#include <ripple/rpc/handlers/LogLevel.cpp>
-#include <ripple/rpc/handlers/LogRotate.cpp>
-#include <ripple/rpc/handlers/NoRippleCheck.cpp>
-#include <ripple/rpc/handlers/OwnerInfo.cpp>
+
 #include <ripple/rpc/handlers/PathFind.cpp>
 #include <ripple/rpc/handlers/PayChanClaim.cpp>
 #include <ripple/rpc/handlers/Peers.cpp>
@@ -90,6 +54,8 @@
 #include <ripple/rpc/impl/Handler.cpp>
 #include <ripple/rpc/impl/LegacyPathFind.cpp>
 #include <ripple/rpc/impl/Role.cpp>
+#include <ripple/rpc/impl/RPCHandler.cpp>
 #include <ripple/rpc/impl/RPCHelpers.cpp>
 #include <ripple/rpc/impl/ServerHandlerImp.cpp>
+#include <ripple/rpc/impl/Status.cpp>
 #include <ripple/rpc/impl/TransactionSign.cpp>

--- a/src/test/unity/app_test_unity1.cpp
+++ b/src/test/unity/app_test_unity1.cpp
@@ -1,3 +1,4 @@
+
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
@@ -17,10 +18,19 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
-
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <test/app/AccountTxPaging_test.cpp>
+#include <test/app/AmendmentTable_test.cpp>
+#include <test/app/CrossingLimits_test.cpp>
+#include <test/app/DeliverMin_test.cpp>
+#include <test/app/Discrepancy_test.cpp>
+#include <test/app/Escrow_test.cpp>
+#include <test/app/Flow_test.cpp>
+#include <test/app/Freeze_test.cpp>
+#include <test/app/HashRouter_test.cpp>
+#include <test/app/LedgerLoad_test.cpp>
+#include <test/app/LoadFeeTrack_test.cpp>
+#include <test/app/Manifest_test.cpp>
+#include <test/app/MultiSign_test.cpp>
+#include <test/app/OfferStream_test.cpp>
+#include <test/app/Offer_test.cpp>
+#include <test/app/OversizeMeta_test.cpp>

--- a/src/test/unity/app_test_unity2.cpp
+++ b/src/test/unity/app_test_unity2.cpp
@@ -18,36 +18,20 @@
 */
 //==============================================================================
 
-#include <test/app/AccountTxPaging_test.cpp>
-#include <test/app/AmendmentTable_test.cpp>
-#include <test/app/CrossingLimits_test.cpp>
-#include <test/app/DeliverMin_test.cpp>
-#include <test/app/Discrepancy_test.cpp>
-#include <test/app/Flow_test.cpp>
-#include <test/app/Freeze_test.cpp>
-#include <test/app/HashRouter_test.cpp>
-#include <test/app/LedgerLoad_test.cpp>
-#include <test/app/LoadFeeTrack_test.cpp>
-#include <test/app/Manifest_test.cpp>
-#include <test/app/MultiSign_test.cpp>
-#include <test/app/OfferStream_test.cpp>
-#include <test/app/Offer_test.cpp>
-#include <test/app/OversizeMeta_test.cpp>
 #include <test/app/Path_test.cpp>
 #include <test/app/PayChan_test.cpp>
 #include <test/app/PayStrand_test.cpp>
+#include <test/app/PseudoTx_test.cpp>
 #include <test/app/Regression_test.cpp>
 #include <test/app/SetAuth_test.cpp>
 #include <test/app/SetRegularKey_test.cpp>
+#include <test/app/SetTrust_test.cpp>
 #include <test/app/SHAMapStore_test.cpp>
-#include <test/app/Escrow_test.cpp>
 #include <test/app/Taker_test.cpp>
+#include <test/app/Ticket_test.cpp>
 #include <test/app/Transaction_ordering_test.cpp>
 #include <test/app/TrustAndBalance_test.cpp>
 #include <test/app/TxQ_test.cpp>
 #include <test/app/ValidatorKeys_test.cpp>
 #include <test/app/ValidatorList_test.cpp>
 #include <test/app/ValidatorSite_test.cpp>
-#include <test/app/SetTrust_test.cpp>
-#include <test/app/Ticket_test.cpp>
-#include <test/app/PseudoTx_test.cpp>

--- a/src/test/unity/beast_test_unity1.cpp
+++ b/src/test/unity/beast_test_unity1.cpp
@@ -1,3 +1,4 @@
+
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
@@ -17,10 +18,11 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
-
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <test/beast/aged_associative_container_test.cpp>
+#include <test/beast/beast_abstract_clock_test.cpp>
+#include <test/beast/beast_asio_error_test.cpp>
+#include <test/beast/beast_basic_seconds_clock_test.cpp>
+#include <test/beast/beast_CurrentThreadName_test.cpp>
+#include <test/beast/beast_Debug_test.cpp>
+#include <test/beast/beast_Journal_test.cpp>
+#include <test/beast/beast_PropertyStream_test.cpp>

--- a/src/test/unity/beast_test_unity2.cpp
+++ b/src/test/unity/beast_test_unity2.cpp
@@ -1,3 +1,4 @@
+
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
@@ -17,10 +18,12 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
-
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <test/beast/beast_tagged_integer_test.cpp>
+#include <test/beast/beast_weak_fn_test.cpp>
+#include <test/beast/beast_Zero_test.cpp>
+#include <test/beast/define_print.cpp>
+#include <test/beast/hash_append_test.cpp>
+#include <test/beast/hash_speed_test.cpp>
+#include <test/beast/IPEndpoint_test.cpp>
+#include <test/beast/LexicalCast_test.cpp>
+#include <test/beast/SemanticVersion_test.cpp>

--- a/src/test/unity/jtx_unity1.cpp
+++ b/src/test/unity/jtx_unity1.cpp
@@ -19,15 +19,19 @@
 
 #include <BeastConfig.h>
 
-#include <ripple/overlay/impl/ConnectAttempt.cpp>
-#include <ripple/overlay/impl/Cluster.cpp>
-#include <ripple/overlay/impl/Message.cpp>
-#include <ripple/overlay/impl/OverlayImpl.cpp>
-#include <ripple/overlay/impl/PeerImp.cpp>
-#include <ripple/overlay/impl/PeerSet.cpp>
-#include <ripple/overlay/impl/TMHello.cpp>
-#include <ripple/overlay/impl/TrafficCount.cpp>
+#include <test/jtx/Env_test.cpp>
+#include <test/jtx/WSClient_test.cpp>
 
-#if DOXYGEN
-#include <ripple/overlay/README.md>
-#endif
+#include <test/jtx/impl/Account.cpp>
+#include <test/jtx/impl/amount.cpp>
+#include <test/jtx/impl/balance.cpp>
+#include <test/jtx/impl/delivermin.cpp>
+#include <test/jtx/impl/Env.cpp>
+#include <test/jtx/impl/envconfig.cpp>
+#include <test/jtx/impl/fee.cpp>
+#include <test/jtx/impl/flags.cpp>
+#include <test/jtx/impl/JSONRPCClient.cpp>
+#include <test/jtx/impl/jtx_json.cpp>
+#include <test/jtx/impl/ManualTimeKeeper.cpp>
+#include <test/jtx/impl/memo.cpp>
+#include <test/jtx/impl/multisign.cpp>

--- a/src/test/unity/jtx_unity2.cpp
+++ b/src/test/unity/jtx_unity2.cpp
@@ -19,17 +19,6 @@
 
 #include <BeastConfig.h>
 
-#include <test/jtx/impl/Account.cpp>
-#include <test/jtx/impl/amount.cpp>
-#include <test/jtx/impl/balance.cpp>
-#include <test/jtx/impl/delivermin.cpp>
-#include <test/jtx/impl/Env.cpp>
-#include <test/jtx/impl/envconfig.cpp>
-#include <test/jtx/impl/fee.cpp>
-#include <test/jtx/impl/flags.cpp>
-#include <test/jtx/impl/jtx_json.cpp>
-#include <test/jtx/impl/memo.cpp>
-#include <test/jtx/impl/multisign.cpp>
 #include <test/jtx/impl/offer.cpp>
 #include <test/jtx/impl/owners.cpp>
 #include <test/jtx/impl/paths.cpp>
@@ -45,9 +34,4 @@
 #include <test/jtx/impl/trust.cpp>
 #include <test/jtx/impl/txflags.cpp>
 #include <test/jtx/impl/utility.cpp>
-
-#include <test/jtx/impl/JSONRPCClient.cpp>
-#include <test/jtx/impl/ManualTimeKeeper.cpp>
 #include <test/jtx/impl/WSClient.cpp>
-#include <test/jtx/Env_test.cpp>
-#include <test/jtx/WSClient_test.cpp>

--- a/src/test/unity/server_status_test_unity.cpp
+++ b/src/test/unity/server_status_test_unity.cpp
@@ -1,3 +1,4 @@
+
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
@@ -17,10 +18,4 @@
 */
 //==============================================================================
 
-#include <BeastConfig.h>
-
-#include <ripple/app/misc/CanonicalTXSet.cpp>
-#include <ripple/app/misc/FeeVoteImpl.cpp>
-#include <ripple/app/misc/HashRouter.cpp>
-#include <ripple/app/misc/NetworkOPs.cpp>
-#include <ripple/app/misc/SHAMapStoreImp.cpp>
+#include <test/server/ServerStatus_test.cpp>

--- a/src/test/unity/server_test_unity.cpp
+++ b/src/test/unity/server_test_unity.cpp
@@ -19,4 +19,3 @@
 //==============================================================================
 
 #include <test/server/Server_test.cpp>
-#include <test/server/ServerStatus_test.cpp>


### PR DESCRIPTION
This pull request makes a number of changes in the interest of getting our Travis builds running in the Travis Trusty environment.

1. The first commit makes two changes.  a) It changes install_dependencies.sh so it doesn't fail if `$HOME/bin` already exists.  b) It splits a number of unit test files (identified as big memory users by @seelabs) into two parts.  This addresses issues where gcc was running out of memory and crashing in unity builds.

2. The second commit runs nounity builds with `-j4`.  This helps keep the nounity builds from timing out.

3. The third commit removes a number of unneeded #includes from files in the overlay directory.  This was an (unsuccessful) attempt to keep the gcc debug.nounity build from crashing the complier on OverlayImpl.cpp.  After removing the unneeded includes the crashing source file changed OverlayImpl.cpp to ConnectAttempt.cpp.  The build recovers after the compiler crashes and the second attempt at compiling succeeds.  So the build is still working (although awkwardly).  Even though removing the unneeded #includes did not accomplish their goal, it's still useful work so I'm leaving it in the pull request.

Reviewers: @seelabs, @bachase.

Additional note: There seems to be some caching going on that I don't understand.  The first build takes longer than following builds?  So people may have to put up with the first build timing out and then needing to restart it.  We'll learn more as we play with it...