### PR TITLE
Report queue time and execute time together always for [insights]

### DIFF
--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -371,6 +371,35 @@ private:
     // without first wiping the database.
     LedgerIndex const max_ledger_difference_ {1000000};
 
+private:
+    struct Stats
+    {
+        template <class Handler>
+        Stats (Handler const& handler, beast::insight::Collector::ptr const& collector)
+            : hook (collector->make_hook (handler)),
+            mValidatedLedgerAge (collector->make_gauge ("LedgerMaster", "Validated_Ledger_Age")),
+            mPublishedLedgerAge (collector->make_gauge ("LedgerMaster", "Published_Ledger_Age"))
+            { }
+
+        beast::insight::Hook hook;
+        beast::insight::Gauge mValidatedLedgerAge;
+        beast::insight::Gauge mPublishedLedgerAge;
+    };
+
+    Stats m_stats;
+
+private:
+    void collect_metrics()
+    {
+        std::lock_guard lock (m_mutex);
+        m_stats.mValidatedLedgerAge.set(getValidatedLedgerAge().count());
+        m_stats.mPublishedLedgerAge.set(getPublishedLedgerAge().count());
+    }
+
+    
+
+
+
 };
 
 } // ripple

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -376,14 +376,14 @@ private:
     {
         template <class Handler>
         Stats (Handler const& handler, beast::insight::Collector::ptr const& collector)
-            : hook (collector->make_hook (handler)),
-            mValidatedLedgerAge (collector->make_gauge ("LedgerMaster", "Validated_Ledger_Age")),
-            mPublishedLedgerAge (collector->make_gauge ("LedgerMaster", "Published_Ledger_Age"))
+            : hook (collector->make_hook (handler))
+            , validatedLedgerAge (collector->make_gauge ("LedgerMaster", "Validated_Ledger_Age"))
+            , publishedLedgerAge (collector->make_gauge ("LedgerMaster", "Published_Ledger_Age"))
             { }
 
         beast::insight::Hook hook;
-        beast::insight::Gauge mValidatedLedgerAge;
-        beast::insight::Gauge mPublishedLedgerAge;
+        beast::insight::Gauge validatedLedgerAge;
+        beast::insight::Gauge publishedLedgerAge;
     };
 
     Stats m_stats;
@@ -392,8 +392,8 @@ private:
     void collect_metrics()
     {
         std::lock_guard lock (m_mutex);
-        m_stats.mValidatedLedgerAge.set(getValidatedLedgerAge().count());
-        m_stats.mPublishedLedgerAge.set(getPublishedLedgerAge().count());
+        m_stats.validatedLedgerAge.set(getValidatedLedgerAge().count());
+        m_stats.publishedLedgerAge.set(getPublishedLedgerAge().count());
     }
 
     

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -155,6 +155,7 @@ LedgerMaster::LedgerMaster (Application& app, Stopwatch& stopwatch,
     , ledger_fetch_size_ (app_.config().getSize (siLedgerFetch))
     , fetch_packs_ ("FetchPack", 65536, std::chrono::seconds {45}, stopwatch,
         app_.journal("TaggedCache"))
+    , m_stats(std::bind (&LedgerMaster::collect_metrics, this),collector)
 {
 }
 

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -429,9 +429,9 @@ JobQueue::processTask (int instance)
             
             job.doJob ();
 
-            //The amount of time it took to dequeue and execute the job
+            //The amount of time it took to execute the job
             auto const x_time = date::ceil<microseconds>(
-                Job::clock_type::now() - job.queue_time());
+                Job::clock_type::now() - start_time);
 
             if (x_time >= 10ms || q_time >= 10ms)
             {

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -420,19 +420,27 @@ JobQueue::processTask (int instance)
             }
             type = job.getType();
             JobTypeData& data(getJobTypeData(type));
-            JLOG(m_journal.trace()) << "Doing " << data.name () << " job";
-            auto const us = date::ceil<microseconds>(
+            JLOG(m_journal.trace()) << "Doing " << data.name () << "job";
+
+            //The amount of time that the job was in the queue
+            auto const q_time = date::ceil<microseconds>( 
                 start_time - job.queue_time());
-            perfLog_.jobStart(type, us, start_time, instance);
-            if (us >= 10ms)
-                getJobTypeData(type).dequeue.notify(us);
+            perfLog_.jobStart(type, q_time, start_time, instance);
+            
             job.doJob ();
+
+            //The amount of time it took to dequeue and execute the job
+            auto const x_time = date::ceil<microseconds>(
+                Job::clock_type::now() - job.queue_time());
+
+            if (x_time >= 10ms || q_time >= 10ms)
+            {
+                getJobTypeData(type).dequeue.notify(q_time);
+                getJobTypeData(type).execute.notify(x_time);
+            }
+            perfLog_.jobFinish(type, x_time, instance);
         }
-        auto const us (
-            date::ceil<microseconds>(Job::clock_type::now() - start_time));
-        perfLog_.jobFinish(type, us, instance);
-        if (us >= 10ms)
-            getJobTypeData(type).execute.notify(us);
+
     }
 
     {


### PR DESCRIPTION
The amount of time that a job spends in the queue and the amount of time that it takes to execute the job are reported independently. It would be good to report them together so that we don't see one without the other. 