### PR TITLE
[Trivial] Remove redundant type qualifier

### DIFF
--- a/src/ripple/rpc/handlers/LedgerHandler.h
+++ b/src/ripple/rpc/handlers/LedgerHandler.h
@@ -55,7 +55,7 @@ public:
     template <class Object>
     void writeResult (Object&);
 
-    static const char* const name()
+    static const char* name()
     {
         return "ledger";
     }

--- a/src/ripple/rpc/handlers/Version.h
+++ b/src/ripple/rpc/handlers/Version.h
@@ -41,7 +41,7 @@ public:
         setVersion (obj);
     }
 
-    static const char* const name()
+    static const char* name()
     {
         return "version";
     }


### PR DESCRIPTION
Summary: the extra `const` type qualifier on the return type has no effect.
Clang emits `-Wignored-qualifiers` warning when I turned on `-Wextra`.

If it is desired by others to turn on `-Wextra`, to compile cleanly without warnings, we'd want something like

```c++
-Wextra -Wno-unused-parameter -Wno-missing-field-initializers
```

We have a lot of unused parameter warnings in both Ripple code and third-party code. The latter warning is noisy for my liking and I think we should just ignore it rather than fix the call sites.

Looks like Jenkins isn't happy that I'm not an official contributor. Do I need to perhaps sign a contributor license agreement or something? @seelabs @bachase 