### PR TITLE
[#2851] added more RPC fields to reply of Submit command

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1062,7 +1062,7 @@ void NetworkOPsImp::apply (std::unique_lock<std::mutex>& batchLock)
         auto newOL = app_.openLedger().current();
         for (TransactionStatus& e : transactions)
         {
-            e.transaction->clearAccepted();
+            e.transaction->clearSubmitResult();
 
             if (e.applied)
             {

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -154,6 +154,118 @@ public:
         mApplying = false;
     }
 
+    /**
+     * @brief Detect if transaction was accepted
+     * @param applied ref to store if transaction was appiled
+     * @param broadcast ref to store if transaction was appiled
+     * @param queued ref to store if transaction was appiled
+     * @param kept ref to store if transaction was appiled
+     * @return true if (applied|broadcast|queued|kept)
+     */
+    bool getAccepted(bool &applied, bool &broadcast,
+        bool &queued, bool &kept) const
+    {
+        applied = mApplied;
+        broadcast = mBroadcast;
+        queued = mQueued;
+        kept = mKept;
+        return mApplied || mBroadcast || mQueued || mKept;
+    }
+
+    /**
+     * Set this flag once was applied to open ledger.
+     */
+    void setApplied() {
+        mApplied = true;
+    }
+
+    /**
+     * Set this flag once was put into heldtxns queue.
+     */
+    void setQueued() {
+        mQueued = true;
+    }
+
+    /**
+     * Set this flag once was broadcasted via network.
+     */
+    void setBroadcast() {
+        mBroadcast = true;
+    }
+
+    /**
+     * Set this flag once was put to localtxns queue.
+     */
+    void setKept() {
+        mKept = true;
+    }
+
+    /**
+     * @brief clear all accepted-related flags
+     */
+    void clearAccepted() {
+        mApplied = false;
+        mBroadcast = false;
+        mQueued = false;
+        mKept = false;
+    }
+
+    /**
+     * Get last account sequence in current ledger and first available.
+     *
+     * @param available ref to save first available account sequence
+     * @return last account sequence in current ledger or early.
+     */
+    std::uint32_t getAccountSequence(std::uint32_t &available) const
+    {
+        available = mAccountSeqAvail;
+        return mAccountSeqNext;
+    }
+
+    /**
+     * Returns minimum fee required at current moment.
+     *
+     * @return minimum fee measured in drops.
+     */
+    XRPAmount getMinimumFeeRequired() const
+    {
+        return mMinFeeRequired;
+    }
+
+    /**
+     * @brief Sets minimum required fee and sequences for the transaction
+     * @param fee minimum fee required for the transaction
+     * @param accountSeq first valid account sequence in current ledger
+     * @param availableSeq first available sequence for the transaction
+     */
+    void setRequiredFeeAndSeq(XRPAmount fee,
+        std::uint32_t accountSeq, std::uint32_t availableSeq)
+    {
+        mMinFeeRequired = fee;
+        mAccountSeqNext = accountSeq;
+        mAccountSeqAvail = availableSeq;
+    }
+
+    /**
+     * Sets last known index of validated ledger.
+     *
+     * @param index number of last validated ledger
+     */
+    void setValidatedLedgerIndex(LedgerIndex index)
+    {
+        mValidatedLedger = index;
+    }
+
+    /**
+     * Returns last known index of validated ledger.
+     *
+     * @return last index of validated ledger.
+     */
+    LedgerIndex getValidatedLedgerIndex() const
+    {
+        return mValidatedLedger;
+    }
+
     Json::Value getJson (JsonOptions options, bool binary = false) const;
 
     static Transaction::pointer load (uint256 const& id, Application& app);
@@ -165,6 +277,18 @@ private:
     TransStatus     mStatus = INVALID;
     TER             mResult = temUNCERTAIN;
     bool            mApplying = false;
+
+    /** different ways for transaction to be accepted */
+    bool            mApplied = false;
+    bool            mQueued = false;
+    bool            mBroadcast = false;
+    bool            mKept = false;
+
+    /** tips on current state of the ledger */
+    LedgerIndex     mValidatedLedger = 0;
+    XRPAmount       mMinFeeRequired = 0;
+    std::uint32_t   mAccountSeqNext = 0;
+    std::uint32_t   mAccountSeqAvail = 0;
 
     std::shared_ptr<STTx const>   mTransaction;
     Application&    mApp;

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -296,7 +296,6 @@ private:
     /** different ways for transaction to be accepted */
     SubmitResult    submitResult_;
 
-    /** current ledger state */
     boost::optional<CurrentLedgerState> currentLedgerState_;
 
     std::shared_ptr<STTx const>   mTransaction;

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -154,116 +154,139 @@ public:
         mApplying = false;
     }
 
-    /**
-     * @brief Detect if transaction was accepted
-     * @param applied ref to store if transaction was appiled
-     * @param broadcast ref to store if transaction was appiled
-     * @param queued ref to store if transaction was appiled
-     * @param kept ref to store if transaction was appiled
-     * @return true if (applied|broadcast|queued|kept)
-     */
-    bool getAccepted(bool &applied, bool &broadcast,
-        bool &queued, bool &kept) const
+    struct AcceptedState
     {
-        applied = mApplied;
-        broadcast = mBroadcast;
-        queued = mQueued;
-        kept = mKept;
-        return mApplied || mBroadcast || mQueued || mKept;
-    }
+        AcceptedState()
+            : applied{false}
+            , broadcast{false}
+            , queued{false}
+            , kept{false}
+        {
+        }
+
+        /**
+         * @brief clear Clear all states
+         */
+        void clear()
+        {
+            applied = false;
+            broadcast = false;
+            queued = false;
+            kept = false;
+        }
+
+        /**
+         * @brief any Get true of any state is true
+         * @return True if any state if true
+         */
+        bool any() const
+        {
+            return applied || broadcast || queued || kept;
+        }
+
+        bool applied;
+        bool broadcast;
+        bool queued;
+        bool kept;
+    };
 
     /**
-     * Set this flag once was applied to open ledger.
+     * @brief getAccepted Return accepted state of transaction
+     * @return Accepted state
      */
-    void setApplied() {
-        mApplied = true;
-    }
-
-    /**
-     * Set this flag once was put into heldtxns queue.
-     */
-    void setQueued() {
-        mQueued = true;
-    }
-
-    /**
-     * Set this flag once was broadcasted via network.
-     */
-    void setBroadcast() {
-        mBroadcast = true;
-    }
-
-    /**
-     * Set this flag once was put to localtxns queue.
-     */
-    void setKept() {
-        mKept = true;
-    }
-
-    /**
-     * @brief clear all accepted-related flags
-     */
-    void clearAccepted() {
-        mApplied = false;
-        mBroadcast = false;
-        mQueued = false;
-        mKept = false;
-    }
-
-    /**
-     * Get last account sequence in current ledger and first available.
-     *
-     * @param available ref to save first available account sequence
-     * @return last account sequence in current ledger or early.
-     */
-    std::uint32_t getAccountSequence(std::uint32_t &available) const
+    AcceptedState getAccepted() const
     {
-        available = mAccountSeqAvail;
-        return mAccountSeqNext;
+        return mAcceptedState;
     }
 
     /**
-     * Returns minimum fee required at current moment.
-     *
-     * @return minimum fee measured in drops.
+     * @brief setApplied Set this flag once was applied to open ledger
      */
-    XRPAmount getMinimumFeeRequired() const
+    void setApplied()
     {
-        return mMinFeeRequired;
+        mAcceptedState.applied = true;
     }
 
     /**
-     * @brief Sets minimum required fee and sequences for the transaction
-     * @param fee minimum fee required for the transaction
-     * @param accountSeq first valid account sequence in current ledger
-     * @param availableSeq first available sequence for the transaction
+     * @brief setQueued Set this flag once was put into heldtxns queue
      */
-    void setRequiredFeeAndSeq(XRPAmount fee,
-        std::uint32_t accountSeq, std::uint32_t availableSeq)
+    void setQueued()
     {
-        mMinFeeRequired = fee;
-        mAccountSeqNext = accountSeq;
-        mAccountSeqAvail = availableSeq;
+        mAcceptedState.queued = true;
     }
 
     /**
-     * Sets last known index of validated ledger.
-     *
-     * @param index number of last validated ledger
+     * @brief setBroadcast Set this flag once was broadcasted via network
      */
-    void setValidatedLedgerIndex(LedgerIndex index)
+    void setBroadcast()
     {
-        mValidatedLedger = index;
+        mAcceptedState.broadcast = true;
     }
 
     /**
-     * Returns last known index of validated ledger.
-     *
-     * @return last index of validated ledger.
+     * @brief setKept Set this flag once was put to localtxns queue
      */
-    LedgerIndex getValidatedLedgerIndex() const
+    void setKept()
     {
-        return mValidatedLedger;
+        mAcceptedState.kept = true;
+    }
+
+    /**
+     * @brief Clear all flags in mAcceptedState
+     */
+    void clearAccepted()
+    {
+        mAcceptedState.clear();
+    }
+
+    struct CurrentLedgerState
+    {
+        CurrentLedgerState() = delete;
+
+        CurrentLedgerState(
+            LedgerIndex li,
+            XRPAmount fee,
+            std::uint32_t accSeqNext,
+            std::uint32_t accSeqAvail)
+            : validatedLedger{li}
+            , minFeeRequired{fee}
+            , accountSeqNext{accSeqNext}
+            , accountSeqAvail{accSeqAvail}
+        {
+        }
+
+        LedgerIndex validatedLedger;
+        XRPAmount minFeeRequired;
+        std::uint32_t accountSeqNext;
+        std::uint32_t accountSeqAvail;
+    };
+
+    /**
+     * @brief getCurrentLedgerState Get current ledger state of transaction
+     * @return Current ledger state
+     */
+    boost::optional<CurrentLedgerState>
+    getCurrentLedgerState() const
+    {
+        return mCurrentLedgetState;
+    }
+
+    /**
+     * @brief setCurrentLedgerState Set current ledger state of transaction
+     * @param validatedLedger Number of last validated ledger
+     * @param fee minimum Fee required for the transaction
+     * @param accountSeq First valid account sequence in current ledger
+     * @param availableSeq First available sequence for the transaction
+     */
+    void
+    setCurrentLedgerState(
+        LedgerIndex validatedLedger,
+        XRPAmount fee,
+        std::uint32_t accountSeq,
+        std::uint32_t availableSeq)
+    {
+        mCurrentLedgetState.emplace(
+            validatedLedger, fee, accountSeq, availableSeq);
     }
 
     Json::Value getJson (JsonOptions options, bool binary = false) const;
@@ -279,16 +302,10 @@ private:
     bool            mApplying = false;
 
     /** different ways for transaction to be accepted */
-    bool            mApplied = false;
-    bool            mQueued = false;
-    bool            mBroadcast = false;
-    bool            mKept = false;
+    AcceptedState   mAcceptedState;
 
-    /** tips on current state of the ledger */
-    LedgerIndex     mValidatedLedger = 0;
-    XRPAmount       mMinFeeRequired = 0;
-    std::uint32_t   mAccountSeqNext = 0;
-    std::uint32_t   mAccountSeqAvail = 0;
+    /** current ledger state */
+    boost::optional<CurrentLedgerState> mCurrentLedgetState;
 
     std::shared_ptr<STTx const>   mTransaction;
     Application&    mApp;

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -154,16 +154,8 @@ public:
         mApplying = false;
     }
 
-    struct AcceptedState
+    struct SubmitResult
     {
-        AcceptedState()
-            : applied{false}
-            , broadcast{false}
-            , queued{false}
-            , kept{false}
-        {
-        }
-
         /**
          * @brief clear Clear all states
          */
@@ -184,19 +176,27 @@ public:
             return applied || broadcast || queued || kept;
         }
 
-        bool applied;
-        bool broadcast;
-        bool queued;
-        bool kept;
+        bool applied = false;
+        bool broadcast = false;
+        bool queued = false;
+        bool kept = false;
     };
 
     /**
-     * @brief getAccepted Return accepted state of transaction
-     * @return Accepted state
+     * @brief getSubmitResult Return submit result
+     * @return SubmitResult struct
      */
-    AcceptedState getAccepted() const
+    SubmitResult getSubmitResult() const
     {
-        return mAcceptedState;
+        return submitResult_;
+    }
+
+    /**
+     * @brief clearSubmitResult Clear all flags in SubmitResult
+     */
+    void clearSubmitResult()
+    {
+        submitResult_.clear();
     }
 
     /**
@@ -204,7 +204,7 @@ public:
      */
     void setApplied()
     {
-        mAcceptedState.applied = true;
+        submitResult_.applied = true;
     }
 
     /**
@@ -212,7 +212,7 @@ public:
      */
     void setQueued()
     {
-        mAcceptedState.queued = true;
+        submitResult_.queued = true;
     }
 
     /**
@@ -220,7 +220,7 @@ public:
      */
     void setBroadcast()
     {
-        mAcceptedState.broadcast = true;
+        submitResult_.broadcast = true;
     }
 
     /**
@@ -228,15 +228,7 @@ public:
      */
     void setKept()
     {
-        mAcceptedState.kept = true;
-    }
-
-    /**
-     * @brief Clear all flags in mAcceptedState
-     */
-    void clearAccepted()
-    {
-        mAcceptedState.clear();
+        submitResult_.kept = true;
     }
 
     struct CurrentLedgerState
@@ -268,7 +260,7 @@ public:
     boost::optional<CurrentLedgerState>
     getCurrentLedgerState() const
     {
-        return mCurrentLedgetState;
+        return currentLedgerState_;
     }
 
     /**
@@ -285,7 +277,7 @@ public:
         std::uint32_t accountSeq,
         std::uint32_t availableSeq)
     {
-        mCurrentLedgetState.emplace(
+        currentLedgerState_.emplace(
             validatedLedger, fee, accountSeq, availableSeq);
     }
 
@@ -302,10 +294,10 @@ private:
     bool            mApplying = false;
 
     /** different ways for transaction to be accepted */
-    AcceptedState   mAcceptedState;
+    SubmitResult    submitResult_;
 
     /** current ledger state */
-    boost::optional<CurrentLedgerState> mCurrentLedgetState;
+    boost::optional<CurrentLedgerState> currentLedgerState_;
 
     std::shared_ptr<STTx const>   mTransaction;
     Application&    mApp;

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -319,6 +319,13 @@ public:
     Metrics
     getMetrics(OpenView const& view) const;
 
+    struct FeeAndSeq
+    {
+        XRPAmount fee;
+        std::uint32_t accountSeq;
+        std::uint32_t availableSeq;
+    };
+
     /**
      * @brief Returns minimum required fee for tx and two sequences:
      *        first vaild sequence for this account in current ledger
@@ -328,7 +335,7 @@ public:
      * @return minimum required fee, first sequence in the ledger
      *        and first available sequence
      */
-    std::tuple<XRPAmount, std::uint32_t, std::uint32_t>
+    FeeAndSeq
     getTxRequiredFeeAndSeq(OpenView const& view,
         std::shared_ptr<STTx const> const& tx) const;
 

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -319,6 +319,25 @@ public:
     Metrics
     getMetrics(OpenView const& view) const;
 
+    /**
+     * @brief Returns minimum required fee for tx and two sequences:
+     *        first vaild sequence for this account in current ledger
+     *        and first available sequence for transaction
+     * @param view current open ledger
+     * @param tx the transaction
+     * @param accountSeq reference to save first sequence in the ledger
+     * @param availableSeq reference to save firts available sequence
+     * @param useFeeIncrease increase minimum required fee in the case
+     *        of multi tx and in the case of replace existing tx
+     * @return minimum required fee
+     */
+    XRPAmount
+    getTxRequiredFeeAndSeq(OpenView const& view,
+        std::shared_ptr<STTx const> const& tx,
+        std::uint32_t &accountSeq,
+        std::uint32_t &availableSeq,
+        bool useFeeIncrease = false) const;
+
     /** Returns information about the transactions currently
         in the queue for the account.
 

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -325,16 +325,12 @@ public:
      *        and first available sequence for transaction
      * @param view current open ledger
      * @param tx the transaction
-     * @param accountSeq reference to save first sequence in the ledger
-     * @param availableSeq reference to save firts available sequence
-     * @param useFeeIncrease increase minimum required fee in the case
-     *        of multi tx and in the case of replace existing tx
-     * @return minimum required fee
+     * @return minimum required fee, first sequence in the ledger
+     *        and first available sequence
      */
     std::tuple<XRPAmount, std::uint32_t, std::uint32_t>
     getTxRequiredFeeAndSeq(OpenView const& view,
-        std::shared_ptr<STTx const> const& tx,
-        bool useFeeIncrease = false) const;
+        std::shared_ptr<STTx const> const& tx) const;
 
     /** Returns information about the transactions currently
         in the queue for the account.

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -331,11 +331,9 @@ public:
      *        of multi tx and in the case of replace existing tx
      * @return minimum required fee
      */
-    XRPAmount
+    std::tuple<XRPAmount, std::uint32_t, std::uint32_t>
     getTxRequiredFeeAndSeq(OpenView const& view,
         std::shared_ptr<STTx const> const& tx,
-        std::uint32_t &accountSeq,
-        std::uint32_t &availableSeq,
         bool useFeeIncrease = false) const;
 
     /** Returns information about the transactions currently

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -1419,6 +1419,7 @@ TxQ::getTxRequiredFeeAndSeq(OpenView const& view,
         auto& txQAcct = iter->second;
         for (auto const& [seq, _] : txQAcct.transactions)
         {
+            (void)_;
             if (seq >= availableSeq)
                 availableSeq = seq + 1;
         }

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -99,7 +99,7 @@ JSS ( TransactionType );            // in: TransactionSign.
 JSS ( TransferRate );               // in: TransferRate.
 JSS ( TrustSet );                   // transaction type.
 JSS ( aborted );                    // out: InboundLedger
-JSS ( accepted );                   // out: LedgerToJson, OwnerInfo
+JSS ( accepted );                   // out: LedgerToJson, OwnerInfo, SubmitTransaction
 JSS ( account );                    // in/out: many
 JSS ( accountState );               // out: LedgerToJson
 JSS ( accountTreeHash );            // out: ledger/Ledger.cpp
@@ -108,6 +108,8 @@ JSS ( account_hash );               // out: LedgerToJson
 JSS ( account_id );                 // out: WalletPropose
 JSS ( account_objects );            // out: AccountObjects
 JSS ( account_root );               // in: LedgerEntry
+JSS ( account_sequence_next );      // out: SubmitTransaction
+JSS ( account_sequence_available ); // out: SubmitTransaction
 JSS ( accounts );                   // in: LedgerEntry, Subscribe,
                                     //     handlers/Ledger, Unsubscribe
 JSS ( accounts_proposed );          // in: Subscribe, Unsubscribe
@@ -120,6 +122,7 @@ JSS ( alternatives );               // out: PathRequest, RipplePathFind
 JSS ( amendment_blocked );          // out: NetworkOPs
 JSS ( amendments );                 // in: AccountObjects, out: NetworkOPs
 JSS ( amount );                     // out: AccountChannels
+JSS ( applied );                    // out: SubmitTransaction
 JSS ( asks );                       // out: Subscribe
 JSS ( assets );                     // out: GatewayBalances
 JSS ( authorized );                 // out: AccountLines
@@ -137,6 +140,7 @@ JSS ( binary );                     // in: AccountTX, LedgerEntry,
 JSS ( books );                      // in: Subscribe, Unsubscribe
 JSS ( both );                       // in: Subscribe, Unsubscribe
 JSS ( both_sides );                 // in: Subscribe, Unsubscribe
+JSS ( broadcast );                  // out: SubmitTransaction
 JSS ( build_path );                 // in: TransactionSign
 JSS ( build_version );              // out: NetworkOPs
 JSS ( cancel_after );               // out: AccountChannels
@@ -267,6 +271,7 @@ JSS ( job_queue );
 JSS ( jobs );
 JSS ( jsonrpc );                    // json version
 JSS ( jq_trans_overflow );          // JobQueue transaction limit overflow.
+JSS ( kept );                       // out: SubmitTransaction
 JSS ( key );                        // out
 JSS ( key_type );                   // in/out: WalletPropose, TransactionSign
 JSS ( latency );                    // out: PeerImp
@@ -365,6 +370,7 @@ JSS ( offers );                     // out: NetworkOPs, AccountOffers, Subscribe
 JSS ( offline );                    // in: TransactionSign
 JSS ( offset );                     // in/out: AccountTxOld
 JSS ( open );                       // out: handlers/Ledger
+JSS ( open_ledger_cost );           // out: SubmitTransaction
 JSS ( open_ledger_fee );            // out: TxQ
 JSS ( open_ledger_level );          // out: TxQ
 JSS ( owner );                      // in: LedgerEntry, out: NetworkOPs
@@ -406,7 +412,7 @@ JSS ( quality_in );                 // out: AccountLines
 JSS ( quality_out );                // out: AccountLines
 JSS ( queue );                      // in: AccountInfo
 JSS ( queue_data );                 // out: AccountInfo
-JSS ( queued );
+JSS ( queued );                     // out: SubmitTransaction
 JSS ( queued_duration_us );
 JSS ( random );                     // out: Random
 JSS ( raw_meta );                   // out: AcceptedLedgerTx
@@ -531,6 +537,7 @@ JSS ( validator_list_expires );     // out: NetworkOps, ValidatorList
 JSS ( validator_list );             // out: NetworkOps, ValidatorList
 JSS ( validators );
 JSS ( validated_ledger );           // out: NetworkOPs
+JSS ( validated_ledger_index );     // out: SubmitTransaction
 JSS ( validated_ledgers );          // out: NetworkOPs
 JSS ( validation_key );             // out: ValidationCreate, ValidationSeed
 JSS ( validation_private_key );     // out: ValidationCreate

--- a/src/ripple/rpc/handlers/Submit.cpp
+++ b/src/ripple/rpc/handlers/Submit.cpp
@@ -142,12 +142,41 @@ Json::Value doSubmit (RPC::Context& context)
         {
             std::string sToken;
             std::string sHuman;
+            std::uint32_t mAccountSeqNext;
+            std::uint32_t mAccountSeqAvail;
+            bool mAccepted;
+            bool mApplied;
+            bool mBroadcast;
+            bool mQueued;
+            bool mKept;
 
             transResultInfo (tpTrans->getResult (), sToken, sHuman);
 
             jvResult[jss::engine_result]           = sToken;
             jvResult[jss::engine_result_code]      = tpTrans->getResult ();
             jvResult[jss::engine_result_message]   = sHuman;
+
+            mAccepted = tpTrans->getAccepted (mApplied, mBroadcast,
+                    mQueued, mKept);
+
+            jvResult[jss::accepted]                = mAccepted;
+            jvResult[jss::applied]                 = mApplied;
+            jvResult[jss::broadcast]               = mBroadcast;
+            jvResult[jss::queued]                  = mQueued;
+            jvResult[jss::kept]                    = mKept;
+
+            mAccountSeqNext = tpTrans->getAccountSequence (mAccountSeqAvail);
+
+            jvResult[jss::account_sequence_next]
+                    = (Json::Value::UInt)mAccountSeqNext;
+            jvResult[jss::account_sequence_available]
+                    = (Json::Value::UInt)mAccountSeqAvail;
+
+            jvResult[jss::open_ledger_cost] = (Json::Value::UInt)
+                    tpTrans->getMinimumFeeRequired ().drops ();
+            jvResult[jss::validated_ledger_index] = (Json::Value::UInt)
+                    tpTrans->getValidatedLedgerIndex ();
+
         }
 
         return jvResult;

--- a/src/ripple/rpc/handlers/Submit.cpp
+++ b/src/ripple/rpc/handlers/Submit.cpp
@@ -149,25 +149,24 @@ Json::Value doSubmit (RPC::Context& context)
             jvResult[jss::engine_result_code]      = tpTrans->getResult ();
             jvResult[jss::engine_result_message]   = sHuman;
 
-            auto const accepted = tpTrans->getAccepted();
+            auto const submitResult = tpTrans->getSubmitResult();
 
-            jvResult[jss::accepted] = accepted.any();
-            jvResult[jss::applied] = accepted.applied;
-            jvResult[jss::broadcast] = accepted.broadcast;
-            jvResult[jss::queued] = accepted.queued;
-            jvResult[jss::kept] = accepted.kept;
+            jvResult[jss::accepted] = submitResult.any();
+            jvResult[jss::applied] = submitResult.applied;
+            jvResult[jss::broadcast] = submitResult.broadcast;
+            jvResult[jss::queued] = submitResult.queued;
+            jvResult[jss::kept] = submitResult.kept;
 
             if (auto currentLedgerState = tpTrans->getCurrentLedgerState())
             {
                 jvResult[jss::account_sequence_next]
-                        = (Json::Value::UInt)currentLedgerState->accountSeqNext;
+                    = safe_cast<Json::Value::UInt>(currentLedgerState->accountSeqNext);
                 jvResult[jss::account_sequence_available]
-                        = (Json::Value::UInt)currentLedgerState->accountSeqAvail;
-
-                jvResult[jss::open_ledger_cost] = (Json::Value::UInt)
-                        currentLedgerState->minFeeRequired.drops ();
-                jvResult[jss::validated_ledger_index] = (Json::Value::UInt)
-                        currentLedgerState->validatedLedger;
+                    = safe_cast<Json::Value::UInt>(currentLedgerState->accountSeqAvail);
+                jvResult[jss::open_ledger_cost]
+                    = to_string(currentLedgerState->minFeeRequired);
+                jvResult[jss::validated_ledger_index]
+                    = safe_cast<Json::Value::UInt>(currentLedgerState->validatedLedger);
             }
         }
 


### PR DESCRIPTION
Here is an example of new reply fields of Submit command:

"result" : {
      "accepted" : true,
      "account_sequence_available" : 11,
      "account_sequence_next" : 11,
      "applied" : true,
      "broadcast" : true,
      "kept" : true,
      "open_ledger_cost" : 10,
      "queued" : false,
      "validated_ledger_index" : 1388096
   }