### PR TITLE
Remove UB from <ctype.h> calls:

### DIFF
--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -24,6 +24,7 @@
 #include <ripple/basics/Blob.h>
 #include <ripple/basics/strHex.h>
 #include <boost/format.hpp>
+#include <boost/optional.hpp>
 #include <sstream>
 #include <string>
 
@@ -94,6 +95,8 @@ struct parsedURL
 bool parseUrl (parsedURL& pUrl, std::string const& strUrl);
 
 std::string trim_whitespace (std::string str);
+
+boost::optional<std::uint64_t> to_uint64(std::string const& s);
 
 } // ripple
 

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -354,20 +354,19 @@ public:
     */
     bool SetHex (const char* psz, bool bStrict = false)
     {
+        // Find beginning.
+        auto pBegin = reinterpret_cast<const unsigned char*>(psz);
         // skip leading spaces
         if (!bStrict)
-            while (isspace (static_cast<unsigned char>(*psz)))
-                psz++;
+            while (isspace(*pBegin))
+                pBegin++;
 
         // skip 0x
-        if (!bStrict && psz[0] == '0' &&
-                tolower(static_cast<unsigned char>(psz[1])) == 'x')
-            psz += 2;
-
-        const unsigned char* pEnd   = reinterpret_cast<const unsigned char*> (psz);
-        const unsigned char* pBegin = pEnd;
+        if (!bStrict && pBegin[0] == '0' && tolower(pBegin[1]) == 'x')
+            pBegin += 2;
 
         // Find end.
+        auto pEnd = pBegin;
         while (charUnHex(*pEnd) != -1)
             pEnd++;
 

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -356,11 +356,12 @@ public:
     {
         // skip leading spaces
         if (!bStrict)
-            while (isspace (*psz))
+            while (isspace (static_cast<unsigned char>(*psz)))
                 psz++;
 
         // skip 0x
-        if (!bStrict && psz[0] == '0' && tolower (psz[1]) == 'x')
+        if (!bStrict && psz[0] == '0' &&
+                tolower(static_cast<unsigned char>(psz[1])) == 'x')
             psz += 2;
 
         const unsigned char* pEnd   = reinterpret_cast<const unsigned char*> (psz);

--- a/src/ripple/basics/impl/ResolverAsio.cpp
+++ b/src/ripple/basics/impl/ResolverAsio.cpp
@@ -279,7 +279,7 @@ public:
         // Attempt to find the first and last valid port separators
         auto const find_port_separator = [](char const c) -> bool
         {
-            if (std::isspace (c))
+            if (std::isspace (static_cast<unsigned char>(c)))
                 return true;
 
             if (c == ':')

--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -123,4 +123,13 @@ std::string trim_whitespace (std::string str)
     return str;
 }
 
+boost::optional<std::uint64_t>
+to_uint64(std::string const& s)
+{
+    std::uint64_t result;
+    if (beast::lexicalCastChecked (result, s))
+        return result;
+    return boost::none;
+}
+
 } // ripple

--- a/src/ripple/beast/core/LexicalCast.h
+++ b/src/ripple/beast/core/LexicalCast.h
@@ -184,7 +184,11 @@ struct LexicalCast <Out, std::string>
     operator () (bool& out, std::string in) const
     {
         // Convert the input to lowercase
-        std::transform(in.begin (), in.end (), in.begin (), ::tolower);
+        std::transform(in.begin (), in.end (), in.begin (),
+                       [](auto c)
+                       {
+                           return ::tolower(static_cast<unsigned char>(c));
+                       });
 
         if (in == "1" || in == "true")
         {

--- a/src/ripple/beast/core/osx_ObjCHelpers.h
+++ b/src/ripple/beast/core/osx_ObjCHelpers.h
@@ -42,7 +42,7 @@ namespace
         // in the range [0-127] is the identity. We are more
         // strict and require only printable characters.
         for (auto const& c : s)
-            assert (isprint(c));
+            assert (isprint(static_cast<unsigned char>(c)));
 #endif
 
         return [NSString stringWithUTF8String: s.c_str()];

--- a/src/ripple/beast/net/detail/Parse.h
+++ b/src/ripple/beast/net/detail/Parse.h
@@ -49,7 +49,7 @@ template <typename InputStream>
 bool expect_whitespace (InputStream& is)
 {
     char c;
-    if (is.get(c) && isspace(c))
+    if (is.get(c) && isspace(static_cast<unsigned char>(c)))
         return true;
     is.unget();
     is.setstate (std::ios_base::failbit);

--- a/src/ripple/beast/net/impl/IPEndpoint.cpp
+++ b/src/ripple/beast/net/impl/IPEndpoint.cpp
@@ -86,7 +86,7 @@ Endpoint Endpoint::from_string_altform (std::string const& s)
             {
                 char c;
                 is.get(c);
-                if (!isspace (c))
+                if (!isspace (static_cast<unsigned char>(c)))
                 {
                     is.unget();
                     break;

--- a/src/ripple/beast/rfc2616.h
+++ b/src/ripple/beast/rfc2616.h
@@ -49,7 +49,8 @@ struct ci_equal_pred
     bool operator()(char c1, char c2)
     {
         // VFALCO TODO Use a table lookup here
-        return std::tolower(c1) == std::tolower(c2);
+        return std::tolower(static_cast<unsigned char>(c1)) ==
+               std::tolower(static_cast<unsigned char>(c2));
     }
 };
 

--- a/src/ripple/crypto/impl/RFC1751.cpp
+++ b/src/ripple/crypto/impl/RFC1751.cpp
@@ -347,8 +347,8 @@ void RFC1751::standard (std::string& strWord)
 {
     for (auto& letter : strWord)
     {
-        if (islower (letter))
-            letter = toupper (letter);
+        if (islower (static_cast<unsigned char>(letter)))
+            letter = toupper (static_cast<unsigned char>(letter));
         else if (letter == '1')
             letter = 'L';
         else if (letter == '0')

--- a/src/ripple/json/impl/json_reader.cpp
+++ b/src/ripple/json/impl/json_reader.cpp
@@ -392,7 +392,7 @@ Reader::readNumber ()
 
         while ( current_ != end_ )
         {
-            if (!std::isdigit (*current_))
+            if (!std::isdigit (static_cast<unsigned char>(*current_)))
             {
                 auto ret = std::find (std::begin (extended_tokens),
                     std::end (extended_tokens), *current_);

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -84,33 +84,6 @@ std::string createHTTPPost (
     return s.str ();
 }
 
-static
-boost::optional<std::uint64_t>
-to_uint64(std::string const& s)
-{
-    if (s.empty())
-        return boost::none;
-
-    for (auto c : s)
-    {
-        if (!isdigit(static_cast<unsigned char>(c)))
-            return boost::none;
-    }
-
-    try
-    {
-        std::size_t pos{};
-        auto const drops = std::stoul(s, &pos);
-        if (s.size() != pos)
-            return boost::none;
-        return drops;
-    }
-    catch (std::exception const&)
-    {
-        return boost::none;
-    }
-}
-
 class RPCParser
 {
 private:

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -93,7 +93,7 @@ to_uint64(std::string const& s)
 
     for (auto c : s)
     {
-        if (!isdigit(c))
+        if (!isdigit(static_cast<unsigned char>(c)))
             return boost::none;
     }
 

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -90,7 +90,11 @@ DatabaseShardImp::init()
         if (!is_directory(d))
             continue;
         auto dirName = d.path().stem().string();
-        if (!std::all_of(dirName.begin(), dirName.end(), ::isdigit))
+        if (!std::all_of(dirName.begin(), dirName.end(),
+                         [](auto c)
+                         {
+                             return ::isdigit(static_cast<unsigned char>(c));
+                         }))
             continue;
         auto const shardIndex {std::stoul(dirName)};
         if (shardIndex < genesisShardIndex)

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -78,7 +78,11 @@ bool to_currency(Currency& currency, std::string const& code)
     {
         Blob codeBlob (CURRENCY_CODE_LENGTH);
 
-        std::transform (code.begin (), code.end (), codeBlob.begin (), ::toupper);
+        std::transform (code.begin (), code.end (), codeBlob.begin (),
+                        [](auto c)
+                        {
+                            return ::toupper(static_cast<unsigned char>(c));
+                        });
 
         Serializer  s;
 

--- a/src/ripple/rpc/handlers/PayChanClaim.cpp
+++ b/src/ripple/rpc/handlers/PayChanClaim.cpp
@@ -35,33 +35,6 @@
 
 namespace ripple {
 
-static
-boost::optional<std::uint64_t>
-to_uint64(std::string const& s)
-{
-    if (s.empty())
-        return boost::none;
-
-    for (auto c : s)
-    {
-        if (!isdigit(static_cast<unsigned char>(c)))
-            return boost::none;
-    }
-
-    try
-    {
-        std::size_t pos{};
-        auto const drops = std::stoul(s, &pos);
-        if (s.size() != pos)
-            return boost::none;
-        return drops;
-    }
-    catch (std::exception const&)
-    {
-        return boost::none;
-    }
-}
-
 // {
 //   secret_key: <signing_secret_key>
 //   channel_id: 256-bit channel id

--- a/src/ripple/rpc/handlers/PayChanClaim.cpp
+++ b/src/ripple/rpc/handlers/PayChanClaim.cpp
@@ -44,7 +44,7 @@ to_uint64(std::string const& s)
 
     for (auto c : s)
     {
-        if (!isdigit(c))
+        if (!isdigit(static_cast<unsigned char>(c)))
             return boost::none;
     }
 

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -45,7 +45,7 @@ isHexTxID (std::string const& txid)
     auto const ret = std::find_if (txid.begin (), txid.end (),
         [](std::string::value_type c)
         {
-            return !std::isxdigit (c);
+            return !std::isxdigit (static_cast<unsigned char>(c));
         });
 
     return (ret == txid.end ());

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -267,7 +267,11 @@ build_map(beast::http::fields const& h)
     {
         auto key (e.name_string().to_string());
         // TODO Replace with safe C++14 version
-        std::transform (key.begin(), key.end(), key.begin(), ::tolower);
+        std::transform (key.begin(), key.end(), key.begin(),
+                        [](auto c)
+                        {
+                            return ::tolower(static_cast<unsigned char>(c));
+                        });
         c [key] = e.value().to_string();
     }
     return c;


### PR DESCRIPTION
*  For the functions defined in <ctype.h> the C standard
   requires that the value of the int argument be in the
   range of an unsigned char, or be EOF.  Violation of
   this requirement results in undefined behavior.