### PR TITLE
Mark move constructors and move assignment operators as noexcept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ beast_test_unity2.cpp
 conditions_test_unity.cpp
 consensus_test_unity.cpp
 core_test_unity.cpp
+crypto_test_unity.cpp
 json_test_unity.cpp
 ledger_test_unity.cpp
 overlay_test_unity.cpp
@@ -273,8 +274,8 @@ foreach(curdir
         app
         basics
         conditions
-        crypto
         consensus
+        crypto
         json
         ledger
         legacy
@@ -310,6 +311,7 @@ foreach(curdir
         conditions
         consensus
         core
+        crypto
         csf
         json
         jtx

--- a/src/ripple/basics/Buffer.h
+++ b/src/ripple/basics/Buffer.h
@@ -82,7 +82,7 @@ public:
     /** Move-construct.
         The other buffer is reset.
     */
-    Buffer (Buffer&& other)
+    Buffer (Buffer&& other) noexcept
         : p_ (std::move(other.p_))
         , size_ (other.size_)
     {
@@ -92,7 +92,7 @@ public:
     /** Move-assign.
         The other buffer is reset.
     */
-    Buffer& operator= (Buffer&& other)
+    Buffer& operator= (Buffer&& other) noexcept
     {
         if (this != &other)
         {

--- a/src/ripple/basics/CountedObject.h
+++ b/src/ripple/basics/CountedObject.h
@@ -31,7 +31,8 @@ namespace ripple {
 class CountedObjects
 {
 public:
-    static CountedObjects& getInstance ();
+    static CountedObjects&
+    getInstance() noexcept;
 
     using Entry = std::pair <std::string, int>;
     using List = std::vector <Entry>;
@@ -46,9 +47,9 @@ public:
     class CounterBase
     {
     public:
-        CounterBase ();
+        CounterBase() noexcept;
 
-        virtual ~CounterBase ();
+        virtual ~CounterBase() noexcept;
 
         int increment () noexcept
         {
@@ -81,8 +82,8 @@ public:
     };
 
 private:
-    CountedObjects ();
-    ~CountedObjects ();
+    CountedObjects() noexcept;
+    ~CountedObjects() noexcept;
 
 private:
     std::atomic <int> m_count;
@@ -102,19 +103,20 @@ template <class Object>
 class CountedObject
 {
 public:
-    CountedObject ()
+    CountedObject() noexcept
     {
         getCounter ().increment ();
     }
 
-    CountedObject (CountedObject const&)
+    CountedObject(CountedObject const&) noexcept
     {
         getCounter ().increment ();
     }
 
-    CountedObject& operator=(CountedObject const&) = default;
+    CountedObject&
+    operator=(CountedObject const&) noexcept = default;
 
-    ~CountedObject ()
+    ~CountedObject() noexcept
     {
         getCounter ().decrement ();
     }
@@ -123,7 +125,9 @@ private:
     class Counter : public CountedObjects::CounterBase
     {
     public:
-        Counter () { }
+        Counter() noexcept
+        {
+        }
 
         char const* getName () const
         {
@@ -134,8 +138,10 @@ private:
     };
 
 private:
-    static Counter& getCounter()
+    static Counter&
+    getCounter() noexcept
     {
+        static_assert(std::is_nothrow_constructible<Counter>{}, "");
         static Counter c;
         return c;
     }

--- a/src/ripple/basics/impl/CountedObject.cpp
+++ b/src/ripple/basics/impl/CountedObject.cpp
@@ -18,23 +18,23 @@
 //==============================================================================
 
 #include <ripple/basics/CountedObject.h>
+#include <type_traits>
 
 namespace ripple {
 
-CountedObjects& CountedObjects::getInstance ()
+CountedObjects&
+CountedObjects::getInstance() noexcept
 {
     static CountedObjects instance;
 
     return instance;
 }
 
-CountedObjects::CountedObjects ()
-    : m_count (0)
-    , m_head (nullptr)
+CountedObjects::CountedObjects() noexcept : m_count(0), m_head(nullptr)
 {
 }
 
-CountedObjects::~CountedObjects ()
+CountedObjects::~CountedObjects() noexcept
 {
 }
 
@@ -70,8 +70,7 @@ CountedObjects::List CountedObjects::getCounts (int minimumThreshold) const
 
 //------------------------------------------------------------------------------
 
-CountedObjects::CounterBase::CounterBase ()
-    : m_count (0)
+CountedObjects::CounterBase::CounterBase() noexcept : m_count(0)
 {
     // Insert ourselves at the front of the lock-free linked list
 
@@ -88,7 +87,7 @@ CountedObjects::CounterBase::CounterBase ()
     ++instance.m_count;
 }
 
-CountedObjects::CounterBase::~CounterBase ()
+CountedObjects::CounterBase::~CounterBase() noexcept
 {
     // VFALCO NOTE If the counters are destroyed before the singleton,
     //             undefined behavior will result if the singleton's member

--- a/src/ripple/basics/qalloc.h
+++ b/src/ripple/basics/qalloc.h
@@ -117,9 +117,9 @@ public:
     };
 
     qalloc_type (qalloc_type const&) = default;
-    qalloc_type (qalloc_type&& other) = default;
+    qalloc_type (qalloc_type&& other) noexcept = default;
     qalloc_type& operator= (qalloc_type const&) = default;
-    qalloc_type& operator= (qalloc_type&&) = default;
+    qalloc_type& operator= (qalloc_type&&) noexcept = default;
 
     qalloc_type();
 

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -328,7 +328,7 @@ private:
         {
         }
 
-        config_t (config_t&& other) noexcept
+        config_t (config_t&& other)
             : KeyValueCompare (std::move (other.key_compare()))
             , boost::beast::detail::empty_base_optimization <ElementAllocator> (
                 std::move (other))
@@ -354,7 +354,7 @@ private:
             return *this;
         }
 
-        config_t& operator= (config_t&& other) noexcept
+        config_t& operator= (config_t&& other)
         {
             compare() = std::move (other.compare());
             alloc() = std::move (other.alloc());
@@ -614,7 +614,7 @@ public:
     aged_ordered_container (aged_ordered_container const& other,
         Allocator const& alloc);
 
-    aged_ordered_container (aged_ordered_container&& other) noexcept;
+    aged_ordered_container (aged_ordered_container&& other);
 
     aged_ordered_container (aged_ordered_container&& other,
         Allocator const& alloc);
@@ -637,7 +637,7 @@ public:
     operator= (aged_ordered_container const& other);
 
     aged_ordered_container&
-    operator= (aged_ordered_container&& other) noexcept;
+    operator= (aged_ordered_container&& other);
 
     aged_ordered_container&
     operator= (std::initializer_list <value_type> init);
@@ -1365,7 +1365,7 @@ aged_ordered_container (aged_ordered_container const& other,
 template <bool IsMulti, bool IsMap, class Key, class T,
     class Clock, class Compare, class Allocator>
 aged_ordered_container <IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
-aged_ordered_container (aged_ordered_container&& other) noexcept
+aged_ordered_container (aged_ordered_container&& other)
     : m_config (std::move (other.m_config))
     , m_cont (std::move (other.m_cont))
 {
@@ -1458,7 +1458,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
     class Clock, class Compare, class Allocator>
 auto
 aged_ordered_container <IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
-operator= (aged_ordered_container&& other) noexcept ->
+operator= (aged_ordered_container&& other) ->
     aged_ordered_container&
 {
     clear();

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -328,7 +328,7 @@ private:
         {
         }
 
-        config_t (config_t&& other)
+        config_t (config_t&& other) noexcept
             : KeyValueCompare (std::move (other.key_compare()))
             , boost::beast::detail::empty_base_optimization <ElementAllocator> (
                 std::move (other))
@@ -354,7 +354,7 @@ private:
             return *this;
         }
 
-        config_t& operator= (config_t&& other)
+        config_t& operator= (config_t&& other) noexcept
         {
             compare() = std::move (other.compare());
             alloc() = std::move (other.alloc());
@@ -614,7 +614,7 @@ public:
     aged_ordered_container (aged_ordered_container const& other,
         Allocator const& alloc);
 
-    aged_ordered_container (aged_ordered_container&& other);
+    aged_ordered_container (aged_ordered_container&& other) noexcept;
 
     aged_ordered_container (aged_ordered_container&& other,
         Allocator const& alloc);
@@ -637,7 +637,7 @@ public:
     operator= (aged_ordered_container const& other);
 
     aged_ordered_container&
-    operator= (aged_ordered_container&& other);
+    operator= (aged_ordered_container&& other) noexcept;
 
     aged_ordered_container&
     operator= (std::initializer_list <value_type> init);
@@ -1365,7 +1365,7 @@ aged_ordered_container (aged_ordered_container const& other,
 template <bool IsMulti, bool IsMap, class Key, class T,
     class Clock, class Compare, class Allocator>
 aged_ordered_container <IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
-aged_ordered_container (aged_ordered_container&& other)
+aged_ordered_container (aged_ordered_container&& other) noexcept
     : m_config (std::move (other.m_config))
     , m_cont (std::move (other.m_cont))
 {
@@ -1458,7 +1458,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
     class Clock, class Compare, class Allocator>
 auto
 aged_ordered_container <IsMulti, IsMap, Key, T, Clock, Compare, Allocator>::
-operator= (aged_ordered_container&& other) ->
+operator= (aged_ordered_container&& other) noexcept ->
     aged_ordered_container&
 {
     clear();

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -379,7 +379,7 @@ private:
         {
         }
 
-        config_t (config_t&& other) noexcept
+        config_t (config_t&& other)
             : ValueHash (std::move (other.hash_function()))
             , KeyValueEqual (std::move (other.key_eq()))
             , boost::beast::detail::empty_base_optimization <ElementAllocator> (
@@ -405,7 +405,7 @@ private:
             return *this;
         }
 
-        config_t& operator= (config_t&& other) noexcept
+        config_t& operator= (config_t&& other)
         {
             hash_function() = std::move (other.hash_function());
             key_eq() = std::move (other.key_eq());
@@ -813,7 +813,7 @@ public:
     aged_unordered_container (aged_unordered_container const& other,
         Allocator const& alloc);
 
-    aged_unordered_container (aged_unordered_container&& other) noexcept;
+    aged_unordered_container (aged_unordered_container&& other);
 
     aged_unordered_container (aged_unordered_container&& other,
         Allocator const& alloc);
@@ -847,7 +847,7 @@ public:
 
     aged_unordered_container& operator= (aged_unordered_container const& other);
 
-    aged_unordered_container& operator= (aged_unordered_container&& other) noexcept;
+    aged_unordered_container& operator= (aged_unordered_container&& other);
 
     aged_unordered_container& operator= (std::initializer_list <value_type> init);
 
@@ -1787,7 +1787,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
     class Clock, class Hash, class KeyEqual, class Allocator>
 aged_unordered_container <IsMulti, IsMap, Key, T, Clock,
     Hash, KeyEqual, Allocator>::
-aged_unordered_container (aged_unordered_container&& other) noexcept
+aged_unordered_container (aged_unordered_container&& other)
     : m_config (std::move (other.m_config))
     , m_buck (std::move (other.m_buck))
     , m_cont (std::move (other.m_cont))
@@ -1973,7 +1973,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
 auto
 aged_unordered_container <IsMulti, IsMap, Key, T, Clock,
     Hash, KeyEqual, Allocator>::
-operator= (aged_unordered_container&& other) noexcept ->
+operator= (aged_unordered_container&& other) ->
     aged_unordered_container&
 {
     size_type const n (other.size());

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -379,7 +379,7 @@ private:
         {
         }
 
-        config_t (config_t&& other)
+        config_t (config_t&& other) noexcept
             : ValueHash (std::move (other.hash_function()))
             , KeyValueEqual (std::move (other.key_eq()))
             , boost::beast::detail::empty_base_optimization <ElementAllocator> (
@@ -405,7 +405,7 @@ private:
             return *this;
         }
 
-        config_t& operator= (config_t&& other)
+        config_t& operator= (config_t&& other) noexcept
         {
             hash_function() = std::move (other.hash_function());
             key_eq() = std::move (other.key_eq());
@@ -813,7 +813,7 @@ public:
     aged_unordered_container (aged_unordered_container const& other,
         Allocator const& alloc);
 
-    aged_unordered_container (aged_unordered_container&& other);
+    aged_unordered_container (aged_unordered_container&& other) noexcept;
 
     aged_unordered_container (aged_unordered_container&& other,
         Allocator const& alloc);
@@ -847,7 +847,7 @@ public:
 
     aged_unordered_container& operator= (aged_unordered_container const& other);
 
-    aged_unordered_container& operator= (aged_unordered_container&& other);
+    aged_unordered_container& operator= (aged_unordered_container&& other) noexcept;
 
     aged_unordered_container& operator= (std::initializer_list <value_type> init);
 
@@ -1787,7 +1787,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
     class Clock, class Hash, class KeyEqual, class Allocator>
 aged_unordered_container <IsMulti, IsMap, Key, T, Clock,
     Hash, KeyEqual, Allocator>::
-aged_unordered_container (aged_unordered_container&& other)
+aged_unordered_container (aged_unordered_container&& other) noexcept
     : m_config (std::move (other.m_config))
     , m_buck (std::move (other.m_buck))
     , m_cont (std::move (other.m_cont))
@@ -1973,7 +1973,7 @@ template <bool IsMulti, bool IsMap, class Key, class T,
 auto
 aged_unordered_container <IsMulti, IsMap, Key, T, Clock,
     Hash, KeyEqual, Allocator>::
-operator= (aged_unordered_container&& other) ->
+operator= (aged_unordered_container&& other) noexcept ->
     aged_unordered_container&
 {
     size_type const n (other.size());

--- a/src/ripple/beast/core/SharedPtr.h
+++ b/src/ripple/beast/core/SharedPtr.h
@@ -176,7 +176,7 @@ public:
     */
     /** @{ */
 #if BEAST_SHAREDPTR_PROVIDE_COMPILER_WORKAROUNDS
-    SharedPtr& operator= (SharedPtr && sp)
+    SharedPtr& operator= (SharedPtr && sp) noexcept
     {
         return assign (sp.swap <T> (nullptr));
     }

--- a/src/ripple/beast/core/SharedPtr.h
+++ b/src/ripple/beast/core/SharedPtr.h
@@ -176,7 +176,7 @@ public:
     */
     /** @{ */
 #if BEAST_SHAREDPTR_PROVIDE_COMPILER_WORKAROUNDS
-    SharedPtr& operator= (SharedPtr && sp) noexcept
+    SharedPtr& operator= (SharedPtr && sp)
     {
         return assign (sp.swap <T> (nullptr));
     }

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -320,7 +320,7 @@ public:
     //! Clock type for measuring time within the consensus code
     using clock_type = beast::abstract_clock<std::chrono::steady_clock>;
 
-    Consensus(Consensus&&) = default;
+    Consensus(Consensus&&) noexcept = default;
 
     /** Constructor.
 

--- a/src/ripple/core/ClosureCounter.h
+++ b/src/ripple/core/ClosureCounter.h
@@ -93,9 +93,9 @@ private:
             ++counter_;
         }
 
-        Wrapper (Wrapper&& rhs) noexcept
-        : counter_ (rhs.counter_)
-        , closure_ (std::move (rhs.closure_))
+        Wrapper(Wrapper&& rhs) noexcept(
+            std::is_nothrow_move_constructible<Closure>::value)
+            : counter_(rhs.counter_), closure_(std::move(rhs.closure_))
         {
             ++counter_;
         }

--- a/src/ripple/core/ClosureCounter.h
+++ b/src/ripple/core/ClosureCounter.h
@@ -93,7 +93,7 @@ private:
             ++counter_;
         }
 
-        Wrapper (Wrapper&& rhs)
+        Wrapper (Wrapper&& rhs) noexcept
         : counter_ (rhs.counter_)
         , closure_ (std::move (rhs.closure_))
         {

--- a/src/ripple/crypto/impl/openssl.h
+++ b/src/ripple/crypto/impl/openssl.h
@@ -85,6 +85,9 @@ public:
     void assign (uint8_t const* data, size_t size);
 };
 
+static_assert(std::is_nothrow_move_constructible<bignum>{}, "");
+static_assert(std::is_nothrow_move_assignable<bignum>{}, "");
+
 inline bool operator< (bignum const& a, bignum const& b)
 {
     return BN_cmp (a.get(), b.get()) < 0;
@@ -172,6 +175,8 @@ public:
     EC_POINT      * get()        { return ptr; }
     EC_POINT const* get() const  { return ptr; }
 };
+
+static_assert(std::is_nothrow_move_constructible<ec_point>{}, "");
 
 void add_to (EC_GROUP const* group,
              ec_point const& a,

--- a/src/ripple/crypto/impl/openssl.h
+++ b/src/ripple/crypto/impl/openssl.h
@@ -61,12 +61,12 @@ public:
         assign_new (thing.data(), thing.size());
     }
 
-    bignum(bignum&& that) : ptr( that.ptr )
+    bignum(bignum&& that) noexcept : ptr( that.ptr )
     {
         that.ptr = nullptr;
     }
 
-    bignum& operator= (bignum&& that)
+    bignum& operator= (bignum&& that) noexcept
     {
         using std::swap;
 
@@ -163,7 +163,7 @@ public:
     ec_point           (ec_point const&) = delete;
     ec_point& operator=(ec_point const&) = delete;
 
-    ec_point(ec_point&& that)
+    ec_point(ec_point&& that) noexcept
     {
         ptr      = that.ptr;
         that.ptr = nullptr;

--- a/src/ripple/crypto/impl/openssl.h
+++ b/src/ripple/crypto/impl/openssl.h
@@ -85,9 +85,6 @@ public:
     void assign (uint8_t const* data, size_t size);
 };
 
-static_assert(std::is_nothrow_move_constructible<bignum>{}, "");
-static_assert(std::is_nothrow_move_assignable<bignum>{}, "");
-
 inline bool operator< (bignum const& a, bignum const& b)
 {
     return BN_cmp (a.get(), b.get()) < 0;
@@ -175,8 +172,6 @@ public:
     EC_POINT      * get()        { return ptr; }
     EC_POINT const* get() const  { return ptr; }
 };
-
-static_assert(std::is_nothrow_move_constructible<ec_point>{}, "");
 
 void add_to (EC_GROUP const* group,
              ec_point const& a,

--- a/src/ripple/ledger/CashDiff.h
+++ b/src/ripple/ledger/CashDiff.h
@@ -62,7 +62,7 @@ class CashDiff
 public:
     CashDiff() = delete;
     CashDiff (CashDiff const&) = delete;
-    CashDiff (CashDiff&& other);
+    CashDiff (CashDiff&& other) noexcept;
     CashDiff& operator= (CashDiff const&) = delete;
     ~CashDiff();
 

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -223,7 +223,7 @@ public:
     {
     }
 
-    ReadView (ReadView&& other)
+    ReadView (ReadView&& other) noexcept
         : sles(*this)
         , txs(*this)
     {

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -223,7 +223,7 @@ public:
     {
     }
 
-    ReadView (ReadView&& other) noexcept
+    ReadView (ReadView&& other)
         : sles(*this)
         , txs(*this)
     {

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -92,7 +92,7 @@ public:
         iterator() = default;
 
         iterator (iterator const& other);
-        iterator (iterator&& other);
+        iterator (iterator&& other) noexcept;
 
         // Used by the implementation
         explicit
@@ -103,7 +103,7 @@ public:
         operator= (iterator const& other);
 
         iterator&
-        operator= (iterator&& other);
+        operator= (iterator&& other) noexcept;
 
         bool
         operator== (iterator const& other) const;

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -74,6 +74,11 @@ public:
     using iter_base =
         ReadViewFwdIter<ValueType>;
 
+    static_assert(
+        std::is_nothrow_move_constructible<ValueType>{},
+        "ReadViewFwdRange move and move assign constructors should be "
+        "noexcept");
+
     class iterator
     {
     public:

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -131,6 +131,9 @@ public:
         boost::optional<value_type> mutable cache_;
     };
 
+    static_assert(std::is_nothrow_move_constructible<iterator>{}, "");
+    static_assert(std::is_nothrow_move_assignable<iterator>{}, "");
+
     using const_iterator = iterator;
 
     using value_type = ValueType;

--- a/src/ripple/ledger/detail/ReadViewFwdRange.ipp
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.ipp
@@ -35,7 +35,7 @@ ReadViewFwdRange<ValueType>::iterator::iterator(
 
 template<class ValueType>
 ReadViewFwdRange<ValueType>::iterator::iterator(
-        iterator&& other)
+        iterator&& other) noexcept
     : view_ (other.view_)
     , impl_ (std::move(other.impl_))
     , cache_ (std::move(other.cache_))
@@ -69,7 +69,7 @@ ReadViewFwdRange<ValueType>::iterator::operator=(
 template<class ValueType>
 auto
 ReadViewFwdRange<ValueType>::iterator::operator=(
-    iterator&& other) ->
+    iterator&& other) noexcept ->
         iterator&
 {
     view_ = other.view_;

--- a/src/ripple/ledger/impl/CashDiff.cpp
+++ b/src/ripple/ledger/impl/CashDiff.cpp
@@ -591,7 +591,7 @@ void CashDiff::Impl::findDiffs (
 //------------------------------------------------------------------------------
 
 // Locates differences between two ApplyStateTables.
-CashDiff::CashDiff (CashDiff&& other)
+CashDiff::CashDiff (CashDiff&& other) noexcept
 : impl_ (std::move (other.impl_))
 {
 }

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -189,7 +189,8 @@ public:
     {
         return fieldCode == -1;
     }
-    bool isUseful () const
+    bool
+    isUseful() const noexcept
     {
         return fieldCode > 0;
     }

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -274,7 +274,8 @@ struct TypedField : SField
     {
     }
 
-    TypedField(TypedField&& u) : SField(std::move(u))
+    TypedField (TypedField&& u)
+        : SField(std::move(u))
     {
     }
 };

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -274,8 +274,7 @@ struct TypedField : SField
     {
     }
 
-    TypedField (TypedField&& u) noexcept
-        : SField(std::move(u))
+    TypedField(TypedField&& u) : SField(std::move(u))
     {
     }
 };

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -274,7 +274,7 @@ struct TypedField : SField
     {
     }
 
-    TypedField (TypedField&& u)
+    TypedField (TypedField&& u) noexcept
         : SField(std::move(u))
     {
     }

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -71,7 +71,7 @@ public:
     */
     SOTemplate () = default;
 
-    SOTemplate(SOTemplate&& other)
+    SOTemplate(SOTemplate&& other) noexcept
         : mTypes(std::move(other.mTypes))
         , mIndex(std::move(other.mIndex))
     {

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -53,7 +53,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace (n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -129,7 +129,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -66,7 +66,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -171,13 +171,6 @@ public:
         return v_.empty ();
     }
 };
-
-static_assert(std::is_default_constructible<STArray>{}, "");
-static_assert(std::is_copy_constructible<STArray>{}, "");
-static_assert(std::is_copy_assignable<STArray>{}, "");
-static_assert(std::is_nothrow_move_constructible<STArray>{}, "");
-static_assert(std::is_nothrow_move_assignable<STArray>{}, "");
-
 } // ripple
 
 #endif

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -172,6 +172,12 @@ public:
     }
 };
 
+static_assert(std::is_default_constructible<STArray>{}, "");
+static_assert(std::is_copy_constructible<STArray>{}, "");
+static_assert(std::is_copy_assignable<STArray>{}, "");
+static_assert(std::is_nothrow_move_constructible<STArray>{}, "");
+static_assert(std::is_nothrow_move_assignable<STArray>{}, "");
+
 } // ripple
 
 #endif

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -50,14 +50,14 @@ public:
     using const_iterator = list_type::const_iterator;
 
     STArray();
-    STArray (STArray&&);
+    STArray (STArray&&) noexcept;
     STArray (STArray const&) = default;
     STArray (SField const& f, int n);
     STArray (SerialIter& sit, SField const& f, int depth = 0);
     explicit STArray (int n);
     explicit STArray (SField const& f);
     STArray& operator= (STArray const&) = default;
-    STArray& operator= (STArray&&);
+    STArray& operator= (STArray&&) noexcept;
 
     STBase*
     copy (std::size_t n, void* buf) const override

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -70,6 +70,10 @@ public:
     STBase(const STBase& t) = default;
     STBase& operator= (const STBase& t);
 
+    STBase(STBase&& t) noexcept = default;
+    STBase&
+    operator=(STBase&& t) noexcept;
+
     bool operator== (const STBase& t) const;
     bool operator!= (const STBase& t) const;
 

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -143,7 +143,7 @@ public:
         This sets the name.
     */
     void
-    setFName (SField const& n);
+    setFName (SField const& n) noexcept;
 
     SField const&
     getFName() const;

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -60,15 +60,15 @@ namespace ripple {
 class STBase
 {
 public:
-    STBase();
+    STBase() noexcept;
 
     explicit
     STBase (SField const& n) noexcept;
 
-    virtual ~STBase() = default;
+    virtual ~STBase() noexcept = default;
 
-    STBase(const STBase& t) = default;
-    STBase& operator= (const STBase& t);
+    STBase(const STBase& t) noexcept = default;
+    STBase& operator= (const STBase& t) noexcept;
 
     STBase(STBase&& t) noexcept = default;
     STBase&
@@ -86,7 +86,7 @@ public:
 
     virtual
     STBase*
-    move (std::size_t n, void* buf)
+    move (std::size_t n, void* buf) noexcept
     {
         return emplace(n, buf, std::move(*this));
     }
@@ -157,7 +157,7 @@ protected:
     template <class T>
     static
     STBase*
-    emplace(std::size_t n, void* buf, T&& val)
+    emplace(std::size_t n, void* buf, T&& val) noexcept
     {
         using U = std::decay_t<T>;
         if (sizeof(U) > n)

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -63,7 +63,7 @@ public:
     STBase();
 
     explicit
-    STBase (SField const& n);
+    STBase (SField const& n) noexcept;
 
     virtual ~STBase() = default;
 

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -69,7 +69,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -79,7 +79,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -49,7 +49,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -62,7 +62,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -279,7 +279,7 @@ public:
 
     static char const* getCountedObjectName () { return "STObject"; }
 
-    STObject(STObject&&);
+    STObject(STObject&&) noexcept;
     STObject(STObject const&) = default;
     STObject (const SOTemplate & type, SField const& name);
     STObject (const SOTemplate & type, SerialIter & sit, SField const& name);
@@ -289,7 +289,7 @@ public:
     {
     }
     STObject& operator= (STObject const&) = default;
-    STObject& operator= (STObject&& other);
+    STObject& operator= (STObject&& other) noexcept;
 
     explicit STObject (SField const& name);
 

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -302,7 +302,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -313,7 +313,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -76,7 +76,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -141,7 +141,7 @@ public:
     }
 
     STBase*
-    move(std::size_t n, void* buf) override
+    move(std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -55,7 +55,7 @@ public:
     }
 
     STBase*
-    move (std::size_t n, void* buf) override
+    move (std::size_t n, void* buf) noexcept override
     {
         return emplace(n, buf, std::move(*this));
     }

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -298,7 +298,7 @@ public:
     // Constructors
     constexpr TERSubset() : code_ (tesSUCCESS) { }
     constexpr TERSubset (TERSubset const& rhs) = default;
-    constexpr TERSubset (TERSubset&& rhs) = default;
+    constexpr TERSubset (TERSubset&& rhs) noexcept = default;
 private:
     constexpr explicit TERSubset (int rhs) : code_ (rhs) { }
 public:
@@ -315,7 +315,7 @@ public:
 
     // Assignment
     constexpr TERSubset& operator=(TERSubset const& rhs) = default;
-    constexpr TERSubset& operator=(TERSubset&& rhs) = default;
+    constexpr TERSubset& operator=(TERSubset&& rhs) noexcept = default;
 
     // Trait tells enable_if which types are allowed for assignment.
     template <typename T>

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -32,13 +32,13 @@ STArray::STArray()
     //v_.reserve(reserveSize);
 }
 
-STArray::STArray (STArray&& other)
+STArray::STArray (STArray&& other) noexcept
     : STBase(other.getFName())
     , v_(std::move(other.v_))
 {
 }
 
-STArray& STArray::operator= (STArray&& other)
+STArray& STArray::operator= (STArray&& other) noexcept
 {
     setFName(other.getFName());
     v_ = std::move(other.v_);

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -19,8 +19,9 @@
 
 #include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
-#include <ripple/protocol/STBase.h>
 #include <ripple/protocol/STArray.h>
+#include <ripple/protocol/STBase.h>
+#include <type_traits>
 
 namespace ripple {
 
@@ -36,6 +37,7 @@ STArray::STArray (STArray&& other) noexcept
     : STBase(other.getFName())
     , v_(std::move(other.v_))
 {
+    static_assert(std::is_nothrow_constructible<CountedObject<STArray>>{}, "");
 }
 
 STArray& STArray::operator= (STArray&& other) noexcept

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -135,7 +135,7 @@ STBase::isDefault() const
 }
 
 void
-STBase::setFName (SField const& n)
+STBase::setFName (SField const& n) noexcept
 {
     fName = &n;
     assert (fName);

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -51,6 +51,16 @@ STBase::operator= (const STBase& t)
     return *this;
 }
 
+STBase&
+STBase::operator=(STBase&& other) noexcept
+{
+    if (!fName->isUseful())
+    {
+        fName = std::move(other.fName);
+    }
+    return *this;
+}
+
 bool
 STBase::operator== (const STBase& t) const
 {

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -29,7 +29,7 @@ STBase::STBase()
 {
 }
 
-STBase::STBase (SField const& n)
+STBase::STBase (SField const& n) noexcept
     : fName(&n)
 {
     assert(fName);

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -24,7 +24,7 @@
 
 namespace ripple {
 
-STBase::STBase()
+STBase::STBase() noexcept
     : fName(&sfGeneric)
 {
 }
@@ -36,7 +36,7 @@ STBase::STBase (SField const& n) noexcept
 }
 
 STBase&
-STBase::operator= (const STBase& t)
+STBase::operator= (const STBase& t) noexcept
 {
     if ((t.fName != fName) && fName->isUseful() && t.fName->isUseful())
     {

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -17,12 +17,13 @@
 */
 //==============================================================================
 
-#include <ripple/protocol/STObject.h>
+#include <ripple/basics/Log.h>
 #include <ripple/protocol/InnerObjectFormats.h>
 #include <ripple/protocol/STAccount.h>
 #include <ripple/protocol/STArray.h>
 #include <ripple/protocol/STBlob.h>
-#include <ripple/basics/Log.h>
+#include <ripple/protocol/STObject.h>
+#include <type_traits>
 
 namespace ripple {
 
@@ -40,6 +41,7 @@ STObject::STObject(STObject&& other) noexcept
     , v_(std::move(other.v_))
     , mType(other.mType)
 {
+    static_assert(std::is_nothrow_constructible<CountedObject<STObject>>{}, "");
 }
 
 STObject::STObject (SField const& name)

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -35,7 +35,7 @@ STObject::~STObject()
 #endif
 }
 
-STObject::STObject(STObject&& other)
+STObject::STObject(STObject&& other) noexcept
     : STBase(other.getFName())
     , v_(std::move(other.v_))
     , mType(other.mType)
@@ -76,7 +76,7 @@ STObject::STObject (SerialIter& sit, SField const& name, int depth)
 }
 
 STObject&
-STObject::operator= (STObject&& other)
+STObject::operator= (STObject&& other) noexcept
 {
     setFName(other.getFName());
     mType = other.mType;

--- a/src/ripple/protocol/impl/STVar.cpp
+++ b/src/ripple/protocol/impl/STVar.cpp
@@ -49,7 +49,7 @@ STVar::STVar (STVar const& other)
         p_ = other.p_->copy(max_size, &d_);
 }
 
-STVar::STVar (STVar&& other)
+STVar::STVar (STVar&& other) noexcept
 {
     if (other.on_heap())
     {
@@ -78,7 +78,7 @@ STVar::operator= (STVar const& rhs)
 }
 
 STVar&
-STVar::operator= (STVar&& rhs)
+STVar::operator= (STVar&& rhs) noexcept
 {
     if (&rhs != this)
     {

--- a/src/ripple/protocol/impl/STVar.cpp
+++ b/src/ripple/protocol/impl/STVar.cpp
@@ -159,7 +159,7 @@ STVar::STVar (SerializedTypeID id, SField const& name)
 }
 
 void
-STVar::destroy()
+STVar::destroy() noexcept
 {
     if (on_heap())
         delete p_;

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -113,6 +113,12 @@ private:
     }
 };
 
+static_assert(!std::is_default_constructible<STVar>{}, "");
+static_assert(std::is_copy_constructible<STVar>{}, "");
+static_assert(std::is_copy_assignable<STVar>{}, "");
+static_assert(std::is_nothrow_move_assignable<STVar>{}, "");
+static_assert(std::is_nothrow_move_constructible<STVar>{}, "");
+
 template <class T, class... Args>
 inline
 STVar

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -113,12 +113,6 @@ private:
     }
 };
 
-static_assert(!std::is_default_constructible<STVar>{}, "");
-static_assert(std::is_copy_constructible<STVar>{}, "");
-static_assert(std::is_copy_assignable<STVar>{}, "");
-static_assert(std::is_nothrow_move_assignable<STVar>{}, "");
-static_assert(std::is_nothrow_move_constructible<STVar>{}, "");
-
 template <class T, class... Args>
 inline
 STVar

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -93,7 +93,7 @@ private:
 
     STVar (SerializedTypeID id, SField const& name);
 
-    void destroy();
+    void destroy() noexcept;
 
     template <class T, class... Args>
     void
@@ -106,7 +106,7 @@ private:
     }
 
     bool
-    on_heap() const
+    on_heap() const noexcept
     {
         return static_cast<void const*>(p_) !=
             static_cast<void const*>(&d_);

--- a/src/ripple/protocol/impl/STVar.h
+++ b/src/ripple/protocol/impl/STVar.h
@@ -58,11 +58,11 @@ private:
 public:
     ~STVar();
     STVar (STVar const& other);
-    STVar (STVar&& other);
+    STVar (STVar&& other) noexcept;
     STVar& operator= (STVar const& rhs);
-    STVar& operator= (STVar&& rhs);
+    STVar& operator= (STVar&& rhs) noexcept;
 
-    STVar (STBase&& t)
+    STVar (STBase&& t) noexcept
     {
         p_ = t.move(max_size, &d_);
     }

--- a/src/test/basics/Buffer_test.cpp
+++ b/src/test/basics/Buffer_test.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/Buffer.h>
 #include <ripple/beast/unit_test.h>
 #include <cstdint>
+#include <type_traits>
 
 namespace ripple {
 namespace test {
@@ -108,6 +109,9 @@ struct Buffer_test : beast::unit_test::suite
         // Check move constructor & move assignments:
         {
             testcase ("Move Construction / Assignment");
+
+            static_assert(std::is_nothrow_move_constructible<Buffer>::value, "");
+            static_assert(std::is_nothrow_move_assignable<Buffer>::value, "");
 
             { // Move-construct from empty buf
                 Buffer x;

--- a/src/test/basics/qalloc_test.cpp
+++ b/src/test/basics/qalloc_test.cpp
@@ -1,8 +1,7 @@
-
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2018 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -18,18 +17,31 @@
 */
 //==============================================================================
 
-#include <test/basics/Buffer_test.cpp>
-#include <test/basics/CheckLibraryVersions_test.cpp>
-#include <test/basics/DetectCrash_test.cpp>
-#include <test/basics/KeyCache_test.cpp>
-#include <test/basics/PerfLog_test.cpp>
-#include <test/basics/RangeSet_test.cpp>
-#include <test/basics/Slice_test.cpp>
-#include <test/basics/StringUtilities_test.cpp>
-#include <test/basics/TaggedCache_test.cpp>
-#include <test/basics/base_uint_test.cpp>
-#include <test/basics/contract_test.cpp>
-#include <test/basics/hardened_hash_test.cpp>
-#include <test/basics/mulDiv_test.cpp>
-#include <test/basics/qalloc_test.cpp>
-#include <test/basics/tagged_integer_test.cpp>
+#include <ripple/basics/qalloc.h>
+#include <ripple/beast/unit_test.h>
+#include <type_traits>
+
+namespace ripple {
+
+struct qalloc_test : beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        BEAST_EXPECT(std::is_default_constructible<qalloc>{});
+        BEAST_EXPECT(std::is_copy_constructible<qalloc>{});
+        BEAST_EXPECT(std::is_copy_assignable<qalloc>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<qalloc>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<qalloc>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(qalloc, ripple_basics, ripple);
+
+}  // namespace ripple

--- a/src/test/core/ClosureCounter_test.cpp
+++ b/src/test/core/ClosureCounter_test.cpp
@@ -126,7 +126,7 @@ class ClosureCounter_test : public beast::unit_test::suite
         , str (rhs.str) {}
 
         // Move constructor
-        TrackedString (TrackedString&& rhs)
+        TrackedString (TrackedString&& rhs) noexcept
         : copies (rhs.copies)
         , moves (rhs.moves + 1)
         , str (std::move(rhs.str)) {}

--- a/src/test/crypto/Openssl_test.cpp
+++ b/src/test/crypto/Openssl_test.cpp
@@ -1,0 +1,54 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/crypto/impl/openssl.h>
+#include <type_traits>
+
+namespace ripple {
+struct Openssl_test : public beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        using namespace openssl;
+
+        BEAST_EXPECT(std::is_default_constructible<bignum>{});
+        BEAST_EXPECT(!std::is_copy_constructible<bignum>{});
+        BEAST_EXPECT(!std::is_copy_assignable<bignum>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<bignum>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<bignum>{});
+
+        BEAST_EXPECT(!std::is_default_constructible<ec_point>{});
+        BEAST_EXPECT(!std::is_copy_constructible<ec_point>{});
+        BEAST_EXPECT(!std::is_copy_assignable<ec_point>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<ec_point>{});
+        BEAST_EXPECT(!std::is_nothrow_move_assignable<ec_point>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    };
+};
+
+BEAST_DEFINE_TESTSUITE(Openssl, crypto, ripple);
+
+}  // namespace ripple

--- a/src/test/ledger/CashDiff_test.cpp
+++ b/src/test/ledger/CashDiff_test.cpp
@@ -17,15 +17,21 @@
 */
 //==============================================================================
 
+#include <ripple/beast/unit_test.h>
 #include <ripple/ledger/CashDiff.h>
 #include <ripple/protocol/STAmount.h>
-#include <ripple/beast/unit_test.h>
+#include <type_traits>
 
 namespace ripple {
 namespace test {
 
 class CashDiff_test : public beast::unit_test::suite
 {
+    static_assert(!std::is_default_constructible<CashDiff>{}, "");
+    static_assert(!std::is_copy_constructible<CashDiff>{}, "");
+    static_assert(!std::is_copy_assignable<CashDiff>{}, "");
+    static_assert(std::is_nothrow_move_constructible<CashDiff>{}, "");
+    static_assert(!std::is_move_assignable<CashDiff>{}, "");
 
     // Exercise diffIsDust (STAmount, STAmount)
     void

--- a/src/test/protocol/SOTemplate_test.cpp
+++ b/src/test/protocol/SOTemplate_test.cpp
@@ -29,10 +29,10 @@ struct SOTemplate_test : public beast::unit_test::suite
     testBasicProperties()
     {
         BEAST_EXPECT(std::is_default_constructible<SOTemplate>{});
-        BEAST_EXPECT(std::is_copy_constructible<SOTemplate>{});
-        BEAST_EXPECT(std::is_copy_assignable<SOTemplate>{});
+        BEAST_EXPECT(!std::is_copy_constructible<SOTemplate>{});
+        BEAST_EXPECT(!std::is_copy_assignable<SOTemplate>{});
         BEAST_EXPECT(std::is_nothrow_move_constructible<SOTemplate>{});
-        BEAST_EXPECT(std::is_nothrow_move_assignable<SOTemplate>{});
+        BEAST_EXPECT(!std::is_nothrow_move_assignable<SOTemplate>{});
     }
 
     void

--- a/src/test/protocol/SOTemplate_test.cpp
+++ b/src/test/protocol/SOTemplate_test.cpp
@@ -1,0 +1,47 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/SOTemplate.h>
+#include <type_traits>
+
+namespace ripple {
+
+struct SOTemplate_test : public beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        BEAST_EXPECT(std::is_default_constructible<SOTemplate>{});
+        BEAST_EXPECT(std::is_copy_constructible<SOTemplate>{});
+        BEAST_EXPECT(std::is_copy_assignable<SOTemplate>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<SOTemplate>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<SOTemplate>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    };
+};
+
+BEAST_DEFINE_TESTSUITE(SOTemplate, protocol, ripple);
+
+}  // namespace ripple

--- a/src/test/protocol/STArray_test.cpp
+++ b/src/test/protocol/STArray_test.cpp
@@ -1,8 +1,7 @@
-
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2018 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -18,22 +17,31 @@
 */
 //==============================================================================
 
-#include <test/protocol/BuildInfo_test.cpp>
-#include <test/protocol/IOUAmount_test.cpp>
-#include <test/protocol/InnerObjectFormats_test.cpp>
-#include <test/protocol/Issue_test.cpp>
-#include <test/protocol/PublicKey_test.cpp>
-#include <test/protocol/Quality_test.cpp>
-#include <test/protocol/SOTemplate_test.cpp>
-#include <test/protocol/STAccount_test.cpp>
-#include <test/protocol/STAmount_test.cpp>
-#include <test/protocol/STArray_test.cpp>
-#include <test/protocol/STObject_test.cpp>
-#include <test/protocol/STTx_test.cpp>
-#include <test/protocol/STValidation_test.cpp>
-#include <test/protocol/SecretKey_test.cpp>
-#include <test/protocol/Seed_test.cpp>
-#include <test/protocol/TER_test.cpp>
-#include <test/protocol/XRPAmount_test.cpp>
-#include <test/protocol/digest_test.cpp>
-#include <test/protocol/types_test.cpp>
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/STArray.h>
+#include <type_traits>
+
+namespace ripple {
+
+struct STArray_test : public beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        BEAST_EXPECT(std::is_default_constructible<STArray>{});
+        BEAST_EXPECT(std::is_copy_constructible<STArray>{});
+        BEAST_EXPECT(std::is_copy_assignable<STArray>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<STArray>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<STArray>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    };
+};
+
+BEAST_DEFINE_TESTSUITE(STArray, protocol, ripple);
+
+}  // namespace ripple

--- a/src/test/protocol/STBase_test.cpp
+++ b/src/test/protocol/STBase_test.cpp
@@ -1,8 +1,7 @@
-
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2018 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -18,24 +17,31 @@
 */
 //==============================================================================
 
-#include <test/protocol/BuildInfo_test.cpp>
-#include <test/protocol/digest_test.cpp>
-#include <test/protocol/InnerObjectFormats_test.cpp>
-#include <test/protocol/IOUAmount_test.cpp>
-#include <test/protocol/Issue_test.cpp>
-#include <test/protocol/PublicKey_test.cpp>
-#include <test/protocol/Quality_test.cpp>
-#include <test/protocol/SecretKey_test.cpp>
-#include <test/protocol/Seed_test.cpp>
-#include <test/protocol/SOTemplate_test.cpp>
-#include <test/protocol/STAccount_test.cpp>
-#include <test/protocol/STAmount_test.cpp>
-#include <test/protocol/STArray_test.cpp>
-#include <test/protocol/STBase_test.cpp>
-#include <test/protocol/STObject_test.cpp>
-#include <test/protocol/STTx_test.cpp>
-#include <test/protocol/STValidation_test.cpp>
-#include <test/protocol/STVar_test.cpp>
-#include <test/protocol/TER_test.cpp>
-#include <test/protocol/types_test.cpp>
-#include <test/protocol/XRPAmount_test.cpp>
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/STBase.h>
+#include <type_traits>
+
+namespace ripple {
+
+struct STBase_test : public beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        BEAST_EXPECT(std::is_default_constructible<STBase>{});
+        BEAST_EXPECT(std::is_copy_constructible<STBase>{});
+        BEAST_EXPECT(std::is_copy_assignable<STBase>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<STBase>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<STBase>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    };
+};
+
+BEAST_DEFINE_TESTSUITE(STBase, protocol, ripple);
+
+}  // namespace ripple

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -40,6 +40,16 @@ public:
         return reader.parse(json, to) && to.isObject();
     }
 
+    void
+    testBasicProperties()
+    {
+        BEAST_EXPECT(!std::is_default_constructible<STObject>{});
+        BEAST_EXPECT(std::is_copy_constructible<STObject>{});
+        BEAST_EXPECT(std::is_copy_assignable<STObject>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<STObject>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<STObject>{});
+    }
+
     void testParseJSONArrayWithInvalidChildrenObjects ()
     {
         testcase ("parse json array invalid children");
@@ -637,6 +647,7 @@ public:
         // Instantiate a jtx::Env so debugLog writes are exercised.
         test::jtx::Env env (*this);
 
+        testBasicProperties();
         testFields();
         testSerialization();
         testParseJSONArray();

--- a/src/test/protocol/STVar_test.cpp
+++ b/src/test/protocol/STVar_test.cpp
@@ -1,8 +1,7 @@
-
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2018 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -18,23 +17,33 @@
 */
 //==============================================================================
 
-#include <test/protocol/BuildInfo_test.cpp>
-#include <test/protocol/IOUAmount_test.cpp>
-#include <test/protocol/InnerObjectFormats_test.cpp>
-#include <test/protocol/Issue_test.cpp>
-#include <test/protocol/PublicKey_test.cpp>
-#include <test/protocol/Quality_test.cpp>
-#include <test/protocol/SOTemplate_test.cpp>
-#include <test/protocol/STAccount_test.cpp>
-#include <test/protocol/STAmount_test.cpp>
-#include <test/protocol/STArray_test.cpp>
-#include <test/protocol/STObject_test.cpp>
-#include <test/protocol/STTx_test.cpp>
-#include <test/protocol/STValidation_test.cpp>
-#include <test/protocol/STVar_test.cpp>
-#include <test/protocol/SecretKey_test.cpp>
-#include <test/protocol/Seed_test.cpp>
-#include <test/protocol/TER_test.cpp>
-#include <test/protocol/XRPAmount_test.cpp>
-#include <test/protocol/digest_test.cpp>
-#include <test/protocol/types_test.cpp>
+#include <ripple/beast/unit_test.h>
+#include <ripple/protocol/impl/STVar.h>
+#include <type_traits>
+
+namespace ripple {
+
+struct STVar_test : public beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        using detail::STVar;
+
+        BEAST_EXPECT(!std::is_default_constructible<STVar>{});
+        BEAST_EXPECT(std::is_copy_constructible<STVar>{});
+        BEAST_EXPECT(std::is_copy_assignable<STVar>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<STVar>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<STVar>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    };
+};
+
+BEAST_DEFINE_TESTSUITE(STVar, protocol, ripple);
+
+}  // namespace ripple

--- a/src/test/unity/basics_test_unity.cpp
+++ b/src/test/unity/basics_test_unity.cpp
@@ -18,18 +18,18 @@
 */
 //==============================================================================
 
+#include <test/basics/base_uint_test.cpp>
 #include <test/basics/Buffer_test.cpp>
 #include <test/basics/CheckLibraryVersions_test.cpp>
+#include <test/basics/contract_test.cpp>
 #include <test/basics/DetectCrash_test.cpp>
+#include <test/basics/hardened_hash_test.cpp>
 #include <test/basics/KeyCache_test.cpp>
+#include <test/basics/mulDiv_test.cpp>
 #include <test/basics/PerfLog_test.cpp>
+#include <test/basics/qalloc_test.cpp>
 #include <test/basics/RangeSet_test.cpp>
 #include <test/basics/Slice_test.cpp>
 #include <test/basics/StringUtilities_test.cpp>
 #include <test/basics/TaggedCache_test.cpp>
-#include <test/basics/base_uint_test.cpp>
-#include <test/basics/contract_test.cpp>
-#include <test/basics/hardened_hash_test.cpp>
-#include <test/basics/mulDiv_test.cpp>
-#include <test/basics/qalloc_test.cpp>
 #include <test/basics/tagged_integer_test.cpp>

--- a/src/test/unity/crypto_test_unity.cpp
+++ b/src/test/unity/crypto_test_unity.cpp
@@ -1,0 +1,21 @@
+
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/crypto/Openssl_test.cpp>

--- a/src/test/unity/protocol_test_unity.cpp
+++ b/src/test/unity/protocol_test_unity.cpp
@@ -19,11 +19,14 @@
 //==============================================================================
 
 #include <test/protocol/BuildInfo_test.cpp>
-#include <test/protocol/IOUAmount_test.cpp>
+#include <test/protocol/digest_test.cpp>
 #include <test/protocol/InnerObjectFormats_test.cpp>
+#include <test/protocol/IOUAmount_test.cpp>
 #include <test/protocol/Issue_test.cpp>
 #include <test/protocol/PublicKey_test.cpp>
 #include <test/protocol/Quality_test.cpp>
+#include <test/protocol/SecretKey_test.cpp>
+#include <test/protocol/Seed_test.cpp>
 #include <test/protocol/SOTemplate_test.cpp>
 #include <test/protocol/STAccount_test.cpp>
 #include <test/protocol/STAmount_test.cpp>
@@ -32,9 +35,6 @@
 #include <test/protocol/STTx_test.cpp>
 #include <test/protocol/STValidation_test.cpp>
 #include <test/protocol/STVar_test.cpp>
-#include <test/protocol/SecretKey_test.cpp>
-#include <test/protocol/Seed_test.cpp>
 #include <test/protocol/TER_test.cpp>
-#include <test/protocol/XRPAmount_test.cpp>
-#include <test/protocol/digest_test.cpp>
 #include <test/protocol/types_test.cpp>
+#include <test/protocol/XRPAmount_test.cpp>

--- a/src/test/unity/protocol_test_unity.cpp
+++ b/src/test/unity/protocol_test_unity.cpp
@@ -27,6 +27,7 @@
 #include <test/protocol/Quality_test.cpp>
 #include <test/protocol/SecretKey_test.cpp>
 #include <test/protocol/Seed_test.cpp>
+#include <test/protocol/SOTemplate_test.cpp>
 #include <test/protocol/STAccount_test.cpp>
 #include <test/protocol/STAmount_test.cpp>
 #include <test/protocol/STObject_test.cpp>


### PR DESCRIPTION
**Problem:**
It is generally recommended to mark move constructors and move-assignment operators as `noexcept`. 

**Solution:**
Mark user-defined move constructors and move assignment operations as `noexcept`. This will help usage with STL containers to enable using move operations (via vendor implementation detail of `move_if_noexcept`) to generally improve performance.

**Questions:**

1. Do people like putting `noexcept` when ` = defaulting` a user-defined-type? I suspect people would prefer to *not* have it as it is extra characters and noise for no perceived benefit. Currently, I *have* added it, but I'm happy to revert in favor of the fewer-character option.

**Reviewers:**
@HowardHinnant @seelabs 