### PR TITLE
Change how fail_hard transactions are handled.

### DIFF
--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -717,7 +717,7 @@ private:
     /** Checks if the indicated transaction fits the conditions
         for being stored in the queue.
     */
-    bool canBeHeld(STTx const&, OpenView const&,
+    bool canBeHeld(STTx const&, ApplyFlags const, OpenView const&,
         AccountMap::iterator,
             boost::optional<FeeMultiSet::iterator>);
 

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -358,16 +358,18 @@ TxQ::isFull() const
 }
 
 bool
-TxQ::canBeHeld(STTx const& tx, OpenView const& view,
+TxQ::canBeHeld(STTx const& tx, ApplyFlags const flags, OpenView const& view,
     AccountMap::iterator accountIter,
         boost::optional<FeeMultiSet::iterator> replacementIter)
 {
     // PreviousTxnID is deprecated and should never be used
     // AccountTxnID is not supported by the transaction
     // queue yet, but should be added in the future
+    // tapFAIL_HARD transactions are never held
     bool canBeHeld =
         ! tx.isFieldPresent(sfPreviousTxnID) &&
-        ! tx.isFieldPresent(sfAccountTxnID);
+        ! tx.isFieldPresent(sfAccountTxnID) &&
+        ! (flags & tapFAIL_HARD);
     if (canBeHeld)
     {
         /* To be queued and relayed, the transaction needs to
@@ -795,7 +797,7 @@ TxQ::apply(Application& app, OpenView& view,
                 // object to hold the info we need to adjust for
                 // prior txns. Otherwise, let preclaim fail as if
                 // we didn't have the queue at all.
-                if (canBeHeld(*tx, view, accountIter, replacedItemDeleteIter))
+                if (canBeHeld(*tx, flags, view, accountIter, replacedItemDeleteIter))
                     multiTxn.emplace();
             }
 
@@ -1044,7 +1046,7 @@ TxQ::apply(Application& app, OpenView& view,
 
     // If `multiTxn` has a value, then `canBeHeld` has already been verified
     if (! multiTxn &&
-        ! canBeHeld(*tx, view, accountIter, replacedItemDeleteIter))
+        ! canBeHeld(*tx, flags, view, accountIter, replacedItemDeleteIter))
     {
         // Bail, transaction cannot be held
         JLOG(j_.trace()) << "Transaction " <<

--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -35,7 +35,7 @@ inline
 bool
 isTecClaimHardFail(TER ter, ApplyFlags flags)
 {
-    return isTecClaim(ter) && !(flags & tapRETRY);
+    return isTecClaim(ter) && (!(flags & tapRETRY) || (flags & tapFAIL_HARD));
 }
 
 /** Describes the results of the `preflight` check

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -670,7 +670,15 @@ Transactor::operator()()
     if (ctx_.size() > oversizeMetaDataCap)
         result = tecOVERSIZE;
 
-    if ((result == tecOVERSIZE) || (result == tecKILLED) ||
+    if (isTecClaim(result) && (view().flags() & tapFAIL_HARD))
+    {
+        // If the tapFAIL_HARD flag is set, a tec result
+        // must not do anything
+
+        ctx_.discard();
+        applied = false;
+    }
+    else if ((result == tecOVERSIZE) || (result == tecKILLED) ||
         (isTecClaimHardFail (result, view().flags())))
     {
         JLOG(j_.trace()) << "reapplying because of " << transToken(result);

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -32,6 +32,10 @@ enum ApplyFlags
 {
     tapNONE             = 0x00,
 
+    // This is a local transaction with the
+    // fail_hard flag set.
+    tapFAIL_HARD        = 0x10,
+
     // This is not the transaction's last pass
     // Transaction can be retried, soft failures allowed
     tapRETRY            = 0x20,

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -81,7 +81,7 @@ enum TEMcodes : TERUnderlyingType
     // - Not applied
     // - Not forwarded
     // - Reject
-    // - Can not succeed in any imagined ledger.
+    // - Cannot succeed in any imagined ledger.
     temMALFORMED    = -299,
 
     temBAD_AMOUNT,


### PR DESCRIPTION
FIXES: #2847

* Transactions that are submitted with the fail_hard flag
  and that result in any TER code besides tesSUCCESS shall
  be neither queued nor held.