### PR TITLE
Do not restart server on deadlock detection:

### DIFF
--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -145,9 +145,12 @@ void LoadManager::run ()
                     {
                         JLOG(journal_.fatal())
                             << "Deadlock detected. Deadlocked time: "
-                            << timeSpentDeadlocked.count()
-                            << "s JobQueue Overloaded: "
-                            << app_.getJobQueue().isOverloaded();
+                            << timeSpentDeadlocked.count() << "s";
+                        if (app_.getJobQueue().isOverloaded())
+                        {
+                            JLOG(journal_.fatal())
+                                << app_.getJobQueue().getJson(0);
+                        }
                     }
                 }
 
@@ -158,10 +161,12 @@ void LoadManager::run ()
                 if (timeSpentDeadlocked >= deadlockLogicErrorTimeLimit)
                 {
                     JLOG(journal_.fatal())
-                            << "LogicError: Deadlock detected. Deadlocked time: "
-                            << timeSpentDeadlocked.count()
-                            << "s JobQueue Overloaded: "
-                            << app_.getJobQueue().isOverloaded();
+                        << "LogicError: Deadlock detected. Deadlocked time: "
+                        << timeSpentDeadlocked.count() << "s";
+                    if (app_.getJobQueue().isOverloaded())
+                    {
+                        JLOG(journal_.fatal()) << app_.getJobQueue().getJson(0);
+                    }
                     LogicError("Deadlock detected");
                 }
             }

--- a/src/ripple/app/main/LoadManager.cpp
+++ b/src/ripple/app/main/LoadManager.cpp
@@ -126,26 +126,44 @@ void LoadManager::run ()
             auto const timeSpentDeadlocked =
                 duration_cast<seconds>(steady_clock::now() - deadLock);
 
-            auto const reportingIntervalSeconds = 10s;
+            constexpr auto reportingIntervalSeconds = 10s;
+            constexpr auto deadlockFatalLogMessageTimeLimit = 90s;
+            constexpr auto deadlockLogicErrorTimeLimit = 600s;
             if (armed && (timeSpentDeadlocked >= reportingIntervalSeconds))
             {
-                // Report the deadlocked condition every 10 seconds
+
+                // Report the deadlocked condition every reportingIntervalSeconds
                 if ((timeSpentDeadlocked % reportingIntervalSeconds) == 0s)
                 {
-                    JLOG(journal_.warn())
-                        << "Server stalled for "
-                        << timeSpentDeadlocked.count() << " seconds.";
+                    if (timeSpentDeadlocked < deadlockFatalLogMessageTimeLimit)
+                    {
+                        JLOG(journal_.warn())
+                            << "Server stalled for "
+                            << timeSpentDeadlocked.count() << " seconds.";
+                    }
+                    else
+                    {
+                        JLOG(journal_.fatal())
+                            << "Deadlock detected. Deadlocked time: "
+                            << timeSpentDeadlocked.count()
+                            << "s JobQueue Overloaded: "
+                            << app_.getJobQueue().isOverloaded();
+                    }
                 }
 
-                // If we go over 90 seconds spent deadlocked, it means that
+                // If we go over the deadlockTimeLimit spent deadlocked, it means that
                 // the deadlock resolution code has failed, which qualifies
                 // as undefined behavior.
                 //
-                constexpr auto deadlockTimeLimit = 90s;
-                assert (timeSpentDeadlocked < deadlockTimeLimit);
-
-                if (timeSpentDeadlocked >= deadlockTimeLimit)
+                if (timeSpentDeadlocked >= deadlockLogicErrorTimeLimit)
+                {
+                    JLOG(journal_.fatal())
+                            << "LogicError: Deadlock detected. Deadlocked time: "
+                            << timeSpentDeadlocked.count()
+                            << "s JobQueue Overloaded: "
+                            << app_.getJobQueue().isOverloaded();
                     LogicError("Deadlock detected");
+                }
             }
         }
 


### PR DESCRIPTION
Replace the logic error with a log message. It's possible an overloaded job
queue is causing false alarms on the deadlock detector.