### PR TITLE
Remove using namespace declarations at namespace scope in headers

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -411,6 +411,7 @@ RCLConsensus::Adaptor::doAccept(
     if (consensusCloseTime == NetClock::time_point{})
     {
         // We agreed to disagree on the close time
+        using namespace std::chrono_literals;
         consensusCloseTime = prevLedger.closeTime() + 1s;
         closeTimeCorrect = false;
     }
@@ -668,6 +669,7 @@ RCLConsensus::Adaptor::buildLCL(
     }();
 
     // Update fee computations based on accepted txs
+    using namespace std::chrono_literals;
     app_.getTxQ().processClosedLedger(app_, *buildLCL, roundTime > 5s);
 
     // And stash the ledger in the ledger master
@@ -685,6 +687,7 @@ RCLConsensus::Adaptor::validate(RCLCxLedger const& ledger,
     RCLTxSet const& txns,
     bool proposing)
 {
+    using namespace std::chrono_literals;
     auto validationTime = app_.timeKeeper().closeTime();
     if (validationTime <= lastValidationTime_)
         validationTime = lastValidationTime_ + 1s;

--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -44,7 +44,7 @@ LedgerHistory::LedgerHistory (
     , mismatch_counter_ (collector->make_counter ("ledger.history", "mismatch"))
     , m_ledgers_by_hash ("LedgerCache", CACHED_LEDGER_NUM, CachedLedgerAge,
         stopwatch(), app_.journal("TaggedCache"))
-    , m_consensus_validated ("ConsensusValidated", 64, 5min,
+    , m_consensus_validated ("ConsensusValidated", 64, std::chrono::minutes {5},
         stopwatch(), app_.journal("TaggedCache"))
     , j_ (app.journal ("LedgerHistory"))
 {

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -28,7 +28,7 @@ namespace ripple {
 
 TransactionMaster::TransactionMaster (Application& app)
     : mApp (app)
-    , mCache ("TransactionCache", 65536, 30min, stopwatch(),
+    , mCache ("TransactionCache", 65536, std::chrono::minutes {30}, stopwatch(),
         mApp.journal("TaggedCache"))
 {
 }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -111,8 +111,8 @@ public:
     AppFamily (Application& app, NodeStore::Database& db,
             CollectorManager& collectorManager)
         : app_ (app)
-        , treecache_ ("TreeNodeCache", 65536, 1min, stopwatch(),
-            app.journal("TaggedCache"))
+        , treecache_ ("TreeNodeCache", 65536, std::chrono::minutes {1},
+            stopwatch(), app.journal("TaggedCache"))
         , fullbelow_ ("full_below", stopwatch(),
             collectorManager.collector(),
                 fullBelowTargetSize, fullBelowExpiration)
@@ -416,8 +416,8 @@ public:
 
         , accountIDCache_(128000)
 
-        , m_tempNodeCache ("NodeCache", 16384, 90s, stopwatch(),
-            logs_->journal("TaggedCache"))
+        , m_tempNodeCache ("NodeCache", 16384, std::chrono::seconds {90},
+            stopwatch(), logs_->journal("TaggedCache"))
 
         , m_collectorManager (CollectorManager::New (
             config_->section (SECTION_INSIGHT), logs_->journal("Collector")))
@@ -470,8 +470,8 @@ public:
                 gotTXSet (set, fromAcquire);
             }))
 
-        , m_acceptedLedgerCache ("AcceptedLedger", 4, 1min, stopwatch(),
-            logs_->journal("TaggedCache"))
+        , m_acceptedLedgerCache ("AcceptedLedger", 4, std::chrono::minutes {1},
+            stopwatch(), logs_->journal("TaggedCache"))
 
         , m_networkOPs (make_NetworkOPs (*this, stopwatch(),
             config_->standalone(), config_->NETWORK_QUORUM, config_->START_VALID,
@@ -608,7 +608,7 @@ public:
         return nodeIdentity_;
     }
 
-    
+
     PublicKey const &
     getValidationPublicKey() const override
     {
@@ -925,6 +925,7 @@ public:
         }
         // Make sure that any waitHandlers pending in our timers are done
         // before we declare ourselves stopped.
+        using namespace std::chrono_literals;
         waitHandlerCounter_.join("Application", 1s, m_journal);
 
         JLOG(m_journal.debug()) << "Flushing validations";

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -104,6 +104,7 @@ void LoadManager::run ()
 {
     beast::setCurrentThreadName ("LoadManager");
 
+    using namespace std::chrono_literals;
     using clock_type = std::chrono::system_clock;
 
     auto t = clock_type::now();

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -766,6 +766,7 @@ void NetworkOPsImp::processHeartbeatTimer ()
 
 void NetworkOPsImp::processClusterTimer ()
 {
+    using namespace std::chrono_literals;
     bool const update = app_.cluster().update(
         app_.nodeIdentity().first,
         "",
@@ -1780,6 +1781,7 @@ void NetworkOPsImp::pubPeerStatus (
 
 void NetworkOPsImp::setMode (OperatingMode om)
 {
+    using namespace std::chrono_literals;
     if (om == omCONNECTED)
     {
         if (app_.getLedgerMaster ().getValidatedLedgerAge () < 1min)
@@ -2314,6 +2316,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin, bool counters)
             auto closeTime = app_.timeKeeper().closeTime();
             if (lCloseTime <= closeTime)
             {
+                using namespace std::chrono_literals;
                 auto age = closeTime - lCloseTime;
                 if (age < 1000000s)
                     l[jss::age] = Json::UInt (age.count());

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -855,6 +855,7 @@ Consensus<Adaptor>::simulate(
     NetClock::time_point const& now,
     boost::optional<std::chrono::milliseconds> consensusDelay)
 {
+    using namespace std::chrono_literals;
     JLOG(j_.info()) << "Simulating consensus";
     now_ = now;
     closeLedger();

--- a/src/ripple/consensus/ConsensusParms.h
+++ b/src/ripple/consensus/ConsensusParms.h
@@ -25,8 +25,6 @@
 
 namespace ripple {
 
-using namespace std::chrono_literals;
-
 /** Consensus algorithm parameters
 
     Parameters which control the consensus algorithm.  This are not
@@ -45,7 +43,7 @@ struct ConsensusParms
         This is a safety to protect against very old validations and the time
         it takes to adjust the close time accuracy window.
     */
-    std::chrono::seconds validationVALID_WALL = 5min;
+    std::chrono::seconds validationVALID_WALL = std::chrono::minutes {5};
 
     /** Duration a validation remains current after first observed.
 
@@ -53,21 +51,21 @@ struct ConsensusParms
        first saw it. This provides faster recovery in very rare cases where the
        number of validations produced by the network is lower than normal
     */
-    std::chrono::seconds validationVALID_LOCAL = 3min;
+    std::chrono::seconds validationVALID_LOCAL = std::chrono::minutes {3};
 
     /**  Duration pre-close in which validations are acceptable.
 
         The number of seconds before a close time that we consider a validation
         acceptable. This protects against extreme clock errors
     */
-    std::chrono::seconds validationVALID_EARLY = 3min;
+    std::chrono::seconds validationVALID_EARLY = std::chrono::minutes {3};
 
 
     //! How long we consider a proposal fresh
-    std::chrono::seconds proposeFRESHNESS = 20s;
+    std::chrono::seconds proposeFRESHNESS = std::chrono::seconds {20};
 
     //! How often we force generating a new proposal to keep ours fresh
-    std::chrono::seconds proposeINTERVAL = 12s;
+    std::chrono::seconds proposeINTERVAL = std::chrono::seconds {12};
 
 
     //-------------------------------------------------------------------------
@@ -78,16 +76,17 @@ struct ConsensusParms
     std::size_t minCONSENSUS_PCT = 80;
 
     //! The duration a ledger may remain idle before closing
-    std::chrono::milliseconds ledgerIDLE_INTERVAL = 15s;
+    std::chrono::milliseconds ledgerIDLE_INTERVAL = std::chrono::seconds {15};
 
     //! The number of seconds we wait minimum to ensure participation
-    std::chrono::milliseconds ledgerMIN_CONSENSUS = 1950ms;
+    std::chrono::milliseconds ledgerMIN_CONSENSUS =
+        std::chrono::milliseconds {1950};
 
     //! Minimum number of seconds to wait to ensure others have computed the LCL
-    std::chrono::milliseconds ledgerMIN_CLOSE = 2s;
+    std::chrono::milliseconds ledgerMIN_CLOSE = std::chrono::seconds {2};
 
     //! How often we check state or change positions
-    std::chrono::milliseconds ledgerGRANULARITY = 1s;
+    std::chrono::milliseconds ledgerGRANULARITY = std::chrono::seconds {1};
 
     /** The minimum amount of time to consider the previous round
         to have taken.
@@ -99,7 +98,7 @@ struct ConsensusParms
         twice the interval between proposals (0.7s) divided by
         the interval between mid and late consensus ([85-50]/100).
     */
-    std::chrono::milliseconds avMIN_CONSENSUS_TIME = 5s;
+    std::chrono::milliseconds avMIN_CONSENSUS_TIME = std::chrono::seconds {5};
 
     //------------------------------------------------------------------------------
     // Avalanche tuning

--- a/src/ripple/consensus/LedgerTiming.h
+++ b/src/ripple/consensus/LedgerTiming.h
@@ -27,15 +27,20 @@
 
 namespace ripple {
 
-using namespace std::chrono_literals;
-
 /**  Possible ledger close time resolutions.
 
     Values should not be duplicated.
     @see getNextLedgerTimeResolution
 */
 std::chrono::seconds constexpr ledgerPossibleTimeResolutions[] =
-    {10s, 20s, 30s, 60s, 90s, 120s};
+    {
+        std::chrono::seconds { 10},
+        std::chrono::seconds { 20},
+        std::chrono::seconds { 30},
+        std::chrono::seconds { 60},
+        std::chrono::seconds { 90},
+        std::chrono::seconds {120}
+    };
 
 //! Initial resolution of ledger close time.
 auto constexpr ledgerDefaultTimeResolution = ledgerPossibleTimeResolutions[2];

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -38,8 +38,6 @@
 
 namespace ripple {
 
-using namespace std::chrono_literals;
-
 class Rules;
 
 //------------------------------------------------------------------------------
@@ -144,7 +142,7 @@ public:
     bool                        PEER_PRIVATE = false;           // True to ask peers not to relay current IP.
     int                         PEERS_MAX = 0;
 
-    std::chrono::seconds        WEBSOCKET_PING_FREQ = 5min;
+    std::chrono::seconds        WEBSOCKET_PING_FREQ = std::chrono::minutes {5};
 
     // Path searching
     int                         PATH_SEARCH_OLD = 7;

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -229,6 +229,7 @@ Shard::validate(Application& app)
 
     // Use a short age to keep memory consumption low
     auto const savedAge {pCache_->getTargetAge()};
+    using namespace std::chrono_literals;
     pCache_->setTargetAge(1s);
 
     // Validate every ledger stored in this shard

--- a/src/ripple/rpc/handlers/GetCounts.cpp
+++ b/src/ripple/rpc/handlers/GetCounts.cpp
@@ -113,6 +113,7 @@ Json::Value doGetCounts (RPC::Context& context)
 
     std::string uptime;
     auto s = UptimeClock::now();
+    using namespace std::chrono_literals;
     textTime (uptime, s, "year", 365 * 24h);
     textTime (uptime, s, "day", 24h);
     textTime (uptime, s, "hour", 1h);

--- a/src/ripple/rpc/impl/Tuning.h
+++ b/src/ripple/rpc/impl/Tuning.h
@@ -55,8 +55,7 @@ static int const defaultAutoFillFeeDivisor = 1;
 static int const maxPathfindsInProgress = 2;
 static int const maxPathfindJobCount = 50;
 static int const maxJobQueueClients = 500;
-using namespace std::chrono_literals;
-auto constexpr maxValidatedLedgerAge = 2min;
+auto constexpr maxValidatedLedgerAge = std::chrono::minutes {2};
 static int const maxRequestSize = 1000000;
 
 /** Maximum number of pages in one response from a binary LedgerData request. */

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -335,6 +335,7 @@ class Check_test : public beast::unit_test::suite
         // expected interaction between these optional fields; other than
         // the expiration, they are just plopped into the ledger.  So I'm
         // not looking at interactions.
+        using namespace std::chrono_literals;
         std::size_t const aliceCount {checksOnAccount (env, alice).size()};
         std::size_t const bobCount   {checksOnAccount (env,   bob).size()};
         env (check::create (alice, bob, USD(50)), expiration (env.now() + 1s));
@@ -540,6 +541,7 @@ class Check_test : public beast::unit_test::suite
             expiration (env.now()), ter (tecEXPIRED));
         env.close();
 
+        using namespace std::chrono_literals;
         env (check::create (alice, bob, USD(50)), expiration (env.now() + 1s));
         env.close();
 
@@ -1341,6 +1343,7 @@ class Check_test : public beast::unit_test::suite
         env (check::create (alice, bob, XRP(10)));
         env.close();
 
+        using namespace std::chrono_literals;
         uint256 const chkIdExp {getCheckIndex (alice, env.seq (alice))};
         env (check::create (alice, bob, XRP(10)), expiration (env.now() + 1s));
         env.close();
@@ -1615,6 +1618,7 @@ class Check_test : public beast::unit_test::suite
         env.close();
 
         // Three checks that expire in 10 minutes.
+        using namespace std::chrono_literals;
         uint256 const chkIdNotExp1 {getCheckIndex (alice, env.seq (alice))};
         env (check::create (alice, bob, XRP(10)), expiration (env.now()+600s));
         env.close();

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -259,6 +259,7 @@ public:
                 g.signal();
             });
 
+        using namespace std::chrono_literals;
         BEAST_EXPECT(g.wait_for(5s));
         BEAST_EXPECT(! result.isMember(jss::error));
         return result;

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -101,6 +101,7 @@ class RCLValidations_test : public beast::unit_test::suite
         std::vector<std::shared_ptr<Ledger const>> altHistory(
             history.begin(), history.begin() + diverge);
         // advance clock to get new ledgers
+        using namespace std::chrono_literals;
         env.timeKeeper().set(env.timeKeeper().now() + 1200s);
         prev = altHistory.back();
         bool forceHash = true;

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -277,6 +277,7 @@ class Ticket_test : public beast::unit_test::suite
         Env env {*this, supported_amendments().set(featureTickets)};
 
         // create and verify
+        using namespace std::chrono_literals;
         uint32_t expire =
             (env.timeKeeper ().closeTime () + 60s)
             .time_since_epoch ().count ();

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -265,6 +265,7 @@ class TrustAndBalance_test : public beast::unit_test::suite
 
             env.close();
 
+            using namespace std::chrono_literals;
             BEAST_EXPECT(wsc->findMsg(5s,
                 [](auto const& jv)
                 {
@@ -470,6 +471,7 @@ class TrustAndBalance_test : public beast::unit_test::suite
             "00000000DEADBEEF");
         env.close();
 
+        using namespace std::chrono_literals;
         BEAST_EXPECT(wsc->findMsg(2s,
             [](auto const& jv)
             {

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -145,6 +145,7 @@ class TxQ_test : public beast::unit_test::suite
 
         // Close the ledger with a delay to force the TxQ stats
         // to stay at the default.
+        using namespace std::chrono_literals;
         env.close(env.now() + 5s, 10000ms);
         checkMetrics(env, 0,
             2 * (ripple::detail::supportedAmendments().size() + 1),
@@ -2463,6 +2464,7 @@ public:
         checkMetrics(env, 0, boost::none, 4, 3, 256);
 
         // First transaction establishes the messaging
+        using namespace std::chrono_literals;
         BEAST_EXPECT(wsc->findMsg(5s,
             [&](auto const& jv)
         {

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -409,6 +409,7 @@ private:
                 manifest1, expiredblob, expiredSig, version));
 
         // apply single list
+        using namespace std::chrono_literals;
         NetClock::time_point const expiration =
             env.timeKeeper().now() + 3600s;
         auto const blob1 = makeList (
@@ -764,6 +765,7 @@ private:
             // do not apply expired list
             auto const version = 1;
             auto const sequence = 1;
+            using namespace std::chrono_literals;
             NetClock::time_point const expiration =
                 env.timeKeeper().now() + 60s;
             auto const blob = makeList (
@@ -929,6 +931,7 @@ private:
 
                 auto const version = 1;
                 auto const sequence = 1;
+                using namespace std::chrono_literals;
                 NetClock::time_point const expiration =
                     env.timeKeeper().now() + 3600s;
                 auto const blob = makeList (
@@ -1011,6 +1014,7 @@ private:
                 NetClock::time_point expiration;
             };
 
+            using namespace std::chrono_literals;
             auto addPublishedList = [this, &env, &trustedKeys, &validators]()
             {
                 auto const publisherSecret = randomSecretKey();

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -174,6 +174,7 @@ private:
 
         auto const sequence = 1;
         auto const version = 1;
+        using namespace std::chrono_literals;
         NetClock::time_point const expiration =
             env.timeKeeper().now() + 3600s;
 

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -393,8 +393,6 @@ struct Peer
     Ledger const*
     acquireLedger(Ledger::ID const& ledgerID)
     {
-        using namespace std::chrono;
-
         auto it = ledgers.find(ledgerID);
         if (it != ledgers.end())
             return &(it->second);
@@ -411,7 +409,7 @@ struct Peer
                 return nullptr;
         }
 
-
+        using namespace std::chrono_literals;
         SimDuration minDuration{10s};
         for (auto const& link : net.links(this))
         {
@@ -457,6 +455,7 @@ struct Peer
                 return nullptr;
         }
 
+        using namespace std::chrono_literals;
         SimDuration minDuration{10s};
         for (auto const& link : net.links(this))
         {

--- a/src/test/csf/impl/ledgers.cpp
+++ b/src/test/csf/impl/ledgers.cpp
@@ -101,6 +101,7 @@ LedgerOracle::accept(
     NetClock::duration closeTimeResolution,
     NetClock::time_point const& consensusCloseTime)
 {
+    using namespace std::chrono_literals;
     Ledger::Instance next(*parent.instance_);
     next.txs.insert(txs.begin(), txs.end());
     next.seq = parent.seq() + Ledger::Seq{1};

--- a/src/test/csf/timers.h
+++ b/src/test/csf/timers.h
@@ -45,12 +45,12 @@ class HeartbeatTimer
 
 public:
     HeartbeatTimer(
-            Scheduler& sched,
-            SimDuration interval = std::chrono::seconds(60s),
-            std::ostream& out = std::cerr)
-            : scheduler_{sched}, interval_{interval}, out_{out},
-              startRealTime_{RealClock::now()},
-              startSimTime_{sched.now()}
+        Scheduler& sched,
+        SimDuration interval = std::chrono::seconds {60},
+        std::ostream& out = std::cerr)
+        : scheduler_{sched}, interval_{interval}, out_{out},
+          startRealTime_{RealClock::now()},
+          startSimTime_{sched.now()}
     {
     }
 

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -130,6 +130,7 @@ Env::close(NetClock::time_point closeTime,
     boost::optional<std::chrono::milliseconds> consensusDelay)
 {
     // Round up to next distinguishable value
+    using namespace std::chrono_literals;
     closeTime += closed()->info().closeTimeResolution - 1s;
     timeKeeper().set(closeTime);
     // Go through the rpc interface unless we need to simulate

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1013,6 +1013,7 @@ public:
         BEAST_EXPECT(jrOffer[jss::owner_funds] == "100");
         BEAST_EXPECT(jrOffer[jss::quality] == "400000000");
 
+        using namespace std::chrono_literals;
         BEAST_EXPECT(wsc->findMsg(5s,
             [&](auto const& jv)
             {
@@ -1156,6 +1157,7 @@ public:
         env(offer(charlie, USD(1000), XRP(1000)));
         env.close();
         env.require(offers(alice, 0), offers(bob, 0), offers(charlie, 0));
+        using namespace std::chrono_literals;
         BEAST_EXPECT(offerOnlyOnceInStream(wsc, 1s, XRP(1000), USD(1000)));
 
         // RPC unsubscribe
@@ -1238,6 +1240,7 @@ public:
         // Charlies places an on offer for EUR -> USD that should auto-bridge
         env(offer(charlie, USD(1), EUR(1)));
         env.close();
+        using namespace std::chrono_literals;
         BEAST_EXPECT(offerOnlyOnceInStream(wsc, 1s, EUR(1), USD(1)));
 
         // RPC unsubscribe

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -666,6 +666,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             return jv;
         };
 
+        using namespace std::chrono_literals;
         env (escrowCreate (alice, alice, XRP(333), env.now() + 2s));
         env.close();
 

--- a/src/test/rpc/Peers_test.cpp
+++ b/src/test/rpc/Peers_test.cpp
@@ -52,6 +52,7 @@ class Peers_test : public beast::unit_test::suite
 
             std::string name = "Node " + std::to_string(i);
 
+            using namespace std::chrono_literals;
             env.app().cluster().update(
                 kp.first,
                 name,

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -360,6 +360,7 @@ public:
             env.close();
 
             // Check stream update
+            using namespace std::chrono_literals;
             BEAST_EXPECT(wsc->findMsg(5s,
                 [&](auto const& jv)
                 {

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -269,6 +269,7 @@ public:
         //----------------------------------------------------------------------
         // Publisher list site available
         {
+            using namespace std::chrono_literals;
             NetClock::time_point const expiration{3600s};
 
             // Manage single thread io_service for server


### PR DESCRIPTION
I identified four different places where there was a `using namespace` directive at namespace scope in our header files.  This had the side effect of leaking `chrono_literals` into source files that did not ask for them.

This pull request removes those four `using namespace` directives and makes the appropriate accommodations in the source tree.  I believe that there are no others once these four are removed.  

It would be defensible to say there should also not be any `using namespace` directives at namespace scope in *.cpp files because of their similar effects in our unity builds.  But I didn't go that far ... although I was tempted :wink: