### PR TITLE
Improve handling of malformed JSON-RPC requests

### DIFF
--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -567,7 +567,7 @@ ServerHandlerImp::processRequest (Port const& port,
         if ((request.size () > RPC::Tuning::maxRequestSize) ||
             ! reader.parse (request, jsonOrig) ||
             ! jsonOrig ||
-            ! (jsonOrig.isObject () || jsonOrig.isArray()))
+            ! jsonOrig.isObject ())
         {
             HTTPReply (400, "Unable to parse request: " +
                        reader.getFormatedErrorMessages(), output, rpcJ);
@@ -578,25 +578,33 @@ ServerHandlerImp::processRequest (Port const& port,
     bool batch = false;
     if (jsonOrig.isMember(jss::method) && jsonOrig[jss::method] == "batch")
         batch = true;
-    auto size = batch ? jsonOrig[jss::params].size() : 1;
+    auto size = batch
+              ? jsonOrig.isMember(jss::params)
+                ? jsonOrig[jss::params].size() : 0
+              : 1;
     Json::Value reply(batch ? Json::arrayValue : Json::objectValue);
     auto const start (std::chrono::high_resolution_clock::now ());
     for (unsigned i = 0; i < size; ++i)
     {
-        Json::Value const& jsonRPC = batch ? jsonOrig[jss::params][i] : jsonOrig;
-        /* ---------------------------------------------------------------------- */
-        // Determine role/usage so we can charge for invalid requests
-        Json::Value const& method = jsonRPC [jss::method];
-
+        Json::Value const& jsonRPC =
+            batch ? jsonOrig[jss::params][i] : jsonOrig;
+        /* ------------------------------------------------------------------ */
         auto role = Role::FORBID;
-        auto required = RPC::roleRequired(method.asString());
+        auto required = Role::FORBID;
+        if (jsonRPC.isMember(jss::method))
+            required = RPC::roleRequired(jsonRPC[jss::method].asString());
+
         if (jsonRPC.isMember(jss::params) &&
             jsonRPC[jss::params].isArray() &&
             jsonRPC[jss::params].size() > 0 &&
             jsonRPC[jss::params][Json::UInt(0)].isObject())
         {
-            role = requestRole(required, port, jsonRPC[jss::params][Json::UInt(0)],
-                remoteIPAddress, user);
+            role = requestRole(
+                required,
+                port,
+                jsonRPC[jss::params][Json::UInt(0)],
+                remoteIPAddress,
+                user);
         }
         else
         {
@@ -641,7 +649,7 @@ ServerHandlerImp::processRequest (Port const& port,
             continue;
         }
 
-        if (method.isNull())
+        if (!jsonRPC.isMember(jss::method) || jsonRPC [jss::method].isNull())
         {
             usage.charge(Resource::feeInvalidRPC);
             if (!batch)
@@ -655,6 +663,7 @@ ServerHandlerImp::processRequest (Port const& port,
             continue;
         }
 
+        Json::Value const& method = jsonRPC [jss::method];
         if (! method.isString ())
         {
             usage.charge(Resource::feeInvalidRPC);

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -896,6 +896,35 @@ class ServerStatus_test :
             BEAST_EXPECT(resp.body == "Unable to parse request: \r\n");
         }
 
+        {
+            beast::http::response<beast::http::string_body> resp;
+            Json::Value jv;
+            jv["invalid"] = 1;
+            doHTTPRequest(env, yield, false, resp, ec, to_string(jv));
+            BEAST_EXPECT(resp.result() == beast::http::status::bad_request);
+            BEAST_EXPECT(resp.body == "Null method\r\n");
+        }
+
+        {
+            beast::http::response<beast::http::string_body> resp;
+            Json::Value jv(Json::arrayValue);
+            jv.append("invalid");
+            doHTTPRequest(env, yield, false, resp, ec, to_string(jv));
+            BEAST_EXPECT(resp.result() == beast::http::status::bad_request);
+            BEAST_EXPECT(resp.body == "Unable to parse request: \r\n");
+        }
+
+        {
+            beast::http::response<beast::http::string_body> resp;
+            Json::Value jv(Json::arrayValue);
+            Json::Value j;
+            j["invalid"] = 1;
+            jv.append(j);
+            doHTTPRequest(env, yield, false, resp, ec, to_string(jv));
+            BEAST_EXPECT(resp.result() == beast::http::status::bad_request);
+            BEAST_EXPECT(resp.body == "Unable to parse request: \r\n");
+        }
+
         Json::Value jv;
         {
             beast::http::response<beast::http::string_body> resp;

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -925,6 +925,27 @@ class ServerStatus_test :
             BEAST_EXPECT(resp.body == "Unable to parse request: \r\n");
         }
 
+        {
+            beast::http::response<beast::http::string_body> resp;
+            Json::Value jv;
+            jv[jss::method] = "batch";
+            jv[jss::params] = 2;
+            doHTTPRequest(env, yield, false, resp, ec, to_string(jv));
+            BEAST_EXPECT(resp.result() == beast::http::status::bad_request);
+            BEAST_EXPECT(resp.body == "Malformed batch request\r\n");
+        }
+
+        {
+            beast::http::response<beast::http::string_body> resp;
+            Json::Value jv;
+            jv[jss::method] = "batch";
+            jv[jss::params] = Json::objectValue;
+            jv[jss::params]["invalid"] = 3;
+            doHTTPRequest(env, yield, false, resp, ec, to_string(jv));
+            BEAST_EXPECT(resp.result() == beast::http::status::bad_request);
+            BEAST_EXPECT(resp.body == "Malformed batch request\r\n");
+        }
+
         Json::Value jv;
         {
             beast::http::response<beast::http::string_body> resp;


### PR DESCRIPTION
Improve handling of malformed JSON-RPC requests by no longer relying on the missing JSON fields defaulting to `null`.