### PR TITLE
Improve RPC error message for fee command:

### DIFF
--- a/src/ripple/rpc/handlers/Fee1.cpp
+++ b/src/ripple/rpc/handlers/Fee1.cpp
@@ -30,6 +30,7 @@ namespace ripple
     {
         // Bail if fee escalation is not enabled.
         auto const view = context.app.openLedger().current();
+        BOOST_ASSERT(view);
         if (!view || !view->rules().enabled(featureFeeEscalation))
         {
             RPC::inject_error(rpcNOT_ENABLED, context.params);

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -77,7 +77,7 @@ Handler const handlerArray[] {
     {   "gateway_balances",     byRef (&doGatewayBalances),     Role::USER,  NO_CONDITION  },
     {   "get_counts",           byRef (&doGetCounts),           Role::ADMIN,   NO_CONDITION     },
     {   "feature",              byRef (&doFeature),             Role::ADMIN,   NO_CONDITION     },
-    {   "fee",                  byRef (&doFee),                 Role::USER,    NO_CONDITION     },
+    {   "fee",                  byRef (&doFee),                 Role::USER,    NEEDS_CURRENT_LEDGER     },
     {   "fetch_info",           byRef (&doFetchInfo),           Role::ADMIN,   NO_CONDITION     },
     {   "ledger_accept",        byRef (&doLedgerAccept),        Role::ADMIN,   NEEDS_CURRENT_LEDGER  },
     {   "ledger_cleaner",       byRef (&doLedgerCleaner),       Role::ADMIN,   NEEDS_NETWORK_CONNECTION  },

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -1664,7 +1664,7 @@ public:
             auto fee = env.rpc("fee");
 
             if (BEAST_EXPECT(fee.isMember(jss::result) &&
-                !RPC::contains_error(fee[jss::result])))
+                BEAST_EXPECT(!RPC::contains_error(fee[jss::result]))))
             {
                 auto const& result = fee[jss::result];
                 BEAST_EXPECT(result.isMember(jss::ledger_current_index)
@@ -1692,7 +1692,7 @@ public:
             fee = env.rpc("fee");
 
             if (BEAST_EXPECT(fee.isMember(jss::result) &&
-                !RPC::contains_error(fee[jss::result])))
+                BEAST_EXPECT(!RPC::contains_error(fee[jss::result]))))
             {
                 auto const& result = fee[jss::result];
                 BEAST_EXPECT(result.isMember(jss::ledger_current_index)


### PR DESCRIPTION
* If rippled is not synced to the network, `fee` will return a
  "no network" error instead of the possibly confusing "not enabled"
  error.
* Resolves RIPD-1588

This turned out a lot simpler than I expected, but I don't think it's trivial since it does change the results of a user-facing API call, so I'm nominating two reviewers.

Note: This change is based off of #2703 to increase the chances of the Jenkins build passing. Please ignore the "Add dependency for NuDB ExternalProject" commit.