### PR TITLE
Explicitly use std::deque for the missing node handler stack:

### DIFF
--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -352,7 +352,13 @@ private:
             int,              // while child we check first
             int,              // which child we check next
             bool>;            // whether we've found any missing children yet
-        std::stack <StackEntry> stack_;
+
+        // We explicitly choose to specify the use of std::deque here, because
+        // we need to ensure that pointers and/or references to existing elements
+        // will not be invalidated during the course of element insertion and
+        // removal. Containers that do not offer this guarantee, such as
+        // std::vector, can't be used here.
+        std::stack <StackEntry, std::deque<StackEntry>> stack_;
 
         // nodes we may acquire from deferred reads
         std::vector <std::tuple <SHAMapInnerNode*, SHAMapNodeID, int>> deferredReads_;


### PR DESCRIPTION
We need to ensure that pointers and/or references to existing elements will not be invalidated during the course of element insertion and removal.

Containers like `std::vector` do not offer this guarantee, and cannot be used as the underlying container for the stack.

By choosing to explicitly specify std::deque as the underlying cotnainer, we avoid:

- the unlikely possibility of the C++ standards committee changing the default template parameter to a container;
- the more likely possibility of an accidental change by a programmer, without fully considering the consequences.