### PR TITLE
Remove -Wno-sign-compare compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,6 @@ else ()
         -frtti
         -Wnon-virtual-dtor
       >
-      -Wno-sign-compare
       -Wno-char-subscripts
       -Wno-format
       -Wno-unused-local-typedefs


### PR DESCRIPTION
This came up from the discussion on https://github.com/ripple/rippled/pull/2631

Problem:
- We currently ignore sign comparison warnings.

Solution:
- Do not ignore sign comparison warnings.

Reviewers:
@seelabs @HowardHinnant 