### PR TITLE
Update dependencies in Dockerfile

### DIFF
--- a/Builds/Docker/Dockerfile
+++ b/Builds/Docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update
 RUN apt-get -y upgrade
 
 # install the dependencies
-RUN apt-get -y install git scons pkg-config protobuf-compiler libprotobuf-dev libssl-dev libboost1.55-all-dev
+RUN apt-get -y install git scons pkg-config protobuf-compiler libprotobuf-dev libssl-dev libboost-all-dev
 
 # download source code from official repository
 RUN git clone https://github.com/ripple/rippled.git src; cd src/; git checkout master


### PR DESCRIPTION
Dockerfile is throwing below error while downloading dependency libboost1.55-all-dev.

E: Unable to locate package libboost1.55-all-dev
E: Couldn't find any package by glob 'libboost1.55-all-dev'
E: Couldn't find any package by regex 'libboost1.55-all-dev'