### PR TITLE
Fix boost::error_code conversions to int:

### DIFF
--- a/src/ripple/basics/impl/ResolverAsio.cpp
+++ b/src/ripple/basics/impl/ResolverAsio.cpp
@@ -242,7 +242,7 @@ public:
 
         // If we get an error message back, we don't return any
         // results that we may have gotten.
-        if (ec == 0)
+        if (!ec)
         {
             while (iter != boost::asio::ip::tcp::resolver::iterator())
             {

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -640,7 +640,7 @@ class ServerStatus_test :
             ++readCount;
             // expect the reads to fail for the clients that connected at or
             // above the limit. If limit is 0, all reads should succeed
-            BEAST_EXPECT((limit == 0 || readCount < limit-1) ? (! ec) : ec);
+            BEAST_EXPECT((limit == 0 || readCount < limit-1) ? (! ec) : bool(ec));
         }
     }
 


### PR DESCRIPTION
* Boost 1.67 removes boost::error_code automatic conversions to int