### PR TITLE
Default ledger_entry by index to return JSON, not hex

### DIFF
--- a/src/ripple/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/rpc/handlers/LedgerEntry.cpp
@@ -50,7 +50,6 @@ Json::Value doLedgerEntry (RPC::Context& context)
     if (context.params.isMember (jss::index))
     {
         uNodeIndex.SetHex (context.params[jss::index].asString());
-        bNodeBinary = true;
     }
     else if (context.params.isMember (jss::account_root))
     {

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -248,12 +248,6 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(jrr[jss::ledger_index] == 3);
         }
 
-        constexpr char alicesAcctRootBinary[] {
-            "1100612200800000240000000225000000032D00000000554294BEBE5B569"
-            "A18C0A2702387C9B1E7146DC3A5850C1E87204951C6FDAA4C426240000002"
-            "540BE4008114AE123A8556F3CF91154711376AFB0F894F832B3D"
-        };
-
         std::string accountRootIndex;
         {
             // Request alice's account root.
@@ -268,6 +262,12 @@ class LedgerRPC_test : public beast::unit_test::suite
             accountRootIndex = jrr[jss::index].asString();
         }
         {
+            constexpr char alicesAcctRootBinary[] {
+                "1100612200800000240000000225000000032D00000000554294BEBE5B569"
+                "A18C0A2702387C9B1E7146DC3A5850C1E87204951C6FDAA4C426240000002"
+                "540BE4008114AE123A8556F3CF91154711376AFB0F894F832B3D"
+            };
+
             // Request alice's account root, but with binary == true;
             Json::Value jvParams;
             jvParams[jss::account_root] = alice.human();

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -248,7 +248,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(jrr[jss::ledger_index] == 3);
         }
 
-        char const alicesAcctRootBinary[] {
+        constexpr char alicesAcctRootBinary[] {
             "1100612200800000240000000225000000032D00000000554294BEBE5B569"
             "A18C0A2702387C9B1E7146DC3A5850C1E87204951C6FDAA4C426240000002"
             "540BE4008114AE123A8556F3CF91154711376AFB0F894F832B3D"
@@ -284,8 +284,10 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::index] = accountRootIndex;
             Json::Value const jrr = env.rpc (
                 "json", "ledger_entry", to_string (jvParams))[jss::result];
-            BEAST_EXPECT(jrr.isMember(jss::node_binary));
-            BEAST_EXPECT(jrr[jss::node_binary] == alicesAcctRootBinary);
+            BEAST_EXPECT(! jrr.isMember(jss::node_binary));
+            BEAST_EXPECT(jrr.isMember(jss::node));
+            BEAST_EXPECT(jrr[jss::node][jss::Account] == alice.human());
+            BEAST_EXPECT(jrr[jss::node][sfBalance.jsonName] == "10000000000");
         }
         {
             // Request alice's account root by index, but with binary == false.


### PR DESCRIPTION
This pull request finishes addressing RIPD-1538.

Typically the ledger_entry RPC command returns its results in JSON -- unless the request is by index.  If the request is by index it returns the results in hex.  This difference in behavior is surprising.

This pull request makes the behavior of the ledger_index command more uniform by removing the special behavior of request by index.  With this change ledger_index command defaults to return all values by JSON.  The unit tests are adjusted to expect the new behavior.