### PR TITLE
Changed strand_.post to strand_.dispatch

### DIFF
--- a/src/ripple/server/impl/BasePeer.h
+++ b/src/ripple/server/impl/BasePeer.h
@@ -96,11 +96,8 @@ void
 BasePeer<Handler, Impl>::
 close()
 {
-    if (! strand_.running_in_this_thread())
-        return strand_.post(std::bind(
+    strand_.dispatch(std::bind(
             &BasePeer::close, impl().shared_from_this()));
-    error_code ec;
-    impl().ws_.lowest_layer().close(ec);
 }
 
 } // ripple


### PR DESCRIPTION
asio already has a built-in function for this operation.
You can check source code: https://github.com/chriskohlhoff/asio/blob/master/asio/include/asio/detail/impl/strand_service.hpp#L58-L63
Referance: http://www.boost.org/doc/libs/1_65_1/doc/html/boost_asio/reference/io_service/dispatch.html