### PR TITLE
Cleanly report invalid [server] settings (RIPD-1562)

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1234,9 +1234,10 @@ bool ApplicationImp::setup()
             setup.makeContexts();
             serverHandler_->setup(setup, m_journal);
         }
-        catch (std::exception const&)
+        catch (std::exception const& e)
         {
-            JLOG(m_journal.fatal()) << "Unable to setup server handler";
+            JLOG(m_journal.fatal())
+                << "Unable to setup server handler " << e.what();
             return false;
         }
     }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -61,6 +61,7 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
+#include <cstring>
 
 namespace ripple {
 
@@ -1236,8 +1237,12 @@ bool ApplicationImp::setup()
         }
         catch (std::exception const& e)
         {
-            JLOG(m_journal.fatal())
-                << "Unable to setup server handler " << e.what();
+            if (auto stream = m_journal.fatal())
+            {
+                stream << "Unable to setup server handler";
+                if(std::strlen(e.what()) > 0)
+                    stream << ": " << e.what();
+            }
             return false;
         }
     }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1227,11 +1227,18 @@ bool ApplicationImp::setup()
     }
 
     {
-        auto setup = setup_ServerHandler(
-            *config_,
-            beast::logstream { m_journal.error() });
-        setup.makeContexts();
-        serverHandler_->setup (setup, m_journal);
+        try
+        {
+            auto setup = setup_ServerHandler(
+                *config_, beast::logstream{m_journal.error()});
+            setup.makeContexts();
+            serverHandler_->setup(setup, m_journal);
+        }
+        catch (std::exception const&)
+        {
+            JLOG(m_journal.fatal()) << "Unable to setup server handler";
+            return false;
+        }
     }
 
     // Begin connecting to network.

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -893,19 +893,19 @@ to_Port(ParsedPort const& parsed, std::ostream& log)
 
     if (! parsed.ip)
     {
-        log << "Missing 'ip' in [" << p.name << "]\n";
+        log << "Missing 'ip' in [" << p.name << "]";
         Throw<std::exception> ();
     }
     p.ip = *parsed.ip;
 
     if (! parsed.port)
     {
-        log << "Missing 'port' in [" << p.name << "]\n";
+        log << "Missing 'port' in [" << p.name << "]";
         Throw<std::exception> ();
     }
     else if (*parsed.port == 0)
     {
-        log << "Port " << *parsed.port << "in [" << p.name << "] is invalid\n";
+        log << "Port " << *parsed.port << "in [" << p.name << "] is invalid";
         Throw<std::exception> ();
     }
     p.port = *parsed.port;
@@ -916,7 +916,7 @@ to_Port(ParsedPort const& parsed, std::ostream& log)
 
     if (parsed.protocol.empty())
     {
-        log << "Missing 'protocol' in [" << p.name << "]\n";
+        log << "Missing 'protocol' in [" << p.name << "]";
         Throw<std::exception> ();
     }
     p.protocol = parsed.protocol;
@@ -947,7 +947,7 @@ parse_Ports (
     if (! config.exists("server"))
     {
         log <<
-            "Required section [server] is missing\n";
+            "Required section [server] is missing";
         Throw<std::exception> ();
     }
 
@@ -961,7 +961,7 @@ parse_Ports (
         if (! config.exists(name))
         {
             log <<
-                "Missing section: [" << name << "]\n";
+                "Missing section: [" << name << "]";
             Throw<std::exception> ();
         }
         ParsedPort parsed = common;
@@ -997,12 +997,12 @@ parse_Ports (
 
         if (count > 1)
         {
-            log << "Error: More than one peer protocol configured in [server]\n";
+            log << "Error: More than one peer protocol configured in [server]";
             Throw<std::exception> ();
         }
 
         if (count == 0)
-            log << "Warning: No peer protocol configured\n";
+            log << "Warning: No peer protocol configured";
     }
 
     return result;

--- a/src/ripple/server/impl/Port.cpp
+++ b/src/ripple/server/impl/Port.cpp
@@ -87,7 +87,7 @@ populate (Section const& section, std::string const& field, std::ostream& log,
             if (! addr.second)
             {
                 log << "Invalid value '" << ip << "' for key '" << field <<
-                    "' in [" << section.name () << "]\n";
+                    "' in [" << section.name () << "]";
                 Throw<std::exception> ();
             }
 
@@ -97,7 +97,7 @@ populate (Section const& section, std::string const& field, std::ostream& log,
                 {
                     log << "0.0.0.0 not allowed'" <<
                         "' for key '" << field << "' in [" <<
-                        section.name () << "]\n";
+                        section.name () << "]";
                     Throw<std::exception> ();
                 }
                 else
@@ -110,7 +110,7 @@ populate (Section const& section, std::string const& field, std::ostream& log,
             {
                 log << "IP specified along with 0.0.0.0 '" << ip <<
                     "' for key '" << field << "' in [" <<
-                    section.name () << "]\n";
+                    section.name () << "]";
                 Throw<std::exception> ();
             }
 
@@ -123,7 +123,7 @@ populate (Section const& section, std::string const& field, std::ostream& log,
                 ) != admin_ip.end())
             {
                 log << "IP specified for " << field << " is also for " <<
-                    "admin: " << ip << " in [" << section.name() << "]\n";
+                    "admin: " << ip << " in [" << section.name() << "]";
                 Throw<std::exception> ();
             }
 
@@ -146,7 +146,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
             catch (std::exception const&)
             {
                 log << "Invalid value '" << result.first <<
-                    "' for key 'ip' in [" << section.name() << "]\n";
+                    "' for key 'ip' in [" << section.name() << "]";
                 Rethrow();
             }
         }
@@ -169,7 +169,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
             {
                 log <<
                     "Invalid value '" << result.first << "' for key " <<
-                    "'port' in [" << section.name() << "]\n";
+                    "'port' in [" << section.name() << "]";
                 Rethrow();
             }
         }
@@ -199,7 +199,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
             {
                 log <<
                     "Invalid value '" << lim << "' for key " <<
-                    "'limit' in [" << section.name() << "]\n";
+                    "'limit' in [" << section.name() << "]";
                 Rethrow();
             }
         }
@@ -222,7 +222,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
             {
                 log <<
                     "Invalid value '" << result.first << "' for key " <<
-                    "'send_queue_limit' in [" << section.name() << "]\n";
+                    "'send_queue_limit' in [" << section.name() << "]";
                 Rethrow();
             }
         }


### PR DESCRIPTION
Ensure when standing up the server at startup, we catch any exceptions related to invalid `[server]` settings and cleanly report them before shutting down.