### PR TITLE
[TRIVIAL] Fix clang warning on self assignment

### DIFF
--- a/src/test/basics/Buffer_test.cpp
+++ b/src/test/basics/Buffer_test.cpp
@@ -98,11 +98,9 @@ struct Buffer_test : beast::unit_test::suite
             x = b0;
             BEAST_EXPECT (x == b0);
             BEAST_EXPECT (sane (x));
-#ifdef __clang__
+#if defined(__clang__) && !defined(__APPLE__) && (__clang_major__ >= 7)
 #pragma clang diagnostic push
-#if __clang_major__ >= 7
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-#endif
 #endif
 
             x = x;
@@ -111,7 +109,7 @@ struct Buffer_test : beast::unit_test::suite
             y = y;
             BEAST_EXPECT (y == b3);
             BEAST_EXPECT (sane (y));
-#ifdef __clang__
+#if defined(__clang__) && !defined(__APPLE__) && (__clang_major__ >= 7)
 #pragma clang diagnostic pop
 #endif
         }

--- a/src/test/basics/Buffer_test.cpp
+++ b/src/test/basics/Buffer_test.cpp
@@ -98,12 +98,22 @@ struct Buffer_test : beast::unit_test::suite
             x = b0;
             BEAST_EXPECT (x == b0);
             BEAST_EXPECT (sane (x));
+#ifdef __clang__
+#pragma clang diagnostic push
+#if __clang_major__ >= 7
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
+#endif
+
             x = x;
             BEAST_EXPECT (x == b0);
             BEAST_EXPECT (sane (x));
             y = y;
             BEAST_EXPECT (y == b3);
             BEAST_EXPECT (sane (y));
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         }
 
         // Check move constructor & move assignments:


### PR DESCRIPTION
Fixes a new warning in clang 7