### PR TITLE
Allow regular key even when it matches the disabled master key

### DIFF
--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -359,16 +359,17 @@ Transactor::checkSingleSign (PreclaimContext const& ctx)
     auto const pkAccount = calcAccountID (
         PublicKey (makeSlice (spk)));
 
-    if (pkAccount == id)
+    // Check regular key first. The regular key may be set to the master key.
+    if (hasAuthKey &&
+        (pkAccount == sle->getAccountID (sfRegularKey)))
+    {
+        // Authorized to continue.
+    }
+    else if (pkAccount == id)
     {
         // Authorized to continue.
         if (sle->isFlag(lsfDisableMaster))
             return tefMASTER_DISABLED;
-    }
-    else if (hasAuthKey &&
-        (pkAccount == sle->getAccountID (sfRegularKey)))
-    {
-        // Authorized to continue.
     }
     else if (hasAuthKey)
     {


### PR DESCRIPTION
If the account has a regular key, first check whether it is being used for this transaction, before checking if it matches the master key. It is currently possible for accounts to set the regular key to be the master key (and then disable the master key). Although this serves no purpose, it should not prevent the account from being used.

This may need to be on an amendment: some transactions that were previously invalid will become valid.

- [ ] Unit test
- [ ] Test/review for performance implications