### PR TITLE
Report on consensus phase changes in server subscription stream

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -455,6 +455,12 @@ public:
         return adaptor_.mode();
     }
 
+    ConsensusPhase
+    phase() const
+    {
+        return consensus_.phase();
+    }
+
     //! @see Consensus::getJson
     Json::Value
     getJson(bool full) const;

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -413,6 +413,12 @@ public:
         return prevLedgerID_;
     }
 
+    ConsensusPhase
+    phase() const
+    {
+        return phase_;
+    }
+
     /** Get the Json state of the consensus process.
 
         Called by the consensus_info RPC.

--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -109,6 +109,9 @@ public:
         virtual bool unsubPeerStatus (std::uint64_t uListener) = 0;
         virtual void pubPeerStatus (std::function<Json::Value(void)> const&) = 0;
 
+        virtual bool subConsensus (ref ispListener) = 0;
+        virtual bool unsubConsensus (std::uint64_t uListener) = 0;
+
         // VFALCO TODO Remove
         //             This was added for one particular partner, it
         //             "pushes" subscription data to a particular URL.

--- a/src/ripple/net/impl/InfoSub.cpp
+++ b/src/ripple/net/impl/InfoSub.cpp
@@ -64,6 +64,7 @@ InfoSub::~InfoSub ()
     m_source.unsubServer (mSeq);
     m_source.unsubValidations (mSeq);
     m_source.unsubPeerStatus (mSeq);
+    m_source.unsubConsensus (mSeq);
 
     // Use the internal unsubscribe so that it won't call
     // back to us and modify its own parameter

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -152,6 +152,10 @@ Json::Value doSubscribe (RPC::Context& context)
                     return rpcError(rpcNO_PERMISSION);
                 context.netOps.subPeerStatus (ispSub);
             }
+            else if (streamName == "consensus")
+            {
+                context.netOps.subConsensus (ispSub);
+            }
             else
             {
                 return rpcError(rpcSTREAM_MALFORMED);

--- a/src/ripple/rpc/handlers/Unsubscribe.cpp
+++ b/src/ripple/rpc/handlers/Unsubscribe.cpp
@@ -97,6 +97,10 @@ Json::Value doUnsubscribe (RPC::Context& context)
             {
                 context.netOps.unsubPeerStatus (ispSub->getSeq ());
             }
+            else if (streamName == "consensus")
+            {
+                context.netOps.unsubConsensus (ispSub->getSeq());
+            }
             else
             {
                 return rpcError(rpcSTREAM_MALFORMED);


### PR DESCRIPTION
According to [documentation](https://xrpl.org/subscribe.html), the "**server**" stream is used to subscribe to changes to the status of the rippled server. Documentation pertaining to what this "status" is is sparse with the docs listing examples such as "network connectivity" and "load_base" with "others, subject to change."

In the spirit of this, this patch utilizes this stream to report about consensus phase changes to a client. Tested locally, this will send a message to the stream whenever the rippled instance changes consensus phase, allowing the client to act appropriately. This was devised when conceptualizing a visual dashboard which could be used to represent the real-time state of a rippled server.