### PR TITLE
Fix node auto-configuration code

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -152,7 +152,7 @@ LedgerMaster::LedgerMaster (Application& app, Stopwatch& stopwatch,
     , fetch_depth_ (app_.getSHAMapStore ().clampFetchDepth (
         app_.config().FETCH_DEPTH))
     , ledger_history_ (app_.config().LEDGER_HISTORY)
-    , ledger_fetch_size_ (app_.config().getSize (siLedgerFetch))
+    , ledger_fetch_size_ (app_.config().getValueFor(SizedItem::ledgerFetch))
     , fetch_packs_ ("FetchPack", 65536, std::chrono::seconds {45}, stopwatch,
         app_.journal("TaggedCache"))
 {

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -866,7 +866,7 @@ public:
                 TxDBInit);
             mTxnDB->getSession() <<
                 boost::str(boost::format("PRAGMA cache_size=-%d;") %
-                kilobytes(config_->getSize(siTxnDBCache)));
+                kilobytes(config_->getValueFor(SizedItem::txnDBCache)));
             mTxnDB->setupCheckpointing(m_jobQueue.get(), logs());
 
             if (!setup.standAlone ||
@@ -908,7 +908,7 @@ public:
                 LgrDBInit);
             mLedgerDB->getSession() <<
                 boost::str(boost::format("PRAGMA cache_size=-%d;") %
-                kilobytes(config_->getSize(siLgrDBCache)));
+                kilobytes(config_->getValueFor(SizedItem::lgrDBCache)));
             mLedgerDB->setupCheckpointing(m_jobQueue.get(), logs());
 
             // wallet database
@@ -964,24 +964,24 @@ public:
         // tune caches
         using namespace std::chrono;
         m_nodeStore->tune(
-            config_->getSize(siNodeCacheSize),
-            seconds{config_->getSize(siNodeCacheAge)});
+            config_->getValueFor(SizedItem::nodeCacheSize),
+            seconds{config_->getValueFor(SizedItem::nodeCacheAge)});
 
         m_ledgerMaster->tune(
-            config_->getSize(siLedgerSize),
-            seconds{config_->getSize(siLedgerAge)});
+            config_->getValueFor(SizedItem::ledgerSize),
+            seconds{config_->getValueFor(SizedItem::ledgerAge)});
 
         family().treecache().setTargetSize(
-            config_->getSize (siTreeCacheSize));
+            config_->getValueFor(SizedItem::treeCacheSize));
         family().treecache().setTargetAge(
-            seconds{config_->getSize(siTreeCacheAge)});
+            seconds{config_->getValueFor(SizedItem::treeCacheAge)});
 
         if (sFamily_)
         {
             sFamily_->treecache().setTargetSize(
-                config_->getSize(siTreeCacheSize));
+                config_->getValueFor(SizedItem::treeCacheSize));
             sFamily_->treecache().setTargetAge(
-                seconds{config_->getSize(siTreeCacheAge)});
+                seconds{config_->getValueFor(SizedItem::treeCacheAge)});
         }
 
         return true;
@@ -1135,7 +1135,7 @@ public:
         {
             using namespace std::chrono;
             sweepTimer_.expires_from_now(
-                seconds{config_->getSize(siSweepInterval)});
+                seconds{config_->getValueFor(SizedItem::sweepInterval)});
             sweepTimer_.async_wait (std::move (*optionalCountedHandler));
         }
     }

--- a/src/ripple/app/main/BasicApp.cpp
+++ b/src/ripple/app/main/BasicApp.cpp
@@ -24,20 +24,22 @@ BasicApp::BasicApp(std::size_t numberOfThreads)
 {
     work_.emplace (io_service_);
     threads_.reserve(numberOfThreads);
+
     while(numberOfThreads--)
-        threads_.emplace_back(
-            [this, numberOfThreads]()
+    {
+        threads_.emplace_back([this, numberOfThreads]()
             {
-                beast::setCurrentThreadName(
-                    std::string("io_service #") +
-                        std::to_string(numberOfThreads));
-                this->io_service_.run();
+              beast::setCurrentThreadName("io svc #" +
+                  std::to_string(numberOfThreads));
+              this->io_service_.run();
             });
+    }
 }
 
 BasicApp::~BasicApp()
 {
     work_ = boost::none;
-    for (auto& _ : threads_)
-        _.join();
+
+    for (auto& t : threads_)
+        t.join();
 }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2167,6 +2167,9 @@ Json::Value NetworkOPsImp::getServerInfo (bool human, bool admin, bool counters)
     if (human)
         info [jss::hostid] = getHostId (admin);
 
+    if (auto const netid = app_.overlay().networkID())
+        info [jss::network_id] = static_cast<Json::UInt>(*netid);
+
     info [jss::build_version] = BuildInfo::getVersionString ();
 
     info [jss::server_state] = strOperatingMode (admin);

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -190,7 +190,7 @@ SHAMapStoreImp::SHAMapStoreImp(
         if (!section.exists("cache_mb"))
         {
             section.set("cache_mb", std::to_string(
-                config.getSize(siHashNodeDBCache)));
+                config.getValueFor(SizedItem::hashNodeDBCache)));
         }
 
         if (!section.exists("filter_bits") && (config.NODE_SIZE >= 2))

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -203,7 +203,6 @@ public:
     std::uint64_t                      FEE_DEFAULT = 10;
     std::uint64_t                      FEE_ACCOUNT_RESERVE = 200*SYSTEM_CURRENCY_PARTS;
     std::uint64_t                      FEE_OWNER_RESERVE = 50*SYSTEM_CURRENCY_PARTS;
-    std::uint64_t                      FEE_OFFER = 10;
 
     // Node storage configuration
     std::uint32_t                      LEDGER_HISTORY = 256;

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -40,7 +40,6 @@ struct ConfigSection
 #define SECTION_DEBUG_LOGFILE           "debug_logfile"
 #define SECTION_ELB_SUPPORT             "elb_support"
 #define SECTION_FEE_DEFAULT             "fee_default"
-#define SECTION_FEE_OFFER               "fee_offer"
 #define SECTION_FEE_ACCOUNT_RESERVE     "fee_account_reserve"
 #define SECTION_FEE_OWNER_RESERVE       "fee_owner_reserve"
 #define SECTION_FETCH_DEPTH             "fetch_depth"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -38,6 +38,54 @@
 
 namespace ripple {
 
+inline constexpr
+std::array<std::pair<SizedItem, std::array<int, 5>>, 11>
+sizedItems
+{{
+    // FIXME: We should document each of these items, explaining exactly what
+    //        they control and whether there exists an explicit config option
+    //        that can be used to override the default.
+    { SizedItem::sweepInterval,
+        {{      10,      30,       60,       90,      120  }} },
+    { SizedItem::treeCacheSize,
+        {{  128000,  256000,   512000,   768000,  2048000  }} },
+    { SizedItem::treeCacheAge,
+        {{      30,      60,       90,      120,      900  }} },
+    { SizedItem::ledgerSize,
+        {{      32,     128,      256,      384,      768  }} },
+    { SizedItem::ledgerAge,
+        {{      30,      90,      180,      240,      900  }} },
+    { SizedItem::ledgerFetch,
+        {{       2,       3,        4,        5,        8  }} },
+    { SizedItem::nodeCacheSize,
+        {{   16384,   32768,   131072,   262144,   524288  }} },
+    { SizedItem::nodeCacheAge,
+        {{      60,      90,      120,      900,     1800  }} },
+    { SizedItem::hashNodeDBCache,
+        {{       4,      12,       24,       64,      128  }} },
+    { SizedItem::txnDBCache,
+        {{       4,      12,       24,       64,      128  }} },
+    { SizedItem::lgrDBCache,
+        {{       4,       8,       16,       32,      128  }} },
+}};
+
+// Ensure that the order of entries in the table corresponds to the
+// order of entries in the enum:
+static_assert([]() constexpr -> bool
+{
+    std::underlying_type_t<SizedItem> idx = 0;
+
+    for (auto const& i : sizedItems)
+    {
+        if (static_cast<std::underlying_type_t<SizedItem>>(i.first) != idx)
+            return false;
+
+        ++idx;
+    }
+
+    return true;
+}(), "Mismatch between sized item enum & array indices");
+
 //
 // TODO: Check permissions on config file before using it.
 //
@@ -589,6 +637,20 @@ boost::filesystem::path Config::getDebugLogFile () const
     }
 
     return log_file;
+}
+
+int
+Config::getValueFor(SizedItem item,
+    boost::optional<std::size_t> node) const
+{
+    auto const index = static_cast<std::underlying_type_t<SizedItem>>(item);
+    assert(index < sizedItems.size());
+
+    if (!node)
+        node = NODE_SIZE;
+
+    assert(*node <= 4);
+    return sizedItems.at(index).second.at(*node);
 }
 
 } // ripple

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -32,6 +32,7 @@
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 #include <boost/system/error_code.hpp>
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -377,14 +378,8 @@ void Config::loadFromString (std::string const& fileContents)
         else if (boost::iequals(strTemp, "huge"))
             NODE_SIZE = 4;
         else
-        {
-            NODE_SIZE = beast::lexicalCastThrow <std::size_t>(strTemp);
-
-            if (NODE_SIZE > 4)
-                NODE_SIZE = 4;
-        }
-
-        assert (NODE_SIZE <= 4);
+            NODE_SIZE = std::min<std::size_t>(4,
+                beast::lexicalCastThrow<std::size_t>(strTemp));
     }
 
     if (getSingleSection (secConfig, SECTION_SIGNING_SUPPORT, strTemp, j_))

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -640,17 +640,12 @@ boost::filesystem::path Config::getDebugLogFile () const
 }
 
 int
-Config::getValueFor(SizedItem item,
-    boost::optional<std::size_t> node) const
+Config::getValueFor(SizedItem item, boost::optional<std::size_t> node) const
 {
     auto const index = static_cast<std::underlying_type_t<SizedItem>>(item);
     assert(index < sizedItems.size());
-
-    if (!node)
-        node = NODE_SIZE;
-
-    assert(*node <= 4);
-    return sizedItems.at(index).second.at(*node);
+    assert(!node || *node <= 4);
+    return sizedItems.at(index).second.at(node.value_or(NODE_SIZE));
 }
 
 } // ripple

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -368,9 +368,6 @@ void Config::loadFromString (std::string const& fileContents)
     if (getSingleSection (secConfig, SECTION_FEE_OWNER_RESERVE, strTemp, j_))
         FEE_OWNER_RESERVE   = beast::lexicalCastThrow <std::uint64_t> (strTemp);
 
-    if (getSingleSection (secConfig, SECTION_FEE_OFFER, strTemp, j_))
-        FEE_OFFER           = beast::lexicalCastThrow <int> (strTemp);
-
     if (getSingleSection (secConfig, SECTION_FEE_DEFAULT, strTemp, j_))
         FEE_DEFAULT         = beast::lexicalCastThrow <int> (strTemp);
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -330,13 +330,13 @@ void Config::loadFromString (std::string const& fileContents)
             NODE_SIZE = 4;
         else
         {
-            NODE_SIZE = beast::lexicalCastThrow <int> (strTemp);
+            NODE_SIZE = beast::lexicalCastThrow <std::size_t>(strTemp);
 
-            if (NODE_SIZE < 0)
-                NODE_SIZE = 0;
-            else if (NODE_SIZE > 4)
+            if (NODE_SIZE > 4)
                 NODE_SIZE = 4;
         }
+
+        assert (NODE_SIZE <= 4);
     }
 
     if (getSingleSection (secConfig, SECTION_SIGNING_SUPPORT, strTemp, j_))

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -253,6 +253,18 @@ public:
     virtual
     Json::Value
     crawlShards(bool pubKey, std::uint32_t hops) = 0;
+
+    /** Returns the ID of the network this server is configured for, if any.
+
+        The ID is just a numerical identifier, with the IDs 0, 1 and 2 used to
+        identify the mainnet, the testnet and the devnet respectively.
+
+        @return The numerical identifier configured by the administrator of the
+                server. An unseated optional, otherwise.
+    */
+    virtual
+    boost::optional<std::uint32_t>
+    networkID() const = 0;
 };
 
 struct ScoreHasLedger

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -1328,14 +1328,17 @@ setup_Overlay (BasicConfig const& config)
             if (id == "testnet")
                 id = "1";
 
+            if (id == "devnet")
+                id = "2";
+
             setup.networkID = beast::lexicalCastThrow<std::uint32_t>(id);
         }
     }
     catch (...)
     {
         Throw<std::runtime_error>(
-            "Configured [network_id] section is invalid: "
-            "must be a number or one of the strings 'main' or 'testnet'");
+            "Configured [network_id] section is invalid: must be a number "
+            "or one of the strings 'main', 'testnet' or 'devnet'.");
     }
 
     return setup;

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -359,9 +359,14 @@ public:
         return peerDisconnectsCharges_;
     }
 
+    boost::optional<std::uint32_t>
+    networkID() const override
+    {
+        return networkID_;
+    }
+
     Json::Value
     crawlShards(bool pubKey, std::uint32_t hops) override;
-
 
     /** Called when the last link from a peer chain is received.
 

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -351,6 +351,7 @@ JSS ( missingCommand );             // error
 JSS ( name );                       // out: AmendmentTableImpl, PeerImp
 JSS ( needed_state_hashes );        // out: InboundLedger
 JSS ( needed_transaction_hashes );  // out: InboundLedger
+JSS ( network_id );                 // out: NetworkOPs
 JSS ( network_ledger );             // out: NetworkOPs
 JSS ( next_refresh_time );          // out: ValidatorSite
 JSS ( no_ripple );                  // out: AccountLines


### PR DESCRIPTION
The `node_size` configuration option is used to automatically configure various parameters (cache sizes, timeouts, etc) for the server.

A previous commit included changes that caused incorrect values to be returned which can result in sub-optimal performance that can manifest as difficulty syncing to the network, or increased disk I/O and/or memory usage. The problem was introduced with commit 66fad62.

This commit, if merged, fixes the code to ensure that the correct values are returned and introduces a compile-time check to prevent this issue from reoccurring.

