### PR TITLE
Rollup of small changes

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -118,6 +118,12 @@ public:
         std::shared_ptr<Ledger const> const& ledger,
             bool isSynchronous, bool isCurrent);
 
+    /** Check the sequence number and parent close time of a
+        ledger against our clock and last validated ledger to
+        see if it can be the network's current ledger
+    */
+    bool canBeCurrent (std::shared_ptr<Ledger const> const& ledger);
+
     void switchLCL (std::shared_ptr<Ledger const> const& lastClosed);
 
     void failedSave(std::uint32_t seq, uint256 const& hash);

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -59,6 +59,9 @@ using namespace std::chrono_literals;
 // Don't acquire history if ledger is too old
 auto constexpr MAX_LEDGER_AGE_ACQUIRE = 1min;
 
+// Don't acquire history if write load is too high
+auto constexpr MAX_WRITE_LOAD_ACQUIRE = 8192;
+
 LedgerMaster::LedgerMaster (Application& app, Stopwatch& stopwatch,
     Stoppable& parent,
     beast::insight::Collector::ptr const& collector, beast::Journal journal)
@@ -1680,7 +1683,8 @@ void LedgerMaster::doAdvance (ScopedLockType& sl)
             if (!standalone_ && !app_.getFeeTrack().isLoadedLocal() &&
                 (app_.getJobQueue().getJobCount(jtPUBOLDLEDGER) < 10) &&
                 (mValidLedgerSeq == mPubLedgerSeq) &&
-                (getValidatedLedgerAge() < MAX_LEDGER_AGE_ACQUIRE))
+                (getValidatedLedgerAge() < MAX_LEDGER_AGE_ACQUIRE) &&
+                (app_.getNodeStore().getWriteLoad() < MAX_WRITE_LOAD_ACQUIRE))
             {
                 // We are in sync, so can acquire
                 InboundLedger::Reason reason = InboundLedger::Reason::HISTORY;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1330,10 +1330,12 @@ bool NetworkOPsImp::checkLastClosedLedger (
             closedLedger, 0, InboundLedger::Reason::CONSENSUS);
 
     if (consensus &&
-        !m_ledgerMaster.isCompatible(
-            *consensus, m_journal.debug(), "Not switching"))
+        (!m_ledgerMaster.canBeCurrent (consensus) ||
+            !m_ledgerMaster.isCompatible(
+                *consensus, m_journal.debug(), "Not switching")))
     {
         // Don't switch to a ledger not on the validated chain
+        // or with an invalid close time or sequence
         networkClosed = ourClosed->info().hash;
         return false;
     }

--- a/src/ripple/nodestore/Types.h
+++ b/src/ripple/nodestore/Types.h
@@ -32,7 +32,13 @@ enum
     // This is only used to pre-allocate the array for
     // batch objects and does not affect the amount written.
     //
-    batchWritePreallocationSize = 256
+    batchWritePreallocationSize = 256,
+
+    // This sets a limit on the maximum number of writes
+    // in a batch. Actual usage can be twice this since
+    // we have a new batch growing as we write the old.
+    //
+    batchWriteLimitSize = 65536
 };
 
 /** Return codes from Backend operations. */

--- a/src/ripple/nodestore/impl/BatchWriter.cpp
+++ b/src/ripple/nodestore/impl/BatchWriter.cpp
@@ -39,7 +39,12 @@ BatchWriter::~BatchWriter ()
 void
 BatchWriter::store (std::shared_ptr<NodeObject> const& object)
 {
-    std::lock_guard<decltype(mWriteMutex)> sl (mWriteMutex);
+    std::unique_lock<decltype(mWriteMutex)> sl (mWriteMutex);
+
+    // If the batch has reached its limit, we wait
+    // until the batch writer is finished
+    while (mWriteSet.size() >= batchWriteLimitSize)
+        mWriteCondition.wait (sl);
 
     mWriteSet.push_back (object);
 

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -135,16 +135,16 @@ public:
         no,
         yes
     };
-    static IsSigning const notSigning = IsSigning::no;
+    static IsSigning const   notSigning = IsSigning::no;
 
-    int const               fieldCode;      // (type<<16)|index
-    SerializedTypeID const  fieldType;      // STI_*
-    int const               fieldValue;     // Code number for protocol
-    std::string             fieldName;
-    int                     fieldMeta;
-    int                     fieldNum;
-    IsSigning const         signingField;
-    std::string             jsonName;
+    int const                fieldCode;      // (type<<16)|index
+    SerializedTypeID const   fieldType;      // STI_*
+    int const                fieldValue;     // Code number for protocol
+    std::string              fieldName;
+    int                      fieldMeta;
+    int                      fieldNum;
+    IsSigning const          signingField;
+    Json::StaticString const jsonName;
 
     SField(SField const&) = delete;
     SField& operator=(SField const&) = delete;
@@ -165,18 +165,23 @@ public:
     {
         return getField (field_code (type, value));
     }
+
     static const SField& getField (SerializedTypeID type, int value)
     {
         return getField (field_code (type, value));
     }
 
-    std::string getName () const;
-    bool hasName () const
+    std::string const& getName () const
     {
-        return !fieldName.empty ();
+        return fieldName;
     }
 
-    std::string const& getJsonName () const
+    bool hasName () const
+    {
+        return fieldCode > 0;
+    }
+
+    Json::StaticString const& getJsonName () const
     {
         return jsonName;
     }

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -148,7 +148,7 @@ public:
 
     SField(SField const&) = delete;
     SField& operator=(SField const&) = delete;
-    SField(SField&&) = default;
+    SField(SField&&);
 
 protected:
     // These constructors can only be called from FieldNames.cpp

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -274,7 +274,7 @@ SField::SField (SerializedTypeID tid, int fv, const char* fn,
     , fieldMeta (meta)
     , fieldNum (++num)
     , signingField (signing)
-    , jsonName (getName ())
+    , jsonName (fieldName.c_str())
 {
 }
 
@@ -285,7 +285,7 @@ SField::SField (int fc)
     , fieldMeta (sMD_Never)
     , fieldNum (++num)
     , signingField (IsSigning::yes)
-    , jsonName (getName ())
+    , jsonName ("")
 {
 }
 
@@ -296,12 +296,12 @@ SField::SField (SerializedTypeID tid, int fv)
         : fieldCode (field_code (tid, fv))
         , fieldType (tid)
         , fieldValue (fv)
+        , fieldName (std::to_string (tid) + '/' + std::to_string (fv))
         , fieldMeta (sMD_Default)
         , fieldNum (++num)
         , signingField (IsSigning::yes)
+        , jsonName (fieldName.c_str())
 {
-    fieldName = std::to_string (tid) + '/' + std::to_string (fv);
-    jsonName = getName ();
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
 }
 
@@ -375,18 +375,6 @@ int SField::compare (SField const& f1, SField const& f2)
         return 1;
 
     return 0;
-}
-
-std::string SField::getName () const
-{
-    if (!fieldName.empty ())
-        return fieldName;
-
-    if (fieldValue == 0)
-        return "";
-
-    return std::to_string(static_cast<int> (fieldType)) + "/" +
-            std::to_string(fieldValue);
 }
 
 SField const&

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -285,7 +285,7 @@ SField::SField (int fc)
     , fieldMeta (sMD_Never)
     , fieldNum (++num)
     , signingField (IsSigning::yes)
-    , jsonName ("")
+    , jsonName (fieldName.c_str())
 {
 }
 
@@ -293,16 +293,29 @@ SField::SField (int fc)
 // This is naturally done with no extra expense
 // from getField(int code).
 SField::SField (SerializedTypeID tid, int fv)
-        : fieldCode (field_code (tid, fv))
-        , fieldType (tid)
-        , fieldValue (fv)
-        , fieldName (std::to_string (tid) + '/' + std::to_string (fv))
-        , fieldMeta (sMD_Default)
-        , fieldNum (++num)
-        , signingField (IsSigning::yes)
-        , jsonName (fieldName.c_str())
+    : fieldCode (field_code (tid, fv))
+    , fieldType (tid)
+    , fieldValue (fv)
+    , fieldName (std::to_string (tid) + '/' + std::to_string (fv))
+    , fieldMeta (sMD_Default)
+    , fieldNum (++num)
+    , signingField (IsSigning::yes)
+    , jsonName (fieldName.c_str())
 {
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
+}
+
+// we can't use the default move constructor because
+// it could leave jsonName referencing a destroyed string
+SField::SField (SField &&s)
+    : fieldCode (s.fieldCode)
+    , fieldType (s.fieldType)
+    , fieldValue (s.fieldValue)
+    , fieldMeta (s.fieldMeta)
+    , fieldNum (s.fieldNum)
+    , signingField (s.signingField)
+    , jsonName (fieldName.c_str())
+{
 }
 
 SField const&

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -144,16 +144,12 @@ std::string STArray::getText () const
 Json::Value STArray::getJson (int p) const
 {
     Json::Value v = Json::arrayValue;
-    int index = 1;
     for (auto const& object: v_)
     {
         if (object.getSType () != STI_NOTPRESENT)
         {
             Json::Value& inner = v.append (Json::objectValue);
-            auto const& fname = object.getFName ();
-            auto k = fname.hasName () ? fname.fieldName : std::to_string(index);
-            inner[k] = object.getJson (p);
-            index++;
+            inner [object.getFName().getJsonName()] = object.getJson (p);
         }
     }
     return v;

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -637,17 +637,10 @@ Json::Value STObject::getJson (int options) const
 {
     Json::Value ret (Json::objectValue);
 
-    // TODO(tom): this variable is never changed...?
-    int index = 1;
     for (auto const& elem : v_)
     {
         if (elem->getSType () != STI_NOTPRESENT)
-        {
-            auto const& n = elem->getFName ();
-            auto key = n.hasName () ? std::string(n.getJsonName ()) :
-                    std::to_string (index);
-            ret[key] = elem->getJson (options);
-        }
+            ret [elem->getFName().getJsonName()] = elem->getJson (options);
     }
     return ret;
 }

--- a/src/ripple/server/impl/BaseWSPeer.h
+++ b/src/ripple/server/impl/BaseWSPeer.h
@@ -169,6 +169,7 @@ BaseWSPeer(
         io_service, journal)
     , request_(std::move(request))
     , timer_(io_service)
+    , payload_ ("12345678")
 {
 }
 

--- a/src/ripple/server/impl/BaseWSPeer.h
+++ b/src/ripple/server/impl/BaseWSPeer.h
@@ -169,7 +169,7 @@ BaseWSPeer(
         io_service, journal)
     , request_(std::move(request))
     , timer_(io_service)
-    , payload_ ("12345678")
+    , payload_ ("12345678") // ensures size is 8 bytes
 {
 }
 

--- a/src/ripple/server/impl/Door.h
+++ b/src/ripple/server/impl/Door.h
@@ -369,7 +369,7 @@ void
 Door<Handler>::
 do_accept(boost::asio::yield_context do_yield)
 {
-    for(;;)
+    while (acceptor_.is_open())
     {
         error_code ec;
         endpoint_type remote_address;


### PR DESCRIPTION
I've had a few changes that I hadn't quite finished that have been sitting around for a while. I rebased them to the current tip of develop, finished them, and am submitting them as a pull request to get automated testing. None of these is major and they're unrelated.

The first one is a small performance improvement in generating large blocks of JSON that include serialized objects such as transactions and ledger entries. The second one fixes a rare case where we see memory growth (due to buffered writes) due to some I/O hiccups. The third fixes a very rare case where we spin on shutdown. The last one is a simple fix for RIPD-1670.