### PR TITLE
Do not use beast base64 encoding without fix:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,7 @@ add_library (xrpl_core
        nounity, main sources:
          subdir: basics (partial)
     #]===============================]
+    src/ripple/basics/impl/base64.cpp
     src/ripple/basics/impl/contract.cpp
     src/ripple/basics/impl/CountedObject.cpp
     src/ripple/basics/impl/Log.cpp
@@ -1179,6 +1180,7 @@ target_link_libraries (xrpl_core
 #]=================================]
 install (
   FILES
+    src/ripple/basics/base64.h
     src/ripple/basics/Blob.h
     src/ripple/basics/Buffer.h
     src/ripple/basics/CountedObject.h
@@ -1790,6 +1792,7 @@ target_sources (rippled PRIVATE
     src/test/basics/Slice_test.cpp
     src/test/basics/StringUtilities_test.cpp
     src/test/basics/TaggedCache_test.cpp
+    src/test/basics/base64_test.cpp
     src/test/basics/base_uint_test.cpp
     src/test/basics/contract_test.cpp
     src/test/basics/hardened_hash_test.cpp

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -39,6 +39,7 @@
 #include <ripple/app/misc/ValidatorList.h>
 #include <ripple/app/misc/impl/AccountTxPaging.h>
 #include <ripple/app/tx/apply.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/mulDiv.h>
 #include <ripple/basics/PerfLog.h>
 #include <ripple/basics/UptimeClock.h>
@@ -55,7 +56,6 @@
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/beast/utility/rngfill.h>
 #include <ripple/basics/make_lock.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/ip/host_name.hpp>
 

--- a/src/ripple/app/misc/impl/Manifest.cpp
+++ b/src/ripple/app/misc/impl/Manifest.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/app/misc/Manifest.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/StringUtilities.h>
@@ -26,7 +27,6 @@
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/Sign.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 #include <numeric>
 #include <stdexcept>
@@ -182,7 +182,7 @@ ValidatorToken::make_ValidatorToken(std::vector<std::string> const& tokenBlob)
         for (auto const& line : tokenBlob)
             tokenStr += beast::rfc2616::trim(line);
 
-        tokenStr = boost::beast::detail::base64_decode(tokenStr);
+        tokenStr = base64_decode(tokenStr);
 
         Json::Reader r;
         Json::Value token;
@@ -384,7 +384,7 @@ ManifestCache::load (
     if (! configManifest.empty())
     {
         auto mo = Manifest::make_Manifest (
-            boost::beast::detail::base64_decode(configManifest));
+            base64_decode(configManifest));
         if (! mo)
         {
             JLOG (j_.error()) << "Malformed validator_token in config";
@@ -419,7 +419,7 @@ ManifestCache::load (
             revocationStr += beast::rfc2616::trim(line);
 
         auto mo = Manifest::make_Manifest (
-            boost::beast::detail::base64_decode(revocationStr));
+            base64_decode(revocationStr));
 
         if (! mo || ! mo->revoked() ||
             applyManifest (std::move(*mo)) == ManifestDisposition::invalid)

--- a/src/ripple/app/misc/impl/ValidatorKeys.cpp
+++ b/src/ripple/app/misc/impl/ValidatorKeys.cpp
@@ -20,10 +20,10 @@
 #include <ripple/app/misc/ValidatorKeys.h>
 
 #include <ripple/app/misc/Manifest.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
-#include <boost/beast/core/detail/base64.hpp>
 
 namespace ripple {
 ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
@@ -45,7 +45,7 @@ ValidatorKeys::ValidatorKeys(Config const& config, beast::Journal j)
             auto const pk = derivePublicKey(
                 KeyType::secp256k1, token->validationSecret);
             auto const m = Manifest::make_Manifest(
-                boost::beast::detail::base64_decode(token->manifest));
+                base64_decode(token->manifest));
 
             if (! m || pk != m->signingKey)
             {

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -18,12 +18,12 @@
 //==============================================================================
 
 #include <ripple/app/misc/ValidatorList.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/date.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/JsonFields.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 
 #include <mutex>
@@ -291,7 +291,7 @@ ValidatorList::applyList (
     for (auto const& valManifest : manifests)
     {
         auto m = Manifest::make_Manifest (
-            boost::beast::detail::base64_decode(valManifest));
+            base64_decode(valManifest));
 
         if (! m || ! keyListings_.count (m->masterKey))
         {
@@ -321,7 +321,7 @@ ValidatorList::verify (
     std::string const& blob,
     std::string const& signature)
 {
-    auto m = Manifest::make_Manifest (boost::beast::detail::base64_decode(manifest));
+    auto m = Manifest::make_Manifest (base64_decode(manifest));
 
     if (! m || ! publisherLists_.count (m->masterKey))
         return ListDisposition::untrusted;
@@ -342,7 +342,7 @@ ValidatorList::verify (
         return ListDisposition::untrusted;
 
     auto const sig = strUnHex(signature);
-    auto const data = boost::beast::detail::base64_decode (blob);
+    auto const data = base64_decode (blob);
     if (! sig.second ||
         ! ripple::verify (
             publisherManifests_.getSigningKey(pubKey),

--- a/src/ripple/app/misc/impl/ValidatorSite.cpp
+++ b/src/ripple/app/misc/impl/ValidatorSite.cpp
@@ -21,10 +21,10 @@
 #include <ripple/app/misc/ValidatorSite.h>
 #include <ripple/app/misc/detail/WorkPlain.h>
 #include <ripple/app/misc/detail/WorkSSL.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/protocol/JsonFields.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 
 namespace ripple {

--- a/src/ripple/basics/base64.h
+++ b/src/ripple/basics/base64.h
@@ -1,0 +1,81 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+/*
+   Portions from http://www.adp-gmbh.ch/cpp/common/base64.html
+   Copyright notice:
+
+   base64.cpp and base64.h
+
+   Copyright (C) 2004-2008 René Nyffenegger
+
+   This source code is provided 'as-is', without any express or implied
+   warranty. In no event will the author be held liable for any damages
+   arising from the use of this software.
+
+   Permission is granted to anyone to use this software for any purpose,
+   including commercial applications, and to alter it and redistribute it
+   freely, subject to the following restrictions:
+
+   1. The origin of this source code must not be misrepresented; you must not
+      claim that you wrote the original source code. If you use this source code
+      in a product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original source code.
+
+   3. This notice may not be removed or altered from any source distribution.
+
+   René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+
+*/
+
+#ifndef RIPPLE_BASICS_BASE64_H_INCLUDED
+#define RIPPLE_BASICS_BASE64_H_INCLUDED
+
+#include <string>
+
+namespace ripple {
+
+std::string
+base64_encode (std::uint8_t const* data,
+    std::size_t len);
+
+inline
+std::string
+base64_encode(std::string const& s)
+{
+    return base64_encode (reinterpret_cast <
+        std::uint8_t const*> (s.data()), s.size());
+}
+
+std::string
+base64_decode(std::string const& data);
+
+} // ripple
+
+#endif

--- a/src/ripple/basics/impl/base64.cpp
+++ b/src/ripple/basics/impl/base64.cpp
@@ -1,0 +1,247 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+//
+// Copyright (c) 2013-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+/*
+   Portions from http://www.adp-gmbh.ch/cpp/common/base64.html
+   Copyright notice:
+
+   base64.cpp and base64.h
+
+   Copyright (C) 2004-2008 René Nyffenegger
+
+   This source code is provided 'as-is', without any express or implied
+   warranty. In no event will the author be held liable for any damages
+   arising from the use of this software.
+
+   Permission is granted to anyone to use this software for any purpose,
+   including commercial applications, and to alter it and redistribute it
+   freely, subject to the following restrictions:
+
+   1. The origin of this source code must not be misrepresented; you must not
+      claim that you wrote the original source code. If you use this source code
+      in a product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original source code.
+
+   3. This notice may not be removed or altered from any source distribution.
+
+   René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+
+*/
+
+#include <ripple/basics/base64.h>
+
+#include <cctype>
+#include <utility>
+
+namespace ripple {
+
+namespace base64 {
+
+inline
+char const*
+get_alphabet()
+{
+    static char constexpr tab[] = {
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    };
+    return &tab[0];
+}
+
+inline
+signed char const*
+get_inverse()
+{
+    static signed char constexpr tab[] = {
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //   0-15
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //  16-31
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, //  32-47
+         52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, //  48-63
+         -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, //  64-79
+         15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, //  80-95
+         -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, //  96-111
+         41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1, // 112-127
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 128-143
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 144-159
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 160-175
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 176-191
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 192-207
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 208-223
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 224-239
+         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1  // 240-255
+    };
+    return &tab[0];
+}
+
+
+/// Returns max chars needed to encode a base64 string
+inline
+std::size_t constexpr
+encoded_size(std::size_t n)
+{
+    return 4 * ((n + 2) / 3);
+}
+
+/// Returns max bytes needed to decode a base64 string
+inline
+std::size_t constexpr
+decoded_size(std::size_t n)
+{
+    return ((n / 4) * 3) + 2;
+}
+
+/** Encode a series of octets as a padded, base64 string.
+
+    The resulting string will not be null terminated.
+
+    @par Requires
+
+    The memory pointed to by `out` points to valid memory
+    of at least `encoded_size(len)` bytes.
+
+    @return The number of characters written to `out`. This
+    will exclude any null termination.
+*/
+std::size_t
+encode(void* dest, void const* src, std::size_t len)
+{
+    char*      out = static_cast<char*>(dest);
+    char const* in = static_cast<char const*>(src);
+    auto const tab = base64::get_alphabet();
+
+    for(auto n = len / 3; n--;)
+    {
+        *out++ = tab[ (in[0] & 0xfc) >> 2];
+        *out++ = tab[((in[0] & 0x03) << 4) + ((in[1] & 0xf0) >> 4)];
+        *out++ = tab[((in[2] & 0xc0) >> 6) + ((in[1] & 0x0f) << 2)];
+        *out++ = tab[  in[2] & 0x3f];
+        in += 3;
+    }
+
+    switch(len % 3)
+    {
+    case 2:
+        *out++ = tab[ (in[0] & 0xfc) >> 2];
+        *out++ = tab[((in[0] & 0x03) << 4) + ((in[1] & 0xf0) >> 4)];
+        *out++ = tab[                         (in[1] & 0x0f) << 2];
+        *out++ = '=';
+        break;
+
+    case 1:
+        *out++ = tab[ (in[0] & 0xfc) >> 2];
+        *out++ = tab[((in[0] & 0x03) << 4)];
+        *out++ = '=';
+        *out++ = '=';
+        break;
+
+    case 0:
+        break;
+    }
+
+    return out - static_cast<char*>(dest);
+}
+
+/** Decode a padded base64 string into a series of octets.
+
+    @par Requires
+
+    The memory pointed to by `out` points to valid memory
+    of at least `decoded_size(len)` bytes.
+
+    @return The number of octets written to `out`, and
+    the number of characters read from the input string,
+    expressed as a pair.
+*/
+std::pair<std::size_t, std::size_t>
+decode(void* dest, char const* src, std::size_t len)
+{
+    char* out = static_cast<char*>(dest);
+    auto in = reinterpret_cast<unsigned char const*>(src);
+    unsigned char c3[3], c4[4];
+    int i = 0;
+    int j = 0;
+
+    auto const inverse = base64::get_inverse();
+
+    while(len-- && *in != '=')
+    {
+        auto const v = inverse[*in];
+        if(v == -1)
+            break;
+        ++in;
+        c4[i] = v;
+        if(++i == 4)
+        {
+            c3[0] =  (c4[0]        << 2) + ((c4[1] & 0x30) >> 4);
+            c3[1] = ((c4[1] & 0xf) << 4) + ((c4[2] & 0x3c) >> 2);
+            c3[2] = ((c4[2] & 0x3) << 6) +   c4[3];
+
+            for(i = 0; i < 3; i++)
+                *out++ = c3[i];
+            i = 0;
+        }
+    }
+
+    if(i)
+    {
+        c3[0] = ( c4[0]        << 2) + ((c4[1] & 0x30) >> 4);
+        c3[1] = ((c4[1] & 0xf) << 4) + ((c4[2] & 0x3c) >> 2);
+        c3[2] = ((c4[2] & 0x3) << 6) +   c4[3];
+
+        for(j = 0; j < i - 1; j++)
+            *out++ = c3[j];
+    }
+
+    return {out - static_cast<char*>(dest),
+        in - reinterpret_cast<unsigned char const*>(src)};
+}
+
+} // base64
+
+std::string
+base64_encode (std::uint8_t const* data,
+    std::size_t len)
+{
+    std::string dest;
+    dest.resize(base64::encoded_size(len));
+    dest.resize(base64::encode(&dest[0], data, len));
+    return dest;
+}
+
+std::string
+base64_decode(std::string const& data)
+{
+    std::string dest;
+    dest.resize(base64::decoded_size(data.size()));
+    auto const result = base64::decode(
+        &dest[0], data.data(), data.size());
+    dest.resize(result.first);
+    return dest;
+}
+
+} // ripple

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -21,6 +21,7 @@
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/net/RPCCall.h>
 #include <ripple/net/RPCErr.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/Log.h>
 #include <ripple/core/Config.h>
@@ -1523,7 +1524,7 @@ void fromNetwork (
     }
 
     // HTTP basic authentication
-    auto const auth = boost::beast::detail::base64_encode(strUsername + ":" + strPassword);
+    auto const auth = base64_encode(strUsername + ":" + strPassword);
 
     std::map<std::string, std::string> mapRequestHeaders;
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -21,6 +21,7 @@
 #include <ripple/app/misc/HashRouter.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/misc/ValidatorList.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/make_SSLContext.h>
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/core/DatabaseCon.h>
@@ -764,7 +765,7 @@ OverlayImpl::crawl()
     for_each ([&](std::shared_ptr<PeerImp>&& sp)
     {
         auto& pv = av.append(Json::Value(Json::objectValue));
-        pv[jss::public_key] = boost::beast::detail::base64_encode(
+        pv[jss::public_key] = base64_encode(
             sp->getNodePublic().data(),
                 sp->getNodePublic().size());
         pv[jss::type] = sp->slot()->inbound() ?

--- a/src/ripple/overlay/impl/TMHello.cpp
+++ b/src/ripple/overlay/impl/TMHello.cpp
@@ -20,10 +20,10 @@
 #include <ripple/overlay/impl/TMHello.h>
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/main/Application.h>
+#include <ripple/basics/base64.h>
 #include <ripple/beast/rfc2616.h>
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/protocol/digest.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/regex.hpp>
 #include <algorithm>
 
@@ -152,7 +152,7 @@ appendHello (boost::beast::http::fields& h,
 
     h.insert ("Public-Key", hello.nodepublic());
 
-    h.insert ("Session-Signature", boost::beast::detail::base64_encode (
+    h.insert ("Session-Signature", base64_encode (
         hello.nodeproof()));
 
     if (hello.has_nettime())
@@ -162,11 +162,11 @@ appendHello (boost::beast::http::fields& h,
         h.insert ("Ledger", std::to_string (hello.ledgerindex()));
 
     if (hello.has_ledgerclosed())
-        h.insert ("Closed-Ledger", boost::beast::detail::base64_encode (
+        h.insert ("Closed-Ledger", base64_encode (
             hello.ledgerclosed()));
 
     if (hello.has_ledgerprevious())
-        h.insert ("Previous-Ledger", boost::beast::detail::base64_encode (
+        h.insert ("Previous-Ledger", base64_encode (
             hello.ledgerprevious()));
 
     if (hello.has_local_ip_str())
@@ -251,7 +251,7 @@ parseHello (bool request, boost::beast::http::fields const& h, beast::Journal jo
         if (iter == h.end())
             return boost::none;
         // TODO Security Review
-        hello.set_nodeproof (boost::beast::detail::base64_decode (iter->value().to_string()));
+        hello.set_nodeproof (base64_decode (iter->value().to_string()));
     }
 
     {
@@ -286,13 +286,13 @@ parseHello (bool request, boost::beast::http::fields const& h, beast::Journal jo
     {
         auto const iter = h.find ("Closed-Ledger");
         if (iter != h.end())
-            hello.set_ledgerclosed (boost::beast::detail::base64_decode (iter->value().to_string()));
+            hello.set_ledgerclosed (base64_decode (iter->value().to_string()));
     }
 
     {
         auto const iter = h.find ("Previous-Ledger");
         if (iter != h.end())
-            hello.set_ledgerprevious (boost::beast::detail::base64_decode (iter->value().to_string()));
+            hello.set_ledgerprevious (base64_decode (iter->value().to_string()));
     }
 
     {

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/app/main/Application.h>
 #include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/basics/base64.h>
 #include <ripple/beast/rfc2616.h>
 #include <ripple/beast/net/IPAddressConversion.h>
 #include <ripple/json/json_reader.h>
@@ -39,7 +40,6 @@
 #include <ripple/rpc/impl/Tuning.h>
 #include <ripple/rpc/RPCHandler.h>
 #include <ripple/server/SimpleWriter.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/beast/http/fields.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <boost/algorithm/string.hpp>
@@ -97,7 +97,7 @@ authorized (
         return false;
     std::string strUserPass64 = it->second.substr (6);
     boost::trim (strUserPass64);
-    std::string strUserPass = boost::beast::detail::base64_decode (strUserPass64);
+    std::string strUserPass = base64_decode (strUserPass64);
     std::string::size_type nColon = strUserPass.find (":");
     if (nColon == std::string::npos)
         return false;

--- a/src/ripple/unity/basics1.cpp
+++ b/src/ripple/unity/basics1.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 
+#include <ripple/basics/impl/base64.cpp>
 #include <ripple/basics/impl/contract.cpp>
 #include <ripple/basics/impl/CountedObject.cpp>
 #include <ripple/basics/impl/Log.cpp>

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/app/misc/Manifest.h>
 #include <ripple/app/misc/ValidatorList.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/StringUtilities.h>
 #include <test/jtx.h>
@@ -27,7 +28,6 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/STExchange.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/utility/in_place_factory.hpp>
@@ -123,7 +123,7 @@ public:
         Serializer s;
         st.add(s);
 
-        return boost::beast::detail::base64_encode (std::string(
+        return base64_encode (std::string(
             static_cast<char const*> (s.data()), s.size()));
     }
 
@@ -176,7 +176,7 @@ public:
         Serializer s;
         st.add(s);
 
-        return boost::beast::detail::base64_encode (std::string(
+        return base64_encode (std::string(
             static_cast<char const*> (s.data()), s.size()));
     }
 

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -19,10 +19,10 @@
 
 #include <ripple/app/misc/ValidatorKeys.h>
 #include <ripple/app/misc/Manifest.h>
+#include <ripple/basics/base64.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <string>
 
 namespace ripple {
@@ -91,7 +91,7 @@ public:
             derivePublicKey(KeyType::secp256k1, tokenSecretKey);
 
         auto const m = Manifest::make_Manifest(
-            boost::beast::detail::base64_decode(tokenManifest));
+            base64_decode(tokenManifest));
         BEAST_EXPECT(m);
         NodeID const tokenNodeID = calcNodeID(m->masterKey);
 

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -17,10 +17,10 @@
 */
 //==============================================================================
 
-#include <boost/beast/core/detail/base64.hpp>
+#include <ripple/app/misc/ValidatorList.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/strHex.h>
-#include <ripple/app/misc/ValidatorList.h>
 #include <test/jtx.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/HashPrefix.h>
@@ -89,7 +89,7 @@ private:
             derivePublicKey(KeyType::ed25519, secret);
         auto const signingKeys = randomKeyPair(KeyType::secp256k1);
         return { masterPublic, signingKeys.first,
-                 boost::beast::detail::base64_encode(makeManifestString (
+                 base64_encode(makeManifestString (
             masterPublic, secret, signingKeys.first, signingKeys.second, 1)) };
     }
 
@@ -112,7 +112,7 @@ private:
 
         data.pop_back();
         data += "]}";
-        return boost::beast::detail::base64_encode(data);
+        return base64_encode(data);
     }
 
     std::string
@@ -120,7 +120,7 @@ private:
         std::string const& blob,
         std::pair<PublicKey, SecretKey> const& keys)
     {
-        auto const data = boost::beast::detail::base64_decode (blob);
+        auto const data = base64_decode (blob);
         return strHex(sign(
             keys.first, keys.second, makeSlice(data)));
     }
@@ -374,7 +374,7 @@ private:
         auto const publisherPublic =
             derivePublicKey(KeyType::ed25519, publisherSecret);
         auto const pubSigningKeys1 = randomKeyPair(KeyType::secp256k1);
-        auto const manifest1 = boost::beast::detail::base64_encode(makeManifestString (
+        auto const manifest1 = base64_encode(makeManifestString (
             publisherPublic, publisherSecret,
             pubSigningKeys1.first, pubSigningKeys1.second, 1));
 
@@ -426,7 +426,7 @@ private:
         }
 
         // do not use list from untrusted publisher
-        auto const untrustedManifest = boost::beast::detail::base64_encode(
+        auto const untrustedManifest = base64_encode(
             makeManifestString (
                 randomMasterKey(), publisherSecret,
                 pubSigningKeys1.first, pubSigningKeys1.second, 1));
@@ -473,7 +473,7 @@ private:
 
         // apply list with new publisher key updated by manifest
         auto const pubSigningKeys2 = randomKeyPair(KeyType::secp256k1);
-        auto manifest2 = boost::beast::detail::base64_encode(makeManifestString (
+        auto manifest2 = base64_encode(makeManifestString (
             publisherPublic, publisherSecret,
             pubSigningKeys2.first, pubSigningKeys2.second, 2));
 
@@ -497,7 +497,7 @@ private:
         // do not apply list with revoked publisher key
         // applied list is removed due to revoked publisher key
         auto const signingKeysMax = randomKeyPair(KeyType::secp256k1);
-        auto maxManifest = boost::beast::detail::base64_encode(makeManifestString (
+        auto maxManifest = base64_encode(makeManifestString (
             publisherPublic, publisherSecret,
             pubSigningKeys2.first, pubSigningKeys2.second,
             std::numeric_limits<std::uint32_t>::max ()));
@@ -747,7 +747,7 @@ private:
             std::vector<std::string> emptyCfgKeys;
             auto const publisherKeys = randomKeyPair(KeyType::secp256k1);
             auto const pubSigningKeys = randomKeyPair(KeyType::secp256k1);
-            auto const manifest = boost::beast::detail::base64_encode (
+            auto const manifest = base64_encode (
                 makeManifestString (
                     publisherKeys.first, publisherKeys.second,
                     pubSigningKeys.first, pubSigningKeys.second, 1));
@@ -917,7 +917,7 @@ private:
                 auto const publisherPublic =
                     derivePublicKey(KeyType::ed25519, publisherSecret);
                 auto const pubSigningKeys = randomKeyPair(KeyType::secp256k1);
-                auto const manifest = boost::beast::detail::base64_encode(makeManifestString (
+                auto const manifest = base64_encode(makeManifestString (
                     publisherPublic, publisherSecret,
                     pubSigningKeys.first, pubSigningKeys.second, 1));
 
@@ -1021,7 +1021,7 @@ private:
                 auto const publisherPublic =
                     derivePublicKey(KeyType::ed25519, publisherSecret);
                 auto const pubSigningKeys = randomKeyPair(KeyType::secp256k1);
-                auto const manifest = boost::beast::detail::base64_encode(makeManifestString (
+                auto const manifest = base64_encode(makeManifestString (
                     publisherPublic, publisherSecret,
                     pubSigningKeys.first, pubSigningKeys.second, 1));
 

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/app/misc/ValidatorSite.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/strHex.h>
 #include <ripple/protocol/digest.h>
@@ -28,7 +29,6 @@
 #include <test/jtx.h>
 #include <test/jtx/TrustedPublisherServer.h>
 #include <boost/asio.hpp>
-#include <boost/beast/core/detail/base64.hpp>
 
 namespace ripple {
 namespace test {
@@ -67,7 +67,7 @@ private:
         Serializer s;
         st.add(s);
 
-        return boost::beast::detail::base64_encode (std::string(
+        return base64_encode (std::string(
             static_cast<char const*> (s.data()), s.size()));
     }
 

--- a/src/test/basics/base64_test.cpp
+++ b/src/test/basics/base64_test.cpp
@@ -1,0 +1,77 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+//
+// Copyright (c) 2016-2017 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/boostorg/beast
+//
+
+#include <ripple/basics/base64.h>
+#include <ripple/beast/unit_test.h>
+
+namespace ripple {
+
+class base64_test : public beast::unit_test::suite
+{
+public:
+    void
+    check (std::string const& in, std::string const& out)
+    {
+        auto const encoded = base64_encode (in);
+        BEAST_EXPECT(encoded == out);
+        BEAST_EXPECT(base64_decode (encoded) == in);
+    }
+
+    void
+    run() override
+    {
+        check ("",       "");
+        check ("f",      "Zg==");
+        check ("fo",     "Zm8=");
+        check ("foo",    "Zm9v");
+        check ("foob",   "Zm9vYg==");
+        check ("fooba",  "Zm9vYmE=");
+        check ("foobar", "Zm9vYmFy");
+
+        check(
+            "Man is distinguished, not only by his reason, but by this singular passion from "
+            "other animals, which is a lust of the mind, that by a perseverance of delight "
+            "in the continued and indefatigable generation of knowledge, exceeds the short "
+            "vehemence of any carnal pleasure."
+            ,
+            "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz"
+            "IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg"
+            "dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu"
+            "dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo"
+            "ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="
+            );
+
+        std::string const notBase64 = "not_base64";
+        std::string const truncated = "not";
+        BEAST_EXPECT(base64_decode(notBase64) == base64_decode(truncated));
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(base64, ripple_basics, ripple);
+
+} // ripple

--- a/src/test/jtx/TrustedPublisherServer.h
+++ b/src/test/jtx/TrustedPublisherServer.h
@@ -22,10 +22,10 @@
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/Sign.h>
+#include <ripple/basics/base64.h>
 #include <ripple/basics/strHex.h>
 #include <test/jtx/envconfig.h>
 #include <boost/asio.hpp>
-#include <boost/beast/core/detail/base64.hpp>
 #include <boost/beast/http.hpp>
 
 namespace ripple {
@@ -80,7 +80,7 @@ public:
         }
         data.pop_back();
         data += "]}";
-        std::string blob = boost::beast::detail::base64_encode(data);
+        std::string blob = base64_encode(data);
 
         list_ = "{\"blob\":\"" + blob + "\"";
 

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -19,12 +19,12 @@
 
 #include <ripple/app/main/BasicApp.h>
 #include <ripple/app/misc/ValidatorSite.h>
+#include <ripple/basics/base64.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/JsonFields.h>
 #include <ripple/protocol/Sign.h>
-#include <boost/beast/core/detail/base64.hpp>
 #include <test/jtx.h>
 #include <test/jtx/TrustedPublisherServer.h>
 
@@ -75,7 +75,7 @@ class ValidatorRPC_test : public beast::unit_test::suite
         Serializer s;
         st.add(s);
 
-        return boost::beast::detail::base64_encode(
+        return base64_encode(
             std::string(static_cast<char const*>(s.data()), s.size()));
     }
 

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -26,6 +26,7 @@
 #include <test/jtx/JSONRPCClient.h>
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/ledger/LedgerMaster.h>
+#include <ripple/basics/base64.h>
 #include <boost/beast/http.hpp>
 #include <beast/test/yield_to.hpp>
 #include <boost/beast/websocket/detail/mask.hpp>
@@ -553,7 +554,7 @@ class ServerStatus_test :
         doHTTPRequest(env, yield, secure, resp, ec, to_string(jr), auth);
         BEAST_EXPECT(resp.result() == boost::beast::http::status::forbidden);
 
-        auth.set("Authorization", "Basic " + boost::beast::detail::base64_encode("me:badpass"));
+        auth.set("Authorization", "Basic " + base64_encode("me:badpass"));
         doHTTPRequest(env, yield, secure, resp, ec, to_string(jr), auth);
         BEAST_EXPECT(resp.result() == boost::beast::http::status::forbidden);
 
@@ -569,7 +570,7 @@ class ServerStatus_test :
 
         // finally if we use the correct user/pass encoded, we should get a 200
         auth.set("Authorization", "Basic " +
-            boost::beast::detail::base64_encode(user + ":" + pass));
+            base64_encode(user + ":" + pass));
         doHTTPRequest(env, yield, secure, resp, ec, to_string(jr), auth);
         BEAST_EXPECT(resp.result() == boost::beast::http::status::ok);
         BEAST_EXPECT(! resp.body().empty());

--- a/src/test/unity/basics_test_unity.cpp
+++ b/src/test/unity/basics_test_unity.cpp
@@ -18,6 +18,7 @@
 */
 //==============================================================================
 
+#include <test/basics/base64_test.cpp>
 #include <test/basics/base_uint_test.cpp>
 #include <test/basics/Buffer_test.cpp>
 #include <test/basics/contract_test.cpp>


### PR DESCRIPTION
We switched to using boost::beast (https://github.com/ripple/rippled/commit/27703859e7c3f8da19098b2d2f7e9445a95ca2b5) but Boost 1.67 and 1.68 are missing this fix
https://github.com/ripple/rippled/commit/0439dcfa7a5215cc74a8e254a28eadace6a524b7

https://github.com/boostorg/beast/blob/boost-1.68.0/include/boost/beast/core/detail/base64.hpp
https://github.com/boostorg/beast/blob/boost-1.68.0/test/beast/core/detail/base64.cpp