### PR TITLE
Avoid AppVeyor stack overflow

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
   # We bundle up protoc.exe and only the parts of boost and openssl we need so
   # that it's a small download. We also use appveyor's free cache, avoiding fees
-  # downloading from S3 each time. 
+  # downloading from S3 each time.
   # TODO: script to create this package.
   RIPPLED_DEPS_PATH: rippled_deps17.01
   RIPPLED_DEPS_URL: https://ripple.github.io/Downloads/appveyor/%RIPPLED_DEPS_PATH%.zip
@@ -20,6 +20,11 @@ environment:
   # Scons honours these environment variables, setting the include/lib paths.
   BOOST_ROOT: C:/%RIPPLED_DEPS_PATH%/boost
   OPENSSL_ROOT: C:/%RIPPLED_DEPS_PATH%/openssl
+
+  # We've had trouble with AppVeyor apparently not having a stack as large
+  # as the *nix CI platforms.  AppVeyor support suggested that we try
+  # GCE VMs.  The following line is supposed to enable that VM type.
+  appveyor_build_worker_cloud: gce
 
   matrix:
   # This build works, but our current Appveyor config runs matrix builds
@@ -127,7 +132,7 @@ test_script:
   - ps: |
         & {
           # Run the rippled unit tests
-          & $exe --unittest --quiet --unittest-log
+          & $exe --unittest --unittest-log
           # https://connect.microsoft.com/PowerShell/feedback/details/751703/option-to-stop-script-if-command-line-exe-fails
           if ($LastExitCode -ne 0) { throw "Unit tests failed" }
         }

--- a/src/ripple/json/json_reader.h
+++ b/src/ripple/json/json_reader.h
@@ -81,7 +81,7 @@ public:
      */
     std::string getFormatedErrorMessages () const;
 
-    static constexpr unsigned nest_limit {1000};
+    static constexpr unsigned nest_limit {25};
 
 private:
     enum TokenType


### PR DESCRIPTION
The `json_value::test_nest_limits` unit test was failing on Appveyor, presumably because the recursion exceeded the available stack.  With this change (suggested by @miguelportilla) I've successfully passed unit tests on Appveyor twice.

Reviewers: @miguelportilla and @mellery451 