### PR TITLE
Simplify strHex:

### DIFF
--- a/src/ripple/basics/Buffer.h
+++ b/src/ripple/basics/Buffer.h
@@ -191,6 +191,26 @@ public:
     {
         return alloc(n);
     }
+
+    auto begin() noexcept
+    {
+        return p_.get();
+    }
+
+    auto cbegin() const noexcept
+    {
+        return p_.get();
+    }
+
+    auto end() noexcept
+    {
+        return p_.get() + size_;
+    }
+
+    auto cend() const noexcept
+    {
+        return p_.get() + size_;
+    }
 };
 
 inline bool operator==(Buffer const& lhs, Buffer const& rhs) noexcept

--- a/src/ripple/basics/Buffer.h
+++ b/src/ripple/basics/Buffer.h
@@ -192,7 +192,7 @@ public:
         return alloc(n);
     }
 
-    auto begin() noexcept
+    auto begin() const noexcept
     {
         return p_.get();
     }
@@ -202,7 +202,7 @@ public:
         return p_.get();
     }
 
-    auto end() noexcept
+    auto end() const noexcept
     {
         return p_.get() + size_;
     }

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -192,9 +192,6 @@ makeSlice (std::basic_string<char, Traits, Alloc> const& s)
     return Slice(s.data(), s.size());
 }
 
-std::string
-strHex (Slice const& slice);
-
 } // ripple
 
 #endif

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -115,7 +115,7 @@ public:
     }
     /** @} */
 
-    auto begin() noexcept
+    auto begin() const noexcept
     {
         return data_;
     }
@@ -125,7 +125,7 @@ public:
         return data_;
     }
 
-    auto end() noexcept
+    auto end() const noexcept
     {
         return data_ + size_;
     }

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -159,7 +159,7 @@ operator< (Slice const& lhs, Slice const& rhs) noexcept
 template <class Stream>
 Stream& operator<<(Stream& s, Slice const& v)
 {
-    s << strHex(v.data(), v.data() + v.size());
+    s << strHex(v);
     return s;
 }
 

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -159,7 +159,7 @@ operator< (Slice const& lhs, Slice const& rhs) noexcept
 template <class Stream>
 Stream& operator<<(Stream& s, Slice const& v)
 {
-    s << strHex(v.data(), v.size());
+    s << strHex(v.data(), v.data() + v.size());
     return s;
 }
 

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -114,6 +114,26 @@ public:
         return temp += n;
     }
     /** @} */
+
+    auto begin() noexcept
+    {
+        return data_;
+    }
+
+    auto cbegin() const noexcept
+    {
+        return data_;
+    }
+
+    auto end() noexcept
+    {
+        return data_ + size_;
+    }
+
+    auto cend() const noexcept
+    {
+        return data_ + size_;
+    }
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -22,6 +22,7 @@
 
 #include <ripple/basics/Blob.h>
 #include <ripple/basics/strHex.h>
+
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <sstream>

--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -22,32 +22,12 @@
 
 #include <ripple/basics/Blob.h>
 #include <ripple/basics/strHex.h>
-#include <boost/endian/conversion.hpp>
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <sstream>
 #include <string>
 
 namespace ripple {
-
-// NIKB TODO Remove the need for all these overloads. Move them out of here.
-inline const std::string strHex (std::string const& strSrc)
-{
-    return strHex (strSrc.begin (), strSrc.size ());
-}
-
-inline std::string strHex (Blob const& vucData)
-{
-    return strHex (vucData.begin (), vucData.size ());
-}
-
-inline std::string strHex (const std::uint64_t uiHost)
-{
-    uint64_t    uBig    = boost::endian::native_to_big (uiHost);
-
-    return strHex ((unsigned char*) &uBig, sizeof (uBig));
-}
-
 inline static std::string sqlEscape (std::string const& strSrc)
 {
     static boost::format f ("X'%s'");

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -510,7 +510,7 @@ inline const base_uint<Bits, Tag> operator+ (
 template <std::size_t Bits, class Tag>
 inline std::string to_string (base_uint<Bits, Tag> const& a)
 {
-    return strHex (a.begin (), a.size ());
+    return strHex (a.cbegin (), a.cend ());
 }
 
 // Function templates that return a base_uint given text in hexadecimal.

--- a/src/ripple/basics/impl/strHex.cpp
+++ b/src/ripple/basics/impl/strHex.cpp
@@ -17,7 +17,6 @@
 */
 //==============================================================================
 
-#include <ripple/basics/Slice.h>
 #include <ripple/basics/strHex.h>
 #include <algorithm>
 #include <string>

--- a/src/ripple/basics/impl/strHex.cpp
+++ b/src/ripple/basics/impl/strHex.cpp
@@ -52,18 +52,4 @@ int charUnHex (unsigned char c)
     return xtab[c];
 }
 
-std::string
-strHex(Slice const& slice)
-{
-    const auto begin = slice.data();
-    const auto end = begin + slice.size();
-    return strHex(begin, end);
-}
-
-std::string
-strHex (Blob const& vucData)
-{
-    return strHex (std::cbegin(vucData), std::cend(vucData));
-}
-
 }

--- a/src/ripple/basics/impl/strHex.cpp
+++ b/src/ripple/basics/impl/strHex.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/strHex.h>
 #include <algorithm>
+#include <string>
 
 namespace ripple {
 
@@ -54,7 +55,15 @@ int charUnHex (unsigned char c)
 std::string
 strHex(Slice const& slice)
 {
-    return strHex(slice.data(), slice.size());
+    const auto begin = slice.data();
+    const auto end = begin + slice.size();
+    return strHex(begin, end);
+}
+
+std::string
+strHex (Blob const& vucData)
+{
+    return strHex (std::cbegin(vucData), std::cend(vucData));
 }
 
 }

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -71,6 +71,7 @@ template<class InputIterator>
 std::string strHex(InputIterator begin, InputIterator end)
 {
     std::string result{};
+    result.reserve (std::distance(begin, end));
     boost::algorithm::hex (begin, end, std::back_inserter(result));
     return result;
 }

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -69,40 +69,15 @@ charUnHex (char c)
 template<class InputIterator>
 std::string strHex(InputIterator begin, InputIterator end)
 {
-    std::string result{};
+    std::string result;
     result.reserve (std::distance(begin, end));
     boost::algorithm::hex (begin, end, std::back_inserter(result));
     return result;
 }
-namespace
+template <class T>
+std::string strHex(T const& blob)
 {
-    // Using void_t since beast/cxx17/type_traits.h hijacked it into
-    // namespace std
-    template<class T, class = void>
-    struct has_data : std::false_type{};
-
-    template<class T>
-    struct has_data<T, std::void_t<decltype(std::declval<T>().data())>>
-    : std::true_type{};
-
-    template<class T, class = void>
-    struct has_size : std::false_type{};
-
-    template<class T>
-    struct has_size<T, std::void_t<decltype(std::declval<T>().size())>>
-    : std::true_type{};
-
-    template<class T>
-    using has_bytes = std::bool_constant<has_size<T>::value &&
-                                         has_data<T>::value>;
-}
-
-template <class T, std::enable_if_t<has_bytes<T>::value>* = nullptr>
-std::string
-strHex(T const& blob)
-{
-    const auto begin = blob.data();
-    return strHex(begin, begin + blob.size());
+    return strHex(blob.cbegin(), blob.cend());
 }
 
 inline std::string strHex (std::string const& src)

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -75,13 +75,6 @@ std::string strHex(InputIterator begin, InputIterator end)
     return result;
 }
 
-template<class InputIterator>
-std::string strHex (InputIterator first, int size)
-{
-    const auto last = first + size;
-    return strHex(first, last);
-}
-
 inline std::string strHex (std::string const& src)
 {
     return boost::algorithm::hex (src);

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -76,14 +76,46 @@ std::string strHex(InputIterator begin, InputIterator end)
     return result;
 }
 
+template<class T>
+class check_has_bytes
+{
+    // has data() method
+    template<class U, class R = decltype(
+        std::declval<U>().data(),
+            std::true_type{})>
+    static R check1(int);
+    template<class>
+    static std::false_type check1(...);
+    using type1 = decltype(check1<T>(0));
+
+    // has size() method
+    template<class U, class R = decltype(
+        std::declval<U>().size(),
+            std::true_type{})>
+    static R check2(int);
+    template<class>
+    static std::false_type check2(...);
+    using type2 = decltype(check2<T>(0));
+
+public:
+    using type = std::integral_constant<bool,
+        type1::value && type2::value>;
+};
+template<class T>
+using is_Bytes = typename check_has_bytes<T>::type;
+
+template <class T, class = std::enable_if_t <is_Bytes<T>::value>>
+std::string
+strHex(T const& bobj)
+{
+    const auto begin = bobj.data();
+    return strHex(begin, begin + bobj.size());
+}
+
 inline std::string strHex (std::string const& src)
 {
     return boost::algorithm::hex (src);
 }
-
-std::string strHex (Blob const& vucData);
-
-std::string strHex (Slice const& slice);
 
 inline std::string strHex (const std::uint64_t uiHost)
 {

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -70,27 +70,22 @@ template<class InputIterator>
 std::string strHex(InputIterator begin, InputIterator end)
 {
     std::string result;
-    result.reserve (std::distance(begin, end));
+    result.reserve(2 * std::distance(begin, end));
     boost::algorithm::hex (begin, end, std::back_inserter(result));
     return result;
 }
-template <class T>
-std::string strHex(T const& blob)
+template <class T, class = decltype(std::declval<T>().begin())>
+std::string strHex(T const& from)
 {
-    return strHex(blob.cbegin(), blob.cend());
-}
-
-inline std::string strHex (std::string const& src)
-{
-    return boost::algorithm::hex (src);
+    return strHex(from.begin(), from.end());
 }
 
 inline std::string strHex (const std::uint64_t uiHost)
 {
     uint64_t uBig    = boost::endian::native_to_big (uiHost);
 
-    const auto begin = (unsigned char*) &uBig;
-    const auto end   = begin + sizeof(uBig);
+    auto const begin = (unsigned char*) &uBig;
+    auto const end   = begin + sizeof(uBig);
     return strHex(begin, end);
 }
 }

--- a/src/ripple/basics/strHex.h
+++ b/src/ripple/basics/strHex.h
@@ -25,7 +25,6 @@
 #ifndef RIPPLE_BASICS_STRHEX_H_INCLUDED
 #define RIPPLE_BASICS_STRHEX_H_INCLUDED
 
-#include <beast/cxx17/type_traits.h>
 #include <cassert>
 #include <string>
 

--- a/src/ripple/beast/cxx17/type_traits.h
+++ b/src/ripple/beast/cxx17/type_traits.h
@@ -26,11 +26,15 @@
 
 namespace std {
 
+#ifndef _MSC_VER
+
 template<class...>
 using void_t = void;
 
 template<bool B>
 using bool_constant = std::integral_constant<bool, B>;
+
+#endif
 
 // Ideas from Howard Hinnant
 //

--- a/src/ripple/beast/cxx17/type_traits.h
+++ b/src/ripple/beast/cxx17/type_traits.h
@@ -26,15 +26,11 @@
 
 namespace std {
 
-#ifndef _MSC_VER
-
 template<class...>
 using void_t = void;
 
 template<bool B>
 using bool_constant = std::integral_constant<bool, B>;
-
-#endif
 
 // Ideas from Howard Hinnant
 //

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -87,6 +87,26 @@ public:
         return size_;
     }
 
+    auto begin() noexcept
+    {
+        return buf_;
+    }
+
+    auto cbegin() const noexcept
+    {
+        return buf_;
+    }
+
+    auto end() noexcept
+    {
+        return buf_ + size_;
+    }
+
+    auto cend() const noexcept
+    {
+        return buf_ + size_;
+    }
+
     bool
     empty() const noexcept
     {

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -87,7 +87,7 @@ public:
         return size_;
     }
 
-    auto begin() noexcept
+    auto begin() const noexcept
     {
         return buf_;
     }
@@ -97,7 +97,7 @@ public:
         return buf_;
     }
 
-    auto end() noexcept
+    auto end() const noexcept
     {
         return buf_ + size_;
     }

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -120,7 +120,7 @@ public:
     STPathElement(STPathElement const&) = default;
     STPathElement& operator=(STPathElement const&) = default;
 
-    int
+    auto
     getNodeType () const
     {
         return mType;

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -67,7 +67,7 @@ public:
     std::string
     to_string() const;
 
-    auto begin() noexcept
+    auto begin() const noexcept
     {
         return buf_;
     }
@@ -77,7 +77,7 @@ public:
         return buf_;
     }
 
-    auto end() noexcept
+    auto end() const noexcept
     {
         return buf_ + sizeof(buf_);
     }

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -66,6 +66,26 @@ public:
     */
     std::string
     to_string() const;
+
+    auto begin() noexcept
+    {
+        return buf_;
+    }
+
+    auto cbegin() const noexcept
+    {
+        return buf_;
+    }
+
+    auto end() noexcept
+    {
+        return buf_ + sizeof(buf_);
+    }
+
+    auto cend() const noexcept
+    {
+        return buf_ + sizeof(buf_);
+    }
 };
 
 inline

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -63,7 +63,7 @@ public:
         return buf_.size();
     }
 
-    auto begin() noexcept
+    auto begin() const noexcept
     {
         return buf_.begin();
     }
@@ -73,7 +73,7 @@ public:
         return buf_.cbegin();
     }
 
-    auto end() noexcept
+    auto end() const noexcept
     {
         return buf_.end();
     }

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -62,6 +62,26 @@ public:
     {
         return buf_.size();
     }
+
+    auto begin() noexcept
+    {
+        return buf_.begin();
+    }
+
+    auto cbegin() const noexcept
+    {
+        return buf_.cbegin();
+    }
+
+    auto end() noexcept
+    {
+        return buf_.end();
+    }
+
+    auto cend() const noexcept
+    {
+        return buf_.cend();
+    }
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -31,7 +31,7 @@ namespace ripple {
 std::ostream&
 operator<<(std::ostream& os, PublicKey const& pk)
 {
-    os << strHex(pk.data(), pk.data() + pk.size());
+    os << strHex(pk);
     return os;
 }
 

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -31,7 +31,7 @@ namespace ripple {
 std::ostream&
 operator<<(std::ostream& os, PublicKey const& pk)
 {
-    os << strHex(pk.data(), pk.size());
+    os << strHex(pk.data(), pk.data() + pk.size());
     return os;
 }
 

--- a/src/ripple/protocol/impl/STBlob.cpp
+++ b/src/ripple/protocol/impl/STBlob.cpp
@@ -31,7 +31,7 @@ STBlob::STBlob (SerialIter& st, SField const& name)
 std::string
 STBlob::getText () const
 {
-    return strHex (value_.data (), value_.data() + value_.size ());
+    return strHex (value_);
 }
 
 bool

--- a/src/ripple/protocol/impl/STBlob.cpp
+++ b/src/ripple/protocol/impl/STBlob.cpp
@@ -31,7 +31,7 @@ STBlob::STBlob (SerialIter& st, SField const& name)
 std::string
 STBlob::getText () const
 {
-    return strHex (value_.data (), value_.size ());
+    return strHex (value_.data (), value_.data() + value_.size ());
 }
 
 bool

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -156,10 +156,10 @@ STPath::getJson (int) const
     for (auto it: mPath)
     {
         Json::Value elem (Json::objectValue);
-        int         iType   = it.getNodeType ();
+        const auto iType   = it.getNodeType ();
 
         elem[jss::type]      = iType;
-        elem[jss::type_hex]  = strHex (iType);
+        elem[jss::type_hex]  = charHex (iType);
 
         if (iType & STPathElement::typeAccount)
             elem[jss::account]  = to_string (it.getAccountID ());

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -156,10 +156,10 @@ STPath::getJson (int) const
     for (auto it: mPath)
     {
         Json::Value elem (Json::objectValue);
-        const auto iType   = it.getNodeType ();
+        auto const iType   = it.getNodeType ();
 
         elem[jss::type]      = iType;
-        elem[jss::type_hex]  = charHex (iType);
+        elem[jss::type_hex]  = strHex (iType);
 
         if (iType & STPathElement::typeAccount)
             elem[jss::account]  = to_string (it.getAccountID ());

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -51,7 +51,7 @@ SecretKey::SecretKey (Slice const& slice)
 std::string
 SecretKey::to_string() const
 {
-    return strHex(data(), data() + size());
+    return strHex(*this);
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -51,7 +51,7 @@ SecretKey::SecretKey (Slice const& slice)
 std::string
 SecretKey::to_string() const
 {
-    return strHex(data(), size());
+    return strHex(data(), data() + size());
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -61,7 +61,7 @@ std::string to_string(Currency const& currency)
         }
     }
 
-    return strHex (currency.begin (), currency.size ());
+    return strHex (currency.cbegin (), currency.cend ());
 }
 
 bool to_currency(Currency& currency, std::string const& code)

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -61,7 +61,7 @@ std::string to_string(Currency const& currency)
         }
     }
 
-    return strHex (currency.cbegin (), currency.cend ());
+    return strHex (currency);
 }
 
 bool to_currency(Currency& currency, std::string const& code)

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -108,7 +108,7 @@ Json::Value walletPropose (Json::Value const& params)
     Json::Value obj (Json::objectValue);
 
     auto const seed1751 = seedAs1751 (*seed);
-    auto const seedHex = strHex (seed->data(), seed->size());
+    auto const seedHex = strHex (seed->data(), seed->data() + seed->size());
     auto const seedBase58 = toBase58 (*seed);
 
     obj[jss::master_seed] = seedBase58;
@@ -117,7 +117,7 @@ Json::Value walletPropose (Json::Value const& params)
     obj[jss::account_id] = toBase58(calcAccountID(publicKey));
     obj[jss::public_key] = toBase58(TokenType::AccountPublic, publicKey);
     obj[jss::key_type] = to_string (keyType);
-    obj[jss::public_key_hex] = strHex (publicKey.data(), publicKey.size());
+    obj[jss::public_key_hex] = strHex (publicKey.data(), publicKey.data() + publicKey.size());
 
     // If a passphrase was specified, and it was hashed and used as a seed
     // run a quick entropy check and add an appropriate warning, because

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -108,7 +108,7 @@ Json::Value walletPropose (Json::Value const& params)
     Json::Value obj (Json::objectValue);
 
     auto const seed1751 = seedAs1751 (*seed);
-    auto const seedHex = strHex (seed->data(), seed->data() + seed->size());
+    auto const seedHex = strHex (*seed);
     auto const seedBase58 = toBase58 (*seed);
 
     obj[jss::master_seed] = seedBase58;
@@ -117,7 +117,7 @@ Json::Value walletPropose (Json::Value const& params)
     obj[jss::account_id] = toBase58(calcAccountID(publicKey));
     obj[jss::public_key] = toBase58(TokenType::AccountPublic, publicKey);
     obj[jss::key_type] = to_string (keyType);
-    obj[jss::public_key_hex] = strHex (publicKey.data(), publicKey.data() + publicKey.size());
+    obj[jss::public_key_hex] = strHex (publicKey);
 
     // If a passphrase was specified, and it was hashed and used as a seed
     // run a quick entropy check and add an appropriate warning, because

--- a/src/test/rpc/AccountSet_test.cpp
+++ b/src/test/rpc/AccountSet_test.cpp
@@ -212,7 +212,8 @@ public:
         env(jt);
         BEAST_EXPECT(! env.le(alice)->isFieldPresent(sfMessageKey));
 
-        jt[sfMessageKey.fieldName] = strHex("NOT_REALLY_A_PUBKEY");
+        using namespace std::string_literals;
+        jt[sfMessageKey.fieldName] = strHex("NOT_REALLY_A_PUBKEY"s);
         env(jt, ter(telBAD_PUBLIC_KEY));
     }
 


### PR DESCRIPTION
Problem:
- There are several specific overloads with some custom code that can be
  easily replaced using Boost.Hex.

Solution:
- Introduce `strHex(itr, itr)` to return a string given a begin and end
  iterator.
- Remove `strHex(itr, size)` in favor of the `strHex(T)` where T is
  something that has a `begin()` member function. This allows us to
  remove the strHex overloads for `std::string`, Blob, and Slice.