### PR TITLE
Add Destination to Check threading

### DIFF
--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -84,7 +84,8 @@ class FeatureCollections
         "fix1578",
         "MultiSignReserve",
         "fixTakerDryOfferRemoval",
-        "fixMasterKeyAsRegularKey"
+        "fixMasterKeyAsRegularKey",
+        "fixCheckThreading",
     };
 
     std::vector<uint256> features;
@@ -371,6 +372,7 @@ extern uint256 const fix1578;
 extern uint256 const featureMultiSignReserve;
 extern uint256 const fixTakerDryOfferRemoval;
 extern uint256 const fixMasterKeyAsRegularKey;
+extern uint256 const fixCheckThreading;
 
 } // ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -118,6 +118,7 @@ detail::supportedAmendments ()
         "MultiSignReserve",
         "fixTakerDryOfferRemoval",
         "fixMasterKeyAsRegularKey",
+        "fixCheckThreading",
     };
     return supported;
 }
@@ -175,5 +176,6 @@ uint256 const fix1578 = *getRegisteredFeature("fix1578");
 uint256 const featureMultiSignReserve = *getRegisteredFeature("MultiSignReserve");
 uint256 const fixTakerDryOfferRemoval = *getRegisteredFeature("fixTakerDryOfferRemoval");
 uint256 const fixMasterKeyAsRegularKey = *getRegisteredFeature("fixMasterKeyAsRegularKey");
+uint256 const fixCheckThreading = *getRegisteredFeature("fixCheckThreading");
 
 } // ripple

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -225,9 +225,9 @@ class AccountTx_test : public beast::unit_test::suite
             };
 
             NetClock::time_point const nextTime {env.now() + 2s};
-            
+
             Json::Value escrowWithFinish {escrow (alice, alice, XRP (500))};
-            escrowWithFinish[sfFinishAfter.jsonName] = 
+            escrowWithFinish[sfFinishAfter.jsonName] =
                 nextTime.time_since_epoch().count();
 
             std::uint32_t const escrowFinishSeq {env.seq(alice)};
@@ -279,10 +279,10 @@ class AccountTx_test : public beast::unit_test::suite
             payChanCreate[sfPublicKey.jsonName] = strHex (alice.pk().slice());
             env (payChanCreate, sig (alie));
             env.close();
-            
+
             std::string const payChanIndex {
                 strHex (keylet::payChan (alice, gw, payChanSeq).key)};
-            
+
             {
                 Json::Value payChanFund;
                 payChanFund[jss::TransactionType] = jss::PaymentChannelFund;
@@ -356,7 +356,7 @@ class AccountTx_test : public beast::unit_test::suite
         {
             BEAST_EXPECT(txNode[jss::validated].asBool() == true);
             BEAST_EXPECT(
-                txNode[jss::tx][sfTransactionType.jsonName].asString() == 
+                txNode[jss::tx][sfTransactionType.jsonName].asString() ==
                 sane.txType);
 
             // Make sure all of the expected node types are present.
@@ -415,13 +415,13 @@ class AccountTx_test : public beast::unit_test::suite
         {
             //    txType,                    created,                                                    deleted,                          modified
             {  0, jss::DepositPreauth,       {jss::DepositPreauth},                                      {},                               {jss::AccountRoot, jss::DirectoryNode}},
-            {  1, jss::CheckCancel,          {},                                                         {jss::Check},                     {jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
-            {  2, jss::CheckCash,            {},                                                         {jss::Check},                     {jss::AccountRoot, jss::AccountRoot,   jss::DirectoryNode, jss::DirectoryNode}},
-            {  3, jss::CheckCreate,          {jss::Check},                                               {},                               {jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
-            {  4, jss::CheckCreate,          {jss::Check},                                               {},                               {jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
-            {  5, jss::PaymentChannelClaim,  {},                                                         {jss::PayChannel},                {jss::AccountRoot, jss::AccountRoot,   jss::DirectoryNode}},
+            {  1, jss::CheckCancel,          {},                                                         {jss::Check},                     {jss::AccountRoot, jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
+            {  2, jss::CheckCash,            {},                                                         {jss::Check},                     {jss::AccountRoot, jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
+            {  3, jss::CheckCreate,          {jss::Check},                                               {},                               {jss::AccountRoot, jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
+            {  4, jss::CheckCreate,          {jss::Check},                                               {},                               {jss::AccountRoot, jss::AccountRoot, jss::DirectoryNode, jss::DirectoryNode}},
+            {  5, jss::PaymentChannelClaim,  {},                                                         {jss::PayChannel},                {jss::AccountRoot, jss::AccountRoot, jss::DirectoryNode}},
             {  6, jss::PaymentChannelFund,   {},                                                         {},                               {jss::AccountRoot, jss::PayChannel   }},
-            {  7, jss::PaymentChannelCreate, {jss::PayChannel},                                          {},                               {jss::AccountRoot, jss::AccountRoot,   jss::DirectoryNode}},
+            {  7, jss::PaymentChannelCreate, {jss::PayChannel},                                          {},                               {jss::AccountRoot, jss::AccountRoot, jss::DirectoryNode}},
             {  8, jss::EscrowCancel,         {},                                                         {jss::Escrow},                    {jss::AccountRoot, jss::DirectoryNode}},
             {  9, jss::EscrowFinish,         {},                                                         {jss::Escrow},                    {jss::AccountRoot, jss::DirectoryNode}},
             { 10, jss::EscrowCreate,         {jss::Escrow},                                              {},                               {jss::AccountRoot, jss::DirectoryNode}},


### PR DESCRIPTION
While working on other code I spotted a bug in the threading implementation for Checks.  The account that creates the Check was threaded, but the destination of the Check was not.  This commit fixes the bug.

The change requires an amendment because it affects transaction results.  Even though Checks are not yet enabled on the network, putting this change on an independent amendment reduces possible concerns about which amendment is enabled first.