### PR TITLE
Add logrotate config to rpm/deb pkgs

### DIFF
--- a/Builds/containers/packaging/dpkg/debian/conffiles
+++ b/Builds/containers/packaging/dpkg/debian/conffiles
@@ -1,2 +1,3 @@
 opt/ripple/etc/rippled.cfg
 opt/ripple/etc/validators.txt
+etc/logrotate.d/rippled

--- a/Builds/containers/packaging/dpkg/debian/rippled.install
+++ b/Builds/containers/packaging/dpkg/debian/rippled.install
@@ -4,3 +4,4 @@ opt/ripple/bin/update-rippled.sh
 opt/ripple/etc/rippled.cfg
 opt/ripple/etc/validators.txt
 opt/ripple/etc/update-rippled-cron
+etc/logrotate.d/rippled

--- a/Builds/containers/packaging/dpkg/debian/rippled.postinst
+++ b/Builds/containers/packaging/dpkg/debian/rippled.postinst
@@ -16,6 +16,7 @@ case "$1" in
         chmod 755 /var/log/rippled/
         chmod 755 /var/lib/rippled/
         chmod 644 /opt/ripple/etc/update-rippled-cron
+        chmod 644 /etc/logrotate.d/rippled
         chown -R root:$GROUP_NAME /opt/ripple/etc/update-rippled-cron
     ;;
 

--- a/Builds/containers/packaging/dpkg/debian/rules
+++ b/Builds/containers/packaging/dpkg/debian/rules
@@ -41,5 +41,6 @@ override_dh_auto_install:
 	install -D bld_vl/validator-keys debian/tmp/opt/ripple/bin/validator-keys
 	install -D Builds/containers/shared/update-rippled.sh debian/tmp/opt/ripple/bin/update-rippled.sh
 	install -D Builds/containers/shared/update-rippled-cron debian/tmp/opt/ripple/etc/update-rippled-cron
+	install -D Builds/containers/shared/rippled-logrotate debian/tmp/etc/logrotate.d/rippled
 	rm -rf bld
 	rm -rf bld_vl

--- a/Builds/containers/packaging/rpm/rippled.spec
+++ b/Builds/containers/packaging/rpm/rippled.spec
@@ -64,6 +64,7 @@ install -D ./rippled/Builds/containers/shared/rippled.service ${RPM_BUILD_ROOT}/
 install -D ./rippled/Builds/containers/packaging/rpm/50-rippled.preset ${RPM_BUILD_ROOT}/usr/lib/systemd/system-preset/50-rippled.preset
 install -D ./rippled/Builds/containers/shared/update-rippled.sh ${RPM_BUILD_ROOT}%{_bindir}/update-rippled.sh
 install -D ./rippled/Builds/containers/shared/update-rippled-cron ${RPM_BUILD_ROOT}%{_prefix}/etc/update-rippled-cron
+install -D ./rippled/Builds/containers/shared/rippled-logrotate ${RPM_BUILD_ROOT}/etc/logrotate.d/rippled
 install -d $RPM_BUILD_ROOT/var/log/rippled
 install -d $RPM_BUILD_ROOT/var/lib/rippled
 
@@ -82,6 +83,7 @@ chmod 755 /var/log/rippled/
 chmod 755 /var/lib/rippled/
 
 chmod 644 %{_prefix}/etc/update-rippled-cron
+chmod 644 /etc/logrotate.d/rippled
 chown -R root:$GROUP_NAME %{_prefix}/etc/update-rippled-cron
 
 %files
@@ -95,6 +97,7 @@ chown -R root:$GROUP_NAME %{_prefix}/etc/update-rippled-cron
 %config(noreplace) /etc/opt/ripple/rippled.cfg
 %config(noreplace) %{_prefix}/etc/validators.txt
 %config(noreplace) /etc/opt/ripple/validators.txt
+%config(noreplace) /etc/logrotate.d/rippled
 %config(noreplace) /usr/lib/systemd/system/rippled.service
 %config(noreplace) /usr/lib/systemd/system-preset/50-rippled.preset
 %dir /var/log/rippled/

--- a/Builds/containers/shared/rippled-logrotate
+++ b/Builds/containers/shared/rippled-logrotate
@@ -1,0 +1,15 @@
+/var/log/rippled/*.log {
+  daily
+  minsize 200M
+  rotate 7
+  nocreate
+  missingok
+  notifempty
+  compress
+  compresscmd /usr/bin/nice
+  compressoptions -n19 ionice -c3 gzip
+  compressext .gz
+  postrotate
+    /opt/ripple/bin/rippled --conf /opt/ripple/etc/rippled.cfg logrotate
+  endscript
+}


### PR DESCRIPTION
@alloyxrp , @crypticrabbit, @MarkusTeufelberger - I tried to compromise on something like 2 wks worth of warn level logs, rolling every two days. Users can always customize after install and/or we can change the defaults as needed in the future.