### PR TITLE
Remove comment about passing allocator to KeyCache

### DIFF
--- a/src/ripple/basics/KeyCache.h
+++ b/src/ripple/basics/KeyCache.h
@@ -34,7 +34,6 @@ namespace ripple {
     older than the maximum age they are eligible for removal during a
     call to @ref sweep.
 */
-// VFALCO TODO Figure out how to pass through the allocator
 template <
     class Key,
     class Hash = hardened_hash <>,


### PR DESCRIPTION
After some discussion on https://github.com/ripple/rippled/pull/2595, we have decided that the allocator should not be plumbed through the `KeyCache` class template. As such, remove the comment suggesting to push the allocator through.

Reviewers:
@scottschurr 