### PR TITLE
[Trivial] Make rippled time zone neutral

### DIFF
--- a/src/ripple/basics/chrono.h
+++ b/src/ripple/basics/chrono.h
@@ -66,6 +66,7 @@ inline
 std::string
 to_string(NetClock::time_point tp)
 {
+    // 2000-01-01 00:00:00 UTC is 946684800s from 1970-01-01 00:00:00 UTC
     using namespace std::chrono;
     return to_string(
         system_clock::time_point{tp.time_since_epoch() + 946684800s});

--- a/src/ripple/core/TimeKeeper.h
+++ b/src/ripple/core/TimeKeeper.h
@@ -47,7 +47,7 @@ public:
     /** Returns the estimate of wall time, in network time.
 
         The network time is wall time adjusted for the Ripple
-        epoch, the beginning of January 1st, 2000. Each server
+        epoch, the beginning of January 1st, 2000 UTC. Each server
         can compute a different value for network time. Other
         servers value for network time is not directly observable,
         but good guesses can be made by looking at validators'

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -36,7 +36,7 @@ namespace ripple {
 NetClock::time_point const& fix1141Time ()
 {
     using namespace std::chrono_literals;
-    // Fri July 1, 2016 10:00:00am PDT
+    // Fri July 1, 2016 17:00:00 UTC
     static NetClock::time_point const soTime{520707600s};
     return soTime;
 }
@@ -49,7 +49,7 @@ bool fix1141 (NetClock::time_point const closeTime)
 NetClock::time_point const& fix1274Time ()
 {
     using namespace std::chrono_literals;
-    // Fri Sep 30, 2016 10:00:00am PDT
+    // Fri Sep 30, 2016 17:00:00 UTC
     static NetClock::time_point const soTime{528570000s};
 
     return soTime;
@@ -63,7 +63,7 @@ bool fix1274 (NetClock::time_point const closeTime)
 NetClock::time_point const& fix1298Time ()
 {
     using namespace std::chrono_literals;
-    // Wed Dec 21, 2016 10:00:00am PST
+    // Wed Dec 21, 2016 18:00:00 UTC
     static NetClock::time_point const soTime{535658400s};
 
     return soTime;
@@ -77,7 +77,7 @@ bool fix1298 (NetClock::time_point const closeTime)
 NetClock::time_point const& fix1443Time ()
 {
     using namespace std::chrono_literals;
-    // Sat Mar 11, 2017 05:00:00pm PST
+    // Sun Mar 12, 2017 01:00:00 UTC
     static NetClock::time_point const soTime{542595600s};
 
     return soTime;
@@ -91,7 +91,7 @@ bool fix1443 (NetClock::time_point const closeTime)
 NetClock::time_point const& fix1449Time ()
 {
     using namespace std::chrono_literals;
-    // Thurs, Mar 30, 2017 01:00:00pm PDT
+    // Thurs, Mar 30, 2017 20:00:00 UTC
     static NetClock::time_point const soTime{544219200s};
 
     return soTime;

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -426,10 +426,10 @@ public:
         *stAmountCalcSwitchover2 = saved2_;
     }
 
-    // Mon Dec 28, 2015 10:00:00am PST
+    // Mon Dec 28, 2015 18:00:00 UTC
     static NetClock::time_point const soTime;
 
-    // Mon Mar 28, 2015 10:00:00am PST
+    // Sat Feb 27, 2016 05:00:00 UTC
     static NetClock::time_point const soTime2;
 
 private:

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -39,9 +39,11 @@ LocalValue<bool> stAmountCalcSwitchover(true);
 LocalValue<bool> stAmountCalcSwitchover2(true);
 
 using namespace std::chrono_literals;
+
+// Mon Dec 28, 2015 18:00:00 UTC
 const NetClock::time_point STAmountSO::soTime{504640800s};
 
-// Fri Feb 26, 2016 9:00:00pm PST
+// Sat Feb 27, 2016 05:00:00 UTC
 const NetClock::time_point STAmountSO::soTime2{509864400s};
 
 static const std::uint64_t tenTo14 = 100000000000000ull;

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -461,7 +461,7 @@ addPaymentDeliveredAmount(Json::Value& meta, RPC::Context& context,
             context.ledgerMaster.getCloseTimeBySeq (transaction->getLedger ());
         if (ct && (*ct > NetClock::time_point{446000000s}))
         {
-            // 446000000 is in Feb 2014, well after DeliveredAmount went live
+            // 446000000 is 2014-02-18 00:53:20 UTC, well after DeliveredAmount went live
             meta[jss::delivered_amount] =
                 serializedTx->getFieldAmount (sfAmount).getJson (1);
             return;


### PR DESCRIPTION
* Fixes RIPD-1659

The survey asked for in RIPD-1659 has been done:  No time zone is referred to except for the UTC standard.  This P/R changes only comments which did not follow this policy.  All of the actual code already did.