### PR TITLE
Minor optimization of STObject::add

### DIFF
--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -354,12 +354,12 @@ public:
 
     virtual void add (Serializer & s) const override
     {
-        add (s, true);    // just inner elements
+        add (s, withAllFields);    // just inner elements
     }
 
     void addWithoutSigningFields (Serializer & s) const
     {
-        add (s, false);
+        add (s, omitSigningFields);
     }
 
     // VFALCO NOTE does this return an expensive copy of an object with a
@@ -368,7 +368,7 @@ public:
     Serializer getSerializer () const
     {
         Serializer s;
-        add (s, true);
+        add (s, withAllFields);
         return s;
     }
 
@@ -538,13 +538,22 @@ public:
     }
 
 private:
-    void add (Serializer & s, bool withSigningFields) const;
+    enum WhichFields : bool
+    {
+        // These values are carefully chosen to do the right thing if passed
+        // to SField::shouldInclude (bool)
+        omitSigningFields = false,
+        withAllFields = true
+    };
+
+    void add (Serializer & s, WhichFields whichFields) const;
 
     // Sort the entries in an STObject into the order that they will be
     // serialized.  Note: they are not sorted into pointer value order, they
     // are sorted by SField::fieldCode.
     static std::vector<STBase const*>
-    getSortedFields (STObject const& objToSort);
+    getSortedFields (
+        STObject const& objToSort, WhichFields whichFields);
 
     // Two different ways to compare STObjects.
     //


### PR DESCRIPTION
Replace a local `std::map` in `STObject::add()` with a sorted `std::vector`.  It is possible to call `reserve()` with a sensible value on the `vector`, so this should give us significantly less freestore activity in the method.  The element types in the `vector` are cheaply copyable, so the `sort` should be inexpensive.

Also replaces two calls to `dynamic_cast` with a single virtual method call.  In any implementation I'm aware of a `dynamic_cast` is more expensive than a single virtual call.

The two added `assert`s are intended to provide confidence that the virtual call really _does_ provide identical functionality to the `dynamic_casts`.  All unit tests pass on a debug build with the asserts in place.  I've also run a debug version of the server against the network for four hours without either assert firing.  I'll probably give it 24 hours of burn in.  Assuming it survives the 24 hour burn in, I'm not convinced that the `assert`s need to be kept long term, but I'm open to opinions on that.

Serialization of `STObject`s is common and important.  It should be as fast as reasonable while still being correct.

Reviewers: @HowardHinnant @seelabs 