### PR TITLE
[Trivial] Fix manual offer test

### DIFF
--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -329,7 +329,7 @@ public:
         for (auto withFix : {false, true})
         {
             if (!withFix &&
-                features[featureFlow] && features[featureFeeEscalation])
+                (features[featureFlow] || features[featureFeeEscalation]))
                 continue;
 
             Env env {*this, features};


### PR DESCRIPTION
I broke this manual test with this commit: https://github.com/ripple/rippled/commit/e8d02c1333a1e72edadab4af629c49e848bfe16e This commit fixes that mistake.