### PR TITLE
Allow `channel_authorize` to use Ed25519 keys

### DIFF
--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -92,7 +92,7 @@ enum error_code_i
     rpcALREADY_MULTISIG      = 36,
     rpcALREADY_SINGLE_SIG    = 37,
     // unused                  38,
-    // unused                  39,
+    rpcBAD_KEY_TYPE          = 39,
     rpcBAD_FEATURE           = 40,
     rpcBAD_ISSUER            = 41,
     rpcBAD_MARKET            = 42,

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -92,7 +92,7 @@ enum error_code_i
     rpcALREADY_MULTISIG      = 36,
     rpcALREADY_SINGLE_SIG    = 37,
     // unused                  38,
-    rpcBAD_KEY_TYPE          = 39,
+    // unused                  39,
     rpcBAD_FEATURE           = 40,
     rpcBAD_ISSUER            = 41,
     rpcBAD_MARKET            = 42,
@@ -131,7 +131,8 @@ enum error_code_i
     rpcINTERNAL              = 73,  // Generic internal error.
     rpcNOT_IMPL              = 74,
     rpcNOT_SUPPORTED         = 75,
-    rpcLAST = rpcNOT_SUPPORTED   // rpcLAST should always equal the last code.
+    rpcBAD_KEY_TYPE          = 76,
+    rpcLAST = rpcBAD_KEY_TYPE      // rpcLAST should always equal the last code.
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -39,6 +39,7 @@ constexpr static ErrorInfo unorderedErrorInfos[]
     {rpcALREADY_SINGLE_SIG,    "alreadySingleSig",    "Already single-signed."},
     {rpcAMENDMENT_BLOCKED,     "amendmentBlocked",    "Amendment blocked, need upgrade."},
     {rpcATX_DEPRECATED,        "deprecated",          "Use the new API or specify a ledger range."},
+    {rpcBAD_KEY_TYPE,          "badKeyType",          "Bad key type."},
     {rpcBAD_FEATURE,           "badFeature",          "Feature unknown or invalid."},
     {rpcBAD_ISSUER,            "badIssuer",           "Issuer account malformed."},
     {rpcBAD_MARKET,            "badMarket",           "No such market."},

--- a/src/ripple/rpc/handlers/PayChanClaim.cpp
+++ b/src/ripple/rpc/handlers/PayChanClaim.cpp
@@ -36,15 +36,22 @@ namespace ripple {
 
 // {
 //   secret_key: <signing_secret_key>
+//   key_type: optional; either ed25519 or secp256k1 (default to secp256k1)
 //   channel_id: 256-bit channel id
 //   drops: 64-bit uint (as string)
 // }
 Json::Value doChannelAuthorize (RPC::Context& context)
 {
     auto const& params (context.params);
-    for (auto const& p : {jss::secret, jss::channel_id, jss::amount})
+    for (auto const& p : {jss::channel_id, jss::amount})
         if (!params.isMember (p))
             return RPC::missing_field_error (p);
+
+    // Compatibility if a key type isn't specified. If it is, the
+    // keypairForSignature code will validate parameters and return
+    // the appropriate error.
+    if (!params.isMember(jss::key_type) && !params.isMember(jss::secret))
+        return RPC::missing_field_error (jss::secret);
 
     Json::Value result;
     auto const [pk, sk] = RPC::keypairForSignature (params, result);

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -1102,6 +1102,81 @@ struct PayChan_test : public beast::unit_test::suite
             BEAST_EXPECT(rs[jss::error] == "channelAmtMalformed");
             rs = env.rpc("channel_authorize", "alice", chan1Str, "x");
             BEAST_EXPECT(rs[jss::error] == "channelAmtMalformed");
+            {
+                // Missing channel_id
+                Json::Value args {Json::objectValue};
+                args[jss::amount] = "2000";
+                args[jss::key_type] = "secp256k1";
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "invalidParams");
+            }
+            {
+                // Missing amount
+                Json::Value args {Json::objectValue};
+                args[jss::channel_id] = chan1Str;
+                args[jss::key_type] = "secp256k1";
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "invalidParams");
+            }
+            {
+                // Missing key_type and no secret.
+                Json::Value args {Json::objectValue};
+                args[jss::amount] = "2000";
+                args[jss::channel_id] = chan1Str;
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "invalidParams");
+            }
+            {
+                // Both passphrase and seed specified.
+                Json::Value args {Json::objectValue};
+                args[jss::amount] = "2000";
+                args[jss::channel_id] = chan1Str;
+                args[jss::key_type] = "secp256k1";
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                args[jss::seed] = "seed can be anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "invalidParams");
+            }
+            {
+                // channel_id is not exact hex.
+                Json::Value args {Json::objectValue};
+                args[jss::amount] = "2000";
+                args[jss::channel_id] = chan1Str + "1";
+                args[jss::key_type] = "secp256k1";
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "channelMalformed");
+            }
+            {
+                //amount is not a string
+                Json::Value args {Json::objectValue};
+                args[jss::amount] = 2000;
+                args[jss::channel_id] = chan1Str;
+                args[jss::key_type] = "secp256k1";
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "channelAmtMalformed");
+            }
+            {
+                // Amount is not a decimal string.
+                Json::Value args {Json::objectValue};
+                args[jss::amount] = "TwoThousand";
+                args[jss::channel_id] = chan1Str;
+                args[jss::key_type] = "secp256k1";
+                args[jss::passphrase] = "passphrase_can_be_anything";
+                rs = env.rpc ("json",
+                    "channel_authorize", args.toStyledString())[jss::result];
+                BEAST_EXPECT(rs[jss::error] == "channelAmtMalformed");
+            }
         }
     }
 

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -2222,10 +2222,11 @@ static RPCCallTestData const rpcCallTestArray [] =
     "channel_authorize: too many arguments.", __LINE__,
     {
         "channel_authorize",
-        "secret_can_be_anything",
+        "secp256k1",
         "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
         "2000",
-        "whatever"
+        "whatever",
+        "whenever"
     },
     RPCCallTestData::no_exception,
     R"({
@@ -2235,6 +2236,27 @@ static RPCCallTestData const rpcCallTestArray [] =
          "error" : "badSyntax",
          "error_code" : 1,
          "error_message" : "Syntax error."
+      }
+    ]
+    })"
+},
+{
+    "channel_authorize: bad key type.", __LINE__,
+    {
+        "channel_authorize",
+        "secp257k1",
+        "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+        "2000",
+        "whatever"
+    },
+    RPCCallTestData::no_exception,
+    R"({
+    "method" : "channel_authorize",
+    "params" : [
+      {
+         "error" : "badKeyType",
+         "error_code" : 1,
+         "error_message" : "Bad key type."
       }
     ]
     })"


### PR DESCRIPTION
This commit fixes a long-standing bug (internally tracked as RIPD-1474) which prevented using  *Ed25519* keys with the `channel_authorize` command.

This commit fixes the problem by allowing an optional key type when the command-line version of this function is used. Additionally, the WebSocket and JSON/RPC version of the function now accepts a `key_type` parameter, and can accept and parse the keying material as a `seed`, `seed_hex` and `passphrase`.

As always, when using server-side signing you are trusting the server to not divulge your keying material. **NEVER USE SERVER-SIDE SIGNING ON A MACHINE YOU DO NOT CONTROL**.

This commit addresses one part of #3105.

cc: @mDuo13 for documentation updates.