### PR TITLE
Reduce likelihood of malformed SOTemplate

### DIFF
--- a/src/ripple/app/misc/impl/Manifest.cpp
+++ b/src/ripple/app/misc/impl/Manifest.cpp
@@ -39,32 +39,30 @@ boost::optional<Manifest> deserializeManifest(Slice s)
     if (s.empty())
         return boost::none;
 
-    static SOTemplate const manifestFormat (
-        [](SOTemplate& t)
-        {
+    static SOTemplate const manifestFormat {
             // A manifest must include:
             // - the master public key
-            t.push_back (SOElement (sfPublicKey,       SOE_REQUIRED));
+            {sfPublicKey,       soeREQUIRED},
 
             // - a signature with that public key
-            t.push_back (SOElement (sfMasterSignature, SOE_REQUIRED));
+            {sfMasterSignature, soeREQUIRED},
 
             // - a sequence number
-            t.push_back (SOElement (sfSequence,        SOE_REQUIRED));
+            {sfSequence,        soeREQUIRED},
 
             // It may, optionally, contain:
             // - a version number which defaults to 0
-            t.push_back (SOElement (sfVersion,          SOE_DEFAULT));
+            {sfVersion,         soeDEFAULT},
 
             // - a domain name
-            t.push_back (SOElement (sfDomain,           SOE_OPTIONAL));
+            {sfDomain,          soeOPTIONAL},
 
             // - an ephemeral signing key that can be changed as necessary
-            t.push_back (SOElement (sfSigningPubKey,    SOE_OPTIONAL));
+            {sfSigningPubKey,   soeOPTIONAL},
 
             // - a signature using the ephemeral signing key, if it is present
-            t.push_back (SOElement (sfSignature,        SOE_OPTIONAL));
-        });
+            {sfSignature,       soeOPTIONAL},
+        };
 
     try
     {

--- a/src/ripple/protocol/InnerObjectFormats.h
+++ b/src/ripple/protocol/InnerObjectFormats.h
@@ -29,18 +29,12 @@ namespace ripple {
 class InnerObjectFormats : public KnownFormats <int>
 {
 private:
-    void addCommonFields (Item& item) override;
-
-public:
-    virtual ~InnerObjectFormats () = default;
-    InnerObjectFormats(InnerObjectFormats const&) = delete;
-    InnerObjectFormats& operator=(InnerObjectFormats const&) = delete;
-
     /** Create the object.
-        This will load the object will all the known inner object formats.
+        This will load the object with all the known inner object formats.
     */
     InnerObjectFormats ();
 
+public:
     static InnerObjectFormats const& getInstance ();
 
     SOTemplate const* findSOTemplateBySField (SField const& sField) const;

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -164,13 +164,13 @@ enum LedgerSpecificFlags
 class LedgerFormats : public KnownFormats <LedgerEntryType>
 {
 private:
+    /** Create the object.
+        This will load the object with all the known ledger formats.
+    */
     LedgerFormats ();
 
 public:
     static LedgerFormats const& getInstance ();
-
-private:
-    void addCommonFields (Item& item) override;
 };
 
 } // ripple

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -136,20 +136,20 @@ public:
         no,
         yes
     };
-    static IsSigning const notSigning = IsSigning::no;
+    static IsSigning const   notSigning = IsSigning::no;
 
-    int const               fieldCode;      // (type<<16)|index
-    SerializedTypeID const  fieldType;      // STI_*
-    int const               fieldValue;     // Code number for protocol
-    std::string             fieldName;
-    int                     fieldMeta;
-    int                     fieldNum;
-    IsSigning const         signingField;
-    std::string             jsonName;
+    int const                fieldCode;      // (type<<16)|index
+    SerializedTypeID const   fieldType;      // STI_*
+    int const                fieldValue;     // Code number for protocol
+    std::string              fieldName;
+    int                      fieldMeta;
+    int                      fieldNum;
+    IsSigning const          signingField;
+    Json::StaticString const jsonName;
 
     SField(SField const&) = delete;
     SField& operator=(SField const&) = delete;
-    SField(SField&&) = default;
+    SField(SField&&);
 
 protected:
     // These constructors can only be called from FieldNames.cpp
@@ -166,18 +166,23 @@ public:
     {
         return getField (field_code (type, value));
     }
+
     static const SField& getField (SerializedTypeID type, int value)
     {
         return getField (field_code (type, value));
     }
 
-    std::string getName () const;
-    bool hasName () const
+    std::string const& getName () const
     {
-        return !fieldName.empty ();
+        return fieldName;
     }
 
-    std::string const& getJsonName () const
+    bool hasName () const
+    {
+        return fieldCode > 0;
+    }
+
+    Json::StaticString const& getJsonName () const
     {
         return jsonName;
     }

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -24,8 +24,6 @@
 #include <ripple/json/json_value.h>
 #include <cstdint>
 #include <map>
-#include <memory>
-#include <mutex>
 #include <utility>
 
 namespace ripple {
@@ -104,17 +102,8 @@ field_code(int id, int index)
 /** Identifies fields.
 
     Fields are necessary to tag data in signed transactions so that
-    the binary format of the transaction can be canonicalized.
-
-    There are two categories of these fields:
-
-    1.  Those that are created at compile time.
-    2.  Those that are created at run time.
-
-    Both are always const.  Category 1 can only be created in FieldNames.cpp.
-    This is enforced at compile time.  Category 2 can only be created by
-    calling getField with an as yet unused fieldType and fieldValue (or the
-    equivalent fieldCode).
+    the binary format of the transaction can be canonicalized.  All
+    SFields are created at compile time.
 
     Each SField, once constructed, lives until program termination, and there
     is only one instance per fieldType/fieldValue pair which serves the entire
@@ -156,21 +145,14 @@ public:
     SField& operator=(SField&&) = delete;
 
 public:
-    struct private_access_tag_t;         // public, but still an implementation detail
+    struct private_access_tag_t;   // public, but still an implementation detail
 
     // These constructors can only be called from SField.cpp
     SField (private_access_tag_t, SerializedTypeID tid, int fv,
         const char* fn, int meta = sMD_Default,
         IsSigning signing = IsSigning::yes);
     explicit SField (private_access_tag_t, int fc);
-    SField (private_access_tag_t, SerializedTypeID tid, int fv);
 
-protected:
-    // These constructors can only be called from SField.cpp
-    explicit SField (SerializedTypeID tid, int fv);
-
-public:
-    // getField will dynamically construct a new SField if necessary
     static const SField& getField (int fieldCode);
     static const SField& getField (std::string const& fieldName);
     static const SField& getField (int type, int value)
@@ -270,10 +252,7 @@ public:
 
 private:
     static int num;
-
-    static std::mutex SField_mutex;
     static std::map<int, SField const*> knownCodeToField;
-    static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
 };
 
 /** A field with a type known at compile time. */

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -23,6 +23,9 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/json/json_value.h>
 #include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <utility>
 
 namespace ripple {
@@ -141,22 +144,30 @@ public:
     int const                fieldCode;      // (type<<16)|index
     SerializedTypeID const   fieldType;      // STI_*
     int const                fieldValue;     // Code number for protocol
-    std::string              fieldName;
-    int                      fieldMeta;
-    int                      fieldNum;
+    std::string const        fieldName;
+    int const                fieldMeta;
+    int const                fieldNum;
     IsSigning const          signingField;
     Json::StaticString const jsonName;
 
     SField(SField const&) = delete;
     SField& operator=(SField const&) = delete;
-    SField(SField&&);
+    SField(SField&&) = delete;
+    SField& operator=(SField&&) = delete;
+
+public:
+    struct private_access_tag_t;         // public, but still an implementation detail
+
+    // These constructors can only be called from SField.cpp
+    SField (private_access_tag_t, SerializedTypeID tid, int fv,
+        const char* fn, int meta = sMD_Default,
+        IsSigning signing = IsSigning::yes);
+    explicit SField (private_access_tag_t, int fc);
+    SField (private_access_tag_t, SerializedTypeID tid, int fv);
 
 protected:
-    // These constructors can only be called from FieldNames.cpp
-    SField (SerializedTypeID tid, int fv, const char* fn,
-            int meta = sMD_Default, IsSigning signing = IsSigning::yes);
-    explicit SField (int fc);
-    SField (SerializedTypeID id, int val);
+    // These constructors can only be called from SField.cpp
+    explicit SField (SerializedTypeID tid, int fv);
 
 public:
     // getField will dynamically construct a new SField if necessary
@@ -238,10 +249,6 @@ public:
     {
         return (fieldMeta & c) != 0;
     }
-    void setMeta (int c)
-    {
-        fieldMeta = c;
-    }
 
     bool shouldInclude (bool withSigningField) const
     {
@@ -261,10 +268,12 @@ public:
 
     static int compare (const SField& f1, const SField& f2);
 
-    struct make;  // public, but still an implementation detail
-
 private:
     static int num;
+
+    static std::mutex SField_mutex;
+    static std::map<int, SField const*> knownCodeToField;
+    static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
 };
 
 /** A field with a type known at compile time. */

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_SOTEMPLATE_H_INCLUDED
 #define RIPPLE_PROTOCOL_SOTEMPLATE_H_INCLUDED
 
+#include <ripple/basics/contract.h>
 #include <ripple/protocol/SField.h>
 #include <boost/range.hpp>
 #include <memory>
@@ -49,6 +50,8 @@ public:
         : e_field (fieldName)
         , flags (flags)
     {
+        if (! e_field.isUseful())
+            Throw<std::runtime_error> ("SField in SOElement must be useful.");
     }
 };
 

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -56,7 +56,7 @@ private:
             typename T::value_type;
 
         STObject* st_;
-        SOE_Flags style_;
+        SOEStyle style_;
         TypedField<T> const* f_;
 
         Proxy (Proxy const&) = default;
@@ -109,7 +109,7 @@ private:
 
         /** Returns `true` if the field is set.
 
-            Fields with SOE_DEFAULT and set to the
+            Fields with soeDEFAULT and set to the
             default value will return `true`
         */
         explicit operator bool() const noexcept;
@@ -672,7 +672,7 @@ STObject::Proxy<T>::Proxy (STObject* st, TypedField<T> const* f)
     }
     else
     {
-        style_ = SOE_INVALID;
+        style_ = soeINVALID;
     }
 }
 
@@ -684,7 +684,7 @@ STObject::Proxy<T>::value() const ->
     auto const t = find();
     if (t)
         return t->value();
-    if (style_ != SOE_DEFAULT)
+    if (style_ != soeDEFAULT)
         Throw<STObject::FieldErr> (
             "Missing field '" + this->f_->getName() + "'");
     return value_type{};
@@ -704,14 +704,14 @@ template <class U>
 void
 STObject::Proxy<T>::assign(U&& u)
 {
-    if (style_ == SOE_DEFAULT &&
+    if (style_ == soeDEFAULT &&
         u == value_type{})
     {
         st_->makeFieldAbsent(*f_);
         return;
     }
     T* t;
-    if (style_ == SOE_INVALID)
+    if (style_ == soeINVALID)
         t = dynamic_cast<T*>(
             st_->getPField(*f_, true));
     else
@@ -832,7 +832,7 @@ template <class T>
 bool
 STObject::OptionalProxy<T>::engaged() const noexcept
 {
-    return this->style_ == SOE_DEFAULT
+    return this->style_ == soeDEFAULT
         || this->find() != nullptr;
 }
 
@@ -840,11 +840,11 @@ template <class T>
 void
 STObject::OptionalProxy<T>::disengage()
 {
-    if (this->style_ == SOE_REQUIRED ||
-            this->style_ == SOE_DEFAULT)
+    if (this->style_ == soeREQUIRED ||
+            this->style_ == soeDEFAULT)
         Throw<STObject::FieldErr> (
             "Template field error '" + this->f_->getName() + "'");
-    if (this->style_ == SOE_INVALID)
+    if (this->style_ == soeINVALID)
         this->st_->delField(*this->f_);
     else
         this->st_->makeFieldAbsent(*this->f_);
@@ -878,10 +878,10 @@ STObject::operator[](TypedField<T> const& f) const
     {
         assert(mType);
         assert(b->getSType() == STI_NOTPRESENT);
-        if(mType->style(f) == SOE_OPTIONAL)
+        if(mType->style(f) == soeOPTIONAL)
             Throw<STObject::FieldErr> (
                 "Missing field '" + f.getName() + "'");
-        assert(mType->style(f) == SOE_DEFAULT);
+        assert(mType->style(f) == soeDEFAULT);
         // Handle the case where value_type is a
         // const reference, otherwise we return
         // the address of a temporary.
@@ -905,9 +905,9 @@ STObject::operator[](OptionaledField<T> const& of) const
     {
         assert(mType);
         assert(b->getSType() == STI_NOTPRESENT);
-        if(mType->style(*of.f) == SOE_OPTIONAL)
+        if(mType->style(*of.f) == soeOPTIONAL)
             return boost::none;
-        assert(mType->style(*of.f) == SOE_DEFAULT);
+        assert(mType->style(*of.f) == soeDEFAULT);
         return typename T::value_type{};
     }
     return u->value();

--- a/src/ripple/protocol/TxFormats.h
+++ b/src/ripple/protocol/TxFormats.h
@@ -65,14 +65,12 @@ enum TxType
 class TxFormats : public KnownFormats <TxType>
 {
 private:
-    void addCommonFields (Item& item) override;
-
-public:
     /** Create the object.
-        This will load the object will all the known transaction formats.
+        This will load the object with all the known transaction formats.
     */
     TxFormats ();
 
+public:
     static TxFormats const& getInstance ();
 };
 

--- a/src/ripple/protocol/impl/InnerObjectFormats.cpp
+++ b/src/ripple/protocol/impl/InnerObjectFormats.cpp
@@ -23,20 +23,18 @@ namespace ripple {
 
 InnerObjectFormats::InnerObjectFormats ()
 {
-    add (sfSignerEntry.getJsonName ().c_str (), sfSignerEntry.getCode ())
-        << SOElement (sfAccount,              SOE_REQUIRED)
-        << SOElement (sfSignerWeight,         SOE_REQUIRED)
-        ;
+    add (sfSignerEntry.jsonName.c_str(), sfSignerEntry.getCode(),
+        {
+            {sfAccount,       soeREQUIRED},
+            {sfSignerWeight,  soeREQUIRED},
+        });
 
-    add (sfSigner.getJsonName ().c_str (), sfSigner.getCode ())
-        << SOElement (sfAccount,              SOE_REQUIRED)
-        << SOElement (sfSigningPubKey,        SOE_REQUIRED)
-        << SOElement (sfTxnSignature,         SOE_REQUIRED)
-        ;
-}
-
-void InnerObjectFormats::addCommonFields (Item& item)
-{
+    add (sfSigner.jsonName.c_str(), sfSigner.getCode(),
+        {
+            {sfAccount,       soeREQUIRED},
+            {sfSigningPubKey, soeREQUIRED},
+            {sfTxnSignature,  soeREQUIRED},
+        });
 }
 
 InnerObjectFormats const&
@@ -49,12 +47,11 @@ InnerObjectFormats::getInstance ()
 SOTemplate const*
 InnerObjectFormats::findSOTemplateBySField (SField const& sField) const
 {
-    SOTemplate const* ret = nullptr;
     auto itemPtr = findByType (sField.getCode ());
     if (itemPtr)
-        ret = &(itemPtr->elements);
+        return &(itemPtr->getSOTemplate());
 
-    return ret;
+    return nullptr;
 }
 
 } // ripple

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -28,163 +28,188 @@ namespace ripple {
 
 LedgerFormats::LedgerFormats ()
 {
-    add ("AccountRoot", ltACCOUNT_ROOT)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfSequence,            SOE_REQUIRED)
-            << SOElement (sfBalance,             SOE_REQUIRED)
-            << SOElement (sfOwnerCount,          SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            << SOElement (sfAccountTxnID,        SOE_OPTIONAL)
-            << SOElement (sfRegularKey,          SOE_OPTIONAL)
-            << SOElement (sfEmailHash,           SOE_OPTIONAL)
-            << SOElement (sfWalletLocator,       SOE_OPTIONAL)
-            << SOElement (sfWalletSize,          SOE_OPTIONAL)
-            << SOElement (sfMessageKey,          SOE_OPTIONAL)
-            << SOElement (sfTransferRate,        SOE_OPTIONAL)
-            << SOElement (sfDomain,              SOE_OPTIONAL)
-            << SOElement (sfTickSize,            SOE_OPTIONAL)
-            ;
+    // Fields shared by all ledger formats:
+    static const std::initializer_list<SOElement> commonFields
+    {
+        { sfLedgerIndex,             soeOPTIONAL },
+        { sfLedgerEntryType,         soeREQUIRED },
+        { sfFlags,                   soeREQUIRED },
+    };
 
-    add ("DirectoryNode", ltDIR_NODE)
-            << SOElement (sfOwner,               SOE_OPTIONAL)  // for owner directories
-            << SOElement (sfTakerPaysCurrency,   SOE_OPTIONAL)  // for order book directories
-            << SOElement (sfTakerPaysIssuer,     SOE_OPTIONAL)  // for order book directories
-            << SOElement (sfTakerGetsCurrency,   SOE_OPTIONAL)  // for order book directories
-            << SOElement (sfTakerGetsIssuer,     SOE_OPTIONAL)  // for order book directories
-            << SOElement (sfExchangeRate,        SOE_OPTIONAL)  // for order book directories
-            << SOElement (sfIndexes,             SOE_REQUIRED)
-            << SOElement (sfRootIndex,           SOE_REQUIRED)
-            << SOElement (sfIndexNext,           SOE_OPTIONAL)
-            << SOElement (sfIndexPrevious,       SOE_OPTIONAL)
-            ;
+    add ("AccountRoot", ltACCOUNT_ROOT,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfSequence,            soeREQUIRED },
+            { sfBalance,             soeREQUIRED },
+            { sfOwnerCount,          soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+            { sfAccountTxnID,        soeOPTIONAL },
+            { sfRegularKey,          soeOPTIONAL },
+            { sfEmailHash,           soeOPTIONAL },
+            { sfWalletLocator,       soeOPTIONAL },
+            { sfWalletSize,          soeOPTIONAL },
+            { sfMessageKey,          soeOPTIONAL },
+            { sfTransferRate,        soeOPTIONAL },
+            { sfDomain,              soeOPTIONAL },
+            { sfTickSize,            soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("Offer", ltOFFER)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfSequence,            SOE_REQUIRED)
-            << SOElement (sfTakerPays,           SOE_REQUIRED)
-            << SOElement (sfTakerGets,           SOE_REQUIRED)
-            << SOElement (sfBookDirectory,       SOE_REQUIRED)
-            << SOElement (sfBookNode,            SOE_REQUIRED)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            << SOElement (sfExpiration,          SOE_OPTIONAL)
-            ;
+    add ("DirectoryNode", ltDIR_NODE,
+        {
+            { sfOwner,               soeOPTIONAL },  // for owner directories
+            { sfTakerPaysCurrency,   soeOPTIONAL },  // for order book directories
+            { sfTakerPaysIssuer,     soeOPTIONAL },  // for order book directories
+            { sfTakerGetsCurrency,   soeOPTIONAL },  // for order book directories
+            { sfTakerGetsIssuer,     soeOPTIONAL },  // for order book directories
+            { sfExchangeRate,        soeOPTIONAL },  // for order book directories
+            { sfIndexes,             soeREQUIRED },
+            { sfRootIndex,           soeREQUIRED },
+            { sfIndexNext,           soeOPTIONAL },
+            { sfIndexPrevious,       soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("RippleState", ltRIPPLE_STATE)
-            << SOElement (sfBalance,             SOE_REQUIRED)
-            << SOElement (sfLowLimit,            SOE_REQUIRED)
-            << SOElement (sfHighLimit,           SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            << SOElement (sfLowNode,             SOE_OPTIONAL)
-            << SOElement (sfLowQualityIn,        SOE_OPTIONAL)
-            << SOElement (sfLowQualityOut,       SOE_OPTIONAL)
-            << SOElement (sfHighNode,            SOE_OPTIONAL)
-            << SOElement (sfHighQualityIn,       SOE_OPTIONAL)
-            << SOElement (sfHighQualityOut,      SOE_OPTIONAL)
-            ;
+    add ("Offer", ltOFFER,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfSequence,            soeREQUIRED },
+            { sfTakerPays,           soeREQUIRED },
+            { sfTakerGets,           soeREQUIRED },
+            { sfBookDirectory,       soeREQUIRED },
+            { sfBookNode,            soeREQUIRED },
+            { sfOwnerNode,           soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+            { sfExpiration,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("Escrow", ltESCROW)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfDestination,         SOE_REQUIRED)
-            << SOElement (sfAmount,              SOE_REQUIRED)
-            << SOElement (sfCondition,           SOE_OPTIONAL)
-            << SOElement (sfCancelAfter,         SOE_OPTIONAL)
-            << SOElement (sfFinishAfter,         SOE_OPTIONAL)
-            << SOElement (sfSourceTag,           SOE_OPTIONAL)
-            << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            << SOElement (sfDestinationNode,     SOE_OPTIONAL)
-            ;
+    add ("RippleState", ltRIPPLE_STATE,
+        {
+            { sfBalance,             soeREQUIRED },
+            { sfLowLimit,            soeREQUIRED },
+            { sfHighLimit,           soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+            { sfLowNode,             soeOPTIONAL },
+            { sfLowQualityIn,        soeOPTIONAL },
+            { sfLowQualityOut,       soeOPTIONAL },
+            { sfHighNode,            soeOPTIONAL },
+            { sfHighQualityIn,       soeOPTIONAL },
+            { sfHighQualityOut,      soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("LedgerHashes", ltLEDGER_HASHES)
-            << SOElement (sfFirstLedgerSequence, SOE_OPTIONAL) // Remove if we do a ledger restart
-            << SOElement (sfLastLedgerSequence,  SOE_OPTIONAL)
-            << SOElement (sfHashes,              SOE_REQUIRED)
-            ;
+    add ("Escrow", ltESCROW,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfDestination,         soeREQUIRED },
+            { sfAmount,              soeREQUIRED },
+            { sfCondition,           soeOPTIONAL },
+            { sfCancelAfter,         soeOPTIONAL },
+            { sfFinishAfter,         soeOPTIONAL },
+            { sfSourceTag,           soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+            { sfOwnerNode,           soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+            { sfDestinationNode,     soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("Amendments", ltAMENDMENTS)
-            << SOElement (sfAmendments,          SOE_OPTIONAL) // Enabled
-            << SOElement (sfMajorities,          SOE_OPTIONAL)
-            ;
+    add ("LedgerHashes", ltLEDGER_HASHES,
+        {
+            { sfFirstLedgerSequence, soeOPTIONAL }, // Remove if we do a ledger restart
+            { sfLastLedgerSequence,  soeOPTIONAL },
+            { sfHashes,              soeREQUIRED },
+        },
+        commonFields);
 
-    add ("FeeSettings", ltFEE_SETTINGS)
-            << SOElement (sfBaseFee,             SOE_REQUIRED)
-            << SOElement (sfReferenceFeeUnits,   SOE_REQUIRED)
-            << SOElement (sfReserveBase,         SOE_REQUIRED)
-            << SOElement (sfReserveIncrement,    SOE_REQUIRED)
-            ;
+    add ("Amendments", ltAMENDMENTS,
+        {
+            { sfAmendments,          soeOPTIONAL }, // Enabled
+            { sfMajorities,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("Ticket", ltTICKET)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfSequence,            SOE_REQUIRED)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfTarget,              SOE_OPTIONAL)
-            << SOElement (sfExpiration,          SOE_OPTIONAL)
-            ;
+    add ("FeeSettings", ltFEE_SETTINGS,
+        {
+            { sfBaseFee,             soeREQUIRED },
+            { sfReferenceFeeUnits,   soeREQUIRED },
+            { sfReserveBase,         soeREQUIRED },
+            { sfReserveIncrement,    soeREQUIRED },
+        },
+        commonFields);
 
-    // All fields are SOE_REQUIRED because there is always a
+    add ("Ticket", ltTICKET,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfSequence,            soeREQUIRED },
+            { sfOwnerNode,           soeREQUIRED },
+            { sfTarget,              soeOPTIONAL },
+            { sfExpiration,          soeOPTIONAL },
+        },
+        commonFields);
+
+    // All fields are soeREQUIRED because there is always a
     // SignerEntries.  If there are no SignerEntries the node is deleted.
-    add ("SignerList", ltSIGNER_LIST)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfSignerQuorum,        SOE_REQUIRED)
-            << SOElement (sfSignerEntries,       SOE_REQUIRED)
-            << SOElement (sfSignerListID,        SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            ;
+    add ("SignerList", ltSIGNER_LIST,
+        {
+            { sfOwnerNode,           soeREQUIRED },
+            { sfSignerQuorum,        soeREQUIRED },
+            { sfSignerEntries,       soeREQUIRED },
+            { sfSignerListID,        soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+        },
+        commonFields);
 
-    add ("PayChannel", ltPAYCHAN)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfDestination,         SOE_REQUIRED)
-            << SOElement (sfAmount,              SOE_REQUIRED)
-            << SOElement (sfBalance,             SOE_REQUIRED)
-            << SOElement (sfPublicKey,           SOE_REQUIRED)
-            << SOElement (sfSettleDelay,         SOE_REQUIRED)
-            << SOElement (sfExpiration,          SOE_OPTIONAL)
-            << SOElement (sfCancelAfter,         SOE_OPTIONAL)
-            << SOElement (sfSourceTag,           SOE_OPTIONAL)
-            << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            ;
+    add ("PayChannel", ltPAYCHAN,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfDestination,         soeREQUIRED },
+            { sfAmount,              soeREQUIRED },
+            { sfBalance,             soeREQUIRED },
+            { sfPublicKey,           soeREQUIRED },
+            { sfSettleDelay,         soeREQUIRED },
+            { sfExpiration,          soeOPTIONAL },
+            { sfCancelAfter,         soeOPTIONAL },
+            { sfSourceTag,           soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+            { sfOwnerNode,           soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+        },
+        commonFields);
 
-    add ("Check", ltCHECK)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfDestination,         SOE_REQUIRED)
-            << SOElement (sfSendMax,             SOE_REQUIRED)
-            << SOElement (sfSequence,            SOE_REQUIRED)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfDestinationNode,     SOE_REQUIRED)
-            << SOElement (sfExpiration,          SOE_OPTIONAL)
-            << SOElement (sfInvoiceID,           SOE_OPTIONAL)
-            << SOElement (sfSourceTag,           SOE_OPTIONAL)
-            << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            ;
+    add ("Check", ltCHECK,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfDestination,         soeREQUIRED },
+            { sfSendMax,             soeREQUIRED },
+            { sfSequence,            soeREQUIRED },
+            { sfOwnerNode,           soeREQUIRED },
+            { sfDestinationNode,     soeREQUIRED },
+            { sfExpiration,          soeOPTIONAL },
+            { sfInvoiceID,           soeOPTIONAL },
+            { sfSourceTag,           soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+        },
+        commonFields);
 
-    add ("DepositPreauth", ltDEPOSIT_PREAUTH)
-            << SOElement (sfAccount,             SOE_REQUIRED)
-            << SOElement (sfAuthorize,           SOE_REQUIRED)
-            << SOElement (sfOwnerNode,           SOE_REQUIRED)
-            << SOElement (sfPreviousTxnID,       SOE_REQUIRED)
-            << SOElement (sfPreviousTxnLgrSeq,   SOE_REQUIRED)
-            ;
-}
-
-void LedgerFormats::addCommonFields (Item& item)
-{
-    item
-        << SOElement(sfLedgerIndex,             SOE_OPTIONAL)
-        << SOElement(sfLedgerEntryType,         SOE_REQUIRED)
-        << SOElement(sfFlags,                   SOE_REQUIRED)
-        ;
+    add ("DepositPreauth", ltDEPOSIT_PREAUTH,
+        {
+            { sfAccount,             soeREQUIRED },
+            { sfAuthorize,           soeREQUIRED },
+            { sfOwnerNode,           soeREQUIRED },
+            { sfPreviousTxnID,       soeREQUIRED },
+            { sfPreviousTxnLgrSeq,   soeREQUIRED },
+        },
+        commonFields);
 }
 
 LedgerFormats const&

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -20,256 +20,232 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/SField.h>
 #include <cassert>
-#include <map>
-#include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 
 namespace ripple {
 
-// These must stay at the top of this file, and in this order
-// Files-cope statics are preferred here because the SFields must be
-// file-scope.  The following 3 objects must have scope prior to
-// the file-scope SFields.
-static std::mutex SField_mutex;
-static std::map<int, SField const*> knownCodeToField;
-static std::map<int, std::unique_ptr<SField const>> unknownCodeToField;
-
-// Storage for static const member.
+// Storage for static const members.
 SField::IsSigning const SField::notSigning;
-
 int SField::num = 0;
+std::mutex SField::SField_mutex;
+std::map<int, SField const*> SField::knownCodeToField;
+std::map<int, std::unique_ptr<SField const>> SField::unknownCodeToField;
 
 using StaticScopedLockType = std::lock_guard <std::mutex>;
 
-// Give this translation unit only, permission to construct SFields
-struct SField::make
+// Give only this translation unit permission to construct SFields
+struct SField::private_access_tag_t
 {
-    explicit make() = default;
-
-    template <class ...Args>
-    static SField one(SField const* p, Args&& ...args)
-    {
-        SField result(std::forward<Args>(args)...);
-        knownCodeToField[result.fieldCode] = p;
-        return result;
-    }
-
-    template <class T, class ...Args>
-    static TypedField<T> one(SField const* p, Args&& ...args)
-    {
-        TypedField<T> result(std::forward<Args>(args)...);
-        knownCodeToField[result.fieldCode] = p;
-        return result;
-    }
+    explicit private_access_tag_t() = default;
 };
 
-using make = SField::make;
+SField::private_access_tag_t access;
 
 // Construct all compile-time SFields, and register them in the knownCodeToField
 // database:
 
-SField const sfInvalid     = make::one(&sfInvalid, -1);
-SField const sfGeneric     = make::one(&sfGeneric, 0);
-SField const sfLedgerEntry = make::one(&sfLedgerEntry, STI_LEDGERENTRY, 257, "LedgerEntry");
-SField const sfTransaction = make::one(&sfTransaction, STI_TRANSACTION, 257, "Transaction");
-SField const sfValidation  = make::one(&sfValidation,  STI_VALIDATION,  257, "Validation");
-SField const sfMetadata    = make::one(&sfMetadata,    STI_METADATA,    257, "Metadata");
-SField const sfHash        = make::one(&sfHash,        STI_HASH256,     257, "hash");
-SField const sfIndex       = make::one(&sfIndex,       STI_HASH256,     258, "index");
+SField const sfInvalid      (access, -1);
+SField const sfGeneric      (access, 0);
+SField const sfLedgerEntry  (access, STI_LEDGERENTRY, 257, "LedgerEntry");
+SField const sfTransaction  (access, STI_TRANSACTION, 257, "Transaction");
+SField const sfValidation   (access, STI_VALIDATION,  257, "Validation");
+SField const sfMetadata     (access, STI_METADATA,    257, "Metadata");
+SField const sfHash         (access, STI_HASH256,     257, "hash");
+SField const sfIndex        (access, STI_HASH256,     258, "index");
 
 // 8-bit integers
-SF_U8 const sfCloseResolution   = make::one<SF_U8::type>(&sfCloseResolution,   STI_UINT8, 1, "CloseResolution");
-SF_U8 const sfMethod            = make::one<SF_U8::type>(&sfMethod,            STI_UINT8, 2, "Method");
-SF_U8 const sfTransactionResult = make::one<SF_U8::type>(&sfTransactionResult, STI_UINT8, 3, "TransactionResult");
+SF_U8 const sfCloseResolution   (access, STI_UINT8, 1, "CloseResolution");
+SF_U8 const sfMethod            (access, STI_UINT8, 2, "Method");
+SF_U8 const sfTransactionResult (access, STI_UINT8, 3, "TransactionResult");
 
 // 8-bit integers (uncommon)
-SF_U8 const sfTickSize          = make::one<SF_U8::type>(&sfTickSize,          STI_UINT8, 16, "TickSize");
+SF_U8 const sfTickSize          (access, STI_UINT8, 16, "TickSize");
 
 // 16-bit integers
-SF_U16 const sfLedgerEntryType = make::one<SF_U16::type>(&sfLedgerEntryType, STI_UINT16,  1, "LedgerEntryType", SField::sMD_Never);
-SF_U16 const sfTransactionType = make::one<SF_U16::type>(&sfTransactionType, STI_UINT16,  2, "TransactionType");
-SF_U16 const sfSignerWeight    = make::one<SF_U16::type>(&sfSignerWeight,    STI_UINT16,  3, "SignerWeight");
+SF_U16 const sfLedgerEntryType (access, STI_UINT16, 1, "LedgerEntryType", SField::sMD_Never);
+SF_U16 const sfTransactionType (access, STI_UINT16, 2, "TransactionType");
+SF_U16 const sfSignerWeight    (access, STI_UINT16, 3, "SignerWeight");
 
 // 16-bit integers (uncommon)
-SF_U16 const sfVersion         = make::one<SF_U16::type>(&sfVersion,         STI_UINT16, 16, "Version");
+SF_U16 const sfVersion         (access, STI_UINT16, 16, "Version");
 
 // 32-bit integers (common)
-SF_U32 const sfFlags             = make::one<SF_U32::type>(&sfFlags,             STI_UINT32,  2, "Flags");
-SF_U32 const sfSourceTag         = make::one<SF_U32::type>(&sfSourceTag,         STI_UINT32,  3, "SourceTag");
-SF_U32 const sfSequence          = make::one<SF_U32::type>(&sfSequence,          STI_UINT32,  4, "Sequence");
-SF_U32 const sfPreviousTxnLgrSeq = make::one<SF_U32::type>(&sfPreviousTxnLgrSeq, STI_UINT32,  5, "PreviousTxnLgrSeq", SField::sMD_DeleteFinal);
-SF_U32 const sfLedgerSequence    = make::one<SF_U32::type>(&sfLedgerSequence,    STI_UINT32,  6, "LedgerSequence");
-SF_U32 const sfCloseTime         = make::one<SF_U32::type>(&sfCloseTime,         STI_UINT32,  7, "CloseTime");
-SF_U32 const sfParentCloseTime   = make::one<SF_U32::type>(&sfParentCloseTime,   STI_UINT32,  8, "ParentCloseTime");
-SF_U32 const sfSigningTime       = make::one<SF_U32::type>(&sfSigningTime,       STI_UINT32,  9, "SigningTime");
-SF_U32 const sfExpiration        = make::one<SF_U32::type>(&sfExpiration,        STI_UINT32, 10, "Expiration");
-SF_U32 const sfTransferRate      = make::one<SF_U32::type>(&sfTransferRate,      STI_UINT32, 11, "TransferRate");
-SF_U32 const sfWalletSize        = make::one<SF_U32::type>(&sfWalletSize,        STI_UINT32, 12, "WalletSize");
-SF_U32 const sfOwnerCount        = make::one<SF_U32::type>(&sfOwnerCount,        STI_UINT32, 13, "OwnerCount");
-SF_U32 const sfDestinationTag    = make::one<SF_U32::type>(&sfDestinationTag,    STI_UINT32, 14, "DestinationTag");
+SF_U32 const sfFlags             (access, STI_UINT32,  2, "Flags");
+SF_U32 const sfSourceTag         (access, STI_UINT32,  3, "SourceTag");
+SF_U32 const sfSequence          (access, STI_UINT32,  4, "Sequence");
+SF_U32 const sfPreviousTxnLgrSeq (access, STI_UINT32,  5, "PreviousTxnLgrSeq", SField::sMD_DeleteFinal);
+SF_U32 const sfLedgerSequence    (access, STI_UINT32,  6, "LedgerSequence");
+SF_U32 const sfCloseTime         (access, STI_UINT32,  7, "CloseTime");
+SF_U32 const sfParentCloseTime   (access, STI_UINT32,  8, "ParentCloseTime");
+SF_U32 const sfSigningTime       (access, STI_UINT32,  9, "SigningTime");
+SF_U32 const sfExpiration        (access, STI_UINT32, 10, "Expiration");
+SF_U32 const sfTransferRate      (access, STI_UINT32, 11, "TransferRate");
+SF_U32 const sfWalletSize        (access, STI_UINT32, 12, "WalletSize");
+SF_U32 const sfOwnerCount        (access, STI_UINT32, 13, "OwnerCount");
+SF_U32 const sfDestinationTag    (access, STI_UINT32, 14, "DestinationTag");
 
 // 32-bit integers (uncommon)
-SF_U32 const sfHighQualityIn       = make::one<SF_U32::type>(&sfHighQualityIn,       STI_UINT32, 16, "HighQualityIn");
-SF_U32 const sfHighQualityOut      = make::one<SF_U32::type>(&sfHighQualityOut,      STI_UINT32, 17, "HighQualityOut");
-SF_U32 const sfLowQualityIn        = make::one<SF_U32::type>(&sfLowQualityIn,        STI_UINT32, 18, "LowQualityIn");
-SF_U32 const sfLowQualityOut       = make::one<SF_U32::type>(&sfLowQualityOut,       STI_UINT32, 19, "LowQualityOut");
-SF_U32 const sfQualityIn           = make::one<SF_U32::type>(&sfQualityIn,           STI_UINT32, 20, "QualityIn");
-SF_U32 const sfQualityOut          = make::one<SF_U32::type>(&sfQualityOut,          STI_UINT32, 21, "QualityOut");
-SF_U32 const sfStampEscrow         = make::one<SF_U32::type>(&sfStampEscrow,         STI_UINT32, 22, "StampEscrow");
-SF_U32 const sfBondAmount          = make::one<SF_U32::type>(&sfBondAmount,          STI_UINT32, 23, "BondAmount");
-SF_U32 const sfLoadFee             = make::one<SF_U32::type>(&sfLoadFee,             STI_UINT32, 24, "LoadFee");
-SF_U32 const sfOfferSequence       = make::one<SF_U32::type>(&sfOfferSequence,       STI_UINT32, 25, "OfferSequence");
-SF_U32 const sfFirstLedgerSequence = make::one<SF_U32::type>(&sfFirstLedgerSequence, STI_UINT32, 26, "FirstLedgerSequence");  // Deprecated: do not use
-SF_U32 const sfLastLedgerSequence  = make::one<SF_U32::type>(&sfLastLedgerSequence,  STI_UINT32, 27, "LastLedgerSequence");
-SF_U32 const sfTransactionIndex    = make::one<SF_U32::type>(&sfTransactionIndex,    STI_UINT32, 28, "TransactionIndex");
-SF_U32 const sfOperationLimit      = make::one<SF_U32::type>(&sfOperationLimit,      STI_UINT32, 29, "OperationLimit");
-SF_U32 const sfReferenceFeeUnits   = make::one<SF_U32::type>(&sfReferenceFeeUnits,   STI_UINT32, 30, "ReferenceFeeUnits");
-SF_U32 const sfReserveBase         = make::one<SF_U32::type>(&sfReserveBase,         STI_UINT32, 31, "ReserveBase");
-SF_U32 const sfReserveIncrement    = make::one<SF_U32::type>(&sfReserveIncrement,    STI_UINT32, 32, "ReserveIncrement");
-SF_U32 const sfSetFlag             = make::one<SF_U32::type>(&sfSetFlag,             STI_UINT32, 33, "SetFlag");
-SF_U32 const sfClearFlag           = make::one<SF_U32::type>(&sfClearFlag,           STI_UINT32, 34, "ClearFlag");
-SF_U32 const sfSignerQuorum        = make::one<SF_U32::type>(&sfSignerQuorum,        STI_UINT32, 35, "SignerQuorum");
-SF_U32 const sfCancelAfter         = make::one<SF_U32::type>(&sfCancelAfter,         STI_UINT32, 36, "CancelAfter");
-SF_U32 const sfFinishAfter         = make::one<SF_U32::type>(&sfFinishAfter,         STI_UINT32, 37, "FinishAfter");
-SF_U32 const sfSignerListID        = make::one<SF_U32::type>(&sfSignerListID,        STI_UINT32, 38, "SignerListID");
-SF_U32 const sfSettleDelay         = make::one<SF_U32::type>(&sfSettleDelay,         STI_UINT32, 39, "SettleDelay");
+SF_U32 const sfHighQualityIn       (access, STI_UINT32, 16, "HighQualityIn");
+SF_U32 const sfHighQualityOut      (access, STI_UINT32, 17, "HighQualityOut");
+SF_U32 const sfLowQualityIn        (access, STI_UINT32, 18, "LowQualityIn");
+SF_U32 const sfLowQualityOut       (access, STI_UINT32, 19, "LowQualityOut");
+SF_U32 const sfQualityIn           (access, STI_UINT32, 20, "QualityIn");
+SF_U32 const sfQualityOut          (access, STI_UINT32, 21, "QualityOut");
+SF_U32 const sfStampEscrow         (access, STI_UINT32, 22, "StampEscrow");
+SF_U32 const sfBondAmount          (access, STI_UINT32, 23, "BondAmount");
+SF_U32 const sfLoadFee             (access, STI_UINT32, 24, "LoadFee");
+SF_U32 const sfOfferSequence       (access, STI_UINT32, 25, "OfferSequence");
+SF_U32 const sfFirstLedgerSequence (access, STI_UINT32, 26, "FirstLedgerSequence");  // Deprecated: do not use
+SF_U32 const sfLastLedgerSequence  (access, STI_UINT32, 27, "LastLedgerSequence");
+SF_U32 const sfTransactionIndex    (access, STI_UINT32, 28, "TransactionIndex");
+SF_U32 const sfOperationLimit      (access, STI_UINT32, 29, "OperationLimit");
+SF_U32 const sfReferenceFeeUnits   (access, STI_UINT32, 30, "ReferenceFeeUnits");
+SF_U32 const sfReserveBase         (access, STI_UINT32, 31, "ReserveBase");
+SF_U32 const sfReserveIncrement    (access, STI_UINT32, 32, "ReserveIncrement");
+SF_U32 const sfSetFlag             (access, STI_UINT32, 33, "SetFlag");
+SF_U32 const sfClearFlag           (access, STI_UINT32, 34, "ClearFlag");
+SF_U32 const sfSignerQuorum        (access, STI_UINT32, 35, "SignerQuorum");
+SF_U32 const sfCancelAfter         (access, STI_UINT32, 36, "CancelAfter");
+SF_U32 const sfFinishAfter         (access, STI_UINT32, 37, "FinishAfter");
+SF_U32 const sfSignerListID        (access, STI_UINT32, 38, "SignerListID");
+SF_U32 const sfSettleDelay         (access, STI_UINT32, 39, "SettleDelay");
 
 // 64-bit integers
-SF_U64 const sfIndexNext        = make::one<SF_U64::type>(&sfIndexNext,        STI_UINT64, 1, "IndexNext");
-SF_U64 const sfIndexPrevious    = make::one<SF_U64::type>(&sfIndexPrevious,    STI_UINT64, 2, "IndexPrevious");
-SF_U64 const sfBookNode         = make::one<SF_U64::type>(&sfBookNode,         STI_UINT64, 3, "BookNode");
-SF_U64 const sfOwnerNode        = make::one<SF_U64::type>(&sfOwnerNode,        STI_UINT64, 4, "OwnerNode");
-SF_U64 const sfBaseFee          = make::one<SF_U64::type>(&sfBaseFee,          STI_UINT64, 5, "BaseFee");
-SF_U64 const sfExchangeRate     = make::one<SF_U64::type>(&sfExchangeRate,     STI_UINT64, 6, "ExchangeRate");
-SF_U64 const sfLowNode          = make::one<SF_U64::type>(&sfLowNode,          STI_UINT64, 7, "LowNode");
-SF_U64 const sfHighNode         = make::one<SF_U64::type>(&sfHighNode,         STI_UINT64, 8, "HighNode");
-SF_U64 const sfDestinationNode  = make::one<SF_U64::type>(&sfDestinationNode,  STI_UINT64, 9, "DestinationNode");
-SF_U64 const sfCookie           = make::one<SF_U64::type>(&sfCookie,           STI_UINT64, 10,"Cookie");
+SF_U64 const sfIndexNext        (access, STI_UINT64, 1, "IndexNext");
+SF_U64 const sfIndexPrevious    (access, STI_UINT64, 2, "IndexPrevious");
+SF_U64 const sfBookNode         (access, STI_UINT64, 3, "BookNode");
+SF_U64 const sfOwnerNode        (access, STI_UINT64, 4, "OwnerNode");
+SF_U64 const sfBaseFee          (access, STI_UINT64, 5, "BaseFee");
+SF_U64 const sfExchangeRate     (access, STI_UINT64, 6, "ExchangeRate");
+SF_U64 const sfLowNode          (access, STI_UINT64, 7, "LowNode");
+SF_U64 const sfHighNode         (access, STI_UINT64, 8, "HighNode");
+SF_U64 const sfDestinationNode  (access, STI_UINT64, 9, "DestinationNode");
+SF_U64 const sfCookie           (access, STI_UINT64, 10,"Cookie");
 
 
 // 128-bit
-SF_U128 const sfEmailHash = make::one<SF_U128::type>(&sfEmailHash, STI_HASH128, 1, "EmailHash");
+SF_U128 const sfEmailHash (access, STI_HASH128, 1, "EmailHash");
 
 // 160-bit (common)
-SF_U160 const sfTakerPaysCurrency = make::one<SF_U160::type>(&sfTakerPaysCurrency, STI_HASH160, 1, "TakerPaysCurrency");
-SF_U160 const sfTakerPaysIssuer   = make::one<SF_U160::type>(&sfTakerPaysIssuer,   STI_HASH160, 2, "TakerPaysIssuer");
-SF_U160 const sfTakerGetsCurrency = make::one<SF_U160::type>(&sfTakerGetsCurrency, STI_HASH160, 3, "TakerGetsCurrency");
-SF_U160 const sfTakerGetsIssuer   = make::one<SF_U160::type>(&sfTakerGetsIssuer,   STI_HASH160, 4, "TakerGetsIssuer");
+SF_U160 const sfTakerPaysCurrency (access, STI_HASH160, 1, "TakerPaysCurrency");
+SF_U160 const sfTakerPaysIssuer   (access, STI_HASH160, 2, "TakerPaysIssuer");
+SF_U160 const sfTakerGetsCurrency (access, STI_HASH160, 3, "TakerGetsCurrency");
+SF_U160 const sfTakerGetsIssuer   (access, STI_HASH160, 4, "TakerGetsIssuer");
 
 // 256-bit (common)
-SF_U256 const sfLedgerHash      = make::one<SF_U256::type>(&sfLedgerHash,      STI_HASH256, 1, "LedgerHash");
-SF_U256 const sfParentHash      = make::one<SF_U256::type>(&sfParentHash,      STI_HASH256, 2, "ParentHash");
-SF_U256 const sfTransactionHash = make::one<SF_U256::type>(&sfTransactionHash, STI_HASH256, 3, "TransactionHash");
-SF_U256 const sfAccountHash     = make::one<SF_U256::type>(&sfAccountHash,     STI_HASH256, 4, "AccountHash");
-SF_U256 const sfPreviousTxnID   = make::one<SF_U256::type>(&sfPreviousTxnID,   STI_HASH256, 5, "PreviousTxnID", SField::sMD_DeleteFinal);
-SF_U256 const sfLedgerIndex     = make::one<SF_U256::type>(&sfLedgerIndex,     STI_HASH256, 6, "LedgerIndex");
-SF_U256 const sfWalletLocator   = make::one<SF_U256::type>(&sfWalletLocator,   STI_HASH256, 7, "WalletLocator");
-SF_U256 const sfRootIndex       = make::one<SF_U256::type>(&sfRootIndex,       STI_HASH256, 8, "RootIndex", SField::sMD_Always);
-SF_U256 const sfAccountTxnID    = make::one<SF_U256::type>(&sfAccountTxnID,    STI_HASH256, 9, "AccountTxnID");
+SF_U256 const sfLedgerHash      (access, STI_HASH256, 1, "LedgerHash");
+SF_U256 const sfParentHash      (access, STI_HASH256, 2, "ParentHash");
+SF_U256 const sfTransactionHash (access, STI_HASH256, 3, "TransactionHash");
+SF_U256 const sfAccountHash     (access, STI_HASH256, 4, "AccountHash");
+SF_U256 const sfPreviousTxnID   (access, STI_HASH256, 5, "PreviousTxnID", SField::sMD_DeleteFinal);
+SF_U256 const sfLedgerIndex     (access, STI_HASH256, 6, "LedgerIndex");
+SF_U256 const sfWalletLocator   (access, STI_HASH256, 7, "WalletLocator");
+SF_U256 const sfRootIndex       (access, STI_HASH256, 8, "RootIndex", SField::sMD_Always);
+SF_U256 const sfAccountTxnID    (access, STI_HASH256, 9, "AccountTxnID");
 
 // 256-bit (uncommon)
-SF_U256 const sfBookDirectory = make::one<SF_U256::type>(&sfBookDirectory, STI_HASH256, 16, "BookDirectory");
-SF_U256 const sfInvoiceID     = make::one<SF_U256::type>(&sfInvoiceID,     STI_HASH256, 17, "InvoiceID");
-SF_U256 const sfNickname      = make::one<SF_U256::type>(&sfNickname,      STI_HASH256, 18, "Nickname");
-SF_U256 const sfAmendment     = make::one<SF_U256::type>(&sfAmendment,     STI_HASH256, 19, "Amendment");
-SF_U256 const sfTicketID      = make::one<SF_U256::type>(&sfTicketID,      STI_HASH256, 20, "TicketID");
-SF_U256 const sfDigest        = make::one<SF_U256::type>(&sfDigest,        STI_HASH256, 21, "Digest");
-SF_U256 const sfPayChannel    = make::one<SF_U256::type>(&sfPayChannel,    STI_HASH256, 22, "Channel");
-SF_U256 const sfConsensusHash = make::one<SF_U256::type>(&sfConsensusHash, STI_HASH256, 23, "ConsensusHash");
-SF_U256 const sfCheckID       = make::one<SF_U256::type>(&sfCheckID,       STI_HASH256, 24, "CheckID");
+SF_U256 const sfBookDirectory (access, STI_HASH256, 16, "BookDirectory");
+SF_U256 const sfInvoiceID     (access, STI_HASH256, 17, "InvoiceID");
+SF_U256 const sfNickname      (access, STI_HASH256, 18, "Nickname");
+SF_U256 const sfAmendment     (access, STI_HASH256, 19, "Amendment");
+SF_U256 const sfTicketID      (access, STI_HASH256, 20, "TicketID");
+SF_U256 const sfDigest        (access, STI_HASH256, 21, "Digest");
+SF_U256 const sfPayChannel    (access, STI_HASH256, 22, "Channel");
+SF_U256 const sfConsensusHash (access, STI_HASH256, 23, "ConsensusHash");
+SF_U256 const sfCheckID       (access, STI_HASH256, 24, "CheckID");
 
 // currency amount (common)
-SF_Amount const sfAmount      = make::one<SF_Amount::type>(&sfAmount,      STI_AMOUNT,  1, "Amount");
-SF_Amount const sfBalance     = make::one<SF_Amount::type>(&sfBalance,     STI_AMOUNT,  2, "Balance");
-SF_Amount const sfLimitAmount = make::one<SF_Amount::type>(&sfLimitAmount, STI_AMOUNT,  3, "LimitAmount");
-SF_Amount const sfTakerPays   = make::one<SF_Amount::type>(&sfTakerPays,   STI_AMOUNT,  4, "TakerPays");
-SF_Amount const sfTakerGets   = make::one<SF_Amount::type>(&sfTakerGets,   STI_AMOUNT,  5, "TakerGets");
-SF_Amount const sfLowLimit    = make::one<SF_Amount::type>(&sfLowLimit,    STI_AMOUNT,  6, "LowLimit");
-SF_Amount const sfHighLimit   = make::one<SF_Amount::type>(&sfHighLimit,   STI_AMOUNT,  7, "HighLimit");
-SF_Amount const sfFee         = make::one<SF_Amount::type>(&sfFee,         STI_AMOUNT,  8, "Fee");
-SF_Amount const sfSendMax     = make::one<SF_Amount::type>(&sfSendMax,     STI_AMOUNT,  9, "SendMax");
-SF_Amount const sfDeliverMin  = make::one<SF_Amount::type>(&sfDeliverMin,  STI_AMOUNT, 10, "DeliverMin");
+SF_Amount const sfAmount      (access, STI_AMOUNT,  1, "Amount");
+SF_Amount const sfBalance     (access, STI_AMOUNT,  2, "Balance");
+SF_Amount const sfLimitAmount (access, STI_AMOUNT,  3, "LimitAmount");
+SF_Amount const sfTakerPays   (access, STI_AMOUNT,  4, "TakerPays");
+SF_Amount const sfTakerGets   (access, STI_AMOUNT,  5, "TakerGets");
+SF_Amount const sfLowLimit    (access, STI_AMOUNT,  6, "LowLimit");
+SF_Amount const sfHighLimit   (access, STI_AMOUNT,  7, "HighLimit");
+SF_Amount const sfFee         (access, STI_AMOUNT,  8, "Fee");
+SF_Amount const sfSendMax     (access, STI_AMOUNT,  9, "SendMax");
+SF_Amount const sfDeliverMin  (access, STI_AMOUNT, 10, "DeliverMin");
 
 // currency amount (uncommon)
-SF_Amount const sfMinimumOffer    = make::one<SF_Amount::type>(&sfMinimumOffer,    STI_AMOUNT, 16, "MinimumOffer");
-SF_Amount const sfRippleEscrow    = make::one<SF_Amount::type>(&sfRippleEscrow,    STI_AMOUNT, 17, "RippleEscrow");
-SF_Amount const sfDeliveredAmount = make::one<SF_Amount::type>(&sfDeliveredAmount, STI_AMOUNT, 18, "DeliveredAmount");
+SF_Amount const sfMinimumOffer    (access, STI_AMOUNT, 16, "MinimumOffer");
+SF_Amount const sfRippleEscrow    (access, STI_AMOUNT, 17, "RippleEscrow");
+SF_Amount const sfDeliveredAmount (access, STI_AMOUNT, 18, "DeliveredAmount");
 
 // variable length (common)
-SF_Blob const sfPublicKey       = make::one<SF_Blob::type>(&sfPublicKey,     STI_VL,  1, "PublicKey");
-SF_Blob const sfMessageKey      = make::one<SF_Blob::type>(&sfMessageKey,    STI_VL,  2, "MessageKey");
-SF_Blob const sfSigningPubKey   = make::one<SF_Blob::type>(&sfSigningPubKey, STI_VL,  3, "SigningPubKey");
-SF_Blob const sfTxnSignature    = make::one<SF_Blob::type>(&sfTxnSignature,  STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
-SF_Blob const sfSignature       = make::one<SF_Blob::type>(&sfSignature,     STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
-SF_Blob const sfDomain          = make::one<SF_Blob::type>(&sfDomain,        STI_VL,  7, "Domain");
-SF_Blob const sfFundCode        = make::one<SF_Blob::type>(&sfFundCode,      STI_VL,  8, "FundCode");
-SF_Blob const sfRemoveCode      = make::one<SF_Blob::type>(&sfRemoveCode,    STI_VL,  9, "RemoveCode");
-SF_Blob const sfExpireCode      = make::one<SF_Blob::type>(&sfExpireCode,    STI_VL, 10, "ExpireCode");
-SF_Blob const sfCreateCode      = make::one<SF_Blob::type>(&sfCreateCode,    STI_VL, 11, "CreateCode");
-SF_Blob const sfMemoType        = make::one<SF_Blob::type>(&sfMemoType,      STI_VL, 12, "MemoType");
-SF_Blob const sfMemoData        = make::one<SF_Blob::type>(&sfMemoData,      STI_VL, 13, "MemoData");
-SF_Blob const sfMemoFormat      = make::one<SF_Blob::type>(&sfMemoFormat,    STI_VL, 14, "MemoFormat");
+SF_Blob const sfPublicKey       (access, STI_VL,  1, "PublicKey");
+SF_Blob const sfMessageKey      (access, STI_VL,  2, "MessageKey");
+SF_Blob const sfSigningPubKey   (access, STI_VL,  3, "SigningPubKey");
+SF_Blob const sfTxnSignature    (access, STI_VL,  4, "TxnSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfSignature       (access, STI_VL,  6, "Signature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfDomain          (access, STI_VL,  7, "Domain");
+SF_Blob const sfFundCode        (access, STI_VL,  8, "FundCode");
+SF_Blob const sfRemoveCode      (access, STI_VL,  9, "RemoveCode");
+SF_Blob const sfExpireCode      (access, STI_VL, 10, "ExpireCode");
+SF_Blob const sfCreateCode      (access, STI_VL, 11, "CreateCode");
+SF_Blob const sfMemoType        (access, STI_VL, 12, "MemoType");
+SF_Blob const sfMemoData        (access, STI_VL, 13, "MemoData");
+SF_Blob const sfMemoFormat      (access, STI_VL, 14, "MemoFormat");
 
 
 // variable length (uncommon)
-SF_Blob const sfFulfillment     = make::one<SF_Blob::type>(&sfFulfillment,     STI_VL, 16, "Fulfillment");
-SF_Blob const sfCondition       = make::one<SF_Blob::type>(&sfCondition,       STI_VL, 17, "Condition");
-SF_Blob const sfMasterSignature = make::one<SF_Blob::type>(&sfMasterSignature, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfFulfillment     (access, STI_VL, 16, "Fulfillment");
+SF_Blob const sfCondition       (access, STI_VL, 17, "Condition");
+SF_Blob const sfMasterSignature (access, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
 
 // account
-SF_Account const sfAccount     = make::one<SF_Account::type>(&sfAccount,     STI_ACCOUNT, 1, "Account");
-SF_Account const sfOwner       = make::one<SF_Account::type>(&sfOwner,       STI_ACCOUNT, 2, "Owner");
-SF_Account const sfDestination = make::one<SF_Account::type>(&sfDestination, STI_ACCOUNT, 3, "Destination");
-SF_Account const sfIssuer      = make::one<SF_Account::type>(&sfIssuer,      STI_ACCOUNT, 4, "Issuer");
-SF_Account const sfAuthorize   = make::one<SF_Account::type>(&sfAuthorize,   STI_ACCOUNT, 5, "Authorize");
-SF_Account const sfUnauthorize = make::one<SF_Account::type>(&sfUnauthorize, STI_ACCOUNT, 6, "Unauthorize");
-SF_Account const sfTarget      = make::one<SF_Account::type>(&sfTarget,      STI_ACCOUNT, 7, "Target");
-SF_Account const sfRegularKey  = make::one<SF_Account::type>(&sfRegularKey,  STI_ACCOUNT, 8, "RegularKey");
+SF_Account const sfAccount     (access, STI_ACCOUNT, 1, "Account");
+SF_Account const sfOwner       (access, STI_ACCOUNT, 2, "Owner");
+SF_Account const sfDestination (access, STI_ACCOUNT, 3, "Destination");
+SF_Account const sfIssuer      (access, STI_ACCOUNT, 4, "Issuer");
+SF_Account const sfAuthorize   (access, STI_ACCOUNT, 5, "Authorize");
+SF_Account const sfUnauthorize (access, STI_ACCOUNT, 6, "Unauthorize");
+SF_Account const sfTarget      (access, STI_ACCOUNT, 7, "Target");
+SF_Account const sfRegularKey  (access, STI_ACCOUNT, 8, "RegularKey");
 
 // path set
-SField const sfPaths = make::one(&sfPaths, STI_PATHSET, 1, "Paths");
+SField const sfPaths (access, STI_PATHSET, 1, "Paths");
 
 // vector of 256-bit
-SF_Vec256 const sfIndexes    = make::one<SF_Vec256::type>(&sfIndexes,    STI_VECTOR256, 1, "Indexes", SField::sMD_Never);
-SF_Vec256 const sfHashes     = make::one<SF_Vec256::type>(&sfHashes,     STI_VECTOR256, 2, "Hashes");
-SF_Vec256 const sfAmendments = make::one<SF_Vec256::type>(&sfAmendments, STI_VECTOR256, 3, "Amendments");
+SF_Vec256 const sfIndexes    (access, STI_VECTOR256, 1, "Indexes", SField::sMD_Never);
+SF_Vec256 const sfHashes     (access, STI_VECTOR256, 2, "Hashes");
+SF_Vec256 const sfAmendments (access, STI_VECTOR256, 3, "Amendments");
 
 // inner object
 // OBJECT/1 is reserved for end of object
-SField const sfTransactionMetaData = make::one(&sfTransactionMetaData, STI_OBJECT,  2, "TransactionMetaData");
-SField const sfCreatedNode         = make::one(&sfCreatedNode,         STI_OBJECT,  3, "CreatedNode");
-SField const sfDeletedNode         = make::one(&sfDeletedNode,         STI_OBJECT,  4, "DeletedNode");
-SField const sfModifiedNode        = make::one(&sfModifiedNode,        STI_OBJECT,  5, "ModifiedNode");
-SField const sfPreviousFields      = make::one(&sfPreviousFields,      STI_OBJECT,  6, "PreviousFields");
-SField const sfFinalFields         = make::one(&sfFinalFields,         STI_OBJECT,  7, "FinalFields");
-SField const sfNewFields           = make::one(&sfNewFields,           STI_OBJECT,  8, "NewFields");
-SField const sfTemplateEntry       = make::one(&sfTemplateEntry,       STI_OBJECT,  9, "TemplateEntry");
-SField const sfMemo                = make::one(&sfMemo,                STI_OBJECT, 10, "Memo");
-SField const sfSignerEntry         = make::one(&sfSignerEntry,         STI_OBJECT, 11, "SignerEntry");
+SField const sfTransactionMetaData (access, STI_OBJECT,  2, "TransactionMetaData");
+SField const sfCreatedNode         (access, STI_OBJECT,  3, "CreatedNode");
+SField const sfDeletedNode         (access, STI_OBJECT,  4, "DeletedNode");
+SField const sfModifiedNode        (access, STI_OBJECT,  5, "ModifiedNode");
+SField const sfPreviousFields      (access, STI_OBJECT,  6, "PreviousFields");
+SField const sfFinalFields         (access, STI_OBJECT,  7, "FinalFields");
+SField const sfNewFields           (access, STI_OBJECT,  8, "NewFields");
+SField const sfTemplateEntry       (access, STI_OBJECT,  9, "TemplateEntry");
+SField const sfMemo                (access, STI_OBJECT, 10, "Memo");
+SField const sfSignerEntry         (access, STI_OBJECT, 11, "SignerEntry");
 
 // inner object (uncommon)
-SField const sfSigner              = make::one(&sfSigner,              STI_OBJECT, 16, "Signer");
+SField const sfSigner              (access, STI_OBJECT, 16, "Signer");
 //                                                                                 17 has not been used yet...
-SField const sfMajority            = make::one(&sfMajority,            STI_OBJECT, 18, "Majority");
+SField const sfMajority            (access, STI_OBJECT, 18, "Majority");
 
 // array of objects
 // ARRAY/1 is reserved for end of array
-// SField const sfSigningAccounts = make::one(&sfSigningAccounts, STI_ARRAY, 2, "SigningAccounts"); // Never been used.
-SField const sfSigners         = make::one(&sfSigners,         STI_ARRAY, 3, "Signers", SField::sMD_Default, SField::notSigning);
-SField const sfSignerEntries   = make::one(&sfSignerEntries,   STI_ARRAY, 4, "SignerEntries");
-SField const sfTemplate        = make::one(&sfTemplate,        STI_ARRAY, 5, "Template");
-SField const sfNecessary       = make::one(&sfNecessary,       STI_ARRAY, 6, "Necessary");
-SField const sfSufficient      = make::one(&sfSufficient,      STI_ARRAY, 7, "Sufficient");
-SField const sfAffectedNodes   = make::one(&sfAffectedNodes,   STI_ARRAY, 8, "AffectedNodes");
-SField const sfMemos           = make::one(&sfMemos,           STI_ARRAY, 9, "Memos");
+// SField const sfSigningAccounts (access, STI_ARRAY, 2, "SigningAccounts"); // Never been used.
+SField const sfSigners         (access, STI_ARRAY, 3, "Signers", SField::sMD_Default, SField::notSigning);
+SField const sfSignerEntries   (access, STI_ARRAY, 4, "SignerEntries");
+SField const sfTemplate        (access, STI_ARRAY, 5, "Template");
+SField const sfNecessary       (access, STI_ARRAY, 6, "Necessary");
+SField const sfSufficient      (access, STI_ARRAY, 7, "Sufficient");
+SField const sfAffectedNodes   (access, STI_ARRAY, 8, "AffectedNodes");
+SField const sfMemos           (access, STI_ARRAY, 9, "Memos");
 
 // array of objects (uncommon)
-SField const sfMajorities      = make::one(&sfMajorities,      STI_ARRAY, 16, "Majorities");
+SField const sfMajorities      (access, STI_ARRAY, 16, "Majorities");
 
-SField::SField (SerializedTypeID tid, int fv, const char* fn,
-                int meta, IsSigning signing)
+SField::SField(private_access_tag_t,
+    SerializedTypeID tid, int fv, const char* fn, int meta,
+    IsSigning signing)
     : fieldCode (field_code (tid, fv))
     , fieldType (tid)
     , fieldValue (fv)
@@ -279,9 +255,10 @@ SField::SField (SerializedTypeID tid, int fv, const char* fn,
     , signingField (signing)
     , jsonName (fieldName.c_str())
 {
+    knownCodeToField[fieldCode] = this;
 }
 
-SField::SField (int fc)
+SField::SField(private_access_tag_t, int fc)
     : fieldCode (fc)
     , fieldType (STI_UNKNOWN)
     , fieldValue (0)
@@ -290,12 +267,13 @@ SField::SField (int fc)
     , signingField (IsSigning::yes)
     , jsonName (fieldName.c_str())
 {
+    knownCodeToField[fieldCode] = this;
 }
 
 // call with the map mutex to protect num.
 // This is naturally done with no extra expense
 // from getField(int code).
-SField::SField (SerializedTypeID tid, int fv)
+SField::SField(SerializedTypeID tid, int fv)
     : fieldCode (field_code (tid, fv))
     , fieldType (tid)
     , fieldValue (fv)
@@ -308,17 +286,11 @@ SField::SField (SerializedTypeID tid, int fv)
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
 }
 
-// we can't use the default move constructor because
-// it could leave jsonName referencing a destroyed string
-SField::SField (SField &&s)
-    : fieldCode (s.fieldCode)
-    , fieldType (s.fieldType)
-    , fieldValue (s.fieldValue)
-    , fieldMeta (s.fieldMeta)
-    , fieldNum (s.fieldNum)
-    , signingField (s.signingField)
-    , jsonName (fieldName.c_str())
+SField::SField(private_access_tag_t,
+    SerializedTypeID tid, int fv)
+    : SField(tid, fv)
 {
+    knownCodeToField[fieldCode] = this;
 }
 
 SField const&

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -277,7 +277,7 @@ SField::SField (SerializedTypeID tid, int fv, const char* fn,
     , fieldMeta (meta)
     , fieldNum (++num)
     , signingField (signing)
-    , jsonName (getName ())
+    , jsonName (fieldName.c_str())
 {
 }
 
@@ -288,7 +288,7 @@ SField::SField (int fc)
     , fieldMeta (sMD_Never)
     , fieldNum (++num)
     , signingField (IsSigning::yes)
-    , jsonName (getName ())
+    , jsonName (fieldName.c_str())
 {
 }
 
@@ -296,16 +296,29 @@ SField::SField (int fc)
 // This is naturally done with no extra expense
 // from getField(int code).
 SField::SField (SerializedTypeID tid, int fv)
-        : fieldCode (field_code (tid, fv))
-        , fieldType (tid)
-        , fieldValue (fv)
-        , fieldMeta (sMD_Default)
-        , fieldNum (++num)
-        , signingField (IsSigning::yes)
+    : fieldCode (field_code (tid, fv))
+    , fieldType (tid)
+    , fieldValue (fv)
+    , fieldName (std::to_string (tid) + '/' + std::to_string (fv))
+    , fieldMeta (sMD_Default)
+    , fieldNum (++num)
+    , signingField (IsSigning::yes)
+    , jsonName (fieldName.c_str())
 {
-    fieldName = std::to_string (tid) + '/' + std::to_string (fv);
-    jsonName = getName ();
     assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
+}
+
+// we can't use the default move constructor because
+// it could leave jsonName referencing a destroyed string
+SField::SField (SField &&s)
+    : fieldCode (s.fieldCode)
+    , fieldType (s.fieldType)
+    , fieldValue (s.fieldValue)
+    , fieldMeta (s.fieldMeta)
+    , fieldNum (s.fieldNum)
+    , signingField (s.signingField)
+    , jsonName (fieldName.c_str())
+{
 }
 
 SField const&
@@ -378,18 +391,6 @@ int SField::compare (SField const& f1, SField const& f2)
         return 1;
 
     return 0;
-}
-
-std::string SField::getName () const
-{
-    if (!fieldName.empty ())
-        return fieldName;
-
-    if (fieldValue == 0)
-        return "";
-
-    return std::to_string(safe_cast<int> (fieldType)) + "/" +
-            std::to_string(fieldValue);
 }
 
 SField const&

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -17,7 +17,6 @@
 */
 //==============================================================================
 
-#include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/SField.h>
 #include <cassert>
 #include <string>
@@ -28,11 +27,7 @@ namespace ripple {
 // Storage for static const members.
 SField::IsSigning const SField::notSigning;
 int SField::num = 0;
-std::mutex SField::SField_mutex;
 std::map<int, SField const*> SField::knownCodeToField;
-std::map<int, std::unique_ptr<SField const>> SField::unknownCodeToField;
-
-using StaticScopedLockType = std::lock_guard <std::mutex>;
 
 // Give only this translation unit permission to construct SFields
 struct SField::private_access_tag_t
@@ -40,7 +35,7 @@ struct SField::private_access_tag_t
     explicit private_access_tag_t() = default;
 };
 
-SField::private_access_tag_t access;
+static SField::private_access_tag_t access;
 
 // Construct all compile-time SFields, and register them in the knownCodeToField
 // database:
@@ -270,29 +265,6 @@ SField::SField(private_access_tag_t, int fc)
     knownCodeToField[fieldCode] = this;
 }
 
-// call with the map mutex to protect num.
-// This is naturally done with no extra expense
-// from getField(int code).
-SField::SField(SerializedTypeID tid, int fv)
-    : fieldCode (field_code (tid, fv))
-    , fieldType (tid)
-    , fieldValue (fv)
-    , fieldName (std::to_string (tid) + '/' + std::to_string (fv))
-    , fieldMeta (sMD_Default)
-    , fieldNum (++num)
-    , signingField (IsSigning::yes)
-    , jsonName (fieldName.c_str())
-{
-    assert ((fv != 1) || ((tid != STI_ARRAY) && (tid != STI_OBJECT)));
-}
-
-SField::SField(private_access_tag_t,
-    SerializedTypeID tid, int fv)
-    : SField(tid, fv)
-{
-    knownCodeToField[fieldCode] = this;
-}
-
 SField const&
 SField::getField (int code)
 {
@@ -300,54 +272,9 @@ SField::getField (int code)
 
     if (it != knownCodeToField.end ())
     {
-        // 99+% of the time, it will be a valid, known field
         return * (it->second);
     }
-
-    int type = code >> 16;
-    int field = code & 0xffff;
-
-    // Don't dynamically extend types that have no binary encoding.
-    if ((field > 255) || (code < 0))
-        return sfInvalid;
-
-    switch (type)
-    {
-    // Types we are willing to dynamically extend
-    // types (common)
-    case STI_UINT16:
-    case STI_UINT32:
-    case STI_UINT64:
-    case STI_HASH128:
-    case STI_HASH256:
-    case STI_AMOUNT:
-    case STI_VL:
-    case STI_ACCOUNT:
-    case STI_OBJECT:
-    case STI_ARRAY:
-    // types (uncommon)
-    case STI_UINT8:
-    case STI_HASH160:
-    case STI_PATHSET:
-    case STI_VECTOR256:
-        break;
-
-    default:
-        return sfInvalid;
-    }
-
-    {
-        // Lookup in the run-time data base, and create if it does not
-        // yet exist.
-        StaticScopedLockType sl (SField_mutex);
-
-        auto it = unknownCodeToField.find (code);
-
-        if (it != unknownCodeToField.end ())
-            return * (it->second);
-        return *(unknownCodeToField[code] = std::unique_ptr<SField const>(
-                       new SField(safe_cast<SerializedTypeID>(type), field)));
-    }
+    return sfInvalid;
 }
 
 int SField::compare (SField const& f1, SField const& f2)
@@ -372,15 +299,6 @@ SField::getField (std::string const& fieldName)
     {
         if (fieldPair.second->fieldName == fieldName)
             return * (fieldPair.second);
-    }
-    {
-        StaticScopedLockType sl (SField_mutex);
-
-        for (auto const & fieldPair : unknownCodeToField)
-        {
-            if (fieldPair.second->fieldName == fieldName)
-                return * (fieldPair.second);
-        }
     }
     return sfInvalid;
 }

--- a/src/ripple/protocol/impl/SOTemplate.cpp
+++ b/src/ripple/protocol/impl/SOTemplate.cpp
@@ -28,18 +28,20 @@ void SOTemplate::push_back (SOElement const& r)
     //
     if (mIndex.empty ())
     {
-        // Unmapped indices will be set to -1
+        // Unmapped indices are initialized to -1
         //
         mIndex.resize (SField::getNumFields () + 1, -1);
     }
 
     // Make sure the field's index is in range
     //
-    assert (r.e_field.getNum () < mIndex.size ());
+    if (r.e_field.getNum() <= 0 || r.e_field.getNum() >= mIndex.size())
+        Throw<std::runtime_error> ("Invalid field index for SOTemplate.");
 
     // Make sure that this field hasn't already been assigned
     //
-    assert (getIndex (r.e_field) == -1);
+    if (getIndex (r.e_field) != -1)
+        Throw<std::runtime_error> ("Duplicate field index for SOTemplate.");
 
     // Add the field to the index mapping table
     //

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -141,16 +141,12 @@ std::string STArray::getText () const
 Json::Value STArray::getJson (int p) const
 {
     Json::Value v = Json::arrayValue;
-    int index = 1;
     for (auto const& object: v_)
     {
         if (object.getSType () != STI_NOTPRESENT)
         {
             Json::Value& inner = v.append (Json::objectValue);
-            auto const& fname = object.getFName ();
-            auto k = fname.hasName () ? fname.fieldName : std::to_string(index);
-            inner[k] = object.getJson (p);
-            index++;
+            inner [object.getFName().getJsonName()] = object.getJson (p);
         }
     }
     return v;

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -43,7 +43,7 @@ STLedgerEntry::STLedgerEntry (Keylet const& k)
     if (format == nullptr)
         Throw<std::runtime_error> ("invalid ledger entry type");
 
-    set (format->elements);
+    set (format->getSOTemplate());
 
     setFieldU16 (sfLedgerEntryType,
         static_cast <std::uint16_t> (type_));
@@ -78,7 +78,7 @@ void STLedgerEntry::setSLEType ()
         Throw<std::runtime_error> ("invalid ledger entry type");
 
     type_ = format->getType ();
-    applyTemplate (format->elements);  // May throw
+    applyTemplate (format->getSOTemplate());  // May throw
 }
 
 std::string STLedgerEntry::getFullText () const

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -91,12 +91,12 @@ void STObject::set (const SOTemplate& type)
     v_.reserve(type.size());
     mType = &type;
 
-    for (auto const& elem : type.all())
+    for (auto const& elem : type)
     {
-        if (elem->flags != SOE_REQUIRED)
-            v_.emplace_back(detail::nonPresentObject, elem->e_field);
+        if (elem.style() != soeREQUIRED)
+            v_.emplace_back(detail::nonPresentObject, elem.sField());
         else
-            v_.emplace_back(detail::defaultObject, elem->e_field);
+            v_.emplace_back(detail::defaultObject, elem.sField());
     }
 }
 
@@ -114,16 +114,16 @@ void STObject::applyTemplate (const SOTemplate& type) noexcept (false)
     mType = &type;
     decltype(v_) v;
     v.reserve(type.size());
-    for (auto const& e : type.all())
+    for (auto const& e : type)
     {
         auto const iter = std::find_if(
             v_.begin(), v_.end(), [&](detail::STVar const& b)
-                { return b.get().getFName() == e->e_field; });
+                { return b.get().getFName() == e.sField(); });
         if (iter != v_.end())
         {
-            if ((e->flags == SOE_DEFAULT) && iter->get().isDefault())
+            if ((e.style() == soeDEFAULT) && iter->get().isDefault())
             {
-                throwFieldErr (e->e_field.fieldName,
+                throwFieldErr (e.sField().fieldName,
                     "may not be explicitly set to default.");
             }
             v.emplace_back(std::move(*iter));
@@ -131,12 +131,12 @@ void STObject::applyTemplate (const SOTemplate& type) noexcept (false)
         }
         else
         {
-            if (e->flags == SOE_REQUIRED)
+            if (e.style() == soeREQUIRED)
             {
-                throwFieldErr (e->e_field.fieldName,
+                throwFieldErr (e.sField().fieldName,
                     "is required but missing.");
             }
-            v.emplace_back(detail::nonPresentObject, e->e_field);
+            v.emplace_back(detail::nonPresentObject, e.sField());
         }
     }
     for (auto const& e : v_)

--- a/src/ripple/protocol/impl/STObject.cpp
+++ b/src/ripple/protocol/impl/STObject.cpp
@@ -658,17 +658,10 @@ Json::Value STObject::getJson (int options) const
 {
     Json::Value ret (Json::objectValue);
 
-    // TODO(tom): this variable is never changed...?
-    int index = 1;
     for (auto const& elem : v_)
     {
         if (elem->getSType () != STI_NOTPRESENT)
-        {
-            auto const& n = elem->getFName ();
-            auto key = n.hasName () ? std::string(n.getJsonName ()) :
-                    std::to_string (index);
-            ret[key] = elem->getJson (options);
-        }
+            ret [elem->getFName().getJsonName()] = elem->getJson (options);
     }
     return ret;
 }

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -60,7 +60,7 @@ STTx::STTx (STObject&& object) noexcept (false)
     : STObject (std::move (object))
 {
     tx_type_ = safe_cast<TxType> (getFieldU16 (sfTransactionType));
-    applyTemplate (getTxFormat (tx_type_)->elements);  //  may throw
+    applyTemplate (getTxFormat (tx_type_)->getSOTemplate());  //  may throw
     tid_ = getHash(HashPrefix::transactionID);
 }
 
@@ -77,7 +77,7 @@ STTx::STTx (SerialIter& sit) noexcept (false)
 
     tx_type_ = safe_cast<TxType> (getFieldU16 (sfTransactionType));
 
-    applyTemplate (getTxFormat (tx_type_)->elements);  // May throw
+    applyTemplate (getTxFormat (tx_type_)->getSOTemplate());  // May throw
     tid_ = getHash(HashPrefix::transactionID);
 }
 
@@ -88,7 +88,7 @@ STTx::STTx (
 {
     auto format = getTxFormat (type);
 
-    set (format->elements);
+    set (format->getSOTemplate());
     setFieldU16 (sfTransactionType, format->getType ());
 
     assembler (*this);

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -147,26 +147,23 @@ SOTemplate const& STValidation::getFormat ()
 {
     struct FormatHolder
     {
-        SOTemplate format;
-
-        FormatHolder ()
+        SOTemplate format
         {
-            format.push_back (SOElement (sfFlags,           SOE_REQUIRED));
-            format.push_back (SOElement (sfLedgerHash,      SOE_REQUIRED));
-            format.push_back (SOElement (sfLedgerSequence,  SOE_OPTIONAL));
-            format.push_back (SOElement (sfCloseTime,       SOE_OPTIONAL));
-            format.push_back (SOElement (sfLoadFee,         SOE_OPTIONAL));
-            format.push_back (SOElement (sfAmendments,      SOE_OPTIONAL));
-            format.push_back (SOElement (sfBaseFee,         SOE_OPTIONAL));
-            format.push_back (SOElement (sfReserveBase,     SOE_OPTIONAL));
-            format.push_back (SOElement (sfReserveIncrement, SOE_OPTIONAL));
-            format.push_back (SOElement (sfSigningTime,     SOE_REQUIRED));
-            format.push_back (SOElement (sfSigningPubKey,   SOE_REQUIRED));
-            format.push_back (SOElement (sfSignature,       SOE_OPTIONAL));
-            format.push_back (SOElement (sfConsensusHash,   SOE_OPTIONAL));
-            format.push_back (SOElement (sfCookie,          SOE_OPTIONAL));
-
-        }
+            { sfFlags,            soeREQUIRED },
+            { sfLedgerHash,       soeREQUIRED },
+            { sfLedgerSequence,   soeOPTIONAL },
+            { sfCloseTime,        soeOPTIONAL },
+            { sfLoadFee,          soeOPTIONAL },
+            { sfAmendments,       soeOPTIONAL },
+            { sfBaseFee,          soeOPTIONAL },
+            { sfReserveBase,      soeOPTIONAL },
+            { sfReserveIncrement, soeOPTIONAL },
+            { sfSigningTime,      soeREQUIRED },
+            { sfSigningPubKey,    soeREQUIRED },
+            { sfSignature,        soeOPTIONAL },
+            { sfConsensusHash,    soeOPTIONAL },
+            { sfCookie,           soeOPTIONAL },
+        };
     };
 
     static const FormatHolder holder;

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -23,164 +23,205 @@ namespace ripple {
 
 TxFormats::TxFormats ()
 {
-    add ("AccountSet", ttACCOUNT_SET)
-        << SOElement (sfEmailHash,           SOE_OPTIONAL)
-        << SOElement (sfWalletLocator,       SOE_OPTIONAL)
-        << SOElement (sfWalletSize,          SOE_OPTIONAL)
-        << SOElement (sfMessageKey,          SOE_OPTIONAL)
-        << SOElement (sfDomain,              SOE_OPTIONAL)
-        << SOElement (sfTransferRate,        SOE_OPTIONAL)
-        << SOElement (sfSetFlag,             SOE_OPTIONAL)
-        << SOElement (sfClearFlag,           SOE_OPTIONAL)
-        << SOElement (sfTickSize,            SOE_OPTIONAL)
-        ;
+    // Fields shared by all txFormats:
+    static const std::initializer_list<SOElement> commonFields
+    {
+        { sfTransactionType,      soeREQUIRED },
+        { sfFlags,                soeOPTIONAL },
+        { sfSourceTag,            soeOPTIONAL },
+        { sfAccount,              soeREQUIRED },
+        { sfSequence,             soeREQUIRED },
+        { sfPreviousTxnID,        soeOPTIONAL }, // emulate027
+        { sfLastLedgerSequence,   soeOPTIONAL },
+        { sfAccountTxnID,         soeOPTIONAL },
+        { sfFee,                  soeREQUIRED },
+        { sfOperationLimit,       soeOPTIONAL },
+        { sfMemos,                soeOPTIONAL },
+        { sfSigningPubKey,        soeREQUIRED },
+        { sfTxnSignature,         soeOPTIONAL },
+        { sfSigners,              soeOPTIONAL }, // submit_multisigned
+    };
 
-    add ("TrustSet", ttTRUST_SET)
-        << SOElement (sfLimitAmount,         SOE_OPTIONAL)
-        << SOElement (sfQualityIn,           SOE_OPTIONAL)
-        << SOElement (sfQualityOut,          SOE_OPTIONAL)
-        ;
+    add ("AccountSet", ttACCOUNT_SET,
+        {
+            { sfEmailHash,           soeOPTIONAL },
+            { sfWalletLocator,       soeOPTIONAL },
+            { sfWalletSize,          soeOPTIONAL },
+            { sfMessageKey,          soeOPTIONAL },
+            { sfDomain,              soeOPTIONAL },
+            { sfTransferRate,        soeOPTIONAL },
+            { sfSetFlag,             soeOPTIONAL },
+            { sfClearFlag,           soeOPTIONAL },
+            { sfTickSize,            soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("OfferCreate", ttOFFER_CREATE)
-        << SOElement (sfTakerPays,           SOE_REQUIRED)
-        << SOElement (sfTakerGets,           SOE_REQUIRED)
-        << SOElement (sfExpiration,          SOE_OPTIONAL)
-        << SOElement (sfOfferSequence,       SOE_OPTIONAL)
-        ;
+    add ("TrustSet", ttTRUST_SET,
+        {
+            { sfLimitAmount,         soeOPTIONAL },
+            { sfQualityIn,           soeOPTIONAL },
+            { sfQualityOut,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("OfferCancel", ttOFFER_CANCEL)
-        << SOElement (sfOfferSequence,       SOE_REQUIRED)
-        ;
+    add ("OfferCreate", ttOFFER_CREATE,
+        {
+            { sfTakerPays,           soeREQUIRED },
+            { sfTakerGets,           soeREQUIRED },
+            { sfExpiration,          soeOPTIONAL },
+            { sfOfferSequence,       soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("SetRegularKey", ttREGULAR_KEY_SET)
-        << SOElement (sfRegularKey,          SOE_OPTIONAL)
-        ;
+    add ("OfferCancel", ttOFFER_CANCEL,
+        {
+            { sfOfferSequence,       soeREQUIRED },
+        },
+        commonFields);
 
-    add ("Payment", ttPAYMENT)
-        << SOElement (sfDestination,         SOE_REQUIRED)
-        << SOElement (sfAmount,              SOE_REQUIRED)
-        << SOElement (sfSendMax,             SOE_OPTIONAL)
-        << SOElement (sfPaths,               SOE_DEFAULT)
-        << SOElement (sfInvoiceID,           SOE_OPTIONAL)
-        << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-        << SOElement (sfDeliverMin,          SOE_OPTIONAL)
-        ;
+    add ("SetRegularKey", ttREGULAR_KEY_SET,
+        {
+            { sfRegularKey,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("EscrowCreate", ttESCROW_CREATE)
-        << SOElement (sfDestination,         SOE_REQUIRED)
-        << SOElement (sfAmount,              SOE_REQUIRED)
-        << SOElement (sfCondition,           SOE_OPTIONAL)
-        << SOElement (sfCancelAfter,         SOE_OPTIONAL)
-        << SOElement (sfFinishAfter,         SOE_OPTIONAL)
-        << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-        ;
+    add ("Payment", ttPAYMENT,
+        {
+            { sfDestination,         soeREQUIRED },
+            { sfAmount,              soeREQUIRED },
+            { sfSendMax,             soeOPTIONAL },
+            { sfPaths,               soeDEFAULT  },
+            { sfInvoiceID,           soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+            { sfDeliverMin,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("EscrowFinish", ttESCROW_FINISH)
-        << SOElement (sfOwner,               SOE_REQUIRED)
-        << SOElement (sfOfferSequence,       SOE_REQUIRED)
-        << SOElement (sfFulfillment,         SOE_OPTIONAL)
-        << SOElement (sfCondition,           SOE_OPTIONAL)
-        ;
+    add ("EscrowCreate", ttESCROW_CREATE,
+        {
+            { sfDestination,         soeREQUIRED },
+            { sfAmount,              soeREQUIRED },
+            { sfCondition,           soeOPTIONAL },
+            { sfCancelAfter,         soeOPTIONAL },
+            { sfFinishAfter,         soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("EscrowCancel", ttESCROW_CANCEL)
-        << SOElement (sfOwner,               SOE_REQUIRED)
-        << SOElement (sfOfferSequence,       SOE_REQUIRED)
-        ;
+    add ("EscrowFinish", ttESCROW_FINISH,
+        {
+            { sfOwner,               soeREQUIRED },
+            { sfOfferSequence,       soeREQUIRED },
+            { sfFulfillment,         soeOPTIONAL },
+            { sfCondition,           soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("EnableAmendment", ttAMENDMENT)
-        << SOElement (sfLedgerSequence,      SOE_REQUIRED)
-        << SOElement (sfAmendment,           SOE_REQUIRED)
-        ;
+    add ("EscrowCancel", ttESCROW_CANCEL,
+        {
+            { sfOwner,               soeREQUIRED },
+            { sfOfferSequence,       soeREQUIRED },
+        },
+        commonFields);
 
-    add ("SetFee", ttFEE)
-        << SOElement (sfLedgerSequence,      SOE_OPTIONAL)
-        << SOElement (sfBaseFee,             SOE_REQUIRED)
-        << SOElement (sfReferenceFeeUnits,   SOE_REQUIRED)
-        << SOElement (sfReserveBase,         SOE_REQUIRED)
-        << SOElement (sfReserveIncrement,    SOE_REQUIRED)
-        ;
+    add ("EnableAmendment", ttAMENDMENT,
+        {
+            { sfLedgerSequence,      soeREQUIRED },
+            { sfAmendment,           soeREQUIRED },
+        },
+        commonFields);
 
-    add ("TicketCreate", ttTICKET_CREATE)
-        << SOElement (sfTarget,              SOE_OPTIONAL)
-        << SOElement (sfExpiration,          SOE_OPTIONAL)
-        ;
+    add ("SetFee", ttFEE,
+        {
+            { sfLedgerSequence,      soeOPTIONAL },
+            { sfBaseFee,             soeREQUIRED },
+            { sfReferenceFeeUnits,   soeREQUIRED },
+            { sfReserveBase,         soeREQUIRED },
+            { sfReserveIncrement,    soeREQUIRED },
+        },
+        commonFields);
 
-    add ("TicketCancel", ttTICKET_CANCEL)
-        << SOElement (sfTicketID,            SOE_REQUIRED)
-        ;
+    add ("TicketCreate", ttTICKET_CREATE,
+        {
+            { sfTarget,              soeOPTIONAL },
+            { sfExpiration,          soeOPTIONAL },
+        },
+        commonFields);
+
+    add ("TicketCancel", ttTICKET_CANCEL,
+        {
+            { sfTicketID,            soeREQUIRED },
+        },
+        commonFields);
 
     // The SignerEntries are optional because a SignerList is deleted by
     // setting the SignerQuorum to zero and omitting SignerEntries.
-    add ("SignerListSet", ttSIGNER_LIST_SET)
-        << SOElement (sfSignerQuorum,        SOE_REQUIRED)
-        << SOElement (sfSignerEntries,       SOE_OPTIONAL)
-        ;
+    add ("SignerListSet", ttSIGNER_LIST_SET,
+        {
+            { sfSignerQuorum,        soeREQUIRED },
+            { sfSignerEntries,       soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("PaymentChannelCreate", ttPAYCHAN_CREATE)
-        << SOElement (sfDestination,         SOE_REQUIRED)
-        << SOElement (sfAmount,              SOE_REQUIRED)
-        << SOElement (sfSettleDelay,         SOE_REQUIRED)
-        << SOElement (sfPublicKey,           SOE_REQUIRED)
-        << SOElement (sfCancelAfter,         SOE_OPTIONAL)
-        << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-        ;
+    add ("PaymentChannelCreate", ttPAYCHAN_CREATE,
+        {
+            { sfDestination,         soeREQUIRED },
+            { sfAmount,              soeREQUIRED },
+            { sfSettleDelay,         soeREQUIRED },
+            { sfPublicKey,           soeREQUIRED },
+            { sfCancelAfter,         soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("PaymentChannelFund", ttPAYCHAN_FUND)
-        << SOElement (sfPayChannel,          SOE_REQUIRED)
-        << SOElement (sfAmount,              SOE_REQUIRED)
-        << SOElement (sfExpiration,          SOE_OPTIONAL)
-        ;
+    add ("PaymentChannelFund", ttPAYCHAN_FUND,
+        {
+            { sfPayChannel,          soeREQUIRED },
+            { sfAmount,              soeREQUIRED },
+            { sfExpiration,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("PaymentChannelClaim", ttPAYCHAN_CLAIM)
-        << SOElement (sfPayChannel,          SOE_REQUIRED)
-        << SOElement (sfAmount,              SOE_OPTIONAL)
-        << SOElement (sfBalance,             SOE_OPTIONAL)
-        << SOElement (sfSignature,           SOE_OPTIONAL)
-        << SOElement (sfPublicKey,           SOE_OPTIONAL)
-        ;
+    add ("PaymentChannelClaim", ttPAYCHAN_CLAIM,
+        {
+            { sfPayChannel,          soeREQUIRED },
+            { sfAmount,              soeOPTIONAL },
+            { sfBalance,             soeOPTIONAL },
+            { sfSignature,           soeOPTIONAL },
+            { sfPublicKey,           soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("CheckCreate", ttCHECK_CREATE)
-        << SOElement (sfDestination,         SOE_REQUIRED)
-        << SOElement (sfSendMax,             SOE_REQUIRED)
-        << SOElement (sfExpiration,          SOE_OPTIONAL)
-        << SOElement (sfDestinationTag,      SOE_OPTIONAL)
-        << SOElement (sfInvoiceID,           SOE_OPTIONAL)
-        ;
+    add ("CheckCreate", ttCHECK_CREATE,
+        {
+            { sfDestination,         soeREQUIRED },
+            { sfSendMax,             soeREQUIRED },
+            { sfExpiration,          soeOPTIONAL },
+            { sfDestinationTag,      soeOPTIONAL },
+            { sfInvoiceID,           soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("CheckCash", ttCHECK_CASH)
-        << SOElement (sfCheckID,             SOE_REQUIRED)
-        << SOElement (sfAmount,              SOE_OPTIONAL)
-        << SOElement (sfDeliverMin,          SOE_OPTIONAL)
-        ;
+    add ("CheckCash", ttCHECK_CASH,
+        {
+            { sfCheckID,             soeREQUIRED },
+            { sfAmount,              soeOPTIONAL },
+            { sfDeliverMin,          soeOPTIONAL },
+        },
+        commonFields);
 
-    add ("CheckCancel", ttCHECK_CANCEL)
-        << SOElement (sfCheckID,             SOE_REQUIRED)
-        ;
+    add ("CheckCancel", ttCHECK_CANCEL,
+        {
+            { sfCheckID,             soeREQUIRED },
+        },
+        commonFields);
 
-    add ("DepositPreauth", ttDEPOSIT_PREAUTH)
-        << SOElement (sfAuthorize,           SOE_OPTIONAL)
-        << SOElement (sfUnauthorize,         SOE_OPTIONAL)
-        ;
-}
-
-void TxFormats::addCommonFields (Item& item)
-{
-    item
-        << SOElement(sfTransactionType,      SOE_REQUIRED)
-        << SOElement(sfFlags,                SOE_OPTIONAL)
-        << SOElement(sfSourceTag,            SOE_OPTIONAL)
-        << SOElement(sfAccount,              SOE_REQUIRED)
-        << SOElement(sfSequence,             SOE_REQUIRED)
-        << SOElement(sfPreviousTxnID,        SOE_OPTIONAL) // emulate027
-        << SOElement(sfLastLedgerSequence,   SOE_OPTIONAL)
-        << SOElement(sfAccountTxnID,         SOE_OPTIONAL)
-        << SOElement(sfFee,                  SOE_REQUIRED)
-        << SOElement(sfOperationLimit,       SOE_OPTIONAL)
-        << SOElement(sfMemos,                SOE_OPTIONAL)
-        << SOElement(sfSigningPubKey,        SOE_REQUIRED)
-        << SOElement(sfTxnSignature,         SOE_OPTIONAL)
-        << SOElement(sfSigners,              SOE_OPTIONAL) // submit_multisigned
-        ;
+    add ("DepositPreauth", ttDEPOSIT_PREAUTH,
+        {
+            { sfAuthorize,           soeOPTIONAL },
+            { sfUnauthorize,         soeOPTIONAL },
+        },
+        commonFields);
 }
 
 TxFormats const&

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -237,10 +237,9 @@ public:
         unexpected (sfGeneric.isUseful (), "sfGeneric must not be useful");
         {
             // Try to put sfGeneric in an SOTemplate.
-            SOTemplate elements;
             except<std::runtime_error>( [&]()
                 {
-                    elements.push_back (SOElement (sfGeneric, SOE_REQUIRED));
+                    SOTemplate elements {{ sfGeneric, soeREQUIRED }};
                 });
         }
 
@@ -260,19 +259,19 @@ public:
         }
         {
             // Try to put sfInvalid in an SOTemplate.
-            SOTemplate elements;
             except<std::runtime_error>( [&]()
                 {
-                    elements.push_back (SOElement (sfInvalid, SOE_REQUIRED));
+                    SOTemplate elements {{ sfInvalid, soeREQUIRED }};
                 });
         }
         {
             // Try to put the same SField into an SOTemplate twice.
-            SOTemplate elements;
-            elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
             except<std::runtime_error>( [&]()
                 {
-                    elements.push_back (SOElement (sfAccount, SOE_REQUIRED));
+                    SOTemplate elements {
+                        { sfAccount, soeREQUIRED },
+                        { sfAccount, soeREQUIRED },
+                    };
                 });
         }
 
@@ -284,12 +283,14 @@ public:
         SField const& sfTestObject = sfMajority;
 
 
-        SOTemplate elements;
-        elements.push_back (SOElement (sfFlags, SOE_REQUIRED));
-        elements.push_back (SOElement (sfTestVL, SOE_REQUIRED));
-        elements.push_back (SOElement (sfTestH256, SOE_OPTIONAL));
-        elements.push_back (SOElement (sfTestU32, SOE_REQUIRED));
-        elements.push_back (SOElement (sfTestV256, SOE_OPTIONAL));
+        SOTemplate const elements
+            {
+                { sfFlags,    soeREQUIRED },
+                { sfTestVL,   soeREQUIRED },
+                { sfTestH256, soeOPTIONAL },
+                { sfTestU32,  soeREQUIRED },
+                { sfTestV256, soeOPTIONAL },
+            };
 
         STObject object1 (elements, sfTestObject);
         STObject object2 (object1);
@@ -419,17 +420,14 @@ public:
         }
 
         // read templated object
-
-        auto const sot = [&]()
-        {
-            SOTemplate sot;
-            sot.push_back(SOElement(sf1, SOE_REQUIRED));
-            sot.push_back(SOElement(sf2, SOE_OPTIONAL));
-            sot.push_back(SOElement(sf3, SOE_DEFAULT));
-            sot.push_back(SOElement(sf4, SOE_OPTIONAL));
-            sot.push_back(SOElement(sf5, SOE_DEFAULT));
-            return sot;
-        }();
+        SOTemplate const sot
+            {
+                { sf1, soeREQUIRED },
+                { sf2, soeOPTIONAL },
+                { sf3, soeDEFAULT },
+                { sf4, soeOPTIONAL },
+                { sf5, soeDEFAULT },
+            };
 
         {
             auto const st = [&]()
@@ -643,14 +641,13 @@ public:
             auto const& sf1 = sfIndexes;
             auto const& sf2 = sfHashes;
             auto const& sf3 = sfAmendments;
-            auto const sot = [&]()
-            {
-                SOTemplate sot;
-                sot.push_back(SOElement(sf1, SOE_REQUIRED));
-                sot.push_back(SOElement(sf2, SOE_OPTIONAL));
-                sot.push_back(SOElement(sf3, SOE_DEFAULT));
-                return sot;
-            }();
+            SOTemplate const sot
+                {
+                    { sf1, soeREQUIRED },
+                    { sf2, soeOPTIONAL },
+                    { sf3, soeDEFAULT  },
+                };
+
             STObject st(sot, sfGeneric);
             auto const& cst(st);
             BEAST_EXPECT(cst[sf1].size() == 0);

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1250,9 +1250,11 @@ public:
         {
             // Construct an SOTemplate to get the ball rolling on building
             // an STObject that can contain another STObject.
-            SOTemplate recurse;
-            recurse.push_back (SOElement {sfTransactionMetaData, SOE_OPTIONAL});
-            recurse.push_back (SOElement {sfTransactionHash, SOE_OPTIONAL});
+            SOTemplate const recurse
+                {
+                    { sfTransactionMetaData, soeOPTIONAL},
+                    { sfTransactionHash,     soeOPTIONAL},
+                };
 
             // Make an STObject that nests objects ten levels deep.  There's
             // a minimum transaction size we must meet, so include a hash256.
@@ -1312,10 +1314,12 @@ public:
 
             // Construct an SOTemplate to get the ball rolling on building
             // an STObject that can contain an STArray.
-            SOTemplate recurse;
-            recurse.push_back (SOElement {sfTransactionMetaData, SOE_OPTIONAL});
-            recurse.push_back (SOElement {sfTransactionHash, SOE_OPTIONAL});
-            recurse.push_back (SOElement {sfTemplate, SOE_OPTIONAL});
+            SOTemplate recurse
+                {
+                    { sfTransactionMetaData, soeOPTIONAL },
+                    { sfTransactionHash,     soeOPTIONAL },
+                    { sfTemplate,            soeOPTIONAL },
+                };
 
             // Make an STObject that nests ten levels deep alternating objects
             // and arrays.  Include a hash256 to meet the minimum transaction


### PR DESCRIPTION
During the code review of https://github.com/ripple/rippled/pull/2854, @mellery451 asked about the consequences of some added `throw`s.  It was noted that those `throw`s could result in a malformed `SOTemplate` being left behind.  This pull request sits atop https://github.com/ripple/rippled/pull/2854 and does its best to address that issue.

Formerly an `SOTemplate` was default constructed and, later, its elements added using `push_back()`.  This left open the possibility of a malformed `SOTemplate` if adding one of the elements caused a throw.

With this commit the `SOTemplate` requires an `initializer_list` of its elements at construction.  Elements may not be added after construction.  With this approach either...

- The `SOTemplate` is fully constructed with all of its elements or
- The constructor throws, which prevents an invalid `SOTemplate` from even existing.

This change requires all callers of the `SOTemplate` constructor to be adjusted at the call site.  Those changes are also in this commit.

The `SOE_Flags` `enum` is also renamed to `SOEStyle`, which harmonizes the name with other uses of the `enum` in the code base.  `SOEStyle` enumerators are renamed (slightly) to have an `soe` prefix rather than `SOE_`.  This heads toward reserving identifiers with all upper case for macros.  The new style also aligns with other prominent `enum`s in the code base like the collection of `TER` identifiers.

`SOElement` is adjusted so it can be stored directly in an STL container (by using `std::reference_wrapper`).  Previously `SOElement` needed to be stored in a `std::unique_ptr` which could be stored in an STL container.  As a result of this change `unique_ptr` usage is removed from both `SOTemplate` and `KnownFormats`.

Only the top-most commit needs to be reviewed. That commit sits atop two other unmerged pull requests:

- https://github.com/ripple/rippled/pull/2854 (its immediate predecessor) and
- https://github.com/ripple/rippled/pull/2770 (which underlies https://github.com/ripple/rippled/pull/2854 ).

I'm assuming that both of the underlying pull requests will be merged and the top-most commit of this branch can be merged afterwards (assuming it passes code review).