### PR TITLE
Report fetch pack errors with shards

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -256,7 +256,7 @@ private:
         std::shared_ptr<Ledger const> ledger);
 
     void getFetchPack(
-        LedgerIndex missingIndex, InboundLedger::Reason reason);
+        LedgerIndex missing, InboundLedger::Reason reason);
 
     boost::optional<LedgerHash> getLedgerHashForHistory(
         LedgerIndex index, InboundLedger::Reason reason);


### PR DESCRIPTION
This commit addresses an issue where requesting a fetch pack for a shard incorrectly logs an error if the ledger past the last ledger of the shard is not locally stored. That doesn't happen when acquiring node history because we work backward from a validated ledger but with shards, we start randomly in history. With shards, the error should only report when a ledger is missing within the shard ledger range.