### PR TITLE
Refine parseUrl regular expression

### DIFF
--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -95,14 +95,14 @@ bool parseUrl (parsedURL& pUrl, std::string const& strUrl)
     static boost::regex reUrl (
         "(?i)\\`\\s*"
         // required scheme
-        "([[:alpha:]][-+.[:alpha:][:digit:]]*):"
+        "([[:alpha:]][-+.[:alpha:][:digit:]]*?):"
         // We choose to support only URIs whose `hier-part` has the form
         // `"//" authority path-abempty`.
         "//"
         // optional userinfo
-        "(?:([^[.[.][.].]:/?#@]*?)(?::([^[.[.][.].]:/?#@]*?))?@)?"
+        "(?:([^:@/]*?)(?::([^@/]*?))?@)?"
         // optional host
-        "((?:\\[[[:digit:]:.]+\\])|(?:[^[.[.][.].]:/?#@]*?))"
+        "([[:digit:]:]*[[:digit:]]|\\[[^]]+\\]|[^:/?#]*?)"
         // optional port
         "(?::([[:digit:]]+))?"
         // optional path

--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -100,9 +100,9 @@ bool parseUrl (parsedURL& pUrl, std::string const& strUrl)
         // `"//" authority path-abempty`.
         "//"
         // optional userinfo
-        "(?:([^/]*?)(?::([^/]*?))?@)?"
+        "(?:([^[.[.][.].]:/?#@]*?)(?::([^[.[.][.].]:/?#@]*?))?@)?"
         // optional host
-        "([^/]*?)"
+        "((?:\\[[[:digit:]:.]+\\])|(?:[^[.[.][.].]:/?#@]*?))"
         // optional port
         "(?::([[:digit:]]+))?"
         // optional path
@@ -110,7 +110,12 @@ bool parseUrl (parsedURL& pUrl, std::string const& strUrl)
         "\\s*?\\'");
     boost::smatch smMatch;
 
-    bool bMatch = boost::regex_match (strUrl, smMatch, reUrl); // Match status code.
+    bool bMatch = false;
+    try {
+      bMatch = boost::regex_match (strUrl, smMatch, reUrl); // Match status code.
+    } catch (...) {
+      return false;
+    }
 
     if (bMatch)
     {

--- a/src/test/basics/StringUtilities_test.cpp
+++ b/src/test/basics/StringUtilities_test.cpp
@@ -78,6 +78,7 @@ public:
             // Do we want to normalize paths?
             BEAST_EXPECT(pUrl.path.empty());
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme:///"));
@@ -88,6 +89,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "lower://domain"));
@@ -98,6 +100,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path.empty());
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "UPPER://domain:234/"));
@@ -108,6 +111,7 @@ public:
             BEAST_EXPECT(*pUrl.port == 234);
             BEAST_EXPECT(pUrl.path == "/");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "Mixed://domain/path"));
@@ -118,6 +122,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/path");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://[::1]:123/path"));
@@ -128,6 +133,7 @@ public:
             BEAST_EXPECT(*pUrl.port == 123);
             BEAST_EXPECT(pUrl.path == "/path");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://user:pass@domain:123/abc:321"));
@@ -138,6 +144,7 @@ public:
             BEAST_EXPECT(*pUrl.port == 123);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://user@domain:123/abc:321"));
@@ -148,6 +155,7 @@ public:
             BEAST_EXPECT(*pUrl.port == 123);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://:pass@domain:123/abc:321"));
@@ -158,6 +166,7 @@ public:
             BEAST_EXPECT(*pUrl.port == 123);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://domain:123/abc:321"));
@@ -168,6 +177,7 @@ public:
             BEAST_EXPECT(*pUrl.port == 123);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://user:pass@domain/abc:321"));
@@ -178,6 +188,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://user@domain/abc:321"));
@@ -188,6 +199,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://:pass@domain/abc:321"));
@@ -198,6 +210,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://domain/abc:321"));
@@ -208,6 +221,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/abc:321");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme:///path/to/file"));
@@ -218,6 +232,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/path/to/file");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (
@@ -229,6 +244,7 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/path/with/an@sign");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (
@@ -240,15 +256,27 @@ public:
             BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/path/with/an@sign");
         }
+
         {
             parsedURL pUrl;
             BEAST_EXPECT(parseUrl (pUrl, "scheme://:999/"));
             BEAST_EXPECT(pUrl.scheme == "scheme");
             BEAST_EXPECT(pUrl.username.empty());
             BEAST_EXPECT(pUrl.password.empty());
-            BEAST_EXPECT(pUrl.domain.empty());
-            BEAST_EXPECT(*pUrl.port == 999);
+            BEAST_EXPECT(pUrl.domain == ":999");
+            BEAST_EXPECT(! pUrl.port);
             BEAST_EXPECT(pUrl.path == "/");
+        }
+
+        {
+            parsedURL pUrl;
+            BEAST_EXPECT(parseUrl (pUrl, "http://::1:1234/validators"));
+            BEAST_EXPECT(pUrl.scheme == "http");
+            BEAST_EXPECT(pUrl.username.empty());
+            BEAST_EXPECT(pUrl.password.empty());
+            BEAST_EXPECT(pUrl.domain == "::0.1.18.52");
+            BEAST_EXPECT(! pUrl.port);
+            BEAST_EXPECT(pUrl.path == "/validators");
         }
 
         // Expected fails.

--- a/src/test/basics/StringUtilities_test.cpp
+++ b/src/test/basics/StringUtilities_test.cpp
@@ -289,12 +289,9 @@ public:
         }
 
         {
-          std::string strUrl("s://");
-          for (size_t i = 0; i < 8192; i++) {
-            strUrl += ":";
-          }
-          parsedURL pUrl;
-          BEAST_EXPECT(! parseUrl (pUrl, strUrl));
+            std::string strUrl("s://" + std::string(8192, ':'));
+            parsedURL pUrl;
+            BEAST_EXPECT(! parseUrl (pUrl, strUrl));
         }
     }
 

--- a/src/test/basics/StringUtilities_test.cpp
+++ b/src/test/basics/StringUtilities_test.cpp
@@ -259,6 +259,15 @@ public:
             BEAST_EXPECT(! parseUrl (pUrl, "://"));
             BEAST_EXPECT(! parseUrl (pUrl, ":///"));
         }
+
+        {
+          std::string strUrl("s://");
+          for (size_t i = 0; i < 8192; i++) {
+            strUrl += ":";
+          }
+          parsedURL pUrl;
+          BEAST_EXPECT(! parseUrl (pUrl, strUrl));
+        }
     }
 
     void testToString ()


### PR DESCRIPTION
We need narrower character sets to handle pathological cases. In case of
an exception, just bail.

Fixes RIPD-1708