### PR TITLE
Allow rippled to be compiled as C++17 on mac OS with Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,8 @@ if (MSVC)
       _CRT_SECURE_NO_WARNINGS
       WIN32_CONSOLE
       NOMINMAX
+      # TODO: Resolve these warnings, don't just silence them
+      _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
       $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_CRTDBG_MAP_ALLOC>)
   target_link_libraries (common
     INTERFACE
@@ -369,7 +371,6 @@ add_library (opts INTERFACE)
 add_library (Ripple::opts ALIAS opts)
 target_compile_definitions (opts
   INTERFACE
-    BOOST_NO_AUTO_PTR
     BOOST_ASIO_HAS_STD_ARRAY
     BOOST_ASIO_DISABLE_HANDLER_TYPE_REQUIREMENTS
     $<$<BOOL:${boost_show_deprecated}>:

--- a/src/ripple/app/paths/impl/PaySteps.cpp
+++ b/src/ripple/app/paths/impl/PaySteps.cpp
@@ -25,9 +25,7 @@
 #include <ripple/protocol/IOUAmount.h>
 #include <ripple/protocol/XRPAmount.h>
 
-#include <boost/range/adaptors.hpp>
-#include <boost/range/algorithm.hpp>
-
+#include <algorithm>
 #include <numeric>
 #include <sstream>
 
@@ -209,7 +207,7 @@ toStrandV1 (
     // Note that for offer crossing (only) we do use an offer book even if
     // all that is changing is the Issue.account.
     STPathElement const* const lastCurrency =
-        *boost::find_if (boost::adaptors::reverse (pes), hasCurrency);
+        *std::find_if (pes.rbegin(), pes.rend(), hasCurrency);
     if ((lastCurrency->getCurrency() != deliver.currency) ||
         (offerCrossing && lastCurrency->getIssuerID() != deliver.account))
     {
@@ -472,7 +470,7 @@ toStrandV2 (
             // Note that for offer crossing (only) we do use an offer book
             // even if all that is changing is the Issue.account.
             STPathElement const& lastCurrency =
-                *boost::find_if (boost::adaptors::reverse (normPath),
+                *std::find_if (normPath.rbegin(), normPath.rend(),
                     hasCurrency);
             if ((lastCurrency.getCurrency() != deliver.currency) ||
                 (offerCrossing &&
@@ -731,7 +729,8 @@ toStrands (
     // Insert the strand into result if it is not already part of the vector
     auto insert = [&](Strand s)
     {
-        bool const hasStrand = boost::find (result, s) != result.end ();
+        bool const hasStrand =
+            std::find (result.begin(), result.end(), s) != result.end ();
 
         if (!hasStrand)
             result.emplace_back (std::move (s));

--- a/src/ripple/beast/container/detail/aged_ordered_container.h
+++ b/src/ripple/beast/container/detail/aged_ordered_container.h
@@ -163,9 +163,17 @@ private:
     // VFALCO TODO This should only be enabled for maps.
     class pair_value_compare
         : public boost::beast::detail::empty_base_optimization <Compare>
+#ifdef _LIBCPP_VERSION
         , public std::binary_function <value_type, value_type, bool>
+#endif
     {
     public:
+#ifndef _LIBCPP_VERSION
+        using first_argument = value_type;
+        using second_argument = value_type;
+        using result_type = bool;
+#endif
+
         bool operator() (value_type const& lhs, value_type const& rhs) const
         {
             return this->member() (lhs.first, rhs.first);
@@ -193,9 +201,17 @@ private:
     // VFALCO TODO hoist to remove template argument dependencies
     class KeyValueCompare
         : public boost::beast::detail::empty_base_optimization <Compare>
+#ifdef _LIBCPP_VERSION
         , public std::binary_function <Key, element, bool>
+#endif
     {
     public:
+#ifndef _LIBCPP_VERSION
+        using first_argument = Key;
+        using second_argument = element;
+        using result_type = bool;
+#endif
+
         KeyValueCompare () = default;
 
         KeyValueCompare (Compare const& compare)

--- a/src/ripple/beast/container/detail/aged_unordered_container.h
+++ b/src/ripple/beast/container/detail/aged_unordered_container.h
@@ -164,9 +164,16 @@ private:
     // VFALCO TODO hoist to remove template argument dependencies
     class ValueHash
         : private boost::beast::detail::empty_base_optimization <Hash>
+#ifdef _LIBCPP_VERSION
         , public std::unary_function <element, std::size_t>
+#endif
     {
     public:
+#ifndef _LIBCPP_VERSION
+        using argument_type = element;
+        using result_type = size_t;
+#endif
+
         ValueHash ()
         {
         }
@@ -196,9 +203,17 @@ private:
     // VFALCO TODO hoist to remove template argument dependencies
     class KeyValueEqual
         : private boost::beast::detail::empty_base_optimization <KeyEqual>
+#ifdef _LIBCPP_VERSION
         , public std::binary_function <Key, element, bool>
+#endif
     {
     public:
+#ifndef _LIBCPP_VERSION
+        using first_argument_type = Key;
+        using second_argument_type = element;
+        using result_type = bool;
+#endif
+
         KeyValueEqual ()
         {
         }

--- a/src/ripple/beast/cxx17/type_traits.h
+++ b/src/ripple/beast/cxx17/type_traits.h
@@ -28,11 +28,19 @@ namespace std {
 
 #ifndef _MSC_VER
 
-template<class...>
-using void_t = void;
+    #if ! __cpp_lib_void_t
 
-template<bool B>
-using bool_constant = std::integral_constant<bool, B>;
+        template<class...>
+        using void_t = void;
+
+    #endif // ! __cpp_lib_void_t
+
+    #if ! __cpp_lib_bool_constant
+
+        template<bool B>
+        using bool_constant = std::integral_constant<bool, B>;
+
+    #endif // ! __cpp_lib_bool_constant
 
 #endif
 

--- a/src/ripple/ledger/impl/CashDiff.cpp
+++ b/src/ripple/ledger/impl/CashDiff.cpp
@@ -263,11 +263,12 @@ getCashFlow (ReadView const& view, CashFilter f, ApplyStateTable const& table)
     auto each = [&result, &filters](uint256 const& key, bool isDelete,
         std::shared_ptr<SLE const> const& before,
         std::shared_ptr<SLE const> const& after) {
-
-        std::find_if (filters.begin(), filters.end(),
-            [&result, isDelete, &before, &after] (FuncType func) {
-                return func (result, isDelete, before, after);
+        auto discarded =
+            std::find_if (filters.begin(), filters.end(),
+                [&result, isDelete, &before, &after] (FuncType func) {
+                    return func (result, isDelete, before, after);
         });
+        (void) discarded;
     };
 
     table.visit (view, each);

--- a/src/ripple/peerfinder/impl/Bootcache.h
+++ b/src/ripple/peerfinder/impl/Bootcache.h
@@ -84,10 +84,18 @@ private:
     using map_type = boost::bimap <left_t, right_t>;
     using value_type = map_type::value_type;
 
-    struct Transform : std::unary_function <
-        map_type::right_map::const_iterator::value_type const&,
-            beast::IP::Endpoint const&>
+    struct Transform
+#ifdef _LIBCPP_VERSION
+        : std::unary_function<
+              map_type::right_map::const_iterator::value_type const&,
+              beast::IP::Endpoint const&>
+#endif
     {
+#ifndef _LIBCPP_VERSION
+        using first_argument_type = map_type::right_map::const_iterator::value_type const&;
+        using result_type = beast::IP::Endpoint const&;
+#endif
+
         explicit Transform() = default;
 
         beast::IP::Endpoint const& operator() (

--- a/src/ripple/peerfinder/impl/Livecache.h
+++ b/src/ripple/peerfinder/impl/Livecache.h
@@ -71,8 +71,15 @@ public:
     public:
         // Iterator transformation to extract the endpoint from Element
         struct Transform
-            : public std::unary_function <Element, Endpoint>
+#ifdef _LIBCPP_VERSION
+            : public std::unary_function<Element, Endpoint>
+#endif
         {
+#ifndef _LIBCPP_VERSION
+            using first_argument = Element;
+            using result_type = Endpoint;
+#endif
+
             explicit Transform() = default;
 
             Endpoint const& operator() (Element const& e) const
@@ -227,9 +234,15 @@ public:
 
         template <bool IsConst>
         struct Transform
-            : public std::unary_function <
-                typename lists_type::value_type, Hop <IsConst>>
+#ifdef _LIBCPP_VERSION
+            : public std::unary_function<typename lists_type::value_type, Hop<IsConst>>
+#endif
         {
+#ifndef _LIBCPP_VERSION
+            using first_argument = typename lists_type::value_type;
+            using result_type = Hop <IsConst>;
+#endif
+
             explicit Transform() = default;
 
             Hop <IsConst> operator() (typename beast::maybe_const <

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -897,7 +897,7 @@ struct PayStrand_test : public beast::unit_test::suite
                 false,
                 env.app().logs().journal("Flow"));
             BEAST_EXPECT(r.first == expTer);
-            if (sizeof...(expSteps))
+            if (sizeof...(expSteps) !=0 )
                 BEAST_EXPECT(equal(
                     r.second, std::forward<decltype(expSteps)>(expSteps)...));
         };


### PR DESCRIPTION
With these few changes I can compile rippled using C++17 on mac OS using Xcode 9.4.1 and Boost 1.67.0.  I selected C++17 by changing the `cxx_std_14` in CMakeLists.txt to `cxx_std_17`.

- The change in PaySteps.cpp was prompted by a build error that came from the boost range library.  Boost was looking for the `std::random_shuffle` algorithm which is no longer in the standard library as of C++17.  The simplest solution was to convert the three uses of `boost::range::find(_if)` to simply use `std::find(_if)`.

- The change in ripple/beast/cxx17/type_traits.h was to guard the, now now duplicated, implementations of `void_t` and `bool_constant` using their standard-provided feature macros.  Without the guards the compiler gave errors about duplicate definitions.

With these changes I was able to build with both C++14 and C++17, pass the unit tests, and sync the server to the network.

I make no claims about whether other environments will be able to build using C++17 :wink: