### PR TITLE
Include 2 missing headers

### DIFF
--- a/src/ripple/beast/core/WaitableEvent.cpp
+++ b/src/ripple/beast/core/WaitableEvent.cpp
@@ -21,6 +21,9 @@
 */
 //==============================================================================
 
+#include <errno.h>
+#include <sys/time.h>
+
 #include <ripple/beast/core/WaitableEvent.h>
 
 #if BEAST_WINDOWS


### PR DESCRIPTION
<errno.h> for ETIMEDOUT
<sys/time.h> for gettimeofday()

fixes #2402 