### PR TITLE
Fix VS2019 debug build

### DIFF
--- a/Builds/CMake/RippledCompiler.cmake
+++ b/Builds/CMake/RippledCompiler.cmake
@@ -28,11 +28,16 @@ target_compile_definitions (common
 if (MSVC)
   # remove existing exception flag since we set it to -EHa
   string (REGEX REPLACE "[-/]EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  # also remove dynamic runtime
+
   foreach (var_
       CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
       CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE)
+
+    # also remove dynamic runtime
     string (REGEX REPLACE "[-/]MD[d]*" " " ${var_} "${${var_}}")
+
+    # /ZI (Edit & Continue debugging information) is incompatible with Gy-
+    string (REPLACE "/ZI" "/Zi" ${var_} "${${var_}}")
   endforeach ()
 
   target_compile_options (common


### PR DESCRIPTION
This is a quick fix to replace the `/ZI` flag with `/Zi`. 

VS2019 has it's own CMake included, which chose different defaults than the flags being used previously (This restriction existed in 2017). These new defaults are incompatible and results in debug builds failing.

https://docs.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=vs-2019