### PR TITLE
Prevent accidental aggregates

### DIFF
--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -152,6 +152,7 @@ public:
     using Seq = LedgerIndex;
     struct MakeGenesis
     {
+        explicit MakeGenesis() = default;
     };
 
     RCLValidatedLedger(MakeGenesis);

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -42,7 +42,10 @@ class TransactionMaster;
 
 class SqliteStatement;
 
-struct create_genesis_t {};
+struct create_genesis_t
+{
+    explicit create_genesis_t() = default;
+};
 extern create_genesis_t const create_genesis;
 
 /** Holds a ledger.

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -120,6 +120,8 @@ class NetworkOPsImp final
     {
         struct Counters
         {
+            explicit Counters() = default;
+
             std::uint32_t transitions = 0;
             std::chrono::microseconds dur = std::chrono::microseconds (0);
         };

--- a/src/ripple/app/misc/SHAMapStore.h
+++ b/src/ripple/app/misc/SHAMapStore.h
@@ -39,6 +39,8 @@ class SHAMapStore
 public:
     struct Setup
     {
+        explicit Setup() = default;
+
         bool standalone = false;
         std::uint32_t deleteInterval = 0;
         bool advisoryDelete = false;

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -57,7 +57,7 @@ private:
 
         // Just instantiate without any logic in case online delete is not
         // configured
-        SavedStateDB() = default;
+        explicit SavedStateDB() = default;
 
         // opens database and, if necessary, creates & initializes its tables.
         void init (BasicConfig const& config, std::string const& dbName);

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -55,6 +55,8 @@ public:
 
     struct Setup
     {
+        explicit Setup() = default;
+
         std::size_t ledgersInQueue = 20;
         std::size_t queueSizeMin = 2000;
         std::uint32_t retrySequencePercent = 25;
@@ -81,6 +83,8 @@ public:
 
     struct Metrics
     {
+        explicit Metrics() = default;
+
         std::size_t txCount;            // Transactions in the queue
         boost::optional<std::size_t> txQMaxSize;    // Max txns in queue
         std::size_t txInLedger;         // Amount currently in the ledger
@@ -93,6 +97,8 @@ public:
 
     struct AccountTxDetails
     {
+        explicit AccountTxDetails() = default;
+
         uint64_t feeLevel;
         boost::optional<LedgerIndex const> lastValid;
         boost::optional<TxConsequences const> consequences;
@@ -100,6 +106,8 @@ public:
 
     struct TxDetails : AccountTxDetails
     {
+        explicit TxDetails() = default;
+
         AccountID account;
         std::shared_ptr<STTx const> txn;
         int retriesRemaining;
@@ -333,6 +341,8 @@ private:
     class GreaterFee
     {
     public:
+        explicit GreaterFee() = default;
+
         bool operator()(const MaybeTx& lhs, const MaybeTx& rhs) const
         {
             return lhs.feeLevel > rhs.feeLevel;

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -64,6 +64,8 @@ to_string(ListDisposition disposition);
 */
 struct TrustChanges
 {
+    explicit TrustChanges() = default;
+
     hash_set<NodeID> added;
     hash_set<NodeID> removed;
 };
@@ -115,6 +117,8 @@ class ValidatorList
 {
     struct PublisherList
     {
+        explicit PublisherList() = default;
+
         bool available;
         std::vector<PublicKey> list;
         std::size_t sequence;

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -91,7 +91,7 @@ struct AmendmentState
     /** The name of this amendment, possibly empty. */
     std::string name;
 
-    AmendmentState () = default;
+    explicit AmendmentState () = default;
 };
 
 /** The status of all amendments requested in a given window. */

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -636,6 +636,8 @@ TxQ::apply(Application& app, OpenView& view,
 
     struct MultiTxn
     {
+        explicit MultiTxn() = default;
+
         boost::optional<ApplyViewImpl> applyView;
         boost::optional<OpenView> openView;
 

--- a/src/ripple/app/paths/Node.h
+++ b/src/ripple/app/paths/Node.h
@@ -31,6 +31,8 @@ namespace path {
 
 struct Node
 {
+    explicit Node() = default;
+
     using List = std::vector<Node>;
 
     inline bool isAccount() const

--- a/src/ripple/app/paths/NodeDirectory.h
+++ b/src/ripple/app/paths/NodeDirectory.h
@@ -31,6 +31,8 @@ namespace ripple {
 class NodeDirectory
 {
 public:
+    explicit NodeDirectory() = default;
+
     // Current directory - the last 64 bits of this are the quality.
     uint256 current;
 

--- a/src/ripple/app/paths/RippleCalc.h
+++ b/src/ripple/app/paths/RippleCalc.h
@@ -46,6 +46,8 @@ class RippleCalc
 public:
     struct Input
     {
+        explicit Input() = default;
+
         bool partialPaymentAllowed = false;
         bool defaultPathsAllowed = true;
         bool limitQuality = false;
@@ -53,6 +55,8 @@ public:
     };
     struct Output
     {
+        explicit Output() = default;
+
         // The computed input amount.
         STAmount actualAmountIn;
 

--- a/src/ripple/app/paths/RippleLineCache.h
+++ b/src/ripple/app/paths/RippleLineCache.h
@@ -81,6 +81,8 @@ private:
 
         struct Hash
         {
+            explicit Hash() = default;
+
             std::size_t
             operator () (AccountKey const& key) const noexcept
             {

--- a/src/ripple/app/paths/impl/AmountSpec.h
+++ b/src/ripple/app/paths/impl/AmountSpec.h
@@ -28,6 +28,8 @@ namespace ripple {
 
 struct AmountSpec
 {
+    explicit AmountSpec() = default;
+
     bool native;
     union
     {

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -197,6 +197,8 @@ class BookPaymentStep
     : public BookStep<TIn, TOut, BookPaymentStep<TIn, TOut>>
 {
 public:
+    explicit BookPaymentStep() = default;
+
     using BookStep<TIn, TOut, BookPaymentStep<TIn, TOut>>::BookStep;
     using BookStep<TIn, TOut, BookPaymentStep<TIn, TOut>>::qualityUpperBound;
 

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -221,6 +221,8 @@ private:
 class DirectIPaymentStep : public DirectStepI<DirectIPaymentStep>
 {
 public:
+    explicit DirectIPaymentStep() = default;
+
     using DirectStepI<DirectIPaymentStep>::DirectStepI;
     using DirectStepI<DirectIPaymentStep>::check;
 
@@ -264,6 +266,8 @@ public:
 class DirectIOfferCrossingStep : public DirectStepI<DirectIOfferCrossingStep>
 {
 public:
+    explicit DirectIOfferCrossingStep() = default;
+
     using DirectStepI<DirectIOfferCrossingStep>::DirectStepI;
     using DirectStepI<DirectIOfferCrossingStep>::check;
 

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -375,6 +375,8 @@ toStrands (ReadView const& sb,
 template <class TIn, class TOut, class TDerived>
 struct StepImp : public Step
 {
+    explicit StepImp() = default;
+
     std::pair<EitherAmount, EitherAmount>
     rev (
         PaymentSandbox& sb,

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -167,6 +167,8 @@ private:
 class XRPEndpointPaymentStep : public XRPEndpointStep<XRPEndpointPaymentStep>
 {
 public:
+    explicit XRPEndpointPaymentStep() = default;
+
     using XRPEndpointStep<XRPEndpointPaymentStep>::XRPEndpointStep;
 
     XRPAmount

--- a/src/ripple/app/tx/impl/InvariantCheck.h
+++ b/src/ripple/app/tx/impl/InvariantCheck.h
@@ -42,6 +42,7 @@ namespace ripple {
 class InvariantChecker_PROTOTYPE
 {
 public:
+    explicit InvariantChecker_PROTOTYPE() = default;
 
     /**
      * @brief called for each ledger entry in the current transaction.

--- a/src/ripple/app/tx/impl/Offer.h
+++ b/src/ripple/app/tx/impl/Offer.h
@@ -41,6 +41,8 @@ protected:
 template<>
 class TOfferBase<STAmount, STAmount>
 {
+public:
+    explicit TOfferBase() = default;
 };
 
 

--- a/src/ripple/app/tx/impl/SignerEntries.h
+++ b/src/ripple/app/tx/impl/SignerEntries.h
@@ -34,6 +34,8 @@ class STObject;
 class SignerEntries
 {
 public:
+    explicit SignerEntries() = default;
+
     struct SignerEntry
     {
         AccountID account;

--- a/src/ripple/app/tx/impl/Taker.h
+++ b/src/ripple/app/tx/impl/Taker.h
@@ -73,6 +73,8 @@ protected:
 
     struct Flow
     {
+        explicit Flow() = default;
+
         Amounts order;
         Amounts issuers;
 

--- a/src/ripple/basics/LocalValue.h
+++ b/src/ripple/basics/LocalValue.h
@@ -30,6 +30,8 @@ namespace detail {
 
 struct LocalValues
 {
+    explicit LocalValues() = default;
+
     bool onCoro = true;
 
     struct BasicValue

--- a/src/ripple/basics/ResolverAsio.h
+++ b/src/ripple/basics/ResolverAsio.h
@@ -29,6 +29,8 @@ namespace ripple {
 class ResolverAsio : public Resolver
 {
 public:
+    explicit ResolverAsio() = default;
+
     static
     std::unique_ptr<ResolverAsio> New (
         boost::asio::io_service&, beast::Journal);

--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -86,6 +86,8 @@ std::pair<Blob, bool> strUnHex (std::string const& strSrc);
 
 struct parsedURL
 {
+    explicit parsedURL() = default;
+
     std::string scheme;
     std::string domain;
     boost::optional<std::uint16_t> port;

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -99,6 +99,8 @@ public:
     class key_equal
     {
     public:
+        explicit key_equal() = default;
+
         bool operator() (base_uint const& lhs, base_uint const& rhs) const
         {
             return lhs == rhs;
@@ -115,7 +117,10 @@ private:
               constructor: something like base_uint(0) is ambiguous.
     */
     // NIKB TODO Remove the need for this constructor.
-    struct VoidHelper {};
+    struct VoidHelper
+    {
+        explicit VoidHelper() = default;
+    };
 
     explicit base_uint (void const* data, VoidHelper)
     {
@@ -578,7 +583,9 @@ namespace beast
 template <std::size_t Bits, class Tag>
 struct is_uniquely_represented<ripple::base_uint<Bits, Tag>>
     : public std::true_type
-    {};
+    {
+        explicit is_uniquely_represented() = default;
+    };
 
 }  // beast
 

--- a/src/ripple/basics/chrono.h
+++ b/src/ripple/basics/chrono.h
@@ -48,6 +48,8 @@ using weeks = std::chrono::duration
 class NetClock
 {
 public:
+    explicit NetClock() = default;
+
     using rep        = std::uint32_t;
     using period     = std::ratio<1>;
     using duration   = std::chrono::duration<rep, period>;

--- a/src/ripple/basics/hardened_hash.h
+++ b/src/ripple/basics/hardened_hash.h
@@ -90,6 +90,8 @@ private:
     }
 
 public:
+    explicit basic_hardened_hash() = default;
+
     using result_type = typename HashAlgorithm::result_type;
 
     template <class T>

--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -44,6 +44,8 @@ struct custom_delete;
 template <>
 struct custom_delete <RSA>
 {
+    explicit custom_delete() = default;
+
     void operator() (RSA* rsa) const
     {
         RSA_free (rsa);
@@ -53,6 +55,8 @@ struct custom_delete <RSA>
 template <>
 struct custom_delete <EVP_PKEY>
 {
+    explicit custom_delete() = default;
+
     void operator() (EVP_PKEY* evp_pkey) const
     {
         EVP_PKEY_free (evp_pkey);
@@ -62,6 +66,8 @@ struct custom_delete <EVP_PKEY>
 template <>
 struct custom_delete <X509>
 {
+    explicit custom_delete() = default;
+
     void operator() (X509* x509) const
     {
         X509_free (x509);
@@ -71,6 +77,8 @@ struct custom_delete <X509>
 template <>
 struct custom_delete <DH>
 {
+    explicit custom_delete() = default;
+
     void operator() (DH* dh) const
     {
         DH_free (dh);

--- a/src/ripple/basics/qalloc.h
+++ b/src/ripple/basics/qalloc.h
@@ -111,6 +111,8 @@ public:
     template <class U>
     struct rebind
     {
+        explicit rebind() = default;
+
         using other = qalloc_type<U, ShareOnCopy>;
     };
 

--- a/src/ripple/basics/tagged_integer.h
+++ b/src/ripple/basics/tagged_integer.h
@@ -228,6 +228,7 @@ template <class Int, class Tag, class HashAlgorithm>
 struct is_contiguously_hashable<ripple::tagged_integer<Int, Tag>, HashAlgorithm>
     : public is_contiguously_hashable<Int, HashAlgorithm>
 {
+    explicit is_contiguously_hashable() = default;
 };
 
 } // beast

--- a/src/ripple/beast/clock/abstract_clock.h
+++ b/src/ripple/beast/clock/abstract_clock.h
@@ -81,6 +81,8 @@ template <class Facade, class Clock>
 struct abstract_clock_wrapper
     : public abstract_clock<Facade>
 {
+    explicit abstract_clock_wrapper() = default;
+
     using typename abstract_clock<Facade>::duration;
     using typename abstract_clock<Facade>::time_point;
 

--- a/src/ripple/beast/clock/basic_seconds_clock.h
+++ b/src/ripple/beast/clock/basic_seconds_clock.h
@@ -155,6 +155,8 @@ template <class Clock>
 class basic_seconds_clock
 {
 public:
+    explicit basic_seconds_clock() = default;
+
     using rep = typename Clock::rep;
     using period = typename Clock::period;
     using duration = typename Clock::duration;

--- a/src/ripple/beast/container/aged_container.h
+++ b/src/ripple/beast/container/aged_container.h
@@ -28,6 +28,7 @@ template <class T>
 struct is_aged_container
     : std::false_type
 {
+    explicit is_aged_container() = default;
 };
 
 }

--- a/src/ripple/beast/container/detail/aged_associative_container.h
+++ b/src/ripple/beast/container/detail/aged_associative_container.h
@@ -29,6 +29,8 @@ namespace detail {
 template <bool maybe_map>
 struct aged_associative_container_extract_t
 {
+    explicit aged_associative_container_extract_t() = default;
+
     template <class Value>
     decltype (Value::first) const&
     operator() (Value const& value) const
@@ -40,6 +42,8 @@ struct aged_associative_container_extract_t
 template <>
 struct aged_associative_container_extract_t <false>
 {
+    explicit aged_associative_container_extract_t() = default;
+
     template <class Value>
     Value const&
     operator() (Value const& value) const

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -44,18 +44,24 @@ namespace detail {
 template <class It>
 struct is_boost_reverse_iterator
     : std::false_type
-{};
+{
+    explicit is_boost_reverse_iterator() = default;
+};
 
 #if BOOST_VERSION >= 105800
 template <class It>
 struct is_boost_reverse_iterator<boost::intrusive::reverse_iterator<It>>
     : std::true_type
-{};
+{
+    explicit is_boost_reverse_iterator() = default;
+};
 #else
 template <class It>
 struct is_boost_reverse_iterator<boost::intrusive::detail::reverse_iterator<It>>
     : std::true_type
-{};
+{
+    explicit is_boost_reverse_iterator() = default;
+};
 #endif
 
 /** Associative container where each element is also indexed by time.
@@ -125,6 +131,8 @@ private:
         // need to see the container declaration.
         struct stashed
         {
+            explicit stashed() = default;
+
             using value_type = typename aged_ordered_container::value_type;
             using time_point = typename aged_ordered_container::time_point;
         };
@@ -1927,6 +1935,7 @@ struct is_aged_container <beast::detail::aged_ordered_container <
         IsMulti, IsMap, Key, T, Clock, Compare, Allocator>>
     : std::true_type
 {
+    explicit is_aged_container() = default;
 };
 
 // Free functions

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -123,6 +123,8 @@ private:
         // need to see the container declaration.
         struct stashed
         {
+            explicit stashed() = default;
+
             using value_type = typename aged_unordered_container::value_type;
             using time_point = typename aged_unordered_container::time_point;
         };
@@ -2514,6 +2516,7 @@ struct is_aged_container <beast::detail::aged_unordered_container <
         IsMulti, IsMap, Key, T, Clock, Hash, KeyEqual, Allocator>>
     : std::true_type
 {
+    explicit is_aged_container() = default;
 };
 
 // Free functions

--- a/src/ripple/beast/core/ByteOrder.h
+++ b/src/ripple/beast/core/ByteOrder.h
@@ -204,6 +204,8 @@ namespace detail
 template <typename IntegralType>
 struct SwapBytes
 {
+    explicit SwapBytes() = default;
+
     inline IntegralType operator() (IntegralType value) const noexcept
     {
         return ByteOrder::swap (value);
@@ -215,6 +217,8 @@ struct SwapBytes
 template <>
 struct SwapBytes <std::int16_t>
 {
+    explicit SwapBytes() = default;
+
     inline std::int16_t operator() (std::int16_t value) const noexcept
     {
         return static_cast <std::int16_t> (ByteOrder::swap (static_cast <std::uint16_t> (value)));
@@ -224,6 +228,8 @@ struct SwapBytes <std::int16_t>
 template <>
 struct SwapBytes <std::int32_t>
 {
+    explicit SwapBytes() = default;
+
     inline std::int32_t operator() (std::int32_t value) const noexcept
     {
         return static_cast <std::int32_t> (ByteOrder::swap (static_cast <std::uint32_t> (value)));
@@ -233,6 +239,8 @@ struct SwapBytes <std::int32_t>
 template <>
 struct SwapBytes <std::int64_t>
 {
+    explicit SwapBytes() = default;
+
     inline std::int64_t operator() (std::int64_t value) const noexcept
     {
         return static_cast <std::int64_t> (ByteOrder::swap (static_cast <std::uint64_t> (value)));

--- a/src/ripple/beast/core/LexicalCast.h
+++ b/src/ripple/beast/core/LexicalCast.h
@@ -141,6 +141,8 @@ struct LexicalCast;
 template <class In>
 struct LexicalCast <std::string, In>
 {
+    explicit LexicalCast() = default;
+
     template <class Arithmetic = In>
     std::enable_if_t <std::is_arithmetic <Arithmetic>::value, bool>
     operator () (std::string& out, Arithmetic in)
@@ -163,6 +165,8 @@ struct LexicalCast <std::string, In>
 template <class Out>
 struct LexicalCast <Out, std::string>
 {
+    explicit LexicalCast() = default;
+
     static_assert (std::is_integral <Out>::value,
         "beast::LexicalCast can only be used with integral types");
 
@@ -212,6 +216,8 @@ struct LexicalCast <Out, std::string>
 template <class Out>
 struct LexicalCast <Out, char const*>
 {
+    explicit LexicalCast() = default;
+
     bool operator() (Out& out, char const* in) const
     {
         return LexicalCast <Out, std::string>()(out, in);
@@ -223,6 +229,8 @@ struct LexicalCast <Out, char const*>
 template <class Out>
 struct LexicalCast <Out, char*>
 {
+    explicit LexicalCast() = default;
+
     bool operator() (Out& out, char* in) const
     {
         return LexicalCast <Out, std::string>()(out, in);
@@ -242,6 +250,7 @@ struct LexicalCast <Out, char*>
 */
 struct BadLexicalCast : public std::bad_cast
 {
+    explicit BadLexicalCast() = default;
 };
 
 /** Intelligently convert from one type to another.

--- a/src/ripple/beast/core/List.h
+++ b/src/ripple/beast/core/List.h
@@ -37,12 +37,16 @@ namespace detail {
 template <typename T, typename U>
 struct CopyConst
 {
+    explicit CopyConst() = default;
+
     using type = typename std::remove_const <U>::type;
 };
 
 template <typename T, typename U>
 struct CopyConst <T const, U>
 {
+    explicit CopyConst() = default;
+
     using type = typename std::remove_const <U>::type const;
 };
 /** @} */

--- a/src/ripple/beast/crypto/detail/ripemd_context.h
+++ b/src/ripple/beast/crypto/detail/ripemd_context.h
@@ -56,6 +56,8 @@ namespace detail {
 
 struct ripemd160_context
 {
+    explicit ripemd160_context() = default;
+
     static unsigned int const block_size = 64;
     static unsigned int const digest_size = 20;
 

--- a/src/ripple/beast/crypto/detail/sha2_context.h
+++ b/src/ripple/beast/crypto/detail/sha2_context.h
@@ -69,6 +69,8 @@ namespace detail {
 
 struct sha256_context
 {
+    explicit sha256_context() = default;
+
     static unsigned int const block_size = 64;
     static unsigned int const digest_size = 32;
 
@@ -80,6 +82,8 @@ struct sha256_context
 
 struct sha512_context
 {
+    explicit sha512_context() = default;
+
     static unsigned int const block_size = 128;
     static unsigned int const digest_size = 64;
 

--- a/src/ripple/beast/cxx17/type_traits.h
+++ b/src/ripple/beast/cxx17/type_traits.h
@@ -49,6 +49,7 @@ struct is_constructible <pair <T, U>>
         is_default_constructible <T>::value &&
         is_default_constructible <U>::value>
 {
+    explicit is_constructible() = default;
 };
 
 } // std

--- a/src/ripple/beast/hash/hash_append.h
+++ b/src/ripple/beast/hash/hash_append.h
@@ -99,22 +99,30 @@ struct is_uniquely_represented
     : public std::integral_constant<bool, std::is_integral<T>::value ||
                                           std::is_enum<T>::value     ||
                                           std::is_pointer<T>::value>
-{};
+{
+    explicit is_uniquely_represented() = default;
+};
 
 template <class T>
 struct is_uniquely_represented<T const>
     : public is_uniquely_represented<T>
-{};
+{
+    explicit is_uniquely_represented() = default;
+};
 
 template <class T>
 struct is_uniquely_represented<T volatile>
     : public is_uniquely_represented<T>
-{};
+{
+    explicit is_uniquely_represented() = default;
+};
 
 template <class T>
 struct is_uniquely_represented<T const volatile>
     : public is_uniquely_represented<T>
-{};
+{
+    explicit is_uniquely_represented() = default;
+};
 
 // is_uniquely_represented<std::pair<T, U>>
 
@@ -124,6 +132,7 @@ struct is_uniquely_represented<std::pair<T, U>>
                                           is_uniquely_represented<U>::value &&
                                           sizeof(T) + sizeof(U) == sizeof(std::pair<T, U>)>
 {
+    explicit is_uniquely_represented() = default;
 };
 
 // is_uniquely_represented<std::tuple<T...>>
@@ -134,6 +143,7 @@ struct is_uniquely_represented<std::tuple<T...>>
             static_and<is_uniquely_represented<T>::value...>::value &&
             static_sum<sizeof(T)...>::value == sizeof(std::tuple<T...>)>
 {
+    explicit is_uniquely_represented() = default;
 };
 
 // is_uniquely_represented<T[N]>
@@ -142,6 +152,7 @@ template <class T, std::size_t N>
 struct is_uniquely_represented<T[N]>
     : public is_uniquely_represented<T>
 {
+    explicit is_uniquely_represented() = default;
 };
 
 // is_uniquely_represented<std::array<T, N>>
@@ -151,6 +162,7 @@ struct is_uniquely_represented<std::array<T, N>>
     : public std::integral_constant<bool, is_uniquely_represented<T>::value &&
                                           sizeof(T)*N == sizeof(std::array<T, N>)>
 {
+    explicit is_uniquely_represented() = default;
 };
 
 /** Metafunction returning `true` if the type can be hashed in one call.
@@ -172,14 +184,18 @@ struct is_contiguously_hashable
     : public std::integral_constant<bool, is_uniquely_represented<T>::value &&
                                       (sizeof(T) == 1 ||
                                        HashAlgorithm::endian == endian::native)>
-{};
+{
+    explicit is_contiguously_hashable() = default;
+};
 
 template <class T, std::size_t N, class HashAlgorithm>
 struct is_contiguously_hashable<T[N], HashAlgorithm>
     : public std::integral_constant<bool, is_uniquely_represented<T[N]>::value &&
                                       (sizeof(T) == 1 ||
                                        HashAlgorithm::endian == endian::native)>
-{};
+{
+    explicit is_contiguously_hashable() = default;
+};
 /** @} */
 
 //------------------------------------------------------------------------------

--- a/src/ripple/beast/hash/meta.h
+++ b/src/ripple/beast/hash/meta.h
@@ -31,12 +31,14 @@ struct static_and <b0, bN...>
     : public std::integral_constant <
         bool, b0 && static_and<bN...>::value>
 {
+    explicit static_and() = default;
 };
 
 template <>
 struct static_and<>
     : public std::true_type
 {
+    explicit static_and() = default;
 };
 
 #ifndef __INTELLISENSE__
@@ -52,12 +54,14 @@ struct static_sum <s0, sN...>
     : public std::integral_constant <
         std::size_t, s0 + static_sum<sN...>::value>
 {
+    explicit static_sum() = default;
 };
 
 template <>
 struct static_sum<>
     : public std::integral_constant<std::size_t, 0>
 {
+    explicit static_sum() = default;
 };
 
 #ifndef __INTELLISENSE__
@@ -72,6 +76,7 @@ struct enable_if_lvalue
     std::is_lvalue_reference<T>::value
     >
 {
+    explicit enable_if_lvalue() = default;
 };
 
 /** Ensure const reference function parameters are valid lvalues.

--- a/src/ripple/beast/hash/uhash.h
+++ b/src/ripple/beast/hash/uhash.h
@@ -30,6 +30,8 @@ namespace beast {
 template <class Hasher = spooky>
 struct uhash
 {
+    explicit uhash() = default;
+
     using result_type = typename Hasher::result_type;
 
     template <class T>

--- a/src/ripple/beast/insight/NullCollector.h
+++ b/src/ripple/beast/insight/NullCollector.h
@@ -29,6 +29,8 @@ namespace insight {
 class NullCollector : public Collector
 {
 public:
+    explicit NullCollector() = default;
+
     static std::shared_ptr <Collector> New ();
 };
 

--- a/src/ripple/beast/insight/StatsDCollector.h
+++ b/src/ripple/beast/insight/StatsDCollector.h
@@ -35,6 +35,8 @@ namespace insight {
 class StatsDCollector : public Collector
 {
 public:
+    explicit StatsDCollector() = default;
+
     /** Create a StatsD collector.
         @param address The IP address and port of the StatsD server.
         @param prefix A string pre-pended before each metric name.

--- a/src/ripple/beast/insight/impl/NullCollector.cpp
+++ b/src/ripple/beast/insight/impl/NullCollector.cpp
@@ -26,6 +26,9 @@ namespace detail {
 
 class NullHookImpl : public HookImpl
 {
+public:
+    explicit NullHookImpl() = default;
+
 private:
     NullHookImpl& operator= (NullHookImpl const&);
 };
@@ -35,6 +38,8 @@ private:
 class NullCounterImpl : public CounterImpl
 {
 public:
+    explicit NullCounterImpl() = default;
+
     void increment (value_type)
     {
     }
@@ -48,6 +53,8 @@ private:
 class NullEventImpl : public EventImpl
 {
 public:
+    explicit NullEventImpl() = default;
+
     void notify (value_type const&)
     {
     }
@@ -61,6 +68,8 @@ private:
 class NullGaugeImpl : public GaugeImpl
 {
 public:
+    explicit NullGaugeImpl() = default;
+
     void set (value_type)
     {
     }
@@ -78,6 +87,8 @@ private:
 class NullMeterImpl : public MeterImpl
 {
 public:
+    explicit NullMeterImpl() = default;
+
     void increment (value_type)
     {
     }

--- a/src/ripple/beast/net/IPAddress.h
+++ b/src/ripple/beast/net/IPAddress.h
@@ -335,6 +335,8 @@ namespace std {
 template <>
 struct hash <beast::IP::Address>
 {
+    explicit hash() = default;
+
     std::size_t
     operator() (beast::IP::Address const& addr) const
     {
@@ -347,6 +349,8 @@ namespace boost {
 template <>
 struct hash <beast::IP::Address>
 {
+    explicit hash() = default;
+
     std::size_t
     operator() (beast::IP::Address const& addr) const
     {

--- a/src/ripple/beast/net/IPAddressConversion.h
+++ b/src/ripple/beast/net/IPAddressConversion.h
@@ -53,6 +53,8 @@ namespace beast {
 // DEPRECATED
 struct IPAddressConversion
 {
+    explicit IPAddressConversion() = default;
+
     static IP::Endpoint from_asio (boost::asio::ip::address const& address)
         { return IP::from_asio (address); }
     static IP::Endpoint from_asio (boost::asio::ip::tcp::endpoint const& endpoint)

--- a/src/ripple/beast/net/IPAddressV4.h
+++ b/src/ripple/beast/net/IPAddressV4.h
@@ -182,6 +182,7 @@ template <class HashAlgorithm>
 struct is_contiguously_hashable<IP::AddressV4, HashAlgorithm>
     : public std::integral_constant<bool, sizeof(IP::AddressV4) == sizeof(std::uint32_t)>
 {
+    explicit is_contiguously_hashable() = default;
 };
 
 }
@@ -193,6 +194,8 @@ namespace std {
 template <>
 struct hash <beast::IP::AddressV4>
 {
+    explicit hash() = default;
+
     std::size_t operator() (beast::IP::AddressV4 const& addr) const
         { return addr.value; }
 };

--- a/src/ripple/beast/net/IPAddressV6.h
+++ b/src/ripple/beast/net/IPAddressV6.h
@@ -33,6 +33,8 @@ namespace IP {
 /** Represents a version 4 IP address. */
 struct AddressV6
 {
+    explicit AddressV6() = default;
+
     // VFALCO TODO
 
     /** Arithmetic comparison. */
@@ -100,6 +102,8 @@ namespace std {
 template <>
 struct hash <beast::IP::AddressV6>
 {
+    explicit hash() = default;
+
     std::size_t operator() (beast::IP::AddressV6 const& addr) const
         { assert(false); return 0; }
 };

--- a/src/ripple/beast/net/IPEndpoint.h
+++ b/src/ripple/beast/net/IPEndpoint.h
@@ -157,6 +157,8 @@ namespace std {
 template <>
 struct hash <beast::IP::Endpoint>
 {
+    explicit hash() = default;
+
     std::size_t operator() (beast::IP::Endpoint const& endpoint) const
         { return beast::uhash<>{} (endpoint); }
 };
@@ -167,6 +169,8 @@ namespace boost {
 template <>
 struct hash <beast::IP::Endpoint>
 {
+    explicit hash() = default;
+
     std::size_t operator() (beast::IP::Endpoint const& endpoint) const
         { return beast::uhash<>{} (endpoint); }
 };

--- a/src/ripple/beast/rfc2616.h
+++ b/src/ripple/beast/rfc2616.h
@@ -46,6 +46,8 @@ namespace detail {
 
 struct ci_equal_pred
 {
+    explicit ci_equal_pred() = default;
+
     bool operator()(char c1, char c2)
     {
         // VFALCO TODO Use a table lookup here

--- a/src/ripple/beast/utility/Zero.h
+++ b/src/ripple/beast/utility/Zero.h
@@ -46,6 +46,7 @@ namespace beast {
 
 struct Zero
 {
+    explicit Zero() = default;
 };
 
 namespace {

--- a/src/ripple/beast/utility/maybe_const.h
+++ b/src/ripple/beast/utility/maybe_const.h
@@ -28,6 +28,7 @@ namespace beast {
 template <bool IsConst, class T>
 struct maybe_const
 {
+    explicit maybe_const() = default;
     using type = typename std::conditional <IsConst,
         typename std::remove_const <T>::type const,
         typename std::remove_const <T>::type>::type;

--- a/src/ripple/beast/utility/weak_fn.h
+++ b/src/ripple/beast/utility/weak_fn.h
@@ -43,6 +43,8 @@ namespace beast {
 template <class V = void>
 struct throw_if_invalid
 {
+    explicit throw_if_invalid() = default;
+
     V operator()() const
     {
         throw std::bad_weak_ptr();
@@ -74,6 +76,8 @@ private:
 template <class V>
 struct ignore_if_invalid
 {
+    explicit ignore_if_invalid() = default;
+
     V operator()() const
     {
         return V();

--- a/src/ripple/conditions/impl/error.cpp
+++ b/src/ripple/conditions/impl/error.cpp
@@ -30,6 +30,8 @@ class cryptoconditions_error_category
     : public std::error_category
 {
 public:
+    explicit cryptoconditions_error_category() = default;
+
     const char*
     name() const noexcept override
     {

--- a/src/ripple/conditions/impl/error.h
+++ b/src/ripple/conditions/impl/error.h
@@ -59,6 +59,8 @@ namespace std
 template<>
 struct is_error_code_enum<ripple::cryptoconditions::error>
 {
+    explicit is_error_code_enum() = default;
+
     static bool const value = true;
 };
 

--- a/src/ripple/conditions/impl/utils.h
+++ b/src/ripple/conditions/impl/utils.h
@@ -45,6 +45,7 @@ namespace der {
 // length octets:
 struct Preamble
 {
+    explicit Preamble() = default;
     std::uint8_t type = 0;
     std::size_t tag = 0;
     std::size_t length = 0;

--- a/src/ripple/consensus/ConsensusParms.h
+++ b/src/ripple/consensus/ConsensusParms.h
@@ -34,6 +34,7 @@ using namespace std::chrono_literals;
 */
 struct ConsensusParms
 {
+    explicit ConsensusParms() = default;
 
     //-------------------------------------------------------------------------
     // Validation and proposal durations are relative to NetClock times, so use

--- a/src/ripple/consensus/ConsensusTypes.h
+++ b/src/ripple/consensus/ConsensusTypes.h
@@ -173,6 +173,8 @@ public:
 */
 struct ConsensusCloseTimes
 {
+    explicit ConsensusCloseTimes() = default;
+
     //! Close time estimates, keep ordered for predictable traverse
     std::map<NetClock::time_point, int> peers;
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -41,6 +41,8 @@ namespace ripple {
  */
 struct ValidationParms
 {
+    explicit ValidationParms() = default;
+
     /** The number of seconds a validation remains current after its ledger's
         close time.
 

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -27,6 +27,8 @@ namespace ripple {
 // VFALCO DEPRECATED in favor of the BasicConfig interface
 struct ConfigSection
 {
+    explicit ConfigSection() = default;
+
     static std::string nodeDatabase ()       { return "node_db"; }
     static std::string shardDatabase ()      { return "shard_db"; }
     static std::string importNodeDatabase () { return "import_db"; }

--- a/src/ripple/core/DatabaseCon.h
+++ b/src/ripple/core/DatabaseCon.h
@@ -79,6 +79,8 @@ class DatabaseCon
 public:
     struct Setup
     {
+        explicit Setup() = default;
+
         Config::StartUpType startUp = Config::NORMAL;
         bool standAlone = false;
         boost::filesystem::path dataDir;

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -32,7 +32,10 @@
 namespace ripple {
 
 class Logs;
-struct Coro_create_t {};
+struct Coro_create_t
+{
+    explicit Coro_create_t() = default;
+};
 
 /** A pool of threads to perform work.
 

--- a/src/ripple/core/impl/Workers.h
+++ b/src/ripple/core/impl/Workers.h
@@ -108,7 +108,10 @@ public:
     //--------------------------------------------------------------------------
 
 private:
-    struct PausedTag { };
+    struct PausedTag
+    {
+        explicit PausedTag() = default;
+    };
 
     /*  A Worker executes tasks on its provided thread.
 

--- a/src/ripple/json/impl/Writer.cpp
+++ b/src/ripple/json/impl/Writer.cpp
@@ -189,6 +189,8 @@ private:
     // JSON collections are either arrrays, or objects.
     struct Collection
     {
+        explicit Collection() = default;
+
         /** What type of collection are we in? */
         Writer::CollectionType type;
 

--- a/src/ripple/json/impl/json_batchallocator.h
+++ b/src/ripple/json/impl/json_batchallocator.h
@@ -106,6 +106,8 @@ public:
 private:
     struct BatchInfo
     {
+        explicit BatchInfo() = default;
+
         BatchInfo* next_;
         AllocatedType* used_;
         AllocatedType* end_;

--- a/src/ripple/json/json_reader.h
+++ b/src/ripple/json/json_reader.h
@@ -106,6 +106,8 @@ private:
     class Token
     {
     public:
+        explicit Token() = default;
+
         TokenType type_;
         Location start_;
         Location end_;
@@ -114,6 +116,8 @@ private:
     class ErrorInfo
     {
     public:
+        explicit ErrorInfo() = default;
+
         Token token_;
         std::string message_;
         Location extra_;

--- a/src/ripple/ledger/OpenView.h
+++ b/src/ripple/ledger/OpenView.h
@@ -36,7 +36,11 @@ namespace ripple {
     rules of open ledgers applied during transaction
     processing.
 */
-struct open_ledger_t {};
+struct open_ledger_t
+{
+    explicit open_ledger_t() = default;
+};
+
 extern open_ledger_t const open_ledger;
 
 //------------------------------------------------------------------------------

--- a/src/ripple/ledger/PaymentSandbox.h
+++ b/src/ripple/ledger/PaymentSandbox.h
@@ -74,6 +74,8 @@ private:
         AccountID, AccountID, Currency>;
     struct Value
     {
+        explicit Value() = default;
+
         STAmount lowAcctCredits;
         STAmount highAcctCredits;
         STAmount lowAcctOrigBalance;

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -50,7 +50,7 @@ struct Fees
     std::uint32_t reserve = 0;      // Reserve base (drops)
     std::uint32_t increment = 0;    // Reserve increment (drops)
 
-    Fees() = default;
+    explicit Fees() = default;
     Fees (Fees const&) = default;
     Fees& operator= (Fees const&) = default;
 
@@ -71,6 +71,8 @@ struct Fees
 /** Information about the notional ledger backing the view. */
 struct LedgerInfo
 {
+    explicit LedgerInfo() = default;
+
     //
     // For all ledgers
     //

--- a/src/ripple/ledger/TxMeta.h
+++ b/src/ripple/ledger/TxMeta.h
@@ -37,7 +37,10 @@ public:
     using ref = const pointer&;
 
 private:
-    struct CtorHelper{};
+    struct CtorHelper
+    {
+        explicit CtorHelper() = default;
+    };
     template<class T>
     TxMeta (uint256 const& txID, std::uint32_t ledger, T const& data, beast::Journal j,
                         CtorHelper);

--- a/src/ripple/ledger/impl/CashDiff.cpp
+++ b/src/ripple/ledger/impl/CashDiff.cpp
@@ -31,6 +31,8 @@ namespace detail {
 // Data structure that summarize cash changes in a single ApplyStateTable.
 struct CashSummary
 {
+    explicit CashSummary() = default;
+
     // Sorted vectors.  All of the vectors fill in for std::maps.
     std::vector<std::pair<
         AccountID, XRPAmount>> xrpChanges;

--- a/src/ripple/net/HTTPClient.h
+++ b/src/ripple/net/HTTPClient.h
@@ -32,6 +32,8 @@ namespace ripple {
 class HTTPClient
 {
 public:
+    explicit HTTPClient() = default;
+
     enum
     {
         maxClientHeaderBytes = 32 * 1024

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1170,6 +1170,8 @@ namespace
 
 struct RPCCallImp
 {
+    explicit RPCCallImp() = default;
+
     // VFALCO NOTE Is this a to-do comment or a doc comment?
     // Place the async result somewhere useful.
     static void callRPCHandler (Json::Value* jvOutput, Json::Value const& jvInput)

--- a/src/ripple/nodestore/NodeObject.h
+++ b/src/ripple/nodestore/NodeObject.h
@@ -66,7 +66,10 @@ private:
     // This hack is used to make the constructor effectively private
     // except for when we use it in the call to make_shared.
     // There's no portable way to make make_shared<> a friend work.
-    struct PrivateAccess { };
+    struct PrivateAccess
+    {
+        explicit PrivateAccess() = default;
+    };
 public:
     // This constructor is private, use createObject instead.
     NodeObject (NodeObjectType type,

--- a/src/ripple/nodestore/Scheduler.h
+++ b/src/ripple/nodestore/Scheduler.h
@@ -29,6 +29,8 @@ namespace NodeStore {
 /** Contains information about a fetch operation. */
 struct FetchReport
 {
+    explicit FetchReport() = default;
+
     std::chrono::milliseconds elapsed;
     bool isAsync;
     bool wentToDisk;
@@ -38,6 +40,8 @@ struct FetchReport
 /** Contains information about a batch write operation. */
 struct BatchWriteReport
 {
+    explicit BatchWriteReport() = default;
+
     std::chrono::milliseconds elapsed;
     int writeCount;
 };

--- a/src/ripple/nodestore/backend/MemoryFactory.cpp
+++ b/src/ripple/nodestore/backend/MemoryFactory.cpp
@@ -31,6 +31,8 @@ namespace NodeStore {
 
 struct MemoryDB
 {
+    explicit MemoryDB() = default;
+
     std::mutex mutex;
     bool open = false;
     std::map <uint256 const, std::shared_ptr<NodeObject>> table;

--- a/src/ripple/nodestore/impl/varint.h
+++ b/src/ripple/nodestore/impl/varint.h
@@ -44,6 +44,8 @@ struct varint_traits;
 template <class T>
 struct varint_traits<T, true>
 {
+    explicit varint_traits() = default;
+
     static std::size_t constexpr max =
         (8 * sizeof(T) + 6) / 7;
 };

--- a/src/ripple/overlay/Cluster.h
+++ b/src/ripple/overlay/Cluster.h
@@ -41,6 +41,8 @@ class Cluster
 private:
     struct Comparator
     {
+        explicit Comparator() = default;
+
         using is_transparent = std::true_type;
 
         bool

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -64,6 +64,8 @@ public:
 
     struct Setup
     {
+        explicit Setup() = default;
+
         std::shared_ptr<boost::asio::ssl::context> context;
         bool expire = false;
         beast::IP::Address public_ip;

--- a/src/ripple/peerfinder/impl/Bootcache.h
+++ b/src/ripple/peerfinder/impl/Bootcache.h
@@ -88,6 +88,8 @@ private:
         map_type::right_map::const_iterator::value_type const&,
             beast::IP::Endpoint const&>
     {
+        explicit Transform() = default;
+
         beast::IP::Endpoint const& operator() (
             map_type::right_map::
                 const_iterator::value_type const& v) const

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -39,6 +39,8 @@ namespace detail {
 
 class LivecacheBase
 {
+public:
+    explicit LivecacheBase() = default;
 protected:
     struct Element
         : boost::intrusive::list_base_hook <>
@@ -68,6 +70,8 @@ public:
         struct Transform
             : public std::unary_function <Element, Endpoint>
         {
+            explicit Transform() = default;
+
             Endpoint const& operator() (Element const& e) const
             {
                 return e.endpoint;
@@ -223,6 +227,8 @@ public:
             : public std::unary_function <
                 typename lists_type::value_type, Hop <IsConst>>
         {
+            explicit Transform() = default;
+
             Hop <IsConst> operator() (typename beast::maybe_const <
                 IsConst, typename lists_type::value_type>::type& list) const
             {

--- a/src/ripple/peerfinder/impl/Reporting.h
+++ b/src/ripple/peerfinder/impl/Reporting.h
@@ -28,6 +28,8 @@ namespace PeerFinder {
 */
 struct Reporting
 {
+    explicit Reporting() = default;
+
     // Report simulation parameters
     static bool const params = true;
 

--- a/src/ripple/peerfinder/impl/Source.h
+++ b/src/ripple/peerfinder/impl/Source.h
@@ -41,6 +41,8 @@ public:
     /** The results of a fetch. */
     struct Results
     {
+        explicit Results() = default;
+
         // error_code on a failure
         boost::system::error_code error;
 

--- a/src/ripple/peerfinder/impl/SourceStrings.h
+++ b/src/ripple/peerfinder/impl/SourceStrings.h
@@ -30,6 +30,8 @@ namespace PeerFinder {
 class SourceStrings : public Source
 {
 public:
+    explicit SourceStrings() = default;
+
     using Strings = std::vector <std::string>;
 
     static beast::SharedPtr <Source> New (std::string const& name, Strings const& strings);

--- a/src/ripple/peerfinder/impl/Store.h
+++ b/src/ripple/peerfinder/impl/Store.h
@@ -36,6 +36,8 @@ public:
     // save the bootstrap cache
     struct Entry
     {
+        explicit Entry() = default;
+
         beast::IP::Endpoint endpoint;
         int valence;
     };

--- a/src/ripple/peerfinder/sim/FunctionQueue.h
+++ b/src/ripple/peerfinder/sim/FunctionQueue.h
@@ -27,6 +27,9 @@ namespace Sim {
 /** Maintains a queue of functors that can be called later. */
 class FunctionQueue
 {
+public:
+    explicit FunctionQueue() = default;
+
 private:
     class BasicWork
     {

--- a/src/ripple/peerfinder/sim/NodeSnapshot.h
+++ b/src/ripple/peerfinder/sim/NodeSnapshot.h
@@ -27,7 +27,7 @@ namespace Sim {
 /** A snapshot of a Node in the network simulator. */
 struct NodeSnapshot
 {
-
+    explicit NodeSnapshot() = default;
 };
 
 }

--- a/src/ripple/protocol/AccountID.h
+++ b/src/ripple/protocol/AccountID.h
@@ -35,7 +35,11 @@ namespace ripple {
 
 namespace detail {
 
-class AccountIDTag { };
+class AccountIDTag
+{
+public:
+    explicit AccountIDTag() = default;
+};
 
 } // detail
 
@@ -183,6 +187,7 @@ namespace std {
 template <>
 struct hash <ripple::AccountID> : ripple::AccountID::hasher
 {
+    explicit hash() = default;
 };
 
 } // std

--- a/src/ripple/protocol/Book.h
+++ b/src/ripple/protocol/Book.h
@@ -108,6 +108,8 @@ private:
         std::hash <ripple::AccountID>, 1>;
 
 public:
+    explicit hash() = default;
+
     using value_type = std::size_t;
     using argument_type = ripple::Issue;
 
@@ -132,6 +134,8 @@ private:
     hasher m_hasher;
 
 public:
+    explicit hash() = default;
+
     using value_type = std::size_t;
     using argument_type = ripple::Book;
 
@@ -153,6 +157,8 @@ template <>
 struct hash <ripple::Issue>
     : std::hash <ripple::Issue>
 {
+    explicit hash() = default;
+
     using Base = std::hash <ripple::Issue>;
     // VFALCO NOTE broken in vs2012
     //using Base::Base; // inherit ctors
@@ -162,6 +168,8 @@ template <>
 struct hash <ripple::Book>
     : std::hash <ripple::Book>
 {
+    explicit hash() = default;
+
     using Base = std::hash <ripple::Book>;
     // VFALCO NOTE broken in vs2012
     //using Base::Base; // inherit ctors

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -109,6 +109,8 @@ namespace keylet {
 /** AccountID root */
 struct account_t
 {
+    explicit account_t() = default;
+
     Keylet operator()(AccountID const& id) const;
 };
 static account_t const account {};
@@ -116,6 +118,8 @@ static account_t const account {};
 /** The amendment table */
 struct amendments_t
 {
+    explicit amendments_t() = default;
+
     Keylet operator()() const;
 };
 static amendments_t const amendments {};
@@ -126,6 +130,8 @@ Keylet child (uint256 const& key);
 /** Skip list */
 struct skip_t
 {
+    explicit skip_t() = default;
+
     Keylet operator()() const;
 
     Keylet operator()(LedgerIndex ledger) const;
@@ -135,6 +141,8 @@ static skip_t const skip {};
 /** The ledger fees */
 struct fees_t
 {
+    explicit fees_t() = default;
+
     // VFALCO This could maybe be constexpr
     Keylet operator()() const;
 };
@@ -143,6 +151,8 @@ static fees_t const fees {};
 /** The beginning of an order book */
 struct book_t
 {
+    explicit book_t() = default;
+
     Keylet operator()(Book const& b) const;
 };
 static book_t const book {};
@@ -150,6 +160,8 @@ static book_t const book {};
 /** A trust line */
 struct line_t
 {
+    explicit line_t() = default;
+
     Keylet operator()(AccountID const& id0,
         AccountID const& id1, Currency const& currency) const;
 
@@ -166,6 +178,8 @@ static line_t const line {};
 /** An offer from an account */
 struct offer_t
 {
+    explicit offer_t() = default;
+
     Keylet operator()(AccountID const& id,
         std::uint32_t seq) const;
 
@@ -179,6 +193,8 @@ static offer_t const offer {};
 /** The initial directory page for a specific quality */
 struct quality_t
 {
+    explicit quality_t() = default;
+
     Keylet operator()(Keylet const& k,
         std::uint64_t q) const;
 };
@@ -187,6 +203,8 @@ static quality_t const quality {};
 /** The directry for the next lower quality */
 struct next_t
 {
+    explicit next_t() = default;
+
     Keylet operator()(Keylet const& k) const;
 };
 static next_t const next {};
@@ -194,6 +212,8 @@ static next_t const next {};
 /** A ticket belonging to an account */
 struct ticket_t
 {
+    explicit ticket_t() = default;
+
     Keylet operator()(AccountID const& id,
         std::uint32_t seq) const;
 
@@ -207,6 +227,8 @@ static ticket_t const ticket {};
 /** A SignerList */
 struct signers_t
 {
+    explicit signers_t() = default;
+
     Keylet operator()(AccountID const& id) const;
 
     Keylet operator()(uint256 const& key) const
@@ -219,6 +241,8 @@ static signers_t const signers {};
 /** A Check */
 struct check_t
 {
+    explicit check_t() = default;
+
     Keylet operator()(AccountID const& id,
         std::uint32_t seq) const;
 

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -141,6 +141,8 @@ hash_append (Hasher& h,
 template<>
 struct STExchange<STBlob, PublicKey>
 {
+    explicit STExchange() = default;
+
     using value_type = PublicKey;
 
     static

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -78,7 +78,10 @@ public:
     //--------------------------------------------------------------------------
     STAmount(SerialIter& sit, SField const& name);
 
-    struct unchecked { };
+    struct unchecked
+    {
+        explicit unchecked() = default;
+    };
 
     // Do not call canonicalize
     STAmount (SField const& name, Issue const& issue,

--- a/src/ripple/protocol/STExchange.h
+++ b/src/ripple/protocol/STExchange.h
@@ -44,6 +44,8 @@ struct STExchange;
 template <class U, class T>
 struct STExchange<STInteger<U>, T>
 {
+    explicit STExchange() = default;
+
     using value_type = U;
 
     static
@@ -66,6 +68,8 @@ struct STExchange<STInteger<U>, T>
 template <>
 struct STExchange<STBlob, Slice>
 {
+    explicit STExchange() = default;
+
     using value_type = Slice;
 
     static
@@ -89,6 +93,8 @@ struct STExchange<STBlob, Slice>
 template <>
 struct STExchange<STBlob, Buffer>
 {
+    explicit STExchange() = default;
+
     using value_type = Buffer;
 
     static

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -251,6 +251,8 @@ private:
 
     struct Transform
     {
+        explicit Transform() = default;
+
         using argument_type = detail::STVar;
         using result_type = STBase;
 

--- a/src/ripple/protocol/TxFlags.h
+++ b/src/ripple/protocol/TxFlags.h
@@ -38,6 +38,8 @@ namespace ripple {
 class TxFlag
 {
 public:
+    explicit TxFlag() = default;
+
     static std::uint32_t const requireDestTag = 0x00010000;
 };
 // VFALCO TODO Move all flags into this container after some study.

--- a/src/ripple/protocol/UintTypes.h
+++ b/src/ripple/protocol/UintTypes.h
@@ -27,9 +27,23 @@
 namespace ripple {
 namespace detail {
 
-class CurrencyTag {};
-class DirectoryTag {};
-class NodeIDTag {};
+class CurrencyTag
+{
+public:
+    explicit CurrencyTag() = default;
+};
+
+class DirectoryTag
+{
+public:
+    explicit DirectoryTag() = default;
+};
+
+class NodeIDTag
+{
+public:
+    explicit NodeIDTag() = default;
+};
 
 } // detail
 
@@ -80,16 +94,19 @@ namespace std {
 template <>
 struct hash <ripple::Currency> : ripple::Currency::hasher
 {
+    explicit hash() = default;
 };
 
 template <>
 struct hash <ripple::NodeID> : ripple::NodeID::hasher
 {
+    explicit hash() = default;
 };
 
 template <>
 struct hash <ripple::Directory> : ripple::Directory::hasher
 {
+    explicit hash() = default;
 };
 
 } // std

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -29,6 +29,8 @@ namespace std {
 template <>
 struct hash <ripple::error_code_i>
 {
+    explicit hash() = default;
+
     std::size_t operator() (ripple::error_code_i value) const
     {
         return value;

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -46,6 +46,8 @@ using StaticScopedLockType = std::lock_guard <std::mutex>;
 // Give this translation unit only, permission to construct SFields
 struct SField::make
 {
+    explicit make() = default;
+
     template <class ...Args>
     static SField one(SField const* p, Args&& ...args)
     {

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -31,8 +31,15 @@
 namespace ripple {
 namespace detail {
 
-struct defaultObject_t { };
-struct nonPresentObject_t { };
+struct defaultObject_t
+{
+    explicit defaultObject_t() = default;
+};
+
+struct nonPresentObject_t
+{
+    explicit nonPresentObject_t() = default;
+};
 
 extern defaultObject_t defaultObject;
 extern nonPresentObject_t nonPresentObject;

--- a/src/ripple/resource/Gossip.h
+++ b/src/ripple/resource/Gossip.h
@@ -28,9 +28,13 @@ namespace Resource {
 /** Data format for exchanging consumption information across peers. */
 struct Gossip
 {
+    explicit Gossip() = default;
+
     /** Describes a single consumer. */
     struct Item
     {
+        explicit Item() = default;
+
         int balance;
         beast::IP::Endpoint address;
     };

--- a/src/ripple/resource/impl/Import.h
+++ b/src/ripple/resource/impl/Import.h
@@ -31,6 +31,8 @@ struct Import
 {
     struct Item
     {
+        explicit Item() = default;
+
         int balance;
         Consumer consumer;
     };

--- a/src/ripple/resource/impl/Key.h
+++ b/src/ripple/resource/impl/Key.h
@@ -77,6 +77,8 @@ struct Key
 
     struct key_equal
     {
+        explicit key_equal() = default;
+
         bool operator() (Key const& lhs, Key const& rhs) const
         {
             if (lhs.kind != rhs.kind)

--- a/src/ripple/rpc/impl/ServerHandlerImp.h
+++ b/src/ripple/rpc/impl/ServerHandlerImp.h
@@ -46,11 +46,15 @@ class ServerHandlerImp
 public:
     struct Setup
     {
+        explicit Setup() = default;
+
         std::vector<Port> ports;
 
         // Memberspace
         struct client_t
         {
+            explicit client_t() = default;
+
             bool secure = false;
             std::string ip;
             std::uint16_t port = 0;
@@ -66,6 +70,8 @@ public:
         // Configuration for the Overlay
         struct overlay_t
         {
+            explicit overlay_t() = default;
+
             boost::asio::ip::address ip;
             std::uint16_t port = 0;
         };

--- a/src/ripple/rpc/json_body.h
+++ b/src/ripple/rpc/json_body.h
@@ -29,6 +29,8 @@ namespace ripple {
 /// Body that holds JSON
 struct json_body
 {
+    explicit json_body() = default;
+
     using value_type = Json::Value;
 
     class reader

--- a/src/ripple/server/Port.h
+++ b/src/ripple/server/Port.h
@@ -37,6 +37,8 @@ namespace ripple {
 /** Configuration information for a Server listening port. */
 struct Port
 {
+    explicit Port() = default;
+
     std::string name;
     boost::asio::ip::address ip;
     std::uint16_t port = 0;
@@ -78,6 +80,8 @@ operator<< (std::ostream& os, Port const& p);
 
 struct ParsedPort
 {
+    explicit ParsedPort() = default;
+
     std::string name;
     std::set<std::string, beast::iless> protocol;
     std::string user;


### PR DESCRIPTION
*  The compiler can provide many non-explicit constructors for
   aggregate types.  This is sometimes desired, but it can
   happen accidentally, resulting in run-time errors.

*  This commit assures that no types are aggregates unless existing
   code is using aggregate initialization.