### PR TITLE
Remove static_assert for minimum Boost and GCC version

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -697,15 +697,6 @@ int main (int argc, char** argv)
     ripple::sha512_deprecatedMSVCWorkaround();
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
-    auto constexpr gccver = (__GNUC__ * 100 * 100) +
-                            (__GNUC_MINOR__ * 100) +
-                            __GNUC_PATCHLEVEL__;
-
-    static_assert (gccver >= 50100,
-        "GCC version 5.1.0 or later is required to compile rippled.");
-#endif
-
     //
     // These debug heap calls do nothing in release or non Visual Studio builds.
     //

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -706,9 +706,6 @@ int main (int argc, char** argv)
         "GCC version 5.1.0 or later is required to compile rippled.");
 #endif
 
-    static_assert (BOOST_VERSION >= 106700,
-        "Boost version 1.67 or later is required to compile rippled");
-
     //
     // These debug heap calls do nothing in release or non Visual Studio builds.
     //


### PR DESCRIPTION
Small follow-up from https://github.com/ripple/rippled/pull/2583 that I missed after removing `CheckLibraryVersions`.

Note: Mike, I think we can remove the GCC version check right next to this one. We should assert something like this

```
if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
    message(FATAL_ERROR, "Must use GCC 5.1 or later.");
endif()
```

in the improved CMake build if we don't do something like this already.


Reviewer:
@mellery451 