### PR TITLE
Properly transition state to disconnected:

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -238,7 +238,7 @@ public:
 
 std::unique_ptr<NetworkOPs>
 make_NetworkOPs (Application& app, NetworkOPs::clock_type& clock,
-    bool standalone, std::size_t network_quorum, bool start_valid,
+    bool standalone, std::size_t minPeerCount, bool start_valid,
     JobQueue& job_queue, LedgerMaster& ledgerMaster, Stoppable& parent,
     ValidatorKeys const & validatorKeys, boost::asio::io_service& io_svc,
     beast::Journal journal);

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -146,7 +146,7 @@ public:
 
     // Peer networking parameters
     bool                        PEER_PRIVATE = false;           // True to ask peers not to relay current IP.
-    int                         PEERS_MAX = 0;
+    std::size_t                 PEERS_MAX = 0;
 
     std::chrono::seconds        WEBSOCKET_PING_FREQ = std::chrono::minutes {5};
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -141,7 +141,8 @@ public:
     int const                   TRANSACTION_FEE_BASE = 10;   // The number of fee units a reference transaction costs
 
     // Note: The following parameters do not relate to the UNL or trust at all
-    std::size_t                 NETWORK_QUORUM = 0;         // Minimum number of nodes to consider the network present
+    // Minimum number of nodes to consider the network present
+    std::size_t                 NETWORK_QUORUM = 1;
 
     // Peer networking parameters
     bool                        PEER_PRIVATE = false;           // True to ask peers not to relay current IP.

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -556,6 +556,11 @@ void Config::loadFromString (std::string const& fileContents)
                 "The minimum number of required peers (network_quorum) exceeds "
                 "the maximum number of allowed peers (peers_max)");
         }
+
+        if (NETWORK_QUORUM == 0)
+            Throw<std::runtime_error> (
+                "The minimum number of required peers (network_quorum) must be "
+                "non-zero.");
     }
 }
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -539,6 +539,14 @@ void Config::loadFromString (std::string const& fileContents)
                     "Unknown feature: " + s + "  in config file.");
         }
     }
+
+    // This doesn't properly belong here:
+    if (NETWORK_QUORUM > PEERS_MAX)
+    {
+        Throw<std::runtime_error>(
+            "The minimum number of required peers (network_quorum) exceeds "
+            "the maximum number of allowed peers (peers_max)");
+    }
 }
 
 int Config::getSize (SizedItemName item) const

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -314,7 +314,7 @@ void Config::loadFromString (std::string const& fileContents)
         PEER_PRIVATE = beast::lexicalCastThrow <bool> (strTemp);
 
     if (getSingleSection (secConfig, SECTION_PEERS_MAX, strTemp, j_))
-        PEERS_MAX = std::max (0, beast::lexicalCastThrow <int> (strTemp));
+        PEERS_MAX = beast::lexicalCastThrow <std::size_t> (strTemp);
 
     if (getSingleSection (secConfig, SECTION_NODE_SIZE, strTemp, j_))
     {
@@ -360,7 +360,7 @@ void Config::loadFromString (std::string const& fileContents)
             "and [" SECTION_VALIDATOR_TOKEN "] config sections");
 
     if (getSingleSection (secConfig, SECTION_NETWORK_QUORUM, strTemp, j_))
-        NETWORK_QUORUM      = beast::lexicalCastThrow <std::size_t> (strTemp);
+        NETWORK_QUORUM      = beast::lexicalCastThrow<std::size_t>(strTemp);
 
     if (getSingleSection (secConfig, SECTION_FEE_ACCOUNT_RESERVE, strTemp, j_))
         FEE_ACCOUNT_RESERVE = beast::lexicalCastThrow <std::uint64_t> (strTemp);
@@ -540,12 +540,22 @@ void Config::loadFromString (std::string const& fileContents)
         }
     }
 
-    // This doesn't properly belong here:
-    if (NETWORK_QUORUM > PEERS_MAX)
+    // This doesn't properly belong here, but check to make sure that the
+    // value specified for network_quorum is achievable:
     {
-        Throw<std::runtime_error>(
-            "The minimum number of required peers (network_quorum) exceeds "
-            "the maximum number of allowed peers (peers_max)");
+        auto pm = PEERS_MAX;
+
+        // FIXME this apparently magic value is actually defined as a constant
+        //       elsewhere (see defaultMaxPeers) but we handle this check here.
+        if (pm == 0)
+            pm = 21;
+
+        if (NETWORK_QUORUM > pm)
+        {
+            Throw<std::runtime_error>(
+                "The minimum number of required peers (network_quorum) exceeds "
+                "the maximum number of allowed peers (peers_max)");
+        }
     }
 }
 


### PR DESCRIPTION
If the number of peers a server has is below the configured minimum peer limit, this commit will properly transition the server's state to "disconnected".

The default limit for the minimum number of peers required was 0 meaning that a server that was connected but lost all its peers would never transition to disconnected, since it could never drop below zero peers.

This commit redefines the default minimum number of peers to 1 and produces a warning if the server is configured in a way that will prevent it from ever achieving sufficient connectivity.