### PR TITLE
Allow account_objects RPC to filter by "check" (RIPD-1589)

### DIFF
--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -104,6 +104,7 @@ JSS ( cancel_after );               // out: AccountChannels
 JSS ( can_delete );                 // out: CanDelete
 JSS ( channel_id );                 // out: AccountChannels
 JSS ( channels );                   // out: AccountChannels
+JSS ( check );                      // in: AccountObjects
 JSS ( check_nodes );                // in: LedgerCleaner
 JSS ( clear );                      // in/out: FetchInfo
 JSS ( close_flags );                // out: LedgerToJson

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -671,19 +671,20 @@ chooseLedgerEntryType(Json::Value const& params)
     if (params.isMember(jss::type))
     {
         static
-            std::array<std::pair<char const *, LedgerEntryType>, 11> const types
+            std::array<std::pair<char const *, LedgerEntryType>, 12> const types
         { {
             { jss::account,         ltACCOUNT_ROOT },
             { jss::amendments,      ltAMENDMENTS },
+            { jss::check,           ltCHECK },
             { jss::directory,       ltDIR_NODE },
+            { jss::escrow,          ltESCROW },
             { jss::fee,             ltFEE_SETTINGS },
             { jss::hashes,          ltLEDGER_HASHES },
             { jss::offer,           ltOFFER },
+            { jss::payment_channel, ltPAYCHAN },
             { jss::signer_list,     ltSIGNER_LIST },
             { jss::state,           ltRIPPLE_STATE },
-            { jss::ticket,          ltTICKET },
-            { jss::escrow,          ltESCROW },
-            { jss::payment_channel, ltPAYCHAN }
+            { jss::ticket,          ltTICKET }
             } };
 
         auto const& p = params[jss::type];

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -97,7 +97,7 @@ getAccountObjects(ReadView const& ledger, AccountID const& account,
         return false;
 
     std::uint32_t i = 0;
-    auto& jvObjects = jvResult[jss::account_objects];
+    auto& jvObjects = (jvResult[jss::account_objects] = Json::arrayValue);
     for (;;)
     {
         auto const& entries = dir->getFieldV256 (sfIndexes);

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -512,22 +512,12 @@ public:
             env.close();
         }
 
-        // Make a lambda that easily identifies null account objects.
-        auto acct_objs_is_null =
-            [&env, &acct_objs] (Account const& acct, char const* type)
-        {
-            Json::Value const resp = acct_objs (acct, type);
-            return resp["result"]["account_objects"].isNull();
-        };
-
         // Verify that the non-returning types still don't return anything.
-        // Note that, interestingly, they now return a null object rather
-        // than an empty array.  Not sure what triggers that...
-        BEAST_EXPECT (acct_objs_is_null (gw, jss::account));
-        BEAST_EXPECT (acct_objs_is_null (gw, jss::amendments));
-        BEAST_EXPECT (acct_objs_is_null (gw, jss::directory));
-        BEAST_EXPECT (acct_objs_is_null (gw, jss::fee));
-        BEAST_EXPECT (acct_objs_is_null (gw, jss::hashes));
+        BEAST_EXPECT (acct_objs_is_empty (gw, jss::account));
+        BEAST_EXPECT (acct_objs_is_empty (gw, jss::amendments));
+        BEAST_EXPECT (acct_objs_is_empty (gw, jss::directory));
+        BEAST_EXPECT (acct_objs_is_empty (gw, jss::fee));
+        BEAST_EXPECT (acct_objs_is_empty (gw, jss::hashes));
     }
 
     void run() override


### PR DESCRIPTION
@mDuo13 found a bug in the Checks implementation (Thanks!).  This fixes that particular bug.  Also adds some more unit tests for `account_objects`.