### PR TITLE
Make KeyCache allocator aware

### DIFF
--- a/src/ripple/basics/KeyCache.h
+++ b/src/ripple/basics/KeyCache.h
@@ -30,11 +30,11 @@ namespace ripple {
 
 namespace detail {
     template<class Clock = beast::abstract_clock <std::chrono::steady_clock>>
-    struct Entry
+    struct KeyCacheEntry
     {
         using time_point_t = typename Clock::time_point;
 
-        explicit Entry (time_point_t const& last_access_) noexcept
+        explicit KeyCacheEntry (time_point_t const& last_access_) noexcept
             : last_access (last_access_)
         {
         }
@@ -54,7 +54,7 @@ template <
     class Hash = hardened_hash <>,
     class KeyEqual = std::equal_to <Key>,
 	class Clock = beast::abstract_clock <std::chrono::steady_clock>,
-    class Allocator = std::allocator <std::pair <Key const, detail::Entry<Clock>>>,
+    class Allocator = std::allocator <std::pair <Key const, detail::KeyCacheEntry<Clock>>>,
     class Mutex = std::mutex
 >
 class KeyCache
@@ -86,7 +86,7 @@ private:
 
 
 
-    using map_type = hardened_hash_map <key_type, detail::Entry<clock_type>, Hash, KeyEqual, Allocator>;
+    using map_type = hardened_hash_map <key_type, detail::KeyCacheEntry<clock_type>, Hash, KeyEqual, Allocator>;
     using iterator = typename map_type::iterator;
     using lock_guard = std::lock_guard <Mutex>;
 


### PR DESCRIPTION
Problem:
`KeyCache` has no way of a user specifying an allocator that would get used as the allocator for the underlying `hardened_hash_map`.

Solution:
Introduce an allocator template argument so that users can customize the underlying `hardened_hash_map`.

Note:
I don't like using the common name of `Entry` even though we're in a detail namespace as we use the detail namespace in several other places and could easily run into name collisions. Perhaps we could use something more verbose like `KeyCacheEntry` to avoid that. 

Requested reviewers:
@HowardHinnant @scottschurr 