### PR TITLE
Trivial: Remove repo package check from update script

### DIFF
--- a/Builds/containers/gitlab-ci/build_container.sh
+++ b/Builds/containers/gitlab-ci/build_container.sh
@@ -15,7 +15,7 @@ if docker pull "${ARTIFACTORY_HUB}/${container_name}:${CI_COMMIT_SHA}"; then
     exit 0
 else
     echo "no existing ${pkgtype} container for this branch - searching history."
-    for CID_PREV in $(git log --pretty=%H -n5) ; do
+    for CID_PREV in $(git log --pretty=%H -n30) ; do
         if docker pull "${ARTIFACTORY_HUB}/${container_name}:${CID_PREV}"; then
             echo "found container for previous commit ${CID_PREV}" \
                 "- using as cache."

--- a/Builds/containers/shared/update-rippled.sh
+++ b/Builds/containers/shared/update-rippled.sh
@@ -33,8 +33,6 @@ if [[ "$ID" == "ubuntu" || "$ID" == "debian" ]] ; then
   }
 elif [[ "$ID" == "fedora" || "$ID" == "centos" || "$ID" == "rhel" || "$ID" == "scientific" ]] ; then
   RIPPLE_REPO=${RIPPLE_REPO-stable}
-  # Update ripple.repo file
-  rpm -Uvh --replacepkgs https://mirrors.ripple.com/ripple-repo-el7.rpm
   yum --disablerepo=* --enablerepo=ripple-$RIPPLE_REPO clean expire-cache
 
   yum check-update -q --enablerepo=ripple-$RIPPLE_REPO rippled || can_update=true


### PR DESCRIPTION
* expand search history to 30 most recent commits when we look for a previous docker build image
* remove the ripple-repo RPM from the update script as we will not be maintaining that package.