### PR TITLE
Use local rippled core lib during pkg build

### DIFF
--- a/Builds/containers/packaging/dpkg/debian/rules
+++ b/Builds/containers/packaging/dpkg/debian/rules
@@ -34,7 +34,7 @@ override_dh_auto_install:
 	cd bld_vl && \
 	cmake ../../validator-keys-tool -G Ninja \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_PREFIX_PATH=../debian/tmp/opt/ripple/ \
+		-DCMAKE_PREFIX_PATH=${PWD}/debian/tmp/opt/ripple/ \
 		-Dstatic=true \
 		-DCMAKE_VERBOSE_MAKEFILE=ON && \
 	cmake --build . --parallel -- -v


### PR DESCRIPTION
validator-keys has been updated to properly use xrpl_core as a dependency. This makes it so during the package build.