### PR TITLE
Add units to all fee calculations

### DIFF
--- a/src/ripple/app/misc/FeeVote.h
+++ b/src/ripple/app/misc/FeeVote.h
@@ -24,6 +24,7 @@
 #include <ripple/shamap/SHAMap.h>
 #include <ripple/protocol/STValidation.h>
 #include <ripple/basics/BasicConfig.h>
+#include <ripple/basics/tagged_integer.h>
 #include <ripple/protocol/SystemParameters.h>
 
 namespace ripple {
@@ -40,16 +41,16 @@ public:
     struct Setup
     {
         /** The cost of a reference transaction in drops. */
-        std::uint64_t reference_fee = 10;
+        Drops64 reference_fee{ 10 };
 
         /** The cost of a reference transaction in fee units. */
-        std::uint32_t const reference_fee_units = 10;
+        FeeUnit32 const reference_fee_units{ 10 };
 
         /** The account reserve requirement in drops. */
-        std::uint64_t account_reserve = 20 * SYSTEM_CURRENCY_PARTS;
+        Drops32 account_reserve{ 20 * SYSTEM_CURRENCY_PARTS };
 
         /** The per-owned item reserve requirement in drops. */
-        std::uint64_t owner_reserve = 5 * SYSTEM_CURRENCY_PARTS;
+        Drops32 owner_reserve{ 5 * SYSTEM_CURRENCY_PARTS };
     };
 
     virtual ~FeeVote () = default;

--- a/src/ripple/app/misc/LoadFeeTrack.h
+++ b/src/ripple/app/misc/LoadFeeTrack.h
@@ -22,6 +22,7 @@
 
 #include <ripple/json/json_value.h>
 #include <ripple/beast/utility/Journal.h>
+#include <ripple/ledger/ReadView.h>
 #include <algorithm>
 #include <cstdint>
 #include <mutex>
@@ -140,7 +141,8 @@ private:
 //------------------------------------------------------------------------------
 
 // Scale using load as well as base rate
-std::uint64_t scaleFeeLoad(std::uint64_t fee, LoadFeeTrack const& feeTrack,
+Drops64
+scaleFeeLoad(FeeUnit64 fee, LoadFeeTrack const& feeTrack,
     Fees const& fees, bool bUnlimited);
 
 } // ripple

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -36,56 +36,26 @@ class Config;
 struct FeeLevelTag;
 using FeeLevel64 = tagged_integer<std::uint64_t, FeeLevelTag>;
 
-template<class T>
 std::pair<bool, FeeLevel64>
-mulDiv(T value, FeeLevel64 mul, T div)
-{
-    auto const result = mulDiv(value, mul.value(), div);
-    return { result.first, FeeLevel64{result.second} };
-}
+mulDiv(std::uint64_t value, FeeLevel64 mul, std::uint64_t div);
 
-template<class T>
 std::pair<bool, FeeLevel64>
-mulDiv(FeeLevel64 value, T mul, T div)
-{
-    auto const result = mulDiv(value.value(), mul, div);
-    return { result.first, FeeLevel64{result.second} };
-}
+mulDiv(FeeLevel64 value, std::uint64_t mul, std::uint64_t div);
 
-template<class T>
 std::pair<bool, FeeLevel64>
-mulDiv(tagged_integer<T, DropsTag> value, FeeLevel64 mul, tagged_integer<T, DropsTag> div)
-{
-    auto const result = mulDiv(value.value(), mul.value(), div.value());
-    return { result.first, FeeLevel64{result.second} };
-}
+mulDiv(Drops64 value, FeeLevel64 mul, Drops64 div);
 
-template<class T>
 std::pair<bool, FeeLevel64>
-mulDiv(FeeLevel64 value, tagged_integer<T, DropsTag> mul, tagged_integer<T, DropsTag> div)
-{
-    auto const result = mulDiv(value.value(), mul.value(), div.value());
-    return { result.first, FeeLevel64{result.second} };
-}
+mulDiv(FeeLevel64 value, Drops64 mul, Drops64 div);
 
-template<class T,
-    class = typename std::enable_if<
-        std::is_integral<T>::value &&
-        sizeof(T) <= sizeof(std::uint64_t)>::type>
 std::pair<bool, std::uint64_t>
-mulDiv(tagged_integer<std::uint64_t, FeeLevelTag> value, T mul,
-    tagged_integer<std::uint64_t, FeeLevelTag> div)
-{
-    return mulDiv(value.value(), mul, div.value());
-}
+mulDiv(FeeLevel64 value, std::uint64_t mul, FeeLevel64 div);
 
-template<class T>
 std::pair<bool, Drops64>
-mulDiv(Drops64 value, tagged_integer<T, FeeLevelTag> mul, tagged_integer<T, FeeLevelTag> div)
-{
-    auto const result = mulDiv(value.value(), mul.value(), div.value());
-    return { result.first, Drops64{result.second} };
-}
+mulDiv(Drops64 value, FeeLevel64 mul, FeeLevel64 div);
+
+std::pair<bool, Drops64>
+mulDiv(FeeLevel64 value, Drops64 mul, FeeLevel64 div);
 
 /**
     Transaction Queue. Used to manage transactions in conjunction with

--- a/src/ripple/app/misc/impl/LoadFeeTrack.cpp
+++ b/src/ripple/app/misc/impl/LoadFeeTrack.cpp
@@ -182,6 +182,14 @@ swap (tagged_integer<T1, FeeUnitTag>& lhs, tagged_integer<T2, DropsTag>& rhs)
     rhs = tagged_integer<T2, DropsTag>{ vRHS };
 }
 
+static
+std::uint64_t
+divide (FeeUnit64 const& lhs,
+    FeeUnit64 const& rhs)
+{
+    return lhs.value() / rhs.value();
+}
+
 // Represents the product of a Drops and a FeeUnit
 struct DropFeeUnit;
 

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -33,6 +33,54 @@
 
 namespace ripple {
 
+std::pair<bool, FeeLevel64>
+mulDiv(std::uint64_t value, FeeLevel64 mul, std::uint64_t div)
+{
+    auto const result = mulDiv(value, mul.value(), div);
+    return { result.first, FeeLevel64{result.second} };
+}
+
+std::pair<bool, FeeLevel64>
+mulDiv(FeeLevel64 value, std::uint64_t mul, std::uint64_t div)
+{
+    auto const result = mulDiv(value.value(), mul, div);
+    return { result.first, FeeLevel64{result.second} };
+}
+
+std::pair<bool, FeeLevel64>
+mulDiv(Drops64 value, FeeLevel64 mul, Drops64 div)
+{
+    auto const result = mulDiv(value.value(), mul.value(), div.value());
+    return { result.first, FeeLevel64{result.second} };
+}
+
+std::pair<bool, FeeLevel64>
+mulDiv(FeeLevel64 value, Drops64 mul, Drops64 div)
+{
+    auto const result = mulDiv(value.value(), mul.value(), div.value());
+    return { result.first, FeeLevel64{result.second} };
+}
+
+std::pair<bool, std::uint64_t>
+mulDiv(FeeLevel64 value, std::uint64_t mul, FeeLevel64 div)
+{
+    return mulDiv(value.value(), mul, div.value());
+}
+
+std::pair<bool, Drops64>
+mulDiv(Drops64 value, FeeLevel64 mul, FeeLevel64 div)
+{
+    auto const result = mulDiv(value.value(), mul.value(), div.value());
+    return { result.first, Drops64{result.second} };
+}
+
+std::pair<bool, Drops64>
+mulDiv(FeeLevel64 value, Drops64 mul, FeeLevel64 div)
+{
+    auto const result = mulDiv(value.value(), mul.value(), div.value());
+    return { result.first, Drops64{result.second} };
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 static

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -234,7 +234,7 @@ preclaim(PreflightResult const& preflightResult,
 
     @return The base fee.
 */
-std::uint64_t
+FeeUnit64
 calculateBaseFee(ReadView const& view,
     STTx const& tx);
 

--- a/src/ripple/app/tx/impl/ApplyContext.cpp
+++ b/src/ripple/app/tx/impl/ApplyContext.cpp
@@ -30,7 +30,7 @@ namespace ripple {
 
 ApplyContext::ApplyContext(Application& app_,
     OpenView& base, STTx const& tx_, TER preclaimResult_,
-        std::uint64_t baseFee_, ApplyFlags flags,
+        FeeUnit64 baseFee_, ApplyFlags flags,
             beast::Journal journal_)
     : app(app_)
     , tx(tx_)

--- a/src/ripple/app/tx/impl/ApplyContext.h
+++ b/src/ripple/app/tx/impl/ApplyContext.h
@@ -40,13 +40,13 @@ public:
     explicit
     ApplyContext (Application& app, OpenView& base,
         STTx const& tx, TER preclaimResult,
-            std::uint64_t baseFee, ApplyFlags flags,
+            FeeUnit64 baseFee, ApplyFlags flags,
                 beast::Journal = beast::Journal{beast::Journal::getNullSink()});
 
     Application& app;
     STTx const& tx;
     TER const preclaimResult;
-    std::uint64_t const baseFee;
+    FeeUnit64 const baseFee;
     beast::Journal const journal;
 
     ApplyView&

--- a/src/ripple/app/tx/impl/Change.h
+++ b/src/ripple/app/tx/impl/Change.h
@@ -46,12 +46,12 @@ public:
     void preCompute() override;
 
     static
-    std::uint64_t
+    FeeUnit64
     calculateBaseFee (
         ReadView const& view,
         STTx const& tx)
     {
-        return 0;
+        return beast::zero;
     }
 
     static

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -349,12 +349,12 @@ EscrowFinish::preflight (PreflightContext const& ctx)
     return tesSUCCESS;
 }
 
-std::uint64_t
+FeeUnit64
 EscrowFinish::calculateBaseFee (
     ReadView const& view,
     STTx const& tx)
 {
-    std::uint64_t extraFee = 0;
+    FeeUnit64 extraFee{ 0 };
 
     if (auto const fb = tx[~sfFulfillment])
     {

--- a/src/ripple/app/tx/impl/Escrow.h
+++ b/src/ripple/app/tx/impl/Escrow.h
@@ -63,7 +63,7 @@ public:
     preflight (PreflightContext const& ctx);
 
     static
-    std::uint64_t
+    FeeUnit64
     calculateBaseFee (
         ReadView const& view,
         STTx const& tx);

--- a/src/ripple/app/tx/impl/InvariantCheck.cpp
+++ b/src/ripple/app/tx/impl/InvariantCheck.cpp
@@ -48,7 +48,7 @@ TransactionFeeCheck::finalize(
 
     // We should never charge a fee that's greater than or equal to the
     // entire XRP supply.
-    if (fee.drops() >= SYSTEM_CURRENCY_START)
+    if (fee >= SYSTEM_CURRENCY_START)
     {
         JLOG(j.fatal()) << "Invariant failed: fee paid exceeds system limit: " << fee.drops();
         return false;

--- a/src/ripple/app/tx/impl/SetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/SetRegularKey.cpp
@@ -23,7 +23,7 @@
 
 namespace ripple {
 
-std::uint64_t
+FeeUnit64
 SetRegularKey::calculateBaseFee (
     ReadView const& view,
     STTx const& tx)
@@ -40,7 +40,7 @@ SetRegularKey::calculateBaseFee (
             if (sle && (! (sle->getFlags () & lsfPasswordSpent)))
             {
                 // flag is armed and they signed with the right account
-                return 0;
+                return beast::zero;
             }
         }
     }

--- a/src/ripple/app/tx/impl/SetRegularKey.h
+++ b/src/ripple/app/tx/impl/SetRegularKey.h
@@ -48,7 +48,7 @@ public:
     preflight (PreflightContext const& ctx);
 
     static
-    std::uint64_t
+    FeeUnit64
     calculateBaseFee (
         ReadView const& view,
         STTx const& tx);

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -121,7 +121,8 @@ Transactor::Transactor(
 {
 }
 
-std::uint64_t Transactor::calculateBaseFee (
+FeeUnit64
+Transactor::calculateBaseFee (
     ReadView const& view,
     STTx const& tx)
 {
@@ -130,13 +131,12 @@ std::uint64_t Transactor::calculateBaseFee (
     // The computation has two parts:
     //  * The base fee, which is the same for most transactions.
     //  * The additional cost of each multisignature on the transaction.
-    std::uint64_t baseFee = view.fees().units;
+    const FeeUnit64& baseFee = view.fees().units;
 
     // Each signer adds one more baseFee to the minimum required fee
     // for the transaction.
-    std::uint32_t signerCount = 0;
-    if (tx.isFieldPresent (sfSigners))
-        signerCount = tx.getFieldArray (sfSigners).size();
+    const std::uint32_t signerCount = tx.isFieldPresent (sfSigners) ?
+        tx.getFieldArray (sfSigners).size() : 0;
 
     return baseFee + (signerCount * baseFee);
 }
@@ -148,7 +148,7 @@ Transactor::calculateFeePaid(STTx const& tx)
 }
 
 XRPAmount
-Transactor::minimumFee (Application& app, std::uint64_t baseFee,
+Transactor::minimumFee (Application& app, FeeUnit64 baseFee,
     Fees const& fees, ApplyFlags flags)
 {
     return scaleFeeLoad (baseFee, app.getFeeTrack (),
@@ -163,7 +163,7 @@ Transactor::calculateMaxSpend(STTx const& tx)
 
 TER
 Transactor::checkFee (PreclaimContext const& ctx,
-    std::uint64_t baseFee)
+    FeeUnit64 baseFee)
 {
     auto const feePaid = calculateFeePaid(ctx.tx);
     if (!isLegalAmount (feePaid) || feePaid < beast::zero)

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -122,7 +122,7 @@ public:
 
     static
     TER
-    checkFee (PreclaimContext const& ctx, std::uint64_t baseFee);
+    checkFee (PreclaimContext const& ctx, FeeUnit64 baseFee);
 
     static
     NotTEC
@@ -130,7 +130,7 @@ public:
 
     // Returns the fee in fee units, not scaled for load.
     static
-    std::uint64_t
+    FeeUnit64
     calculateBaseFee (
         ReadView const& view,
         STTx const& tx);
@@ -182,7 +182,7 @@ protected:
      */
     static
     XRPAmount
-    minimumFee (Application& app, std::uint64_t baseFee,
+    minimumFee (Application& app, FeeUnit64 baseFee,
         Fees const& fees, ApplyFlags flags);
 
 private:

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -141,7 +141,7 @@ invoke_preclaim (PreclaimContext const& ctx)
 }
 
 static
-std::uint64_t
+FeeUnit64
 invoke_calculateBaseFee(
     ReadView const& view,
     STTx const& tx)
@@ -171,7 +171,7 @@ invoke_calculateBaseFee(
     case ttFEE:                  return Change::calculateBaseFee(view, tx);
     default:
         assert(false);
-        return 0;
+        return beast::zero;
     }
 }
 
@@ -308,7 +308,7 @@ preclaim (PreflightResult const& preflightResult,
     }
 }
 
-std::uint64_t
+FeeUnit64
 calculateBaseFee(ReadView const& view,
     STTx const& tx)
 {

--- a/src/ripple/basics/impl/mulDiv.cpp
+++ b/src/ripple/basics/impl/mulDiv.cpp
@@ -36,7 +36,7 @@ mulDiv(std::uint64_t value, std::uint64_t mul, std::uint64_t div)
 
     result /= div;
 
-    auto const limit = std::numeric_limits<std::uint64_t>::max();
+    auto constexpr limit = std::numeric_limits<std::uint64_t>::max();
 
     if (result > limit)
         return { false, limit };

--- a/src/ripple/basics/tagged_integer.h
+++ b/src/ripple/basics/tagged_integer.h
@@ -21,6 +21,7 @@
 #define BEAST_UTILITY_TAGGED_INTEGER_H_INCLUDED
 
 #include <ripple/beast/hash/hash_append.h>
+#include <ripple/beast/utility/Zero.h>
 #include <boost/operators.hpp>
 #include <functional>
 #include <iostream>
@@ -68,13 +69,45 @@ public:
             std::is_integral<OtherInt>::value &&
             sizeof(OtherInt) <= sizeof(Int)>::type>
     explicit
-        /* constexpr */
-        tagged_integer(OtherInt value) noexcept
+    constexpr
+    tagged_integer(OtherInt value) noexcept
         : m_value(value)
     {
         static_assert(
             sizeof(tagged_integer) == sizeof(Int),
             "tagged_integer is adding padding");
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    constexpr
+    tagged_integer(tagged_integer<OtherInt, Tag> value) noexcept
+    : m_value(value.value())
+    {
+        static_assert(
+            sizeof(tagged_integer) == sizeof(Int),
+            "tagged_integer is adding padding");
+    }
+
+    constexpr
+    tagged_integer(beast::Zero)
+    : m_value(0)
+    {
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    tagged_integer&
+    operator=(OtherInt value) noexcept
+    {
+        m_value = value;
+        return *this;
     }
 
     bool
@@ -83,10 +116,74 @@ public:
         return m_value < rhs.m_value;
     }
 
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    bool
+    operator<(OtherInt rhs) const noexcept
+    {
+        return m_value < rhs;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    bool
+    operator<=(OtherInt rhs) const noexcept
+    {
+        return m_value <= rhs;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    bool
+    operator>(OtherInt rhs) const noexcept
+    {
+        return m_value > rhs;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    bool
+    operator>=(OtherInt rhs) const noexcept
+    {
+        return m_value >= rhs;
+    }
+
     bool
     operator==(const tagged_integer & rhs) const noexcept
     {
         return m_value == rhs.m_value;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    bool
+    operator==(OtherInt const& rhs) const noexcept
+    {
+        return m_value == rhs;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    bool
+    operator!=(OtherInt const& rhs) const noexcept
+    {
+        return m_value != rhs;
     }
 
     tagged_integer&
@@ -96,11 +193,90 @@ public:
         return *this;
     }
 
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            // This odd use of operators is because of an unresolved bug in MSVC
+            // which causes compilation errors on the "<" operator in a template
+            // https://developercommunity.visualstudio.com/content/problem/374878/vs2017-158-c-errors-c2059-c1004-when-less-than-ope.html
+            !( sizeof(OtherInt) >= sizeof(Int) )>::type>
+    tagged_integer&
+    operator+=(tagged_integer<OtherInt, Tag> const& rhs) noexcept
+    {
+        m_value += rhs.value();
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    tagged_integer&
+    operator+=(OtherInt const& rhs) noexcept
+    {
+        m_value += rhs;
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    tagged_integer
+    operator+(OtherInt const& rhs) const noexcept
+    {
+        tagged_integer copy = *this;
+        copy += rhs;
+        return copy;
+    }
+
     tagged_integer&
     operator-=(tagged_integer const& rhs) noexcept
     {
         m_value -= rhs.m_value;
         return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            // This odd use of operators is because of an unresolved bug in MSVC
+            // which causes compilation errors on the "<" operator in a template
+            // https://developercommunity.visualstudio.com/content/problem/374878/vs2017-158-c-errors-c2059-c1004-when-less-than-ope.html
+            !( sizeof(OtherInt) >= sizeof(Int) )>::type>
+    tagged_integer&
+    operator-=(tagged_integer<OtherInt, Tag> const& rhs) noexcept
+    {
+        m_value -= rhs.m_value;
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value &&
+            sizeof(OtherInt) <= sizeof(Int)>::type>
+    tagged_integer&
+    operator-=(OtherInt const& rhs) noexcept
+    {
+        m_value -= rhs;
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer
+    operator-(OtherInt const& rhs) const noexcept
+    {
+        tagged_integer copy = *this;
+        copy.m_value -= rhs;
+        return copy;
     }
 
     tagged_integer&
@@ -110,6 +286,29 @@ public:
         return *this;
     }
 
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer&
+    operator*=(OtherInt const& rhs) noexcept
+    {
+        m_value *= rhs;
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer
+    operator*(OtherInt const& rhs) const noexcept
+    {
+        tagged_integer copy = *this;
+        copy.m_value *= rhs;
+        return copy;
+    }
+
     tagged_integer&
     operator/=(tagged_integer const& rhs) noexcept
     {
@@ -117,11 +316,57 @@ public:
         return *this;
     }
 
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer&
+    operator/=(OtherInt const& rhs) noexcept
+    {
+        m_value /= rhs;
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer
+    operator/(OtherInt const& rhs) const noexcept
+    {
+        tagged_integer copy = *this;
+        copy.m_value /= rhs;
+        return copy;
+    }
+
     tagged_integer&
     operator%=(tagged_integer const& rhs) noexcept
     {
         m_value %= rhs.m_value;
         return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer&
+    operator%=(OtherInt const& rhs) noexcept
+    {
+        m_value %= rhs;
+        return *this;
+    }
+
+    template <
+        class OtherInt,
+        class = typename std::enable_if<
+            std::is_integral<OtherInt>::value>>
+    tagged_integer
+    operator%(OtherInt const& rhs) const noexcept
+    {
+        tagged_integer copy = *this;
+        copy.m_value %= rhs;
+        return copy;
     }
 
     tagged_integer&
@@ -192,7 +437,14 @@ public:
     }
 
     explicit
+    constexpr
     operator Int() const noexcept
+    {
+        return m_value;
+    }
+
+    constexpr
+    Int value() const noexcept
     {
         return m_value;
     }
@@ -219,7 +471,108 @@ public:
     {
         return std::to_string(t.m_value);
     }
+
+    /** Return the sign of the value */
+    constexpr
+    int
+    signum() const noexcept
+    {
+        return (m_value < 0) ? -1 : (m_value ? 1 : 0);
+    }
 };
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+tagged_integer<Int, Tag>
+operator*(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs * lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value &&
+        sizeof(OtherInt) <= sizeof(Int)>::type>
+tagged_integer<Int, Tag>
+operator+(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs + lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value &&
+        sizeof(OtherInt) <= sizeof(Int)>::type>
+tagged_integer<Int, Tag>
+operator-(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    // Just in case Int is unsigned, do straight math
+    return tagged_integer<Int, Tag>(lhs - rhs.value());
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+bool
+operator==(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs == lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+bool
+operator!=(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs != lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+bool
+operator<(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs > lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+bool
+operator<=(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs >= lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+bool
+operator>(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs < lhs;
+}
+
+template <class Int, class Tag,
+    class OtherInt,
+    class = typename std::enable_if<
+        std::is_integral<OtherInt>::value>>
+bool
+operator>=(OtherInt const& lhs, tagged_integer<Int, Tag> const& rhs) noexcept
+{
+    return rhs <= lhs;
+}
 
 } // ripple
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -22,6 +22,7 @@
 
 #include <ripple/basics/BasicConfig.h>
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/tagged_integer.h>
 #include <ripple/protocol/SystemParameters.h> // VFALCO Breaks levelization
 #include <ripple/beast/net/IPEndpoint.h>
 #include <boost/beast/core/string.hpp>
@@ -39,6 +40,10 @@
 namespace ripple {
 
 class Rules;
+
+// Forward declaration - defined in ReadView.h
+struct DropsTag;
+struct FeeUnitTag;
 
 //------------------------------------------------------------------------------
 
@@ -138,7 +143,8 @@ public:
     std::string                 START_LEDGER;
 
     // Network parameters
-    int const                   TRANSACTION_FEE_BASE = 10;   // The number of fee units a reference transaction costs
+    static constexpr tagged_integer<int, FeeUnitTag>
+                                TRANSACTION_FEE_BASE{ 10 };   // The number of fee units a reference transaction costs
 
     // Note: The following parameters do not relate to the UNL or trust at all
     // Minimum number of nodes to consider the network present
@@ -159,10 +165,12 @@ public:
     // Validation
     boost::optional<std::size_t> VALIDATION_QUORUM;     // validations to consider ledger authoritative
 
-    std::uint64_t                      FEE_DEFAULT = 10;
-    std::uint64_t                      FEE_ACCOUNT_RESERVE = 200*SYSTEM_CURRENCY_PARTS;
-    std::uint64_t                      FEE_OWNER_RESERVE = 50*SYSTEM_CURRENCY_PARTS;
-    std::uint64_t                      FEE_OFFER = 10;
+    tagged_integer<std::uint64_t, DropsTag>
+                                FEE_DEFAULT{ 10 };
+    tagged_integer<std::uint32_t, DropsTag>
+                                FEE_ACCOUNT_RESERVE{ 200 * SYSTEM_CURRENCY_PARTS };
+    tagged_integer<std::uint32_t, DropsTag>
+                                FEE_OWNER_RESERVE{ 50 * SYSTEM_CURRENCY_PARTS };
 
     // Node storage configuration
     std::uint32_t                      LEDGER_HISTORY = 256;

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -40,7 +40,6 @@ struct ConfigSection
 #define SECTION_DEBUG_LOGFILE           "debug_logfile"
 #define SECTION_ELB_SUPPORT             "elb_support"
 #define SECTION_FEE_DEFAULT             "fee_default"
-#define SECTION_FEE_OFFER               "fee_offer"
 #define SECTION_FEE_ACCOUNT_RESERVE     "fee_account_reserve"
 #define SECTION_FEE_OWNER_RESERVE       "fee_owner_reserve"
 #define SECTION_FETCH_DEPTH             "fetch_depth"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -151,6 +151,8 @@ getEnvVar (char const* name)
     return value;
 }
 
+constexpr tagged_integer<int, FeeUnitTag> Config::TRANSACTION_FEE_BASE;
+
 void Config::setupControl(bool bQuiet,
     bool bSilent, bool bStandalone)
 {
@@ -363,16 +365,16 @@ void Config::loadFromString (std::string const& fileContents)
         NETWORK_QUORUM      = beast::lexicalCastThrow<std::size_t>(strTemp);
 
     if (getSingleSection (secConfig, SECTION_FEE_ACCOUNT_RESERVE, strTemp, j_))
-        FEE_ACCOUNT_RESERVE = beast::lexicalCastThrow <std::uint64_t> (strTemp);
+        FEE_ACCOUNT_RESERVE = tagged_integer<std::uint32_t, DropsTag>{
+        beast::lexicalCastThrow <std::uint32_t>(strTemp) };
 
     if (getSingleSection (secConfig, SECTION_FEE_OWNER_RESERVE, strTemp, j_))
-        FEE_OWNER_RESERVE   = beast::lexicalCastThrow <std::uint64_t> (strTemp);
-
-    if (getSingleSection (secConfig, SECTION_FEE_OFFER, strTemp, j_))
-        FEE_OFFER           = beast::lexicalCastThrow <int> (strTemp);
+        FEE_OWNER_RESERVE = tagged_integer<std::uint32_t, DropsTag>{
+        beast::lexicalCastThrow <std::uint32_t>(strTemp) };
 
     if (getSingleSection (secConfig, SECTION_FEE_DEFAULT, strTemp, j_))
-        FEE_DEFAULT         = beast::lexicalCastThrow <int> (strTemp);
+        FEE_DEFAULT = tagged_integer<std::uint64_t, DropsTag>{
+        beast::lexicalCastThrow <std::uint64_t>(strTemp) };
 
     if (getSingleSection (secConfig, SECTION_LEDGER_HISTORY, strTemp, j_))
     {

--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -21,6 +21,7 @@
 #define RIPPLE_JSON_JSON_VALUE_H_INCLUDED
 
 #include <ripple/json/json_forwards.h>
+#include <ripple/json/json_conversions.h>
 #include <cstring>
 #include <functional>
 #include <map>

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -49,52 +49,20 @@ using Drops64 = tagged_integer<std::uint64_t, DropsTag>;
 using FeeUnit32 = tagged_integer<std::uint32_t, FeeUnitTag>;
 using FeeUnit64 = tagged_integer<std::uint64_t, FeeUnitTag>;
 
-template<class Integer>
-Integer divide (tagged_integer<Integer, FeeUnitTag> const& lhs,
-    tagged_integer<Integer, FeeUnitTag> const& rhs)
-{
-    return lhs.value() / rhs.value();
-}
-
-template<class T>
 std::pair<bool, Drops64>
-mulDiv(T value, Drops64 mul, T div)
-{
-    auto const result = mulDiv(value, mul.value(), div);
-    return { result.first, Drops64{result.second} };
-}
+mulDiv(std::uint64_t value, Drops64 mul, std::uint64_t div);
 
-template<class T>
 std::pair<bool, Drops64>
-mulDiv(Drops64 value, T mul, T div)
-{
-    auto const result = mulDiv(value.value(), mul, div);
-    return { result.first, Drops64{result.second} };
-}
+mulDiv(Drops64 value, std::uint64_t mul, std::uint64_t div);
 
-template<class T>
 std::pair<bool, Drops64>
-mulDiv(tagged_integer<T, FeeUnitTag> value, Drops64 mul, tagged_integer<T, FeeUnitTag> div)
-{
-    auto const result = mulDiv(value.value(), mul.value(), div.value());
-    return { result.first, Drops64{result.second} };
-}
+mulDiv(FeeUnit64 value, Drops64 mul, FeeUnit64 div);
 
-template<class T>
 std::pair<bool, Drops64>
-mulDiv(Drops64 value, tagged_integer<T, FeeUnitTag> mul, tagged_integer<T, FeeUnitTag> div)
-{
-    auto const result = mulDiv(value.value(), mul.value(), div.value());
-    return { result.first, Drops64{result.second} };
-}
+mulDiv(Drops64 value, FeeUnit64 mul, FeeUnit64 div);
 
-inline
 std::pair<bool, std::uint64_t>
-mulDiv(tagged_integer<std::uint64_t, DropsTag> value, std::uint64_t mul,
-    tagged_integer<std::uint64_t, DropsTag> div)
-{
-    return mulDiv(value.value(), mul, div.value());
-}
+mulDiv(Drops64 value, std::uint64_t mul, Drops64 div);
 
 /** Reflects the fee settings for a particular ledger.
 

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -22,6 +22,40 @@
 
 namespace ripple {
 
+std::pair<bool, Drops64>
+mulDiv(std::uint64_t value, Drops64 mul, std::uint64_t div)
+{
+    auto const result = mulDiv(value, mul.value(), div);
+    return { result.first, Drops64{result.second} };
+}
+
+std::pair<bool, Drops64>
+mulDiv(Drops64 value, std::uint64_t mul, std::uint64_t div)
+{
+    auto const result = mulDiv(value.value(), mul, div);
+    return { result.first, Drops64{result.second} };
+}
+
+std::pair<bool, Drops64>
+mulDiv(FeeUnit64 value, Drops64 mul, FeeUnit64 div)
+{
+    auto const result = mulDiv(value.value(), mul.value(), div.value());
+    return { result.first, Drops64{result.second} };
+}
+
+std::pair<bool, Drops64>
+mulDiv(Drops64 value, FeeUnit64 mul, FeeUnit64 div)
+{
+    auto const result = mulDiv(value.value(), mul.value(), div.value());
+    return { result.first, Drops64{result.second} };
+}
+
+std::pair<bool, std::uint64_t>
+mulDiv(Drops64 value, std::uint64_t mul, Drops64 div)
+{
+    return mulDiv(value.value(), mul, div.value());
+}
+
 class Rules::Impl
 {
 private:

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -32,6 +32,9 @@
 
 namespace ripple {
 
+// Forward declaration - defined in ReadView.h
+struct DropsTag;
+
 // Internal form:
 // 1: If amount is zero, then value is zero and offset is -100
 // 2: Otherwise:
@@ -106,6 +109,15 @@ public:
         std::uint64_t mantissa = 0, int exponent = 0, bool negative = false);
 
     STAmount (std::uint64_t mantissa = 0, bool negative = false);
+
+    template <class Integer,
+        class = typename std::enable_if_t <
+            std::is_integral<Integer>::value>>
+    explicit
+    STAmount (tagged_integer<Integer, DropsTag> const& drops)
+        : STAmount (drops.value(), false)
+    {
+    }
 
     STAmount (Issue const& issue, std::uint64_t mantissa = 0, int exponent = 0,
         bool negative = false);
@@ -209,6 +221,15 @@ public:
         return *this;
     }
 
+    template <class Integer,
+        class = typename std::enable_if_t <
+            std::is_integral<Integer>::value>>
+    STAmount& operator=(tagged_integer<Integer, DropsTag> const& drops)
+    {
+        *this = STAmount(drops);
+        return *this;
+    }
+
     //--------------------------------------------------------------------------
     //
     // Modification
@@ -285,6 +306,7 @@ public:
     }
 
     XRPAmount xrp () const;
+    tagged_integer<std::uint64_t, DropsTag> taggeddrops () const;
     IOUAmount iou () const;
 };
 

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -481,6 +481,13 @@ public:
     void setAccountID (SField const& field, AccountID const&);
 
     void setFieldAmount (SField const& field, STAmount const&);
+    template<class Integer,
+        class = typename std::enable_if_t <
+            std::is_integral<Integer>::value>>
+    void setFieldAmount (SField const& field, tagged_integer<Integer, DropsTag> const& v)
+    {
+        setFieldAmount(field, STAmount{ v });
+    }
     void setFieldPathSet (SField const& field, STPathSet const&);
     void setFieldV256 (SField const& field, STVector256 const& v);
     void setFieldArray (SField const& field, STArray const& v);

--- a/src/ripple/protocol/SystemParameters.h
+++ b/src/ripple/protocol/SystemParameters.h
@@ -20,10 +20,14 @@
 #ifndef RIPPLE_PROTOCOL_SYSTEMPARAMETERS_H_INCLUDED
 #define RIPPLE_PROTOCOL_SYSTEMPARAMETERS_H_INCLUDED
 
+#include <ripple/basics/tagged_integer.h>
 #include <cstdint>
 #include <string>
 
 namespace ripple {
+
+// Forward declaration - defined in ReadView.h
+struct DropsTag;
 
 // Various protocol and system specific constant globals.
 
@@ -38,22 +42,22 @@ systemName ()
 
 /** Configure the native currency. */
 static
-std::uint64_t const
+std::uint64_t constexpr
 SYSTEM_CURRENCY_GIFT = 1000;
 
 static
-std::uint64_t const
+std::uint64_t constexpr
 SYSTEM_CURRENCY_USERS = 100000000;
 
 /** Number of drops per 1 XRP */
 static
-std::uint64_t const
-SYSTEM_CURRENCY_PARTS = 1000000;
+tagged_integer<std::uint32_t, DropsTag> constexpr
+SYSTEM_CURRENCY_PARTS{ 1000000 };
 
 /** Number of drops in the genesis account. */
 static
-std::uint64_t const
-SYSTEM_CURRENCY_START = SYSTEM_CURRENCY_GIFT * SYSTEM_CURRENCY_USERS * SYSTEM_CURRENCY_PARTS;
+tagged_integer<std::uint64_t, DropsTag> constexpr
+SYSTEM_CURRENCY_START{ SYSTEM_CURRENCY_GIFT * SYSTEM_CURRENCY_USERS * SYSTEM_CURRENCY_PARTS.value() };
 
 /* The currency code for the native currency. */
 static inline

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -280,9 +280,9 @@ STAmount::STAmount (XRPAmount const& amount)
     , mIsNegative (amount < beast::zero)
 {
     if (mIsNegative)
-        mValue = static_cast<std::uint64_t> (-amount.drops ());
+        mValue = unsafe_cast<std::uint64_t> (-amount.drops ());
     else
-        mValue = static_cast<std::uint64_t> (amount.drops ());
+        mValue = unsafe_cast<std::uint64_t> (amount.drops ());
 
     canonicalize ();
 }
@@ -303,12 +303,23 @@ XRPAmount STAmount::xrp () const
     if (!mIsNative)
         Throw<std::logic_error> ("Cannot return non-native STAmount as XRPAmount");
 
-    auto drops = static_cast<std::int64_t> (mValue);
+    auto drops = unsafe_cast<std::int64_t> (mValue);
 
     if (mIsNegative)
         drops = -drops;
 
     return { drops };
+}
+
+tagged_integer<std::uint64_t, DropsTag>
+STAmount::taggeddrops () const
+{
+    if (!mIsNative)
+        Throw<std::logic_error> ("Cannot return non-native STAmount as drops");
+    if (mIsNegative)
+        Throw<std::logic_error> ("Cannot return negative STAmount as drops");
+
+    return tagged_integer<std::uint64_t, DropsTag>{ mValue };
 }
 
 IOUAmount STAmount::iou () const

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -43,7 +43,7 @@ static void fillTransaction (
     auto& fees = ledger.fees();
     // Convert the reference transaction cost in fee units to drops
     // scaled to represent the current fee load.
-    txArray["Fee"] = Json::UInt (scaleFeeLoad(fees.units,
+    txArray["Fee"] = Json::toUInt(scaleFeeLoad(fees.units,
         context.app.getFeeTrack(), fees, false));
 }
 

--- a/src/ripple/rpc/impl/Tuning.h
+++ b/src/ripple/rpc/impl/Tuning.h
@@ -33,48 +33,48 @@ struct LimitRange {
 };
 
 /** Limits for the account_lines command. */
-static LimitRange const accountLines = {10, 200, 400};
+static LimitRange constexpr accountLines = {10, 200, 400};
 
 /** Limits for the account_channels command. */
-static LimitRange const accountChannels = {10, 200, 400};
+static LimitRange constexpr accountChannels = {10, 200, 400};
 
 /** Limits for the account_objects command. */
-static LimitRange const accountObjects = {10, 200, 400};
+static LimitRange constexpr accountObjects = {10, 200, 400};
 
 /** Limits for the account_offers command. */
-static LimitRange const accountOffers = {10, 200, 400};
+static LimitRange constexpr accountOffers = {10, 200, 400};
 
 /** Limits for the book_offers command. */
-static LimitRange const bookOffers = {0, 300, 400};
+static LimitRange constexpr bookOffers = {0, 300, 400};
 
 /** Limits for the no_ripple_check command. */
-static LimitRange const noRippleCheck = {10, 300, 400};
+static LimitRange constexpr noRippleCheck = {10, 300, 400};
 
-static int const defaultAutoFillFeeMultiplier = 10;
-static int const defaultAutoFillFeeDivisor = 1;
-static int const maxPathfindsInProgress = 2;
-static int const maxPathfindJobCount = 50;
-static int const maxJobQueueClients = 500;
+static int constexpr defaultAutoFillFeeMultiplier = 10;
+static int constexpr defaultAutoFillFeeDivisor = 1;
+static int constexpr maxPathfindsInProgress = 2;
+static int constexpr maxPathfindJobCount = 50;
+static int constexpr maxJobQueueClients = 500;
 auto constexpr maxValidatedLedgerAge = std::chrono::minutes {2};
-static int const maxRequestSize = 1000000;
+static int constexpr maxRequestSize = 1000000;
 
 /** Maximum number of pages in one response from a binary LedgerData request. */
-static int const binaryPageLength = 2048;
+static int constexpr binaryPageLength = 2048;
 
 /** Maximum number of pages in one response from a Json LedgerData request. */
-static int const jsonPageLength = 256;
+static int constexpr jsonPageLength = 256;
 
 /** Maximum number of pages in a LedgerData response. */
-inline int pageLength(bool isBinary)
+inline int constexpr pageLength(bool isBinary)
 {
     return isBinary ? binaryPageLength : jsonPageLength;
 }
 
 /** Maximum number of source currencies allowed in a path find request. */
-static int const max_src_cur = 18;
+static int constexpr max_src_cur = 18;
 
 /** Maximum number of auto source currencies in a path find request. */
-static int const max_auto_src_cur = 88;
+static int constexpr max_auto_src_cur = 88;
 
 } // Tuning
 /** @} */

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -668,9 +668,9 @@ struct Escrow_test : public beast::unit_test::suite
             env.close();
 
             auto const baseFee = env.current()->fees().base;
-            env.require(balance("alice", XRP(4000) - (baseFee * 5)));
-            env.require(balance("bob", XRP(6000) - (baseFee * 5)));
-            env.require(balance("zelda", XRP(5000) - (baseFee * 4)));
+            env.require(balance("alice", XRP(4000) - drops(baseFee * 5)));
+            env.require(balance("bob", XRP(6000) - drops(baseFee * 5)));
+            env.require(balance("zelda", XRP(5000) - drops(baseFee * 4)));
         }
         {
             // Bob sets DepositAuth but preauthorizes Zelda, so Zelda can
@@ -696,9 +696,9 @@ struct Escrow_test : public beast::unit_test::suite
             env.close();
 
             auto const baseFee = env.current()->fees().base;
-            env.require(balance("alice", XRP(4000) - (baseFee * 2)));
-            env.require(balance("bob", XRP(6000) - (baseFee * 2)));
-            env.require(balance("zelda", XRP(5000) - (baseFee * 1)));
+            env.require(balance("alice", XRP(4000) - drops(baseFee * 2)));
+            env.require(balance("bob", XRP(6000) - drops(baseFee * 2)));
+            env.require(balance("zelda", XRP(5000) - drops(baseFee * 1)));
         }
         {
             // Conditional

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -816,7 +816,7 @@ struct Flow_test : public beast::unit_test::suite
         // The fee that's charged for transactions.
         auto const f = env.current ()->fees ().base;
 
-        env.fund (reserve (env, 3) + f * 4, alice);
+        env.fund (reserve (env, 3) + drops(f * 4), alice);
         env.close ();
 
         env (trust (alice, USD (2000)));
@@ -890,7 +890,7 @@ struct Flow_test : public beast::unit_test::suite
         // The fee that's charged for transactions.
         auto const f = env.current ()->fees ().base;
 
-        env.fund (reserve (env, 3) + f * 4, alice);
+        env.fund (reserve (env, 3) + drops(f * 4), alice);
         env.close ();
 
         env (trust (alice, USD (506)));
@@ -1211,8 +1211,8 @@ struct Flow_test : public beast::unit_test::suite
         auto const CTB = gw["CTB"];
 
         auto const fee = env.current ()->fees ().base;
-        env.fund (reserve(env, 2) + drops (9999640) + (fee), ann);
-        env.fund (reserve(env, 2) + (fee*4), gw);
+        env.fund (reserve(env, 2) + drops (9999640 + fee), ann);
+        env.fund (reserve(env, 2) + drops(fee*4), gw);
         env.close();
 
         env (rate(gw, 1.002));

--- a/src/test/app/LoadFeeTrack_test.cpp
+++ b/src/test/app/LoadFeeTrack_test.cpp
@@ -41,8 +41,8 @@ public:
             return f;
         }();
 
-        BEAST_EXPECT (scaleFeeLoad (10000, l, fees, false) == 10000);
-        BEAST_EXPECT (scaleFeeLoad (1, l, fees, false) == 1);
+        BEAST_EXPECT(scaleFeeLoad(FeeUnit64{ 10000 }, l, fees, false) == 10000);
+        BEAST_EXPECT(scaleFeeLoad(FeeUnit64{ 1 }, l, fees, false) == 1);
     }
 };
 

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -64,7 +64,7 @@ public:
             env.require (owners (alice, 0));
 
             // Fund alice enough to set the signer list, then attach signers.
-            env(pay(env.master, alice, fee + drops (1)));
+            env(pay(env.master, alice, drops (fee + 1)));
             env.close();
             env(smallSigners);
             env.close();
@@ -74,7 +74,7 @@ public:
             // Pay alice enough to almost make the reserve for the biggest
             // possible list.
             auto const addReserveBigSigners = reserve1 ? XRP(0) : XRP(350);
-            env(pay(env.master, alice, addReserveBigSigners + fee - drops(1)));
+            env(pay(env.master, alice, addReserveBigSigners + drops(fee - 1)));
 
             // Replace with the biggest possible signer list.  Should fail.
             Json::Value bigSigners = signers(alice, 1, {
@@ -85,7 +85,7 @@ public:
             env.require (owners (alice, reserve1 ? 1 : 3));
 
             // Fund alice one more drop (plus the fee) and succeed.
-            env(pay(env.master, alice, fee + drops(1)));
+            env(pay(env.master, alice, drops(fee + 1)));
             env.close();
             env(bigSigners);
             env.close();
@@ -482,7 +482,7 @@ public:
             Json::Value jv;
             jv[jss::tx_json][jss::Account]         = alice.human();
             jv[jss::tx_json][jss::TransactionType] = "AccountSet";
-            jv[jss::tx_json][jss::Fee]             = static_cast<uint32_t>(8 * baseFee);
+            jv[jss::tx_json][jss::Fee]             = Json::toUInt(8 * baseFee);
             jv[jss::tx_json][jss::Sequence]        = env.seq(alice);
             jv[jss::tx_json][jss::SigningPubKey]   = "";
             return jv;
@@ -1211,7 +1211,7 @@ public:
 
         // Use sign_for to sign a transaction where alice pays 10 XRP to
         // masterpassphrase.
-        std::uint32_t baseFee = env.current()->fees().base;
+        std::uint32_t baseFee = env.current()->fees().base.value();
         Json::Value jvSig1;
         jvSig1[jss::account] = bogie.human();
         jvSig1[jss::secret]  = bogie.name();

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -503,7 +503,7 @@ public:
 
             env.fund (XRP (1000000), gw);
 
-            auto const f = env.current ()->fees ().base;
+            auto const f = drops(env.current ()->fees ().base);
             auto const r = reserve (env, 0);
 
             env.fund (r + f, alice);
@@ -528,7 +528,7 @@ public:
 
             env.fund (XRP (1000000), gw);
 
-            auto const f = env.current ()->fees ().base;
+            auto const f = drops(env.current ()->fees ().base);
             auto const r = reserve (env, 0);
 
             auto const usdOffer2 = USD (500);
@@ -562,7 +562,7 @@ public:
 
             env.fund (XRP (1000000), gw);
 
-            auto const f = env.current ()->fees ().base;
+            auto const f = drops(env.current ()->fees ().base);
             auto const r = reserve (env, 0);
 
             auto const usdOffer2 = USD (500);
@@ -665,11 +665,11 @@ public:
                     txflags (tfFillOrKill),         ter(killedCode));
             }
             env.require (
-                balance (alice, startBalance - (f * 2)),
+                balance (alice, startBalance - drops(f * 2)),
                 balance (alice, USD (1000)),
                 owners (alice, 1),
                 offers (alice, 0),
-                balance (bob, startBalance - (f * 2)),
+                balance (bob, startBalance - drops(f * 2)),
                 balance (bob, USD (none)),
                 owners (bob, 1),
                 offers (bob, 1));
@@ -679,11 +679,11 @@ public:
                 txflags (tfFillOrKill),              ter(tesSUCCESS));
 
             env.require (
-                balance (alice, startBalance - (f * 3) + XRP (500)),
+                balance (alice, startBalance - drops(f * 3) + XRP (500)),
                 balance (alice, USD (500)),
                 owners (alice, 1),
                 offers (alice, 0),
-                balance (bob, startBalance - (f * 2) - XRP (500)),
+                balance (bob, startBalance - drops(f * 2) - XRP (500)),
                 balance (bob, USD (500)),
                 owners (bob, 1),
                 offers (bob, 0));
@@ -698,7 +698,7 @@ public:
                     100 * env.closed ()->info ().closeTimeResolution;
             env.close (closeTime);
 
-            auto const f = env.current ()->fees ().base;
+            auto const f = drops(env.current ()->fees ().base);
 
             env.fund (startBalance, gw, alice, bob);
 
@@ -967,7 +967,7 @@ public:
         env.fund (startBalance, gw, alice, bob);
         env.close();
 
-        auto const f = env.current ()->fees ().base;
+        auto const f = drops(env.current ()->fees ().base);
 
         env (trust (alice, usdOffer),             ter(tesSUCCESS));
         env (pay (gw, alice, usdOffer),           ter(tesSUCCESS));
@@ -1046,7 +1046,7 @@ public:
         env.fund (XRP(1000000), gw);
 
         // The fee that's charged for transactions
-        auto const f = env.current ()->fees ().base;
+        XRPAmount const f{ env.current()->fees().base };
 
         // Account is at the reserve, and will dip below once
         // fees are subtracted.
@@ -1287,14 +1287,14 @@ public:
         BEAST_EXPECT(jrr[jss::node][sfBalance.fieldName][jss::value] == "50");
         BEAST_EXPECT(env.balance (alice, xrpIssue()) ==
             alice_initial_balance -
-                env.current ()->fees ().base * 3 - crossingDelta
+                drops(env.current ()->fees ().base * 3) - crossingDelta
         );
 
         jrr = ledgerEntryState (env, bob, gw, "USD");
         BEAST_EXPECT( jrr[jss::node][sfBalance.fieldName][jss::value] == "0");
         BEAST_EXPECT(env.balance (bob, xrpIssue()) ==
             bob_initial_balance -
-                env.current ()->fees ().base * 2 + crossingDelta
+                drops(env.current ()->fees ().base * 2) + crossingDelta
         );
     }
 
@@ -1345,7 +1345,7 @@ public:
             std::to_string(
                 XRP (10000).value ().mantissa () -
                 XRP (reverse_order ? 4000 : 3000).value ().mantissa () -
-                env.current ()->fees ().base * 2)
+                drops(env.current ()->fees ().base * 2).value ().mantissa ())
         );
 
         jrr = ledgerEntryState (env, alice, gw, "USD");
@@ -1356,7 +1356,7 @@ public:
             std::to_string(
                 XRP (10000).value ().mantissa( ) +
                 XRP(reverse_order ? 4000 : 3000).value ().mantissa () -
-                env.current ()->fees ().base * 2)
+                drops(env.current ()->fees ().base * 2).value ().mantissa ())
         );
     }
 
@@ -1395,7 +1395,7 @@ public:
             std::to_string(
                 XRP (100000).value ().mantissa () -
                 XRP (3000).value ().mantissa () -
-                env.current ()->fees ().base * 1)
+                drops(env.current ()->fees ().base * 1).value ().mantissa ())
         );
 
         jrr = ledgerEntryState (env, alice, gw, "USD");
@@ -1406,7 +1406,7 @@ public:
             std::to_string(
                 XRP (100000).value ().mantissa () +
                 XRP (3000).value ().mantissa () -
-                env.current ()->fees ().base * 2)
+                drops(env.current ()->fees ().base * 2).value ().mantissa ())
         );
     }
 
@@ -1528,7 +1528,7 @@ public:
             std::to_string(
                 XRP (10000).value ().mantissa () +
                 XRP (500).value ().mantissa () -
-                env.current ()->fees ().base * 2)
+                drops(env.current ()->fees ().base * 2).value ().mantissa ())
         );
 
         jrr = ledgerEntryState (env, bob, gw, "USD");
@@ -1623,7 +1623,7 @@ public:
             std::to_string(
                 XRP (10000).value ().mantissa () +
                 XRP (200).value ().mantissa () -
-                env.current ()->fees ().base * 2)
+                drops(env.current ()->fees ().base * 2).value ().mantissa ())
         );
 
         // bob got 40 USD from partial consumption of the offer
@@ -1658,7 +1658,7 @@ public:
                 XRP (10000).value ().mantissa () +
                 XRP (200).value ().mantissa () +
                 XRP (300).value ().mantissa () -
-                env.current ()->fees ().base * 4)
+                drops(env.current ()->fees ().base * 4).value ().mantissa ())
         );
 
         // bob now has 100 USD - 40 from the first payment and 60 from the
@@ -1938,7 +1938,7 @@ public:
         //  1 for payment          == 4
         auto const starting_xrp = XRP (100) +
             env.current ()->fees ().accountReserve (3) +
-            env.current ()->fees ().base * 4;
+            drops(env.current ()->fees ().base * 4);
 
         env.fund (starting_xrp, gw1, gw2, gw3, alice, bob);
 
@@ -2026,7 +2026,7 @@ public:
 
         auto const starting_xrp = XRP (100) +
             env.current ()->fees ().accountReserve (1) +
-            env.current ()->fees ().base * 2;
+            drops(env.current ()->fees ().base * 2);
 
         env.fund (starting_xrp, gw, alice, bob);
 
@@ -2072,7 +2072,7 @@ public:
 
         auto const starting_xrp = XRP (100) +
             env.current ()->fees ().accountReserve (1) +
-            env.current ()->fees ().base * 2;
+            drops(env.current ()->fees ().base * 2);
 
         env.fund (starting_xrp, gw, alice, bob);
 
@@ -2121,7 +2121,7 @@ public:
 
         auto const starting_xrp = XRP (100.1) +
             env.current ()->fees ().accountReserve (1) +
-            env.current ()->fees ().base * 2;
+            drops(env.current ()->fees ().base * 2);
 
         env.fund (starting_xrp, gw, alice, bob);
 
@@ -2148,8 +2148,8 @@ public:
         payment[jss::tx_json][jss::Sequence] =
             env.current ()->read (
                 keylet::account (bob.id ()))->getFieldU32 (sfSequence);
-        payment[jss::tx_json][jss::Fee] =
-            std::to_string( env.current ()->fees ().base);
+        payment[jss::tx_json][jss::Fee] = to_string(
+            env.current()->fees().base);
         payment[jss::tx_json][jss::SendMax] =
             bob ["XTS"] (1.5).value ().getJson (0);
         auto jrr = wsc->invoke("submit", payment);
@@ -2225,7 +2225,7 @@ public:
         env.fund (XRP(10000000), gw);
 
         // The fee that's charged for transactions
-        auto const f = env.current ()->fees ().base;
+        auto const f = env.current ()->fees ().base.value();
 
         // To keep things simple all offers are 1 : 1 for XRP : USD.
         enum preTrustType {noPreTrust, gwPreTrust, acctPreTrust};
@@ -2392,7 +2392,7 @@ public:
 
         // alice's account has enough for the reserve, one trust line plus two
         // offers, and two fees.
-        env.fund (reserve (env, 2) + (fee * 2), alice);
+        env.fund (reserve (env, 2) + drops(fee * 2), alice);
         env.close();
 
         env (trust(alice, usdOffer));
@@ -2420,8 +2420,8 @@ public:
         env.require (
             balance (alice, USD(0)),
             balance (bob, usdOffer),
-            balance (alice, alicesXRP + xrpOffer - fee),
-            balance (bob,   bobsXRP   - xrpOffer - fee),
+            balance (alice, alicesXRP + xrpOffer - drops(fee)),
+            balance (bob,   bobsXRP   - xrpOffer - drops(fee)),
             offers (alice, 0),
             offers (bob, 0));
 
@@ -2477,8 +2477,8 @@ public:
 
         // Each account has enough for the reserve, two trust lines, one
         // offer, and two fees.
-        env.fund (reserve (env, 3) + (fee * 3), alice);
-        env.fund (reserve (env, 3) + (fee * 2), bob);
+        env.fund (reserve (env, 3) + drops(fee * 3), alice);
+        env.fund (reserve (env, 3) + drops(fee * 2), bob);
         env.close();
         env (trust(alice, usdOffer));
         env (trust(bob, eurOffer));
@@ -2667,7 +2667,7 @@ public:
         env.fund (XRP(10000000), gw);
 
         // The fee that's charged for transactions
-        auto const f = env.current ()->fees ().base;
+        auto const f = env.current ()->fees ().base.value();
 
         // To keep things simple all offers are 1 : 1 for XRP : USD.
         enum preTrustType {noPreTrust, gwPreTrust, acctPreTrust};
@@ -2936,7 +2936,7 @@ public:
         {
             auto const ann = Account("ann");
             auto const bob = Account("bob");
-            env.fund (XRP(100) + reserve(env, 2) + (fee*2), ann, bob);
+            env.fund (XRP(100) + reserve(env, 2) + drops(fee*2), ann, bob);
             env.close();
 
             env (trust(ann, USD(200)));
@@ -2971,7 +2971,7 @@ public:
             // in return for USD.  Gateway rate should still apply identically.
             auto const che = Account("che");
             auto const deb = Account("deb");
-            env.fund (XRP(100) + reserve(env, 2) + (fee*2), che, deb);
+            env.fund (XRP(100) + reserve(env, 2) + drops(fee*2), che, deb);
             env.close();
 
             env (trust(che, USD(200)));
@@ -2999,7 +2999,7 @@ public:
             auto const eve = Account("eve");
             auto const fyn = Account("fyn");
 
-            env.fund (XRP(20000) + fee*2, eve, fyn);
+            env.fund (XRP(20000) + drops(fee*2), eve, fyn);
             env.close();
 
             env (trust (eve, USD(1000)));
@@ -3051,7 +3051,7 @@ public:
             // apply in the same transaction.
             auto const gay = Account("gay");
             auto const hal = Account("hal");
-            env.fund (reserve(env, 3) + (fee*3), gay, hal);
+            env.fund (reserve(env, 3) + drops(fee*3), gay, hal);
             env.close();
 
             env (trust(gay, USD(200)));
@@ -3084,7 +3084,7 @@ public:
             // A trust line's QualityIn should not affect offer crossing.
             auto const ivy = Account("ivy");
             auto const joe = Account("joe");
-            env.fund (reserve(env, 3) + (fee*3), ivy, joe);
+            env.fund (reserve(env, 3) + drops(fee*3), ivy, joe);
             env.close();
 
             env (trust(ivy, USD(400)), qualityInPercent (90));
@@ -3125,7 +3125,7 @@ public:
             auto const N_BUX = ned["BUX"];
 
             // Verify trust line QualityOut affects payments.
-            env.fund (reserve(env, 4) + (fee*4), kim, lex, meg, ned);
+            env.fund (reserve(env, 4) + drops(fee*4), kim, lex, meg, ned);
             env.close();
 
             env (trust (lex, K_BUX(400)));
@@ -3170,7 +3170,7 @@ public:
             auto const ova = Account("ova");
             auto const pat = Account("pat");
             auto const qae = Account("qae");
-            env.fund (XRP(2) + reserve(env, 3) + (fee*3), ova, pat, qae);
+            env.fund (XRP(2) + reserve(env, 3) + drops(fee*3), ova, pat, qae);
             env.close();
 
             //   o ova has USD but wants XPR.
@@ -3255,7 +3255,7 @@ public:
         auto const fee = env.current ()->fees ().base;
         auto const startBalance = XRP(1000000);
 
-        env.fund (startBalance + (fee*4), gw);
+        env.fund (startBalance + drops(fee*4), gw);
         env.close();
 
         env (offer (gw, USD(60), XRP(600)));
@@ -3266,7 +3266,7 @@ public:
         env.close();
 
         env.require (owners (gw, 3));
-        env.require (balance (gw, startBalance + fee));
+        env.require (balance (gw, startBalance + drops(fee)));
 
         auto gwOffers = offersOnAccount (env, gw);
         BEAST_EXPECT (gwOffers.size() == 3);
@@ -3318,7 +3318,7 @@ public:
         env.close();
 
         // The fee that's charged for transactions.
-        auto const f = env.current ()->fees ().base;
+        auto const f = env.current ()->fees ().base.value();
 
         // Test cases
         struct TestData
@@ -3440,7 +3440,7 @@ public:
         auto const USD = bob["USD"];
         auto const f = env.current ()->fees ().base;
 
-        env.fund(XRP(50000) + f, alice, bob);
+        env.fund(XRP(50000) + drops(f), alice, bob);
         env.close();
 
         env(offer(alice, USD(5000), XRP(50000)));
@@ -3499,7 +3499,7 @@ public:
             auto const D_BUX = dan["BUX"];
 
             // Verify trust line QualityOut affects payments.
-            env.fund (reserve(env, 4) + (fee*4), ann, bob, cam, dan);
+            env.fund (reserve(env, 4) + drops(fee*4), ann, bob, cam, dan);
             env.close();
 
             env (trust (bob, A_BUX(400)));
@@ -3572,7 +3572,7 @@ public:
         auto const B_BUX = bob["BUX"];
 
         auto const fee = env.current ()->fees ().base;
-        env.fund (reserve(env, 4) + (fee*5), ann, bob, cam);
+        env.fund (reserve(env, 4) + drops(fee*5), ann, bob, cam);
         env.close();
 
         env (trust (ann, B_BUX(40)));
@@ -3625,8 +3625,8 @@ public:
         auto const BTC = gw["BTC"];
 
         auto const fee = env.current ()->fees ().base;
-        env.fund (reserve(env, 2) + drops (9999640) + (fee), ann);
-        env.fund (reserve(env, 2) + (fee*4), gw);
+        env.fund (reserve(env, 2) + drops (9999640 + fee), ann);
+        env.fund (reserve(env, 2) + drops(fee*4), gw);
         env.close();
 
         env (rate(gw, 1.002));
@@ -3666,8 +3666,8 @@ public:
         auto const CNY = gw["CNY"];
 
         auto const fee = env.current ()->fees ().base;
-        env.fund (reserve(env, 2) + drops (400000000000) + (fee), alice, bob);
-        env.fund (reserve(env, 2) + (fee*4), gw);
+        env.fund (reserve(env, 2) + drops (400000000000 + fee), alice, bob);
+        env.fund (reserve(env, 2) + drops(fee*4), gw);
         env.close();
 
         env (trust(bob, CNY(500)));
@@ -3716,8 +3716,8 @@ public:
         auto const JPY = gw["JPY"];
 
         auto const fee = env.current ()->fees ().base;
-        env.fund (reserve(env, 2) + drops (400000000000) + (fee), alice, bob);
-        env.fund (reserve(env, 2) + (fee*4), gw);
+        env.fund (reserve(env, 2) + drops (400000000000 + fee), alice, bob);
+        env.fund (reserve(env, 2) + drops(fee*4), gw);
         env.close();
 
         env (rate(gw, 1.002));
@@ -3771,8 +3771,8 @@ public:
         auto const JPY = gw2["JPY"];
 
         auto const fee = env.current ()->fees ().base;
-        env.fund (reserve(env, 2) + drops (400000000000) + (fee), alice, bob);
-        env.fund (reserve(env, 2) + (fee*4), gw1, gw2);
+        env.fund (reserve(env, 2) + drops (400000000000 + fee), alice, bob);
+        env.fund (reserve(env, 2) + drops(fee*4), gw1, gw2);
         env.close();
 
         env (rate(gw1, 1.002));
@@ -3827,7 +3827,7 @@ public:
         auto const bob = Account("bob");
         auto const CNY = gw["CNY"];
         auto const fee = env.current()->fees().base;
-        auto const startXrpBalance = drops (400000000000) + (fee * 2);
+        auto const startXrpBalance = drops (400000000000 + fee * 2);
 
         env.fund (startXrpBalance, gw, alice, bob);
         env.close();
@@ -3854,9 +3854,9 @@ public:
         env.close();
 
         env.require (balance (alice, alicesCnyOffer));
-        env.require (balance (alice, startXrpBalance - fee - drops(1)));
+        env.require (balance (alice, startXrpBalance - drops(fee + 1)));
         env.require (balance (bob, bobsCnyStartBalance - alicesCnyOffer));
-        env.require (balance (bob, startXrpBalance - (fee * 2) + drops(1)));
+        env.require (balance (bob, startXrpBalance - drops((fee * 2) - 1)));
     }
 
     void testSelfPayXferFeeOffer (FeatureBitset features)

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -189,7 +189,7 @@ struct PayChan_test : public beast::unit_test::suite
         {
             auto const preAlice = env.balance (alice);
             env (fund (alice, chan, XRP (1000)));
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             BEAST_EXPECT (env.balance (alice) == preAlice - XRP (1000) - feeDrops);
         }
 
@@ -268,7 +268,7 @@ struct PayChan_test : public beast::unit_test::suite
             env (claim (bob, chan, reqBal, authAmt, Slice (sig), alice.pk ()));
             BEAST_EXPECT (channelBalance (*env.current (), chan) == reqBal);
             BEAST_EXPECT (channelAmount (*env.current (), chan) == chanAmt);
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             BEAST_EXPECT (env.balance (bob) == preBob + delta - feeDrops);
             chanBal = reqBal;
 
@@ -326,7 +326,7 @@ struct PayChan_test : public beast::unit_test::suite
             auto const preBob = env.balance (bob);
             env (claim (bob, chan), txflags (tfClose));
             BEAST_EXPECT (!channelExists (*env.current (), chan));
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             auto const delta = chanAmt - chanBal;
             assert (delta > beast::zero);
             BEAST_EXPECT (env.balance (alice) == preAlice + delta);
@@ -376,7 +376,7 @@ struct PayChan_test : public beast::unit_test::suite
                     signClaimAuth (alice.pk (), alice.sk (), chan, authAmt);
                 env (claim (
                     bob, chan, reqBal, authAmt, Slice (sig), alice.pk ()));
-                auto const feeDrops = env.current ()->fees ().base;
+                auto const feeDrops = drops(env.current ()->fees ().base);
                 BEAST_EXPECT (!channelExists (*env.current (), chan));
                 BEAST_EXPECT (env.balance (bob) == preBob - feeDrops);
                 BEAST_EXPECT (env.balance (alice) == preAlice + channelFunds);
@@ -505,7 +505,7 @@ struct PayChan_test : public beast::unit_test::suite
             env (claim (bob, chan, reqBal, authAmt, Slice (sig), alice.pk ()));
             BEAST_EXPECT (channelBalance (*env.current (), chan) == reqBal);
             BEAST_EXPECT (channelAmount (*env.current (), chan) == chanAmt);
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             BEAST_EXPECT (env.balance (bob) == preBob + delta - feeDrops);
         }
         env.close (settleTimepoint);
@@ -523,7 +523,7 @@ struct PayChan_test : public beast::unit_test::suite
                 signClaimAuth (alice.pk (), alice.sk (), chan, authAmt);
             env (claim (bob, chan, reqBal, authAmt, Slice (sig), alice.pk ()));
             BEAST_EXPECT (!channelExists (*env.current (), chan));
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             BEAST_EXPECT (env.balance (alice) == preAlice + chanAmt - chanBal);
             BEAST_EXPECT (env.balance (bob) == preBob - feeDrops);
         }
@@ -560,7 +560,7 @@ struct PayChan_test : public beast::unit_test::suite
         // Channel is now dry, can close before expiration date
         env (claim (alice, chan), txflags (tfClose));
         BEAST_EXPECT (!channelExists (*env.current (), chan));
-        auto const feeDrops = env.current ()->fees ().base;
+        auto const feeDrops = drops(env.current ()->fees ().base);
         BEAST_EXPECT (env.balance (alice) == preAlice - feeDrops);
     }
 
@@ -597,7 +597,7 @@ struct PayChan_test : public beast::unit_test::suite
             env (claim (
                 bob, chan, reqBal, boost::none, Slice (sig), alice.pk ()));
             BEAST_EXPECT (channelBalance (*env.current (), chan) == reqBal);
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             BEAST_EXPECT (env.balance (bob) == preBob + delta - feeDrops);
             chanBal = reqBal;
         }
@@ -615,7 +615,7 @@ struct PayChan_test : public beast::unit_test::suite
             env (claim (
                 bob, chan, reqBal, boost::none, Slice (sig), alice.pk ()));
             BEAST_EXPECT (channelBalance (*env.current (), chan) == reqBal);
-            auto const feeDrops = env.current ()->fees ().base;
+            auto const feeDrops = drops(env.current ()->fees ().base);
             BEAST_EXPECT (env.balance (bob) == preBob + delta - feeDrops);
             chanBal = reqBal;
         }
@@ -768,7 +768,8 @@ struct PayChan_test : public beast::unit_test::suite
                 // transaction.
                 env (claim (bob, chan, delta, delta, Slice (sig), pk));
                 env.close();
-                BEAST_EXPECT (env.balance (bob) == preBob + delta - baseFee);
+                BEAST_EXPECT (env.balance (bob) == preBob + delta -
+                    drops(baseFee));
             }
             {
                 // Explore the limits of deposit preauthorization.
@@ -804,7 +805,7 @@ struct PayChan_test : public beast::unit_test::suite
                 env.close();
 
                 BEAST_EXPECT (
-                    env.balance (bob) == preBob + delta - (3 * baseFee));
+                    env.balance (bob) == preBob + delta - drops(3 * baseFee));
             }
             {
                 // bob removes preauthorization of alice.  Once again she
@@ -825,8 +826,8 @@ struct PayChan_test : public beast::unit_test::suite
                 // alice claims successfully.
                 env (claim (alice, chan, delta, delta));
                 env.close();
-                BEAST_EXPECT (
-                    env.balance (bob) == preBob + XRP (800) - (5 * baseFee));
+                BEAST_EXPECT (env.balance (bob) ==
+                    preBob + XRP (800) - drops(5 * baseFee));
             }
         }
     }

--- a/src/test/basics/tagged_integer_test.cpp
+++ b/src/test/basics/tagged_integer_test.cpp
@@ -52,17 +52,17 @@ private:
         "TagUInt3 should be constructible using a std::uint64_t");
 
     // Check assignment of tagged_integers
-    static_assert (!std::is_assignable<TagUInt1, std::uint32_t>::value,
-        "TagUInt1 should not be assignable with a std::uint32_t");
+    static_assert (std::is_assignable<TagUInt1, std::uint32_t>::value,
+        "TagUInt1 should be assignable with a std::uint32_t");
 
     static_assert (!std::is_assignable<TagUInt1, std::uint64_t>::value,
         "TagUInt1 should not be assignable with a std::uint64_t");
 
-    static_assert (!std::is_assignable<TagUInt3, std::uint32_t>::value,
-        "TagUInt3 should not be assignable with a std::uint32_t");
+    static_assert (std::is_assignable<TagUInt3, std::uint32_t>::value,
+        "TagUInt3 should be assignable with a std::uint32_t");
 
-    static_assert (!std::is_assignable<TagUInt3, std::uint64_t>::value,
-        "TagUInt3 should not be assignable with a std::uint64_t");
+    static_assert (std::is_assignable<TagUInt3, std::uint64_t>::value,
+        "TagUInt3 should be assignable with a std::uint64_t");
 
     static_assert (std::is_assignable<TagUInt1, TagUInt1>::value,
         "TagUInt1 should be assignable with a TagUInt1");
@@ -76,8 +76,8 @@ private:
     static_assert (!std::is_assignable<TagUInt1, TagUInt3>::value,
         "TagUInt1 should not be assignable with a TagUInt3");
 
-    static_assert (!std::is_assignable<TagUInt3, TagUInt1>::value,
-        "TagUInt3 should not be assignable with a TagUInt1");
+    static_assert (std::is_assignable<TagUInt3, TagUInt1>::value,
+        "TagUInt3 should be assignable with a TagUInt1");
 
     // Check convertibility of tagged_integers
     static_assert (!std::is_convertible<std::uint32_t, TagUInt1>::value,
@@ -95,8 +95,8 @@ private:
     static_assert (!std::is_convertible<TagUInt1, TagUInt2>::value,
         "TagUInt1 should not be convertible to TagUInt2");
 
-    static_assert (!std::is_convertible<TagUInt1, TagUInt3>::value,
-        "TagUInt1 should not be convertible to TagUInt3");
+    static_assert (std::is_convertible<TagUInt1, TagUInt3>::value,
+        "TagUInt1 should be convertible to TagUInt3");
 
     static_assert (!std::is_convertible<TagUInt2, TagUInt3>::value,
         "TagUInt2 should not be convertible to a TagUInt3");

--- a/src/test/jtx/impl/utility.cpp
+++ b/src/test/jtx/impl/utility.cpp
@@ -62,7 +62,7 @@ fill_fee (Json::Value& jv,
 {
     if (jv.isMember(jss::Fee))
         return;
-    jv[jss::Fee] = std::to_string(
+    jv[jss::Fee] = to_string(
         view.fees().base);
 }
 

--- a/src/test/ledger/Invariants_test.cpp
+++ b/src/test/ledger/Invariants_test.cpp
@@ -94,7 +94,7 @@ class Invariants_test : public beast::unit_test::suite
             ov,
             tx,
             tesSUCCESS,
-            env.current()->fees().base,
+            env.current()->fees().units,
             tapNONE,
             jlog
         };
@@ -308,9 +308,9 @@ class Invariants_test : public beast::unit_test::suite
 
         doInvariantCheck (enabled,
             {{ "fee paid exceeds system limit: "s +
-                std::to_string(SYSTEM_CURRENCY_START) },
+                to_string(SYSTEM_CURRENCY_START) },
              { "XRP net change of 0 doesn't match fee "s +
-                std::to_string(SYSTEM_CURRENCY_START) }},
+                to_string(SYSTEM_CURRENCY_START) }},
             [](Account const&, Account const&, ApplyContext&) { return true; },
             XRPAmount{SYSTEM_CURRENCY_START});
 

--- a/src/test/rpc/AmendmentBlocked_test.cpp
+++ b/src/test/rpc/AmendmentBlocked_test.cpp
@@ -90,7 +90,7 @@ class AmendmentBlocked_test : public beast::unit_test::suite
         set_tx[jss::Account] = bob.human();
         set_tx[jss::TransactionType] = "AccountSet";
         set_tx[jss::Fee] =
-            static_cast<uint32_t>(8 * env.current()->fees().base);
+            Json::toUInt(8 * env.current()->fees().base);
         set_tx[jss::Sequence] = env.seq(bob);
         set_tx[jss::SigningPubKey] = "";
 

--- a/src/test/rpc/NoRippleCheck_test.cpp
+++ b/src/test/rpc/NoRippleCheck_test.cpp
@@ -288,16 +288,23 @@ class NoRippleCheckLimits_test : public beast::unit_test::suite
             auto& txq = env.app().getTxQ();
             auto const gw = Account {"gw" + std::to_string(i)};
             env.memoize(gw);
+            auto const& baseFee = env.current()->fees().base;
             env (pay (env.master, gw, XRP(1000)),
                 seq (autofill),
-                fee (txq.getMetrics(*env.current()).openLedgerFeeLevel + 1),
+                fee (toDrops(
+                    txq.getMetrics(*env.current()).openLedgerFeeLevel,
+                    baseFee).second + 1),
                 sig (autofill));
             env (fset (gw, asfDefaultRipple),
                 seq (autofill),
-                fee (txq.getMetrics(*env.current()).openLedgerFeeLevel + 1),
+                fee (toDrops(
+                    txq.getMetrics(*env.current()).openLedgerFeeLevel,
+                    baseFee).second + 1),
                 sig (autofill));
             env (trust (alice, gw["USD"](10)),
-                fee (txq.getMetrics(*env.current()).openLedgerFeeLevel + 1));
+                fee (toDrops(
+                    txq.getMetrics(*env.current()).openLedgerFeeLevel,
+                    baseFee).second + 1));
             env.close();
         }
 


### PR DESCRIPTION
While investigating #2451, I decided to do an audit of all fee calculations. I found a couple where units were not used correctly (eg. treating a drops value as fee units, and applying the conversion again), including those mentioned in the original problem. I figured that rather than fixing problems one at a time only to risk them being reintroduced, I'd convert all usages of fee values into a typed variable rather than a generic `uint32_t` or `uint64_t`.

Implementation notes:
1. I used and greatly expanded the `tagged_integer` template class, which is currently used for some typed values in tests. Surprisingly, it doesn't seem to be used in the main code base. Still, since I made such significant changes, I'm not sure if I should have made a new class or not.
2. I created a new `unsafe_cast` alongside `safe_cast`, because it helped me better visualize some of what was going on.
3. I'm open to feedback on how to organize some of these changes. It feels messy, but I'm not sure how to make it better.

Here is the list of locations that fell out of this work as using the wrong units. Line numbers are approximate since things may have moved around since I started and rebased, but reviewers may want to pay a little extra attention to these files:
* NetworkOps.cpp line 2327 & 2331
* TxQ.cpp line 95 (baseFee) & 672 (baseFee)
* Invariants_test.cpp line 97
* NoRippleCheck_test.cpp line 293, 297, 300
