### PR TITLE
Add a LogicError when a deadlock is detected

### DIFF
--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -139,7 +139,7 @@ void LoadManager::run ()
                 // as undefined behavior.
                 //
                 constexpr auto deadlockTimeLimit = 90s;
-                assert (timeSpentDeadlocked < deadlockTimeLimits);
+                assert (timeSpentDeadlocked < deadlockTimeLimit);
 
                 if (timeSpentDeadlocked > deadlockTimeLimit)
                     LogicError("Deadlock detected");

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -134,11 +134,15 @@ void LoadManager::run ()
                         << timeSpentDeadlocked.count() << " seconds.";
                 }
 
-                // If we go over 500 seconds spent deadlocked, it means that
+                // If we go over 90 seconds spent deadlocked, it means that
                 // the deadlock resolution code has failed, which qualifies
                 // as undefined behavior.
                 //
-                assert (timeSpentDeadlocked < 500s);
+                constexpr auto deadlockTimeLimit = 90s;
+                assert (timeSpentDeadlocked < deadlockTimeLimits);
+
+                if (timeSpentDeadlocked > deadlockTimeLimit)
+                    LogicError("Deadlock detected");
             }
         }
 

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -141,7 +141,7 @@ void LoadManager::run ()
                 constexpr auto deadlockTimeLimit = 90s;
                 assert (timeSpentDeadlocked < deadlockTimeLimit);
 
-                if (timeSpentDeadlocked > deadlockTimeLimit)
+                if (timeSpentDeadlocked >= deadlockTimeLimit)
                     LogicError("Deadlock detected");
             }
         }


### PR DESCRIPTION
In the rare scenario of a deadlock being detected, it's better for the system to restart instead of continuing in the degenerate state. One way to trigger a restart is via crashing, rippled already has a mechanism to detect a crash and restart the process. See Sustain.cpp -> DoSustain.

Tested by adding a `sleep(100)` to `PeerImpl.cpp` to simulate a deadlock in the system, verified it restarts correctly. 