### PR TITLE
Rename LoadEvent member function reName to setName

### DIFF
--- a/src/ripple/core/LoadEvent.h
+++ b/src/ripple/core/LoadEvent.h
@@ -55,8 +55,7 @@ public:
     std::chrono::steady_clock::duration
     runTime() const;
 
-    // VFALCO TODO rename this to setName () or setLabel ()
-    void reName (std::string const& name);
+    void setName (std::string const& name);
 
     // Start the measurement. If already started, then
     // restart, assigning the elapsed time to the "waiting"

--- a/src/ripple/core/impl/Job.cpp
+++ b/src/ripple/core/impl/Job.cpp
@@ -78,7 +78,7 @@ void Job::doJob ()
 {
     beast::setCurrentThreadName ("doJob: " + mName);
     m_loadEvent->start ();
-    m_loadEvent->reName (mName);
+    m_loadEvent->setName (mName);
 
     mJob (*this);
 

--- a/src/ripple/core/impl/LoadEvent.cpp
+++ b/src/ripple/core/impl/LoadEvent.cpp
@@ -60,7 +60,7 @@ LoadEvent::runTime() const
     return timeRunning_;
 }
 
-void LoadEvent::reName (std::string const& name)
+void LoadEvent::setName (std::string const& name)
 {
     name_ = name;
 }


### PR DESCRIPTION
Per Vinnie's comment, renamed the member function to be consistent with the preferred naming conventions for setter methods.