### PR TITLE
[TRIVIAL] Remove noisy log write from Stoppable.cpp

### DIFF
--- a/src/ripple/core/impl/Stoppable.cpp
+++ b/src/ripple/core/impl/Stoppable.cpp
@@ -103,20 +103,7 @@ void Stoppable::startRecursive ()
 
 void Stoppable::stopAsyncRecursive (beast::Journal j)
 {
-    using namespace std::chrono;
-    auto const start = high_resolution_clock::now();
     onStop ();
-    auto const ms = duration_cast<milliseconds>(
-        high_resolution_clock::now() - start);
-
-#ifdef NDEBUG
-    using namespace std::chrono_literals;
-    if (ms >= 10ms)
-        if (auto stream = j.fatal())
-            stream << m_name << "::onStop took " << ms.count() << "ms";
-#else
-    (void)ms;
-#endif
 
     for (Children::const_iterator iter (m_children.cbegin ());
         iter != m_children.cend(); ++iter)


### PR DESCRIPTION
The Jenkins msvc.Release build unit test log has been flooded with lines that look like this:
```
...
2> FTL:Application Application::onStop took 21ms
5> FTL:Application Application::onStop took 58ms
4> FTL:Application Application::onStop took 95ms
3> FTL:Application Application::onStop took 84ms
...
```
This logging was added about 3 years ago.  I don't believe anyone cares any more.  So this pull request removes the offending log write (rather than lower the threshold).