### PR TITLE
Better error messages for out of range integral values

### DIFF
--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1228,7 +1228,8 @@ struct RPCCallImp
 
             // Parse reply
             JLOG (j.debug()) << "RPC reply: " << strData << std::endl;
-
+            if (strData.find("Unable to parse request") == 0)
+                Throw<std::runtime_error> (strData);
             Json::Reader    reader;
             Json::Value     jvReply;
             if (!reader.parse (strData, jvReply))
@@ -1442,9 +1443,18 @@ rpcClient(std::vector<std::string> const& args,
     }
     catch (std::exception& e)
     {
-        jvOutput                = rpcError (rpcINTERNAL);
-        jvOutput["error_what"]  = e.what ();
-        nRet                    = rpcINTERNAL;
+        if (memcmp(e.what(), "Unable to parse request", 23) == 0)
+        {
+            jvOutput                = rpcError(rpcINVALID_PARAMS);
+            jvOutput["error_what"]  = e.what();
+            nRet                    = rpcINVALID_PARAMS;
+        }
+        else
+        {
+            jvOutput                = rpcError (rpcINTERNAL);
+            jvOutput["error_what"]  = e.what ();
+            nRet                    = rpcINTERNAL;
+        }
     }
 
     return { nRet, std::move(jvOutput) };

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -569,7 +569,8 @@ ServerHandlerImp::processRequest (Port const& port,
             ! jsonOrig ||
             ! (jsonOrig.isObject () || jsonOrig.isArray()))
         {
-            HTTPReply (400, "Unable to parse request", output, rpcJ);
+            HTTPReply (400, "Unable to parse request: " +
+                       reader.getFormatedErrorMessages(), output, rpcJ);
             return;
         }
     }

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -121,6 +121,20 @@ class LedgerRPC_test : public beast::unit_test::suite
             checkErrorValue(jrr, "invalidParams", "Invalid parameters.");
         }
 
+        {
+            // Request a ledger with a very large (double) sequence.
+            auto const ret = env.rpc (
+                "json", "ledger", "{ \"ledger_index\" : 2e15 }");
+            BEAST_EXPECT (RPC::contains_error(ret));
+            BEAST_EXPECT (ret[jss::error_message] == "Invalid parameters.");
+        }
+
+        {
+            // Request a ledger with very large (integer) sequence.
+            auto const ret = env.rpc (
+                "json", "ledger", "{ \"ledger_index\" : 1000000000000000 }");
+            checkErrorValue(ret, "invalidParams", "Invalid parameters.");
+        }
     }
 
     void testLedgerCurrent()

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -893,7 +893,7 @@ class ServerStatus_test :
             beast::http::response<beast::http::string_body> resp;
             doHTTPRequest(env, yield, false, resp, ec, "{}");
             BEAST_EXPECT(resp.result() == beast::http::status::bad_request);
-            BEAST_EXPECT(resp.body == "Unable to parse request\r\n");
+            BEAST_EXPECT(resp.body == "Unable to parse request: \r\n");
         }
 
         Json::Value jv;


### PR DESCRIPTION
* This change passes detailed error messages from the JSON parser
  on the server side, back to the client for inclusion into the
  reply's error message.

* Errors originating from the server's inability to parse are
  reclassified from rpcINTERNAL to rpcINVALID_PARAMS.

Addresses https://ripplelabs.atlassian.net/browse/RIPD-1111