### PR TITLE
Add missing virtual destructors:

### DIFF
--- a/src/ripple/core/impl/Workers.h
+++ b/src/ripple/core/impl/Workers.h
@@ -44,6 +44,8 @@ public:
     /** Called to perform tasks as needed. */
     struct Callback
     {
+        virtual ~Callback () = default;
+
         /** Perform a task.
 
             The call is made on a thread owned by Workers. It is important

--- a/src/ripple/nodestore/Manager.h
+++ b/src/ripple/nodestore/Manager.h
@@ -31,6 +31,8 @@ namespace NodeStore {
 class Manager
 {
 public:
+    virtual ~Manager () = default;
+
     /** Returns the instance of the manager singleton. */
     static
     Manager&

--- a/src/ripple/nodestore/impl/BatchWriter.h
+++ b/src/ripple/nodestore/impl/BatchWriter.h
@@ -43,6 +43,8 @@ public:
     /** This callback does the actual writing. */
     struct Callback
     {
+        virtual ~Callback () = default;
+
         virtual void writeBatch (Batch const& batch) = 0;
     };
 

--- a/src/ripple/protocol/InnerObjectFormats.h
+++ b/src/ripple/protocol/InnerObjectFormats.h
@@ -32,6 +32,8 @@ private:
     void addCommonFields (Item& item);
 
 public:
+    virtual ~InnerObjectFormats () = default;
+
     /** Create the object.
         This will load the object will all the known inner object formats.
     */

--- a/src/ripple/protocol/KnownFormats.h
+++ b/src/ripple/protocol/KnownFormats.h
@@ -87,17 +87,13 @@ public:
 
         Derived classes will load the object will all the known formats.
     */
-    KnownFormats ()
-    {
-    }
+    KnownFormats () = default;
 
     /** Destroy the known formats object.
 
         The defined formats are deleted.
     */
-    ~KnownFormats ()
-    {
-    }
+    virtual ~KnownFormats () = default;
 
     /** Retrieve the type for a format specified by name.
 

--- a/src/ripple/server/Session.h
+++ b/src/ripple/server/Session.h
@@ -42,6 +42,7 @@ class Session
 public:
     Session() = default;
     Session (Session const&) = delete;
+    virtual ~Session () = default;
 
     /** A user-definable pointer.
         The initial value is always zero.

--- a/src/ripple/server/WSSession.h
+++ b/src/ripple/server/WSSession.h
@@ -110,6 +110,8 @@ struct WSSession
 {
     std::shared_ptr<void> appDefined;
 
+    virtual ~WSSession () = default;
+
     virtual
     void
     run() = 0;


### PR DESCRIPTION
Some classes had virtual methods, but were missing a virtual
destructor.

Technically, every unit test that inherits from the Beast test suite
would get flagged by `-Wnon-virtual-dtor` but I did not think it would
be a great idea to go sprinkle a virtual destructor for every Ripple
test suite.