### PR TITLE
Lock ledger.

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1422,7 +1422,7 @@ void NetworkOPsImp::switchLastClosedLedger (
     // TODO: Needs an open ledger
     //app_.getTxQ().processClosedLedger(app_, *newLCL, true);
 
-    // Caller must own master lock
+    std::lock_guard <std::recursive_mutex> lock (m_ledgerMaster.peekMutex());
     {
         // Apply tx in old open ledger to new
         // open ledger. Then apply local tx.


### PR DESCRIPTION
The call path starting from NetworkOPsImp::onAccept() -> NetworkOPs::endConsensus() -> checkLastClosedLedger() -> switchClosedLedger() says that no lock is necessary. But switchClosedLedger() has a comment that the caller must be holding the master lock already. OpenLedger::accept()'s other callers are locked and it, in turn, applies transactions to the ledger.