### PR TITLE
Mark some move and move-assignment ctors noexcept (no protocol/ST types)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ beast_test_unity2.cpp
 conditions_test_unity.cpp
 consensus_test_unity.cpp
 core_test_unity.cpp
+crypto_test_unity.cpp
 json_test_unity.cpp
 ledger_test_unity.cpp
 overlay_test_unity.cpp
@@ -273,8 +274,8 @@ foreach(curdir
         app
         basics
         conditions
-        crypto
         consensus
+        crypto
         json
         ledger
         legacy
@@ -310,6 +311,7 @@ foreach(curdir
         conditions
         consensus
         core
+        crypto
         csf
         json
         jtx

--- a/src/ripple/basics/Buffer.h
+++ b/src/ripple/basics/Buffer.h
@@ -82,7 +82,7 @@ public:
     /** Move-construct.
         The other buffer is reset.
     */
-    Buffer (Buffer&& other)
+    Buffer (Buffer&& other) noexcept
         : p_ (std::move(other.p_))
         , size_ (other.size_)
     {
@@ -92,7 +92,7 @@ public:
     /** Move-assign.
         The other buffer is reset.
     */
-    Buffer& operator= (Buffer&& other)
+    Buffer& operator= (Buffer&& other) noexcept
     {
         if (this != &other)
         {

--- a/src/ripple/basics/CountedObject.h
+++ b/src/ripple/basics/CountedObject.h
@@ -31,7 +31,7 @@ namespace ripple {
 class CountedObjects
 {
 public:
-    static CountedObjects& getInstance ();
+    static CountedObjects& getInstance () noexcept;
 
     using Entry = std::pair <std::string, int>;
     using List = std::vector <Entry>;
@@ -46,9 +46,9 @@ public:
     class CounterBase
     {
     public:
-        CounterBase ();
+        CounterBase () noexcept;
 
-        virtual ~CounterBase ();
+        virtual ~CounterBase () noexcept;
 
         int increment () noexcept
         {
@@ -81,8 +81,8 @@ public:
     };
 
 private:
-    CountedObjects ();
-    ~CountedObjects ();
+    CountedObjects () noexcept;
+    ~CountedObjects () noexcept;
 
 private:
     std::atomic <int> m_count;
@@ -102,19 +102,19 @@ template <class Object>
 class CountedObject
 {
 public:
-    CountedObject ()
+    CountedObject () noexcept
     {
         getCounter ().increment ();
     }
 
-    CountedObject (CountedObject const&)
+    CountedObject (CountedObject const&) noexcept
     {
         getCounter ().increment ();
     }
 
-    CountedObject& operator=(CountedObject const&) = default;
+    CountedObject& operator=(CountedObject const&) noexcept = default;
 
-    ~CountedObject ()
+    ~CountedObject () noexcept
     {
         getCounter ().decrement ();
     }
@@ -123,7 +123,7 @@ private:
     class Counter : public CountedObjects::CounterBase
     {
     public:
-        Counter () { }
+        Counter () noexcept { }
 
         char const* getName () const override
         {
@@ -134,8 +134,9 @@ private:
     };
 
 private:
-    static Counter& getCounter()
+    static Counter& getCounter() noexcept
     {
+        static_assert(std::is_nothrow_constructible<Counter>{}, "");
         static Counter c;
         return c;
     }

--- a/src/ripple/basics/impl/CountedObject.cpp
+++ b/src/ripple/basics/impl/CountedObject.cpp
@@ -18,23 +18,24 @@
 //==============================================================================
 
 #include <ripple/basics/CountedObject.h>
+#include <type_traits>
 
 namespace ripple {
 
-CountedObjects& CountedObjects::getInstance ()
+CountedObjects& CountedObjects::getInstance () noexcept
 {
     static CountedObjects instance;
 
     return instance;
 }
 
-CountedObjects::CountedObjects ()
+CountedObjects::CountedObjects () noexcept
     : m_count (0)
     , m_head (nullptr)
 {
 }
 
-CountedObjects::~CountedObjects ()
+CountedObjects::~CountedObjects () noexcept
 {
 }
 
@@ -70,7 +71,7 @@ CountedObjects::List CountedObjects::getCounts (int minimumThreshold) const
 
 //------------------------------------------------------------------------------
 
-CountedObjects::CounterBase::CounterBase ()
+CountedObjects::CounterBase::CounterBase () noexcept
     : m_count (0)
 {
     // Insert ourselves at the front of the lock-free linked list
@@ -88,7 +89,7 @@ CountedObjects::CounterBase::CounterBase ()
     ++instance.m_count;
 }
 
-CountedObjects::CounterBase::~CounterBase ()
+CountedObjects::CounterBase::~CounterBase () noexcept
 {
     // VFALCO NOTE If the counters are destroyed before the singleton,
     //             undefined behavior will result if the singleton's member

--- a/src/ripple/basics/qalloc.h
+++ b/src/ripple/basics/qalloc.h
@@ -117,9 +117,9 @@ public:
     };
 
     qalloc_type (qalloc_type const&) = default;
-    qalloc_type (qalloc_type&& other) = default;
+    qalloc_type (qalloc_type&& other) noexcept = default;
     qalloc_type& operator= (qalloc_type const&) = default;
-    qalloc_type& operator= (qalloc_type&&) = default;
+    qalloc_type& operator= (qalloc_type&&) noexcept = default;
 
     qalloc_type();
 

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -320,7 +320,7 @@ public:
     //! Clock type for measuring time within the consensus code
     using clock_type = beast::abstract_clock<std::chrono::steady_clock>;
 
-    Consensus(Consensus&&) = default;
+    Consensus(Consensus&&) noexcept = default;
 
     /** Constructor.
 

--- a/src/ripple/core/ClosureCounter.h
+++ b/src/ripple/core/ClosureCounter.h
@@ -93,7 +93,8 @@ private:
             ++counter_;
         }
 
-        Wrapper (Wrapper&& rhs)
+        Wrapper (Wrapper&& rhs) noexcept(
+          std::is_nothrow_move_constructible<Closure>::value)
         : counter_ (rhs.counter_)
         , closure_ (std::move (rhs.closure_))
         {

--- a/src/ripple/crypto/impl/openssl.h
+++ b/src/ripple/crypto/impl/openssl.h
@@ -61,12 +61,12 @@ public:
         assign_new (thing.data(), thing.size());
     }
 
-    bignum(bignum&& that) : ptr( that.ptr )
+    bignum(bignum&& that) noexcept : ptr( that.ptr )
     {
         that.ptr = nullptr;
     }
 
-    bignum& operator= (bignum&& that)
+    bignum& operator= (bignum&& that) noexcept
     {
         using std::swap;
 
@@ -163,7 +163,7 @@ public:
     ec_point           (ec_point const&) = delete;
     ec_point& operator=(ec_point const&) = delete;
 
-    ec_point(ec_point&& that)
+    ec_point(ec_point&& that) noexcept
     {
         ptr      = that.ptr;
         that.ptr = nullptr;

--- a/src/ripple/ledger/CashDiff.h
+++ b/src/ripple/ledger/CashDiff.h
@@ -62,7 +62,7 @@ class CashDiff
 public:
     CashDiff() = delete;
     CashDiff (CashDiff const&) = delete;
-    CashDiff (CashDiff&& other);
+    CashDiff (CashDiff&& other) noexcept;
     CashDiff& operator= (CashDiff const&) = delete;
     ~CashDiff();
 

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -74,6 +74,11 @@ public:
     using iter_base =
         ReadViewFwdIter<ValueType>;
 
+   static_assert(
+        std::is_nothrow_move_constructible<ValueType>{},
+        "ReadViewFwdRange move and move assign constructors should be "
+        "noexcept");
+
     class iterator
     {
     public:
@@ -92,7 +97,7 @@ public:
         iterator() = default;
 
         iterator (iterator const& other);
-        iterator (iterator&& other);
+        iterator (iterator&& other) noexcept;
 
         // Used by the implementation
         explicit
@@ -103,7 +108,7 @@ public:
         operator= (iterator const& other);
 
         iterator&
-        operator= (iterator&& other);
+        operator= (iterator&& other) noexcept;
 
         bool
         operator== (iterator const& other) const;
@@ -131,6 +136,9 @@ public:
         boost::optional<value_type> mutable cache_;
     };
 
+    static_assert(std::is_nothrow_move_constructible<iterator>{}, "");
+    static_assert(std::is_nothrow_move_assignable<iterator>{}, "");
+ 
     using const_iterator = iterator;
 
     using value_type = ValueType;

--- a/src/ripple/ledger/detail/ReadViewFwdRange.ipp
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.ipp
@@ -35,7 +35,7 @@ ReadViewFwdRange<ValueType>::iterator::iterator(
 
 template<class ValueType>
 ReadViewFwdRange<ValueType>::iterator::iterator(
-        iterator&& other)
+        iterator&& other) noexcept
     : view_ (other.view_)
     , impl_ (std::move(other.impl_))
     , cache_ (std::move(other.cache_))
@@ -69,7 +69,7 @@ ReadViewFwdRange<ValueType>::iterator::operator=(
 template<class ValueType>
 auto
 ReadViewFwdRange<ValueType>::iterator::operator=(
-    iterator&& other) ->
+    iterator&& other) noexcept ->
         iterator&
 {
     view_ = other.view_;

--- a/src/ripple/ledger/impl/CashDiff.cpp
+++ b/src/ripple/ledger/impl/CashDiff.cpp
@@ -633,7 +633,7 @@ void CashDiff::Impl::findDiffs (
 //------------------------------------------------------------------------------
 
 // Locates differences between two ApplyStateTables.
-CashDiff::CashDiff (CashDiff&& other)
+CashDiff::CashDiff (CashDiff&& other) noexcept
 : impl_ (std::move (other.impl_))
 {
 }

--- a/src/test/basics/Buffer_test.cpp
+++ b/src/test/basics/Buffer_test.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/Buffer.h>
 #include <ripple/beast/unit_test.h>
 #include <cstdint>
+#include <type_traits>
 
 namespace ripple {
 namespace test {
@@ -108,6 +109,9 @@ struct Buffer_test : beast::unit_test::suite
         // Check move constructor & move assignments:
         {
             testcase ("Move Construction / Assignment");
+ 
+            static_assert(std::is_nothrow_move_constructible<Buffer>::value, "");
+            static_assert(std::is_nothrow_move_assignable<Buffer>::value, "");
 
             { // Move-construct from empty buf
                 Buffer x;

--- a/src/test/basics/qalloc_test.cpp
+++ b/src/test/basics/qalloc_test.cpp
@@ -1,8 +1,7 @@
-
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2018 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -18,17 +17,31 @@
 */
 //==============================================================================
 
-#include <test/basics/base_uint_test.cpp>
-#include <test/basics/Buffer_test.cpp>
-#include <test/basics/contract_test.cpp>
-#include <test/basics/DetectCrash_test.cpp>
-#include <test/basics/hardened_hash_test.cpp>
-#include <test/basics/KeyCache_test.cpp>
-#include <test/basics/mulDiv_test.cpp>
-#include <test/basics/PerfLog_test.cpp>
-#include <test/basics/qalloc_test.cpp>
-#include <test/basics/RangeSet_test.cpp>
-#include <test/basics/Slice_test.cpp>
-#include <test/basics/StringUtilities_test.cpp>
-#include <test/basics/TaggedCache_test.cpp>
-#include <test/basics/tagged_integer_test.cpp>
+#include <ripple/basics/qalloc.h>
+#include <ripple/beast/unit_test.h>
+#include <type_traits>
+
+namespace ripple {
+
+struct qalloc_test : beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        BEAST_EXPECT(std::is_default_constructible<qalloc>{});
+        BEAST_EXPECT(std::is_copy_constructible<qalloc>{});
+        BEAST_EXPECT(std::is_copy_assignable<qalloc>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<qalloc>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<qalloc>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(qalloc, ripple_basics, ripple);
+
+}  // namespace ripple

--- a/src/test/core/ClosureCounter_test.cpp
+++ b/src/test/core/ClosureCounter_test.cpp
@@ -126,7 +126,7 @@ class ClosureCounter_test : public beast::unit_test::suite
         , str (rhs.str) {}
 
         // Move constructor
-        TrackedString (TrackedString&& rhs)
+        TrackedString (TrackedString&& rhs) noexcept
         : copies (rhs.copies)
         , moves (rhs.moves + 1)
         , str (std::move(rhs.str)) {}

--- a/src/test/crypto/Openssl_test.cpp
+++ b/src/test/crypto/Openssl_test.cpp
@@ -1,0 +1,54 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/crypto/impl/openssl.h>
+#include <type_traits>
+
+namespace ripple {
+struct Openssl_test : public beast::unit_test::suite
+{
+    void
+    testBasicProperties()
+    {
+        using namespace openssl;
+
+        BEAST_EXPECT(std::is_default_constructible<bignum>{});
+        BEAST_EXPECT(!std::is_copy_constructible<bignum>{});
+        BEAST_EXPECT(!std::is_copy_assignable<bignum>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<bignum>{});
+        BEAST_EXPECT(std::is_nothrow_move_assignable<bignum>{});
+
+        BEAST_EXPECT(!std::is_default_constructible<ec_point>{});
+        BEAST_EXPECT(!std::is_copy_constructible<ec_point>{});
+        BEAST_EXPECT(!std::is_copy_assignable<ec_point>{});
+        BEAST_EXPECT(std::is_nothrow_move_constructible<ec_point>{});
+        BEAST_EXPECT(!std::is_nothrow_move_assignable<ec_point>{});
+    }
+
+    void
+    run() override
+    {
+        testBasicProperties();
+    };
+};
+
+BEAST_DEFINE_TESTSUITE(Openssl, crypto, ripple);
+
+}  // namespace ripple

--- a/src/test/ledger/CashDiff_test.cpp
+++ b/src/test/ledger/CashDiff_test.cpp
@@ -20,14 +20,20 @@
 #include <ripple/ledger/CashDiff.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/beast/unit_test.h>
+#include <type_traits>
 
 namespace ripple {
 namespace test {
 
 class CashDiff_test : public beast::unit_test::suite
 {
+    static_assert(!std::is_default_constructible<CashDiff>{}, "");
+    static_assert(!std::is_copy_constructible<CashDiff>{}, "");
+    static_assert(!std::is_copy_assignable<CashDiff>{}, "");
+    static_assert(std::is_nothrow_move_constructible<CashDiff>{}, "");
+    static_assert(!std::is_move_assignable<CashDiff>{}, "");
 
-    // Exercise diffIsDust (STAmount, STAmount)
+	// Exercise diffIsDust (STAmount, STAmount)
     void
     testDust ()
     {

--- a/src/test/unity/crypto_test_unity.cpp
+++ b/src/test/unity/crypto_test_unity.cpp
@@ -2,7 +2,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2018 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -18,17 +18,4 @@
 */
 //==============================================================================
 
-#include <test/basics/base_uint_test.cpp>
-#include <test/basics/Buffer_test.cpp>
-#include <test/basics/contract_test.cpp>
-#include <test/basics/DetectCrash_test.cpp>
-#include <test/basics/hardened_hash_test.cpp>
-#include <test/basics/KeyCache_test.cpp>
-#include <test/basics/mulDiv_test.cpp>
-#include <test/basics/PerfLog_test.cpp>
-#include <test/basics/qalloc_test.cpp>
-#include <test/basics/RangeSet_test.cpp>
-#include <test/basics/Slice_test.cpp>
-#include <test/basics/StringUtilities_test.cpp>
-#include <test/basics/TaggedCache_test.cpp>
-#include <test/basics/tagged_integer_test.cpp>
+#include <test/crypto/Openssl_test.cpp>


### PR DESCRIPTION
This PR is a subset of the work from https://github.com/ripple/rippled/pull/2551: namely, without any of the protocol/ST types as they were much more complicated to make `noexcept-friendly`, so we opt to decouple them from the other work.

Requested reviewers:
@HowardHinnant @scottschurr 