### PR TITLE
Fix memory leak in Json move assignment operator

### DIFF
--- a/src/ripple/json/impl/json_value.cpp
+++ b/src/ripple/json/impl/json_value.cpp
@@ -348,10 +348,9 @@ Value::~Value ()
 }
 
 Value&
-Value::operator= ( const Value& other )
+Value::operator= ( Value other )
 {
-    Value temp ( other );
-    swap ( temp );
+    swap ( other );
     return *this;
 }
 
@@ -362,13 +361,6 @@ Value::Value ( Value&& other ) noexcept
 {
     other.type_ = nullValue;
     other.allocated_ = 0;
-}
-
-Value&
-Value::operator= ( Value&& other ) noexcept
-{
-    swap ( other );
-    return *this;
 }
 
 void

--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -233,10 +233,9 @@ public:
     Value ( const Value& other );
     ~Value ();
 
-    Value& operator= ( const Value& other );
+    Value& operator= ( Value other );
 
     Value ( Value&& other ) noexcept;
-    Value& operator= ( Value&& other ) noexcept;
 
     /// Swap values.
     /// \note Currently, comments are intentionally not swapped, for


### PR DESCRIPTION
*  When move assignment is creates a cyclic ownership pattern
   memory was being leaked.  This patch breaks the cycle.

*  Address issue https://github.com/ripple/rippled/issues/2572