### PR TITLE
Modernize base_uint:

### DIFF
--- a/src/ripple/app/ledger/OrderBookDB.cpp
+++ b/src/ripple/app/ledger/OrderBookDB.cpp
@@ -114,14 +114,10 @@ void OrderBookDB::update(
                 sle->getFieldH256 (sfRootIndex) == sle->key())
             {
                 Book book;
-                book.in.currency.copyFrom(sle->getFieldH160(
-                    sfTakerPaysCurrency));
-                book.in.account.copyFrom(sle->getFieldH160 (
-                    sfTakerPaysIssuer));
-                book.out.account.copyFrom(sle->getFieldH160(
-                    sfTakerGetsIssuer));
-                book.out.currency.copyFrom (sle->getFieldH160(
-                    sfTakerGetsCurrency));
+                book.in.currency = sle->getFieldH160(sfTakerPaysCurrency);
+                book.in.account = sle->getFieldH160(sfTakerPaysIssuer);
+                book.out.account = sle->getFieldH160(sfTakerGetsIssuer);
+                book.out.currency = sle->getFieldH160(sfTakerGetsCurrency);
 
                 uint256 index = getBookBase (book);
                 if (seen.insert (index).second)

--- a/src/ripple/app/paths/NodeDirectory.h
+++ b/src/ripple/app/paths/NodeDirectory.h
@@ -51,7 +51,7 @@ public:
     void restart (bool multiQuality)
     {
         if (multiQuality)
-            current = 0;             // Restart book searching.
+            current = beast::zero;             // Restart book searching.
         else
             restartNeeded  = true;   // Restart at same quality.
     }
@@ -61,8 +61,8 @@ public:
         if (current != beast::zero)
             return false;
 
-        current.copyFrom (getBookBase (book));
-        next.copyFrom (getQualityNext (current));
+        current = getBookBase(book);
+        next = getQualityNext(current);
 
         // TODO(tom): it seems impossible that any actual offers with
         // quality == 0 could occur - we should disallow them, and clear

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -89,7 +89,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
                 JLOG (j_.trace())
                     << "advanceNode: No more offers.";
 
-                node().offerIndex_ = 0;
+                node().offerIndex_ = beast::zero;
                 break;
             }
             else
@@ -177,7 +177,7 @@ TER PathCursor::advanceNode (bool const bReverse) const
             {
                 // Ran off end of offers.
                 node().bEntryAdvance   = false;        // Done.
-                node().offerIndex_ = 0;            // Report no more entries.
+                node().offerIndex_ = beast::zero;      // Report no more entries.
             }
         }
         else

--- a/src/ripple/crypto/GenerateDeterministicKey.h
+++ b/src/ripple/crypto/GenerateDeterministicKey.h
@@ -26,6 +26,7 @@
 #define RIPPLE_CRYPTO_GENERATEDETERMINISTICKEY_H_INCLUDED
 
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/Blob.h>
 
 namespace ripple {
 

--- a/src/ripple/nodestore/NodeObject.h
+++ b/src/ripple/nodestore/NodeObject.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_NODESTORE_NODEOBJECT_H_INCLUDED
 #define RIPPLE_NODESTORE_NODEOBJECT_H_INCLUDED
 
+#include <ripple/basics/Blob.h>
 #include <ripple/basics/CountedObject.h>
 #include <ripple/protocol/Protocol.h>
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1578,8 +1578,8 @@ PeerImp::onMessage (std::shared_ptr <protocol::TMProposeSet> const& m)
         return;
     }
 
-    auto const proposeHash = uint256::fromVoid(set.currenttxhash().data());
-    auto const prevLedger = uint256::fromVoid(set.previousledger().data());
+    uint256 const proposeHash{set.currenttxhash()};
+    uint256 const prevLedger{set.previousledger()};
 
     PublicKey const publicKey {makeSlice(set.nodepubkey())};
     NetClock::time_point const closeTime { NetClock::duration{set.closetime()} };

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -34,7 +34,7 @@ private:
     // But an STAccount is always 160 bits, so we can store it with less
     // overhead in a ripple::uint160.  However, so the serialized format of the
     // STAccount stays unchanged, we serialize and deserialize like an STBlob.
-    uint160 value_;
+    AccountID value_;
     bool default_;
 
 public:
@@ -101,14 +101,12 @@ public:
     AccountID
     value() const noexcept
     {
-        AccountID result;
-        result.copyFrom (value_);
-        return result;
+        return value_;
     }
 
     void setValue (AccountID const& v)
     {
-        value_.copyFrom (v);
+        value_ = v;
         default_ = false;
     }
 };

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -102,7 +102,7 @@ public:
     template <typename Tag>
     void setValue (base_uint<Bits, Tag> const& v)
     {
-        value_.copyFrom(v);
+        value_ = v;
     }
 
     value_type const&

--- a/src/ripple/protocol/Serializer.h
+++ b/src/ripple/protocol/Serializer.h
@@ -21,6 +21,7 @@
 #define RIPPLE_PROTOCOL_SERIALIZER_H_INCLUDED
 
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/Blob.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/Buffer.h>
 #include <ripple/basics/safe_cast.h>

--- a/src/ripple/protocol/impl/AccountID.cpp
+++ b/src/ripple/protocol/impl/AccountID.cpp
@@ -148,7 +148,7 @@ calcAccountID (PublicKey const& pk)
 AccountID const&
 xrpAccount()
 {
-    static AccountID const account(0);
+    static AccountID const account(beast::zero);
     return account;
 }
 

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -60,9 +60,9 @@ STAccount::STAccount (SerialIter& sit, SField const& name)
 
 STAccount::STAccount (SField const& n, AccountID const& v)
     : STBase (n)
+    , value_(v)
     , default_ (false)
 {
-    value_.copyFrom (v);
 }
 
 std::string STAccount::getText () const

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -106,12 +106,12 @@ STAmount::STAmount(SerialIter& sit, SField const& name)
     }
 
     Issue issue;
-    issue.currency.copyFrom (sit.get160 ());
+    issue.currency = sit.get160();
 
     if (isXRP (issue.currency))
         Throw<std::runtime_error> ("invalid native currency");
 
-    issue.account.copyFrom (sit.get160 ());
+    issue.account = sit.get160();
 
     if (isXRP (issue.account))
         Throw<std::runtime_error> ("invalid native account");

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -91,13 +91,13 @@ STPathSet::STPathSet (SerialIter& sit, SField const& name)
             AccountID issuer;
 
             if (hasAccount)
-                account.copyFrom (sit.get160 ());
+                account = sit.get160();
 
             if (hasCurrency)
-                currency.copyFrom (sit.get160 ());
+                currency = sit.get160();
 
             if (hasIssuer)
-                issuer.copyFrom (sit.get160 ());
+                issuer = sit.get160();
 
             path.emplace_back (account, currency, issuer, hasCurrency);
         }

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -110,7 +110,7 @@ Currency to_currency(std::string const& code)
 
 Currency const& xrpCurrency()
 {
-    static Currency const currency(0);
+    static Currency const currency(beast::zero);
     return currency;
 }
 

--- a/src/test/basics/base_uint_test.cpp
+++ b/src/test/basics/base_uint_test.cpp
@@ -18,9 +18,11 @@
 //==============================================================================
 
 #include <ripple/basics/base_uint.h>
+#include <ripple/basics/Blob.h>
 #include <ripple/basics/hardened_hash.h>
 #include <ripple/beast/unit_test.h>
 #include <boost/algorithm/string.hpp>
+#include <complex>
 
 #include <type_traits>
 
@@ -57,6 +59,8 @@ struct base_uint_test : beast::unit_test::suite
 
     void run() override
     {
+        static_assert(!std::is_constructible<test96, std::complex<double>>::value, "");
+        static_assert(!std::is_assignable<test96&, std::complex<double>>::value, "");
         // used to verify set insertion (hashing required)
         std::unordered_set<test96, hardened_hash<>> uset;
 

--- a/src/test/protocol/SecretKey_test.cpp
+++ b/src/test/protocol/SecretKey_test.cpp
@@ -77,7 +77,7 @@ public:
     {
         blob b;
         hex_to_binary (s.begin (), s.end (), b);
-        return uint256::fromVoid(b.data());
+        return uint256{b};
     }
 
     static

--- a/src/test/protocol/digest_test.cpp
+++ b/src/test/protocol/digest_test.cpp
@@ -22,6 +22,7 @@
 #include <ripple/beast/xor_shift_engine.h>
 #include <ripple/beast/unit_test.h>
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <numeric>
@@ -115,12 +116,12 @@ public:
     digest_test ()
     {
         beast::xor_shift_engine g(19207813);
-        std::uint8_t buf[32];
+        std::array<std::uint8_t, 32> buf;
 
         for (int i = 0; i < 1000000; i++)
         {
-            beast::rngfill (buf, sizeof(buf), g);
-            dataset1.push_back (uint256::fromVoid (buf));
+            beast::rngfill (buf.data(), buf.size(), g);
+            dataset1.push_back (uint256{buf});
         }
     }
 


### PR DESCRIPTION
*  Add construction and assignment from a generic
   contiguous container.  Both compile-time and run time
   safety checks are made to ensure the safety of this
   conversion.

*  Remove base_uint::copyFrom.  The generic copy assignment
   operator now does this functionality with enhanced
   safety and better syntax.

*  Remove construction from and dedendence on Blob.
   The generic constructor and assignment now handle this
   functionality.

*  Fix client code to adhere to this new API.

*  Removed the use of fromVoid in PeerImp.cpp as it was
   an inappropriate use of this dangerous API.  The
   generic container constructors do it with enhanced
   safety and better syntax.