### PR TITLE
Backwards compatible workaround for boost 1.72

### DIFF
--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -27,6 +27,8 @@
 #include <ripple/core/Stoppable.h>
 #include <ripple/core/impl/Workers.h>
 #include <ripple/json/json_value.h>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
 #include <boost/coroutine/all.hpp>
 
 namespace ripple {

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -27,8 +27,8 @@
 #include <ripple/core/Stoppable.h>
 #include <ripple/core/impl/Workers.h>
 #include <ripple/json/json_value.h>
-#include <boost/range/begin.hpp>
-#include <boost/range/end.hpp>
+#include <boost/range/begin.hpp>   // workaround for boost 1.72 bug
+#include <boost/range/end.hpp>     // workaround for boost 1.72 bug
 #include <boost/coroutine/all.hpp>
 
 namespace ripple {


### PR DESCRIPTION
This small change gets us working with boost 1.70 thru 1.72.