### PR TITLE
Prefer ledger by branch

### DIFF
--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -1634,6 +1634,8 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\LedgerTiming.h">
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\consensus\LedgerTrie.h">
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\Validations.h">
     </ClInclude>
     <ClInclude Include="..\..\src\ripple\core\ClosureCounter.h">
@@ -4682,6 +4684,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\test\consensus\LedgerTiming_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\consensus\LedgerTrie_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>

--- a/Builds/VisualStudio2015/RippleD.vcxproj
+++ b/Builds/VisualStudio2015/RippleD.vcxproj
@@ -4503,6 +4503,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\app\RCLValidations_test.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\app\Regression_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='debug|x64'">True</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='release|x64'">True</ExcludedFromBuild>

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -2151,6 +2151,9 @@
     <ClInclude Include="..\..\src\ripple\consensus\LedgerTiming.h">
       <Filter>ripple\consensus</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ripple\consensus\LedgerTrie.h">
+      <Filter>ripple\consensus</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\ripple\consensus\Validations.h">
       <Filter>ripple\consensus</Filter>
     </ClInclude>
@@ -5404,6 +5407,9 @@
       <Filter>test\consensus</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\consensus\LedgerTiming_test.cpp">
+      <Filter>test\consensus</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\test\consensus\LedgerTrie_test.cpp">
       <Filter>test\consensus</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\test\consensus\ScaleFreeSim_test.cpp">

--- a/Builds/VisualStudio2015/RippleD.vcxproj.filters
+++ b/Builds/VisualStudio2015/RippleD.vcxproj.filters
@@ -5271,6 +5271,9 @@
     <ClCompile Include="..\..\src\test\app\PseudoTx_test.cpp">
       <Filter>test\app</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\app\RCLValidations_test.cpp">
+      <Filter>test\app</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\test\app\Regression_test.cpp">
       <Filter>test\app</Filter>
     </ClCompile>

--- a/docs/source.dox
+++ b/docs/source.dox
@@ -114,6 +114,7 @@ INPUT                  = \
     ../src/ripple/consensus/ConsensusTypes.h \
     ../src/ripple/consensus/DisputedTx.h \
     ../src/ripple/consensus/LedgerTiming.h \
+    ../src/ripple/consensus/LedgerTrie.h \
     ../src/ripple/consensus/Validations.h \
     ../src/ripple/consensus/ConsensusParms.h \
     ../src/ripple/app/consensus/RCLCxTx.h \

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -839,9 +839,14 @@ RCLConsensus::Adaptor::validate(RCLCxLedger const& ledger, bool proposing)
         validationTime = lastValidationTime_ + 1s;
     lastValidationTime_ = validationTime;
 
+    // Can only fully validate later sequenced ledgers
+    const bool isFull = proposing && ledger.seq() > largestFullValidationSeq_;
+    largestFullValidationSeq_ =
+        std::max(largestFullValidationSeq_, ledger.seq());
+
     // Build validation
     auto v = std::make_shared<STValidation>(
-        ledger.id(), validationTime, valPublic_, proposing);
+        ledger.id(), validationTime, valPublic_, isFull);
     v->setFieldU32(sfLedgerSequence, ledger.seq());
 
     // Add our load fee to the validation
@@ -955,6 +960,9 @@ RCLConsensus::Adaptor::preStartRound(RCLCxLedger const & prevLgr)
     validating_ = valPublic_.size() != 0 &&
                   prevLgr.seq() >= app_.getMaxDisallowedLedger() &&
                   !app_.getOPs().isAmendmentBlocked();
+
+    largestFullValidationSeq_ =
+        std::max(largestFullValidationSeq_, app_.getMaxDisallowedLedger());
 
     const bool synced = app_.getOPs().getOperatingMode() == NetworkOPs::omFULL;
 

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -204,12 +204,13 @@ class RCLConsensus
         /** Number of proposers that have validated a ledger descended from
            requested ledger.
 
-            @param h The hash of the ledger of interest.
+            @param ledger The current working ledger
+            @param h The hash of the preferred working ledger
             @return The number of validating peers that have validated a ledger
-                    succeeding the one provided.
+                    descended from the preferred working ledger.
         */
         std::size_t
-        proposersFinished(LedgerHash const& h) const;
+        proposersFinished(RCLCxLedger const & ledger, LedgerHash const& h) const;
 
         /** Propose the given position to my peers.
 

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -69,6 +69,9 @@ class RCLConsensus
         // The timestamp of the last validation we used
         NetClock::time_point lastValidationTime_;
 
+        // Largest sequence number fully validated
+        LedgerIndex largestFullValidationSeq_ = 0;
+
         // These members are queried via public accesors and are atomic for
         // thread safety.
         std::atomic<bool> validating_{false};

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -29,6 +29,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/consensus/Consensus.h>
+#include <ripple/consensus/Validations.h>
 #include <ripple/core/JobQueue.h>
 #include <ripple/overlay/Message.h>
 #include <ripple/protocol/RippleLedgerHash.h>
@@ -69,8 +70,8 @@ class RCLConsensus
         // The timestamp of the last validation we used
         NetClock::time_point lastValidationTime_;
 
-        // Largest sequence number fully validated
-        LedgerIndex largestFullValidationSeq_ = 0;
+        // Enforces invariants on issuing full validations
+        FullSeqEnforcer<LedgerIndex> fullSeqEnforcer_;
 
         // These members are queried via public accesors and are atomic for
         // thread safety.

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -29,7 +29,6 @@
 #include <ripple/basics/Log.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/consensus/Consensus.h>
-#include <ripple/consensus/Validations.h>
 #include <ripple/core/JobQueue.h>
 #include <ripple/overlay/Message.h>
 #include <ripple/protocol/RippleLedgerHash.h>
@@ -69,9 +68,6 @@ class RCLConsensus
 
         // The timestamp of the last validation we used
         NetClock::time_point lastValidationTime_;
-
-        // Enforces invariants on issuing full validations
-        FullSeqEnforcer<LedgerIndex> fullSeqEnforcer_;
 
         // These members are queried via public accesors and are atomic for
         // thread safety.

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -139,7 +139,7 @@ RCLValidationsAdaptor::acquire(LedgerHash const & hash)
         app_.getJobQueue().addJob(
             jtADVANCE, "getConsensusLedger", [pApp, hash](Job&) {
                 pApp ->getInboundLedgers().acquire(
-                    hash, 0, InboundLedger::fcVALIDATION);
+                    hash, 0, InboundLedger::Reason::CONSENSUS);
             });
         return boost::none;
     }
@@ -316,10 +316,10 @@ handleNewValidation(Application& app,
         if(j.debug())
             dmp(j.debug(), to_string(outcome));
 
-        if(outcome == ValStatus::badFullSeq && j.warn())
+        if(outcome == ValStatus::badSeq && j.warn())
         {
             auto const seq = val->getFieldU32(sfLedgerSequence);
-            dmp(j.warn(), " already fully validated sequence past " + to_string(seq));
+            dmp(j.warn(), " already validated sequence past " + to_string(seq));
         }
 
         if (val->isTrusted() && outcome == ValStatus::current)

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -366,4 +366,17 @@ getPreferred(
         RCLValidatedLedger{std::move(ledger), vals.adaptor().journal()},
         minValidSeq);
 }
+
+uint256
+getPreferredLCL(
+    RCLValidations& vals,
+    std::shared_ptr<Ledger const> ledger,
+    LedgerIndex minSeq,
+    hash_map<uint256, std::uint32_t> const& peerCounts)
+{
+    return vals.getPreferredLCL(
+        RCLValidatedLedger{std::move(ledger), vals.adaptor().journal()},
+        minSeq,
+        peerCounts);
+}
 }  // namespace ripple

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -226,16 +226,14 @@ handleNewValidation(
     // only add trusted or listed
     if (pubKey)
     {
-        using AddOutcome = RCLValidations::AddOutcome;
-
-        AddOutcome const res = validations.add(*pubKey, val);
+        ValStatus const res = validations.add(*pubKey, val);
 
         // This is a duplicate validation
-        if (res == AddOutcome::repeat)
+        if (res == ValStatus::repeat)
             return false;
 
         // This validation replaced a prior one with the same sequence number
-        if (res == AddOutcome::sameSeq)
+        if (res == ValStatus::sameSeq)
         {
             auto const seq = val->getFieldU32(sfLedgerSequence);
             JLOG(j.warn()) << "Trusted node "
@@ -248,13 +246,13 @@ handleNewValidation(
                         << toBase58(TokenType::TOKEN_NODE_PUBLIC, signer)
                         << " added "
                         << (val->isTrusted() ? "trusted/" : "UNtrusted/")
-                        << ((res == AddOutcome::current) ? "current" : "stale");
+                        << ((res == ValStatus::current) ? "current" : "stale");
 
         // Trusted current validations should be checked and relayed.
         // Trusted validations with sameSeq replaced an older validation
         // with that sequence number, so should still be checked and relayed.
         if (val->isTrusted() &&
-            (res == AddOutcome::current || res == AddOutcome::sameSeq))
+            (res == ValStatus::current || res == ValStatus::sameSeq))
         {
             app.getLedgerMaster().checkAccept(
                 hash, val->getFieldU32(sfLedgerSequence));

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -171,100 +171,60 @@ RCLValidationsAdaptor::doStaleWrite(ScopedLockType&)
 }
 
 bool
-handleNewValidation(
-    Application& app,
+handleNewValidation(Application& app,
     STValidation::ref val,
     std::string const& source)
 {
-    PublicKey const& signer = val->getSignerPublic();
+    PublicKey const& signingKey = val->getSignerPublic();
     uint256 const& hash = val->getLedgerHash();
 
     // Ensure validation is marked as trusted if signer currently trusted
-    boost::optional<PublicKey> pubKey = app.validators().getTrustedKey(signer);
-    if (!val->isTrusted() && pubKey)
+    boost::optional<PublicKey> masterKey =
+        app.validators().getTrustedKey(signingKey);
+    if (!val->isTrusted() && masterKey)
         val->setTrusted();
-    RCLValidations& validations = app.getValidations();
-
-    beast::Journal j = validations.adaptor().journal();
-
-    // Do not process partial validations.
-    if (!val->isFull())
-    {
-        const bool current = isCurrent(
-            validations.parms(),
-            app.timeKeeper().closeTime(),
-            val->getSignTime(),
-            val->getSeenTime());
-
-        JLOG(j.debug()) << "Val (partial) for " << hash << " from "
-                        << toBase58(TokenType::TOKEN_NODE_PUBLIC, signer)
-                        << " ignored "
-                        << (val->isTrusted() ? "trusted/" : "UNtrusted/")
-                        << (current ? "current" : "stale");
-
-        // Only forward if current and trusted
-        return current && val->isTrusted();
-    }
-
-    if (!val->isTrusted())
-    {
-        JLOG(j.trace()) << "Node "
-                        << toBase58(TokenType::TOKEN_NODE_PUBLIC, signer)
-                        << " not in UNL st="
-                        << val->getSignTime().time_since_epoch().count()
-                        << ", hash=" << hash
-                        << ", shash=" << val->getSigningHash()
-                        << " src=" << source;
-    }
 
     // If not currently trusted, see if signer is currently listed
-    if (!pubKey)
-        pubKey = app.validators().getListedKey(signer);
+    if (!masterKey)
+        masterKey = app.validators().getListedKey(signingKey);
 
     bool shouldRelay = false;
+    RCLValidations& validations = app.getValidations();
+    beast::Journal j = validations.adaptor().journal();
 
-    // only add trusted or listed
-    if (pubKey)
+    // masterKey is seated only if validator is trusted or listed
+    if (masterKey)
     {
-        ValStatus const res = validations.add(*pubKey, val);
+        ValStatus const outcome = validations.add(*masterKey, val);
 
-        // This is a duplicate validation
-        if (res == ValStatus::repeat)
-            return false;
+        auto dmp = [&](beast::Journal::Stream s, std::string const& msg) {
+            s << "Val for " << hash
+              << (val->isTrusted() ? " trusted/" : " UNtrusted/")
+              << (val->isFull() ? " full" : "partial") << " from "
+              << toBase58(TokenType::TOKEN_NODE_PUBLIC, *masterKey)
+              << "signing key "
+              << toBase58(TokenType::TOKEN_NODE_PUBLIC, signingKey) << " "
+              << msg
+              << " src=" << source;
+        };
 
-        // This validation replaced a prior one with the same sequence number
-        if (res == ValStatus::sameSeq)
-        {
-            auto const seq = val->getFieldU32(sfLedgerSequence);
-            JLOG(j.warn()) << "Trusted node "
-                           << toBase58(TokenType::TOKEN_NODE_PUBLIC, *pubKey)
-                           << " published multiple validations for ledger "
-                           << seq;
-        }
+        if(j.debug())
+            dmp(j.debug(), to_string(outcome));
 
-        JLOG(j.debug()) << "Val for " << hash << " from "
-                        << toBase58(TokenType::TOKEN_NODE_PUBLIC, signer)
-                        << " added "
-                        << (val->isTrusted() ? "trusted/" : "UNtrusted/")
-                        << ((res == ValStatus::current) ? "current" : "stale");
-
-        // Trusted current validations should be checked and relayed.
-        // Trusted validations with sameSeq replaced an older validation
-        // with that sequence number, so should still be checked and relayed.
-        if (val->isTrusted() &&
-            (res == ValStatus::current || res == ValStatus::sameSeq))
+        if (val->isTrusted() && outcome == ValStatus::current)
         {
             app.getLedgerMaster().checkAccept(
                 hash, val->getFieldU32(sfLedgerSequence));
 
             shouldRelay = true;
         }
+
     }
     else
     {
         JLOG(j.debug()) << "Val for " << hash << " from "
-                        << toBase58(TokenType::TOKEN_NODE_PUBLIC, signer)
-                        << " not added UNtrusted/";
+                    << toBase58(TokenType::TOKEN_NODE_PUBLIC, signingKey)
+                    << " not added UNlisted";
     }
 
     // This currently never forwards untrusted validations, though we may

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -83,8 +83,7 @@ auto RCLValidatedLedger::operator[](Seq const& s) const -> ID
         if (s == seq())
             return ledgerID_;
         Seq const diff = seq() - s;
-        if (ancestors_.size() >= diff)
-            return ancestors_[ancestors_.size() - diff];
+        return ancestors_[ancestors_.size() - diff];
     }
 
     JLOG(j_.warn()) << "Unable to determine hash of ancestor seq=" << s
@@ -300,9 +299,9 @@ handleNewValidation(Application& app,
     auto dmp = [&](beast::Journal::Stream s, std::string const& msg) {
             s << "Val for " << hash
               << (val->isTrusted() ? " trusted/" : " UNtrusted/")
-              << (val->isFull() ? " full" : "partial") << " from "
+              << (val->isFull() ? "full" : "partial") << " from "
               << toBase58(TokenType::TOKEN_NODE_PUBLIC, *masterKey)
-              << "signing key "
+              << " signing key "
               << toBase58(TokenType::TOKEN_NODE_PUBLIC, signingKey) << " "
               << msg
               << " src=" << source;
@@ -311,7 +310,7 @@ handleNewValidation(Application& app,
     if(!val->isFieldPresent(sfLedgerSequence))
     {
         if(j.error())
-            dmp(j.error(), " missing ledger seqeuence field");
+            dmp(j.error(), "missing ledger sequence field");
         return false;
     }
 
@@ -328,13 +327,13 @@ handleNewValidation(Application& app,
         if(outcome == ValStatus::badSeq && j.warn())
         {
             auto const seq = val->getFieldU32(sfLedgerSequence);
-            dmp(j.warn(), " already validated sequence past " + to_string(seq));
+            dmp(j.warn(), "already validated sequence past " + to_string(seq));
         }
-        else if(outcome == ValStatus::repeat && j.warn())
+        else if(outcome == ValStatus::repeatID && j.warn())
         {
             auto const seq = val->getFieldU32(sfLedgerSequence);
             dmp(j.warn(),
-                " already validated ledger with same id but different seq "
+                "already validated ledger with same id but different seq "
                 "than" + to_string(seq));
         }
 

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -91,7 +91,7 @@ auto RCLValidatedLedger::operator[](Seq const& s) const -> ID
                     << " from ledger hash=" << ledgerID_
                     << " seq=" << ledgerSeq_;
     // Default ID that is less than all others
-    return ID{};
+    return ID{0};
 }
 
 // Return the sequence number of the earliest possible mismatching ancestor

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -203,8 +203,11 @@ RCLValidationsAdaptor::doStaleWrite(ScopedLockType&)
 
                 Serializer s(1024);
                 soci::transaction tr(*db);
-                for (auto const& rclValidation : currentStale)
+                for (RCLValidation const& wValidation : currentStale)
                 {
+                    // Only save full validations until we update the schema
+                    if(!wValidation.isFull())
+                        continue;
                     s.erase();
                     STValidation::pointer const& val = rclValidation.unwrap();
                     val->add(s);

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -105,7 +105,7 @@ mismatch(RCLValidatedLedger const& a, RCLValidatedLedger const& b)
     Seq const upper = std::min(a.seq(), b.seq());
 
     Seq curr = upper;
-    while (a[curr] != b[curr] && curr >= lower && curr != Seq{0})
+    while (curr != Seq{0} && a[curr] != b[curr] && curr >= lower)
         --curr;
 
     // If the searchable interval mismatches entirely, then we have to

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -211,6 +211,12 @@ handleNewValidation(Application& app,
         if(j.debug())
             dmp(j.debug(), to_string(outcome));
 
+        if(outcome == ValStatus::badFullSeq && j.warn())
+        {
+            auto const seq = val->getFieldU32(sfLedgerSequence);
+            dmp(j.warn(), " already fully validated sequence past " + to_string(seq));
+        }
+
         if (val->isTrusted() && outcome == ValStatus::current)
         {
             app.getLedgerMaster().checkAccept(

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -344,4 +344,26 @@ handleNewValidation(Application& app,
     // ability/bandwidth to. None of that was implemented.
     return shouldRelay;
 }
+
+std::size_t
+getNodesAfter(
+    RCLValidations& vals,
+    std::shared_ptr<Ledger const> ledger,
+    uint256 const& ledgerID)
+{
+    return vals.getNodesAfter(
+        RCLValidatedLedger{std::move(ledger), vals.adaptor().journal()},
+        ledgerID);
+}
+
+uint256
+getPreferred(
+    RCLValidations& vals,
+    std::shared_ptr<Ledger const> ledger,
+    LedgerIndex minValidSeq)
+{
+    return vals.getPreferred(
+        RCLValidatedLedger{std::move(ledger), vals.adaptor().journal()},
+        minValidSeq);
+}
 }  // namespace ripple

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -160,7 +160,7 @@ public:
 
         @param s The sequence (index) of the ancestor
         @return The ID of this ledger's ancestor with that sequence number or
-                ID{} if one was not determined
+                ID{0} if one was not determined
     */
     ID operator[](Seq const& s) const;
 

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -101,11 +101,13 @@ public:
         return val_->isTrusted();
     }
 
+    /// Whether the validatioon is full (not-partial)
     bool
     full() const
     {
         return val_->isFull();
     }
+
     /// Get the load fee of the validation if it exists
     boost::optional<std::uint32_t>
     loadFee() const

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -63,9 +63,7 @@ public:
     std::uint32_t
     seq() const
     {
-        if(auto res = (*val_)[~sfLedgerSequence])
-            return *res;
-        return 0;
+        return val_->getFieldU32(sfLedgerSequence);
     }
 
     /// Validation's signing time

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -242,12 +242,11 @@ private:
 /// Alias for RCL-specific instantiation of generic Validations
 using RCLValidations = Validations<RCLValidationsAdaptor>;
 
+
 /** Handle a new validation
 
-    1. Set the trust status of a validation based on the validating node's
-       public key and this node's current UNL.
-    2. Add the validation to the set of validations if current.
-    3. If new and trusted, send the validation to the ledgerMaster.
+    Also sets the trust status of a validation based on the validating node's
+    public key and this node's current UNL.
 
     @param app Application object containing validations and ledgerMaster
     @param val The validation to add
@@ -256,8 +255,24 @@ using RCLValidations = Validations<RCLValidationsAdaptor>;
     @return Whether the validation should be relayed
 */
 bool
-handleNewValidation(Application & app, STValidation::ref val, std::string const& source);
+handleNewValidation(
+    Application& app,
+    STValidation::ref val,
+    std::string const& source);
 
+// @see Validations::getNodesAfter
+std::size_t
+getNodesAfter(
+    RCLValidations& vals,
+    std::shared_ptr<Ledger const> ledger,
+    uint256 const& ledgerID);
+
+// @see Validations::getPreferred
+uint256
+getPreferred(
+    RCLValidations& vals,
+    std::shared_ptr<Ledger const> ledger,
+    LedgerIndex minSeq);
 
 }  // namespace ripple
 

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -274,6 +274,13 @@ getPreferred(
     std::shared_ptr<Ledger const> ledger,
     LedgerIndex minSeq);
 
+// @see Validations::getPreferredLCL
+uint256
+getPreferredLCL(RCLValidations& vals,
+    std::shared_ptr<Ledger const> ledger,
+    LedgerIndex minSeq,
+    hash_map<uint256, std::uint32_t> const & peerCounts);
+
 }  // namespace ripple
 
 #endif

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -178,7 +178,7 @@ private:
     beast::Journal j_;
 };
 
-/** Generic validations adaptor classs for RCL
+/** Generic validations adaptor class for RCL
 
     Manages storing and writing stale RCLValidations to the sqlite DB and
     acquiring validated ledgers from the network.

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -138,8 +138,9 @@ class RCLValidatedLedger
 public:
     using ID = LedgerHash;
     using Seq = LedgerIndex;
+    struct MakeGenesis{};
 
-    RCLValidatedLedger() = default;
+    RCLValidatedLedger(MakeGenesis) {};
 
     RCLValidatedLedger(std::shared_ptr<Ledger const> ledger, beast::Journal j);
 

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -138,11 +138,15 @@ class RCLValidatedLedger
 public:
     using ID = LedgerHash;
     using Seq = LedgerIndex;
-    struct MakeGenesis{};
+    struct MakeGenesis
+    {
+    };
 
-    RCLValidatedLedger(MakeGenesis) {};
+    RCLValidatedLedger(MakeGenesis);
 
-    RCLValidatedLedger(std::shared_ptr<Ledger const> ledger, beast::Journal j);
+    RCLValidatedLedger(
+        std::shared_ptr<Ledger const> const& ledger,
+        beast::Journal j);
 
     /// The sequence (index) of the ledger
     Seq
@@ -168,7 +172,8 @@ public:
     minSeq() const;
 
 private:
-    std::shared_ptr<Ledger const> ledger_;
+    ID ledgerID_;
+    Seq ledgerSeq_;
     std::vector<uint256> ancestors_;
     beast::Journal j_;
 };
@@ -260,27 +265,6 @@ handleNewValidation(
     Application& app,
     STValidation::ref val,
     std::string const& source);
-
-// @see Validations::getNodesAfter
-std::size_t
-getNodesAfter(
-    RCLValidations& vals,
-    std::shared_ptr<Ledger const> ledger,
-    uint256 const& ledgerID);
-
-// @see Validations::getPreferred
-uint256
-getPreferred(
-    RCLValidations& vals,
-    std::shared_ptr<Ledger const> ledger,
-    LedgerIndex minSeq);
-
-// @see Validations::getPreferredLCL
-uint256
-getPreferredLCL(RCLValidations& vals,
-    std::shared_ptr<Ledger const> ledger,
-    LedgerIndex minSeq,
-    hash_map<uint256, std::uint32_t> const & peerCounts);
 
 }  // namespace ripple
 

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -102,6 +102,11 @@ public:
         return val_->isTrusted();
     }
 
+    bool
+    full() const
+    {
+        return val_->isFull();
+    }
     /// Get the load fee of the validation if it exists
     boost::optional<std::uint32_t>
     loadFee() const

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -497,8 +497,7 @@ public:
             stopwatch(), HashRouter::getDefaultHoldTime (),
             HashRouter::getDefaultRecoverLimit ()))
 
-        , mValidations (ValidationParms(),stopwatch(), logs_->journal("Validations"),
-            *this)
+        , mValidations (ValidationParms(),stopwatch(), *this, logs_->journal("Validations"))
 
         , m_loadManager (make_LoadManager (*this, *this, logs_->journal("LoadManager")))
 
@@ -916,7 +915,9 @@ public:
         // before we declare ourselves stopped.
         waitHandlerCounter_.join("Application", 1s, m_journal);
 
+        JLOG(m_journal.debug()) << "Flushing validations";
         mValidations.flush ();
+        JLOG(m_journal.debug()) << "Validations flushed";
 
         validatorSites_->stop ();
 

--- a/src/ripple/app/main/Application.h
+++ b/src/ripple/app/main/Application.h
@@ -74,12 +74,10 @@ class SHAMapStore;
 
 using NodeCache     = TaggedCache <SHAMapHash, Blob>;
 
-template <class StalePolicy, class Validation, class MutexType>
+template <class Adaptor>
 class Validations;
-class RCLValidation;
-class RCLValidationsPolicy;
-using RCLValidations =
-    Validations<RCLValidationsPolicy, RCLValidation, std::mutex>;
+class RCLValidationsAdaptor;
+using RCLValidations = Validations<RCLValidationsAdaptor>;
 
 class Application : public beast::PropertyStream::Source
 {

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1273,84 +1273,40 @@ bool NetworkOPsImp::checkLastClosedLedger (
     JLOG(m_journal.trace()) << "OurClosed:  " << closedLedger;
     JLOG(m_journal.trace()) << "PrevClosed: " << prevClosedLedger;
 
-    struct ValidationCount
-    {
-        std::uint32_t trustedValidations = 0;
-        std::uint32_t nodesUsing = 0;
-    };
+    //-------------------------------------------------------------------------
+    // Determine preferred last closed ledger
 
-    hash_map<uint256, ValidationCount> ledgers;
-    {
-        hash_map<uint256, std::uint32_t> current =
-            app_.getValidations().currentTrustedDistribution(
-                closedLedger,
-                prevClosedLedger,
-                m_ledgerMaster.getValidLedgerIndex());
+    auto & validations = app_.getValidations();
+    JLOG(m_journal.debug())
+        << "ValidationTrie " << Json::Compact(validations.getJsonTrie());
 
-        for (auto& it: current)
-            ledgers[it.first].trustedValidations += it.second;
-    }
-
-    auto& ourVC = ledgers[closedLedger];
-
+    // Will rely on peer LCL if no trusted validations exist
+    hash_map<uint256, std::uint32_t> peerCounts;
+    peerCounts[closedLedger] = 0;
     if (mMode >= omTRACKING)
+        peerCounts[closedLedger]++;
+
+    for (auto& peer : peerList)
     {
-        ++ourVC.nodesUsing;
+        uint256 peerLedger = peer->getClosedLedgerHash();
+
+        if (peerLedger.isNonZero())
+            ++peerCounts[peerLedger];
     }
 
-    for (auto& peer: peerList)
-    {
-        uint256 peerLedger = peer->getClosedLedgerHash ();
+    for(auto const & it: peerCounts)
+        JLOG(m_journal.debug()) << "L: " << it.first << " n=" << it.second;
 
-        if (peerLedger.isNonZero ())
-            ++ledgers[peerLedger].nodesUsing;
-    }
+    uint256 preferredLCL = getPreferredLCL(
+        validations,
+        ourClosed,
+        m_ledgerMaster.getValidLedgerIndex(),
+        peerCounts);
 
-
-    // 3) Is there a network ledger we'd like to switch to? If so, do we have
-    // it?
-    bool switchLedgers = false;
-    ValidationCount bestCounts = ledgers[closedLedger];
-
-    for (auto const& it: ledgers)
-    {
-        uint256 const & currLedger =  it.first;
-        ValidationCount const & currCounts = it.second;
-
-        JLOG(m_journal.debug()) << "L: " << currLedger
-                              << " t=" << currCounts.trustedValidations
-                              << ", n=" << currCounts.nodesUsing;
-
-        bool const preferCurr = [&]()
-        {
-            // Prefer ledger with more trustedValidations
-            if (currCounts.trustedValidations > bestCounts.trustedValidations)
-                return true;
-            if (currCounts.trustedValidations < bestCounts.trustedValidations)
-                return false;
-            // If neither are trusted, prefer more nodesUsing
-            if (currCounts.trustedValidations == 0)
-            {
-                if (currCounts.nodesUsing > bestCounts.nodesUsing)
-                    return true;
-                if (currCounts.nodesUsing < bestCounts.nodesUsing)
-                    return false;
-            }
-            // If tied trustedValidations (non-zero) or tied nodesUsing,
-            // prefer higher ledger hash
-            return currLedger > closedLedger;
-
-        }();
-
-        // Switch to current ledger if it is preferred over best so far
-        if (preferCurr)
-        {
-            bestCounts = currCounts;
-            closedLedger = currLedger;
-            switchLedgers = true;
-        }
-    }
-
+    bool switchLedgers = preferredLCL != closedLedger;
+    if(switchLedgers)
+        closedLedger = preferredLCL;
+    //-------------------------------------------------------------------------
     if (switchLedgers && (closedLedger == prevClosedLedger))
     {
         // don't switch to our own previous ledger
@@ -1364,15 +1320,15 @@ bool NetworkOPsImp::checkLastClosedLedger (
     if (!switchLedgers)
         return false;
 
-    auto consensus = m_ledgerMaster.getLedgerByHash (closedLedger);
+    auto consensus = m_ledgerMaster.getLedgerByHash(closedLedger);
 
     if (!consensus)
-        consensus = app_.getInboundLedgers().acquire (
+        consensus = app_.getInboundLedgers().acquire(
             closedLedger, 0, InboundLedger::Reason::CONSENSUS);
 
     if (consensus &&
-        ! m_ledgerMaster.isCompatible (*consensus, m_journal.debug(),
-            "Not switching"))
+        !m_ledgerMaster.isCompatible(
+            *consensus, m_journal.debug(), "Not switching"))
     {
         // Don't switch to a ledger not on the validated chain
         networkClosed = ourClosed->info().hash;
@@ -1380,18 +1336,18 @@ bool NetworkOPsImp::checkLastClosedLedger (
     }
 
     JLOG(m_journal.warn()) << "We are not running on the consensus ledger";
-    JLOG(m_journal.info()) << "Our LCL: " << getJson (*ourClosed);
+    JLOG(m_journal.info()) << "Our LCL: " << getJson(*ourClosed);
     JLOG(m_journal.info()) << "Net LCL " << closedLedger;
 
     if ((mMode == omTRACKING) || (mMode == omFULL))
-        setMode (omCONNECTED);
+        setMode(omCONNECTED);
 
     if (consensus)
     {
-        // FIXME: If this rewinds the ledger sequence, or has the same sequence, we
-        // should update the status on any stored transactions in the invalidated
-        // ledgers.
-        switchLastClosedLedger (consensus);
+        // FIXME: If this rewinds the ledger sequence, or has the same
+        // sequence, we should update the status on any stored transactions
+        // in the invalidated ledgers.
+        switchLastClosedLedger(consensus);
     }
 
     return true;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1297,9 +1297,8 @@ bool NetworkOPsImp::checkLastClosedLedger (
     for(auto const & it: peerCounts)
         JLOG(m_journal.debug()) << "L: " << it.first << " n=" << it.second;
 
-    uint256 preferredLCL = getPreferredLCL(
-        validations,
-        ourClosed,
+    uint256 preferredLCL = validations.getPreferredLCL(
+        RCLValidatedLedger{ourClosed, validations.adaptor().journal()},
         m_ledgerMaster.getValidLedgerIndex(),
         peerCounts);
 

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -227,7 +227,7 @@ checkConsensus(
       // Number of proposers that have validated a ledger descended from the
       // given ledger; if prevLedger.id() != prevLedgerID, use prevLedgerID
       // for the determination
-      std::size_t proposersFinished(Ledger conost & prev,
+      std::size_t proposersFinished(Ledger const & prevLedger,
                                     Ledger::ID const & prevLedger) const;
 
       // Return the ID of the last closed (and validated) ledger that the

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -225,8 +225,10 @@ checkConsensus(
       std::size_t proposersValidated(Ledger::ID const & prevLedger) const;
 
       // Number of proposers that have validated a ledger descended from the
-      // given ledger
-      std::size_t proposersFinished(Ledger::ID const & prevLedger) const;
+      // given ledger; if prevLedger.id() != prevLedgerID, use prevLedgerID
+      // for the determination
+      std::size_t proposersFinished(Ledger conost & prev,
+                                    Ledger::ID const & prevLedger) const;
 
       // Return the ID of the last closed (and validated) ledger that the
       // application thinks consensus should use as the prior ledger.
@@ -1410,7 +1412,8 @@ Consensus<Adaptor>::haveConsensus()
             ++disagree;
         }
     }
-    auto currentFinished = adaptor_.proposersFinished(prevLedgerID_);
+    auto currentFinished =
+        adaptor_.proposersFinished(previousLedger_, prevLedgerID_);
 
     JLOG(j_.debug()) << "Checking for TX consensus: agree=" << agree
                      << ", disagree=" << disagree;

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -605,7 +605,7 @@ public:
              not have heard from those nodes yet.
 
         The preferred ledger for this sequence number is then the ledger
-        with relative majority of support, where uncommited support
+        with relative majority of support, where uncommitted support
         can be given to ANY ledger at that sequence number
         (including one not yet known). If no such preferred ledger exists, then
         the prior sequence preferred ledger is the overall preferred ledger.
@@ -621,7 +621,7 @@ public:
 
         @param largestIssued The sequence number of the largest validation
                              issued by this node.
-        @return Pair with the seqeuence number and ID of the preferred ledger
+        @return Pair with the sequence number and ID of the preferred ledger
     */
     std::pair<Seq,ID>
     getPreferred(Seq const largestIssued) const
@@ -637,9 +637,9 @@ public:
         {
             // Within a single span, the preferred by branch strategy is simply
             // to continue along the span as long as the branch support of
-            // the next ledger exceeds the uncommited support for that ledger.
+            // the next ledger exceeds the uncommitted support for that ledger.
             {
-                // Add any initial uncommited support prior for ledgers
+                // Add any initial uncommitted support prior for ledgers
                 // earlier than nextSeq or earlier than largestIssued
                 Seq nextSeq = curr->span.start() + Seq{1};
                 while (uncommittedIt != seqSupport.end() &&
@@ -704,7 +704,7 @@ public:
                     margin++;
             }
 
-            // If the best child has margin exceeding the uncommited support,
+            // If the best child has margin exceeding the uncommitted support,
             // continue from that child, otherwise we are done
             if (best && ((margin > uncommitted) || (uncommitted == 0)))
                 curr = best;

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -55,7 +55,7 @@ namespace ripple {
                             + sum_(child : node->children) child->branchSupport
         @endcode
 
-    This is analagous to the merkle tree property in which a node's hash is
+    This is analogous to the merkle tree property in which a node's hash is
     the hash of the concatenation of its child node hashes.
 
     The templated Ledger type represents a ledger which has a unique history.
@@ -501,7 +501,7 @@ public:
     /** Return the count of branch support for the specific ledger
 
         @param ledger The ledger to lookup
-        @return The number of entries in the trie for this ledger or a descendent
+        @return The number of entries in the trie for this ledger or a descendant
      */
     std::uint32_t
     branchSupport(Ledger const& ledger) const
@@ -550,7 +550,7 @@ public:
            - The prior sequence preferred ledger, e.g. B.
            - The (tip) support of ledgers with this sequence number,e.g. the
              number of validators whose last validation was for C or D.
-           - The (branch) total support of all descendents of the current
+           - The (branch) total support of all descendants of the current
              sequence number ledgers, e.g. the branch support of D is the
              tip support of D plus the tip support of E; the branch support of
              C is just the tip support of C.
@@ -572,8 +572,8 @@ public:
         If a preferred ledger does exist, then we continue with the next
         sequence but increase prefixSupport with the non-preferred tip support
         this round, e.g. if C were preferred over D, then prefixSupport would
-        incerase by the support of D and E, since if those validators are
-        following the protocl, they will switch to the C branch, but might
+        increase by the support of D and E, since if those validators are
+        following the protocol, they will switch to the C branch, but might
         initially support a different descendant.
     */
     std::pair<Seq,ID>
@@ -631,12 +631,12 @@ public:
                 // of curr and its ancestors, along with the branch support of
                 // any of its siblings that are inconsistent.
                 //
-                // The additional prefix suppport that is carried to best is
+                // The additional prefix support that is carried to best is
                 //   A->branchSupport + B->branchSupport + best->tipSupport
                 // This is the amount of support that has not yet voted
-                // on a descendent of best, or has voted on a conflicting
-                // descendent and will switch to best in the future. This means
-                // that they may support an arbitrary descendent of best.
+                // on a descendant of best, or has voted on a conflicting
+                // descendant and will switch to best in the future. This means
+                // that they may support an arbitrary descendant of best.
                 //
                 // The calculation is simplified using
                 //     A->branchSupport+B->branchSupport

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -1,0 +1,699 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_CONSENSUS_LEDGERS_TRIE_H_INCLUDED
+#define RIPPLE_APP_CONSENSUS_LEDGERS_TRIE_H_INCLUDED
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+#include <ripple/json/json_value.h>
+
+namespace ripple {
+
+/** Ancestry trie of ledgers
+
+    Combination of a compressed trie and merkle-ish tree that maintains
+    validation support of recent ledgers based on their ancestry.
+
+    The compressed trie structure comes from recognizing that ledger history
+    can be viewed as a string over the alphabet of ledger ids. That is,
+    a given ledger with sequence number `seq` defines a length `seq` string,
+    with i-th entry equal to the id of the ancestor ledger with sequence
+    number i. "Sequence" strings with a common prefix share those ancestor
+    ledgers in common. Tracking this ancestry information and relations across
+    all validated ledgers is done conveniently in a compressed trie. A node in
+    the trie is an ancestor of all its children. If a parent node has sequence
+    number `seq`, each child node has a different ledger starting at `seq+1`.
+    The compression comes from the invariant that any non-root node with 0 tip
+    support has either no children or multiple children. In other words, a
+    non-root 0-tip-support node can be combined with its single child.
+
+    The merkle-ish property is based on the branch support calculation. Each
+    node has a tipSupport, which is the number of current validations for that
+    particular ledger. The branch support is the sum of the tip support and
+    the branch support of that node's children:
+
+        @code
+        node->branchSupport = node->tipSupport
+                            + sum_(child : node->children) child->branchSupport
+        @endcode
+
+    This is analagous to the merkle tree property in which a node's hash is
+    the hash of the concatenation of its child node hashes.
+
+    The templated Ledger type represents a ledger which has a unique history.
+    It should be lightweight and cheap to copy.
+
+       @code
+       // Identifier types that should be equality-comparable and copyable
+       struct ID;
+       struct Seq;
+
+       struct Ledger
+       {
+          // The default ledger represents a ledger that prefixes all other
+          // ledgers, e.g. the genesis ledger
+          Ledger();
+
+          Ledger(Ledger &);
+          Ledger& operator=(Ledger );
+
+          // Return the sequence number of this ledger
+          Seq seq() const;
+
+          // Return the ID of this ledger's ancestor with given sequence number
+          // or ID{0} if unknown
+          ID
+          operator[](Seq s);
+
+       };
+
+       // Return the sequence number of the first possible mismatching ancestor
+       // between two ledgers
+       Seq
+       mismatch(ledgerA, ledgerB);
+       @endcode
+
+    The unique history invariant of ledgers requires any ledgers that agree
+    on the id of a given sequence number agree on ALL ancestors before that
+    ledger:
+
+        @code
+        Ledger a,b;
+        // For all Seq s:
+        if(a[s] == b[s]);
+            for(Seq p = 0; p < s; ++p)
+                assert(a[p] == b[p]);
+        @endcode
+
+    @tparam Ledger A type representing a ledger and its history
+*/
+template <class Ledger>
+class LedgerTrie
+{
+    using Seq = typename Ledger::Seq;
+    using ID = typename Ledger::ID;
+
+    /// Represents a span of ancestry of a ledger
+    class Span
+    {
+        // The span is the half-open interval [start,end) of ledger_
+        Seq start_{0};
+        Seq end_{1};
+        Ledger ledger_;
+
+    public:
+        Span()
+        {
+            // Require default ledger to be genesis seq
+            assert(ledger_.seq() == start_);
+        }
+
+        Span(Ledger ledger)
+            : start_{0}, end_{ledger.seq() + Seq{1}}, ledger_{std::move(ledger)}
+        {
+        }
+
+        Span(Span const& s) = default;
+        Span(Span&& s) = default;
+        Span&
+        operator=(Span const&) = default;
+        Span&
+        operator=(Span&&) = default;
+
+        Seq
+        end() const
+        {
+            return end_;
+        }
+
+        // Return the Span from (spot,end_]
+        Span
+        from(Seq spot)
+        {
+            return sub(spot, end_);
+        }
+
+        // Return the Span from (start_,spot]
+        Span
+        before(Seq spot)
+        {
+            return sub(start_, spot);
+        }
+
+        bool
+        empty() const
+        {
+            return start_ == end_;
+        }
+
+        //Return the ID of the ledger that starts this span
+        ID
+        startID() const
+        {
+            return ledger_[start_];
+        }
+
+        // Return the ledger sequence number of the first possible difference
+        // between this span and a given ledger.
+        Seq
+        diff(Ledger const& o) const
+        {
+            return clamp(mismatch(ledger_, o));
+        }
+
+        //  The Seq and ID of the end of the span
+        std::pair<Seq, ID>
+        tip() const
+        {
+            Seq tipSeq{end_ -Seq{1}};
+            return {tipSeq, ledger_[tipSeq]};
+        }
+
+    private:
+        Span(Seq start, Seq end, Ledger const& l)
+            : start_{start}, end_{end}, ledger_{l}
+        {
+            assert(start <= end);
+        }
+
+        Seq
+        clamp(Seq val) const
+        {
+            return std::min(std::max(start_, val), end_);
+        };
+
+        // Return a span of this over the half-open interval [from,to)
+        Span
+        sub(Seq from, Seq to)
+        {
+            return Span(clamp(from), clamp(to), ledger_);
+        }
+
+        friend std::ostream&
+        operator<<(std::ostream& o, Span const& s)
+        {
+            return o << s.tip().second << "(" << s.start_ << "," << s.end_
+                     << "]";
+        }
+
+        friend Span
+        merge(Span const& a, Span const& b)
+        {
+            // Return combined span, using ledger_ from higher sequence span
+            if (a.end_ < b.end_)
+                return Span(std::min(a.start_, b.start_), b.end_, b.ledger_);
+
+            return Span(std::min(a.start_, b.start_), a.end_, a.ledger_);
+        }
+    };
+
+    // A node in the trie
+    struct Node
+    {
+        Node() : span{}, tipSupport{0}, branchSupport{0}
+        {
+        }
+
+        Node(Ledger const& l) : span{l}, tipSupport{1}, branchSupport{1}
+        {
+        }
+
+        Node(Span s) : span{std::move(s)}
+        {
+        }
+
+        Span span;
+        std::uint32_t tipSupport = 0;
+        std::uint32_t branchSupport = 0;
+
+        std::vector<std::unique_ptr<Node>> children;
+        Node* parent = nullptr;
+
+        /** Remove the given node from this Node's children
+
+            @param child The address of the child node to remove
+            @note The child must be a member of the vector. The passed pointer
+                  will be dangling as a result of this call
+        */
+        void
+        erase(Node const* child)
+        {
+            auto it = std::remove_if(
+                    children.begin(),
+                    children.end(),
+                    [child](std::unique_ptr<Node> const& curr) {
+                        return curr.get() == child;
+                    });
+            assert(it != children.end());
+            children.erase(it, children.end());
+        }
+
+        friend std::ostream&
+        operator<<(std::ostream& o, Node const& s)
+        {
+            return o << s.span << "(T:" << s.tipSupport
+                     << ",B:" << s.branchSupport << ")";
+        }
+
+        Json::Value
+        getJson() const
+        {
+            Json::Value res;
+            res["id"] = to_string(span.tip().second);
+            res["seq"] = static_cast<std::uint32_t>(span.tip().first);
+            res["tipSupport"] = tipSupport;
+            res["branchSupport"] = branchSupport;
+            if(!children.empty())
+            {
+                Json::Value &cs = (res["children"] = Json::arrayValue);
+                for(auto const & child : children)
+                {
+                    cs.append(child->getJson());
+                }
+            }
+            return res;
+        }
+    };
+
+    // The root of the trie. The root is allowed to break the no-single child
+    // invariant.
+    std::unique_ptr<Node> root;
+
+    /** Find the node in the trie that represents the longest common ancestry
+        with the given ledger.
+
+        @return Pair of the found node and the sequence number of the first
+                ledger difference.
+    */
+    std::pair<Node*, Seq>
+    find(Ledger const& ledger) const
+    {
+        Node* curr = root.get();
+
+        // Root is always defined and is in common with all ledgers
+        assert(curr);
+        Seq pos = curr->span.diff(ledger);
+
+        bool done = false;
+
+        // Continue searching for a better span as long as the current position
+        // matches the entire span
+        while (!done && pos == curr->span.end())
+        {
+            done = true;
+            // Find the child with the longest ancestry match
+            for (std::unique_ptr<Node> const& child : curr->children)
+            {
+                auto childPos = child->span.diff(ledger);
+                if (childPos > pos)
+                {
+                    done = false;
+                    pos = childPos;
+                    curr = child.get();
+                    break;
+                }
+            }
+        }
+        return std::make_pair(curr, pos);
+    }
+
+    void
+    dumpImpl(std::ostream& o, std::unique_ptr<Node> const& curr, int offset)
+        const
+    {
+        if (curr)
+        {
+            if (offset > 0)
+                o << std::setw(offset) << "|-";
+
+            std::stringstream ss;
+            ss << *curr;
+            o << ss.str() << std::endl;
+            for (std::unique_ptr<Node> const& child : curr->children)
+                dumpImpl(o, child, offset + 1 + ss.str().size() + 2);
+        }
+    }
+
+public:
+    LedgerTrie() : root{std::make_unique<Node>()}
+    {
+    }
+
+    /** Insert and/or increment the support for the given ledger.
+
+        @param ledger A ledger and its ancestry
+        @param count The count of support for this ledger
+     */
+    void
+    insert(Ledger const& ledger, std::uint32_t count = 1)
+    {
+        Node* loc;
+        Seq diffSeq;
+        std::tie(loc, diffSeq) = find(ledger);
+
+        // There is always a place to insert
+        assert(loc);
+
+        Span lTmp{ledger};
+        Span prefix = lTmp.before(diffSeq);
+        Span oldSuffix = loc->span.from(diffSeq);
+        Span newSuffix = lTmp.from(diffSeq);
+        Node* incNode = loc;
+
+        if (!oldSuffix.empty())
+        {
+            // new is a prefix of current
+            // e.g. abcdef->..., adding abcd
+            //    becomes abcd->ef->...
+
+            // Create oldSuffix node that takes over loc
+            std::unique_ptr<Node> newNode{std::make_unique<Node>(oldSuffix)};
+            newNode->tipSupport = loc->tipSupport;
+            newNode->branchSupport = loc->branchSupport;
+            using std::swap;
+            swap(newNode->children, loc->children);
+            for(std::unique_ptr<Node> & child : newNode->children)
+                child->parent = newNode.get();
+
+            // Loc truncates to prefix and newNode is its child
+            loc->span = prefix;
+            newNode->parent = loc;
+            loc->children.emplace_back(std::move(newNode));
+            loc->tipSupport = 0;
+        }
+        if (!newSuffix.empty())
+        {
+            //  current is a substring of new
+            // e.g.  abc->... adding abcde
+            // ->   abc->  ...
+            //          -> de
+
+            std::unique_ptr<Node> newNode{std::make_unique<Node>(newSuffix)};
+            newNode->parent = loc;
+            // increment support starting from the new node
+            incNode = newNode.get();
+            loc->children.push_back(std::move(newNode));
+        }
+
+        incNode->tipSupport += count;
+        while (incNode)
+        {
+            incNode->branchSupport += count;
+            incNode = incNode->parent;
+        }
+    }
+
+    /** Decrease support for a ledger, removing and compressing if possible.
+
+        @param ledger The ledger history to remove
+        @param count The amount of tip support to remove
+
+        @return Whether a matching node was decremented and possibly removed.
+    */
+    bool
+    remove(Ledger const& ledger, std::uint32_t count = 1)
+    {
+        Node* loc;
+        Seq diffSeq;
+        std::tie(loc, diffSeq) = find(ledger);
+
+        // Cannot erase root
+        if (loc && loc != root.get())
+        {
+            // Must be exact match with tip support
+            if (diffSeq == loc->span.end() && diffSeq > ledger.seq() &&
+                loc->tipSupport > 0)
+            {
+                count = std::min(count, loc->tipSupport);
+                loc->tipSupport -= count;
+
+                Node* decNode = loc;
+                while (decNode)
+                {
+                    decNode->branchSupport -= count;
+                    decNode = decNode->parent;
+                }
+
+                while (loc->tipSupport == 0 && loc != root.get())
+                {
+                    Node* parent = loc->parent;
+                    if (loc->children.empty())
+                    {
+                        // this node can be erased
+                        parent->erase(loc);
+                    }
+                    else if (loc->children.size() == 1)
+                    {
+                        // This node can be combined with its child
+                        std::unique_ptr<Node> child =
+                            std::move(loc->children.front());
+                        child->span = merge(loc->span, child->span);
+                        child->parent = parent;
+                        parent->children.emplace_back(std::move(child));
+                        parent->erase(loc);
+                    }
+                    else
+                        break;
+                    loc = parent;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Return count of tip support for the specific ledger.
+
+        @param ledger The ledger to lookup
+        @return The number of entries in the trie for this *exact* ledger
+     */
+    std::uint32_t
+    tipSupport(Ledger const& ledger) const
+    {
+        Node const* loc;
+        Seq diffSeq;
+        std::tie(loc, diffSeq) = find(ledger);
+
+        // Exact match
+        if (loc && diffSeq == loc->span.end() && diffSeq > ledger.seq())
+            return loc->tipSupport;
+        return 0;
+    }
+
+    /** Return the count of branch support for the specific ledger
+
+        @param ledger The ledger to lookup
+        @return The number of entries in the trie for this ledger or a descendent
+     */
+    std::uint32_t
+    branchSupport(Ledger const& ledger) const
+    {
+        Node const* loc;
+        Seq diffSeq;
+        std::tie(loc, diffSeq) = find(ledger);
+
+        // Check that ledger is is an exact match or proper
+        // prefix of loc
+        if (loc && diffSeq > ledger.seq() &&
+            ledger.seq() < loc->span.end())
+        {
+            return loc->branchSupport;
+        }
+        return 0;
+    }
+
+    /** Return the preferred ledger ID
+
+        The preferred ledger is used to determine the working ledger
+        for consensus amongst competing alternatives.
+
+        Recall that each validator is normally validating a chain of ledgers,
+        e.g. A->B->C->D. However, if due to network connectivity or other issues,
+        validators generate different chains
+
+        @code
+               /->C
+           A->B
+               \->D->E
+        @endcode
+
+        we need a way for validators to converge on the chain with the most
+        support. We call this the preferred ledger.  Intuitively, the idea is to
+        be conservative and only switch to a different branch when you see enough
+        peer validations to *know* another branch won't have preferred support.
+        This ensures the preferred branch has monotonically increasing support.
+
+        The preferred ledger is found by walking this tree of validated ledgers
+        starting from the common ancestor ledger.
+
+        At each sequence number, we have
+
+           - The prior sequence preferred ledger (B).
+           - The support of ledgers that have been explicitly validated by a
+             validator (C,D), or are an ancestor of that validators current
+             validated ledger (E).
+           - The number of validators that have yet to validate a ledger
+             with this sequence number (prefixSupport).
+
+        The preferred ledger for this sequence number is then the ledger
+        with relative majority of support, where prefixSupport can be given to
+        ANY ledger at that sequence number (including one not yet known). If no
+        such preferred ledger exists, than prior sequence preferred ledger is
+        the overall preferred ledger.  If one does exist, then we continue
+        with the next sequence but increase prefixSupport with the non
+        preferred ones this round, e.g. if C were preferred over D, then
+        prefixSupport would incerase by the support of D and E.
+
+    */
+    std::pair<Seq,ID>
+    getPreferred()
+    {
+        Node* curr = root.get();
+
+        bool done = false;
+        std::uint32_t prefixSupport = curr->tipSupport;
+        while (curr && !done)
+        {
+            Node* best = nullptr;
+            std::uint32_t margin = 0;
+
+            if (curr->children.size() == 1)
+            {
+                best = curr->children[0].get();
+                margin = best->branchSupport;
+            }
+            else if (!curr->children.empty())
+            {
+                // Sort placing children with largest branch support in the
+                // front, breaking ties with the span's starting ID
+                std::partial_sort(
+                    curr->children.begin(),
+                    curr->children.begin() + 2,
+                    curr->children.end(),
+                    [](std::unique_ptr<Node> const& a,
+                       std::unique_ptr<Node> const& b) {
+                        return std::make_tuple(a->branchSupport, a->span.startID()) >
+                            std::make_tuple(b->branchSupport, b->span.startID());
+                    });
+
+                best = curr->children[0].get();
+                margin = curr->children[0]->branchSupport -
+                    curr->children[1]->branchSupport;
+
+                // If best holds the tie-breaker, gets one larger margin
+                // since the second best needs additional branchSupport
+                // to overcome the tie
+                if (best->span.startID() > curr->children[1]->span.startID())
+                    margin++;
+            }
+
+            // If the best child has margin exceeding the prefix support,
+            // continue from that child, otherwise we are done
+            if (best && ((margin > prefixSupport) || (prefixSupport == 0)))
+            {
+                // Prefix support is all the support not on the branch we
+                // are moving to
+                //       curr
+                //    _/  |  \_
+                //    A   B  best
+                // At curr, the prefix support already includes the tip support
+                // of curr and its ancestors, along with the branch support of
+                // any of its siblings that are inconsistent.
+                //
+                // The additional prefix suppport that is carried to best is
+                //   A->branchSupport + B->branchSupport + best->tipSupport
+                // This is the amount of support that has not yet voted
+                // on a descendent of best, or has voted on a conflicting
+                // descendent and will switch to best in the future. This means
+                // that they may support an arbitrary descendent of best.
+                //
+                // The calculation is simplified using
+                //     A->branchSupport+B->branchSupport
+                //               =  curr->branchSupport - best->branchSupport
+                //                                      - curr->tipSupport
+                //
+                // This will not overflow by definition of the above quantities
+                prefixSupport += (curr->branchSupport - best->branchSupport
+                                 - curr->tipSupport) + best->tipSupport;
+
+                curr = best;
+            }
+            else  // current is the best
+                done = true;
+        }
+        return curr->span.tip();
+    }
+
+    /** Dump an ascii representation of the trie to the stream
+     */
+    void
+    dump(std::ostream& o) const
+    {
+        dumpImpl(o, root, 0);
+    }
+
+    /** Dump JSON representation of trie state
+    */
+    Json::Value
+    getJson() const
+    {
+        return root->getJson();
+    }
+
+    /** Check the compressed trie and support invariants.
+     */
+    bool
+    checkInvariants() const
+    {
+        std::stack<Node const*> nodes;
+        nodes.push(root.get());
+        while (!nodes.empty())
+        {
+            Node const* curr = nodes.top();
+            nodes.pop();
+            if (!curr)
+                continue;
+
+            // Node with 0 tip support must have multiple children
+            // unless it is the root node
+            if (curr != root.get() && curr->tipSupport == 0 &&
+                curr->children.size() < 2)
+                return false;
+
+            // branchSupport = tipSupport + sum(child->branchSupport)
+            std::size_t support = curr->tipSupport;
+            for (auto const& child : curr->children)
+            {
+                if(child->parent != curr)
+                    return false;
+
+                support += child->branchSupport;
+                nodes.push(child.get());
+            }
+            if (support != curr->branchSupport)
+                return false;
+        }
+        return true;
+    }
+};
+
+}  // namespace ripple
+#endif

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -418,7 +418,7 @@ public:
                 child->parent = newNode.get();
 
             // Loc truncates to prefix and newNode is its child
-            assert(!prefix.empty());
+            assert(prefix);
             loc->span = *prefix;
             newNode->parent = loc;
             loc->children.emplace_back(std::move(newNode));

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -20,10 +20,10 @@
 #ifndef RIPPLE_APP_CONSENSUS_LEDGERS_TRIE_H_INCLUDED
 #define RIPPLE_APP_CONSENSUS_LEDGERS_TRIE_H_INCLUDED
 
+#include <ripple/json/json_value.h>
 #include <algorithm>
 #include <memory>
 #include <vector>
-#include <ripple/json/json_value.h>
 
 namespace ripple {
 

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -42,7 +42,7 @@ public:
     {
     }
 
-    // The sequence number the tip ledger
+    // The sequence number of the tip ledger
     Seq seq;
     // The ID of the tip ledger
     ID id;
@@ -53,7 +53,7 @@ public:
         @return The ID of the ancestor with that sequence number
 
         @note s must be less than or equal to the sequence number of the
-              preferred ledger
+              tip ledger
     */
     ID
     ancestor(Seq const& s) const

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -146,14 +146,14 @@ class LedgerTrie
 
         // Return the Span from (spot,end_]
         Span
-        from(Seq spot)
+        from(Seq spot) const
         {
             return sub(spot, end_);
         }
 
         // Return the Span from (start_,spot]
         Span
-        before(Seq spot)
+        before(Seq spot) const
         {
             return sub(start_, spot);
         }
@@ -202,7 +202,7 @@ class LedgerTrie
 
         // Return a span of this over the half-open interval [from,to)
         Span
-        sub(Seq from, Seq to)
+        sub(Seq from, Seq to) const
         {
             return Span(clamp(from), clamp(to), ledger_);
         }
@@ -577,7 +577,7 @@ public:
         initially support a different descendant.
     */
     std::pair<Seq,ID>
-    getPreferred()
+    getPreferred() const
     {
         Node* curr = root.get();
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -791,7 +791,7 @@ public:
 
     /** Get the set of known public keys associated with current validations
 
-        @return The set of knows keys for current listed validators
+        @return The set of known keys for current listed validators
     */
     hash_set<NodeKey>
     getCurrentPublicKeys()

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -152,7 +152,7 @@ enum class ValStatus {
     /// This was a new validation and was added
     current,
     /// Already had this validation for this ID but different seq
-    repeat,
+    repeatID,
     /// Not current or was older than current from this node
     stale,
     /// A validation violates the increasing seq requirement
@@ -166,8 +166,8 @@ to_string(ValStatus m)
     {
         case ValStatus::current:
             return "current";
-        case ValStatus::repeat:
-            return "repeat";
+        case ValStatus::repeatID:
+            return "repeatID";
         case ValStatus::stale:
             return "stale";
         case ValStatus::badSeq:
@@ -370,7 +370,7 @@ private:
     /** Process a new validation
 
         Process a new trusted validation from a validator. This will be
-        reflected only after the validated ledger is succesfully acquired by
+        reflected only after the validated ledger is successfully acquired by
         the local node. In the interim, the prior validated ledger from this
         node remains.
 
@@ -554,7 +554,7 @@ public:
         @param val The validation to store
         @return The outcome
 
-        @note The provided key may differ from the validations's  key()
+        @note The provided key may differ from the validation's  key()
               member if the validator is using ephemeral signing keys.
     */
     ValStatus
@@ -577,7 +577,7 @@ public:
             // one with the same id for this key
             auto const ret = byLedger_[val.ledgerID()].emplace(key, val);
             if (!ret.second && ret.first->second.key() == val.key())
-                return ValStatus::repeat;
+                return ValStatus::repeatID;
 
             auto const ins = current_.emplace(key, val);
             if (!ins.second)
@@ -667,7 +667,7 @@ public:
         }
 
         // A ledger ahead of us is preferred regardless of whether it is
-        // a descendent of our working ledger or it is on a different chain
+        // a descendant of our working ledger or it is on a different chain
         if (preferredSeq > currSeq)
             return std::make_pair(preferredSeq, preferredID);
 
@@ -795,7 +795,7 @@ public:
 
     /** Get the set of known public keys associated with current validations
 
-        @return The set of of knowns keys for current listed validators
+        @return The set of knows keys for current listed validators
     */
     hash_set<NodeKey>
     getCurrentPublicKeys()

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -611,14 +611,14 @@ public:
         @param currLedger The local nodes current working ledger
 
         @return The sequence and id of the preferred working ledger,
-                or Seq{0},ID{} if no trusted validations are available to
+                or Seq{0},ID{0} if no trusted validations are available to
                 determine the preferred ledger.
     */
     std::pair<Seq, ID>
     getPreferred(Ledger const& currLedger)
     {
-        Seq preferredSeq;
-        ID preferredID;
+        Seq preferredSeq{0};
+        ID preferredID{0};
 
         ScopedLock lock{mutex_};
         std::tie(preferredSeq, preferredID) = withTrie(
@@ -671,7 +671,7 @@ public:
     getPreferred(Ledger const& currLedger, Seq minValidSeq)
     {
         std::pair<Seq, ID> preferred = getPreferred(currLedger);
-        if(preferred.first >= minValidSeq && preferred.second != ID{})
+        if(preferred.first >= minValidSeq && preferred.second != ID{0})
             return preferred.second;
         return currLedger.id();
 
@@ -702,7 +702,7 @@ public:
         std::pair<Seq, ID> preferred = getPreferred(lcl);
 
         // Trusted validations exist
-        if (preferred.second != ID{} && preferred.first > Seq{0})
+        if (preferred.second != ID{0} && preferred.first > Seq{0})
             return (preferred.first >= minSeq) ? preferred.second : lcl.id();
 
         // Otherwise, rely on peer ledgers

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -186,6 +186,9 @@ getPreferredLedger(
         // arrived
         bool trusted() const;
 
+        // Whether this is a full or partial validation
+        bool full() const;
+
         implementation_specific_t
         unwrap() -> return the implementation-specific type being wrapped
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -644,8 +644,10 @@ public:
         ID preferredID{0};
 
         ScopedLock lock{mutex_};
-        std::tie(preferredSeq, preferredID) = withTrie(
-            lock, [](LedgerTrie<Ledger>& trie) { return trie.getPreferred(); });
+        std::tie(preferredSeq, preferredID) =
+            withTrie(lock, [this](LedgerTrie<Ledger>& trie) {
+                return trie.getPreferred(localSeqEnforcer_.largest());
+            });
 
         // No trusted validations to determine branch
         if (preferredSeq == Seq{0})
@@ -672,8 +674,7 @@ public:
         if (preferredSeq > currSeq)
             return std::make_pair(preferredSeq, preferredID);
 
-        // Only switch to earlier sequence numbers if it is a different
-        // chain to avoid jumping backward unnecessarily
+        // Only switch to earlier sequence numbers if it is a different chain.
         if (currLedger[preferredSeq] != preferredID)
             return std::make_pair(preferredSeq, preferredID);
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -402,10 +402,19 @@ private:
 
         checkAcquired(lock);
 
-        if (boost::optional<Ledger> ledger = adaptor_.acquire(val.ledgerID()))
-            updateTrie(lock, key, *ledger);
+        auto it = acquiring_.find(val.ledgerID());
+        if(it != acquiring_.end())
+        {
+            it->second.insert(key);
+        }
         else
-            acquiring_[val.ledgerID()].insert(key);
+        {
+            if (boost::optional<Ledger> ledger = adaptor_.acquire(val.ledgerID()))
+                updateTrie(lock, key, *ledger);
+            else
+                acquiring_[val.ledgerID()].insert(key);
+        }
+
     }
 
     /** Use the trie for a calculation

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -1,0 +1,207 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <BeastConfig.h>
+#include <ripple/app/consensus/RCLValidations.h>
+#include <ripple/app/ledger/Ledger.h>
+#include <ripple/basics/Log.h>
+#include <ripple/ledger/View.h>
+#include <test/jtx.h>
+#include <ripple/beast/unit_test.h>
+
+namespace ripple {
+namespace test {
+
+class RCLValidations_test : public beast::unit_test::suite
+{
+
+public:
+    void
+    run() override
+    {
+        beast::Journal j;
+
+        using Seq = RCLValidatedLedger::Seq;
+        using ID = RCLValidatedLedger::ID;
+
+        // This tests RCLValidatedLedger properly implements the type
+        // requirements of a LedgerTrie ledger, with its added behavior that
+        // only the 256 prior ledger hashes are available to determine ancestry.
+        Seq const maxAncestors = 256;
+
+        //----------------------------------------------------------------------
+        // Generate two ledger histories that agree on the first maxAncestors
+        // ledgers, then diverge.
+
+        std::vector<std::shared_ptr<Ledger>> history;
+
+        jtx::Env env(*this);
+        Config config;
+        auto prev = std::make_shared<Ledger>(
+            create_genesis, config,
+            std::vector<uint256>{}, env.app().family());
+        history.push_back(prev);
+        for (auto i = 0; i < (2*maxAncestors + 1); ++i)
+        {
+            auto next = std::make_shared<Ledger>(
+                *prev,
+                env.app().timeKeeper().closeTime());
+            next->updateSkipList();
+            history.push_back(next);
+            prev = next;
+        }
+
+        // altHistory agrees with first half of regular history
+        Seq const diverge = history.size()/2;
+        std::vector<std::shared_ptr<Ledger>> altHistory(
+            history.begin(), history.begin() + diverge);
+        // advance clock too get new ledgers
+        env.timeKeeper().set(env.timeKeeper().now() + 1200s);
+        prev = altHistory.back();
+        bool forceHash = true;
+        while(altHistory.size() < history.size())
+        {
+            auto next = std::make_shared<Ledger>(
+                *prev,
+                env.app().timeKeeper().closeTime());
+            // Force a different hash on the first iteration
+            next->updateSkipList();
+            if(forceHash)
+            {
+                next->setImmutable(config);
+                forceHash = false;
+            }
+
+            altHistory.push_back(next);
+            prev = next;
+        }
+
+        //----------------------------------------------------------------------
+
+
+        // Empty ledger
+        {
+            RCLValidatedLedger a;
+            BEAST_EXPECT(a.seq() == Seq{0});
+            BEAST_EXPECT(a[Seq{0}] == ID{0});
+            BEAST_EXPECT(a.minSeq() == Seq{0});
+        }
+
+        // Full history ledgers
+        {
+            std::shared_ptr<Ledger> ledger = history.back();
+            RCLValidatedLedger a{ledger, j};
+            BEAST_EXPECT(a.seq() == ledger->info().seq);
+            BEAST_EXPECT(
+                a.minSeq() == a.seq() - maxAncestors);
+            // Ensure the ancestral 256 ledgers have proper ID
+            for(Seq s = a.seq(); s > 0; s--)
+            {
+                if(s >= a.minSeq())
+                    BEAST_EXPECT(a[s] == history[s-1]->info().hash);
+                else
+                    BEAST_EXPECT(a[s] == ID{0});
+            }
+        }
+
+        // Mismatch tests
+
+        // Empty with non-empty
+        {
+            RCLValidatedLedger a;
+
+            for (auto ledger : {history.back(),
+                                history[maxAncestors - 1]})
+            {
+                RCLValidatedLedger b{ledger, j};
+                BEAST_EXPECT(mismatch(a, b) == 1);
+                BEAST_EXPECT(mismatch(b, a) == 1);
+            }
+        }
+        // Same chains, different seqs
+        {
+            RCLValidatedLedger a{history.back(), j};
+            for(Seq s = a.seq(); s > 0; s--)
+            {
+                RCLValidatedLedger b{history[s-1], j};
+                if(s >= a.minSeq())
+                {
+                    BEAST_EXPECT(mismatch(a, b) == b.seq() + 1);
+                    BEAST_EXPECT(mismatch(b, a) == b.seq() + 1);
+                }
+                else
+                {
+                    BEAST_EXPECT(mismatch(a, b) == Seq{1});
+                    BEAST_EXPECT(mismatch(b, a) == Seq{1});
+                }
+            }
+
+        }
+        // Different chains, same seqs
+        {
+            // Alt history diverged at history.size()/2
+            for(Seq s = 1; s < history.size(); ++s)
+            {
+                RCLValidatedLedger a{history[s-1], j};
+                RCLValidatedLedger b{altHistory[s-1], j};
+
+                BEAST_EXPECT(a.seq() == b.seq());
+                if(s <= diverge)
+                {
+                    BEAST_EXPECT(a[a.seq()] == b[b.seq()]);
+                    BEAST_EXPECT(mismatch(a,b) == a.seq() + 1);
+                    BEAST_EXPECT(mismatch(b,a) == a.seq() + 1);
+                }
+                else
+                {
+                    BEAST_EXPECT(a[a.seq()] != b[b.seq()]);
+                    BEAST_EXPECT(mismatch(a,b) == diverge + 1);
+                    BEAST_EXPECT(mismatch(b,a) == diverge + 1);
+                }
+            }
+        }
+        // Different chains, different seqs
+        {
+            // Compare around the divergence point
+            for(auto ledger : {history[diverge]})
+            {
+                RCLValidatedLedger a{ledger, j};
+                for(Seq offset = diverge/2; offset < 3*diverge/2; ++offset)
+                {
+                    RCLValidatedLedger b{altHistory[offset-1], j};
+                    if(offset <= diverge)
+                    {
+                        BEAST_EXPECT(mismatch(a,b) == b.seq() + 1);
+                    }
+                    else
+                    {
+                        BEAST_EXPECT(mismatch(a,b) == diverge + 1);
+                    }
+                }
+            }
+        }
+
+
+    }
+};  // namespace test
+
+BEAST_DEFINE_TESTSUITE(RCLValidations, app, ripple);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -49,11 +49,11 @@ public:
         // Generate two ledger histories that agree on the first maxAncestors
         // ledgers, then diverge.
 
-        std::vector<std::shared_ptr<Ledger>> history;
+        std::vector<std::shared_ptr<Ledger const>> history;
 
         jtx::Env env(*this);
         Config config;
-        auto prev = std::make_shared<Ledger>(
+        auto prev = std::make_shared<Ledger const>(
             create_genesis, config,
             std::vector<uint256>{}, env.app().family());
         history.push_back(prev);
@@ -69,7 +69,7 @@ public:
 
         // altHistory agrees with first half of regular history
         Seq const diverge = history.size()/2;
-        std::vector<std::shared_ptr<Ledger>> altHistory(
+        std::vector<std::shared_ptr<Ledger const>> altHistory(
             history.begin(), history.begin() + diverge);
         // advance clock too get new ledgers
         env.timeKeeper().set(env.timeKeeper().now() + 1200s);
@@ -105,7 +105,7 @@ public:
 
         // Full history ledgers
         {
-            std::shared_ptr<Ledger> ledger = history.back();
+            std::shared_ptr<Ledger const> ledger = history.back();
             RCLValidatedLedger a{ledger, j};
             BEAST_EXPECT(a.seq() == ledger->info().seq);
             BEAST_EXPECT(

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -97,7 +97,7 @@ public:
 
         // Empty ledger
         {
-            RCLValidatedLedger a;
+            RCLValidatedLedger a{RCLValidatedLedger::MakeGenesis{}};
             BEAST_EXPECT(a.seq() == Seq{0});
             BEAST_EXPECT(a[Seq{0}] == ID{0});
             BEAST_EXPECT(a.minSeq() == Seq{0});
@@ -124,7 +124,7 @@ public:
 
         // Empty with non-empty
         {
-            RCLValidatedLedger a;
+            RCLValidatedLedger a{RCLValidatedLedger::MakeGenesis{}};
 
             for (auto ledger : {history.back(),
                                 history[maxAncestors - 1]})

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -71,7 +71,7 @@ public:
         Seq const diverge = history.size()/2;
         std::vector<std::shared_ptr<Ledger const>> altHistory(
             history.begin(), history.begin() + diverge);
-        // advance clock too get new ledgers
+        // advance clock to get new ledgers
         env.timeKeeper().set(env.timeKeeper().now() + 1200s);
         prev = altHistory.back();
         bool forceHash = true;
@@ -179,27 +179,24 @@ public:
         // Different chains, different seqs
         {
             // Compare around the divergence point
-            for(auto ledger : {history[diverge]})
+            RCLValidatedLedger a{history[diverge], j};
+            for(Seq offset = diverge/2; offset < 3*diverge/2; ++offset)
             {
-                RCLValidatedLedger a{ledger, j};
-                for(Seq offset = diverge/2; offset < 3*diverge/2; ++offset)
+                RCLValidatedLedger b{altHistory[offset-1], j};
+                if(offset <= diverge)
                 {
-                    RCLValidatedLedger b{altHistory[offset-1], j};
-                    if(offset <= diverge)
-                    {
-                        BEAST_EXPECT(mismatch(a,b) == b.seq() + 1);
-                    }
-                    else
-                    {
-                        BEAST_EXPECT(mismatch(a,b) == diverge + 1);
-                    }
+                    BEAST_EXPECT(mismatch(a,b) == b.seq() + 1);
+                }
+                else
+                {
+                    BEAST_EXPECT(mismatch(a,b) == diverge + 1);
                 }
             }
         }
 
 
     }
-};  // namespace test
+};
 
 BEAST_DEFINE_TESTSUITE(RCLValidations, app, ripple);
 

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -974,17 +974,10 @@ public:
 
         // Disruptor will reconnect all but the fastC node
         sim.run(1);
-        BEAST_EXPECT(!sim.synchronized());
 
         if(BEAST_EXPECT(sim.branches() == 1))
         {
-            // New approach will not fork and will resync once the fast node
-            // reconnects for a few rounds
-            network.connect(groupCfast, fDelay);
-            sim.run(4);
             BEAST_EXPECT(sim.synchronized());
-            BEAST_EXPECT(sim.branches() == 1);
-
         }
         else // old approach caused a fork
         {

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -512,8 +512,7 @@ public:
                                 peerJumps.closeJumps.front();
                             // Jump is to a different chain
                             BEAST_EXPECT(jump.from.seq() <= jump.to.seq());
-                            BEAST_EXPECT(
-                                !sim.oracle.isAncestor(jump.from, jump.to));
+                            BEAST_EXPECT(!jump.to.isAncestor(jump.from));
                         }
                     }
                     // fully validated jump forward in same chain
@@ -525,8 +524,7 @@ public:
                                 peerJumps.fullyValidatedJumps.front();
                             // Jump is to a different chain with same seq
                             BEAST_EXPECT(jump.from.seq() < jump.to.seq());
-                            BEAST_EXPECT(
-                                sim.oracle.isAncestor(jump.from, jump.to));
+                            BEAST_EXPECT(jump.to.isAncestor(jump.from));
                         }
                     }
                 }

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -981,7 +981,7 @@ public:
             // New approach will not fork and will resync once the fast node
             // reconnects for a few rounds
             network.connect(groupCfast, fDelay);
-            sim.run(2);
+            sim.run(4);
             BEAST_EXPECT(sim.synchronized());
             BEAST_EXPECT(sim.branches() == 1);
 

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -869,7 +869,7 @@ public:
         on(csf::PeerID who, csf::SimTime, csf::AcceptLedger const& e)
         {
             // As soon as anyone generates a child of B or C, reconnect the
-            // network so those validation make it through
+            // network so those validations make it through
             if (!reconnected && e.ledger.seq() == csf::Ledger::Seq{3})
             {
                 reconnected = true;
@@ -902,12 +902,11 @@ public:
         // - All nodes generate the common ledger A
         // - 2 nodes generate B and 8 nodes generate C
         // - Only 1 of the C nodes sees all the C validations and fully
-        //   validates C. The rest of the C nodes disconnect split at just
-        //   the right time such that they never see any C validations but
-        //   their own.
+        //   validates C. The rest of the C nodes split at just the right time
+        //   such that they never see any C validations but their own.
         // - The C nodes continue and generate 8 different child ledgers.
         // - Meanwhile, the D nodes only saw 1 validation for C and 2 validations
-        //   for C.
+        //   for B.
         // - The network reconnects and the validations for generation 3 ledgers
         //   are observed (D and the 8 C's)
         // - In the old approach, 2 votes for D outweights 1 vote for each C'
@@ -938,7 +937,7 @@ public:
         // other nodes
         network.connect(groupCfast, fDelay);
         // The rest of the network is connected at the same speed
-        (network - groupCfast).connect(network - groupCfast, delay);
+        groupNotFastC.connect(groupNotFastC, delay);
 
         Disruptor dc(network, groupCfast, groupCsplit, delay);
         sim.collectors.add(dc);

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -992,6 +992,7 @@ public:
             BEAST_EXPECT(sim.synchronized(groupNotFastC) == 1);
         }
     }
+
     void
     run() override
     {

--- a/src/test/consensus/LedgerTrie_test.cpp
+++ b/src/test/consensus/LedgerTrie_test.cpp
@@ -1,0 +1,537 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#include <BeastConfig.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/consensus/LedgerTrie.h>
+#include <test/csf/ledgers.h>
+#include <unordered_map>
+#include <random>
+
+namespace ripple {
+namespace test {
+
+class LedgerTrie_test : public beast::unit_test::suite
+{
+    beast::Journal j;
+
+
+    void
+    testInsert()
+    {
+        using namespace csf;
+        // Single entry by itself
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 1);
+
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+        }
+        // Suffix of existing (extending tree)
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.checkInvariants());
+            // extend with no siblings
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.checkInvariants());
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 1);
+
+            // extend with existing sibling
+            t.insert(h["abce"]);
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 3);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["abce"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abce"]) == 1);
+        }
+        // Prefix of existing node
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.checkInvariants());
+            // prefix with no siblings
+            t.insert(h["abcdf"]);
+            BEAST_EXPECT(t.checkInvariants());
+
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abcdf"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcdf"]) == 1);
+
+            // prefix with existing child
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.checkInvariants());
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 3);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abcdf"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcdf"]) == 1);
+        }
+        // Suffix + prefix of existing node
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.checkInvariants());
+            t.insert(h["abce"]);
+            BEAST_EXPECT(t.checkInvariants());
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["abce"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abce"]) == 1);
+        }
+        // Suffix + prefix with existing child
+        {
+            //  abcd : abcde, abcf
+
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.checkInvariants());
+            t.insert(h["abcde"]);
+            BEAST_EXPECT(t.checkInvariants());
+            t.insert(h["abcf"]);
+            BEAST_EXPECT(t.checkInvariants());
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 3);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abcf"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcf"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["abcde"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcde"]) == 1);
+        }
+
+        // Multiple counts
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["ab"],4);
+            BEAST_EXPECT(t.tipSupport(h["ab"]) == 4);
+            BEAST_EXPECT(t.branchSupport(h["ab"]) == 4);
+            BEAST_EXPECT(t.tipSupport(h["a"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["a"]) == 4);
+
+            t.insert(h["abc"],2);
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["ab"]) == 4);
+            BEAST_EXPECT(t.branchSupport(h["ab"]) == 6);
+            BEAST_EXPECT(t.tipSupport(h["a"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["a"]) == 6);
+
+        }
+    }
+
+    void
+    testRemove()
+    {
+        using namespace csf;
+        // Not in trie
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+
+            BEAST_EXPECT(!t.remove(h["ab"]));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(!t.remove(h["a"]));
+            BEAST_EXPECT(t.checkInvariants());
+        }
+        // In trie but with 0 tip support
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abcd"]);
+            t.insert(h["abce"]);
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+            BEAST_EXPECT(!t.remove(h["abc"]));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+        }
+        // In trie with > 1 tip support
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"],2);
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.remove(h["abc"]));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+
+            t.insert(h["abc"], 1);
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.remove(h["abc"], 2));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+
+            t.insert(h["abc"], 3);
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 3);
+            BEAST_EXPECT(t.remove(h["abc"], 300));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+
+        }
+        // In trie with = 1 tip support, no children
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["ab"]);
+            t.insert(h["abc"]);
+
+            BEAST_EXPECT(t.tipSupport(h["ab"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["ab"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 1);
+
+            BEAST_EXPECT(t.remove(h["abc"]));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["ab"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["ab"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 0);
+        }
+        // In trie with = 1 tip support, 1 child
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["ab"]);
+            t.insert(h["abc"]);
+            t.insert(h["abcd"]);
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 1);
+
+            BEAST_EXPECT(t.remove(h["abc"]));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["abcd"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abcd"]) == 1);
+        }
+        // In trie with = 1 tip support, > 1 children
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["ab"]);
+            t.insert(h["abc"]);
+            t.insert(h["abcd"]);
+            t.insert(h["abce"]);
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 3);
+
+            BEAST_EXPECT(t.remove(h["abc"]));
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["abc"]) == 2);
+        }
+
+        // In trie with = 1 tip support, parent compaction
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["ab"]);
+            t.insert(h["abc"]);
+            t.insert(h["abd"]);
+            BEAST_EXPECT(t.checkInvariants());
+            t.remove(h["ab"]);
+            BEAST_EXPECT(t.checkInvariants());
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["abd"]) == 1);
+            BEAST_EXPECT(t.tipSupport(h["ab"]) == 0);
+            BEAST_EXPECT(t.branchSupport(h["ab"]) == 2);
+
+            t.remove(h["abd"]);
+            BEAST_EXPECT(t.checkInvariants());
+
+            BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+            BEAST_EXPECT(t.branchSupport(h["ab"]) == 1);
+
+        }
+    }
+
+    void
+    testTipAndBranchSupport()
+    {
+        using namespace csf;
+        LedgerTrie<Ledger> t;
+        LedgerHistoryHelper h;
+        BEAST_EXPECT(t.tipSupport(h["a"]) == 0);
+        BEAST_EXPECT(t.tipSupport(h["axy"]) == 0);
+        BEAST_EXPECT(t.branchSupport(h["a"]) == 0);
+        BEAST_EXPECT(t.branchSupport(h["axy"]) == 0);
+
+        t.insert(h["abc"]);
+        BEAST_EXPECT(t.tipSupport(h["a"]) == 0);
+        BEAST_EXPECT(t.tipSupport(h["ab"]) == 0);
+        BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+        BEAST_EXPECT(t.tipSupport(h["abcd"]) == 0);
+        BEAST_EXPECT(t.branchSupport(h["a"]) == 1);
+        BEAST_EXPECT(t.branchSupport(h["ab"]) == 1);
+        BEAST_EXPECT(t.branchSupport(h["abc"]) == 1);
+        BEAST_EXPECT(t.branchSupport(h["abcd"]) == 0);
+
+        t.insert(h["abe"]);
+        BEAST_EXPECT(t.tipSupport(h["a"]) == 0);
+        BEAST_EXPECT(t.tipSupport(h["ab"]) == 0);
+        BEAST_EXPECT(t.tipSupport(h["abc"]) == 1);
+        BEAST_EXPECT(t.tipSupport(h["abe"]) == 1);
+
+        BEAST_EXPECT(t.branchSupport(h["a"]) == 2);
+        BEAST_EXPECT(t.branchSupport(h["ab"]) == 2);
+        BEAST_EXPECT(t.branchSupport(h["abc"]) == 1);
+        BEAST_EXPECT(t.branchSupport(h["abe"]) == 1);
+    }
+
+    void
+    testGetPreferred()
+    {
+        using namespace csf;
+        // Empty
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            BEAST_EXPECT(t.getPreferred().second == Ledger::ID{0});
+        }
+        // Single node no children
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+        }
+        // Single node smaller child support
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+        }
+        // Single node larger child
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcd"],2);
+            BEAST_EXPECT(t.getPreferred().second == h["abcd"].id());
+        }
+        // Single node smaller children support
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcd"]);
+            t.insert(h["abce"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+
+            t.insert(h["abc"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+        }
+        // Single node larger children
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcd"],2);
+            t.insert(h["abce"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abcd"].id());
+        }
+        // Tie-breaker by id
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abcd"],2);
+            t.insert(h["abce"],2);
+
+            BEAST_EXPECT(h["abce"].id() > h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred().second == h["abce"].id());
+
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(h["abce"].id() > h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred().second == h["abcd"].id());
+        }
+
+        // Tie-breaker not needed
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcd"]);
+            t.insert(h["abce"],2);
+            // abce only has a margin of 1, but it owns the tie-breaker
+            BEAST_EXPECT(h["abce"].id() > h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred().second == h["abce"].id());
+
+            // Switch support from abce to abcd, tie-breaker now needed
+            t.remove(h["abce"]);
+            t.insert(h["abcd"]);
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+        }
+
+        // Single node larger grand child
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcd"],2);
+            t.insert(h["abcde"],4);
+            BEAST_EXPECT(t.getPreferred().second == h["abcde"].id());
+        }
+
+        // Too much prefix support from competing branches
+        {
+            LedgerTrie<Ledger> t;
+            LedgerHistoryHelper h;
+            t.insert(h["abc"]);
+            t.insert(h["abcde"],2);
+            t.insert(h["abcfg"],2);
+            // 'de' and 'fg' are tied without 'abc' vote
+            BEAST_EXPECT(t.getPreferred().second == h["abc"].id());
+            t.remove(h["abc"]);
+            t.insert(h["abcd"]);
+            // 'de' branch has 3 votes to 2, but not enough suport for 'e'
+            // since the node on 'd' and the 2 on 'fg' could go in a
+            // different direction
+            BEAST_EXPECT(t.getPreferred().second == h["abcd"].id());
+        }
+    }
+
+    void
+    testRootRelated()
+    {
+        using namespace csf;
+        // Since the root is a special node that breaks the no-single child
+        // invariant, do some tests that exercise it.
+
+        LedgerTrie<Ledger> t;
+        LedgerHistoryHelper h;
+        BEAST_EXPECT(!t.remove(h[""]));
+        BEAST_EXPECT(t.branchSupport(h[""]) == 0);
+        BEAST_EXPECT(t.tipSupport(h[""]) == 0);
+
+        t.insert(h["a"]);
+        BEAST_EXPECT(t.checkInvariants());
+        BEAST_EXPECT(t.branchSupport(h[""]) == 1);
+        BEAST_EXPECT(t.tipSupport(h[""]) == 0);
+
+        t.insert(h["e"]);
+        BEAST_EXPECT(t.checkInvariants());
+        BEAST_EXPECT(t.branchSupport(h[""]) == 2);
+        BEAST_EXPECT(t.tipSupport(h[""]) == 0);
+
+        BEAST_EXPECT(t.remove(h["e"]));
+        BEAST_EXPECT(t.checkInvariants());
+        BEAST_EXPECT(t.branchSupport(h[""]) == 1);
+        BEAST_EXPECT(t.tipSupport(h[""]) == 0);
+    }
+
+    void
+    testStress()
+    {
+        using namespace csf;
+        LedgerTrie<Ledger> t;
+        LedgerHistoryHelper h;
+
+        // Test quasi-randomly add/remove supporting for different ledgers
+        // from a branching history.
+
+        // Ledgers have sequence 1,2,3,4
+        std::uint32_t const depth = 4;
+        // Each ledger has 4 possible children
+        std::uint32_t const width  = 4;
+
+        std::uint32_t const iterations = 10000;
+
+        // Use explicit seed to have same results for CI
+        std::mt19937 gen{ 42 };
+        std::uniform_int_distribution<> depthDist(0, depth-1);
+        std::uniform_int_distribution<> widthDist(0, width-1);
+        std::uniform_int_distribution<> flip(0, 1);
+        for(std::uint32_t i = 0; i < iterations; ++i)
+        {
+            // pick a random ledger history
+            std::string curr = "";
+            char depth = depthDist(gen);
+            char offset = 0;
+            for(char d = 0; d < depth; ++d)
+            {
+                char a = offset + widthDist(gen);
+                curr += a;
+                offset = (a + 1) * width;
+            }
+
+            // 50-50 to add remove
+            if(flip(gen) == 0)
+                t.insert(h[curr]);
+            else
+                t.remove(h[curr]);
+            if(!BEAST_EXPECT(t.checkInvariants()))
+                return;
+        }
+    }
+
+    void
+    run()
+    {
+        testInsert();
+        testRemove();
+        testTipAndBranchSupport();
+        testGetPreferred();
+        testRootRelated();
+        testStress();
+
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(LedgerTrie, consensus, ripple);
+}  // namespace test
+}  // namespace ripple

--- a/src/test/consensus/LedgerTrie_test.cpp
+++ b/src/test/consensus/LedgerTrie_test.cpp
@@ -352,15 +352,15 @@ class LedgerTrie_test : public beast::unit_test::suite
         {
             LedgerTrie<Ledger> t;
             LedgerHistoryHelper h;
-            BEAST_EXPECT(t.getPreferred(Seq{0}).second == h[""].id());
-            BEAST_EXPECT(t.getPreferred(Seq{2}).second == h[""].id());
+            BEAST_EXPECT(t.getPreferred(Seq{0}).id == h[""].id());
+            BEAST_EXPECT(t.getPreferred(Seq{2}).id == h[""].id());
         }
         // Single node no children
         {
             LedgerTrie<Ledger> t;
             LedgerHistoryHelper h;
             t.insert(h["abc"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
         }
         // Single node smaller child support
         {
@@ -368,8 +368,8 @@ class LedgerTrie_test : public beast::unit_test::suite
             LedgerHistoryHelper h;
             t.insert(h["abc"]);
             t.insert(h["abcd"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abc"].id());
         }
         // Single node larger child
         {
@@ -377,8 +377,8 @@ class LedgerTrie_test : public beast::unit_test::suite
             LedgerHistoryHelper h;
             t.insert(h["abc"]);
             t.insert(h["abcd"],2);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abcd"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abcd"].id());
         }
         // Single node smaller children support
         {
@@ -387,12 +387,12 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abc"]);
             t.insert(h["abcd"]);
             t.insert(h["abce"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abc"].id());
 
             t.insert(h["abc"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abc"].id());
         }
         // Single node larger children
         {
@@ -401,12 +401,12 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abc"]);
             t.insert(h["abcd"],2);
             t.insert(h["abce"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abc"].id());
 
             t.insert(h["abcd"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abcd"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abcd"].id());
         }
         // Tie-breaker by id
         {
@@ -416,11 +416,11 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abce"],2);
 
             BEAST_EXPECT(h["abce"].id() > h["abcd"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abce"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abce"].id());
 
             t.insert(h["abcd"]);
             BEAST_EXPECT(h["abce"].id() > h["abcd"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abcd"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abcd"].id());
         }
 
         // Tie-breaker not needed
@@ -432,14 +432,14 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abce"],2);
             // abce only has a margin of 1, but it owns the tie-breaker
             BEAST_EXPECT(h["abce"].id() > h["abcd"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abce"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abce"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abce"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abce"].id());
 
             // Switch support from abce to abcd, tie-breaker now needed
             t.remove(h["abce"]);
             t.insert(h["abcd"]);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abc"].id());
         }
 
         // Single node larger grand child
@@ -449,9 +449,9 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abc"]);
             t.insert(h["abcd"],2);
             t.insert(h["abcde"],4);
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abcde"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abcde"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["abcde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abcde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abcde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["abcde"].id());
         }
 
         // Too much uncommitted support from competing branches
@@ -462,22 +462,22 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abcde"],2);
             t.insert(h["abcfg"],2);
             // 'de' and 'fg' are tied without 'abc' vote
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abc"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["abc"].id());
 
             t.remove(h["abc"]);
             t.insert(h["abcd"]);
 
             // 'de' branch has 3 votes to 2, so earlier sequences see it as
             // preferred
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abcde"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["abcde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abcde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["abcde"].id());
 
             // However, if you validated a ledger with Seq 5, potentially on
             // a different branch, you do not yet know if they chose abcd
             // or abcf because of you, so abc remains preferred
-            BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["abc"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["abc"].id());
         }
 
         // Changing largestSeq perspective changes preferred branch
@@ -501,40 +501,40 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(h["abde"],2);
 
             // B has more branch support
-            BEAST_EXPECT(t.getPreferred(Seq{1}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{2}).second == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{1}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{2}).id == h["ab"].id());
             // But if you last validated D,F or E, you do not yet know
             // if someone used that validation to commit to B or C
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["a"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["a"].id());
 
             // One of E advancing to G doesn't change anything
             t.remove(h["abde"]);
             t.insert(h["abdeg"]);
 
-            BEAST_EXPECT(t.getPreferred(Seq{1}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{2}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["a"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["a"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{1}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{2}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["a"].id());
 
             // C advancing to H does advance the seq 3 preferred ledger
             t.remove(h["ac"]);
             t.insert(h["abh"]);
-            BEAST_EXPECT(t.getPreferred(Seq{1}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{2}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["a"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{1}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{2}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["a"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["a"].id());
 
             // F advancing to E also moves the preferred ledger forward
             t.remove(h["acf"]);
             t.insert(h["abde"]);
-            BEAST_EXPECT(t.getPreferred(Seq{1}).second == h["abde"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{2}).second == h["abde"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{3}).second == h["abde"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{4}).second == h["ab"].id());
-            BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{1}).id == h["abde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{2}).id == h["abde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["abde"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["ab"].id());
+            BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["ab"].id());
 
         }
 
@@ -625,7 +625,6 @@ class LedgerTrie_test : public beast::unit_test::suite
         testGetPreferred();
         testRootRelated();
         testStress();
-
     }
 };
 

--- a/src/test/consensus/LedgerTrie_test.cpp
+++ b/src/test/consensus/LedgerTrie_test.cpp
@@ -482,7 +482,7 @@ class LedgerTrie_test : public beast::unit_test::suite
 
         // Changing largestSeq perspective changes preferred branch
         {
-            /** Build the tree below with tip support annotated
+            /** Build the tree below with initial tip support annotated
                    A
                   / \
                B(1)  C(1)
@@ -508,7 +508,17 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.getPreferred(Seq{3}).id == h["a"].id());
             BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["a"].id());
 
-            // One of E advancing to G doesn't change anything
+            /** One of E advancing to G doesn't change anything
+                   A
+                  / \
+               B(1)  C(1)
+              /  |   |
+             H   D   F(1)
+                 |
+                 E(1)
+                 |
+                 G(1)
+            */
             t.remove(h["abde"]);
             t.insert(h["abdeg"]);
 
@@ -518,7 +528,17 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["a"].id());
             BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["a"].id());
 
-            // C advancing to H does advance the seq 3 preferred ledger
+            /** C advancing to H does advance the seq 3 preferred ledger
+                   A
+                  / \
+               B(1)  C
+              /  |   |
+             H(1)D   F(1)
+                 |
+                 E(1)
+                 |
+                 G(1)
+            */
             t.remove(h["ac"]);
             t.insert(h["abh"]);
             BEAST_EXPECT(t.getPreferred(Seq{1}).id == h["ab"].id());
@@ -527,7 +547,17 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.getPreferred(Seq{4}).id == h["a"].id());
             BEAST_EXPECT(t.getPreferred(Seq{5}).id == h["a"].id());
 
-            // F advancing to E also moves the preferred ledger forward
+            /** F advancing to E also moves the preferred ledger forward
+                   A
+                  / \
+               B(1)  C
+              /  |   |
+             H(1)D   F
+                 |
+                 E(2)
+                 |
+                 G(1)
+            */
             t.remove(h["acf"]);
             t.insert(h["abde"]);
             BEAST_EXPECT(t.getPreferred(Seq{1}).id == h["abde"].id());

--- a/src/test/consensus/LedgerTrie_test.cpp
+++ b/src/test/consensus/LedgerTrie_test.cpp
@@ -73,13 +73,13 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.tipSupport(h["abce"]) == 1);
             BEAST_EXPECT(t.branchSupport(h["abce"]) == 1);
         }
-        // Prefix of existing node
+        // uncommitted of existing node
         {
             LedgerTrie<Ledger> t;
             LedgerHistoryHelper h;
             t.insert(h["abcd"]);
             BEAST_EXPECT(t.checkInvariants());
-            // prefix with no siblings
+            // uncommitted with no siblings
             t.insert(h["abcdf"]);
             BEAST_EXPECT(t.checkInvariants());
 
@@ -88,7 +88,7 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.tipSupport(h["abcdf"]) == 1);
             BEAST_EXPECT(t.branchSupport(h["abcdf"]) == 1);
 
-            // prefix with existing child
+            // uncommitted with existing child
             t.insert(h["abc"]);
             BEAST_EXPECT(t.checkInvariants());
 
@@ -99,7 +99,7 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.tipSupport(h["abcdf"]) == 1);
             BEAST_EXPECT(t.branchSupport(h["abcdf"]) == 1);
         }
-        // Suffix + prefix of existing node
+        // Suffix + uncommitted of existing node
         {
             LedgerTrie<Ledger> t;
             LedgerHistoryHelper h;
@@ -115,7 +115,7 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.tipSupport(h["abce"]) == 1);
             BEAST_EXPECT(t.branchSupport(h["abce"]) == 1);
         }
-        // Suffix + prefix with existing child
+        // Suffix + uncommitted with existing child
         {
             //  abcd : abcde, abcf
 
@@ -454,7 +454,7 @@ class LedgerTrie_test : public beast::unit_test::suite
             BEAST_EXPECT(t.getPreferred(Seq{5}).second == h["abcde"].id());
         }
 
-        // Too much prefix support from competing branches
+        // Too much uncommitted support from competing branches
         {
             LedgerTrie<Ledger> t;
             LedgerHistoryHelper h;

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -870,10 +870,11 @@ class Validations_test : public beast::unit_test::suite
         for (auto const& node : {a, b, c, d})
             BEAST_EXPECT(
                 ValStatus::current == harness.add(node.validate(ledgerAC)));
+        // Parent of preferred stays put
         BEAST_EXPECT(harness.vals().getPreferred(ledgerA) == pref(ledgerA));
         // Earlier different chain, switch
         BEAST_EXPECT(harness.vals().getPreferred(ledgerB) == pref(ledgerAC));
-        // Earlier same chain stays where it is
+        // Later on chain, stays where it is
         BEAST_EXPECT(harness.vals().getPreferred(ledgerACD) == pref(ledgerACD));
 
         // Any later grandchild or different chain is preferred

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -970,6 +970,20 @@ class Validations_test : public beast::unit_test::suite
         BEAST_EXPECT(harness.vals().numTrustedForLedger(ID{2}) == 1);
         // but ledger based data is not
         BEAST_EXPECT(harness.vals().getNodesAfter(genesisLedger, ID{0}) == 0);
+        // Initial preferred branch falls back to the ledger we are trying to
+        // acquire
+        BEAST_EXPECT(
+            harness.vals().getPreferred(genesisLedger) ==
+            std::make_pair(Seq{2}, ID{2}));
+
+        // After adding another unavailable validation, the preferred ledger
+        // breaks ties via higher ID
+        BEAST_EXPECT(
+            ValStatus::current ==
+            harness.add(b.validate(ID{3}, Seq{2}, 0s, 0s, true)));
+        BEAST_EXPECT(
+            harness.vals().getPreferred(genesisLedger) ==
+            std::make_pair(Seq{2}, ID{3}));
 
         // Create the ledger
         Ledger ledgerAB = h["ab"];

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -291,6 +291,8 @@ class Validations_test : public beast::unit_test::suite
         }
     };
 
+     Ledger const genesisLedger{Ledger::MakeGenesis{}};
+
     void
     testAddValidation()
     {
@@ -439,10 +441,12 @@ class Validations_test : public beast::unit_test::suite
         Ledger ledgerA = h["a"];
         Ledger ledgerAB = h["ab"];
 
+
         using Trigger = std::function<void(TestValidations&)>;
+
         std::vector<Trigger> triggers = {
             [&](TestValidations& vals) { vals.currentTrusted(); },
-            [&](TestValidations& vals) { vals.getPreferred(Ledger{}); },
+            [&](TestValidations& vals) { vals.getPreferred(genesisLedger); },
             [&](TestValidations& vals) {
                 vals.getNodesAfter(ledgerA, ledgerA.id());
             }};
@@ -457,7 +461,7 @@ class Validations_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 harness.vals().getNodesAfter(ledgerA, ledgerA.id()) == 1);
             BEAST_EXPECT(
-                harness.vals().getPreferred(Ledger{}) ==
+                harness.vals().getPreferred(genesisLedger) ==
                 std::make_pair(ledgerAB.seq(), ledgerAB.id()));
             BEAST_EXPECT(harness.stale().empty());
             harness.clock().advance(harness.parms().validationCURRENT_LOCAL);
@@ -470,7 +474,7 @@ class Validations_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 harness.vals().getNodesAfter(ledgerA, ledgerA.id()) == 0);
             BEAST_EXPECT(
-                harness.vals().getPreferred(Ledger{}) ==
+                harness.vals().getPreferred(genesisLedger) ==
                 std::make_pair(Ledger::Seq{0}, Ledger::ID{0}));
         }
     }
@@ -819,7 +823,8 @@ class Validations_test : public beast::unit_test::suite
         };
 
         // Empty (no ledgers)
-        BEAST_EXPECT(harness.vals().getPreferred(ledgerA) == pref(Ledger{}));
+        BEAST_EXPECT(
+            harness.vals().getPreferred(ledgerA) == pref(genesisLedger));
 
         // Single ledger
         BEAST_EXPECT(ValStatus::current == harness.add(a.validate(ledgerB)));
@@ -939,12 +944,12 @@ class Validations_test : public beast::unit_test::suite
         // Validation is available
         BEAST_EXPECT(harness.vals().numTrustedForLedger(ID{2}) == 1);
         // but ledger based data is not
-        BEAST_EXPECT(harness.vals().getNodesAfter(Ledger{}, ID{0}) == 0);
+        BEAST_EXPECT(harness.vals().getNodesAfter(genesisLedger, ID{0}) == 0);
 
         // Create the ledger
         Ledger ledgerAB = h["ab"];
         // Now it should be available
-        BEAST_EXPECT(harness.vals().getNodesAfter(Ledger{}, ID{0}) == 1);
+        BEAST_EXPECT(harness.vals().getNodesAfter(genesisLedger, ID{0}) == 1);
 
         // Create a validation that is not available
         harness.clock().advance(5s);
@@ -952,7 +957,7 @@ class Validations_test : public beast::unit_test::suite
         BEAST_EXPECT(ValStatus::current == harness.add(val2));
         BEAST_EXPECT(harness.vals().numTrustedForLedger(ID{5}) == 1);
         BEAST_EXPECT(
-            harness.vals().getPreferred(Ledger{}) ==
+            harness.vals().getPreferred(genesisLedger) ==
             std::make_pair(ledgerAB.seq(), ledgerAB.id()));
 
         // Switch to validation that is available
@@ -960,7 +965,7 @@ class Validations_test : public beast::unit_test::suite
         Ledger ledgerABC = h["abc"];
         BEAST_EXPECT(ValStatus::current == harness.add(a.partial(ledgerABC)));
         BEAST_EXPECT(
-            harness.vals().getPreferred(Ledger{}) ==
+            harness.vals().getPreferred(genesisLedger) ==
             std::make_pair(ledgerABC.seq(), ledgerABC.id()));
     }
 

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -462,6 +462,7 @@ class Validations_test : public beast::unit_test::suite
 
         std::vector<Trigger> triggers = {
             [&](TestValidations& vals) { vals.currentTrusted(); },
+            [&](TestValidations& vals) { vals.getCurrentPublicKeys(); },
             [&](TestValidations& vals) { vals.getPreferred(genesisLedger); },
             [&](TestValidations& vals) {
                 vals.getNodesAfter(ledgerA, ledgerA.id());
@@ -516,7 +517,7 @@ class Validations_test : public beast::unit_test::suite
              c = harness.makeNode(), d = harness.makeNode();
         c.untrust();
 
-        // first round a,b,c agree, d has differing id
+        // first round a,b,c agree, d has is partial
         BEAST_EXPECT(ValStatus::current == harness.add(a.validate(ledgerA)));
         BEAST_EXPECT(ValStatus::current == harness.add(b.validate(ledgerA)));
         BEAST_EXPECT(ValStatus::current == harness.add(c.validate(ledgerA)));

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -1007,14 +1007,14 @@ class Validations_test : public beast::unit_test::suite
 
         ValidationParms p;
 
-        BEAST_EXPECT(enforcer.tryAdvance(clock.now(), Seq{1}, p));
-        BEAST_EXPECT(enforcer.tryAdvance(clock.now(), Seq{10}, p));
-        BEAST_EXPECT(!enforcer.tryAdvance(clock.now(), Seq{9}, p));
-        BEAST_EXPECT(!enforcer.tryAdvance(clock.now(), Seq{5}, p));
+        BEAST_EXPECT(enforcer(clock.now(), Seq{1}, p));
+        BEAST_EXPECT(enforcer(clock.now(), Seq{10}, p));
+        BEAST_EXPECT(!enforcer(clock.now(), Seq{9}, p));
+        BEAST_EXPECT(!enforcer(clock.now(), Seq{5}, p));
         clock.advance(p.validationSET_EXPIRES - 1ms);
-        BEAST_EXPECT(!enforcer.tryAdvance(clock.now(), Seq{1}, p));
+        BEAST_EXPECT(!enforcer(clock.now(), Seq{1}, p));
         clock.advance(2ms);
-        BEAST_EXPECT(enforcer.tryAdvance(clock.now(), Seq{1}, p));
+        BEAST_EXPECT(enforcer(clock.now(), Seq{1}, p));
     }
 
     void

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -294,7 +294,7 @@ class Validations_test : public beast::unit_test::suite
     void
     testAddValidation()
     {
-        // Test adding current,stale,repeat,sameSeq validations
+        // Test adding current,stale,repeat validations
         using namespace std::chrono_literals;
 
         TestHarness harness;
@@ -340,39 +340,12 @@ class Validations_test : public beast::unit_test::suite
                 BEAST_EXPECT(harness.vals().getNodesAfter(Ledger::ID{2}) == 0);
 
                 BEAST_EXPECT(
-                    ValStatus::sameSeq ==
+                    ValStatus::stale ==
                     harness.add(a.validate(Ledger::Seq{2}, Ledger::ID{20})));
 
-                // Old ID should be gone ...
-                BEAST_EXPECT(harness.vals().numTrustedForLedger(Ledger::ID{2}) == 0);
-                BEAST_EXPECT(harness.vals().numTrustedForLedger(Ledger::ID{20}) == 1);
-                {
-                    // Should be the only trusted for ID{20}
-                    auto trustedVals =
-                        harness.vals().getTrustedForLedger(Ledger::ID{20});
-                    BEAST_EXPECT(trustedVals.size() == 1);
-                    BEAST_EXPECT(trustedVals[0].key() == a.currKey());
-                    // ... and should be the only node after ID{2}
-                    BEAST_EXPECT(harness.vals().getNodesAfter(Ledger::ID{2}) == 1);
-
-                }
-
-                // A new key, but re-issue a validation with the same ID and
-                // Sequence
-                a.advanceKey();
-
-                BEAST_EXPECT(
-                    ValStatus::sameSeq ==
-                    harness.add(a.validate(Ledger::Seq{2}, Ledger::ID{20})));
-                {
-                    // Still the only trusted validation for ID{20}
-                    auto trustedVals =
-                        harness.vals().getTrustedForLedger(Ledger::ID{20});
-                    BEAST_EXPECT(trustedVals.size() == 1);
-                    BEAST_EXPECT(trustedVals[0].key() == a.currKey());
-                    // and still follows ID{2} since it was a re-issue
-                    BEAST_EXPECT(harness.vals().getNodesAfter(Ledger::ID{2}) == 1);
-                }
+                BEAST_EXPECT(harness.vals().numTrustedForLedger(Ledger::ID{2}) == 1);
+                // THIS FAILS pending filtering on increasing seq #'s
+                BEAST_EXPECT(harness.vals().numTrustedForLedger(Ledger::ID{20}) == 0);
             }
 
             {

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -285,7 +285,9 @@ struct Peer
         , scheduler{s}
         , net{n}
         , trustGraph(tg)
+        , lastClosedLedger{Ledger::MakeGenesis{}}
         , validations{ValidationParms{}, s.clock(), *this}
+        , fullyValidatedLedger{Ledger::MakeGenesis{}}
         , collectors{c}
     {
         // All peers start from the default constructed genesis ledger

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -555,7 +555,7 @@ struct Peer
             // Only send validation if the new ledger is compatible with our
             // fully validated ledger
             bool const isCompatible =
-                oracle.isAncestor(fullyValidatedLedger, newLedger);
+                newLedger.isAncestor(fullyValidatedLedger);
 
             if (runAsValidator && isCompatible)
             {
@@ -691,7 +691,7 @@ struct Peer
         std::size_t const count = validations.numTrustedForLedger(ledger.id());
         std::size_t const numTrustedPeers = trustGraph.graph().outDegree(this);
         quorum = static_cast<std::size_t>(std::ceil(numTrustedPeers * 0.8));
-        if (count >= quorum && oracle.isAncestor(fullyValidatedLedger, ledger))
+        if (count >= quorum && ledger.isAncestor(fullyValidatedLedger))
         {
             issue(FullyValidateLedger{ledger, fullyValidatedLedger});
             fullyValidatedLedger = ledger;

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -203,7 +203,6 @@ struct Peer
 
     //! Validations from trusted nodes
     Validations<ValAdaptor> validations;
-    using AddOutcome = Validations<ValAdaptor>::AddOutcome;
 
     //! The most recent ledger that has been fully validated by the network from
     //! the perspective of this Peer
@@ -675,9 +674,9 @@ struct Peer
     {
         v.setTrusted();
         v.setSeen(now());
-        AddOutcome const res = validations.add(v.key(), v);
+        ValStatus const res = validations.add(v.key(), v);
 
-        if(res == AddOutcome::stale || res == AddOutcome::repeat)
+        if(res == ValStatus::stale || res == ValStatus::repeat)
             return false;
 
         // Acquire will try to get from network if not already local

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -153,6 +153,14 @@ struct Peer
         {
         }
 
+        boost::optional<Ledger>
+        acquire(Ledger::ID const & id)
+        {
+            if(Ledger const * ledger = p_.acquireLedger(id))
+                return *ledger;
+            return boost::none;
+        }
+
         beast::Journal
         journal() const
         {

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -587,7 +587,7 @@ struct Peer
                              key,
                              id,
                              isFull};
-                // share thew new validation; it is trusted by the receiver
+                // share the new validation; it is trusted by the receiver
                 share(v);
                 // we trust ourselves
                 addTrustedValidation(v);

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -683,7 +683,7 @@ struct Peer
         v.setSeen(now());
         ValStatus const res = validations.add(v.key(), v);
 
-        if(res == ValStatus::stale || res == ValStatus::repeat)
+        if(res == ValStatus::stale || res == ValStatus::repeatID)
             return false;
 
         // Acquire will try to get from network if not already local

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -160,12 +160,6 @@ struct Peer
                 return *ledger;
             return boost::none;
         }
-
-        beast::Journal
-        journal() const
-        {
-            return p_.j;
-        }
     };
 
     //! Type definitions for generic consensus

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -872,7 +872,7 @@ struct Peer
         // yet
         Ledger::ID bestLCL =
             validations.getPreferred(lastClosedLedger, earliestAllowedSeq());
-        if(bestLCL == Ledger::ID{})
+        if(bestLCL == Ledger::ID{0})
             bestLCL = lastClosedLedger.id();
 
         issue(StartRound{bestLCL, lastClosedLedger});

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -575,8 +575,9 @@ struct Peer
             if (runAsValidator && isCompatible && !consensusFail)
             {
                 // Can only send one fully validated ledger per seq
-                bool isFull = proposing &&
-                    fullSeqEnforcer.tryAdvance(
+                bool isFull =
+                    proposing &&
+                    fullSeqEnforcer(
                         scheduler.now(), newLedger.seq(), validations.parms());
 
                 Validation v{newLedger.id(),
@@ -630,7 +631,7 @@ struct Peer
         Ledger::ID const netLgr =
             validations.getPreferred(ledger, earliestAllowedSeq());
 
-        if (netLgr != ledgerID && netLgr != Ledger::ID{})
+        if (netLgr != ledgerID)
         {
             JLOG(j.trace()) << Json::Compact(validations.getJsonTrie());
             issue(WrongPrevLedger{ledgerID, netLgr});

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -613,9 +613,7 @@ struct Peer
     Ledger::Seq
     earliestAllowedSeq() const
     {
-        if (lastClosedLedger.seq() > Ledger::Seq{20})
-            return lastClosedLedger.seq() - Ledger::Seq{20};
-        return Ledger::Seq{0};
+        return fullyValidatedLedger.seq();
     }
 
     Ledger::ID

--- a/src/test/csf/PeerGroup.h
+++ b/src/test/csf/PeerGroup.h
@@ -47,7 +47,6 @@ public:
     using const_reference = peers_type::const_reference;
 
     PeerGroup() = default;
-    PeerGroup(PeerGroup const&) = default;
     PeerGroup(Peer* peer) : peers_{1, peer}
     {
     }

--- a/src/test/csf/PeerGroup.h
+++ b/src/test/csf/PeerGroup.h
@@ -62,7 +62,6 @@ public:
 
     PeerGroup(std::set<Peer*> const& peers) : peers_{peers.begin(), peers.end()}
     {
-
     }
 
     iterator
@@ -99,6 +98,14 @@ public:
     contains(Peer const * p)
     {
         return std::find(peers_.begin(), peers_.end(), p) != peers_.end();
+    }
+
+    bool
+    contains(PeerID id)
+    {
+        return std::find_if(peers_.begin(), peers_.end(), [id](Peer const* p) {
+                   return p->id == id;
+               }) != peers_.end();
     }
 
     std::size_t

--- a/src/test/csf/Sim.h
+++ b/src/test/csf/Sim.h
@@ -65,6 +65,7 @@ class Sim
     // Use a deque to have stable pointers even when dynamically adding peers
     //  - Alternatively consider using unique_ptrs allocated from arena
     std::deque<Peer> peers;
+    PeerGroup allPeers;
 
 public:
     std::mt19937_64 rng;
@@ -113,7 +114,9 @@ public:
                 j);
             newPeers.emplace_back(&peers.back());
         }
-        return PeerGroup{newPeers};
+        PeerGroup res{newPeers};
+        allPeers = allPeers + res;
+        return res;
     }
 
     //! The number of peers in the simulation
@@ -136,18 +139,30 @@ public:
     void
     run(SimDuration const& dur);
 
-    /** Check whether all peers in the network are synchronized.
+    /** Check whether all peers in the group are synchronized.
 
         Nodes in the network are synchronized if they share the same last
         fully validated and last generated ledger.
     */
     bool
+    synchronized(PeerGroup const & g) const;
+
+
+    /** Check whether all peers in the network are synchronized
+    */
+    bool
     synchronized() const;
 
-    /** Calculate the number of branches in the network.
+
+    /** Calculate the number of branches in the group.
 
         A branch occurs if two peers have fullyValidatedLedgers that are not on
         the same chain of ledgers.
+    */
+    std::size_t
+    branches(PeerGroup const & g) const;
+
+    /** Calculate the number  of branches in the network
     */
     std::size_t
     branches() const;

--- a/src/test/csf/Sim.h
+++ b/src/test/csf/Sim.h
@@ -155,7 +155,7 @@ public:
     /** Calculate the number of branches in the group.
 
         A branch occurs if two nodes in the group have fullyValidatedLedgers
-       that are not on the same chain of ledgers.
+        that are not on the same chain of ledgers.
     */
     std::size_t
     branches(PeerGroup const& g) const;

--- a/src/test/csf/Sim.h
+++ b/src/test/csf/Sim.h
@@ -141,26 +141,24 @@ public:
 
     /** Check whether all peers in the group are synchronized.
 
-        Nodes in the network are synchronized if they share the same last
+        Nodes in the group are synchronized if they share the same last
         fully validated and last generated ledger.
     */
     bool
-    synchronized(PeerGroup const & g) const;
-
+    synchronized(PeerGroup const& g) const;
 
     /** Check whether all peers in the network are synchronized
     */
     bool
     synchronized() const;
 
-
     /** Calculate the number of branches in the group.
 
-        A branch occurs if two peers have fullyValidatedLedgers that are not on
-        the same chain of ledgers.
+        A branch occurs if two nodes in the group have fullyValidatedLedgers
+       that are not on the same chain of ledgers.
     */
     std::size_t
-    branches(PeerGroup const & g) const;
+    branches(PeerGroup const& g) const;
 
     /** Calculate the number  of branches in the network
     */

--- a/src/test/csf/Validation.h
+++ b/src/test/csf/Validation.h
@@ -53,7 +53,8 @@ class Validation
     NetClock::time_point seenTime_;
     PeerKey key_;
     PeerID nodeID_{0};
-    bool trusted_ = true;
+    bool trusted_ = false;
+    bool full_ = false;
     boost::optional<std::uint32_t> loadFee_;
 
 public:
@@ -66,7 +67,7 @@ public:
         NetClock::time_point seen,
         PeerKey key,
         PeerID nodeID,
-        bool trusted,
+        bool full,
         boost::optional<std::uint32_t> loadFee = boost::none)
         : ledgerID_{id}
         , seq_{seq}
@@ -74,7 +75,7 @@ public:
         , seenTime_{seen}
         , key_{key}
         , nodeID_{nodeID}
-        , trusted_{trusted}
+        , full_{full}
         , loadFee_{loadFee}
     {
     }
@@ -121,6 +122,13 @@ public:
         return trusted_;
     }
 
+    bool
+    full() const
+    {
+        return full_;
+    }
+
+
     boost::optional<std::uint32_t>
     loadFee() const
     {
@@ -136,8 +144,9 @@ public:
     auto
     asTie() const
     {
+        // trusted is a status set by the receiver, so it is not part of the tie
         return std::tie(ledgerID_, seq_, signTime_, seenTime_, key_, nodeID_,
-            trusted_, loadFee_);
+            trusted_, loadFee_, full_);
     }
     bool
     operator==(Validation const& o) const

--- a/src/test/csf/Validation.h
+++ b/src/test/csf/Validation.h
@@ -145,8 +145,15 @@ public:
     asTie() const
     {
         // trusted is a status set by the receiver, so it is not part of the tie
-        return std::tie(ledgerID_, seq_, signTime_, seenTime_, key_, nodeID_,
-            trusted_, loadFee_, full_);
+        return std::tie(
+            ledgerID_,
+            seq_,
+            signTime_,
+            seenTime_,
+            key_,
+            nodeID_,
+            loadFee_,
+            full_);
     }
     bool
     operator==(Validation const& o) const

--- a/src/test/csf/Validation.h
+++ b/src/test/csf/Validation.h
@@ -57,6 +57,9 @@ class Validation
     boost::optional<std::uint32_t> loadFee_;
 
 public:
+    using NodeKey = PeerKey;
+    using NodeID = PeerID;
+
     Validation(Ledger::ID id,
         Ledger::Seq seq,
         NetClock::time_point sign,

--- a/src/test/csf/impl/Sim.cpp
+++ b/src/test/csf/impl/Sim.cpp
@@ -48,25 +48,36 @@ Sim::run(SimDuration const & dur)
 bool
 Sim::synchronized() const
 {
-    if (peers.size() < 1)
+    return synchronized(allPeers);
+}
+
+bool
+Sim::synchronized(PeerGroup const & g) const
+{
+    if (g.size() < 1)
         return true;
-    Peer const& ref = peers.front();
-    return std::all_of(peers.begin(), peers.end(), [&ref](Peer const& p) {
-        return p.lastClosedLedger.id() ==
-            ref.lastClosedLedger.id() &&
-            p.fullyValidatedLedger.id() ==
-            ref.fullyValidatedLedger.id();
+    Peer const * ref = g[0];
+    return std::all_of(g.begin(), g.end(), [&ref](Peer const* p) {
+        return p->lastClosedLedger.id() ==
+            ref->lastClosedLedger.id() &&
+            p->fullyValidatedLedger.id() ==
+            ref->fullyValidatedLedger.id();
     });
 }
 
 std::size_t
 Sim::branches() const
 {
-    if(peers.size() < 1)
+    return branches(allPeers);
+}
+std::size_t
+Sim::branches(PeerGroup const & g) const
+{
+    if(g.size() < 1)
         return 0;
     std::set<Ledger> ledgers;
-    for(auto const & peer : peers)
-        ledgers.insert(peer.fullyValidatedLedger);
+    for(auto const & peer : g)
+        ledgers.insert(peer->fullyValidatedLedger);
 
     return oracle.branches(ledgers);
 }

--- a/src/test/csf/impl/ledgers.cpp
+++ b/src/test/csf/impl/ledgers.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 #include <BeastConfig.h>
 #include <test/csf/ledgers.h>
+#include <algorithm>
 
 #include <sstream>
 
@@ -34,6 +35,53 @@ Ledger::getJson() const
     res["id"] = static_cast<ID::value_type>(id());
     res["seq"] = static_cast<Seq::value_type>(seq());
     return res;
+}
+
+bool
+Ledger::isAncestor(Ledger const& ancestor) const
+{
+    if (ancestor.seq() < seq())
+        return operator[](ancestor.seq()) == ancestor.id();
+    return false;
+}
+
+Ledger::ID
+Ledger::operator[](Seq s) const
+{
+    if(s > seq())
+        return {};
+    if(s== seq())
+        return id();
+    return instance_->ancestors[static_cast<Seq::value_type>(s)];
+
+}
+
+Ledger::Seq
+mismatch(Ledger const& a, Ledger const& b)
+{
+    using Seq = Ledger::Seq;
+
+    // end is 1 past end of range
+    Seq start{0};
+    Seq end = std::min(a.seq() + Seq{1}, b.seq() + Seq{1});
+
+    // Find mismatch in [start,end)
+    // Binary search
+    Seq count = end - start;
+    while(count > Seq{0})
+    {
+        Seq step = count/Seq{2};
+        Seq curr = start + step;
+        if(a[curr] == b[curr])
+        {
+            // go to second half
+            start = ++curr;
+            count -= step + Seq{1};
+        }
+        else
+            count = step;
+    }
+    return start;
 }
 
 LedgerOracle::LedgerOracle()
@@ -67,6 +115,8 @@ LedgerOracle::accept(
 
     next.parentCloseTime = parent.closeTime();
     next.parentID = parent.id();
+    next.ancestors.push_back(parent.id());
+
     auto it = instances_.left.find(next);
     if (it == instances_.left.end())
     {
@@ -88,19 +138,6 @@ LedgerOracle::lookup(Ledger::ID const & id) const
 }
 
 
-bool
-LedgerOracle::isAncestor(Ledger const & ancestor, Ledger const& descendant) const
-{
-    // The ancestor must have an earlier sequence number than the descendent
-    if(ancestor.seq() >= descendant.seq())
-        return false;
-
-    boost::optional<Ledger> current{descendant};
-    while(current && current->seq() > ancestor.seq())
-        current = lookup(current->parentID());
-    return current && (current->id() == ancestor.id());
-}
-
 std::size_t
 LedgerOracle::branches(std::set<Ledger> const & ledgers) const
 {
@@ -121,7 +158,7 @@ LedgerOracle::branches(std::set<Ledger> const & ledgers) const
             bool const idxEarlier = tips[idx].seq() < ledger.seq();
             Ledger const & earlier = idxEarlier ? tips[idx] : ledger;
             Ledger const & later = idxEarlier ? ledger : tips[idx] ;
-            if (isAncestor(earlier, later))
+            if (later.isAncestor(earlier))
             {
                 tips[idx] = later;
                 found = true;

--- a/src/test/csf/ledgers.h
+++ b/src/test/csf/ledgers.h
@@ -96,7 +96,7 @@ private:
         NetClock::time_point parentCloseTime;
 
         //! IDs of this ledgers ancestors. Since each ledger already has unique
-        //! ancestors based on the parentID, this member is not needed foor any
+        //! ancestors based on the parentID, this member is not needed for any
         //! of the operators below.
         std::vector<Ledger::ID> ancestors;
 
@@ -323,7 +323,7 @@ struct LedgerHistoryHelper
 
     /** Get or create the ledger with the given string history.
 
-        Creates an necessary intermediate ledgers, but asserts if
+        Creates any necessary intermediate ledgers, but asserts if
         a letter is re-used (e.g. "abc" then "adc" would assert)
     */
     Ledger const& operator[](std::string const& s)

--- a/src/test/unity/app_test_unity2.cpp
+++ b/src/test/unity/app_test_unity2.cpp
@@ -22,6 +22,7 @@
 #include <test/app/PayChan_test.cpp>
 #include <test/app/PayStrand_test.cpp>
 #include <test/app/PseudoTx_test.cpp>
+#include <test/app/RCLValidations_test.cpp>
 #include <test/app/Regression_test.cpp>
 #include <test/app/SetAuth_test.cpp>
 #include <test/app/SetRegularKey_test.cpp>

--- a/src/test/unity/consensus_test_unity.cpp
+++ b/src/test/unity/consensus_test_unity.cpp
@@ -21,5 +21,6 @@
 #include <test/consensus/Consensus_test.cpp>
 #include <test/consensus/DistributedValidatorsSim_test.cpp>
 #include <test/consensus/LedgerTiming_test.cpp>
+#include <test/consensus/LedgerTrie_test.cpp>
 #include <test/consensus/ScaleFreeSim_test.cpp>
 #include <test/consensus/Validations_test.cpp>


### PR DESCRIPTION
These changes leverage the ancestry information of validated ledgers to better select a preferred working ledger for consensus.  Additionally, the `Validations` class now tracks both full and partial validations. Partial validations are only used to determine the working ledger; full validations are required for any quorum related function. Validators are also now explicitly restricted to sending full validations with increasing ledger index, otherwise the validation is marked partial.

The algorithm for determining the preferred ledger is described in the [LedgerTrie::getPreferred](http://bachase.github.io/ripd1551/rippled/ref/ripple__LedgerTrie/getPreferred.html) documentation. The [LedgerTrie](http://bachase.github.io/ripd1551/rippled/ref/ripple__LedgerTrie.html) documentation describes the trie data structure used to support this calculation.

- 99494837fc13e831300a8f4591756912d6626d6b is a motivating consensus simulation 
- c6060d8 introduces the LedgerTrie data structure
- The subsequent commits are meant to be manageable sized commits that transition to use the ledger trie for the preferred branch calculations.

febedc4 is from #2292 