### PR TITLE
Strip down Travis CI support toward future deprecation:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,19 @@ language: cpp
 
 env:
   global:
-    - LLVM_VERSION=3.8.0
     # Maintenance note: to move to a new version
     # of boost, update both BOOST_ROOT and BOOST_URL.
     # Note that for simplicity, BOOST_ROOT's final
     # namepart must match the folder name internal
     # to boost's .tar.gz.
-    - LCOV_ROOT=$HOME/lcov
-    - GDB_ROOT=$HOME/gdb
-    - BOOST_ROOT=$HOME/boost_1_60_0
-    - BOOST_URL='http://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.tar.gz'
-
-# Travis is timing out on Trusty.  So, for now, use Precise.  July 2017
-dist: precise
+    - BOOST_ROOT=$HOME/boost_1_65_1
+    - BOOST_URL='https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz'
 
 addons:
   apt:
-    sources: ['ubuntu-toolchain-r-test']
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-5.0
     packages:
       - gcc-5
       - g++-5
@@ -29,43 +25,41 @@ addons:
       - libssl-dev
       - libstdc++6
       - binutils-gold
-      # Provides a backtrace if the unittests crash
-      - gdb
-      # needed to build gdb
-      - texinfo
+      - cmake
+      - lcov
+      - llvm-5.0
+      - clang-5.0
 
 matrix:
   include:
     # Default BUILD is "scons".
 
+    - compiler: gcc
+      env: GCC_VER=5 BUILD=cmake TARGET=debug
+      # - APP_ARGS="--unittest-jobs=2"
+
     # - compiler: gcc
     #   env: GCC_VER=5 TARGET=debug.nounity
 
-    - compiler: gcc
-      env: GCC_VER=5 BUILD=cmake TARGET=coverage PATH=$PWD/cmake/bin:$PATH
+    # - compiler: gcc
+    #   env: GCC_VER=5 BUILD=cmake TARGET=coverage PATH=$PWD/cmake/bin:$PATH
 
     - compiler: clang
-      env: GCC_VER=5 BUILD=cmake TARGET=debug CLANG_VER=3.8 PATH=$PWD/llvm-$LLVM_VERSION/bin:$PWD/cmake/bin:$PATH
-      cache:
-        directories:
-          - $GDB_ROOT
+      env: GCC_VER=5 BUILD=cmake TARGET=debug
 
-    - compiler: clang
-      env: GCC_VER=5 TARGET=debug.nounity CLANG_VER=3.8 PATH=$PWD/llvm-$LLVM_VERSION/bin:$PATH
+    # - compiler: clang
+    #   env: GCC_VER=5 TARGET=debug.nounity
 
     # The clang cmake builds do not link.
     # - compiler: clang
-    #   env: GCC_VER=5 BUILD=cmake TARGET=debug CLANG_VER=3.8 PATH=$PWD/llvm-$LLVM_VERSION/bin:$PWD/cmake/bin:$PATH
+    #   env: GCC_VER=5 BUILD=cmake TARGET=debug
 
     # - compiler: clang
-    #   env: GCC_VER=5 BUILD=cmake TARGET=debug.nounity CLANG_VER=3.8 PATH=$PWD/llvm-$LLVM_VERSION/bin:$PWD/cmake/bin:$PATH
+    #   env: GCC_VER=5 BUILD=cmake TARGET=debug.nounity
 
 cache:
   directories:
   - $BOOST_ROOT
-  - llvm-$LLVM_VERSION
-  - cmake
-  - $GDB_ROOT
 
 before_install:
   - bin/ci/ubuntu/install-dependencies.sh
@@ -80,4 +74,3 @@ notifications:
     channels:
       - "chat.freenode.net#ripple-dev"
 
-dist: precise

--- a/bin/ci/ubuntu/install-dependencies.sh
+++ b/bin/ci/ubuntu/install-dependencies.sh
@@ -15,42 +15,11 @@ do
   ln -sv $(type -p ${g}-$GCC_VER) $HOME/bin/${g}
 done
 
-if [[ -n ${CLANG_VER:-} ]]; then
-    # There are cases where the directory exists, but the exe is not available.
-    # Use this workaround for now.
-    if [[ ! -x ${TWD}/llvm-${LLVM_VERSION}/bin/llvm-config && -d ${TWD}/llvm-${LLVM_VERSION} ]]; then
-        rm -fr ${TWD}/llvm-${LLVM_VERSION}
-    fi
-    if [[ ! -d ${TWD}/llvm-${LLVM_VERSION} ]]; then
-        mkdir ${TWD}/llvm-${LLVM_VERSION}
-        LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz"
-        wget -O - ${LLVM_URL} | tar -Jxvf - --strip 1 -C ${TWD}/llvm-${LLVM_VERSION}
-    fi
-    ${TWD}/llvm-${LLVM_VERSION}/bin/llvm-config --version;
-    export LLVM_CONFIG="${TWD}/llvm-${LLVM_VERSION}/bin/llvm-config";
-fi
-
-if [[ ${BUILD:-} == cmake ]]; then
-    # There are cases where the directory exists, but the exe is not available.
-    # Use this workaround for now.
-    if [[ ! -x ${TWD}/cmake/bin/cmake && -d ${TWD}/cmake ]]; then
-        rm -fr ${TWD}/cmake
-    fi
-    if [[ ! -d ${TWD}/cmake ]]; then
-      CMAKE_URL="https://www.cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz"
-      wget --version
-      # wget version 1.13.4 thinks this certificate is invalid, even though it's fine.
-      # "ERROR: no certificate subject alternative name matches"
-      # See also: https://github.com/travis-ci/travis-ci/issues/5059
-      mkdir ${TWD}/cmake &&
-        wget -O - --no-check-certificate ${CMAKE_URL} | tar --strip-components=1 -xz -C ${TWD}/cmake
-      cmake --version
-    fi
-fi
-
 # What versions are we ACTUALLY running?
 if [ -x $HOME/bin/g++ ]; then
     $HOME/bin/g++ -v
+else
+    g++ -v
 fi
 
 pip install --user requests==2.13.0
@@ -58,24 +27,3 @@ pip install --user https://github.com/codecov/codecov-python/archive/master.zip
 
 bash bin/sh/install-boost.sh
 
-# Install lcov
-# Download the archive
-wget https://github.com/linux-test-project/lcov/releases/download/v1.12/lcov-1.12.tar.gz
-# Extract to ~/lcov-1.12
-tar xfvz lcov-1.12.tar.gz -C $HOME
-# Set install path
-mkdir -p $LCOV_ROOT
-cd $HOME/lcov-1.12 && make install PREFIX=$LCOV_ROOT
-
-if [[ ${TARGET} == debug* && ! -x ${GDB_ROOT}/bin/gdb ]]; then
-    pushd $HOME
-    #install gdb
-    wget https://ftp.gnu.org/gnu/gdb/gdb-8.0.tar.xz
-    tar xf gdb-8.0.tar.xz
-    pushd gdb-8.0
-    ./configure CFLAGS='-w -O2' CXXFLAGS='-std=gnu++11 -g -O2 -w' --prefix=$GDB_ROOT
-    make -j2
-    make install
-    popd
-    popd
-fi

--- a/bin/sh/install-boost.sh
+++ b/bin/sh/install-boost.sh
@@ -8,6 +8,14 @@
 # https://travis-ci.org/ripple/rippled/caches
 set -e
 
+if [ -x /usr/bin/time ] ; then
+  : ${TIME:="Duration: %E"}
+  export TIME
+  time=/usr/bin/time
+else
+  time=
+fi
+
 if [ ! -d "$BOOST_ROOT/lib" ]
 then
   wget $BOOST_URL -O /tmp/boost.tar.gz
@@ -15,9 +23,9 @@ then
   rm -fr ${BOOST_ROOT}
   tar xzf /tmp/boost.tar.gz
   cd $BOOST_ROOT && \
-    ./bootstrap.sh --prefix=$BOOST_ROOT && \
-    ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 -j$((2*${NUM_PROCESSORS:-2})) &&\
-    ./b2 -d0 define=_GLIBCXX_USE_CXX11_ABI=0 install
+    $time ./bootstrap.sh --prefix=$BOOST_ROOT && \
+    $time ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 -j$((2*${NUM_PROCESSORS:-2})) &&\
+    $time ./b2 -d0 define=_GLIBCXX_USE_CXX11_ABI=0 install
 else
   echo "Using cached boost at $BOOST_ROOT"
 fi


### PR DESCRIPTION
* Remove all builds except cmake gcc debug.
* Time some dependency and build operations.
* Use Travis's "trusty" infrastructure.
* Install more dependencies via apt.
* Update boost version to 1.65.1.
* Do not run unit tests under gdb - several security features prevent
  it from running correctly.
* Run test job with two processes.


NOTE: Do not pass or merge this PR until it passes all CI builds - specifically Jenkins.