### PR TITLE
Display validator status only to admin requests:

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -237,7 +237,7 @@ public:
     {
         return mMode;
     }
-    std::string strOperatingMode () const override;
+    std::string strOperatingMode (bool admin = false) const override;
 
     //
     // Transaction operations.
@@ -824,9 +824,9 @@ void NetworkOPsImp::processClusterTimer ()
 //------------------------------------------------------------------------------
 
 
-std::string NetworkOPsImp::strOperatingMode () const
+std::string NetworkOPsImp::strOperatingMode (bool admin) const
 {
-    if (mMode == omFULL)
+    if (mMode == omFULL && admin)
     {
         auto const mode = mConsensus.mode();
         if (mode != ConsensusMode::wrongLedger)
@@ -2103,7 +2103,7 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin, bool counters)
 
     info [jss::build_version] = BuildInfo::getVersionString ();
 
-    info [jss::server_state] = strOperatingMode ();
+    info [jss::server_state] = strOperatingMode (admin);
 
     info [jss::time] = to_string(date::floor<std::chrono::microseconds>(
         std::chrono::system_clock::now()));
@@ -2860,7 +2860,7 @@ bool NetworkOPsImp::subServer (InfoSub::ref isrListener, Json::Value& jvResult,
 
     auto const& feeTrack = app_.getFeeTrack();
     jvResult[jss::random]          = to_string (uRandom);
-    jvResult[jss::server_status]   = strOperatingMode ();
+    jvResult[jss::server_status]   = strOperatingMode (admin);
     jvResult[jss::load_base]       = feeTrack.getLoadBase ();
     jvResult[jss::load_factor]     = feeTrack.getLoadFactor ();
     jvResult [jss::hostid]         = getHostId (admin);

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -105,7 +105,7 @@ public:
     //
 
     virtual OperatingMode getOperatingMode () const = 0;
-    virtual std::string strOperatingMode () const = 0;
+    virtual std::string strOperatingMode (bool admin = false) const = 0;
 
     //--------------------------------------------------------------------------
     //

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1663,15 +1663,13 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMStatusChange> const& m)
 
     if (m->has_firstseq () && m->has_lastseq())
     {
+        std::lock_guard<std::mutex> sl (recentLock_);
+
         minLedger_ = m->firstseq ();
         maxLedger_ = m->lastseq ();
 
-        // VFALCO Is this workaround still needed?
-        // Work around some servers that report sequences incorrectly
-        if (minLedger_ == 0)
-            maxLedger_ = 0;
-        if (maxLedger_ == 0)
-            minLedger_ = 0;
+        if ((maxLedger_ < minLedger_) || (minLedger_ == 0) || (maxLedger_ == 0))
+            minLedger_ = maxLedger_ = 0;
     }
 
     if (m->has_ledgerseq() &&


### PR DESCRIPTION
Several commands allow a user to retrieve a server's status. Commands will typically limit disclosure of information that can reveal that a particular server is a validator to connections that are not verified to make it more difficult to determine validators via fingerprinting.

Prior to this commit, servers configured to operate as validators would, instead of simply reporting their server state as 'full', augment their state information to indicate whether they are  'proposing' or 'validating'.

Servers will only provide this enhanced state information for connections that have elevated privileges.

Acknowledgements:
Ripple thanks Markus Teufelberger for responsibly disclosing this issue.

Bug Bounties and Responsible Disclosures:
We welcome reviews of the rippled code and urge researchers to responsibly disclose any issues that they may find. For more on Ripple's Bug Bounty program, please visit: https://ripple.com/bug-bounty