### PR TITLE
Update validations on UNL change (RIPD-1566)

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -81,7 +81,7 @@ RCLConsensus::Adaptor::Adaptor(
         , localTxs_(localTxs)
         , inboundTransactions_{inboundTransactions}
         , j_(journal)
-        , nodeID_{calcNodeID(app.nodeIdentity().first)}
+        , nodeID_{validatorKeys.nodeID}
         , valPublic_{validatorKeys.publicKey}
         , valSecret_{validatorKeys.secretKey}
 {
@@ -837,6 +837,7 @@ RCLConsensus::Adaptor::validate(RCLCxLedger const& ledger, bool proposing)
         ledger.id(),
         validationTime,
         valPublic_,
+        nodeID_,
         proposing /* full if proposed */);
     v->setFieldU32(sfLedgerSequence, ledger.seq());
 
@@ -980,10 +981,11 @@ void
 RCLConsensus::startRound(
     NetClock::time_point const& now,
     RCLCxLedger::ID const& prevLgrId,
-    RCLCxLedger const& prevLgr)
+    RCLCxLedger const& prevLgr,
+    hash_set<NodeID> const& nowUntrusted)
 {
     ScopedLockType _{mutex_};
     consensus_.startRound(
-        now, prevLgrId, prevLgr, adaptor_.preStartRound(prevLgr));
+        now, prevLgrId, prevLgr, nowUntrusted, adaptor_.preStartRound(prevLgr));
 }
 }

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -427,7 +427,8 @@ public:
     startRound(
         NetClock::time_point const& now,
         RCLCxLedger::ID const& prevLgrId,
-        RCLCxLedger const& prevLgr);
+        RCLCxLedger const& prevLgr,
+        hash_set<NodeID> const& nowUntrusted);
 
     //! @see Consensus::timerEntry
     void

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -172,7 +172,7 @@ RCLValidationsAdaptor::onStale(RCLValidation&& v)
 }
 
 void
-RCLValidationsAdaptor::flush(hash_map<PublicKey, RCLValidation>&& remaining)
+RCLValidationsAdaptor::flush(hash_map<NodeID, RCLValidation>&& remaining)
 {
     bool anyNew = false;
     {
@@ -317,7 +317,7 @@ handleNewValidation(Application& app,
     // masterKey is seated only if validator is trusted or listed
     if (masterKey)
     {
-        ValStatus const outcome = validations.add(*masterKey, val);
+        ValStatus const outcome = validations.add(calcNodeID(*masterKey), val);
         if(j.debug())
             dmp(j.debug(), to_string(outcome));
 
@@ -326,13 +326,6 @@ handleNewValidation(Application& app,
             auto const seq = val->getFieldU32(sfLedgerSequence);
             dmp(j.warn(),
                 "already validated sequence at or past " + to_string(seq));
-        }
-        else if(outcome == ValStatus::repeatID && j.warn())
-        {
-            auto const seq = val->getFieldU32(sfLedgerSequence);
-            dmp(j.warn(),
-                "already validated ledger with same id but different seq "
-                "than" + to_string(seq));
         }
 
         if (val->isTrusted() && outcome == ValStatus::current)

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -101,7 +101,19 @@ public:
         return val_->isTrusted();
     }
 
-    /// Whether the validatioon is full (not-partial)
+    void
+    setTrusted()
+    {
+        val_->setTrusted();
+    }
+
+    void
+    setUntrusted()
+    {
+        val_->setUntrusted();
+    }
+
+    /// Whether the validation is full (not-partial)
     bool
     full() const
     {
@@ -214,7 +226,7 @@ public:
         @param remaining The remaining validations to flush
     */
     void
-    flush(hash_map<PublicKey, RCLValidation>&& remaining);
+    flush(hash_map<NodeID, RCLValidation>&& remaining);
 
     /** Attempt to acquire the ledger with given id from the network */
     boost::optional<RCLValidatedLedger>

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -153,8 +153,7 @@ public:
 
     // ledger proposal/close functions
     virtual void processTrustedProposal (RCLCxPeerPos peerPos,
-        std::shared_ptr<protocol::TMProposeSet> set,
-            NodeID const& node) = 0;
+        std::shared_ptr<protocol::TMProposeSet> set) = 0;
 
     virtual bool recvValidation (STValidation::ref val,
         std::string const& source) = 0;

--- a/src/ripple/app/misc/ValidatorKeys.h
+++ b/src/ripple/app/misc/ValidatorKeys.h
@@ -23,6 +23,7 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
+#include <ripple/protocol/UintTypes.h>
 #include <string>
 
 namespace ripple {
@@ -37,6 +38,7 @@ class ValidatorKeys
 public:
     PublicKey publicKey;
     SecretKey secretKey;
+    NodeID nodeID;
     std::string manifest;
     ValidatorKeys(Config const& config, beast::Journal j);
 

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -60,6 +60,14 @@ enum class ListDisposition
 std::string
 to_string(ListDisposition disposition);
 
+/** Changes in trusted nodes after updating validator list
+*/
+struct TrustChanges
+{
+    hash_set<NodeID> added;
+    hash_set<NodeID> removed;
+};
+
 /**
     Trusted Validators List
     -----------------------
@@ -202,22 +210,23 @@ public:
         std::string const& signature,
         std::uint32_t version);
 
-    /** Update trusted keys
+    /** Update trusted nodes
 
-        Reset the trusted keys based on latest manifests, received validations,
+        Reset the trusted nodes based on latest manifests, received validations,
         and lists.
 
-        @param seenValidators Set of public keys used to sign recently
-        received validations
+        @param seenValidators Set of NodeIDs of validators that have signed
+        recently received validations
+
+        @return TrustedKeyChanges instance with newly trusted or untrusted
+        node identities.
 
         @par Thread Safety
 
         May be called concurrently
     */
-    template<class KeySet>
-    void
-    onConsensusStart (
-        KeySet const& seenValidators);
+    TrustChanges
+    updateTrusted (hash_set<NodeID> const& seenValidators);
 
     /** Get quorum value for current trusted key set
 
@@ -390,133 +399,6 @@ private:
     calculateMinimumQuorum (
         std::size_t nListedKeys, bool unlistedLocal=false);
 };
-
-//------------------------------------------------------------------------------
-
-template<class KeySet>
-void
-ValidatorList::onConsensusStart (
-    KeySet const& seenValidators)
-{
-    boost::unique_lock<boost::shared_mutex> lock{mutex_};
-
-    // Check that lists from all configured publishers are available
-    bool allListsAvailable = true;
-
-    for (auto const& list : publisherLists_)
-    {
-        // Remove any expired published lists
-        if (TimeKeeper::time_point{} < list.second.expiration &&
-            list.second.expiration <= timeKeeper_.now())
-            removePublisherList(list.first);
-
-        if (! list.second.available)
-            allListsAvailable = false;
-    }
-
-    std::multimap<std::size_t, PublicKey> rankedKeys;
-    bool localKeyListed = false;
-
-    // "Iterate" the listed keys in random order so that the rank of multiple
-    // keys with the same number of listings is not deterministic
-    std::vector<std::size_t> indexes (keyListings_.size());
-    std::iota (indexes.begin(), indexes.end(), 0);
-    std::shuffle (indexes.begin(), indexes.end(), crypto_prng());
-
-    for (auto const& index : indexes)
-    {
-        auto const& val = std::next (keyListings_.begin(), index);
-
-        if (validatorManifests_.revoked (val->first))
-            continue;
-
-        if (val->first == localPubKey_)
-        {
-            localKeyListed = val->second > 1;
-            rankedKeys.insert (
-                std::pair<std::size_t,PublicKey>(
-                    std::numeric_limits<std::size_t>::max(), localPubKey_));
-        }
-        // If the total number of validators is too small, or
-        // no validations are being received, use all validators.
-        // Otherwise, do not use validators whose validations aren't
-        // being received.
-        else if (keyListings_.size() < MINIMUM_RESIZEABLE_UNL ||
-                 seenValidators.empty() ||
-                 seenValidators.find (val->first) != seenValidators.end ())
-        {
-            rankedKeys.insert (
-                std::pair<std::size_t,PublicKey>(val->second, val->first));
-        }
-    }
-
-    // This minimum quorum guarantees safe overlap with the trusted sets of
-    // other nodes using the same set of published lists.
-    std::size_t quorum = calculateMinimumQuorum (keyListings_.size(),
-        localPubKey_.size() && !localKeyListed);
-
-    JLOG (j_.debug()) <<
-        rankedKeys.size() << "  of " << keyListings_.size() <<
-        " listed validators eligible for inclusion in the trusted set";
-
-    auto size = rankedKeys.size();
-
-    // Require 80% quorum if there are lots of validators.
-    if (rankedKeys.size() > BYZANTINE_THRESHOLD)
-    {
-        // Use all eligible keys if there is only one trusted list
-        if (publisherLists_.size() == 1 ||
-                keyListings_.size() < MINIMUM_RESIZEABLE_UNL)
-        {
-            // Try to raise the quorum to at least 80% of the trusted set
-            quorum = std::max(quorum, size - size / 5);
-        }
-        else
-        {
-            // Reduce the trusted set size so that the quorum represents
-            // at least 80%
-            size = quorum * 1.25;
-        }
-    }
-
-    if (minimumQuorum_ && seenValidators.size() < quorum)
-    {
-        quorum = *minimumQuorum_;
-        JLOG (j_.warn())
-            << "Using unsafe quorum of "
-            << quorum_
-            << " as specified in the command line";
-    }
-
-    // Do not use achievable quorum until lists from all configured
-    // publishers are available
-    else if (! allListsAvailable)
-        quorum = std::numeric_limits<std::size_t>::max();
-
-    trustedKeys_.clear();
-    quorum_ = quorum;
-
-    for (auto const& val : boost::adaptors::reverse (rankedKeys))
-    {
-        if (size <= trustedKeys_.size())
-            break;
-
-        trustedKeys_.insert (val.second);
-    }
-
-    JLOG (j_.debug()) <<
-        "Using quorum of " << quorum_ << " for new set of " <<
-        trustedKeys_.size() << " trusted validators";
-
-    if (trustedKeys_.size() < quorum_)
-    {
-        JLOG (j_.warn()) <<
-            "New quorum of " << quorum_ <<
-            " exceeds the number of trusted validators (" <<
-            trustedKeys_.size() << ")";
-    }
-}
-
 } // ripple
 
 #endif

--- a/src/ripple/app/misc/impl/ValidatorKeys.cpp
+++ b/src/ripple/app/misc/impl/ValidatorKeys.cpp
@@ -47,7 +47,6 @@ ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
                 KeyType::secp256k1, token->validationSecret);
             auto const m = Manifest::make_Manifest(
                 beast::detail::base64_decode(token->manifest));
-
             if (! m || pk != m->signingKey)
             {
                 configInvalid_ = true;
@@ -58,6 +57,7 @@ ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
             {
                 secretKey = token->validationSecret;
                 publicKey = pk;
+                nodeID = calcNodeID(m->masterKey);
                 manifest = std::move(token->manifest);
             }
         }
@@ -82,6 +82,7 @@ ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
         {
             secretKey = generateSecretKey(KeyType::secp256k1, *seed);
             publicKey = derivePublicKey(KeyType::secp256k1, secretKey);
+            nodeID = calcNodeID(publicKey);
         }
     }
 }

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -597,4 +597,140 @@ ValidatorList::calculateMinimumQuorum (
     return nListedKeys * 2/3 + 1;
 }
 
+TrustChanges
+ValidatorList::updateTrusted(hash_set<NodeID> const& seenValidators)
+{
+    boost::unique_lock<boost::shared_mutex> lock{mutex_};
+
+    // Check that lists from all configured publishers are available
+    bool allListsAvailable = true;
+
+    for (auto const& list : publisherLists_)
+    {
+        // Remove any expired published lists
+        if (TimeKeeper::time_point{} < list.second.expiration &&
+            list.second.expiration <= timeKeeper_.now())
+            removePublisherList(list.first);
+
+        if (! list.second.available)
+            allListsAvailable = false;
+    }
+
+    std::multimap<std::size_t, PublicKey> rankedKeys;
+    bool localKeyListed = false;
+
+    // "Iterate" the listed keys in random order so that the rank of multiple
+    // keys with the same number of listings is not deterministic
+    std::vector<std::size_t> indexes (keyListings_.size());
+    std::iota (indexes.begin(), indexes.end(), 0);
+    std::shuffle (indexes.begin(), indexes.end(), crypto_prng());
+
+    for (auto const& index : indexes)
+    {
+        auto const& val = std::next (keyListings_.begin(), index);
+
+        if (validatorManifests_.revoked (val->first))
+            continue;
+
+        if (val->first == localPubKey_)
+        {
+            localKeyListed = val->second > 1;
+            rankedKeys.insert (
+                std::pair<std::size_t,PublicKey>(
+                    std::numeric_limits<std::size_t>::max(), localPubKey_));
+        }
+        // If the total number of validators is too small, or
+        // no validations are being received, use all validators.
+        // Otherwise, do not use validators whose validations aren't
+        // being received.
+        else if (
+            keyListings_.size() < MINIMUM_RESIZEABLE_UNL ||
+            seenValidators.empty() ||
+            seenValidators.find(calcNodeID(val->first)) != seenValidators.end())
+        {
+            rankedKeys.insert (
+                std::pair<std::size_t,PublicKey>(val->second, val->first));
+        }
+    }
+
+    // This minimum quorum guarantees safe overlap with the trusted sets of
+    // other nodes using the same set of published lists.
+    std::size_t quorum = calculateMinimumQuorum (keyListings_.size(),
+        localPubKey_.size() && !localKeyListed);
+
+    JLOG (j_.debug()) <<
+        rankedKeys.size() << "  of " << keyListings_.size() <<
+        " listed validators eligible for inclusion in the trusted set";
+
+    auto size = rankedKeys.size();
+
+    // Require 80% quorum if there are lots of validators.
+    if (rankedKeys.size() > BYZANTINE_THRESHOLD)
+    {
+        // Use all eligible keys if there is only one trusted list
+        if (publisherLists_.size() == 1 ||
+                keyListings_.size() < MINIMUM_RESIZEABLE_UNL)
+        {
+            // Try to raise the quorum to at least 80% of the trusted set
+            quorum = std::max(quorum, size - size / 5);
+        }
+        else
+        {
+            // Reduce the trusted set size so that the quorum represents
+            // at least 80%
+            size = quorum * 1.25;
+        }
+    }
+
+    if (minimumQuorum_ && seenValidators.size() < quorum)
+    {
+        quorum = *minimumQuorum_;
+        JLOG (j_.warn())
+            << "Using unsafe quorum of "
+            << quorum_
+            << " as specified in the command line";
+    }
+
+    // Do not use achievable quorum until lists from all configured
+    // publishers are available
+    else if (! allListsAvailable)
+        quorum = std::numeric_limits<std::size_t>::max();
+
+    TrustChanges trustChanges;
+    {
+        hash_set<PublicKey> newTrustedKeys;
+        for (auto const& val : boost::adaptors::reverse(rankedKeys))
+        {
+            if (size <= newTrustedKeys.size())
+                break;
+            newTrustedKeys.insert(val.second);
+
+            if (trustedKeys_.erase(val.second) == 0)
+                trustChanges.added.insert(calcNodeID(val.second));
+        }
+
+        for (auto const& k : trustedKeys_)
+            trustChanges.removed.insert(calcNodeID(k));
+        trustedKeys_ = std::move(newTrustedKeys);
+    }
+
+    quorum_ = quorum;
+
+
+    JLOG(j_.debug()) << "Using quorum of " << quorum_ << " for new set of "
+                     << trustedKeys_.size() << " trusted validators ("
+                     << trustChanges.added.size() << " added, "
+                     << trustChanges.removed.size() << " removed)";
+
+    if (trustedKeys_.size() < quorum_)
+    {
+        JLOG (j_.warn()) <<
+            "New quorum of " << quorum_ <<
+            " exceeds the number of trusted validators (" <<
+            trustedKeys_.size() << ")";
+    }
+
+    return trustChanges;
+}
+
 } // ripple

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -337,6 +337,7 @@ public:
         @param now The network adjusted time
         @param prevLedgerID the ID of the last ledger
         @param prevLedger The last ledger
+        @param nowUntrusted ID of nodes that are newly untrusted this round
         @param proposing Whether we want to send proposals to peers this round.
 
         @note @b prevLedgerID is not required to the ID of @b prevLedger since
@@ -347,6 +348,7 @@ public:
         NetClock::time_point const& now,
         typename Ledger_t::ID const& prevLedgerID,
         Ledger_t prevLedger,
+        hash_set<NodeID_t> const & nowUntrusted,
         bool proposing);
 
     /** A peer has proposed a new position, adjust our tracking.
@@ -552,7 +554,7 @@ private:
     hash_map<NodeID_t, PeerPosition_t> currPeerPositions_;
 
     // Recently received peer positions, available when transitioning between
-    // ledgers or roundss
+    // ledgers or rounds
     hash_map<NodeID_t, std::deque<PeerPosition_t>> recentPeerPositions_;
 
     // The number of proposers who participated in the last consensus round
@@ -583,6 +585,7 @@ Consensus<Adaptor>::startRound(
     NetClock::time_point const& now,
     typename Ledger_t::ID const& prevLedgerID,
     Ledger_t prevLedger,
+    hash_set<NodeID_t> const& nowUntrusted,
     bool proposing)
 {
     if (firstRound_)
@@ -596,6 +599,9 @@ Consensus<Adaptor>::startRound(
     {
         prevCloseTime_ = rawCloseTimes_.self;
     }
+
+    for(NodeID_t const& n : nowUntrusted)
+        recentPeerPositions_.erase(n);
 
     ConsensusMode startMode =
         proposing ? ConsensusMode::proposing : ConsensusMode::observing;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -899,8 +899,12 @@ OverlayImpl::send (protocol::TMValidation& m)
     });
 
     SerialIter sit (m.validation().data(), m.validation().size());
-    auto val = std::make_shared <
-        STValidation> (std::ref (sit), false);
+    auto val = std::make_shared<STValidation>(
+        std::ref(sit),
+        [this](PublicKey const& pk) {
+            return calcNodeID(app_.validatorManifests().getMasterKey(pk));
+        },
+        false);
     app_.getOPs().pubValidation (val);
 }
 

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -26,35 +26,19 @@
 
 namespace ripple {
 
-STValidation::STValidation (SerialIter& sit, bool checkSignature)
-    : STObject (getFormat (), sit, sfValidation)
-{
-    mNodeID = calcNodeID(
-        PublicKey(makeSlice (getFieldVL (sfSigningPubKey))));
-    assert (mNodeID.isNonZero ());
-
-    if  (checkSignature && !isValid ())
-    {
-        JLOG (debugLog().error())
-            << "Invalid validation" << getJson (0);
-        Throw<std::runtime_error> ("Invalid validation");
-    }
-}
-
-STValidation::STValidation (
-        uint256 const& ledgerHash,
-        NetClock::time_point signTime,
-        PublicKey const& publicKey,
-        bool isFull)
-    : STObject (getFormat (), sfValidation)
-    , mSeen (signTime)
+STValidation::STValidation(
+    uint256 const& ledgerHash,
+    NetClock::time_point signTime,
+    PublicKey const& publicKey,
+    NodeID const& nodeID,
+    bool isFull)
+    : STObject(getFormat(), sfValidation), mNodeID(nodeID), mSeen(signTime)
 {
     // Does not sign
     setFieldH256 (sfLedgerHash, ledgerHash);
     setFieldU32 (sfSigningTime, signTime.time_since_epoch().count());
 
     setFieldVL (sfSigningPubKey, publicKey.slice());
-    mNodeID = calcNodeID(publicKey);
     assert (mNodeID.isNonZero ());
 
     if (isFull)

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -379,7 +379,7 @@ public:
         for (auto const& val : validators)
         {
             auto v = std::make_shared <STValidation> (
-                uint256(), roundTime, val, true);
+                uint256(), roundTime, val, calcNodeID(val), true);
 
             ++i;
             STVector256 field (sfAmendments);

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -31,14 +31,37 @@ namespace test {
 class RCLValidations_test : public beast::unit_test::suite
 {
 
-public:
     void
-    run() override
+    testChangeTrusted()
     {
+        testcase("Change validation trusted status");
+        PublicKey key = derivePublicKey(KeyType::ed25519, randomSecretKey());
+        auto v = std::make_shared<STValidation>(
+            uint256(), NetClock::time_point(), key, calcNodeID(key), true);
+
+        BEAST_EXPECT(!v->isTrusted());
+        v->setTrusted();
+        BEAST_EXPECT(v->isTrusted());
+        v->setUntrusted();
+        BEAST_EXPECT(!v->isTrusted());
+
+        RCLValidation rcv{v};
+        BEAST_EXPECT(!rcv.trusted());
+        rcv.setTrusted();
+        BEAST_EXPECT(rcv.trusted());
+        rcv.setUntrusted();
+        BEAST_EXPECT(!rcv.trusted());
+    }
+
+    void
+    testRCLValidatedLedger()
+    {
+        testcase("RCLValidatedLedger ancestry");
         beast::Journal j;
 
         using Seq = RCLValidatedLedger::Seq;
         using ID = RCLValidatedLedger::ID;
+
 
         // This tests RCLValidatedLedger properly implements the type
         // requirements of a LedgerTrie ledger, with its added behavior that
@@ -193,8 +216,14 @@ public:
                 }
             }
         }
+    }
 
-
+public:
+    void
+    run() override
+    {
+        testChangeTrusted();
+        testRCLValidatedLedger();
     }
 };
 

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -169,7 +169,7 @@ class Validations_test : public beast::unit_test::suite
     struct StaleData
     {
         std::vector<Validation> stale;
-        hash_map<PeerKey, Validation> flushed;
+        hash_map<PeerID, Validation> flushed;
     };
 
     // Generic Validations adaptor that saves stale/flushed data into
@@ -216,7 +216,7 @@ class Validations_test : public beast::unit_test::suite
         }
 
         void
-        flush(hash_map<PeerKey, Validation>&& remaining)
+        flush(hash_map<PeerID, Validation>&& remaining)
         {
             staleData_.flushed = std::move(remaining);
         }
@@ -250,8 +250,7 @@ class Validations_test : public beast::unit_test::suite
         ValStatus
         add(Validation const& v)
         {
-            PeerKey masterKey{v.nodeID(), 0};
-            return tv_.add(masterKey, v);
+            return tv_.add(v.nodeID(), v);
         }
 
         TestValidations&
@@ -284,7 +283,7 @@ class Validations_test : public beast::unit_test::suite
             return staleData_.stale;
         }
 
-        hash_map<PeerKey, Validation> const&
+        hash_map<PeerID, Validation> const&
         flushed() const
         {
             return staleData_.flushed;
@@ -462,7 +461,7 @@ class Validations_test : public beast::unit_test::suite
 
         std::vector<Trigger> triggers = {
             [&](TestValidations& vals) { vals.currentTrusted(); },
-            [&](TestValidations& vals) { vals.getCurrentPublicKeys(); },
+            [&](TestValidations& vals) { vals.getCurrentNodeIDs(); },
             [&](TestValidations& vals) { vals.getPreferred(genesisLedger); },
             [&](TestValidations& vals) {
                 vals.getNodesAfter(ledgerA, ledgerA.id());
@@ -610,9 +609,9 @@ class Validations_test : public beast::unit_test::suite
                 ValStatus::current == harness.add(node.validate(ledgerA)));
 
         {
-            hash_set<PeerKey> const expectedKeys = {a.masterKey(),
-                                                    b.masterKey()};
-            BEAST_EXPECT(harness.vals().getCurrentPublicKeys() == expectedKeys);
+            hash_set<PeerID> const expectedKeys = {a.nodeID(),
+                                                    b.nodeID()};
+            BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
         }
 
         harness.clock().advance(3s);
@@ -626,14 +625,14 @@ class Validations_test : public beast::unit_test::suite
                 ValStatus::current == harness.add(node.partial(ledgerAC)));
 
         {
-            hash_set<PeerKey> const expectedKeys = {a.masterKey(),
-                                                    b.masterKey()};
-            BEAST_EXPECT(harness.vals().getCurrentPublicKeys() == expectedKeys);
+            hash_set<PeerID> const expectedKeys = {a.nodeID(),
+                                                    b.nodeID()};
+            BEAST_EXPECT(harness.vals().getCurrentNodeIDs() == expectedKeys);
         }
 
         // Pass enough time for them to go stale
         harness.clock().advance(harness.parms().validationCURRENT_LOCAL);
-        BEAST_EXPECT(harness.vals().getCurrentPublicKeys().empty());
+        BEAST_EXPECT(harness.vals().getCurrentNodeIDs().empty());
     }
 
     void
@@ -719,7 +718,7 @@ class Validations_test : public beast::unit_test::suite
             if (val.trusted())
                 trustedValidations[val.ledgerID()].emplace_back(val);
         }
-        // d diagrees
+        // d disagrees
         {
             auto const val = d.validate(ledgerB);
             BEAST_EXPECT(ValStatus::current == harness.add(val));
@@ -786,21 +785,21 @@ class Validations_test : public beast::unit_test::suite
         Ledger ledgerA = h["a"];
         Ledger ledgerAB = h["ab"];
 
-        hash_map<PeerKey, Validation> expected;
+        hash_map<PeerID, Validation> expected;
         for (auto const& node : {a, b, c})
         {
             auto const val = node.validate(ledgerA);
             BEAST_EXPECT(ValStatus::current == harness.add(val));
-            expected.emplace(node.masterKey(), val);
+            expected.emplace(node.nodeID(), val);
         }
-        Validation staleA = expected.find(a.masterKey())->second;
+        Validation staleA = expected.find(a.nodeID())->second;
 
         // Send in a new validation for a, saving the new one into the expected
         // map after setting the proper prior ledger ID it replaced
         harness.clock().advance(1s);
         auto newVal = a.validate(ledgerAB);
         BEAST_EXPECT(ValStatus::current == harness.add(newVal));
-        expected.find(a.masterKey())->second = newVal;
+        expected.find(a.nodeID())->second = newVal;
 
         // Now flush
         harness.vals().flush();
@@ -1057,6 +1056,97 @@ class Validations_test : public beast::unit_test::suite
     }
 
     void
+    testTrustChanged()
+    {
+        testcase("TrustChanged");
+        using namespace std::chrono;
+
+        auto checker = [this](
+                           TestValidations& vals,
+                           hash_set<PeerID> const& listed,
+                           std::vector<Validation> const& trustedVals) {
+            Ledger::ID testID = trustedVals.empty() ? this->genesisLedger.id()
+                                                    : trustedVals[0].ledgerID();
+            BEAST_EXPECT(vals.currentTrusted() == trustedVals);
+            BEAST_EXPECT(vals.getCurrentNodeIDs() == listed);
+            BEAST_EXPECT(
+                vals.getNodesAfter(this->genesisLedger, genesisLedger.id()) ==
+                trustedVals.size());
+            BEAST_EXPECT(
+                vals.getPreferred(this->genesisLedger).second == testID);
+            BEAST_EXPECT(vals.getTrustedForLedger(testID) == trustedVals);
+            BEAST_EXPECT(
+                vals.numTrustedForLedger(testID) == trustedVals.size());
+        };
+
+        {
+            // Trusted to untrusted
+            LedgerHistoryHelper h;
+            TestHarness harness(h.oracle);
+            Node a = harness.makeNode();
+            Ledger ledgerAB = h["ab"];
+            Validation v = a.validate(ledgerAB);
+            BEAST_EXPECT(ValStatus::current == harness.add(v));
+
+            hash_set<PeerID> listed({a.nodeID()});
+            std::vector<Validation> trustedVals({v});
+            checker(harness.vals(), listed, trustedVals);
+
+            trustedVals.clear();
+            harness.vals().trustChanged({}, {a.nodeID()});
+            checker(harness.vals(), listed, trustedVals);
+        }
+
+        {
+            // Untrusted to trusted
+            LedgerHistoryHelper h;
+            TestHarness harness(h.oracle);
+            Node a = harness.makeNode();
+            a.untrust();
+            Ledger ledgerAB = h["ab"];
+            Validation v = a.validate(ledgerAB);
+            BEAST_EXPECT(ValStatus::current == harness.add(v));
+
+            hash_set<PeerID> listed({a.nodeID()});
+            std::vector<Validation> trustedVals;
+            checker(harness.vals(), listed, trustedVals);
+
+            trustedVals.push_back(v);
+            harness.vals().trustChanged({a.nodeID()}, {});
+            checker(harness.vals(), listed, trustedVals);
+        }
+
+        {
+            // Trusted but not acquired -> untrusted
+            LedgerHistoryHelper h;
+            TestHarness harness(h.oracle);
+            Node a = harness.makeNode();
+            Validation v =
+                a.validate(Ledger::ID{2}, Ledger::Seq{2}, 0s, 0s, true);
+            BEAST_EXPECT(ValStatus::current == harness.add(v));
+
+            hash_set<PeerID> listed({a.nodeID()});
+            std::vector<Validation> trustedVals({v});
+            auto& vals = harness.vals();
+            BEAST_EXPECT(vals.currentTrusted() == trustedVals);
+            BEAST_EXPECT(
+                vals.getPreferred(genesisLedger).second == v.ledgerID());
+            BEAST_EXPECT(
+                vals.getNodesAfter(genesisLedger, genesisLedger.id()) == 0);
+
+            trustedVals.clear();
+            harness.vals().trustChanged({}, {a.nodeID()});
+            // make acquiring ledger available
+            h["ab"];
+            BEAST_EXPECT(vals.currentTrusted() == trustedVals);
+            BEAST_EXPECT(
+                vals.getPreferred(genesisLedger).second == genesisLedger.id());
+            BEAST_EXPECT(
+                vals.getNodesAfter(genesisLedger, genesisLedger.id()) == 0);
+        }
+    }
+
+    void
     run() override
     {
         testAddValidation();
@@ -1072,6 +1162,7 @@ class Validations_test : public beast::unit_test::suite
         testAcquireValidatedLedger();
         testNumTrustedForLedger();
         testSeqEnforcer();
+        testTrustChanged();
     }
 };
 

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -149,7 +149,7 @@ struct Peer
         }
 
         void
-        flush(hash_map<PeerKey, Validation>&& remaining)
+        flush(hash_map<PeerID, Validation>&& remaining)
         {
         }
 
@@ -681,9 +681,9 @@ struct Peer
     {
         v.setTrusted();
         v.setSeen(now());
-        ValStatus const res = validations.add(v.key(), v);
+        ValStatus const res = validations.add(v.nodeID(), v);
 
-        if(res == ValStatus::stale || res == ValStatus::repeatID)
+        if(res == ValStatus::stale)
             return false;
 
         // Acquire will try to get from network if not already local
@@ -875,8 +875,10 @@ struct Peer
 
         issue(StartRound{bestLCL, lastClosedLedger});
 
+        // Not yet modeling dynamic UNL.
+        hash_set<PeerID> nowUntrusted;
         consensus.startRound(
-            now(), bestLCL, lastClosedLedger, runAsValidator);
+            now(), bestLCL, lastClosedLedger, nowUntrusted, runAsValidator);
     }
 
     // Start the consensus process assuming it is not yet running
@@ -895,7 +897,7 @@ struct Peer
     {
         // We don't care about the actual epochs, but do want the
         // generated NetClock time to be well past its epoch to ensure
-        // any subtractions of two NetClock::time_point in the consensu
+        // any subtractions of two NetClock::time_point in the consensus
         // code are positive. (e.g. proposeFRESHNESS)
         using namespace std::chrono;
         using namespace std::chrono_literals;

--- a/src/test/csf/Validation.h
+++ b/src/test/csf/Validation.h
@@ -174,6 +174,12 @@ public:
     }
 
     void
+    setUntrusted()
+    {
+        trusted_ = false;
+    }
+
+    void
     setSeen(NetClock::time_point seen)
     {
         seenTime_ = seen;

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -308,11 +308,11 @@ public:
 
             env.app().validatorSites().start();
             env.app().validatorSites().join();
-            std::set<PublicKey> startKeys;
+            hash_set<NodeID> startKeys;
             for (auto const& val : validators)
-                startKeys.insert(val.masterPublic);
+                startKeys.insert(calcNodeID(val.masterPublic));
 
-            env.app().validators().onConsensusStart(startKeys);
+            env.app().validators().updateTrusted(startKeys);
 
             {
                 auto const jrr = env.rpc("server_info")[jss::result];


### PR DESCRIPTION
When validators are removed or added via dynamic UNL change, these changes ensure a node updates the trust status of any existing validations.

The first set of changes switch to use `NodeID` to consistently refer to the sender of consensus proposals and validations even when using manifests.