### PR TITLE
Update to NuDB 2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     # to boost's .tar.gz.
     - LCOV_ROOT=$HOME/lcov
     - GDB_ROOT=$HOME/gdb
-    - BOOST_ROOT=$HOME/boost_1_67_0
-    - BOOST_URL='http://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz'
+    - BOOST_ROOT=$HOME/boost_1_70_0
+    - BOOST_URL='http://sourceforge.net/projects/boost/files/boost/1.70.0/boost_1_70_0.tar.gz'
 
 addons:
   apt:

--- a/Builds/VisualStudio2017/README.md
+++ b/Builds/VisualStudio2017/README.md
@@ -17,7 +17,7 @@ need these software components
 | [Visual Studio 2017](README.md#install-visual-studio-2017)| 15.5.4 |
 | [Git for Windows](README.md#install-git-for-windows)| 2.16.1 |
 | [OpenSSL Library](README.md#install-openssl) | 1.0.2n |
-| [Boost library](README.md#build-boost) | 1.67.0 |
+| [Boost library](README.md#build-boost) | 1.70.0 |
 | [CMake for Windows](README.md#optional-install-cmake-for-windows)* | 3.12 |
 
 \* Only needed if not using the integrated CMake in VS 2017 and prefer generating dedicated project/solution files.
@@ -78,13 +78,13 @@ to get the correct 32-/64-bit variant.
 
 ### Build Boost
 
-Boost 1.67 or later is required.
+Boost 1.70 or later is required.
 
 After [downloading boost](http://www.boost.org/users/download/) and unpacking it
-to `c:\lib`. As of this writing, the most recent version of boost is 1.68.0,
-which will unpack into a directory named `boost_1_68_0`. We recommended either
+to `c:\lib`. As of this writing, the most recent version of boost is 1.70.0,
+which will unpack into a directory named `boost_1_70_0`. We recommended either
 renaming this directory to `boost`, or creating a junction link `mklink /J boost
-boost_1_68_0`, so that you can more easily switch between versions.
+boost_1_70_0`, so that you can more easily switch between versions.
 
 Next, open **Developer Command Prompt** and type the following commands
 
@@ -214,7 +214,7 @@ execute the following commands within your `rippled` cloned repository:
 ```
 mkdir build\cmake
 cd build\cmake
-cmake ..\.. -G"Visual Studio 15 2017 Win64" -DBOOST_ROOT="C:\lib\boost_1_68_0" -DOPENSSL_ROOT="C:\lib\OpenSSL-Win64"
+cmake ..\.. -G"Visual Studio 15 2017 Win64" -DBOOST_ROOT="C:\lib\boost_1_70_0" -DOPENSSL_ROOT="C:\lib\OpenSSL-Win64"
 ```
 Now launch Visual Studio 2017 and select **File | Open | Project/Solution**.
 Navigate to the `build\cmake` folder created above and select the `rippled.sln`

--- a/Builds/linux/README.md
+++ b/Builds/linux/README.md
@@ -25,14 +25,14 @@ protobuf will give errors.
 
 ### Build Boost
 
-Boost 1.67 or later is required. We recommend downloading and compiling boost
+Boost 1.70 or later is required. We recommend downloading and compiling boost
 with the following process: After changing to the directory where
 you wish to download and compile boost, run
 
 ``` 
-$ wget https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz
-$ tar -xzf boost_1_68_0.tar.gz
-$ cd boost_1_68_0
+$ wget https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.gz
+$ tar -xzf boost_1_70_0.tar.gz
+$ cd boost_1_70_0
 $ ./bootstrap.sh
 $ ./b2 headers
 $ ./b2 -j<Num Parallel>
@@ -81,14 +81,14 @@ git checkout develop
 If you didn't persistently set the `BOOST_ROOT` environment variable to the
 directory in which you compiled boost, then you should set it temporarily.
 
-For example, you built Boost in your home directory `~/boost_1_68_0`, you
+For example, you built Boost in your home directory `~/boost_1_70_0`, you
 would do for any shell in which you want to build:
 
 ```
-export BOOST_ROOT=~/boost_1_68_0
+export BOOST_ROOT=~/boost_1_70_0
 ```
 
-Alternatively, you can add `DBOOST_ROOT=~/boost_1_68_0` to the command line when
+Alternatively, you can add `DBOOST_ROOT=~/boost_1_70_0` to the command line when
 invoking `cmake`.
 
 ### Generate and Build

--- a/Builds/macos/README.md
+++ b/Builds/macos/README.md
@@ -60,11 +60,11 @@ brew install git cmake pkg-config protobuf openssl ninja
 
 ### Build Boost
 
-Boost 1.67 or later is required.
+Boost 1.70 or later is required.
 
 We want to compile boost with clang/libc++
 
-Download [a release](https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2)
+Download [a release](https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2)
 
 Extract it to a folder, making note of where, open a terminal, then:
 
@@ -120,11 +120,11 @@ If you didn't persistently set the `BOOST_ROOT` environment variable to the
 root of the extracted directory above, then you should set it temporarily.
 
 For example, assuming your username were `Abigail` and you extracted Boost
-1.68.0 in `/Users/Abigail/Downloads/boost_1_68_0`, you would do for any
+1.70.0 in `/Users/Abigail/Downloads/boost_1_70_0`, you would do for any
 shell in which you want to build:
 
 ```
-export BOOST_ROOT=/Users/Abigail/Downloads/boost_1_68_0
+export BOOST_ROOT=/Users/Abigail/Downloads/boost_1_70_0
 ```
 
 ### Generate and Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ if (static AND NOT APPLE)
 else ()
   set (Boost_USE_STATIC_RUNTIME OFF)
 endif ()
-find_package (Boost 1.67 REQUIRED
+find_package (Boost 1.70 REQUIRED
   COMPONENTS
     chrono
     context
@@ -748,15 +748,6 @@ target_link_libraries (ripple_boost
     Boost::serialization
     Boost::system
     Boost::thread)
-
-# workaround for xcode 10.2 and boost < 1.69
-# once we require Boost 1.69 or higher, this can be removed
-# see:  https://github.com/boostorg/asio/commit/43874d5
-if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0.1.10010043 AND
-    Boost_VERSION LESS 106900)
-  target_compile_definitions (opts INTERFACE BOOST_ASIO_HAS_STD_STRING_VIEW)
-endif ()
 
 #[===================================================================[
    NIH dep: openssl
@@ -1419,8 +1410,8 @@ if (is_root_project) # NuDB not needed in the case of xrpl_core inclusion build
   if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.11)
     FetchContent_Declare(
       nudb_src
-      GIT_REPOSITORY https://github.com/vinniefalco/NuDB.git
-      GIT_TAG        1.0.0
+      GIT_REPOSITORY https://github.com/CPPAlliance/NuDB.git
+      GIT_TAG        2.0.1
     )
     FetchContent_GetProperties(nudb_src)
     if(NOT nudb_src_POPULATED)
@@ -1430,8 +1421,8 @@ if (is_root_project) # NuDB not needed in the case of xrpl_core inclusion build
   else ()
     ExternalProject_Add (nudb_src
       PREFIX ${nih_cache_path}
-      GIT_REPOSITORY https://github.com/vinniefalco/NuDB.git
-      GIT_TAG 1.0.0
+      GIT_REPOSITORY https://github.com/CPPAlliance/NuDB.git
+      GIT_TAG 2.0.1
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
       TEST_COMMAND ""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,7 +202,7 @@ try {
                         "NIH_CACHE_ROOT=${cdir}/.nih_c"])
                     if (compiler == 'msvc') {
                         env_vars.addAll([
-                            'BOOST_ROOT=c:\\lib\\boost_1_67',
+                            'BOOST_ROOT=c:\\lib\\boost_1_70',
                             'PROJECT_NAME=rippled',
                             'MSBUILDDISABLENODEREUSE=1',  // this ENV setting is probably redundant since we also pass /nr:false to msbuild
                             'OPENSSL_ROOT=c:\\OpenSSL-Win64'])
@@ -219,7 +219,7 @@ try {
                             'LCOV_ROOT=""',
                             'PATH+CMAKE_BIN=/opt/local/cmake',
                             'GDB_ROOT=/opt/local/gdb',
-                            'BOOST_ROOT=/opt/local/boost_1_67_0',
+                            'BOOST_ROOT=/opt/local/boost_1_70_0',
                             "USE_CCACHE=${ucc}"])
                     }
 

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -868,18 +868,10 @@
 #       ...
 #
 #   Example:
-#       type=nudb
 #       path=db/shards/nudb
 #
-#   The "type" field must be present and controls the choice of backend:
-#
-#   type = NuDB
-#       NuDB is recommended for shards.
-#
-#   type = RocksDB
-#
 #   Required keys:
-#       path                Location to store the database (all types)
+#       path                Location to store the database
 #
 #       max_size_gb         Maximum disk space the database will utilize (in gigabytes)
 #
@@ -1193,7 +1185,6 @@ advisory_delete=0
 # NuDB requires SSD storage. Helpful information can be found here
 # https://ripple.com/build/history-sharding
 #[shard_db]
-#type=NuDB
 #path=/var/lib/rippled/db/shards/nudb
 #max_size_gb=500
 

--- a/src/ripple/nodestore/Backend.h
+++ b/src/ripple/nodestore/Backend.h
@@ -109,11 +109,18 @@ public:
     /** Remove contents on disk upon destruction. */
     virtual void setDeletePath() = 0;
 
-    /** Perform consistency checks on database .*/
+    /** Perform consistency checks on database. */
     virtual void verify() = 0;
 
-    /** Returns the number of file handles the backend expects to need */
+    /** Returns the number of file handles the backend expects to need. */
     virtual int fdlimit() const = 0;
+
+    /** Returns true if the backend uses permanent storage. */
+    bool
+    backed() const
+    {
+        return fdlimit();
+    }
 };
 
 }

--- a/src/ripple/nodestore/Factory.h
+++ b/src/ripple/nodestore/Factory.h
@@ -23,6 +23,7 @@
 #include <ripple/nodestore/Backend.h>
 #include <ripple/nodestore/Scheduler.h>
 #include <ripple/beast/utility/Journal.h>
+#include <nudb/store.hpp>
 
 namespace ripple {
 namespace NodeStore {
@@ -42,14 +43,37 @@ public:
     /** Create an instance of this factory's backend.
 
         @param keyBytes The fixed number of bytes per key.
-        @param keyValues A set of key/value configuration pairs.
+        @param parameters A set of key/value configuration pairs.
         @param scheduler The scheduler to use for running tasks.
         @return A pointer to the Backend object.
     */
     virtual
     std::unique_ptr <Backend>
-    createInstance (size_t keyBytes, Section const& parameters,
-        Scheduler& scheduler, beast::Journal journal) = 0;
+    createInstance (
+        size_t keyBytes,
+        Section const& parameters,
+        Scheduler& scheduler,
+        beast::Journal journal) = 0;
+
+    /** Create an instance of this factory's backend.
+
+        @param keyBytes The fixed number of bytes per key.
+        @param parameters A set of key/value configuration pairs.
+        @param scheduler The scheduler to use for running tasks.
+        @param context The context used by database.
+        @return A pointer to the Backend object.
+    */
+    virtual
+    std::unique_ptr <Backend>
+    createInstance (
+        size_t keyBytes,
+        Section const& parameters,
+        Scheduler& scheduler,
+        nudb::context& context,
+        beast::Journal journal)
+    {
+        return {};
+    }
 };
 
 }

--- a/src/ripple/nodestore/impl/DatabaseShardImp.h
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.h
@@ -31,11 +31,18 @@ class DatabaseShardImp : public DatabaseShard
 public:
     DatabaseShardImp() = delete;
     DatabaseShardImp(DatabaseShardImp const&) = delete;
+    DatabaseShardImp(DatabaseShardImp&&) = delete;
     DatabaseShardImp& operator=(DatabaseShardImp const&) = delete;
+    DatabaseShardImp& operator=(DatabaseShardImp&&) = delete;
 
-    DatabaseShardImp(Application& app, std::string const& name,
-        Stoppable& parent, Scheduler& scheduler, int readThreads,
-            Section const& config, beast::Journal j);
+    DatabaseShardImp(
+        Application& app,
+        std::string const& name,
+        Stoppable& parent,
+        Scheduler& scheduler,
+        int readThreads,
+        Section const& config,
+        beast::Journal j);
 
     ~DatabaseShardImp() override;
 
@@ -160,6 +167,9 @@ private:
     Application& app_;
     mutable std::mutex m_;
     bool init_ {false};
+
+    // The context shared with all shard backend databases
+    std::unique_ptr<nudb::context> ctx_;
 
     // Complete shards
     std::map<std::uint32_t, std::unique_ptr<Shard>> complete_;

--- a/src/ripple/nodestore/impl/Shard.h
+++ b/src/ripple/nodestore/impl/Shard.h
@@ -26,6 +26,7 @@
 #include <ripple/nodestore/NodeObject.h>
 #include <ripple/nodestore/Scheduler.h>
 
+#include <nudb/nudb.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/archive/text_oarchive.hpp>
@@ -69,7 +70,7 @@ public:
         std::chrono::seconds cacheAge, beast::Journal& j);
 
     bool
-    open(Section config, Scheduler& scheduler);
+    open(Section config, Scheduler& scheduler, nudb::context& ctx);
 
     bool
     setStored(std::shared_ptr<Ledger const> const& l);


### PR DESCRIPTION
This PR implements new functionality in NuDB introduced here: [NuDB 2.0](https://github.com/CPPAlliance/NuDB/pull/68)

The new context object in NuDB 2.0, allows one or more database instances to share a pool of threads. This feature is especially helpful to Rippled in reducing processing overhead on servers that have many shards. This version of NuDB requires Boost 1.69 which is unfortunately broken on MacOS. I expect the PR approval to be delayed until that matter is resolved but can be tested on other platforms in the meantime.

It is important to note that with these changes, NuDB will be the only permanent storage backend supported for shards. RocksDB will no longer be supported. The `type` field in the `shard_db` is no longer required.

Because of MacOS, this PR depends on [PR2905](https://github.com/ripple/rippled/pull/2905).