### PR TITLE
Properly handle expired validator lists when validating (RIPD-1661):

### DIFF
--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -331,6 +331,10 @@ public:
     for_each_listed (
         std::function<void(PublicKey const&, bool)> func) const;
 
+    /** Return the number of configured validator list sites. */
+    std::size_t
+    count() const;
+
     /** Return the time when the validator list will expire
 
         @note This may be a time in the past if a published list has not

--- a/src/ripple/protocol/JsonFields.h
+++ b/src/ripple/protocol/JsonFields.h
@@ -481,6 +481,7 @@ JSS ( validate );                   // in: DownloadShard
 JSS ( validated );                  // out: NetworkOPs, RPCHelpers, AccountTx*
                                     //      Tx
 JSS ( validator_list_expires );     // out: NetworkOps, ValidatorList
+JSS ( validator_list );             // out: NetworkOps, ValidatorList
 JSS ( validated_ledger );           // out: NetworkOPs
 JSS ( validated_ledgers );          // out: NetworkOPs
 JSS ( validation_key );             // out: ValidationCreate, ValidationSeed

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -111,7 +111,7 @@ public:
                 auto const jrr = env.rpc("server_info")[jss::result];
                 BEAST_EXPECT(jrr[jss::status] == "success");
                 BEAST_EXPECT(jrr[jss::info].isMember(
-                                 jss::validator_list_expires) == isAdmin);
+                                 jss::validator_list) == isAdmin);
             }
 
             {
@@ -145,7 +145,8 @@ public:
         {
             auto const jrr = env.rpc("server_info")[jss::result];
             BEAST_EXPECT(
-                jrr[jss::info][jss::validator_list_expires] == "never");
+                jrr[jss::info][jss::validator_list][jss::expiration] ==
+                "never");
         }
         {
             auto const jrr = env.rpc("server_state")[jss::result];
@@ -156,7 +157,7 @@ public:
         // All our keys are in the response
         {
             auto const jrr = env.rpc("validators")[jss::result];
-            BEAST_EXPECT(jrr[jss::validator_list_expires] == "never");
+            BEAST_EXPECT(jrr[jss::validator_list][jss::expiration] == "never");
             BEAST_EXPECT(jrr[jss::validation_quorum].asUInt() == keys.size());
             BEAST_EXPECT(jrr[jss::trusted_validator_keys].size() == keys.size());
             BEAST_EXPECT(jrr[jss::publisher_lists].size() == 0);
@@ -226,7 +227,8 @@ public:
             {
                 auto const jrr = env.rpc("server_info")[jss::result];
                 BEAST_EXPECT(
-                    jrr[jss::info][jss::validator_list_expires] == "unknown");
+                    jrr[jss::info][jss::validator_list][jss::expiration] ==
+                    "unknown");
             }
             {
                 auto const jrr = env.rpc("server_state")[jss::result];
@@ -239,7 +241,8 @@ public:
                     std::numeric_limits<std::uint32_t>::max());
                 BEAST_EXPECT(jrr[jss::local_static_keys].size() == 0);
                 BEAST_EXPECT(jrr[jss::trusted_validator_keys].size() == 0);
-                BEAST_EXPECT(jrr[jss::validator_list_expires] == "unknown");
+                BEAST_EXPECT(
+                    jrr[jss::validator_list][jss::expiration] == "unknown");
 
                 if (BEAST_EXPECT(jrr[jss::publisher_lists].size() == 1))
                 {
@@ -312,7 +315,8 @@ public:
 
             {
                 auto const jrr = env.rpc("server_info")[jss::result];
-                BEAST_EXPECT(jrr[jss::info][jss::validator_list_expires] ==
+                BEAST_EXPECT(
+                    jrr[jss::info][jss::validator_list][jss::expiration] ==
                     to_string(expiration));
             }
             {
@@ -325,7 +329,8 @@ public:
                 auto const jrr = env.rpc("validators")[jss::result];
                 BEAST_EXPECT(jrr[jss::validation_quorum].asUInt() == 2);
                 BEAST_EXPECT(
-                    jrr[jss::validator_list_expires] == to_string(expiration));
+                    jrr[jss::validator_list][jss::expiration] ==
+                    to_string(expiration));
                 BEAST_EXPECT(jrr[jss::local_static_keys].size() == 0);
 
                 BEAST_EXPECT(jrr[jss::trusted_validator_keys].size() ==


### PR DESCRIPTION
A validator that was configured to use a published validator list could exhibit aberrent behavior if that validator list expired.

This commit introduces additional logic that makes validators operating with an expired validator list bow out of the consensus process instead of continuing to publish validations. Normal operation will resume once a non-expired validator list becomes available.

This commit also enhances status reporting when using the `server_info` and `validators` commands. Before, only the expiration time of the list would be returned; now, its current status is also reported in a format that is clearer.