### PR TITLE
Add testnet to example configs (RIPD-1622)

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1104,9 +1104,13 @@ time.nist.gov
 pool.ntp.org
 
 # Where to find some other servers speaking the Ripple protocol.
-#
 [ips]
 r.ripple.com 51235
+
+# To use the XRP test network (see https://ripple.com/build/xrp-test-net/),
+# use the following [ips] section instead:
+# [ips]
+# r.altnet.rippletest.net 51235
 
 # File containing trusted validator keys or validator list publishers.
 # Unless an absolute path is specified, it will be considered relative to the

--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -28,7 +28,7 @@
 #   List of URIs serving lists of recommended validators.
 #
 #   Examples:
-#    https://ripple.com/validators
+#    https://vl.ripple.com
 #    http://127.0.0.1:8000
 #
 # [validator_list_keys]
@@ -46,10 +46,19 @@
 #
 
 # The default validator list publishers that the rippled instance
-# trusts
+# trusts.
 
 [validator_list_sites]
 https://vl.ripple.com
 
 [validator_list_keys]
 ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+
+# To use the XRP test network (see https://ripple.com/build/xrp-test-net/),
+# use the following configuration instead:
+#
+# [validator_list_sites]
+# https://vl.altnet.rippletest.net
+#
+# [validator_list_keys]
+# ED264807102805220DA0F312E71FC2C69E1552C9C5790F6C25E3729DEB573D5860


### PR DESCRIPTION
This changeset includes the testnet configuration settings commented out in the example configuration files.