### PR TITLE
[TRIVIAL] Change conflicting example websocket port

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1113,7 +1113,7 @@ admin = 127.0.0.1
 protocol = ws
 
 #[port_ws_public]
-#port = 5005
+#port = 6005
 #ip = 127.0.0.1
 #protocol = wss
 


### PR DESCRIPTION
The example configuration file uses port 5005 for the public websocket which conflicts with the RPC port.