### PR TITLE
Migrate more code into the chrono type system, including:

### DIFF
--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -32,9 +32,9 @@ namespace ripple {
 #define CACHED_LEDGER_NUM 96
 #endif
 
-#ifndef CACHED_LEDGER_AGE
-#define CACHED_LEDGER_AGE 120
-#endif
+using namespace std::chrono;
+
+seconds constexpr CACHED_LEDGER_AGE = 2min;
 
 // FIXME: Need to clean up ledgers by index at some point
 
@@ -46,7 +46,7 @@ LedgerHistory::LedgerHistory (
     , mismatch_counter_ (collector->make_counter ("ledger.history", "mismatch"))
     , m_ledgers_by_hash ("LedgerCache", CACHED_LEDGER_NUM, CACHED_LEDGER_AGE,
         stopwatch(), app_.journal("TaggedCache"))
-    , m_consensus_validated ("ConsensusValidated", 64, 300,
+    , m_consensus_validated ("ConsensusValidated", 64, 5min,
         stopwatch(), app_.journal("TaggedCache"))
     , j_ (app.journal ("LedgerHistory"))
 {
@@ -517,7 +517,7 @@ bool LedgerHistory::fixIndex (
     return true;
 }
 
-void LedgerHistory::tune (int size, int age)
+void LedgerHistory::tune (int size, std::chrono::seconds age)
 {
     m_ledgers_by_hash.setTargetSize (size);
     m_ledgers_by_hash.setTargetAge (age);

--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -32,9 +32,7 @@ namespace ripple {
 #define CACHED_LEDGER_NUM 96
 #endif
 
-using namespace std::chrono;
-
-seconds constexpr CACHED_LEDGER_AGE = 2min;
+std::chrono::seconds constexpr CachedLedgerAge = std::chrono::minutes{2};
 
 // FIXME: Need to clean up ledgers by index at some point
 
@@ -44,7 +42,7 @@ LedgerHistory::LedgerHistory (
     : app_ (app)
     , collector_ (collector)
     , mismatch_counter_ (collector->make_counter ("ledger.history", "mismatch"))
-    , m_ledgers_by_hash ("LedgerCache", CACHED_LEDGER_NUM, CACHED_LEDGER_AGE,
+    , m_ledgers_by_hash ("LedgerCache", CACHED_LEDGER_NUM, CachedLedgerAge,
         stopwatch(), app_.journal("TaggedCache"))
     , m_consensus_validated ("ConsensusValidated", 64, 5min,
         stopwatch(), app_.journal("TaggedCache"))

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -69,7 +69,7 @@ public:
         @param size The target size of the cache
         @param age The target age of the cache, in seconds
     */
-    void tune (int size, int age);
+    void tune (int size, std::chrono::seconds age);
 
     /** Remove stale cache entries
     */

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -188,7 +188,7 @@ public:
     bool getFullValidatedRange (
         std::uint32_t& minVal, std::uint32_t& maxVal);
 
-    void tune (int size, int age);
+    void tune (int size, std::chrono::seconds age);
     void sweep ();
     float getCacheHitRate ();
 

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -73,7 +73,7 @@ LedgerMaster::LedgerMaster (Application& app, Stopwatch& stopwatch,
         app_.config().FETCH_DEPTH))
     , ledger_history_ (app_.config().LEDGER_HISTORY)
     , ledger_fetch_size_ (app_.config().getSize (siLedgerFetch))
-    , fetch_packs_ ("FetchPack", 65536, 45, stopwatch,
+    , fetch_packs_ ("FetchPack", 65536, 45s, stopwatch,
         app_.journal("TaggedCache"))
 {
 }
@@ -1459,7 +1459,7 @@ LedgerMaster::setLedgerRangePresent (std::uint32_t minV, std::uint32_t maxV)
 }
 
 void
-LedgerMaster::tune (int size, int age)
+LedgerMaster::tune (int size, std::chrono::seconds age)
 {
     mLedgerHistory.tune (size, age);
 }

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -26,8 +26,6 @@
 
 namespace ripple {
 
-using namespace std::chrono_literals;
-
 TransactionMaster::TransactionMaster (Application& app)
     : mApp (app)
     , mCache ("TransactionCache", 65536, 30min, stopwatch(),

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -26,9 +26,11 @@
 
 namespace ripple {
 
+using namespace std::chrono_literals;
+
 TransactionMaster::TransactionMaster (Application& app)
     : mApp (app)
-    , mCache ("TransactionCache", 65536, 1800, stopwatch(),
+    , mCache ("TransactionCache", 65536, 30min, stopwatch(),
         mApp.journal("TaggedCache"))
 {
 }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -986,7 +986,7 @@ public:
         {
             using namespace std::chrono;
             sweepTimer_.expires_from_now(
-                                   seconds{config_->getSize(siSweepInterval)});
+                seconds{config_->getSize(siSweepInterval)});
             sweepTimer_.async_wait (std::move (*optionalCountedHandler));
         }
     }
@@ -1256,20 +1256,20 @@ bool ApplicationImp::setup()
     }
 
     using namespace std::chrono;
-    m_nodeStore->tune (config_->getSize (siNodeCacheSize),
-                       seconds{config_->getSize(siNodeCacheAge)});
-    m_ledgerMaster->tune (config_->getSize (siLedgerSize),
-                          seconds{config_->getSize(siLedgerAge)});
-    family().treecache().setTargetSize (config_->getSize (siTreeCacheSize));
+    m_nodeStore->tune(config_->getSize(siNodeCacheSize),
+                      seconds{config_->getSize(siNodeCacheAge)});
+    m_ledgerMaster->tune(config_->getSize(siLedgerSize),
+                         seconds{config_->getSize(siLedgerAge)});
+    family().treecache().setTargetSize(config_->getSize (siTreeCacheSize));
     family().treecache().setTargetAge(
-                       seconds{config_->getSize(siTreeCacheAge)});
+        seconds{config_->getSize(siTreeCacheAge)});
     if (shardStore_)
     {
         shardStore_->tune(config_->getSize(siNodeCacheSize),
             seconds{config_->getSize(siNodeCacheAge)});
         sFamily_->treecache().setTargetSize(config_->getSize(siTreeCacheSize));
         sFamily_->treecache().setTargetAge(
-                       seconds{config_->getSize(siTreeCacheAge)});
+            seconds{config_->getSize(siTreeCacheAge)});
     }
 
     //----------------------------------------------------------------------

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -72,6 +72,8 @@ static int const MAJORITY_FRACTION (204);
 
 namespace detail {
 
+using namespace std::chrono_literals;
+
 class AppFamily : public Family
 {
 private:
@@ -111,11 +113,11 @@ public:
     AppFamily (Application& app, NodeStore::Database& db,
             CollectorManager& collectorManager)
         : app_ (app)
-        , treecache_ ("TreeNodeCache", 65536, 60, stopwatch(),
+        , treecache_ ("TreeNodeCache", 65536, 1min, stopwatch(),
             app.journal("TaggedCache"))
         , fullbelow_ ("full_below", stopwatch(),
             collectorManager.collector(),
-                fullBelowTargetSize, fullBelowExpirationSeconds)
+                fullBelowTargetSize, fullBelowExpiration)
         , db_ (db)
         , shardBacked_ (
             dynamic_cast<NodeStore::DatabaseShard*>(&db) != nullptr)
@@ -416,7 +418,7 @@ public:
 
         , accountIDCache_(128000)
 
-        , m_tempNodeCache ("NodeCache", 16384, 90, stopwatch(),
+        , m_tempNodeCache ("NodeCache", 16384, 90s, stopwatch(),
             logs_->journal("TaggedCache"))
 
         , m_collectorManager (CollectorManager::New (
@@ -470,7 +472,7 @@ public:
                 gotTXSet (set, fromAcquire);
             }))
 
-        , m_acceptedLedgerCache ("AcceptedLedger", 4, 60, stopwatch(),
+        , m_acceptedLedgerCache ("AcceptedLedger", 4, 1min, stopwatch(),
             logs_->journal("TaggedCache"))
 
         , m_networkOPs (make_NetworkOPs (*this, stopwatch(),
@@ -1254,16 +1256,20 @@ bool ApplicationImp::setup()
         return false;
     }
 
-    m_nodeStore->tune (config_->getSize (siNodeCacheSize), config_->getSize (siNodeCacheAge));
-    m_ledgerMaster->tune (config_->getSize (siLedgerSize), config_->getSize (siLedgerAge));
+    m_nodeStore->tune (config_->getSize (siNodeCacheSize),
+                       std::chrono::seconds{config_->getSize(siNodeCacheAge)});
+    m_ledgerMaster->tune (config_->getSize (siLedgerSize),
+                          std::chrono::seconds{config_->getSize(siLedgerAge)});
     family().treecache().setTargetSize (config_->getSize (siTreeCacheSize));
-    family().treecache().setTargetAge (config_->getSize (siTreeCacheAge));
+    family().treecache().setTargetAge(
+                       std::chrono::seconds{config_->getSize(siTreeCacheAge)});
     if (shardStore_)
     {
         shardStore_->tune(config_->getSize(siNodeCacheSize),
-            config_->getSize(siNodeCacheAge));
+            std::chrono::seconds{config_->getSize(siNodeCacheAge)});
         sFamily_->treecache().setTargetSize(config_->getSize(siTreeCacheSize));
-        sFamily_->treecache().setTargetAge(config_->getSize(siTreeCacheAge));
+        sFamily_->treecache().setTargetAge(
+                       std::chrono::seconds{config_->getSize(siTreeCacheAge)});
     }
 
     //----------------------------------------------------------------------

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -72,8 +72,6 @@ static int const MAJORITY_FRACTION (204);
 
 namespace detail {
 
-using namespace std::chrono_literals;
-
 class AppFamily : public Family
 {
 private:
@@ -986,8 +984,9 @@ public:
                 }
             }))
         {
-            sweepTimer_.expires_from_now (
-                std::chrono::seconds {config_->getSize (siSweepInterval)});
+            using namespace std::chrono;
+            sweepTimer_.expires_from_now(
+                                   seconds{config_->getSize(siSweepInterval)});
             sweepTimer_.async_wait (std::move (*optionalCountedHandler));
         }
     }
@@ -1256,20 +1255,21 @@ bool ApplicationImp::setup()
         return false;
     }
 
+    using namespace std::chrono;
     m_nodeStore->tune (config_->getSize (siNodeCacheSize),
-                       std::chrono::seconds{config_->getSize(siNodeCacheAge)});
+                       seconds{config_->getSize(siNodeCacheAge)});
     m_ledgerMaster->tune (config_->getSize (siLedgerSize),
-                          std::chrono::seconds{config_->getSize(siLedgerAge)});
+                          seconds{config_->getSize(siLedgerAge)});
     family().treecache().setTargetSize (config_->getSize (siTreeCacheSize));
     family().treecache().setTargetAge(
-                       std::chrono::seconds{config_->getSize(siTreeCacheAge)});
+                       seconds{config_->getSize(siTreeCacheAge)});
     if (shardStore_)
     {
         shardStore_->tune(config_->getSize(siNodeCacheSize),
-            std::chrono::seconds{config_->getSize(siNodeCacheAge)});
+            seconds{config_->getSize(siNodeCacheAge)});
         sFamily_->treecache().setTargetSize(config_->getSize(siTreeCacheSize));
         sFamily_->treecache().setTargetAge(
-                       std::chrono::seconds{config_->getSize(siTreeCacheAge)});
+                       seconds{config_->getSize(siTreeCacheAge)});
     }
 
     //----------------------------------------------------------------------
@@ -1592,7 +1592,8 @@ ApplicationImp::loadLedgerFromFile (
             }
             if (ledger.get().isMember ("close_time_resolution"))
             {
-                closeTimeResolution = std::chrono::seconds{
+                using namespace std::chrono;
+                closeTimeResolution = seconds{
                     ledger.get()["close_time_resolution"].asUInt()};
             }
             if (ledger.get().isMember ("close_time_estimated"))

--- a/src/ripple/app/main/Tuning.h
+++ b/src/ripple/app/main/Tuning.h
@@ -22,11 +22,7 @@
 
 namespace ripple {
 
-enum
-{
-     fullBelowTargetSize = 524288
-};
-
+constexpr std::size_t fullBelowTargetSize = 524288;
 constexpr std::chrono::seconds fullBelowExpiration = std::chrono::minutes{10};
 
 }

--- a/src/ripple/app/main/Tuning.h
+++ b/src/ripple/app/main/Tuning.h
@@ -25,8 +25,9 @@ namespace ripple {
 enum
 {
      fullBelowTargetSize = 524288
-    ,fullBelowExpirationSeconds = 600
 };
+
+constexpr std::chrono::seconds fullBelowExpiration = std::chrono::minutes{10};
 
 }
 

--- a/src/ripple/basics/KeyCache.h
+++ b/src/ripple/basics/KeyCache.h
@@ -103,27 +103,28 @@ public:
     */
     KeyCache (std::string const& name, clock_type& clock,
         beast::insight::Collector::ptr const& collector, size_type target_size = 0,
-            clock_type::rep expiration_seconds = 120)
+            std::chrono::seconds expiration = std::chrono::minutes{2})
         : m_stats (name,
             std::bind (&KeyCache::collect_metrics, this),
                 collector)
         , m_clock (clock)
         , m_name (name)
         , m_target_size (target_size)
-        , m_target_age (std::chrono::seconds (expiration_seconds))
+        , m_target_age (expiration)
     {
     }
 
     // VFALCO TODO Use a forwarding constructor call here
     KeyCache (std::string const& name, clock_type& clock,
-        size_type target_size = 0, clock_type::rep expiration_seconds = 120)
+        size_type target_size = 0,
+        std::chrono::seconds expiration = std::chrono::minutes{2})
         : m_stats (name,
             std::bind (&KeyCache::collect_metrics, this),
                 beast::insight::NullCollector::New ())
         , m_clock (clock)
         , m_name (name)
         , m_target_size (target_size)
-        , m_target_age (std::chrono::seconds (expiration_seconds))
+        , m_target_age (expiration)
     {
     }
 
@@ -169,10 +170,10 @@ public:
         m_target_size = s;
     }
 
-    void setTargetAge (size_type s)
+    void setTargetAge (std::chrono::seconds s)
     {
         lock_guard lock (m_mutex);
-        m_target_age = std::chrono::seconds (s);
+        m_target_age = s;
     }
 
     /** Returns `true` if the key was found.

--- a/src/ripple/basics/TaggedCache.h
+++ b/src/ripple/basics/TaggedCache.h
@@ -70,7 +70,6 @@ public:
     using clock_type = beast::abstract_clock <std::chrono::steady_clock>;
 
 public:
-    // VFALCO TODO Change expiration_seconds to clock_type::duration
     TaggedCache (std::string const& name, int size,
         clock_type::duration expiration, clock_type& clock, beast::Journal journal,
             beast::insight::Collector::ptr const& collector = beast::insight::NullCollector::New ())

--- a/src/ripple/basics/TaggedCache.h
+++ b/src/ripple/basics/TaggedCache.h
@@ -72,7 +72,7 @@ public:
 public:
     // VFALCO TODO Change expiration_seconds to clock_type::duration
     TaggedCache (std::string const& name, int size,
-        clock_type::rep expiration_seconds, clock_type& clock, beast::Journal journal,
+        clock_type::duration expiration, clock_type& clock, beast::Journal journal,
             beast::insight::Collector::ptr const& collector = beast::insight::NullCollector::New ())
         : m_journal (journal)
         , m_clock (clock)
@@ -81,7 +81,7 @@ public:
                 collector)
         , m_name (name)
         , m_target_size (size)
-        , m_target_age (std::chrono::seconds (expiration_seconds))
+        , m_target_age (expiration)
         , m_cache_count (0)
         , m_hits (0)
         , m_misses (0)
@@ -113,16 +113,16 @@ public:
             m_name << " target size set to " << s;
     }
 
-    clock_type::rep getTargetAge () const
+    clock_type::duration getTargetAge () const
     {
         lock_guard lock (m_mutex);
-        return m_target_age.count();
+        return m_target_age;
     }
 
-    void setTargetAge (clock_type::rep s)
+    void setTargetAge (clock_type::duration s)
     {
         lock_guard lock (m_mutex);
-        m_target_age = std::chrono::seconds (s);
+        m_target_age = s;
         JLOG(m_journal.debug()) <<
             m_name << " target age set to " << m_target_age.count();
     }
@@ -186,8 +186,7 @@ public:
             }
             else
             {
-                when_expire = now - clock_type::duration (
-                    m_target_age.count() * m_target_size / m_cache.size ());
+                when_expire = now - m_target_age*m_target_size/m_cache.size();
 
                 clock_type::duration const minimumAge (
                     std::chrono::seconds (1));

--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -177,7 +177,7 @@ public:
     */
     virtual
     void
-    tune(int size, int age) = 0;
+    tune(int size, std::chrono::seconds age) = 0;
 
     /** Remove expired entries from the positive and negative caches. */
     virtual

--- a/src/ripple/nodestore/impl/DatabaseNodeImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseNodeImp.cpp
@@ -52,7 +52,7 @@ DatabaseNodeImp::asyncFetch(uint256 const& hash,
 }
 
 void
-DatabaseNodeImp::tune(int size, int age)
+DatabaseNodeImp::tune(int size, std::chrono::seconds age)
 {
     pCache_->setTargetSize(size);
     pCache_->setTargetAge(age);

--- a/src/ripple/nodestore/impl/DatabaseNodeImp.h
+++ b/src/ripple/nodestore/impl/DatabaseNodeImp.h
@@ -43,9 +43,9 @@ public:
         beast::Journal j)
         : Database(name, parent, scheduler, readThreads, config, j)
         , pCache_(std::make_shared<TaggedCache<uint256, NodeObject>>(
-            name, cacheTargetSize, cacheTarget, stopwatch(), j))
+            name, cacheTargetSize, cacheTargetAge, stopwatch(), j))
         , nCache_(std::make_shared<KeyCache<uint256>>(
-            name, stopwatch(), cacheTargetSize, cacheTarget))
+            name, stopwatch(), cacheTargetSize, cacheTargetAge))
         , backend_(std::move(backend))
     {
         assert(backend_);

--- a/src/ripple/nodestore/impl/DatabaseNodeImp.h
+++ b/src/ripple/nodestore/impl/DatabaseNodeImp.h
@@ -43,9 +43,9 @@ public:
         beast::Journal j)
         : Database(name, parent, scheduler, readThreads, config, j)
         , pCache_(std::make_shared<TaggedCache<uint256, NodeObject>>(
-            name, cacheTargetSize, cacheTargetSeconds, stopwatch(), j))
+            name, cacheTargetSize, cacheTarget, stopwatch(), j))
         , nCache_(std::make_shared<KeyCache<uint256>>(
-            name, stopwatch(), cacheTargetSize, cacheTargetSeconds))
+            name, stopwatch(), cacheTargetSize, cacheTarget))
         , backend_(std::move(backend))
     {
         assert(backend_);
@@ -109,7 +109,7 @@ public:
     getCacheHitRate() override {return pCache_->getHitRate();}
 
     void
-    tune(int size, int age) override;
+    tune(int size, std::chrono::seconds age) override;
 
     void
     sweep() override;

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.cpp
@@ -35,9 +35,9 @@ DatabaseRotatingImp::DatabaseRotatingImp(
     beast::Journal j)
     : DatabaseRotating(name, parent, scheduler, readThreads, config, j)
     , pCache_(std::make_shared<TaggedCache<uint256, NodeObject>>(
-        name, cacheTargetSize, cacheTargetSeconds, stopwatch(), j))
+        name, cacheTargetSize, cacheTarget, stopwatch(), j))
     , nCache_(std::make_shared<KeyCache<uint256>>(
-        name, stopwatch(), cacheTargetSize, cacheTargetSeconds))
+        name, stopwatch(), cacheTargetSize, cacheTarget))
     , writableBackend_(std::move(writableBackend))
     , archiveBackend_(std::move(archiveBackend))
 {
@@ -86,7 +86,7 @@ DatabaseRotatingImp::asyncFetch(uint256 const& hash,
 }
 
 void
-DatabaseRotatingImp::tune(int size, int age)
+DatabaseRotatingImp::tune(int size, std::chrono::seconds age)
 {
     pCache_->setTargetSize(size);
     pCache_->setTargetAge(age);

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.cpp
@@ -35,9 +35,9 @@ DatabaseRotatingImp::DatabaseRotatingImp(
     beast::Journal j)
     : DatabaseRotating(name, parent, scheduler, readThreads, config, j)
     , pCache_(std::make_shared<TaggedCache<uint256, NodeObject>>(
-        name, cacheTargetSize, cacheTarget, stopwatch(), j))
+        name, cacheTargetSize, cacheTargetAge, stopwatch(), j))
     , nCache_(std::make_shared<KeyCache<uint256>>(
-        name, stopwatch(), cacheTargetSize, cacheTarget))
+        name, stopwatch(), cacheTargetSize, cacheTargetAge))
     , writableBackend_(std::move(writableBackend))
     , archiveBackend_(std::move(archiveBackend))
 {

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -111,7 +111,7 @@ public:
     getCacheHitRate() override {return pCache_->getHitRate();}
 
     void
-    tune(int size, int age) override;
+    tune(int size, std::chrono::seconds age) override;
 
     void
     sweep() override;

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -677,7 +677,7 @@ DatabaseShardImp::getCacheHitRate()
 }
 
 void
-DatabaseShardImp::tune(int size, int age)
+DatabaseShardImp::tune(int size, std::chrono::seconds age)
 {
     std::lock_guard<std::mutex> l(m_);
     assert(init_);

--- a/src/ripple/nodestore/impl/DatabaseShardImp.h
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.h
@@ -176,7 +176,7 @@ private:
 
     // Shard cache tuning
     int cacheSz_ {shardCacheSz};
-    std::chrono::seconds cacheAge_ {shardCache};
+    std::chrono::seconds cacheAge_ {shardCacheAge};
 
     // File name used to mark shards being imported from node store
     static constexpr auto importMarker_ = "import";

--- a/src/ripple/nodestore/impl/DatabaseShardImp.h
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.h
@@ -134,7 +134,7 @@ public:
     getCacheHitRate() override;
 
     void
-    tune(int size, int age) override;
+    tune(int size, std::chrono::seconds age) override;
 
     void
     sweep() override;
@@ -176,7 +176,7 @@ private:
 
     // Shard cache tuning
     int cacheSz_ {shardCacheSz};
-    PCache::clock_type::rep cacheAge_ {shardCacheSeconds};
+    std::chrono::seconds cacheAge_ {shardCache};
 
     // File name used to mark shards being imported from node store
     static constexpr auto importMarker_ = "import";

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -28,7 +28,7 @@ namespace ripple {
 namespace NodeStore {
 
 Shard::Shard(DatabaseShard const& db, std::uint32_t index,
-    int cacheSz, PCache::clock_type::rep cacheAge, beast::Journal& j)
+    int cacheSz, std::chrono::seconds cacheAge, beast::Journal& j)
     : index_(index)
     , firstSeq_(db.firstLedgerSeq(index))
     , lastSeq_(std::max(firstSeq_, db.lastLedgerSeq(index)))
@@ -228,8 +228,8 @@ Shard::validate(Application& app)
         "-" << lastSeq_;
 
     // Use a short age to keep memory consumption low
-    PCache::clock_type::rep const savedAge {pCache_->getTargetAge()};
-    pCache_->setTargetAge(1);
+    auto const savedAge {pCache_->getTargetAge()};
+    pCache_->setTargetAge(1s);
 
     // Validate every ledger stored in this shard
     std::shared_ptr<Ledger const> next;

--- a/src/ripple/nodestore/impl/Shard.h
+++ b/src/ripple/nodestore/impl/Shard.h
@@ -48,7 +48,7 @@ class Shard
 {
 public:
     Shard(DatabaseShard const& db, std::uint32_t index, int cacheSz,
-        PCache::clock_type::rep cacheAge, beast::Journal& j);
+        std::chrono::seconds cacheAge, beast::Journal& j);
 
     bool
     open(Section config, Scheduler& scheduler,

--- a/src/ripple/nodestore/impl/Tuning.h
+++ b/src/ripple/nodestore/impl/Tuning.h
@@ -33,9 +33,9 @@ enum
 };
 
 // Expiration time for cached nodes
-std::chrono::seconds constexpr cacheTarget = std::chrono::minutes{5};
+std::chrono::seconds constexpr cacheTargetAge = std::chrono::minutes{5};
 auto constexpr shardCacheSz = 16384;
-std::chrono::seconds constexpr shardCache = std::chrono::minutes{1};
+std::chrono::seconds constexpr shardCacheAge = std::chrono::minutes{1};
 
 }
 }

--- a/src/ripple/nodestore/impl/Tuning.h
+++ b/src/ripple/nodestore/impl/Tuning.h
@@ -28,15 +28,14 @@ enum
     // Target cache size of the TaggedCache used to hold nodes
     cacheTargetSize     = 16384
 
-    // Expiration time for cached nodes
-    ,cacheTargetSeconds = 300
-
     // Fraction of the cache one query source can take
     ,asyncDivider = 8
 };
 
+// Expiration time for cached nodes
+std::chrono::seconds constexpr cacheTarget = std::chrono::minutes{5};
 auto constexpr shardCacheSz = 16384;
-auto constexpr shardCacheSeconds = 60;
+std::chrono::seconds constexpr shardCache = std::chrono::minutes{1};
 
 }
 }

--- a/src/ripple/shamap/FullBelowCache.h
+++ b/src/ripple/shamap/FullBelowCache.h
@@ -43,7 +43,6 @@ public:
     enum
     {
          defaultCacheTargetSize = 0
-        ,defaultCacheExpirationSeconds = 120
     };
 
     using key_type   = Key;
@@ -61,9 +60,9 @@ public:
         beast::insight::Collector::ptr const& collector =
             beast::insight::NullCollector::New (),
         std::size_t target_size = defaultCacheTargetSize,
-        std::size_t expiration_seconds = defaultCacheExpirationSeconds)
+        std::chrono::seconds expiration = std::chrono::minutes{2})
         : m_cache (name, clock, collector, target_size,
-            expiration_seconds)
+            expiration)
         , m_gen (1)
     {
     }

--- a/src/test/basics/KeyCache_test.cpp
+++ b/src/test/basics/KeyCache_test.cpp
@@ -24,6 +24,8 @@
 
 namespace ripple {
 
+using namespace std::chrono_literals;
+
 class KeyCache_test : public beast::unit_test::suite
 {
 public:
@@ -37,7 +39,7 @@ public:
 
         // Insert an item, retrieve it, and age it so it gets purged.
         {
-            Cache c ("test", clock, 1, 2);
+            Cache c ("test", clock, 1, 2s);
 
             BEAST_EXPECT(c.size () == 0);
             BEAST_EXPECT(c.insert ("one"));
@@ -58,7 +60,7 @@ public:
 
         // Insert two items, have one expire
         {
-            Cache c ("test", clock, 2, 2);
+            Cache c ("test", clock, 2, 2s);
 
             BEAST_EXPECT(c.insert ("one"));
             BEAST_EXPECT(c.size  () == 1);
@@ -76,7 +78,7 @@ public:
 
         // Insert three items (1 over limit), sweep
         {
-            Cache c ("test", clock, 2, 3);
+            Cache c ("test", clock, 2, 3s);
 
             BEAST_EXPECT(c.insert ("one"));
             ++clock;

--- a/src/test/basics/KeyCache_test.cpp
+++ b/src/test/basics/KeyCache_test.cpp
@@ -24,13 +24,12 @@
 
 namespace ripple {
 
-using namespace std::chrono_literals;
-
 class KeyCache_test : public beast::unit_test::suite
 {
 public:
     void run () override
     {
+        using namespace std::chrono_literals;
         TestStopwatch clock;
         clock.set (0);
 

--- a/src/test/basics/TaggedCache_test.cpp
+++ b/src/test/basics/TaggedCache_test.cpp
@@ -24,8 +24,6 @@
 
 namespace ripple {
 
-using namespace std::chrono_literals;
-
 /*
 I guess you can put some items in, make sure they're still there. Let some
 time pass, make sure they're gone. Keep a strong pointer to one of them, make
@@ -41,6 +39,7 @@ class TaggedCache_test : public beast::unit_test::suite
 public:
     void run () override
     {
+        using namespace std::chrono_literals;
         beast::Journal const j;
 
         TestStopwatch clock;

--- a/src/test/basics/TaggedCache_test.cpp
+++ b/src/test/basics/TaggedCache_test.cpp
@@ -24,6 +24,8 @@
 
 namespace ripple {
 
+using namespace std::chrono_literals;
+
 /*
 I guess you can put some items in, make sure they're still there. Let some
 time pass, make sure they're gone. Keep a strong pointer to one of them, make
@@ -48,7 +50,7 @@ public:
         using Value = std::string;
         using Cache = TaggedCache <Key, Value>;
 
-        Cache c ("test", 1, 1, clock, j);
+        Cache c ("test", 1, 1s, clock, j);
 
         // Insert an item, retrieve it, and age it so it gets purged.
         {

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -249,9 +249,10 @@ public:
     void testMoreThan256Closed()
     {
         using namespace test::jtx;
+        using namespace std::chrono_literals;
         Env env {*this};
         Account const gw {"gateway"};
-        env.app().getLedgerMaster().tune(0, 3600);
+        env.app().getLedgerMaster().tune(0, 1h);
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
 

--- a/src/test/shamap/common.h
+++ b/src/test/shamap/common.h
@@ -29,6 +29,8 @@
 namespace ripple {
 namespace tests {
 
+using namespace std::chrono_literals;
+
 class TestFamily : public Family
 {
 private:
@@ -43,7 +45,7 @@ private:
 
 public:
     TestFamily (beast::Journal j)
-        : treecache_ ("TreeNodeCache", 65536, 60, clock_, j)
+        : treecache_ ("TreeNodeCache", 65536, 1min, clock_, j)
         , fullbelow_ ("full_below", clock_)
         , parent_ ("TestRootStoppable")
         , j_ (j)

--- a/src/test/shamap/common.h
+++ b/src/test/shamap/common.h
@@ -29,8 +29,6 @@
 namespace ripple {
 namespace tests {
 
-using namespace std::chrono_literals;
-
 class TestFamily : public Family
 {
 private:
@@ -45,7 +43,8 @@ private:
 
 public:
     TestFamily (beast::Journal j)
-        : treecache_ ("TreeNodeCache", 65536, 1min, clock_, j)
+        : treecache_ ("TreeNodeCache", 65536, std::chrono::minutes{1},
+                      clock_, j)
         , fullbelow_ ("full_below", clock_)
         , parent_ ("TestRootStoppable")
         , j_ (j)


### PR DESCRIPTION
*  Database::tune and all tune overrides
*  TaggedCache TargetAge
*  KeyCache TargetAge

This P/R cleans up chrono code by reducing use of `.count()` and keeping more timing code within the chrono type system.  It does not claim to get all such code within the chrono type system, just this self-contained and self-consistent set of code.