### PR TITLE
Streamline pkg and travis CI:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 env:
   global:
-    - DOCKER_IMAGE="mellery451/rippled-ci-builder:2019-08-26"
+    - DOCKER_IMAGE="mellery451/rippled-ci-builder:2019-12-06"
     - CMAKE_EXTRA_ARGS="-Dwerr=ON -Dwextra=ON"
     - NINJA_BUILD=true
     # change this if we get more VM capacity
@@ -35,9 +35,6 @@ matrix:
   allow_failures:
     # TODO these all need more investigation
     #
-    # current tsan failure might be related to:
-    # https://github.com/google/sanitizers/issues/1104
-    - name: tsan, clang-8
     # there are a number of UBs caught currently that need triage
     - name: ubsan, clang-8
 
@@ -132,14 +129,18 @@ matrix:
         - UBSAN_OPTIONS="print_stacktrace=1:report_error_type=1"
         - PARALLEL_TESTS=false
     # tsan
-    - compiler: clang-8
-      name: tsan, clang-8
-      env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
-        - BUILD_TYPE=Release
-        - CMAKE_ADD="-Dsan=thread"
-        - TSAN_OPTIONS="history_size=3 external_symbolizer_path=/usr/bin/llvm-symbolizer verbosity=1"
-        - PARALLEL_TESTS=false
+    # current tsan failure *might* be related to:
+    # https://github.com/google/sanitizers/issues/1104
+    #  but we can't get it to run, so leave it disabled for now
+    #    - compiler: clang-8
+    #      name: tsan, clang-8
+    #      env:
+    #        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
+    #        - BUILD_TYPE=Release
+    #        - CMAKE_ADD="-Dsan=thread"
+    #        - TSAN_OPTIONS="history_size=3 external_symbolizer_path=/usr/bin/llvm-symbolizer verbosity=1"
+    #        - PARALLEL_TESTS=false
+
     # dynamic lib builds
     - compiler: gcc-8
       name: non-static, gcc-8
@@ -210,9 +211,12 @@ matrix:
     # macos
     - &macos
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode10.3
       name: xcode10, debug
       env:
+        # put NIH in non-cache location since it seems to
+        # cause failures when homebrew updates
+        - NIH_CACHE_ROOT=${TRAVIS_BUILD_DIR}/nih_c
         - BLD_CONFIG=Debug
         - TEST_EXTRA_ARGS=""
         - BOOST_ROOT=${CACHE_DIR}/boost_1_70_0
@@ -225,10 +229,14 @@ matrix:
       addons:
         homebrew:
           packages:
+            - pkg-config
             - bash
             - ninja
             - cmake
             - wget
+            - zstd
+            - protobuf
+            - libarchive
             - openssl@1.1
           update: true
       install:
@@ -250,13 +258,7 @@ matrix:
       before_script:
         - export TEST_EXTRA_ARGS="--unittest-ipv6"
     - <<: *macos
-      osx_image: xcode9.4
-      name: xcode9, debug
-      before_script:
-        # turn off warnings as err for this build
-        - export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -Dwerr=OFF"
-    - <<: *macos
-      osx_image: xcode11
+      osx_image: xcode11.2
       name: xcode11, debug
     # windows
     - &windows
@@ -280,7 +282,8 @@ matrix:
           -DVCPKG_TARGET_TRIPLET=x64-windows-static"
       install:
         - choco upgrade cmake.install
-        - choco install ninja visualstudio2017-workload-vctools -y
+        - choco install ninja -y
+        - choco install visualstudio2017-workload-vctools -y
         - travis_wait 30 bin/sh/install-vcpkg.sh
         - travis_wait ${MAX_TIME_MIN} Builds/containers/shared/install_boost.sh
       before_script:
@@ -293,6 +296,17 @@ matrix:
         - ./rippled.exe --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows
       name: windows, release
+      before_script:
+        - export BLD_CONFIG=Release
+    - <<: *windows
+      name: windows, vc2019
+      install:
+        - choco upgrade cmake.install
+        - choco install ninja -y
+        - choco install visualstudio2019buildtools visualstudio2019community visualstudio2019-workload-vctools -y
+        - travis_wait 30 bin/sh/install-vcpkg.sh
+        - export BOOST_TOOLSET=msvc-14.2
+        - travis_wait ${MAX_TIME_MIN} Builds/containers/shared/install_boost.sh
       before_script:
         - export BLD_CONFIG=Release
     - <<: *windows

--- a/Builds/CMake/deps/Boost.cmake
+++ b/Builds/CMake/deps/Boost.cmake
@@ -70,7 +70,9 @@ target_link_libraries (ripple_boost
     Boost::serialization
     Boost::system
     Boost::thread)
-if (san)
+if (san AND is_clang)
+  # TODO: gcc does not support -fsanitize-blacklist...can we do something else 
+  # for gcc ?
   if (NOT Boost_INCLUDE_DIRS AND TARGET Boost::headers)
     get_target_property (Boost_INCLUDE_DIRS Boost::headers INTERFACE_INCLUDE_DIRECTORIES)
   endif ()

--- a/Builds/CMake/deps/Findlibarchive.cmake
+++ b/Builds/CMake/deps/Findlibarchive.cmake
@@ -1,5 +1,7 @@
-find_package (PkgConfig REQUIRED)
-pkg_search_module (libarchive_PC QUIET libarchive>=3.3.3)
+find_package (PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (libarchive_PC QUIET libarchive>=3.3.3)
+endif ()
 
 if(static)
   set(LIBARCHIVE_LIB libarchive.a)

--- a/Builds/CMake/deps/Findlz4.cmake
+++ b/Builds/CMake/deps/Findlz4.cmake
@@ -1,5 +1,7 @@
-find_package (PkgConfig REQUIRED)
-pkg_search_module (lz4_PC QUIET liblz4>=1.8)
+find_package (PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (lz4_PC QUIET liblz4>=1.8)
+endif ()
 
 if(static)
   set(LZ4_LIB liblz4.a)

--- a/Builds/CMake/deps/Findsecp256k1.cmake
+++ b/Builds/CMake/deps/Findsecp256k1.cmake
@@ -1,5 +1,7 @@
-find_package (PkgConfig REQUIRED)
-pkg_search_module (secp256k1_PC QUIET libsecp256k1)
+find_package (PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (secp256k1_PC QUIET libsecp256k1)
+endif ()
 
 if(static)
   set(SECP256K1_LIB libsecp256k1.a)

--- a/Builds/CMake/deps/Findsnappy.cmake
+++ b/Builds/CMake/deps/Findsnappy.cmake
@@ -1,5 +1,7 @@
-find_package (PkgConfig REQUIRED)
-pkg_search_module (snappy_PC QUIET snappy>=1.1.7)
+find_package (PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (snappy_PC QUIET snappy>=1.1.7)
+endif ()
 
 if(static)
   set(SNAPPY_LIB libsnappy.a)

--- a/Builds/CMake/deps/Findsoci.cmake
+++ b/Builds/CMake/deps/Findsoci.cmake
@@ -1,7 +1,8 @@
-find_package (PkgConfig REQUIRED)
-
-# no soci pkgconfig
-#pkg_search_module (soci_PC QUIET libsoci_core>=3.2)
+find_package (PkgConfig)
+if (PKG_CONFIG_FOUND)
+  # TBD - currently no soci pkgconfig
+  #pkg_search_module (soci_PC QUIET libsoci_core>=3.2)
+endif ()
 
 if(static)
   set(SOCI_LIB libsoci.a)

--- a/Builds/CMake/deps/Findsqlite.cmake
+++ b/Builds/CMake/deps/Findsqlite.cmake
@@ -1,5 +1,7 @@
-find_package (PkgConfig REQUIRED)
-pkg_search_module (sqlite_PC QUIET sqlite3>=3.26.0)
+find_package (PkgConfig)
+if (PKG_CONFIG_FOUND)
+  pkg_search_module (sqlite_PC QUIET sqlite3>=3.26.0)
+endif ()
 
 if(static)
   set(SQLITE_LIB libsqlite3.a)

--- a/Builds/CMake/deps/Protobuf.cmake
+++ b/Builds/CMake/deps/Protobuf.cmake
@@ -96,6 +96,16 @@ if (local_protobuf OR NOT TARGET protobuf::libprotobuf)
   set_target_properties (protobuf::protoc PROPERTIES
     IMPORTED_LOCATION "${BINARY_DIR}/protoc${CMAKE_EXECUTABLE_SUFFIX}")
   add_dependencies (protobuf::protoc protobuf_src)
+else ()
+  if (NOT TARGET protobuf::protoc)
+    if (EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
+      add_executable (protobuf::protoc IMPORTED)
+      set_target_properties (protobuf::protoc PROPERTIES
+        IMPORTED_LOCATION "${Protobuf_PROTOC_EXECUTABLE}")
+    else ()
+      message (FATAL_ERROR "Protobuf import failed")
+    endif ()
+  endif ()
 endif ()
 
 file (MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/proto_gen)

--- a/Builds/CMake/deps/Secp256k1.cmake
+++ b/Builds/CMake/deps/Secp256k1.cmake
@@ -8,7 +8,6 @@ if (NOT WIN32)
   find_package(secp256k1)
 endif()
 
-
 if(secp256k1)
   set_target_properties (secp256k1_lib PROPERTIES
     IMPORTED_LOCATION_DEBUG

--- a/Builds/containers/centos-builder/Dockerfile
+++ b/Builds/containers/centos-builder/Dockerfile
@@ -16,8 +16,8 @@ RUN chmod +x /tmp/centos_setup.sh && \
     chmod +x /tmp/extras.sh
 RUN /tmp/centos_setup.sh
 
-RUN /tmp/install_cmake.sh 3.15.2 /opt/local/cmake-3.15
-RUN ln -s /opt/local/cmake-3.15 /opt/local/cmake
+RUN /tmp/install_cmake.sh 3.16.0-rc3 /opt/local/cmake-3.16
+RUN ln -s /opt/local/cmake-3.16 /opt/local/cmake
 ENV PATH="/opt/local/cmake/bin:$PATH"
 # also install min supported cmake for testing
 RUN if [ "${CI_USE}" = true ] ; then /tmp/install_cmake.sh 3.9.0 /opt/local/cmake-3.9; fi

--- a/Builds/containers/centos-builder/centos_setup.sh
+++ b/Builds/containers/centos-builder/centos_setup.sh
@@ -7,7 +7,7 @@ yum -y upgrade
 yum -y update
 yum -y install epel-release centos-release-scl
 yum -y install \
-    wget curl time gcc-c++ time yum-utils \
+    wget curl time gcc-c++ time yum-utils autoconf automake pkgconfig libtool \
     libstdc++-static rpm-build gnupg which make cmake \
     devtoolset-7 devtoolset-7-gdb devtoolset-7-libasan-devel devtoolset-7-libtsan-devel devtoolset-7-libubsan-devel \
     devtoolset-8 devtoolset-8-gdb devtoolset-8-binutils devtoolset-8-libstdc++-devel \
@@ -22,8 +22,6 @@ yum -y install \
     python-devel python27-python-devel rh-python35-python-devel \
     python27 rh-python35 \
     ninja-build git svn \
-    protobuf protobuf-static protobuf-c-devel \
-    protobuf-compiler protobuf-devel \
     swig perl-Digest-MD5 python2-pip
 
 if [ "${CI_USE}" = true ] ; then

--- a/Builds/containers/centos-builder/extras.sh
+++ b/Builds/containers/centos-builder/extras.sh
@@ -3,50 +3,31 @@ set -ex
 
 if [ "${CI_USE}" = true ] ; then
     cd /tmp
-    wget https://ftp.gnu.org/gnu/gdb/gdb-8.2.tar.xz
-    tar xf gdb-8.2.tar.xz
-    cd gdb-8.2
-    ./configure CFLAGS="-w -O2" CXXFLAGS="-std=gnu++11 -g -O2 -w" --prefix=/opt/local/gdb-8.2
+    wget https://ftp.gnu.org/gnu/gdb/gdb-8.3.1.tar.xz
+    tar xf gdb-8.3.1.tar.xz
+    cd gdb-8.3
+    ./configure CFLAGS="-w -O2" CXXFLAGS="-std=gnu++11 -g -O2 -w" --prefix=/opt/local/gdb-8.3
     make -j$(nproc)
     make install
-    ln -s /opt/local/gdb-8.2 /opt/local/gdb
+    ln -s /opt/local/gdb-8.3 /opt/local/gdb
     cd ..
-    rm -f gdb-8.2.tar.xz
-    rm -rf gdb-8.2
+    rm -f gdb-8.3.tar.xz
+    rm -rf gdb-8.3
 
     # clang from source
-    RELEASE=tags/RELEASE_701/final
-    INSTALL=/opt/llvm-7.0.1/
-    mkdir -p /tmp/clang-src
-    cd /tmp/clang-src
-    TOPDIR=`pwd`
-    svn co -q http://llvm.org/svn/llvm-project/llvm/${RELEASE} llvm
-    cd ${TOPDIR}/llvm/tools
-    svn co -q http://llvm.org/svn/llvm-project/cfe/${RELEASE} clang
-    cd ${TOPDIR}/llvm/tools/clang/tools
-    svn co -q http://llvm.org/svn/llvm-project/clang-tools-extra/${RELEASE} extra
-    cd ${TOPDIR}/llvm/tools
-    svn co -q http://llvm.org/svn/llvm-project/lld/${RELEASE} lld
-    cd ${TOPDIR}/llvm/tools
-    svn co -q http://llvm.org/svn/llvm-project/polly/${RELEASE} polly
-    cd ${TOPDIR}/llvm/projects
-    svn co -q http://llvm.org/svn/llvm-project/compiler-rt/${RELEASE} compiler-rt
-    cd ${TOPDIR}/llvm/projects
-    svn co -q http://llvm.org/svn/llvm-project/openmp/${RELEASE} openmp
-    cd ${TOPDIR}/llvm/projects
-    svn co -q http://llvm.org/svn/llvm-project/libcxx/${RELEASE} libcxx
-    svn co -q http://llvm.org/svn/llvm-project/libcxxabi/${RELEASE} libcxxabi
-    cd ${TOPDIR}/llvm/projects
-    ## config/build
-    cd ${TOPDIR}
+    cd /tmp
+    git clone https://github.com/llvm/llvm-project.git
+    cd llvm-project
+    git checkout llvmorg-9.0.0
+    INSTALL=/opt/llvm-9/
     mkdir mybuilddir && cd mybuilddir
+    # TODO figure out necessary options
     cmake ../llvm -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;libcxx;libcxxabi;lldb;compiler-rt;lld;polly' \
       -DCMAKE_INSTALL_PREFIX=${INSTALL} \
-      -DLLVM_LIBDIR_SUFFIX=64 \
-      -DLLVM_ENABLE_EH=ON \
-      -DLLVM_ENABLE_RTTI=ON
+      -DLLVM_LIBDIR_SUFFIX=64
     cmake --build . --parallel --target install
     cd /tmp
-    rm -rf clang-src
+    rm -rf llvm-project
 fi

--- a/Builds/containers/gitlab-ci/build_package.sh
+++ b/Builds/containers/gitlab-ci/build_package.sh
@@ -2,22 +2,27 @@
 set -ex
 pkgtype=$1
 if [ "${pkgtype}" = "rpm" ] ; then
-    container_name="${RPM_CONTAINER_NAME}"
+    container_name="${RPM_CONTAINER_FULLNAME}"
+    container_tag="${RPM_CONTAINER_TAG}"
 elif [ "${pkgtype}" = "dpkg" ] ; then
-    container_name="${DPKG_CONTAINER_NAME}"
+    container_name="${DPKG_CONTAINER_FULLNAME}"
+    container_tag="${DPKG_CONTAINER_TAG}"
 else
     echo "invalid package type"
     exit 1
 fi
-time docker pull "${ARTIFACTORY_HUB}/${container_name}:${CI_COMMIT_SHA}"
+time docker pull "${ARTIFACTORY_HUB}/${container_name}"
 docker tag \
-  "${ARTIFACTORY_HUB}/${container_name}:${CI_COMMIT_SHA}" \
-  "${container_name}:${CI_COMMIT_SHA}"
+  "${ARTIFACTORY_HUB}/${container_name}" \
+  "${container_name}"
 docker images
 test -d build && rm -rf build
 mkdir -p build/${pkgtype} && cd build/${pkgtype}
 time cmake \
-  -Dpackages_only=ON -Dhave_package_container=ON -DCMAKE_VERBOSE_MAKEFILE=ON \
+  -Dpackages_only=ON \
+  -Dcontainer_label="${container_tag}" \
+  -Dhave_package_container=ON \
+  -DCMAKE_VERBOSE_MAKEFILE=ON \
   -G Ninja ../..
 time cmake --build . --target ${pkgtype} -- -v
 

--- a/Builds/containers/gitlab-ci/pkgbuild.yml
+++ b/Builds/containers/gitlab-ci/pkgbuild.yml
@@ -8,8 +8,15 @@
 # NOTE: these are sensible defaults for Ripple pipelines. These
 # can be overridden by project or group variables as needed.
 variables:
+  # these containers are built manually using the rippled
+  # cmake build (container targets) and tagged/pushed so they 
+  # can be used here
+  RPM_CONTAINER_TAG: "2019-12-06"
   RPM_CONTAINER_NAME: "rippled-rpm-builder"
+  RPM_CONTAINER_FULLNAME: "${RPM_CONTAINER_NAME}:${RPM_CONTAINER_TAG}"
+  DPKG_CONTAINER_TAG: "2019-12-06"
   DPKG_CONTAINER_NAME: "rippled-dpkg-builder"
+  DPKG_CONTAINER_FULLNAME: "${DPKG_CONTAINER_NAME}:${DPKG_CONTAINER_TAG}"
   ARTIFACTORY_HOST: "artifactory.ops.ripple.com"
   ARTIFACTORY_HUB: "${ARTIFACTORY_HOST}:6555"
   GIT_SIGN_PUBKEYS_URL: "https://gitlab.ops.ripple.com/snippets/11/raw"
@@ -19,7 +26,6 @@ variables:
   #   IS_PRIMARY_REPO = "true"
 
 stages:
-  - build_containers
   - build_packages
   - sign_packages
   - smoketest
@@ -31,6 +37,7 @@ stages:
   - push_to_prod
   - verify_from_prod
   - get_final_hashes
+  - build_containers
 
 .dind_template: &dind_param
   before_script:
@@ -67,35 +74,6 @@ stages:
 
 #########################################################################
 ##                                                                     ##
-##  stage: build_containers                                            ##
-##                                                                     ##
-##  build containers from docker definitions. These containers are     ##
-##  subsequently used to build the rpm and deb packages.               ##
-##                                                                     ##
-#########################################################################
-
-build_centos_container:
-  stage: build_containers
-  <<: *dind_param
-  cache:
-    key: containers
-    paths:
-      - .nih_c
-  script:
-    - . ./Builds/containers/gitlab-ci/build_container.sh rpm
-
-build_ubuntu_container:
-  stage: build_containers
-  <<: *dind_param
-  cache:
-    key: containers
-    paths:
-      - .nih_c
-  script:
-    - . ./Builds/containers/gitlab-ci/build_container.sh dpkg
-
-#########################################################################
-##                                                                     ##
 ##  stage: build_packages                                              ##
 ##                                                                     ##
 ##  build packages using containers from previous stage.               ##
@@ -104,31 +82,19 @@ build_ubuntu_container:
 
 rpm_build:
   stage: build_packages
-  dependencies:
-    - build_centos_container
   <<: *dind_param
   artifacts:
     paths:
       - build/rpm/packages/
-  cache:
-    key: rpm
-    paths:
-      - .nih_c/pkgbuild
   script:
     - . ./Builds/containers/gitlab-ci/build_package.sh rpm
 
 dpkg_build:
   stage: build_packages
-  dependencies:
-    - build_ubuntu_container
   <<: *dind_param
   artifacts:
     paths:
       - build/dpkg/packages/
-  cache:
-    key: dpkg
-    paths:
-      - .nih_c/pkgbuild
   script:
     - . ./Builds/containers/gitlab-ci/build_package.sh dpkg
 
@@ -146,7 +112,7 @@ rpm_sign:
     - rpm_build
   image:
     name: centos:7
-    # <<: *dind_param
+  <<: *only_primary
   before_script:
   - |
     # Make sure GnuPG is installed
@@ -175,7 +141,7 @@ dpkg_sign:
     - dpkg_build
   image:
     name: ubuntu:18.04
-    # <<: *dind_param
+  <<: *only_primary
   before_script:
   - |
     # make sure we have GnuPG
@@ -620,4 +586,29 @@ get_prod_hashes:
   <<: *only_primary
   script:
     - . ./Builds/containers/gitlab-ci/push_to_artifactory.sh "GET" ".checksums"
+
+#########################################################################
+##                                                                     ##
+##  stage: build_containers                                            ##
+##                                                                     ##
+##  build containers from docker definitions. These containers are NOT ##
+##  used for the package build. This step is only used to ensure that  ##
+##  the package build targets and files are still working properly.    ##
+##                                                                     ##
+#########################################################################
+
+build_centos_container:
+  stage: build_containers
+  <<: *dind_param
+  script:
+    - . ./Builds/containers/gitlab-ci/build_container.sh rpm
+  allow_failure: true
+
+build_ubuntu_container:
+  stage: build_containers
+  <<: *dind_param
+  script:
+    - . ./Builds/containers/gitlab-ci/build_container.sh dpkg
+  allow_failure: true
+
 

--- a/Builds/containers/gitlab-ci/tag_docker_image.sh
+++ b/Builds/containers/gitlab-ci/tag_docker_image.sh
@@ -4,17 +4,17 @@ docker login -u rippled \
     -p ${ARTIFACTORY_DEPLOY_KEY_RIPPLED} "${ARTIFACTORY_HUB}"
 # this gives us rippled_version :
 source build/rpm/packages/build_vars
-docker pull "${ARTIFACTORY_HUB}/${RPM_CONTAINER_NAME}:${CI_COMMIT_SHA}"
-docker pull "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_NAME}:${CI_COMMIT_SHA}"
+docker pull "${ARTIFACTORY_HUB}/${RPM_CONTAINER_FULLNAME}"
+docker pull "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_FULLNAME}"
 # tag/push two labels...one using the current rippled version and one just using "latest"
 for label in ${rippled_version} latest ; do
     docker tag \
-        "${ARTIFACTORY_HUB}/${RPM_CONTAINER_NAME}:${CI_COMMIT_SHA}" \
+        "${ARTIFACTORY_HUB}/${RPM_CONTAINER_FULLNAME}" \
         "${ARTIFACTORY_HUB}/${RPM_CONTAINER_NAME}:${label}_${CI_COMMIT_REF_SLUG}"
     docker tag \
-        "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_NAME}:${CI_COMMIT_SHA}" \
+        "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_FULLNAME}" \
         "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_NAME}:${label}_${CI_COMMIT_REF_SLUG}"
-    docker push "${ARTIFACTORY_HUB}/${RPM_CONTAINER_NAME}"
-    docker push "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_NAME}"
+    docker push "${ARTIFACTORY_HUB}/${RPM_CONTAINER_FULLNAME}"
+    docker push "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_FULLNAME}"
 done
 

--- a/Builds/containers/packaging/dpkg/debian/control
+++ b/Builds/containers/packaging/dpkg/debian/control
@@ -2,7 +2,7 @@ Source: rippled
 Section: misc
 Priority: extra
 Maintainer: Ripple Labs Inc. <support@ripple.com>
-Build-Depends: cmake, debhelper (>=9), libprotobuf-dev, libssl-dev, zlib1g-dev, dh-systemd, ninja-build
+Build-Depends: cmake, debhelper (>=9), zlib1g-dev, dh-systemd, ninja-build
 Standards-Version: 3.9.7
 Homepage: http://ripple.com/
 

--- a/Builds/containers/packaging/dpkg/debian/rules
+++ b/Builds/containers/packaging/dpkg/debian/rules
@@ -20,7 +20,6 @@ override_dh_auto_configure:
 		-DCMAKE_INSTALL_PREFIX=/opt/ripple \
 		-DCMAKE_BUILD_TYPE=Release \
 		-Dstatic=true \
-		-Dlocal_protobuf=ON \
 		-Dvalidator_keys=ON \
 		-DCMAKE_VERBOSE_MAKEFILE=ON
 
@@ -34,5 +33,8 @@ override_dh_auto_install:
 	install -D Builds/containers/shared/update-rippled.sh debian/tmp/opt/ripple/bin/update-rippled.sh
 	install -D Builds/containers/shared/update-rippled-cron debian/tmp/opt/ripple/etc/update-rippled-cron
 	install -D Builds/containers/shared/rippled-logrotate debian/tmp/etc/logrotate.d/rippled
+    rm -f debian/tmp/opt/ripple/lib64/cmake/date/dateConfig.cmake
 	rm -rf bld
 	rm -rf bld_vl
+
+

--- a/Builds/containers/packaging/rpm/rippled.spec
+++ b/Builds/containers/packaging/rpm/rippled.spec
@@ -12,7 +12,7 @@ License:        MIT
 URL:            http://ripple.com/
 Source0:        rippled.tar.gz
 
-BuildRequires:  protobuf-static openssl-static cmake zlib-static ninja-build
+BuildRequires:  cmake zlib-static ninja-build
 
 %description
 rippled
@@ -32,7 +32,7 @@ core library for development of standalone applications that sign transactions.
 cd rippled
 mkdir -p bld.release
 cd bld.release
-cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_BUILD_TYPE=Release -Dstatic=true -DCMAKE_VERBOSE_MAKEFILE=ON -Dlocal_protobuf=ON -Dvalidator_keys=ON
+cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_BUILD_TYPE=Release -Dstatic=true -DCMAKE_VERBOSE_MAKEFILE=ON -Dvalidator_keys=ON
 cmake --build . --parallel --target rippled --target validator-keys -- -v
 
 %pre
@@ -41,6 +41,7 @@ test -e /etc/pki/tls || { mkdir -p /etc/pki; ln -s /usr/lib/ssl /etc/pki/tls; }
 %install
 rm -rf $RPM_BUILD_ROOT
 DESTDIR=$RPM_BUILD_ROOT cmake --build rippled/bld.release --target install -- -v
+rm -f ${RPM_BUILD_ROOT}/%{_prefix}/lib64/cmake/date/dateConfig.cmake
 install -d ${RPM_BUILD_ROOT}/etc/opt/ripple
 install -d ${RPM_BUILD_ROOT}/usr/local/bin
 ln -s %{_prefix}/etc/rippled.cfg ${RPM_BUILD_ROOT}/etc/opt/ripple/rippled.cfg

--- a/Builds/containers/shared/build_deps.sh
+++ b/Builds/containers/shared/build_deps.sh
@@ -22,7 +22,7 @@ build_boost "1.70.0" true
 # installed in opt, so won't be used
 # unless specified by OPENSSL_ROOT_DIR
 cd /tmp
-OPENSSL_VER=1.1.1
+OPENSSL_VER=1.1.1d
 wget https://www.openssl.org/source/openssl-${OPENSSL_VER}.tar.gz
 tar xf openssl-${OPENSSL_VER}.tar.gz
 cd openssl-${OPENSSL_VER}
@@ -36,7 +36,34 @@ rm -f openssl-${OPENSSL_VER}.tar.gz
 rm -rf openssl-${OPENSSL_VER}
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/opt/local/openssl/lib /opt/local/openssl/bin/openssl version -a
 
+cd /tmp
+wget https://libarchive.org/downloads/libarchive-3.3.3.tar.gz
+tar xzf libarchive-3.3.3.tar.gz
+cd libarchive-3.3.3
+./configure
+make
+make install
+cd ..
+rm -f libarchive-3.3.3.tar.gz
+rm -rf libarchive-3.3.3
+
+cd /tmp
+wget https://github.com/protocolbuffers/protobuf/releases/download/v3.10.1/protobuf-all-3.10.1.tar.gz
+tar xf protobuf-all-3.10.1.tar.gz
+cd protobuf-3.10.1
+./autogen.sh
+./configure
+make -j$(nproc)
+make install
+ldconfig
+cd ..
+rm -f protobuf-all-3.10.1.tar.gz
+rm -rf protobuf-3.10.1
+
 if [ "${CI_USE}" = true ] ; then
+
+    build_boost "1.71.0" false
+
     cd /tmp
     wget https://github.com/doxygen/doxygen/archive/Release_1_8_16.tar.gz
     tar xf Release_1_8_16.tar.gz
@@ -62,15 +89,15 @@ if [ "${CI_USE}" = true ] ; then
     rm -r lcov-1.14 lcov-1.14.tar.gz
 
     cd /tmp
-    wget https://github.com/ccache/ccache/releases/download/v3.7.3/ccache-3.7.3.tar.gz
-    tar xf ccache-3.7.3.tar.gz
-    cd ccache-3.7.3
+    wget https://github.com/ccache/ccache/releases/download/v3.7.5/ccache-3.7.5.tar.gz
+    tar xf ccache-3.7.5.tar.gz
+    cd ccache-3.7.5
     ./configure --prefix=/usr/local
     make
     make install
     cd ..
-    rm -f ccache-3.7.3.tar.gz
-    rm -rf ccache-3.7.3
+    rm -f ccache-3.7.5.tar.gz
+    rm -rf ccache-3.7.5
 
     pip install requests
     pip install https://github.com/codecov/codecov-python/archive/master.zip

--- a/Builds/containers/shared/install_boost.sh
+++ b/Builds/containers/shared/install_boost.sh
@@ -9,6 +9,7 @@
 set -exu
 
 odir=$(pwd)
+: ${BOOST_TOOLSET:=msvc-14.1}
 
 if [[ -d "$BOOST_ROOT/lib" || -d "${BOOST_ROOT}/stage/lib" ]] ; then
     echo "Using cached boost at $BOOST_ROOT"
@@ -60,7 +61,7 @@ if [[ -z ${COMSPEC:-} ]]; then
 else
     BLDARGS+=(runtime-link="static,shared")
     BLDARGS+=(--layout=versioned)
-    BLDARGS+=(--toolset="msvc-14.1")
+    BLDARGS+=(--toolset="${BOOST_TOOLSET}")
     BLDARGS+=(address-model=64)
     BLDARGS+=(architecture=x86)
     BLDARGS+=(link=static)

--- a/Builds/containers/ubuntu-builder/Dockerfile
+++ b/Builds/containers/ubuntu-builder/Dockerfile
@@ -15,8 +15,8 @@ RUN chmod +x /tmp/ubuntu_setup.sh && \
     chmod +x /tmp/install_cmake.sh
 RUN /tmp/ubuntu_setup.sh
 
-RUN /tmp/install_cmake.sh 3.15.2 /opt/local/cmake-3.15
-RUN ln -s /opt/local/cmake-3.15 /opt/local/cmake
+RUN /tmp/install_cmake.sh 3.16.0-rc3 /opt/local/cmake-3.16
+RUN ln -s /opt/local/cmake-3.16 /opt/local/cmake
 ENV PATH="/opt/local/cmake/bin:$PATH"
 # also install min supported cmake for testing
 RUN if [ "${CI_USE}" = true ] ; then /tmp/install_cmake.sh 3.9.0 /opt/local/cmake-3.9; fi

--- a/Builds/containers/ubuntu-builder/ubuntu_setup.sh
+++ b/Builds/containers/ubuntu-builder/ubuntu_setup.sh
@@ -30,8 +30,8 @@ apt-get -y clean
 apt-get -y update
 
 apt-get -y --fix-missing install \
-    make cmake ninja-build \
-    protobuf-compiler libprotobuf-dev openssl libssl-dev \
+    make cmake ninja-build autoconf automake libtool pkg-config libtool \
+    openssl libssl-dev \
     liblzma-dev libbz2-dev zlib1g-dev \
     libjemalloc-dev \
     python-pip \

--- a/bin/sh/install-vcpkg.sh
+++ b/bin/sh/install-vcpkg.sh
@@ -17,7 +17,7 @@ if [[ -d "${VCPKG_DIR}" ]] ; then
     rm -rf "${VCPKG_DIR}"
 fi
 
-git clone --branch 2019.06 https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR}
+git clone --branch 2019.10 https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR}
 pushd ${VCPKG_DIR}
 if [[ -z ${COMSPEC:-} ]]; then
     chmod +x ./bootstrap-vcpkg.sh

--- a/bin/sh/setup-msvc.sh
+++ b/bin/sh/setup-msvc.sh
@@ -22,6 +22,8 @@ while read line ; do
     fi
   fi
 done <<EOL
+"C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
+"C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
 "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
 "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
 "C:/Program Files (x86)/Microsoft Visual Studio 15.0/VC/vcvarsall.bat" amd64

--- a/src/ripple/overlay/impl/Message.cpp
+++ b/src/ripple/overlay/impl/Message.cpp
@@ -27,7 +27,7 @@ namespace ripple {
 Message::Message (::google::protobuf::Message const& message, int type)
     : mCategory(TrafficCount::categorize(message, type, false))
 {
-    unsigned const messageBytes = message.ByteSize ();
+    auto const messageBytes = message.ByteSizeLong ();
     assert (messageBytes != 0);
 
     /** Number of bytes in a message header. */


### PR DESCRIPTION
* use tagged (prebuilt) containers for pkg build
* continue to build container images in pipeline, but allow failure (non-block)
* limit travis macos cache
* add vs2019 windows to travis