### PR TITLE
Return WS error code & reason on closure due to balance threshold exceeded

### DIFF
--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -359,7 +359,7 @@ ServerHandlerImp::onWSMessage(
     if (postResult == nullptr)
     {
         // The coroutine was rejected, probably because we're shutting down.
-        session->close();
+        session->close({boost::beast::websocket::going_away, "Shutting Down"});
     }
 }
 
@@ -388,7 +388,7 @@ ServerHandlerImp::processSession(
     auto is = std::static_pointer_cast<WSInfoSub> (session->appDefined);
     if (is->getConsumer().disconnect())
     {
-        session->close();
+        session->close({boost::beast::websocket::policy_error, "threshold exceeded"});
         // FIX: This rpcError is not delivered since the session
         // was just closed.
         return rpcError(rpcSLOW_DOWN);

--- a/src/ripple/server/WSSession.h
+++ b/src/ripple/server/WSSession.h
@@ -136,9 +136,12 @@ struct WSSession
     void
     send(std::shared_ptr<WSMsg> w) = 0;
 
+    virtual void
+    close() = 0;
+
     virtual
     void
-    close() = 0;
+    close(boost::beast::websocket::close_reason const& reason) = 0;
 
     /** Indicate that the response is complete.
         The handler should call this when it has completed writing


### PR DESCRIPTION
Clients can now inspect error code & msg to ascertain reason for connection being closed.

Fixes issues #2883 and #2887 