### PR TITLE
[Performance] Reduce memory allocations for RCLCensorshipDetector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1487,6 +1487,7 @@ install (
     src/ripple/basics/StringUtilities.h
     src/ripple/basics/ToString.h
     src/ripple/basics/UnorderedContainers.h
+    src/ripple/basics/algorithm.h
     src/ripple/basics/base_uint.h
     src/ripple/basics/chrono.h
     src/ripple/basics/contract.h

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -330,15 +330,16 @@ RCLConsensus::Adaptor::onClose(
 
     if (!wrongLCL)
     {
-        std::vector<TxID> proposed;
+        LedgerIndex const seq = prevLedger->info().seq + 1;
+        RCLCensorshipDetector<TxID, LedgerIndex>::TxIDSeqVec proposed;
 
         initialSet->visitLeaves(
-            [&proposed](std::shared_ptr<SHAMapItem const> const& item)
+            [&proposed, seq](std::shared_ptr<SHAMapItem const> const& item)
             {
-                proposed.push_back(item->key());
+                proposed.emplace_back(item->key(), seq);
             });
 
-        censorshipDetector_.propose(prevLedger->info().seq + 1, std::move(proposed));
+        censorshipDetector_.propose(std::move(proposed));
     }
 
     // Needed because of the move below.

--- a/src/ripple/basics/algorithm.h
+++ b/src/ripple/basics/algorithm.h
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2019 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_ALGORITHM_H_INCLUDED
+#define RIPPLE_ALGORITHM_H_INCLUDED
+
+#include <utility>
+
+namespace ripple {
+
+// Requires: [first1, last1) and [first2, last2) are ordered ranges according to
+// comp.
+
+// Effects: For each pair of elements {i, j} in the intersection of the sorted
+// sequences [first1, last1) and [first2, last2), perform action(i, j).
+
+// Note: This algorithm is evolved from std::set_intersection.
+template <class InputIter1, class InputIter2, class Action, class Comp>
+void
+generalized_set_intersection(InputIter1 first1, InputIter1 last1,
+                             InputIter2 first2, InputIter2 last2,
+                             Action action, Comp comp)
+{
+    while (first1 != last1 && first2 != last2)
+    {
+        
+        if (comp(*first1, *first2))       // if *first1 < *first2
+            ++first1;                     //     then reduce first range
+        else
+        {
+            if (!comp(*first2, *first1))  // if *first1 == *first2
+            {                             //     then this is an intersection
+                action(*first1, *first2); //     do the action
+                ++first1;                 //     reduce first range
+            }
+            ++first2;        // Reduce second range because *first2 <= *first1
+        }
+    }
+}
+
+// Requires: [first1, last1) and [first2, last2) are ordered ranges according to
+// comp.
+
+// Effects: Eliminates all the elements i in the range [first1, last1) which are
+// equivalent to some value in [first2, last2) or for which pred(i) returns true.
+
+// Returns: A FwdIter1 E such that [first1, E) is the range of elements not
+// removed by this algorithm.
+
+// Note: This algorithm is evolved from std::remove_if and std::set_intersection.
+template <class FwdIter1, class InputIter2, class Pred, class Comp>
+FwdIter1
+remove_if_intersect_or_match(FwdIter1 first1, FwdIter1 last1,
+                             InputIter2 first2, InputIter2 last2,
+                             Pred pred, Comp comp)
+{
+    // [original-first1, current-first1) is the set of elements to be preserved.
+    // [current-first1, i) is the set of elements that have been removed.
+    // [i, last1) is the set of elements not tested yet.
+    
+    // Test each *i in [first1, last1) against [first2, last2) and pred
+    for (auto i = first1; i != last1;)
+    {
+        // if (*i is not in [first2, last2)
+        if (first2 == last2 || comp(*i, *first2))
+        {
+            if (!pred(*i))
+            {
+                // *i should not be removed, so append it to the preserved set
+                if (i != first1)
+                    *first1 = std::move(*i);
+                ++first1;
+            }
+            // *i has been fully tested, prepare for next i by
+            // appending i to the removed set, whether or not
+            // it has been moved from above.
+            ++i;
+        }
+        else  // *i might be in [first2, last2) because *i >= *first2
+        {
+            if (!comp(*first2, *i))  // if *i == *first2
+                ++i;                 //    then append *i to the removed set
+            // All elements in [i, last1) are known to be greater than *first2,
+            // so reduce the second range.
+            ++first2;
+        }
+        // Continue to test *i against [first2, last2) and pred
+    }
+    return first1;
+}
+
+} // ripple
+
+#endif

--- a/src/test/app/RCLCensorshipDetector_test.cpp
+++ b/src/test/app/RCLCensorshipDetector_test.cpp
@@ -33,7 +33,10 @@ class RCLCensorshipDetector_test : public beast::unit_test::suite
         std::vector<int> remain, std::vector<int> remove)
     {
         // Begin tracking what we're proposing this round
-        cdet.propose(round, std::move(proposed));
+        RCLCensorshipDetector<int, int>::TxIDSeqVec proposal;
+        for (auto const& i : proposed)
+            proposal.emplace_back(i, round);
+        cdet.propose(std::move(proposal));
 
         // Finalize the round, by processing what we accepted; then
         // remove anything that needs to be removed and ensure that
@@ -68,7 +71,7 @@ public:
 
         RCLCensorshipDetector<int, int> cdet;
         int round = 0;
-
+                             // proposed            accepted    remain          remove
         test(cdet, ++round,     { },                { },        { },            { });
         test(cdet, ++round,     { 10, 11, 12, 13 }, { 11, 2 },  { 10, 13 },     { });
         test(cdet, ++round,     { 10, 13, 14, 15 }, { 14 },     { 10, 13, 15 }, { });


### PR DESCRIPTION
There should be no change in behavior for this PR.

The objective is to reduce the number of memory allocations and deallocations to perform the RCLCensorshipDetector test by replacing the internal map structure with a vector, and reduce O(N) complexity by customizing some algorithms.