### PR TITLE
Proposed 0.70.2 hotfix

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -11,6 +11,21 @@ If you are using Red Hat Enterprise Linux 7 or CentOS 7, you can [update using `
 
 # Releases
 
+## Version 0.70.2
+
+The `rippled` 0.70.2 release corrects an emergent behavior which causes large numbers of transactions to get
+stuck in different nodes' open ledgers without being passed on to validators, resulting in a spike in the open
+ledger fee on those nodes.
+
+**New and Updated Features**
+
+This release has no new features.
+
+**Bug Fixes**
+
+- Recent fee rises and TxQ issues ([#2215](https://github.com/ripple/rippled/issues/2215))
+
+
 ## Version 0.70.1
 
 The `rippled` 0.70.1 release corrects a technical flaw in the newly refactored consensus code that could cause a node to get stuck in consensus due to stale votes from a

--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -475,6 +475,12 @@
 #       time a transaction with a higher fee level is added.
 #       Default: 20.
 #
+#   minimum_queue_size = <number>
+#
+#       The queue will always be able to hold at least this <number> of
+#       transactions, regardless of recent ledger sizes or the value of
+#       ledgers_in_queue. Default: 2000.
+#
 #   retry_sequence_percent = <number>
 #
 #       If a client replaces a transaction in the queue (same sequence

--- a/src/ripple/app/ledger/impl/OpenLedger.cpp
+++ b/src/ripple/app/ledger/impl/OpenLedger.cpp
@@ -20,9 +20,13 @@
 #include <BeastConfig.h>
 #include <ripple/app/ledger/OpenLedger.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/app/tx/apply.h>
 #include <ripple/ledger/CachedView.h>
+#include <ripple/overlay/Message.h>
+#include <ripple/overlay/Overlay.h>
+#include <ripple/overlay/predicates.h>
 #include <ripple/protocol/Feature.h>
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -84,14 +88,20 @@ OpenLedger::accept(Application& app, Rules const& rules,
     JLOG(j_.trace()) <<
         "accept ledger " << ledger->seq() << " " << suffix;
     auto next = create(rules, ledger);
+    std::map<uint256, bool> shouldRecover;
     if (retriesFirst)
     {
+        for (auto const& tx : retries)
+        {
+            auto const txID = tx.second->getTransactionID();
+            shouldRecover[txID] = app.getHashRouter().shouldRecover(txID);
+        }
         // Handle disputed tx, outside lock
         using empty =
             std::vector<std::shared_ptr<
                 STTx const>>;
         apply (app, *next, *ledger, empty{},
-            retries, flags, j_);
+            retries, flags, shouldRecover, j_);
     }
     // Block calls to modify, otherwise
     // new tx going into the open ledger
@@ -100,6 +110,19 @@ OpenLedger::accept(Application& app, Rules const& rules,
         std::mutex> lock1(modify_mutex_);
     // Apply tx from the current open view
     if (! current_->txs.empty())
+    {
+        for (auto const& tx : current_->txs)
+        {
+            auto const txID = tx.first->getTransactionID();
+            auto iter = shouldRecover.lower_bound(txID);
+            if (iter != shouldRecover.end()
+                && iter->first == txID)
+                // already had a chance via disputes
+                iter->second = false;
+            else
+                shouldRecover.emplace_hint(iter, txID,
+                    app.getHashRouter().shouldRecover(txID));
+        }
         apply (app, *next, *ledger,
             boost::adaptors::transform(
                 current_->txs,
@@ -109,7 +132,8 @@ OpenLedger::accept(Application& app, Rules const& rules,
             {
                 return p.first;
             }),
-                retries, flags, j_);
+                retries, flags, shouldRecover, j_);
+    }
     // Call the modifier
     if (f)
         f(*next, j_);
@@ -117,6 +141,29 @@ OpenLedger::accept(Application& app, Rules const& rules,
     for (auto const& item : locals)
         app.getTxQ().apply(app, *next,
             item.second, flags, j_);
+
+    // If we didn't relay this transaction recently, relay it to all peers
+    for (auto const& txpair : next->txs)
+    {
+        auto const& tx = txpair.first;
+        auto const txId = tx->getTransactionID();
+        if (auto const toSkip = app.getHashRouter().shouldRelay(txId))
+        {
+            JLOG(j_.debug()) << "Relaying recovered tx " << txId;
+            protocol::TMTransaction msg;
+            Serializer s;
+
+            tx->add(s);
+            msg.set_rawtransaction(s.data(), s.size());
+            msg.set_status(protocol::tsNEW);
+            msg.set_receivetimestamp(
+                app.timeKeeper().now().time_since_epoch().count());
+            app.overlay().foreach(send_if_not(
+                std::make_shared<Message>(msg, protocol::mtTRANSACTION),
+                peer_in_set(*toSkip)));
+        }
+    }
+
     // Switch to the new open view
     std::lock_guard<
         std::mutex> lock2(current_mutex_);
@@ -138,14 +185,24 @@ OpenLedger::create (Rules const& rules,
 auto
 OpenLedger::apply_one (Application& app, OpenView& view,
     std::shared_ptr<STTx const> const& tx,
-        bool retry, ApplyFlags flags,
+        bool retry, ApplyFlags flags, bool shouldRecover,
             beast::Journal j) -> Result
 {
     if (retry)
         flags = flags | tapRETRY;
-    auto const result = ripple::apply(
-        app, view, *tx, flags, j);
-    if (result.second)
+    auto const result = [&]
+    {
+        auto const queueResult = app.getTxQ().apply(
+            app, view, tx, flags | tapPREFER_QUEUE, j);
+        // If the transaction can't get into the queue for intrinsic
+        // reasons, and it can still be recovered, try to put it
+        // directly into the open ledger, else drop it.
+        if (queueResult.first == telCAN_NOT_QUEUE && shouldRecover)
+            return ripple::apply(app, view, *tx, flags, j);
+        return queueResult;
+    }();
+    if (result.second ||
+            result.first == terQUEUED)
         return Result::success;
     if (isTefFailure (result.first) ||
         isTemMalformed (result.first) ||

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -469,7 +469,8 @@ public:
         , mFeeTrack (std::make_unique<LoadFeeTrack>(logs_->journal("LoadManager")))
 
         , mHashRouter (std::make_unique<HashRouter>(
-            stopwatch(), HashRouter::getDefaultHoldTime ()))
+            stopwatch(), HashRouter::getDefaultHoldTime (),
+            HashRouter::getDefaultRecoverLimit ()))
 
         , mValidations (make_Validations (*this))
 

--- a/src/ripple/app/misc/HashRouter.cpp
+++ b/src/ripple/app/misc/HashRouter.cpp
@@ -107,4 +107,14 @@ HashRouter::shouldRelay (uint256 const& key)
     return s.releasePeerSet();
 }
 
+bool
+HashRouter::shouldRecover(uint256 const& key)
+{
+    std::lock_guard <std::mutex> lock(mutex_);
+
+    auto& s = emplace(key).first;
+
+    return s.shouldRecover(recoverLimit_);
+}
+
 } // ripple

--- a/src/ripple/app/misc/HashRouter.h
+++ b/src/ripple/app/misc/HashRouter.h
@@ -34,7 +34,6 @@ namespace ripple {
 // VFALCO NOTE How can both bad and good be set on a hash?
 #define SF_BAD          0x02    // Temporarily bad
 #define SF_SAVED        0x04
-#define SF_RETRY        0x08    // Transaction can be retried
 #define SF_TRUSTED      0x10    // comes from trusted source
 // Private flags, used internally in apply.cpp.
 // Do not attempt to read, set, or reuse.
@@ -66,7 +65,6 @@ private:
         static char const* getCountedObjectName () { return "HashRouterEntry"; }
 
         Entry ()
-            : flags_ (0)
         {
         }
 
@@ -107,12 +105,26 @@ private:
             return true;
         }
 
+        /** Determines if this item should be recovered from the open ledger.
+
+            Counts the number of times the item has been recovered.
+            Every `limit` times the function is called, return false.
+            Else return true.
+
+            @note The limit must be > 0
+        */
+        bool shouldRecover(std::uint32_t limit)
+        {
+            return ++recoveries_ % limit != 0;
+        }
+
     private:
-        int flags_;
+        int flags_ = 0;
         std::set <PeerShortID> peers_;
         // This could be generalized to a map, if more
         // than one flag needs to expire independently.
         boost::optional<Stopwatch::time_point> relayed_;
+        std::uint32_t recoveries_ = 0;
     };
 
 public:
@@ -123,9 +135,16 @@ public:
         return 300s;
     }
 
-    HashRouter (Stopwatch& clock, std::chrono::seconds entryHoldTimeInSeconds)
+    static inline std::uint32_t getDefaultRecoverLimit()
+    {
+        return 1;
+    }
+
+    HashRouter (Stopwatch& clock, std::chrono::seconds entryHoldTimeInSeconds,
+        std::uint32_t recoverLimit)
         : suppressionMap_(clock)
         , holdTime_ (entryHoldTimeInSeconds)
+        , recoverLimit_ (recoverLimit + 1u)
     {
     }
 
@@ -164,6 +183,12 @@ public:
     */
     boost::optional<std::set<PeerShortID>> shouldRelay(uint256 const& key);
 
+    /** Determines whether the hashed item should be recovered
+
+        @return `bool` indicates whether the item should be relayed
+    */
+    bool shouldRecover(uint256 const& key);
+
 private:
     // pair.second indicates whether the entry was created
     std::pair<Entry&, bool> emplace (uint256 const&);
@@ -175,6 +200,8 @@ private:
         hardened_hash<strong_hash>> suppressionMap_;
 
     std::chrono::seconds const holdTime_;
+
+    std::uint32_t const recoverLimit_;
 };
 
 } // ripple

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -788,12 +788,6 @@ void NetworkOPsImp::submitTransaction (std::shared_ptr<STTx const> const& iTrans
     auto const txid = trans->getTransactionID ();
     auto const flags = app_.getHashRouter().getFlags(txid);
 
-    if ((flags & SF_RETRY) != 0)
-    {
-        JLOG(m_journal.warn()) << "Redundant transactions submitted";
-        return;
-    }
-
     if ((flags & SF_BAD) != 0)
     {
         JLOG(m_journal.warn()) << "Submitted transaction cached bad";
@@ -1102,7 +1096,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
                     Serializer s;
 
                     e.transaction->getSTransaction()->add (s);
-                    tx.set_rawtransaction (&s.getData().front(), s.getLength());
+                    tx.set_rawtransaction (s.data(), s.size());
                     tx.set_status (protocol::tsCURRENT);
                     tx.set_receivetimestamp (app_.timeKeeper().now().time_since_epoch().count());
                     tx.set_deferred(e.result == terQUEUED);

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -55,6 +55,7 @@ public:
     struct Setup
     {
         std::size_t ledgersInQueue = 20;
+        std::size_t queueSizeMin = 2000;
         std::uint32_t retrySequencePercent = 25;
         // TODO: eahennis. Can we remove the multi tx factor?
         std::int32_t multiTxnPercent = -90;

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -339,7 +339,7 @@ TxQ::canBeHeld(STTx const& tx, OpenView const& view,
             promise to stick around for long enough that it has
             a realistic chance of getting into a ledger.
         */
-        auto lastValid = getLastLedgerSequence(tx);
+        auto const lastValid = getLastLedgerSequence(tx);
         canBeHeld = !lastValid || *lastValid >=
             view.info().seq + setup_.minimumLastLedgerBuffer;
     }
@@ -349,10 +349,31 @@ TxQ::canBeHeld(STTx const& tx, OpenView const& view,
             can queue. Mitigates the lost cost of relaying should
             an early one fail or get dropped.
         */
-        canBeHeld = accountIter == byAccount_.end() ||
-            replacementIter ||
-                accountIter->second.getTxnCount() <
-                    setup_.maximumTxnPerAccount;
+
+        // Allow if the account is not in the queue at all
+        canBeHeld = accountIter == byAccount_.end();
+
+        if(!canBeHeld)
+        {
+            // Allow this tx to replace another one
+            canBeHeld = replacementIter.is_initialized();
+        }
+
+        if (!canBeHeld)
+        {
+            // Allow if there are fewer than the limit
+            canBeHeld = accountIter->second.getTxnCount() <
+                setup_.maximumTxnPerAccount;
+        }
+
+        if (!canBeHeld)
+        {
+            // Allow if the transaction goes in front of any
+            // queued transactions. Enables recovery of open
+            // ledger transactions, and stuck transactions.
+            auto const tSeq = tx.getSequence();
+            canBeHeld = tSeq < accountIter->second.transactions.rbegin()->first;
+        }
     }
     return canBeHeld;
 }
@@ -512,8 +533,7 @@ TxQ::tryClearAccountQueue(Application& app, OpenView& view,
                 non-blockers?
             Yes: Remove the queued transaction. Continue to next
                 step.
-            No: Reject `txn` with `telINSUF_FEE_P` or
-                `telCAN_NOT_QUEUE`. Stop.
+            No: Reject `txn` with `telCAN_NOT_QUEUE_FEE`. Stop.
         No: Continue to next step.
     3. Does this tx have the expected sequence number for the
             account?
@@ -527,11 +547,11 @@ TxQ::tryClearAccountQueue(Application& app, OpenView& view,
                     than the previous tx?
                 No: Reject with `telINSUF_FEE_P`. Stop.
                 Yes: Are any of the prior sequence txs blockers?
-                    Yes: Reject with `telCAN_NOT_QUEUE`. Stop.
+                    Yes: Reject with `telCAN_NOT_QUEUE_BLOCKED`. Stop.
                     No: Are the fees in-flight of the other
                             queued txs >= than the account
                             balance or minimum account reserve?
-                        Yes: Reject with `telCAN_NOT_QUEUE`. Stop.
+                        Yes: Reject with `telCAN_NOT_QUEUE_BALANCE`. Stop.
                         No: Create a throwaway sandbox `View`. Modify
                             the account's sequence number to match
                             the tx (avoid `terPRE_SEQ`), and decrease
@@ -550,8 +570,7 @@ TxQ::tryClearAccountQueue(Application& app, OpenView& view,
                 it to `doApply()` and return that result.
             No: Continue to the next step.
     6. Can the tx be held in the queue? (See TxQ::canBeHeld).
-            No: Reject `txn` with `telINSUF_FEE_P` if this tx
-                has the current sequence, or `telCAN_NOT_QUEUE`
+            No: Reject `txn` with `telCAN_NOT_QUEUE_FULL`
                 if not. Stop.
             Yes: Continue to the next step.
     7. Is the queue full?
@@ -613,8 +632,15 @@ TxQ::apply(Application& app, OpenView& view,
     auto const baseFee = calculateBaseFee(app, view, *tx, j);
     auto const feeLevelPaid = getFeeLevelPaid(*tx,
         baseLevel, baseFee, setup_);
-    auto const requiredFeeLevel = FeeMetrics::scaleFeeLevel(
-        metricsSnapshot, view);
+    auto const requiredFeeLevel = [&]()
+    {
+        auto feeLevel = FeeMetrics::scaleFeeLevel(metricsSnapshot, view);
+        if ((flags & tapPREFER_QUEUE) && byFee_.size())
+        {
+            return std::max(feeLevel, byFee_.begin()->feeLevel);
+        }
+        return feeLevel;
+    }();
 
     auto accountIter = byAccount_.find(account);
     bool const accountExists = accountIter != byAccount_.end();
@@ -679,8 +705,7 @@ TxQ::apply(Application& app, OpenView& view,
                                 transactionID <<
                                 " in favor of normal queued " <<
                                 existingIter->second.txID;
-                            return{existingIter == txQAcct.transactions.begin() ?
-                                telINSUF_FEE_P : telCAN_NOT_QUEUE, false };
+                            return {telCAN_NOT_QUEUE_BLOCKS, false };
                         }
                     }
                 }
@@ -710,7 +735,7 @@ TxQ::apply(Application& app, OpenView& view,
                     transactionID <<
                     " in favor of queued " <<
                     existingIter->second.txID;
-                return{ telINSUF_FEE_P, false };
+                return{ telCAN_NOT_QUEUE_FEE, false };
             }
         }
     }
@@ -806,7 +831,7 @@ TxQ::apply(Application& app, OpenView& view,
                             transactionID <<
                             ". A blocker-type transaction " <<
                             "is in the queue.";
-                        return{ telCAN_NOT_QUEUE, false };
+                        return{ telCAN_NOT_QUEUE_BLOCKED, false };
                     }
                     multiTxn->fee +=
                         workingIter->second.consequences->fee;
@@ -824,7 +849,7 @@ TxQ::apply(Application& app, OpenView& view,
                     than the account's current balance, or the
                     minimum reserve. If it is, then there's a risk
                     that the fees won't get paid, so drop this
-                    transaction with a telCAN_NOT_QUEUE result.
+                    transaction with a telCAN_NOT_QUEUE_BALANCE result.
                     TODO: Decide whether to count the current txn fee
                         in this limit if it's the last transaction for
                         this account. Currently, it will not count,
@@ -866,7 +891,7 @@ TxQ::apply(Application& app, OpenView& view,
                         "Ignoring transaction " <<
                         transactionID <<
                         ". Total fees in flight too high.";
-                    return{ telCAN_NOT_QUEUE, false };
+                    return{ telCAN_NOT_QUEUE_BALANCE, false };
                 }
 
                 // Create the test view from the current view
@@ -904,24 +929,27 @@ TxQ::apply(Application& app, OpenView& view,
 
     /* Quick heuristic check to see if it's worth checking that this
         tx has a high enough fee to clear all the txs in the queue.
-        1) Must be an account already in the queue.
-        2) Must be have passed the multiTxn checks (tx is not the next
+        1) Transaction is trying to get into the open ledger
+        2) Must be an account already in the queue.
+        3) Must be have passed the multiTxn checks (tx is not the next
             account seq, the skipped seqs are in the queue, the reserve
             doesn't get exhausted, etc).
-        3) The next transaction must not have previously tried and failed
+        4) The next transaction must not have previously tried and failed
             to apply to an open ledger.
-        4) Tx must be paying more than just the required fee level to
+        5) Tx must be paying more than just the required fee level to
             get itself into the queue.
-        5) Fee level must be escalated above the default (if it's not,
+        6) Fee level must be escalated above the default (if it's not,
             then the first tx _must_ have failed to process in `accept`
             for some other reason. Tx is allowed to queue in case
             conditions change, but don't waste the effort to clear).
-        6) Tx is not a 0-fee / free transaction, regardless of fee level.
+        7) Tx is not a 0-fee / free transaction, regardless of fee level.
     */
-    if (accountExists && multiTxn.is_initialized() &&
-        multiTxn->nextTxIter->second.retriesRemaining == MaybeTx::retriesAllowed &&
-        feeLevelPaid > requiredFeeLevel &&
-            requiredFeeLevel > baseLevel && baseFee != 0)
+    if (!(flags & tapPREFER_QUEUE) && accountExists &&
+        multiTxn.is_initialized() &&
+        multiTxn->nextTxIter->second.retriesRemaining ==
+            MaybeTx::retriesAllowed &&
+                feeLevelPaid > requiredFeeLevel &&
+                    requiredFeeLevel > baseLevel && baseFee != 0)
     {
         OpenView sandbox(open_ledger, &view, view.rules());
 
@@ -970,8 +998,7 @@ TxQ::apply(Application& app, OpenView& view,
         JLOG(j_.trace()) << "Transaction " <<
             transactionID <<
             " can not be held";
-        return { feeLevelPaid >= requiredFeeLevel ?
-            telCAN_NOT_QUEUE : telINSUF_FEE_P, false };
+        return { telCAN_NOT_QUEUE, false };
     }
 
     // If the queue is full, decide whether to drop the current
@@ -986,7 +1013,7 @@ TxQ::apply(Application& app, OpenView& view,
                 transactionID <<
                 " would kick a transaction from the same account (" <<
                 account << ") out of the queue.";
-            return { telCAN_NOT_QUEUE, false };
+            return { telCAN_NOT_QUEUE_FULL, false };
         }
         auto const& endAccount = byAccount_.at(lastRIter->account);
         auto endEffectiveFeeLevel = [&]()
@@ -1038,7 +1065,7 @@ TxQ::apply(Application& app, OpenView& view,
             JLOG(j_.warn()) << "Queue is full, and transaction " <<
                 transactionID <<
                 " fee is lower than end item's account average fee";
-            return { telINSUF_FEE_P, false };
+            return { telCAN_NOT_QUEUE_FULL, false };
         }
     }
 
@@ -1105,7 +1132,8 @@ TxQ::processClosedLedger(Application& app,
     auto ledgerSeq = view.info().seq;
 
     if (!timeLeap)
-        maxSize_ = snapshot.txnsExpected * setup_.ledgersInQueue;
+        maxSize_ = std::max (snapshot.txnsExpected * setup_.ledgersInQueue,
+             setup_.queueSizeMin);
 
     // Remove any queued candidates whose LastLedgerSequence has gone by.
     for(auto candidateIter = byFee_.begin(); candidateIter != byFee_.end(); )
@@ -1454,6 +1482,7 @@ setup_TxQ(Config const& config)
     TxQ::Setup setup;
     auto const& section = config.section("transaction_queue");
     set(setup.ledgersInQueue, "ledgers_in_queue", section);
+    set(setup.queueSizeMin, "minimum_queue_size", section);
     set(setup.retrySequencePercent, "retry_sequence_percent", section);
     set(setup.multiTxnPercent, "multi_txn_percent", section);
     set(setup.minimumEscalationMultiplier,

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -36,6 +36,11 @@ enum ApplyFlags
     // Transaction can be retried, soft failures allowed
     tapRETRY            = 0x20,
 
+    // Transaction must pay more than both the open ledger
+    // fee and all transactions in the queue to get into the
+    // open ledger
+    tapPREFER_QUEUE     = 0x40,
+
     // Transaction came from a privileged source
     tapUNLIMITED        = 0x400,
 };

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1056,6 +1056,8 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
     {
         // If we've never been in synch, there's nothing we can do
         // with a transaction
+        JLOG(p_journal_.debug()) << "Ignoring incoming transaction: " <<
+            "Need network ledger";
         return;
     }
 
@@ -1075,11 +1077,10 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMTransaction> const& m)
             if (flags & SF_BAD)
             {
                 fee_ = Resource::feeInvalidSignature;
+                JLOG(p_journal_.debug()) << "Ignoring known bad tx " <<
+                    txID;
                 return;
             }
-
-            if (!(flags & SF_RETRY))
-                return;
         }
 
         JLOG(p_journal_.debug()) << "Got tx " << txID;

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -47,6 +47,11 @@ enum TER
     telINSUF_FEE_P,
     telNO_DST_PARTIAL,
     telCAN_NOT_QUEUE,
+    telCAN_NOT_QUEUE_BALANCE,
+    telCAN_NOT_QUEUE_BLOCKS,
+    telCAN_NOT_QUEUE_BLOCKED,
+    telCAN_NOT_QUEUE_FEE,
+    telCAN_NOT_QUEUE_FULL,
 
     // -299 .. -200: M Malformed (bad signature)
     // Causes:

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ char const* const versionString =
     //  The build version number. You must edit this for each release
     //  and follow the format described at http://semver.org/
     //
-        "0.70.1"
+        "0.70.2"
 
 #if defined(DEBUG) || defined(SANITIZER)
        "+"

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -99,7 +99,12 @@ transResults()
         { telFAILED_PROCESSING,      { "telFAILED_PROCESSING",     "Failed to correctly process transaction."                                      } },
         { telINSUF_FEE_P,            { "telINSUF_FEE_P",           "Fee insufficient."                                                             } },
         { telNO_DST_PARTIAL,         { "telNO_DST_PARTIAL",        "Partial payment to create account not allowed."                                } },
-        { telCAN_NOT_QUEUE,          { "telCAN_NOT_QUEUE",         "Can not queue at this time." } },
+        { telCAN_NOT_QUEUE,          { "telCAN_NOT_QUEUE",         "Can not queue at this time."                                                   } },
+        { telCAN_NOT_QUEUE_BALANCE,  { "telCAN_NOT_QUEUE_BALANCE", "Can not queue at this time: insufficient balance to pay all queued fees."      } },
+        { telCAN_NOT_QUEUE_BLOCKS,   { "telCAN_NOT_QUEUE_BLOCKS",  "Can not queue at this time: would block later queued transaction(s)."          } },
+        { telCAN_NOT_QUEUE_BLOCKED,  { "telCAN_NOT_QUEUE_BLOCKED", "Can not queue at this time: blocking transaction in queue."                    } },
+        { telCAN_NOT_QUEUE_FEE,      { "telCAN_NOT_QUEUE_FEE",     "Can not queue at this time: fee insufficient to replace queued transaction."   } },
+        { telCAN_NOT_QUEUE_FULL,     { "telCAN_NOT_QUEUE_FULL",    "Can not queue at this time: queue is full."                                    } },
 
         { temMALFORMED,              { "temMALFORMED",             "Malformed transaction."                                                        } },
         { temBAD_AMOUNT,             { "temBAD_AMOUNT",            "Can only send positive amounts."                                               } },

--- a/src/test/app/HashRouter_test.cpp
+++ b/src/test/app/HashRouter_test.cpp
@@ -32,7 +32,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s);
+        HashRouter router(stopwatch, 2s, 2);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -69,7 +69,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s);
+        HashRouter router(stopwatch, 2s, 2);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -148,7 +148,7 @@ class HashRouter_test : public beast::unit_test::suite
         // Normal HashRouter
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s);
+        HashRouter router(stopwatch, 2s, 2);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -178,7 +178,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s);
+        HashRouter router(stopwatch, 2s, 2);
 
         uint256 const key1(1);
         BEAST_EXPECT(router.setFlags(key1, 10));
@@ -191,7 +191,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 1s);
+        HashRouter router(stopwatch, 1s, 2);
 
         uint256 const key1(1);
 
@@ -229,6 +229,41 @@ class HashRouter_test : public beast::unit_test::suite
         BEAST_EXPECT(peers && peers->size() == 0);
     }
 
+    void
+    testRecover()
+    {
+        using namespace std::chrono_literals;
+        TestStopwatch stopwatch;
+        HashRouter router(stopwatch, 1s, 5);
+
+        uint256 const key1(1);
+
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(!router.shouldRecover(key1));
+        // Expire, but since the next search will
+        // be for this entry, it will get refreshed
+        // instead.
+        ++stopwatch;
+        BEAST_EXPECT(router.shouldRecover(key1));
+        // Expire, but since the next search will
+        // be for this entry, it will get refreshed
+        // instead.
+        ++stopwatch;
+        // Recover again. Recovery is independent of
+        // time as long as the entry doesn't expire.
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(router.shouldRecover(key1));
+        // Expire again
+        ++stopwatch;
+        BEAST_EXPECT(router.shouldRecover(key1));
+        BEAST_EXPECT(!router.shouldRecover(key1));
+    }
+
 public:
 
     void
@@ -239,6 +274,7 @@ public:
         testSuppression();
         testSetFlags();
         testRelay();
+        testRecover();
     }
 };
 


### PR DESCRIPTION
Recover old open ledger transactions to the queue:

* Recover to the open ledger once, then to the queue.
* If transaction fails to queue for any reason, drop it.
* New result codes for transactions that can not queue.
* Add minimum queue size
* RIPD-1530
fix #2215