### PR TITLE
Allow user to make backups

### DIFF
--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -527,8 +527,6 @@ SHAMapStoreImp::dbPaths()
             writableDbExists = true;
         else if (! state.archiveDb.compare (it->path().string()))
             archiveDbExists = true;
-        else if (! dbPrefix_.compare (it->path().stem().string()))
-            boost::filesystem::remove_all (it->path());
     }
 
     if ((!writableDbExists && state.writableDb.size()) ||


### PR DESCRIPTION
When `[node_db]` path changed and there is a blockchain already: rippled deletes `[node_db]` path content so user can't make blockchain backups. The deleted codes running because there is a something that has no `dbPrefix_` in the **changed** `[node_db]` path.

Also if deleted codes are necessary that problem can be fixed with using multiple conditions in comparing `dbPrefix_`.