### PR TITLE
Remove use of deprecated behavior involving copy members from rippled

### DIFF
--- a/Builds/CMake/CMakeFuncs.cmake
+++ b/Builds/CMake/CMakeFuncs.cmake
@@ -606,7 +606,7 @@ macro(setup_build_boilerplate)
 
   if (NOT WIN32)
     add_definitions(-D_FILE_OFFSET_BITS=64)
-    append_flags(CMAKE_CXX_FLAGS -frtti -std=c++14 -Wno-invalid-offsetof
+    append_flags(CMAKE_CXX_FLAGS -frtti -std=c++14 -Wno-invalid-offsetof -Wdeprecated
       -DBOOST_COROUTINE_NO_DEPRECATION_WARNING -DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
     add_compile_options(-Wall -Wno-sign-compare -Wno-char-subscripts -Wno-format
       -Wno-unused-local-typedefs -g)
@@ -634,7 +634,7 @@ macro(setup_build_boilerplate)
     if (APPLE)
       add_definitions(-DBEAST_COMPILE_OBJECTIVE_CPP=1)
       add_compile_options(
-        -Wno-deprecated -Wno-deprecated-declarations -Wno-unused-function)
+        -Wno-deprecated-declarations -Wno-unused-function)
     endif()
 
     if (is_gcc)

--- a/SConstruct
+++ b/SConstruct
@@ -563,7 +563,8 @@ def config_env(toolchain, variant, env):
         env.Append(CXXFLAGS=[
             '-frtti',
             '-std=c++14',
-            '-Wno-invalid-offsetof'
+            '-Wno-invalid-offsetof',
+            '-Wdeprecated'
             ])
 
         env.Append(CPPDEFINES=['_FILE_OFFSET_BITS=64'])
@@ -576,7 +577,6 @@ def config_env(toolchain, variant, env):
         # These should be the same regardless of platform...
         if Beast.system.osx:
             env.Append(CCFLAGS=[
-                '-Wno-deprecated',
                 '-Wno-deprecated-declarations',
                 '-Wno-unused-function',
                 ])

--- a/src/beast/include/beast/http/detail/chunk_encode.hpp
+++ b/src/beast/include/beast/http/detail/chunk_encode.hpp
@@ -70,6 +70,14 @@ public:
         copy(other);
     }
 
+    /// Copy assignment
+    chunk_header& operator=(chunk_header const& other)
+    {
+        if (this != &other)
+            copy(other);
+        return *this;
+    }
+
     /** Construct a chunk header
 
         @param n The number of octets in this chunk.

--- a/src/beast/include/beast/http/impl/fields.ipp
+++ b/src/beast/include/beast/http/impl/fields.ipp
@@ -119,8 +119,6 @@ public:
         using value_type =
             typename const_iterator::value_type;
 
-        field_range(field_range const&) = default;
-
         field_range(iter_type first, iter_type last)
             : first_(first)
             , last_(last)

--- a/src/ripple/app/paths/impl/FlowDebugInfo.h
+++ b/src/ripple/app/paths/impl/FlowDebugInfo.h
@@ -161,6 +161,7 @@ struct FlowDebugInfo
                 auto const end = FlowDebugInfo::clock::now ();
                 info->timePoints[tag].second = end;
             }
+            Stopper(Stopper&&) = default;
         };
         return Stopper (std::move (name), *this);
     }

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -61,6 +61,7 @@ public:
     {
     }
 
+    PreflightResult(PreflightResult const&) = default;
     /// Deleted copy assignment operator
     PreflightResult& operator=(PreflightResult const&) = delete;
 };
@@ -114,6 +115,7 @@ public:
     {
     }
 
+    PreclaimResult(PreclaimResult const&) = default;
     /// Deleted copy assignment operator
     PreclaimResult& operator=(PreclaimResult const&) = delete;
 };

--- a/src/ripple/basics/CountedObject.h
+++ b/src/ripple/basics/CountedObject.h
@@ -112,6 +112,8 @@ public:
         getCounter ().increment ();
     }
 
+    CountedObject& operator=(CountedObject const&) = default;
+
     ~CountedObject ()
     {
         getCounter ().decrement ();

--- a/src/ripple/beast/clock/abstract_clock.h
+++ b/src/ripple/beast/clock/abstract_clock.h
@@ -66,6 +66,8 @@ public:
     static bool const is_steady = Clock::is_steady;
 
     virtual ~abstract_clock() = default;
+    abstract_clock() = default;
+    abstract_clock(abstract_clock const&) = default;
 
     /** Returns the current time. */
     virtual time_point now() const = 0;

--- a/src/ripple/beast/container/detail/aged_container_iterator.h
+++ b/src/ripple/beast/container/detail/aged_container_iterator.h
@@ -51,15 +51,7 @@ class aged_container_iterator
 public:
     using time_point = typename Iterator::value_type::stashed::time_point;
 
-    // Could be '= default', but Visual Studio 2013 chokes on it [Aug 2014]
-    aged_container_iterator ()
-    {
-    }
-
-    // copy constructor
-    aged_container_iterator (
-        aged_container_iterator<is_const, Iterator, Base>
-            const& other) = default;
+    aged_container_iterator() = default;
 
     // Disable constructing a const_iterator from a non-const_iterator.
     // Converting between reverse and non-reverse iterators should be explicit.

--- a/src/ripple/beast/insight/Base.h
+++ b/src/ripple/beast/insight/Base.h
@@ -30,6 +30,9 @@ class Base
 {
 public:
     virtual ~Base () = 0;
+    Base() = default;
+    Base(Base const&) = default;
+    Base& operator=(Base const&) = default;
 };
 
 }

--- a/src/ripple/core/SociDB.h
+++ b/src/ripple/core/SociDB.h
@@ -28,6 +28,11 @@
     This module requires the @ref beast_sqlite external module.
 */
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 #include <ripple/basics/Log.h>
 #include <ripple/core/JobQueue.h>
 #define SOCI_USE_BOOST
@@ -136,6 +141,10 @@ std::unique_ptr <Checkpointer> makeCheckpointer (soci::session&, JobQueue&, Logs
 // Do not remove this dead code. It forces `scons vcxproj` to include version.h.
 #if 0
 #include "version.h"
+#endif
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
 #endif
 
 #endif

--- a/src/ripple/core/impl/DummySociDynamicBackend.cpp
+++ b/src/ripple/core/impl/DummySociDynamicBackend.cpp
@@ -24,6 +24,11 @@
     header file and some macros to be defined.)
 */
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 #include <BeastConfig.h>
 #include <ripple/basics/contract.h>
 #include <ripple/core/SociDB.h>
@@ -57,3 +62,6 @@ void unload_all (){};
 }  // namespace dynamic_backends
 }  // namespace soci
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/ripple/core/impl/SociDB.cpp
+++ b/src/ripple/core/impl/SociDB.cpp
@@ -17,6 +17,11 @@
 */
 //==============================================================================
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 #include <BeastConfig.h>
 
 #include <ripple/basics/contract.h>
@@ -271,3 +276,7 @@ std::unique_ptr <Checkpointer> makeCheckpointer (
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/ripple/ledger/RawView.h
+++ b/src/ripple/ledger/RawView.h
@@ -38,6 +38,9 @@ class RawView
 {
 public:
     virtual ~RawView() = default;
+    RawView() = default;
+    RawView(RawView const&) = default;
+    RawView& operator=(RawView const&) = delete;
 
     /** Delete an existing state item.
 

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -67,6 +67,7 @@ public:
 
     virtual ~STBase() = default;
 
+    STBase(const STBase& t) = default;
     STBase& operator= (const STBase& t);
 
     bool operator== (const STBase& t) const;

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -98,6 +98,7 @@ private:
             typename T::value_type;
 
     public:
+        ValueProxy(ValueProxy const&) = default;
         ValueProxy& operator= (ValueProxy const&) = delete;
 
         template <class U>
@@ -125,6 +126,7 @@ private:
             typename std::decay<value_type>::type>;
 
     public:
+        OptionalProxy(OptionalProxy const&) = default;
         OptionalProxy& operator= (OptionalProxy const&) = delete;
 
         /** Returns `true` if the field is set.

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -118,6 +118,7 @@ public:
     }
 
     STPathElement(STPathElement const&) = default;
+    STPathElement& operator=(STPathElement const&) = default;
 
     int
     getNodeType () const

--- a/src/ripple/unity/soci.cpp
+++ b/src/ripple/unity/soci.cpp
@@ -16,6 +16,12 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 //==============================================================================
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
+#endif
+
 #include <BeastConfig.h>
 
 // Core soci
@@ -50,3 +56,7 @@
 
 #include <core/blob.cpp>
 #include <backends/sqlite3/blob.cpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Only the second commit needs to be reviewed.  The first commit is P/R https://github.com/ripple/rippled/pull/2222 which did this just for beast.

This installs the `-Wdeprecated` for macOS, which picks up when we rely on deprecated behavior by depending on compiler-generated copy members when we shouldn't.  It fixes the outstanding errors, except for those we inherit from soci.  This warning is effectively turned off for soci.