### PR TITLE
Update some old comments

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -639,7 +639,6 @@ RCLConsensus::Adaptor::doAccept(
 
         for (auto const& p : rawCloseTimes.peers)
         {
-            // FIXME: Use median, not average
             JLOG(j_.info())
                 << std::to_string(p.second) << " time votes for "
                 << std::to_string(p.first.time_since_epoch().count());

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -194,8 +194,6 @@ class NetworkOPsImp final
 
 
 public:
-    // VFALCO TODO Make LedgerMaster a SharedPtr or a reference.
-    //
     NetworkOPsImp (Application& app, NetworkOPs::clock_type& clock,
         bool standalone, std::size_t minPeerCount, bool start_valid,
         JobQueue& job_queue, LedgerMaster& ledgerMaster, Stoppable& parent,
@@ -322,9 +320,6 @@ public:
         bool fromAcquire) override;
 
     // Network state machine.
-
-    // VFALCO TODO Try to make all these private since they seem to be...private
-    //
 
     // Used for the "jump" case.
 private:

--- a/src/ripple/nodestore/NodeObject.h
+++ b/src/ripple/nodestore/NodeObject.h
@@ -34,7 +34,6 @@ enum NodeObjectType
 {
     hotUNKNOWN = 0,
     hotLEDGER = 1,
-    //hotTRANSACTION = 2        // Not used
     hotACCOUNT_NODE = 3,
     hotTRANSACTION_NODE = 4
 };
@@ -53,16 +52,7 @@ class NodeObject : public CountedObject <NodeObject>
 public:
     static char const* getCountedObjectName () { return "NodeObject"; }
 
-    enum
-    {
-        /** Size of the fixed keys, in bytes.
-
-            We use a 256-bit hash for the keys.
-
-            @see NodeObject
-        */
-        keyBytes = 32,
-    };
+    static constexpr std::size_t keyBytes = 32;
 
 private:
     // This hack is used to make the constructor effectively private

--- a/src/ripple/nodestore/NodeObject.h
+++ b/src/ripple/nodestore/NodeObject.h
@@ -40,7 +40,7 @@ enum NodeObjectType
 };
 
 /** A simple object that the Ledger uses to store entries.
-    NodeObjects are comprised of a type, a hash, a ledger index and a blob.
+    NodeObjects are comprised of a type, a hash, and a blob.
     They can be uniquely identified by the hash, which is a half-SHA512 of
     the blob. The blob is a variable length block of serialized data. The
     type identifies what the blob contains.

--- a/src/ripple/nodestore/README.md
+++ b/src/ripple/nodestore/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 A `NodeObject` is a simple object that the Ledger uses to store entries. It is 
-comprised of a type, a hash, a ledger index and a blob. It can be uniquely 
+comprised of a type, a hash and a blob. It can be uniquely
 identified by the hash, which is a 256 bit hash of the blob. The blob is a 
 variable length block of serialized data. The type identifies what the blob 
 contains. The fields are as follows: 
@@ -33,19 +33,14 @@ contains. The fields are as follows:
 
  A 256-bit hash of the blob.
 
-* `mLedgerIndex`
-      
- An unsigned integer that uniquely identifies the ledger in which this 
-   NodeObject appears.
-
 * `mData`
       
  A blob containing the payload. Stored in the following format.
  
 |Byte   |                     |                          |
 |:------|:--------------------|:-------------------------|
-|0...3  |ledger index         |32-bit big endian integer |
-|4...7  |reserved ledger index|32-bit big endian integer |
+|0...3  |unused               |32-bit big endian integer |
+|4...7  |unused               |32-bit big endian integer |
 |8      |type                 |NodeObjectType enumeration|
 |9...end|data                 |body of the object data   |
 ---    

--- a/src/ripple/nodestore/README.md
+++ b/src/ripple/nodestore/README.md
@@ -39,8 +39,7 @@ contains. The fields are as follows:
  
 |Byte   |                     |                          |
 |:------|:--------------------|:-------------------------|
-|0...3  |unused               |32-bit big endian integer |
-|4...7  |unused               |32-bit big endian integer |
+|0...7  |unused               |                          |
 |8      |type                 |NodeObjectType enumeration|
 |9...end|data                 |body of the object data   |
 ---    

--- a/src/ripple/nodestore/impl/DecodedBlob.cpp
+++ b/src/ripple/nodestore/impl/DecodedBlob.cpp
@@ -31,8 +31,7 @@ DecodedBlob::DecodedBlob (void const* key, void const* value, int valueBytes)
 
         Bytes
 
-        0...3       Unused
-        4...7       Unused
+        0...7       Unused
         8           char            One of NodeObjectType
         9...end                     The body of the object data
     */

--- a/src/ripple/nodestore/impl/DecodedBlob.cpp
+++ b/src/ripple/nodestore/impl/DecodedBlob.cpp
@@ -31,8 +31,8 @@ DecodedBlob::DecodedBlob (void const* key, void const* value, int valueBytes)
 
         Bytes
 
-        0...3       LedgerIndex     32-bit big endian integer
-        4...7       Unused?         An unused copy of the LedgerIndex
+        0...3       Unused
+        4...7       Unused
         8           char            One of NodeObjectType
         9...end                     The body of the object data
     */


### PR DESCRIPTION
Ledger index was removed from persistent nodestore a while back:
  https://github.com/ripple/rippled/commit/f946d7b447452d2b28a086696889034e2d894f2a#diff-06e0962214bab48948f689d95d5e6dc7

But these docs were never updated