### PR TITLE
[TRIVIAL] Remove unused lambda capture

### DIFF
--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -201,7 +201,7 @@ struct Directory_test : public beast::unit_test::suite
         env.close();
         BEAST_EXPECT(dirIsEmpty (*env.closed(), keylet::ownerDir(alice)));
 
-        std::vector<IOU> const currencies = [this,&eng,&gw]()
+        std::vector<IOU> const currencies = [this, &gw]()
         {
             std::vector<IOU> c;
 


### PR DESCRIPTION
Clang 5 warns about this unused lambda capture