### PR TITLE
Update SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1305,6 +1305,6 @@ def do_count(target, source, env):
     lines = 0
     for f in testfiles:
         lines = lines + sum(1 for line in open(f))
-    print "Total unit test lines: %d" % lines
+    print("Total unit test lines: %d" % lines)
 
 PhonyTargets(env, count = do_count)


### PR DESCRIPTION
Make sure the SConstruct file always uses the print() syntax.

Should be a relatively small change but might fix some syntax errors I found on distros that use Python3 by default.