### PR TITLE
Remove per-process hash seeding for gcc.

### DIFF
--- a/src/ripple/basics/hardened_hash.h
+++ b/src/ripple/basics/hardened_hash.h
@@ -32,17 +32,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-// When set to 1, makes the seed per-process instead
-// of per default-constructed instance of hardened_hash
-//
-#ifndef RIPPLE_NO_HARDENED_HASH_INSTANCE_SEED
-# ifdef __GLIBCXX__
-#  define RIPPLE_NO_HARDENED_HASH_INSTANCE_SEED 1
-# else
-#  define RIPPLE_NO_HARDENED_HASH_INSTANCE_SEED 0
-# endif
-#endif
-
 namespace ripple {
 
 namespace detail {
@@ -159,13 +148,8 @@ public:
     template parameter (the hashing algorithm).  For details
     see https://131002.net/siphash/#at
 */
-#if RIPPLE_NO_HARDENED_HASH_INSTANCE_SEED
-template <class HashAlgorithm = beast::xxhasher>
-    using hardened_hash = basic_hardened_hash<HashAlgorithm, true>;
-#else
 template <class HashAlgorithm = beast::xxhasher>
     using hardened_hash = basic_hardened_hash<HashAlgorithm, false>;
-#endif
 
 } // ripple
 


### PR DESCRIPTION
* gcc now seeds hardened_hash per instance.

* Other platforms were already doing this.

This addresses RIPD-213.

The per-process seeding of hardened_hash was originally done to work around a bug in the gcc std::lib.  The alternative, which macOS and VS have been using for years now, is to seed hardened_hash per instance of hardened_hash.

I've left in the (currently unused) code to seed hardened_hash on a per-process basis so that we can easily choose to do so on a per-container basis should the need arise.