### PR TITLE
[Trivial] Fix extra semicolon warnings

### DIFF
--- a/src/beast/include/beast/websocket/stream.hpp
+++ b/src/beast/include/beast/websocket/stream.hpp
@@ -617,7 +617,7 @@ public:
             BOOST_THROW_EXCEPTION(std::invalid_argument{
                 "write buffer size underflow"});
         wr_buf_size_ = n;
-    };
+    }
 
     /// Returns the size of the write buffer.
     std::size_t

--- a/src/nudb/include/nudb/progress.hpp
+++ b/src/nudb/include/nudb/progress.hpp
@@ -24,7 +24,7 @@ no_progress
     void
     operator()(std::uint64_t, std::uint64_t) const noexcept
     {
-    };
+    }
 };
 
 } // nudb

--- a/src/ripple/app/misc/Manifest.h
+++ b/src/ripple/app/misc/Manifest.h
@@ -176,7 +176,7 @@ public:
     ManifestCache (beast::Journal j = beast::Journal())
         : j_ (j)
     {
-    };
+    }
 
     /** Returns master key's current signing key.
 

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -249,7 +249,7 @@ public:
     quorum () const
     {
         return quorum_;
-    };
+    }
 
     /** Returns `true` if public key is trusted
 

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -80,7 +80,7 @@ public:
     Book const& book() const
     {
         return book_;
-    };
+    }
 
     boost::optional<EitherAmount>
     cachedIn () const override

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -67,7 +67,7 @@ public:
     AccountID const& acc () const
     {
         return acc_;
-    };
+    }
 
     boost::optional<std::pair<AccountID,AccountID>>
     directStepAccts () const override

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -65,7 +65,7 @@ public:
         std::uint32_t count() const
         {
             return count_;
-        };
+        }
     };
 
 protected:
@@ -181,7 +181,7 @@ public:
     boost::container::flat_set<uint256> const& permToRemove () const
     {
         return permToRemove_;
-    };
+    }
 };
 }
 

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -160,7 +160,7 @@ private:
     clamp(Seq val) const
     {
         return std::min(std::max(start_, val), end_);
-    };
+    }
 
     // Return a span of this over the half-open interval [from,to)
     boost::optional<Span>

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -224,7 +224,7 @@ public:
     virtual
     void adjustOwnerCountHook (AccountID const& account,
         std::uint32_t cur, std::uint32_t next)
-    {};
+    {}
 
     /** Append an entry to a directory
 

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -338,7 +338,7 @@ public:
     getPeerDisconnectCharges() const override
     {
         return peerDisconnectsCharges_;
-    };
+    }
 
 private:
     std::shared_ptr<Writer>

--- a/src/ripple/peerfinder/impl/Counts.h
+++ b/src/ripple/peerfinder/impl/Counts.h
@@ -92,7 +92,7 @@ public:
     std::size_t attempts () const
     {
         return m_attempts;
-    };
+    }
 
     /** Returns the total number of outbound slots. */
     int out_max () const

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -142,18 +142,19 @@ public:
     hasIssuer () const
     {
         return getNodeType () & STPathElement::typeIssuer;
-    };
+    }
+
     bool
     hasCurrency () const
     {
         return getNodeType () & STPathElement::typeCurrency;
-    };
+    }
 
     bool
     isNone () const
     {
         return getNodeType () == STPathElement::typeNone;
-    };
+    }
 
     // Nodes are either an account ID or a offer prefix. Offer prefixs denote a
     // class of offers.

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -122,7 +122,7 @@ public:
             makeSection (m_set1),
             makeSection (m_set2),
             makeSection (m_set3));
-    };
+    }
 
     void testConstruct ()
     {

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -45,7 +45,7 @@ struct DepositAuth_test : public beast::unit_test::suite
     static bool hasDepositAuth (jtx::Env const& env, jtx::Account const& acct)
     {
         return ((*env.le(acct))[sfFlags] & lsfDepositAuth) == lsfDepositAuth;
-    };
+    }
 
 
     void testEnable()

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -46,7 +46,7 @@ class Offer_test : public beast::unit_test::suite
         using namespace jtx;
         auto feeDrops = env.current()->fees().base;
         return drops (dropsPerXRP<std::int64_t>::value * xrpAmount - feeDrops);
-    };
+    }
 
     static auto
     ledgerEntryState(jtx::Env & env, jtx::Account const& acct_a,
@@ -60,7 +60,7 @@ class Offer_test : public beast::unit_test::suite
         jvParams[jss::ripple_state][jss::accounts].append(acct_b.human());
         return env.rpc ("json", "ledger_entry",
             to_string(jvParams))[jss::result];
-    };
+    }
 
     static auto
     ledgerEntryRoot (jtx::Env & env, jtx::Account const& acct)
@@ -70,7 +70,7 @@ class Offer_test : public beast::unit_test::suite
         jvParams[jss::account_root] = acct.human();
         return env.rpc ("json", "ledger_entry",
             to_string(jvParams))[jss::result];
-    };
+    }
 
     static auto
     ledgerEntryOffer (jtx::Env & env,
@@ -81,7 +81,7 @@ class Offer_test : public beast::unit_test::suite
         jvParams[jss::offer][jss::seq] = offer_seq;
         return env.rpc ("json", "ledger_entry",
             to_string(jvParams))[jss::result];
-    };
+    }
 
     static auto
     getBookOffers(jtx::Env & env,

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -42,7 +42,7 @@ class TrustAndBalance_test : public beast::unit_test::suite
         jvParams[jss::ripple_state][jss::accounts].append(acct_a.human());
         jvParams[jss::ripple_state][jss::accounts].append(acct_b.human());
         return env.rpc ("json", "ledger_entry", to_string(jvParams))[jss::result];
-    };
+    }
 
     void
     testPayNonexistent (FeatureBitset features)

--- a/src/test/beast/aged_associative_container_test.cpp
+++ b/src/test/beast/aged_associative_container_test.cpp
@@ -252,7 +252,7 @@ public:
                 "orange",
             };
             return v;
-        };
+        }
 
     protected:
         static std::string name_map_part()
@@ -285,7 +285,7 @@ public:
                 std::make_pair ("orange", 5)
             };
             return v;
-        };
+        }
 
     protected:
         static std::string name_map_part()

--- a/src/test/core/Config_test.cpp
+++ b/src/test/core/Config_test.cpp
@@ -140,7 +140,7 @@ protected:
         else
             test_.log << "Expected " << toRm.string ()
                       << " to be an empty existing directory." << std::endl;
-    };
+    }
 
 public:
     ConfigGuard (beast::unit_test::suite& test, path subDir,

--- a/src/test/csf/timers.h
+++ b/src/test/csf/timers.h
@@ -52,13 +52,13 @@ public:
               startRealTime_{RealClock::now()},
               startSimTime_{sched.now()}
     {
-    };
+    }
 
     void
     start()
     {
         scheduler_.in(interval_, [this](){beat(scheduler_.now());});
-    };
+    }
 
     void
     beat(SimTime when)

--- a/src/test/jtx/PathSet.h
+++ b/src/test/jtx/PathSet.h
@@ -69,7 +69,7 @@ public:
     Path& push_back (STPathElement const& pe);
     Json::Value json () const;
  private:
-    Path& addHelper (){return *this;};
+    Path& addHelper (){return *this;}
     template <class First, class... Rest>
     Path& addHelper (First&& first, Rest&&... rest);
 };
@@ -133,7 +133,7 @@ private:
     PathSet& addHelper ()
     {
         return *this;
-    };
+    }
     template <class First, class... Rest>
     PathSet& addHelper (First first, Rest... rest)
     {

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1094,7 +1094,7 @@ public:
             return false;
         // Make sure no other message is waiting
         return wsc->getMsg(timeout) == boost::none;
-    };
+    }
 
     void
     testCrossingSingleBookOffer()

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -46,7 +46,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         }
         else if (BEAST_EXPECT(jv.isMember(jss::error_message)))
             BEAST_EXPECT(jv[jss::error_message] == msg);
-    };
+    }
 
     // Corrupt a valid address by replacing the 10th character with '!'.
     // '!' is not part of the ripple alphabet.

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -432,7 +432,7 @@ class ServerStatus_test :
                 return;
             BEAST_EXPECT(resp.result() == beast::http::status::ok);
         }
-    };
+    }
 
     void
     testTruncatedWSUpgrade(boost::asio::yield_context& yield)
@@ -481,7 +481,7 @@ class ServerStatus_test :
         // keep trying to read until it gives up (by timeout)
         async_read(sock, sb, resp, yield[ec]);
         BEAST_EXPECT(ec);
-    };
+    }
 
     void
     testCantConnect(
@@ -1049,7 +1049,7 @@ public:
             testStatusNotOkay (yield);
         });
 
-    };
+    }
 };
 
 BEAST_DEFINE_TESTSUITE(ServerStatus, server, ripple);


### PR DESCRIPTION
Summary: several member functions had an extra semicolon
in both Ripple code and third-party code. This removes them.