### PR TITLE
Improve shard downloader status report

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -225,7 +225,7 @@ public:
     reset () override
     {
         {
-            std::lock_guard<std::mutex> l(maxSeqLock);
+            std::lock_guard<std::mutex> lock(maxSeqLock);
             maxSeq = 0;
         }
         fullbelow_.reset();

--- a/src/ripple/net/SSLHTTPDownloader.h
+++ b/src/ripple/net/SSLHTTPDownloader.h
@@ -65,8 +65,10 @@ public:
 private:
     boost::asio::ssl::context ctx_;
     boost::asio::io_service::strand strand_;
-    boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream_;
+    boost::optional<
+        boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> stream_;
     boost::beast::flat_buffer read_buf_;
+    bool ssl_verify_;
     beast::Journal j_;
 
     void

--- a/src/ripple/net/SSLHTTPDownloader.h
+++ b/src/ripple/net/SSLHTTPDownloader.h
@@ -80,6 +80,13 @@ private:
         boost::filesystem::path dstPath,
         std::function<void(boost::filesystem::path)> complete,
         boost::asio::yield_context yield);
+
+    void
+    fail(
+        boost::filesystem::path dstPath,
+        std::function<void(boost::filesystem::path)> const& complete,
+        boost::system::error_code const& ec,
+        std::string const& errMsg);
 };
 
 } // ripple

--- a/src/ripple/net/impl/SSLHTTPDownloader.cpp
+++ b/src/ripple/net/impl/SSLHTTPDownloader.cpp
@@ -25,7 +25,7 @@ namespace ripple {
 SSLHTTPDownloader::SSLHTTPDownloader(
     boost::asio::io_service& io_service,
     beast::Journal j)
-    : ctx_(boost::asio::ssl::context::sslv23_client)
+    : ctx_(boost::asio::ssl::context::tlsv12_client)
     , strand_(io_service)
     , stream_(io_service, ctx_)
     , j_(j)

--- a/src/ripple/net/impl/SSLHTTPDownloader.cpp
+++ b/src/ripple/net/impl/SSLHTTPDownloader.cpp
@@ -19,6 +19,7 @@
 
 #include <ripple/net/SSLHTTPDownloader.h>
 #include <ripple/net/RegisterSSLCerts.h>
+#include <boost/asio/ssl.hpp>
 
 namespace ripple {
 
@@ -27,7 +28,6 @@ SSLHTTPDownloader::SSLHTTPDownloader(
     beast::Journal j)
     : ctx_(boost::asio::ssl::context::tlsv12_client)
     , strand_(io_service)
-    , stream_(io_service, ctx_)
     , j_(j)
 {
 }
@@ -61,6 +61,8 @@ SSLHTTPDownloader::init(Config const& config)
             return false;
         }
     }
+
+    ssl_verify_ = config.SSL_VERIFY;
     return true;
 }
 
@@ -149,24 +151,48 @@ SSLHTTPDownloader::do_session(
         complete(std::move(dstPath));
     };
 
-    if (!SSL_set_tlsext_host_name(stream_.native_handle(), host.c_str()))
-    {
-        ec.assign(static_cast<int>(
-            ::ERR_get_error()), boost::asio::error::get_ssl_category());
-        return fail("SSL_set_tlsext_host_name");
-    }
-
-    ip::tcp::resolver resolver {stream_.get_io_context()};
+    ip::tcp::resolver resolver {strand_.get_io_context()};
     auto const results = resolver.async_resolve(host, port, yield[ec]);
     if (ec)
         return fail("async_resolve");
 
+    stream_.emplace(strand_.get_io_service(), ctx_);
+    if (ssl_verify_)
+    {
+        // If we intend to verify the SSL connection, we need to set the
+        // default domain for server name indication *prior* to connecting
+        if (!SSL_set_tlsext_host_name(stream_->native_handle(), host.c_str()))
+        {
+            ec.assign(static_cast<int>(
+                ::ERR_get_error()), boost::asio::error::get_ssl_category());
+            return fail("SSL_set_tlsext_host_name");
+        }
+    }
+    else
+    {
+        stream_->set_verify_mode(boost::asio::ssl::verify_none, ec);
+        if (ec)
+            return fail("set_verify_mode");
+    }
+
     boost::asio::async_connect(
-        stream_.next_layer(), results.begin(), results.end(), yield[ec]);
+        stream_->next_layer(), results.begin(), results.end(), yield[ec]);
     if (ec)
         return fail("async_connect");
 
-    stream_.async_handshake(ssl::stream_base::client, yield[ec]);
+    if (ssl_verify_)
+    {
+        stream_->set_verify_mode(boost::asio::ssl::verify_peer, ec);
+        if (ec)
+            return fail("set_verify_mode");
+
+        stream_->set_verify_callback(
+            boost::asio::ssl::rfc2818_verification(host.c_str()), ec);
+        if (ec)
+            return fail("set_verify_callback");
+    }
+
+    stream_->async_handshake(ssl::stream_base::client, yield[ec]);
     if (ec)
         return fail("async_handshake");
 
@@ -175,7 +201,7 @@ SSLHTTPDownloader::do_session(
     req.set(http::field::host, host);
     req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
 
-    http::async_write(stream_, req, yield[ec]);
+    http::async_write(*stream_, req, yield[ec]);
     if(ec)
         return fail("async_write");
 
@@ -183,7 +209,7 @@ SSLHTTPDownloader::do_session(
         // Check if available storage for file size
         http::response_parser<http::empty_body> p;
         p.skip(true);
-        http::async_read(stream_, read_buf_, p, yield[ec]);
+        http::async_read(*stream_, read_buf_, p, yield[ec]);
         if(ec)
             return fail("async_read");
         if (auto len = p.content_length())
@@ -204,7 +230,7 @@ SSLHTTPDownloader::do_session(
 
     // Set up an HTTP GET request message to download the file
     req.method(http::verb::get);
-    http::async_write(stream_, req, yield[ec]);
+    http::async_write(*stream_, req, yield[ec]);
     if(ec)
         return fail("async_write");
 
@@ -221,7 +247,7 @@ SSLHTTPDownloader::do_session(
         return fail("open");
     }
 
-    http::async_read(stream_, read_buf_, p, yield[ec]);
+    http::async_read(*stream_, read_buf_, p, yield[ec]);
     if (ec)
     {
         p.get().body().close();
@@ -230,7 +256,7 @@ SSLHTTPDownloader::do_session(
     p.get().body().close();
 
     // Gracefully close the stream
-    stream_.async_shutdown(yield[ec]);
+    stream_->async_shutdown(yield[ec]);
     if (ec == boost::asio::error::eof)
         ec.assign(0, ec.category());
     if (ec)
@@ -240,6 +266,7 @@ SSLHTTPDownloader::do_session(
         JLOG(j_.trace()) <<
             "async_shutdown: " << ec.message();
     }
+    stream_ = boost::none;
 
     JLOG(j_.trace()) <<
         "download completed: " << dstPath.string();

--- a/src/ripple/nodestore/DatabaseShard.h
+++ b/src/ripple/nodestore/DatabaseShard.h
@@ -99,11 +99,11 @@ public:
 
     /** Get shard indexes being imported
 
-        @return The number of shards prepared for import
+        @return a string representing the shards prepared for import
     */
     virtual
-    std::uint32_t
-    getNumPreShard() = 0;
+    std::string
+    getPreShards() = 0;
 
     /** Import a shard into the shard database
 

--- a/src/ripple/nodestore/impl/DatabaseShardImp.h
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.h
@@ -51,8 +51,8 @@ public:
     void
     removePreShard(std::uint32_t shardIndex) override;
 
-    std::uint32_t
-    getNumPreShard() override;
+    std::string
+    getPreShards() override;
 
     bool
     importShard(std::uint32_t shardIndex,

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -377,10 +377,8 @@ PeerImp::hasLedger (uint256 const& hash, std::uint32_t seq) const
             return true;
     }
 
-    if (seq >= app_.getNodeStore().earliestSeq())
-        return hasShard(
-            (seq - 1) / NodeStore::DatabaseShard::ledgersPerShardDefault);
-    return false;
+    return seq >= app_.getNodeStore().earliestSeq() &&
+        hasShard(NodeStore::seqToShardIndex(seq));
 }
 
 void

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -152,7 +152,7 @@ bool
 ServerHandlerImp::onAccept (Session& session,
     boost::asio::ip::tcp::endpoint endpoint)
 {
-    std::lock_guard<std::mutex> l(countlock_);
+    std::lock_guard<std::mutex> lock(countlock_);
 
     auto const c = ++count_[session.port()];
 
@@ -363,7 +363,7 @@ void
 ServerHandlerImp::onClose (Session& session,
     boost::system::error_code const&)
 {
-    std::lock_guard<std::mutex> l(countlock_);
+    std::lock_guard<std::mutex> lock(countlock_);
     --count_[session.port()];
 }
 


### PR DESCRIPTION
The 'Add shard downloader status update` commit allows subsequent RPC calls to receive an update on an ongoing shard download process. The current model rejects RPC downloads issued when there is an ongoing process.

For testing purposes, I have created the following archives in NuDB and RocksDB formats.

The RPC takes the following form
```
    {
      shards: [{index: <integer>, url: <string>}]
      validate: <bool> // optional, default is true
    }
```

NuDB format
```
{
  "command": "download_shard",
  "shards": [
    {"index": 1, "url": "https://dl.dropboxusercontent.com/s/bwfu5q3l1301hmk/1.tar.lz4"},
    {"index": 2, "url": "https://dl.dropboxusercontent.com/s/l4rgpqhod25twld/2.tar.lz4"},
    {"index": 5, "url": "https://dl.dropboxusercontent.com/s/nvi91jvpjh5ox32/5.tar.lz4"},
    {"index": 8, "url": "https://dl.dropboxusercontent.com/s/iogb048ggbzhzyn/8.tar.lz4"},
    {"index": 9, "url": "https://dl.dropboxusercontent.com/s/2vuznabw1pp9w8l/9.tar.lz4"}
  ]
}
```

RocksDB format
```
{
  "command": "download_shard",
  "shards": [
  	{"index": 1, "url": "https://dl.dropboxusercontent.com/s/ru8fp7qghgh6pd8/1.tar.lz4"},
  	{"index": 2, "url": "https://dl.dropboxusercontent.com/s/gjxcxzpwqtl8lz4/2.tar.lz4"},
  	{"index": 5, "url": "https://dl.dropboxusercontent.com/s/cm6grhsh8xlv27m/5.tar.lz4"},
  	{"index": 8, "url": "https://dl.dropboxusercontent.com/s/ah8h14zm8h1zqip/8.tar.lz4"},
  	{"index": 9, "url": "https://dl.dropboxusercontent.com/s/1uad5aiq81yfqom/9.tar.lz4"}
  ]
}
```

The RPC can be issued using a browser and this site http://www.websocket.org/echo.html or from the command line using curl eg.

```curl -X POST -d '{ "method" : "download_shard", "params" : [ { "shards" : [{"index": 1, "url": "https://dl.dropboxusercontent.com/s/bwfu5q3l1301hmk/1.tar.lz4"}] } ] }' http://localhost:5005```