### PR TITLE
Remove censorshipMaxWarnings

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -512,14 +512,7 @@ RCLConsensus::Adaptor::doAccept(
                        << " has not been included as of ledger " << curr
                        << ".";
 
-                    if (wait / censorshipWarnInternal == censorshipMaxWarnings)
-                    {
-                        JLOG(j.error()) << ss.str() << " Additional warnings suppressed.";
-                    }
-                    else
-                    {
-                        JLOG(j.warn()) << ss.str();
-                    }
+                    JLOG(j.warn()) << ss.str();
                 }
 
                 return false;

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -51,9 +51,6 @@ class RCLConsensus
     /** Warn for transactions that haven't been included every so many ledgers. */
     constexpr static unsigned int censorshipWarnInternal = 15;
 
-    /** Stop warning after several warnings. */
-    constexpr static unsigned int censorshipMaxWarnings = 5;
-
     // Implements the Adaptor template interface required by Consensus.
     class Adaptor
     {


### PR DESCRIPTION
Currently the warning logs for potential censorship will print "Additional warnings suppressed" after logging censorshipMaxWarnings times, but then afterwards continue logging as normal. Since additional warnings are not currently suppressed, removing this logic entirely shouldn't be a significant change. It seems better to remove this logic instead of making censorshipMaxWarnings actually function the way it should, since capping the warnings would make it more difficult to detect when censorship is occurring.