### PR TITLE
Make protocol message counters more granular:

### DIFF
--- a/src/ripple/overlay/Message.h
+++ b/src/ripple/overlay/Message.h
@@ -75,7 +75,7 @@ public:
     }
 
     /** Get the traffic category */
-    int
+    std::size_t
     getCategory () const
     {
         return mCategory;
@@ -167,7 +167,7 @@ private:
 
     std::vector <uint8_t> mBuffer;
 
-    int mCategory;
+    std::size_t mCategory;
 };
 
 }

--- a/src/ripple/overlay/impl/Message.cpp
+++ b/src/ripple/overlay/impl/Message.cpp
@@ -39,8 +39,7 @@ Message::Message (::google::protobuf::Message const& message, int type)
         message.SerializeToArray (&mBuffer [Message::kHeaderBytes], messageBytes);
     }
 
-    mCategory = safe_cast<int>(TrafficCount::categorize
-        (message, type, false));
+    mCategory = TrafficCount::categorize(message, type, false);
 }
 
 bool Message::operator== (Message const& other) const

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -593,26 +593,18 @@ void
 OverlayImpl::onWrite (beast::PropertyStream::Map& stream)
 {
     beast::PropertyStream::Set set ("traffic", stream);
-    auto stats = m_traffic.getCounts();
-    for (auto& i : stats)
+    auto const stats = m_traffic.getCounts();
+    for (auto const& i : stats)
     {
-        if (! i.second.messagesIn && ! i.second.messagesOut)
-            continue;
-
-        beast::PropertyStream::Map item (set);
-        item["category"] = i.first;
-        item["bytes_in"] =
-            beast::lexicalCast<std::string>
-                (i.second.bytesIn.load());
-        item["messages_in"] =
-            beast::lexicalCast<std::string>
-                (i.second.messagesIn.load());
-        item["bytes_out"] =
-            beast::lexicalCast<std::string>
-                (i.second.bytesOut.load());
-        item["messages_out"] =
-            beast::lexicalCast<std::string>
-                (i.second.messagesOut.load());
+        if (i)
+        {
+            beast::PropertyStream::Map item(set);
+            item["category"] = i.name;
+            item["bytes_in"] = std::to_string(i.bytesIn.load());
+            item["messages_in"] = std::to_string(i.messagesIn.load());
+            item["bytes_out"] = std::to_string(i.bytesOut.load());
+            item["messages_out"] = std::to_string(i.messagesOut.load());
+        }
     }
 }
 

--- a/src/ripple/overlay/impl/TrafficCount.cpp
+++ b/src/ripple/overlay/impl/TrafficCount.cpp
@@ -21,55 +21,6 @@
 
 namespace ripple {
 
-const char* TrafficCount::getName (category c)
-{
-    switch (c)
-    {
-    case category::base:              return "overhead";
-    case category::cluster:           return "cluster management";
-    case category::overlay:           return "overlay management";
-    case category::manifests:         return "manifest management";
-    case category::transaction:       return "transactions";
-    case category::proposal:          return "proposals management";
-    case category::validation:        return "validations";
-    case category::shards:            return "shards";
-    case category::get_set:           return "set management (get)";
-    case category::share_set:         return "set management(share)";
-    case category::ld_tsc_get:        return "ledger data: Transaction Set candidate (get)";
-    case category::ld_tsc_share:      return "ledger data: Transaction Set candidate (share)";
-    case category::ld_txn_get:        return "ledger data: Transaction Node (get)";
-    case category::ld_txn_share:      return "ledger data: Transaction Node (share)";
-    case category::ld_asn_get:        return "ledger data: Account State Node (get)";
-    case category::ld_asn_share:      return "ledger data: Account State Node (share)";
-    case category::ld_get:            return "ledger data (get)";
-    case category::ld_share:          return "ledger data (share)";
-    case category::gl_tsc_share:      return "ledger: Transaction Set candidate (share)";
-    case category::gl_tsc_get:        return "ledger: Transaction Set candidate (get)";
-    case category::gl_txn_share:      return "ledger: Transaction node (share)";
-    case category::gl_txn_get:        return "ledger: Transaction node (get)";
-    case category::gl_asn_share:      return "ledger: Account State node (share)";
-    case category::gl_asn_get:        return "ledger: Account State node (get)";
-    case category::gl_share:          return "ledger (share)";
-    case category::gl_get:            return "ledger (get)";
-    case category::share_hash_ledger: return "getobject: Ledger (share)";
-    case category::get_hash_ledger:   return "getobject: Ledger (get)";
-    case category::share_hash_tx:     return "getobject: Transaction (share)";
-    case category::get_hash_tx:       return "getobject: Transaction (get)";
-    case category::share_hash_txnode: return "getobject: Transaction node (share)";
-    case category::get_hash_txnode:   return "getobject: Transaction node (get)";
-    case category::share_hash_asnode: return "getobject: Account State node (share)";
-    case category::get_hash_asnode:   return "getobject: Account State node (get)";
-    case category::share_cas_object:  return "getobject: CAS (share)";
-    case category::get_cas_object:    return "getobject: CAS (get)";
-    case category::share_fetch_pack:  return "getobject: Fetch Pack (share)";
-    case category::get_fetch_pack:    return "getobject: Fetch Pack (get)";
-    case category::share_hash:        return "getobject (share)";
-    case category::get_hash:          return "getobject (get)";
-    default:
-    case category::unknown:           return "unknown";
-    }
-}
-
 TrafficCount::category TrafficCount::categorize (
     ::google::protobuf::Message const& message,
     int type, bool inbound)

--- a/src/ripple/overlay/impl/TrafficCount.h
+++ b/src/ripple/overlay/impl/TrafficCount.h
@@ -23,9 +23,9 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/protocol/messages.h>
 
+#include <array>
 #include <atomic>
 #include <cstdint>
-#include <map>
 
 namespace ripple {
 
@@ -34,17 +34,22 @@ class TrafficCount
 public:
     class TrafficStats
     {
-        public:
+    public:
+        std::string const name;
 
         std::atomic<std::uint64_t> bytesIn {0};
         std::atomic<std::uint64_t> bytesOut {0};
         std::atomic<std::uint64_t> messagesIn {0};
         std::atomic<std::uint64_t> messagesOut {0};
 
-        TrafficStats() = default;
+        TrafficStats(char const* n)
+            : name (n)
+        {
+        }
 
-        TrafficStats(const TrafficStats& ts)
-            : bytesIn (ts.bytesIn.load())
+        TrafficStats(TrafficStats const& ts)
+            : name (ts.name)
+            , bytesIn (ts.bytesIn.load())
             , bytesOut (ts.bytesOut.load())
             , messagesIn (ts.messagesIn.load())
             , messagesOut (ts.messagesOut.load())
@@ -57,8 +62,10 @@ public:
         }
     };
 
-
-    enum class category
+    // If you add entries to this enum, you need to update the initialization
+    // of the array at the bottom of this file which maps array numbers to
+    // human-readable names.
+    enum category : std::size_t
     {
         base,           // basic peer overhead, must be first
 
@@ -137,54 +144,85 @@ public:
         unknown         // must be last
     };
 
-    static const char* getName (category c);
-
+    /** Given a protocol message, determine which traffic category it belongs to */
     static category categorize (
         ::google::protobuf::Message const& message,
         int type, bool inbound);
 
-    void addCount (category cat, bool inbound, int number)
+    /** Account for traffic associated with the given category */
+    void addCount (category cat, bool inbound, int bytes)
     {
+        assert (cat <= category::unknown);
+
         if (inbound)
         {
-            counts_[cat].bytesIn += number;
+            counts_[cat].bytesIn += bytes;
             ++counts_[cat].messagesIn;
         }
         else
         {
-            counts_[cat].bytesOut += number;
+            counts_[cat].bytesOut += bytes;
             ++counts_[cat].messagesOut;
         }
     }
 
-    TrafficCount()
-    {
-        for (category i = category::base;
-            i <= category::unknown;
-            i = safe_cast<category>(safe_cast<std::underlying_type_t<category>>(i) + 1))
-        {
-            counts_[i];
-        }
-    }
+    TrafficCount() = default;
 
-    std::map <std::string, TrafficStats>
+    /** An up-to-date copy of all the counters
+
+        @return an object which satisfies the requirements of Container
+     */
+    auto
     getCounts () const
     {
-        std::map <std::string, TrafficStats> ret;
-
-        for (auto& i : counts_)
-        {
-            if (i.second)
-                ret.emplace (std::piecewise_construct,
-                    std::forward_as_tuple (getName (i.first)),
-                    std::forward_as_tuple (i.second));
-        }
-
-        return ret;
+        return counts_;
     }
 
 protected:
-    std::map<category, TrafficStats> counts_;
+    std::array<TrafficStats, category::unknown + 1> counts_
+    {{
+        { "overhead" },                                           // category::base
+        { "overhead: cluster" },                                  // category::cluster
+        { "overhead: overlay" },                                  // category::overlay
+        { "overhead: manifest" },                                 // category::manifests
+        { "transactions" },                                       // category::transaction
+        { "proposals" },                                          // category::proposal
+        { "validations" },                                        // category::validation
+        { "shards" },                                             // category::shards
+        { "set (get)" },                                          // category::get_set
+        { "set (share)" },                                        // category::share_set
+        { "ledger data: Transaction Set candidate (get)" },       // category::ld_tsc_get
+        { "ledger data: Transaction Set candidate (share)" },     // category::ld_tsc_share
+        { "ledger data: Transaction Node (get)" },                // category::ld_txn_get
+        { "ledger data: Transaction Node (share)" },              // category::ld_txn_share
+        { "ledger data: Account State Node (get)" },              // category::ld_asn_get
+        { "ledger data: Account State Node (share)" },            // category::ld_asn_share
+        { "ledger data (get)" },                                  // category::ld_get
+        { "ledger data (share)" },                                // category::ld_share
+        { "ledger: Transaction Set candidate (share)" },          // category::gl_tsc_share
+        { "ledger: Transaction Set candidate (get)" },            // category::gl_tsc_get
+        { "ledger: Transaction node (share)" },                   // category::gl_txn_share
+        { "ledger: Transaction node (get)" },                     // category::gl_txn_get
+        { "ledger: Account State node (share)" },                 // category::gl_asn_share
+        { "ledger: Account State node (get)" },                   // category::gl_asn_get
+        { "ledger (share)" },                                     // category::gl_share
+        { "ledger (get)" },                                       // category::gl_get
+        { "getobject: Ledger (share)" },                          // category::share_hash_ledger
+        { "getobject: Ledger (get)" },                            // category::get_hash_ledger
+        { "getobject: Transaction (share)" },                     // category::share_hash_tx
+        { "getobject: Transaction (get)" },                       // category::get_hash_tx
+        { "getobject: Transaction node (share)" },                // category::share_hash_txnode
+        { "getobject: Transaction node (get)" },                  // category::get_hash_txnode
+        { "getobject: Account State node (share)" },              // category::share_hash_asnode
+        { "getobject: Account State node (get)" },                // category::get_hash_asnode
+        { "getobject: CAS (share)" },                             // category::share_cas_object
+        { "getobject: CAS (get)" },                               // category::get_cas_object
+        { "getobject: Fetch Pack (share)" },                      // category::share_fetch_pack
+        { "getobject: Fetch Pack (get)" },                        // category::get_fetch_pack
+        { "getobject (share)" },                                  // category::share_hash
+        { "getobject (get)" },                                    // category::get_hash
+        { "unknown" }                                             // category::unknown
+    }};
 };
 
 }


### PR DESCRIPTION
A running instance of the server tracks the number of protocol messages and the number of bytes it sends and receives.

This commit makes the counters more granular, allowing server operators to better track and understand bandwidth usage.