### PR TITLE
Payment paths with a zero output step are dry (RIPD-1749):

### DIFF
--- a/src/ripple/app/paths/impl/AmountSpec.h
+++ b/src/ripple/app/paths/impl/AmountSpec.h
@@ -105,6 +105,18 @@ struct EitherAmount
         else
             iou = a.iou;
     }
+
+#ifndef NDEBUG
+    friend std::ostream&
+    operator<<(std::ostream& stream, EitherAmount const& amt)
+    {
+        if (amt.native)
+            stream << to_string(amt.xrp);
+        else
+            stream << to_string(amt.iou);
+        return stream;
+    }
+#endif
 };
 
 template <class T>

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1248,6 +1248,40 @@ struct Flow_test : public beast::unit_test::suite
             ter(temBAD_PATH));
     }
 
+    void
+    testZeroOutputStep()
+    {
+        testcase("Zero Output Step");
+
+        using namespace jtx;
+        auto const alice = Account("alice");
+        auto const bob = Account("bob");
+        auto const carol = Account("carol");
+        auto const gw = Account("gw");
+        auto const USD = gw["USD"];
+        auto const EUR = gw["EUR"];
+
+        auto const features = supported_amendments();
+        Env env(*this, features);
+        env.fund(XRP(10000), alice, bob, carol, gw);
+        env.trust(USD(1000), alice, bob, carol);
+        env.trust(EUR(1000), alice, bob, carol);
+        env(pay(gw, alice, USD(100)));
+        env(pay(gw, bob, USD(100)));
+        env(pay(gw, bob, EUR(100)));
+        env.close();
+
+        env(offer(bob, USD(100), EUR(100)));
+        env(offer(bob, EUR(100), XRP(0.000001)));
+        env.close();
+
+        env(pay(alice, carol, XRP(1)),
+            path(~EUR, ~XRP),
+            sendmax(USD(1)),
+            txflags(tfPartialPayment),
+            ter(tecPATH_DRY));
+    }
+
     void testWithFeats(FeatureBitset features)
     {
         using namespace jtx;
@@ -1276,6 +1310,7 @@ struct Flow_test : public beast::unit_test::suite
     void run() override
     {
         testLimitQuality();
+        testZeroOutputStep();
         testRIPD1443(true);
         testRIPD1443(false);
         testRIPD1449(true);


### PR DESCRIPTION
A tiny input amount to a payment step can cause this step to output zero. For
example, if a previous steps outputs a dust amount of 10^-80, and this step is a
IOU -> XRP offer, the offer may output zero drops. In this case, call the strand
dry. Before this patch, an error would be logged, the strand would be called
dry; in debug mode an assert triggered.

Note, this patch is not transaction breaking, as the caller did not user the ter
code. The caller only checked for success or failuer.

This patch addresses github issue issue reported here:
https://github.com/ripple/rippled/issues/2929

@HowardHinnant @jwbusch 