### PR TITLE
[TRIVIAL] Remove incorrectly defaulted functions:

### DIFF
--- a/src/beast/extras/beast/unit_test/recorder.hpp
+++ b/src/beast/extras/beast/unit_test/recorder.hpp
@@ -24,8 +24,6 @@ private:
 
 public:
     recorder() = default;
-    recorder(recorder const&) = default;
-    recorder& operator=(recorder const&) = default;
 
     /** Returns a report with the results of all completed suites. */
     results const&

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -220,8 +220,6 @@ private:
 class DirectIPaymentStep : public DirectStepI<DirectIPaymentStep>
 {
 public:
-    explicit DirectIPaymentStep() = default;
-
     using DirectStepI<DirectIPaymentStep>::DirectStepI;
     using DirectStepI<DirectIPaymentStep>::check;
 
@@ -265,8 +263,6 @@ public:
 class DirectIOfferCrossingStep : public DirectStepI<DirectIOfferCrossingStep>
 {
 public:
-    explicit DirectIOfferCrossingStep() = default;
-
     using DirectStepI<DirectIOfferCrossingStep>::DirectStepI;
     using DirectStepI<DirectIOfferCrossingStep>::check;
 

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -166,8 +166,6 @@ private:
 class XRPEndpointPaymentStep : public XRPEndpointStep<XRPEndpointPaymentStep>
 {
 public:
-    explicit XRPEndpointPaymentStep() = default;
-
     using XRPEndpointStep<XRPEndpointPaymentStep>::XRPEndpointStep;
 
     XRPAmount

--- a/src/ripple/ledger/Directory.h
+++ b/src/ripple/ledger/Directory.h
@@ -60,8 +60,6 @@ public:
     using iterator_category =
         std::forward_iterator_tag;
 
-    const_iterator() = default;
-
     bool
     operator==(const_iterator const& other) const;
 


### PR DESCRIPTION
* The functions removed in this commit were explicitly defaulted
  but implicitly deleted

@HowardHinnant 