### PR TITLE
Fix a few issues encountered during RPM/Docker buildprocess

### DIFF
--- a/Builds/containers/centos-builder/Dockerfile
+++ b/Builds/containers/centos-builder/Dockerfile
@@ -1,6 +1,6 @@
+FROM centos:7
 ARG GIT_COMMIT=unknown
 
-FROM centos:7
 LABEL git-commit=$GIT_COMMIT
 
 COPY centos-builder/centos_setup.sh /tmp/


### PR DESCRIPTION
When running "**cmake --build . --target rpm**" on a recent
Fedora Release (28) against Docker 1.13.1 (both stock Fedora/Docker
installations with updates) I encountered two issues prevening RPM
building from completing.

First a Docker-specific error about "FROM" macro usage:
```
  Step 1/25 : ARG GIT_COMMIT=unknown
  Please provide a source image with `from` prior to commit
  gmake[3]: *** [CMakeFiles/rpm_container.dir/build.make:57: CMakeFiles/rpm_container] Error 1
  gmake[2]: *** [CMakeFiles/Makefile2:202: CMakeFiles/rpm_container.dir/all] Error 2
  gmake[1]: *** [CMakeFiles/Makefile2:361: CMakeFiles/rpm.dir/rule] Error 2
  gmake: *** [Makefile:268: rpm] Error 2
```

And after that is fixed an error about rpmbuild check-buildroot failing:
```
  + /usr/lib/rpm/check-buildroot
  Binary file /opt/rippled_bld/pkg/rpmbuild/BUILDROOT/rippled-1.3.0-0.1.b3.el7.x86_64/opt/ripple/bin/validator-keys matches
  Binary file /opt/rippled_bld/pkg/rpmbuild/BUILDROOT/rippled-1.3.0-0.1.b3.el7.x86_64/usr/lib/debug/opt/ripple/bin/validator-keys.debug matches
  Found '/opt/rippled_bld/pkg/rpmbuild/BUILDROOT/rippled-1.3.0-0.1.b3.el7.x86_64' in installed files; aborting
  error: Bad exit status from /var/tmp/rpm-tmp.YPR0mV (%install)

  RPM build errors:
      Bad exit status from /var/tmp/rpm-tmp.YPR0mV (%install)
```

This patch fixes both of those issues such that the RPM can sucessfully be built locally.