### PR TITLE
Deprecate dirDelete

### DIFF
--- a/src/ripple/app/tx/impl/CancelCheck.cpp
+++ b/src/ripple/app/tx/impl/CancelCheck.cpp
@@ -18,8 +18,10 @@
 //==============================================================================
 
 #include <ripple/app/tx/impl/CancelCheck.h>
+
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/basics/Log.h>
+#include <ripple/ledger/ApplyView.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/STAccount.h>
@@ -104,22 +106,18 @@ CancelCheck::doApply ()
     if (srcId != dstId)
     {
         std::uint64_t const page {(*sleCheck)[sfDestinationNode]};
-        TER const ter {dirDelete (view(), true, page,
-            keylet::ownerDir (dstId), checkId, false, false, viewJ)};
-        if (! isTesSuccess (ter))
+        if (! view().dirRemove (keylet::ownerDir(dstId), page, checkId, true))
         {
             JLOG(j_.warn()) << "Unable to delete check from destination.";
-            return ter;
+            return tefBAD_LEDGER;
         }
     }
     {
         std::uint64_t const page {(*sleCheck)[sfOwnerNode]};
-        TER const ter {dirDelete (view(), true, page,
-            keylet::ownerDir (srcId), checkId, false, false, viewJ)};
-        if (! isTesSuccess (ter))
+        if (! view().dirRemove (keylet::ownerDir(srcId), page, checkId, true))
         {
             JLOG(j_.warn()) << "Unable to delete check from owner.";
-            return ter;
+            return tefBAD_LEDGER;
         }
     }
 

--- a/src/ripple/app/tx/impl/CancelTicket.cpp
+++ b/src/ripple/app/tx/impl/CancelTicket.cpp
@@ -80,15 +80,18 @@ CancelTicket::doApply ()
 
     std::uint64_t const hint (sleTicket->getFieldU64 (sfOwnerNode));
 
-    auto viewJ = ctx_.app.journal ("View");
-    TER const result = dirDelete (ctx_.view (), false, hint,
-        keylet::ownerDir (ticket_owner), ticketId, false, (hint == 0), viewJ);
+    if (! ctx_.view().dirRemove(
+            keylet::ownerDir(ticket_owner), hint, ticketId, false))
+    {
+        return tefBAD_LEDGER;
+    }
 
+    auto viewJ = ctx_.app.journal ("View");
     adjustOwnerCount(view(), view().peek(
         keylet::account(ticket_owner)), -1, viewJ);
     ctx_.view ().erase (sleTicket);
 
-    return result;
+    return tesSUCCESS;
 }
 
 }

--- a/src/ripple/app/tx/impl/CashCheck.cpp
+++ b/src/ripple/app/tx/impl/CashCheck.cpp
@@ -375,23 +375,21 @@ CashCheck::doApply ()
     if (srcId != account_)
     {
         std::uint64_t const page {(*sleCheck)[sfDestinationNode]};
-        TER const ter {dirDelete (psb, true, page,
-            keylet::ownerDir (account_), checkKey, false, false, viewJ)};
-        if (! isTesSuccess (ter))
+        if (! ctx_.view().dirRemove(
+                keylet::ownerDir(account_), page, checkKey, true))
         {
             JLOG(j_.warn()) << "Unable to delete check from destination.";
-            return ter;
+            return tefBAD_LEDGER;
         }
     }
     // Remove check from check owner's directory.
     {
         std::uint64_t const page {(*sleCheck)[sfOwnerNode]};
-        TER const ter {dirDelete (psb, true, page,
-            keylet::ownerDir (srcId), checkKey, false, false, viewJ)};
-        if (! isTesSuccess (ter))
+        if (! ctx_.view().dirRemove(
+                keylet::ownerDir(srcId), page, checkKey, true))
         {
             JLOG(j_.warn()) << "Unable to delete check from owner.";
-            return ter;
+            return tefBAD_LEDGER;
         }
     }
     // If we succeeded, update the check owner's reserve.

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -42,7 +42,7 @@ template<class TIn, class TOut>
 void
 TOfferStreamBase<TIn, TOut>::erase (ApplyView& view)
 {
-    // NIKB NOTE This should be using ApplyView::dirDelete, which would
+    // NIKB NOTE This should be using ApplyView::dirRemove, which would
     //           correctly remove the directory if its the last entry.
     //           Unfortunately this is a protocol breaking change.
 

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -18,18 +18,18 @@
 //==============================================================================
 
 #include <ripple/app/tx/impl/PayChan.h>
-
 #include <ripple/basics/chrono.h>
 #include <ripple/basics/Log.h>
+#include <ripple/ledger/ApplyView.h>
+#include <ripple/ledger/View.h>
 #include <ripple/protocol/digest.h>
-#include <ripple/protocol/st.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/PayChan.h>
 #include <ripple/protocol/PublicKey.h>
+#include <ripple/protocol/st.h>
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/XRPAmount.h>
-#include <ripple/ledger/View.h>
 
 namespace ripple {
 
@@ -133,10 +133,10 @@ closeChannel (
     // Remove PayChan from owner directory
     {
         auto const page = (*slep)[sfOwnerNode];
-        TER const ter = dirDelete (view, true, page, keylet::ownerDir (src),
-            key, false, page == 0, j);
-        if (!isTesSuccess (ter))
-            return ter;
+        if (! view.dirRemove(keylet::ownerDir(src), page, key, true))
+        {
+            return tefBAD_LEDGER;
+        }
     }
 
     // Transfer amount back to owner, decrement owner count

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -236,17 +236,6 @@ dirAdd (ApplyView& view,
     std::function<void (SLE::ref)>      fDescriber,
     beast::Journal j);
 
-// deprecated
-TER
-dirDelete (ApplyView& view,
-    const bool           bKeepRoot,
-    std::uint64_t        uNodeDir,      // Node item is mentioned in.
-    Keylet const&        uRootIndex,
-    uint256 const&       uLedgerIndex,  // Item being deleted
-    const bool           bStable,
-    const bool           bSoft,
-    beast::Journal j);
-
 // VFALCO NOTE Both STAmount parameters should just
 //             be "Amount", a unit-less number.
 //


### PR DESCRIPTION
@JoeLoser went to the effort to replace all uses of `dirDelete()` with calls to `ApplyView::dirRemove()`.  This pull request preserves that effort.

There was also an attempt made to deal with the deprecated `dirAdd()` function.  We can't get rid of `dirAdd()` until the `SortedDirectories` amendment has been enabled on the network for at least a year.  But we should go ahead and remove `dirDelete()`.  Don't let the perfect be the enemy of the good.

Reviewers: @mellery451 @wilsonianb 