### PR TITLE
Allow trailing comments in config file:

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -661,6 +661,17 @@ int run (int argc, char** argv)
     // No arguments. Run server.
     if (!vm.count ("parameters"))
     {
+        // TODO: this comment can be removed in a future release -
+        // say 1.7 or higher
+        if (config->had_trailing_comments())
+        {
+            JLOG(logs->journal("Application").warn()) <<
+            "Trailing comments were seen in your config file. " <<
+            "The treatment of inline/trailing comments has changed recently. " <<
+            "Any `#` characters NOT intended to delimit comments should be " <<
+            "preceded by a \\";
+        }
+
         // We want at least 1024 file descriptors. We'll
         // tweak this further.
         if (!adjustDescriptorLimit(1024, logs->journal("Application")))

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -100,7 +100,7 @@ getIniFileSection (IniFileSections& secSource, std::string const& strSection)
     IniFileSections::mapped_type* smtResult;
     it  = secSource.find (strSection);
     if (it == secSource.end ())
-        smtResult   = 0;
+        smtResult   = nullptr;
     else
         smtResult   = & (it->second);
     return smtResult;


### PR DESCRIPTION
Fixes: #3121

Treat all `#` characters in config files as comments (and remove) *unless* the `#` is immediately preceded by `\`. Write a warning to log file when trailing comments are found/ignored in the config
to let operators know that the treatment of trailing `#` has changed.