### PR TITLE
Don't filter proposals by close time at the wire protocol level

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1267,10 +1267,6 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMProposeSet> const& m)
     if (set.has_hops() && ! slot_->cluster())
         set.set_hops(set.hops() + 1);
 
-    // VFALCO Magic numbers are bad
-    if ((set.closetime() + 180) < app_.timeKeeper().closeTime().time_since_epoch().count())
-        return;
-
     auto const type = publicKeyType(
         makeSlice(set.nodepubkey()));
 


### PR DESCRIPTION
When validators publish a proposal, they include the close time that they believe the new ledger should have, and the network attempts to reach consensus on that.

Instead of delaying consensus if no close time has the required majority the servers can "agree to disagree"; if this happens, they switch to proposing a close time of 0, and the network avalanches to that value.

If that occurs, determinstic rules record the new ledger's close time as being one second later than its parent, and set a flag indicating that no consensus on the close time was reached.

The wire protocol decoder would incorrectly filter such proposals, so that they would not be seen by the higher level consensus engine.

This commit removes the low-level filtering, and allows higher level code to filter out stale proposals instead.