### PR TITLE
Use lock when initializing peer shard RangeSet

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1381,9 +1381,10 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMStatusChange> const& m)
 
     if (m->has_shardseqs())
     {
-        shards_.clear();
         std::vector<std::string> tokens;
         boost::split(tokens, m->shardseqs(), boost::algorithm::is_any_of(","));
+        std::lock_guard<std::mutex> sl(recentLock_);
+        shards_.clear();
         for (auto const& t : tokens)
         {
             std::vector<std::string> seqs;


### PR DESCRIPTION
Not locking when initializing a Peer shard RangeSet could lead to addressing bad memory by other threads. This pull request fixes the issue by properly locking the resource.