### PR TITLE
Add metrics for PeerImp to track bandwidth usage of peers

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -377,10 +377,10 @@ PeerImp::json()
     }
 
     ret[jss::metrics] = Json::Value(Json::objectValue);
-    ret[jss::metrics][jss::total_bytes_recv] = Json::UInt(metrics_.recv.total_bytes());
-    ret[jss::metrics][jss::total_bytes_sent] = Json::UInt(metrics_.sent.total_bytes());
-    ret[jss::metrics][jss::avg_bps_recv] = Json::UInt(metrics_.recv.average_bytes());
-    ret[jss::metrics][jss::avg_bps_sent] = Json::UInt(metrics_.sent.average_bytes());
+    ret[jss::metrics][jss::total_bytes_recv] = std::to_string(metrics_.recv.total_bytes());
+    ret[jss::metrics][jss::total_bytes_sent] = std::to_string(metrics_.sent.total_bytes());
+    ret[jss::metrics][jss::avg_bps_recv] = std::to_string(metrics_.recv.average_bytes());
+    ret[jss::metrics][jss::avg_bps_sent] = std::to_string(metrics_.sent.average_bytes());
 
     return ret;
 }

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -33,13 +33,13 @@
 #include <ripple/protocol/STValidation.h>
 #include <ripple/resource/Fees.h>
 
+#include <boost/circular_buffer.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/optional.hpp>
 #include <cstdint>
 #include <deque>
 #include <queue>
 #include <shared_mutex>
-#include <numeric>
 
 namespace ripple {
 
@@ -201,17 +201,23 @@ private:
 
     class Metrics {
     public:
+        Metrics() = default;
+        Metrics(Metrics const&) = delete;
+        Metrics& operator=(Metrics const&) = delete;
+        Metrics(Metrics&&) = delete;
+        Metrics& operator=(Metrics&&) = delete;
+
         void add_message(std::uint64_t bytes);
         std::uint64_t average_bytes() const;
         std::uint64_t total_bytes() const;
 
     private:
-        std::uint64_t totalBytes = 0;
-        std::uint64_t accumBytes = 0;
-        std::uint64_t rollingAvgBytes = 0;
-        std::array<std::uint64_t, 30> rollingAvg = {};
-        std::size_t currIndex = 0;
-        clock_type::time_point intervalStart = clock_type::now();
+        std::shared_mutex mutable mutex_;
+        boost::circular_buffer<std::uint64_t> rollingAvg_{ 30, 0ull };
+        clock_type::time_point intervalStart_{ clock_type::now() };
+        std::uint64_t totalBytes_{ 0 };
+        std::uint64_t accumBytes_{ 0 };
+        std::uint64_t rollingAvgBytes_{ 0 };
     };
 
     struct {

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -39,6 +39,7 @@
 #include <deque>
 #include <queue>
 #include <shared_mutex>
+#include <numeric>
 
 namespace ripple {
 
@@ -197,6 +198,26 @@ private:
     hash_map<PublicKey, ShardInfo> shardInfo_;
 
     friend class OverlayImpl;
+
+    class Metrics {
+    public:
+        void add_message(std::uint64_t bytes);
+        std::uint64_t average_bytes() const;
+        std::uint64_t total_bytes() const;
+
+    private:
+        std::uint64_t totalBytes = 0;
+        std::uint64_t accumBytes = 0;
+        std::uint64_t rollingAvgBytes = 0;
+        std::array<std::uint64_t, 30> rollingAvg = {};
+        std::size_t currIndex = 0;
+        clock_type::time_point intervalStart = clock_type::now();
+    };
+
+    struct {
+        Metrics sent;
+        Metrics recv;
+    } metrics_;
 
 public:
     PeerImp (PeerImp const&) = delete;

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -126,6 +126,8 @@ JSS ( authorized );                 // out: AccountLines
 JSS ( auth_change );                // out: AccountInfo
 JSS ( auth_change_queued );         // out: AccountInfo
 JSS ( available );                  // out: ValidatorList
+JSS ( avg_bps_recv );               // out: Peers
+JSS ( avg_bps_sent );               // out: Peers
 JSS ( balance );                    // out: AccountLines
 JSS ( balances );                   // out: GatewayBalances
 JSS ( base );                       // out: LogLevel
@@ -139,10 +141,6 @@ JSS ( both );                       // in: Subscribe, Unsubscribe
 JSS ( both_sides );                 // in: Subscribe, Unsubscribe
 JSS ( build_path );                 // in: TransactionSign
 JSS ( build_version );              // out: NetworkOPs
-JSS ( bytes_recv_avg );             // out: Peers
-JSS ( bytes_sent_avg );             // out: Peers
-JSS ( bytes_recv_total );           // out: Peers
-JSS ( bytes_sent_total );           // out: Peers
 JSS ( cancel_after );               // out: AccountChannels
 JSS ( can_delete );                 // out: CanDelete
 JSS ( channel_id );                 // out: AccountChannels
@@ -494,6 +492,8 @@ JSS ( timeouts );                   // out: InboundLedger
 JSS ( traffic );                    // out: Overlay
 JSS ( total );                      // out: counters
 JSS ( totalCoins );                 // out: LedgerToJson
+JSS ( total_bytes_recv );           // out: Peers
+JSS ( total_bytes_sent );           // out: Peers
 JSS ( total_coins );                // out: LedgerToJson
 JSS ( transTreeHash );              // out: ledger/Ledger.cpp
 JSS ( transaction );                // in: Tx

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -139,6 +139,10 @@ JSS ( both );                       // in: Subscribe, Unsubscribe
 JSS ( both_sides );                 // in: Subscribe, Unsubscribe
 JSS ( build_path );                 // in: TransactionSign
 JSS ( build_version );              // out: NetworkOPs
+JSS ( bytes_recv_avg );             // out: Peers
+JSS ( bytes_sent_avg );             // out: Peers
+JSS ( bytes_recv_total );           // out: Peers
+JSS ( bytes_sent_total );           // out: Peers
 JSS ( cancel_after );               // out: AccountChannels
 JSS ( can_delete );                 // out: CanDelete
 JSS ( channel_id );                 // out: AccountChannels
@@ -338,6 +342,7 @@ JSS ( metaData );
 JSS ( metadata );                   // out: TransactionEntry
 JSS ( method );                     // RPC
 JSS ( methods );
+JSS ( metrics );                    // out: Peers
 JSS ( min_count );                  // in: GetCounts
 JSS ( min_ledger );                 // in: LedgerCleaner
 JSS ( minimum_fee );                // out: TxQ


### PR DESCRIPTION
This change will allow server operators to see how much bandwidth each peer is consuming (both send/recv). 