### PR TITLE
Rename some member functions

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1200,7 +1200,7 @@ bool ApplicationImp::setup()
     {
         // This should probably become the default once we have a stable network.
         if (!config_->standalone())
-            m_networkOPs->needNetworkLedger ();
+            m_networkOPs->setNeedNetworkLedger();
 
         startGenesisLedger ();
     }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -334,7 +334,7 @@ public:
     */
     void setStateTimer () override;
 
-    void needNetworkLedger () override
+    void setNeedNetworkLedger () override
     {
         needNetworkLedger_ = true;
     }

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -167,8 +167,7 @@ public:
     virtual void setStandAlone () = 0;
     virtual void setStateTimer () = 0;
 
-    // VFALCO TODO rename to setNeedNetworkLedger
-    virtual void needNetworkLedger () = 0;
+    virtual void setNeedNetworkLedger () = 0;
     virtual void clearNeedNetworkLedger () = 0;
     virtual bool isNeedNetworkLedger () = 0;
     virtual bool isFull () = 0;

--- a/src/ripple/core/LoadEvent.h
+++ b/src/ripple/core/LoadEvent.h
@@ -55,8 +55,7 @@ public:
     std::chrono::steady_clock::duration
     runTime() const;
 
-    // VFALCO TODO rename this to setName () or setLabel ()
-    void reName (std::string const& name);
+    void setName (std::string const& name);
 
     // Start the measurement. If already started, then
     // restart, assigning the elapsed time to the "waiting"

--- a/src/ripple/core/impl/Job.cpp
+++ b/src/ripple/core/impl/Job.cpp
@@ -78,7 +78,7 @@ void Job::doJob ()
 {
     beast::setCurrentThreadName ("doJob: " + mName);
     m_loadEvent->start ();
-    m_loadEvent->reName (mName);
+    m_loadEvent->setName (mName);
 
     mJob (*this);
 

--- a/src/ripple/core/impl/LoadEvent.cpp
+++ b/src/ripple/core/impl/LoadEvent.cpp
@@ -60,7 +60,7 @@ LoadEvent::runTime() const
     return timeRunning_;
 }
 
-void LoadEvent::reName (std::string const& name)
+void LoadEvent::setName (std::string const& name)
 {
     name_ = name;
 }


### PR DESCRIPTION
LoadEvent `reName` renamed to `setName`
NetworkOPs `needNetworkLedger` renamed to `setNeedNetworkLedger`

This is the new PR for https://github.com/ripple/rippled/pull/2543 and https://github.com/ripple/rippled/pull/2544