### PR TITLE
Replace deprecated usages of std::random_shuffle

### DIFF
--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -28,6 +28,7 @@
 #include <ripple/beast/utility/maybe_const.h>
 #include <boost/intrusive/list.hpp>
 #include <boost/iterator/transform_iterator.hpp>
+#include <random>
 
 namespace ripple {
 namespace PeerFinder {
@@ -482,7 +483,9 @@ Livecache <Allocator>::hops_t::shuffle()
         v.reserve (list.size());
         std::copy (list.begin(), list.end(),
             std::back_inserter (v));
-        std::random_shuffle (v.begin(), v.end());
+        std::random_device rng;
+        std::mt19937 urng{rng()};
+        std::shuffle (v.begin(), v.end(), urng);
         list.clear();
         for (auto& e : v)
             list.push_back (e);

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PEERFINDER_LIVECACHE_H_INCLUDED
 
 #include <ripple/basics/Log.h>
+#include <ripple/basics/random.h>
 #include <ripple/peerfinder/PeerfinderManager.h>
 #include <ripple/peerfinder/impl/iosformat.h>
 #include <ripple/peerfinder/impl/Tuning.h>
@@ -28,7 +29,8 @@
 #include <ripple/beast/utility/maybe_const.h>
 #include <boost/intrusive/list.hpp>
 #include <boost/iterator/transform_iterator.hpp>
-#include <random>
+
+#include <algorithm>
 
 namespace ripple {
 namespace PeerFinder {
@@ -483,9 +485,7 @@ Livecache <Allocator>::hops_t::shuffle()
         v.reserve (list.size());
         std::copy (list.begin(), list.end(),
             std::back_inserter (v));
-        std::random_device rng;
-        std::mt19937 urng{rng()};
-        std::shuffle (v.begin(), v.end(), urng);
+        std::shuffle (v.begin(), v.end(), default_prng());
         list.clear();
         for (auto& e : v)
             list.push_back (e);

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -38,6 +38,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <random>
 #include <set>
 
 namespace ripple {
@@ -590,7 +591,9 @@ public:
                         if (value.second->state() == Slot::active)
                             slots.emplace_back (value.second);
                     });
-                std::random_shuffle (slots.begin(), slots.end());
+                std::random_device rng;
+                std::mt19937 urng{rng()};
+                std::shuffle (slots.begin(), slots.end(), urng);
 
                 // build target vector
                 targets.reserve (slots.size());

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PEERFINDER_LOGIC_H_INCLUDED
 
 #include <ripple/basics/Log.h>
+#include <ripple/basics/random.h>
 #include <ripple/basics/contract.h>
 #include <ripple/beast/container/aged_container_utility.h>
 #include <ripple/beast/net/IPAddressConversion.h>
@@ -35,10 +36,11 @@
 #include <ripple/peerfinder/impl/Source.h>
 #include <ripple/peerfinder/impl/Store.h>
 #include <ripple/peerfinder/impl/iosformat.h>
+
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <memory>
-#include <random>
 #include <set>
 
 namespace ripple {
@@ -591,9 +593,7 @@ public:
                         if (value.second->state() == Slot::active)
                             slots.emplace_back (value.second);
                     });
-                std::random_device rng;
-                std::mt19937 urng{rng()};
-                std::shuffle (slots.begin(), slots.end(), urng);
+                std::shuffle (slots.begin(), slots.end(), default_prng());
 
                 // build target vector
                 targets.reserve (slots.size());


### PR DESCRIPTION
Summary:
`std::random_shuffle` is deprecated in C++14 and removed completely
in C++17. The two-iterator version of `std::random_shuffle` usually
depends on `std::rand` and also on a global state. The preferred
replacement is to use `std::shuffle` with a pseudo-random number
generator.

Reviewers:
@scottschurr @HowardHinnant 