### PR TITLE
Change linear whitespace handling:

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -799,6 +799,7 @@ else ()
     src/test/beast/beast_asio_error_test.cpp
     src/test/beast/beast_basic_seconds_clock_test.cpp
     src/test/beast/beast_io_latency_probe_test.cpp
+    src/test/beast/beast_rfc2616_test.cpp
     src/test/beast/define_print.cpp
     #[===============================[
        nounity, test sources:

--- a/src/ripple/beast/rfc2616.h
+++ b/src/ripple/beast/rfc2616.h
@@ -247,7 +247,7 @@ split(FwdIt first, FwdIt last, Char delim)
         }
         else if (*iter == delim)
         {
-            e = trim_right (e);
+            e = trim (e);
             if (! e.empty())
             {
                 result.emplace_back(std::move(e));
@@ -257,7 +257,10 @@ split(FwdIt first, FwdIt last, Char delim)
         }
         else if (is_lws (*iter))
         {
-            ++iter;
+            e.append (1, ' ');
+            do
+                iter++;
+            while (iter != last && is_lws (*iter));
         }
         else
         {
@@ -267,7 +270,7 @@ split(FwdIt first, FwdIt last, Char delim)
 
     if (! e.empty())
     {
-        e = trim_right (e);
+        e = trim (e);
         if (! e.empty())
             result.emplace_back(std::move(e));
     }

--- a/src/test/beast/beast_rfc2616_test.cpp
+++ b/src/test/beast/beast_rfc2616_test.cpp
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+/*
+This file is part of rippled: https://github.com/ripple/rippled
+Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose  with  or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+//==============================================================================
+
+#include <ripple/basics/random.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/beast/rfc2616.h>
+#include <ripple/beast/xor_shift_engine.h>
+
+namespace beast {
+
+class rfc2616_test : public unit_test::suite
+{
+public:
+    void run() override
+    {
+        testcase("LWS compression & trimming during parsing");
+
+        beast::xor_shift_engine rng(0x243F6A8885A308D3);
+
+        std::vector<std::string> words;
+
+        for (int i = 0; i != 64; ++i)
+            words.push_back("X-" + std::to_string(ripple::rand_int(rng, 100, 1000)));
+
+        std::string question;
+
+        for (auto w : words)
+        {
+            if (!question.empty())
+                question += ",";
+
+            question.append(ripple::rand_int(rng, 0, 3), ' ');
+            question.append(w);
+            question.append(ripple::rand_int(rng, 0, 3), ' ');
+        }
+
+        BEAST_EXPECT(beast::rfc2616::split_commas(question) == words);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(rfc2616, utility, beast);
+
+}

--- a/src/test/overlay/TMHello_test.cpp
+++ b/src/test/overlay/TMHello_test.cpp
@@ -28,14 +28,14 @@ private:
     template <class FwdIt>
     static
     std::string
-    join (FwdIt first, FwdIt last, char c = ',')
+    join (FwdIt first, FwdIt last, char const *sep = ",")
     {
         std::string result;
         if (first == last)
             return result;
         result = to_string(*first++);
         while(first != last)
-            result += "," + to_string(*first++);
+            result += sep + to_string(*first++);
         return result;
     }
 

--- a/src/test/unity/beast_test_unity1.cpp
+++ b/src/test/unity/beast_test_unity1.cpp
@@ -23,6 +23,7 @@
 #include <test/beast/beast_asio_error_test.cpp>
 #include <test/beast/beast_basic_seconds_clock_test.cpp>
 #include <test/beast/beast_io_latency_probe_test.cpp>
+#include <test/beast/beast_rfc2616_test.cpp>
 #include <test/beast/beast_CurrentThreadName_test.cpp>
 #include <test/beast/beast_Debug_test.cpp>
 #include <test/beast/beast_Journal_test.cpp>


### PR DESCRIPTION
When splitting a string, the existing code would compress linear whitespace away completely; this seems to not be intention of [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2), which allows replacing any amount of linear whitespace with a single space.

Requesting an additional signoff from @vinniefalco.