### PR TITLE
Properly use ledger hash to break ties

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -381,7 +381,7 @@ RCLConsensus::Adaptor::onAccept(
     app_.getJobQueue().addJob(
         jtACCEPT,
         "acceptLedger",
-        [&, cj = std::move(consensusJson) ](auto&) mutable {
+        [=, cj = std::move(consensusJson) ](auto&) mutable {
             // Note that no lock is held or acquired during this job.
             // This is because generic Consensus guarantees that once a ledger
             // is accepted, the consensus results and capture by reference state

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -239,11 +239,15 @@ class RCLConsensus
             RCLCxLedger const& ledger,
             ConsensusMode mode);
 
+        /** Notified of change in consensus mode
+
+            @param before The prior consensus mode
+            @param after The new consensus mode
+        */
         void
-        onModeChange(ConsensusMode before, ConsensusMode after)
-        {
-            mode_ = after;
-        }
+        onModeChange(
+            ConsensusMode before,
+            ConsensusMode after);
 
         /** Close the open ledger and return initial consensus position.
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1305,7 +1305,7 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMStatusChange> const& m)
     {
         if (!closedLedgerHash_.isZero ())
         {
-            JLOG(p_journal_.trace()) << "Status: Out of sync";
+            JLOG(p_journal_.debug()) << "Status: Out of sync";
             closedLedgerHash_.zero ();
         }
 
@@ -1318,11 +1318,11 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMStatusChange> const& m)
         // a peer has changed ledgers
         memcpy (closedLedgerHash_.begin (), m->ledgerhash ().data (), 256 / 8);
         addLedger (closedLedgerHash_);
-        JLOG(p_journal_.trace()) << "LCL is " << closedLedgerHash_;
+        JLOG(p_journal_.debug()) << "LCL is " << closedLedgerHash_;
     }
     else
     {
-        JLOG(p_journal_.trace()) << "Status: No ledger";
+        JLOG(p_journal_.debug()) << "Status: No ledger";
         closedLedgerHash_.zero ();
     }
 


### PR DESCRIPTION
#2169 changed the behavior for selecting the best working ledger for the next consensus round. This fix restores that behavior, so that if there are several ledgers with the same number of `trustedValidations > 0`, the best is chosen based on the ledger hash, as opposed to the current code which prefers the `nodesUsing` count to break such ties.