### PR TITLE
Relax STTx test failure criterion:

### DIFF
--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1419,6 +1419,17 @@ public:
         try
         {
             protocol::TMTransaction tx2;
+            // In all versions of protobuf, the parsing of this payload fails.
+            // However, different versions of protobuf will leave the parsed
+            // message (tx2) in different states. Versions 3.10+ seem to clear
+            // the message, whereas earlier versions would leave the message
+            // in a partial state. The varying nature of the failed-parsed
+            // message means that the STTx constructor will throw slightly
+            // different exceptions: for version 3.10+ we get
+            // "Transaction length invalid" whereas the half-parsed message
+            // from earlier versions results in "Unknown field". Either way,
+            // we expect an exception from STTx, but the specific message will
+            // vary.
             BEAST_EXPECT(! tx2.ParseFromArray(payload1, sizeof(payload1)));
 
             ripple::SerialIter sit (ripple::makeSlice(tx2.rawtransaction()));

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1419,16 +1419,16 @@ public:
         try
         {
             protocol::TMTransaction tx2;
-            tx2.ParseFromArray(payload1, sizeof(payload1));
+            BEAST_EXPECT(! tx2.ParseFromArray(payload1, sizeof(payload1)));
 
             ripple::SerialIter sit (ripple::makeSlice(tx2.rawtransaction()));
 
             auto stx = std::make_shared<ripple::STTx const>(sit);
             fail("An exception should have been thrown");
         }
-        catch (std::exception const& ex)
+        catch (std::exception const&)
         {
-            BEAST_EXPECT(strcmp(ex.what(), "Unknown field") == 0);
+            pass();
         }
 
         try


### PR DESCRIPTION
FIXES: #3106

Different versions of protobuf produce subtly different
results when given invalid message payloads. This leads to
subtly different behavior when we try to deserialize these
invalid messages. As such, we can't tie success to a
particular exception.