### PR TITLE
Supply ConsensusTimer with milliseconds or finer precision

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -203,7 +203,7 @@ public:
             ledgerMaster,
             *m_localTX,
             app.getInboundTransactions(),
-            stopwatch(),
+            beast::get_abstract_clock<std::chrono::steady_clock>(),
             validatorKeys,
             app_.logs().journal("LedgerConsensus"))
         , m_ledgerMaster (ledgerMaster)


### PR DESCRIPTION
`ConsensusTimer`, and `Consensus<Adaptor>` which uses `ConsensusTimer`, use `milliseconds` precision.  However the clock it is using, `stopwatch()`, is updated with the correct time only once a second.

This change provides a clock that truly supports millisecond-precision.  A later P/R will modify `stopwatch()` to return a clock that advertises its true precision: seconds.

This change may need to be tested on the alt net, and may also require tweaking of the `ledgerMIN_CONSENSUS` constant.