### PR TITLE
Remove Transactor::mFeeDue member variable

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -86,8 +86,7 @@ TxQ::FeeMetrics::update(Application& app,
     feeLevels.reserve(txnsExpected_);
     for (auto const& tx : view.txs)
     {
-        auto const baseFee = calculateBaseFee(app, view,
-            *tx.first, j_);
+        auto const baseFee = calculateBaseFee(view, *tx.first);
         feeLevels.push_back(getFeeLevelPaid(*tx.first,
             baseLevel, baseFee, setup));
     }
@@ -660,7 +659,7 @@ TxQ::apply(Application& app, OpenView& view,
     // or transaction replacement, so just pull it up now.
     // TODO: Do we want to avoid doing it again during
     //   preclaim?
-    auto const baseFee = calculateBaseFee(app, view, *tx, j);
+    auto const baseFee = calculateBaseFee(view, *tx);
     auto const feeLevelPaid = getFeeLevelPaid(*tx,
         baseLevel, baseFee, setup_);
     auto const requiredFeeLevel = [&]()

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -86,8 +86,6 @@ public:
 
     /// Intermediate transaction result
     TER const ter;
-    /// Transaction-specific base fee
-    std::uint64_t const baseFee;
     /// Success flag - whether the transaction is likely to
     /// claim a fee
     bool const likelyToClaimFee;
@@ -95,23 +93,14 @@ public:
     /// Constructor
     template<class Context>
     PreclaimResult(Context const& ctx_,
-        TER ter_, std::uint64_t const& baseFee_)
+        TER ter_)
         : view(ctx_.view)
         , tx(ctx_.tx)
         , flags(ctx_.flags)
         , j(ctx_.j)
         , ter(ter_)
-        , baseFee(baseFee_)
         , likelyToClaimFee(ter == tesSUCCESS
             || isTecClaim(ter))
-    {
-    }
-
-    /// Constructor
-    template<class Context>
-    PreclaimResult(Context const& ctx_,
-        std::pair<TER, std::uint64_t> const& result)
-        : PreclaimResult(ctx_, result.first, result.second)
     {
     }
 
@@ -231,16 +220,14 @@ preclaim(PreflightResult const& preflightResult,
     Since none should be thrown, that will usually
     mean terminating.
 
-    @param app The current running `Application`.
     @param view The current open ledger.
     @param tx The transaction to be checked.
-    @param j A journal.
 
     @return The base fee.
 */
 std::uint64_t
-calculateBaseFee(Application& app, ReadView const& view,
-    STTx const& tx, beast::Journal j);
+calculateBaseFee(ReadView const& view,
+    STTx const& tx);
 
 /** Determine the XRP balance consequences if a transaction
     consumes the maximum XRP allowed.

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -92,8 +92,7 @@ public:
 
     /// Constructor
     template<class Context>
-    PreclaimResult(Context const& ctx_,
-        TER ter_)
+    PreclaimResult(Context const& ctx_, TER ter_)
         : view(ctx_.view)
         , tx(ctx_.tx)
         , flags(ctx_.flags)

--- a/src/ripple/app/tx/impl/ApplyContext.h
+++ b/src/ripple/app/tx/impl/ApplyContext.h
@@ -41,7 +41,7 @@ public:
     ApplyContext (Application& app, OpenView& base,
         STTx const& tx, TER preclaimResult,
             std::uint64_t baseFee, ApplyFlags flags,
-                    beast::Journal = {});
+                beast::Journal = {});
 
     Application& app;
     STTx const& tx;

--- a/src/ripple/app/tx/impl/Change.h
+++ b/src/ripple/app/tx/impl/Change.h
@@ -48,7 +48,8 @@ public:
     static
     std::uint64_t
     calculateBaseFee (
-        PreclaimContext const& ctx)
+        ReadView const& view,
+        STTx const& tx)
     {
         return 0;
     }

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -347,17 +347,19 @@ EscrowFinish::preflight (PreflightContext const& ctx)
 }
 
 std::uint64_t
-EscrowFinish::calculateBaseFee (PreclaimContext const& ctx)
+EscrowFinish::calculateBaseFee (
+    ReadView const& view,
+    STTx const& tx)
 {
     std::uint64_t extraFee = 0;
 
-    if (auto const fb = ctx.tx[~sfFulfillment])
+    if (auto const fb = tx[~sfFulfillment])
     {
-        extraFee += ctx.view.fees().units *
+        extraFee += view.fees().units *
             (32 + static_cast<std::uint64_t> (fb->size() / 16));
     }
 
-    return Transactor::calculateBaseFee (ctx) + extraFee;
+    return Transactor::calculateBaseFee (view, tx) + extraFee;
 }
 
 TER

--- a/src/ripple/app/tx/impl/Escrow.h
+++ b/src/ripple/app/tx/impl/Escrow.h
@@ -64,7 +64,9 @@ public:
 
     static
     std::uint64_t
-    calculateBaseFee (PreclaimContext const& ctx);
+    calculateBaseFee (
+        ReadView const& view,
+        STTx const& tx);
 
     TER
     doApply() override;

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -70,13 +70,10 @@ SetRegularKey::preflight (PreflightContext const& ctx)
 TER
 SetRegularKey::doApply ()
 {
-    auto const sle = view().peek(
-        keylet::account(account_));
+    auto const sle = view ().peek (
+        keylet::account (account_));
 
-	auto const feeDue = calculateFee(ctx_.app, ctx_.baseFee,
-		view().fees(), view().flags());
-
-	if (feeDue == zero)
+    if (!calculateFee (ctx_.app, ctx_.baseFee, view ().fees (), view ().flags ()))
         sle->setFlag (lsfPasswordSpent);
 
     if (ctx_.tx.isFieldPresent (sfRegularKey))

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -73,7 +73,10 @@ SetRegularKey::doApply ()
     auto const sle = view().peek(
         keylet::account(account_));
 
-    if (mFeeDue == zero)
+	auto const feeDue = calculateFee(ctx_.app, ctx_.baseFee,
+		view().fees(), view().flags());
+
+	if (feeDue == zero)
         sle->setFlag (lsfPasswordSpent);
 
     if (ctx_.tx.isFieldPresent (sfRegularKey))

--- a/src/ripple/app/tx/impl/SetRegularKey.h
+++ b/src/ripple/app/tx/impl/SetRegularKey.h
@@ -50,7 +50,8 @@ public:
     static
     std::uint64_t
     calculateBaseFee (
-        PreclaimContext const& ctx);
+        ReadView const& view,
+        STTx const& tx);
 
     TER doApply () override;
 };

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -151,10 +151,10 @@ Transactor::calculateFeePaid(STTx const& tx)
 
 XRPAmount
 Transactor::calculateFee(Application& app, std::uint64_t const baseFee,
-	Fees const& fees, ApplyFlags flags)
+    Fees const& fees, ApplyFlags flags)
 {
-	return scaleFeeLoad(baseFee, app.getFeeTrack(),
-		fees, flags & tapUNLIMITED);
+    return scaleFeeLoad(baseFee, app.getFeeTrack(),
+        fees, flags & tapUNLIMITED);
 }
 
 XRPAmount

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -150,10 +150,10 @@ Transactor::calculateFeePaid(STTx const& tx)
 }
 
 XRPAmount
-Transactor::calculateFee(Application& app, std::uint64_t const baseFee,
+Transactor::calculateFee (Application& app, std::uint64_t baseFee,
     Fees const& fees, ApplyFlags flags)
 {
-    return scaleFeeLoad(baseFee, app.getFeeTrack(),
+    return scaleFeeLoad (baseFee, app.getFeeTrack (),
         fees, flags & tapUNLIMITED);
 }
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -169,10 +169,10 @@ protected:
 
     virtual TER doApply () = 0;
 
-	static
-	XRPAmount
-	calculateFee(Application& app, std::uint64_t const baseFee,
-		Fees const& fees, ApplyFlags flags);
+    static
+    XRPAmount
+    calculateFee (Application& app, std::uint64_t baseFee,
+        Fees const& fees, ApplyFlags flags);
 
 private:
     XRPAmount reset(XRPAmount fee);

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -81,7 +81,6 @@ protected:
     beast::Journal j_;
 
     AccountID     account_;
-    XRPAmount     mFeeDue;
     XRPAmount     mPriorBalance;  // Balance before fees.
     XRPAmount     mSourceBalance; // Balance after fees.
 
@@ -169,6 +168,11 @@ protected:
     virtual void preCompute();
 
     virtual TER doApply () = 0;
+
+	static
+	XRPAmount
+	calculateFee(Application& app, std::uint64_t const baseFee,
+		Fees const& fees, ApplyFlags flags);
 
 private:
     XRPAmount reset(XRPAmount fee);

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -170,9 +170,8 @@ protected:
 
     virtual TER doApply () = 0;
 
-    /** Compute the minimum fee required for to process a
-        transaction with a given baseFee based on the current
-        server load.
+    /** Compute the minimum fee required to process a transaction
+        with a given baseFee based on the current server load.
 
         @param app The application hosting the server
         @param baseFee The base fee of a candidate transaction

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -121,7 +121,7 @@ public:
 
     static
     TER
-    checkFee (PreclaimContext const& ctx, std::uint64_t baseFee);
+    checkFee (PreclaimContext const& ctxx, std::uint64_t baseFee);
 
     static
     NotTEC
@@ -131,7 +131,8 @@ public:
     static
     std::uint64_t
     calculateBaseFee (
-        PreclaimContext const& ctx);
+        ReadView const& view,
+        STTx const& tx);
 
     static
     bool
@@ -171,7 +172,7 @@ protected:
 
     static
     XRPAmount
-    calculateFee (Application& app, std::uint64_t baseFee,
+    minimumFee (Application& app, std::uint64_t baseFee,
         Fees const& fees, ApplyFlags flags);
 
 private:

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -121,7 +121,7 @@ public:
 
     static
     TER
-    checkFee (PreclaimContext const& ctxx, std::uint64_t baseFee);
+    checkFee (PreclaimContext const& ctx, std::uint64_t baseFee);
 
     static
     NotTEC
@@ -170,6 +170,16 @@ protected:
 
     virtual TER doApply () = 0;
 
+    /** Compute the minimum fee required for to process a
+        transaction with a given baseFee based on the current
+        server load.
+
+        @param app The application hosting the server
+        @param baseFee The base fee of a candidate transaction
+            @see ripple::calculateBaseFee
+        @param fees Fee settings from the current ledger
+        @param flags Transaction processing fees
+     */
     static
     XRPAmount
     minimumFee (Application& app, std::uint64_t baseFee,


### PR DESCRIPTION
* mFeeDue is only used in one place by one derived class, so
  only compute it as a local in that function.

This is a pretty small change, not quite trivial, that I noticed while looking at something completely unrelated. In the interest of not mixing concerns, I split this out into its own PR.