### PR TITLE
[TRIVIAL] Add delimiter when appending to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if (MSVC)
       -machine:X64)
 else ()
   # HACK : because these need to come first, before any warning demotion
-  string (APPEND CMAKE_CXX_FLAGS "-Wall -Wdeprecated")
+  string (APPEND CMAKE_CXX_FLAGS " -Wall -Wdeprecated")
   # not MSVC
   target_compile_options (common
     INTERFACE


### PR DESCRIPTION
I ran into an issue when setting CMAKE_CXX_FLAGS from the command line when running an experiment. We need to add a delimiter when appending to CMAKE_CXX_FLAGS before appending.