### PR TITLE
 Delay ledger close when network stalled (RIPD-1628)

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -797,6 +797,12 @@ RCLConsensus::peerProposal(
     return consensus_.peerProposal(now, newProposal);
 }
 
+LedgerIndex
+RCLConsensus::Adaptor::fullyValidatedSeq() const
+{
+    return ledgerMaster_.getValidLedgerIndex();
+}
+
 bool
 RCLConsensus::Adaptor::preStartRound(RCLCxLedger const & prevLgr)
 {

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -364,6 +364,9 @@ class RCLConsensus
         void
         validate(RCLCxLedger const& ledger, RCLTxSet const& txns, bool proposing);
 
+        /** The index of the fully validated ledger */
+        LedgerIndex
+        fullyValidatedSeq() const;
     };
 
 public:

--- a/src/ripple/consensus/Consensus.cpp
+++ b/src/ripple/consensus/Consensus.cpp
@@ -69,7 +69,9 @@ shouldCloseLedger(
         if ((proposersClosed + proposersValidated) > (prevProposers / 2))
         {
             // If more than half of the network has closed, we close
-            JLOG(j.trace()) << "Others have closed";
+            JLOG(j.trace()) << "Others have closed"
+                            <<  " proposersClosed:  " << proposersClosed
+                            <<  " proposersValidated: " << proposersValidated;
             return true;
         }
     }
@@ -77,13 +79,19 @@ shouldCloseLedger(
     if (!anyTransactions)
     {
         // Only close at the end of the idle interval when no txs
+        JLOG(j.debug()) << "Checking idle interval (no txs)"
+                        << " timeSincePrevClose: " << timeSincePrevClose.count()
+                        << " minOpenTime: " << minOpenTime.count()
+                        << " idleInterval: " << idleInterval.count();
         return timeSincePrevClose >= std::max(minOpenTime,idleInterval);
     }
 
     // Preserve minimum ledger open time
     if (openTime < minOpenTime)
     {
-        JLOG(j.debug()) << "Must wait minimum time before closing";
+        JLOG(j.debug()) << "Must wait minimum time before closing"
+                        << " openTime: " << openTime.count()
+                        << " minOpenTime: " << minOpenTime.count();
         return false;
     }
 
@@ -92,7 +100,9 @@ shouldCloseLedger(
     // the network
     if (openTime < (prevRoundTime / 2))
     {
-        JLOG(j.debug()) << "Ledger has not been open long enough";
+        JLOG(j.debug()) << "Ledger has not been open long enough"
+                        << " openTime: " << openTime.count()
+                        << " prevRoundTime: " << prevRoundTime.count();
         return false;
     }
 

--- a/src/ripple/consensus/ConsensusParms.h
+++ b/src/ripple/consensus/ConsensusParms.h
@@ -87,7 +87,7 @@ struct ConsensusParms
     /** Define the minimum open ledger duration before closing. Given by
 
         min_close = ledgerMIN_CLOSE + (max(diff - 2, 0)) ^2
-                                                    * ledgerMIN_CLOSE_ADJUST
+                                                    * ledgerMIN_CLOSE_ADJ
 
         where diff is the number of ledgers between the consensus parent ledger
         and the last fully validated ledger.

--- a/src/ripple/consensus/ConsensusParms.h
+++ b/src/ripple/consensus/ConsensusParms.h
@@ -77,14 +77,23 @@ struct ConsensusParms
     //! The percentage threshold above which we can declare consensus.
     std::size_t minCONSENSUS_PCT = 80;
 
-    //! The duration a ledger may remain idle before closing
+    //! The duration a ledger may remain idle before closing, assuming the node
+    //! is in sync with the network.
     std::chrono::milliseconds ledgerIDLE_INTERVAL = 15s;
 
     //! The number of seconds we wait minimum to ensure participation
     std::chrono::milliseconds ledgerMIN_CONSENSUS = 1950ms;
 
-    //! Minimum number of seconds to wait to ensure others have computed the LCL
+    /** Define the minimum open ledger duration before closing. Given by
+
+        min_close = ledgerMIN_CLOSE + (max(diff - 2, 0)) ^2
+                                                    * ledgerMIN_CLOSE_ADJUST
+
+        where diff is the number of ledgers between the consensus parent ledger
+        and the last fully validated ledger.
+    */
     std::chrono::milliseconds ledgerMIN_CLOSE = 2s;
+    std::chrono::milliseconds ledgerMIN_CLOSE_ADJ = 10s;
 
     //! How often we check state or change positions
     std::chrono::milliseconds ledgerGRANULARITY = 1s;

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -611,7 +611,7 @@ struct Peer
     // Earliest allowed sequence number when checking for ledgers with more
     // validations than our current ledger
     Ledger::Seq
-    earliestAllowedSeq() const
+    fullyValidatedSeq() const
     {
         return fullyValidatedLedger.seq();
     }
@@ -627,7 +627,7 @@ struct Peer
             return ledgerID;
 
         Ledger::ID const netLgr =
-            validations.getPreferred(ledger, earliestAllowedSeq());
+            validations.getPreferred(ledger, fullyValidatedSeq());
 
         if (netLgr != ledgerID)
         {
@@ -869,7 +869,7 @@ struct Peer
         // In the future, consider taking peer dominant ledger if no validations
         // yet
         Ledger::ID bestLCL =
-            validations.getPreferred(lastClosedLedger, earliestAllowedSeq());
+            validations.getPreferred(lastClosedLedger, fullyValidatedSeq());
         if(bestLCL == Ledger::ID{0})
             bestLCL = lastClosedLedger.id();
 

--- a/src/test/csf/collectors.h
+++ b/src/test/csf/collectors.h
@@ -658,7 +658,7 @@ struct LedgerCollector
     }
 };
 
-/** Write out stream of ledger activity
+/** Write out stream of ledger accpet/validation activity
 
     Writes information about every accepted and fully-validated ledger to a
     provided std::ostream.
@@ -689,6 +689,21 @@ struct StreamCollector
             << "\n";
     }
 };
+
+/** Write out stream of all event activity */
+struct AllStreamCollector
+{
+    std::ostream& out;
+
+    template <class E>
+    void
+    on(PeerID who, SimTime when, E const& e)
+    {
+        out << when.time_since_epoch().count() << ": Node " << who
+            << " " << e << "\n";
+    }
+};
+
 
 /** Saves information about Jumps for closed and fully validated ledgers. A
     jump occurs when a node closes/fully validates a new ledger that is not the

--- a/src/test/csf/collectors.h
+++ b/src/test/csf/collectors.h
@@ -658,7 +658,7 @@ struct LedgerCollector
     }
 };
 
-/** Write out stream of ledger accpet/validation activity
+/** Write out stream of ledger accept/validation activity
 
     Writes information about every accepted and fully-validated ledger to a
     provided std::ostream.

--- a/src/test/csf/events.h
+++ b/src/test/csf/events.h
@@ -19,19 +19,20 @@
 #ifndef RIPPLE_TEST_CSF_EVENTS_H_INCLUDED
 #define RIPPLE_TEST_CSF_EVENTS_H_INCLUDED
 
+#include <ripple/beast/type_name.h>
+#include <chrono>
+#include <ostream>
+#include <test/csf/Proposal.h>
 #include <test/csf/Tx.h>
 #include <test/csf/Validation.h>
 #include <test/csf/ledgers.h>
-#include <test/csf/Proposal.h>
-#include <chrono>
-
 
 namespace ripple {
 namespace test {
 namespace csf {
 
 // Events are emitted by peers at a variety of points during the simulation.
-// Each event is emitted by a particlar peer at a particular time. Collectors
+// Each event is emitted by a particular peer at a particular time. Collectors
 // process these events, perhaps calculating statistics or storing events to
 // a log for post-processing.
 //
@@ -53,8 +54,6 @@ namespace csf {
 // CollectorRef.f defines a type-erased holder for arbitrary Collectors.  If
 // any new events are added, the interface there needs to be updated.
 
-
-
 /** A value to be flooded to all other peers starting from this peer.
  */
 template <class V>
@@ -62,6 +61,12 @@ struct Share
 {
     //! Event that is shared
     V val;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, Share const& s)
+    {
+        return o << "Share( " << beast::type_name<V>() << " )";
+    }
 };
 
 /** A value relayed to another peer as part of flooding
@@ -74,6 +79,12 @@ struct Relay
 
     //! The value to relay
     V val;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, Relay const& r)
+    {
+        return o << "Relay(to=" << r.to << "," << beast::type_name<V>() << " )";
+    }
 };
 
 /** A value received from another peer as part of flooding
@@ -86,6 +97,13 @@ struct Receive
 
     //! The received value
     V val;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, Receive const& r)
+    {
+        return o << "Receive(from=" << r.from << "," << beast::type_name<V>()
+                 << " )";
+    }
 };
 
 /** A transaction submitted to a peer */
@@ -93,6 +111,12 @@ struct SubmitTx
 {
     //! The submitted transaction
     Tx tx;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, SubmitTx const& s)
+    {
+        return o << "SubmitTx(id=" << s.tx << ")";
+    }
 };
 
 /** Peer starts a new consensus round
@@ -104,6 +128,14 @@ struct StartRound
 
     //! The prior ledger on hand
     Ledger prevLedger;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, StartRound const& r)
+    {
+        return o << "StartRound(bestID=" << r.bestLedger
+                 << ",prevSeq=" << r.prevLedger.seq()
+                 << ", prevID=" << r.prevLedger.id() << " )";
+    }
 };
 
 /** Peer closed the open ledger
@@ -115,6 +147,14 @@ struct CloseLedger
 
     // Initial txs for including in ledger
     TxSetType txs;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, CloseLedger const& r)
+    {
+        return o << "CloseLedger("
+                 << "prevSeq=" << r.prevLedger.seq()
+                 << ",prevID=" << r.prevLedger.id() << ",txs=" << r.txs << " )";
+    }
 };
 
 //! Peer accepted consensus results
@@ -125,6 +165,15 @@ struct AcceptLedger
 
     // The prior ledger (this is a jump if prior.id() != ledger.parentID())
     Ledger prior;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, AcceptLedger const& r)
+    {
+        return o << "AcceptLedger(ledgerID=" << r.ledger.id()
+                 << ",ledgerSeq=" << r.ledger.seq()
+                 << ",priorSeq=" << r.prior.seq()
+                 << ", priorID=" << r.prior.id() << " )";
+    }
 };
 
 //! Peer detected a wrong prior ledger during consensus
@@ -134,6 +183,13 @@ struct WrongPrevLedger
     Ledger::ID wrong;
     // ID of what we think is the correct ledger
     Ledger::ID right;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, WrongPrevLedger const& r)
+    {
+        return o << "WrongPrevLedger(wrong=" << r.wrong << ",right=" << r.right
+                 << " )";
+    }
 };
 
 //! Peer fully validated a new ledger
@@ -145,8 +201,16 @@ struct FullyValidateLedger
     //! The prior fully validated ledger
     //! This is a jump if prior.id() != ledger.parentID()
     Ledger prior;
-};
 
+    friend std::ostream&
+    operator<<(std::ostream& o, FullyValidateLedger const& r)
+    {
+        return o << "FullyValidateLedger(ledgerID=" << r.ledger.id()
+                 << ",ledgerSeq=" << r.ledger.seq()
+                 << ",priorSeq=" << r.prior.seq()
+                 << ", priorID=" << r.prior.id() << " )";
+    }
+};
 
 }  // namespace csf
 }  // namespace test


### PR DESCRIPTION
When a node is not advancing the fully validated ledger, this change will delay closing the next ledger as part of consensus to give more time for the node to reconnect with the network. This limits the number of intermediary ledgers the node generates while not in sync with enough of its peers.