### PR TITLE
[TRIVIAL] remove duplicated include

### DIFF
--- a/src/ripple/beast/core/BasicNativeHeaders.h
+++ b/src/ripple/beast/core/BasicNativeHeaders.h
@@ -272,7 +272,6 @@
  #if BEAST_LINUX || BEAST_ANDROID
   #include <sys/types.h>
   #include <sys/socket.h>
-  #include <sys/errno.h>
   #include <unistd.h>
   #include <netinet/in.h>
  #endif


### PR DESCRIPTION
The errno.h header is already included for both Linux and Android above