### PR TITLE
Consensus changes to support decentralization:

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -49,6 +49,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <utility>
+#include <stdexcept>
 
 
 #if defined(BEAST_LINUX) || defined(BEAST_MAC) || defined(BEAST_BSD)
@@ -379,12 +380,11 @@ int run (int argc, char** argv)
                 vm["rpc_port"].as<std::uint16_t>());
 
             if (*config->rpc_port == 0)
-                Throw<std::domain_error> ("");
+                throw std::domain_error("0");
         }
-        catch(std::exception const&)
+        catch(std::exception const& e)
         {
-            std::cerr << "Invalid rpc_port = " <<
-                vm["rpc_port"].as<std::string>() << std::endl;
+            std::cerr << "Invalid rpc_port = " << e.what() << "\n";
             return -1;
         }
     }
@@ -394,11 +394,15 @@ int run (int argc, char** argv)
         try
         {
             config->VALIDATION_QUORUM = vm["quorum"].as <std::size_t> ();
+            if (config->VALIDATION_QUORUM == std::size_t{})
+            {
+                throw std::domain_error("0");
+            }
         }
-        catch(std::exception const&)
+        catch(std::exception const& e)
         {
-            std::cerr << "Invalid quorum = " <<
-                vm["quorum"].as <std::string> () << std::endl;
+            std::cerr << "Invalid value specified for --quorum ("
+                      << e.what() << ")\n";
             return -1;
         }
     }

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -125,6 +125,15 @@ class ValidatorList
 
     PublicKey localPubKey_;
 
+    // The minimum number of listed validators required to allow removing
+    // non-communicative validators from the trusted set. In other words, if the
+    // number of listed validators is less, then use all of them in the
+    // trusted set.
+    std::size_t const MINIMUM_RESIZEABLE_UNL {25};
+    // The maximum size of a trusted set for which greater than Byzantine fault
+    // tolerance isn't needed.
+    std::size_t const BYZANTINE_THRESHOLD {32};
+
 public:
     ValidatorList (
         ManifestCache& validatorManifests,
@@ -395,10 +404,13 @@ ValidatorList::onConsensusStart (
                 std::pair<std::size_t,PublicKey>(
                     std::numeric_limits<std::size_t>::max(), localPubKey_));
         }
-        // If no validations are being received, use all validators.
-        // Otherwise, do not use validators whose validations aren't being received
-        else if (seenValidators.empty() ||
-            seenValidators.find (val->first) != seenValidators.end ())
+        // If the total number of validators is too small, or
+        // no validations are being received, use all validators.
+        // Otherwise, do not use validators whose validations aren't
+        // being received.
+        else if (keyListings_.size() < MINIMUM_RESIZEABLE_UNL ||
+                 seenValidators.empty() ||
+                 seenValidators.find (val->first) != seenValidators.end ())
         {
             rankedKeys.insert (
                 std::pair<std::size_t,PublicKey>(val->second, val->first));
@@ -416,11 +428,12 @@ ValidatorList::onConsensusStart (
 
     auto size = rankedKeys.size();
 
-    // Do not require 80% quorum for less than 10 trusted validators
-    if (rankedKeys.size() >= 10)
+    // Require 80% quorum if there are lots of validators.
+    if (rankedKeys.size() > BYZANTINE_THRESHOLD)
     {
         // Use all eligible keys if there is only one trusted list
-        if (publisherLists_.size() == 1)
+        if (publisherLists_.size() == 1 ||
+                keyListings_.size() < MINIMUM_RESIZEABLE_UNL)
         {
             // Try to raise the quorum to at least 80% of the trusted set
             quorum = std::max(quorum, size - size / 5);
@@ -433,13 +446,13 @@ ValidatorList::onConsensusStart (
         }
     }
 
-    if (minimumQuorum_ && (seenValidators.empty() ||
-            rankedKeys.size() < quorum))
+    if (minimumQuorum_ && seenValidators.size() < quorum)
     {
         quorum = *minimumQuorum_;
-        JLOG (j_.warn()) <<
-            "Using unsafe quorum of " << quorum_ <<
-            " as specified in the command line";
+        JLOG (j_.warn())
+            << "Using unsafe quorum of "
+            << quorum_
+            << " as specified in the command line";
     }
 
     // Do not use achievable quorum until lists from all configured

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -36,7 +36,7 @@ ValidatorList::ValidatorList (
     , publisherManifests_ (publisherManifests)
     , timeKeeper_ (timeKeeper)
     , j_ (j)
-    , quorum_ (minimumQuorum ? *minimumQuorum : 1) // Genesis ledger quorum
+    , quorum_ (minimumQuorum.value_or(1)) // Genesis ledger quorum
     , minimumQuorum_ (minimumQuorum)
 {
 }

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -150,7 +150,7 @@ public:
     int                         PATH_SEARCH_MAX = 10;
 
     // Validation
-    boost::optional<std::size_t> VALIDATION_QUORUM;     // Minimum validations to consider ledger authoritative
+    boost::optional<std::size_t> VALIDATION_QUORUM;     // validations to consider ledger authoritative
 
     std::uint64_t                      FEE_DEFAULT = 10;
     std::uint64_t                      FEE_ACCOUNT_RESERVE = 200*SYSTEM_CURRENCY_PARTS;


### PR DESCRIPTION
  * Use fixed size UNL if the total listed validators are below threshold.
  * Set quorum to provide Byzantine fault tolerance until a threshold of
    total validators is exceeded, at which time quorum is 80%.
  * Honor configured quorum setting.
  * Ensure that a quorum of 0 cannot be configured.