### PR TITLE
Add xrpRoundToZero logging for FlowCross compareSandboxes

### DIFF
--- a/src/ripple/ledger/CashDiff.h
+++ b/src/ripple/ledger/CashDiff.h
@@ -83,6 +83,21 @@ public:
     // Returns true is there are any differences to report.
     bool hasDiff() const;
 
+    // Checks for the XRP round-to-zero case.  Returns zero if not detected.
+    // Otherwise returns -1 if seen on lhs, +1 if seen on rhs.
+    //
+    // For tiny offers of TakerPays IOU and TakerGets XRP, cases have been
+    // observed where XRP rounding allows a tiny amount of IOU to be
+    // removed from an Offer while returning no XRP to the offer owner.
+    // That's because the XRP amount was rounded down to zero drops.
+    //
+    // The person submitting the tiny offer does not, however, get something
+    // for nothing.  The transaction's fee is significantly larger than the
+    // value of the received IOU.
+    //
+    // This check should be made before calling rmDust().
+    int xrpRoundToZero() const;
+
     // Remove dust-sized differences.  Returns true is dust was removed.
     bool rmDust();
 
@@ -123,7 +138,7 @@ private:
 // If v1 and v2 have different issues, then their difference is never dust.
 // If v1 < v2, smallness is computed as v1 / (v2 - v1).
 // The e10 argument says at least how big that ratio must be.  Default is 10^6.
-// If both v1 and v2 are XRP, any difference of 2 or smaller is considered dust.
+// If both v1 and v2 are XRP, consider any diff of 2 drops or less to be dust.
 bool diffIsDust (STAmount const& v1, STAmount const& v2, std::uint8_t e10 = 6);
 
 } // ripple


### PR DESCRIPTION
This adds a case to the FlowCross debug logging that identifies differences in behavior between Taker and FlowCross.  The logging is only enabled if the `CompareTakerFlowCross` feature is enabled in the config file.  So you needn't be concerned about a flood of new warning-level log messages.

When it is generated, a typical message looks like:
```
FlowCross: Both Taker and Flow fully crossed different; Taker XRP rounded to zero.  tx: ...
```
Reviewers: @ximinez, @mellery451.  Thanks.