### PR TITLE
Prefer regex to manual parsing in parseURL

### DIFF
--- a/src/test/basics/StringUtilities_test.cpp
+++ b/src/test/basics/StringUtilities_test.cpp
@@ -63,23 +63,89 @@ public:
     {
         testcase ("parseUrl");
 
-        parsedURL pUrl;
-
-        BEAST_EXPECT(parseUrl (pUrl, "lower://domain"));
-        BEAST_EXPECT(pUrl.scheme == "lower");
-        BEAST_EXPECT(pUrl.domain == "domain");
-        BEAST_EXPECT(! pUrl.port);
-        BEAST_EXPECT(pUrl.path == "");
-        BEAST_EXPECT(parseUrl (pUrl, "UPPER://domain:234/"));
-        BEAST_EXPECT(pUrl.scheme == "upper");
-        BEAST_EXPECT(*pUrl.port == 234);
-        BEAST_EXPECT(pUrl.path == "/");
-        BEAST_EXPECT(parseUrl (pUrl, "Mixed://domain/path"));
-        BEAST_EXPECT(pUrl.scheme == "mixed");
-        BEAST_EXPECT(pUrl.path == "/path");
-        BEAST_EXPECT(parseUrl (pUrl, "scheme://[::1]:123/path"));
-        BEAST_EXPECT(*pUrl.port == 123);
-        BEAST_EXPECT(pUrl.domain == "::1");
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "lower://domain"));
+            BEAST_EXPECT(pUrl.scheme == "lower");
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(! pUrl.port);
+            BEAST_EXPECT(pUrl.path == "");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "UPPER://domain:234/"));
+            BEAST_EXPECT(pUrl.scheme == "upper");
+            BEAST_EXPECT(*pUrl.port == 234);
+            BEAST_EXPECT(pUrl.path == "/");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "Mixed://domain/path"));
+            BEAST_EXPECT(pUrl.scheme == "mixed");
+            BEAST_EXPECT(pUrl.path == "/path");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://[::1]:123/path"));
+            BEAST_EXPECT(*pUrl.port == 123);
+            BEAST_EXPECT(pUrl.domain == "::1");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://user:pass@domain:123/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(*pUrl.port == 123);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://user@domain:123/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(*pUrl.port == 123);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://:pass@domain:123/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(*pUrl.port == 123);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://domain:123/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(*pUrl.port == 123);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://user:pass@domain/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(! pUrl.port);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://user@domain/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(! pUrl.port);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://:pass@domain/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(! pUrl.port);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "scheme://domain/abc:321"));
+            BEAST_EXPECT(pUrl.domain == "domain");
+            BEAST_EXPECT(! pUrl.port);
+            BEAST_EXPECT(pUrl.path == "/abc:321");
+        }
     }
 
     void testToString ()


### PR DESCRIPTION
`parseURL` in `StringUtilities.cpp` uses a regex to pull the authority
out of the URL, then further parsing to get the host and port.  Roll
that parsing into the regex. Note that the host can be a name, an IPv4
address, or an IPv6 address.

------

Because this is my first PR, I'm going to bet I'm running afoul of some conventions that I'm just ignorant of. Please point them out.

I scoped the individual test cases in blocks to reset the `parsedURL` object. I was tripped up in development when the test cases I added at the end asserted no port number, but one was set by an earlier test case.

I'm not sure when to prefer assignment initialization and when to prefer braced initialization. The existing code had a mix.

I explicitly typed some declarations. Should I just prefer auto everywhere until the compiler complains?