### PR TITLE
Relay untrusted validations/proposals from cluster members (RIPD-1549)

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1259,7 +1259,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMProposeSet> const& m)
             return;
         }
 
-        if (app_.getFeeTrack ().isLoadedLocal () && ! cluster())
+        if (! cluster() && app_.getFeeTrack ().isLoadedLocal())
         {
             JLOG(p_journal_.debug()) << "Proposal: Dropping UNTRUSTED (load)";
             return;
@@ -1901,8 +1901,8 @@ PeerImp::checkPropose (Job& job,
     }
     else
     {
-        if (app_.getOPs().getConsensusLCL() == peerPos.proposal().prevLedger() ||
-            cluster())
+        if (cluster() ||
+            (app_.getOPs().getConsensusLCL() == peerPos.proposal().prevLedger()))
         {
             // relay untrusted proposal
             JLOG(p_journal_.trace()) <<

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1259,7 +1259,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMProposeSet> const& m)
             return;
         }
 
-        if (app_.getFeeTrack ().isLoadedLocal ())
+        if (app_.getFeeTrack ().isLoadedLocal () && ! cluster())
         {
             JLOG(p_journal_.debug()) << "Proposal: Dropping UNTRUSTED (load)";
             return;
@@ -1587,7 +1587,8 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMValidation> const& m)
             JLOG(p_journal_.debug()) <<
                 "Validation: dropping untrusted from insane peer";
         }
-        if (isTrusted || !app_.getFeeTrack ().isLoadedLocal ())
+        if (isTrusted || cluster() ||
+            ! app_.getFeeTrack ().isLoadedLocal ())
         {
             std::weak_ptr<PeerImp> weak = shared_from_this();
             app_.getJobQueue ().addJob (
@@ -1900,7 +1901,8 @@ PeerImp::checkPropose (Job& job,
     }
     else
     {
-        if (app_.getOPs().getConsensusLCL() == peerPos.proposal().prevLedger())
+        if (app_.getOPs().getConsensusLCL() == peerPos.proposal().prevLedger() ||
+            cluster())
         {
             // relay untrusted proposal
             JLOG(p_journal_.trace()) <<
@@ -1931,9 +1933,11 @@ PeerImp::checkValidation (STValidation::pointer val,
             return;
         }
 
-        if (app_.getOPs ().recvValidation(
-                val, std::to_string(id())))
+        if (app_.getOPs ().recvValidation(val, std::to_string(id())) ||
+            cluster())
+        {
             overlay_.relay(*packet, signingHash);
+        }
     }
     catch (std::exception const&)
     {


### PR DESCRIPTION
It is common for a validator operator to connect their validator only to other nodes under their control, using clustering. Relaying of untrusted validations and proposals must be unreliable to prevent denial of service attacks. But currently, they are unreliable  even within a cluster.

With this change, a cluster member's decisison to relay (or originate) a validation or proposal is honored by other cluster members. This ensures that validators in a cluster will get reliable relaying to hubs outside the cluster, even if other members of the cluster do not have that validator on their UNL.