### PR TITLE
[TRIVIAL] Fix snprintf warning

### DIFF
--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -396,7 +396,7 @@ struct ExistingElementPool
         currencyNames.clear();
         currencyNames.reserve(numCur);
 
-        constexpr size_t bufSize = 8;
+        constexpr size_t bufSize = 32;
         char buf[bufSize];
 
         for (size_t id = 0; id < numAct; ++id)


### PR DESCRIPTION
Fix warning about possible truncation in snprintf