### PR TITLE
Only check validation cookie with enabled amendment

### DIFF
--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -316,7 +316,11 @@ handleNewValidation(Application& app,
     // masterKey is seated only if validator is trusted or listed
     if (masterKey)
     {
-        ValStatus const outcome = validations.add(calcNodeID(*masterKey), val);
+        ValStatus const outcome = validations.add(
+            calcNodeID(*masterKey),
+            val,
+            app.getLedgerMaster().getValidatedRules().enabled(
+                featureValidationCookies));
         if(j.debug())
             dmp(j.debug(), to_string(outcome));
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -592,7 +592,7 @@ public:
         @return The outcome
     */
     ValStatus
-    add(NodeID const& nodeID, Validation const& val)
+    add(NodeID const& nodeID, Validation const& val, bool checkCookie=false)
     {
         if (!isCurrent(parms_, adaptor_.now(), val.signTime(), val.seenTime()))
             return ValStatus::stale;
@@ -602,8 +602,9 @@ public:
 
             // Check if a validator with this nodeID already issued a validation
             // for this sequence using a different cookie
+
             auto const bySeqIt = bySeq_[val.seq()].emplace(nodeID, val);
-            if(!bySeqIt.second)
+            if(!bySeqIt.second && checkCookie)
             {
                 if(bySeqIt.first->second.cookie() != val.cookie())
                 {

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -256,9 +256,9 @@ class Validations_test : public beast::unit_test::suite
         }
 
         ValStatus
-        add(Validation const& v)
+        add(Validation const& v, bool checkCookie=false)
         {
-            return tv_.add(v.nodeID(), v);
+            return tv_.add(v.nodeID(), v, checkCookie);
         }
 
         TestValidations&
@@ -1160,8 +1160,12 @@ class Validations_test : public beast::unit_test::suite
         Node aReuse{a.nodeID(), harness.clock()};
         Node b = harness.makeNode();
 
-        BEAST_EXPECT(ValStatus::current == harness.add(a.validate(h["a"])));
-        BEAST_EXPECT(ValStatus::current == harness.add(b.validate(h["b"])));
+        BEAST_EXPECT(
+            ValStatus::current ==
+            harness.add(a.validate(h["a"]), true /* checkCookie */));
+        BEAST_EXPECT(
+            ValStatus::current ==
+            harness.add(b.validate(h["b"]), true /* checkCookie */));
 
         BEAST_EXPECT(harness.vals().numTrustedForLedger(h["a"].id()) == 1);
         BEAST_EXPECT(harness.vals().numTrustedForLedger(h["b"].id()) == 1);
@@ -1169,7 +1173,8 @@ class Validations_test : public beast::unit_test::suite
         // Re-issuing for the same ledger gives badCookie status, but does not
         // ignore that ledger
         BEAST_EXPECT(
-            ValStatus::badCookie == harness.add(aReuse.validate(h["a"])));
+            ValStatus::badCookie ==
+            harness.add(aReuse.validate(h["a"]), true /* checkCookie */));
 
         BEAST_EXPECT(harness.vals().numTrustedForLedger(h["a"].id()) == 1);
         BEAST_EXPECT(harness.vals().numTrustedForLedger(h["b"].id()) == 1);
@@ -1178,14 +1183,16 @@ class Validations_test : public beast::unit_test::suite
         // Re-issuing for a different ledger gives badCookie status and ignores
         // the prior validated ledger
         BEAST_EXPECT(
-            ValStatus::badCookie == harness.add(aReuse.validate(h["b"])));
+            ValStatus::badCookie ==
+            harness.add(aReuse.validate(h["b"]), true /* checkCookie */));
 
         BEAST_EXPECT(harness.vals().numTrustedForLedger(h["a"].id()) == 0);
         BEAST_EXPECT(harness.vals().numTrustedForLedger(h["b"].id()) == 1);
         BEAST_EXPECT(harness.vals().currentTrusted().size() == 1);
 
         BEAST_EXPECT(
-            ValStatus::badCookie == harness.add(aReuse.validate(h["b"])));
+            ValStatus::badCookie ==
+            harness.add(aReuse.validate(h["b"]), true /* checkCookie */));
     }
 
     void


### PR DESCRIPTION
It looks like `bySeq_` is only used for that cookies-related check, so I'm not sure if we want more of it behind the amendment enabled check.