### PR TITLE
Simplify and document validator list parsing

### DIFF
--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -256,7 +256,7 @@ ValidatorList::applyList (
             std::vector<PublicKey> removed;
             std::set_difference(oldList.begin(), oldList.end(),
                 publisherList.begin(), publisherList.end(),
-                std::back_inserter(removed), comparator);
+                std::back_inserter(removed));
             for (auto const& r : removed)
                 keyListings_[r]--;
         }


### PR DESCRIPTION
This is a slimdown version of the more ambitious #2619 which is withdranw.
It changes one loop from a single-pass to a three pass but the code is not performance critical & is much now easier to read and verify that it is correct.