### PR TITLE
Cleanup openssl location overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,19 +523,28 @@ target_link_libraries (ripple_boost
    NIH dep: openssl
 #]===================================================================]
 
-if (APPLE AND NOT DEFINED ENV{OPENSSL_ROOT_DIR})
-  find_program (HOMEBREW brew)
-  if (NOT HOMEBREW STREQUAL "HOMEBREW-NOTFOUND")
-    execute_process (COMMAND ${HOMEBREW} --prefix openssl
-      OUTPUT_VARIABLE OPENSSL_ROOT_DIR
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
+#[===============================================[
+  OPENSSL_ROOT_DIR is the only variable that
+  FindOpenSSL honors for locating, so convert any
+  OPENSSL_ROOT vars to this
+#]===============================================]
+if (NOT DEFINED OPENSSL_ROOT_DIR)
+  if (DEFINED OPENSSL_ROOT)
+    set (OPENSSL_ROOT_DIR ${OPENSSL_ROOT})
+  elseif (DEFINED ENV{OPENSSL_ROOT})
+    set (OPENSSL_ROOT_DIR $ENV{OPENSSL_ROOT})
   endif ()
-endif ()
 
-if ((NOT DEFINED OPENSSL_ROOT) AND (DEFINED ENV{OPENSSL_ROOT}))
-  set (OPENSSL_ROOT $ENV{OPENSSL_ROOT})
-endif ()
-file (TO_CMAKE_PATH "${OPENSSL_ROOT}" OPENSSL_ROOT)
+  if (APPLE AND NOT DEFINED OPENSSL_ROOT_DIR)
+    find_program (homebrew brew)
+    if (homebrew)
+      execute_process (COMMAND ${homebrew} --prefix openssl
+        OUTPUT_VARIABLE OPENSSL_ROOT_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif ()
+  endif ()
+  file (TO_CMAKE_PATH "${OPENSSL_ROOT_DIR}" OPENSSL_ROOT_DIR)
+endif()
 
 if (static)
   set (OPENSSL_USE_STATIC_LIBS ON)


### PR DESCRIPTION
Minor cleanup to the way we detect/set the openssl directory for building.