### PR TITLE
Flow enum

### DIFF
--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -401,10 +401,10 @@ boost::optional<Quality>
 qualityUpperBound(ReadView const& v, Strand const& strand)
 {
     Quality q{STAmount::uRateOne};
-    bool redeems = false;
-    for(auto const& step : strand)
+    DebtDirection dir = DebtDirection::issues;
+    for (auto const& step : strand)
     {
-        if (auto const stepQ = step->qualityUpperBound(v, redeems))
+        if (auto const stepQ = step->qualityUpperBound(v, dir))
             q = composed_quality(q, *stepQ);
         else
             return boost::none;

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -89,8 +89,14 @@ public:
         return cached ();
     }
 
+    DebtDirection
+    debtDirection(ReadView const& sb, StrandDirection dir) const override
+    {
+        return DebtDirection::issues;
+    }
+
     boost::optional<Quality>
-    qualityUpperBound(ReadView const& v, bool& redeems) const override;
+    qualityUpperBound(ReadView const& v, DebtDirection& dir) const override;
 
     std::pair<XRPAmount, XRPAmount>
     revImp (
@@ -237,9 +243,9 @@ inline bool operator==(XRPEndpointStep<TDerived> const& lhs,
 template <class TDerived>
 boost::optional<Quality>
 XRPEndpointStep<TDerived>::qualityUpperBound(
-    ReadView const& v, bool& redeems) const
+    ReadView const& v, DebtDirection& dir) const
 {
-    redeems = this->redeems(v, true);
+    dir = this->debtDirection(v, StrandDirection::forward);
     return Quality{STAmount::uRateOne};
 }
 


### PR DESCRIPTION
Refactoring some payment code (this will be used in another w.i.p. PR, but since it's small and stands on it's own I gave it its own PR). There should be no functional changes in these patches.

A couple notes:

1) The splitting `qualities` into `qualitiesSrcRedeems` and `qualitiesSrcIssues` is needed in the w.i.p. PR. Otherwise I would have kept the single function.

2) I added a commit for convenience function for one of the enums. There's always a tradeoff for small functions like this. I left it separate so it'll be easy to remove if reviewers don't like it.