### PR TITLE
update Ripple License 2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The accompanying files under various copyrights.
 
-Copyright (c) 2012, 2013, 2014 Ripple Labs Inc.
+Copyright (c) 2012-2019 Ripple Labs Inc.
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
### Fix license of use, 
update 2019; 
Format ISO 8869-1;
----------------------------------------------------------------------------------------------------------------------
in Memoriam Guto Schiavon 
![guto-schiavon_bitcoin](https://user-images.githubusercontent.com/7637553/50562143-a7506f80-0cf8-11e9-9e58-bed4565c4715.jpg)
R.I.P pioneer and friend. 

#ripGUTO