### PR TITLE
Remove unused execinfo.h header

### DIFF
--- a/src/ripple/beast/core/BasicNativeHeaders.h
+++ b/src/ripple/beast/core/BasicNativeHeaders.h
@@ -290,7 +290,7 @@
  #include <net/if.h>
  #include <sys/ioctl.h>
 
- #if ! BEAST_ANDROID && ! BEAST_BSD
+ #if ! BEAST_ANDROID && ! BEAST_BSD && ( ! BEAST_LINUX || BEAST_LINUX && __GLIBC__ )
   #include <execinfo.h>
  #endif
 #endif

--- a/src/ripple/beast/core/BasicNativeHeaders.h
+++ b/src/ripple/beast/core/BasicNativeHeaders.h
@@ -289,11 +289,12 @@
  #include <sys/time.h>
  #include <net/if.h>
  #include <sys/ioctl.h>
+#endif	
 
 #if BEAST_MAC || BEAST_IOS
  #include <xlocale.h>
  #include <mach/mach.h>
-#endif
+#endif	
 
 #if BEAST_ANDROID
  #include <android/log.h>

--- a/src/ripple/beast/core/BasicNativeHeaders.h
+++ b/src/ripple/beast/core/BasicNativeHeaders.h
@@ -294,7 +294,7 @@
 #if BEAST_MAC || BEAST_IOS
  #include <xlocale.h>
  #include <mach/mach.h>
-#endif	
+#endif
 
 #if BEAST_ANDROID
  #include <android/log.h>

--- a/src/ripple/beast/core/BasicNativeHeaders.h
+++ b/src/ripple/beast/core/BasicNativeHeaders.h
@@ -290,11 +290,6 @@
  #include <net/if.h>
  #include <sys/ioctl.h>
 
- #if ! BEAST_ANDROID && ! BEAST_BSD && ( ! BEAST_LINUX || BEAST_LINUX && __GLIBC__ )
-  #include <execinfo.h>
- #endif
-#endif
-
 #if BEAST_MAC || BEAST_IOS
  #include <xlocale.h>
  #include <mach/mach.h>


### PR DESCRIPTION
Fixes #2671 and #2159 

I'm not sure if this is legible/understandable enough, but execinfo.h is a GNU-only header and causes issues with non-glibc builds for quite a while now. This should be the quick and dirty fix, maybe a  `BEAST_BACKTRACES` flag or so might be better? I'm not so sure how much you anyways want to rely on "ripplebeast" in the future though, so I didn't try to be fancy about it.