### PR TITLE
Remove use of deprecated behavior involving copy members

### DIFF
--- a/src/beast/include/beast/http/detail/chunk_encode.hpp
+++ b/src/beast/include/beast/http/detail/chunk_encode.hpp
@@ -70,6 +70,14 @@ public:
         copy(other);
     }
 
+    /// Copy assignment
+    chunk_header& operator=(chunk_header const& other)
+    {
+        if (this != &other)
+            copy(other);
+        return *this;
+    }
+
     /** Construct a chunk header
 
         @param n The number of octets in this chunk.

--- a/src/beast/include/beast/http/impl/fields.ipp
+++ b/src/beast/include/beast/http/impl/fields.ipp
@@ -119,8 +119,6 @@ public:
         using value_type =
             typename const_iterator::value_type;
 
-        field_range(field_range const&) = default;
-
         field_range(iter_type first, iter_type last)
             : first_(first)
             , last_(last)


### PR DESCRIPTION
*  If any of the destructor, copy assignment or copy constructor
   are user-declared, both copy members should be user-declared,
   otherwise the compiler-generation of them is deprecated.

This P/R just does beast.  An upstream fix has been submitted to boostorg/beast.  A subsequent P/R will fix several instances of this same problem under src/rippled.