### PR TITLE
Support --unittest-jobs in Test.py scons builds:

### DIFF
--- a/Builds/Test.py
+++ b/Builds/Test.py
@@ -304,7 +304,9 @@ def run_tests(args):
                 testflag += ('=' + ARGS.test)
             if ARGS.quiet:
                 quiet = '-q'
-            resultcode, lines = shell(executable, (testflag, quiet,))
+            if ARGS.testjobs:
+                testjobs = ('--unittest-jobs=' + str(ARGS.testjobs))
+            resultcode, lines = shell(executable, (testflag, quiet, testjobs,))
 
             if resultcode:
                 if not ARGS.verbose:

--- a/Builds/Ubuntu/install_rippled_depends_ubuntu.sh
+++ b/Builds/Ubuntu/install_rippled_depends_ubuntu.sh
@@ -19,18 +19,6 @@ if [ -z "${ubuntu_release}" ]; then
     exit 1
 fi
 
-if [ ${ubuntu_release} == "12.04" ]; then
-    apt-get install python-software-properties
-    add-apt-repository ppa:afrank/boost
-    add-apt-repository ppa:ubuntu-toolchain-r/test
-    apt-get update
-    apt-get -y upgrade
-    apt-get -y install curl git scons ctags pkg-config protobuf-compiler libprotobuf-dev libssl-dev python-software-properties boost1.57-all-dev g++-5 g++-4.9
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 99 --slave /usr/bin/g++ g++ /usr/bin/g++-5
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 99 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
-    exit 0
-fi
-
 if [ ${ubuntu_release} == "14.04" ] || [ ${ubuntu_release} == "15.04" ]; then
     apt-get install python-software-properties
     echo "deb [arch=amd64] https://mirrors.ripple.com/ubuntu/ trusty stable contrib" | sudo tee /etc/apt/sources.list.d/ripple.list
@@ -38,7 +26,7 @@ if [ ${ubuntu_release} == "14.04" ] || [ ${ubuntu_release} == "15.04" ]; then
     add-apt-repository ppa:ubuntu-toolchain-r/test
     apt-get update
     apt-get -y upgrade
-    apt-get -y install curl git scons ctags pkg-config protobuf-compiler libprotobuf-dev libssl-dev python-software-properties boost-all-dev g++-5 g++-4.9
+    apt-get -y install curl git cmake ctags pkg-config protobuf-compiler libprotobuf-dev libssl-dev python-software-properties boost-all-dev g++-5 g++-4.9
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 99 --slave /usr/bin/g++ g++ /usr/bin/g++-5
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 99 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
     exit 0
@@ -51,7 +39,7 @@ function version_check() { test "$(printf '%s\n' "$@" | sort -V | tail -n 1)" ==
 if version_check ${ubuntu_release} 15.10; then
     apt-get update
     apt-get -y upgrade
-    apt-get -y install python-software-properties curl git scons ctags pkg-config protobuf-compiler libprotobuf-dev libssl-dev python-software-properties libboost-all-dev
+    apt-get -y install python-software-properties curl git cmake ctags pkg-config protobuf-compiler libprotobuf-dev libssl-dev python-software-properties libboost-all-dev
     exit 0
 fi
 


### PR DESCRIPTION
* Replace Ubuntu scons dependency with cmake
* Remove dependency installation support for Ubuntu 12.04 Precise Pangolin.
  It is EOL'd as of 2017-04-28. http://releases.ubuntu.com/12.04/


Even though we're getting closer to deprecating scons support, until we're there, this oversight in the Test script is really getting on my nerves.