### PR TITLE
Force json commands to be objects

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -458,7 +458,7 @@ private:
             if (reader.parse (jvParams[2u].asString (), txJSON))
             {
                 // sign_for txJSON.
-                Json::Value jvRequest;
+                Json::Value jvRequest{Json::objectValue};
 
                 jvRequest[jss::account] = jvParams[0u].asString ();
                 jvRequest[jss::secret]  = jvParams[1u].asString ();
@@ -802,7 +802,7 @@ private:
     Json::Value parseRipplePathFind (Json::Value const& jvParams)
     {
         Json::Reader    reader;
-        Json::Value     jvRequest;
+        Json::Value     jvRequest{Json::objectValue};
         bool            bLedger     = 2 == jvParams.size ();
 
         JLOG (j_.trace()) << "RPC json: " << jvParams[0u];
@@ -835,7 +835,7 @@ private:
         {
             // Submitting tx_blob
 
-            Json::Value jvRequest;
+            Json::Value jvRequest{Json::objectValue};
 
             jvRequest[jss::tx_blob]    = jvParams[0u].asString ();
 
@@ -845,7 +845,7 @@ private:
                  && reader.parse (jvParams[1u].asString (), txJSON))
         {
             // Signing or submitting tx_json.
-            Json::Value jvRequest;
+            Json::Value jvRequest{Json::objectValue};
 
             jvRequest[jss::secret]     = jvParams[0u].asString ();
             jvRequest[jss::tx_json]    = txJSON;
@@ -870,7 +870,7 @@ private:
             Json::Reader    reader;
             if (reader.parse (jvParams[0u].asString (), txJSON))
             {
-                Json::Value jvRequest;
+                Json::Value jvRequest{Json::objectValue};
                 jvRequest[jss::tx_json] = txJSON;
                 return jvRequest;
             }
@@ -889,7 +889,7 @@ private:
         if (txHash.length() != 64)
             return rpcError (rpcINVALID_PARAMS);
 
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
         jvRequest[jss::tx_hash] = txHash;
 
         jvParseLedger (jvRequest, jvParams[1u].asString());
@@ -907,7 +907,7 @@ private:
     // tx <transaction_id>
     Json::Value parseTx (Json::Value const& jvParams)
     {
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         if (jvParams.size () > 1)
         {
@@ -922,7 +922,7 @@ private:
     // tx_history <index>
     Json::Value parseTxHistory (Json::Value const& jvParams)
     {
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         jvRequest[jss::start]  = jvParams[0u].asUInt ();
 
@@ -935,7 +935,7 @@ private:
     // shell history file (e.g. .bash_history) and it may be leaked via the process status command (i.e. ps).
     Json::Value parseValidationCreate (Json::Value const& jvParams)
     {
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         if (jvParams.size ())
             jvRequest[jss::secret]     = jvParams[0u].asString ();
@@ -949,7 +949,7 @@ private:
     // shell history file (e.g. .bash_history) and it may be leaked via the process status command (i.e. ps).
     Json::Value parseValidationSeed (Json::Value const& jvParams)
     {
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         if (jvParams.size ())
             jvRequest[jss::secret]     = jvParams[0u].asString ();
@@ -961,7 +961,7 @@ private:
     // <passphrase> is only for testing. Master seeds should only be generated randomly.
     Json::Value parseWalletPropose (Json::Value const& jvParams)
     {
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         if (jvParams.size ())
             jvRequest[jss::passphrase]     = jvParams[0u].asString ();
@@ -972,7 +972,7 @@ private:
     // wallet_seed [<seed>|<passphrase>|<passkey>]
     Json::Value parseWalletSeed (Json::Value const& jvParams)
     {
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         if (jvParams.size ())
             jvRequest[jss::secret]     = jvParams[0u].asString ();
@@ -988,7 +988,7 @@ private:
         unsigned int index = 0;
         const unsigned int size = jvParams.size ();
 
-        Json::Value jvRequest;
+        Json::Value jvRequest{Json::objectValue};
 
         std::string param = jvParams[index++].asString ();
         if (param.empty ())

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -393,6 +393,10 @@ public:
         auto result = env.rpc("validation_create");
         BEAST_EXPECT(result.isMember(jss::result) &&
                      result[jss::result][jss::status] == "success");
+        result = env.rpc("validation_create",
+                         "BAWL MAN JADE MOON DOVE GEM SON NOW HAD ADEN GLOW TIRE");
+        BEAST_EXPECT(result.isMember(jss::result) &&
+                     result[jss::result][jss::status] == "success");
     }
 
     void

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -386,11 +386,22 @@ public:
     }
 
     void
+    test_validation_create()
+    {
+        using namespace test::jtx;
+        Env env{*this};
+        auto result = env.rpc("validation_create");
+        BEAST_EXPECT(result.isMember(jss::result) &&
+                     result[jss::result][jss::status] == "success");
+    }
+
+    void
     run()
     {
         testPrivileges();
         testStaticUNL();
         testDynamicUNL();
+        test_validation_create();
     }
 };
 


### PR DESCRIPTION
* Null json values can be objects or arrays.
* json arrays are now interpreted as batch commands.
* json objects are single commands.
* null jsons are ambiguous as to whether they are single or batch
  commands and should be avoided.

This fixes a regression introduced with 0.90 by the batch json support.