### PR TITLE
Change permessage-deflate and compress defaults (RIPD-506)

### DIFF
--- a/src/ripple/server/impl/Port.cpp
+++ b/src/ripple/server/impl/Port.cpp
@@ -247,7 +247,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
     set(port.ssl_ciphers, "ssl_ciphers", section);
 
     port.pmd_options.server_enable =
-        section.value_or("permessage_deflate", false);
+        section.value_or("permessage_deflate", true);
     port.pmd_options.client_max_window_bits =
         section.value_or("client_max_window_bits", 15);
     port.pmd_options.server_max_window_bits =
@@ -257,7 +257,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
     port.pmd_options.server_no_context_takeover =
         section.value_or("server_no_context_takeover", false);
     port.pmd_options.compLevel =
-        section.value_or("compress_level", 3);
+        section.value_or("compress_level", 8);
     port.pmd_options.memLevel =
         section.value_or("memory_level", 4);
 }


### PR DESCRIPTION
The objective of this task was to explore and find ways to reduce the size of JSON returned to clients from WebSocket and HTTP connections. By default, rippled already minifies RPC JSON output by omitting white space and new lines. Websockets can be easily configured to compress the output using permessage_deflate. I performed some testing and listed my findings which lead me to believe we should have permessage_deflate turned on by default.

Adding Transfer and Content-Encoding for RPC over HTTP/S, is unfortunately plagued with problems and difficulty because of the overall poor client implementations. Proxies, overcautious web browsers, and misconfigured servers can prevent the client from correctly receiving data. (https://en.wikipedia.org/wiki/HTTP_compression) And although workarounds can be used to solve the different client issues, it is not worth the effort.

Using the WebSocket deflate compression with various settings, I measured the following output differences. (Boost 1.66)

RPC command:
{ "command": "tx_history", "start": 0 }

permessage_deflate turned OFF (default)
SOCKET_BYTES_RECEIVED 13013

permessage_deflate turned ON
compress_level 3
memory_level 4
SOCKET_BYTES_RECEIVED 5131

permessage_deflate turned ON
compress_level 8
memory_level 4
SOCKET_BYTES_RECEIVED 4928

permessage_deflate turned ON
compress_level 8
memory_level 8
SOCKET_BYTES_RECEIVED 4815

Considering the trade-offs, a compression level of 8 with a memory level of 4 is likely the ideal setting giving an average improvement of over 200% reduction in the payload. The change necessary to have WebSocket compression on by default is trivial. However, the real world impact on server resources usage remains to be seen. 