### PR TITLE
Explain/promote IPv6 usage in sample config

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -148,7 +148,8 @@
 #   ip = <IP-address>
 #
 #       Required. Determines the IP address of the network interface to bind
-#       to. To bind to all available interfaces, uses 0.0.0.0
+#       to. To bind to all available interfaces, use 0.0.0.0
+#       For binding to both IPv4 and IPv6 interfaces, use ::
 #
 #   port = <number>
 #
@@ -1149,6 +1150,7 @@ protocol = http
 [port_peer]
 port = 51235
 ip = 0.0.0.0
+# ip = ::
 protocol = peer
 
 [port_ws_admin_local]

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1150,7 +1150,7 @@ protocol = http
 [port_peer]
 port = 51235
 ip = 0.0.0.0
-# ip = ::
+#ip = ::
 protocol = peer
 
 [port_ws_admin_local]


### PR DESCRIPTION
- Explain how to bind to both IPv4 and IPv6 interfaces
- Provide a hint in the default [port_peer] section
- Do not enable it by default 

Note that use of '::'  and IPv4-mapped IPv6 depends on a sysctl value setting 'net.ipv6.bindv6only = 0' which seems to be the default on most Linux distributions.