### PR TITLE
Remove the state file for the random number generator

### DIFF
--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -81,9 +81,6 @@ public:
     /** Returns the full path and filename of the debug log file. */
     boost::filesystem::path getDebugLogFile () const;
 
-    /** Returns the full path and filename of the entropy seed file. */
-    boost::filesystem::path getEntropyFile () const;
-
 private:
     boost::filesystem::path CONFIG_FILE;
 public:

--- a/src/ripple/crypto/csprng.h
+++ b/src/ripple/crypto/csprng.h
@@ -61,14 +61,6 @@ public:
     void
     mix_entropy (void* buffer = nullptr, std::size_t count = 0);
 
-    /** Load entropy from the specified file */
-    void
-    load_state (std::string const& file);
-
-    /** Save entropy to the specified file */
-    void
-    save_state (std::string const& file);
-
     /** Generate a random integer */
     result_type
     operator()();

--- a/src/ripple/crypto/impl/csprng.cpp
+++ b/src/ripple/crypto/impl/csprng.cpp
@@ -51,27 +51,6 @@ csprng_engine::~csprng_engine ()
 }
 
 void
-csprng_engine::load_state (std::string const& file)
-{
-    if (!file.empty())
-    {
-        std::lock_guard<std::mutex> lock (mutex_);
-        RAND_load_file (file.c_str (), kilobytes(1));
-        RAND_write_file (file.c_str ());
-    }
-}
-
-void
-csprng_engine::save_state (std::string const& file)
-{
-    if (!file.empty())
-    {
-        std::lock_guard<std::mutex> lock (mutex_);
-        RAND_write_file (file.c_str ());
-    }
-}
-
-void
 csprng_engine::mix_entropy (void* buffer, std::size_t count)
 {
     std::array<std::random_device::result_type, 128> entropy;

--- a/src/test/core/CryptoPRNG_test.cpp
+++ b/src/test/core/CryptoPRNG_test.cpp
@@ -49,74 +49,10 @@ class CryptoPRNG_test : public beast::unit_test::suite
         }
     }
 
-    void
-    testSaveLoad()
-    {
-        testcase ("Save/Load State");
-        try
-        {
-            // create a temporary path to write crypto state files
-            beast::temp_dir td;
-
-            auto stateFile = boost::filesystem::path {td.file("cryptostate")};
-            auto& engine = crypto_prng();
-            engine.save_state(stateFile.string());
-
-            size_t size_before_load;
-            std::string data_before_load, data_after_load;
-
-            {
-                boost::system::error_code ec;
-                size_before_load = file_size(stateFile, ec);
-                if(! BEAST_EXPECTS(!ec, ec.message()))
-                    return;
-                if(! BEAST_EXPECT(size_before_load > 0))
-                    return;
-
-                std::ifstream ifs(
-                    stateFile.string(),
-                    std::ios::in | std::ios::binary);
-                data_before_load =
-                    std::string{std::istreambuf_iterator<char>{ifs}, {}};
-                BEAST_EXPECT(data_before_load.size() == size_before_load);
-            }
-
-            engine.load_state(stateFile.string());
-
-            // load_state actually causes a new state file to be written
-            // ...verify it has changed
-
-            {
-                boost::system::error_code ec;
-                size_t size_after_load = file_size(stateFile, ec);
-                if(! BEAST_EXPECTS(!ec, ec.message()))
-                    return;
-                BEAST_EXPECT(size_after_load == size_before_load);
-
-                std::ifstream ifs(
-                    stateFile.string(),
-                    std::ios::in | std::ios::binary);
-                data_after_load =
-                    std::string{std::istreambuf_iterator<char>{ifs}, {}};
-                BEAST_EXPECT(data_after_load.size() == size_after_load);
-                BEAST_EXPECT(data_after_load != data_before_load);
-            }
-
-            // verify the loaded engine works
-            engine();
-            pass();
-        }
-        catch(std::exception&)
-        {
-            fail();
-        }
-    }
-
 public:
     void run () override
     {
         testGetValues();
-        testSaveLoad();
     }
 };
 


### PR DESCRIPTION
Existence of this file is only documented in code (and kinda unexpected anyways, especially in a folder reserved for databases), it leaves a minor attack surface (if the contents of the file are replaced by an attacker) and doesn't really increase security that much (rippled gets started at a point where the operating system had enough time to gather entropy and if the operating system already has bad entropy, storing and re-loading it the next time won't help much either).