### PR TITLE
Remove hardcoded ports in several unit tests:

### DIFF
--- a/src/ripple/server/impl/Door.h
+++ b/src/ripple/server/impl/Door.h
@@ -106,6 +106,11 @@ public:
     */
     void close();
 
+    endpoint_type get_endpoint() const
+    {
+        return acceptor_.local_endpoint();
+    }
+
 private:
     template <class ConstBufferSequence>
     void create (bool ssl, ConstBufferSequence const& buffers,


### PR DESCRIPTION
Fixes: RIPD-1522

I observed occasional failures with these tests (port in use) - allowing the OS to select seems innocuous in these tests.