### PR TITLE
Properly handle the `--rpc_port` command line argument

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -621,7 +621,8 @@ int run (int argc, char** argv)
                 std::cerr << "WARNING: using deprecated rpc_port param.\n";
                 try
                 {
-                    res.first.at_port(vm["rpc_port"].as<std::uint16_t>());
+                    res.first = res.first.at_port(
+                        vm["rpc_port"].as<std::uint16_t>());
                     if (res.first.port() == 0)
                         throw std::domain_error("0");
                 }


### PR DESCRIPTION
The `--rpc_port` command-line option is effectively ignored. We construct an `Endpoint` with the given port, but then drop it on the floor. (Perhaps the author thought the `Endpoint::at_port` method is a mutation instead of a transformation.) This small change adds the missing assignment to hold on to it.

Fixes #2764 