### PR TITLE
Add a reset code for the regular keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2075,6 +2075,7 @@ else ()
     src/ripple/app/tx/impl/OfferStream.cpp
     src/ripple/app/tx/impl/PayChan.cpp
     src/ripple/app/tx/impl/Payment.cpp
+    src/ripple/app/tx/impl/ResetRegularKey.cpp
     src/ripple/app/tx/impl/SetAccount.cpp
     src/ripple/app/tx/impl/SetRegularKey.cpp
     src/ripple/app/tx/impl/SetSignerList.cpp

--- a/src/ripple/app/tx/impl/ResetRegularKey.cpp
+++ b/src/ripple/app/tx/impl/ResetRegularKey.cpp
@@ -1,0 +1,80 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2019, Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/tx/impl/ResetRegularKey.h>
+#include <ripple/basics/Log.h>
+#include <ripple/conditions/Condition.h>
+#include <ripple/conditions/Fulfillment.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/TxFlags.h>
+
+namespace ripple
+{
+
+NotTEC
+ResetRegularKey::preflight (PreflightContext const& ctx)
+{
+    auto const ret = preflight1 (ctx);
+    if (!isTesSuccess (ret))
+        return ret;
+    if (ctx.tx.getFlags() & tfUniversalMask)
+        return temINVALID_FLAG;
+    return preflight2(ctx);
+}
+
+TER
+ResetRegularKey::doApply ()
+{
+    auto const target = ctx_.tx.getAccountID(sfTarget);
+    auto const root = view().peek(keylet::account(target));
+
+    if (!root)
+        return tecNO_TARGET;
+
+    // Reset can't lock a account out
+    if (root->isFlag(lsfDisableMaster) && !view().peek(keylet::signers(target)))
+        return tecNO_ALTERNATIVE_KEY;
+
+    auto const cb = (*root)[~sfRegularKeyReset];
+
+    if (!cb)
+        return tecNO_PERMISSION;
+
+    using namespace cryptoconditions;
+
+    std::error_code ec;
+
+    auto rc = Condition::deserialize(*cb, ec);
+    if (!rc)
+        return tecCRYPTOCONDITION_ERROR;
+
+    auto rf = Fulfillment::deserialize(ctx_.tx[sfRegularKeyReset], ec);
+    if (!rf)
+        return tecCRYPTOCONDITION_ERROR;
+
+    if (!validate(*rf, *rc))
+        return tecNO_AUTH;
+
+    root->makeFieldAbsent(sfRegularKeyReset);
+    root->makeFieldAbsent(sfRegularKey);
+
+    return tesSUCCESS;
+}
+
+}

--- a/src/ripple/app/tx/impl/ResetRegularKey.h
+++ b/src/ripple/app/tx/impl/ResetRegularKey.h
@@ -1,0 +1,56 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2019 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TX_RESETREGULARKEY_H_INCLUDED
+#define RIPPLE_TX_RESETREGULARKEY_H_INCLUDED
+
+#include <ripple/app/tx/impl/Transactor.h>
+#include <ripple/basics/Log.h>
+#include <ripple/protocol/TxFlags.h>
+#include <ripple/protocol/UintTypes.h>
+
+namespace ripple {
+
+class ResetRegularKey
+    : public Transactor
+{
+public:
+    explicit ResetRegularKey (ApplyContext& ctx)
+        : Transactor(ctx)
+    {
+    }
+
+    static
+    bool
+    affectsSubsequentTransactionAuth(STTx const& tx)
+    {
+        return true;
+    }
+
+    static
+    NotTEC
+    preflight (PreflightContext const& ctx);
+
+    TER doApply () override;
+};
+
+} // ripple
+
+#endif
+

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -30,6 +30,7 @@
 #include <ripple/app/tx/impl/DepositPreauth.h>
 #include <ripple/app/tx/impl/Escrow.h>
 #include <ripple/app/tx/impl/Payment.h>
+#include <ripple/app/tx/impl/ResetRegularKey.h>
 #include <ripple/app/tx/impl/SetAccount.h>
 #include <ripple/app/tx/impl/SetRegularKey.h>
 #include <ripple/app/tx/impl/SetSignerList.h>
@@ -63,6 +64,7 @@ invoke_preflight (PreflightContext const& ctx)
     case ttTICKET_CANCEL:        return CancelTicket      ::preflight(ctx);
     case ttTICKET_CREATE:        return CreateTicket      ::preflight(ctx);
     case ttTRUST_SET:            return SetTrust          ::preflight(ctx);
+    case ttREGULAR_KEY_RESET:    return ResetRegularKey   ::preflight(ctx);
     case ttAMENDMENT:
     case ttFEE:                  return Change            ::preflight(ctx);
     default:
@@ -132,6 +134,7 @@ invoke_preclaim (PreclaimContext const& ctx)
     case ttTICKET_CANCEL:        return invoke_preclaim<CancelTicket>(ctx);
     case ttTICKET_CREATE:        return invoke_preclaim<CreateTicket>(ctx);
     case ttTRUST_SET:            return invoke_preclaim<SetTrust>(ctx);
+    case ttREGULAR_KEY_RESET:    return invoke_preclaim<ResetRegularKey>(ctx);
     case ttAMENDMENT:
     case ttFEE:                  return invoke_preclaim<Change>(ctx);
     default:
@@ -167,6 +170,7 @@ invoke_calculateBaseFee(
     case ttTICKET_CANCEL:        return CancelTicket::calculateBaseFee(view, tx);
     case ttTICKET_CREATE:        return CreateTicket::calculateBaseFee(view, tx);
     case ttTRUST_SET:            return SetTrust::calculateBaseFee(view, tx);
+    case ttREGULAR_KEY_RESET:    return ResetRegularKey::calculateBaseFee(view, tx);
     case ttAMENDMENT:
     case ttFEE:                  return Change::calculateBaseFee(view, tx);
     default:
@@ -213,6 +217,7 @@ invoke_calculateConsequences(STTx const& tx)
     case ttTICKET_CANCEL:        return invoke_calculateConsequences<CancelTicket>(tx);
     case ttTICKET_CREATE:        return invoke_calculateConsequences<CreateTicket>(tx);
     case ttTRUST_SET:            return invoke_calculateConsequences<SetTrust>(tx);
+    case ttREGULAR_KEY_RESET:    return invoke_calculateConsequences<ResetRegularKey>(tx);
     case ttAMENDMENT:
     case ttFEE:
         // fall through to default
@@ -248,6 +253,7 @@ invoke_apply (ApplyContext& ctx)
     case ttTICKET_CANCEL:        { CancelTicket       p(ctx); return p(); }
     case ttTICKET_CREATE:        { CreateTicket       p(ctx); return p(); }
     case ttTRUST_SET:            { SetTrust           p(ctx); return p(); }
+    case ttREGULAR_KEY_RESET:    { ResetRegularKey    p(ctx); return p(); }
     case ttAMENDMENT:
     case ttFEE:                { Change           p(ctx); return p(); }
     default:

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -84,7 +84,8 @@ class FeatureCollections
         "fix1578",
         "MultiSignReserve",
         "fixTakerDryOfferRemoval",
-        "fixMasterKeyAsRegularKey"
+        "fixMasterKeyAsRegularKey",
+        "ResetRegularKey",
     };
 
     std::vector<uint256> features;
@@ -374,6 +375,7 @@ extern uint256 const fix1578;
 extern uint256 const featureMultiSignReserve;
 extern uint256 const fixTakerDryOfferRemoval;
 extern uint256 const fixMasterKeyAsRegularKey;
+extern uint256 const featureResetRegularKey;
 
 } // ripple
 

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -455,6 +455,7 @@ extern SF_Blob const sfMemoFormat;
 extern SF_Blob const sfFulfillment;
 extern SF_Blob const sfCondition;
 extern SF_Blob const sfMasterSignature;
+extern SF_Blob const sfRegularKeyReset;
 
 // account
 extern SF_Account const sfAccount;

--- a/src/ripple/protocol/TxFormats.h
+++ b/src/ripple/protocol/TxFormats.h
@@ -55,6 +55,7 @@ enum TxType
     ttCHECK_CANCEL       =  18,
     ttDEPOSIT_PREAUTH    =  19,
     ttTRUST_SET          =  20,
+    ttREGULAR_KEY_RESET  =  21,
 
     ttAMENDMENT          = 100,
     ttFEE                = 101,

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -118,6 +118,7 @@ detail::supportedAmendments ()
         "MultiSignReserve",
         "fixTakerDryOfferRemoval",
         "fixMasterKeyAsRegularKey",
+        "ResetRegularKey",
     };
     return supported;
 }
@@ -175,5 +176,6 @@ uint256 const fix1578 = *getRegisteredFeature("fix1578");
 uint256 const featureMultiSignReserve = *getRegisteredFeature("MultiSignReserve");
 uint256 const fixTakerDryOfferRemoval = *getRegisteredFeature("fixTakerDryOfferRemoval");
 uint256 const fixMasterKeyAsRegularKey = *getRegisteredFeature("fixMasterKeyAsRegularKey");
+uint256 const featureResetRegularKey = *getRegisteredFeature("ResetRegularKey");
 
 } // ripple

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -53,6 +53,7 @@ LedgerFormats::LedgerFormats ()
             { sfTransferRate,        soeOPTIONAL },
             { sfDomain,              soeOPTIONAL },
             { sfTickSize,            soeOPTIONAL },
+            { sfRegularKeyReset,     soeOPTIONAL },
         },
         commonFields);
 

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -187,6 +187,7 @@ SF_Blob const sfMemoFormat      (access, STI_VL, 14, "MemoFormat");
 SF_Blob const sfFulfillment     (access, STI_VL, 16, "Fulfillment");
 SF_Blob const sfCondition       (access, STI_VL, 17, "Condition");
 SF_Blob const sfMasterSignature (access, STI_VL, 18, "MasterSignature", SField::sMD_Default, SField::notSigning);
+SF_Blob const sfRegularKeyReset (access, STI_VL, 19, "RegularKeyReset");
 
 // account
 SF_Account const sfAccount     (access, STI_ACCOUNT, 1, "Account");

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -54,6 +54,7 @@ TxFormats::TxFormats ()
             { sfSetFlag,             soeOPTIONAL },
             { sfClearFlag,           soeOPTIONAL },
             { sfTickSize,            soeOPTIONAL },
+            { sfRegularKeyReset,     soeOPTIONAL },
         },
         commonFields);
 
@@ -221,6 +222,13 @@ TxFormats::TxFormats ()
         {
             { sfAuthorize,           soeOPTIONAL },
             { sfUnauthorize,         soeOPTIONAL },
+        },
+        commonFields);
+
+    add (jss::ResetRegularKey, ttREGULAR_KEY_RESET,
+        {
+            { sfTarget,               soeREQUIRED },
+            { sfRegularKeyReset,      soeREQUIRED },
         },
         commonFields);
 }

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -71,6 +71,7 @@ JSS ( PaymentChannelClaim );        // transaction type.
 JSS ( PaymentChannelCreate );       // transaction type.
 JSS ( PaymentChannelFund );         // transaction type.
 JSS ( RippleState );                // ledger type.
+JSS ( ResetRegularKey );
 JSS ( SLE_hit_rate );               // out: GetCounts.
 JSS ( SetFee );                     // transaction type.
 JSS ( SettleDelay );                // in: TransactionSign

--- a/src/ripple/unity/app_tx.cpp
+++ b/src/ripple/unity/app_tx.cpp
@@ -35,6 +35,7 @@
 #include <ripple/app/tx/impl/OfferStream.cpp>
 #include <ripple/app/tx/impl/Payment.cpp>
 #include <ripple/app/tx/impl/PayChan.cpp>
+#include <ripple/app/tx/impl/ResetRegularKey.cpp>
 #include <ripple/app/tx/impl/SetAccount.cpp>
 #include <ripple/app/tx/impl/SetRegularKey.cpp>
 #include <ripple/app/tx/impl/SetSignerList.cpp>

--- a/src/test/app/SetRegularKey_test.cpp
+++ b/src/test/app/SetRegularKey_test.cpp
@@ -182,8 +182,14 @@ public:
         env(jv, ter(temINVALID_FLAG));
     }
 
+    void testResetReglarKey()
+    {
+        // need help to do the test of the change in code
+    }
+
     void run() override
     {
+        testResetReglarKey();
         testDisableMasterKey();
         testDisableMasterKeyAfterFix();
         testDisabledRegularKey();


### PR DESCRIPTION
The wallets provider (like Gatehub) stores the wallet seed or master private key in database, and encrypt  using the account password so wallet provider cannot access the wallet without the user loging in. This is good but also it is the problem as Gatehub hack shows this can mean that wallet provider is not able to act to protect users until users login.

If providers used a regular private key to sign better uses security could be possible by having a reset code that is in the cold storage. That way if the database is taken the provider can use the reset code form the cold storage to remove the regular key without having the wait for the user. That way the provider loses the access but they users still has the regular key and can use the account without  problem.

I add a reset reguarl key code using the crypto-condition PreimageSha256 which can be used to remove a regular key from the wallet.