### PR TITLE
 Disallow both single- and multi-signing in RPC (RIPD-1713)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: cpp
+dist: xenial
 
 env:
   global:
@@ -17,10 +18,12 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-xenial-7
     packages:
-      - gcc-5
-      - g++-5
+      - gcc-7
+      - g++-7
+      - gcc-8
+      - g++-8
       - python-software-properties
       - protobuf-compiler
       - libprotobuf-dev
@@ -29,17 +32,15 @@ addons:
       - binutils-gold
       - cmake
       - lcov
-      - llvm-5.0
-      - clang-5.0
+      - llvm-7
+      - clang-7
 
 matrix:
   include:
-
     - compiler: gcc
-      env: GCC_VER=5 BUILD_TYPE=Debug
-
+      env: GCC_VER=7 BUILD_TYPE=Debug
     - compiler: clang
-      env: GCC_VER=5 BUILD_TYPE=Debug
+      env: GCC_VER=7 BUILD_TYPE=Debug
 
 cache:
   directories:

--- a/bin/sh/install-boost.sh
+++ b/bin/sh/install-boost.sh
@@ -24,8 +24,9 @@ then
   tar xzf /tmp/boost.tar.gz
   cd $BOOST_ROOT && \
     $time ./bootstrap.sh --prefix=$BOOST_ROOT && \
-    $time ./b2 -d1 define=_GLIBCXX_USE_CXX11_ABI=0 -j$((2*${NUM_PROCESSORS:-2})) &&\
-    $time ./b2 -d0 define=_GLIBCXX_USE_CXX11_ABI=0 install
+    $time ./b2 cxxflags="-std=c++14" -j$((2*${NUM_PROCESSORS:-2})) &&\
+    $time ./b2 install
+  
 else
   echo "Using cached boost at $BOOST_ROOT"
 fi

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -115,16 +115,23 @@ namespace RPC {
 /** Maps an rpc error code to its token and default message. */
 struct ErrorInfo
 {
-    ErrorInfo (error_code_i code_, std::string const& token_,
-        std::string const& message_)
+    // Default ctor needed to produce an empty std::array during constexpr eval.
+    constexpr ErrorInfo ()
+    : code (rpcUNKNOWN)
+    , token ("unknown")
+    , message ("An unknown error code.")
+    { }
+
+    constexpr ErrorInfo (error_code_i code_, char const* token_,
+        char const* message_)
         : code (code_)
         , token (token_)
         , message (message_)
     { }
 
     error_code_i code;
-    std::string token;
-    std::string message;
+    Json::StaticString token;
+    Json::StaticString message;
 };
 
 /** Returns an ErrorInfo that reflects the error code. */

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -41,11 +41,8 @@ enum error_code_i
     // Programs should use error tokens.
 
     // Misc failure
-    rpcGENERAL,
-    rpcLOAD_FAILED,
     rpcNO_PERMISSION,
     rpcNO_EVENTS,
-    rpcNOT_STANDALONE,
     rpcTOO_BUSY,
     rpcSLOW_DOWN,
     rpcHIGH_FEE,
@@ -59,19 +56,11 @@ enum error_code_i
     rpcNO_NETWORK,
 
     // Ledger state
-    rpcACT_EXISTS,
     rpcACT_NOT_FOUND,
-    rpcINSUF_FUNDS,
     rpcLGR_NOT_FOUND,
     rpcLGR_NOT_VALIDATED,
     rpcMASTER_DISABLED,
-    rpcNO_ACCOUNT,
-    rpcNO_PATH,
-    rpcPASSWD_CHANGED,
-    rpcSRC_MISSING,
-    rpcSRC_UNCLAIMED,
     rpcTXN_NOT_FOUND,
-    rpcWRONG_SEED,
 
     // Malformed command
     rpcINVALID_PARAMS,
@@ -83,8 +72,6 @@ enum error_code_i
     rpcACT_MALFORMED,
     rpcALREADY_MULTISIG,
     rpcALREADY_SINGLE_SIG,
-    rpcQUALITY_MALFORMED,
-    rpcBAD_BLOB,
     rpcBAD_FEATURE,
     rpcBAD_ISSUER,
     rpcBAD_MARKET,
@@ -99,21 +86,14 @@ enum error_code_i
     rpcDST_AMT_MALFORMED,
     rpcDST_AMT_MISSING,
     rpcDST_ISR_MALFORMED,
-    rpcGETS_ACT_MALFORMED,
-    rpcGETS_AMT_MALFORMED,
-    rpcHOST_IP_MALFORMED,
     rpcLGR_IDXS_INVALID,
     rpcLGR_IDX_MALFORMED,
-    rpcPAYS_ACT_MALFORMED,
-    rpcPAYS_AMT_MALFORMED,
-    rpcPORT_MALFORMED,
     rpcPUBLIC_MALFORMED,
     rpcSIGNING_MALFORMED,
     rpcSENDMAX_MALFORMED,
     rpcSRC_ACT_MALFORMED,
     rpcSRC_ACT_MISSING,
     rpcSRC_ACT_NOT_FOUND,
-    rpcSRC_AMT_MALFORMED,
     rpcSRC_CUR_MALFORMED,
     rpcSRC_ISR_MALFORMED,
     rpcSTREAM_MALFORMED,
@@ -123,6 +103,7 @@ enum error_code_i
     rpcINTERNAL,        // Generic internal error.
     rpcNOT_IMPL,
     rpcNOT_SUPPORTED,
+    rpcLAST = rpcNOT_SUPPORTED   // rpcLAST should always equal the last code.
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012 - 2019 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -81,6 +81,8 @@ enum error_code_i
     // Bad parameter
     rpcACT_BITCOIN,
     rpcACT_MALFORMED,
+    rpcALREADY_MULTISIG,
+    rpcALREADY_SINGLE_SIG,
     rpcQUALITY_MALFORMED,
     rpcBAD_BLOB,
     rpcBAD_FEATURE,
@@ -106,7 +108,7 @@ enum error_code_i
     rpcPAYS_AMT_MALFORMED,
     rpcPORT_MALFORMED,
     rpcPUBLIC_MALFORMED,
-    rpcSIGN_FOR_MALFORMED,
+    rpcSIGNING_MALFORMED,
     rpcSENDMAX_MALFORMED,
     rpcSRC_ACT_MALFORMED,
     rpcSRC_ACT_MISSING,

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -17,137 +17,149 @@
 */
 //==============================================================================
 
-#include <ripple/basics/contract.h>
-#include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <cassert>
-#include <unordered_map>
-#include <utility>
 
-namespace std {
-
-template <>
-struct hash <ripple::error_code_i>
-{
-    explicit hash() = default;
-
-    std::size_t operator() (ripple::error_code_i value) const
-    {
-        return value;
-    }
-};
-
-}
 namespace ripple {
 namespace RPC {
 
 namespace detail {
 
-class ErrorCategory
+// Unordered array of ErrorInfos, so we don't have to maintain the list
+// ordering by hand.
+//
+// This array will be omitted from the object file; only the sorted version
+// will remain in the object file.  But the string literals will remain.
+constexpr static ErrorInfo unorderedErrorInfos[]
 {
-public:
-    using Map = std::unordered_map <error_code_i, ErrorInfo>;
-
-    ErrorCategory ()
-        : m_unknown (rpcUNKNOWN, "unknown", "An unknown error code.")
-    {
-        add (rpcACT_BITCOIN,           "actBitcoin",          "Account is bitcoin address.");
-        add (rpcACT_MALFORMED,         "actMalformed",        "Account malformed.");
-        add (rpcACT_NOT_FOUND,         "actNotFound",         "Account not found.");
-        add (rpcALREADY_MULTISIG,      "alreadyMultisig",     "Already multisigned.");
-        add (rpcALREADY_SINGLE_SIG,    "alreadySingleSig",    "Already single-signed.");
-        add (rpcAMENDMENT_BLOCKED,     "amendmentBlocked",    "Amendment blocked, need upgrade.");
-        add (rpcATX_DEPRECATED,        "deprecated",          "Use the new API or specify a ledger range.");
-        add (rpcBAD_FEATURE,           "badFeature",          "Feature unknown or invalid.");
-        add (rpcBAD_ISSUER,            "badIssuer",           "Issuer account malformed.");
-        add (rpcBAD_MARKET,            "badMarket",           "No such market.");
-        add (rpcBAD_SECRET,            "badSecret",           "Secret does not match account.");
-        add (rpcBAD_SEED,              "badSeed",             "Disallowed seed.");
-        add (rpcBAD_SYNTAX,            "badSyntax",           "Syntax error.");
-        add (rpcCHANNEL_MALFORMED,     "channelMalformed",    "Payment channel is malformed.");
-        add (rpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed", "Payment channel amount is malformed.");
-        add (rpcCOMMAND_MISSING,       "commandMissing",      "Missing command entry.");
-        add (rpcDST_ACT_MALFORMED,     "dstActMalformed",     "Destination account is malformed.");
-        add (rpcDST_ACT_MISSING,       "dstActMissing",       "Destination account not provided.");
-        add (rpcDST_ACT_NOT_FOUND,     "dstActNotFound",      "Destination account not found.");
-        add (rpcDST_AMT_MALFORMED,     "dstAmtMalformed",     "Destination amount/currency/issuer is malformed.");
-        add (rpcDST_AMT_MISSING,       "dstAmtMissing",       "Destination amount/currency/issuer is missing.");
-        add (rpcDST_ISR_MALFORMED,     "dstIsrMalformed",     "Destination issuer is malformed.");
-        add (rpcFORBIDDEN,             "forbidden",           "Bad credentials.");
-        add (rpcHIGH_FEE,              "highFee",             "Current transaction fee exceeds your limit.");
-        add (rpcINTERNAL,              "internal",            "Internal error.");
-        add (rpcINVALID_PARAMS,        "invalidParams",       "Invalid parameters.");
-        add (rpcJSON_RPC,              "json_rpc",            "JSON-RPC transport error.");
-        add (rpcLGR_IDXS_INVALID,      "lgrIdxsInvalid",      "Ledger indexes invalid.");
-        add (rpcLGR_IDX_MALFORMED,     "lgrIdxMalformed",     "Ledger index malformed.");
-        add (rpcLGR_NOT_FOUND,         "lgrNotFound",         "Ledger not found.");
-        add (rpcLGR_NOT_VALIDATED,     "lgrNotValidated",     "Ledger not validated.");
-        add (rpcMASTER_DISABLED,       "masterDisabled",      "Master key is disabled.");
-        add (rpcNOT_ENABLED,           "notEnabled",          "Not enabled in configuration.");
-        add (rpcNOT_IMPL,              "notImpl",             "Not implemented.");
-        add (rpcNOT_READY,             "notReady",            "Not ready to handle this request.");
-        add (rpcNOT_SUPPORTED,         "notSupported",        "Operation not supported.");
-        add (rpcNO_CLOSED,             "noClosed",            "Closed ledger is unavailable.");
-        add (rpcNO_CURRENT,            "noCurrent",           "Current ledger is unavailable.");
-        add (rpcNO_EVENTS,             "noEvents",            "Current transport does not support events.");
-        add (rpcNO_NETWORK,            "noNetwork",           "Not synced to Ripple network.");
-        add (rpcNO_PERMISSION,         "noPermission",        "You don't have permission for this command.");
-        add (rpcNO_PF_REQUEST,         "noPathRequest",       "No pathfinding request in progress.");
-        add (rpcPUBLIC_MALFORMED,      "publicMalformed",     "Public key is malformed.");
-        add (rpcSIGNING_MALFORMED,     "signingMalformed",    "Signing of transaction is malformed.");
-        add (rpcSLOW_DOWN,             "slowDown",            "You are placing too much load on the server.");
-        add (rpcSRC_ACT_MALFORMED,     "srcActMalformed",     "Source account is malformed.");
-        add (rpcSRC_ACT_MISSING,       "srcActMissing",       "Source account not provided.");
-        add (rpcSRC_ACT_NOT_FOUND,     "srcActNotFound",      "Source account not found.");
-        add (rpcSRC_CUR_MALFORMED,     "srcCurMalformed",     "Source currency is malformed.");
-        add (rpcSRC_ISR_MALFORMED,     "srcIsrMalformed",     "Source issuer is malformed.");
-        add (rpcSTREAM_MALFORMED,      "malformedStream",     "Stream malformed.");
-        add (rpcTOO_BUSY,              "tooBusy",             "The server is too busy to help you now.");
-        add (rpcTXN_NOT_FOUND,         "txnNotFound",         "Transaction not found.");
-        add (rpcUNKNOWN_COMMAND,       "unknownCmd",          "Unknown method.");
-        add (rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed.");
-
-        // Verify that the number of entries in m_map equals the number of
-        // enums that have descriptions.  That skips rpcUNKNOWN and rpcSUCCESS,
-        // which are -1 and 0 respectively.
-        assert (safe_cast<int>(rpcLAST) == m_map.size());
-    }
-
-    ErrorInfo const& get (error_code_i code) const
-    {
-        Map::const_iterator const iter {m_map.find (code)};
-        assert (iter != m_map.end());
-        if (iter != m_map.end())
-            return iter->second;
-        return m_unknown;
-    }
-
-private:
-    void add (error_code_i code, std::string const& token,
-        std::string const& message)
-    {
-        std::pair <Map::iterator, bool> const result {
-            m_map.emplace (std::piecewise_construct,
-                std::forward_as_tuple (code), std::forward_as_tuple (
-                    code, token, message))};
-
-        if (! result.second)
-            Throw<std::invalid_argument> ("duplicate error code");
-    }
-
-private:
-    Map m_map;
-    ErrorInfo const m_unknown;
+    {rpcACT_BITCOIN,           "actBitcoin",          "Account is bitcoin address."},
+    {rpcACT_MALFORMED,         "actMalformed",        "Account malformed."},
+    {rpcACT_NOT_FOUND,         "actNotFound",         "Account not found."},
+    {rpcALREADY_MULTISIG,      "alreadyMultisig",     "Already multisigned."},
+    {rpcALREADY_SINGLE_SIG,    "alreadySingleSig",    "Already single-signed."},
+    {rpcAMENDMENT_BLOCKED,     "amendmentBlocked",    "Amendment blocked, need upgrade."},
+    {rpcATX_DEPRECATED,        "deprecated",          "Use the new API or specify a ledger range."},
+    {rpcBAD_FEATURE,           "badFeature",          "Feature unknown or invalid."},
+    {rpcBAD_ISSUER,            "badIssuer",           "Issuer account malformed."},
+    {rpcBAD_MARKET,            "badMarket",           "No such market."},
+    {rpcBAD_SECRET,            "badSecret",           "Secret does not match account."},
+    {rpcBAD_SEED,              "badSeed",             "Disallowed seed."},
+    {rpcBAD_SYNTAX,            "badSyntax",           "Syntax error."},
+    {rpcCHANNEL_MALFORMED,     "channelMalformed",    "Payment channel is malformed."},
+    {rpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed", "Payment channel amount is malformed."},
+    {rpcCOMMAND_MISSING,       "commandMissing",      "Missing command entry."},
+    {rpcDST_ACT_MALFORMED,     "dstActMalformed",     "Destination account is malformed."},
+    {rpcDST_ACT_MISSING,       "dstActMissing",       "Destination account not provided."},
+    {rpcDST_ACT_NOT_FOUND,     "dstActNotFound",      "Destination account not found."},
+    {rpcDST_AMT_MALFORMED,     "dstAmtMalformed",     "Destination amount/currency/issuer is malformed."},
+    {rpcDST_AMT_MISSING,       "dstAmtMissing",       "Destination amount/currency/issuer is missing."},
+    {rpcDST_ISR_MALFORMED,     "dstIsrMalformed",     "Destination issuer is malformed."},
+    {rpcFORBIDDEN,             "forbidden",           "Bad credentials."},
+    {rpcHIGH_FEE,              "highFee",             "Current transaction fee exceeds your limit."},
+    {rpcINTERNAL,              "internal",            "Internal error."},
+    {rpcINVALID_PARAMS,        "invalidParams",       "Invalid parameters."},
+    {rpcJSON_RPC,              "json_rpc",            "JSON-RPC transport error."},
+    {rpcLGR_IDXS_INVALID,      "lgrIdxsInvalid",      "Ledger indexes invalid."},
+    {rpcLGR_IDX_MALFORMED,     "lgrIdxMalformed",     "Ledger index malformed."},
+    {rpcLGR_NOT_FOUND,         "lgrNotFound",         "Ledger not found."},
+    {rpcLGR_NOT_VALIDATED,     "lgrNotValidated",     "Ledger not validated."},
+    {rpcMASTER_DISABLED,       "masterDisabled",      "Master key is disabled."},
+    {rpcNOT_ENABLED,           "notEnabled",          "Not enabled in configuration."},
+    {rpcNOT_IMPL,              "notImpl",             "Not implemented."},
+    {rpcNOT_READY,             "notReady",            "Not ready to handle this request."},
+    {rpcNOT_SUPPORTED,         "notSupported",        "Operation not supported."},
+    {rpcNO_CLOSED,             "noClosed",            "Closed ledger is unavailable."},
+    {rpcNO_CURRENT,            "noCurrent",           "Current ledger is unavailable."},
+    {rpcNO_EVENTS,             "noEvents",            "Current transport does not support events."},
+    {rpcNO_NETWORK,            "noNetwork",           "Not synced to Ripple network."},
+    {rpcNO_PERMISSION,         "noPermission",        "You don't have permission for this command."},
+    {rpcNO_PF_REQUEST,         "noPathRequest",       "No pathfinding request in progress."},
+    {rpcPUBLIC_MALFORMED,      "publicMalformed",     "Public key is malformed."},
+    {rpcSIGNING_MALFORMED,     "signingMalformed",    "Signing of transaction is malformed."},
+    {rpcSLOW_DOWN,             "slowDown",            "You are placing too much load on the server."},
+    {rpcSRC_ACT_MALFORMED,     "srcActMalformed",     "Source account is malformed."},
+    {rpcSRC_ACT_MISSING,       "srcActMissing",       "Source account not provided."},
+    {rpcSRC_ACT_NOT_FOUND,     "srcActNotFound",      "Source account not found."},
+    {rpcSRC_CUR_MALFORMED,     "srcCurMalformed",     "Source currency is malformed."},
+    {rpcSRC_ISR_MALFORMED,     "srcIsrMalformed",     "Source issuer is malformed."},
+    {rpcSTREAM_MALFORMED,      "malformedStream",     "Stream malformed."},
+    {rpcTOO_BUSY,              "tooBusy",             "The server is too busy to help you now."},
+    {rpcTXN_NOT_FOUND,         "txnNotFound",         "Transaction not found."},
+    {rpcUNKNOWN_COMMAND,       "unknownCmd",          "Unknown method."},
+    {rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed."},
 };
 
+// C++ does not allow you to return an array from a function.  You must
+// return an object which may in turn contain an array.  The following
+// struct is simply defined so the enclosed array can be returned from a
+// constexpr function.
+//
+// In C++17 this struct can be replaced by a std::array.  But in C++14
+// the constexpr methods of a std::array are not sufficient to perform the
+// necessary work at compile time.
+template <int N>
+struct ErrorInfoArray
+{
+    // Visual Studio doesn't treat a templated aggregate as an aggregate.
+    // So, for Visual Studio, we define a constexpr default constructor.
+    constexpr ErrorInfoArray()
+    : infos {}
+    { }
+
+    ErrorInfo infos[N];
+};
+
+// Sort and validate unorderedErrorInfos at compile time.  Should be
+// converted to consteval when get to C++20.
+template<int N>
+constexpr auto
+sortErrorInfos (ErrorInfo const (&unordered)[N]) -> ErrorInfoArray<N>
+{
+    ErrorInfoArray<N> ret;
+
+    for (ErrorInfo const& info : unordered)
+    {
+        if (info.code <= rpcSUCCESS || info.code > rpcLAST)
+            throw (std::out_of_range ("Invalid error_code_i"));
+
+        // The first valid code follows rpcSUCCESS immediately.
+        static_assert (rpcSUCCESS == 0, "Unexpected error_code_i layout.");
+        int const index {info.code - 1};
+
+        if (ret.infos[index].code != rpcUNKNOWN)
+            throw (std::invalid_argument ("Duplicate error_code_i in list"));
+
+        ret.infos[index].code    = info.code;
+        ret.infos[index].token   = info.token;
+        ret.infos[index].message = info.message;
+    }
+
+    // Verify that all entries are filled in starting with 1 and proceeding
+    // to rpcLAST.
+    int expect = 0;
+    for (ErrorInfo const& info : ret.infos)
+    {
+        if (info.code != ++expect)
+            throw (std::invalid_argument ("Empty error_code_i in list"));
+    }
+    if (expect != rpcLAST)
+        throw (std::invalid_argument ("Insufficient list entries"));
+
+    return ret;
 }
+
+constexpr auto sortedErrorInfos {sortErrorInfos(unorderedErrorInfos)};
+constexpr ErrorInfo unknownError;
+
+} // detail
 
 //------------------------------------------------------------------------------
 
 ErrorInfo const& get_error_info (error_code_i code)
 {
-    static detail::ErrorCategory const category;
-    return category.get (code);
+    if (code <= rpcSUCCESS || code > rpcLAST)
+        return detail::unknownError;
+    return detail::sortedErrorInfos.infos[code - 1];
 }
 
 Json::Value make_error (error_code_i code)

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/basics/contract.h>
+#include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <cassert>
 #include <unordered_map>
@@ -51,14 +52,12 @@ public:
         : m_unknown (rpcUNKNOWN, "unknown", "An unknown error code.")
     {
         add (rpcACT_BITCOIN,           "actBitcoin",          "Account is bitcoin address.");
-        add (rpcACT_EXISTS,            "actExists",           "Account already exists.");
         add (rpcACT_MALFORMED,         "actMalformed",        "Account malformed.");
         add (rpcACT_NOT_FOUND,         "actNotFound",         "Account not found.");
         add (rpcALREADY_MULTISIG,      "alreadyMultisig",     "Already multisigned.");
         add (rpcALREADY_SINGLE_SIG,    "alreadySingleSig",    "Already single-signed.");
         add (rpcAMENDMENT_BLOCKED,     "amendmentBlocked",    "Amendment blocked, need upgrade.");
         add (rpcATX_DEPRECATED,        "deprecated",          "Use the new API or specify a ledger range.");
-        add (rpcBAD_BLOB,              "badBlob",             "Blob must be a non-empty hex string.");
         add (rpcBAD_FEATURE,           "badFeature",          "Feature unknown or invalid.");
         add (rpcBAD_ISSUER,            "badIssuer",           "Issuer account malformed.");
         add (rpcBAD_MARKET,            "badMarket",           "No such market.");
@@ -72,14 +71,10 @@ public:
         add (rpcDST_ACT_MISSING,       "dstActMissing",       "Destination account not provided.");
         add (rpcDST_ACT_NOT_FOUND,     "dstActNotFound",      "Destination account not found.");
         add (rpcDST_AMT_MALFORMED,     "dstAmtMalformed",     "Destination amount/currency/issuer is malformed.");
+        add (rpcDST_AMT_MISSING,       "dstAmtMissing",       "Destination amount/currency/issuer is missing.");
         add (rpcDST_ISR_MALFORMED,     "dstIsrMalformed",     "Destination issuer is malformed.");
         add (rpcFORBIDDEN,             "forbidden",           "Bad credentials.");
-        add (rpcGENERAL,               "general",             "Generic error reason.");
-        add (rpcGETS_ACT_MALFORMED,    "getsActMalformed",    "Gets account malformed.");
-        add (rpcGETS_AMT_MALFORMED,    "getsAmtMalformed",    "Gets amount malformed.");
         add (rpcHIGH_FEE,              "highFee",             "Current transaction fee exceeds your limit.");
-        add (rpcHOST_IP_MALFORMED,     "hostIpMalformed",     "Host IP is malformed.");
-        add (rpcINSUF_FUNDS,           "insufFunds",          "Insufficient funds.");
         add (rpcINTERNAL,              "internal",            "Internal error.");
         add (rpcINVALID_PARAMS,        "invalidParams",       "Invalid parameters.");
         add (rpcJSON_RPC,              "json_rpc",            "JSON-RPC transport error.");
@@ -87,48 +82,40 @@ public:
         add (rpcLGR_IDX_MALFORMED,     "lgrIdxMalformed",     "Ledger index malformed.");
         add (rpcLGR_NOT_FOUND,         "lgrNotFound",         "Ledger not found.");
         add (rpcLGR_NOT_VALIDATED,     "lgrNotValidated",     "Ledger not validated.");
-        add (rpcLOAD_FAILED,           "loadFailed",          "Load failed");
         add (rpcMASTER_DISABLED,       "masterDisabled",      "Master key is disabled.");
         add (rpcNOT_ENABLED,           "notEnabled",          "Not enabled in configuration.");
         add (rpcNOT_IMPL,              "notImpl",             "Not implemented.");
         add (rpcNOT_READY,             "notReady",            "Not ready to handle this request.");
-        add (rpcNOT_STANDALONE,        "notStandAlone",       "Operation valid in debug mode only.");
         add (rpcNOT_SUPPORTED,         "notSupported",        "Operation not supported.");
-        add (rpcNO_ACCOUNT,            "noAccount",           "No such account.");
         add (rpcNO_CLOSED,             "noClosed",            "Closed ledger is unavailable.");
         add (rpcNO_CURRENT,            "noCurrent",           "Current ledger is unavailable.");
         add (rpcNO_EVENTS,             "noEvents",            "Current transport does not support events.");
         add (rpcNO_NETWORK,            "noNetwork",           "Not synced to Ripple network.");
-        add (rpcNO_PATH,               "noPath",              "Unable to find a ripple path.");
         add (rpcNO_PERMISSION,         "noPermission",        "You don't have permission for this command.");
         add (rpcNO_PF_REQUEST,         "noPathRequest",       "No pathfinding request in progress.");
-        add (rpcPASSWD_CHANGED,        "passwdChanged",       "Wrong key, password changed.");
-        add (rpcPAYS_ACT_MALFORMED,    "paysActMalformed",    "Pays account malformed.");
-        add (rpcPAYS_AMT_MALFORMED,    "paysAmtMalformed",    "Pays amount malformed.");
-        add (rpcPORT_MALFORMED,        "portMalformed",       "Port is malformed.");
         add (rpcPUBLIC_MALFORMED,      "publicMalformed",     "Public key is malformed.");
-        add (rpcQUALITY_MALFORMED,     "qualityMalformed",    "Quality malformed.");
         add (rpcSIGNING_MALFORMED,     "signingMalformed",    "Signing of transaction is malformed.");
         add (rpcSLOW_DOWN,             "slowDown",            "You are placing too much load on the server.");
         add (rpcSRC_ACT_MALFORMED,     "srcActMalformed",     "Source account is malformed.");
         add (rpcSRC_ACT_MISSING,       "srcActMissing",       "Source account not provided.");
         add (rpcSRC_ACT_NOT_FOUND,     "srcActNotFound",      "Source account not found.");
-        add (rpcSRC_AMT_MALFORMED,     "srcAmtMalformed",     "Source amount/currency/issuer is malformed.");
         add (rpcSRC_CUR_MALFORMED,     "srcCurMalformed",     "Source currency is malformed.");
         add (rpcSRC_ISR_MALFORMED,     "srcIsrMalformed",     "Source issuer is malformed.");
-        add (rpcSRC_MISSING,           "srcMissing",          "Source is missing.");
-        add (rpcSRC_UNCLAIMED,         "srcUnclaimed",        "Source account is not claimed.");
         add (rpcSTREAM_MALFORMED,      "malformedStream",     "Stream malformed.");
         add (rpcTOO_BUSY,              "tooBusy",             "The server is too busy to help you now.");
         add (rpcTXN_NOT_FOUND,         "txnNotFound",         "Transaction not found.");
         add (rpcUNKNOWN_COMMAND,       "unknownCmd",          "Unknown method.");
-        add (rpcWRONG_SEED,            "wrongSeed",           "The regular key does not point as the master key.");
         add (rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed.");
+
+        // Verify that the number of entries in m_map equals the number of
+        // enums that have descriptions.  That skips rpcUNKNOWN and rpcSUCCESS,
+        // which are -1 and 0 respectively.
+        assert (safe_cast<int>(rpcLAST) == m_map.size());
     }
 
     ErrorInfo const& get (error_code_i code) const
     {
-        Map::const_iterator const iter (m_map.find (code));
+        Map::const_iterator const iter {m_map.find (code)};
         assert (iter != m_map.end());
         if (iter != m_map.end())
             return iter->second;
@@ -139,17 +126,18 @@ private:
     void add (error_code_i code, std::string const& token,
         std::string const& message)
     {
-        std::pair <Map::iterator, bool> result (
+        std::pair <Map::iterator, bool> const result {
             m_map.emplace (std::piecewise_construct,
                 std::forward_as_tuple (code), std::forward_as_tuple (
-                    code, token, message)));
+                    code, token, message))};
+
         if (! result.second)
             Throw<std::invalid_argument> ("duplicate error code");
     }
 
 private:
     Map m_map;
-    ErrorInfo m_unknown;
+    ErrorInfo const m_unknown;
 };
 
 }
@@ -158,7 +146,7 @@ private:
 
 ErrorInfo const& get_error_info (error_code_i code)
 {
-    static detail::ErrorCategory category;
+    static detail::ErrorCategory const category;
     return category.get (code);
 }
 

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -1,7 +1,7 @@
 //------------------------------------------------------------------------------
 /*
     This file is part of rippled: https://github.com/ripple/rippled
-    Copyright (c) 2012, 2013 Ripple Labs Inc.
+    Copyright (c) 2012 - 2019 Ripple Labs Inc.
 
     Permission to use, copy, modify, and/or distribute this software for any
     purpose  with  or without fee is hereby granted, provided that the above
@@ -50,78 +50,80 @@ public:
     ErrorCategory ()
         : m_unknown (rpcUNKNOWN, "unknown", "An unknown error code.")
     {
-        add (rpcACT_BITCOIN,           "actBitcoin",        "Account is bitcoin address.");
-        add (rpcACT_EXISTS,            "actExists",         "Account already exists.");
-        add (rpcACT_MALFORMED,         "actMalformed",      "Account malformed.");
-        add (rpcACT_NOT_FOUND,         "actNotFound",       "Account not found.");
-        add (rpcAMENDMENT_BLOCKED,     "amendmentBlocked",  "Amendment blocked, need upgrade.");
-        add (rpcATX_DEPRECATED,        "deprecated",        "Use the new API or specify a ledger range.");
-        add (rpcBAD_BLOB,              "badBlob",           "Blob must be a non-empty hex string.");
-        add (rpcBAD_FEATURE,           "badFeature",        "Feature unknown or invalid.");
-        add (rpcBAD_ISSUER,            "badIssuer",         "Issuer account malformed.");
-        add (rpcBAD_MARKET,            "badMarket",         "No such market.");
-        add (rpcBAD_SECRET,            "badSecret",         "Secret does not match account.");
-        add (rpcBAD_SEED,              "badSeed",           "Disallowed seed.");
-        add (rpcBAD_SYNTAX,            "badSyntax",         "Syntax error.");
-        add (rpcCHANNEL_MALFORMED,     "channelMalformed",  "Payment channel is malformed.");
-        add (rpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed","Payment channel amount is malformed.");
-        add (rpcCOMMAND_MISSING,       "commandMissing",    "Missing command entry.");
-        add (rpcDST_ACT_MALFORMED,     "dstActMalformed",   "Destination account is malformed.");
-        add (rpcDST_ACT_MISSING,       "dstActMissing",     "Destination account not provided.");
-        add (rpcDST_ACT_NOT_FOUND,     "dstActNotFound",    "Destination account not found.");
-        add (rpcDST_AMT_MALFORMED,     "dstAmtMalformed",   "Destination amount/currency/issuer is malformed.");
-        add (rpcDST_ISR_MALFORMED,     "dstIsrMalformed",   "Destination issuer is malformed.");
-        add (rpcFORBIDDEN,             "forbidden",         "Bad credentials.");
-        add (rpcGENERAL,               "general",           "Generic error reason.");
-        add (rpcGETS_ACT_MALFORMED,    "getsActMalformed",  "Gets account malformed.");
-        add (rpcGETS_AMT_MALFORMED,    "getsAmtMalformed",  "Gets amount malformed.");
-        add (rpcHIGH_FEE,              "highFee",           "Current transaction fee exceeds your limit.");
-        add (rpcHOST_IP_MALFORMED,     "hostIpMalformed",   "Host IP is malformed.");
-        add (rpcINSUF_FUNDS,           "insufFunds",        "Insufficient funds.");
-        add (rpcINTERNAL,              "internal",          "Internal error.");
-        add (rpcINVALID_PARAMS,        "invalidParams",     "Invalid parameters.");
-        add (rpcJSON_RPC,              "json_rpc",          "JSON-RPC transport error.");
-        add (rpcLGR_IDXS_INVALID,      "lgrIdxsInvalid",    "Ledger indexes invalid.");
-        add (rpcLGR_IDX_MALFORMED,     "lgrIdxMalformed",   "Ledger index malformed.");
-        add (rpcLGR_NOT_FOUND,         "lgrNotFound",       "Ledger not found.");
-        add (rpcLGR_NOT_VALIDATED,     "lgrNotValidated",   "Ledger not validated.");
-        add (rpcLOAD_FAILED,           "loadFailed",        "Load failed");
-        add (rpcMASTER_DISABLED,       "masterDisabled",    "Master key is disabled.");
-        add (rpcNOT_ENABLED,           "notEnabled",        "Not enabled in configuration.");
-        add (rpcNOT_IMPL,              "notImpl",           "Not implemented.");
-        add (rpcNOT_READY,             "notReady",          "Not ready to handle this request.");
-        add (rpcNOT_STANDALONE,        "notStandAlone",     "Operation valid in debug mode only.");
-        add (rpcNOT_SUPPORTED,         "notSupported",      "Operation not supported.");
-        add (rpcNO_ACCOUNT,            "noAccount",         "No such account.");
-        add (rpcNO_CLOSED,             "noClosed",          "Closed ledger is unavailable.");
-        add (rpcNO_CURRENT,            "noCurrent",         "Current ledger is unavailable.");
-        add (rpcNO_EVENTS,             "noEvents",          "Current transport does not support events.");
-        add (rpcNO_NETWORK,            "noNetwork",         "Not synced to Ripple network.");
-        add (rpcNO_PATH,               "noPath",            "Unable to find a ripple path.");
-        add (rpcNO_PERMISSION,         "noPermission",      "You don't have permission for this command.");
-        add (rpcNO_PF_REQUEST,         "noPathRequest",     "No pathfinding request in progress.");
-        add (rpcPASSWD_CHANGED,        "passwdChanged",     "Wrong key, password changed.");
-        add (rpcPAYS_ACT_MALFORMED,    "paysActMalformed",  "Pays account malformed.");
-        add (rpcPAYS_AMT_MALFORMED,    "paysAmtMalformed",  "Pays amount malformed.");
-        add (rpcPORT_MALFORMED,        "portMalformed",     "Port is malformed.");
-        add (rpcPUBLIC_MALFORMED,      "publicMalformed",   "Public key is malformed.");
-        add (rpcQUALITY_MALFORMED,     "qualityMalformed",  "Quality malformed.");
-        add (rpcSIGN_FOR_MALFORMED,    "signForMalformed",  "Signing for account is malformed.");
-        add (rpcSLOW_DOWN,             "slowDown",          "You are placing too much load on the server.");
-        add (rpcSRC_ACT_MALFORMED,     "srcActMalformed",   "Source account is malformed.");
-        add (rpcSRC_ACT_MISSING,       "srcActMissing",     "Source account not provided.");
-        add (rpcSRC_ACT_NOT_FOUND,     "srcActNotFound",    "Source account not found.");
-        add (rpcSRC_AMT_MALFORMED,     "srcAmtMalformed",   "Source amount/currency/issuer is malformed.");
-        add (rpcSRC_CUR_MALFORMED,     "srcCurMalformed",   "Source currency is malformed.");
-        add (rpcSRC_ISR_MALFORMED,     "srcIsrMalformed",   "Source issuer is malformed.");
-        add (rpcSRC_MISSING,           "srcMissing",        "Source is missing.");
-        add (rpcSRC_UNCLAIMED,         "srcUnclaimed",      "Source account is not claimed.");
-        add (rpcSTREAM_MALFORMED,      "malformedStream",   "Stream malformed.");
-        add (rpcTOO_BUSY,              "tooBusy",           "The server is too busy to help you now.");
-        add (rpcTXN_NOT_FOUND,         "txnNotFound",       "Transaction not found.");
-        add (rpcUNKNOWN_COMMAND,       "unknownCmd",        "Unknown method.");
-        add (rpcWRONG_SEED,            "wrongSeed",         "The regular key does not point as the master key.");
-        add (rpcSENDMAX_MALFORMED,     "sendMaxMalformed",  "SendMax amount malformed.");
+        add (rpcACT_BITCOIN,           "actBitcoin",          "Account is bitcoin address.");
+        add (rpcACT_EXISTS,            "actExists",           "Account already exists.");
+        add (rpcACT_MALFORMED,         "actMalformed",        "Account malformed.");
+        add (rpcACT_NOT_FOUND,         "actNotFound",         "Account not found.");
+        add (rpcALREADY_MULTISIG,      "alreadyMultisig",     "Already multisigned.");
+        add (rpcALREADY_SINGLE_SIG,    "alreadySingleSig",    "Already single-signed.");
+        add (rpcAMENDMENT_BLOCKED,     "amendmentBlocked",    "Amendment blocked, need upgrade.");
+        add (rpcATX_DEPRECATED,        "deprecated",          "Use the new API or specify a ledger range.");
+        add (rpcBAD_BLOB,              "badBlob",             "Blob must be a non-empty hex string.");
+        add (rpcBAD_FEATURE,           "badFeature",          "Feature unknown or invalid.");
+        add (rpcBAD_ISSUER,            "badIssuer",           "Issuer account malformed.");
+        add (rpcBAD_MARKET,            "badMarket",           "No such market.");
+        add (rpcBAD_SECRET,            "badSecret",           "Secret does not match account.");
+        add (rpcBAD_SEED,              "badSeed",             "Disallowed seed.");
+        add (rpcBAD_SYNTAX,            "badSyntax",           "Syntax error.");
+        add (rpcCHANNEL_MALFORMED,     "channelMalformed",    "Payment channel is malformed.");
+        add (rpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed", "Payment channel amount is malformed.");
+        add (rpcCOMMAND_MISSING,       "commandMissing",      "Missing command entry.");
+        add (rpcDST_ACT_MALFORMED,     "dstActMalformed",     "Destination account is malformed.");
+        add (rpcDST_ACT_MISSING,       "dstActMissing",       "Destination account not provided.");
+        add (rpcDST_ACT_NOT_FOUND,     "dstActNotFound",      "Destination account not found.");
+        add (rpcDST_AMT_MALFORMED,     "dstAmtMalformed",     "Destination amount/currency/issuer is malformed.");
+        add (rpcDST_ISR_MALFORMED,     "dstIsrMalformed",     "Destination issuer is malformed.");
+        add (rpcFORBIDDEN,             "forbidden",           "Bad credentials.");
+        add (rpcGENERAL,               "general",             "Generic error reason.");
+        add (rpcGETS_ACT_MALFORMED,    "getsActMalformed",    "Gets account malformed.");
+        add (rpcGETS_AMT_MALFORMED,    "getsAmtMalformed",    "Gets amount malformed.");
+        add (rpcHIGH_FEE,              "highFee",             "Current transaction fee exceeds your limit.");
+        add (rpcHOST_IP_MALFORMED,     "hostIpMalformed",     "Host IP is malformed.");
+        add (rpcINSUF_FUNDS,           "insufFunds",          "Insufficient funds.");
+        add (rpcINTERNAL,              "internal",            "Internal error.");
+        add (rpcINVALID_PARAMS,        "invalidParams",       "Invalid parameters.");
+        add (rpcJSON_RPC,              "json_rpc",            "JSON-RPC transport error.");
+        add (rpcLGR_IDXS_INVALID,      "lgrIdxsInvalid",      "Ledger indexes invalid.");
+        add (rpcLGR_IDX_MALFORMED,     "lgrIdxMalformed",     "Ledger index malformed.");
+        add (rpcLGR_NOT_FOUND,         "lgrNotFound",         "Ledger not found.");
+        add (rpcLGR_NOT_VALIDATED,     "lgrNotValidated",     "Ledger not validated.");
+        add (rpcLOAD_FAILED,           "loadFailed",          "Load failed");
+        add (rpcMASTER_DISABLED,       "masterDisabled",      "Master key is disabled.");
+        add (rpcNOT_ENABLED,           "notEnabled",          "Not enabled in configuration.");
+        add (rpcNOT_IMPL,              "notImpl",             "Not implemented.");
+        add (rpcNOT_READY,             "notReady",            "Not ready to handle this request.");
+        add (rpcNOT_STANDALONE,        "notStandAlone",       "Operation valid in debug mode only.");
+        add (rpcNOT_SUPPORTED,         "notSupported",        "Operation not supported.");
+        add (rpcNO_ACCOUNT,            "noAccount",           "No such account.");
+        add (rpcNO_CLOSED,             "noClosed",            "Closed ledger is unavailable.");
+        add (rpcNO_CURRENT,            "noCurrent",           "Current ledger is unavailable.");
+        add (rpcNO_EVENTS,             "noEvents",            "Current transport does not support events.");
+        add (rpcNO_NETWORK,            "noNetwork",           "Not synced to Ripple network.");
+        add (rpcNO_PATH,               "noPath",              "Unable to find a ripple path.");
+        add (rpcNO_PERMISSION,         "noPermission",        "You don't have permission for this command.");
+        add (rpcNO_PF_REQUEST,         "noPathRequest",       "No pathfinding request in progress.");
+        add (rpcPASSWD_CHANGED,        "passwdChanged",       "Wrong key, password changed.");
+        add (rpcPAYS_ACT_MALFORMED,    "paysActMalformed",    "Pays account malformed.");
+        add (rpcPAYS_AMT_MALFORMED,    "paysAmtMalformed",    "Pays amount malformed.");
+        add (rpcPORT_MALFORMED,        "portMalformed",       "Port is malformed.");
+        add (rpcPUBLIC_MALFORMED,      "publicMalformed",     "Public key is malformed.");
+        add (rpcQUALITY_MALFORMED,     "qualityMalformed",    "Quality malformed.");
+        add (rpcSIGNING_MALFORMED,     "signingMalformed",    "Signing of transaction is malformed.");
+        add (rpcSLOW_DOWN,             "slowDown",            "You are placing too much load on the server.");
+        add (rpcSRC_ACT_MALFORMED,     "srcActMalformed",     "Source account is malformed.");
+        add (rpcSRC_ACT_MISSING,       "srcActMissing",       "Source account not provided.");
+        add (rpcSRC_ACT_NOT_FOUND,     "srcActNotFound",      "Source account not found.");
+        add (rpcSRC_AMT_MALFORMED,     "srcAmtMalformed",     "Source amount/currency/issuer is malformed.");
+        add (rpcSRC_CUR_MALFORMED,     "srcCurMalformed",     "Source currency is malformed.");
+        add (rpcSRC_ISR_MALFORMED,     "srcIsrMalformed",     "Source issuer is malformed.");
+        add (rpcSRC_MISSING,           "srcMissing",          "Source is missing.");
+        add (rpcSRC_UNCLAIMED,         "srcUnclaimed",        "Source account is not claimed.");
+        add (rpcSTREAM_MALFORMED,      "malformedStream",     "Stream malformed.");
+        add (rpcTOO_BUSY,              "tooBusy",             "The server is too busy to help you now.");
+        add (rpcTXN_NOT_FOUND,         "txnNotFound",         "Transaction not found.");
+        add (rpcUNKNOWN_COMMAND,       "unknownCmd",          "Unknown method.");
+        add (rpcWRONG_SEED,            "wrongSeed",           "The regular key does not point as the master key.");
+        add (rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed.");
     }
 
     ErrorInfo const& get (error_code_i code) const

--- a/src/ripple/rpc/impl/Status.cpp
+++ b/src/ripple/rpc/impl/Status.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/rpc/Status.h>
+#include <sstream>
 
 namespace ripple {
 namespace RPC {
@@ -46,7 +47,9 @@ std::string Status::codeString () const
     if (type_ == Status::Type::error_code_i)
     {
         auto info = get_error_info (toErrorCode ());
-        return info.token +  ": " + info.message;
+        std::ostringstream sStr;
+        sStr << info.token.c_str() << ": " << info.message.c_str();
+        return sStr.str();
     }
 
     assert (false);

--- a/src/test/rpc/JSONRPC_test.cpp
+++ b/src/test/rpc/JSONRPC_test.cpp
@@ -855,6 +855,36 @@ R"({
 "Missing field 'tx_json.Sequence'.",
 "Missing field 'tx_json.Sequence'."}}},
 
+{ "Single-sign a multisigned transaction.", __LINE__,
+R"({
+    "command": "doesnt_matter",
+    "account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+    "secret": "a",
+    "tx_json": {
+        "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Amount" : "1000000000",
+        "Destination" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Fee" : "50",
+        "Sequence" : 0,
+        "Signers" : [
+            {
+                "Signer" : {
+                    "Account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                    "SigningPubKey" : "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+                    "TxnSignature" : "304502210080EB23E78A841DDC5E3A4F10DE6EAF052207D6B519BF8954467ADB221B3F349002202CA458E8D4E4DE7176D27A91628545E7B295A5DFC8ADF0B5CD3E279B6FA02998"
+                }
+            }
+        ],
+        "SigningPubKey" : "",
+        "TransactionType" : "Payment"
+    }
+})",
+{{
+"Already multisigned.",
+"Already multisigned.",
+"Secret does not match account.",
+""}}},
+
 { "Minimal sign_for.", __LINE__,
 R"({
     "command": "doesnt_matter",
@@ -1109,8 +1139,8 @@ R"({
     }
 })",
 {{
-"Secret does not match account.",
-"Secret does not match account.",
+"Already multisigned.",
+"Already multisigned.",
 "Duplicate Signers:Signer:Account entries (rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh) are not allowed.",
 ""}}},
 
@@ -1139,8 +1169,8 @@ R"({
     }
 })",
 {{
-"Secret does not match account.",
-"Secret does not match account.",
+"Already multisigned.",
+"Already multisigned.",
 "",
 ""}}},
 
@@ -1169,8 +1199,8 @@ R"({
     }
 })",
 {{
-"Secret does not match account.",
-"Secret does not match account.",
+"Already multisigned.",
+"Already multisigned.",
 "Invalid signature.",
 "Invalid signature."}}},
 
@@ -1214,6 +1244,37 @@ R"({
 "Missing field 'tx_json.TransactionType'.",
 "Missing field 'tx_json.TransactionType'.",
 "Missing field 'tx_json.TransactionType'."}}},
+
+{ "TxnSignature in sign_for.", __LINE__,
+R"({
+    "command": "doesnt_matter",
+    "account": "rPcNzota6B8YBokhYtcTNqQVCngtbnWfux",
+    "secret": "c",
+    "tx_json": {
+        "Account" : "rnUy2SHTrB9DubsPmkJZUXTf5FcNDGrYEA",
+        "Amount" : "1000000000",
+        "Destination" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "Fee" : "50",
+        "Sequence" : 0,
+        "Signers" : [
+            {
+                "Signer" : {
+                    "Account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+                    "SigningPubKey" : "0330E7FC9D56BB25D6893BA3F317AE5BCF33B3291BD63DB32654A313222F7FD020",
+                    "TxnSignature" : "304502210080EB23E78A841DDC5E3A4F10DE6EAF052207D6B519BF8954467ADB221B3F349002202CA458E8D4E4DE7176D27A91628545E7B295A5DFC8ADF0B5CD3E279B6FA02998"
+                }
+            }
+        ],
+        "SigningPubKey" : "",
+        "TxnSignature" : "304502210080EB23E78A841DDC5E3A4F10DE6EAF052207D6B519BF8954467ADB221B3F349002202CA458E8D4E4DE7176D27A91628545E7B295A5DFC8ADF0B5CD3E279B6FA02998",
+        "TransactionType" : "Payment"
+    }
+})",
+{{
+"Already multisigned.",
+"Already multisigned.",
+"Already single-signed.",
+"Signing of transaction is malformed."}}},
 
 { "Invalid field 'tx_json': string instead of object", __LINE__,
 R"({
@@ -2337,7 +2398,8 @@ public:
                     {
                         std::ostringstream description;
                         description << txnTest.description << "  Called "
-                            << get<2>(testFunc) << "()";
+                            << get<2>(testFunc) << "().  Got \'"
+                            << errStr << "\'";
                         fail (description.str(), __FILE__, txnTest.line);
                     }
                 }

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -6970,10 +6970,20 @@ public:
             Json::Value exp;
             Json::Reader{}.parse (rpcCallTest.exp, exp);
 
-            // If there is an "error_code" field, remove it.  Error codes
-            // are not expected to stay stable between releases.
-            got.removeMember ("error_code");
-            exp.removeMember ("error_code");
+            // Lambda to remove the "params[0u]:error_code" field if present.
+            // Error codes are not expected to be stable between releases.
+            auto rmErrorCode = [] (Json::Value& json)
+            {
+                if (json.isMember (jss::params) &&
+                    json[jss::params].isArray() &&
+                    json[jss::params].size() > 0 &&
+                    json[jss::params][0u].isObject())
+                {
+                    json[jss::params][0u].removeMember (jss::error_code);
+                }
+            };
+            rmErrorCode (got);
+            rmErrorCode (exp);
 
             // Pass if we didn't expect a throw and we got what we expected.
             if ((rpcCallTest.throwsWhat == RPCCallTestData::no_exception) &&


### PR DESCRIPTION
This pull request is composed of two related commits.

The first commit adds some checking in the signing RPC commands (like submit and sign_for) to return an error when a transaction being multisigned is already single-signed and vice versa.  The transaction layer already protected against this problem.  So the commit just improves the error message for the user and stops processing earlier on this kind of error.  It also adds a couple of new error codes to ErrorCodes.h.  More on that in a bit.

In the process of making this change a bug was uncovered in the RPCCall unit test.  The first commit fixes that bug as well.

Also during the work on the first commit it was discovered that there was at least one code in ErrorCode.h that is currently unused anywhere in the current code base.  That led to an audit.  The audit in turn led to the second commit.

The second commit removes all of the codes in ErrorCodes.h that are unused.  The corresponding support code is also removed from ErrorCodes.cpp.

This leads me to my last question.  The source code in ErrorCodes.h notes that the numeric values below a certain point are unstable: https://github.com/ripple/rippled/blob/develop/src/ripple/protocol/ErrorCodes.h#L40-L41  And they certainly will be unstable after these two commits.

However the online documentation does not seem to spell out that the numeric codes are not stable.  Here's where I would expect to see that indication: https://developers.ripple.com/error-formatting.html  It doesn't assert that the numeric codes are _stable_.  But it also doesn't say they can't be relied on.  There _is_ documentation to say that `TER` codes are unstable: https://developers.ripple.com/transaction-results.html#immediate-response  Still, `TER` codes are a different matter from RPC error codes.

One additional data point is that the numeric values in ErrorCodes.h _have_ been changing over time.  So it seems like users must not be relying on the stability of these values; we probably would have heard.  The last change was in version 1.1.0.  Before that there were changes in versions 0.80.0 and 0.33.0.  And there were lots of changes before 0.33.0.

So my feeling is that we can probably continue to get away with changing these codes.  But if we do we should probably add a warning regarding their stability in https://developers.ripple.com/error-formatting.html

Alternatively, if we decide that the codes should be treated as stable, then I should rework the first commit and throw out the second commit.  I'd be good with that too.

Thanks for your thoughts.