### PR TITLE
Provide additional info with `txnNotFound` errors.

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -990,6 +990,7 @@ else ()
     src/test/rpc/ServerInfo_test.cpp
     src/test/rpc/Status_test.cpp
     src/test/rpc/Subscribe_test.cpp
+    src/test/rpc/Transaction_test.cpp
     src/test/rpc/TransactionEntry_test.cpp
     src/test/rpc/TransactionHistory_test.cpp
     src/test/rpc/ValidatorRPC_test.cpp

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -81,7 +81,7 @@ ConsensusTransSetSF::getNode (SHAMapHash const& nodeHash) const
     if (m_nodeCache.retrieve (nodeHash, nodeData))
         return nodeData;
 
-    auto txn = app_.getMasterTransaction().fetch(nodeHash.as_uint256(), false);
+    auto txn = app_.getMasterTransaction().fetch_from_cache (nodeHash.as_uint256());
 
     if (txn)
     {

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -23,6 +23,7 @@
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/shamap/SHAMapItem.h>
 #include <ripple/shamap/SHAMapTreeNode.h>
+#include <ripple/basics/RangeSet.h>
 
 namespace ripple {
 
@@ -43,7 +44,9 @@ public:
     fetch_from_cache (uint256 const&);
 
     std::shared_ptr<Transaction>
-    fetch (uint256 const& , error_code_i& ec);
+    fetch (uint256 const& , error_code_i& ec,
+               ClosedInterval<uint32_t> const& range = {},
+                   bool* searchedAll = nullptr);
 
     std::shared_ptr<STTx const>
     fetch (std::shared_ptr<SHAMapItem> const& item,

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -24,11 +24,11 @@
 #include <ripple/shamap/SHAMapItem.h>
 #include <ripple/shamap/SHAMapTreeNode.h>
 #include <ripple/basics/RangeSet.h>
+#include <ripple/app/misc/Transaction.h>
 
 namespace ripple {
 
 class Application;
-class Transaction;
 class STTx;
 
 // Tracks all transactions in memory
@@ -44,14 +44,14 @@ public:
     fetch_from_cache (uint256 const&);
 
     std::shared_ptr<Transaction>
-    fetch (uint256 const& , error_code_i& ec,
-               ClosedInterval<uint32_t> const& range = {},
-                   bool* searchedAll = nullptr);
+    fetch (uint256 const& , error_code_i& ec);
+
+    Transaction::variant
+    fetch (uint256 const& , error_code_i& ec, ClosedInterval<uint32_t> const& range);
 
     std::shared_ptr<STTx const>
     fetch (std::shared_ptr<SHAMapItem> const& item,
-        SHAMapTreeNode::TNType type, bool checkDisk,
-            std::uint32_t uCommitLedger);
+        SHAMapTreeNode::TNType type, std::uint32_t uCommitLedger);
 
     // return value: true = we had the transaction already
     bool inLedger (uint256 const& hash, std::uint32_t ledger);

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_APP_LEDGER_TRANSACTIONMASTER_H_INCLUDED
 #define RIPPLE_APP_LEDGER_TRANSACTIONMASTER_H_INCLUDED
 
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/shamap/SHAMapItem.h>
 #include <ripple/shamap/SHAMapTreeNode.h>
 
@@ -39,7 +40,10 @@ public:
     TransactionMaster& operator= (TransactionMaster const&) = delete;
 
     std::shared_ptr<Transaction>
-    fetch (uint256 const& , bool checkDisk);
+    fetch_from_cache (uint256 const&);
+
+    std::shared_ptr<Transaction>
+    fetch (uint256 const& , error_code_i& ec);
 
     std::shared_ptr<STTx const>
     fetch (std::shared_ptr<SHAMapItem> const& item,

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -55,7 +55,7 @@ public:
      *         the provided range were present in the database
      *         while the search was conducted.
      */
-    Transaction::variant
+    boost::variant<Transaction::pointer, bool>
     fetch (uint256 const& , ClosedInterval<uint32_t> const& range, error_code_i& ec);
 
     std::shared_ptr<STTx const>

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -46,8 +46,17 @@ public:
     std::shared_ptr<Transaction>
     fetch (uint256 const& , error_code_i& ec);
 
+    /**
+     * Fetch transaction from the cache or database.
+     *
+     * @return A boost::variant that contains either a
+     *         shared_pointer to the retrieved transaction or a
+     *         bool indicating whether or not the all ledgers in
+     *         the provided range were present in the database
+     *         while the search was conducted.
+     */
     Transaction::variant
-    fetch (uint256 const& , error_code_i& ec, ClosedInterval<uint32_t> const& range);
+    fetch (uint256 const& , ClosedInterval<uint32_t> const& range, error_code_i& ec);
 
     std::shared_ptr<STTx const>
     fetch (std::shared_ptr<SHAMapItem> const& item,

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -45,14 +45,20 @@ bool TransactionMaster::inLedger (uint256 const& hash, std::uint32_t ledger)
 }
 
 std::shared_ptr<Transaction>
-TransactionMaster::fetch (uint256 const& txnID, bool checkDisk)
+TransactionMaster::fetch_from_cache (uint256 const& txnID)
 {
-    auto txn = mCache.fetch (txnID);
+    return mCache.fetch (txnID);
+}
 
-    if (!checkDisk || txn)
+std::shared_ptr<Transaction>
+TransactionMaster::fetch (uint256 const& txnID, error_code_i& ec)
+{
+    auto txn = fetch_from_cache (txnID);
+
+    if (txn)
         return txn;
 
-    txn = Transaction::load (txnID, mApp);
+    txn = Transaction::load (txnID, mApp, ec);
 
     if (!txn)
         return txn;
@@ -68,7 +74,7 @@ TransactionMaster::fetch (std::shared_ptr<SHAMapItem> const& item,
         bool checkDisk, std::uint32_t uCommitLedger)
 {
     std::shared_ptr<STTx const>  txn;
-    auto iTx = fetch (item->key(), false);
+    auto iTx = fetch_from_cache (item->key());
 
     if (!iTx)
     {

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -51,14 +51,15 @@ TransactionMaster::fetch_from_cache (uint256 const& txnID)
 }
 
 std::shared_ptr<Transaction>
-TransactionMaster::fetch (uint256 const& txnID, error_code_i& ec)
+TransactionMaster::fetch (uint256 const& txnID, error_code_i& ec,
+    ClosedInterval<uint32_t> const& range, bool* searchedAll)
 {
     auto txn = fetch_from_cache (txnID);
 
     if (txn)
         return txn;
 
-    txn = Transaction::load (txnID, mApp, ec);
+    txn = Transaction::load (txnID, mApp, ec, range, searchedAll);
 
     if (!txn)
         return txn;

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -67,7 +67,7 @@ TransactionMaster::fetch (uint256 const& txnID, error_code_i& ec)
     return txn;
 }
 
-Transaction::variant
+boost::variant<Transaction::pointer, bool>
 TransactionMaster::fetch (uint256 const& txnID, ClosedInterval<uint32_t> const& range,
     error_code_i& ec)
 {
@@ -78,7 +78,8 @@ TransactionMaster::fetch (uint256 const& txnID, ClosedInterval<uint32_t> const& 
     if (txn)
         return txn;
 
-    Transaction::variant v = Transaction::load (txnID, mApp, range, ec);
+    boost::variant<Transaction::pointer, bool> v = Transaction::load (
+        txnID, mApp, range, ec);
 
     if (v.which () == 0 && boost::get<pointer> (v))
         mCache.canonicalize (txnID, boost::get<pointer> (v));

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -68,18 +68,20 @@ TransactionMaster::fetch (uint256 const& txnID, error_code_i& ec)
 }
 
 Transaction::variant
-TransactionMaster::fetch (uint256 const& txnID, error_code_i& ec,
-    ClosedInterval<uint32_t> const& range)
+TransactionMaster::fetch (uint256 const& txnID, ClosedInterval<uint32_t> const& range,
+    error_code_i& ec)
 {
+    using pointer = Transaction::pointer;
+
     auto txn = mCache.fetch (txnID);
 
     if (txn)
         return txn;
 
-    auto v = Transaction::load (txnID, mApp, ec, range);
+    Transaction::variant v = Transaction::load (txnID, mApp, range, ec);
 
-    if (v.index () == 0 && std::get<0> (v))
-        mCache.canonicalize (txnID, std::get<0> (v));
+    if (v.which () == 0 && boost::get<pointer> (v))
+        mCache.canonicalize (txnID, boost::get<pointer> (v));
 
     return v;
 }

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -27,6 +27,7 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/basics/RangeSet.h>
 #include <boost/optional.hpp>
+#include <variant>
 
 namespace ripple {
 
@@ -63,8 +64,8 @@ public:
 
     using pointer = std::shared_ptr<Transaction>;
     using ref = const pointer&;
+    using variant = std::variant<Transaction::pointer, bool>;
 
-public:
     Transaction (
         std::shared_ptr<STTx const> const&, std::string&, Application&) noexcept;
 
@@ -150,11 +151,18 @@ public:
 
     Json::Value getJson (JsonOptions options, bool binary = false) const;
 
-    static Transaction::pointer load (uint256 const& id, Application& app,
-        error_code_i& ec, ClosedInterval<uint32_t> const& range = {},
-            bool* searchedAll = nullptr);
+    static pointer
+    load (uint256 const& id, Application& app, error_code_i& ec);
+
+    static variant
+    load (uint256 const& id, Application& app, error_code_i& ec, ClosedInterval<uint32_t> const& range);
 
 private:
+
+    static variant
+    load (uint256 const& id, Application& app, error_code_i& ec, ClosedInterval<uint32_t> const& range,
+        bool useRange);
+
     uint256         mTransactionID;
 
     LedgerIndex     mInLedger = 0;

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -64,7 +64,6 @@ public:
 
     using pointer = std::shared_ptr<Transaction>;
     using ref = const pointer&;
-    using variant = boost::variant<Transaction::pointer, bool>;
 
     Transaction (
         std::shared_ptr<STTx const> const&, std::string&, Application&) noexcept;
@@ -154,12 +153,12 @@ public:
     static pointer
     load (uint256 const& id, Application& app, error_code_i& ec);
 
-    static variant
+    static boost::variant<Transaction::pointer, bool>
     load (uint256 const& id, Application& app, ClosedInterval<uint32_t> const& range, error_code_i& ec);
 
 private:
 
-    static variant
+    static boost::variant<Transaction::pointer, bool>
     load (uint256 const& id, Application& app, boost::optional<ClosedInterval<uint32_t>> const& range,
         error_code_i& ec);
 

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -25,6 +25,7 @@
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/TER.h>
 #include <ripple/beast/utility/Journal.h>
+#include <ripple/basics/RangeSet.h>
 #include <boost/optional.hpp>
 
 namespace ripple {
@@ -149,7 +150,9 @@ public:
 
     Json::Value getJson (JsonOptions options, bool binary = false) const;
 
-    static Transaction::pointer load (uint256 const& id, Application& app, error_code_i& ec);
+    static Transaction::pointer load (uint256 const& id, Application& app,
+        error_code_i& ec, ClosedInterval<uint32_t> const& range = {},
+            bool* searchedAll = nullptr);
 
 private:
     uint256         mTransactionID;

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_APP_MISC_TRANSACTION_H_INCLUDED
 #define RIPPLE_APP_MISC_TRANSACTION_H_INCLUDED
 
+#include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/TER.h>
@@ -69,14 +70,6 @@ public:
     static
     Transaction::pointer
     transactionFromSQL (
-        boost::optional<std::uint64_t> const& ledgerSeq,
-        boost::optional<std::string> const& status,
-        Blob const& rawTxn,
-        Application& app);
-
-    static
-    Transaction::pointer
-    transactionFromSQLValidated (
         boost::optional<std::uint64_t> const& ledgerSeq,
         boost::optional<std::string> const& status,
         Blob const& rawTxn,
@@ -156,7 +149,7 @@ public:
 
     Json::Value getJson (JsonOptions options, bool binary = false) const;
 
-    static Transaction::pointer load (uint256 const& id, Application& app);
+    static Transaction::pointer load (uint256 const& id, Application& app, error_code_i& ec);
 
 private:
     uint256         mTransactionID;

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -27,7 +27,7 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/basics/RangeSet.h>
 #include <boost/optional.hpp>
-#include <variant>
+#include <boost/variant.hpp>
 
 namespace ripple {
 
@@ -64,7 +64,7 @@ public:
 
     using pointer = std::shared_ptr<Transaction>;
     using ref = const pointer&;
-    using variant = std::variant<Transaction::pointer, bool>;
+    using variant = boost::variant<Transaction::pointer, bool>;
 
     Transaction (
         std::shared_ptr<STTx const> const&, std::string&, Application&) noexcept;
@@ -155,13 +155,13 @@ public:
     load (uint256 const& id, Application& app, error_code_i& ec);
 
     static variant
-    load (uint256 const& id, Application& app, error_code_i& ec, ClosedInterval<uint32_t> const& range);
+    load (uint256 const& id, Application& app, ClosedInterval<uint32_t> const& range, error_code_i& ec);
 
 private:
 
     static variant
-    load (uint256 const& id, Application& app, error_code_i& ec, ClosedInterval<uint32_t> const& range,
-        bool useRange);
+    load (uint256 const& id, Application& app, boost::optional<ClosedInterval<uint32_t>> const& range,
+        error_code_i& ec);
 
     uint256         mTransactionID;
 

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -102,9 +102,7 @@ Transaction::pointer Transaction::transactionFromSQL (
 
 Transaction::pointer Transaction::load (uint256 const& id, Application& app, error_code_i& ec)
 {
-    using op = boost::optional<ClosedInterval<uint32_t>>;
-
-    return boost::get<pointer> (load (id, app, op {}, ec));
+    return boost::get<pointer> (load (id, app, boost::none, ec));
 }
 
 boost::variant<Transaction::pointer, bool>

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -107,18 +107,18 @@ Transaction::pointer Transaction::load (uint256 const& id, Application& app, err
     return boost::get<pointer> (load (id, app, op {}, ec));
 }
 
-auto
+boost::variant<Transaction::pointer, bool>
 Transaction::load (uint256 const& id, Application& app, ClosedInterval<uint32_t> const& range,
-    error_code_i& ec) -> variant
+    error_code_i& ec)
 {
     using op = boost::optional<ClosedInterval<uint32_t>>;
 
     return load (id, app, op {range}, ec);
 }
 
-auto
+boost::variant<Transaction::pointer, bool>
 Transaction::load (uint256 const& id, Application& app, boost::optional<ClosedInterval<uint32_t>> const& range,
-    error_code_i& ec) -> variant
+    error_code_i& ec)
 {
     std::string sql = "SELECT LedgerSeq,Status,RawTxn "
                       "FROM Transactions WHERE TransID='";

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1008,7 +1008,13 @@ private:
                 jvRequest[jss::binary] = true;
         }
 
-        jvRequest["transaction"]    = jvParams[0u].asString ();
+        if (jvParams.size () > 3)
+        {
+            jvRequest[jss::min_ledger] = jvParams[2u].asString ();
+            jvRequest[jss::max_ledger] = jvParams[3u].asString ();
+        }
+
+        jvRequest[jss::transaction] = jvParams[0u].asString ();
         return jvRequest;
     }
 
@@ -1182,7 +1188,7 @@ public:
             {   "crawl_shards",         &RPCParser::parseAsIs,                  0,  2   },
             {   "stop",                 &RPCParser::parseAsIs,                  0,  0   },
             {   "transaction_entry",    &RPCParser::parseTransactionEntry,      2,  2   },
-            {   "tx",                   &RPCParser::parseTx,                    1,  2   },
+            {   "tx",                   &RPCParser::parseTx,                    1,  4   },
             {   "tx_account",           &RPCParser::parseTxAccount,             1,  7   },
             {   "tx_history",           &RPCParser::parseTxHistory,             1,  1   },
             {   "unl_list",             &RPCParser::parseAsIs,                  0,  0   },

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -996,22 +996,23 @@ private:
         return jvRequest;
     }
 
-
     // tx <transaction_id>
     Json::Value parseTx (Json::Value const& jvParams)
     {
         Json::Value jvRequest{Json::objectValue};
 
-        if (jvParams.size () > 1)
+        if (jvParams.size () == 2 || jvParams.size () == 4)
         {
             if (jvParams[1u].asString () == jss::binary)
                 jvRequest[jss::binary] = true;
         }
 
-        if (jvParams.size () > 3)
+        if (jvParams.size () >= 3)
         {
-            jvRequest[jss::min_ledger] = jvParams[2u].asString ();
-            jvRequest[jss::max_ledger] = jvParams[3u].asString ();
+            const auto offset = jvParams.size () == 3 ? 0 : 1;
+
+            jvRequest[jss::min_ledger] = jvParams[1u + offset].asString ();
+            jvRequest[jss::max_ledger] = jvParams[2u + offset].asString ();
         }
 
         jvRequest[jss::transaction] = jvParams[0u].asString ();

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -132,7 +132,8 @@ enum error_code_i
     rpcNOT_IMPL              = 74,
     rpcNOT_SUPPORTED         = 75,
     rpcBAD_KEY_TYPE          = 76,
-    rpcLAST = rpcBAD_KEY_TYPE      // rpcLAST should always equal the last code.
+    rpcDB_DESERIALIZATION    = 77,
+    rpcLAST = rpcDB_DESERIALIZATION   // rpcLAST should always equal the last code.
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -133,7 +133,9 @@ enum error_code_i
     rpcNOT_SUPPORTED         = 75,
     rpcBAD_KEY_TYPE          = 76,
     rpcDB_DESERIALIZATION    = 77,
-    rpcLAST = rpcDB_DESERIALIZATION   // rpcLAST should always equal the last code.
+    rpcEXCESSIVE_LGR_RANGE   = 78,
+    rpcINVALID_LGR_RANGE     = 79,
+    rpcLAST = rpcINVALID_LGR_RANGE // rpcLAST should always equal the last code.=
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -88,6 +88,7 @@ constexpr static ErrorInfo unorderedErrorInfos[]
     {rpcTXN_NOT_FOUND,         "txnNotFound",         "Transaction not found."},
     {rpcUNKNOWN_COMMAND,       "unknownCmd",          "Unknown method."},
     {rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed."},
+    {rpcDB_DESERIALIZATION,    "dbDeserialization",   "Database deserialization error."},
 };
 
 // C++ does not allow you to return an array from a function.  You must

--- a/src/ripple/protocol/impl/ErrorCodes.cpp
+++ b/src/ripple/protocol/impl/ErrorCodes.cpp
@@ -49,15 +49,18 @@ constexpr static ErrorInfo unorderedErrorInfos[]
     {rpcCHANNEL_MALFORMED,     "channelMalformed",    "Payment channel is malformed."},
     {rpcCHANNEL_AMT_MALFORMED, "channelAmtMalformed", "Payment channel amount is malformed."},
     {rpcCOMMAND_MISSING,       "commandMissing",      "Missing command entry."},
+    {rpcDB_DESERIALIZATION,    "dbDeserialization",   "Database deserialization error."},
     {rpcDST_ACT_MALFORMED,     "dstActMalformed",     "Destination account is malformed."},
     {rpcDST_ACT_MISSING,       "dstActMissing",       "Destination account not provided."},
     {rpcDST_ACT_NOT_FOUND,     "dstActNotFound",      "Destination account not found."},
     {rpcDST_AMT_MALFORMED,     "dstAmtMalformed",     "Destination amount/currency/issuer is malformed."},
     {rpcDST_AMT_MISSING,       "dstAmtMissing",       "Destination amount/currency/issuer is missing."},
     {rpcDST_ISR_MALFORMED,     "dstIsrMalformed",     "Destination issuer is malformed."},
+    {rpcEXCESSIVE_LGR_RANGE,   "excessiveLgrRange",   "Ledger range exceeds 1000."},
     {rpcFORBIDDEN,             "forbidden",           "Bad credentials."},
     {rpcHIGH_FEE,              "highFee",             "Current transaction fee exceeds your limit."},
     {rpcINTERNAL,              "internal",            "Internal error."},
+    {rpcINVALID_LGR_RANGE,     "invalidLgrRange",     "Ledger range is invalid."},
     {rpcINVALID_PARAMS,        "invalidParams",       "Invalid parameters."},
     {rpcJSON_RPC,              "json_rpc",            "JSON-RPC transport error."},
     {rpcLGR_IDXS_INVALID,      "lgrIdxsInvalid",      "Ledger indexes invalid."},
@@ -87,8 +90,7 @@ constexpr static ErrorInfo unorderedErrorInfos[]
     {rpcTOO_BUSY,              "tooBusy",             "The server is too busy to help you now."},
     {rpcTXN_NOT_FOUND,         "txnNotFound",         "Transaction not found."},
     {rpcUNKNOWN_COMMAND,       "unknownCmd",          "Unknown method."},
-    {rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed."},
-    {rpcDB_DESERIALIZATION,    "dbDeserialization",   "Database deserialization error."},
+    {rpcSENDMAX_MALFORMED,     "sendMaxMalformed",    "SendMax amount malformed."}
 };
 
 // C++ does not allow you to return an array from a function.  You must

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -437,6 +437,7 @@ JSS ( rt_accounts );                // in: Subscribe, Unsubscribe
 JSS ( running_duration_us );
 JSS ( sanity );                     // out: PeerImp
 JSS ( search_depth );               // in: RipplePathFind
+JSS ( searched_all );               // out: Tx
 JSS ( secret );                     // in: TransactionSign,
                                     //     ValidationCreate, ValidationSeed,
                                     //     channel_authorize

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -97,11 +97,12 @@ Json::Value doTx (RPC::Context& context)
     if (!isHexTxID (txid))
         return rpcError (rpcNOT_IMPL);
 
+    error_code_i ec = rpcSUCCESS;
     auto txn = context.app.getMasterTransaction ().fetch (
-        from_hex_text<uint256>(txid), true);
+        from_hex_text<uint256>(txid), ec);
 
     if (!txn)
-        return rpcError (rpcTXN_NOT_FOUND);
+        return rpcError (ec);
 
     Json::Value ret = txn->getJson (JsonOptions::include_date, binary);
 

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -133,8 +133,9 @@ Json::Value doTx (RPC::Context& context)
 
     if (rangeProvided)
     {
-        Transaction::variant v = context.app.getMasterTransaction().fetch(
-            from_hex_text<uint256>(txid), range, ec);
+        boost::variant<Transaction::pointer, bool> v =
+            context.app.getMasterTransaction().fetch(
+                from_hex_text<uint256>(txid), range, ec);
 
         if (v.which () != 0 || !boost::get<pointer> (v))
             searchedAll = boost::get<bool> (v);

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -6138,6 +6138,8 @@ static RPCCallTestData const rpcCallTestArray [] =
         "tx",
         "transaction_hash_is_not_validated",
         "binary",
+        "1",
+        "2",
         "extra"
     },
     RPCCallTestData::no_exception,

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -46,7 +46,6 @@ class Transaction_test : public beast::unit_test::suite
         auto const alice = Account("alice");
         env.fund(XRP(1000), alice);
         env.close();
-        
         std::vector<std::shared_ptr<STTx const>> txns;
         auto const startLegSeq = env.current()->info().seq;
         for (int i = 0; i < 750; ++i)

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -22,6 +22,7 @@
 #include <test/jtx/envconfig.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/core/DatabaseCon.h>
+#include <ripple/protocol/ErrorCodes.h>
 
 namespace ripple {
 
@@ -243,10 +244,10 @@ class Transaction_test : public beast::unit_test::suite
 
             // Since we only provided one value for the range,
             // the interface parses it as a false binary flag,
-            // since single-value ranges are not accepted.
-            BEAST_EXPECT(
-                result[jss::result][jss::status] == jss::error &&
-                result[jss::result][jss::error] == NOT_FOUND);
+            // as single-value ranges are not accepted. Since
+            // the error this causes differs depending on the platform
+            // we don't call out a specific error here.
+            BEAST_EXPECT(result[jss::result][jss::status] == jss::error);
 
             BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
         }

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -46,6 +46,7 @@ class Transaction_test : public beast::unit_test::suite
         auto const alice = Account("alice");
         env.fund(XRP(1000), alice);
         env.close();
+
         std::vector<std::shared_ptr<STTx const>> txns;
         auto const startLegSeq = env.current()->info().seq;
         for (int i = 0; i < 750; ++i)

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -1,0 +1,281 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012-2017 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <test/jtx.h>
+#include <test/jtx/Env.h>
+#include <test/jtx/envconfig.h>
+#include <ripple/protocol/jss.h>
+#include <ripple/core/DatabaseCon.h>
+
+namespace ripple {
+
+class Transaction_test : public beast::unit_test::suite
+{
+
+    void
+    testRangeRequest()
+    {
+        testcase("Test Range Request");
+
+        using namespace test::jtx;
+
+        const char* COMMAND   = jss::tx.c_str();
+        const char* BINARY    = jss::binary.c_str();
+        const char* NOT_FOUND = RPC::get_error_info(rpcTXN_NOT_FOUND).token;
+        const char* INVALID   = RPC::get_error_info(rpcINVALID_LGR_RANGE).token;
+        const char* EXCESSIVE = RPC::get_error_info(rpcEXCESSIVE_LGR_RANGE).token;
+
+        Env env(*this);
+        auto const alice = Account("alice");
+        env.fund(XRP(1000), alice);
+        env.close();
+        
+        std::vector<std::shared_ptr<STTx const>> txns;
+        auto const startLegSeq = env.current()->info().seq;
+        for (int i = 0; i < 750; ++i)
+        {
+            env(noop(alice));
+            txns.emplace_back(env.tx());
+            env.close();
+        }
+        auto const endLegSeq = env.closed()->info().seq;
+
+        // Find the existing transactions
+        for (auto&& tx : txns)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(startLegSeq),
+                to_string(endLegSeq));
+
+            BEAST_EXPECT(result[jss::result][jss::status] == jss::success);
+        }
+
+        auto const tx = env.jt(noop(alice), seq(env.seq(alice))).stx;
+        for (int deltaEndSeq = 0; deltaEndSeq < 2; ++deltaEndSeq)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(startLegSeq),
+                to_string(endLegSeq + deltaEndSeq));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == NOT_FOUND);
+
+            if (deltaEndSeq)
+                BEAST_EXPECT(!result[jss::result][jss::searched_all].asBool());
+            else
+                BEAST_EXPECT(result[jss::result][jss::searched_all].asBool());
+        }
+
+        // Find transactions outside of provided range.
+        for (auto&& tx : txns)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(endLegSeq + 1),
+                to_string(endLegSeq + 100));
+
+            BEAST_EXPECT(result[jss::result][jss::status] == jss::success);
+            BEAST_EXPECT(!result[jss::result][jss::searched_all].asBool());
+        }
+
+        const auto deletedLedger = (startLegSeq + endLegSeq) / 2;
+        {
+            // Remove one of the ledgers from the database directly
+            auto db = env.app().getTxnDB().checkoutDb();
+            *db << "DELETE FROM Transactions WHERE LedgerSeq == "
+                << deletedLedger << ";";
+        }
+
+        for (int deltaEndSeq = 0; deltaEndSeq < 2; ++deltaEndSeq)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(startLegSeq),
+                to_string(endLegSeq + deltaEndSeq));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == NOT_FOUND);
+            BEAST_EXPECT(!result[jss::result][jss::searched_all].asBool());
+        }
+
+        // Provide range without providing the `binary`
+        // field. (Tests parameter parsing)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                to_string(startLegSeq),
+                to_string(endLegSeq));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == NOT_FOUND);
+
+            BEAST_EXPECT(!result[jss::result][jss::searched_all].asBool());
+        }
+
+        // Provide range without providing the `binary`
+        // field. (Tests parameter parsing)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                to_string(startLegSeq),
+                to_string(deletedLedger - 1));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == NOT_FOUND);
+
+            BEAST_EXPECT(result[jss::result][jss::searched_all].asBool());
+        }
+
+        // Provide range without providing the `binary`
+        // field. (Tests parameter parsing)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(txns[0]->getTransactionID()),
+                to_string(startLegSeq),
+                to_string(deletedLedger - 1));
+
+            BEAST_EXPECT(result[jss::result][jss::status] == jss::success);
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+        // Provide an invalid range: (min > max)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(deletedLedger - 1),
+                to_string(startLegSeq));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == INVALID);
+
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+        // Provide an invalid range: (min < 0)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(-1),
+                to_string(deletedLedger - 1));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == INVALID);
+
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+        // Provide an invalid range: (min < 0, max < 0)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(-20),
+                to_string(-10));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == INVALID);
+
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+        // Provide an invalid range: (only one value)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(20));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == INVALID);
+
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+        // Provide an invalid range: (only one value)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                to_string(20));
+
+            // Since we only provided one value for the range,
+            // the interface parses it as a false binary flag,
+            // since single-value ranges are not accepted.
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == NOT_FOUND);
+
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+        // Provide an invalid range: (max - min > 1000)
+        {
+            auto const result = env.rpc(
+                COMMAND,
+                to_string(tx->getTransactionID()),
+                BINARY,
+                to_string(startLegSeq),
+                to_string(startLegSeq + 1001));
+
+            BEAST_EXPECT(
+                result[jss::result][jss::status] == jss::error &&
+                result[jss::result][jss::error] == EXCESSIVE);
+
+            BEAST_EXPECT(!result[jss::result].isMember(jss::searched_all));
+        }
+
+    }
+
+public:
+    void run () override
+    {
+        testRangeRequest();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE (Transaction, rpc, ripple);
+
+}  // ripple

--- a/src/test/unity/rpc_test_unity.cpp
+++ b/src/test/unity/rpc_test_unity.cpp
@@ -49,6 +49,7 @@
 #include <test/rpc/ServerInfo_test.cpp>
 #include <test/rpc/Status_test.cpp>
 #include <test/rpc/Subscribe_test.cpp>
+#include <test/rpc/Transaction_test.cpp>
 #include <test/rpc/TransactionEntry_test.cpp>
 #include <test/rpc/TransactionHistory_test.cpp>
 #include <test/rpc/ValidatorRPC_test.cpp>


### PR DESCRIPTION
FIXES: #2924

* Tx command now supports min_ledger and max_ledger fields.
* If the requested transaction isn't found and these fields are
  provided, the error response indicates whether or not every
  ledger in the the provided range was searched.