### PR TITLE
Improved error message on mistyped command [RIPD-1527]

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -497,6 +497,17 @@ private:
 
     bool isValidJson2(Json::Value const& jv)
     {
+        if (jv.isArray())
+        {
+            if (jv.size() == 0)
+                return false;
+            for (auto const& j : jv)
+            {
+                if (!isValidJson2(j))
+                    return false;
+            }
+            return true;
+        }
         if (jv.isObject())
         {
             if (jv.isMember(jss::jsonrpc) && jv[jss::jsonrpc] == "2.0" &&
@@ -504,7 +515,7 @@ private:
                 jv.isMember(jss::id) && jv.isMember(jss::method))
             {
                 if (jv.isMember(jss::params) &&
-                      !(jv[jss::params].isArray() || jv[jss::params].isNull()))
+                      !(jv[jss::params].isArray() || jv[jss::params].isObject()))
                     return false;
                 return true;
             }
@@ -519,17 +530,36 @@ private:
         bool valid_parse = reader.parse(jvParams[0u].asString(), jv);
         if (valid_parse && isValidJson2(jv))
         {
-            Json::Value jv1{Json::objectValue};
-            if (jv.isMember(jss::params))
+            if (jv.isObject())
             {
-                auto const& params = jv[jss::params][0u];
-                for (auto i = params.begin(); i != params.end(); ++i)
-                    jv1[i.key().asString()] = *i;
+                Json::Value jv1{Json::objectValue};
+                if (jv.isMember(jss::params))
+                {
+                    auto const& params = jv[jss::params];
+                    for (auto i = params.begin(); i != params.end(); ++i)
+                        jv1[i.key().asString()] = *i;
+                }
+                jv1[jss::jsonrpc] = jv[jss::jsonrpc];
+                jv1[jss::ripplerpc] = jv[jss::ripplerpc];
+                jv1[jss::id] = jv[jss::id];
+                jv1[jss::method] = jv[jss::method];
+                return jv1;
             }
-            jv1[jss::jsonrpc] = jv[jss::jsonrpc];
-            jv1[jss::ripplerpc] = jv[jss::ripplerpc];
-            jv1[jss::id] = jv[jss::id];
-            jv1[jss::method] = jv[jss::method];
+            // else jv.isArray()
+            Json::Value jv1{Json::arrayValue};
+            for (Json::UInt j = 0; j < jv.size(); ++j)
+            {
+                if (jv[j].isMember(jss::params))
+                {
+                    auto const& params = jv[j][jss::params];
+                    for (auto i = params.begin(); i != params.end(); ++i)
+                        jv1[j][i.key().asString()] = *i;
+                }
+                jv1[j][jss::jsonrpc] = jv[j][jss::jsonrpc];
+                jv1[j][jss::ripplerpc] = jv[j][jss::ripplerpc];
+                jv1[j][jss::id] = jv[j][jss::id];
+                jv1[j][jss::method] = jv[j][jss::method];
+            }
             return jv1;
         }
         auto jv_error = rpcError(rpcINVALID_PARAMS);
@@ -1145,7 +1175,6 @@ struct RPCCallImp
 
             Json::Reader    reader;
             Json::Value     jvReply;
-
             if (!reader.parse (strData, jvReply))
                 Throw<std::runtime_error> ("couldn't parse reply from server");
 
@@ -1202,7 +1231,6 @@ rpcCmdLineToJson (std::vector<std::string> const& args,
     jvRequest   = rpParser.parseCommand (args[0], jvRpcParams, true);
 
     JLOG (j.trace()) << "RPC Request: " << jvRequest << std::endl;
-
     return jvRequest;
 }
 
@@ -1287,7 +1315,13 @@ rpcClient(std::vector<std::string> const& args,
             if (!setup.client.admin_password.empty ())
                 jvRequest["admin_password"] = setup.client.admin_password;
 
-            jvParams.append (jvRequest);
+            if (jvRequest.isObject())
+                jvParams.append (jvRequest);
+            else if (jvRequest.isArray())
+            {
+                for (Json::UInt i = 0; i < jvRequest.size(); ++i)
+                    jvParams.append(jvRequest[i]);
+            }
 
             if (jvRequest.isMember(jss::params))
             {
@@ -1305,7 +1339,10 @@ rpcClient(std::vector<std::string> const& args,
                     setup.client.password,
                     "",
                     jvRequest.isMember (jss::method)           // Allow parser to rewrite method.
-                        ? jvRequest[jss::method].asString () : args[0],
+                        ? jvRequest[jss::method].asString ()
+                        : jvRequest.isArray()
+                           ? "batch"
+                           : args[0],
                     jvParams,                               // Parsed, execute.
                     setup.client.secure != 0,                // Use SSL
                     config.quiet(),
@@ -1314,7 +1351,6 @@ rpcClient(std::vector<std::string> const& args,
                                std::placeholders::_1));
                 isService.run(); // This blocks until there is no more outstanding async calls.
             }
-
             if (jvOutput.isMember ("result"))
             {
                 // Had a successful JSON-RPC 2.0 call.
@@ -1343,10 +1379,12 @@ rpcClient(std::vector<std::string> const& args,
         if (jvOutput.isMember (jss::error))
         {
             jvOutput[jss::status]  = "error";
-
-            nRet    = jvOutput.isMember (jss::error_code)
-                      ? beast::lexicalCast <int> (jvOutput[jss::error_code].asString ())
-                      : rpcBAD_SYNTAX;
+            if (jvOutput.isMember(jss::error_code))
+                nRet = std::stoi(jvOutput[jss::error_code].asString());
+            else if (jvOutput[jss::error].isMember(jss::error_code))
+                nRet = std::stoi(jvOutput[jss::error][jss::error_code].asString());
+            else
+                nRet = rpcBAD_SYNTAX;
         }
 
         // YYY We could have a command line flag for single line output for scripts.
@@ -1358,13 +1396,6 @@ rpcClient(std::vector<std::string> const& args,
         jvOutput["error_what"]  = e.what ();
         nRet                    = rpcINTERNAL;
     }
-
-    if (jvRequest.isMember(jss::jsonrpc))
-        jvOutput[jss::jsonrpc] = jvRequest[jss::jsonrpc];
-    if (jvRequest.isMember(jss::ripplerpc))
-        jvOutput[jss::ripplerpc] = jvRequest[jss::ripplerpc];
-    if (jvRequest.isMember(jss::id))
-        jvOutput[jss::id] = jvRequest[jss::id];
 
     return { nRet, std::move(jvOutput) };
 }

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -465,31 +465,7 @@ Env::st (JTx const& jt)
 Json::Value
 Env::do_rpc(std::vector<std::string> const& args)
 {
-    auto jv = cmdLineToJSONRPC(args, journal);
-    if (!jv.isMember(jss::jsonrpc))
-    {
-        jv[jss::jsonrpc] = "2.0";
-        jv[jss::ripplerpc] = "2.0";
-        jv[jss::id] = 5;
-    }
-    auto response = client().invoke(
-        jv[jss::method].asString(),
-        jv[jss::params][0U]);
-
-    if (jv.isMember(jss::jsonrpc))
-    {
-        response[jss::jsonrpc] = jv[jss::jsonrpc];
-        response[jss::ripplerpc] = jv[jss::ripplerpc];
-        response[jss::id] = jv[jss::id];
-    }
-
-    if (jv[jss::params][0u].isMember(jss::error) &&
-        (! response.isMember(jss::error)))
-    {
-        response["client_error"] = jv[jss::params][0u];
-    }
-
-    return response;
+    return rpcClient(args, app().config(), app().logs()).second;
 }
 
 void

--- a/src/test/rpc/AccountInfo_test.cpp
+++ b/src/test/rpc/AccountInfo_test.cpp
@@ -174,17 +174,17 @@ public:
             "\"ripplerpc\": \"2.0\", "
             "\"id\": 5, "
             "\"method\": \"account_info\", "
-            "\"params\": [{ "
-            "\"account\": \"" + alice.human() + "\"}]}";
+            "\"params\": { "
+            "\"account\": \"" + alice.human() + "\"}}";
 
         auto const withSigners = std::string ("{ ") +
             "\"jsonrpc\": \"2.0\", "
             "\"ripplerpc\": \"2.0\", "
-            "\"id\": 5, "
+            "\"id\": 6, "
             "\"method\": \"account_info\", "
-            "\"params\": [{ "
+            "\"params\": { "
             "\"account\": \"" + alice.human() + "\", " +
-            "\"signer_lists\": true }]}";
+            "\"signer_lists\": true }}";
         // Alice has no SignerList yet.
         {
             // account_info without the "signer_lists" argument.
@@ -209,7 +209,30 @@ public:
             BEAST_EXPECT(signerLists.size() == 0);
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 5);
+            BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 6);
+        }
+        {
+            // Do both of the above as a batch job
+            auto const info = env.rpc ("json2", '[' + withoutSigners + ", "
+                                                    + withSigners + ']');
+            BEAST_EXPECT(info[0u].isMember(jss::result) &&
+                info[0u][jss::result].isMember(jss::account_data));
+            BEAST_EXPECT(! info[0u][jss::result][jss::account_data].
+                isMember (jss::signer_lists));
+            BEAST_EXPECT(info[0u].isMember(jss::jsonrpc) && info[0u][jss::jsonrpc] == "2.0");
+            BEAST_EXPECT(info[0u].isMember(jss::ripplerpc) && info[0u][jss::ripplerpc] == "2.0");
+            BEAST_EXPECT(info[0u].isMember(jss::id) && info[0u][jss::id] == 5);
+
+            BEAST_EXPECT(info[1u].isMember(jss::result) &&
+                info[1u][jss::result].isMember(jss::account_data));
+            auto const& data = info[1u][jss::result][jss::account_data];
+            BEAST_EXPECT(data.isMember (jss::signer_lists));
+            auto const& signerLists = data[jss::signer_lists];
+            BEAST_EXPECT(signerLists.isArray());
+            BEAST_EXPECT(signerLists.size() == 0);
+            BEAST_EXPECT(info[1u].isMember(jss::jsonrpc) && info[1u][jss::jsonrpc] == "2.0");
+            BEAST_EXPECT(info[1u].isMember(jss::ripplerpc) && info[1u][jss::ripplerpc] == "2.0");
+            BEAST_EXPECT(info[1u].isMember(jss::id) && info[1u][jss::id] == 6);
         }
 
         // Give alice a SignerList.
@@ -247,7 +270,7 @@ public:
             BEAST_EXPECT(entry0[sfSignerWeight.jsonName] == 3);
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 5);
+            BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 6);
         }
 
         // Give alice a big signer list
@@ -287,7 +310,7 @@ public:
             }
             BEAST_EXPECT(info.isMember(jss::jsonrpc) && info[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(info.isMember(jss::ripplerpc) && info[jss::ripplerpc] == "2.0");
-            BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 5);
+            BEAST_EXPECT(info.isMember(jss::id) && info[jss::id] == 6);
         }
     }
 

--- a/src/test/rpc/AccountLinesRPC_test.cpp
+++ b/src/test/rpc/AccountLinesRPC_test.cpp
@@ -374,7 +374,7 @@ public:
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5)"
                 " }");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 RPC::missing_field_error(jss::account)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -387,10 +387,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": )"
-                R"("n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj"}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj"}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 RPC::make_error(rpcBAD_SEED)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -404,9 +404,9 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
-                R"({"account": ")" + alice.human() + R"("}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("params": )"
+                R"({"account": ")" + alice.human() + R"("}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 RPC::make_error(rpcACT_NOT_FOUND)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -424,8 +424,8 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
-                R"({"account": ")" + alice.human() + R"("}]})");
+                R"("params": )"
+                R"({"account": ")" + alice.human() + R"("}})");
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 0);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
@@ -439,10 +439,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("ledger_index": "nonsense"}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("ledger_index": "nonsense"}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 "ledgerIndexMalformed");
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -455,10 +455,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("ledger_index": 50000}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("ledger_index": 50000}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 "ledgerNotFound");
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -525,9 +525,9 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + account.human() + R"(", )"
-                R"("ledger_index": )" + std::to_string(info.seq) + "}]}");
+                R"("ledger_index": )" + std::to_string(info.seq) + "}}");
             BEAST_EXPECT(linesSeq[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesSeq[jss::result][jss::lines].size() == count);
             BEAST_EXPECT(linesSeq.isMember(jss::jsonrpc) && linesSeq[jss::jsonrpc] == "2.0");
@@ -540,9 +540,9 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + account.human() + R"(", )"
-                R"("ledger_hash": ")" + to_string(info.hash) + R"("}]})");
+                R"("ledger_hash": ")" + to_string(info.hash) + R"("}})");
             BEAST_EXPECT(linesHash[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesHash[jss::result][jss::lines].size() == count);
             BEAST_EXPECT(linesHash.isMember(jss::jsonrpc) && linesHash[jss::jsonrpc] == "2.0");
@@ -567,10 +567,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
                 R"("ledger_hash": ")" + to_string(ledger4Info.hash) + R"(", )"
-                R"("ledger_index": )" + std::to_string(ledger58Info.seq) + "}]}");
+                R"("ledger_index": )" + std::to_string(ledger58Info.seq) + "}}");
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 26);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
@@ -584,8 +584,8 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
-                R"({"account": ")" + alice.human() + R"("}]})");
+                R"("params": )"
+                R"({"account": ")" + alice.human() + R"("}})");
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 52);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
@@ -599,9 +599,9 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("peer": ")" + gw1.human() + R"("}]})");
+                R"("peer": ")" + gw1.human() + R"("}})");
             BEAST_EXPECT(lines[jss::result][jss::lines].isArray());
             BEAST_EXPECT(lines[jss::result][jss::lines].size() == 26);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
@@ -615,11 +615,11 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
                 R"("peer": )"
-                R"("n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj"}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("n9MJkEKHDhy5eTLuHUQeAAjo382frHNbFK4C8hcwN4nwM2SrLdBj"}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 RPC::make_error(rpcBAD_SEED)[jss::error_message]);
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -632,10 +632,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("limit": -1}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("limit": -1}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 RPC::expected_field_message(jss::limit, "unsigned integer"));
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -648,9 +648,9 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("limit": 1}]})");
+                R"("limit": 1}})");
             BEAST_EXPECT(linesA[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesA[jss::result][jss::lines].size() == 1);
             BEAST_EXPECT(linesA.isMember(jss::jsonrpc) && linesA[jss::jsonrpc] == "2.0");
@@ -664,9 +664,9 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("marker": ")" + marker + R"("}]})");
+                R"("marker": ")" + marker + R"("}})");
             BEAST_EXPECT(linesB[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesB[jss::result][jss::lines].size() == 51);
             BEAST_EXPECT(linesB.isMember(jss::jsonrpc) && linesB[jss::jsonrpc] == "2.0");
@@ -679,10 +679,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
                 R"("limit": 3, )"
-                R"("marker": ")" + marker + R"("}]})");
+                R"("marker": ")" + marker + R"("}})");
             BEAST_EXPECT(linesC[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesC[jss::result][jss::lines].size() == 3);
             BEAST_EXPECT(linesC.isMember(jss::jsonrpc) && linesC[jss::jsonrpc] == "2.0");
@@ -696,10 +696,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("marker": ")" + marker + R"("}]})");
-            BEAST_EXPECT(linesD[jss::result][jss::error_message] ==
+                R"("marker": ")" + marker + R"("}})");
+            BEAST_EXPECT(linesD[jss::error][jss::message] ==
                 RPC::make_error(rpcINVALID_PARAMS)[jss::error_message]);
             BEAST_EXPECT(linesD.isMember(jss::jsonrpc) && linesD[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(linesD.isMember(jss::ripplerpc) && linesD[jss::ripplerpc] == "2.0");
@@ -712,10 +712,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
-                R"("marker": true}]})");
-            BEAST_EXPECT(lines[jss::result][jss::error_message] ==
+                R"("marker": true}})");
+            BEAST_EXPECT(lines[jss::error][jss::message] ==
                 RPC::expected_field_message(jss::marker, "string"));
             BEAST_EXPECT(lines.isMember(jss::jsonrpc) && lines[jss::jsonrpc] == "2.0");
             BEAST_EXPECT(lines.isMember(jss::ripplerpc) && lines[jss::ripplerpc] == "2.0");
@@ -728,10 +728,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + alice.human() + R"(", )"
                 R"("limit": 1, )"
-                R"("peer": ")" + gw2.human() + R"("}]})");
+                R"("peer": ")" + gw2.human() + R"("}})");
             auto const& line = lines[jss::result][jss::lines][0u];
             BEAST_EXPECT(line[jss::freeze].asBool() == true);
             BEAST_EXPECT(line[jss::no_ripple].asBool() == true);
@@ -747,10 +747,10 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + gw2.human() + R"(", )"
                 R"("limit": 1, )"
-                R"("peer": ")" + alice.human() + R"("}]})");
+                R"("peer": ")" + alice.human() + R"("}})");
             auto const& lineA = linesA[jss::result][jss::lines][0u];
             BEAST_EXPECT(lineA[jss::freeze_peer].asBool() == true);
             BEAST_EXPECT(lineA[jss::no_ripple_peer].asBool() == true);
@@ -767,11 +767,11 @@ public:
                 R"("jsonrpc" : "2.0",)"
                 R"("ripplerpc" : "2.0",)"
                 R"("id" : 5,)"
-                R"("params": [ )"
+                R"("params": )"
                 R"({"account": ")" + gw2.human() + R"(", )"
                 R"("limit": 25, )"
                 R"("marker": ")" + marker + R"(", )"
-                R"("peer": ")" + alice.human() + R"("}]})");
+                R"("peer": ")" + alice.human() + R"("}})");
             BEAST_EXPECT(linesB[jss::result][jss::lines].isArray());
             BEAST_EXPECT(linesB[jss::result][jss::lines].size() == 25);
             BEAST_EXPECT(! linesB[jss::result].isMember(jss::marker));
@@ -833,9 +833,9 @@ public:
             R"("jsonrpc" : "2.0",)"
             R"("ripplerpc" : "2.0",)"
             R"("id" : 5,)"
-            R"("params": [ )"
+            R"("params": )"
             R"({"account": ")" + alice.human() + R"(", )"
-            R"("limit": 1}]})");
+            R"("limit": 1}})");
         BEAST_EXPECT(linesBeg[jss::result][jss::lines][0u][jss::currency] == "USD");
         BEAST_EXPECT(linesBeg[jss::result].isMember(jss::marker));
         BEAST_EXPECT(linesBeg.isMember(jss::jsonrpc) && linesBeg[jss::jsonrpc] == "2.0");
@@ -853,11 +853,11 @@ public:
             R"("jsonrpc" : "2.0",)"
             R"("ripplerpc" : "2.0",)"
             R"("id" : 5,)"
-            R"("params": [ )"
+            R"("params": )"
             R"({"account": ")" + alice.human() + R"(", )"
             R"("marker": ")" +
-            linesBeg[jss::result][jss::marker].asString() + R"("}]})");
-        BEAST_EXPECT(linesEnd[jss::result][jss::error_message] ==
+            linesBeg[jss::result][jss::marker].asString() + R"("}})");
+        BEAST_EXPECT(linesEnd[jss::error][jss::message] ==
                 RPC::make_error(rpcINVALID_PARAMS)[jss::error_message]);
         BEAST_EXPECT(linesEnd.isMember(jss::jsonrpc) && linesEnd[jss::jsonrpc] == "2.0");
         BEAST_EXPECT(linesEnd.isMember(jss::ripplerpc) && linesEnd[jss::ripplerpc] == "2.0");

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -122,9 +122,9 @@ public:
 
         // test error on no account
         {
-            auto resp = env.rpc("account_objects");
-            BEAST_EXPECT( resp[jss::result][jss::error_message] ==
-                "Missing field 'account'.");
+            auto resp = env.rpc("json", "account_objects");
+            BEAST_EXPECT( resp[jss::error_message] ==
+                "Syntax error.");
         }
         // test error on  malformed account string.
         {

--- a/src/test/rpc/AccountOffers_test.cpp
+++ b/src/test/rpc/AccountOffers_test.cpp
@@ -197,10 +197,10 @@ public:
 
         {
             // no account field
-            auto const jrr = env.rpc ("account_offers")[jss::result];
-            BEAST_EXPECT(jrr[jss::error]         == "invalidParams");
+            auto const jrr = env.rpc ("account_offers");
+            BEAST_EXPECT(jrr[jss::error]         == "badSyntax");
             BEAST_EXPECT(jrr[jss::status]        == "error");
-            BEAST_EXPECT(jrr[jss::error_message] == "Missing field 'account'.");
+            BEAST_EXPECT(jrr[jss::error_message] == "Syntax error.");
         }
 
         {

--- a/src/test/rpc/Feature_test.cpp
+++ b/src/test/rpc/Feature_test.cpp
@@ -257,10 +257,8 @@ class Feature_test : public beast::unit_test::suite
 
         // anything other than accept or reject is an error
         jrr = env.rpc("feature", "CryptoConditions", "maybe");
-        if(! BEAST_EXPECT(jrr.isMember("client_error")))
-            return;
-        BEAST_EXPECT(jrr["client_error"][jss::error] == "invalidParams");
-        BEAST_EXPECT(jrr["client_error"][jss::error_message] == "Invalid parameters.");
+        BEAST_EXPECT(jrr[jss::error] == "invalidParams");
+        BEAST_EXPECT(jrr[jss::error_message] == "Invalid parameters.");
     }
 
 public:

--- a/src/test/rpc/JSONRPC_test.cpp
+++ b/src/test/rpc/JSONRPC_test.cpp
@@ -1840,6 +1840,17 @@ R"({
 class JSONRPC_test : public beast::unit_test::suite
 {
 public:
+    void testBadRpcCommand ()
+    {
+        test::jtx::Env env(*this);
+        Json::Value const result {
+            env.rpc ("bad_command", R"({"MakingThisUp": 0})")};
+
+        BEAST_EXPECT (result[jss::result][jss::error] == "unknownCmd");
+        BEAST_EXPECT (
+            result[jss::result][jss::request][jss::command] == "bad_command");
+    }
+
     void testAutoFillFees ()
     {
         test::jtx::Env env(*this);
@@ -2346,6 +2357,7 @@ public:
 
     void run ()
     {
+        testBadRpcCommand ();
         testAutoFillFees ();
         testAutoFillEscalatedFees ();
         testTransactionRPC ();

--- a/src/test/rpc/ServerInfo_test.cpp
+++ b/src/test/rpc/ServerInfo_test.cpp
@@ -73,16 +73,16 @@ public:
 
         {
             Env env(*this);
-            auto const result = env.rpc("server_info", "1");
+            auto const result = env.rpc("server_info");
             BEAST_EXPECT(!result[jss::result].isMember (jss::error));
-            BEAST_EXPECT(result[jss::status] == "success");
+            BEAST_EXPECT(result[jss::result][jss::status] == "success");
             BEAST_EXPECT(result[jss::result].isMember(jss::info));
         }
         {
             Env env(*this, makeValidatorConfig());
-            auto const result = env.rpc("server_info", "1");
+            auto const result = env.rpc("server_info");
             BEAST_EXPECT(!result[jss::result].isMember (jss::error));
-            BEAST_EXPECT(result[jss::status] == "success");
+            BEAST_EXPECT(result[jss::result][jss::status] == "success");
             BEAST_EXPECT(result[jss::result].isMember(jss::info));
             BEAST_EXPECT(result[jss::result][jss::info]
                 [jss::pubkey_validator] == validator_data::public_key);

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -786,7 +786,7 @@ class ServerStatus_test :
         using namespace beast::http;
         Env env {*this, validator( envconfig([](std::unique_ptr<Config> cfg)
             {
-                cfg->section("port_rpc").set("protocol", "http,https");
+                cfg->section("port_rpc").set("protocol", "http");
                 return cfg;
             }), "")};
 


### PR DESCRIPTION
First things first; only the (currently) top-most commit needs to be reviewed.  This pull request sits atop an earlier pull request from @HowardHinnant who is working in the same area.

Previously if you mistyped the "submit_multisigned" command as "submit_multisign", the returned message was "Internal error".  Not very helpful.  It turns out this was caused by a small amount of code in RPCCall.cpp.  Removing that code improves two situations:
    
1. It improves the situation with a mistyped command.  Now the command returns "Unknown method" and provides the string of the mistyped command.
    
2. The "transaction_entry" RPC command, if properly entered in its command line form, would fire an assert.  That assert is now removed.
    
In the process, it was discovered that the command line form of the "transaction_entry" command has not worked correctly for at least a year.  Therefore support for the command line form of "transaction_entry" is added along with appropriate unit tests.

Reviewers: @HowardHinnant for familiarity with RPC, @mellery451 for familiarity with TransactionEntry_test.cpp.