### PR TITLE
Fix SNTPClock shutdown

### DIFF
--- a/src/ripple/core/impl/SNTPClock.cpp
+++ b/src/ripple/core/impl/SNTPClock.cpp
@@ -157,6 +157,7 @@ public:
 
         using namespace boost::asio;
         socket_.open (ip::udp::v4 ());
+        socket_.bind (ep_);
         socket_.async_receive_from (buffer (buf_, 256),
             ep_, std::bind(
                 &SNTPClientImp::onRead, this,
@@ -167,9 +168,6 @@ public:
             &SNTPClientImp::onTimer, this,
                 std::placeholders::_1));
 
-        // VFALCO Is it correct to launch the thread
-        //        here after queuing I/O?
-        //
         thread_ = std::thread(&SNTPClientImp::doRun, this);
     }
 


### PR DESCRIPTION
This PR addresses a problem where the server could hang indefinitely on shutdown. The cause of the problem is the SNTPClock class was not binding the socket to an endpoint on initialization. This can create an error sent to the read handler. Unfortunately, the handler ignores the error, reads again and enters into a loop preventing the io_service from ever completing.