### PR TITLE
[TRIVIAL] Add test for size_varint

### DIFF
--- a/src/test/nodestore/varint_test.cpp
+++ b/src/test/nodestore/varint_test.cpp
@@ -35,17 +35,12 @@ public:
         testcase("encode, decode");
         for (auto const v : vv)
         {
-            std::array<std::uint8_t,
-                varint_traits<
-                    std::size_t>::max> vi;
-            auto const n0 =
-                write_varint(
-                    vi.data(), v);
+            std::array<std::uint8_t, varint_traits<std::size_t>::max> vi;
+            auto const n0 = write_varint(vi.data(), v);
             expect (n0 > 0, "write error");
+            expect(n0 == size_varint(v), "size error");
             std::size_t v1;
-            auto const n1 =
-                read_varint(
-                    vi.data(), n0, v1);
+            auto const n1 = read_varint(vi.data(), n0, v1);
             expect(n1 == n0, "read error");
             expect(v == v1, "wrong value");
         }


### PR DESCRIPTION
While reviewing https://ripplelabs.atlassian.net/browse/RIPD-1267, which I'm going to mark as WONTFIX as Nik suggested, I noted that `varint_size` wasn't tested.  I also changed whitespace in an effort to make the test readable, I can put that back the way it was if anyone objects.