### PR TITLE
Retried transactions that `tec` move from TxQ to open ledger:

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -654,7 +654,7 @@ RCLConsensus::Adaptor::buildLCL(
         if (replayData)
         {
             assert(replayData->parent()->info().hash == previousLedger.id());
-            return buildLedger(*replayData, tapNO_CHECK_SIGN, app_, j_);
+            return buildLedger(*replayData, tapNONE, app_, j_);
         }
         return buildLedger(
             previousLedger.ledger_,

--- a/src/ripple/app/ledger/impl/BuildLedger.cpp
+++ b/src/ripple/app/ledger/impl/BuildLedger.cpp
@@ -139,7 +139,7 @@ applyTransactions(
             try
             {
                 switch (applyTransaction(
-                    app, view, *it->second, certainRetry, tapNO_CHECK_SIGN, j))
+                    app, view, *it->second, certainRetry, tapNONE, j))
                 {
                     case ApplyResult::Success:
                         it = retriableTxs.erase(it);

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1028,8 +1028,8 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
             {
                 for (TransactionStatus& e : transactions)
                 {
-                    // we check before addingto the batch
-                    ApplyFlags flags = tapNO_CHECK_SIGN;
+                    // we check before adding to the batch
+                    ApplyFlags flags = tapNONE;
                     if (e.admin)
                         flags = flags | tapUNLIMITED;
 

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -335,7 +335,7 @@ private:
                     PreflightResult const& pfresult);
 
         std::pair<TER, bool>
-        apply(Application& app, OpenView& view);
+        apply(Application& app, OpenView& view, beast::Journal j);
     };
 
     class GreaterFee

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -28,9 +28,15 @@ namespace ripple {
 class Application;
 class STTx;
 
-/** Check if a tec fee can currently be claimed
+/** Return true if the transaction can claim a fee (tec),
+    and the `ApplyFlags` do not allow soft failures.
  */
-bool isTecClaimValid(TER ter, ApplyFlags flags);
+inline
+bool
+isTecClaimHardFail(TER ter, ApplyFlags flags)
+{
+    return isTecClaim(ter) && !(flags & tapRETRY);
+}
 
 /** Describes the results of the `preflight` check
 
@@ -103,7 +109,7 @@ public:
         , j(ctx_.j)
         , ter(ter_)
         , likelyToClaimFee(ter == tesSUCCESS
-            || isTecClaimValid(ter, flags))
+            || isTecClaimHardFail(ter, flags))
     {
     }
 

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -28,6 +28,10 @@ namespace ripple {
 class Application;
 class STTx;
 
+/** Check if a tec fee can currently be claimed
+ */
+bool isTecClaimValid(TER ter, ApplyFlags flags);
+
 /** Describes the results of the `preflight` check
 
     @note All members are const to make it more difficult
@@ -99,7 +103,7 @@ public:
         , j(ctx_.j)
         , ter(ter_)
         , likelyToClaimFee(ter == tesSUCCESS
-            || isTecClaim(ter))
+            || isTecClaimValid(ter, flags))
     {
     }
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -635,7 +635,7 @@ Transactor::operator()()
         result = tecOVERSIZE;
 
     if ((result == tecOVERSIZE) ||
-        (isTecClaimValid (result, view().flags())))
+        (isTecClaimHardFail (result, view().flags())))
     {
         JLOG(j_.trace()) << "reapplying because of " << transToken(result);
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -638,7 +638,7 @@ Transactor::operator()()
         result = tecOVERSIZE;
 
     if ((result == tecOVERSIZE) ||
-        (isTecClaim (result) && !(view().flags() & tapRETRY)))
+        (isTecClaimValid (result, view().flags())))
     {
         JLOG(j_.trace()) << "reapplying because of " << transToken(result);
 

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -88,16 +88,13 @@ preflight1 (PreflightContext const& ctx)
 NotTEC
 preflight2 (PreflightContext const& ctx)
 {
-    if(!( ctx.flags & tapNO_CHECK_SIGN))
+    auto const sigValid = checkValidity(ctx.app.getHashRouter(),
+        ctx.tx, ctx.rules, ctx.app.config());
+    if (sigValid.first == Validity::SigBad)
     {
-        auto const sigValid = checkValidity(ctx.app.getHashRouter(),
-            ctx.tx, ctx.rules, ctx.app.config());
-        if (sigValid.first == Validity::SigBad)
-        {
-            JLOG(ctx.j.debug()) <<
-                "preflight2: bad signature. " << sigValid.second;
-            return temINVALID;
-        }
+        JLOG(ctx.j.debug()) <<
+            "preflight2: bad signature. " << sigValid.second;
+        return temINVALID;
     }
     return tesSUCCESS;
 }

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -354,10 +354,4 @@ doApply(PreclaimResult const& preclaimResult,
     }
 }
 
-bool
-isTecClaimValid(TER ter, ApplyFlags flags)
-{
-  return isTecClaim(ter) && !(flags & tapRETRY);
-}
-
 } // ripple

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -354,4 +354,10 @@ doApply(PreclaimResult const& preclaimResult,
     }
 }
 
+bool
+isTecClaimValid(TER ter, ApplyFlags flags)
+{
+  return isTecClaim(ter) && !(flags & tapRETRY);
+}
+
 } // ripple

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -43,33 +43,46 @@ enum ApplyFlags
     tapUNLIMITED        = 0x400,
 };
 
-inline
+constexpr
 ApplyFlags
 operator|(ApplyFlags const& lhs,
     ApplyFlags const& rhs)
 {
     return static_cast<ApplyFlags>(
-        static_cast<int>(lhs) |
-            static_cast<int>(rhs));
+        static_cast<std::underlying_type_t<ApplyFlags>>(lhs) |
+            static_cast<std::underlying_type_t<ApplyFlags>>(rhs));
 }
 
-inline
+static_assert((tapPREFER_QUEUE | tapRETRY) == static_cast<ApplyFlags>(0x60),
+    "ApplyFlags operator |");
+static_assert((tapRETRY | tapPREFER_QUEUE) == static_cast<ApplyFlags>(0x60),
+    "ApplyFlags operator |");
+
+constexpr
 ApplyFlags
 operator&(ApplyFlags const& lhs,
     ApplyFlags const& rhs)
 {
     return static_cast<ApplyFlags>(
-        static_cast<int>(lhs) &
-            static_cast<int>(rhs));
+        static_cast<std::underlying_type_t<ApplyFlags>>(lhs) &
+            static_cast<std::underlying_type_t<ApplyFlags>>(rhs));
 }
 
-inline
+static_assert((tapPREFER_QUEUE & tapRETRY) == tapNONE,
+    "ApplyFlags operator &");
+static_assert((tapRETRY & tapPREFER_QUEUE) == tapNONE,
+    "ApplyFlags operator &");
+
+constexpr
 ApplyFlags
 operator~(ApplyFlags const& flags)
 {
     return static_cast<ApplyFlags>(
-        ~static_cast<int>(flags));
+        ~static_cast<std::underlying_type_t<ApplyFlags>>(flags));
 }
+
+static_assert(~tapRETRY == static_cast<ApplyFlags>(~0x20),
+    "ApplyFlags operator ~");
 
 inline
 ApplyFlags

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -66,6 +66,14 @@ operator&(ApplyFlags const& lhs,
             static_cast<int>(rhs));
 }
 
+inline
+ApplyFlags
+operator~(ApplyFlags const& flags)
+{
+    return static_cast<ApplyFlags>(
+        ~static_cast<int>(flags));
+}
+
 //------------------------------------------------------------------------------
 
 /** Writeable view to a ledger, for applying a transaction.

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -30,9 +30,6 @@ enum ApplyFlags
 {
     tapNONE             = 0x00,
 
-    // Signature already checked
-    tapNO_CHECK_SIGN    = 0x01,
-
     // This is not the transaction's last pass
     // Transaction can be retried, soft failures allowed
     tapRETRY            = 0x20,
@@ -72,6 +69,24 @@ operator~(ApplyFlags const& flags)
 {
     return static_cast<ApplyFlags>(
         ~static_cast<int>(flags));
+}
+
+inline
+ApplyFlags
+operator|=(ApplyFlags & lhs,
+    ApplyFlags const& rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+inline
+ApplyFlags
+operator&=(ApplyFlags& lhs,
+    ApplyFlags const& rhs)
+{
+    lhs = lhs & rhs;
+    return lhs;
 }
 
 //------------------------------------------------------------------------------

--- a/src/test/app/LedgerHistory_test.cpp
+++ b/src/test/app/LedgerHistory_test.cpp
@@ -115,7 +115,7 @@ public:
         {
             OpenView accum(&*res);
             applyTransaction(
-                env.app(), accum, *stx, false, tapNO_CHECK_SIGN, env.journal);
+                env.app(), accum, *stx, false, tapNONE, env.journal);
             accum.apply(*res);
         }
         res->updateSkipList();

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -48,7 +48,7 @@ struct LedgerReplay_test : public beast::unit_test::suite
 
         auto const replayed = buildLedger(
             LedgerReplay(lastClosedParent,lastClosed),
-            tapNO_CHECK_SIGN,
+            tapNONE,
             env.app(),
             env.journal);
 

--- a/src/test/ledger/View_test.cpp
+++ b/src/test/ledger/View_test.cpp
@@ -363,25 +363,25 @@ class View_test
                 BEAST_EXPECT(v1.parentCloseTime() ==
                     v1.parentCloseTime());
 
-                ApplyViewImpl v2(&v1, tapNO_CHECK_SIGN);
+                ApplyViewImpl v2(&v1, tapRETRY);
                 BEAST_EXPECT(v2.parentCloseTime() ==
                     v1.parentCloseTime());
                 BEAST_EXPECT(v2.seq() == v1.seq());
-                BEAST_EXPECT(v2.flags() == tapNO_CHECK_SIGN);
+                BEAST_EXPECT(v2.flags() == tapRETRY);
 
                 Sandbox v3(&v2);
                 BEAST_EXPECT(v3.seq() == v2.seq());
                 BEAST_EXPECT(v3.parentCloseTime() ==
                     v2.parentCloseTime());
-                BEAST_EXPECT(v3.flags() == tapNO_CHECK_SIGN);
+                BEAST_EXPECT(v3.flags() == tapRETRY);
             }
             {
-                ApplyViewImpl v1(&v0, tapNO_CHECK_SIGN);
+                ApplyViewImpl v1(&v0, tapRETRY);
                 PaymentSandbox v2(&v1);
                 BEAST_EXPECT(v2.seq() == v0.seq());
                 BEAST_EXPECT(v2.parentCloseTime() ==
                     v0.parentCloseTime());
-                BEAST_EXPECT(v2.flags() == tapNO_CHECK_SIGN);
+                BEAST_EXPECT(v2.flags() == tapRETRY);
                 PaymentSandbox v3(&v2);
                 BEAST_EXPECT(v3.seq() == v2.seq());
                 BEAST_EXPECT(v3.parentCloseTime() ==


### PR DESCRIPTION
* Unit test of tec code handling.
* Extra TxQ debug logging

Notes: 
* The unit test doesn't really test the issue at hand, because it happens during consensus, and `Env` doesn't really simulate that whole process.
* `isTecClaimValid` can probably be inlined.