### PR TITLE
Allow validators to detect transaction censorship attempts:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2028,6 +2028,7 @@ else ()
     src/test/app/PayChan_test.cpp
     src/test/app/PayStrand_test.cpp
     src/test/app/PseudoTx_test.cpp
+    src/test/app/RCLCensorshipDetector_test.cpp
     src/test/app/RCLValidations_test.cpp
     src/test/app/Regression_test.cpp
     src/test/app/SHAMapStore_test.cpp

--- a/src/ripple/app/consensus/RCLCensorshipDetector.h
+++ b/src/ripple/app/consensus/RCLCensorshipDetector.h
@@ -1,0 +1,143 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_CONSENSUS_RCLCENSORSHIPDETECTOR_H_INCLUDED
+#define RIPPLE_APP_CONSENSUS_RCLCENSORSHIPDETECTOR_H_INCLUDED
+
+#include <ripple/shamap/SHAMap.h>
+#include <algorithm>
+#include <map>
+
+namespace ripple {
+
+template <class TxID, class Sequence>
+class RCLCensorshipDetector
+{
+private:
+    std::map<TxID, Sequence> tracker_;
+
+    /** Removes all elements satisfying specific criteria from the tracker
+
+        @param pred A predicate which returns true for tracking entries that
+                    should be removed. The predicate must be callable as:
+                        bool pred(TxID const&, Sequence)
+                    It must return true for entries that should be removed.
+
+        @note This could be replaced with std::erase_if when it becomes part
+              of the standard. For example:
+
+                prune ([](TxID const& id, Sequence seq)
+                    {
+                        return id.isZero() || seq == 314159;
+                    });
+
+              would become:
+
+                std::erase_if(tracker_.begin(), tracker_.end(),
+                    [](auto const& e)
+                    {
+                        return e.first.isZero() || e.second == 314159;
+                    }
+    */
+    template <class Predicate>
+    void prune(Predicate&& pred)
+    {
+        auto t = tracker_.begin();
+
+        while (t != tracker_.end())
+        {
+            if (pred(t->first, t->second))
+                t = tracker_.erase(t);
+            else
+                t = std::next(t);
+        }
+    }
+
+public:
+    RCLCensorshipDetector() = default;
+
+    /** Add transactions being proposed for the current consensus round.
+
+        @param seq      The sequence number of the ledger being built.
+        @param proposed The set of transactions that we are initially proposing
+                        for this round.
+    */
+    void propose(
+        Sequence seq,
+        std::vector<TxID> proposed)
+    {
+        std::sort (proposed.begin(), proposed.end());
+
+        // We want to remove any entries that we proposed in a previous round
+        // that did not make it in yet if we are no longer proposing them.
+        prune ([&proposed](TxID const& id, Sequence seq)
+            {
+                return !std::binary_search(proposed.begin(), proposed.end(), id);
+            });
+
+        // Track the entries that we are proposing in this round.
+        for (auto const& p : proposed)
+            tracker_.emplace(p, seq); // FIXME C++17: use try_emplace
+    }
+
+    /** Determine which transactions made it and perform censorship detection.
+
+        This function is called when the server is proposing and a consensus
+        round it participated in completed.
+
+        @param accepted The set of transactions that the network agreed
+                        should be included in the ledger being built.
+        @param pred     A predicate invoked for every transaction we've proposed
+                        but which hasn't yet made it. The predicate must be
+                        callable as:
+                            bool pred(TxID const&, Sequence)
+                        It must return true for entries that should be removed.
+    */
+    template <class Predicate>
+    void check(
+        std::vector<TxID> accepted,
+        Predicate&& pred)
+    {
+        std::sort (accepted.begin(), accepted.end());
+
+        // We want to remove all tracking entries for transactions that were
+        // accepted as well as those which match the predicate.
+        prune ([&pred, &accepted](TxID const& id, Sequence seq)
+            {
+                if (std::binary_search(accepted.begin(), accepted.end(), id))
+                    return true;
+
+                return pred(id, seq);
+            });
+    }
+
+    /** Removes all elements from the tracker
+
+        Typically, this function might be called after we reconnect to the
+        network following an outage, or after we start tracking the network.
+    */
+    void reset()
+    {
+        tracker_.clear();
+    }
+};
+
+}
+
+#endif

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -807,7 +807,7 @@ RCLConsensus::Adaptor::onModeChange(
 
     // If we were proposing but aren't any longer, we need to reset the
     // censorship tracking to avoid bogus warnings.
-    if (before == ConsensusMode::proposing && before != after)
+    if ((before == ConsensusMode::proposing || before == ConsensusMode::observing) && before != after)
         censorshipDetector_.reset();
 
     mode_ = after;

--- a/src/ripple/app/ledger/BuildLedger.h
+++ b/src/ripple/app/ledger/BuildLedger.h
@@ -44,9 +44,10 @@ class SHAMap;
     @param closeTime The time the ledger closed
     @param closeTimeCorrect Whether consensus agreed on close time
     @param closeResolution Resolution used to determine consensus close time
-    @param txs The consensus transactions to attempt to apply
     @param app Handle to application instance
-    @param retriableTxs Populate with transactions to retry in next round
+    @param txs On entry, transactions to apply; on exit, transactions that must
+               be retried in next round.
+    @param failedTxs Populated with transactions that failed in this round
     @param j Journal to use for logging
     @return The newly built ledger
  */
@@ -56,9 +57,9 @@ buildLedger(
     NetClock::time_point closeTime,
     const bool closeTimeCorrect,
     NetClock::duration closeResolution,
-    SHAMap const& txs,
     Application& app,
-    CanonicalTXSet& retriableTxs,
+    CanonicalTXSet& txns,
+    std::set<TxID>& failedTxs,
     beast::Journal j);
 
 /** Build a new ledger by replaying transactions

--- a/src/ripple/app/misc/CanonicalTXSet.cpp
+++ b/src/ripple/app/misc/CanonicalTXSet.cpp
@@ -81,13 +81,13 @@ uint256 CanonicalTXSet::accountKey (AccountID const& account)
         ret.begin (),
         account.begin (),
         account.size ());
-    ret ^= mSetHash;
+    ret ^= salt_;
     return ret;
 }
 
 void CanonicalTXSet::insert (std::shared_ptr<STTx const> const& txn)
 {
-    mMap.insert (
+    map_.insert (
         std::make_pair (
             Key (
                 accountKey (txn->getAccountID(sfAccount)),
@@ -106,29 +106,16 @@ CanonicalTXSet::prune(AccountID const& account,
     Key keyHigh(effectiveAccount, seq+1, beast::zero);
 
     auto range = boost::make_iterator_range(
-        mMap.lower_bound(keyLow),
-            mMap.lower_bound(keyHigh));
-    auto txRange = boost::adaptors::transform(
-        range,
-    [](auto const& p)
-    {
-        return p.second;
-    });
+        map_.lower_bound(keyLow),
+        map_.lower_bound(keyHigh));
+    auto txRange = boost::adaptors::transform(range,
+        [](auto const& p) { return p.second; });
 
     std::vector<std::shared_ptr<STTx const>> result(
         txRange.begin(), txRange.end());
 
-    mMap.erase(range.begin(), range.end());
-
+    map_.erase(range.begin(), range.end());
     return result;
-}
-
-CanonicalTXSet::iterator CanonicalTXSet::erase (iterator const& it)
-{
-    iterator tmp = it;
-    ++tmp;
-    mMap.erase (it);
-    return tmp;
 }
 
 } // ripple

--- a/src/ripple/app/misc/CanonicalTXSet.h
+++ b/src/ripple/app/misc/CanonicalTXSet.h
@@ -75,12 +75,11 @@ private:
     uint256 accountKey (AccountID const& account);
 
 public:
-    using iterator = std::map <Key, std::shared_ptr<STTx const>>::iterator;
     using const_iterator = std::map <Key, std::shared_ptr<STTx const>>::const_iterator;
 
 public:
     explicit CanonicalTXSet (LedgerHash const& saltHash)
-        : mSetHash (saltHash)
+        : salt_ (saltHash)
     {
     }
 
@@ -90,45 +89,46 @@ public:
     prune(AccountID const& account, std::uint32_t const seq);
 
     // VFALCO TODO remove this function
-    void reset (LedgerHash const& saltHash)
+    void reset (LedgerHash const& salt)
     {
-        mSetHash = saltHash;
-
-        mMap.clear ();
+        salt_ = salt;
+        map_.clear ();
     }
 
-    iterator erase (iterator const& it);
+    const_iterator erase (const_iterator const& it)
+    {
+        return map_.erase(it);
+    }
 
-    iterator begin ()
+    const_iterator begin () const
     {
-        return mMap.begin ();
+        return map_.begin();
     }
-    iterator end ()
+
+    const_iterator end() const
     {
-        return mMap.end ();
+        return map_.end();
     }
-    const_iterator begin ()  const
-    {
-        return mMap.begin ();
-    }
-    const_iterator end () const
-    {
-        return mMap.end ();
-    }
+
     size_t size () const
     {
-        return mMap.size ();
+        return map_.size ();
     }
     bool empty () const
     {
-        return mMap.empty ();
+        return map_.empty ();
+    }
+
+    uint256 const& key() const
+    {
+        return salt_;
     }
 
 private:
-    // Used to salt the accounts so people can't mine for low account numbers
-    uint256 mSetHash;
+    std::map <Key, std::shared_ptr<STTx const>> map_;
 
-    std::map <Key, std::shared_ptr<STTx const>> mMap;
+    // Used to salt the accounts so people can't mine for low account numbers
+    uint256 salt_;
 };
 
 } // ripple

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -123,16 +123,12 @@ applyTransaction (Application& app, OpenView& view,
     if (retryAssured)
         flags = flags | tapRETRY;
 
-    JLOG (j.debug()) << "TXN "
-        << txn.getTransactionID ()
-        //<< (engine.view().open() ? " open" : " closed")
-        // because of the optional in engine
+    JLOG (j.debug()) << "TXN " << txn.getTransactionID ()
         << (retryAssured ? "/retry" : "/final");
 
     try
     {
-        auto const result = apply(app,
-            view, txn, flags, j);
+        auto const result = apply(app, view, txn, flags, j);
         if (result.second)
         {
             JLOG (j.debug())

--- a/src/test/app/RCLCensorshipDetector_test.cpp
+++ b/src/test/app/RCLCensorshipDetector_test.cpp
@@ -1,0 +1,96 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/app/consensus/RCLCensorshipDetector.h>
+#include <algorithm>
+#include <vector>
+
+namespace ripple {
+namespace test {
+
+class RCLCensorshipDetector_test : public beast::unit_test::suite
+{
+    void test(
+        RCLCensorshipDetector<int, int>& cdet, int round,
+        std::vector<int> proposed, std::vector<int> accepted,
+        std::vector<int> remain, std::vector<int> remove)
+    {
+        // Begin tracking what we're proposing this round
+        cdet.propose(round, std::move(proposed));
+
+        // Finalize the round, by processing what we accepted; then
+        // remove anything that needs to be removed and ensure that
+        // what remains is correct.
+        cdet.check(std::move(accepted),
+            [&remove, &remain](auto id, auto seq)
+            {
+                // If the item is supposed to be removed from the censorship
+                // detector internal tracker manually, do it now:
+                if (std::find(remove.begin(), remove.end(), id) != remove.end())
+                    return true;
+
+                // If the item is supposed to still remain in the censorship
+                // detector internal tracker; remove it from the vector.
+                auto it = std::find(remain.begin(), remain.end(), id);
+                if (it != remain.end())
+                    remain.erase(it);
+                return false;
+            });
+
+        // On entry, this set contained all the elements that should be tracked
+        // by the detector after we process this round. We removed all the items
+        // that actually were in the tracker, so this should now be empty:
+        BEAST_EXPECT(remain.empty());
+    }
+
+public:
+    void
+    run() override
+    {
+        testcase ("Censorship Detector");
+
+        RCLCensorshipDetector<int, int> cdet;
+        int round = 0;
+
+        test(cdet, ++round,     { },                { },        { },            { });
+        test(cdet, ++round,     { 10, 11, 12, 13 }, { 11, 2 },  { 10, 13 },     { });
+        test(cdet, ++round,     { 10, 13, 14, 15 }, { 14 },     { 10, 13, 15 }, { });
+        test(cdet, ++round,     { 10, 13, 15, 16 }, { 15, 16 }, { 10, 13 },     { });
+        test(cdet, ++round,     { 10, 13 },         { 17, 18 }, { 10, 13 },     { });
+        test(cdet, ++round,     { 10, 19 },         { },        { 10, 19 },     { });
+        test(cdet, ++round,     { 10, 19, 20 },     { 20 },     { 10 },         { 19 });
+        test(cdet, ++round,     { 21 },             { 21 },     { },            { });
+        test(cdet, ++round,     { },                { 22 },     { },            { });
+        test(cdet, ++round,     { 23, 24, 25, 26 }, { 25, 27 }, { 23, 26 },     { 24 });
+        test(cdet, ++round,     { 23, 26, 28 },     { 26, 28 }, { 23 },         { });
+
+        for (int i = 0; i != 10; ++i)
+            test(cdet, ++round, { 23 },             { },        { 23 },         { });
+
+        test(cdet, ++round,     { 23, 29 },         { 29 },     { 23 },         { });
+        test(cdet, ++round,     { 30, 31 },         { 31 },     { 30 },         { });
+        test(cdet, ++round,     { 30 },             { 30 },     { },            { });
+        test(cdet, ++round,     { },                { },        { },            { });
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(RCLCensorshipDetector, app, ripple);
+}  // namespace test
+}  // namespace ripple

--- a/src/test/unity/app_test_unity2.cpp
+++ b/src/test/unity/app_test_unity2.cpp
@@ -22,6 +22,7 @@
 #include <test/app/PayChan_test.cpp>
 #include <test/app/PayStrand_test.cpp>
 #include <test/app/PseudoTx_test.cpp>
+#include <test/app/RCLCensorshipDetector_test.cpp>
 #include <test/app/RCLValidations_test.cpp>
 #include <test/app/Regression_test.cpp>
 #include <test/app/SetAuth_test.cpp>


### PR DESCRIPTION
The XRP Ledger is designed to be censorship resistant. Any attempt to censor transactions would require coordinated action by a majority of the system's validators.

Importantly, the design of the system is such that such an attempt is detectable and can be easily proven since every validators must sign the validations it publishes.

This commit adds an automated censorship detector which is active on servers configured as validators. The detector tracks all transactions proposed by the validator and issues warnings of increasing severity for any transactions which, despite being proposed repeatedly by the validator, has not been included.