### PR TITLE
 Remove runtime inference of unrecognized SFields

### DIFF
--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -24,8 +24,6 @@
 #include <ripple/json/json_value.h>
 #include <cstdint>
 #include <map>
-#include <memory>
-#include <mutex>
 #include <utility>
 
 namespace ripple {
@@ -163,14 +161,7 @@ public:
         const char* fn, int meta = sMD_Default,
         IsSigning signing = IsSigning::yes);
     explicit SField (private_access_tag_t, int fc);
-    SField (private_access_tag_t, SerializedTypeID tid, int fv);
 
-protected:
-    // These constructors can only be called from SField.cpp
-    explicit SField (SerializedTypeID tid, int fv);
-
-public:
-    // getField will dynamically construct a new SField if necessary
     static const SField& getField (int fieldCode);
     static const SField& getField (std::string const& fieldName);
     static const SField& getField (int type, int value)
@@ -270,10 +261,7 @@ public:
 
 private:
     static int num;
-
-    static std::mutex SField_mutex;
     static std::map<int, SField const*> knownCodeToField;
-    static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
 };
 
 /** A field with a type known at compile time. */

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -102,17 +102,8 @@ field_code(int id, int index)
 /** Identifies fields.
 
     Fields are necessary to tag data in signed transactions so that
-    the binary format of the transaction can be canonicalized.
-
-    There are two categories of these fields:
-
-    1.  Those that are created at compile time.
-    2.  Those that are created at run time.
-
-    Both are always const.  Category 1 can only be created in FieldNames.cpp.
-    This is enforced at compile time.  Category 2 can only be created by
-    calling getField with an as yet unused fieldType and fieldValue (or the
-    equivalent fieldCode).
+    the binary format of the transaction can be canonicalized.  All
+    SFields are created at compile time.
 
     Each SField, once constructed, lives until program termination, and there
     is only one instance per fieldType/fieldValue pair which serves the entire
@@ -154,7 +145,7 @@ public:
     SField& operator=(SField&&) = delete;
 
 public:
-    struct private_access_tag_t;         // public, but still an implementation detail
+    struct private_access_tag_t;   // public, but still an implementation detail
 
     // These constructors can only be called from SField.cpp
     SField (private_access_tag_t, SerializedTypeID tid, int fv,

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -136,20 +136,20 @@ public:
         no,
         yes
     };
-    static IsSigning const notSigning = IsSigning::no;
+    static IsSigning const   notSigning = IsSigning::no;
 
-    int const               fieldCode;      // (type<<16)|index
-    SerializedTypeID const  fieldType;      // STI_*
-    int const               fieldValue;     // Code number for protocol
-    std::string             fieldName;
-    int                     fieldMeta;
-    int                     fieldNum;
-    IsSigning const         signingField;
-    std::string             jsonName;
+    int const                fieldCode;      // (type<<16)|index
+    SerializedTypeID const   fieldType;      // STI_*
+    int const                fieldValue;     // Code number for protocol
+    std::string              fieldName;
+    int                      fieldMeta;
+    int                      fieldNum;
+    IsSigning const          signingField;
+    Json::StaticString const jsonName;
 
     SField(SField const&) = delete;
     SField& operator=(SField const&) = delete;
-    SField(SField&&) = default;
+    SField(SField&&);
 
 protected:
     // These constructors can only be called from FieldNames.cpp
@@ -166,18 +166,23 @@ public:
     {
         return getField (field_code (type, value));
     }
+
     static const SField& getField (SerializedTypeID type, int value)
     {
         return getField (field_code (type, value));
     }
 
-    std::string getName () const;
-    bool hasName () const
+    std::string const& getName () const
     {
-        return !fieldName.empty ();
+        return fieldName;
     }
 
-    std::string const& getJsonName () const
+    bool hasName () const
+    {
+        return fieldCode > 0;
+    }
+
+    Json::StaticString const& getJsonName () const
     {
         return jsonName;
     }

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -144,9 +144,9 @@ public:
     int const                fieldCode;      // (type<<16)|index
     SerializedTypeID const   fieldType;      // STI_*
     int const                fieldValue;     // Code number for protocol
-    std::string              fieldName;
-    int                      fieldMeta;
-    int                      fieldNum;
+    std::string const        fieldName;
+    int const                fieldMeta;
+    int const                fieldNum;
     IsSigning const          signingField;
     Json::StaticString const jsonName;
 
@@ -248,10 +248,6 @@ public:
     bool shouldMeta (int c) const
     {
         return (fieldMeta & c) != 0;
-    }
-    void setMeta (int c)
-    {
-        fieldMeta = c;
     }
 
     bool shouldInclude (bool withSigningField) const

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_SOTEMPLATE_H_INCLUDED
 #define RIPPLE_PROTOCOL_SOTEMPLATE_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/SField.h>
 #include <boost/range.hpp>
 #include <memory>
@@ -49,6 +50,8 @@ public:
         : e_field (fieldName)
         , flags (flags)
     {
+        if (! e_field.isUseful())
+            Throw<std::runtime_error> ("SField in SOElement must be useful.");
     }
 };
 

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -20,254 +20,229 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/SField.h>
 #include <cassert>
-#include <map>
-#include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 
 namespace ripple {
 
-// These must stay at the top of this file, and in this order
-// Files-cope statics are preferred here because the SFields must be
-// file-scope.  The following 3 objects must have scope prior to
-// the file-scope SFields.
-static std::mutex SField_mutex;
-static std::map<int, SField const*> knownCodeToField;
-static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
-
-// Storage for static const member.
+// Storage for static const members.
 SField::IsSigning const SField::notSigning;
-
 int SField::num = 0;
+std::mutex SField::SField_mutex;
+std::map<int, SField const*> SField::knownCodeToField;
+std::map<int, std::unique_ptr<SField const>> SField::unknownCodeToField;
 
 using StaticScopedLockType = std::lock_guard <std::mutex>;
 
-// Give this translation unit only, permission to construct SFields
-struct SField::make
+// Give only this translation unit permission to construct SFields
+struct SField::private_access_tag_t
 {
-    explicit make() = default;
-
-    template <class ...Args>
-    static SField one(SField const* p, Args&& ...args)
-    {
-        SField result(std::forward<Args>(args)...);
-        knownCodeToField[result.fieldCode] = p;
-        return result;
-    }
-
-    template <class T, class ...Args>
-    static TypedField<T> one(SField const* p, Args&& ...args)
-    {
-        TypedField<T> result(std::forward<Args>(args)...);
-        knownCodeToField[result.fieldCode] = p;
-        return result;
-    }
 };
 
-using make = SField::make;
+SField::private_access_tag_t dummy;
 
 // Construct all compile-time SFields, and register them in the knownCodeToField
 // database:
 
-SField const sfInvalid     = make::one(&sfInvalid, -1);
-SField const sfGeneric     = make::one(&sfGeneric, 0);
-SField const sfLedgerEntry = make::one(&sfLedgerEntry, STI_LEDGERENTRY, 257, "LedgerEntry");
-SField const sfTransaction = make::one(&sfTransaction, STI_TRANSACTION, 257, "Transaction");
-SField const sfValidation  = make::one(&sfValidation,  STI_VALIDATION,  257, "Validation");
-SField const sfMetadata    = make::one(&sfMetadata,    STI_METADATA,    257, "Metadata");
-SField const sfHash        = make::one(&sfHash,        STI_HASH256,     257, "hash");
-SField const sfIndex       = make::one(&sfIndex,       STI_HASH256,     258, "index");
+SField const sfInvalid      (dummy, -1);
+SField const sfGeneric      (dummy, 0);
+SField const sfLedgerEntry  (dummy, STI_LEDGERENTRY, 257, "LedgerEntry");
+SField const sfTransaction  (dummy, STI_TRANSACTION, 257, "Transaction");
+SField const sfValidation   (dummy, STI_VALIDATION,  257, "Validation");
+SField const sfMetadata     (dummy, STI_METADATA,    257, "Metadata");
+SField const sfHash         (dummy, STI_HASH256,     257, "hash");
+SField const sfIndex        (dummy, STI_HASH256,     258, "index");
 
 // 8-bit integers
-SF_U8 const sfCloseResolution   = make::one<SF_U8::type>(&sfCloseResolution,   STI_UINT8, 1, "CloseResolution");
-SF_U8 const sfMethod            = make::one<SF_U8::type>(&sfMethod,            STI_UINT8, 2, "Method");
-SF_U8 const sfTransactionResult = make::one<SF_U8::type>(&sfTransactionResult, STI_UINT8, 3, "TransactionResult");
+SF_U8 const sfCloseResolution   (dummy, STI_UINT8, 1, "CloseResolution");
+SF_U8 const sfMethod            (dummy, STI_UINT8, 2, "Method");
+SF_U8 const sfTransactionResult (dummy, STI_UINT8, 3, "TransactionResult");
 
 // 8-bit integers (uncommon)
-SF_U8 const sfTickSize          = make::one<SF_U8::type>(&sfTickSize,          STI_UINT8, 16, "TickSize");
+SF_U8 const sfTickSize          (dummy, STI_UINT8, 16, "TickSize");
 
 // 16-bit integers
-SF_U16 const sfLedgerEntryType = make::one<SF_U16::type>(&sfLedgerEntryType, STI_UINT16, 1, "LedgerEntryType", SField::sMD_Never);
-SF_U16 const sfTransactionType = make::one<SF_U16::type>(&sfTransactionType, STI_UINT16, 2, "TransactionType");
-SF_U16 const sfSignerWeight    = make::one<SF_U16::type>(&sfSignerWeight,    STI_UINT16, 3, "SignerWeight");
+SF_U16 const sfLedgerEntryType (dummy, STI_UINT16, 1, "LedgerEntryType", SField::sMD_Never);
+SF_U16 const sfTransactionType (dummy, STI_UINT16, 2, "TransactionType");
+SF_U16 const sfSignerWeight    (dummy, STI_UINT16, 3, "SignerWeight");
 
 // 32-bit integers (common)
-SF_U32 const sfFlags             = make::one<SF_U32::type>(&sfFlags,             STI_UINT32,  2, "Flags");
-SF_U32 const sfSourceTag         = make::one<SF_U32::type>(&sfSourceTag,         STI_UINT32,  3, "SourceTag");
-SF_U32 const sfSequence          = make::one<SF_U32::type>(&sfSequence,          STI_UINT32,  4, "Sequence");
-SF_U32 const sfPreviousTxnLgrSeq = make::one<SF_U32::type>(&sfPreviousTxnLgrSeq, STI_UINT32,  5, "PreviousTxnLgrSeq", SField::sMD_DeleteFinal);
-SF_U32 const sfLedgerSequence    = make::one<SF_U32::type>(&sfLedgerSequence,    STI_UINT32,  6, "LedgerSequence");
-SF_U32 const sfCloseTime         = make::one<SF_U32::type>(&sfCloseTime,         STI_UINT32,  7, "CloseTime");
-SF_U32 const sfParentCloseTime   = make::one<SF_U32::type>(&sfParentCloseTime,   STI_UINT32,  8, "ParentCloseTime");
-SF_U32 const sfSigningTime       = make::one<SF_U32::type>(&sfSigningTime,       STI_UINT32,  9, "SigningTime");
-SF_U32 const sfExpiration        = make::one<SF_U32::type>(&sfExpiration,        STI_UINT32, 10, "Expiration");
-SF_U32 const sfTransferRate      = make::one<SF_U32::type>(&sfTransferRate,      STI_UINT32, 11, "TransferRate");
-SF_U32 const sfWalletSize        = make::one<SF_U32::type>(&sfWalletSize,        STI_UINT32, 12, "WalletSize");
-SF_U32 const sfOwnerCount        = make::one<SF_U32::type>(&sfOwnerCount,        STI_UINT32, 13, "OwnerCount");
-SF_U32 const sfDestinationTag    = make::one<SF_U32::type>(&sfDestinationTag,    STI_UINT32, 14, "DestinationTag");
+SF_U32 const sfFlags             (dummy, STI_UINT32,  2, "Flags");
+SF_U32 const sfSourceTag         (dummy, STI_UINT32,  3, "SourceTag");
+SF_U32 const sfSequence          (dummy, STI_UINT32,  4, "Sequence");
+SF_U32 const sfPreviousTxnLgrSeq (dummy, STI_UINT32,  5, "PreviousTxnLgrSeq", SField::sMD_DeleteFinal);
+SF_U32 const sfLedgerSequence    (dummy, STI_UINT32,  6, "LedgerSequence");
+SF_U32 const sfCloseTime         (dummy, STI_UINT32,  7, "CloseTime");
+SF_U32 const sfParentCloseTime   (dummy, STI_UINT32,  8, "ParentCloseTime");
+SF_U32 const sfSigningTime       (dummy, STI_UINT32,  9, "SigningTime");
+SF_U32 const sfExpiration        (dummy, STI_UINT32, 10, "Expiration");
+SF_U32 const sfTransferRate      (dummy, STI_UINT32, 11, "TransferRate");
+SF_U32 const sfWalletSize        (dummy, STI_UINT32, 12, "WalletSize");
+SF_U32 const sfOwnerCount        (dummy, STI_UINT32, 13, "OwnerCount");
+SF_U32 const sfDestinationTag    (dummy, STI_UINT32, 14, "DestinationTag");
 
 // 32-bit integers (uncommon)
-SF_U32 const sfHighQualityIn       = make::one<SF_U32::type>(&sfHighQualityIn,       STI_UINT32, 16, "HighQualityIn");
-SF_U32 const sfHighQualityOut      = make::one<SF_U32::type>(&sfHighQualityOut,      STI_UINT32, 17, "HighQualityOut");
-SF_U32 const sfLowQualityIn        = make::one<SF_U32::type>(&sfLowQualityIn,        STI_UINT32, 18, "LowQualityIn");
-SF_U32 const sfLowQualityOut       = make::one<SF_U32::type>(&sfLowQualityOut,       STI_UINT32, 19, "LowQualityOut");
-SF_U32 const sfQualityIn           = make::one<SF_U32::type>(&sfQualityIn,           STI_UINT32, 20, "QualityIn");
-SF_U32 const sfQualityOut          = make::one<SF_U32::type>(&sfQualityOut,          STI_UINT32, 21, "QualityOut");
-SF_U32 const sfStampEscrow         = make::one<SF_U32::type>(&sfStampEscrow,         STI_UINT32, 22, "StampEscrow");
-SF_U32 const sfBondAmount          = make::one<SF_U32::type>(&sfBondAmount,          STI_UINT32, 23, "BondAmount");
-SF_U32 const sfLoadFee             = make::one<SF_U32::type>(&sfLoadFee,             STI_UINT32, 24, "LoadFee");
-SF_U32 const sfOfferSequence       = make::one<SF_U32::type>(&sfOfferSequence,       STI_UINT32, 25, "OfferSequence");
-SF_U32 const sfFirstLedgerSequence = make::one<SF_U32::type>(&sfFirstLedgerSequence, STI_UINT32, 26, "FirstLedgerSequence");  // Deprecated: do not use
-SF_U32 const sfLastLedgerSequence  = make::one<SF_U32::type>(&sfLastLedgerSequence,  STI_UINT32, 27, "LastLedgerSequence");
-SF_U32 const sfTransactionIndex    = make::one<SF_U32::type>(&sfTransactionIndex,    STI_UINT32, 28, "TransactionIndex");
-SF_U32 const sfOperationLimit      = make::one<SF_U32::type>(&sfOperationLimit,      STI_UINT32, 29, "OperationLimit");
-SF_U32 const sfReferenceFeeUnits   = make::one<SF_U32::type>(&sfReferenceFeeUnits,   STI_UINT32, 30, "ReferenceFeeUnits");
-SF_U32 const sfReserveBase         = make::one<SF_U32::type>(&sfReserveBase,         STI_UINT32, 31, "ReserveBase");
-SF_U32 const sfReserveIncrement    = make::one<SF_U32::type>(&sfReserveIncrement,    STI_UINT32, 32, "ReserveIncrement");
-SF_U32 const sfSetFlag             = make::one<SF_U32::type>(&sfSetFlag,             STI_UINT32, 33, "SetFlag");
-SF_U32 const sfClearFlag           = make::one<SF_U32::type>(&sfClearFlag,           STI_UINT32, 34, "ClearFlag");
-SF_U32 const sfSignerQuorum        = make::one<SF_U32::type>(&sfSignerQuorum,        STI_UINT32, 35, "SignerQuorum");
-SF_U32 const sfCancelAfter         = make::one<SF_U32::type>(&sfCancelAfter,         STI_UINT32, 36, "CancelAfter");
-SF_U32 const sfFinishAfter         = make::one<SF_U32::type>(&sfFinishAfter,         STI_UINT32, 37, "FinishAfter");
-SF_U32 const sfSignerListID        = make::one<SF_U32::type>(&sfSignerListID,        STI_UINT32, 38, "SignerListID");
-SF_U32 const sfSettleDelay         = make::one<SF_U32::type>(&sfSettleDelay,         STI_UINT32, 39, "SettleDelay");
+SF_U32 const sfHighQualityIn       (dummy, STI_UINT32, 16, "HighQualityIn");
+SF_U32 const sfHighQualityOut      (dummy, STI_UINT32, 17, "HighQualityOut");
+SF_U32 const sfLowQualityIn        (dummy, STI_UINT32, 18, "LowQualityIn");
+SF_U32 const sfLowQualityOut       (dummy, STI_UINT32, 19, "LowQualityOut");
+SF_U32 const sfQualityIn           (dummy, STI_UINT32, 20, "QualityIn");
+SF_U32 const sfQualityOut          (dummy, STI_UINT32, 21, "QualityOut");
+SF_U32 const sfStampEscrow         (dummy, STI_UINT32, 22, "StampEscrow");
+SF_U32 const sfBondAmount          (dummy, STI_UINT32, 23, "BondAmount");
+SF_U32 const sfLoadFee             (dummy, STI_UINT32, 24, "LoadFee");
+SF_U32 const sfOfferSequence       (dummy, STI_UINT32, 25, "OfferSequence");
+SF_U32 const sfFirstLedgerSequence (dummy, STI_UINT32, 26, "FirstLedgerSequence");  // Deprecated: do not use
+SF_U32 const sfLastLedgerSequence  (dummy, STI_UINT32, 27, "LastLedgerSequence");
+SF_U32 const sfTransactionIndex    (dummy, STI_UINT32, 28, "TransactionIndex");
+SF_U32 const sfOperationLimit      (dummy, STI_UINT32, 29, "OperationLimit");
+SF_U32 const sfReferenceFeeUnits   (dummy, STI_UINT32, 30, "ReferenceFeeUnits");
+SF_U32 const sfReserveBase         (dummy, STI_UINT32, 31, "ReserveBase");
+SF_U32 const sfReserveIncrement    (dummy, STI_UINT32, 32, "ReserveIncrement");
+SF_U32 const sfSetFlag             (dummy, STI_UINT32, 33, "SetFlag");
+SF_U32 const sfClearFlag           (dummy, STI_UINT32, 34, "ClearFlag");
+SF_U32 const sfSignerQuorum        (dummy, STI_UINT32, 35, "SignerQuorum");
+SF_U32 const sfCancelAfter         (dummy, STI_UINT32, 36, "CancelAfter");
+SF_U32 const sfFinishAfter         (dummy, STI_UINT32, 37, "FinishAfter");
+SF_U32 const sfSignerListID        (dummy, STI_UINT32, 38, "SignerListID");
+SF_U32 const sfSettleDelay         (dummy, STI_UINT32, 39, "SettleDelay");
 
 // 64-bit integers
-SF_U64 const sfIndexNext        = make::one<SF_U64::type>(&sfIndexNext,        STI_UINT64, 1, "IndexNext");
-SF_U64 const sfIndexPrevious    = make::one<SF_U64::type>(&sfIndexPrevious,    STI_UINT64, 2, "IndexPrevious");
-SF_U64 const sfBookNode         = make::one<SF_U64::type>(&sfBookNode,         STI_UINT64, 3, "BookNode");
-SF_U64 const sfOwnerNode        = make::one<SF_U64::type>(&sfOwnerNode,        STI_UINT64, 4, "OwnerNode");
-SF_U64 const sfBaseFee          = make::one<SF_U64::type>(&sfBaseFee,          STI_UINT64, 5, "BaseFee");
-SF_U64 const sfExchangeRate     = make::one<SF_U64::type>(&sfExchangeRate,     STI_UINT64, 6, "ExchangeRate");
-SF_U64 const sfLowNode          = make::one<SF_U64::type>(&sfLowNode,          STI_UINT64, 7, "LowNode");
-SF_U64 const sfHighNode         = make::one<SF_U64::type>(&sfHighNode,         STI_UINT64, 8, "HighNode");
-SF_U64 const sfDestinationNode  = make::one<SF_U64::type>(&sfDestinationNode,  STI_UINT64, 9, "DestinationNode");
-SF_U64 const sfCookie           = make::one<SF_U64::type>(&sfCookie,           STI_UINT64, 10,"Cookie");
+SF_U64 const sfIndexNext        (dummy, STI_UINT64, 1, "IndexNext");
+SF_U64 const sfIndexPrevious    (dummy, STI_UINT64, 2, "IndexPrevious");
+SF_U64 const sfBookNode         (dummy, STI_UINT64, 3, "BookNode");
+SF_U64 const sfOwnerNode        (dummy, STI_UINT64, 4, "OwnerNode");
+SF_U64 const sfBaseFee          (dummy, STI_UINT64, 5, "BaseFee");
+SF_U64 const sfExchangeRate     (dummy, STI_UINT64, 6, "ExchangeRate");
+SF_U64 const sfLowNode          (dummy, STI_UINT64, 7, "LowNode");
+SF_U64 const sfHighNode         (dummy, STI_UINT64, 8, "HighNode");
+SF_U64 const sfDestinationNode  (dummy, STI_UINT64, 9, "DestinationNode");
+SF_U64 const sfCookie           (dummy, STI_UINT64, 10,"Cookie");
 
 
 // 128-bit
-SF_U128 const sfEmailHash = make::one<SF_U128::type>(&sfEmailHash, STI_HASH128, 1, "EmailHash");
+SF_U128 const sfEmailHash (dummy, STI_HASH128, 1, "EmailHash");
 
 // 160-bit (common)
-SF_U160 const sfTakerPaysCurrency = make::one<SF_U160::type>(&sfTakerPaysCurrency, STI_HASH160, 1, "TakerPaysCurrency");
-SF_U160 const sfTakerPaysIssuer   = make::one<SF_U160::type>(&sfTakerPaysIssuer,   STI_HASH160, 2, "TakerPaysIssuer");
-SF_U160 const sfTakerGetsCurrency = make::one<SF_U160::type>(&sfTakerGetsCurrency, STI_HASH160, 3, "TakerGetsCurrency");
-SF_U160 const sfTakerGetsIssuer   = make::one<SF_U160::type>(&sfTakerGetsIssuer,   STI_HASH160, 4, "TakerGetsIssuer");
+SF_U160 const sfTakerPaysCurrency (dummy, STI_HASH160, 1, "TakerPaysCurrency");
+SF_U160 const sfTakerPaysIssuer   (dummy, STI_HASH160, 2, "TakerPaysIssuer");
+SF_U160 const sfTakerGetsCurrency (dummy, STI_HASH160, 3, "TakerGetsCurrency");
+SF_U160 const sfTakerGetsIssuer   (dummy, STI_HASH160, 4, "TakerGetsIssuer");
 
 // 256-bit (common)
-SF_U256 const sfLedgerHash      = make::one<SF_U256::type>(&sfLedgerHash,      STI_HASH256, 1, "LedgerHash");
-SF_U256 const sfParentHash      = make::one<SF_U256::type>(&sfParentHash,      STI_HASH256, 2, "ParentHash");
-SF_U256 const sfTransactionHash = make::one<SF_U256::type>(&sfTransactionHash, STI_HASH256, 3, "TransactionHash");
-SF_U256 const sfAccountHash     = make::one<SF_U256::type>(&sfAccountHash,     STI_HASH256, 4, "AccountHash");
-SF_U256 const sfPreviousTxnID   = make::one<SF_U256::type>(&sfPreviousTxnID,   STI_HASH256, 5, "PreviousTxnID", SField::sMD_DeleteFinal);
-SF_U256 const sfLedgerIndex     = make::one<SF_U256::type>(&sfLedgerIndex,     STI_HASH256, 6, "LedgerIndex");
-SF_U256 const sfWalletLocator   = make::one<SF_U256::type>(&sfWalletLocator,   STI_HASH256, 7, "WalletLocator");
-SF_U256 const sfRootIndex       = make::one<SF_U256::type>(&sfRootIndex,       STI_HASH256, 8, "RootIndex", SField::sMD_Always);
-SF_U256 const sfAccountTxnID    = make::one<SF_U256::type>(&sfAccountTxnID,    STI_HASH256, 9, "AccountTxnID");
+SF_U256 const sfLedgerHash      (dummy, STI_HASH256, 1, "LedgerHash");
+SF_U256 const sfParentHash      (dummy, STI_HASH256, 2, "ParentHash");
+SF_U256 const sfTransactionHash (dummy, STI_HASH256, 3, "TransactionHash");
+SF_U256 const sfAccountHash     (dummy, STI_HASH256, 4, "AccountHash");
+SF_U256 const sfPreviousTxnID   (dummy, STI_HASH256, 5, "PreviousTxnID", SField::sMD_DeleteFinal);
+SF_U256 const sfLedgerIndex     (dummy, STI_HASH256, 6, "LedgerIndex");
+SF_U256 const sfWalletLocator   (dummy, STI_HASH256, 7, "WalletLocator");
+SF_U256 const sfRootIndex       (dummy, STI_HASH256, 8, "RootIndex", SField::sMD_Always);
+SF_U256 const sfAccountTxnID    (dummy, STI_HASH256, 9, "AccountTxnID");
 
 // 256-bit (uncommon)
-SF_U256 const sfBookDirectory = make::one<SF_U256::type>(&sfBookDirectory, STI_HASH256, 16, "BookDirectory");
-SF_U256 const sfInvoiceID     = make::one<SF_U256::type>(&sfInvoiceID,     STI_HASH256, 17, "InvoiceID");
-SF_U256 const sfNickname      = make::one<SF_U256::type>(&sfNickname,      STI_HASH256, 18, "Nickname");
-SF_U256 const sfAmendment     = make::one<SF_U256::type>(&sfAmendment,     STI_HASH256, 19, "Amendment");
-SF_U256 const sfTicketID      = make::one<SF_U256::type>(&sfTicketID,      STI_HASH256, 20, "TicketID");
-SF_U256 const sfDigest        = make::one<SF_U256::type>(&sfDigest,        STI_HASH256, 21, "Digest");
-SF_U256 const sfPayChannel    = make::one<SF_U256::type>(&sfPayChannel,    STI_HASH256, 22, "Channel");
-SF_U256 const sfConsensusHash = make::one<SF_U256::type>(&sfConsensusHash, STI_HASH256, 23, "ConsensusHash");
-SF_U256 const sfCheckID       = make::one<SF_U256::type>(&sfCheckID,       STI_HASH256, 24, "CheckID");
+SF_U256 const sfBookDirectory (dummy, STI_HASH256, 16, "BookDirectory");
+SF_U256 const sfInvoiceID     (dummy, STI_HASH256, 17, "InvoiceID");
+SF_U256 const sfNickname      (dummy, STI_HASH256, 18, "Nickname");
+SF_U256 const sfAmendment     (dummy, STI_HASH256, 19, "Amendment");
+SF_U256 const sfTicketID      (dummy, STI_HASH256, 20, "TicketID");
+SF_U256 const sfDigest        (dummy, STI_HASH256, 21, "Digest");
+SF_U256 const sfPayChannel    (dummy, STI_HASH256, 22, "Channel");
+SF_U256 const sfConsensusHash (dummy, STI_HASH256, 23, "ConsensusHash");
+SF_U256 const sfCheckID       (dummy, STI_HASH256, 24, "CheckID");
 
 // currency amount (common)
-SF_Amount const sfAmount      = make::one<SF_Amount::type>(&sfAmount,      STI_AMOUNT,  1, "Amount");
-SF_Amount const sfBalance     = make::one<SF_Amount::type>(&sfBalance,     STI_AMOUNT,  2, "Balance");
-SF_Amount const sfLimitAmount = make::one<SF_Amount::type>(&sfLimitAmount, STI_AMOUNT,  3, "LimitAmount");
-SF_Amount const sfTakerPays   = make::one<SF_Amount::type>(&sfTakerPays,   STI_AMOUNT,  4, "TakerPays");
-SF_Amount const sfTakerGets   = make::one<SF_Amount::type>(&sfTakerGets,   STI_AMOUNT,  5, "TakerGets");
-SF_Amount const sfLowLimit    = make::one<SF_Amount::type>(&sfLowLimit,    STI_AMOUNT,  6, "LowLimit");
-SF_Amount const sfHighLimit   = make::one<SF_Amount::type>(&sfHighLimit,   STI_AMOUNT,  7, "HighLimit");
-SF_Amount const sfFee         = make::one<SF_Amount::type>(&sfFee,         STI_AMOUNT,  8, "Fee");
-SF_Amount const sfSendMax     = make::one<SF_Amount::type>(&sfSendMax,     STI_AMOUNT,  9, "SendMax");
-SF_Amount const sfDeliverMin  = make::one<SF_Amount::type>(&sfDeliverMin,  STI_AMOUNT, 10, "DeliverMin");
+SF_Amount const sfAmount      (dummy, STI_AMOUNT,  1, "Amount");
+SF_Amount const sfBalance     (dummy, STI_AMOUNT,  2, "Balance");
+SF_Amount const sfLimitAmount (dummy, STI_AMOUNT,  3, "LimitAmount");
+SF_Amount const sfTakerPays   (dummy, STI_AMOUNT,  4, "TakerPays");
+SF_Amount const sfTakerGets   (dummy, STI_AMOUNT,  5, "TakerGets");
+SF_Amount const sfLowLimit    (dummy, STI_AMOUNT,  6, "LowLimit");
+SF_Amount const sfHighLimit   (dummy, STI_AMOUNT,  7, "HighLimit");
+SF_Amount const sfFee         (dummy, STI_AMOUNT,  8, "Fee");
+SF_Amount const sfSendMax     (dummy, STI_AMOUNT,  9, "SendMax");
+SF_Amount const sfDeliverMin  (dummy, STI_AMOUNT, 10, "DeliverMin");
 
 // currency amount (uncommon)
-SF_Amount const sfMinimumOffer    = make::one<SF_Amount::type>(&sfMinimumOffer,    STI_AMOUNT, 16, "MinimumOffer");
-SF_Amount const sfRippleEscrow    = make::one<SF_Amount::type>(&sfRippleEscrow,    STI_AMOUNT, 17, "RippleEscrow");
-SF_Amount const sfDeliveredAmount = make::one<SF_Amount::type>(&sfDeliveredAmount, STI_AMOUNT, 18, "DeliveredAmount");
+SF_Amount const sfMinimumOffer    (dummy, STI_AMOUNT, 16, "MinimumOffer");
+SF_Amount const sfRippleEscrow    (dummy, STI_AMOUNT, 17, "RippleEscrow");
+SF_Amount const sfDeliveredAmount (dummy, STI_AMOUNT, 18, "DeliveredAmount");
 
 // variable length (common)
-SF_Blob const sfPublicKey       = make::one<SF_Blob::type>(&sfPublicKey,     STI_VL,  1, "PublicKey");
-SF_Blob const sfSigningPubKey   = make::one<SF_Blob::type>(&sfSigningPubKey, STI_VL,  3, "SigningPubKey");
-SF_Blob const sfSignature       = make::one<SF_Blob::type>(&sfSignature,     STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
-SF_Blob const sfMessageKey      = make::one<SF_Blob::type>(&sfMessageKey,    STI_VL,  2, "MessageKey");
-SF_Blob const sfTxnSignature    = make::one<SF_Blob::type>(&sfTxnSignature,  STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
-SF_Blob const sfDomain          = make::one<SF_Blob::type>(&sfDomain,        STI_VL,  7, "Domain");
-SF_Blob const sfFundCode        = make::one<SF_Blob::type>(&sfFundCode,      STI_VL,  8, "FundCode");
-SF_Blob const sfRemoveCode      = make::one<SF_Blob::type>(&sfRemoveCode,    STI_VL,  9, "RemoveCode");
-SF_Blob const sfExpireCode      = make::one<SF_Blob::type>(&sfExpireCode,    STI_VL, 10, "ExpireCode");
-SF_Blob const sfCreateCode      = make::one<SF_Blob::type>(&sfCreateCode,    STI_VL, 11, "CreateCode");
-SF_Blob const sfMemoType        = make::one<SF_Blob::type>(&sfMemoType,      STI_VL, 12, "MemoType");
-SF_Blob const sfMemoData        = make::one<SF_Blob::type>(&sfMemoData,      STI_VL, 13, "MemoData");
-SF_Blob const sfMemoFormat      = make::one<SF_Blob::type>(&sfMemoFormat,    STI_VL, 14, "MemoFormat");
+SF_Blob const sfPublicKey       (dummy, STI_VL,  1, "PublicKey");
+SF_Blob const sfSigningPubKey   (dummy, STI_VL,  3, "SigningPubKey");
+SF_Blob const sfSignature       (dummy, STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfMessageKey      (dummy, STI_VL,  2, "MessageKey");
+SF_Blob const sfTxnSignature    (dummy, STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfDomain          (dummy, STI_VL,  7, "Domain");
+SF_Blob const sfFundCode        (dummy, STI_VL,  8, "FundCode");
+SF_Blob const sfRemoveCode      (dummy, STI_VL,  9, "RemoveCode");
+SF_Blob const sfExpireCode      (dummy, STI_VL, 10, "ExpireCode");
+SF_Blob const sfCreateCode      (dummy, STI_VL, 11, "CreateCode");
+SF_Blob const sfMemoType        (dummy, STI_VL, 12, "MemoType");
+SF_Blob const sfMemoData        (dummy, STI_VL, 13, "MemoData");
+SF_Blob const sfMemoFormat      (dummy, STI_VL, 14, "MemoFormat");
 
 
 // variable length (uncommon)
-SF_Blob const sfFulfillment     = make::one<SF_Blob::type>(&sfFulfillment,     STI_VL, 16, "Fulfillment");
-SF_Blob const sfCondition       = make::one<SF_Blob::type>(&sfCondition,       STI_VL, 17, "Condition");
-SF_Blob const sfMasterSignature = make::one<SF_Blob::type>(&sfMasterSignature, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfFulfillment     (dummy, STI_VL, 16, "Fulfillment");
+SF_Blob const sfCondition       (dummy, STI_VL, 17, "Condition");
+SF_Blob const sfMasterSignature (dummy, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
 
 
 // account
-SF_Account const sfAccount     = make::one<SF_Account::type>(&sfAccount,     STI_ACCOUNT, 1, "Account");
-SF_Account const sfOwner       = make::one<SF_Account::type>(&sfOwner,       STI_ACCOUNT, 2, "Owner");
-SF_Account const sfDestination = make::one<SF_Account::type>(&sfDestination, STI_ACCOUNT, 3, "Destination");
-SF_Account const sfIssuer      = make::one<SF_Account::type>(&sfIssuer,      STI_ACCOUNT, 4, "Issuer");
-SF_Account const sfAuthorize   = make::one<SF_Account::type>(&sfAuthorize,   STI_ACCOUNT, 5, "Authorize");
-SF_Account const sfUnauthorize = make::one<SF_Account::type>(&sfUnauthorize, STI_ACCOUNT, 6, "Unauthorize");
-SF_Account const sfTarget      = make::one<SF_Account::type>(&sfTarget,      STI_ACCOUNT, 7, "Target");
-SF_Account const sfRegularKey  = make::one<SF_Account::type>(&sfRegularKey,  STI_ACCOUNT, 8, "RegularKey");
+SF_Account const sfAccount     (dummy, STI_ACCOUNT, 1, "Account");
+SF_Account const sfOwner       (dummy, STI_ACCOUNT, 2, "Owner");
+SF_Account const sfDestination (dummy, STI_ACCOUNT, 3, "Destination");
+SF_Account const sfIssuer      (dummy, STI_ACCOUNT, 4, "Issuer");
+SF_Account const sfAuthorize   (dummy, STI_ACCOUNT, 5, "Authorize");
+SF_Account const sfUnauthorize (dummy, STI_ACCOUNT, 6, "Unauthorize");
+SF_Account const sfTarget      (dummy, STI_ACCOUNT, 7, "Target");
+SF_Account const sfRegularKey  (dummy, STI_ACCOUNT, 8, "RegularKey");
 
 // path set
-SField const sfPaths = make::one(&sfPaths, STI_PATHSET, 1, "Paths");
+SField const sfPaths (dummy, STI_PATHSET, 1, "Paths");
 
 // vector of 256-bit
-SF_Vec256 const sfIndexes    = make::one<SF_Vec256::type>(&sfIndexes,    STI_VECTOR256, 1, "Indexes", SField::sMD_Never);
-SF_Vec256 const sfHashes     = make::one<SF_Vec256::type>(&sfHashes,     STI_VECTOR256, 2, "Hashes");
-SF_Vec256 const sfAmendments = make::one<SF_Vec256::type>(&sfAmendments, STI_VECTOR256, 3, "Amendments");
+SF_Vec256 const sfIndexes    (dummy, STI_VECTOR256, 1, "Indexes", SField::sMD_Never);
+SF_Vec256 const sfHashes     (dummy, STI_VECTOR256, 2, "Hashes");
+SF_Vec256 const sfAmendments (dummy, STI_VECTOR256, 3, "Amendments");
 
 // inner object
 // OBJECT/1 is reserved for end of object
-SField const sfTransactionMetaData = make::one(&sfTransactionMetaData, STI_OBJECT,  2, "TransactionMetaData");
-SField const sfCreatedNode         = make::one(&sfCreatedNode,         STI_OBJECT,  3, "CreatedNode");
-SField const sfDeletedNode         = make::one(&sfDeletedNode,         STI_OBJECT,  4, "DeletedNode");
-SField const sfModifiedNode        = make::one(&sfModifiedNode,        STI_OBJECT,  5, "ModifiedNode");
-SField const sfPreviousFields      = make::one(&sfPreviousFields,      STI_OBJECT,  6, "PreviousFields");
-SField const sfFinalFields         = make::one(&sfFinalFields,         STI_OBJECT,  7, "FinalFields");
-SField const sfNewFields           = make::one(&sfNewFields,           STI_OBJECT,  8, "NewFields");
-SField const sfTemplateEntry       = make::one(&sfTemplateEntry,       STI_OBJECT,  9, "TemplateEntry");
-SField const sfMemo                = make::one(&sfMemo,                STI_OBJECT, 10, "Memo");
-SField const sfSignerEntry         = make::one(&sfSignerEntry,         STI_OBJECT, 11, "SignerEntry");
+SField const sfTransactionMetaData (dummy, STI_OBJECT,  2, "TransactionMetaData");
+SField const sfCreatedNode         (dummy, STI_OBJECT,  3, "CreatedNode");
+SField const sfDeletedNode         (dummy, STI_OBJECT,  4, "DeletedNode");
+SField const sfModifiedNode        (dummy, STI_OBJECT,  5, "ModifiedNode");
+SField const sfPreviousFields      (dummy, STI_OBJECT,  6, "PreviousFields");
+SField const sfFinalFields         (dummy, STI_OBJECT,  7, "FinalFields");
+SField const sfNewFields           (dummy, STI_OBJECT,  8, "NewFields");
+SField const sfTemplateEntry       (dummy, STI_OBJECT,  9, "TemplateEntry");
+SField const sfMemo                (dummy, STI_OBJECT, 10, "Memo");
+SField const sfSignerEntry         (dummy, STI_OBJECT, 11, "SignerEntry");
 
 // inner object (uncommon)
-SField const sfSigner              = make::one(&sfSigner,              STI_OBJECT, 16, "Signer");
+SField const sfSigner              (dummy, STI_OBJECT, 16, "Signer");
 //                                                                                 17 has not been used yet...
-SField const sfMajority            = make::one(&sfMajority,            STI_OBJECT, 18, "Majority");
+SField const sfMajority            (dummy, STI_OBJECT, 18, "Majority");
 
 // array of objects
 // ARRAY/1 is reserved for end of array
-// SField const sfSigningAccounts = make::one(&sfSigningAccounts, STI_ARRAY, 2, "SigningAccounts"); // Never been used.
-SField const sfSigners         = make::one(&sfSigners,         STI_ARRAY, 3, "Signers", SField::sMD_Default, SField::notSigning);
-SField const sfSignerEntries   = make::one(&sfSignerEntries,   STI_ARRAY, 4, "SignerEntries");
-SField const sfTemplate        = make::one(&sfTemplate,        STI_ARRAY, 5, "Template");
-SField const sfNecessary       = make::one(&sfNecessary,       STI_ARRAY, 6, "Necessary");
-SField const sfSufficient      = make::one(&sfSufficient,      STI_ARRAY, 7, "Sufficient");
-SField const sfAffectedNodes   = make::one(&sfAffectedNodes,   STI_ARRAY, 8, "AffectedNodes");
-SField const sfMemos           = make::one(&sfMemos,           STI_ARRAY, 9, "Memos");
+// SField const sfSigningAccounts (dummy, STI_ARRAY, 2, "SigningAccounts"); // Never been used.
+SField const sfSigners         (dummy, STI_ARRAY, 3, "Signers", SField::sMD_Default, SField::notSigning);
+SField const sfSignerEntries   (dummy, STI_ARRAY, 4, "SignerEntries");
+SField const sfTemplate        (dummy, STI_ARRAY, 5, "Template");
+SField const sfNecessary       (dummy, STI_ARRAY, 6, "Necessary");
+SField const sfSufficient      (dummy, STI_ARRAY, 7, "Sufficient");
+SField const sfAffectedNodes   (dummy, STI_ARRAY, 8, "AffectedNodes");
+SField const sfMemos           (dummy, STI_ARRAY, 9, "Memos");
 
 // array of objects (uncommon)
-SField const sfMajorities      = make::one(&sfMajorities,      STI_ARRAY, 16, "Majorities");
+SField const sfMajorities      (dummy, STI_ARRAY, 16, "Majorities");
 
-SField::SField (SerializedTypeID tid, int fv, const char* fn,
-                int meta, IsSigning signing)
+SField::SField(private_access_tag_t,
+    SerializedTypeID tid, int fv, const char* fn, int meta,
+    IsSigning signing)
     : fieldCode (field_code (tid, fv))
     , fieldType (tid)
     , fieldValue (fv)
@@ -277,9 +252,10 @@ SField::SField (SerializedTypeID tid, int fv, const char* fn,
     , signingField (signing)
     , jsonName (fieldName.c_str())
 {
+    knownCodeToField[fieldCode] = this;
 }
 
-SField::SField (int fc)
+SField::SField(private_access_tag_t, int fc)
     : fieldCode (fc)
     , fieldType (STI_UNKNOWN)
     , fieldValue (0)
@@ -288,12 +264,13 @@ SField::SField (int fc)
     , signingField (IsSigning::yes)
     , jsonName (fieldName.c_str())
 {
+    knownCodeToField[fieldCode] = this;
 }
 
 // call with the map mutex to protect num.
 // This is naturally done with no extra expense
 // from getField(int code).
-SField::SField (SerializedTypeID tid, int fv)
+SField::SField(SerializedTypeID tid, int fv)
     : fieldCode (field_code (tid, fv))
     , fieldType (tid)
     , fieldValue (fv)
@@ -306,17 +283,11 @@ SField::SField (SerializedTypeID tid, int fv)
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
 }
 
-// we can't use the default move constructor because
-// it could leave jsonName referencing a destroyed string
-SField::SField (SField &&s)
-    : fieldCode (s.fieldCode)
-    , fieldType (s.fieldType)
-    , fieldValue (s.fieldValue)
-    , fieldMeta (s.fieldMeta)
-    , fieldNum (s.fieldNum)
-    , signingField (s.signingField)
-    , jsonName (fieldName.c_str())
+SField::SField(private_access_tag_t,
+    SerializedTypeID tid, int fv)
+    : SField(tid, fv)
 {
+    knownCodeToField[fieldCode] = this;
 }
 
 SField const&

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -275,7 +275,7 @@ SField::SField (SerializedTypeID tid, int fv, const char* fn,
     , fieldMeta (meta)
     , fieldNum (++num)
     , signingField (signing)
-    , jsonName (getName ())
+    , jsonName (fieldName.c_str())
 {
 }
 
@@ -286,7 +286,7 @@ SField::SField (int fc)
     , fieldMeta (sMD_Never)
     , fieldNum (++num)
     , signingField (IsSigning::yes)
-    , jsonName (getName ())
+    , jsonName (fieldName.c_str())
 {
 }
 
@@ -294,16 +294,29 @@ SField::SField (int fc)
 // This is naturally done with no extra expense
 // from getField(int code).
 SField::SField (SerializedTypeID tid, int fv)
-        : fieldCode (field_code (tid, fv))
-        , fieldType (tid)
-        , fieldValue (fv)
-        , fieldMeta (sMD_Default)
-        , fieldNum (++num)
-        , signingField (IsSigning::yes)
+    : fieldCode (field_code (tid, fv))
+    , fieldType (tid)
+    , fieldValue (fv)
+    , fieldName (std::to_string (tid) + '/' + std::to_string (fv))
+    , fieldMeta (sMD_Default)
+    , fieldNum (++num)
+    , signingField (IsSigning::yes)
+    , jsonName (fieldName.c_str())
 {
-    fieldName = std::to_string (tid) + '/' + std::to_string (fv);
-    jsonName = getName ();
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
+}
+
+// we can't use the default move constructor because
+// it could leave jsonName referencing a destroyed string
+SField::SField (SField &&s)
+    : fieldCode (s.fieldCode)
+    , fieldType (s.fieldType)
+    , fieldValue (s.fieldValue)
+    , fieldMeta (s.fieldMeta)
+    , fieldNum (s.fieldNum)
+    , signingField (s.signingField)
+    , jsonName (fieldName.c_str())
+{
 }
 
 SField const&
@@ -376,18 +389,6 @@ int SField::compare (SField const& f1, SField const& f2)
         return 1;
 
     return 0;
-}
-
-std::string SField::getName () const
-{
-    if (!fieldName.empty ())
-        return fieldName;
-
-    if (fieldValue == 0)
-        return "";
-
-    return std::to_string(safe_cast<int> (fieldType)) + "/" +
-            std::to_string(fieldValue);
 }
 
 SField const&

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -37,208 +37,209 @@ using StaticScopedLockType = std::lock_guard <std::mutex>;
 // Give only this translation unit permission to construct SFields
 struct SField::private_access_tag_t
 {
+    explicit private_access_tag_t() = default;
 };
 
-SField::private_access_tag_t dummy;
+SField::private_access_tag_t access;
 
 // Construct all compile-time SFields, and register them in the knownCodeToField
 // database:
 
-SField const sfInvalid      (dummy, -1);
-SField const sfGeneric      (dummy, 0);
-SField const sfLedgerEntry  (dummy, STI_LEDGERENTRY, 257, "LedgerEntry");
-SField const sfTransaction  (dummy, STI_TRANSACTION, 257, "Transaction");
-SField const sfValidation   (dummy, STI_VALIDATION,  257, "Validation");
-SField const sfMetadata     (dummy, STI_METADATA,    257, "Metadata");
-SField const sfHash         (dummy, STI_HASH256,     257, "hash");
-SField const sfIndex        (dummy, STI_HASH256,     258, "index");
+SField const sfInvalid      (access, -1);
+SField const sfGeneric      (access, 0);
+SField const sfLedgerEntry  (access, STI_LEDGERENTRY, 257, "LedgerEntry");
+SField const sfTransaction  (access, STI_TRANSACTION, 257, "Transaction");
+SField const sfValidation   (access, STI_VALIDATION,  257, "Validation");
+SField const sfMetadata     (access, STI_METADATA,    257, "Metadata");
+SField const sfHash         (access, STI_HASH256,     257, "hash");
+SField const sfIndex        (access, STI_HASH256,     258, "index");
 
 // 8-bit integers
-SF_U8 const sfCloseResolution   (dummy, STI_UINT8, 1, "CloseResolution");
-SF_U8 const sfMethod            (dummy, STI_UINT8, 2, "Method");
-SF_U8 const sfTransactionResult (dummy, STI_UINT8, 3, "TransactionResult");
+SF_U8 const sfCloseResolution   (access, STI_UINT8, 1, "CloseResolution");
+SF_U8 const sfMethod            (access, STI_UINT8, 2, "Method");
+SF_U8 const sfTransactionResult (access, STI_UINT8, 3, "TransactionResult");
 
 // 8-bit integers (uncommon)
-SF_U8 const sfTickSize          (dummy, STI_UINT8, 16, "TickSize");
+SF_U8 const sfTickSize          (access, STI_UINT8, 16, "TickSize");
 
 // 16-bit integers
-SF_U16 const sfLedgerEntryType (dummy, STI_UINT16, 1, "LedgerEntryType", SField::sMD_Never);
-SF_U16 const sfTransactionType (dummy, STI_UINT16, 2, "TransactionType");
-SF_U16 const sfSignerWeight    (dummy, STI_UINT16, 3, "SignerWeight");
+SF_U16 const sfLedgerEntryType (access, STI_UINT16, 1, "LedgerEntryType", SField::sMD_Never);
+SF_U16 const sfTransactionType (access, STI_UINT16, 2, "TransactionType");
+SF_U16 const sfSignerWeight    (access, STI_UINT16, 3, "SignerWeight");
 
 // 32-bit integers (common)
-SF_U32 const sfFlags             (dummy, STI_UINT32,  2, "Flags");
-SF_U32 const sfSourceTag         (dummy, STI_UINT32,  3, "SourceTag");
-SF_U32 const sfSequence          (dummy, STI_UINT32,  4, "Sequence");
-SF_U32 const sfPreviousTxnLgrSeq (dummy, STI_UINT32,  5, "PreviousTxnLgrSeq", SField::sMD_DeleteFinal);
-SF_U32 const sfLedgerSequence    (dummy, STI_UINT32,  6, "LedgerSequence");
-SF_U32 const sfCloseTime         (dummy, STI_UINT32,  7, "CloseTime");
-SF_U32 const sfParentCloseTime   (dummy, STI_UINT32,  8, "ParentCloseTime");
-SF_U32 const sfSigningTime       (dummy, STI_UINT32,  9, "SigningTime");
-SF_U32 const sfExpiration        (dummy, STI_UINT32, 10, "Expiration");
-SF_U32 const sfTransferRate      (dummy, STI_UINT32, 11, "TransferRate");
-SF_U32 const sfWalletSize        (dummy, STI_UINT32, 12, "WalletSize");
-SF_U32 const sfOwnerCount        (dummy, STI_UINT32, 13, "OwnerCount");
-SF_U32 const sfDestinationTag    (dummy, STI_UINT32, 14, "DestinationTag");
+SF_U32 const sfFlags             (access, STI_UINT32,  2, "Flags");
+SF_U32 const sfSourceTag         (access, STI_UINT32,  3, "SourceTag");
+SF_U32 const sfSequence          (access, STI_UINT32,  4, "Sequence");
+SF_U32 const sfPreviousTxnLgrSeq (access, STI_UINT32,  5, "PreviousTxnLgrSeq", SField::sMD_DeleteFinal);
+SF_U32 const sfLedgerSequence    (access, STI_UINT32,  6, "LedgerSequence");
+SF_U32 const sfCloseTime         (access, STI_UINT32,  7, "CloseTime");
+SF_U32 const sfParentCloseTime   (access, STI_UINT32,  8, "ParentCloseTime");
+SF_U32 const sfSigningTime       (access, STI_UINT32,  9, "SigningTime");
+SF_U32 const sfExpiration        (access, STI_UINT32, 10, "Expiration");
+SF_U32 const sfTransferRate      (access, STI_UINT32, 11, "TransferRate");
+SF_U32 const sfWalletSize        (access, STI_UINT32, 12, "WalletSize");
+SF_U32 const sfOwnerCount        (access, STI_UINT32, 13, "OwnerCount");
+SF_U32 const sfDestinationTag    (access, STI_UINT32, 14, "DestinationTag");
 
 // 32-bit integers (uncommon)
-SF_U32 const sfHighQualityIn       (dummy, STI_UINT32, 16, "HighQualityIn");
-SF_U32 const sfHighQualityOut      (dummy, STI_UINT32, 17, "HighQualityOut");
-SF_U32 const sfLowQualityIn        (dummy, STI_UINT32, 18, "LowQualityIn");
-SF_U32 const sfLowQualityOut       (dummy, STI_UINT32, 19, "LowQualityOut");
-SF_U32 const sfQualityIn           (dummy, STI_UINT32, 20, "QualityIn");
-SF_U32 const sfQualityOut          (dummy, STI_UINT32, 21, "QualityOut");
-SF_U32 const sfStampEscrow         (dummy, STI_UINT32, 22, "StampEscrow");
-SF_U32 const sfBondAmount          (dummy, STI_UINT32, 23, "BondAmount");
-SF_U32 const sfLoadFee             (dummy, STI_UINT32, 24, "LoadFee");
-SF_U32 const sfOfferSequence       (dummy, STI_UINT32, 25, "OfferSequence");
-SF_U32 const sfFirstLedgerSequence (dummy, STI_UINT32, 26, "FirstLedgerSequence");  // Deprecated: do not use
-SF_U32 const sfLastLedgerSequence  (dummy, STI_UINT32, 27, "LastLedgerSequence");
-SF_U32 const sfTransactionIndex    (dummy, STI_UINT32, 28, "TransactionIndex");
-SF_U32 const sfOperationLimit      (dummy, STI_UINT32, 29, "OperationLimit");
-SF_U32 const sfReferenceFeeUnits   (dummy, STI_UINT32, 30, "ReferenceFeeUnits");
-SF_U32 const sfReserveBase         (dummy, STI_UINT32, 31, "ReserveBase");
-SF_U32 const sfReserveIncrement    (dummy, STI_UINT32, 32, "ReserveIncrement");
-SF_U32 const sfSetFlag             (dummy, STI_UINT32, 33, "SetFlag");
-SF_U32 const sfClearFlag           (dummy, STI_UINT32, 34, "ClearFlag");
-SF_U32 const sfSignerQuorum        (dummy, STI_UINT32, 35, "SignerQuorum");
-SF_U32 const sfCancelAfter         (dummy, STI_UINT32, 36, "CancelAfter");
-SF_U32 const sfFinishAfter         (dummy, STI_UINT32, 37, "FinishAfter");
-SF_U32 const sfSignerListID        (dummy, STI_UINT32, 38, "SignerListID");
-SF_U32 const sfSettleDelay         (dummy, STI_UINT32, 39, "SettleDelay");
+SF_U32 const sfHighQualityIn       (access, STI_UINT32, 16, "HighQualityIn");
+SF_U32 const sfHighQualityOut      (access, STI_UINT32, 17, "HighQualityOut");
+SF_U32 const sfLowQualityIn        (access, STI_UINT32, 18, "LowQualityIn");
+SF_U32 const sfLowQualityOut       (access, STI_UINT32, 19, "LowQualityOut");
+SF_U32 const sfQualityIn           (access, STI_UINT32, 20, "QualityIn");
+SF_U32 const sfQualityOut          (access, STI_UINT32, 21, "QualityOut");
+SF_U32 const sfStampEscrow         (access, STI_UINT32, 22, "StampEscrow");
+SF_U32 const sfBondAmount          (access, STI_UINT32, 23, "BondAmount");
+SF_U32 const sfLoadFee             (access, STI_UINT32, 24, "LoadFee");
+SF_U32 const sfOfferSequence       (access, STI_UINT32, 25, "OfferSequence");
+SF_U32 const sfFirstLedgerSequence (access, STI_UINT32, 26, "FirstLedgerSequence");  // Deprecated: do not use
+SF_U32 const sfLastLedgerSequence  (access, STI_UINT32, 27, "LastLedgerSequence");
+SF_U32 const sfTransactionIndex    (access, STI_UINT32, 28, "TransactionIndex");
+SF_U32 const sfOperationLimit      (access, STI_UINT32, 29, "OperationLimit");
+SF_U32 const sfReferenceFeeUnits   (access, STI_UINT32, 30, "ReferenceFeeUnits");
+SF_U32 const sfReserveBase         (access, STI_UINT32, 31, "ReserveBase");
+SF_U32 const sfReserveIncrement    (access, STI_UINT32, 32, "ReserveIncrement");
+SF_U32 const sfSetFlag             (access, STI_UINT32, 33, "SetFlag");
+SF_U32 const sfClearFlag           (access, STI_UINT32, 34, "ClearFlag");
+SF_U32 const sfSignerQuorum        (access, STI_UINT32, 35, "SignerQuorum");
+SF_U32 const sfCancelAfter         (access, STI_UINT32, 36, "CancelAfter");
+SF_U32 const sfFinishAfter         (access, STI_UINT32, 37, "FinishAfter");
+SF_U32 const sfSignerListID        (access, STI_UINT32, 38, "SignerListID");
+SF_U32 const sfSettleDelay         (access, STI_UINT32, 39, "SettleDelay");
 
 // 64-bit integers
-SF_U64 const sfIndexNext        (dummy, STI_UINT64, 1, "IndexNext");
-SF_U64 const sfIndexPrevious    (dummy, STI_UINT64, 2, "IndexPrevious");
-SF_U64 const sfBookNode         (dummy, STI_UINT64, 3, "BookNode");
-SF_U64 const sfOwnerNode        (dummy, STI_UINT64, 4, "OwnerNode");
-SF_U64 const sfBaseFee          (dummy, STI_UINT64, 5, "BaseFee");
-SF_U64 const sfExchangeRate     (dummy, STI_UINT64, 6, "ExchangeRate");
-SF_U64 const sfLowNode          (dummy, STI_UINT64, 7, "LowNode");
-SF_U64 const sfHighNode         (dummy, STI_UINT64, 8, "HighNode");
-SF_U64 const sfDestinationNode  (dummy, STI_UINT64, 9, "DestinationNode");
-SF_U64 const sfCookie           (dummy, STI_UINT64, 10,"Cookie");
+SF_U64 const sfIndexNext        (access, STI_UINT64, 1, "IndexNext");
+SF_U64 const sfIndexPrevious    (access, STI_UINT64, 2, "IndexPrevious");
+SF_U64 const sfBookNode         (access, STI_UINT64, 3, "BookNode");
+SF_U64 const sfOwnerNode        (access, STI_UINT64, 4, "OwnerNode");
+SF_U64 const sfBaseFee          (access, STI_UINT64, 5, "BaseFee");
+SF_U64 const sfExchangeRate     (access, STI_UINT64, 6, "ExchangeRate");
+SF_U64 const sfLowNode          (access, STI_UINT64, 7, "LowNode");
+SF_U64 const sfHighNode         (access, STI_UINT64, 8, "HighNode");
+SF_U64 const sfDestinationNode  (access, STI_UINT64, 9, "DestinationNode");
+SF_U64 const sfCookie           (access, STI_UINT64, 10,"Cookie");
 
 
 // 128-bit
-SF_U128 const sfEmailHash (dummy, STI_HASH128, 1, "EmailHash");
+SF_U128 const sfEmailHash (access, STI_HASH128, 1, "EmailHash");
 
 // 160-bit (common)
-SF_U160 const sfTakerPaysCurrency (dummy, STI_HASH160, 1, "TakerPaysCurrency");
-SF_U160 const sfTakerPaysIssuer   (dummy, STI_HASH160, 2, "TakerPaysIssuer");
-SF_U160 const sfTakerGetsCurrency (dummy, STI_HASH160, 3, "TakerGetsCurrency");
-SF_U160 const sfTakerGetsIssuer   (dummy, STI_HASH160, 4, "TakerGetsIssuer");
+SF_U160 const sfTakerPaysCurrency (access, STI_HASH160, 1, "TakerPaysCurrency");
+SF_U160 const sfTakerPaysIssuer   (access, STI_HASH160, 2, "TakerPaysIssuer");
+SF_U160 const sfTakerGetsCurrency (access, STI_HASH160, 3, "TakerGetsCurrency");
+SF_U160 const sfTakerGetsIssuer   (access, STI_HASH160, 4, "TakerGetsIssuer");
 
 // 256-bit (common)
-SF_U256 const sfLedgerHash      (dummy, STI_HASH256, 1, "LedgerHash");
-SF_U256 const sfParentHash      (dummy, STI_HASH256, 2, "ParentHash");
-SF_U256 const sfTransactionHash (dummy, STI_HASH256, 3, "TransactionHash");
-SF_U256 const sfAccountHash     (dummy, STI_HASH256, 4, "AccountHash");
-SF_U256 const sfPreviousTxnID   (dummy, STI_HASH256, 5, "PreviousTxnID", SField::sMD_DeleteFinal);
-SF_U256 const sfLedgerIndex     (dummy, STI_HASH256, 6, "LedgerIndex");
-SF_U256 const sfWalletLocator   (dummy, STI_HASH256, 7, "WalletLocator");
-SF_U256 const sfRootIndex       (dummy, STI_HASH256, 8, "RootIndex", SField::sMD_Always);
-SF_U256 const sfAccountTxnID    (dummy, STI_HASH256, 9, "AccountTxnID");
+SF_U256 const sfLedgerHash      (access, STI_HASH256, 1, "LedgerHash");
+SF_U256 const sfParentHash      (access, STI_HASH256, 2, "ParentHash");
+SF_U256 const sfTransactionHash (access, STI_HASH256, 3, "TransactionHash");
+SF_U256 const sfAccountHash     (access, STI_HASH256, 4, "AccountHash");
+SF_U256 const sfPreviousTxnID   (access, STI_HASH256, 5, "PreviousTxnID", SField::sMD_DeleteFinal);
+SF_U256 const sfLedgerIndex     (access, STI_HASH256, 6, "LedgerIndex");
+SF_U256 const sfWalletLocator   (access, STI_HASH256, 7, "WalletLocator");
+SF_U256 const sfRootIndex       (access, STI_HASH256, 8, "RootIndex", SField::sMD_Always);
+SF_U256 const sfAccountTxnID    (access, STI_HASH256, 9, "AccountTxnID");
 
 // 256-bit (uncommon)
-SF_U256 const sfBookDirectory (dummy, STI_HASH256, 16, "BookDirectory");
-SF_U256 const sfInvoiceID     (dummy, STI_HASH256, 17, "InvoiceID");
-SF_U256 const sfNickname      (dummy, STI_HASH256, 18, "Nickname");
-SF_U256 const sfAmendment     (dummy, STI_HASH256, 19, "Amendment");
-SF_U256 const sfTicketID      (dummy, STI_HASH256, 20, "TicketID");
-SF_U256 const sfDigest        (dummy, STI_HASH256, 21, "Digest");
-SF_U256 const sfPayChannel    (dummy, STI_HASH256, 22, "Channel");
-SF_U256 const sfConsensusHash (dummy, STI_HASH256, 23, "ConsensusHash");
-SF_U256 const sfCheckID       (dummy, STI_HASH256, 24, "CheckID");
+SF_U256 const sfBookDirectory (access, STI_HASH256, 16, "BookDirectory");
+SF_U256 const sfInvoiceID     (access, STI_HASH256, 17, "InvoiceID");
+SF_U256 const sfNickname      (access, STI_HASH256, 18, "Nickname");
+SF_U256 const sfAmendment     (access, STI_HASH256, 19, "Amendment");
+SF_U256 const sfTicketID      (access, STI_HASH256, 20, "TicketID");
+SF_U256 const sfDigest        (access, STI_HASH256, 21, "Digest");
+SF_U256 const sfPayChannel    (access, STI_HASH256, 22, "Channel");
+SF_U256 const sfConsensusHash (access, STI_HASH256, 23, "ConsensusHash");
+SF_U256 const sfCheckID       (access, STI_HASH256, 24, "CheckID");
 
 // currency amount (common)
-SF_Amount const sfAmount      (dummy, STI_AMOUNT,  1, "Amount");
-SF_Amount const sfBalance     (dummy, STI_AMOUNT,  2, "Balance");
-SF_Amount const sfLimitAmount (dummy, STI_AMOUNT,  3, "LimitAmount");
-SF_Amount const sfTakerPays   (dummy, STI_AMOUNT,  4, "TakerPays");
-SF_Amount const sfTakerGets   (dummy, STI_AMOUNT,  5, "TakerGets");
-SF_Amount const sfLowLimit    (dummy, STI_AMOUNT,  6, "LowLimit");
-SF_Amount const sfHighLimit   (dummy, STI_AMOUNT,  7, "HighLimit");
-SF_Amount const sfFee         (dummy, STI_AMOUNT,  8, "Fee");
-SF_Amount const sfSendMax     (dummy, STI_AMOUNT,  9, "SendMax");
-SF_Amount const sfDeliverMin  (dummy, STI_AMOUNT, 10, "DeliverMin");
+SF_Amount const sfAmount      (access, STI_AMOUNT,  1, "Amount");
+SF_Amount const sfBalance     (access, STI_AMOUNT,  2, "Balance");
+SF_Amount const sfLimitAmount (access, STI_AMOUNT,  3, "LimitAmount");
+SF_Amount const sfTakerPays   (access, STI_AMOUNT,  4, "TakerPays");
+SF_Amount const sfTakerGets   (access, STI_AMOUNT,  5, "TakerGets");
+SF_Amount const sfLowLimit    (access, STI_AMOUNT,  6, "LowLimit");
+SF_Amount const sfHighLimit   (access, STI_AMOUNT,  7, "HighLimit");
+SF_Amount const sfFee         (access, STI_AMOUNT,  8, "Fee");
+SF_Amount const sfSendMax     (access, STI_AMOUNT,  9, "SendMax");
+SF_Amount const sfDeliverMin  (access, STI_AMOUNT, 10, "DeliverMin");
 
 // currency amount (uncommon)
-SF_Amount const sfMinimumOffer    (dummy, STI_AMOUNT, 16, "MinimumOffer");
-SF_Amount const sfRippleEscrow    (dummy, STI_AMOUNT, 17, "RippleEscrow");
-SF_Amount const sfDeliveredAmount (dummy, STI_AMOUNT, 18, "DeliveredAmount");
+SF_Amount const sfMinimumOffer    (access, STI_AMOUNT, 16, "MinimumOffer");
+SF_Amount const sfRippleEscrow    (access, STI_AMOUNT, 17, "RippleEscrow");
+SF_Amount const sfDeliveredAmount (access, STI_AMOUNT, 18, "DeliveredAmount");
 
 // variable length (common)
-SF_Blob const sfPublicKey       (dummy, STI_VL,  1, "PublicKey");
-SF_Blob const sfSigningPubKey   (dummy, STI_VL,  3, "SigningPubKey");
-SF_Blob const sfSignature       (dummy, STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
-SF_Blob const sfMessageKey      (dummy, STI_VL,  2, "MessageKey");
-SF_Blob const sfTxnSignature    (dummy, STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
-SF_Blob const sfDomain          (dummy, STI_VL,  7, "Domain");
-SF_Blob const sfFundCode        (dummy, STI_VL,  8, "FundCode");
-SF_Blob const sfRemoveCode      (dummy, STI_VL,  9, "RemoveCode");
-SF_Blob const sfExpireCode      (dummy, STI_VL, 10, "ExpireCode");
-SF_Blob const sfCreateCode      (dummy, STI_VL, 11, "CreateCode");
-SF_Blob const sfMemoType        (dummy, STI_VL, 12, "MemoType");
-SF_Blob const sfMemoData        (dummy, STI_VL, 13, "MemoData");
-SF_Blob const sfMemoFormat      (dummy, STI_VL, 14, "MemoFormat");
+SF_Blob const sfPublicKey       (access, STI_VL,  1, "PublicKey");
+SF_Blob const sfSigningPubKey   (access, STI_VL,  3, "SigningPubKey");
+SF_Blob const sfSignature       (access, STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfMessageKey      (access, STI_VL,  2, "MessageKey");
+SF_Blob const sfTxnSignature    (access, STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfDomain          (access, STI_VL,  7, "Domain");
+SF_Blob const sfFundCode        (access, STI_VL,  8, "FundCode");
+SF_Blob const sfRemoveCode      (access, STI_VL,  9, "RemoveCode");
+SF_Blob const sfExpireCode      (access, STI_VL, 10, "ExpireCode");
+SF_Blob const sfCreateCode      (access, STI_VL, 11, "CreateCode");
+SF_Blob const sfMemoType        (access, STI_VL, 12, "MemoType");
+SF_Blob const sfMemoData        (access, STI_VL, 13, "MemoData");
+SF_Blob const sfMemoFormat      (access, STI_VL, 14, "MemoFormat");
 
 
 // variable length (uncommon)
-SF_Blob const sfFulfillment     (dummy, STI_VL, 16, "Fulfillment");
-SF_Blob const sfCondition       (dummy, STI_VL, 17, "Condition");
-SF_Blob const sfMasterSignature (dummy, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfFulfillment     (access, STI_VL, 16, "Fulfillment");
+SF_Blob const sfCondition       (access, STI_VL, 17, "Condition");
+SF_Blob const sfMasterSignature (access, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
 
 
 // account
-SF_Account const sfAccount     (dummy, STI_ACCOUNT, 1, "Account");
-SF_Account const sfOwner       (dummy, STI_ACCOUNT, 2, "Owner");
-SF_Account const sfDestination (dummy, STI_ACCOUNT, 3, "Destination");
-SF_Account const sfIssuer      (dummy, STI_ACCOUNT, 4, "Issuer");
-SF_Account const sfAuthorize   (dummy, STI_ACCOUNT, 5, "Authorize");
-SF_Account const sfUnauthorize (dummy, STI_ACCOUNT, 6, "Unauthorize");
-SF_Account const sfTarget      (dummy, STI_ACCOUNT, 7, "Target");
-SF_Account const sfRegularKey  (dummy, STI_ACCOUNT, 8, "RegularKey");
+SF_Account const sfAccount     (access, STI_ACCOUNT, 1, "Account");
+SF_Account const sfOwner       (access, STI_ACCOUNT, 2, "Owner");
+SF_Account const sfDestination (access, STI_ACCOUNT, 3, "Destination");
+SF_Account const sfIssuer      (access, STI_ACCOUNT, 4, "Issuer");
+SF_Account const sfAuthorize   (access, STI_ACCOUNT, 5, "Authorize");
+SF_Account const sfUnauthorize (access, STI_ACCOUNT, 6, "Unauthorize");
+SF_Account const sfTarget      (access, STI_ACCOUNT, 7, "Target");
+SF_Account const sfRegularKey  (access, STI_ACCOUNT, 8, "RegularKey");
 
 // path set
-SField const sfPaths (dummy, STI_PATHSET, 1, "Paths");
+SField const sfPaths (access, STI_PATHSET, 1, "Paths");
 
 // vector of 256-bit
-SF_Vec256 const sfIndexes    (dummy, STI_VECTOR256, 1, "Indexes", SField::sMD_Never);
-SF_Vec256 const sfHashes     (dummy, STI_VECTOR256, 2, "Hashes");
-SF_Vec256 const sfAmendments (dummy, STI_VECTOR256, 3, "Amendments");
+SF_Vec256 const sfIndexes    (access, STI_VECTOR256, 1, "Indexes", SField::sMD_Never);
+SF_Vec256 const sfHashes     (access, STI_VECTOR256, 2, "Hashes");
+SF_Vec256 const sfAmendments (access, STI_VECTOR256, 3, "Amendments");
 
 // inner object
 // OBJECT/1 is reserved for end of object
-SField const sfTransactionMetaData (dummy, STI_OBJECT,  2, "TransactionMetaData");
-SField const sfCreatedNode         (dummy, STI_OBJECT,  3, "CreatedNode");
-SField const sfDeletedNode         (dummy, STI_OBJECT,  4, "DeletedNode");
-SField const sfModifiedNode        (dummy, STI_OBJECT,  5, "ModifiedNode");
-SField const sfPreviousFields      (dummy, STI_OBJECT,  6, "PreviousFields");
-SField const sfFinalFields         (dummy, STI_OBJECT,  7, "FinalFields");
-SField const sfNewFields           (dummy, STI_OBJECT,  8, "NewFields");
-SField const sfTemplateEntry       (dummy, STI_OBJECT,  9, "TemplateEntry");
-SField const sfMemo                (dummy, STI_OBJECT, 10, "Memo");
-SField const sfSignerEntry         (dummy, STI_OBJECT, 11, "SignerEntry");
+SField const sfTransactionMetaData (access, STI_OBJECT,  2, "TransactionMetaData");
+SField const sfCreatedNode         (access, STI_OBJECT,  3, "CreatedNode");
+SField const sfDeletedNode         (access, STI_OBJECT,  4, "DeletedNode");
+SField const sfModifiedNode        (access, STI_OBJECT,  5, "ModifiedNode");
+SField const sfPreviousFields      (access, STI_OBJECT,  6, "PreviousFields");
+SField const sfFinalFields         (access, STI_OBJECT,  7, "FinalFields");
+SField const sfNewFields           (access, STI_OBJECT,  8, "NewFields");
+SField const sfTemplateEntry       (access, STI_OBJECT,  9, "TemplateEntry");
+SField const sfMemo                (access, STI_OBJECT, 10, "Memo");
+SField const sfSignerEntry         (access, STI_OBJECT, 11, "SignerEntry");
 
 // inner object (uncommon)
-SField const sfSigner              (dummy, STI_OBJECT, 16, "Signer");
+SField const sfSigner              (access, STI_OBJECT, 16, "Signer");
 //                                                                                 17 has not been used yet...
-SField const sfMajority            (dummy, STI_OBJECT, 18, "Majority");
+SField const sfMajority            (access, STI_OBJECT, 18, "Majority");
 
 // array of objects
 // ARRAY/1 is reserved for end of array
-// SField const sfSigningAccounts (dummy, STI_ARRAY, 2, "SigningAccounts"); // Never been used.
-SField const sfSigners         (dummy, STI_ARRAY, 3, "Signers", SField::sMD_Default, SField::notSigning);
-SField const sfSignerEntries   (dummy, STI_ARRAY, 4, "SignerEntries");
-SField const sfTemplate        (dummy, STI_ARRAY, 5, "Template");
-SField const sfNecessary       (dummy, STI_ARRAY, 6, "Necessary");
-SField const sfSufficient      (dummy, STI_ARRAY, 7, "Sufficient");
-SField const sfAffectedNodes   (dummy, STI_ARRAY, 8, "AffectedNodes");
-SField const sfMemos           (dummy, STI_ARRAY, 9, "Memos");
+// SField const sfSigningAccounts (access, STI_ARRAY, 2, "SigningAccounts"); // Never been used.
+SField const sfSigners         (access, STI_ARRAY, 3, "Signers", SField::sMD_Default, SField::notSigning);
+SField const sfSignerEntries   (access, STI_ARRAY, 4, "SignerEntries");
+SField const sfTemplate        (access, STI_ARRAY, 5, "Template");
+SField const sfNecessary       (access, STI_ARRAY, 6, "Necessary");
+SField const sfSufficient      (access, STI_ARRAY, 7, "Sufficient");
+SField const sfAffectedNodes   (access, STI_ARRAY, 8, "AffectedNodes");
+SField const sfMemos           (access, STI_ARRAY, 9, "Memos");
 
 // array of objects (uncommon)
-SField const sfMajorities      (dummy, STI_ARRAY, 16, "Majorities");
+SField const sfMajorities      (access, STI_ARRAY, 16, "Majorities");
 
 SField::SField(private_access_tag_t,
     SerializedTypeID tid, int fv, const char* fn, int meta,

--- a/src/ripple/protocol/impl/SOTemplate.cpp
+++ b/src/ripple/protocol/impl/SOTemplate.cpp
@@ -28,18 +28,20 @@ void SOTemplate::push_back (SOElement const& r)
     //
     if (mIndex.empty ())
     {
-        // Unmapped indices will be set to -1
+        // Unmapped indices are initialized to -1
         //
         mIndex.resize (SField::getNumFields () + 1, -1);
     }
 
     // Make sure the field's index is in range
     //
-    assert (r.e_field.getNum () < mIndex.size ());
+    if (r.e_field.getNum() <= 0 || r.e_field.getNum() >= mIndex.size())
+        Throw<std::runtime_error> ("Invalid field index for SOTemplate.");
 
     // Make sure that this field hasn't already been assigned
     //
-    assert (getIndex (r.e_field) == -1);
+    if (getIndex (r.e_field) != -1)
+        Throw<std::runtime_error> ("Duplicate field index for SOTemplate.");
 
     // Add the field to the index mapping table
     //

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -141,16 +141,12 @@ std::string STArray::getText () const
 Json::Value STArray::getJson (int p) const
 {
     Json::Value v = Json::arrayValue;
-    int index = 1;
     for (auto const& object: v_)
     {
         if (object.getSType () != STI_NOTPRESENT)
         {
             Json::Value& inner = v.append (Json::objectValue);
-            auto const& fname = object.getFName ();
-            auto k = fname.hasName () ? fname.fieldName : std::to_string(index);
-            inner[k] = object.getJson (p);
-            index++;
+            inner [object.getFName().getJsonName()] = object.getJson (p);
         }
     }
     return v;

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -658,17 +658,10 @@ Json::Value STObject::getJson (int options) const
 {
     Json::Value ret (Json::objectValue);
 
-    // TODO(tom): this variable is never changed...?
-    int index = 1;
     for (auto const& elem : v_)
     {
         if (elem->getSType () != STI_NOTPRESENT)
-        {
-            auto const& n = elem->getFName ();
-            auto key = n.hasName () ? std::string(n.getJsonName ()) :
-                    std::to_string (index);
-            ret[key] = elem->getJson (options);
-        }
+            ret [elem->getFName().getJsonName()] = elem->getJson (options);
     }
     return ret;
 }

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -235,12 +235,72 @@ public:
         testcase ("serialization");
 
         unexpected (sfGeneric.isUseful (), "sfGeneric must not be useful");
+        {
+            // Try to put sfGeneric in an SOTemplate.
+            SOTemplate elements;
+            bool genericFieldInSOTemplateThrowsException = false;
+            try
+            {
+                elements.push_back (SOElement (sfGeneric, SOE_REQUIRED));
+            }
+            catch (std::runtime_error const&)
+            {
+                genericFieldInSOTemplateThrowsException = true;
+            }
+            BEAST_EXPECT (genericFieldInSOTemplateThrowsException == true);
+        }
 
-        SField const& sfTestVL = SField::getField (STI_VL, 255);
-        SField const& sfTestH256 = SField::getField (STI_HASH256, 255);
-        SField const& sfTestU32 = SField::getField (STI_UINT32, 255);
-        SField const& sfTestV256 = SField::getField(STI_VECTOR256, 255);
-        SField const& sfTestObject = SField::getField (STI_OBJECT, 255);
+        unexpected (sfInvalid.isUseful (), "sfInvalid must not be useful");
+        {
+            // Test return of sfInvalid.
+            auto testInvalid = [this] (SerializedTypeID tid, int fv)
+            {
+                SField const& shouldBeInvalid {SField::getField (tid, fv)};
+                BEAST_EXPECT (shouldBeInvalid == sfInvalid);
+            };
+            testInvalid (STI_VL, 255);
+            testInvalid (STI_HASH256, 255);
+            testInvalid (STI_UINT32, 255);
+            testInvalid (STI_VECTOR256, 255);
+            testInvalid (STI_OBJECT, 255);
+        }
+        {
+            // Try to put sfInvalid in an SOTemplate.
+            SOTemplate elements;
+            bool invalidFieldInSOTemplateThrowsException = false;
+            try
+            {
+                elements.push_back (SOElement (sfInvalid, SOE_REQUIRED));
+            }
+            catch (std::runtime_error const&)
+            {
+                invalidFieldInSOTemplateThrowsException = true;
+            }
+            BEAST_EXPECT (invalidFieldInSOTemplateThrowsException == true);
+        }
+        {
+            // Try to put the same SField into an SOTemplate twice.
+            SOTemplate elements;
+            bool duplicateFieldInSOTemplateThrowsException = false;
+            elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
+            try
+            {
+                elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
+            }
+            catch (std::runtime_error const&)
+            {
+                duplicateFieldInSOTemplateThrowsException = true;
+            }
+            BEAST_EXPECT (duplicateFieldInSOTemplateThrowsException == true);
+        }
+
+        // Put a variety of SFields of different types in an SOTemplate.
+        SField const& sfTestVL = sfMasterSignature;
+        SField const& sfTestH256 = sfCheckID;
+        SField const& sfTestU32 = sfSettleDelay;
+        SField const& sfTestV256 = sfAmendments;
+        SField const& sfTestObject = sfMajority;
+
 
         SOTemplate elements;
         elements.push_back (SOElement (sfFlags, SOE_REQUIRED));
@@ -639,15 +699,15 @@ public:
 
         try
         {
-            std::array<std::uint8_t, 5> const payload {{ 0xee, 0xee, 0xe1, 0xee, 0xee }};
+            std::array<std::uint8_t, 7> const payload {
+                { 0xe9, 0x12, 0xab, 0xcd, 0x12, 0xfe, 0xdc }};
             SerialIter sit{makeSlice(payload)};
             auto obj = std::make_shared<STArray>(sit, sfMetadata);
             BEAST_EXPECT(!obj);
         }
         catch (std::exception const& e)
         {
-            BEAST_EXPECT(strcmp(e.what(),
-                "Duplicate field detected") == 0);
+            BEAST_EXPECT(strcmp(e.what(), "Duplicate field detected") == 0);
         }
 
         try
@@ -659,45 +719,7 @@ public:
         }
         catch (std::exception const& e)
         {
-            BEAST_EXPECT(strcmp(e.what(),
-                "Duplicate field detected") == 0);
-        }
-
-        try
-        {
-            std::array<std::uint8_t, 250> const payload
-            {{
-                0x12, 0x00, 0x65, 0x24, 0x00, 0x00, 0x00, 0x00, 0x20, 0x1e, 0x00, 0x4f,
-                0x00, 0x00, 0x20, 0x1f, 0x03, 0xf6, 0x00, 0x00, 0x20, 0x20, 0x00, 0x00,
-                0x00, 0x00, 0x35, 0x00, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68,
-                0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x73, 0x00, 0x81, 0x14,
-                0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x24, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe5, 0xfe, 0xf3, 0xe7, 0xe5, 0x65,
-                0x24, 0x00, 0x00, 0x00, 0x00, 0x20, 0x1e, 0x00, 0x6f, 0x00, 0x00, 0x20,
-                0x1f, 0x03, 0xf6, 0x00, 0x00, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x35,
-                0x00, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x68, 0x40, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x02, 0x00, 0x12, 0x00, 0x65, 0x24, 0x00, 0x00, 0x00,
-                0x00, 0x20, 0x1e, 0x00, 0x4f, 0x00, 0x00, 0x20, 0x1f, 0x03, 0xf6, 0x00,
-                0x00, 0x20, 0x20, 0x00, 0x00, 0x00, 0x00, 0x35, 0x24, 0x59, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x68, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
-                0x00, 0x54, 0x72, 0x61, 0x6e, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x65, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe5,
-                0xfe, 0xf3, 0xe7, 0xe5, 0x65, 0x24, 0x00, 0x00, 0x00, 0x00, 0x20, 0x1e,
-                0x00, 0x6f, 0x00, 0x00, 0x20, 0xf6, 0x00, 0x00, 0x03, 0x1f, 0x20, 0x20,
-                0x00, 0x00, 0x00, 0x00, 0x35, 0x00, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x68, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x73, 0x00,
-                0x81, 0x14, 0x00, 0x10, 0x00, 0x73, 0x00, 0x81, 0x14, 0x00, 0x10, 0x00,
-                0x00, 0x00, 0x00, 0x26, 0x00, 0x00, 0x00, 0x00, 0xe5, 0xfe
-            }};
-
-            SerialIter sit{makeSlice(payload)};
-            auto obj = std::make_shared<STTx>(sit);
-            BEAST_EXPECT(!obj);
-        }
-        catch (std::exception const& e)
-        {
-            BEAST_EXPECT(strcmp(e.what(),
-                "Duplicate field detected") == 0);
+            BEAST_EXPECT(strcmp(e.what(), "Duplicate field detected") == 0);
         }
     }
 

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -238,16 +238,10 @@ public:
         {
             // Try to put sfGeneric in an SOTemplate.
             SOTemplate elements;
-            bool genericFieldInSOTemplateThrowsException = false;
-            try
-            {
-                elements.push_back (SOElement (sfGeneric, SOE_REQUIRED));
-            }
-            catch (std::runtime_error const&)
-            {
-                genericFieldInSOTemplateThrowsException = true;
-            }
-            BEAST_EXPECT (genericFieldInSOTemplateThrowsException == true);
+            except<std::runtime_error>( [&]()
+                {
+                    elements.push_back (SOElement (sfGeneric, SOE_REQUIRED));
+                });
         }
 
         unexpected (sfInvalid.isUseful (), "sfInvalid must not be useful");
@@ -267,31 +261,19 @@ public:
         {
             // Try to put sfInvalid in an SOTemplate.
             SOTemplate elements;
-            bool invalidFieldInSOTemplateThrowsException = false;
-            try
-            {
-                elements.push_back (SOElement (sfInvalid, SOE_REQUIRED));
-            }
-            catch (std::runtime_error const&)
-            {
-                invalidFieldInSOTemplateThrowsException = true;
-            }
-            BEAST_EXPECT (invalidFieldInSOTemplateThrowsException == true);
+            except<std::runtime_error>( [&]()
+                {
+                    elements.push_back (SOElement (sfInvalid, SOE_REQUIRED));
+                });
         }
         {
             // Try to put the same SField into an SOTemplate twice.
             SOTemplate elements;
-            bool duplicateFieldInSOTemplateThrowsException = false;
             elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
-            try
-            {
-                elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
-            }
-            catch (std::runtime_error const&)
-            {
-                duplicateFieldInSOTemplateThrowsException = true;
-            }
-            BEAST_EXPECT (duplicateFieldInSOTemplateThrowsException == true);
+            except<std::runtime_error>( [&]()
+                {
+                    elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
+                });
         }
 
         // Put a variety of SFields of different types in an SOTemplate.


### PR DESCRIPTION
For years the `SField` implementation has been able to infer certain classes of `SField`s from serialized data.  This capability gives the `SField` handling a certain degree of "forward compatibility".  It allows a server to handle `SField`s that another server might know about, but the local server does not.

However, inferring `SField`s comes with a disadvantage too.  Given the current system with amendments, all servers that can successfully participate in the protocol should have hard definitions for every `SField` used in communications.  So there should never be any need to infer `SField`s; the definitions should in all cases be known.  If an unknown `SField` is encountered it should be flagged as an error and not inferred as a new and unknown `SField`.

This branch removes the ability to infer `SField`s.

As a sanity check, I ran this branch against the network for 12 hours.  During that run the server never lost sync with the network and I shutdown the server normally.  That suggests to me that there is probably not some unexpected reliance on `SField` inference.

With this change, malformed serialized data is detected sooner.  That affected a few of our unit tests which contained malformed serialized data.  The affected unit tests now fail with an "Unknown field" rather than their intended error condition.  In one case I was able to tweak the serialized data so it no longer contained inferred `SField`s.  In other cases I added unit tests that use well known `SField`s to recreate the desired error condition.

Only the top-most commit needs to be reviewed.  That commit sits atop a different pull request by @ximinez who is also making improvements to `SField`s.  I'm assuming that the underlying pull request will be merged and the top-most commit of this branch can be merged afterwards (assuming it passes code review).