### PR TITLE
Support for boost 1.71:

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -63,8 +63,11 @@
 #include <ripple/resource/Fees.h>
 #include <ripple/beast/asio/io_latency_probe.h>
 #include <ripple/beast/core/LexicalCast.h>
+
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/system/error_code.hpp>
+
 #include <condition_variable>
 #include <cstring>
 #include <fstream>
@@ -1912,7 +1915,7 @@ bool ApplicationImp::loadOldLedger (
                 }
             }
         }
-        else if (ledgerID.empty () || boost::beast::detail::iequals(ledgerID, "latest"))
+        else if (ledgerID.empty () || boost::iequals(ledgerID, "latest"))
         {
             loadLedger = getLastFullLedger ();
         }

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -25,7 +25,7 @@
 #include <ripple/core/ConfigSections.h>
 #include <ripple/nodestore/impl/DatabaseRotatingImp.h>
 
-#include <boost/beast/core/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 namespace ripple {
 void SHAMapStoreImp::SavedStateDB::init (BasicConfig const& config,
@@ -184,7 +184,7 @@ SHAMapStoreImp::SHAMapStoreImp(
     }
 
     // RocksDB only. Use sensible defaults if no values specified.
-    if (boost::beast::detail::iequals(
+    if (boost::iequals(
         get<std::string>(section, "type"), "RocksDB"))
     {
         if (!section.exists("cache_mb"))

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -318,15 +318,15 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_NODE_SIZE, strTemp, j_))
     {
-        if (boost::beast::detail::iequals(strTemp, "tiny"))
+        if (boost::iequals(strTemp, "tiny"))
             NODE_SIZE = 0;
-        else if (boost::beast::detail::iequals(strTemp, "small"))
+        else if (boost::iequals(strTemp, "small"))
             NODE_SIZE = 1;
-        else if (boost::beast::detail::iequals(strTemp, "medium"))
+        else if (boost::iequals(strTemp, "medium"))
             NODE_SIZE = 2;
-        else if (boost::beast::detail::iequals(strTemp, "large"))
+        else if (boost::iequals(strTemp, "large"))
             NODE_SIZE = 3;
-        else if (boost::beast::detail::iequals(strTemp, "huge"))
+        else if (boost::iequals(strTemp, "huge"))
             NODE_SIZE = 4;
         else
         {
@@ -376,9 +376,9 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_LEDGER_HISTORY, strTemp, j_))
     {
-        if (boost::beast::detail::iequals(strTemp, "full"))
+        if (boost::iequals(strTemp, "full"))
             LEDGER_HISTORY = 1000000000u;
-        else if (boost::beast::detail::iequals(strTemp, "none"))
+        else if (boost::iequals(strTemp, "none"))
             LEDGER_HISTORY = 0;
         else
             LEDGER_HISTORY = beast::lexicalCastThrow <std::uint32_t> (strTemp);
@@ -386,9 +386,9 @@ void Config::loadFromString (std::string const& fileContents)
 
     if (getSingleSection (secConfig, SECTION_FETCH_DEPTH, strTemp, j_))
     {
-        if (boost::beast::detail::iequals(strTemp, "none"))
+        if (boost::iequals(strTemp, "none"))
             FETCH_DEPTH = 0;
-        else if (boost::beast::detail::iequals(strTemp, "full"))
+        else if (boost::iequals(strTemp, "full"))
             FETCH_DEPTH = 1000000000u;
         else
             FETCH_DEPTH = beast::lexicalCastThrow <std::uint32_t> (strTemp);

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -37,10 +37,13 @@
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/rpc/ServerHandler.h>
 #include <ripple/beast/core/LexicalCast.h>
+
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/beast/core/string.hpp>
 #include <boost/asio/streambuf.hpp>
 #include <boost/optional.hpp>
 #include <boost/regex.hpp>
+
 #include <array>
 #include <iostream>
 #include <type_traits>
@@ -163,10 +166,9 @@ private:
         // If odd number of params then 'novalidate' may have been specified
         if (sz & 1)
         {
-            using namespace boost::beast::detail;
-            if (iequals(jvParams[0u].asString(), "novalidate"))
+            if (boost::iequals(jvParams[0u].asString(), "novalidate"))
                 ++i;
-            else if (!iequals(jvParams[--sz].asString(), "novalidate"))
+            else if (!boost::iequals(jvParams[--sz].asString(), "novalidate"))
                 return rpcError(rpcINVALID_PARAMS);
             jvResult[jss::validate] = false;
         }
@@ -471,9 +473,9 @@ private:
             // This may look reversed, but it's intentional: jss::vetoed
             // determines whether an amendment is vetoed - so "reject" means
             // that jss::vetoed is true.
-            if (boost::beast::detail::iequals(action, "reject"))
+            if (boost::iequals(action, "reject"))
                 jvRequest[jss::vetoed] = Json::Value (true);
-            else if (boost::beast::detail::iequals(action, "accept"))
+            else if (boost::iequals(action, "accept"))
                 jvRequest[jss::vetoed] = Json::Value (false);
             else
                 return rpcError (rpcINVALID_PARAMS);

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -30,6 +30,8 @@
 #include <ripple/overlay/predicates.h>
 #include <ripple/protocol/HashPrefix.h>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 namespace ripple {
 namespace NodeStore {
 
@@ -72,7 +74,6 @@ bool
 DatabaseShardImp::init()
 {
     using namespace boost::filesystem;
-    using namespace boost::beast::detail;
 
     std::lock_guard lock(m_);
     auto fail = [j = j_](std::string const& msg)
@@ -149,9 +150,9 @@ DatabaseShardImp::init()
     // NuDB is the default and only supported permanent storage backend
     // "Memory" and "none" types are supported for tests
     backendName_ = get<std::string>(section, "type", "nudb");
-    if (!iequals(backendName_, "NuDB") &&
-        !iequals(backendName_, "Memory") &&
-        !iequals(backendName_, "none"))
+    if (!boost::iequals(backendName_, "NuDB") &&
+        !boost::iequals(backendName_, "Memory") &&
+        !boost::iequals(backendName_, "none"))
     {
         return fail("'type' value unsupported");
     }

--- a/src/ripple/nodestore/impl/ManagerImp.cpp
+++ b/src/ripple/nodestore/impl/ManagerImp.cpp
@@ -102,7 +102,7 @@ ManagerImp::find (std::string const& name)
     auto const iter = std::find_if(list_.begin(), list_.end(),
         [&name](Factory* other)
         {
-            return boost::beast::detail::iequals(name, other->getName());
+            return boost::iequals(name, other->getName());
         } );
     if (iter == list_.end())
         return nullptr;

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -57,6 +57,7 @@ Shard::Shard(
 bool
 Shard::open(Scheduler& scheduler, nudb::context& ctx)
 {
+    using namespace boost::filesystem;
     std::lock_guard lock(mutex_);
     assert(!backend_);
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -36,6 +36,7 @@
 #include <ripple/rpc/handlers/GetCounts.h>
 #include <ripple/server/SimpleWriter.h>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
 namespace ripple {
@@ -226,7 +227,7 @@ OverlayImpl::onHandoff (std::unique_ptr <beast::asio::ssl_bundle>&& ssl_bundle,
         if (std::find_if(types.begin(), types.end(),
                 [](std::string const& s)
                 {
-                    return boost::beast::detail::iequals(s, "peer");
+                    return boost::iequals(s, "peer");
                 }) == types.end())
         {
             handoff.moved = false;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -42,6 +42,8 @@
 #include <boost/algorithm/clamp.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/beast/core/ostream.hpp>
+
 #include <algorithm>
 #include <memory>
 #include <sstream>
@@ -251,7 +253,7 @@ PeerImp::crawl() const
     auto const iter = headers_.find("Crawl");
     if (iter == headers_.end())
         return false;
-    return boost::beast::detail::iequals(iter->value(), "public");
+    return boost::iequals(iter->value(), "public");
 }
 
 bool

--- a/src/ripple/rpc/impl/Role.cpp
+++ b/src/ripple/rpc/impl/Role.cpp
@@ -118,13 +118,18 @@ forwardedFor(http_request_type const& request)
     it = request.find("Forwarded");
     if (it != request.end())
     {
+        auto ascii_tolower = [](char c) -> char
+        {
+            return ((static_cast<unsigned>(c) - 65U) < 26) ?
+                    c + 'a' - 'A' : c;
+        };
+
         static std::string const forStr{"for="};
         auto found = std::search(it->value().begin(), it->value().end(),
             forStr.begin(), forStr.end(),
-            [](char c1, char c2)
+            [&ascii_tolower](char c1, char c2)
             {
-                return boost::beast::detail::ascii_tolower(c1) ==
-                       boost::beast::detail::ascii_tolower(c2);
+                return ascii_tolower(c1) == ascii_tolower(c2);
             }
         );
 

--- a/src/ripple/server/WSSession.h
+++ b/src/ripple/server/WSSession.h
@@ -23,10 +23,13 @@
 #include <ripple/server/Handoff.h>
 #include <ripple/server/Port.h>
 #include <ripple/server/Writer.h>
+
+#include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/core/buffers_prefix.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/logic/tribool.hpp>
+
 #include <algorithm>
 #include <functional>
 #include <memory>

--- a/src/ripple/server/impl/Port.cpp
+++ b/src/ripple/server/impl/Port.cpp
@@ -189,7 +189,7 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
     {
         auto const lim = get (section, "limit", "unlimited");
 
-        if (!boost::beast::detail::iequals (lim, "unlimited"))
+        if (!boost::iequals (lim, "unlimited"))
         {
             try
             {

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -749,7 +749,7 @@ class ServerStatus_test :
             Json::Reader jr;
             if(! BEAST_EXPECT(jr.parse(
                 boost::lexical_cast<std::string>(
-                    boost::beast::buffers(sb.data())), resp)))
+                    boost::beast::make_printable(sb.data())), resp)))
                 return Json::objectValue;
             sb.consume(sb.size());
             return resp;


### PR DESCRIPTION
* replace boost::beast::detail::iequals with boost::iequals
* replace deprecated `buffers` function with `make_printable`
* replace boost::beast::detail::ascii_tolower with lambda
* add missing includes