### PR TITLE
Include validator manifests in published list:

### DIFF
--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -72,8 +72,9 @@ enum class ListDisposition
         "expiration", and @c "validators" field. @c "expiration" contains the
         Ripple timestamp (seconds since January 1st, 2000 (00:00 UTC)) for when
         the list expires. @c "validators" contains an array of objects with a
-        @c "validation_public_key" field.
+        @c "validation_public_key" and optional @c "manifest" field.
         @c "validation_public_key" should be the hex-encoded master public key.
+        @c "manifest" should be the base64-encoded validator manifest.
 
     @li @c "manifest": Base64-encoded serialization of a manifest containing the
         publisher's master and signing public keys.

--- a/src/ripple/app/misc/ValidatorSite.h
+++ b/src/ripple/app/misc/ValidatorSite.h
@@ -44,8 +44,9 @@ namespace ripple {
         "expiration", and @c "validators" field. @c "expiration" contains the
         Ripple timestamp (seconds since January 1st, 2000 (00:00 UTC)) for when
         the list expires. @c "validators" contains an array of objects with a
-        @c "validation_public_key" field.
+        @c "validation_public_key" and optional @c "manifest" field.
         @c "validation_public_key" should be the hex-encoded master public key.
+        @c "manifest" should be the base64-encoded validator manifest.
 
     @li @c "manifest": Base64-encoded serialization of a manifest containing the
         publisher's master and signing public keys.


### PR DESCRIPTION
Manifests of validators newly added to a published validator list are
not reliably propagated to network nodes.
This solves the problem by allowing a published validator list to
include the manifest.

RIPD-1559

This will need to be reconciled with the test changes in https://github.com/ripple/rippled/pull/2242