### PR TITLE
rippled-example.cfg - Remove trailing comments from [crawl] example

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -34,14 +34,13 @@
 #
 #     rippled.cfg
 #
-#   For more information on where the rippled server instance searches for
-#   the file please visit the Ripple wiki. Specifically, the section explaining
-#   the --conf command line option:
+#   For more information on where the rippled server instance searches for the
+#   file, visit:
 #
-#     https://ripple.com/wiki/Rippled#--conf.3Dpath
+#     https://developers.ripple.com/commandline-usage.html#generic-options
 #
-#   This file should be named rippled.cfg.  This file is UTF-8 with Dos, UNIX,
-#   or Mac style end of lines.  Blank lines and lines beginning with '#' are
+#   This file should be named rippled.cfg. This file is UTF-8 with DOS, UNIX,
+#   or Mac style end of lines. Blank lines and lines beginning with '#' are
 #   ignored. Undefined sections are reserved. No escapes are currently defined.
 #
 # Notation
@@ -49,8 +48,8 @@
 #   In this document a simple BNF notation is used. Angle brackets denote
 #   required elements, square brackets denote optional elements, and single
 #   quotes indicate string literals. A vertical bar separating 1 or more
-#   elements is a logical "or"; Any one of the elements may be chosen.
-#   Parenthesis are notational only, and used to group elements, they are not
+#   elements is a logical "or"; any one of the elements may be chosen.
+#   Parentheses are notational only, and used to group elements; they are not
 #   part of the syntax unless they appear in quotes. White space may always
 #   appear between elements, it has no effect on values.
 #
@@ -126,13 +125,13 @@
 #       port = 80
 #
 #       [port_public]
-#       ip=0.0.0.0
+#       ip = 0.0.0.0
 #       port = 443
-#       protocol=peer,https
+#       protocol = peer,https
 #
 #       [port_private]
-#       ip=127.0.0.1
-#       protocol=http
+#       ip = 127.0.0.1
+#       protocol = http
 #
 #   When rippled is used as a command line client (for example, issuing a
 #   server stop command), the first port advertising the http or https
@@ -282,7 +281,7 @@
 #               keep rippled from connecting to other instances of rippled or
 #               prevent RPC and WebSocket clients from connecting.
 #
-#   send_queue_limit = = [1..65535]
+#   send_queue_limit = [1..65535]
 #
 #       A Websocket will disconnect when its send queue exceeds this limit.
 #       The default is 100. A larger value may help with erratic disconnects but
@@ -845,7 +844,7 @@
 #
 #       earliest_seq        The default is 32570 to match the XRP ledger
 #                           network's earliest allowed sequence. Alternate
-#                           networks may set this value. Minimum value of 1. 
+#                           networks may set this value. Minimum value of 1.
 #
 #   Notes:
 #       The 'node_db' entry configures the primary, persistent storage.
@@ -1023,7 +1022,7 @@
 #
 # 8. Misc Settings
 #
-#----------
+#-----------------
 #
 # [signing_support]
 #
@@ -1051,38 +1050,42 @@
 #
 #   <flag>
 #
-#       Enable or disable access to /crawl requests. Default is '1'
+#       Enable or disable access to /crawl requests. Default is '1' which
+#       enables access.
 #
 #   overlay = <flag>
 #
 #       Report information about peers this server is connected to, similar
-#       to the "peers" RPC API. Default is '1'.
+#       to the "peers" RPC API. Default is '1' which means to report peer
+#       overlay info.
 #
 #   server = <flag>
 #
 #       Report information about the local server, similar to the "server_state"
-#       RPC API. Default is '1'.
+#       RPC API. Default is '1' which means to report local server info.
 #
 #   counts = <flag>
 #
 #       Report information about the local server health counters, similar to
-#       the "get_counts" RPC API. Default is '0'.
+#       the "get_counts" RPC API. Default is '0' which means not to report
+#       server counts.
 #
 #   unl = <flag>
 #
 #       Report information about the local server's validator lists, similar to
-#       the "validators" and "validator_list_sites" RPC APIs. Default is '1'.
+#       the "validators" and "validator_list_sites" RPC APIs. Default is '1'
+#       which means to report server validator lists.
 #
-#   Example:
+#   Examples:
 #
 #   [crawl]
 #   0
 #
 #   [crawl]
-#   overlay = 1   # report peer overlay info
-#   server = 1    # report local server info
-#   counts = 0    # do not report server counts
-#   unl = 1       # report server validator lists
+#   overlay = 1
+#   server = 1
+#   counts = 0
+#   unl = 1
 #
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Trailing comments are not permitted; they cause the lines containing
them to be ignored.