### PR TITLE
Trivial: correct werr flag for jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ try {
                 'BUILD=cmake',
                 "MAX_TIME=${max_minutes}m",
                 "BUILD_DIR=${bldlabel}",
-                "CMAKE_EXTRA_ARGS=-Werr=ON ${cmake_extra}",
+                "CMAKE_EXTRA_ARGS=-Dwerr=ON ${cmake_extra}",
                 'VERBOSE_BUILD=true']
 
             builds[bldlabel] = {


### PR DESCRIPTION
Fixes a typo in Jenkinsfile that failed to set Werror properly for CI builds.