### PR TITLE
test pr please ignore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,10 @@
     - bin/ci/build.sh
     - bin/ci/test.sh
   cache:
-    # Generate a new UUID whenever you want to bust the cache, e.g. when the
+    # Use a different key for each unique combination of (generator, compiler,
+    # build type). Caches are stored as `.zip` files; they are not merged.
+    # Generate a new key whenever you want to bust the cache, e.g. when the
     # dependency versions have been bumped.
-    key: 910f11a6-8869-4ee4-9681-905f21b14b0c
     # By default, jobs pull the cache. Only a few specially chosen jobs update
     # the cache (with policy `pull-push`); one for each unique combination of
     # (generator, compiler, build type).
@@ -38,6 +39,7 @@
     COMPILER: gcc
     BUILD_TYPE: Debug
   cache:
+    key: ae412fb0-5fc8-4fd5-8e48-e3a60e91ed46
     policy: pull-push
 
 'build+test Ninja GCC Debug':
@@ -47,6 +49,7 @@
     COMPILER: gcc
     BUILD_TYPE: Debug
   cache:
+    key: 3a314872-4faa-4712-b8ab-a8d54ac83342
     policy: pull-push
 
 'build+test Ninja GCC Debug -Dstatic=OFF':
@@ -56,6 +59,8 @@
     COMPILER: gcc
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dstatic=OFF'
+  cache:
+    key: 3a314872-4faa-4712-b8ab-a8d54ac83342
 
 'build+test Ninja GCC Debug -Dstatic=OFF -DBUILD_SHARED_LIBS=ON':
   extends: .job_linux_build_test
@@ -64,6 +69,8 @@
     COMPILER: gcc
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dstatic=OFF -DBUILD_SHARED_LIBS=ON'
+  cache:
+    key: 3a314872-4faa-4712-b8ab-a8d54ac83342
 
 'build+test Ninja GCC Debug -Dunity=OFF':
   extends: .job_linux_build_test
@@ -72,6 +79,8 @@
     COMPILER: gcc
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF'
+  cache:
+    key: 3a314872-4faa-4712-b8ab-a8d54ac83342
 
 'build+test Ninja GCC Release -Dassert=ON':
   extends: .job_linux_build_test
@@ -81,6 +90,7 @@
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
   cache:
+    key: ac5e7a8a-bfcb-4480-a3cc-07d0336f4408
     policy: pull-push
 
 'build+test(manual) Ninja GCC Release -Dassert=ON':
@@ -91,6 +101,8 @@
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
     MANUAL_TEST: 'true'
+  cache:
+    key: ac5e7a8a-bfcb-4480-a3cc-07d0336f4408
 
 'build+test Make clang Debug':
   extends: .job_linux_build_test
@@ -99,6 +111,7 @@
     COMPILER: clang
     BUILD_TYPE: Debug
   cache:
+    key: 09cec2ce-83f5-4ce9-8a3b-23737edefd4f
     policy: pull-push
 
 'build+test Ninja clang Debug':
@@ -108,6 +121,7 @@
     COMPILER: clang
     BUILD_TYPE: Debug
   cache:
+    key: c6e29541-e539-4d57-86c5-57d923521f35
     policy: pull-push
 
 'build+test Ninja clang Debug -Dunity=OFF':
@@ -117,6 +131,8 @@
     COMPILER: clang
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF'
+  cache:
+    key: c6e29541-e539-4d57-86c5-57d923521f35
 
 'build+test Ninja clang Debug -Dunity=OFF -Dsan=address':
   extends: .job_linux_build_test
@@ -126,6 +142,8 @@
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF -Dsan=address'
     CONCURRENT_TESTS: 1
+  cache:
+    key: c6e29541-e539-4d57-86c5-57d923521f35
 
 'build+test Ninja clang Debug -Dunity=OFF -Dsan=undefined':
   extends: .job_linux_build_test
@@ -134,6 +152,8 @@
     COMPILER: clang
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF -Dsan=undefined'
+  cache:
+    key: c6e29541-e539-4d57-86c5-57d923521f35
 
 'build+test Ninja clang Release -Dassert=ON':
   extends: .job_linux_build_test
@@ -143,4 +163,5 @@
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
   cache:
+    key: 2e48f4d8-e0d7-4aa9-b646-499cef6c1a87
     policy: pull-push

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,17 @@
 # 3. Build type (Debug, Release)
 # 4. Definitions (-Dunity=OFF, -Dassert=ON, ...)
 
+cache:
+  # Generate a new UUID whenever you want to bust the cache, e.g. when the
+  # dependency versions have been bumped.
+  key: 910f11a6-8869-4ee4-9681-905f21b14b0c
+  # By default, jobs pull the cache. Only a few specially chosen jobs update
+  # the cache (with policy `pull-push`); one for each unique combination of
+  # (generator, compiler, build type).
+  policy: pull
+  paths:
+    - .nih_c/
+
 .jog_linux_build_test: &job_linux_build_test
   stage: build
   tags:
@@ -27,6 +38,8 @@
     GENERATOR: Unix Makefiles
     COMPILER: gcc
     BUILD_TYPE: Debug
+  cache:
+    policy: pull-push
 
 'build+test Ninja GCC Debug':
   <<: *job_linux_build_test
@@ -34,6 +47,8 @@
     GENERATOR: Ninja
     COMPILER: gcc
     BUILD_TYPE: Debug
+  cache:
+    policy: pull-push
 
 'build+test Make GCC Debug -Dstatic=OFF':
   <<: *job_linux_build_test
@@ -66,6 +81,8 @@
     COMPILER: gcc
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
+  cache:
+    policy: pull-push
 
 'build+test(manual) Make GCC Release -Dassert=ON':
   <<: *job_linux_build_test
@@ -82,6 +99,8 @@
     GENERATOR: Unix Makefiles
     COMPILER: clang
     BUILD_TYPE: Debug
+  cache:
+    policy: pull-push
 
 'build+test Make clang Debug -Dunity=OFF':
   <<: *job_linux_build_test
@@ -115,3 +134,5 @@
     COMPILER: clang
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
+  cache:
+    policy: pull-push

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 # I don't know what the minimum size is, but we cannot build on t3.micro.
 
 # TODO: Factor common builds between different tests.
-# TODO: Prefer Ninja builds because they are faster.
 
 # The parameters for our job matrix:
 #
@@ -50,44 +49,44 @@ cache:
   cache:
     policy: pull-push
 
-'build+test Make GCC Debug -Dstatic=OFF':
+'build+test Ninja GCC Debug -Dstatic=OFF':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: gcc
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dstatic=OFF'
 
-'build+test Make GCC Debug -Dstatic=OFF -DBUILD_SHARED_LIBS=ON':
+'build+test Ninja GCC Debug -Dstatic=OFF -DBUILD_SHARED_LIBS=ON':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: gcc
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dstatic=OFF -DBUILD_SHARED_LIBS=ON'
 
-'build+test Make GCC Debug -Dunity=OFF':
+'build+test Ninja GCC Debug -Dunity=OFF':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: gcc
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF'
 
-'build+test Make GCC Release -Dassert=ON':
+'build+test Ninja GCC Release -Dassert=ON':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: gcc
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
   cache:
     policy: pull-push
 
-'build+test(manual) Make GCC Release -Dassert=ON':
+'build+test(manual) Ninja GCC Release -Dassert=ON':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: gcc
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'
@@ -102,35 +101,44 @@ cache:
   cache:
     policy: pull-push
 
-'build+test Make clang Debug -Dunity=OFF':
+'build+test Ninja clang Debug':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
+    COMPILER: clang
+    BUILD_TYPE: Debug
+  cache:
+    policy: pull-push
+
+'build+test Ninja clang Debug -Dunity=OFF':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Ninja
     COMPILER: clang
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF'
 
-'build+test Make clang Debug -Dunity=OFF -Dsan=address':
+'build+test Ninja clang Debug -Dunity=OFF -Dsan=address':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: clang
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF -Dsan=address'
     CONCURRENT_TESTS: 1
 
-'build+test Make clang Debug -Dunity=OFF -Dsan=undefined':
+'build+test Ninja clang Debug -Dunity=OFF -Dsan=undefined':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: clang
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF -Dsan=undefined'
 
-'build+test Make clang Release -Dassert=ON':
+'build+test Ninja clang Release -Dassert=ON':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Unix Makefiles
+    GENERATOR: Ninja
     COMPILER: clang
     BUILD_TYPE: Release
     CMAKE_ARGS: '-Dassert=ON'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,8 @@
 # I don't know what the minimum size is, but we cannot build on t3.micro.
 
+# TODO: Factor common builds between different tests.
+# TODO: Prefer Ninja builds because they are faster.
+
 # The parameters for our job matrix:
 #
 # 1. Generator (Make, Ninja, MSBuild)
@@ -18,41 +21,12 @@
     - bin/ci/build.sh
     - bin/ci/test.sh
 
-'build+test Make GCC Release -Dassert=ON':
-  <<: *job_linux_build_test
-  variables:
-    GENERATOR: Unix Makefiles
-    COMPILER: gcc
-    BUILD_TYPE: Release
-    CMAKE_ARGS: '-Dassert=ON'
-
 'build+test Make GCC Debug':
   <<: *job_linux_build_test
   variables:
     GENERATOR: Unix Makefiles
     COMPILER: gcc
     BUILD_TYPE: Debug
-
-'build+test Make GCC Release':
-  <<: *job_linux_build_test
-  variables:
-    GENERATOR: Unix Makefiles
-    COMPILER: gcc
-    BUILD_TYPE: Release
-
-'build+test Make clang Debug':
-  <<: *job_linux_build_test
-  variables:
-    GENERATOR: Unix Makefiles
-    COMPILER: clang
-    BUILD_TYPE: Debug
-
-'build+test Make clang Release':
-  <<: *job_linux_build_test
-  variables:
-    GENERATOR: Unix Makefiles
-    COMPILER: clang
-    BUILD_TYPE: Release
 
 'build+test Ninja GCC Debug':
   <<: *job_linux_build_test
@@ -61,9 +35,82 @@
     COMPILER: gcc
     BUILD_TYPE: Debug
 
-'build+test Ninja GCC Release':
+'build+test Make GCC Debug -Dstatic=OFF':
   <<: *job_linux_build_test
   variables:
-    GENERATOR: Ninja
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Debug
+    CMAKE_ARGS: '-Dstatic=OFF'
+
+'build+test Make GCC Debug -Dstatic=OFF -DBUILD_SHARED_LIBS=ON':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Debug
+    CMAKE_ARGS: '-Dstatic=OFF -DBUILD_SHARED_LIBS=ON'
+
+'build+test Make GCC Debug -Dunity=OFF':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Debug
+    CMAKE_ARGS: '-Dunity=OFF'
+
+'build+test Make GCC Release -Dassert=ON':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
     COMPILER: gcc
     BUILD_TYPE: Release
+    CMAKE_ARGS: '-Dassert=ON'
+
+'build+test(manual) Make GCC Release -Dassert=ON':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Release
+    CMAKE_ARGS: '-Dassert=ON'
+    MANUAL_TEST: 'true'
+
+'build+test Make clang Debug':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Debug
+
+'build+test Make clang Debug -Dunity=OFF':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Debug
+    CMAKE_ARGS: '-Dunity=OFF'
+
+'build+test Make clang Debug -Dunity=OFF -Dsan=address':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Debug
+    CMAKE_ARGS: '-Dunity=OFF -Dsan=address'
+
+'build+test Make clang Debug -Dunity=OFF -Dsan=undefined':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Debug
+    CMAKE_ARGS: '-Dunity=OFF -Dsan=undefined'
+
+'build+test Make clang Release -Dassert=ON':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Release
+    CMAKE_ARGS: '-Dassert=ON'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,18 +9,8 @@
 # 3. Build type (Debug, Release)
 # 4. Definitions (-Dunity=OFF, -Dassert=ON, ...)
 
-cache:
-  # Generate a new UUID whenever you want to bust the cache, e.g. when the
-  # dependency versions have been bumped.
-  key: 910f11a6-8869-4ee4-9681-905f21b14b0c
-  # By default, jobs pull the cache. Only a few specially chosen jobs update
-  # the cache (with policy `pull-push`); one for each unique combination of
-  # (generator, compiler, build type).
-  policy: pull
-  paths:
-    - .nih_c/
 
-.jog_linux_build_test: &job_linux_build_test
+.job_linux_build_test:
   stage: build
   tags:
     - jfreeman
@@ -30,9 +20,19 @@ cache:
   script:
     - bin/ci/build.sh
     - bin/ci/test.sh
+  cache:
+    # Generate a new UUID whenever you want to bust the cache, e.g. when the
+    # dependency versions have been bumped.
+    key: 910f11a6-8869-4ee4-9681-905f21b14b0c
+    # By default, jobs pull the cache. Only a few specially chosen jobs update
+    # the cache (with policy `pull-push`); one for each unique combination of
+    # (generator, compiler, build type).
+    policy: pull
+    paths:
+      - .nih_c/
 
 'build+test Make GCC Debug':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Unix Makefiles
     COMPILER: gcc
@@ -41,7 +41,7 @@ cache:
     policy: pull-push
 
 'build+test Ninja GCC Debug':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: gcc
@@ -50,7 +50,7 @@ cache:
     policy: pull-push
 
 'build+test Ninja GCC Debug -Dstatic=OFF':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: gcc
@@ -58,7 +58,7 @@ cache:
     CMAKE_ARGS: '-Dstatic=OFF'
 
 'build+test Ninja GCC Debug -Dstatic=OFF -DBUILD_SHARED_LIBS=ON':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: gcc
@@ -66,7 +66,7 @@ cache:
     CMAKE_ARGS: '-Dstatic=OFF -DBUILD_SHARED_LIBS=ON'
 
 'build+test Ninja GCC Debug -Dunity=OFF':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: gcc
@@ -74,7 +74,7 @@ cache:
     CMAKE_ARGS: '-Dunity=OFF'
 
 'build+test Ninja GCC Release -Dassert=ON':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: gcc
@@ -84,7 +84,7 @@ cache:
     policy: pull-push
 
 'build+test(manual) Ninja GCC Release -Dassert=ON':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: gcc
@@ -93,7 +93,7 @@ cache:
     MANUAL_TEST: 'true'
 
 'build+test Make clang Debug':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Unix Makefiles
     COMPILER: clang
@@ -102,7 +102,7 @@ cache:
     policy: pull-push
 
 'build+test Ninja clang Debug':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: clang
@@ -111,7 +111,7 @@ cache:
     policy: pull-push
 
 'build+test Ninja clang Debug -Dunity=OFF':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: clang
@@ -119,7 +119,7 @@ cache:
     CMAKE_ARGS: '-Dunity=OFF'
 
 'build+test Ninja clang Debug -Dunity=OFF -Dsan=address':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: clang
@@ -128,7 +128,7 @@ cache:
     CONCURRENT_TESTS: 1
 
 'build+test Ninja clang Debug -Dunity=OFF -Dsan=undefined':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: clang
@@ -136,7 +136,7 @@ cache:
     CMAKE_ARGS: '-Dunity=OFF -Dsan=undefined'
 
 'build+test Ninja clang Release -Dassert=ON':
-  <<: *job_linux_build_test
+  extends: .job_linux_build_test
   variables:
     GENERATOR: Ninja
     COMPILER: clang

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@
   tags:
     - linux
     - c5.2xlarge
-  image: thejohnfreeman/rippled-build-ubuntu:develop
+  image: thejohnfreeman/rippled-build-ubuntu:1bc7230e5b97
   script:
     - bin/ci/build.sh
     - bin/ci/test.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,9 +11,11 @@
 
 
 .job_linux_build_test:
+  only:
+    variables:
+      - $CI_PROJECT_URL =~ /^https?:\/\/gitlab.com\//
   stage: build
   tags:
-    - jfreeman
     - linux
     - c5.2xlarge
   image: thejohnfreeman/rippled-build-ubuntu:develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,6 +98,7 @@
     COMPILER: clang
     BUILD_TYPE: Debug
     CMAKE_ARGS: '-Dunity=OFF -Dsan=address'
+    CONCURRENT_TESTS: 1
 
 'build+test Make clang Debug -Dunity=OFF -Dsan=undefined':
   <<: *job_linux_build_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,69 @@
+# I don't know what the minimum size is, but we cannot build on t3.micro.
+
+# The parameters for our job matrix:
+#
+# 1. Generator (Make, Ninja, MSBuild)
+# 2. Compiler (GCC, Clang, MSVC)
+# 3. Build type (Debug, Release)
+# 4. Definitions (-Dunity=OFF, -Dassert=ON, ...)
+
+.jog_linux_build_test: &job_linux_build_test
+  stage: build
+  tags:
+    - jfreeman
+    - linux
+    - c5.2xlarge
+  image: thejohnfreeman/rippled-build-ubuntu:develop
+  script:
+    - bin/ci/build.sh
+    - bin/ci/test.sh
+
+'build+test Make GCC Release -Dassert=ON':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Release
+    CMAKE_ARGS: '-Dassert=ON'
+
+'build+test Make GCC Debug':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Debug
+
+'build+test Make GCC Release':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: gcc
+    BUILD_TYPE: Release
+
+'build+test Make clang Debug':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Debug
+
+'build+test Make clang Release':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Unix Makefiles
+    COMPILER: clang
+    BUILD_TYPE: Release
+
+'build+test Ninja GCC Debug':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Ninja
+    COMPILER: gcc
+    BUILD_TYPE: Debug
+
+'build+test Ninja GCC Release':
+  <<: *job_linux_build_test
+  variables:
+    GENERATOR: Ninja
+    COMPILER: gcc
+    BUILD_TYPE: Release

--- a/bin/ci/README.md
+++ b/bin/ci/README.md
@@ -1,0 +1,24 @@
+In this directory are two scripts, `build.sh` and `test.sh` used for building
+and testing rippled.
+
+(For now, they assume Bash and Linux. Once I get Windows containers for
+testing, I'll try them there, but if Bash is not available, then they will
+soon be joined by PowerShell scripts `build.ps` and `test.ps`.)
+
+We don't want these scripts to require arcane invocations that can only be
+pieced together from within a CI configuration. We want something that humans
+can easily invoke, read, and understand, for when we eventually have to test
+and debug them interactively. That means:
+
+(1) They should work with no arguments.
+(2) They should document their arguments.
+(3) They should expand short arguments into long arguments.
+
+While we want to provide options for common use cases, we don't need to offer
+the kitchen sink. We can rightfully expect users with esoteric, complicated
+needs to write their own scripts.
+
+To make argument-handling easy for us, the implementers, we can just take all
+arguments from environment variables. They have the nice advantage that every
+command-line uses named arguments. For the benefit of us and our users, we
+document those variables at the top of each script.

--- a/bin/ci/build.sh
+++ b/bin/ci/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# The build system. Either 'Unix Makefiles' or 'Ninja'.
+GENERATOR=${GENERATOR:-Unix Makefiles}
+# The compiler. Either 'gcc' or 'clang'.
+COMPILER=${COMPILER:-gcc}
+# The build type. Either 'Debug' or 'Release'.
+BUILD_TYPE=${BUILD_TYPE:-Debug}
+# Additional arguments to CMake.
+CMAKE_ARGS=${CMAKE_ARGS:-}
+
+if [[ ${COMPILER} == 'gcc' ]]; then
+  export CC='gcc'
+  export CXX='g++'
+elif [[ ${COMPILER} == 'clang' ]]; then
+  export CC='clang'
+  export CXX='clang++'
+fi
+
+mkdir build
+cd build
+cmake -G "${GENERATOR}" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_ARGS} ..
+cmake --build . -- -j $(nproc)

--- a/bin/ci/build.sh
+++ b/bin/ci/build.sh
@@ -10,7 +10,9 @@ COMPILER=${COMPILER:-gcc}
 # The build type. Either 'Debug' or 'Release'.
 BUILD_TYPE=${BUILD_TYPE:-Debug}
 # Additional arguments to CMake.
-CMAKE_ARGS=${CMAKE_ARGS:-}
+# We use the `-` substitution here instead of `:-` so that callers can erase
+# the default by setting `$CMAKE_ARGS` to the empty string.
+CMAKE_ARGS=${CMAKE_ARGS-'-Dwerr=ON'}
 
 if [[ ${COMPILER} == 'gcc' ]]; then
   export CC='gcc'

--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# Set to 'true' to run the known "manual" tests in rippled.
+MANUAL_TESTS=${MANUAL_TESTS:-false}
+# The maximum number of concurrent tests.
+JOBS=${JOBS:-$(nproc)}
+# The path to rippled.
+RIPPLED=${RIPPLED:-build/rippled}
+# Additional arguments to rippled.
+RIPPLED_ARGS=${RIPPLED_ARGS:-}
+
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+declare -a manual_tests=(
+  'beast.chrono.abstract_clock'
+  'beast.unit_test.print'
+  'ripple.NodeStore.Timing'
+  'ripple.app.Flow_manual'
+  'ripple.app.NoRippleCheckLimits'
+  'ripple.app.PayStrandAllPairs'
+  'ripple.consensus.ByzantineFailureSim'
+  'ripple.consensus.DistributedValidators'
+  'ripple.consensus.ScaleFreeSim'
+  'ripple.ripple_data.digest'
+  'ripple.tx.CrossingLimits'
+  'ripple.tx.FindOversizeCross'
+  'ripple.tx.Offer_manual'
+  'ripple.tx.OversizeMeta'
+  'ripple.tx.PlumpBook'
+)
+
+if [[ ${MANUAL_TESTS} == 'true' ]]; then
+  RIPPLED_ARGS+=" --unittest=$(join_by , "${manual_tests[@]}")"
+else
+  RIPPLED_ARGS+=" --unittest --quiet --unittest-log"
+fi
+RIPPLED_ARGS+=" --unittest-jobs ${JOBS}"
+
+${RIPPLED} ${RIPPLED_ARGS}

--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -6,7 +6,7 @@ set -o errexit
 # Set to 'true' to run the known "manual" tests in rippled.
 MANUAL_TESTS=${MANUAL_TESTS:-false}
 # The maximum number of concurrent tests.
-JOBS=${JOBS:-$(nproc)}
+CONCURRENT_TESTS=${CONCURRENT_TESTS:-$(nproc)}
 # The path to rippled.
 RIPPLED=${RIPPLED:-build/rippled}
 # Additional arguments to rippled.
@@ -37,6 +37,6 @@ if [[ ${MANUAL_TESTS} == 'true' ]]; then
 else
   RIPPLED_ARGS+=" --unittest --quiet --unittest-log"
 fi
-RIPPLED_ARGS+=" --unittest-jobs ${JOBS}"
+RIPPLED_ARGS+=" --unittest-jobs ${CONCURRENT_TESTS}"
 
 ${RIPPLED} ${RIPPLED_ARGS}


### PR DESCRIPTION
Pushing the feature branch `gitlab-ci` (whose name I absent-mindedly forgot to prefix with `jfreeman-`) automatically triggered a [pipeline](https://gitlab.com/ripple/rippled/pipelines/59296447) on gitlab.com as wanted. This PR exists just to see whether GitLab will report the result of that pipeline in a commit status on GitHub and whether GitHub will reflect that commit status here. The real PR for these changes (and where you should direct your comments) is #2897.