### PR TITLE
Reserve correct vector size for fee calculations:

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -83,15 +83,20 @@ TxQ::FeeMetrics::update(Application& app,
     TxQ::Setup const& setup)
 {
     std::vector<uint64_t> feeLevels;
-    feeLevels.reserve(txnsExpected_);
-    for (auto const& tx : view.txs)
-    {
-        auto const baseFee = calculateBaseFee(view, *tx.first);
-        feeLevels.push_back(getFeeLevelPaid(*tx.first,
-            baseLevel, baseFee, setup));
-    }
+    auto const txBegin = view.txs.begin();
+    auto const txEnd = view.txs.end();
+    auto const size = std::distance(txBegin, txEnd);
+    feeLevels.reserve(size);
+    std::for_each(txBegin, txEnd,
+        [&](auto const& tx)
+        {
+            auto const baseFee = calculateBaseFee(view, *tx.first);
+            feeLevels.push_back(getFeeLevelPaid(*tx.first,
+                baseLevel, baseFee, setup));
+        }
+    );
     std::sort(feeLevels.begin(), feeLevels.end());
-    auto const size = feeLevels.size();
+    assert(size == feeLevels.size());
 
     JLOG(j_.debug()) << "Ledger " << view.info().seq <<
         " has " << size << " transactions. " <<


### PR DESCRIPTION
* Using txnsExpected_, which is influenced by both the config
  and network behavior, can reserve far too much or far too
  little memory, wasting time and resources.
* Not an issue during normal operation, but a user could
  cause problems on their local node with extreme configuration
  settings.