### PR TITLE
Remove unused variables

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -80,7 +80,6 @@ class Ledger::sles_iter_impl
     : public sles_type::iter_base
 {
 private:
-    ReadView const* view_;
     SHAMap::const_iterator iter_;
 
 public:
@@ -89,10 +88,8 @@ public:
 
     sles_iter_impl (sles_iter_impl const&) = default;
 
-    sles_iter_impl (SHAMap::const_iterator iter,
-            ReadView const& view)
-        : view_ (&view)
-        , iter_ (iter)
+    sles_iter_impl (SHAMap::const_iterator iter)
+        : iter_ (iter)
     {
     }
 
@@ -134,7 +131,6 @@ class Ledger::txs_iter_impl
 {
 private:
     bool metadata_;
-    ReadView const* view_;
     SHAMap::const_iterator iter_;
 
 public:
@@ -143,12 +139,9 @@ public:
 
     txs_iter_impl (txs_iter_impl const&) = default;
 
-    txs_iter_impl (bool metadata,
-        SHAMap::const_iterator iter,
-            ReadView const& view)
-        : metadata_ (metadata)
-        , view_ (&view)
-        , iter_ (iter)
+    txs_iter_impl(bool metadata,
+        SHAMap::const_iterator iter)
+        : metadata_(metadata), iter_(iter)
     {
     }
 
@@ -458,43 +451,35 @@ auto
 Ledger::slesBegin() const ->
     std::unique_ptr<sles_type::iter_base>
 {
-    return std::make_unique<
-        sles_iter_impl>(
-            stateMap_->begin(), *this);
+    return std::make_unique<sles_iter_impl>(stateMap_->begin());
 }
 
 auto
 Ledger::slesEnd() const ->
     std::unique_ptr<sles_type::iter_base>
 {
-    return std::make_unique<
-        sles_iter_impl>(
-            stateMap_->end(), *this);
+    return std::make_unique<sles_iter_impl>(stateMap_->end());
 }
 
 auto
 Ledger::slesUpperBound(uint256 const& key) const ->
     std::unique_ptr<sles_type::iter_base>
 {
-    return std::make_unique<
-        sles_iter_impl>(
-            stateMap_->upper_bound(key), *this);
+    return std::make_unique<sles_iter_impl>(stateMap_->upper_bound(key));
 }
 
 auto
 Ledger::txsBegin() const ->
     std::unique_ptr<txs_type::iter_base>
 {
-    return std::make_unique<txs_iter_impl>(
-        !open(), txMap_->begin(), *this);
+    return std::make_unique<txs_iter_impl>(!open(), txMap_->begin());
 }
 
 auto
 Ledger::txsEnd() const ->
     std::unique_ptr<txs_type::iter_base>
 {
-    return std::make_unique<txs_iter_impl>(
-        !open(), txMap_->end(), *this);
+    return std::make_unique<txs_iter_impl>(!open(), txMap_->end());
 }
 
 bool

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -253,6 +253,8 @@ public:
     {
     }
 
+    virtual ~Env() = default;
+
     Application&
     app()
     {

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -130,9 +130,6 @@ public:
         std::vector< Blob > gotNodes;
         std::vector<uint256> hashes;
 
-        std::vector<SHAMapNodeID>::iterator nodeIDIterator;
-        std::vector< Blob >::iterator rawNodeIterator;
-
         destination.setSynching ();
 
         {


### PR DESCRIPTION
This commit resolves some warnings flagged by clang 6:

* Unused variables/member vars
* delete called on non-final class that has virtual functions