### PR TITLE
Get names of transactions and ledger types from jss

### DIFF
--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -36,7 +36,7 @@ LedgerFormats::LedgerFormats ()
         { sfFlags,                   soeREQUIRED },
     };
 
-    add ("AccountRoot", ltACCOUNT_ROOT,
+    add (jss::AccountRoot, ltACCOUNT_ROOT,
         {
             { sfAccount,             soeREQUIRED },
             { sfSequence,            soeREQUIRED },
@@ -56,7 +56,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("DirectoryNode", ltDIR_NODE,
+    add (jss::DirectoryNode, ltDIR_NODE,
         {
             { sfOwner,               soeOPTIONAL },  // for owner directories
             { sfTakerPaysCurrency,   soeOPTIONAL },  // for order book directories
@@ -71,7 +71,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("Offer", ltOFFER,
+    add (jss::Offer, ltOFFER,
         {
             { sfAccount,             soeREQUIRED },
             { sfSequence,            soeREQUIRED },
@@ -86,7 +86,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("RippleState", ltRIPPLE_STATE,
+    add (jss::RippleState, ltRIPPLE_STATE,
         {
             { sfBalance,             soeREQUIRED },
             { sfLowLimit,            soeREQUIRED },
@@ -102,7 +102,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("Escrow", ltESCROW,
+    add (jss::Escrow, ltESCROW,
         {
             { sfAccount,             soeREQUIRED },
             { sfDestination,         soeREQUIRED },
@@ -119,7 +119,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("LedgerHashes", ltLEDGER_HASHES,
+    add (jss::LedgerHashes, ltLEDGER_HASHES,
         {
             { sfFirstLedgerSequence, soeOPTIONAL }, // Remove if we do a ledger restart
             { sfLastLedgerSequence,  soeOPTIONAL },
@@ -127,14 +127,14 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("Amendments", ltAMENDMENTS,
+    add (jss::Amendments, ltAMENDMENTS,
         {
             { sfAmendments,          soeOPTIONAL }, // Enabled
             { sfMajorities,          soeOPTIONAL },
         },
         commonFields);
 
-    add ("FeeSettings", ltFEE_SETTINGS,
+    add (jss::FeeSettings, ltFEE_SETTINGS,
         {
             { sfBaseFee,             soeREQUIRED },
             { sfReferenceFeeUnits,   soeREQUIRED },
@@ -143,7 +143,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("Ticket", ltTICKET,
+    add (jss::Ticket, ltTICKET,
         {
             { sfAccount,             soeREQUIRED },
             { sfSequence,            soeREQUIRED },
@@ -155,7 +155,7 @@ LedgerFormats::LedgerFormats ()
 
     // All fields are soeREQUIRED because there is always a
     // SignerEntries.  If there are no SignerEntries the node is deleted.
-    add ("SignerList", ltSIGNER_LIST,
+    add (jss::SignerList, ltSIGNER_LIST,
         {
             { sfOwnerNode,           soeREQUIRED },
             { sfSignerQuorum,        soeREQUIRED },
@@ -166,7 +166,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("PayChannel", ltPAYCHAN,
+    add (jss::PayChannel, ltPAYCHAN,
         {
             { sfAccount,             soeREQUIRED },
             { sfDestination,         soeREQUIRED },
@@ -184,7 +184,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("Check", ltCHECK,
+    add (jss::Check, ltCHECK,
         {
             { sfAccount,             soeREQUIRED },
             { sfDestination,         soeREQUIRED },
@@ -201,7 +201,7 @@ LedgerFormats::LedgerFormats ()
         },
         commonFields);
 
-    add ("DepositPreauth", ltDEPOSIT_PREAUTH,
+    add (jss::DepositPreauth, ltDEPOSIT_PREAUTH,
         {
             { sfAccount,             soeREQUIRED },
             { sfAuthorize,           soeREQUIRED },

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/protocol/TxFormats.h>
+#include <ripple/protocol/jss.h>
 
 namespace ripple {
 
@@ -42,7 +43,7 @@ TxFormats::TxFormats ()
         { sfSigners,              soeOPTIONAL }, // submit_multisigned
     };
 
-    add ("AccountSet", ttACCOUNT_SET,
+    add (jss::AccountSet, ttACCOUNT_SET,
         {
             { sfEmailHash,           soeOPTIONAL },
             { sfWalletLocator,       soeOPTIONAL },
@@ -56,7 +57,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("TrustSet", ttTRUST_SET,
+    add (jss::TrustSet, ttTRUST_SET,
         {
             { sfLimitAmount,         soeOPTIONAL },
             { sfQualityIn,           soeOPTIONAL },
@@ -64,7 +65,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("OfferCreate", ttOFFER_CREATE,
+    add (jss::OfferCreate, ttOFFER_CREATE,
         {
             { sfTakerPays,           soeREQUIRED },
             { sfTakerGets,           soeREQUIRED },
@@ -73,19 +74,19 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("OfferCancel", ttOFFER_CANCEL,
+    add (jss::OfferCancel, ttOFFER_CANCEL,
         {
             { sfOfferSequence,       soeREQUIRED },
         },
         commonFields);
 
-    add ("SetRegularKey", ttREGULAR_KEY_SET,
+    add (jss::SetRegularKey, ttREGULAR_KEY_SET,
         {
             { sfRegularKey,          soeOPTIONAL },
         },
         commonFields);
 
-    add ("Payment", ttPAYMENT,
+    add (jss::Payment, ttPAYMENT,
         {
             { sfDestination,         soeREQUIRED },
             { sfAmount,              soeREQUIRED },
@@ -97,7 +98,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("EscrowCreate", ttESCROW_CREATE,
+    add (jss::EscrowCreate, ttESCROW_CREATE,
         {
             { sfDestination,         soeREQUIRED },
             { sfAmount,              soeREQUIRED },
@@ -108,7 +109,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("EscrowFinish", ttESCROW_FINISH,
+    add (jss::EscrowFinish, ttESCROW_FINISH,
         {
             { sfOwner,               soeREQUIRED },
             { sfOfferSequence,       soeREQUIRED },
@@ -117,21 +118,21 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("EscrowCancel", ttESCROW_CANCEL,
+    add (jss::EscrowCancel, ttESCROW_CANCEL,
         {
             { sfOwner,               soeREQUIRED },
             { sfOfferSequence,       soeREQUIRED },
         },
         commonFields);
 
-    add ("EnableAmendment", ttAMENDMENT,
+    add (jss::EnableAmendment, ttAMENDMENT,
         {
             { sfLedgerSequence,      soeREQUIRED },
             { sfAmendment,           soeREQUIRED },
         },
         commonFields);
 
-    add ("SetFee", ttFEE,
+    add (jss::SetFee, ttFEE,
         {
             { sfLedgerSequence,      soeOPTIONAL },
             { sfBaseFee,             soeREQUIRED },
@@ -141,14 +142,14 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("TicketCreate", ttTICKET_CREATE,
+    add (jss::TicketCreate, ttTICKET_CREATE,
         {
             { sfTarget,              soeOPTIONAL },
             { sfExpiration,          soeOPTIONAL },
         },
         commonFields);
 
-    add ("TicketCancel", ttTICKET_CANCEL,
+    add (jss::TicketCancel, ttTICKET_CANCEL,
         {
             { sfTicketID,            soeREQUIRED },
         },
@@ -156,14 +157,14 @@ TxFormats::TxFormats ()
 
     // The SignerEntries are optional because a SignerList is deleted by
     // setting the SignerQuorum to zero and omitting SignerEntries.
-    add ("SignerListSet", ttSIGNER_LIST_SET,
+    add (jss::SignerListSet, ttSIGNER_LIST_SET,
         {
             { sfSignerQuorum,        soeREQUIRED },
             { sfSignerEntries,       soeOPTIONAL },
         },
         commonFields);
 
-    add ("PaymentChannelCreate", ttPAYCHAN_CREATE,
+    add (jss::PaymentChannelCreate, ttPAYCHAN_CREATE,
         {
             { sfDestination,         soeREQUIRED },
             { sfAmount,              soeREQUIRED },
@@ -174,7 +175,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("PaymentChannelFund", ttPAYCHAN_FUND,
+    add (jss::PaymentChannelFund, ttPAYCHAN_FUND,
         {
             { sfPayChannel,          soeREQUIRED },
             { sfAmount,              soeREQUIRED },
@@ -182,7 +183,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("PaymentChannelClaim", ttPAYCHAN_CLAIM,
+    add (jss::PaymentChannelClaim, ttPAYCHAN_CLAIM,
         {
             { sfPayChannel,          soeREQUIRED },
             { sfAmount,              soeOPTIONAL },
@@ -192,7 +193,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("CheckCreate", ttCHECK_CREATE,
+    add (jss::CheckCreate, ttCHECK_CREATE,
         {
             { sfDestination,         soeREQUIRED },
             { sfSendMax,             soeREQUIRED },
@@ -202,7 +203,7 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("CheckCash", ttCHECK_CASH,
+    add (jss::CheckCash, ttCHECK_CASH,
         {
             { sfCheckID,             soeREQUIRED },
             { sfAmount,              soeOPTIONAL },
@@ -210,13 +211,13 @@ TxFormats::TxFormats ()
         },
         commonFields);
 
-    add ("CheckCancel", ttCHECK_CANCEL,
+    add (jss::CheckCancel, ttCHECK_CANCEL,
         {
             { sfCheckID,             soeREQUIRED },
         },
         commonFields);
 
-    add ("DepositPreauth", ttDEPOSIT_PREAUTH,
+    add (jss::DepositPreauth, ttDEPOSIT_PREAUTH,
         {
             { sfAuthorize,           soeOPTIONAL },
             { sfUnauthorize,         soeOPTIONAL },

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -35,29 +35,61 @@ namespace jss {
 
 JSS ( AL_hit_rate );                // out: GetCounts
 JSS ( Account );                    // in: TransactionSign; field.
+JSS ( AccountRoot );                // ledger type.
+JSS ( AccountSet );                 // transaction type.
+JSS ( Amendments );                 // ledger type.
 JSS ( Amount );                     // in: TransactionSign; field.
+JSS ( Check );                      // ledger type.
+JSS ( CheckCancel );                // transaction type.
+JSS ( CheckCash );                  // transaction type.
+JSS ( CheckCreate );                // transaction type.
 JSS ( ClearFlag );                  // field.
-JSS ( Destination );                // in: TransactionSign; field.
 JSS ( DeliverMin );                 // in: TransactionSign
+JSS ( DepositPreauth );             // transaction and ledger type.
+JSS ( Destination );                // in: TransactionSign; field.
+JSS ( DirectoryNode );              // ledger type.
+JSS ( EnableAmendment );            // transaction type.
+JSS ( Escrow );                     // ledger type.
+JSS ( EscrowCancel );               // transaction type.
+JSS ( EscrowCreate );               // transaction type.
+JSS ( EscrowFinish );               // transaction type.
 JSS ( Fee );                        // in/out: TransactionSign; field.
+JSS ( FeeSettings );                // ledger type.
 JSS ( Flags );                      // in/out: TransactionSign; field.
 JSS ( Invalid );                    //
 JSS ( LastLedgerSequence );         // in: TransactionSign; field
+JSS ( LedgerHashes );               // ledger type.
 JSS ( LimitAmount );                // field.
+JSS ( Offer );                      // ledger type.
+JSS ( OfferCancel );                // transaction type.
+JSS ( OfferCreate );                // transaction type.
 JSS ( OfferSequence );              // field.
 JSS ( Paths );                      // in/out: TransactionSign
-JSS ( TransferRate );               // in: TransferRate
-JSS ( historical_perminute );       // historical_perminute
-JSS ( SLE_hit_rate );               // out: GetCounts
+JSS ( PayChannel );                 // ledger type.
+JSS ( Payment );                    // transaction type.
+JSS ( PaymentChannelClaim );        // transaction type.
+JSS ( PaymentChannelCreate );       // transaction type.
+JSS ( PaymentChannelFund );         // transaction type.
+JSS ( RippleState );                // ledger type.
+JSS ( SLE_hit_rate );               // out: GetCounts.
+JSS ( SetFee );                     // transaction type.
 JSS ( SettleDelay );                // in: TransactionSign
 JSS ( SendMax );                    // in: TransactionSign
 JSS ( Sequence );                   // in/out: TransactionSign; field.
 JSS ( SetFlag );                    // field.
-JSS ( SigningPubKey );              // field
+JSS ( SetRegularKey );              // transaction type.
+JSS ( SignerList );                 // ledger type.
+JSS ( SignerListSet );              // transaction type.
+JSS ( SigningPubKey );              // field.
 JSS ( TakerGets );                  // field.
 JSS ( TakerPays );                  // field.
-JSS ( TxnSignature );               // field
-JSS ( TransactionType );            // in: TransactionSign
+JSS ( Ticket );                     // ledger type.
+JSS ( TicketCancel );               // transaction type.
+JSS ( TicketCreate );               // transaction type.
+JSS ( TxnSignature );               // field.
+JSS ( TransactionType );            // in: TransactionSign.
+JSS ( TransferRate );               // in: TransferRate.
+JSS ( TrustSet );                   // transaction type.
 JSS ( aborted );                    // out: InboundLedger
 JSS ( accepted );                   // out: LedgerToJson, OwnerInfo
 JSS ( account );                    // in/out: many
@@ -202,6 +234,7 @@ JSS ( have_header );                // out: InboundLedger
 JSS ( have_state );                 // out: InboundLedger
 JSS ( have_transactions );          // out: InboundLedger
 JSS ( highest_sequence );           // out: AccountInfo
+JSS ( historical_perminute );       // historical_perminute.
 JSS ( hostid );                     // out: NetworkOPs
 JSS ( hotwallet );                  // in: GatewayBalances
 JSS ( id );                         // websocket.

--- a/src/ripple/rpc/handlers/NoRippleCheck.cpp
+++ b/src/ripple/rpc/handlers/NoRippleCheck.cpp
@@ -121,7 +121,7 @@ Json::Value doNoRippleCheck (RPC::Context& context)
         if (transactions)
         {
             Json::Value& tx = jvTransactions.append (Json::objectValue);
-            tx["TransactionType"] = "AccountSet";
+            tx["TransactionType"] = jss::AccountSet;
             tx["SetFlag"] = 8;
             fillTransaction (context, tx, accountID, seq, *ledger);
         }
@@ -164,7 +164,7 @@ Json::Value doNoRippleCheck (RPC::Context& context)
                     limitAmount.setIssuer (peer);
 
                     Json::Value& tx = jvTransactions.append (Json::objectValue);
-                    tx["TransactionType"] = "TrustSet";
+                    tx["TransactionType"] = jss::TrustSet;
                     tx["LimitAmount"] = limitAmount.getJson (0);
                     tx["Flags"] = bNoRipple ? tfClearNoRipple : tfSetNoRipple;
                     fillTransaction(context, tx, accountID, seq, *ledger);

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -155,7 +155,7 @@ static Json::Value checkPayment(
     bool doPath)
 {
     // Only path find for Payments.
-    if (tx_json[jss::TransactionType].asString () != "Payment")
+    if (tx_json[jss::TransactionType].asString () != jss::Payment)
         return Json::Value();
 
     if (!tx_json.isMember (jss::Amount))

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -40,7 +40,7 @@ create (jtx::Account const& account,
     jv[sfAccount.jsonName] = account.human();
     jv[sfSendMax.jsonName] = sendMax.getJson(0);
     jv[sfDestination.jsonName] = dest.human();
-    jv[sfTransactionType.jsonName] = "CheckCreate";
+    jv[sfTransactionType.jsonName] = jss::CheckCreate;
     jv[sfFlags.jsonName] = tfUniversal;
     return jv;
 }
@@ -62,7 +62,7 @@ cash (jtx::Account const& dest,
     jv[sfAccount.jsonName] = dest.human();
     jv[sfAmount.jsonName]  = amount.getJson(0);
     jv[sfCheckID.jsonName] = to_string (checkId);
-    jv[sfTransactionType.jsonName] = "CheckCash";
+    jv[sfTransactionType.jsonName] = jss::CheckCash;
     jv[sfFlags.jsonName] = tfUniversal;
     return jv;
 }
@@ -75,7 +75,7 @@ cash (jtx::Account const& dest,
     jv[sfAccount.jsonName] = dest.human();
     jv[sfDeliverMin.jsonName]  = atLeast.value.getJson(0);
     jv[sfCheckID.jsonName] = to_string (checkId);
-    jv[sfTransactionType.jsonName] = "CheckCash";
+    jv[sfTransactionType.jsonName] = jss::CheckCash;
     jv[sfFlags.jsonName] = tfUniversal;
     return jv;
 }
@@ -87,7 +87,7 @@ cancel (jtx::Account const& dest, uint256 const& checkId)
     Json::Value jv;
     jv[sfAccount.jsonName] = dest.human();
     jv[sfCheckID.jsonName] = to_string (checkId);
-    jv[sfTransactionType.jsonName] = "CheckCancel";
+    jv[sfTransactionType.jsonName] = jss::CheckCancel;
     jv[sfFlags.jsonName] = tfUniversal;
     return jv;
 }

--- a/src/test/app/Discrepancy_test.cpp
+++ b/src/test/app/Discrepancy_test.cpp
@@ -117,7 +117,7 @@ class Discrepancy_test : public beast::unit_test::suite
             else if(an.isMember(sfDeletedNode.fieldName))
                 node = an[sfDeletedNode.fieldName];
 
-            if(node && node[sfLedgerEntryType.fieldName] == "AccountRoot")
+            if(node && node[sfLedgerEntryType.fieldName] == jss::AccountRoot)
             {
                 Json::Value prevFields =
                     node.isMember(sfPreviousFields.fieldName) ?

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -171,7 +171,7 @@ struct Escrow_test : public beast::unit_test::suite
     {
         using namespace jtx;
         Json::Value jv;
-        jv[jss::TransactionType] = "EscrowCreate";
+        jv[jss::TransactionType] = jss::EscrowCreate;
         jv[jss::Flags] = tfUniversal;
         jv[jss::Account] = account.human();
         jv[jss::Destination] = to.human();
@@ -185,7 +185,7 @@ struct Escrow_test : public beast::unit_test::suite
         jtx::Account const& from, std::uint32_t seq)
     {
         Json::Value jv;
-        jv[jss::TransactionType] = "EscrowFinish";
+        jv[jss::TransactionType] = jss::EscrowFinish;
         jv[jss::Flags] = tfUniversal;
         jv[jss::Account] = account.human();
         jv[sfOwner.jsonName] = from.human();
@@ -199,7 +199,7 @@ struct Escrow_test : public beast::unit_test::suite
         jtx::Account const& from, std::uint32_t seq)
     {
         Json::Value jv;
-        jv[jss::TransactionType] = "EscrowCancel";
+        jv[jss::TransactionType] = jss::EscrowCancel;
         jv[jss::Flags] = tfUniversal;
         jv[jss::Account] = account.human();
         jv[sfOwner.jsonName] = from.human();

--- a/src/test/app/Freeze_test.cpp
+++ b/src/test/app/Freeze_test.cpp
@@ -415,7 +415,7 @@ class Freeze_test : public beast::unit_test::suite
 
         auto let =
             affected[0u][sfModifiedNode.fieldName][sfLedgerEntryType.fieldName];
-        BEAST_EXPECT(let == "AccountRoot");
+        BEAST_EXPECT(let == jss::AccountRoot);
     }
 
     void

--- a/src/test/app/LedgerLoad_test.cpp
+++ b/src/test/app/LedgerLoad_test.cpp
@@ -85,7 +85,7 @@ class LedgerLoad_test : public beast::unit_test::suite
         retval.hashes = [&] {
             for(auto const& it : retval.ledger[jss::ledger][jss::accountState])
             {
-                if(it[sfLedgerEntryType.fieldName] == "LedgerHashes")
+                if(it[sfLedgerEntryType.fieldName] == jss::LedgerHashes)
                     return it[sfHashes.fieldName];
             }
             return Json::Value {};

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -481,7 +481,7 @@ public:
         auto setup_tx = [&]() -> Json::Value {
             Json::Value jv;
             jv[jss::tx_json][jss::Account]         = alice.human();
-            jv[jss::tx_json][jss::TransactionType] = "AccountSet";
+            jv[jss::tx_json][jss::TransactionType] = jss::AccountSet;
             jv[jss::tx_json][jss::Fee]             = static_cast<uint32_t>(8 * baseFee);
             jv[jss::tx_json][jss::Sequence]        = env.seq(alice);
             jv[jss::tx_json][jss::SigningPubKey]   = "";
@@ -951,7 +951,7 @@ public:
             Json::Value cancelOffer;
             cancelOffer[jss::Account] = alice.human();
             cancelOffer[jss::OfferSequence] = offerSeq;
-            cancelOffer[jss::TransactionType] = "OfferCancel";
+            cancelOffer[jss::TransactionType] = jss::OfferCancel;
             env (cancelOffer, seq (aliceSeq),
                 msig (becky, bogie), fee(3 * baseFee));
             env.close();
@@ -1220,7 +1220,7 @@ public:
         jvSig1[jss::tx_json][jss::Destination]     = env.master.human();
         jvSig1[jss::tx_json][jss::Fee]             = 3 * baseFee;
         jvSig1[jss::tx_json][jss::Sequence]        = env.seq(alice);
-        jvSig1[jss::tx_json][jss::TransactionType] = "Payment";
+        jvSig1[jss::tx_json][jss::TransactionType] = jss::Payment;
 
         Json::Value jvSig2 = env.rpc (
             "json", "sign_for", to_string (jvSig1));

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -221,7 +221,7 @@ public:
             Json::Value cancelOffer;
             cancelOffer[jss::Account] = alice.human();
             cancelOffer[jss::OfferSequence] = offer4Seq;
-            cancelOffer[jss::TransactionType] = "OfferCancel";
+            cancelOffer[jss::TransactionType] = jss::OfferCancel;
             env (cancelOffer);
         }
         env.close();
@@ -1180,7 +1180,7 @@ public:
         Json::Value cancelOffer;
         cancelOffer[jss::Account] = account_to_test.human();
         cancelOffer[jss::OfferSequence] = secondLegSeq;
-        cancelOffer[jss::TransactionType] = "OfferCancel";
+        cancelOffer[jss::TransactionType] = jss::OfferCancel;
         env (cancelOffer);
         env.require (offers (account_to_test, 0));
 
@@ -1432,7 +1432,7 @@ public:
         Json::Value cancelOffer;
         cancelOffer[jss::Account] = env.master.human();
         cancelOffer[jss::OfferSequence] = nextOfferSeq;
-        cancelOffer[jss::TransactionType] = "OfferCancel";
+        cancelOffer[jss::TransactionType] = jss::OfferCancel;
         env (cancelOffer);
         BEAST_EXPECT(env.seq (env.master) == nextOfferSeq + 2);
 
@@ -1464,7 +1464,7 @@ public:
         Json::Value cancelOffer;
         cancelOffer[jss::Account] = env.master.human();
         cancelOffer[jss::OfferSequence] = nextOfferSeq;
-        cancelOffer[jss::TransactionType] = "OfferCancel";
+        cancelOffer[jss::TransactionType] = jss::OfferCancel;
         env (cancelOffer);
 
         cancelOffer[jss::OfferSequence] = env.seq (env.master);

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -109,7 +109,7 @@ struct PayChan_test : public beast::unit_test::suite
     {
         using namespace jtx;
         Json::Value jv;
-        jv[jss::TransactionType] = "PaymentChannelCreate";
+        jv[jss::TransactionType] = jss::PaymentChannelCreate;
         jv[jss::Flags] = tfUniversal;
         jv[jss::Account] = account.human ();
         jv[jss::Destination] = to.human ();
@@ -132,7 +132,7 @@ struct PayChan_test : public beast::unit_test::suite
     {
         using namespace jtx;
         Json::Value jv;
-        jv[jss::TransactionType] = "PaymentChannelFund";
+        jv[jss::TransactionType] = jss::PaymentChannelFund;
         jv[jss::Flags] = tfUniversal;
         jv[jss::Account] = account.human ();
         jv["Channel"] = to_string (channel);
@@ -153,7 +153,7 @@ struct PayChan_test : public beast::unit_test::suite
     {
         using namespace jtx;
         Json::Value jv;
-        jv[jss::TransactionType] = "PaymentChannelClaim";
+        jv[jss::TransactionType] = jss::PaymentChannelClaim;
         jv[jss::Flags] = tfUniversal;
         jv[jss::Account] = account.human ();
         jv["Channel"] = to_string (channel);

--- a/src/test/app/SetAuth_test.cpp
+++ b/src/test/app/SetAuth_test.cpp
@@ -40,7 +40,7 @@ struct SetAuth_test : public beast::unit_test::suite
         jv[jss::Account] = account.human();
         jv[jss::LimitAmount] = STAmount(
             { to_currency(currency), dest }).getJson(0);
-        jv[jss::TransactionType] = "TrustSet";
+        jv[jss::TransactionType] = jss::TrustSet;
         jv[jss::Flags] = tfSetfAuth;
         return jv;
     }

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -105,7 +105,7 @@ public:
         Json::Value jv;
         jv[jss::Account] = a.human();
         jv[jss::LimitAmount] = amt.getJson(0);
-        jv[jss::TransactionType] = "TrustSet";
+        jv[jss::TransactionType] = jss::TrustSet;
         jv[jss::Flags] = 0;
         return jv;
     }

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -52,7 +52,7 @@ class Ticket_test : public beast::unit_test::suite
     {
         using namespace std::string_literals;
         auto const& tx = env.tx ()->getJson (0);
-        bool is_cancel = tx[jss::TransactionType] == "TicketCancel";
+        bool is_cancel = tx[jss::TransactionType] == jss::TicketCancel;
 
         auto const& jvm = env.meta ()->getJson (0);
         std::array<Json::Value, 4> retval;
@@ -61,32 +61,26 @@ class Ticket_test : public beast::unit_test::suite
         // a few different scenarios.
         // tuple is index, field name, and label (LedgerEntryType)
         std::vector<
-            std::tuple<std::size_t, std::string, std::string>
+            std::tuple<std::size_t, std::string, Json::StaticString>
         > expected_nodes;
 
         if (is_cancel && other_target)
         {
             expected_nodes = {
-                std::make_tuple(0, sfModifiedNode.fieldName, "AccountRoot"s),
-                std::make_tuple(
-                    expiration ? 2: 1, sfModifiedNode.fieldName, "AccountRoot"s),
-                std::make_tuple(
-                    expiration ? 1: 2, sfDeletedNode.fieldName, "Ticket"s),
-                std::make_tuple(3, sfDeletedNode.fieldName, "DirectoryNode"s)
+                {0, sfModifiedNode.fieldName, jss::AccountRoot},
+                {expiration ? 2: 1, sfModifiedNode.fieldName, jss::AccountRoot},
+                {expiration ? 1: 2, sfDeletedNode.fieldName, jss::Ticket},
+                {3, sfDeletedNode.fieldName, jss::DirectoryNode}
             };
         }
         else
         {
             expected_nodes = {
-                std::make_tuple(0, sfModifiedNode.fieldName, "AccountRoot"s),
-                std::make_tuple(1,
-                    is_cancel ?
-                        sfDeletedNode.fieldName : sfCreatedNode.fieldName,
-                    "Ticket"s),
-                std::make_tuple(2,
-                    is_cancel ?
-                        sfDeletedNode.fieldName : sfCreatedNode.fieldName,
-                 "DirectoryNode"s)
+                {0, sfModifiedNode.fieldName, jss::AccountRoot},
+                {1, is_cancel ? sfDeletedNode.fieldName :
+                    sfCreatedNode.fieldName, jss::Ticket},
+                {2, is_cancel ? sfDeletedNode.fieldName :
+                    sfCreatedNode.fieldName, jss::DirectoryNode}
             };
         }
 
@@ -241,7 +235,7 @@ class Ticket_test : public beast::unit_test::suite
         auto const& jticket = cr[1];
         BEAST_EXPECT(
             jacct[sfFinalFields.fieldName][sfOwnerCount.fieldName] == 1);
-        BEAST_EXPECT(jticket[sfLedgerEntryType.fieldName] == "Ticket");
+        BEAST_EXPECT(jticket[sfLedgerEntryType.fieldName] == jss::Ticket);
         BEAST_EXPECT(jticket[sfLedgerIndex.fieldName] ==
             "C231BA31A0E13A4D524A75F990CE0D6890B800FF1AE75E51A2D33559547AC1A2");
         BEAST_EXPECT(jticket[sfNewFields.fieldName][jss::Account] ==
@@ -330,7 +324,7 @@ class Ticket_test : public beast::unit_test::suite
         auto const& jacct =
             jvm[sfAffectedNodes.fieldName][0u][sfModifiedNode.fieldName];
         BEAST_EXPECT(
-            jacct[sfLedgerEntryType.fieldName] == "AccountRoot");
+            jacct[sfLedgerEntryType.fieldName] == jss::AccountRoot);
         BEAST_EXPECT(jacct[sfFinalFields.fieldName][jss::Account] ==
             env.master.human());
     }

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -270,7 +270,7 @@ class TrustAndBalance_test : public beast::unit_test::suite
                 [](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "Payment";
+                    return t[jss::TransactionType] == jss::Payment;
                 }));
             BEAST_EXPECT(wsc->findMsg(5s,
                 [](auto const& jv)
@@ -477,7 +477,7 @@ class TrustAndBalance_test : public beast::unit_test::suite
             {
                 auto const& t = jv[jss::transaction];
                 return
-                    t[jss::TransactionType] == "Payment" &&
+                    t[jss::TransactionType] == jss::Payment &&
                     t[sfInvoiceID.fieldName] ==
                         "0000000000000000"
                         "0000000000000000"

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -1756,7 +1756,7 @@ public:
             Json::Value cancelOffer;
             cancelOffer[jss::Account] = alice.human();
             cancelOffer[jss::OfferSequence] = 3;
-            cancelOffer[jss::TransactionType] = "OfferCancel";
+            cancelOffer[jss::TransactionType] = jss::OfferCancel;
             auto const jtx = env.jt(cancelOffer,
                 seq(1), fee(10));
             auto const pf = preflight(env.app(), env.current()->rules(),
@@ -1798,7 +1798,7 @@ public:
             Json::Value cancelTicket;
             cancelTicket[jss::Account] = alice.human();
             cancelTicket["TicketID"] = to_string(uint256());
-            cancelTicket[jss::TransactionType] = "TicketCancel";
+            cancelTicket[jss::TransactionType] = jss::TicketCancel;
             auto const jtx = env.jt(cancelTicket,
                 seq(1), fee(10));
             auto const pf = preflight(env.app(), env.current()->rules(),

--- a/src/test/jtx/impl/deposit.cpp
+++ b/src/test/jtx/impl/deposit.cpp
@@ -33,7 +33,7 @@ auth (jtx::Account const& account, jtx::Account const& auth)
     Json::Value jv;
     jv[sfAccount.jsonName] = account.human();
     jv[sfAuthorize.jsonName] = auth.human();
-    jv[sfTransactionType.jsonName] = "DepositPreauth";
+    jv[sfTransactionType.jsonName] = jss::DepositPreauth;
     return jv;
 }
 
@@ -44,7 +44,7 @@ unauth (jtx::Account const& account, jtx::Account const& unauth)
     Json::Value jv;
     jv[sfAccount.jsonName] = account.human();
     jv[sfUnauthorize.jsonName] = unauth.human();
-    jv[sfTransactionType.jsonName] = "DepositPreauth";
+    jv[sfTransactionType.jsonName] = jss::DepositPreauth;
     return jv;
 }
 

--- a/src/test/jtx/impl/flags.cpp
+++ b/src/test/jtx/impl/flags.cpp
@@ -30,7 +30,7 @@ fset (Account const& account,
 {
     Json::Value jv;
     jv[jss::Account] = account.human();
-    jv[jss::TransactionType] = "AccountSet";
+    jv[jss::TransactionType] = jss::AccountSet;
     if (on != 0)
         jv[jss::SetFlag] = on;
     if (off != 0)

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -36,7 +36,7 @@ signers (Account const& account,
 {
     Json::Value jv;
     jv[jss::Account] = account.human();
-    jv[jss::TransactionType] = "SignerListSet";
+    jv[jss::TransactionType] = jss::SignerListSet;
     jv[sfSignerQuorum.getJsonName()] = quorum;
     auto& ja = jv[sfSignerEntries.getJsonName()];
     ja.resize(v.size());
@@ -55,7 +55,7 @@ signers (Account const& account, none_t)
 {
     Json::Value jv;
     jv[jss::Account] = account.human();
-    jv[jss::TransactionType] = "SignerListSet";
+    jv[jss::TransactionType] = jss::SignerListSet;
     jv[sfSignerQuorum.getJsonName()] = 0;
     return jv;
 }

--- a/src/test/jtx/impl/offer.cpp
+++ b/src/test/jtx/impl/offer.cpp
@@ -34,7 +34,7 @@ offer (Account const& account,
     jv[jss::TakerGets] = out.getJson(0);
     if (flags)
         jv[jss::Flags] = flags;
-    jv[jss::TransactionType] = "OfferCreate";
+    jv[jss::TransactionType] = jss::OfferCreate;
     return jv;
 }
 
@@ -44,7 +44,7 @@ offer_cancel (Account const& account, std::uint32_t offerSeq)
     Json::Value jv;
     jv[jss::Account] = account.human();
     jv[jss::OfferSequence] = offerSeq;
-    jv[jss::TransactionType] = "OfferCancel";
+    jv[jss::TransactionType] = jss::OfferCancel;
     return jv;
 }
 

--- a/src/test/jtx/impl/pay.cpp
+++ b/src/test/jtx/impl/pay.cpp
@@ -35,7 +35,7 @@ pay (Account const& account,
     jv[jss::Account] = account.human();
     jv[jss::Amount] = amount.value.getJson(0);
     jv[jss::Destination] = to.human();
-    jv[jss::TransactionType] = "Payment";
+    jv[jss::TransactionType] = jss::Payment;
     jv[jss::Flags] = tfUniversal;
     return jv;
 }

--- a/src/test/jtx/impl/rate.cpp
+++ b/src/test/jtx/impl/rate.cpp
@@ -36,7 +36,7 @@ rate (Account const& account, double multiplier)
     jv[jss::Account] = account.human();
     jv[jss::TransferRate] = std::uint32_t(
         1000000000 * multiplier);
-    jv[jss::TransactionType] = "AccountSet";
+    jv[jss::TransactionType] = jss::AccountSet;
     return jv;
 }
 

--- a/src/test/jtx/impl/regkey.cpp
+++ b/src/test/jtx/impl/regkey.cpp
@@ -30,7 +30,7 @@ regkey (Account const& account,
 {
     Json::Value jv;
     jv[jss::Account] = account.human();
-    jv[jss::TransactionType] = "SetRegularKey";
+    jv[jss::TransactionType] = jss::SetRegularKey;
     return jv;
 }
 
@@ -41,7 +41,7 @@ regkey (Account const& account,
     Json::Value jv;
     jv[jss::Account] = account.human();
     jv["RegularKey"] = to_string(signer.id());
-    jv[jss::TransactionType] = "SetRegularKey";
+    jv[jss::TransactionType] = jss::SetRegularKey;
     return jv;
 }
 

--- a/src/test/jtx/impl/ticket.cpp
+++ b/src/test/jtx/impl/ticket.cpp
@@ -35,7 +35,7 @@ create (Account const& account,
 {
     Json::Value jv;
     jv[jss::Account] = account.human();
-    jv[jss::TransactionType] = "TicketCreate";
+    jv[jss::TransactionType] = jss::TicketCreate;
     if (expire)
         jv["Expiration"] = *expire;
     if (target)
@@ -49,7 +49,7 @@ Json::Value
 cancel(Account const& account, std::string const & ticketId)
 {
     Json::Value jv;
-    jv[jss::TransactionType] = "TicketCancel";
+    jv[jss::TransactionType] = jss::TicketCancel;
     jv[jss::Account] = account.human();
     jv["TicketID"] = ticketId;
     return jv;

--- a/src/test/jtx/impl/trust.cpp
+++ b/src/test/jtx/impl/trust.cpp
@@ -37,7 +37,7 @@ trust (Account const& account,
     Json::Value jv;
     jv[jss::Account] = account.human();
     jv[jss::LimitAmount] = amount.getJson(0);
-    jv[jss::TransactionType] = "TrustSet";
+    jv[jss::TransactionType] = jss::TrustSet;
     jv[jss::Flags] = flags;
     return jv;
 }
@@ -57,7 +57,7 @@ trust (Account const& account,
         auto& ja = jv[jss::LimitAmount] = amount.getJson(0);
         ja[jss::issuer] = peer.human();
     }
-    jv[jss::TransactionType] = "TrustSet";
+    jv[jss::TransactionType] = jss::TrustSet;
     jv[jss::Flags] = flags;
     return jv;
 }

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -315,7 +315,7 @@ struct Directory_test : public beast::unit_test::suite
                 cancelOffer[jss::Account] = alice.human();
                 cancelOffer[jss::OfferSequence] =
                     Json::UInt(firstOfferSeq + page * dirNodeMaxEntries + i);
-                cancelOffer[jss::TransactionType] = "OfferCancel";
+                cancelOffer[jss::TransactionType] = jss::OfferCancel;
                 env(cancelOffer);
                 env.close();
             }

--- a/src/test/rpc/AccountObjects_test.cpp
+++ b/src/test/rpc/AccountObjects_test.cpp
@@ -386,7 +386,7 @@ public:
             jvCheck[sfAccount.jsonName] = gw.human();
             jvCheck[sfSendMax.jsonName] = USD(10).value().getJson(0);
             jvCheck[sfDestination.jsonName] = alice.human();
-            jvCheck[sfTransactionType.jsonName] = "CheckCreate";
+            jvCheck[sfTransactionType.jsonName] = jss::CheckCreate;
             jvCheck[sfFlags.jsonName] = tfUniversal;
             env (jvCheck);
             env.close();
@@ -416,7 +416,7 @@ public:
         {
             // gw creates an escrow that we can look for in the ledger.
             Json::Value jvEscrow;
-            jvEscrow[jss::TransactionType] = "EscrowCreate";
+            jvEscrow[jss::TransactionType] = jss::EscrowCreate;
             jvEscrow[jss::Flags] = tfUniversal;
             jvEscrow[jss::Account] = gw.human();
             jvEscrow[jss::Destination] = gw.human();
@@ -452,7 +452,7 @@ public:
         {
             // Create a payment channel from qw to alice that we can look for.
             Json::Value jvPayChan;
-            jvPayChan[jss::TransactionType] = "PaymentChannelCreate";
+            jvPayChan[jss::TransactionType] = jss::PaymentChannelCreate;
             jvPayChan[jss::Flags] = tfUniversal;
             jvPayChan[jss::Account] = gw.human ();
             jvPayChan[jss::Destination] = alice.human ();
@@ -497,7 +497,7 @@ public:
 
             auto const& ticket = resp[jss::result][jss::account_objects][0u];
             BEAST_EXPECT (ticket[sfAccount.jsonName] == gw.human());
-            BEAST_EXPECT (ticket[sfLedgerEntryType.jsonName] == "Ticket");
+            BEAST_EXPECT (ticket[sfLedgerEntryType.jsonName] == jss::Ticket);
             BEAST_EXPECT (ticket[sfSequence.jsonName].asUInt() == 9);
         }
         // Run up the number of directory entries so gw has two

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -46,9 +46,9 @@ class AccountTX_test : public beast::unit_test::suite
                 (j[jss::result][jss::status] == "success") &&
                 (j[jss::result][jss::transactions].size() == 2) &&
                 (j[jss::result][jss::transactions][0u][jss::tx]
-                  [jss::TransactionType] == "AccountSet") &&
+                  [jss::TransactionType] == jss::AccountSet) &&
                 (j[jss::result][jss::transactions][1u][jss::tx]
-                  [jss::TransactionType] == "Payment");
+                  [jss::TransactionType] == jss::Payment);
         };
 
         auto noTxs = [](Json::Value const& j) {

--- a/src/test/rpc/AmendmentBlocked_test.cpp
+++ b/src/test/rpc/AmendmentBlocked_test.cpp
@@ -88,7 +88,7 @@ class AmendmentBlocked_test : public beast::unit_test::suite
 
         Json::Value set_tx;
         set_tx[jss::Account] = bob.human();
-        set_tx[jss::TransactionType] = "AccountSet";
+        set_tx[jss::TransactionType] = jss::AccountSet;
         set_tx[jss::Fee] =
             static_cast<uint32_t>(8 * env.current()->fees().base);
         set_tx[jss::Sequence] = env.seq(bob);

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -96,7 +96,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -183,7 +183,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -259,7 +259,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -276,7 +276,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == XRP(75).value().getJson(0) &&
                             t[jss::TakerPays] == USD(100).value().getJson(0);
                 }));
@@ -361,7 +361,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -378,7 +378,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == XRP(75).value().getJson(0) &&
                             t[jss::TakerPays] == USD(100).value().getJson(0);
                 }));
@@ -454,7 +454,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -479,7 +479,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == JPY(100).value().getJson(0) &&
                             t[jss::TakerPays] == CNY(700).value().getJson(0);
                 }));
@@ -588,7 +588,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -613,7 +613,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == JPY(100).value().getJson(0) &&
                             t[jss::TakerPays] == CNY(700).value().getJson(0);
                 }));
@@ -700,7 +700,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -717,7 +717,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == XRP(75).value().getJson(0) &&
                             t[jss::TakerPays] == USD(100).value().getJson(0);
                 }));
@@ -734,7 +734,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == JPY(100).value().getJson(0) &&
                             t[jss::TakerPays] == CNY(700).value().getJson(0);
                 }));
@@ -751,7 +751,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == CNY(75).value().getJson(0) &&
                             t[jss::TakerPays] == JPY(100).value().getJson(0);
                 }));
@@ -864,7 +864,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == USD(100).value().getJson(0) &&
                             t[jss::TakerPays] == XRP(700).value().getJson(0);
                 }));
@@ -881,7 +881,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == XRP(75).value().getJson(0) &&
                             t[jss::TakerPays] == USD(100).value().getJson(0);
                 }));
@@ -898,7 +898,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == JPY(100).value().getJson(0) &&
                             t[jss::TakerPays] == CNY(700).value().getJson(0);
                 }));
@@ -915,7 +915,7 @@ public:
                 [&](auto const& jv)
                 {
                     auto const& t = jv[jss::transaction];
-                    return t[jss::TransactionType] == "OfferCreate" &&
+                    return t[jss::TransactionType] == jss::OfferCreate &&
                         t[jss::TakerGets] == CNY(75).value().getJson(0) &&
                             t[jss::TakerPays] == JPY(100).value().getJson(0);
                 }));
@@ -1005,7 +1005,7 @@ public:
             getBookDir(env, XRP, USD.issue()));
         BEAST_EXPECT(jrOffer[sfBookNode.fieldName] == "0000000000000000");
         BEAST_EXPECT(jrOffer[jss::Flags] == 0);
-        BEAST_EXPECT(jrOffer[sfLedgerEntryType.fieldName] == "Offer");
+        BEAST_EXPECT(jrOffer[sfLedgerEntryType.fieldName] == jss::Offer);
         BEAST_EXPECT(jrOffer[sfOwnerNode.fieldName] == "0000000000000000");
         BEAST_EXPECT(jrOffer[sfSequence.fieldName] == 3);
         BEAST_EXPECT(jrOffer[jss::TakerGets] == USD(10).value().getJson(0));
@@ -1018,7 +1018,7 @@ public:
             [&](auto const& jv)
             {
                 auto const& t = jv[jss::transaction];
-                return t[jss::TransactionType] == "OfferCreate" &&
+                return t[jss::TransactionType] == jss::OfferCreate &&
                        t[jss::TakerGets] == USD(10).value().getJson(0) &&
                        t[jss::owner_funds] == "100" &&
                        t[jss::TakerPays] == XRP(4000).value().getJson(0);
@@ -1031,7 +1031,7 @@ public:
             [&](auto const& jv)
             {
                 auto const& t = jv[jss::transaction];
-                return t[jss::TransactionType] == "OfferCreate" &&
+                return t[jss::TransactionType] == jss::OfferCreate &&
                        t[jss::TakerGets] == USD(5).value().getJson(0) &&
                        t[jss::owner_funds] == "50" &&
                        t[jss::TakerPays] == XRP(2000).value().getJson(0);
@@ -1054,7 +1054,7 @@ public:
             getBookDir(env, XRP, USD.issue()));
         BEAST_EXPECT(jrNextOffer[sfBookNode.fieldName] == "0000000000000000");
         BEAST_EXPECT(jrNextOffer[jss::Flags] == 0);
-        BEAST_EXPECT(jrNextOffer[sfLedgerEntryType.fieldName] == "Offer");
+        BEAST_EXPECT(jrNextOffer[sfLedgerEntryType.fieldName] == jss::Offer);
         BEAST_EXPECT(jrNextOffer[sfOwnerNode.fieldName] == "0000000000000000");
         BEAST_EXPECT(jrNextOffer[sfSequence.fieldName] == 3);
         BEAST_EXPECT(jrNextOffer[jss::TakerGets] == USD(5).value().getJson(0));
@@ -1089,7 +1089,7 @@ public:
         if(!(*maybeJv).isMember(jss::transaction))
             return false;
         auto const& t = (*maybeJv)[jss::transaction];
-        if (t[jss::TransactionType] != "OfferCreate" ||
+        if (t[jss::TransactionType] != jss::OfferCreate ||
             t[jss::TakerGets] != takerGets.value().getJson(0) ||
             t[jss::TakerPays] != takerPays.value().getJson(0))
             return false;

--- a/src/test/rpc/DeliveredAmount_test.cpp
+++ b/src/test/rpc/DeliveredAmount_test.cpp
@@ -103,7 +103,7 @@ public:
     bool
     checkTxn(Json::Value const& t, Json::Value const& metaData)
     {
-        if (t[jss::TransactionType].asString() != "Payment")
+        if (t[jss::TransactionType].asString() != jss::Payment)
             return true;
 
         bool isSet = metaData.isMember(jss::delivered_amount);

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -299,7 +299,7 @@ public:
 
         {
             Json::Value jv;
-            jv[jss::TransactionType] = "EscrowCreate";
+            jv[jss::TransactionType] = jss::EscrowCreate;
             jv[jss::Flags] = tfUniversal;
             jv[jss::Account] = Account{"bob5"}.human();
             jv[jss::Destination] = Account{"bob6"}.human();
@@ -312,7 +312,7 @@ public:
 
         {
             Json::Value jv;
-            jv[jss::TransactionType] = "PaymentChannelCreate";
+            jv[jss::TransactionType] = jss::PaymentChannelCreate;
             jv[jss::Flags] = tfUniversal;
             jv[jss::Account] = Account{"bob6"}.human ();
             jv[jss::Destination] = Account{"bob7"}.human ();
@@ -322,6 +322,16 @@ public:
             jv[sfCancelAfter.fieldName] =
                 NetClock::time_point{env.now() + 300s}
                     .time_since_epoch().count();
+            env(jv);
+        }
+
+        {
+            Json::Value jv;
+            jv[sfAccount.jsonName] = Account{"bob6"}.human ();
+            jv[sfSendMax.jsonName] = "100000000";
+            jv[sfDestination.jsonName] = Account{"bob7"}.human ();
+            jv[sfTransactionType.jsonName] = jss::CheckCreate;
+            jv[sfFlags.jsonName] = tfUniversal;
             env(jv);
         }
 
@@ -344,84 +354,91 @@ public:
         auto const jrr = makeRequest(jss::account);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 12) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "AccountRoot" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::AccountRoot );
         }
 
         {  // jvParams[jss::type] = "amendments";
         auto const jrr = makeRequest(jss::amendments);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "Amendments" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::Amendments );
+        }
+
+        {  // jvParams[jss::type] = "check";
+        auto const jrr = makeRequest(jss::check);
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
+        for (auto const& j : jrr[jss::state])
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::Check );
         }
 
         {  // jvParams[jss::type] = "directory";
         auto const jrr = makeRequest(jss::directory);
-        BEAST_EXPECT( checkArraySize(jrr[jss::state], 8) );
+        BEAST_EXPECT( checkArraySize(jrr[jss::state], 9) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "DirectoryNode" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::DirectoryNode );
         }
 
         {  // jvParams[jss::type] = "fee";
         auto const jrr = makeRequest(jss::fee);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "FeeSettings" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::FeeSettings );
         }
 
         {  // jvParams[jss::type] = "hashes";
         auto const jrr = makeRequest(jss::hashes);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 2) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "LedgerHashes" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::LedgerHashes );
         }
 
         {  // jvParams[jss::type] = "offer";
         auto const jrr = makeRequest(jss::offer);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "Offer" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::Offer );
         }
 
         {  // jvParams[jss::type] = "signer_list";
         auto const jrr = makeRequest(jss::signer_list);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "SignerList" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::SignerList );
         }
 
         {  // jvParams[jss::type] = "state";
         auto const jrr = makeRequest(jss::state);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "RippleState" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::RippleState );
         }
 
         {  // jvParams[jss::type] = "ticket";
         auto const jrr = makeRequest(jss::ticket);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "Ticket" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::Ticket );
         }
 
         {  // jvParams[jss::type] = "escrow";
         auto const jrr = makeRequest(jss::escrow);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "Escrow" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::Escrow );
         }
 
         {  // jvParams[jss::type] = "payment_channel";
         auto const jrr = makeRequest(jss::payment_channel);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 1) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "PayChannel" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::PayChannel );
         }
 
         {  // jvParams[jss::type] = "deposit_preauth";
         auto const jrr = makeRequest(jss::deposit_preauth);
         BEAST_EXPECT( checkArraySize(jrr[jss::state], 2) );
         for (auto const& j : jrr[jss::state])
-            BEAST_EXPECT( j["LedgerEntryType"] == "DepositPreauth" );
+            BEAST_EXPECT( j["LedgerEntryType"] == jss::DepositPreauth );
         }
 
         {  // jvParams[jss::type] = "misspelling";

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -342,7 +342,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             jv[sfAccount.jsonName] = account.human();
             jv[sfSendMax.jsonName] = sendMax.getJson(0);
             jv[sfDestination.jsonName] = dest.human();
-            jv[sfTransactionType.jsonName] = "CheckCreate";
+            jv[sfTransactionType.jsonName] = jss::CheckCreate;
             jv[sfFlags.jsonName] = tfUniversal;
             return jv;
         };
@@ -358,7 +358,8 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_hash] = ledgerHash;
             Json::Value const jrr = env.rpc (
                 "json", "ledger_entry", to_string (jvParams))[jss::result];
-            BEAST_EXPECT(jrr[jss::node][sfLedgerEntryType.jsonName] == "Check");
+            BEAST_EXPECT(
+                jrr[jss::node][sfLedgerEntryType.jsonName] == jss::Check);
             BEAST_EXPECT(jrr[jss::node][sfSendMax.jsonName] == "100000000");
         }
         {
@@ -407,7 +408,7 @@ class LedgerRPC_test : public beast::unit_test::suite
                 "json", "ledger_entry", to_string (jvParams))[jss::result];
 
             BEAST_EXPECT(
-                jrr[jss::node][sfLedgerEntryType.jsonName] == "DepositPreauth");
+                jrr[jss::node][sfLedgerEntryType.jsonName] == jss::DepositPreauth);
             BEAST_EXPECT(jrr[jss::node][sfAccount.jsonName] == alice.human());
             BEAST_EXPECT(jrr[jss::node][sfAuthorize.jsonName] == becky.human());
             depositPreauthIndex = jrr[jss::node][jss::index].asString();
@@ -420,8 +421,8 @@ class LedgerRPC_test : public beast::unit_test::suite
             Json::Value const jrr = env.rpc (
                 "json", "ledger_entry", to_string (jvParams))[jss::result];
 
-            BEAST_EXPECT(
-                jrr[jss::node][sfLedgerEntryType.jsonName] == "DepositPreauth");
+            BEAST_EXPECT(jrr[jss::node][sfLedgerEntryType.jsonName] ==
+                jss::DepositPreauth);
             BEAST_EXPECT(jrr[jss::node][sfAccount.jsonName] == alice.human());
             BEAST_EXPECT(jrr[jss::node][sfAuthorize.jsonName] == becky.human());
         }
@@ -660,7 +661,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             STAmount const& amount, NetClock::time_point const& cancelAfter)
         {
             Json::Value jv;
-            jv[jss::TransactionType] = "EscrowCreate";
+            jv[jss::TransactionType] = jss::EscrowCreate;
             jv[jss::Flags] = tfUniversal;
             jv[jss::Account] = account.human();
             jv[jss::Destination] = to.human();
@@ -849,7 +850,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             PublicKey const& pk)
         {
             Json::Value jv;
-            jv[jss::TransactionType] = "PaymentChannelCreate";
+            jv[jss::TransactionType] = jss::PaymentChannelCreate;
             jv[jss::Account] = account.human();
             jv[jss::Destination] = to.human();
             jv[jss::Amount] = amount.getJson (0);
@@ -1358,7 +1359,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(txj.isMember(jss::tx));
             auto const& tx = txj[jss::tx];
             BEAST_EXPECT(tx[jss::Account] == alice.human());
-            BEAST_EXPECT(tx[jss::TransactionType] == "OfferCreate");
+            BEAST_EXPECT(tx[jss::TransactionType] == jss::OfferCreate);
             txid1 = tx[jss::hash].asString();
         }
 
@@ -1442,7 +1443,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(txj.isMember(jss::tx));
             auto const& tx = txj[jss::tx];
             BEAST_EXPECT(tx[jss::Account] == alice.human());
-            BEAST_EXPECT(tx[jss::TransactionType] == "AccountSet");
+            BEAST_EXPECT(tx[jss::TransactionType] == jss::AccountSet);
             BEAST_EXPECT(tx[jss::hash] == txid2);
         }
     }
@@ -1470,7 +1471,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(jrr[jss::ledger][jss::accountState].size() == 1u);
             BEAST_EXPECT(
                 jrr[jss::ledger][jss::accountState][0u]["LedgerEntryType"]
-                == "LedgerHashes");
+                == jss::LedgerHashes);
             index = jrr[jss::ledger][jss::accountState][0u]["index"].asString();
         }
         {

--- a/src/test/rpc/NoRippleCheck_test.cpp
+++ b/src/test/rpc/NoRippleCheck_test.cpp
@@ -208,7 +208,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             if (! user)
             {
                 BEAST_EXPECT (txs[0u][jss::Account] == alice.human());
-                BEAST_EXPECT (txs[0u][jss::TransactionType] == "AccountSet");
+                BEAST_EXPECT (txs[0u][jss::TransactionType] == jss::AccountSet);
             }
 
             BEAST_EXPECT (
@@ -216,7 +216,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
                 alice.human());
             BEAST_EXPECT (
                 result[jss::transactions][txs.size()-1][jss::TransactionType] ==
-                "TrustSet");
+                jss::TrustSet);
             BEAST_EXPECT (
                 result[jss::transactions][txs.size()-1][jss::LimitAmount] ==
                 gw["USD"](100).value ().getJson (0));

--- a/src/test/rpc/RobustTransaction_test.cpp
+++ b/src/test/rpc/RobustTransaction_test.cpp
@@ -451,7 +451,7 @@ public:
                 [&](auto const& jv)
                 {
                     return jv[jss::transaction][jss::TransactionType] ==
-                        "AccountSet";
+                        jss::AccountSet;
                 }));
         }
 

--- a/src/test/rpc/TransactionEntry_test.cpp
+++ b/src/test/rpc/TransactionEntry_test.cpp
@@ -230,7 +230,7 @@ class TransactionEntry_test : public beast::unit_test::suite
         env.close();
 
         check_tx(env.closed()->seq(), trust_tx);
-        check_tx(env.closed()->seq(), pay_tx, "Payment");
+        check_tx(env.closed()->seq(), pay_tx, jss::Payment.c_str());
 
         env(offer(A2, XRP(100), A2["USD"](1)));
         auto offer_tx =
@@ -238,7 +238,7 @@ class TransactionEntry_test : public beast::unit_test::suite
 
         env.close();
 
-        check_tx(env.closed()->seq(), offer_tx, "OfferCreate");
+        check_tx(env.closed()->seq(), offer_tx, jss::OfferCreate.c_str());
     }
 
 public:

--- a/src/test/rpc/TransactionHistory_test.cpp
+++ b/src/test/rpc/TransactionHistory_test.cpp
@@ -125,10 +125,10 @@ class TransactionHistory_test : public beast::unit_test::suite
             }
         }
         BEAST_EXPECT(total == 117);
-        BEAST_EXPECT(typeCounts["AccountSet"] == 20);
-        BEAST_EXPECT(typeCounts["TrustSet"] == 19);
-        BEAST_EXPECT(typeCounts["Payment"] == 58);
-        BEAST_EXPECT(typeCounts["OfferCreate"] == 20);
+        BEAST_EXPECT(typeCounts[jss::AccountSet.c_str()] == 20);
+        BEAST_EXPECT(typeCounts[jss::TrustSet.c_str()] == 19);
+        BEAST_EXPECT(typeCounts[jss::Payment.c_str()] == 58);
+        BEAST_EXPECT(typeCounts[jss::OfferCreate.c_str()] == 20);
 
         // also, try a request with max non-admin start value
         {


### PR DESCRIPTION
The code base, on the whole, is pretty good about using symbolic names, rather than local string literals, for strings that are visible through the API.  Sharing one symbol for a given name has the advantage that misspelling that symbol will cause a compile error, and all users of the symbol are guaranteed to use identical spellings.

One place where we haven't been following the symbolic name pattern is has been the names of transactions and the names of ledger objects.  This pull request corrects that oversight.

The pull request has many small commits.  The goal was to make the code a little easier for reviewers to audit.  Only a few names are transitioned from string literal to symbolic name in each commit.  By doing the review one commit at a time a reviewer will have fewer changing names to track.  But feel free to do the review any way you like.

Once the review is complete all of the commits will be squashed into a single commit.