### PR TITLE
Refactor base58 decoding (RIPD-1679):

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2235,6 +2235,7 @@ else ()
          subdir: protocol
     #]===============================]
     src/test/protocol/BuildInfo_test.cpp
+    src/test/protocol/Base58_test.cpp
     src/test/protocol/IOUAmount_test.cpp
     src/test/protocol/InnerObjectFormats_test.cpp
     src/test/protocol/Issue_test.cpp

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,9 +157,9 @@ try {
                 target = 'docs'
             }
             def cc =
-                (compiler == 'clang') ? '/opt/llvm-5.0.1/bin/clang' : 'gcc'
+                (compiler == 'clang') ? '/opt/llvm-7.0.0/bin/clang' : 'gcc'
             def cxx =
-                (compiler == 'clang') ? '/opt/llvm-5.0.1/bin/clang++' : 'g++'
+                (compiler == 'clang') ? '/opt/llvm-7.0.0/bin/clang++' : 'g++'
             def ucc = isNoUnity(cmake_extra) ? 'true' : 'false'
             def node_type =
                 (compiler == 'msvc') ? 'rippled-win' : 'rippled-dev'

--- a/src/ripple/basics/Slice.h
+++ b/src/ripple/basics/Slice.h
@@ -71,7 +71,7 @@ public:
     /** Can convert from a mutable slice to a non-mutable slice */
     template<class T,
              class = std::enable_if_t<!Mutable && std::is_same<T, SliceImpl<true>>::value>>
-    SliceImpl (/*SliceImpl<true>*/T const& rhs) noexcept
+    SliceImpl (T const& rhs) noexcept
         :SliceImpl{rhs.data(), rhs.size()}
     {
     }

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -124,7 +124,7 @@ public:
     Slice
     slice() const noexcept
     {
-        return {buf_.data(), buf_.size()};
+        return {data(), size()};
     }
 
     operator Slice() const noexcept

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -58,12 +58,14 @@ namespace ripple {
 */
 class PublicKey
 {
-protected:
-    std::size_t size_ = 0;
-    std::uint8_t buf_[33]; // should be large enough
+private:
+    bool empty_{true};
+    std::array<std::uint8_t, 33> buf_; // all supported public keys are 33 bytes
 
+    friend boost::optional<PublicKey>
+    parseBase58<PublicKey> (TokenType type, std::string const& s);
 public:
-    using const_iterator = std::uint8_t const*;
+    using const_iterator = std::array<std::uint8_t, 33>::const_iterator;
 
     PublicKey() = default;
     PublicKey (PublicKey const& other);
@@ -80,49 +82,49 @@ public:
     std::uint8_t const*
     data() const noexcept
     {
-        return buf_;
+        return buf_.data();
     }
 
     std::size_t
     size() const noexcept
     {
-        return size_;
+        return empty_ ? 0 : buf_.size();
     }
 
     const_iterator
     begin() const noexcept
     {
-        return buf_;
+        return buf_.begin();
     }
 
     const_iterator
     cbegin() const noexcept
     {
-        return buf_;
+        return buf_.cbegin();
     }
 
     const_iterator
     end() const noexcept
     {
-        return buf_ + size_;
+        return empty_ ? buf_.begin() : buf_.end();
     }
 
     const_iterator
     cend() const noexcept
     {
-        return buf_ + size_;
+        return empty_ ? buf_.cbegin() : buf_.cend();
     }
 
     bool
     empty() const noexcept
     {
-        return size_ == 0;
+        return empty_;
     }
 
     Slice
     slice() const noexcept
     {
-        return { buf_, size_ };
+        return {buf_.data(), buf_.size()};
     }
 
     operator Slice() const noexcept

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -41,7 +41,7 @@ private:
     boost::optional<SecretKey>
     parseBase58SecretKey (TokenType type, std::string const& s);
 public:
-    using const_iterator = std::uint8_t const*;
+    using const_iterator = std::array<std::uint8_t, 32>::const_iterator;
 
     SecretKey() = default;
     SecretKey (SecretKey const&) = default;
@@ -75,25 +75,25 @@ public:
     const_iterator
     begin() const noexcept
     {
-        return buf_.data();
+        return buf_.begin();
     }
 
     const_iterator
     cbegin() const noexcept
     {
-        return buf_.data();
+        return buf_.cbegin();
     }
 
     const_iterator
     end() const noexcept
     {
-        return buf_.data() + buf_.size();
+        return buf_.end();
     }
 
     const_iterator
     cend() const noexcept
     {
-        return buf_.data() + buf_.size();
+        return buf_.cend();
     }
 };
 

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -39,7 +39,7 @@ private:
 
     friend
     boost::optional<SecretKey>
-    parseBase58SecretKey (TokenType type, std::string const& s);
+    parseBase58<SecretKey> (TokenType type, std::string const& s);
 public:
     using const_iterator = std::array<std::uint8_t, 32>::const_iterator;
 

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -35,8 +35,11 @@ namespace ripple {
 class SecretKey
 {
 private:
-    std::uint8_t buf_[32];
+    std::array<std::uint8_t, 32> buf_;
 
+    friend
+    boost::optional<SecretKey>
+    parseBase58SecretKey (TokenType type, std::string const& s);
 public:
     using const_iterator = std::uint8_t const*;
 
@@ -52,13 +55,13 @@ public:
     std::uint8_t const*
     data() const
     {
-        return buf_;
+        return buf_.data();
     }
 
     std::size_t
     size() const
     {
-        return sizeof(buf_);
+        return buf_.size();
     }
 
     /** Convert the secret key to a hexadecimal string.
@@ -72,25 +75,25 @@ public:
     const_iterator
     begin() const noexcept
     {
-        return buf_;
+        return buf_.data();
     }
 
     const_iterator
     cbegin() const noexcept
     {
-        return buf_;
+        return buf_.data();
     }
 
     const_iterator
     end() const noexcept
     {
-        return buf_ + sizeof(buf_);
+        return buf_.data() + buf_.size();
     }
 
     const_iterator
     cend() const noexcept
     {
-        return buf_ + sizeof(buf_);
+        return buf_.data() + buf_.size();
     }
 };
 

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -41,7 +41,7 @@ private:
     boost::optional<SecretKey>
     parseBase58<SecretKey> (TokenType type, std::string const& s);
 public:
-    using const_iterator = std::array<std::uint8_t, 32>::const_iterator;
+    using const_iterator = decltype(buf_)::const_iterator;
 
     SecretKey() = default;
     SecretKey (SecretKey const&) = default;

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -22,6 +22,7 @@
 
 #include <ripple/basics/base_uint.h>
 #include <ripple/basics/Slice.h>
+#include <ripple/crypto/KeyType.h>
 #include <ripple/protocol/tokens.h>
 #include <boost/optional.hpp>
 #include <array>
@@ -115,8 +116,13 @@ template <>
 boost::optional<Seed>
 parseBase58 (std::string const& s);
 
+/** Same as above, but inculde optional keyType
+*/
+boost::optional<std::pair<Seed, boost::optional<KeyType>>>
+parseBase58Seed (std::string const& s);
+
 /** Attempt to parse a string as a seed */
-boost::optional<Seed>
+boost::optional<std::pair<Seed, boost::optional<KeyType>>>
 parseGenericSeed (std::string const& str);
 
 /** Encode a Seed in RFC1751 format */

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -29,7 +29,7 @@
 
 namespace ripple {
 
-/** Seeds are used to a generate deterministic secret key. */
+/** Seeds are used to generate a deterministic secret key. */
 class Seed
 {
 private:

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -29,12 +29,12 @@
 
 namespace ripple {
 
-/** Seeds are used to generate deterministic secret keys. */
+/** Seeds are used to a generate deterministic secret key. */
 class Seed
 {
 private:
     std::array<uint8_t, 16> buf_;
-
+    boost::optional<KeyType> keyType_;
 public:
     using const_iterator = std::array<uint8_t, 16>::const_iterator;
 
@@ -50,9 +50,19 @@ public:
 
     /** Construct a seed */
     /** @{ */
-    explicit Seed (Slice const& slice);
-    explicit Seed (uint128 const& seed);
+    explicit Seed(
+        Slice const& slice,
+        boost::optional<KeyType> const& keyType = {});
+    explicit Seed(
+        uint128 const& seed,
+        boost::optional<KeyType> const& keyType = {});
     /** @} */
+
+    boost::optional<KeyType> const&
+    keyType() const
+    {
+        return keyType_;
+    }
 
     std::uint8_t const*
     data() const
@@ -116,13 +126,8 @@ template <>
 boost::optional<Seed>
 parseBase58 (std::string const& s);
 
-/** Same as above, but inculde optional keyType
-*/
-boost::optional<std::pair<Seed, boost::optional<KeyType>>>
-parseBase58Seed (std::string const& s);
-
 /** Attempt to parse a string as a seed */
-boost::optional<std::pair<Seed, boost::optional<KeyType>>>
+boost::optional<Seed>
 parseGenericSeed (std::string const& str);
 
 /** Encode a Seed in RFC1751 format */

--- a/src/ripple/protocol/impl/AccountID.cpp
+++ b/src/ripple/protocol/impl/AccountID.cpp
@@ -35,28 +35,24 @@ template<>
 boost::optional<AccountID>
 parseBase58 (std::string const& s)
 {
-    auto const result = decodeBase58Token(s, TokenType::AccountID);
-    if (result.empty())
-        return boost::none;
     AccountID id;
-    if (result.size() != id.size())
+    if (!decodeBase58Token(
+            makeSlice(s),
+            TokenType::AccountID,
+            MutableSlice(id.data(), id.size())))
         return boost::none;
-    std::memcpy(id.data(),
-        result.data(), result.size());
     return id;
 }
 
 boost::optional<AccountID>
 deprecatedParseBitcoinAccountID (std::string const& s)
 {
-    auto const result = decodeBase58TokenBitcoin(s, TokenType::AccountID);
-    if (result.empty())
-        return boost::none;
     AccountID id;
-    if (result.size() != id.size())
+    if (!decodeBase58TokenBitcoin(
+            makeSlice(s),
+            TokenType::AccountID,
+            MutableSlice(id.data(), id.size())))
         return boost::none;
-    std::memcpy(id.data(),
-        result.data(), result.size());
     return id;
 }
 

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -181,7 +181,7 @@ ed25519Canonical (Slice const& sig)
 
 PublicKey::PublicKey (Slice const& slice)
 {
-    if (slice.size() != buf_.size() || !publicKeyType(slice))
+    if (!publicKeyType(slice))
         LogicError("PublicKey::PublicKey invalid type");
     empty_ = false;
     std::memcpy(buf_.data(), slice.data(), slice.size());

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -39,11 +39,18 @@ template<>
 boost::optional<PublicKey>
 parseBase58 (TokenType type, std::string const& s)
 {
-    auto const result = decodeBase58Token(s, type);
-    auto const pks = makeSlice(result);
-    if (!publicKeyType(pks))
+    std::array<std::uint8_t, 33> result_buf;
+    // decoded may be 33 or 32 bytes
+    auto decoded = decodeBase58Token(
+        makeSlice(s),
+        type,
+        makeMutableSlice(result_buf),
+        /*allow resize*/ true);
+    if (!decoded || !(decoded->size() == 32 || decoded->size()==33))
         return boost::none;
-    return PublicKey(pks);
+    if (!publicKeyType(*decoded))
+        return boost::none;
+    return PublicKey(*decoded);
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -289,20 +289,14 @@ randomKeyPair (KeyType type)
     return { derivePublicKey(type, sk), sk };
 }
 
+template <>
 boost::optional<SecretKey>
-parseBase58SecretKey(TokenType type, std::string const& s)
+parseBase58(TokenType type, std::string const& s)
 {
     SecretKey result;
     if (!decodeBase58Token(makeSlice(s), type, makeMutableSlice(result.buf_)))
         return boost::none;
     return result;
-}
-
-template <>
-boost::optional<SecretKey>
-parseBase58(TokenType type, std::string const& s)
-{
-    return parseBase58SecretKey(type, s);
 }
 
 } // ripple

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -36,9 +36,9 @@ SecretKey::~SecretKey()
     beast::secure_erase(buf_.data(), buf_.size());
 }
 
-SecretKey::SecretKey (std::array<std::uint8_t, 32> const& key)
+SecretKey::SecretKey(std::array<std::uint8_t, 32> const& key)
+    : buf_{key}
 {
-    std::memcpy(buf_.data(), key.data(), key.size());
 }
 
 SecretKey::SecretKey (Slice const& slice)

--- a/src/ripple/protocol/impl/Seed.cpp
+++ b/src/ripple/protocol/impl/Seed.cpp
@@ -117,10 +117,10 @@ parseBase58 (std::string const& s)
     zero_after_use_buf<std::uint8_t, 16> result;
     auto resultSlice = makeMutableSlice(result);
     boost::optional<KeyType> keyType;
-    if (boost::optional<std::pair<Slice, ExtraB58Encoding>> r =
+    if (boost::optional<ExtraB58Encoding> r =
         decodeBase58FamilySeed(makeSlice(s), resultSlice))
     {
-        if (r->second == ExtraB58Encoding::RippleLib)
+        if (*r == ExtraB58Encoding::RippleLib)
             keyType = KeyType::ed25519;
         return Seed(resultSlice, keyType);
     }

--- a/src/ripple/protocol/impl/Seed.cpp
+++ b/src/ripple/protocol/impl/Seed.cpp
@@ -76,9 +76,7 @@ struct zero_after_use_uint256 : uint256
 {
     using uint256::uint256;
     zero_after_use_uint256() = default;
-    zero_after_use_uint256(zero_after_use_uint256 const& other) : uint256{other}
-    {
-    }
+    zero_after_use_uint256(zero_after_use_uint256 const& other) = default;
     zero_after_use_uint256(uint256 const& other) : uint256{other}
     {
     }
@@ -136,8 +134,8 @@ parseGenericSeed (std::string const& str)
     // large enough to hold either a public key, account, secret key, or seed
     zero_after_use_buf<std::uint8_t, 33> buffer;
 
-    boost::optional<std::pair<Slice, DecodeMetadata>> rawDecode = decodeBase58(
-        makeSlice(str), makeMutableSlice(buffer), /*allowResize*/ true);
+    boost::optional<std::pair<Slice, DecodeMetadata>> rawDecode =
+        decodeBase58Resizable(makeSlice(str), makeMutableSlice(buffer));
 
     Slice decodedSlice;
     DecodeMetadata metadata;

--- a/src/ripple/protocol/impl/tokens.cpp
+++ b/src/ripple/protocol/impl/tokens.cpp
@@ -96,6 +96,7 @@ digest2(Args const&... args)
 
     @note This checksum algorithm is part of the client API
 */
+static
 void
 checksum(void* out, void const* message, std::size_t size)
 {
@@ -103,6 +104,7 @@ checksum(void* out, void const* message, std::size_t size)
     std::memcpy(out, h.data(), checksumBytes);
 }
 
+static
 void
 checksum(void* out, Slice prefix, Slice message)
 {

--- a/src/ripple/protocol/impl/tokens.cpp
+++ b/src/ripple/protocol/impl/tokens.cpp
@@ -588,38 +588,39 @@ static InverseAlphabet rippleInverse(rippleAlphabet);
 
 static InverseAlphabet bitcoinInverse(bitcoinAlphabet);
 
-boost::optional<Slice>
+bool
 decodeBase58Token(
     Slice s,
     TokenType type,
-    MutableSlice result,
-    bool allowResize)
+    MutableSlice result)
 {
     DecodeBase58Detail::bitset flags;
-    if (allowResize)
-        flags.set(DecodeBase58Detail::allowResize);
     if (auto r = decodeBase58Token(s, type, result, rippleInverse, flags))
-        return r->first;
-    return {};
+        return true;
+    return false;
 }
 
-boost::optional<std::pair<Slice, ExtraB58Encoding>>
+boost::optional<ExtraB58Encoding>
 decodeBase58FamilySeed(Slice s, MutableSlice result)
 {
     DecodeBase58Detail::bitset flags;
     flags.set(DecodeBase58Detail::maybeRippleLibEncoded);
     flags.set(DecodeBase58Detail::maybeSecret);
-    return decodeBase58Token(
-        s, TokenType::FamilySeed, result, rippleInverse, flags);
+    if (auto const r = decodeBase58Token(
+            s, TokenType::FamilySeed, result, rippleInverse, flags))
+    {
+        return r->second;
+    }
+    return {};
 }
 
-boost::optional<Slice>
+bool
 decodeBase58TokenBitcoin(Slice s, TokenType type, MutableSlice result)
 {
     DecodeBase58Detail::bitset flags;
     if (auto r = decodeBase58Token(s, type, result, bitcoinInverse, flags))
-        return r->first;
-    return {};
+        return true;
+    return false;
 }
 
 boost::optional<std::pair<Slice, DecodeMetadata>>

--- a/src/ripple/protocol/tokens.h
+++ b/src/ripple/protocol/tokens.h
@@ -161,18 +161,15 @@ struct DecodeMetadata
     Token type is known, use either `decodeBase58Token` or `decodeBase58FamilySeed`.
 
     The checksum must match or `boost::none` is returned. The value will be
-    decoded into the slice specified by the `result` parameter. If `allowResize`
-    is true, the result may be smaller than the specified slice. In that case
-    the returned slice will be a proper subset of the result slice. If
-    `allowResize` is false, the returned slice is always either `boost::none` or
-    is the same slice as `result`. If the result is larger than the space
+    decoded into the slice specified by the `result` parameter. The result may be
+    smaller than the specified slice. In that case the returned slice will be a
+    proper subset of the result slice. If the result is larger than the space
     allowed by `result` then `boost::none` is returned.
 */
 boost::optional<std::pair<Slice, DecodeMetadata>>
-decodeBase58(
+decodeBase58Resizable(
     Slice s,
-    MutableSlice result,
-    bool allowResize);
+    MutableSlice result);
 
 } // ripple
 

--- a/src/ripple/protocol/tokens.h
+++ b/src/ripple/protocol/tokens.h
@@ -96,23 +96,16 @@ base58EncodeTokenBitcoin (TokenType type, void const* token, std::size_t size);
 
 /** Decode a Base58 token
 
-    The type and checksum must match or `boost::none` is returned. The
-    value will be decoded into the slice specified by the `result` parameter.
-    If `allowResize` is true, the result may be smaller than the specified
-    slice. In that case the returned slice will be a proper subset of the
-    result slice. If `allowResize` is false, the returned slice is always
-    either `boost::none` or is the same slice as `result`. If the result is
-    larger than the space allowed by `result` then `boost::none` is returned.
-
-    @note `allowResize` is used to support public keys, which may be either
-    32 or 33 bytes. All other token types have known fixed sizes.
+    The type and checksum must match or `false` is returned. The
+    value will be decoded into the slice specified by the `result` parameter. The
+    decoded result must fit exactly into the specified buffer or `false` is returned.
+    `true` is returned on successful decoding.
 */
-boost::optional<Slice>
+bool
 decodeBase58Token(
     Slice s,
     TokenType type,
-    MutableSlice result,
-    bool allowResize = false);
+    MutableSlice result);
 
 /** Distinguish between ripple lib encoded seeds and regular encoded seeds.
 
@@ -124,26 +117,26 @@ enum class ExtraB58Encoding {None, RippleLib};
 
 /** Decode a base58 family seed.
 
-    Return the decoded type and extra encoding type. The extra encoding type is
-    either `RippleLib` for ripple lib encoded seeds (these are ed25519 seeds with
+    Return `boost::none` if the encoding could not be interpreted as a family seed.
+    return the extra encoding type if the encoding is a family seed. The extra encoding
+    type is either `RippleLib` for ripple lib encoded seeds (these are ed25519 seeds with
     a special prefix) to `None` for regular seeds.
 */
-boost::optional<std::pair<Slice, ExtraB58Encoding>>
+boost::optional<ExtraB58Encoding>
 decodeBase58FamilySeed(Slice s, MutableSlice result);
 
 /** Decode a Base58 token using Bitcoin alphabet
 
    The type and checksum must match or `boost::none is returned``. The slice
    must decode into exactly as many bytes as specified as the result slice or
-   `boost::none` is returned. The value will be decoded into the slice specified
-   by the `result` parameter. The returned slice is always either `boost::none`
-   or is the same slice as `result`.
+   `false` is returned. The value will be decoded into the slice specified
+   by the `result` parameter.
 
    @note This is used to detect user error. Specifically, when an AccountID is
    specified using the wrong base58 alphabet, so that a better error message may
    be returned.
 */
-boost::optional<Slice>
+bool
 decodeBase58TokenBitcoin(
     Slice s,
     TokenType type,

--- a/src/ripple/rpc/handlers/ValidationCreate.cpp
+++ b/src/ripple/rpc/handlers/ValidationCreate.cpp
@@ -33,9 +33,7 @@ validationSeed (Json::Value const& params)
     if (!params.isMember (jss::secret))
         return randomSeed ();
 
-    if (auto r = parseGenericSeed (params[jss::secret].asString ()))
-        return r->first;
-    return {};
+    return parseGenericSeed(params[jss::secret].asString());
 }
 
 // {

--- a/src/ripple/rpc/handlers/ValidationCreate.cpp
+++ b/src/ripple/rpc/handlers/ValidationCreate.cpp
@@ -33,7 +33,9 @@ validationSeed (Json::Value const& params)
     if (!params.isMember (jss::secret))
         return randomSeed ();
 
-    return parseGenericSeed (params[jss::secret].asString ());
+    if (auto r = parseGenericSeed (params[jss::secret].asString ()))
+        return r->first;
+    return {};
 }
 
 // {

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -97,19 +97,20 @@ Json::Value walletPropose (Json::Value const& params)
         {
             Json::Value err;
 
-            boost::optional<std::pair<Seed, boost::optional<KeyType>>> const r =
+            auto const r =
                 RPC::getSeedFromRPC(params, err);
 
             if (!r)
                 return err;
-            if (keyType && r->second && *keyType != *r->second)
+            auto const decodedKeyType = r->keyType();
+            if (keyType && decodedKeyType && *keyType != *decodedKeyType)
             {
                 return rpcError(rpcBAD_SEED);
             }
-            rippleLibSeed = !keyType && r->second == KeyType::ed25519;
+            rippleLibSeed = !keyType && r->keyType() == KeyType::ed25519;
             if (!keyType)
-                keyType = r->second.value_or(KeyType::secp256k1);
-            seed = r->first;
+                keyType = decodedKeyType.value_or(KeyType::secp256k1);
+            seed = r;
         }
         else
         {

--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -109,7 +109,7 @@ injectSLE(Json::Value& jv, SLE const& sle);
 boost::optional<Json::Value>
 readLimitField(unsigned int& limit, Tuning::LimitRange const&, Context const&);
 
-boost::optional<std::pair<Seed, boost::optional<KeyType>>>
+boost::optional<Seed>
 getSeedFromRPC(Json::Value const& params, Json::Value& error);
 
 std::pair<PublicKey, SecretKey>

--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -109,11 +109,8 @@ injectSLE(Json::Value& jv, SLE const& sle);
 boost::optional<Json::Value>
 readLimitField(unsigned int& limit, Tuning::LimitRange const&, Context const&);
 
-boost::optional<Seed>
+boost::optional<std::pair<Seed, boost::optional<KeyType>>>
 getSeedFromRPC(Json::Value const& params, Json::Value& error);
-
-boost::optional<Seed>
-parseRippleLibSeed(Json::Value const& params);
 
 std::pair<PublicKey, SecretKey>
 keypairForSignature(Json::Value const& params, Json::Value& error);

--- a/src/test/protocol/Base58_test.cpp
+++ b/src/test/protocol/Base58_test.cpp
@@ -1,0 +1,861 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2018 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/beast/unit_test.h>
+#include <ripple/beast/xor_shift_engine.h>
+#include <ripple/protocol/digest.h>
+#include <ripple/protocol/tokens.h>
+#include <boost/container/small_vector.hpp>
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace ripple {
+
+namespace Base58TestDetail {
+// old implementation of decoding functions used as reference to confirm the
+// new implementation matches the old implementation
+
+static char rippleAlphabet[] =
+    "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz";
+
+static char bitcoinAlphabet[] =
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+//------------------------------------------------------------------------------
+
+template <class Hasher>
+static typename Hasher::result_type
+digest(void const* data, std::size_t size) noexcept
+{
+    Hasher h;
+    h(data, size);
+    return static_cast<typename Hasher::result_type>(h);
+}
+
+template <
+    class Hasher,
+    class T,
+    std::size_t N,
+    class = std::enable_if_t<sizeof(T) == 1>>
+static typename Hasher::result_type
+digest(std::array<T, N> const& v)
+{
+    return digest<Hasher>(v.data(), v.size());
+}
+
+// Computes a double digest (e.g. digest of the digest)
+template <class Hasher, class... Args>
+static typename Hasher::result_type
+digest2(Args const&... args)
+{
+    return digest<Hasher>(digest<Hasher>(args...));
+}
+
+/*  Calculate a 4-byte checksum of the data
+
+    The checksum is calculated as the first 4 bytes
+    of the SHA256 digest of the message. This is added
+    to the base58 encoding of identifiers to detect
+    user error in data entry.
+
+    @note This checksum algorithm is part of the client API
+*/
+void
+checksum(void* out, void const* message, std::size_t size)
+{
+    auto const h = digest2<sha256_hasher>(message, size);
+    std::memcpy(out, h.data(), 4);
+}
+
+//------------------------------------------------------------------------------
+
+// Code from Bitcoin: https://github.com/bitcoin/bitcoin
+// Copyright (c) 2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// Modified from the original
+//
+// WARNING Do not call this directly, use
+//         encodeBase58Token instead since it
+//         calculates the size of buffer needed.
+static std::string
+encodeBase58(
+    void const* message,
+    std::size_t size,
+    void* temp,
+    std::size_t temp_size,
+    char const* const alphabet)
+{
+    auto pbegin = reinterpret_cast<unsigned char const*>(message);
+    auto const pend = pbegin + size;
+
+    // Skip & count leading zeroes.
+    int zeroes = 0;
+    while (pbegin != pend && *pbegin == 0)
+    {
+        pbegin++;
+        zeroes++;
+    }
+
+    auto const b58begin = reinterpret_cast<unsigned char*>(temp);
+    auto const b58end = b58begin + temp_size;
+
+    std::fill(b58begin, b58end, 0);
+
+    while (pbegin != pend)
+    {
+        int carry = *pbegin;
+        // Apply "b58 = b58 * 256 + ch".
+        for (auto iter = b58end; iter != b58begin; --iter)
+        {
+            carry += 256 * (iter[-1]);
+            iter[-1] = carry % 58;
+            carry /= 58;
+        }
+        assert(carry == 0);
+        pbegin++;
+    }
+
+    // Skip leading zeroes in base58 result.
+    auto iter = b58begin;
+    while (iter != b58end && *iter == 0)
+        ++iter;
+
+    // Translate the result into a string.
+    std::string str;
+    str.reserve(zeroes + (b58end - iter));
+    str.assign(zeroes, alphabet[0]);
+    while (iter != b58end)
+        str += alphabet[*(iter++)];
+    return str;
+}
+
+static std::string
+encodeToken(
+    TokenType type,
+    void const* token,
+    std::size_t size,
+    char const* const alphabet)
+{
+    // expanded token includes type + 4 byte checksum
+    auto const expanded = 1 + size + 4;
+
+    // We need expanded + expanded * (log(256) / log(58)) which is
+    // bounded by expanded + expanded * (138 / 100 + 1) which works
+    // out to expanded * 3:
+    auto const bufsize = expanded * 3;
+
+    boost::container::small_vector<std::uint8_t, 1024> buf(bufsize);
+
+    // Lay the data out as
+    //      <type><token><checksum>
+    buf[0] = static_cast<std::underlying_type_t<TokenType>>(type);
+    if (size)
+        std::memcpy(buf.data() + 1, token, size);
+    checksum(buf.data() + 1 + size, buf.data(), 1 + size);
+
+    return encodeBase58(
+        buf.data(),
+        expanded,
+        buf.data() + expanded,
+        bufsize - expanded,
+        alphabet);
+}
+
+std::string
+base58EncodeToken(TokenType type, void const* token, std::size_t size)
+{
+    return encodeToken(type, token, size, rippleAlphabet);
+}
+
+std::string
+base58EncodeTokenBitcoin(TokenType type, void const* token, std::size_t size)
+{
+    return encodeToken(type, token, size, bitcoinAlphabet);
+}
+
+//------------------------------------------------------------------------------
+
+// Code from Bitcoin: https://github.com/bitcoin/bitcoin
+// Copyright (c) 2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// Modified from the original
+template <class InverseArray>
+static std::string
+decodeBase58(std::string const& s, InverseArray const& inv)
+{
+    auto psz = s.c_str();
+    auto remain = s.size();
+    // Skip and count leading zeroes
+    int zeroes = 0;
+    while (remain > 0 && inv[*psz] == 0)
+    {
+        ++zeroes;
+        ++psz;
+        --remain;
+    }
+    // Allocate enough space in big-endian base256 representation.
+    // log(58) / log(256), rounded up.
+    std::vector<unsigned char> b256(remain * 733 / 1000 + 1);
+    while (remain > 0)
+    {
+        auto carry = inv[*psz];
+        if (carry == -1)
+            return {};
+        // Apply "b256 = b256 * 58 + carry".
+        for (auto iter = b256.rbegin(); iter != b256.rend(); ++iter)
+        {
+            carry += 58 * *iter;
+            *iter = carry % 256;
+            carry /= 256;
+        }
+        assert(carry == 0);
+        ++psz;
+        --remain;
+    }
+    // Skip leading zeroes in b256.
+    auto iter = std::find_if(
+        b256.begin(), b256.end(), [](unsigned char c) { return c != 0; });
+    std::string result;
+    result.reserve(zeroes + (b256.end() - iter));
+    result.assign(zeroes, 0x00);
+    while (iter != b256.end())
+        result.push_back(*(iter++));
+    return result;
+}
+
+/*  Base58 decode a Ripple token
+
+    The type and checksum are are checked
+    and removed from the returned result.
+*/
+template <class InverseArray>
+static std::string
+decodeBase58Token(std::string const& s, TokenType type, InverseArray const& inv)
+{
+    auto ret = decodeBase58(s, inv);
+
+    // Reject zero length tokens
+    if (ret.size() < 6)
+        return {};
+
+    // The type must match.
+    if (type != static_cast<TokenType>(ret[0]))
+        return {};
+
+    // And the checksum must as well.
+    std::array<char, 4> guard;
+    checksum(guard.data(), ret.data(), ret.size() - guard.size());
+    if (!std::equal(guard.rbegin(), guard.rend(), ret.rbegin()))
+        return {};
+
+    // Skip the leading type byte and the trailing checksum.
+    return ret.substr(1, ret.size() - 1 - guard.size());
+}
+
+//------------------------------------------------------------------------------
+
+// Maps characters to their base58 digit
+class InverseAlphabet
+{
+private:
+    std::array<int, 256> map_;
+
+public:
+    explicit InverseAlphabet(std::string const& digits)
+    {
+        map_.fill(-1);
+        int i = 0;
+        for (auto const c : digits)
+            map_[static_cast<unsigned char>(c)] = i++;
+    }
+
+    int operator[](char c) const
+    {
+        return map_[static_cast<unsigned char>(c)];
+    }
+};
+
+static InverseAlphabet rippleInverse(rippleAlphabet);
+
+static InverseAlphabet bitcoinInverse(bitcoinAlphabet);
+
+std::string
+decodeBase58Token(std::string const& s, TokenType type)
+{
+    return decodeBase58Token(s, type, rippleInverse);
+}
+
+std::string
+decodeBase58TokenBitcoin(std::string const& s, TokenType type)
+{
+    return decodeBase58Token(s, type, bitcoinInverse);
+}
+
+template <class Log>
+bool
+checkMatch(Log&& log, Slice expected, Slice got, DecodeMetadata const& metadata)
+{
+    auto printIt = [&] {
+        log << std::hex;
+        log << "Exp, Got:\n";
+        for (auto c : expected)
+            log << std::uint32_t(c);
+        log << "\n";
+        log << std::uint32_t(metadata.tokenType);
+        if (metadata.isRippleLibEncoded())
+        {
+            for (auto c : metadata.encodingType)
+                log << std::uint32_t(c);
+        }
+        for (auto c : got)
+            log << std::uint32_t(c);
+        for (auto c : metadata.checksum)
+            log << std::uint32_t(c);
+        log << std::dec;
+        log << "\n";
+    };
+
+    if (expected[0] != metadata.tokenType)
+    {
+        log << "Token type mismatch\n";
+        printIt();
+        return false;
+    }
+    expected += 1;
+    if (metadata.isRippleLibEncoded())
+    {
+        if (expected[0] == std::uint8_t(0xE1) &&
+            expected[1] == std::uint8_t(0x4B))
+            expected += 2;
+        else
+        {
+            log << "Ripple lib encoded mismatch\n";
+            printIt();
+            return false;
+        }
+    }
+    if (!std::equal(
+            expected.data() + expected.size() - 4,
+            expected.data() + expected.size(),
+            metadata.checksum.begin(),
+            metadata.checksum.end()))
+    {
+        log << "Checksum mismatch\n";
+        printIt();
+        return false;
+    }
+    if (!std::equal(
+            expected.data(),
+            expected.data() + expected.size() - 4,
+            got.data(),
+            got.data() + got.size()))
+    {
+        log << "Data mismatch\n";
+        printIt();
+        return false;
+    }
+    return true;
+}
+}  // namespace Base58TestDetail
+
+class Base58Manual_test : public beast::unit_test::suite
+{
+    void
+    randomEncodedBase58(beast::xor_shift_engine& engine, MutableSlice result)
+    {
+        std::uniform_int_distribution<std::uint8_t> d(0, 57);
+        for (auto i = result.data(), e = result.data() + result.size(); i != e;
+             ++i)
+            *i = Base58TestDetail::rippleAlphabet[d(engine)];
+    }
+
+    void
+    randomFill(beast::xor_shift_engine& engine, MutableSlice result)
+    {
+        std::uniform_int_distribution<std::uint8_t> d(0, 255);
+        for (auto i = result.data(), e = result.data() + result.size(); i != e;
+             ++i)
+            *i = d(engine);
+    }
+
+    void
+    testRandomEncodeDecode(std::size_t numTestIterations)
+    {
+        testcase("base58 random encode/decode");
+        beast::xor_shift_engine
+            engine;  // use the default seed for repeatability
+        std::uniform_int_distribution<std::uint8_t> decodeSizeDist(10, 34);
+        std::uniform_int_distribution<std::uint8_t> leadingZeroesDist(1, 6);
+        std::uniform_real_distribution<float> zeroOneDist(0.0f, 1.0f);
+        std::array<std::uint8_t, MaxDecodedTokenBytes> decodeBuf;
+        for (int i = 0; i < numTestIterations; i++)
+        {
+            std::size_t const decodeSize = decodeSizeDist(engine);
+            // 25% chance of leading zeros;
+            std::size_t const leadingZeroes =
+                (zeroOneDist(engine) > 0.75) ? leadingZeroesDist(engine) : 0;
+            // 2% of test cases will start with 0x01e14b - the prefix used to
+            // distinguish a ripple lib encoded seed
+            bool const forceRippleLibPrefix = zeroOneDist(engine) > 0.98f;
+            assert(decodeSize <= decodeBuf.size() - 4);
+            MutableSlice decodeSlice(decodeBuf.data(), decodeSize);
+            MutableSlice noChecksumDecodeSlice(
+                decodeSlice.data(), decodeSlice.size() - 4);
+            randomFill(engine, noChecksumDecodeSlice);
+            if (leadingZeroes > 0)
+                memset(
+                    noChecksumDecodeSlice.data(),
+                    0,
+                    std::min(leadingZeroes, noChecksumDecodeSlice.size()));
+            if (forceRippleLibPrefix)
+            {
+                noChecksumDecodeSlice.data()[0] = 0x01;
+                noChecksumDecodeSlice.data()[1] = 0xE1;
+                noChecksumDecodeSlice.data()[2] = 0x4B;
+            }
+            Base58TestDetail::checksum(
+                decodeSlice.data() + decodeSlice.size() - 4,
+                noChecksumDecodeSlice.data(),
+                noChecksumDecodeSlice.size());
+            DecodeMetadata const metadataRef = [&decodeSlice] {
+                DecodeMetadata result;
+                result.tokenType = decodeSlice[0];
+                if (decodeSlice.size() == 23 &&
+                    result.tokenType ==
+                        static_cast<std::uint8_t>(TokenType::None) &&
+                    decodeSlice[1] == std::uint8_t(0xE1) &&
+                    decodeSlice[2] == std::uint8_t(0x4B))
+                {
+                    result.encodingType[0] = 0xE1;
+                    result.encodingType[1] = 0x4B;
+                }
+                else
+                {
+                    result.encodingType[0] = 0;
+                    result.encodingType[1] = 0;
+                }
+                memcpy(
+                    result.checksum.data(),
+                    decodeSlice.data() + decodeSlice.size() - 4,
+                    4);
+                return result;
+            }();
+            auto const decodeAsToken = metadataRef.isRippleLibEncoded()
+                ? TokenType::FamilySeed
+                : static_cast<TokenType>(decodeSlice[0]);
+
+            // encode with old impl
+            std::string encoded = Base58TestDetail::base58EncodeToken(
+                static_cast<TokenType>(decodeSlice[0]),
+                decodeSlice.data() + 1,
+                decodeSlice.size() - 5);  // 1 for token, 4 for checksum
+            std::string encodedBitcoin =
+                Base58TestDetail::base58EncodeTokenBitcoin(
+                    static_cast<TokenType>(decodeSlice[0]),
+                    decodeSlice.data() + 1,
+                    decodeSlice.size() - 5);  // 1 for token, 4 for checksum
+            // decode with new impl
+            std::array<std::uint8_t, 2 * MaxDecodedTokenBytes>
+                decodeResultBuf;  //*2 to allow oversized tests
+
+            for (auto allowResize : {true, false})
+            {
+                for (auto resultBufSizeDelta : {-5, -1, 0, 1, 5})
+                {
+                    auto resultBuf = MutableSlice(
+                        decodeResultBuf.data(),
+                        decodeSize - 5 +
+                            resultBufSizeDelta);  // -5 for token and checksum
+                    auto const decodedRaw = decodeBase58(
+                        makeSlice(encoded), resultBuf, allowResize);
+                    if (!metadataRef.isRippleLibEncoded())
+                    {
+                        bool const expectDecoded = resultBufSizeDelta == 0 ||
+                            (resultBufSizeDelta > 0 && allowResize);
+                        BEAST_EXPECT(expectDecoded == bool(decodedRaw));
+                        if (decodedRaw)
+                            BEAST_EXPECT(Base58TestDetail::checkMatch(
+                                log,
+                                decodeSlice,
+                                decodedRaw->first,
+                                decodedRaw->second));
+                    }
+                    else
+                    {
+                        // TBD
+                    }
+                    if (!allowResize)
+                    {
+                        {
+                            auto const decodedToken = decodeBase58Token(
+                                makeSlice(encoded), decodeAsToken, resultBuf);
+                            auto const decodedTokenRef =
+                                Base58TestDetail::decodeBase58Token(
+                                    encoded, decodeAsToken);
+                            if (resultBufSizeDelta == 0)
+                            {
+                                if (!metadataRef.isRippleLibEncoded())
+                                {
+                                    BEAST_EXPECT(
+                                        decodedTokenRef.empty() !=
+                                        bool(decodedToken));
+                                    if (decodedToken)
+                                        BEAST_EXPECT(std::equal(
+                                            makeSlice(decodedTokenRef).begin(),
+                                            makeSlice(decodedTokenRef).end(),
+                                            decodedToken->begin(),
+                                            decodedToken->end()));
+                                }
+                                else
+                                {
+                                    // TBD
+                                }
+                            }
+                            else
+                            {
+                                BEAST_EXPECT(!decodedToken);
+                            }
+                            memset(resultBuf.data(), 0, resultBuf.size());
+                        }
+
+                        {
+                            auto const decodedToken = decodeBase58TokenBitcoin(
+                                makeSlice(encodedBitcoin),
+                                decodeAsToken,
+                                resultBuf);
+                            auto const decodedTokenRef =
+                                Base58TestDetail::decodeBase58Token(
+                                    encoded, decodeAsToken);
+                            if (resultBufSizeDelta == 0)
+                            {
+                                // ripple lib encoding shouldn't matter for
+                                // bitcoin encoding
+                                BEAST_EXPECT(
+                                    decodedTokenRef.empty() !=
+                                    bool(decodedToken));
+                                if (decodedToken)
+                                    BEAST_EXPECT(std::equal(
+                                        makeSlice(decodedTokenRef).begin(),
+                                        makeSlice(decodedTokenRef).end(),
+                                        decodedToken->begin(),
+                                        decodedToken->end()));
+                            }
+                            else
+                            {
+                                BEAST_EXPECT(!decodedToken);
+                            }
+                            memset(resultBuf.data(), 0, resultBuf.size());
+                        }
+
+                        {
+                            auto const decodedToken = [&] {
+                                MutableSlice rb = resultBuf;
+                                if (metadataRef.isRippleLibEncoded() &&
+                                    resultBuf.size() == 18)
+                                {
+                                    rb = MutableSlice(
+                                        resultBuf.data(), resultBuf.size() - 2);
+                                }
+                                return decodeBase58FamilySeed(
+                                    makeSlice(encoded), rb);
+                            }();
+                            auto const decodedTokenRef =
+                                Base58TestDetail::decodeBase58Token(
+                                    encoded,
+                                    metadataRef.isRippleLibEncoded()
+                                        ? TokenType::None
+                                        : TokenType::FamilySeed);
+                            size_t const validTokenRefSize =
+                                metadataRef.isRippleLibEncoded() ? 18 : 16;
+                            if (resultBufSizeDelta == 0 &&
+                                decodedTokenRef.size() == validTokenRefSize)
+                            {
+                                BEAST_EXPECT(
+                                    decodeAsToken == TokenType::FamilySeed ||
+                                    !decodedToken);
+                                bool const decodedAsRippleLib = decodedToken &&
+                                    decodedToken->second ==
+                                        ExtraB58Encoding::RippleLib;
+                                BEAST_EXPECT(
+                                    !decodedToken ||
+                                    decodedAsRippleLib ==
+                                        metadataRef.isRippleLibEncoded());
+                                BEAST_EXPECT(
+                                    decodedTokenRef.empty() !=
+                                    bool(decodedToken));
+                                if (!metadataRef.isRippleLibEncoded())
+                                {
+                                    if (decodedToken)
+                                        BEAST_EXPECT(std::equal(
+                                            makeSlice(decodedTokenRef).begin(),
+                                            makeSlice(decodedTokenRef).end(),
+                                            decodedToken->first.begin(),
+                                            decodedToken->first.end()));
+                                }
+                                else
+                                {
+                                    if (decodedToken)
+                                        BEAST_EXPECT(std::equal(
+                                            makeSlice(decodedTokenRef).begin() +
+                                                2,
+                                            makeSlice(decodedTokenRef).end(),
+                                            decodedToken->first.begin(),
+                                            decodedToken->first.end()));
+                                }
+                            }
+                            else
+                            {
+                                // TBD
+                            }
+                            memset(resultBuf.data(), 0, resultBuf.size());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void
+    testRandomDecode(std::size_t numTestIterations)
+    {
+        testcase("Random Decode");
+        beast::xor_shift_engine
+            engine;  // use the default seed for repeatability
+        constexpr size_t maxEncodeSize = 52;  // ceil(log(2^(8*38), 58))
+        std::uniform_int_distribution<std::uint8_t> encodeSizeDist(
+            5, maxEncodeSize);
+        std::uniform_int_distribution<std::uint8_t> leadingZeroesDist(0, 6);
+        std::string encoded;
+        encoded.reserve(maxEncodeSize);
+        std::array<std::uint8_t, 2 * MaxDecodedTokenBytes>
+            decodeResultBuf;  //*2 to allow oversized tests
+        for (int i = 0; i < numTestIterations; i++)
+        {
+            std::size_t const encodeSize = encodeSizeDist(engine);
+            std::size_t const leadingZeroes = leadingZeroesDist(engine);
+            encoded.resize(encodeSize);
+            randomEncodedBase58(engine, makeMutableSlice(encoded));
+            for (int si = 0, se = std::min(encoded.size(), leadingZeroes);
+                 si != se;
+                 ++si)
+            {
+                encoded[si] = 'r';
+            }
+
+            auto const decodedRef = Base58TestDetail::decodeBase58(
+                encoded, Base58TestDetail::rippleInverse);
+            auto const decodeSize = decodedRef.size();
+            for (auto allowResize : {true, false})
+            {
+                for (auto resultBufSizeDelta : {-5, -1, 0, 1, 5})
+                {
+                    auto resultBuf = MutableSlice(
+                        decodeResultBuf.data(),
+                        decodeSize - 5 +
+                            resultBufSizeDelta);  // -5 for token and checksum
+                    auto const decoded = decodeBase58(
+                        makeSlice(encoded), resultBuf, allowResize);
+                    bool const expectDecoded = !decodedRef.empty() &&
+                        (decodeSize > 4) &&
+                        (decodeSize - 5 + resultBufSizeDelta <=
+                         MaxDecodedTokenBytes) &&
+                        decodeSize <= MaxDecodedTokenBytes &&
+                        (resultBufSizeDelta == 0 ||
+                         (resultBufSizeDelta > 0 && allowResize));
+                    BEAST_EXPECT(expectDecoded == bool(decoded));
+                    if (decoded)
+                        BEAST_EXPECT(Base58TestDetail::checkMatch(
+                            log,
+                            makeSlice(decodedRef),
+                            decoded->first,
+                            decoded->second));
+                }
+            }
+        }
+    }
+
+public:
+    void
+    run() override
+    {
+        constexpr std::size_t numTestIterations = 1'000'000;
+        testRandomEncodeDecode(numTestIterations);
+        testRandomDecode(numTestIterations);
+    }
+};
+
+class Base58_test : public beast::unit_test::suite
+{
+    void
+    testMinMaxEncodeDecode()
+    {
+        testcase("base58 min/max encode/decode");
+        // encode all zeros and all 0xff of different sizes
+        constexpr std::size_t maxTestDecodeBytes = 40;
+        std::array<std::uint8_t, maxTestDecodeBytes + 4> decodeBuf;
+        for (std::size_t decodeSize = 5; decodeSize <= maxTestDecodeBytes;
+             ++decodeSize)
+        {
+            assert(decodeSize <= decodeBuf.size() - 4);
+            MutableSlice decodeSlice(decodeBuf.data(), decodeSize);
+            MutableSlice noChecksumDecodeSlice(
+                decodeSlice.data(), decodeSlice.size() - 4);
+            for (bool allZeros : {true, false})
+            {
+                if (decodeSize > 0)
+                {
+                    std::uint8_t const fillVal = allZeros ? 0 : 0xff;
+                    memset(
+                        noChecksumDecodeSlice.data(),
+                        fillVal,
+                        noChecksumDecodeSlice.size());
+                }
+                Base58TestDetail::checksum(
+                    decodeSlice.data() + decodeSlice.size() - 4,
+                    noChecksumDecodeSlice.data(),
+                    noChecksumDecodeSlice.size());
+                // encode with old impl
+                std::string encoded = Base58TestDetail::base58EncodeToken(
+                    static_cast<TokenType>(decodeSlice[0]),
+                    decodeSlice.data() + 1,
+                    decodeSlice.size() - 5);  // 1 for token, 4 for checksum
+                // decode with new impl
+                std::array<std::uint8_t, 2 * MaxDecodedTokenBytes>
+                    decodeResultBuf;  //*2 to allow oversized tests
+
+                for (auto allowResize : {true, false})
+                {
+                    for (auto resultBufSizeDelta : {-5, -1, 0, 1, 5})
+                    {
+                        auto resultBuf = MutableSlice(
+                            decodeResultBuf.data(),
+                            decodeSize - 5 +
+                                resultBufSizeDelta);  // -5 for token and
+                                                      // checksum
+                        auto const decoded = decodeBase58(
+                            makeSlice(encoded), resultBuf, allowResize);
+                        bool const expectDecoded =
+                            decodeSize <= MaxDecodedTokenBytes &&
+                            (resultBufSizeDelta == 0 ||
+                             (resultBufSizeDelta > 0 && allowResize));
+                        BEAST_EXPECT(expectDecoded == bool(decoded));
+                        if (decoded)
+                            BEAST_EXPECT(Base58TestDetail::checkMatch(
+                                log,
+                                decodeSlice,
+                                decoded->first,
+                                decoded->second));
+                    }
+                }
+            }
+        }
+    }
+
+    void
+    testMinMaxDecode()
+    {
+        testcase("base58 min/max decode");
+        // encode all 'r'(0) and all 'z' (58) of different sizes
+        constexpr size_t maxValidEncodeChars = 52;  // ceir(log(2^(8*38), 58))
+        constexpr size_t maxEncodeChars =
+            3 + maxValidEncodeChars;  // encode some that could overflow
+        std::string encoded;
+        encoded.reserve(maxEncodeChars);
+        std::array<std::uint8_t, 2 * MaxDecodedTokenBytes>
+            decodeResultBuf;  //*2 to allow oversized tests
+        for (std::size_t decodeSize = 1; decodeSize <= maxEncodeChars;
+             ++decodeSize)
+        {
+            encoded.resize(decodeSize);
+            for (bool allZeros : {true, false})
+            {
+                encoded.assign(decodeSize, allZeros ? 'r' : 'z');
+                auto const decodedRef = Base58TestDetail::decodeBase58(
+                    encoded, Base58TestDetail::rippleInverse);
+                auto const decodeSize = decodedRef.size();
+                for (auto allowResize : {true, false})
+                {
+                    for (auto resultBufSizeDelta : {-5, -1, 0, 1, 5})
+                    {
+                        auto resultBuf = MutableSlice(
+                            decodeResultBuf.data(),
+                            decodeSize - 5 +
+                                resultBufSizeDelta);  // -5 for token and
+                                                      // checksum
+                        auto const decoded = decodeBase58(
+                            makeSlice(encoded), resultBuf, allowResize);
+                        bool const expectDecoded = !decodedRef.empty() &&
+                            (decodeSize > 4) &&
+                            (decodeSize - 5 + resultBufSizeDelta <=
+                             MaxDecodedTokenBytes) &&
+                            decodeSize <= MaxDecodedTokenBytes &&
+                            (resultBufSizeDelta == 0 ||
+                             (resultBufSizeDelta > 0 && allowResize));
+                        BEAST_EXPECT(expectDecoded == bool(decoded));
+                        if (decoded)
+                            BEAST_EXPECT(Base58TestDetail::checkMatch(
+                                log,
+                                makeSlice(decodedRef),
+                                decoded->first,
+                                decoded->second));
+                    }
+                }
+            }
+        }
+    }
+
+    void
+    testRippleLibEncoded()
+    {
+        // TBD
+        pass();
+    }
+
+    void
+    testMalformed()
+    {
+        // TBD
+        // bad char
+        // bad checksum
+        pass();
+    }
+
+public:
+    void
+    run() override
+    {
+        testRippleLibEncoded();
+        testMalformed();
+        testMinMaxEncodeDecode();
+        testMinMaxDecode();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE_MANUAL(Base58Manual, protocol, ripple);
+BEAST_DEFINE_TESTSUITE(Base58, protocol, ripple);
+
+}  // namespace ripple

--- a/src/test/unity/protocol_test_unity.cpp
+++ b/src/test/unity/protocol_test_unity.cpp
@@ -19,6 +19,7 @@
 //==============================================================================
 
 #include <test/protocol/BuildInfo_test.cpp>
+#include <test/protocol/Base58_test.cpp>
 #include <test/protocol/digest_test.cpp>
 #include <test/protocol/InnerObjectFormats_test.cpp>
 #include <test/protocol/IOUAmount_test.cpp>


### PR DESCRIPTION
1) Change the interface to the decoding functions so the caller provides the
buffer that is decoded into.

This allows for an implementation that allocates less memory from the heap, and
potentially makes less memory copies. Since all token types except public keys
have know decoded sizes, it is easy for the caller to provide the buffer. If the
decoded result does not fit exactly in the provided buffer (except for public
keys), the decode fails, as the encoded string cannot represent the expected
token. A flag may be passed to the low-level decoding functions to allow to
decode into a smaller buffer. This is used for public keys, which may decode to
either 32 or 33 bytes.

2) Securely zero memory used in decoding in more situations.

When the low-level decoding routines are decoding a potential secret - like
seeds - then intermediate memory is securely zeroed. When decoding non-secrets -
like account ids - then it does not zero the memory.

3) Use a new algorithm for base 58 decoding.

The algorithm first encodes the base 58 number as a base 58^10 number. All these
coefficients will fit into a 64-bit number. This base 58^10 is then decoded
using boost's multi-precision integer library. This greatly improves decoding
times. My benchmark shows approx 10x improvement on 256-bit decodes, not
including the checksum. An end-to-end test of the old and new decoder shows a
2x-4x improvement, depending on what's being decoded.

4) Decode ripple lib encoded seeds at a low level.

ED25519 encoded with ripple lib used a special encoding. Instead of
<TokenId::FamilySeed><16-bytes seed data>, it uses
<TokenId::None><0xE1><0x4B><16-bytes seed data>. This encoding is handled at the
lowest level. A special flag is passed into the decoder to control if this
decoding should be checked for or not. This simplifies calling client code.
Although it does make testing more complex.

Note that I have not finished writing all the tests I intend for this PR. However, it was suggested to get this in review before all the tests were finished. Also note that as of now some of test are marked "manual" b/c they take ~10 minutes to run.