### PR TITLE
Resolve gcc8 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,9 +420,9 @@ add_with_props(rippled_src_all src/ripple/unity/ed25519_donna.c
   -I"${CMAKE_SOURCE_DIR}/"src/ed25519-donna)
 
 if (is_gcc)
-  set(no_init_w -Wno-maybe-uninitialized)
+  set(no_gcc_warnings -w)
 else()
-  unset(no_init_w)
+  unset(no_gcc_warnings)
 endif()
 
 add_with_props(rippled_src_all src/ripple/unity/rocksdb.cpp
@@ -430,7 +430,7 @@ add_with_props(rippled_src_all src/ripple/unity/rocksdb.cpp
   -I"${CMAKE_SOURCE_DIR}/"src/rocksdb2/include
   -I"${CMAKE_SOURCE_DIR}/"src/snappy/snappy
   -I"${CMAKE_SOURCE_DIR}/"src/snappy/config
-  ${no_init_w} ${rocks_db_system_header})
+  ${no_gcc_warnings} ${rocks_db_system_header})
 
 if (NOT is_msvc)
   set(no_unused_w -Wno-unused-function)

--- a/src/ripple/json/impl/json_value.cpp
+++ b/src/ripple/json/impl/json_value.cpp
@@ -365,7 +365,8 @@ Value::Value ( Value&& other ) noexcept
     , type_ ( other.type_ )
     , allocated_ ( other.allocated_ )
 {
-    std::memset( &other, 0, sizeof(Value) );
+    other.type_ = nullValue;
+    other.allocated_ = 0;
 }
 
 Value&


### PR DESCRIPTION
This commit resolves new warnings in gcc8. In particular, there's a new warning "when objects of non-trivial class types are manipulated in potentially unsafe ways by raw memory functions such as memcpy, or realloc" (see release notes: https://gcc.gnu.org/gcc-8/changes.html).

I resolved the warning in our code by rewritting the offending fragment and in rocksdb by disabling warnings (it's third-party code, I feel OK doing that).