### PR TITLE
[Looking for feedback, not to merge] Use -std=c++17

### DIFF
--- a/Builds/CMake/CMakeFuncs.cmake
+++ b/Builds/CMake/CMakeFuncs.cmake
@@ -652,7 +652,7 @@ macro(setup_build_boilerplate)
 
   if (NOT WIN32)
     add_definitions(-D_FILE_OFFSET_BITS=64)
-    append_flags(CMAKE_CXX_FLAGS -frtti -std=c++14 -Wno-invalid-offsetof -Wdeprecated -Wnon-virtual-dtor
+    append_flags(CMAKE_CXX_FLAGS -frtti -std=c++17 -Wno-invalid-offsetof -Wdeprecated -Wnon-virtual-dtor
       -DBOOST_COROUTINE_NO_DEPRECATION_WARNING -DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
     add_compile_options(-Wall -Wno-sign-compare -Wno-char-subscripts -Wno-format
       -Wno-unused-local-typedefs -g)

--- a/src/ripple/beast/cxx17/type_traits.h
+++ b/src/ripple/beast/cxx17/type_traits.h
@@ -28,9 +28,6 @@ namespace std {
 
 #ifndef _MSC_VER
 
-template<class...>
-using void_t = void;
-
 template<bool B>
 using bool_constant = std::integral_constant<bool, B>;
 

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -28,6 +28,7 @@
 #include <ripple/beast/utility/maybe_const.h>
 #include <boost/intrusive/list.hpp>
 #include <boost/iterator/transform_iterator.hpp>
+#include <random>
 
 namespace ripple {
 namespace PeerFinder {
@@ -482,7 +483,10 @@ Livecache <Allocator>::hops_t::shuffle()
         v.reserve (list.size());
         std::copy (list.begin(), list.end(),
             std::back_inserter (v));
-        std::random_shuffle (v.begin(), v.end());
+
+        std::random_device rng;
+        std::mt19937 urng{rng()};
+        std::shuffle (v.begin(), v.end(), urng);
         list.clear();
         for (auto& e : v)
             list.push_back (e);

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -38,6 +38,7 @@
 #include <ripple/beast/core/SharedPtr.h>
 #include <functional>
 #include <map>
+#include <random>
 #include <set>
 
 namespace ripple {
@@ -590,7 +591,10 @@ public:
                         if (value.second->state() == Slot::active)
                             slots.emplace_back (value.second);
                     });
-                std::random_shuffle (slots.begin(), slots.end());
+
+                std::random_device rng;
+                std::mt19937 urng( rng() );
+                std::shuffle (slots.begin(), slots.end(), urng);
 
                 // build target vector
                 targets.reserve (slots.size());

--- a/src/soci/src/backends/sqlite3/statement.cpp
+++ b/src/soci/src/backends/sqlite3/statement.cpp
@@ -9,6 +9,7 @@
 #include "soci/sqlite3/soci-sqlite3.h"
 // std
 #include <algorithm>
+#include <cctype>
 #include <functional>
 #include <sstream>
 #include <string>
@@ -492,7 +493,7 @@ void sqlite3_statement_backend::describe_column(int colNum, data_type & type,
     std::string dt = declType;
 
     // remove extra characters for example "(20)" in "varchar(20)"
-    std::string::iterator siter = std::find_if(dt.begin(), dt.end(), std::not1(std::ptr_fun(isalnum)));
+    std::string::iterator siter = std::find_if(dt.begin(), dt.end(), [](const auto c) { return std::isalnum(c); });
     if (siter != dt.end())
         dt.resize(siter - dt.begin());
 


### PR DESCRIPTION
In trying to figure out what obstacles awaited for turning on `-std=c++17`, I just gave it a whirl and fixed the small culprit code needed. I do have several questions though:

1. Is there a desire from others to move to using C++17? I've read some code that can be cleaned up with the latest language standard. We could use feature test macros to clean up some stuff in `ripple/basics/date.h` from just poking around there tonight. I suspect there are other such places that would benefit.
2. What do we want to do about vendor code (soci) not being C++17-compliant due to the use of a function that got removed in C++17? I filed an [issue](https://github.com/SOCI/soci/issues/651) in the upstream GitHub repo. I don't know if there is an alternative approach here other than just making the one line code change in our fork of the vendor code.
3. Are there other spots in the CMake we need to adjust the `-std` flag?

The only other changes I had to make were to account for the removal of `std::random_shuffle` in C++17 and also removing `void_t`  that would get brought in during ADL which would cause ambiguity since `std::void_t` is implemented in C++17.

**Test Plan:**
All unit tests pass. I suspect there may be other system-like tests that people may want to perform with a big change like this. I am open to opinions or concerns with testing.

Requested reviewers:
@mellery451 @seelabs @nbougalis 