### PR TITLE
Replace boost::unique_lock with std::unique_lock

### DIFF
--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -29,9 +29,8 @@
 #include <ripple/protocol/PublicKey.h>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/range/adaptors.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <mutex>
+#include <shared_mutex>
 #include <numeric>
 
 namespace ripple {
@@ -129,7 +128,7 @@ class ValidatorList
     ManifestCache& publisherManifests_;
     TimeKeeper& timeKeeper_;
     beast::Journal j_;
-    boost::shared_mutex mutable mutex_;
+    std::shared_timed_mutex mutable mutex_;
 
     std::atomic<std::size_t> quorum_;
     boost::optional<std::size_t> minimumQuorum_;

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -26,6 +26,8 @@
 #include <boost/beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 
+#include <mutex>
+
 namespace ripple {
 
 std::string
@@ -82,7 +84,7 @@ ValidatorList::load (
         ")?"                      // end optional comment block
     );
 
-    boost::unique_lock<boost::shared_mutex> read_lock{mutex_};
+    std::unique_lock<boost::shared_mutex> read_lock{mutex_};
 
     JLOG (j_.debug()) <<
         "Loading configured trusted validator list publisher keys";
@@ -198,7 +200,7 @@ ValidatorList::applyList (
     if (version != requiredListVersion)
         return ListDisposition::unsupported_version;
 
-    boost::unique_lock<boost::shared_mutex> lock{mutex_};
+    std::unique_lock<boost::shared_mutex> lock{mutex_};
 
     Json::Value list;
     PublicKey pubKey;
@@ -601,7 +603,7 @@ ValidatorList::calculateMinimumQuorum (
 TrustChanges
 ValidatorList::updateTrusted(hash_set<NodeID> const& seenValidators)
 {
-    boost::unique_lock<boost::shared_mutex> lock{mutex_};
+    std::unique_lock<boost::shared_mutex> lock{mutex_};
 
     // Check that lists from all configured publishers are available
     bool allListsAvailable = true;

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -27,6 +27,7 @@
 #include <boost/regex.hpp>
 
 #include <mutex>
+#include <shared_mutex>
 
 namespace ripple {
 
@@ -378,7 +379,7 @@ bool
 ValidatorList::listed (
     PublicKey const& identity) const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     return keyListings_.find (pubKey) != keyListings_.end ();
@@ -387,7 +388,7 @@ ValidatorList::listed (
 bool
 ValidatorList::trusted (PublicKey const& identity) const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     return trustedKeys_.find (pubKey) != trustedKeys_.end();
@@ -397,7 +398,7 @@ boost::optional<PublicKey>
 ValidatorList::getListedKey (
     PublicKey const& identity) const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     if (keyListings_.find (pubKey) != keyListings_.end ())
@@ -408,7 +409,7 @@ ValidatorList::getListedKey (
 boost::optional<PublicKey>
 ValidatorList::getTrustedKey (PublicKey const& identity) const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     if (trustedKeys_.find (pubKey) != trustedKeys_.end())
@@ -419,14 +420,14 @@ ValidatorList::getTrustedKey (PublicKey const& identity) const
 bool
 ValidatorList::trustedPublisher (PublicKey const& identity) const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
     return identity.size() && publisherLists_.count (identity);
 }
 
 PublicKey
 ValidatorList::localPublicKey () const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
     return localPubKey_;
 }
 
@@ -462,7 +463,7 @@ ValidatorList::removePublisherList (PublicKey const& publisherKey)
 boost::optional<TimeKeeper::time_point>
 ValidatorList::expires() const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
     boost::optional<TimeKeeper::time_point> res{boost::none};
     for (auto const& p : publisherLists_)
     {
@@ -482,7 +483,7 @@ ValidatorList::getJson() const
 {
     Json::Value res(Json::objectValue);
 
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
 
     res[jss::validation_quorum] = static_cast<Json::UInt>(quorum());
 
@@ -564,7 +565,7 @@ void
 ValidatorList::for_each_listed (
     std::function<void(PublicKey const&, bool)> func) const
 {
-    boost::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
 
     for (auto const& v : keyListings_)
         func (v.first, trusted(v.first));

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -85,7 +85,7 @@ ValidatorList::load (
         ")?"                      // end optional comment block
     );
 
-    std::unique_lock<boost::shared_mutex> read_lock{mutex_};
+    std::unique_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     JLOG (j_.debug()) <<
         "Loading configured trusted validator list publisher keys";
@@ -201,7 +201,7 @@ ValidatorList::applyList (
     if (version != requiredListVersion)
         return ListDisposition::unsupported_version;
 
-    std::unique_lock<boost::shared_mutex> lock{mutex_};
+    std::unique_lock<std::shared_timed_mutex> lock{mutex_};
 
     Json::Value list;
     PublicKey pubKey;
@@ -379,7 +379,7 @@ bool
 ValidatorList::listed (
     PublicKey const& identity) const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     return keyListings_.find (pubKey) != keyListings_.end ();
@@ -388,7 +388,7 @@ ValidatorList::listed (
 bool
 ValidatorList::trusted (PublicKey const& identity) const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     return trustedKeys_.find (pubKey) != trustedKeys_.end();
@@ -398,7 +398,7 @@ boost::optional<PublicKey>
 ValidatorList::getListedKey (
     PublicKey const& identity) const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     if (keyListings_.find (pubKey) != keyListings_.end ())
@@ -409,7 +409,7 @@ ValidatorList::getListedKey (
 boost::optional<PublicKey>
 ValidatorList::getTrustedKey (PublicKey const& identity) const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     auto const pubKey = validatorManifests_.getMasterKey (identity);
     if (trustedKeys_.find (pubKey) != trustedKeys_.end())
@@ -420,14 +420,14 @@ ValidatorList::getTrustedKey (PublicKey const& identity) const
 bool
 ValidatorList::trustedPublisher (PublicKey const& identity) const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
     return identity.size() && publisherLists_.count (identity);
 }
 
 PublicKey
 ValidatorList::localPublicKey () const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
     return localPubKey_;
 }
 
@@ -463,7 +463,7 @@ ValidatorList::removePublisherList (PublicKey const& publisherKey)
 boost::optional<TimeKeeper::time_point>
 ValidatorList::expires() const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
     boost::optional<TimeKeeper::time_point> res{boost::none};
     for (auto const& p : publisherLists_)
     {
@@ -483,7 +483,7 @@ ValidatorList::getJson() const
 {
     Json::Value res(Json::objectValue);
 
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     res[jss::validation_quorum] = static_cast<Json::UInt>(quorum());
 
@@ -565,7 +565,7 @@ void
 ValidatorList::for_each_listed (
     std::function<void(PublicKey const&, bool)> func) const
 {
-    std::shared_lock<boost::shared_mutex> read_lock{mutex_};
+    std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
 
     for (auto const& v : keyListings_)
         func (v.first, trusted(v.first));
@@ -604,7 +604,7 @@ ValidatorList::calculateMinimumQuorum (
 TrustChanges
 ValidatorList::updateTrusted(hash_set<NodeID> const& seenValidators)
 {
-    std::unique_lock<boost::shared_mutex> lock{mutex_};
+    std::unique_lock<std::shared_timed_mutex> lock{mutex_};
 
     // Check that lists from all configured publishers are available
     bool allListsAvailable = true;


### PR DESCRIPTION
Came up in a discussion from https://github.com/ripple/rippled/pull/2613 

Reviewer:
@wilsonianb 