### PR TITLE
Add user defined literals for megabytes and kilobytes

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -44,6 +44,7 @@
 #include <ripple/app/misc/ValidatorKeys.h>
 #include <ripple/app/paths/PathRequests.h>
 #include <ripple/app/tx/apply.h>
+#include <ripple/basics/literals.h>
 #include <ripple/basics/ResolverAsio.h>
 #include <ripple/basics/Sustain.h>
 #include <ripple/basics/PerfLog.h>
@@ -608,7 +609,6 @@ public:
         return nodeIdentity_;
     }
 
-    
     PublicKey const &
     getValidationPublicKey() const override
     {
@@ -1026,8 +1026,7 @@ public:
             boost::filesystem::space_info space =
                 boost::filesystem::space (config_->legacy ("database_path"));
 
-            constexpr std::uintmax_t bytes512M = 512 * 1024 * 1024;
-            if (space.available < (bytes512M))
+            if (space.available < 512_mb)
             {
                 JLOG(m_journal.fatal())
                     << "Remaining free disk space is less than 512MB";
@@ -1143,11 +1142,11 @@ bool ApplicationImp::setup()
 
     getLedgerDB ().getSession ()
         << boost::str (boost::format ("PRAGMA cache_size=-%d;") %
-                        (config_->getSize (siLgrDBCache) * 1024));
+                        (config_->getSize (siLgrDBCache) * 1_kb));
 
     getTxnDB ().getSession ()
             << boost::str (boost::format ("PRAGMA cache_size=-%d;") %
-                            (config_->getSize (siTxnDBCache) * 1024));
+                            (config_->getSize (siTxnDBCache) * 1_kb));
 
     mTxnDB->setupCheckpointing (m_jobQueue.get(), logs());
     mLedgerDB->setupCheckpointing (m_jobQueue.get(), logs());

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -44,7 +44,7 @@
 #include <ripple/app/misc/ValidatorKeys.h>
 #include <ripple/app/paths/PathRequests.h>
 #include <ripple/app/tx/apply.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/basics/ResolverAsio.h>
 #include <ripple/basics/Sustain.h>
 #include <ripple/basics/PerfLog.h>
@@ -1026,7 +1026,7 @@ public:
             boost::filesystem::space_info space =
                 boost::filesystem::space (config_->legacy ("database_path"));
 
-            if (space.available < 512_mb)
+            if (space.available < megabytes(512))
             {
                 JLOG(m_journal.fatal())
                     << "Remaining free disk space is less than 512MB";
@@ -1142,11 +1142,11 @@ bool ApplicationImp::setup()
 
     getLedgerDB ().getSession ()
         << boost::str (boost::format ("PRAGMA cache_size=-%d;") %
-                        (config_->getSize (siLgrDBCache) * 1_kb));
+                        (config_->getSize (siLgrDBCache) * kilobytes(1)));
 
     getTxnDB ().getSession ()
             << boost::str (boost::format ("PRAGMA cache_size=-%d;") %
-                            (config_->getSize (siTxnDBCache) * 1_kb));
+                            (config_->getSize (siTxnDBCache) * kilobytes(1)));
 
     mTxnDB->setupCheckpointing (m_jobQueue.get(), logs());
     mLedgerDB->setupCheckpointing (m_jobQueue.get(), logs());

--- a/src/ripple/basics/ByteUtilities.h
+++ b/src/ripple/basics/ByteUtilities.h
@@ -17,18 +17,21 @@
 */
 //==============================================================================
 
-#ifndef RIPPLE_BASICS_LITERALS_H_INCLUDED
-#define RIPPLE_BASICS_LITERALS_H_INCLUDED
+#ifndef RIPPLE_BASICS_BYTEUTILITIES_H_INCLUDED
+#define RIPPLE_BASICS_BYTEUTILITIES_H_INCLUDED
 
 namespace ripple {
-    constexpr auto operator""_kb(unsigned long long x) noexcept
+
+    template<class T>
+    constexpr auto kilobytes(T value) noexcept
     {
-        return 1024ull * x;
+        return value * 1024;
     }
 
-    constexpr auto operator""_mb(unsigned long long x) noexcept
+    template<class T>
+    constexpr auto megabytes(T value) noexcept
     {
-        return 1024ull * 1024ull * x;
+        return kilobytes(1) * kilobytes(1) * value;
     }
 }
 

--- a/src/ripple/basics/literals.h
+++ b/src/ripple/basics/literals.h
@@ -17,11 +17,6 @@
 */
 //==============================================================================
 
-// Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2011 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file license.txt or http://www.opensource.org/licenses/mit-license.php.
-
 #ifndef RIPPLE_BASICS_LITERALS_H_INCLUDED
 #define RIPPLE_BASICS_LITERALS_H_INCLUDED
 

--- a/src/ripple/basics/literals.h
+++ b/src/ripple/basics/literals.h
@@ -1,0 +1,40 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2011 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RIPPLE_BASICS_LITERALS_H_INCLUDED
+#define RIPPLE_BASICS_LITERALS_H_INCLUDED
+
+namespace ripple {
+    constexpr auto operator""_kb(unsigned long long x) noexcept
+    {
+        return 1024ull * x;
+    }
+
+    constexpr auto operator""_mb(unsigned long long x) noexcept
+    {
+        return 1024ull * 1024ull * x;
+    }
+}
+
+#endif

--- a/src/ripple/basics/qalloc.h
+++ b/src/ripple/basics/qalloc.h
@@ -21,6 +21,7 @@
 #define RIPPLE_BASICS_QALLOC_H_INCLUDED
 
 #include <ripple/basics/contract.h>
+#include <ripple/basics/literals.h>
 #include <boost/intrusive/list.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -67,10 +68,7 @@ private:
     block* free_ = nullptr;
 
 public:
-    enum
-    {
-        block_size = 256 * 1024
-    };
+    static constexpr auto block_size = 256_kb;
 
     qalloc_impl() = default;
     qalloc_impl (qalloc_impl const&) = delete;

--- a/src/ripple/basics/qalloc.h
+++ b/src/ripple/basics/qalloc.h
@@ -21,7 +21,7 @@
 #define RIPPLE_BASICS_QALLOC_H_INCLUDED
 
 #include <ripple/basics/contract.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <boost/intrusive/list.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -68,7 +68,7 @@ private:
     block* free_ = nullptr;
 
 public:
-    static constexpr auto block_size = 256_kb;
+    static constexpr auto block_size = kilobytes(256);
 
     qalloc_impl() = default;
     qalloc_impl (qalloc_impl const&) = delete;

--- a/src/ripple/core/Coro.ipp
+++ b/src/ripple/core/Coro.ipp
@@ -20,6 +20,8 @@
 #ifndef RIPPLE_CORE_COROINL_H_INCLUDED
 #define RIPPLE_CORE_COROINL_H_INCLUDED
 
+#include <ripple/basics/literals.h>
+
 namespace ripple {
 
 template <class F>
@@ -40,7 +42,7 @@ Coro(Coro_create_t, JobQueue& jq, JobType type,
 #ifndef NDEBUG
             finished_ = true;
 #endif
-        }, boost::coroutines::attributes (1024 * 1024))
+        }, boost::coroutines::attributes (1_mb))
 {
 }
 

--- a/src/ripple/core/Coro.ipp
+++ b/src/ripple/core/Coro.ipp
@@ -20,7 +20,7 @@
 #ifndef RIPPLE_CORE_COROINL_H_INCLUDED
 #define RIPPLE_CORE_COROINL_H_INCLUDED
 
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 
 namespace ripple {
 
@@ -42,7 +42,7 @@ Coro(Coro_create_t, JobQueue& jq, JobType type,
 #ifndef NDEBUG
             finished_ = true;
 #endif
-        }, boost::coroutines::attributes (1_mb))
+        }, boost::coroutines::attributes (megabytes(1)))
 {
 }
 

--- a/src/ripple/core/impl/SociDB.cpp
+++ b/src/ripple/core/impl/SociDB.cpp
@@ -24,7 +24,7 @@
 
 
 #include <ripple/basics/contract.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/core/SociDB.h>
 #include <ripple/core/Config.h>
@@ -130,7 +130,7 @@ size_t getKBUsedAll (soci::session& s)
 {
     if (! getConnection (s))
         Throw<std::logic_error> ("No connection found.");
-    return static_cast <size_t> (sqlite_api::sqlite3_memory_used () / 1_kb);
+    return static_cast <size_t> (sqlite_api::sqlite3_memory_used () / kilobytes(1));
 }
 
 size_t getKBUsedDB (soci::session& s)
@@ -141,7 +141,7 @@ size_t getKBUsedDB (soci::session& s)
         int cur = 0, hiw = 0;
         sqlite_api::sqlite3_db_status (
             conn, SQLITE_DBSTATUS_CACHE_USED, &cur, &hiw, 0);
-        return cur / 1_kb;
+        return cur / kilobytes(1);
     }
     Throw<std::logic_error> ("");
     return 0; // Silence compiler warning.

--- a/src/ripple/core/impl/SociDB.cpp
+++ b/src/ripple/core/impl/SociDB.cpp
@@ -24,6 +24,7 @@
 
 
 #include <ripple/basics/contract.h>
+#include <ripple/basics/literals.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/core/SociDB.h>
 #include <ripple/core/Config.h>
@@ -129,7 +130,7 @@ size_t getKBUsedAll (soci::session& s)
 {
     if (! getConnection (s))
         Throw<std::logic_error> ("No connection found.");
-    return static_cast <size_t> (sqlite_api::sqlite3_memory_used () / 1024);
+    return static_cast <size_t> (sqlite_api::sqlite3_memory_used () / 1_kb);
 }
 
 size_t getKBUsedDB (soci::session& s)
@@ -140,7 +141,7 @@ size_t getKBUsedDB (soci::session& s)
         int cur = 0, hiw = 0;
         sqlite_api::sqlite3_db_status (
             conn, SQLITE_DBSTATUS_CACHE_USED, &cur, &hiw, 0);
-        return cur / 1024;
+        return cur / 1_kb;
     }
     Throw<std::logic_error> ("");
     return 0; // Silence compiler warning.
@@ -159,7 +160,6 @@ void convert (soci::blob& from, std::string& to)
     std::vector<std::uint8_t> tmp;
     convert (from, tmp);
     to.assign (tmp.begin (), tmp.end());
-
 }
 
 void convert (std::vector<std::uint8_t> const& from, soci::blob& to)

--- a/src/ripple/crypto/impl/csprng.cpp
+++ b/src/ripple/crypto/impl/csprng.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/basics/contract.h>
+#include <ripple/basics/literals.h>
 #include <ripple/crypto/csprng.h>
 #include <openssl/rand.h>
 #include <array>
@@ -55,7 +56,7 @@ csprng_engine::load_state (std::string const& file)
     if (!file.empty())
     {
         std::lock_guard<std::mutex> lock (mutex_);
-        RAND_load_file (file.c_str (), 1024);
+        RAND_load_file (file.c_str (), 1_kb);
         RAND_write_file (file.c_str ());
     }
 }

--- a/src/ripple/crypto/impl/csprng.cpp
+++ b/src/ripple/crypto/impl/csprng.cpp
@@ -18,7 +18,7 @@
 //==============================================================================
 
 #include <ripple/basics/contract.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/crypto/csprng.h>
 #include <openssl/rand.h>
 #include <array>
@@ -56,7 +56,7 @@ csprng_engine::load_state (std::string const& file)
     if (!file.empty())
     {
         std::lock_guard<std::mutex> lock (mutex_);
-        RAND_load_file (file.c_str (), 1_kb);
+        RAND_load_file (file.c_str (), kilobytes(1));
         RAND_write_file (file.c_str ());
     }
 }

--- a/src/ripple/net/HTTPClient.h
+++ b/src/ripple/net/HTTPClient.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_NET_HTTPCLIENT_H_INCLUDED
 #define RIPPLE_NET_HTTPCLIENT_H_INCLUDED
 
+#include <ripple/basics/literals.h>
 #include <ripple/core/Config.h>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/streambuf.hpp>
@@ -34,10 +35,7 @@ class HTTPClient
 public:
     explicit HTTPClient() = default;
 
-    enum
-    {
-        maxClientHeaderBytes = 32 * 1024
-    };
+    static constexpr auto maxClientHeaderBytes = 32_kb;
 
     static void initializeSSLContext (Config const& config, beast::Journal j);
 

--- a/src/ripple/net/HTTPClient.h
+++ b/src/ripple/net/HTTPClient.h
@@ -20,7 +20,7 @@
 #ifndef RIPPLE_NET_HTTPCLIENT_H_INCLUDED
 #define RIPPLE_NET_HTTPCLIENT_H_INCLUDED
 
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/core/Config.h>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/streambuf.hpp>
@@ -35,7 +35,7 @@ class HTTPClient
 public:
     explicit HTTPClient() = default;
 
-    static constexpr auto maxClientHeaderBytes = 32_kb;
+    static constexpr auto maxClientHeaderBytes = kilobytes(32);
 
     static void initializeSSLContext (Config const& config, beast::Journal j);
 

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/app/main/Application.h>
 #include <ripple/basics/StringUtilities.h>
+#include <ripple/basics/literals.h>
 #include <ripple/net/RPCCall.h>
 #include <ripple/net/RPCErr.h>
 #include <ripple/basics/contract.h>
@@ -1501,7 +1502,7 @@ void fromNetwork (
 
     // Number of bytes to try to receive if no
     // Content-Length header received
-    const int RPC_REPLY_MAX_BYTES (256*1024*1024);
+    constexpr auto RPC_REPLY_MAX_BYTES = 256_mb;
 
     using namespace std::chrono_literals;
     auto constexpr RPC_NOTIFY = 10min;

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -19,7 +19,7 @@
 
 #include <ripple/app/main/Application.h>
 #include <ripple/basics/StringUtilities.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/net/RPCCall.h>
 #include <ripple/net/RPCErr.h>
 #include <ripple/basics/contract.h>
@@ -1502,7 +1502,7 @@ void fromNetwork (
 
     // Number of bytes to try to receive if no
     // Content-Length header received
-    constexpr auto RPC_REPLY_MAX_BYTES = 256_mb;
+    constexpr auto RPC_REPLY_MAX_BYTES = megabytes(256);
 
     using namespace std::chrono_literals;
     auto constexpr RPC_NOTIFY = 10min;

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -42,7 +42,7 @@ class NuDBBackend
 public:
     // This needs to be tuned for the
     // distribution of data sizes.
-    static constexpr std::size_t arena_alloc_size = 16_mb;
+    static constexpr std::size_t arena_alloc_size = megabytes(16);
     static constexpr std::size_t currentType = 1;
 
     beast::Journal j_;

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -40,14 +40,10 @@ class NuDBBackend
     : public Backend
 {
 public:
-    enum
-    {
-        // This needs to be tuned for the
-        // distribution of data sizes.
-        arena_alloc_size = 16 * 1024 * 1024,
-
-        currentType = 1
-    };
+    // This needs to be tuned for the
+    // distribution of data sizes.
+    static constexpr std::size_t arena_alloc_size = 16_mb;
+    static constexpr std::size_t currentType = 1;
 
     beast::Journal j_;
     size_t const keyBytes_;

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -23,7 +23,7 @@
 #if RIPPLE_ROCKSDB_AVAILABLE
 
 #include <ripple/basics/contract.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
@@ -119,7 +119,7 @@ public:
 
         if (keyValues.exists ("cache_mb"))
             table_options.block_cache = rocksdb::NewLRUCache (
-                get<int>(keyValues, "cache_mb") * 1_mb);
+                get<int>(keyValues, "cache_mb") * megabytes(1));
 
         if (auto const v = get<int>(keyValues, "filter_bits"))
         {
@@ -133,7 +133,7 @@ public:
 
         if (keyValues.exists ("file_size_mb"))
         {
-            m_options.target_file_size_base = 1_mb * get<int>(keyValues,"file_size_mb");
+            m_options.target_file_size_base = megabytes(1) * get<int>(keyValues,"file_size_mb");
             m_options.max_bytes_for_level_base = 5 * m_options.target_file_size_base;
             m_options.write_buffer_size = 2 * m_options.target_file_size_base;
         }

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -23,6 +23,7 @@
 #if RIPPLE_ROCKSDB_AVAILABLE
 
 #include <ripple/basics/contract.h>
+#include <ripple/basics/literals.h>
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
@@ -118,7 +119,7 @@ public:
 
         if (keyValues.exists ("cache_mb"))
             table_options.block_cache = rocksdb::NewLRUCache (
-                get<int>(keyValues, "cache_mb") * 1024L * 1024L);
+                get<int>(keyValues, "cache_mb") * 1_mb);
 
         if (auto const v = get<int>(keyValues, "filter_bits"))
         {
@@ -132,7 +133,7 @@ public:
 
         if (keyValues.exists ("file_size_mb"))
         {
-            m_options.target_file_size_base = 1024 * 1024 * get<int>(keyValues,"file_size_mb");
+            m_options.target_file_size_base = 1_mb * get<int>(keyValues,"file_size_mb");
             m_options.max_bytes_for_level_base = 5 * m_options.target_file_size_base;
             m_options.write_buffer_size = 2 * m_options.target_file_size_base;
         }

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -23,7 +23,7 @@
 #if RIPPLE_ROCKSDB_AVAILABLE
 
 #include <ripple/basics/contract.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
@@ -110,7 +110,7 @@ public:
                 "Missing path in RocksDBQuickFactory backend");
 
         // Defaults
-        std::uint64_t budget = 512_mb;
+        std::uint64_t budget = megabytes(512);
         std::string style("level");
         std::uint64_t threads=4;
 
@@ -129,7 +129,7 @@ public:
             m_options.OptimizeUniversalStyleCompaction(budget);
 
         if (style == "point")
-            m_options.OptimizeForPointLookup(budget / 1_mb); // In MB
+            m_options.OptimizeForPointLookup(budget / megabytes(1)); // In MB
 
         m_options.IncreaseParallelism(threads);
 

--- a/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBQuickFactory.cpp
@@ -23,6 +23,7 @@
 #if RIPPLE_ROCKSDB_AVAILABLE
 
 #include <ripple/basics/contract.h>
+#include <ripple/basics/literals.h>
 #include <ripple/core/Config.h> // VFALCO Bad dependency
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
@@ -109,7 +110,7 @@ public:
                 "Missing path in RocksDBQuickFactory backend");
 
         // Defaults
-        std::uint64_t budget = 512 * 1024 * 1024;  // 512MB
+        std::uint64_t budget = 512_mb;
         std::string style("level");
         std::uint64_t threads=4;
 
@@ -128,7 +129,7 @@ public:
             m_options.OptimizeUniversalStyleCompaction(budget);
 
         if (style == "point")
-            m_options.OptimizeForPointLookup(budget / 1024 / 1024);  // In MB
+            m_options.OptimizeForPointLookup(budget / 1_mb); // In MB
 
         m_options.IncreaseParallelism(threads);
 

--- a/src/ripple/protocol/Protocol.h
+++ b/src/ripple/protocol/Protocol.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_PROTOCOL_H_INCLUDED
 
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/literals.h>
 #include <cstdint>
 
 namespace ripple {
@@ -38,7 +39,7 @@ namespace ripple {
 std::size_t constexpr txMinSizeBytes = 32;
 
 /** Largest legal byte size of a transaction. */
-std::size_t constexpr txMaxSizeBytes = 1024 * 1024;
+std::size_t constexpr txMaxSizeBytes = 1_mb;
 
 /** The maximum number of unfunded offers to delete at once */
 std::size_t constexpr unfundedOfferRemoveLimit = 1000;

--- a/src/ripple/protocol/Protocol.h
+++ b/src/ripple/protocol/Protocol.h
@@ -21,7 +21,7 @@
 #define RIPPLE_PROTOCOL_PROTOCOL_H_INCLUDED
 
 #include <ripple/basics/base_uint.h>
-#include <ripple/basics/literals.h>
+#include <ripple/basics/ByteUtilities.h>
 #include <cstdint>
 
 namespace ripple {
@@ -39,7 +39,7 @@ namespace ripple {
 std::size_t constexpr txMinSizeBytes = 32;
 
 /** Largest legal byte size of a transaction. */
-std::size_t constexpr txMaxSizeBytes = 1_mb;
+std::size_t constexpr txMaxSizeBytes = megabytes(1);
 
 /** The maximum number of unfunded offers to delete at once */
 std::size_t constexpr unfundedOfferRemoveLimit = 1000;


### PR DESCRIPTION
I know that there is some developer overhead in knowing that these user-defined-literals exist in the codebase, but I felt the several usages of simple multiplications of `1024` combined with comments detailing the units justified introducing the two simple UDLs.

Note that I didn't introduce the whole slew of byte-like UDLs as I only saw widespread usage of kb and mb.

Requested reviewers:
@seelabs @HowardHinnant 