### PR TITLE
Remove Journal default ctor

### DIFF
--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -38,7 +38,7 @@
 namespace ripple {
 
 RCLValidatedLedger::RCLValidatedLedger(MakeGenesis)
-    : ledgerID_{0}, ledgerSeq_{0}
+    : ledgerID_{0}, ledgerSeq_{0}, j_{beast::Journal::getNullSink()}
 {
 }
 

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -133,7 +133,8 @@ Json::Value fillJsonTx (LedgerFill const& fill,
             if (account != amount.getIssuer())
             {
                 auto const ownerFunds = accountFunds(fill.ledger,
-                    account, amount, fhIGNORE_FREEZE, beast::Journal());
+                    account, amount, fhIGNORE_FREEZE,
+                    beast::Journal {beast::Journal::getNullSink()});
                 txJson[jss::owner_funds] = ownerFunds.getText ();
             }
         }

--- a/src/ripple/app/misc/LoadFeeTrack.h
+++ b/src/ripple/app/misc/LoadFeeTrack.h
@@ -42,7 +42,8 @@ struct Fees;
 class LoadFeeTrack final
 {
 public:
-    explicit LoadFeeTrack (beast::Journal journal = beast::Journal())
+    explicit LoadFeeTrack (beast::Journal journal =
+        beast::Journal(beast::Journal::getNullSink()))
         : j_ (journal)
         , localTxnLoadFee_ (lftNormalFee)
         , remoteTxnLoadFee_ (lftNormalFee)

--- a/src/ripple/app/misc/Manifest.h
+++ b/src/ripple/app/misc/Manifest.h
@@ -189,7 +189,8 @@ private:
 
 public:
     explicit
-    ManifestCache (beast::Journal j = beast::Journal())
+    ManifestCache (beast::Journal j =
+        beast::Journal(beast::Journal::getNullSink()))
         : j_ (j)
     {
     }

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -57,7 +57,9 @@ private:
 
         // Just instantiate without any logic in case online delete is not
         // configured
-        explicit SavedStateDB() = default;
+        explicit SavedStateDB()
+        : journal_ {beast::Journal::getNullSink()}
+        { }
 
         // opens database and, if necessary, creates & initializes its tables.
         void init (BasicConfig const& config, std::string const& dbName);

--- a/src/ripple/app/tx/impl/ApplyContext.h
+++ b/src/ripple/app/tx/impl/ApplyContext.h
@@ -41,7 +41,7 @@ public:
     ApplyContext (Application& app, OpenView& base,
         STTx const& tx, TER preclaimResult,
             std::uint64_t baseFee, ApplyFlags flags,
-                beast::Journal = {});
+                beast::Journal = beast::Journal{beast::Journal::getNullSink()});
 
     Application& app;
     STTx const& tx;

--- a/src/ripple/app/tx/impl/Taker.h
+++ b/src/ripple/app/tx/impl/Taker.h
@@ -139,7 +139,8 @@ public:
     BasicTaker (
         CrossType cross_type, AccountID const& account, Amounts const& amount,
         Quality const& quality, std::uint32_t flags, Rate const& rate_in,
-        Rate const& rate_out, beast::Journal journal = beast::Journal ());
+        Rate const& rate_out,
+        beast::Journal journal = beast::Journal{beast::Journal::getNullSink()});
 
     virtual ~BasicTaker () = default;
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -58,7 +58,8 @@ public:
 
     PreclaimContext(Application& app_, ReadView const& view_,
         TER preflightResult_, STTx const& tx_,
-            ApplyFlags flags_, beast::Journal j_ = {})
+            ApplyFlags flags_,
+            beast::Journal j_ = beast::Journal{beast::Journal::getNullSink()})
         : app(app_)
         , view(view_)
         , preflightResult(preflightResult_)

--- a/src/ripple/beast/utility/Journal.h
+++ b/src/ripple/beast/utility/Journal.h
@@ -253,10 +253,8 @@ static_assert(std::is_nothrow_destructible<Stream>::value == true, "");
 
     //--------------------------------------------------------------------------
 
-    /** Create a journal that writes to the null sink. */
-    Journal ()
-    : Journal (getNullSink())
-    { }
+    /** Journal has no default constructor. */
+    Journal () = delete;
 
     /** Create a journal that writes to the specified sink. */
     explicit Journal (Sink& sink)
@@ -319,7 +317,7 @@ static_assert(std::is_nothrow_destructible<Stream>::value == true, "");
 };
 
 #ifndef __INTELLISENSE__
-static_assert(std::is_default_constructible<Journal>::value == true, "");
+static_assert(std::is_default_constructible<Journal>::value == false, "");
 static_assert(std::is_copy_constructible<Journal>::value == true, "");
 static_assert(std::is_move_constructible<Journal>::value == true, "");
 static_assert(std::is_copy_assignable<Journal>::value == true, "");

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -184,7 +184,9 @@ public:
     std::unordered_set<uint256, beast::uhash<>> features;
 
 public:
-    Config() = default;
+    Config()
+    : j_ {beast::Journal::getNullSink()}
+    { }
 
     int getSize (SizedItemName) const;
     /* Be very careful to make sure these bool params

--- a/src/ripple/ledger/impl/BookDirs.cpp
+++ b/src/ripple/ledger/impl/BookDirs.cpp
@@ -33,9 +33,9 @@ BookDirs::BookDirs(ReadView const& view, Book const& book)
     if (key_ != beast::zero)
     {
         if (! cdirFirst(*view_, key_, sle_, entry_, index_,
-            beast::Journal()))
+            beast::Journal {beast::Journal::getNullSink()}))
         {
-            assert(false);            
+            assert(false);
         }
     }
 }
@@ -63,7 +63,8 @@ BookDirs::end() const  ->
 }
 
 
-beast::Journal BookDirs::const_iterator::j_ = beast::Journal();
+beast::Journal BookDirs::const_iterator::j_ =
+    beast::Journal{beast::Journal::getNullSink()};
 
 bool
 BookDirs::const_iterator::operator==

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -241,7 +241,7 @@ static
 std::uint32_t
 confineOwnerCount (std::uint32_t current, std::int32_t adjustment,
     boost::optional<AccountID> const& id = boost::none,
-    beast::Journal j = beast::Journal{})
+    beast::Journal j = beast::Journal {beast::Journal::getNullSink()})
 {
     std::uint32_t adjusted {current + adjustment};
     if (adjustment > 0)
@@ -456,7 +456,7 @@ areCompatible (ReadView const& validLedger, ReadView const& testLedger,
     {
         // valid -> ... -> test
         auto hash = hashOfSeq (testLedger, validLedger.info().seq,
-            beast::Journal());
+            beast::Journal {beast::Journal::getNullSink()});
         if (hash && (*hash != validLedger.info().hash))
         {
             JLOG(s) << reason << " incompatible with valid ledger";
@@ -470,7 +470,7 @@ areCompatible (ReadView const& validLedger, ReadView const& testLedger,
     {
         // test -> ... -> valid
         auto hash = hashOfSeq (validLedger, testLedger.info().seq,
-            beast::Journal());
+            beast::Journal {beast::Journal::getNullSink()});
         if (hash && (*hash != testLedger.info().hash))
         {
             JLOG(s) << reason << " incompatible preceding ledger";
@@ -510,7 +510,7 @@ bool areCompatible (uint256 const& validHash, LedgerIndex validIndex,
     {
         // Ledger we are testing follows last valid ledger
         auto hash = hashOfSeq (testLedger, validIndex,
-            beast::Journal());
+            beast::Journal {beast::Journal::getNullSink()});
         if (hash && (*hash != validHash))
         {
             JLOG(s) << reason << " incompatible following ledger";

--- a/src/ripple/net/AutoSocket.h
+++ b/src/ripple/net/AutoSocket.h
@@ -52,6 +52,7 @@ public:
             bool plainOnly)
         : mSecure (secureOnly)
         , mBuffer ((plainOnly || secureOnly) ? 0 : 4)
+        , j_ {beast::Journal::getNullSink()}
     {
         mSocket = std::make_unique<ssl_socket> (s, c);
     }

--- a/src/ripple/nodestore/backend/MemoryFactory.cpp
+++ b/src/ripple/nodestore/backend/MemoryFactory.cpp
@@ -21,6 +21,7 @@
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
 #include <boost/beast/core/string.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -89,6 +90,7 @@ public:
         : name_ (get<std::string>(keyValues, "path"))
         , journal_ (journal)
     {
+        boost::ignore_unused (journal_); // Keep unused journal_ just in case.
         if (name_.empty())
             Throw<std::runtime_error> ("Missing path in Memory backend");
     }

--- a/src/ripple/peerfinder/impl/StoreSqdb.h
+++ b/src/ripple/peerfinder/impl/StoreSqdb.h
@@ -42,7 +42,8 @@ public:
         currentSchemaVersion = 4
     };
 
-    explicit StoreSqdb (beast::Journal journal = beast::Journal())
+    explicit StoreSqdb (beast::Journal journal =
+            beast::Journal {beast::Journal::getNullSink()})
         : m_journal (journal)
     {
     }

--- a/src/ripple/resource/impl/ResourceManager.cpp
+++ b/src/ripple/resource/impl/ResourceManager.cpp
@@ -22,6 +22,7 @@
 #include <ripple/basics/chrono.h>
 #include <ripple/basics/Log.h>
 #include <ripple/beast/core/CurrentThreadName.h>
+#include <boost/core/ignore_unused.hpp>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -45,6 +46,7 @@ public:
         : journal_ (journal)
         , logic_ (collector, stopwatch(), journal)
     {
+        boost::ignore_unused (journal_); // Keep unused journal_ just in case.
         thread_ = std::thread {&ManagerImp::run, this};
     }
 

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -29,7 +29,7 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/TxFlags.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple
 {

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -90,8 +90,7 @@ private:
 
     Section const emptySection;
 
-    test::SuiteJournalSink sink;
-    beast::Journal journal;
+    test::SuiteJournal journal;
 
 public:
     AmendmentTable_test ()
@@ -99,8 +98,7 @@ public:
         , m_set2 (createSet (2, 12))
         , m_set3 (createSet (3, 12))
         , m_set4 (createSet (4, 12))
-        , sink ("AmendmentTable_test", beast::severities::kFatal, *this)
-        , journal (sink)
+        , journal ("AmendmentTable_test", *this)
     {
     }
 

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -22,13 +22,14 @@
 #include <ripple/basics/BasicConfig.h>
 #include <ripple/basics/chrono.h>
 #include <ripple/basics/Log.h>
+#include <ripple/beast/unit_test.h>
 #include <ripple/core/ConfigSections.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/TxFlags.h>
-#include <ripple/beast/unit_test.h>
+#include <test/jtx/Env.h>
 
 namespace ripple
 {
@@ -89,12 +90,15 @@ private:
 
     Section const emptySection;
 
+    test::jtx::Env env;  // Used only for its Journal.
+
 public:
     AmendmentTable_test ()
         : m_set1 (createSet (1, 12))
         , m_set2 (createSet (2, 12))
         , m_set3 (createSet (3, 12))
         , m_set4 (createSet (4, 12))
+        , env (*this)
     {
     }
 
@@ -111,7 +115,7 @@ public:
             supported,
             enabled,
             vetoed,
-            beast::Journal{});
+            env.journal);
     }
 
     std::unique_ptr<AmendmentTable>

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -29,7 +29,7 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/protocol/TxFlags.h>
-#include <test/jtx/Env.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 namespace ripple
 {
@@ -90,7 +90,8 @@ private:
 
     Section const emptySection;
 
-    test::jtx::Env env;  // Used only for its Journal.
+    test::SuiteJournalSink sink;
+    beast::Journal journal;
 
 public:
     AmendmentTable_test ()
@@ -98,7 +99,8 @@ public:
         , m_set2 (createSet (2, 12))
         , m_set3 (createSet (3, 12))
         , m_set4 (createSet (4, 12))
-        , env (*this)
+        , sink ("AmendmentTable_test", beast::severities::kFatal, *this)
+        , journal (sink)
     {
     }
 
@@ -115,7 +117,7 @@ public:
             supported,
             enabled,
             vetoed,
-            env.journal);
+            journal);
     }
 
     std::unique_ptr<AmendmentTable>

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -218,10 +218,9 @@ public:
             std::vector<Manifest const*> const inManifests (
                 sort (getPopulatedManifests (m)));
 
-            beast::Journal journal;
             jtx::Env env (*this);
             auto unl = std::make_unique<ValidatorList> (
-                m, m, env.timeKeeper(), journal);
+                m, m, env.timeKeeper(), env.journal);
 
             {
                 // save should not store untrusted master keys to db

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -230,7 +230,7 @@ public:
         auto& app = env.app();
         Resource::Charge loadType = Resource::feeReferenceRPC;
         Resource::Consumer c;
-        RPC::Context context {beast::Journal(), {}, app, loadType,
+        RPC::Context context {env.journal, {}, app, loadType,
             app.getOPs(), app.getLedgerMaster(), c, Role::USER, {}};
 
         Json::Value params = Json::objectValue;
@@ -328,7 +328,7 @@ public:
         auto& app = env.app();
         Resource::Charge loadType = Resource::feeReferenceRPC;
         Resource::Consumer c;
-        RPC::Context context {beast::Journal(), {}, app, loadType,
+        RPC::Context context {env.journal, {}, app, loadType,
             app.getOPs(), app.getLedgerMaster(), c, Role::USER, {}};
         Json::Value result;
         gate g;

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -21,8 +21,8 @@
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/basics/Log.h>
 #include <ripple/ledger/View.h>
-#include <test/jtx.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx.h>
 
 namespace ripple {
 namespace test {
@@ -63,7 +63,6 @@ class RCLValidations_test : public beast::unit_test::suite
     testRCLValidatedLedger()
     {
         testcase("RCLValidatedLedger ancestry");
-        beast::Journal j;
 
         using Seq = RCLValidatedLedger::Seq;
         using ID = RCLValidatedLedger::ID;
@@ -136,7 +135,7 @@ class RCLValidations_test : public beast::unit_test::suite
         // Full history ledgers
         {
             std::shared_ptr<Ledger const> ledger = history.back();
-            RCLValidatedLedger a{ledger, j};
+            RCLValidatedLedger a{ledger, env.journal};
             BEAST_EXPECT(a.seq() == ledger->info().seq);
             BEAST_EXPECT(
                 a.minSeq() == a.seq() - maxAncestors);
@@ -159,17 +158,17 @@ class RCLValidations_test : public beast::unit_test::suite
             for (auto ledger : {history.back(),
                                 history[maxAncestors - 1]})
             {
-                RCLValidatedLedger b{ledger, j};
+                RCLValidatedLedger b{ledger, env.journal};
                 BEAST_EXPECT(mismatch(a, b) == 1);
                 BEAST_EXPECT(mismatch(b, a) == 1);
             }
         }
         // Same chains, different seqs
         {
-            RCLValidatedLedger a{history.back(), j};
+            RCLValidatedLedger a{history.back(), env.journal};
             for(Seq s = a.seq(); s > 0; s--)
             {
-                RCLValidatedLedger b{history[s-1], j};
+                RCLValidatedLedger b{history[s-1], env.journal};
                 if(s >= a.minSeq())
                 {
                     BEAST_EXPECT(mismatch(a, b) == b.seq() + 1);
@@ -188,8 +187,8 @@ class RCLValidations_test : public beast::unit_test::suite
             // Alt history diverged at history.size()/2
             for(Seq s = 1; s < history.size(); ++s)
             {
-                RCLValidatedLedger a{history[s-1], j};
-                RCLValidatedLedger b{altHistory[s-1], j};
+                RCLValidatedLedger a{history[s-1], env.journal};
+                RCLValidatedLedger b{altHistory[s-1], env.journal};
 
                 BEAST_EXPECT(a.seq() == b.seq());
                 if(s <= diverge)
@@ -209,10 +208,10 @@ class RCLValidations_test : public beast::unit_test::suite
         // Different chains, different seqs
         {
             // Compare around the divergence point
-            RCLValidatedLedger a{history[diverge], j};
+            RCLValidatedLedger a{history[diverge], env.journal};
             for(Seq offset = diverge/2; offset < 3*diverge/2; ++offset)
             {
-                RCLValidatedLedger b{altHistory[offset-1], j};
+                RCLValidatedLedger b{altHistory[offset-1], env.journal};
                 if(offset <= diverge)
                 {
                     BEAST_EXPECT(mismatch(a,b) == b.seq() + 1);

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -75,9 +75,7 @@ public:
     void
     run() override
     {
-        SuiteJournalSink sink (
-            "ValidatorKeys_test", beast::severities::kFatal, *this);
-        beast::Journal journal (sink);
+        SuiteJournal journal ("ValidatorKeys_test", *this);
 
         // Keys/ID when using [validation_seed]
         SecretKey const seedSecretKey =

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -23,6 +23,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
+#include <test/jtx/Env.h>
 #include <string>
 
 namespace ripple {
@@ -74,7 +75,7 @@ public:
     void
     run() override
     {
-        beast::Journal j;
+        jtx::Env env (*this);  // Used only for its Journal.
 
         // Keys/ID when using [validation_seed]
         SecretKey const seedSecretKey =
@@ -98,7 +99,7 @@ public:
         {
             // No config -> no key but valid
             Config c;
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
             BEAST_EXPECT(k.publicKey.size() == 0);
             BEAST_EXPECT(k.manifest.empty());
             BEAST_EXPECT(!k.configInvalid());
@@ -109,7 +110,7 @@ public:
             Config c;
             c.section(SECTION_VALIDATION_SEED).append(seed);
 
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
             BEAST_EXPECT(k.publicKey == seedPublicKey);
             BEAST_EXPECT(k.secretKey == seedSecretKey);
             BEAST_EXPECT(k.nodeID == seedNodeID);
@@ -122,7 +123,7 @@ public:
             Config c;
             c.section(SECTION_VALIDATION_SEED).append("badseed");
 
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);
             BEAST_EXPECT(k.manifest.empty());
@@ -132,7 +133,7 @@ public:
             // validator token
             Config c;
             c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
 
             BEAST_EXPECT(k.publicKey == tokenPublicKey);
             BEAST_EXPECT(k.secretKey == tokenSecretKey);
@@ -144,7 +145,7 @@ public:
             // invalid validator token
             Config c;
             c.section(SECTION_VALIDATOR_TOKEN).append("badtoken");
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);
             BEAST_EXPECT(k.manifest.empty());
@@ -155,7 +156,7 @@ public:
             Config c;
             c.section(SECTION_VALIDATION_SEED).append(seed);
             c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
 
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);
@@ -166,7 +167,7 @@ public:
             // Token manifest and private key must match
             Config c;
             c.section(SECTION_VALIDATOR_TOKEN).append(invalidTokenBlob);
-            ValidatorKeys k{c, j};
+            ValidatorKeys k{c, env.journal};
 
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -23,7 +23,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
-#include <test/jtx/Env.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <string>
 
 namespace ripple {
@@ -75,7 +75,9 @@ public:
     void
     run() override
     {
-        jtx::Env env (*this);  // Used only for its Journal.
+        SuiteJournalSink sink (
+            "ValidatorKeys_test", beast::severities::kFatal, *this);
+        beast::Journal journal (sink);
 
         // Keys/ID when using [validation_seed]
         SecretKey const seedSecretKey =
@@ -99,7 +101,7 @@ public:
         {
             // No config -> no key but valid
             Config c;
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
             BEAST_EXPECT(k.publicKey.size() == 0);
             BEAST_EXPECT(k.manifest.empty());
             BEAST_EXPECT(!k.configInvalid());
@@ -110,7 +112,7 @@ public:
             Config c;
             c.section(SECTION_VALIDATION_SEED).append(seed);
 
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
             BEAST_EXPECT(k.publicKey == seedPublicKey);
             BEAST_EXPECT(k.secretKey == seedSecretKey);
             BEAST_EXPECT(k.nodeID == seedNodeID);
@@ -123,7 +125,7 @@ public:
             Config c;
             c.section(SECTION_VALIDATION_SEED).append("badseed");
 
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);
             BEAST_EXPECT(k.manifest.empty());
@@ -133,7 +135,7 @@ public:
             // validator token
             Config c;
             c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
 
             BEAST_EXPECT(k.publicKey == tokenPublicKey);
             BEAST_EXPECT(k.secretKey == tokenSecretKey);
@@ -145,7 +147,7 @@ public:
             // invalid validator token
             Config c;
             c.section(SECTION_VALIDATOR_TOKEN).append("badtoken");
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);
             BEAST_EXPECT(k.manifest.empty());
@@ -156,7 +158,7 @@ public:
             Config c;
             c.section(SECTION_VALIDATION_SEED).append(seed);
             c.section(SECTION_VALIDATOR_TOKEN).append(tokenBlob);
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
 
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);
@@ -167,7 +169,7 @@ public:
             // Token manifest and private key must match
             Config c;
             c.section(SECTION_VALIDATOR_TOKEN).append(invalidTokenBlob);
-            ValidatorKeys k{c, env.journal};
+            ValidatorKeys k{c, journal};
 
             BEAST_EXPECT(k.configInvalid());
             BEAST_EXPECT(k.publicKey.size() == 0);

--- a/src/test/app/ValidatorKeys_test.cpp
+++ b/src/test/app/ValidatorKeys_test.cpp
@@ -23,7 +23,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <string>
 
 namespace ripple {

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -140,18 +140,17 @@ private:
     {
         testcase ("Genesis Quorum");
 
-        beast::Journal journal;
         ManifestCache manifests;
         jtx::Env env (*this);
         {
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
             BEAST_EXPECT(trustedKeys->quorum () == 1);
         }
         {
             std::size_t minQuorum = 0;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal, minQuorum);
+                manifests, manifests, env.timeKeeper(), env.journal, minQuorum);
             BEAST_EXPECT(trustedKeys->quorum () == minQuorum);
         }
     }
@@ -161,7 +160,6 @@ private:
     {
         testcase ("Config Load");
 
-        beast::Journal journal;
         jtx::Env env (*this);
         PublicKey emptyLocalKey;
         std::vector<std::string> emptyCfgKeys;
@@ -211,7 +209,7 @@ private:
         {
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             // Correct (empty) configuration
             BEAST_EXPECT(trustedKeys->load (
@@ -233,7 +231,7 @@ private:
             // load should add validator keys from config
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             BEAST_EXPECT(trustedKeys->load (
                 emptyLocalKey, cfgKeys, emptyCfgPublishers));
@@ -278,7 +276,7 @@ private:
             // local validator key on config list
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             auto const localSigningPublic = parseBase58<PublicKey> (
                 TokenType::NodePublic, cfgKeys.front());
@@ -295,7 +293,7 @@ private:
             // local validator key not on config list
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             auto const localSigningPublic = randomNode();
             BEAST_EXPECT(trustedKeys->load (
@@ -310,7 +308,7 @@ private:
             // local validator key (with manifest) not on config list
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             manifests.applyManifest (*Manifest::make_Manifest(cfgManifest));
 
@@ -326,7 +324,7 @@ private:
         {
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             // load should reject invalid validator list signing keys
             std::vector<std::string> badPublishers(
@@ -364,11 +362,10 @@ private:
     {
         testcase ("Apply list");
 
-        beast::Journal journal;
         ManifestCache manifests;
         jtx::Env env (*this);
         auto trustedKeys = std::make_unique<ValidatorList> (
-            manifests, manifests, env.app().timeKeeper(), journal);
+            manifests, manifests, env.app().timeKeeper(), env.journal);
 
         auto const publisherSecret = randomSecretKey();
         auto const publisherPublic =
@@ -528,7 +525,7 @@ private:
         ManifestCache manifests;
         jtx::Env env (*this);
         auto trustedKeys = std::make_unique <ValidatorList> (
-            manifests, manifests, env.timeKeeper(), beast::Journal ());
+            manifests, manifests, env.timeKeeper(), env.journal);
 
         std::vector<std::string> cfgPublishers;
         hash_set<NodeID> activeValidators;
@@ -677,7 +674,7 @@ private:
         {
             // Make quorum unattainable if lists from any publishers are unavailable
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), beast::Journal ());
+                manifests, manifests, env.timeKeeper(), env.journal);
             auto const publisherSecret = randomSecretKey();
             auto const publisherPublic =
                 derivePublicKey(KeyType::ed25519, publisherSecret);
@@ -701,7 +698,7 @@ private:
             std::size_t const minQuorum = 1;
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), beast::Journal (), minQuorum);
+                manifests, manifests, env.timeKeeper(), env.journal, minQuorum);
 
             std::size_t n = 10;
             std::vector<std::string> cfgKeys;
@@ -741,7 +738,7 @@ private:
         {
             // Remove expired published list
             auto trustedKeys = std::make_unique<ValidatorList> (
-                manifests, manifests, env.app().timeKeeper(), beast::Journal ());
+                manifests, manifests, env.app().timeKeeper(), env.journal);
 
             PublicKey emptyLocalKey;
             std::vector<std::string> emptyCfgKeys;
@@ -827,7 +824,7 @@ private:
         {
             // Test 1-9 configured validators
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), beast::Journal ());
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             std::vector<std::string> cfgPublishers;
             hash_set<NodeID> activeValidators;
@@ -858,7 +855,7 @@ private:
         {
             // Test 2-9 configured validators as validator
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), beast::Journal ());
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             auto const localKey = randomNode();
             std::vector<std::string> cfgPublishers;
@@ -898,7 +895,7 @@ private:
             // Trusted set should include all validators from multiple lists
             ManifestCache manifests;
             auto trustedKeys = std::make_unique <ValidatorList> (
-                manifests, manifests, env.timeKeeper(), beast::Journal ());
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             hash_set<NodeID> activeValidators;
             std::vector<Validator> valKeys;
@@ -968,7 +965,6 @@ private:
     {
         testcase("Expires");
 
-        beast::Journal journal;
         jtx::Env env(*this);
 
         auto toStr = [](PublicKey const& publicKey) {
@@ -979,7 +975,7 @@ private:
         {
             ManifestCache manifests;
             auto trustedKeys = std::make_unique<ValidatorList>(
-                manifests, manifests, env.timeKeeper(), journal);
+                manifests, manifests, env.timeKeeper(), env.journal);
 
             // Empty list has no expiration
             BEAST_EXPECT(trustedKeys->expires() == boost::none);
@@ -998,7 +994,7 @@ private:
         {
             ManifestCache manifests;
             auto trustedKeys = std::make_unique<ValidatorList>(
-                manifests, manifests, env.app().timeKeeper(), journal);
+                manifests, manifests, env.app().timeKeeper(), env.journal);
 
             std::vector<Validator> validators = {randomValidator()};
             hash_set<NodeID> activeValidators;

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -92,7 +92,7 @@ private:
 
         Env env (*this);
         auto trustedSites = std::make_unique<ValidatorSite> (
-            env.app().getIOService(), env.app().validators(), beast::Journal());
+            env.app().getIOService(), env.app().validators(), env.journal);
 
         // load should accept empty sites list
         std::vector<std::string> emptyCfgSites;
@@ -130,8 +130,6 @@ private:
 
         Env env (*this);
         auto& trustedKeys = env.app ().validators ();
-
-        beast::Journal journal;
 
         PublicKey emptyLocalKey;
         std::vector<std::string> emptyCfgKeys;
@@ -205,7 +203,7 @@ private:
             std::vector<std::string> cfgSites({ url1.str() });
 
             auto sites = std::make_unique<ValidatorSite> (
-                env.app().getIOService(), env.app().validators(), journal);
+                env.app().getIOService(), env.app().validators(), env.journal);
 
             sites->load (cfgSites);
             sites->start();
@@ -222,7 +220,7 @@ private:
             std::vector<std::string> cfgSites({ url1.str(), url2.str() });
 
             auto sites = std::make_unique<ValidatorSite> (
-                env.app().getIOService(), env.app().validators(), journal);
+                env.app().getIOService(), env.app().validators(), env.journal);
 
             sites->load (cfgSites);
             sites->start();

--- a/src/test/basics/TaggedCache_test.cpp
+++ b/src/test/basics/TaggedCache_test.cpp
@@ -21,6 +21,7 @@
 #include <ripple/basics/TaggedCache.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/clock/manual_clock.h>
+#include <test/jtx.h>
 
 namespace ripple {
 
@@ -40,7 +41,7 @@ public:
     void run () override
     {
         using namespace std::chrono_literals;
-        beast::Journal const j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
         TestStopwatch clock;
         clock.set (0);
@@ -49,7 +50,7 @@ public:
         using Value = std::string;
         using Cache = TaggedCache <Key, Value>;
 
-        Cache c ("test", 1, 1s, clock, j);
+        Cache c ("test", 1, 1s, clock, env.journal);
 
         // Insert an item, retrieve it, and age it so it gets purged.
         {

--- a/src/test/basics/TaggedCache_test.cpp
+++ b/src/test/basics/TaggedCache_test.cpp
@@ -21,7 +21,7 @@
 #include <ripple/basics/TaggedCache.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/clock/manual_clock.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 

--- a/src/test/basics/TaggedCache_test.cpp
+++ b/src/test/basics/TaggedCache_test.cpp
@@ -21,7 +21,7 @@
 #include <ripple/basics/TaggedCache.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/clock/manual_clock.h>
-#include <test/jtx.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 namespace ripple {
 
@@ -41,7 +41,8 @@ public:
     void run () override
     {
         using namespace std::chrono_literals;
-        test::jtx::Env env (*this);  // Used only for its Journal.
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("TaggedCache_test", kFatal, *this);
 
         TestStopwatch clock;
         clock.set (0);
@@ -50,7 +51,7 @@ public:
         using Value = std::string;
         using Cache = TaggedCache <Key, Value>;
 
-        Cache c ("test", 1, 1s, clock, env.journal);
+        Cache c ("test", 1, 1s, clock, beast::Journal (sink));
 
         // Insert an item, retrieve it, and age it so it gets purged.
         {

--- a/src/test/basics/TaggedCache_test.cpp
+++ b/src/test/basics/TaggedCache_test.cpp
@@ -42,7 +42,7 @@ public:
     {
         using namespace std::chrono_literals;
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("TaggedCache_test", kFatal, *this);
+        test::SuiteJournal journal ("TaggedCache_test", *this);
 
         TestStopwatch clock;
         clock.set (0);
@@ -51,7 +51,7 @@ public:
         using Value = std::string;
         using Cache = TaggedCache <Key, Value>;
 
-        Cache c ("test", 1, 1s, clock, beast::Journal (sink));
+        Cache c ("test", 1, 1s, clock, journal);
 
         // Insert an item, retrieve it, and age it so it gets purged.
         {

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -21,6 +21,7 @@
 #include <ripple/consensus/Consensus.h>
 #include <ripple/consensus/ConsensusProposal.h>
 #include <test/csf.h>
+#include <test/jtx/Env.h>
 #include <utility>
 
 namespace ripple {
@@ -36,36 +37,36 @@ public:
 
         // Use default parameters
         ConsensusParms const p{};
-        beast::Journal j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
         // Bizarre times forcibly close
         BEAST_EXPECT(
-            shouldCloseLedger(true, 10, 10, 10, -10s, 10s, 1s, 1s, p, j));
+            shouldCloseLedger(true, 10, 10, 10, -10s, 10s, 1s, 1s, p, env.journal));
         BEAST_EXPECT(
-            shouldCloseLedger(true, 10, 10, 10, 100h, 10s, 1s, 1s, p, j));
+            shouldCloseLedger(true, 10, 10, 10, 100h, 10s, 1s, 1s, p, env.journal));
         BEAST_EXPECT(
-            shouldCloseLedger(true, 10, 10, 10, 10s, 100h, 1s, 1s, p, j));
+            shouldCloseLedger(true, 10, 10, 10, 10s, 100h, 1s, 1s, p, env.journal));
 
         // Rest of network has closed
         BEAST_EXPECT(
-            shouldCloseLedger(true, 10, 3, 5, 10s, 10s, 10s, 10s, p, j));
+            shouldCloseLedger(true, 10, 3, 5, 10s, 10s, 10s, 10s, p, env.journal));
 
         // No transactions means wait until end of internval
         BEAST_EXPECT(
-            !shouldCloseLedger(false, 10, 0, 0, 1s, 1s, 1s, 10s, p, j));
+            !shouldCloseLedger(false, 10, 0, 0, 1s, 1s, 1s, 10s, p, env.journal));
         BEAST_EXPECT(
-            shouldCloseLedger(false, 10, 0, 0, 1s, 10s, 1s, 10s, p, j));
+            shouldCloseLedger(false, 10, 0, 0, 1s, 10s, 1s, 10s, p, env.journal));
 
         // Enforce minimum ledger open time
         BEAST_EXPECT(
-            !shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 1s, 10s, p, j));
+            !shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 1s, 10s, p, env.journal));
 
         // Don't go too much faster than last time
         BEAST_EXPECT(
-            !shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 3s, 10s, p, j));
+            !shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 3s, 10s, p, env.journal));
 
         BEAST_EXPECT(
-            shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 10s, 10s, p, j));
+            shouldCloseLedger(true, 10, 0, 0, 10s, 10s, 10s, 10s, p, env.journal));
     }
 
     void
@@ -75,39 +76,39 @@ public:
 
         // Use default parameterss
         ConsensusParms const p{};
-        beast::Journal j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
         // Not enough time has elapsed
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 2, 0, 3s, 2s, p, true, j));
+            checkConsensus(10, 2, 2, 0, 3s, 2s, p, true, env.journal));
 
         // If not enough peers have propsed, ensure
         // more time for proposals
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 2, 0, 3s, 4s, p, true, j));
+            checkConsensus(10, 2, 2, 0, 3s, 4s, p, true, env.journal));
 
         // Enough time has elapsed and we all agree
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(10, 2, 2, 0, 3s, 10s, p, true, j));
+            checkConsensus(10, 2, 2, 0, 3s, 10s, p, true, env.journal));
 
         // Enough time has elapsed and we don't yet agree
         BEAST_EXPECT(
             ConsensusState::No ==
-            checkConsensus(10, 2, 1, 0, 3s, 10s, p, true, j));
+            checkConsensus(10, 2, 1, 0, 3s, 10s, p, true, env.journal));
 
         // Our peers have moved on
         // Enough time has elapsed and we all agree
         BEAST_EXPECT(
             ConsensusState::MovedOn ==
-            checkConsensus(10, 2, 1, 8, 3s, 10s, p, true, j));
+            checkConsensus(10, 2, 1, 8, 3s, 10s, p, true, env.journal));
 
         // No peers makes it easy to agree
         BEAST_EXPECT(
             ConsensusState::Yes ==
-            checkConsensus(0, 0, 0, 0, 3s, 10s, p, true, j));
+            checkConsensus(0, 0, 0, 0, 3s, 10s, p, true, env.journal));
     }
 
     void

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -21,7 +21,7 @@
 #include <ripple/consensus/Consensus.h>
 #include <ripple/consensus/ConsensusProposal.h>
 #include <test/csf.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <utility>
 
 namespace ripple {

--- a/src/test/consensus/Consensus_test.cpp
+++ b/src/test/consensus/Consensus_test.cpp
@@ -29,13 +29,11 @@ namespace test {
 
 class Consensus_test : public beast::unit_test::suite
 {
-    SuiteJournalSink sink_;
-    beast::Journal journal_;
+    SuiteJournal journal_;
 
 public:
     Consensus_test ()
-    : sink_ ("Consensus_test", beast::severities::kFatal, *this)
-    , journal_ (sink_)
+    : journal_ ("Consensus_test", *this)
     { }
 
     void

--- a/src/test/consensus/LedgerTiming_test.cpp
+++ b/src/test/consensus/LedgerTiming_test.cpp
@@ -24,8 +24,6 @@ namespace test {
 
 class LedgerTiming_test : public beast::unit_test::suite
 {
-    beast::Journal j;
-
     void testGetNextLedgerTimeResolution()
     {
         // helper to iteratively call into getNextLedgerTimeResolution

--- a/src/test/consensus/LedgerTrie_test.cpp
+++ b/src/test/consensus/LedgerTrie_test.cpp
@@ -27,9 +27,6 @@ namespace test {
 
 class LedgerTrie_test : public beast::unit_test::suite
 {
-    beast::Journal j;
-
-
     void
     testInsert()
     {

--- a/src/test/core/Stoppable_test.cpp
+++ b/src/test/core/Stoppable_test.cpp
@@ -400,8 +400,7 @@ class Stoppable_test
         B b_;
         C c_;
         Stoppable_test& test_;
-        SuiteJournalSink sink_;
-        beast::Journal journal_;
+        SuiteJournal journal_;
 
     public:
         explicit Root(Stoppable_test& test)
@@ -410,8 +409,7 @@ class Stoppable_test
             , b_(*this, test)
             , c_(*this, test)
             , test_(test)
-            , sink_("Stoppable_test", beast::severities::kFatal, test)
-            , journal_(sink_)
+            , journal_("Stoppable_test", test)
         {}
 
         void run()

--- a/src/test/core/Stoppable_test.cpp
+++ b/src/test/core/Stoppable_test.cpp
@@ -19,7 +19,7 @@
 
 #include <ripple/core/Stoppable.h>
 #include <ripple/beast/unit_test.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <thread>
 
 namespace ripple {

--- a/src/test/core/Stoppable_test.cpp
+++ b/src/test/core/Stoppable_test.cpp
@@ -19,7 +19,7 @@
 
 #include <ripple/core/Stoppable.h>
 #include <ripple/beast/unit_test.h>
-#include <test/jtx/Env.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <thread>
 
 namespace ripple {
@@ -400,7 +400,8 @@ class Stoppable_test
         B b_;
         C c_;
         Stoppable_test& test_;
-        jtx::Env env_;  // Used only for its Journal
+        SuiteJournalSink sink_;
+        beast::Journal journal_;
 
     public:
         explicit Root(Stoppable_test& test)
@@ -409,14 +410,15 @@ class Stoppable_test
             , b_(*this, test)
             , c_(*this, test)
             , test_(test)
-            , env_(test)
+            , sink_("Stoppable_test", beast::severities::kFatal, test)
+            , journal_(sink_)
         {}
 
         void run()
         {
             prepare();
             start();
-            stop (env_.journal);
+            stop (journal_);
         }
 
         void onPrepare() override
@@ -445,7 +447,7 @@ class Stoppable_test
         {
             // Calling stop() a second time should have no negative
             // consequences.
-            stop (env_.journal);
+            stop (journal_);
         }
     };
 

--- a/src/test/core/Stoppable_test.cpp
+++ b/src/test/core/Stoppable_test.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/core/Stoppable.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx/Env.h>
 #include <thread>
 
 namespace ripple {
@@ -399,6 +400,8 @@ class Stoppable_test
         B b_;
         C c_;
         Stoppable_test& test_;
+        jtx::Env env_;  // Used only for its Journal
+
     public:
         explicit Root(Stoppable_test& test)
             : RootStoppable("R")
@@ -406,13 +409,14 @@ class Stoppable_test
             , b_(*this, test)
             , c_(*this, test)
             , test_(test)
+            , env_(test)
         {}
 
         void run()
         {
             prepare();
             start();
-            stop({});
+            stop (env_.journal);
         }
 
         void onPrepare() override
@@ -441,7 +445,7 @@ class Stoppable_test
         {
             // Calling stop() a second time should have no negative
             // consequences.
-            stop({});
+            stop (env_.journal);
         }
     };
 

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -28,7 +28,7 @@
 #include <test/jtx/tags.h>
 #include <test/jtx/AbstractClient.h>
 #include <test/jtx/ManualTimeKeeper.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/ledger/OpenLedger.h>

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -142,15 +142,12 @@ class Env
 public:
     beast::unit_test::suite& test;
 
-    beast::Journal const journal;
-
     Account const& master = Account::master;
 
 private:
     struct AppBundle
     {
         Application* app;
-        std::unique_ptr<Logs> logs;
         std::unique_ptr<Application> owned;
         ManualTimeKeeper* timeKeeper;
         std::thread thread;
@@ -165,6 +162,8 @@ private:
     AppBundle bundle_;
 
 public:
+    beast::Journal const journal;
+
     Env() = delete;
     Env& operator= (Env const&) = delete;
     Env (Env const&) = delete;
@@ -192,6 +191,7 @@ public:
             suite_,
             std::move(config),
             logs ? std::move(logs) : std::make_unique<SuiteLogs>(suite_))
+        , journal {bundle_.app->journal ("Env")}
     {
         memoize(Account::master);
         Pathfinder::initPathTable();

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -28,6 +28,7 @@
 #include <test/jtx/tags.h>
 #include <test/jtx/AbstractClient.h>
 #include <test/jtx/ManualTimeKeeper.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <ripple/app/main/Application.h>
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/ledger/OpenLedger.h>
@@ -45,7 +46,6 @@
 #include <ripple/protocol/STObject.h>
 #include <ripple/protocol/STTx.h>
 #include <boost/beast/core/detail/type_traits.hpp>
-#include <ripple/beast/unit_test.h>
 #include <functional>
 #include <string>
 #include <tuple>
@@ -87,30 +87,7 @@ supported_amendments()
     return ids;
 }
 
-class SuiteSink : public beast::Journal::Sink
-{
-    std::string partition_;
-    beast::unit_test::suite& suite_;
-
-public:
-    SuiteSink(std::string const& partition,
-            beast::severities::Severity threshold,
-            beast::unit_test::suite& suite)
-        : Sink (threshold, false)
-        , partition_(partition + " ")
-        , suite_ (suite)
-    {
-    }
-
-    // For unit testing, always generate logging text.
-    inline bool active(beast::severities::Severity level) const override
-    {
-        return true;
-    }
-
-    void
-    write(beast::severities::Severity level, std::string const& text) override;
-};
+//------------------------------------------------------------------------------
 
 class SuiteLogs : public Logs
 {
@@ -130,7 +107,8 @@ public:
     makeSink(std::string const& partition,
         beast::severities::Severity threshold) override
     {
-        return std::make_unique<SuiteSink>(partition, threshold, suite_);
+        return std::make_unique<SuiteJournalSink>(
+            partition, threshold, suite_);
     }
 };
 

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -54,27 +54,6 @@ namespace ripple {
 namespace test {
 namespace jtx {
 
-void
-SuiteSink::write(beast::severities::Severity level, std::string const& text)
-{
-    using namespace beast::severities;
-    std::string s;
-    switch(level)
-    {
-    case kTrace:    s = "TRC:"; break;
-    case kDebug:    s = "DBG:"; break;
-    case kInfo:     s = "INF:"; break;
-    case kWarning:  s = "WRN:"; break;
-    case kError:    s = "ERR:"; break;
-    default:
-    case kFatal:    s = "FTL:"; break;
-    }
-
-    // Only write the string if the level at least equals the threshold.
-    if (level >= threshold())
-        suite_.log << s << partition_ << text << std::endl;
-}
-
 //------------------------------------------------------------------------------
 
 Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
@@ -83,7 +62,8 @@ Env::AppBundle::AppBundle(beast::unit_test::suite& suite,
 {
     using namespace beast::severities;
     // Use kFatal threshold to reduce noise from STObject.
-    setDebugLogSink (std::make_unique<SuiteSink>("Debug", kFatal, suite));
+    setDebugLogSink (std::make_unique<SuiteJournalSink>(
+        "Debug", kFatal, suite));
     auto timeKeeper_ =
         std::make_unique<ManualTimeKeeper>();
     timeKeeper = timeKeeper_.get();

--- a/src/test/ledger/PaymentSandbox_test.cpp
+++ b/src/test/ledger/PaymentSandbox_test.cpp
@@ -297,13 +297,11 @@ class PaymentSandbox_test : public beast::unit_test::suite
         testcase ("Reserve");
         using namespace jtx;
 
-        beast::Journal dj;
-
-        auto accountFundsXRP = [&dj](
-            ReadView const& view, AccountID const& id) -> XRPAmount
+        auto accountFundsXRP = [](ReadView const& view,
+            AccountID const& id, beast::Journal j) -> XRPAmount
         {
             return toAmount<XRPAmount> (accountHolds (
-                view, id, xrpCurrency (), xrpAccount (), fhZERO_IF_FROZEN, dj));
+                view, id, xrpCurrency (), xrpAccount (), fhZERO_IF_FROZEN, j));
         };
 
         auto reserve = [](jtx::Env& env, std::uint32_t count) -> XRPAmount
@@ -326,9 +324,10 @@ class PaymentSandbox_test : public beast::unit_test::suite
             // to drop below the reserve. Make sure her funds are zero (there was a bug that
             // caused her funds to become negative).
 
-            accountSend (sb, xrpAccount (), alice, XRP(100), dj);
-            accountSend (sb, alice, xrpAccount (), XRP(100), dj);
-            BEAST_EXPECT(accountFundsXRP (sb, alice) == beast::zero);
+            accountSend (sb, xrpAccount (), alice, XRP(100), env.journal);
+            accountSend (sb, alice, xrpAccount (), XRP(100), env.journal);
+            BEAST_EXPECT(
+                accountFundsXRP (sb, alice, env.journal) == beast::zero);
         }
     }
 

--- a/src/test/ledger/SkipList_test.cpp
+++ b/src/test/ledger/SkipList_test.cpp
@@ -20,8 +20,8 @@
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/basics/Log.h>
 #include <ripple/ledger/View.h>
-#include <test/jtx.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx.h>
 
 namespace ripple {
 namespace test {
@@ -31,10 +31,9 @@ class SkipList_test : public beast::unit_test::suite
     void
     testSkipList()
     {
-        beast::Journal const j;
+        jtx::Env env(*this);
         std::vector<std::shared_ptr<Ledger>> history;
         {
-            jtx::Env env(*this);
             Config config;
             auto prev = std::make_shared<Ledger>(
                 create_genesis, config,
@@ -56,13 +55,13 @@ class SkipList_test : public beast::unit_test::suite
             BEAST_EXPECT((*std::begin(history))->info().seq <
                 l->info().seq);
             BEAST_EXPECT(hashOfSeq(*l, l->info().seq + 1,
-                j) == boost::none);
+                env.journal) == boost::none);
             BEAST_EXPECT(hashOfSeq(*l, l->info().seq,
-                j) == l->info().hash);
+                env.journal) == l->info().hash);
             BEAST_EXPECT(hashOfSeq(*l, l->info().seq - 1,
-                j) == l->info().parentHash);
+                env.journal) == l->info().parentHash);
             BEAST_EXPECT(hashOfSeq(*history.back(),
-                l->info().seq, j) == boost::none);
+                l->info().seq, env.journal) == boost::none);
         }
 
         // ledger skip lists store up to the previous 256 hashes
@@ -75,13 +74,13 @@ class SkipList_test : public beast::unit_test::suite
                 ++n)
             {
                 BEAST_EXPECT(hashOfSeq(**i,
-                    (*n)->info().seq, j) ==
+                    (*n)->info().seq, env.journal) ==
                         (*n)->info().hash);
             }
 
             // edge case accessing beyond 256
             BEAST_EXPECT(hashOfSeq(**i,
-                (*i)->info().seq - 258, j) ==
+                (*i)->info().seq - 258, env.journal) ==
                     boost::none);
         }
 
@@ -95,7 +94,7 @@ class SkipList_test : public beast::unit_test::suite
                 n += 256)
             {
                 BEAST_EXPECT(hashOfSeq(**i,
-                    (*n)->info().seq, j) ==
+                    (*n)->info().seq, env.journal) ==
                         (*n)->info().hash);
             }
         }

--- a/src/test/nodestore/Backend_test.cpp
+++ b/src/test/nodestore/Backend_test.cpp
@@ -22,7 +22,7 @@
 #include <ripple/nodestore/Manager.h>
 #include <ripple/beast/utility/temp_dir.h>
 #include <test/nodestore/TestBase.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <algorithm>
 
 namespace ripple {

--- a/src/test/nodestore/Backend_test.cpp
+++ b/src/test/nodestore/Backend_test.cpp
@@ -18,10 +18,11 @@
 //==============================================================================
 
 #include <ripple/unity/rocksdb.h>
-#include <test/nodestore/TestBase.h>
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/beast/utility/temp_dir.h>
+#include <test/jtx/Env.h>
+#include <test/nodestore/TestBase.h>
 #include <algorithm>
 
 namespace ripple {
@@ -52,12 +53,13 @@ public:
         auto batch = createPredictableBatch (
             numObjectsToTest, rng());
 
-        beast::Journal j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
         {
             // Open the backend
             std::unique_ptr <Backend> backend =
-                Manager::instance().make_Backend (params, scheduler, j);
+                Manager::instance().make_Backend (
+                    params, scheduler, env.journal);
             backend->open();
 
             // Write the batch
@@ -85,7 +87,7 @@ public:
         {
             // Re-open the backend
             std::unique_ptr <Backend> backend = Manager::instance().make_Backend (
-                params, scheduler, j);
+                params, scheduler, env.journal);
             backend->open();
 
             // Read it back in

--- a/src/test/nodestore/Backend_test.cpp
+++ b/src/test/nodestore/Backend_test.cpp
@@ -21,8 +21,8 @@
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/beast/utility/temp_dir.h>
-#include <test/jtx/Env.h>
 #include <test/nodestore/TestBase.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <algorithm>
 
 namespace ripple {
@@ -53,13 +53,15 @@ public:
         auto batch = createPredictableBatch (
             numObjectsToTest, rng());
 
-        test::jtx::Env env (*this);  // Used only for its Journal.
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("Backend_test", kFatal, *this);
+        beast::Journal journal (sink);
 
         {
             // Open the backend
             std::unique_ptr <Backend> backend =
                 Manager::instance().make_Backend (
-                    params, scheduler, env.journal);
+                    params, scheduler, journal);
             backend->open();
 
             // Write the batch
@@ -87,7 +89,7 @@ public:
         {
             // Re-open the backend
             std::unique_ptr <Backend> backend = Manager::instance().make_Backend (
-                params, scheduler, env.journal);
+                params, scheduler, journal);
             backend->open();
 
             // Read it back in

--- a/src/test/nodestore/Backend_test.cpp
+++ b/src/test/nodestore/Backend_test.cpp
@@ -54,8 +54,7 @@ public:
             numObjectsToTest, rng());
 
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("Backend_test", kFatal, *this);
-        beast::Journal journal (sink);
+        test::SuiteJournal journal ("Backend_test", *this);
 
         {
             // Open the backend

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -21,6 +21,7 @@
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/beast/utility/temp_dir.h>
+#include <test/jtx/Env.h>
 
 namespace ripple {
 namespace NodeStore {
@@ -43,12 +44,12 @@ public:
         auto batch = createPredictableBatch (
             numObjectsToTest, seedValue);
 
-        beast::Journal j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
         // Write to source db
         {
             std::unique_ptr <Database> src = Manager::instance().make_Database (
-                "test", scheduler, 2, parent, srcParams, j);
+                "test", scheduler, 2, parent, srcParams, env.journal);
             storeBatch (*src, batch);
         }
 
@@ -57,7 +58,7 @@ public:
         {
             // Re-open the db
             std::unique_ptr <Database> src = Manager::instance().make_Database (
-                "test", scheduler, 2, parent, srcParams, j);
+                "test", scheduler, 2, parent, srcParams, env.journal);
 
             // Set up the destination database
             beast::temp_dir dest_db;
@@ -66,7 +67,7 @@ public:
             destParams.set ("path", dest_db.path());
 
             std::unique_ptr <Database> dest = Manager::instance().make_Database (
-                "test", scheduler, 2, parent, destParams, j);
+                "test", scheduler, 2, parent, destParams, env.journal);
 
             testcase ("import into '" + destBackendType +
                 "' from '" + srcBackendType + "'");
@@ -109,12 +110,12 @@ public:
         auto batch = createPredictableBatch (
             numObjectsToTest, rng());
 
-        beast::Journal j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
         {
             // Open the database
             std::unique_ptr <Database> db = Manager::instance().make_Database (
-                "test", scheduler, 2, parent, nodeParams, j);
+                "test", scheduler, 2, parent, nodeParams, env.journal);
 
             // Write the batch
             storeBatch (*db, batch);
@@ -142,7 +143,7 @@ public:
         {
             // Re-open the database without the ephemeral DB
             std::unique_ptr <Database> db = Manager::instance().make_Database (
-                "test", scheduler, 2, parent, nodeParams, j);
+                "test", scheduler, 2, parent, nodeParams, env.journal);
 
             // Read it back in
             Batch copy;
@@ -161,7 +162,7 @@ public:
                 // Verify default earliest ledger sequence
                 std::unique_ptr<Database> db =
                     Manager::instance().make_Database(
-                        "test", scheduler, 2, parent, nodeParams, j);
+                        "test", scheduler, 2, parent, nodeParams, env.journal);
                 BEAST_EXPECT(db->earliestSeq() == XRP_LEDGER_EARLIEST_SEQ);
             }
 
@@ -171,7 +172,7 @@ public:
                 nodeParams.set("earliest_seq", "0");
                 std::unique_ptr<Database> db =
                     Manager::instance().make_Database(
-                        "test", scheduler, 2, parent, nodeParams, j);
+                        "test", scheduler, 2, parent, nodeParams, env.journal);
             }
             catch (std::runtime_error const& e)
             {
@@ -184,7 +185,7 @@ public:
                 nodeParams.set("earliest_seq", "1");
                 std::unique_ptr<Database> db =
                     Manager::instance().make_Database(
-                        "test", scheduler, 2, parent, nodeParams, j);
+                        "test", scheduler, 2, parent, nodeParams, env.journal);
 
                 // Verify database uses the earliest ledger sequence setting
                 BEAST_EXPECT(db->earliestSeq() == 1);
@@ -199,7 +200,7 @@ public:
                     std::to_string(XRP_LEDGER_EARLIEST_SEQ));
                 std::unique_ptr<Database> db2 =
                     Manager::instance().make_Database(
-                        "test", scheduler, 2, parent, nodeParams, j);
+                        "test", scheduler, 2, parent, nodeParams, env.journal);
             }
             catch (std::runtime_error const& e)
             {

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -28,13 +28,11 @@ namespace NodeStore {
 
 class Database_test : public TestBase
 {
-    test::SuiteJournalSink sink_;
-    beast::Journal journal_;
+    test::SuiteJournal journal_;
 
 public:
     Database_test ()
-    : sink_ ("Database_test", beast::severities::kFatal, *this)
-    , journal_ (sink_)
+    : journal_ ("Database_test", *this)
     { }
 
     void testImport (std::string const& destBackendType,

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -21,7 +21,7 @@
 #include <ripple/nodestore/DummyScheduler.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/beast/utility/temp_dir.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace NodeStore {

--- a/src/test/nodestore/Timing_test.cpp
+++ b/src/test/nodestore/Timing_test.cpp
@@ -25,9 +25,9 @@
 #include <ripple/beast/utility/temp_dir.h>
 #include <ripple/beast/xor_shift_engine.h>
 #include <ripple/beast/unit_test.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <beast/unit_test/thread.hpp>
 #include <boost/algorithm/string.hpp>
-#include <test/jtx/Env.h>
 #include <atomic>
 #include <chrono>
 #include <iterator>
@@ -677,7 +677,9 @@ public:
             log << ss.str() << std::endl;
         }
 
-        test::jtx::Env env (*this);  // Used only for its Journal
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("Timing_test", kFatal, *this);
+        beast::Journal journal (sink);
 
         for (auto const& config_string : config_strings)
         {
@@ -694,7 +696,7 @@ public:
                     get(config, "type", std::string()) << std::right;
                 for (auto const& test : tests)
                     ss << " " << setw(w) << to_string(
-                        do_test (test.second, config, params, env.journal));
+                        do_test (test.second, config, params, journal));
                 ss << "   " << to_string(config);
                 log << ss.str() << std::endl;
             }

--- a/src/test/nodestore/Timing_test.cpp
+++ b/src/test/nodestore/Timing_test.cpp
@@ -25,7 +25,7 @@
 #include <ripple/beast/utility/temp_dir.h>
 #include <ripple/beast/xor_shift_engine.h>
 #include <ripple/beast/unit_test.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <beast/unit_test/thread.hpp>
 #include <boost/algorithm/string.hpp>
 #include <atomic>

--- a/src/test/nodestore/Timing_test.cpp
+++ b/src/test/nodestore/Timing_test.cpp
@@ -678,8 +678,7 @@ public:
         }
 
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("Timing_test", kFatal, *this);
-        beast::Journal journal (sink);
+        test::SuiteJournal journal ("Timing_test", *this);
 
         for (auto const& config_string : config_strings)
         {

--- a/src/test/overlay/cluster_test.cpp
+++ b/src/test/overlay/cluster_test.cpp
@@ -29,13 +29,11 @@ namespace tests {
 
 class cluster_test : public ripple::TestSuite
 {
-    test::SuiteJournalSink sink_;
-    beast::Journal journal_;
+    test::SuiteJournal journal_;
 
 public:
     cluster_test ()
-    : sink_ ("cluster_test", beast::severities::kFatal, *this)
-    , journal_ (sink_)
+    : journal_ ("cluster_test", *this)
     { }
 
     std::unique_ptr<Cluster>

--- a/src/test/overlay/cluster_test.cpp
+++ b/src/test/overlay/cluster_test.cpp
@@ -22,24 +22,26 @@
 #include <ripple/overlay/ClusterNode.h>
 #include <ripple/protocol/SecretKey.h>
 #include <test/jtx/TestSuite.h>
-#include <test/jtx/Env.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 namespace ripple {
 namespace tests {
 
 class cluster_test : public ripple::TestSuite
 {
-    test::jtx::Env env_;  // Used only for its Journal.
+    test::SuiteJournalSink sink_;
+    beast::Journal journal_;
 
 public:
     cluster_test ()
-    : env_ (*this)
+    : sink_ ("cluster_test", beast::severities::kFatal, *this)
+    , journal_ (sink_)
     { }
 
     std::unique_ptr<Cluster>
     create (std::vector<PublicKey> const& nodes)
     {
-        auto cluster = std::make_unique <Cluster> (env_.journal);
+        auto cluster = std::make_unique <Cluster> (journal_);
 
         for (auto const& n : nodes)
             cluster->update (n, "Test");
@@ -195,7 +197,7 @@ public:
     {
         testcase ("Config Load");
 
-        auto c = std::make_unique <Cluster> (env_.journal);
+        auto c = std::make_unique <Cluster> (journal_);
 
         // The servers on the network
         std::vector<PublicKey> network;

--- a/src/test/overlay/cluster_test.cpp
+++ b/src/test/overlay/cluster_test.cpp
@@ -22,7 +22,7 @@
 #include <ripple/overlay/ClusterNode.h>
 #include <ripple/protocol/SecretKey.h>
 #include <test/jtx/TestSuite.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace tests {

--- a/src/test/overlay/cluster_test.cpp
+++ b/src/test/overlay/cluster_test.cpp
@@ -18,21 +18,28 @@
 //==============================================================================
 
 #include <ripple/basics/BasicConfig.h>
-#include <test/jtx/TestSuite.h>
 #include <ripple/overlay/Cluster.h>
 #include <ripple/overlay/ClusterNode.h>
 #include <ripple/protocol/SecretKey.h>
+#include <test/jtx/TestSuite.h>
+#include <test/jtx/Env.h>
 
 namespace ripple {
 namespace tests {
 
 class cluster_test : public ripple::TestSuite
 {
+    test::jtx::Env env_;  // Used only for its Journal.
+
 public:
+    cluster_test ()
+    : env_ (*this)
+    { }
+
     std::unique_ptr<Cluster>
     create (std::vector<PublicKey> const& nodes)
     {
-        auto cluster = std::make_unique <Cluster> (beast::Journal ());
+        auto cluster = std::make_unique <Cluster> (env_.journal);
 
         for (auto const& n : nodes)
             cluster->update (n, "Test");
@@ -188,7 +195,7 @@ public:
     {
         testcase ("Config Load");
 
-        auto c = std::make_unique <Cluster> (beast::Journal ());
+        auto c = std::make_unique <Cluster> (env_.journal);
 
         // The servers on the network
         std::vector<PublicKey> network;

--- a/src/test/peerfinder/Livecache_test.cpp
+++ b/src/test/peerfinder/Livecache_test.cpp
@@ -22,6 +22,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/clock/manual_clock.h>
 #include <test/beast/IPEndpointCommon.h>
+#include <test/jtx/Env.h>
 #include <boost/algorithm/string.hpp>
 
 namespace ripple {
@@ -37,6 +38,11 @@ class Livecache_test : public beast::unit_test::suite
 {
 public:
     TestStopwatch m_clock;
+    test::jtx::Env env_;  // Used only for its Journal.
+
+    Livecache_test()
+    : env_ (*this)
+    { }
 
     // Add the address as an endpoint
     template <class C>
@@ -49,7 +55,7 @@ public:
     void testBasicInsert ()
     {
         testcase ("Basic Insert");
-        Livecache <> c (m_clock, beast::Journal());
+        Livecache <> c (m_clock, env_.journal);
         BEAST_EXPECT(c.empty());
 
         for (auto i = 0; i < 10; ++i)
@@ -68,7 +74,7 @@ public:
     void testInsertUpdate ()
     {
         testcase ("Insert/Update");
-        Livecache <> c (m_clock, beast::Journal());
+        Livecache <> c (m_clock, env_.journal);
 
         auto ep1 = Endpoint {beast::IP::randomEP(), 2};
         c.insert(ep1);
@@ -101,7 +107,7 @@ public:
     {
         testcase ("Expire");
         using namespace std::chrono_literals;
-        Livecache <> c (m_clock, beast::Journal());
+        Livecache <> c (m_clock, env_.journal);
 
         auto ep1 = Endpoint {beast::IP::randomEP(), 1};
         c.insert(ep1);
@@ -123,7 +129,7 @@ public:
     {
         testcase ("Histogram");
         constexpr auto num_eps = 40;
-        Livecache <> c (m_clock, beast::Journal());
+        Livecache <> c (m_clock, env_.journal);
         for (auto i = 0; i < num_eps; ++i)
             add(
                 beast::IP::randomEP(true),
@@ -148,7 +154,7 @@ public:
     void testShuffle ()
     {
         testcase ("Shuffle");
-        Livecache <> c (m_clock, beast::Journal());
+        Livecache <> c (m_clock, env_.journal);
         for (auto i = 0; i < 100; ++i)
             add(
                 beast::IP::randomEP(true),

--- a/src/test/peerfinder/Livecache_test.cpp
+++ b/src/test/peerfinder/Livecache_test.cpp
@@ -37,13 +37,11 @@ bool operator== (Endpoint const& a, Endpoint const& b)
 class Livecache_test : public beast::unit_test::suite
 {
     TestStopwatch clock_;
-    test::SuiteJournalSink sink_;
-    beast::Journal journal_;
+    test::SuiteJournal journal_;
 
 public:
     Livecache_test()
-    : sink_ ("Livecache_test", beast::severities::kFatal, *this)
-    , journal_ (sink_)
+    : journal_ ("Livecache_test", *this)
     { }
 
     // Add the address as an endpoint

--- a/src/test/peerfinder/Livecache_test.cpp
+++ b/src/test/peerfinder/Livecache_test.cpp
@@ -22,7 +22,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/clock/manual_clock.h>
 #include <test/beast/IPEndpointCommon.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <boost/algorithm/string.hpp>
 
 namespace ripple {

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -23,6 +23,7 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/peerfinder/impl/Logic.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx/Env.h>
 
 namespace ripple {
 namespace PeerFinder {
@@ -30,6 +31,12 @@ namespace PeerFinder {
 class Logic_test : public beast::unit_test::suite
 {
 public:
+    test::jtx::Env env_;  // Used only for its Journal.
+
+    Logic_test()
+    : env_ (*this)
+    { }
+
     struct TestStore : Store
     {
         std::size_t
@@ -74,7 +81,7 @@ public:
         TestStore store;
         TestChecker checker;
         TestStopwatch clock;
-        Logic<TestChecker> logic (clock, store, checker, beast::Journal{});
+        Logic<TestChecker> logic (clock, store, checker, env_.journal);
         logic.addFixedPeer ("test",
             beast::IP::Endpoint::from_string("65.0.0.1:5"));
         {
@@ -112,7 +119,7 @@ public:
         TestStore store;
         TestChecker checker;
         TestStopwatch clock;
-        Logic<TestChecker> logic (clock, store, checker, beast::Journal{});
+        Logic<TestChecker> logic (clock, store, checker, env_.journal);
         logic.addFixedPeer ("test",
             beast::IP::Endpoint::from_string("65.0.0.1:5"));
         {

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -23,7 +23,7 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/peerfinder/impl/Logic.h>
 #include <ripple/beast/unit_test.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace PeerFinder {

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -30,13 +30,11 @@ namespace PeerFinder {
 
 class PeerFinder_test : public beast::unit_test::suite
 {
-    test::SuiteJournalSink sink_;
-    beast::Journal journal_;
+    test::SuiteJournal journal_;
 
 public:
     PeerFinder_test()
-    : sink_ ("PeerFinder_test", beast::severities::kFatal, *this)
-    , journal_ (sink_)
+    : journal_ ("PeerFinder_test", *this)
     { }
 
     struct TestStore : Store

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -23,18 +23,20 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/peerfinder/impl/Logic.h>
 #include <ripple/beast/unit_test.h>
-#include <test/jtx/Env.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 namespace ripple {
 namespace PeerFinder {
 
-class Logic_test : public beast::unit_test::suite
+class PeerFinder_test : public beast::unit_test::suite
 {
-public:
-    test::jtx::Env env_;  // Used only for its Journal.
+    test::SuiteJournalSink sink_;
+    beast::Journal journal_;
 
-    Logic_test()
-    : env_ (*this)
+public:
+    PeerFinder_test()
+    : sink_ ("PeerFinder_test", beast::severities::kFatal, *this)
+    , journal_ (sink_)
     { }
 
     struct TestStore : Store
@@ -81,7 +83,7 @@ public:
         TestStore store;
         TestChecker checker;
         TestStopwatch clock;
-        Logic<TestChecker> logic (clock, store, checker, env_.journal);
+        Logic<TestChecker> logic (clock, store, checker, journal_);
         logic.addFixedPeer ("test",
             beast::IP::Endpoint::from_string("65.0.0.1:5"));
         {
@@ -119,7 +121,7 @@ public:
         TestStore store;
         TestChecker checker;
         TestStopwatch clock;
-        Logic<TestChecker> logic (clock, store, checker, env_.journal);
+        Logic<TestChecker> logic (clock, store, checker, journal_);
         logic.addFixedPeer ("test",
             beast::IP::Endpoint::from_string("65.0.0.1:5"));
         {
@@ -163,7 +165,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(Logic,PeerFinder,ripple);
+BEAST_DEFINE_TESTSUITE(PeerFinder,PeerFinder,ripple);
 
 }
 }

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -248,8 +248,7 @@ public:
     void run() override
     {
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("ResourceManager_test", kFatal, *this);
-        beast::Journal journal (sink);
+        test::SuiteJournal journal ("ResourceManager_test", *this);
 
         testDrop (journal);
         testCharges (journal);

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -20,11 +20,12 @@
 #include <ripple/basics/chrono.h>
 #include <ripple/basics/random.h>
 #include <ripple/beast/unit_test.h>
-#include <boost/utility/base_from_member.hpp>
 #include <ripple/resource/Consumer.h>
 #include <ripple/resource/impl/Entry.h>
 #include <ripple/resource/impl/Logic.h>
+#include <test/jtx/Env.h>
 
+#include <boost/utility/base_from_member.hpp>
 
 
 namespace ripple {
@@ -246,12 +247,12 @@ public:
 
     void run() override
     {
-        beast::Journal j;
+        test::jtx::Env env (*this);  // Used only for its Journal.
 
-        testDrop (j);
-        testCharges (j);
-        testImports (j);
-        testImport (j);
+        testDrop (env.journal);
+        testCharges (env.journal);
+        testImports (env.journal);
+        testImport (env.journal);
     }
 };
 

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -23,7 +23,7 @@
 #include <ripple/resource/Consumer.h>
 #include <ripple/resource/impl/Entry.h>
 #include <ripple/resource/impl/Logic.h>
-#include <test/jtx/Env.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 #include <boost/utility/base_from_member.hpp>
 
@@ -31,7 +31,7 @@
 namespace ripple {
 namespace Resource {
 
-class Manager_test : public beast::unit_test::suite
+class ResourceManager_test : public beast::unit_test::suite
 {
 public:
     class TestLogic
@@ -247,16 +247,18 @@ public:
 
     void run() override
     {
-        test::jtx::Env env (*this);  // Used only for its Journal.
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("ResourceManager_test", kFatal, *this);
+        beast::Journal journal (sink);
 
-        testDrop (env.journal);
-        testCharges (env.journal);
-        testImports (env.journal);
-        testImport (env.journal);
+        testDrop (journal);
+        testCharges (journal);
+        testImports (journal);
+        testImport (journal);
     }
 };
 
-BEAST_DEFINE_TESTSUITE(Manager,resource,ripple);
+BEAST_DEFINE_TESTSUITE(ResourceManager,resource,ripple);
 
 }
 }

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -23,7 +23,7 @@
 #include <ripple/resource/Consumer.h>
 #include <ripple/resource/impl/Entry.h>
 #include <ripple/resource/impl/Logic.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 #include <boost/utility/base_from_member.hpp>
 

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -347,8 +347,7 @@ public:
         };
 
         using namespace beast::severities;
-        SuiteJournalSink sink ("Server_test", kFatal, *this);
-        beast::Journal journal (sink);
+        SuiteJournal journal ("Server_test", *this);
 
         NullHandler h;
         for(int i = 0; i < 1000; ++i)

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -25,7 +25,7 @@
 #include <ripple/core/ConfigSections.h>
 #include <test/jtx.h>
 #include <test/jtx/envconfig.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <boost/asio.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -25,6 +25,7 @@
 #include <ripple/core/ConfigSections.h>
 #include <test/jtx.h>
 #include <test/jtx/envconfig.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <boost/asio.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
@@ -345,13 +346,16 @@ public:
             }
         };
 
-        test::jtx::Env env (*this);  // Used only for its Journal
+        using namespace beast::severities;
+        SuiteJournalSink sink ("Server_test", kFatal, *this);
+        beast::Journal journal (sink);
+
         NullHandler h;
         for(int i = 0; i < 1000; ++i)
         {
             TestThread thread;
             auto s = make_Server(h,
-                thread.get_io_service(), env.journal);
+                thread.get_io_service(), journal);
             std::vector<Port> serverPort(1);
             serverPort.back().ip =
                 beast::IP::Address::from_string (getEnvLocalhostAddr()),

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -345,12 +345,13 @@ public:
             }
         };
 
+        test::jtx::Env env (*this);  // Used only for its Journal
         NullHandler h;
         for(int i = 0; i < 1000; ++i)
         {
             TestThread thread;
             auto s = make_Server(h,
-                thread.get_io_service(), {});
+                thread.get_io_service(), env.journal);
             std::vector<Port> serverPort(1);
             serverPort.back().ip =
                 beast::IP::Address::from_string (getEnvLocalhostAddr()),

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -118,8 +118,7 @@ public:
     void run () override
     {
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("FetchPack_test", kFatal, *this);
-        beast::Journal journal (sink);
+        test::SuiteJournal journal ("FetchPack_test", *this);
 
         TestFamily f(journal);
         std::shared_ptr <Table> t1 (std::make_shared <Table> (

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -26,7 +26,7 @@
 #include <ripple/beast/xor_shift_engine.h>
 #include <ripple/beast/unit_test.h>
 #include <test/shamap/common.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 #include <functional>
 #include <stdexcept>
 

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -25,8 +25,8 @@
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/beast/xor_shift_engine.h>
 #include <ripple/beast/unit_test.h>
-#include <test/jtx/Env.h>
 #include <test/shamap/common.h>
+#include <test/unit_test/SuiteJournalSink.h>
 #include <functional>
 #include <stdexcept>
 
@@ -117,8 +117,11 @@ public:
 
     void run () override
     {
-        test::jtx::Env env (*this);  // Used only for its Journal.
-        TestFamily f(env.journal);
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("FetchPack_test", kFatal, *this);
+        beast::Journal journal (sink);
+
+        TestFamily f(journal);
         std::shared_ptr <Table> t1 (std::make_shared <Table> (
             SHAMapType::FREE, f, SHAMap::version{2}));
 

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include <ripple/shamap/SHAMap.h>
-#include <test/shamap/common.h>
 #include <ripple/protocol/digest.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/random.h>
@@ -26,6 +25,8 @@
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/beast/xor_shift_engine.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx/Env.h>
+#include <test/shamap/common.h>
 #include <functional>
 #include <stdexcept>
 
@@ -116,8 +117,8 @@ public:
 
     void run () override
     {
-        beast::Journal const j;                            // debug journal
-        TestFamily f(j);
+        test::jtx::Env env (*this);  // Used only for its Journal.
+        TestFamily f(env.journal);
         std::shared_ptr <Table> t1 (std::make_shared <Table> (
             SHAMapType::FREE, f, SHAMap::version{2}));
 

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -24,7 +24,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/xor_shift_engine.h>
 #include <test/shamap/common.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace tests {

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -19,11 +19,12 @@
 
 #include <ripple/shamap/SHAMap.h>
 #include <ripple/shamap/SHAMapItem.h>
-#include <test/shamap/common.h>
 #include <ripple/basics/random.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/xor_shift_engine.h>
+#include <test/jtx/Env.h>
+#include <test/shamap/common.h>
 
 namespace ripple {
 namespace tests {
@@ -95,8 +96,8 @@ public:
 
     void run(SHAMap::version v)
     {
-        beast::Journal const j; // debug journal
-        TestFamily f(j), f2(j);
+        test::jtx::Env env (*this);  // Used only for its Journal.
+        TestFamily f(env.journal), f2(env.journal);
         SHAMap source (SHAMapType::FREE, f, v);
         SHAMap destination (SHAMapType::FREE, f2, v);
 

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -88,8 +88,7 @@ public:
     void run() override
     {
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("SHAMapSync_test", kFatal, *this);
-        beast::Journal journal (sink);
+        test::SuiteJournal journal ("SHAMapSync_test", *this);
 
         log << "Run, version 1\n" << std::endl;
         run(SHAMap::version{1}, journal);

--- a/src/test/shamap/SHAMapSync_test.cpp
+++ b/src/test/shamap/SHAMapSync_test.cpp
@@ -23,8 +23,8 @@
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/xor_shift_engine.h>
-#include <test/jtx/Env.h>
 #include <test/shamap/common.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 namespace ripple {
 namespace tests {
@@ -87,17 +87,20 @@ public:
 
     void run() override
     {
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("SHAMapSync_test", kFatal, *this);
+        beast::Journal journal (sink);
+
         log << "Run, version 1\n" << std::endl;
-        run(SHAMap::version{1});
+        run(SHAMap::version{1}, journal);
 
         log << "Run, version 2\n" << std::endl;
-        run(SHAMap::version{2});
+        run(SHAMap::version{2}, journal);
     }
 
-    void run(SHAMap::version v)
+    void run(SHAMap::version v, beast::Journal const& journal)
     {
-        test::jtx::Env env (*this);  // Used only for its Journal.
-        TestFamily f(env.journal), f2(env.journal);
+        TestFamily f(journal), f2(journal);
         SHAMap source (SHAMapType::FREE, f, v);
         SHAMap destination (SHAMapType::FREE, f2, v);
 

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -18,11 +18,12 @@
 //==============================================================================
 
 #include <ripple/shamap/SHAMap.h>
-#include <test/shamap/common.h>
 #include <ripple/basics/Blob.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/utility/Journal.h>
+#include <test/jtx/Env.h>
+#include <test/shamap/common.h>
 
 namespace ripple {
 namespace tests {
@@ -132,8 +133,8 @@ public:
         else
             testcase ("add/traverse unbacked");
 
-        beast::Journal const j;                            // debug journal
-        tests::TestFamily f(j);
+        test::jtx::Env env (*this);  // Used only for its Journal.
+        tests::TestFamily f(env.journal);
 
         // h3 and h4 differ only in the leaf, same terminal node (level 19)
         uint256 h1, h2, h3, h4, h5;
@@ -301,7 +302,7 @@ public:
             keys[6].SetHex ("b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
             keys[7].SetHex ("292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
 
-            tests::TestFamily tf{beast::Journal{}};
+            tests::TestFamily tf{env.journal};
             SHAMap map{SHAMapType::FREE, tf, v};
             if (! backed)
                 map.setUnbacked ();

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -22,8 +22,8 @@
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/utility/Journal.h>
-#include <test/jtx/Env.h>
 #include <test/shamap/common.h>
+#include <test/unit_test/SuiteJournalSink.h>
 
 namespace ripple {
 namespace tests {
@@ -120,21 +120,24 @@ public:
 
     void run () override
     {
-        run (true,  SHAMap::version{1});
-        run (false, SHAMap::version{1});
-        run (true,  SHAMap::version{2});
-        run (false, SHAMap::version{2});
+        using namespace beast::severities;
+        test::SuiteJournalSink sink ("SHAMap_test", kFatal, *this);
+        beast::Journal journal (sink);
+
+        run (true,  SHAMap::version{1}, journal);
+        run (false, SHAMap::version{1}, journal);
+        run (true,  SHAMap::version{2}, journal);
+        run (false, SHAMap::version{2}, journal);
     }
 
-    void run (bool backed, SHAMap::version v)
+    void run (bool backed, SHAMap::version v, beast::Journal const& journal)
     {
         if (backed)
             testcase ("add/traverse backed");
         else
             testcase ("add/traverse unbacked");
 
-        test::jtx::Env env (*this);  // Used only for its Journal.
-        tests::TestFamily f(env.journal);
+        tests::TestFamily f(journal);
 
         // h3 and h4 differ only in the leaf, same terminal node (level 19)
         uint256 h1, h2, h3, h4, h5;
@@ -302,7 +305,7 @@ public:
             keys[6].SetHex ("b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
             keys[7].SetHex ("292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
 
-            tests::TestFamily tf{env.journal};
+            tests::TestFamily tf{journal};
             SHAMap map{SHAMapType::FREE, tf, v};
             if (! backed)
                 map.setUnbacked ();

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -121,8 +121,7 @@ public:
     void run () override
     {
         using namespace beast::severities;
-        test::SuiteJournalSink sink ("SHAMap_test", kFatal, *this);
-        beast::Journal journal (sink);
+        test::SuiteJournal journal ("SHAMap_test", *this);
 
         run (true,  SHAMap::version{1}, journal);
         run (false, SHAMap::version{1}, journal);

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -23,7 +23,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/utility/Journal.h>
 #include <test/shamap/common.h>
-#include <test/unit_test/SuiteJournalSink.h>
+#include <test/unit_test/SuiteJournal.h>
 
 namespace ripple {
 namespace tests {

--- a/src/test/unit_test/SuiteJournal.h
+++ b/src/test/unit_test/SuiteJournal.h
@@ -17,8 +17,8 @@
 */
 //==============================================================================
 
-#ifndef TEST_UNIT_TEST_SUITE_JOURNAL_SINK_H
-#define TEST_UNIT_TEST_SUITE_JOURNAL_SINK_H
+#ifndef TEST_UNIT_TEST_SUITE_JOURNAL_H
+#define TEST_UNIT_TEST_SUITE_JOURNAL_H
 
 #include <ripple/beast/unit_test.h>
 #include <ripple/beast/utility/Journal.h>

--- a/src/test/unit_test/SuiteJournalSink.h
+++ b/src/test/unit_test/SuiteJournalSink.h
@@ -78,6 +78,22 @@ SuiteJournalSink::write (
         suite_.log << s << partition_ << text << std::endl;
 }
 
+class SuiteJournal
+{
+    SuiteJournalSink sink_;
+    beast::Journal journal_;
+
+public:
+    SuiteJournal(std::string const& partition,
+            beast::unit_test::suite& suite,
+            beast::severities::Severity threshold = beast::severities::kFatal)
+        : sink_ (partition, threshold, suite)
+        , journal_ (sink_)
+    {
+    }
+    operator beast::Journal&() { return journal_; }
+};
+
 } // test
 } // ripple
 

--- a/src/test/unit_test/SuiteJournalSink.h
+++ b/src/test/unit_test/SuiteJournalSink.h
@@ -1,0 +1,84 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef TEST_UNIT_TEST_SUITE_JOURNAL_SINK_H
+#define TEST_UNIT_TEST_SUITE_JOURNAL_SINK_H
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/beast/utility/Journal.h>
+
+namespace ripple {
+namespace test {
+
+// A Journal::Sink intended for use with the beast unit test framework.
+class SuiteJournalSink : public beast::Journal::Sink
+{
+    std::string partition_;
+    beast::unit_test::suite& suite_;
+
+public:
+    SuiteJournalSink(std::string const& partition,
+            beast::severities::Severity threshold,
+            beast::unit_test::suite& suite)
+        : Sink (threshold, false)
+        , partition_(partition + " ")
+        , suite_ (suite)
+    {
+    }
+
+    // For unit testing, always generate logging text.
+    inline bool active(beast::severities::Severity level) const override
+    {
+        return true;
+    }
+
+    void
+    write(beast::severities::Severity level, std::string const& text) override;
+};
+
+inline void
+SuiteJournalSink::write (
+    beast::severities::Severity level, std::string const& text)
+{
+    using namespace beast::severities;
+
+    char const* const s = [level]()
+    {
+        switch(level)
+        {
+        case kTrace:    return "TRC:";
+        case kDebug:    return "DBG:";
+        case kInfo:     return "INF:";
+        case kWarning:  return "WRN:";
+        case kError:    return "ERR:";
+        default:        break;
+        case kFatal:    break;
+        }
+        return "FTL:";
+    }();
+
+    // Only write the string if the level at least equals the threshold.
+    if (level >= threshold())
+        suite_.log << s << partition_ << text << std::endl;
+}
+
+} // test
+} // ripple
+
+#endif


### PR DESCRIPTION
The pull request has two commits so far.

1. The first commit removes the default constructor of `beast::Journal`.  This constructor provided a `Journal` that would not write anything.  I believe that choice is a dangerous default.  There were places in the code using a default constructed `Journal` where it was not obvious that the `Journal` would not write.  A non-writing `Journal` has a place in the world, but it should be asked for explicitly.  The bulk of the commit is simply fixing up the places that were relying on the default constructor.

2. The second commit makes it easier for unit tests to use a `Journal` intended for unit testing.  Previously this kind of a `Journal` was only available from an `Env`.  Now they can create these `Journal`s independent of `Env`.  The bulk of the commit is converting those unit tests that used `Env` for its `Journal` to construct their own `Journal` directly.