### PR TITLE
Add validator list RPC calls (RIPD-1541)

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -3025,6 +3025,14 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\ValidatorListSites.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\Validators.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\handlers\Version.h">
     </ClInclude>
     <ClCompile Include="..\..\src\ripple\rpc\handlers\WalletPropose.cpp">
@@ -4761,6 +4769,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\trust.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\test\jtx\TrustedPublisherServer.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\txflags.h">
     </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\utility.h">
@@ -5044,6 +5054,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\test\rpc\TransactionHistory_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\rpc\ValidatorRPC_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -3630,6 +3630,12 @@
     <ClCompile Include="..\..\src\ripple\rpc\handlers\ValidationSeed.cpp">
       <Filter>ripple\rpc\handlers</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\ValidatorListSites.cpp">
+      <Filter>ripple\rpc\handlers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ripple\rpc\handlers\Validators.cpp">
+      <Filter>ripple\rpc\handlers</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\src\ripple\rpc\handlers\Version.h">
       <Filter>ripple\rpc\handlers</Filter>
     </ClInclude>
@@ -5523,6 +5529,9 @@
     <ClInclude Include="..\..\src\test\jtx\trust.h">
       <Filter>test\jtx</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\test\jtx\TrustedPublisherServer.h">
+      <Filter>test\jtx</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\test\jtx\txflags.h">
       <Filter>test\jtx</Filter>
     </ClInclude>
@@ -5734,6 +5743,9 @@
       <Filter>test\rpc</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\rpc\TransactionHistory_test.cpp">
+      <Filter>test\rpc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\rpc\ValidatorRPC_test.cpp">
       <Filter>test\rpc</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\server\ServerStatus_test.cpp">

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2148,6 +2148,29 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin)
     info[jss::validation_quorum] = static_cast<Json::UInt>(
         app_.validators ().quorum ());
 
+    if (admin)
+    {
+        if (auto when = app_.validators().expires())
+        {
+            if (human)
+            {
+                if(*when == TimeKeeper::time_point::max())
+                    info[jss::validator_list_expires] = "never";
+                else
+                    info[jss::validator_list_expires] = to_string(*when);
+            }
+            else
+                info[jss::validator_list_expires] =
+                    static_cast<Json::UInt>(when->time_since_epoch().count());
+        }
+        else
+        {
+            if (human)
+                info[jss::validator_list_expires] = "unknown";
+            else
+                info[jss::validator_list_expires] = 0;
+        }
+    }
     info[jss::io_latency_ms] = static_cast<Json::UInt> (
         app_.getIOLatency().count());
 

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -25,6 +25,7 @@
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/core/TimeKeeper.h>
 #include <ripple/crypto/csprng.h>
+#include <ripple/json/json_value.h>
 #include <ripple/protocol/PublicKey.h>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/range/adaptors.hpp>
@@ -40,6 +41,9 @@ enum class ListDisposition
     /// List is valid
     accepted = 0,
 
+    /// Same sequence as current list
+    same_sequence,
+
     /// List version is not supported
     unsupported_version,
 
@@ -50,8 +54,11 @@ enum class ListDisposition
     stale,
 
     /// Invalid format or signature
-    invalid,
+    invalid
 };
+
+std::string
+to_string(ListDisposition disposition);
 
 /**
     Trusted Validators List
@@ -102,7 +109,7 @@ class ValidatorList
         bool available;
         std::vector<PublicKey> list;
         std::size_t sequence;
-        std::size_t expiration;
+        TimeKeeper::time_point expiration;
     };
 
     ManifestCache& validatorManifests_;
@@ -125,6 +132,9 @@ class ValidatorList
 
     PublicKey localPubKey_;
 
+    // Currently supported version of publisher list format
+    static constexpr std::uint32_t requiredListVersion = 1;
+
     // The minimum number of listed validators required to allow removing
     // non-communicative validators from the trusted set. In other words, if the
     // number of listed validators is less, then use all of them in the
@@ -133,6 +143,8 @@ class ValidatorList
     // The maximum size of a trusted set for which greater than Byzantine fault
     // tolerance isn't needed.
     std::size_t const BYZANTINE_THRESHOLD {32};
+
+
 
 public:
     ValidatorList (
@@ -317,6 +329,26 @@ public:
     for_each_listed (
         std::function<void(PublicKey const&, bool)> func) const;
 
+    /** Return the time when the validator list will expire
+
+        @note This may be a time in the past if a published list has not
+        been updated since its expiration. It will be boost::none if any
+        configured published list has not been fetched.
+
+        @par Thread Safety
+        May be called concurrently
+    */
+    boost::optional<TimeKeeper::time_point>
+    expires() const;
+
+    /** Return a JSON representation of the state of the validator list
+
+        @par Thread Safety
+        May be called concurrently
+    */
+    Json::Value
+    getJson() const;
+
 private:
     /** Check response for trusted valid published list
 
@@ -373,10 +405,9 @@ ValidatorList::onConsensusStart (
     for (auto const& list : publisherLists_)
     {
         // Remove any expired published lists
-        if (list.second.expiration &&
-                list.second.expiration <=
-                timeKeeper_.now().time_since_epoch().count())
-            removePublisherList (list.first);
+        if (TimeKeeper::time_point{} < list.second.expiration &&
+            list.second.expiration <= timeKeeper_.now())
+            removePublisherList(list.first);
 
         if (! list.second.available)
             allListsAvailable = false;

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -377,7 +377,8 @@ ValidatorList::onConsensusStart (
                 list.second.expiration <=
                 timeKeeper_.now().time_since_epoch().count())
             removePublisherList (list.first);
-        else if (! list.second.available)
+
+        if (! list.second.available)
             allListsAvailable = false;
     }
 

--- a/src/ripple/app/misc/ValidatorSite.h
+++ b/src/ripple/app/misc/ValidatorSite.h
@@ -24,6 +24,7 @@
 #include <ripple/app/misc/detail/Work.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
+#include <ripple/json/json_value.h>
 #include <boost/asio.hpp>
 #include <mutex>
 
@@ -67,10 +68,17 @@ private:
 
     struct Site
     {
+        struct Status
+        {
+            clock_type::time_point refreshed;
+            ListDisposition disposition;
+        };
+
         std::string uri;
         parsedURL pUrl;
         std::chrono::minutes refreshInterval;
         clock_type::time_point nextRefresh;
+        boost::optional<Status> lastRefreshStatus;
     };
 
     boost::asio::io_service& ios_;
@@ -144,6 +152,11 @@ public:
     */
     void
     stop ();
+
+    /** Return JSON representation of configured validator sites
+     */
+    Json::Value
+    getJson() const;
 
 private:
     /// Queue next site to be fetched

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -235,7 +235,7 @@ ValidatorList::applyList (
             (iOld != oldList.end () && *iOld < *iNew))
         {
             // Decrement list count for removed keys
-            if (keyListings_[*iOld] == 1)
+            if (keyListings_[*iOld] <= 1)
                 keyListings_.erase (*iOld);
             else
                 --keyListings_[*iOld];
@@ -394,6 +394,9 @@ ValidatorList::removePublisherList (PublicKey const& publisherKey)
         else
             --iVal->second;
     }
+
+    iList->second.list.clear();
+    iList->second.available = false;
 
     return true;
 }

--- a/src/ripple/app/misc/impl/ValidatorSite.cpp
+++ b/src/ripple/app/misc/impl/ValidatorSite.cpp
@@ -17,12 +17,13 @@
 */
 //==============================================================================
 
-#include <ripple/app/misc/detail/WorkPlain.h>
-#include <ripple/app/misc/detail/WorkSSL.h>
 #include <ripple/app/misc/ValidatorList.h>
 #include <ripple/app/misc/ValidatorSite.h>
+#include <ripple/app/misc/detail/WorkPlain.h>
+#include <ripple/app/misc/detail/WorkSSL.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/json/json_reader.h>
+#include <ripple/protocol/JsonFields.h>
 #include <beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 
@@ -211,6 +212,9 @@ ValidatorSite::onSiteFetch(
         JLOG (j_.warn()) <<
             "Request for validator list at " <<
             sites_[siteIdx].uri << " returned " << res.result_int();
+
+        sites_[siteIdx].lastRefreshStatus.emplace(
+                Site::Status{clock_type::now(), ListDisposition::invalid});
     }
     else if (! ec)
     {
@@ -231,10 +235,19 @@ ValidatorSite::onSiteFetch(
                 body["signature"].asString(),
                 body["version"].asUInt());
 
+            sites_[siteIdx].lastRefreshStatus.emplace(
+                Site::Status{clock_type::now(), disp});
+
             if (ListDisposition::accepted == disp)
             {
                 JLOG (j_.debug()) <<
                     "Applied new validator list from " <<
+                    sites_[siteIdx].uri;
+            }
+            else if (ListDisposition::same_sequence == disp)
+            {
+                JLOG (j_.debug()) <<
+                    "Validator list with current sequence from " <<
                     sites_[siteIdx].uri;
             }
             else if (ListDisposition::stale == disp)
@@ -277,10 +290,17 @@ ValidatorSite::onSiteFetch(
             JLOG (j_.warn()) <<
                 "Unable to parse JSON response from  " <<
                 sites_[siteIdx].uri;
+
+            sites_[siteIdx].lastRefreshStatus.emplace(
+                Site::Status{clock_type::now(), ListDisposition::invalid});
         }
     }
     else
     {
+        std::lock_guard <std::mutex> lock{sites_mutex_};
+        sites_[siteIdx].lastRefreshStatus.emplace(
+                Site::Status{clock_type::now(), ListDisposition::invalid});
+
         JLOG (j_.warn()) <<
             "Problem retrieving from " <<
             sites_[siteIdx].uri <<
@@ -297,4 +317,32 @@ ValidatorSite::onSiteFetch(
     cv_.notify_all();
 }
 
+Json::Value
+ValidatorSite::getJson() const
+{
+    using namespace std::chrono;
+    using Int = Json::Value::Int;
+
+    Json::Value jrr(Json::objectValue);
+    Json::Value& jSites = (jrr[jss::validator_sites] = Json::arrayValue);
+    {
+        std::lock_guard<std::mutex> lock{sites_mutex_};
+        for (Site const& site : sites_)
+        {
+            Json::Value& v = jSites.append(Json::objectValue);
+            v[jss::uri] = site.uri;
+            if (site.lastRefreshStatus)
+            {
+                v[jss::last_refresh_time] =
+                    to_string(site.lastRefreshStatus->refreshed);
+                v[jss::last_refresh_status] =
+                    to_string(site.lastRefreshStatus->disposition);
+            }
+
+            v[jss::refresh_interval_min] =
+                static_cast<Int>(site.refreshInterval.count());
+        }
+    }
+    return jrr;
+}
 } // ripple

--- a/src/ripple/app/misc/impl/ValidatorSite.cpp
+++ b/src/ripple/app/misc/impl/ValidatorSite.cpp
@@ -254,6 +254,16 @@ ValidatorSite::onSiteFetch(
                     "Invalid validator list from " <<
                     sites_[siteIdx].uri;
             }
+            else if (ListDisposition::unsupported_version == disp)
+            {
+                JLOG (j_.warn()) <<
+                    "Unsupported version validator list from " <<
+                    sites_[siteIdx].uri;
+            }
+            else
+            {
+                BOOST_ASSERT(false);
+            }
 
             if (body.isMember ("refresh_interval") &&
                 body["refresh_interval"].isNumeric ())
@@ -268,6 +278,16 @@ ValidatorSite::onSiteFetch(
                 "Unable to parse JSON response from  " <<
                 sites_[siteIdx].uri;
         }
+    }
+    else
+    {
+        JLOG (j_.warn()) <<
+            "Problem retrieving from " <<
+            sites_[siteIdx].uri <<
+            " " <<
+            ec.value() <<
+            ":" <<
+            ec.message();
     }
 
     std::lock_guard <std::mutex> lock{state_mutex_};

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -87,6 +87,7 @@ JSS ( assets );                     // out: GatewayBalances
 JSS ( authorized );                 // out: AccountLines
 JSS ( auth_change );                // out: AccountInfo
 JSS ( auth_change_queued );         // out: AccountInfo
+JSS ( available );                  // out: ValidatorList
 JSS ( balance );                    // out: AccountLines
 JSS ( balances );                   // out: GatewayBalances
 JSS ( base );                       // out: LogLevel
@@ -124,7 +125,7 @@ JSS ( complete_ledgers );           // out: NetworkOPs, PeerImp
 JSS ( consensus );                  // out: NetworkOPs, LedgerConsensus
 JSS ( converge_time );              // out: NetworkOPs
 JSS ( converge_time_s );            // out: NetworkOPs
-JSS ( count );                      // in: AccountTx*
+JSS ( count );                      // in: AccountTx*, ValidatorList
 JSS ( currency );                   // in: paths/PathRequest, STAmount
                                     // out: paths/Node, STPathSet, STAmount
 JSS ( current );                    // out: OwnerInfo
@@ -162,7 +163,8 @@ JSS ( error_message );              // out: error
 JSS ( escrow );                     // in: LedgerEntry
 JSS ( expand );                     // in: handler/Ledger
 JSS ( expected_ledger_size );       // out: TxQ
-JSS ( expiration );                 // out: AccountOffers, AccountChannels
+JSS ( expiration );                 // out: AccountOffers, AccountChannels,
+                                    //      ValidatorList
 JSS ( fail_hard );                  // in: Sign, Submit
 JSS ( failed );                     // out: InboundLedger
 JSS ( feature );                    // in: Feature
@@ -218,6 +220,8 @@ JSS ( key_type );                   // in/out: WalletPropose, TransactionSign
 JSS ( latency );                    // out: PeerImp
 JSS ( last );                       // out: RPCVersion
 JSS ( last_close );                 // out: NetworkOPs
+JSS ( last_refresh_time );          // out: ValidatorSite
+JSS ( last_refresh_status );        // out: ValidatorSite
 JSS ( ledger );                     // in: NetworkOPs, LedgerCleaner,
                                     //     RPCHelpers
                                     // out: NetworkOPs, PeerImp
@@ -242,6 +246,7 @@ JSS ( limit );                      // in/out: AccountTx*, AccountOffers,
                                     // in: LedgerData, BookOffers
 JSS ( limit_peer );                 // out: AccountLines
 JSS ( lines );                      // out: AccountLines
+JSS ( list );                       // out: ValidatorList
 JSS ( load );                       // out: NetworkOPs, PeerImp
 JSS ( load_base );                  // out: NetworkOPs
 JSS ( load_factor );                // out: NetworkOPs
@@ -255,6 +260,7 @@ JSS ( load_factor_server );         // out: NetworkOPs
 JSS ( load_fee );                   // out: LoadFeeTrackImp, NetworkOPs
 JSS ( local );                      // out: resource/Logic.h
 JSS ( local_txs );                  // out: GetCounts
+JSS ( local_static_keys );          // out: ValidatorList
 JSS ( lowest_sequence );            // out: AccountInfo
 JSS ( majority );                   // out: RPC feature
 JSS ( marker );                     // in/out: AccountTx, AccountOffers,
@@ -327,10 +333,12 @@ JSS ( propose_seq );                // out: LedgerPropose
 JSS ( proposers );                  // out: NetworkOPs, LedgerConsensus
 JSS ( protocol );                   // out: PeerImp
 JSS ( pubkey_node );                // out: NetworkOPs
-JSS ( pubkey_validator );           // out: NetworkOPs
+JSS ( pubkey_publisher );           // out: ValidatorList
+JSS ( pubkey_validator );           // out: NetworkOPs, ValidatorList
 JSS ( public_key );                 // out: OverlayImpl, PeerImp, WalletPropose
 JSS ( public_key_hex );             // out: WalletPropose
 JSS ( published_ledger );           // out: NetworkOPs
+JSS ( publisher_lists );            // out: ValidatorList
 JSS ( quality );                    // out: NetworkOPs
 JSS ( quality_in );                 // out: AccountLines
 JSS ( quality_out );                // out: AccountLines
@@ -340,6 +348,7 @@ JSS ( random );                     // out: Random
 JSS ( raw_meta );                   // out: AcceptedLedgerTx
 JSS ( receive_currencies );         // out: AccountCurrencies
 JSS ( reference_level );            // out: TxQ
+JSS ( refresh_interval_min );       // out: ValidatorSites
 JSS ( regular_seed );               // in/out: LedgerEntry
 JSS ( remote );                     // out: Logic.h
 JSS ( request );                    // RPC
@@ -364,7 +373,8 @@ JSS ( seed_hex );                   // in: WalletPropose, TransactionSign
 JSS ( send_currencies );            // out: AccountCurrencies
 JSS ( send_max );                   // in: PathRequest, RipplePathFind
 JSS ( seq );                        // in: LedgerEntry;
-                                    // out: NetworkOPs, RPCSub, AccountOffers
+                                    // out: NetworkOPs, RPCSub, AccountOffers,
+                                    //      ValidatorList
 JSS ( seqNum );                     // out: LedgerToJson
 JSS ( server_state );               // out: NetworkOPs
 JSS ( server_status );              // out: NetworkOPs
@@ -417,6 +427,7 @@ JSS ( transitions );                // out: NetworkOPs
 JSS ( treenode_cache_size );        // out: GetCounts
 JSS ( treenode_track_size );        // out: GetCounts
 JSS ( trusted );                    // out: UnlList
+JSS ( trusted_validator_keys );     // out: ValidatorList
 JSS ( tx );                         // out: STTx, AccountTx*
 JSS ( tx_blob );                    // in/out: Submit,
                                     // in: TransactionSign, AccountTx*
@@ -434,6 +445,7 @@ JSS ( type_hex );                   // out: STPathSet
 JSS ( unl );                        // out: UnlList
 JSS ( unlimited);                   // out: Connection.h
 JSS ( uptime );                     // out: GetCounts
+JSS ( uri );                        // out: ValidatorSites
 JSS ( url );                        // in/out: Subscribe, Unsubscribe
 JSS ( url_password );               // in: Subscribe
 JSS ( url_username );               // in: Subscribe
@@ -441,6 +453,7 @@ JSS ( urlgravatar );                //
 JSS ( username );                   // in: Subscribe
 JSS ( validated );                  // out: NetworkOPs, RPCHelpers, AccountTx*
                                     //      Tx
+JSS ( validator_list_expires );     // out: NetworkOps, ValidatorList
 JSS ( validated_ledger );           // out: NetworkOPs
 JSS ( validated_ledgers );          // out: NetworkOPs
 JSS ( validation_key );             // out: ValidationCreate, ValidationSeed
@@ -449,6 +462,7 @@ JSS ( validation_public_key );      // out: ValidationCreate, ValidationSeed
 JSS ( validation_quorum );          // out: NetworkOPs
 JSS ( validation_seed );            // out: ValidationCreate, ValidationSeed
 JSS ( validations );                // out: AmendmentTableImpl
+JSS ( validator_sites );            // out: ValidatorSites
 JSS ( value );                      // out: STAmount
 JSS ( version );                    // out: RPCVersion
 JSS ( vetoed );                     // out: AmendmentTableImpl

--- a/src/ripple/rpc/handlers/Handlers.h
+++ b/src/ripple/rpc/handlers/Handlers.h
@@ -85,7 +85,8 @@ Json::Value doWalletPropose         (RPC::Context&);
 Json::Value doWalletSeed            (RPC::Context&);
 Json::Value doWalletUnlock          (RPC::Context&);
 Json::Value doWalletVerify          (RPC::Context&);
-
+Json::Value doValidators            (RPC::Context&);
+Json::Value doValidatorListSites    (RPC::Context&);
 } // ripple
 
 #endif

--- a/src/ripple/rpc/handlers/ValidatorListSites.cpp
+++ b/src/ripple/rpc/handlers/ValidatorListSites.cpp
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2014 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/app/misc/ValidatorSite.h>
+#include <ripple/rpc/Context.h>
+
+namespace ripple {
+
+Json::Value
+doValidatorListSites(RPC::Context& context)
+{
+    return context.app.validatorSites().getJson();
+}
+
+}  // namespace ripple

--- a/src/ripple/rpc/handlers/Validators.cpp
+++ b/src/ripple/rpc/handlers/Validators.cpp
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2014 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/app/misc/ValidatorList.h>
+#include <ripple/rpc/Context.h>
+
+namespace ripple {
+
+Json::Value
+doValidators(RPC::Context& context)
+{
+    return context.app.validators().getJson();
+}
+
+}  // namespace ripple

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -151,6 +151,8 @@ Handler handlerArray[] {
     {   "unl_list",             byRef (&doUnlList),             Role::ADMIN,   NO_CONDITION     },
     {   "validation_create",    byRef (&doValidationCreate),    Role::ADMIN,   NO_CONDITION     },
     {   "validation_seed",      byRef (&doValidationSeed),      Role::ADMIN,   NO_CONDITION     },
+    {   "validators",           byRef (&doValidators),          Role::ADMIN,   NO_CONDITION     },
+    {   "validator_list_sites", byRef (&doValidatorListSites),  Role::ADMIN,   NO_CONDITION     },
     {   "wallet_propose",       byRef (&doWalletPropose),       Role::ADMIN,   NO_CONDITION     },
     {   "wallet_seed",          byRef (&doWalletSeed),          Role::ADMIN,   NO_CONDITION     },
 

--- a/src/ripple/unity/rpcx2.cpp
+++ b/src/ripple/unity/rpcx2.cpp
@@ -48,6 +48,8 @@
 #include <ripple/rpc/handlers/Unsubscribe.cpp>
 #include <ripple/rpc/handlers/ValidationCreate.cpp>
 #include <ripple/rpc/handlers/ValidationSeed.cpp>
+#include <ripple/rpc/handlers/Validators.cpp>
+#include <ripple/rpc/handlers/ValidatorListSites.cpp>
 #include <ripple/rpc/handlers/WalletPropose.cpp>
 #include <ripple/rpc/handlers/WalletSeed.cpp>
 
@@ -59,3 +61,5 @@
 #include <ripple/rpc/impl/ServerHandlerImp.cpp>
 #include <ripple/rpc/impl/Status.cpp>
 #include <ripple/rpc/impl/TransactionSign.cpp>
+
+

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include <beast/core/detail/base64.hpp>
-#include <beast/http.hpp>
 #include <ripple/app/misc/ValidatorSite.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/strHex.h>
@@ -28,169 +27,11 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/Sign.h>
 #include <test/jtx.h>
-#include <boost/utility/in_place_factory.hpp>
+#include <test/jtx/TrustedPublisherServer.h>
 #include <boost/asio.hpp>
 
 namespace ripple {
 namespace test {
-
-class http_sync_server
-{
-    using endpoint_type = boost::asio::ip::tcp::endpoint;
-    using address_type = boost::asio::ip::address;
-    using socket_type = boost::asio::ip::tcp::socket;
-
-    using req_type = beast::http::request<beast::http::string_body>;
-    using resp_type = beast::http::response<beast::http::string_body>;
-    using error_code = boost::system::error_code;
-
-    socket_type sock_;
-    boost::asio::ip::tcp::acceptor acceptor_;
-
-    std::string list_;
-
-public:
-    http_sync_server(endpoint_type const& ep,
-            boost::asio::io_service& ios,
-            std::pair<PublicKey, SecretKey> keys,
-            std::string const& manifest,
-            int sequence,
-            std::size_t expiration,
-            int version,
-            std::vector <PublicKey> const& validators)
-        : sock_(ios)
-        , acceptor_(ios)
-    {
-        std::string data =
-            "{\"sequence\":" + std::to_string(sequence) +
-            ",\"expiration\":" + std::to_string(expiration) +
-            ",\"validators\":[";
-
-        for (auto const& val : validators)
-        {
-            data += "{\"validation_public_key\":\"" + strHex (val) + "\"},";
-        }
-        data.pop_back();
-        data += "]}";
-        std::string blob = beast::detail::base64_encode(data);
-
-        list_ = "{\"blob\":\"" + blob + "\"";
-
-        auto const sig = sign(keys.first, keys.second, makeSlice(data));
-
-        list_ += ",\"signature\":\"" + strHex(sig) + "\"";
-        list_ += ",\"manifest\":\"" + manifest + "\"";
-        list_ += ",\"version\":" + std::to_string(version) + '}';
-
-        acceptor_.open(ep.protocol());
-        error_code ec;
-        acceptor_.set_option(
-            boost::asio::ip::tcp::acceptor::reuse_address(true), ec);
-        acceptor_.bind(ep);
-        acceptor_.listen(boost::asio::socket_base::max_connections);
-        acceptor_.async_accept(sock_,
-            std::bind(&http_sync_server::on_accept, this,
-                std::placeholders::_1));
-    }
-
-    ~http_sync_server()
-    {
-        error_code ec;
-        acceptor_.close(ec);
-    }
-
-private:
-    struct lambda
-    {
-        int id;
-        http_sync_server& self;
-        socket_type sock;
-        boost::asio::io_service::work work;
-
-        lambda(int id_, http_sync_server& self_,
-                socket_type&& sock_)
-            : id(id_)
-            , self(self_)
-            , sock(std::move(sock_))
-            , work(sock.get_io_service())
-        {
-        }
-
-        void operator()()
-        {
-            self.do_peer(id, std::move(sock));
-        }
-    };
-
-    void
-    on_accept(error_code ec)
-    {
-        // ec must be checked before `acceptor_` or the member variable may be
-        // accessed after the destructor has completed
-        if(ec || !acceptor_.is_open())
-            return;
-
-        static int id_ = 0;
-        std::thread{lambda{++id_, *this, std::move(sock_)}}.detach();
-        acceptor_.async_accept(sock_,
-            std::bind(&http_sync_server::on_accept, this,
-                std::placeholders::_1));
-    }
-
-    void
-    do_peer(int id, socket_type&& sock0)
-    {
-        socket_type sock(std::move(sock0));
-        beast::multi_buffer sb;
-        error_code ec;
-        for(;;)
-        {
-            req_type req;
-            beast::http::read(sock, sb, req, ec);
-            if(ec)
-                break;
-            auto path = req.target().to_string();
-            if(path != "/validators")
-            {
-                resp_type res;
-                res.result(beast::http::status::not_found);
-                res.version = req.version;
-                res.insert("Server", "http_sync_server");
-                res.insert("Content-Type", "text/html");
-                res.body = "The file '" + path + "' was not found";
-                res.prepare_payload();
-                write(sock, res, ec);
-                if(ec)
-                    break;
-            }
-            resp_type res;
-            res.result(beast::http::status::ok);
-            res.version = req.version;
-            res.insert("Server", "http_sync_server");
-            res.insert("Content-Type", "application/json");
-
-            res.body = list_;
-            try
-            {
-                res.prepare_payload();
-            }
-            catch(std::exception const& e)
-            {
-                res = {};
-                res.result(beast::http::status::internal_server_error);
-                res.version = req.version;
-                res.insert("Server", "http_sync_server");
-                res.insert("Content-Type", "text/html");
-                res.body =
-                    std::string{"An internal error occurred"} + e.what();
-                res.prepare_payload();
-            }
-            write(sock, res, ec);
-            if(ec)
-                break;
-        }
-    }
-};
 
 class ValidatorSite_test : public beast::unit_test::suite
 {
@@ -272,7 +113,6 @@ private:
         using namespace jtx;
 
         Env env (*this);
-        auto& ioService = env.app ().getIOService ();
         auto& trustedKeys = env.app ().validators ();
 
         beast::Journal journal;
@@ -316,27 +156,42 @@ private:
         while (list2.size () < listSize)
             list2.push_back (randomNode());
 
-        std::uint16_t constexpr port1 = 7475;
-        std::uint16_t constexpr port2 = 7476;
 
         using endpoint_type = boost::asio::ip::tcp::endpoint;
         using address_type = boost::asio::ip::address;
 
-        endpoint_type ep1{address_type::from_string("127.0.0.1"), port1};
-        endpoint_type ep2{address_type::from_string("127.0.0.1"), port2};
+        // Use ports of 0 to allow OS selection
+        endpoint_type ep1{address_type::from_string("127.0.0.1"), 0};
+        endpoint_type ep2{address_type::from_string("127.0.0.1"), 0};
 
         auto const sequence = 1;
         auto const version = 1;
         NetClock::time_point const expiration =
             env.timeKeeper().now() + 3600s;
 
-        http_sync_server server1(
-            ep1, ioService, pubSigningKeys1, manifest1, sequence,
-            expiration.time_since_epoch().count(), version, list1);
+        TrustedPublisherServer server1(
+            ep1,
+            env.app().getIOService(),
+            pubSigningKeys1,
+            manifest1,
+            sequence,
+            expiration,
+            version,
+            list1);
 
-        http_sync_server server2(
-            ep2, ioService, pubSigningKeys2, manifest2, sequence,
-            expiration.time_since_epoch().count(), version, list2);
+        TrustedPublisherServer server2(
+            ep2,
+            env.app().getIOService(),
+            pubSigningKeys2,
+            manifest2,
+            sequence,
+            expiration,
+            version,
+            list2);
+
+        std::uint16_t const port1 = server1.local_endpoint().port();
+        std::uint16_t const port2 = server2.local_endpoint().port();
+
 
         {
             // fetch single site

--- a/src/test/jtx/TrustedPublisherServer.h
+++ b/src/test/jtx/TrustedPublisherServer.h
@@ -1,0 +1,201 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#ifndef RIPPLE_TEST_TRUSTED_PUBLISHER_SERVER_H_INCLUDED
+#define RIPPLE_TEST_TRUSTED_PUBLISHER_SERVER_H_INCLUDED
+
+#include <beast/core/detail/base64.hpp>
+#include <ripple/protocol/PublicKey.h>
+#include <ripple/protocol/SecretKey.h>
+#include <ripple/protocol/Sign.h>
+#include <ripple/basics/strHex.h>
+#include <boost/asio.hpp>
+#include <beast/core/detail/base64.hpp>
+#include <beast/http.hpp>
+
+namespace ripple {
+namespace test {
+
+class TrustedPublisherServer
+{
+    using endpoint_type = boost::asio::ip::tcp::endpoint;
+    using address_type = boost::asio::ip::address;
+    using socket_type = boost::asio::ip::tcp::socket;
+
+    using req_type = beast::http::request<beast::http::string_body>;
+    using resp_type = beast::http::response<beast::http::string_body>;
+    using error_code = boost::system::error_code;
+
+    socket_type sock_;
+    boost::asio::ip::tcp::acceptor acceptor_;
+
+    std::string list_;
+
+public:
+    TrustedPublisherServer(
+        endpoint_type const& ep,
+        boost::asio::io_service& ios,
+        std::pair<PublicKey, SecretKey> keys,
+        std::string const& manifest,
+        int sequence,
+        NetClock::time_point expiration,
+        int version,
+        std::vector<PublicKey> const& validators)
+        : sock_(ios), acceptor_(ios)
+    {
+        std::string data = "{\"sequence\":" + std::to_string(sequence) +
+            ",\"expiration\":" +
+            std::to_string(expiration.time_since_epoch().count()) +
+            ",\"validators\":[";
+
+        for (auto const& val : validators)
+        {
+            data += "{\"validation_public_key\":\"" + strHex(val) + "\"},";
+        }
+        data.pop_back();
+        data += "]}";
+        std::string blob = beast::detail::base64_encode(data);
+
+        list_ = "{\"blob\":\"" + blob + "\"";
+
+        auto const sig = sign(keys.first, keys.second, makeSlice(data));
+
+        list_ += ",\"signature\":\"" + strHex(sig) + "\"";
+        list_ += ",\"manifest\":\"" + manifest + "\"";
+        list_ += ",\"version\":" + std::to_string(version) + '}';
+
+        acceptor_.open(ep.protocol());
+        error_code ec;
+        acceptor_.set_option(
+            boost::asio::ip::tcp::acceptor::reuse_address(true), ec);
+        acceptor_.bind(ep);
+        acceptor_.listen(boost::asio::socket_base::max_connections);
+        acceptor_.async_accept(
+            sock_,
+            std::bind(
+                &TrustedPublisherServer::on_accept, this, std::placeholders::_1));
+    }
+
+    ~TrustedPublisherServer()
+    {
+        error_code ec;
+        acceptor_.close(ec);
+    }
+
+    endpoint_type
+    local_endpoint() const
+    {
+        return acceptor_.local_endpoint();
+    }
+
+private:
+    struct lambda
+    {
+        int id;
+        TrustedPublisherServer& self;
+        socket_type sock;
+        boost::asio::io_service::work work;
+
+        lambda(int id_, TrustedPublisherServer& self_, socket_type&& sock_)
+            : id(id_)
+            , self(self_)
+            , sock(std::move(sock_))
+            , work(sock.get_io_service())
+        {
+        }
+
+        void
+        operator()()
+        {
+            self.do_peer(id, std::move(sock));
+        }
+    };
+
+    void
+    on_accept(error_code ec)
+    {
+        // ec must be checked before `acceptor_` or the member variable may be
+        // accessed after the destructor has completed
+        if (ec || !acceptor_.is_open())
+            return;
+
+        static int id_ = 0;
+        std::thread{lambda{++id_, *this, std::move(sock_)}}.detach();
+        acceptor_.async_accept(
+            sock_,
+            std::bind(
+                &TrustedPublisherServer::on_accept, this, std::placeholders::_1));
+    }
+
+    void
+    do_peer(int id, socket_type&& sock0)
+    {
+        socket_type sock(std::move(sock0));
+        beast::multi_buffer sb;
+        error_code ec;
+        for (;;)
+        {
+            req_type req;
+            beast::http::read(sock, sb, req, ec);
+            if (ec)
+                break;
+            auto path = req.target().to_string();
+            if (path != "/validators")
+            {
+                resp_type res;
+                res.result(beast::http::status::not_found);
+                res.version = req.version;
+                res.insert("Server", "TrustedPublisherServer");
+                res.insert("Content-Type", "text/html");
+                res.body = "The file '" + path + "' was not found";
+                res.prepare_payload();
+                write(sock, res, ec);
+                if (ec)
+                    break;
+            }
+            resp_type res;
+            res.result(beast::http::status::ok);
+            res.version = req.version;
+            res.insert("Server", "TrustedPublisherServer");
+            res.insert("Content-Type", "application/json");
+
+            res.body = list_;
+            try
+            {
+                res.prepare_payload();
+            }
+            catch (std::exception const& e)
+            {
+                res = {};
+                res.result(beast::http::status::internal_server_error);
+                res.version = req.version;
+                res.insert("Server", "TrustedPublisherServer");
+                res.insert("Content-Type", "text/html");
+                res.body = std::string{"An internal error occurred"} + e.what();
+                res.prepare_payload();
+            }
+            write(sock, res, ec);
+            if (ec)
+                break;
+        }
+    }
+};
+
+}  // namespace test
+}  // namespace ripple
+#endif

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -1,0 +1,377 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2016 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/main/BasicApp.h>
+#include <ripple/app/misc/ValidatorSite.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/core/ConfigSections.h>
+#include <ripple/json/json_value.h>
+#include <ripple/protocol/JsonFields.h>
+#include <ripple/protocol/Sign.h>
+#include <beast/core/detail/base64.hpp>
+#include <test/jtx.h>
+#include <test/jtx/TrustedPublisherServer.h>
+
+#include <set>
+
+namespace ripple {
+
+namespace test {
+
+class ValidatorRPC_test : public beast::unit_test::suite
+{
+    static PublicKey
+    randomNode()
+    {
+        return derivePublicKey(KeyType::secp256k1, randomSecretKey());
+    }
+
+    std::string
+    makeManifestString(
+        PublicKey const& pk,
+        SecretKey const& sk,
+        PublicKey const& spk,
+        SecretKey const& ssk,
+        int seq)
+    {
+        STObject st(sfGeneric);
+        st[sfSequence] = seq;
+        st[sfPublicKey] = pk;
+        st[sfSigningPubKey] = spk;
+
+        sign(st, HashPrefix::manifest, *publicKeyType(spk), ssk);
+        sign(
+            st,
+            HashPrefix::manifest,
+            *publicKeyType(pk),
+            sk,
+            sfMasterSignature);
+
+        Serializer s;
+        st.add(s);
+
+        return beast::detail::base64_encode(
+            std::string(static_cast<char const*>(s.data()), s.size()));
+    }
+
+public:
+    void
+    testPrivileges()
+    {
+        using namespace test::jtx;
+
+        for (bool const isAdmin : {true, false})
+        {
+            for (std::string cmd : {"validators", "validator_list_sites"})
+            {
+                Env env{*this, isAdmin ? envconfig() : envconfig(no_admin)};
+                auto const jrr = env.rpc(cmd)[jss::result];
+                if (isAdmin)
+                {
+                    BEAST_EXPECT(!jrr.isMember(jss::error));
+                    BEAST_EXPECT(jrr[jss::status] == "success");
+                }
+                else
+                {
+                    // The current HTTP/S ServerHandler returns an HTTP 403
+                    // error code here rather than a noPermission JSON error.
+                    // The JSONRPCClient just eats that error and returns null
+                    // result.
+                    BEAST_EXPECT(jrr.isNull());
+                }
+            }
+
+            {
+                Env env{*this, isAdmin ? envconfig() : envconfig(no_admin)};
+                auto const jrr = env.rpc("server_info")[jss::result];
+                BEAST_EXPECT(jrr[jss::status] == "success");
+                BEAST_EXPECT(jrr[jss::info].isMember(
+                                 jss::validator_list_expires) == isAdmin);
+            }
+
+            {
+                Env env{*this, isAdmin ? envconfig() : envconfig(no_admin)};
+                auto const jrr = env.rpc("server_state")[jss::result];
+                BEAST_EXPECT(jrr[jss::status] == "success");
+                BEAST_EXPECT(jrr[jss::state].isMember(
+                                 jss::validator_list_expires) == isAdmin);
+            }
+        }
+    }
+
+    void
+    testStaticUNL()
+    {
+        using namespace test::jtx;
+
+        std::set<std::string> const keys = {
+            "n949f75evCHwgyP4fPVgaHqNHxUVN15PsJEZ3B3HnXPcPjcZAoy7",
+            "n9MD5h24qrQqiyBC8aeqqCWvpiBiYQ3jxSr91uiDvmrkyHRdYLUj"};
+        Env env{
+            *this,
+            envconfig([&keys](std::unique_ptr<Config> cfg) {
+                for (auto const& key : keys)
+                    cfg->section(SECTION_VALIDATORS).append(key);
+                return cfg;
+            }),
+        };
+
+        // Server info reports maximum expiration since not dynamic
+        {
+            auto const jrr = env.rpc("server_info")[jss::result];
+            BEAST_EXPECT(
+                jrr[jss::info][jss::validator_list_expires] == "never");
+        }
+        {
+            auto const jrr = env.rpc("server_state")[jss::result];
+            BEAST_EXPECT(
+                jrr[jss::state][jss::validator_list_expires].asUInt() ==
+                NetClock::time_point::max().time_since_epoch().count());
+        }
+        // All our keys are in the response
+        {
+            auto const jrr = env.rpc("validators")[jss::result];
+            BEAST_EXPECT(jrr[jss::validator_list_expires] == "never");
+            BEAST_EXPECT(jrr[jss::validation_quorum].asUInt() == keys.size());
+            BEAST_EXPECT(jrr[jss::trusted_validator_keys].size() == keys.size());
+            BEAST_EXPECT(jrr[jss::publisher_lists].size() == 0);
+            BEAST_EXPECT(jrr[jss::local_static_keys].size() == keys.size());
+            for (auto const& jKey : jrr[jss::local_static_keys])
+            {
+                BEAST_EXPECT(keys.count(jKey.asString())== 1);
+            }
+        }
+        // No validator sites configured
+        {
+            auto const jrr = env.rpc("validator_list_sites")[jss::result];
+            BEAST_EXPECT(jrr[jss::validator_sites].size() == 0);
+        }
+    }
+
+    void
+    testDynamicUNL()
+    {
+        using namespace test::jtx;
+        using endpoint_type = boost::asio::ip::tcp::endpoint;
+        using address_type = boost::asio::ip::address;
+
+        auto toStr = [](PublicKey const& publicKey) {
+            return toBase58(TokenType::TOKEN_NODE_PUBLIC, publicKey);
+        };
+
+        // Publisher manifest/signing keys
+        auto const publisherSecret = randomSecretKey();
+        auto const publisherPublic =
+            derivePublicKey(KeyType::ed25519, publisherSecret);
+        auto const publisherSigningKeys = randomKeyPair(KeyType::secp256k1);
+        auto const manifest = makeManifestString(
+            publisherPublic,
+            publisherSecret,
+            publisherSigningKeys.first,
+            publisherSigningKeys.second,
+            1);
+
+        // Validator keys that will be in the published list
+        std::vector<PublicKey> keys = {randomNode(), randomNode()};
+        std::set<std::string> expectedKeys;
+        for (auto const& key : keys)
+            expectedKeys.insert(toStr(key));
+
+
+        //----------------------------------------------------------------------
+        // Publisher list site unavailable
+        {
+            // Publisher site information
+            std::string siteURI = "http://127.0.0.1:1234/validators";
+
+            Env env{
+                *this,
+                envconfig([&](std::unique_ptr<Config> cfg) {
+                    cfg->section(SECTION_VALIDATOR_LIST_SITES).append(siteURI);
+                    cfg->section(SECTION_VALIDATOR_LIST_KEYS)
+                        .append(strHex(publisherPublic));
+                    return cfg;
+                }),
+            };
+
+            env.app().validatorSites().start();
+            env.app().validatorSites().join();
+
+            {
+                auto const jrr = env.rpc("server_info")[jss::result];
+                BEAST_EXPECT(
+                    jrr[jss::info][jss::validator_list_expires] == "unknown");
+            }
+            {
+                auto const jrr = env.rpc("server_state")[jss::result];
+                BEAST_EXPECT(
+                    jrr[jss::state][jss::validator_list_expires].asInt() == 0);
+            }
+            {
+                auto const jrr = env.rpc("validators")[jss::result];
+                BEAST_EXPECT(jrr[jss::validation_quorum].asUInt() ==
+                    std::numeric_limits<std::uint32_t>::max());
+                BEAST_EXPECT(jrr[jss::local_static_keys].size() == 0);
+                BEAST_EXPECT(jrr[jss::trusted_validator_keys].size() == 0);
+                BEAST_EXPECT(jrr[jss::validator_list_expires] == "unknown");
+
+                if (BEAST_EXPECT(jrr[jss::publisher_lists].size() == 1))
+                {
+                    auto jp = jrr[jss::publisher_lists][0u];
+                    BEAST_EXPECT(jp[jss::available] == false);
+                    BEAST_EXPECT(jp[jss::list].size() == 0);
+                    BEAST_EXPECT(!jp.isMember(jss::seq));
+                    BEAST_EXPECT(!jp.isMember(jss::expiration));
+                    BEAST_EXPECT(!jp.isMember(jss::version));
+                    BEAST_EXPECT(
+                        jp[jss::pubkey_publisher] == strHex(publisherPublic));
+                }
+            }
+            {
+                auto const jrr = env.rpc("validator_list_sites")[jss::result];
+                if (BEAST_EXPECT(jrr[jss::validator_sites].size() == 1))
+                {
+                    auto js = jrr[jss::validator_sites][0u];
+                    BEAST_EXPECT(js[jss::refresh_interval_min].asUInt() == 5);
+                    BEAST_EXPECT(js[jss::uri] == siteURI);
+                    BEAST_EXPECT(js.isMember(jss::last_refresh_time));
+                    BEAST_EXPECT(js[jss::last_refresh_status] == "invalid");
+                }
+            }
+        }
+        //----------------------------------------------------------------------
+        // Publisher list site available
+        {
+            NetClock::time_point const expiration{3600s};
+
+            // 0 port means to use OS port selection
+            endpoint_type ep{address_type::from_string("127.0.0.1"), 0};
+
+            // Manage single thread io_service for server
+            struct Worker : BasicApp
+            {
+                Worker() : BasicApp(1) {}
+            };
+            Worker w;
+
+            TrustedPublisherServer server(
+                ep,
+                w.get_io_service(),
+                publisherSigningKeys,
+                manifest,
+                1,
+                expiration,
+                1,
+                keys);
+
+            endpoint_type const & local_ep = server.local_endpoint();
+            std::string siteURI = "http://127.0.0.1:" +
+                std::to_string(local_ep.port()) + "/validators";
+
+            Env env{
+                *this,
+                envconfig([&](std::unique_ptr<Config> cfg) {
+                    cfg->section(SECTION_VALIDATOR_LIST_SITES).append(siteURI);
+                    cfg->section(SECTION_VALIDATOR_LIST_KEYS)
+                        .append(strHex(publisherPublic));
+                    return cfg;
+                }),
+            };
+
+            env.app().validatorSites().start();
+            env.app().validatorSites().join();
+            env.app().validators().onConsensusStart(
+                std::set<PublicKey>{keys.begin(), keys.end()});
+
+            {
+                auto const jrr = env.rpc("server_info")[jss::result];
+                BEAST_EXPECT(jrr[jss::info][jss::validator_list_expires] ==
+                    to_string(expiration));
+            }
+            {
+                auto const jrr = env.rpc("server_state")[jss::result];
+                BEAST_EXPECT(
+                    jrr[jss::state][jss::validator_list_expires].asUInt() ==
+                    expiration.time_since_epoch().count());
+            }
+            {
+                auto const jrr = env.rpc("validators")[jss::result];
+                BEAST_EXPECT(jrr[jss::validation_quorum].asUInt() == 2);
+                BEAST_EXPECT(
+                    jrr[jss::validator_list_expires] == to_string(expiration));
+                BEAST_EXPECT(jrr[jss::local_static_keys].size() == 0);
+
+                BEAST_EXPECT(jrr[jss::trusted_validator_keys].size() ==
+                    expectedKeys.size());
+                for (auto const& jKey : jrr[jss::trusted_validator_keys])
+                {
+                    BEAST_EXPECT(expectedKeys.count(jKey.asString()) == 1);
+                }
+
+                if (BEAST_EXPECT(jrr[jss::publisher_lists].size() == 1))
+                {
+                    auto jp = jrr[jss::publisher_lists][0u];
+                    BEAST_EXPECT(jp[jss::available] == true);
+                    if (BEAST_EXPECT(jp[jss::list].size() == 2))
+                    {
+                        // check entries
+                        std::set<std::string> foundKeys;
+                        for (auto const& k : jp[jss::list])
+                        {
+                            foundKeys.insert(k.asString());
+                        }
+                        BEAST_EXPECT(foundKeys == expectedKeys);
+                    }
+                    BEAST_EXPECT(jp[jss::seq].asUInt() == 1);
+                    BEAST_EXPECT(
+                        jp[jss::pubkey_publisher] == strHex(publisherPublic));
+                    BEAST_EXPECT(jp[jss::expiration] == to_string(expiration));
+                    BEAST_EXPECT(jp[jss::version] == 1);
+                }
+            }
+            {
+                auto const jrr = env.rpc("validator_list_sites")[jss::result];
+                if (BEAST_EXPECT(jrr[jss::validator_sites].size() == 1))
+                {
+                    auto js = jrr[jss::validator_sites][0u];
+                    BEAST_EXPECT(js[jss::refresh_interval_min].asUInt() == 5);
+                    BEAST_EXPECT(js[jss::uri] == siteURI);
+                    BEAST_EXPECT(js[jss::last_refresh_status] == "accepted");
+                    // The actual time of the update will vary run to run, so
+                    // just verify the time is there
+                    BEAST_EXPECT(js.isMember(jss::last_refresh_time));
+                }
+            }
+        }
+    }
+
+    void
+    run()
+    {
+        testPrivileges();
+        testStaticUNL();
+        testDynamicUNL();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(ValidatorRPC, app, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/unity/rpc_test_unity.cpp
+++ b/src/test/unity/rpc_test_unity.cpp
@@ -46,3 +46,4 @@
 #include <test/rpc/Subscribe_test.cpp>
 #include <test/rpc/TransactionEntry_test.cpp>
 #include <test/rpc/TransactionHistory_test.cpp>
+#include <test/rpc/ValidatorRPC_test.cpp>


### PR DESCRIPTION
In support of dynamic validator list, this changeset

1. Adds a new `validator_list_expires` field to `server_info` that indicates when the current validator list will become stale.
2. Adds a new admin only `validator_lists` RPC that returns the current list of known validators and the most recent published validator lists.
3. Adds a new admin only `validator_sites` RPC that returns the list of configured validator publisher sites and when they were most recently queried.

This builds on PR #2240, which is the first two commits in this changeset.  