### PR TITLE
Report StateAccounting metrics and fixed StatsD bug

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -495,7 +495,7 @@ public:
         , m_networkOPs (make_NetworkOPs (*this, stopwatch(),
             config_->standalone(), config_->NETWORK_QUORUM, config_->START_VALID,
             *m_jobQueue, *m_ledgerMaster, *m_jobQueue, validatorKeys_,
-            get_io_service(), logs_->journal("NetworkOPs")))
+            get_io_service(), logs_->journal("NetworkOPs"), m_collectorManager->collector()))
 
         , cluster_ (std::make_unique<Cluster> (
             logs_->journal("Overlay")))

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -638,11 +638,11 @@ private:
             , syncing_duration(collector->make_gauge("State_Accounting", "Syncing_duration"))
             , tracking_duration (collector->make_gauge("State_Accounting", "Tracking_duration"))
             , full_duration (collector-> make_gauge("State_Accounting", "Full_duration"))
-            , disconnected_trasitions (collector->make_gauge("State_Accounting","Disconnected_trasitions"))
-            , connected_trasitions (collector->make_gauge("State_Accounting","Connected_trasitions"))
-            , syncing_trasitions(collector->make_gauge("State_Accounting", "Syncing_trasitions"))
-            , tracking_trasitions (collector->make_gauge("State_Accounting", "Tracking_trasitions"))
-            , full_trasitions (collector-> make_gauge("State_Accounting", "Full_trasitions"))
+            , disconnected_transitions (collector->make_gauge("State_Accounting","Disconnected_transitions"))
+            , connected_transitions (collector->make_gauge("State_Accounting","Connected_transitions"))
+            , syncing_transitions(collector->make_gauge("State_Accounting", "Syncing_transitions"))
+            , tracking_transitions (collector->make_gauge("State_Accounting", "Tracking_transitions"))
+            , full_transitions (collector-> make_gauge("State_Accounting", "Full_transitions"))
             { }
 
         beast::insight::Hook hook;
@@ -652,11 +652,11 @@ private:
         beast::insight::Gauge tracking_duration;
         beast::insight::Gauge full_duration;
 
-        beast::insight::Gauge disconnected_trasitions;
-        beast::insight::Gauge connected_trasitions;
-        beast::insight::Gauge syncing_trasitions;
-        beast::insight::Gauge tracking_trasitions;
-        beast::insight::Gauge full_trasitions;
+        beast::insight::Gauge disconnected_transitions;
+        beast::insight::Gauge connected_transitions;
+        beast::insight::Gauge syncing_transitions;
+        beast::insight::Gauge tracking_transitions;
+        beast::insight::Gauge full_transitions;
     };
 
     Stats m_stats;
@@ -675,11 +675,11 @@ private:
         m_stats.tracking_duration.set(counters[static_cast<std::size_t>(OperatingMode::TRACKING)].dur.count());
         m_stats.full_duration.set(counters[static_cast<std::size_t>(OperatingMode::FULL)].dur.count());
 
-        m_stats.disconnected_trasitions.set(counters[static_cast<std::size_t>(OperatingMode::DISCONNECTED)].transitions);
-        m_stats.connected_trasitions.set(counters[static_cast<std::size_t>(OperatingMode::CONNECTED)].transitions);
-        m_stats.syncing_trasitions.set(counters[static_cast<std::size_t>(OperatingMode::SYNCING)].transitions);
-        m_stats.tracking_trasitions.set(counters[static_cast<std::size_t>(OperatingMode::TRACKING)].transitions);
-        m_stats.full_trasitions.set(counters[static_cast<std::size_t>(OperatingMode::FULL)].transitions);
+        m_stats.disconnected_transitions.set(counters[static_cast<std::size_t>(OperatingMode::DISCONNECTED)].transitions);
+        m_stats.connected_transitions.set(counters[static_cast<std::size_t>(OperatingMode::CONNECTED)].transitions);
+        m_stats.syncing_transitions.set(counters[static_cast<std::size_t>(OperatingMode::SYNCING)].transitions);
+        m_stats.tracking_transitions.set(counters[static_cast<std::size_t>(OperatingMode::TRACKING)].transitions);
+        m_stats.full_transitions.set(counters[static_cast<std::size_t>(OperatingMode::FULL)].transitions);
     }
 };
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -170,7 +170,6 @@ class NetworkOPsImp final
          */
         StateCountersJson json() const;
 
-
         struct CounterData {
             decltype(counters_) counters;
             decltype(mode_) mode;
@@ -181,7 +180,6 @@ class NetworkOPsImp final
             std::lock_guard lock(mutex_);
             return { counters_, mode_, start_ };
         }
-
     };
 
     //! Server fees published on `server` subscription
@@ -668,18 +666,11 @@ private:
     
     std::mutex m_statsMutex;//Mutex to lock m_stats
     Stats m_stats;
-    
-
 
 private:
     void collect_metrics()
     {   
-        NetworkOPsImp::StateAccounting::CounterData cd = accounting_.getCounterData();
-
-        auto counters= cd.counters;
-        auto mode = cd.mode;
-        auto start = cd.start;
-
+        auto [counters, mode, start] = accounting_.getCounterData();
         auto const current = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - start);
         counters[static_cast<std::size_t>(mode)].dur += current;
 
@@ -3534,15 +3525,7 @@ void NetworkOPsImp::StateAccounting::mode (OperatingMode om)
 NetworkOPsImp::StateAccounting::StateCountersJson
 NetworkOPsImp::StateAccounting::json() const
 {
-   
-    NetworkOPsImp::StateAccounting::CounterData cd = getCounterData();
-
-    auto counters= cd.counters;
-    auto mode = cd.mode;
-    auto start = cd.start;
-
-
-
+    auto [counters, mode, start] = getCounterData();
     auto const current = std::chrono::duration_cast<
         std::chrono::microseconds>(std::chrono::system_clock::now() - start);
     counters[static_cast<std::size_t>(mode)].dur += current;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -658,17 +658,22 @@ private:
         beast::insight::Gauge tracking_transitions;
         beast::insight::Gauge full_transitions;
     };
-
+    
+    std::mutex m_statsMutex;//Mutex to lock m_stats
     Stats m_stats;
+    
+
 
 private:
     void collect_metrics()
-    {     
+    {   
+        
         auto [counters, mode, start] = accounting_.getCounterData();
 
         auto const current = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - start);
         counters[static_cast<std::size_t>(mode)].dur += current;
 
+        std::lock_guard lock (m_statsMutex);  
         m_stats.disconnected_duration.set(counters[static_cast<std::size_t>(OperatingMode::DISCONNECTED)].dur.count());
         m_stats.connected_duration.set(counters[static_cast<std::size_t>(OperatingMode::CONNECTED)].dur.count());
         m_stats.syncing_duration.set(counters[static_cast<std::size_t>(OperatingMode::SYNCING)].dur.count());

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -170,22 +170,9 @@ class NetworkOPsImp final
          */
         StateCountersJson json() const;
 
-        std::array<Counters, 5> getCounters(){
+        auto getCounterData() const {
             std::lock_guard lock(mutex_);
-            auto counters = counters_;
-            return counters;
-        }
-
-        OperatingMode getMode(){
-            std::lock_guard lock(mutex_);
-            auto mode = mode_;
-            return mode;
-        }
-
-        std::chrono::system_clock::time_point getStart(){
-            std::lock_guard lock(mutex_);
-            auto start = start_;
-            return start;
+            return std::make_tuple(counters_, mode_, start_);
         }
 
     };
@@ -676,10 +663,8 @@ private:
 
 private:
     void collect_metrics()
-    {   
-        auto counters = accounting_.getCounters();
-        auto start = accounting_.getStart();
-        auto mode = accounting_.getMode();
+    {     
+        auto [counters, mode, start] = accounting_.getCounterData();
 
         auto const current = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - start);
         counters[static_cast<std::size_t>(mode)].dur += current;

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -244,6 +244,9 @@ public:
         std::shared_ptr<ReadView const> const& lpCurrent,
         std::shared_ptr<STTx const> const& stTxn, TER terResult) = 0;
     virtual void pubValidation (STValidation::ref val) = 0;
+
+
+
 };
 
 //------------------------------------------------------------------------------
@@ -253,7 +256,7 @@ make_NetworkOPs (Application& app, NetworkOPs::clock_type& clock,
     bool standalone, std::size_t minPeerCount, bool start_valid,
     JobQueue& job_queue, LedgerMaster& ledgerMaster, Stoppable& parent,
     ValidatorKeys const & validatorKeys, boost::asio::io_service& io_svc,
-    beast::Journal journal);
+    beast::Journal journal, beast::insight::Collector::ptr const& collector);
 
 } // ripple
 

--- a/src/ripple/beast/insight/impl/StatsDCollector.cpp
+++ b/src/ripple/beast/insight/impl/StatsDCollector.cpp
@@ -589,7 +589,7 @@ void StatsDGaugeImpl::flush ()
         ss <<
             m_impl->prefix() << "." <<
             m_name << ":" <<
-            m_value << "|c" <<
+            m_value << "|g" <<
             "\n";
         m_impl->post_buffer (ss.str ());
     }


### PR DESCRIPTION
StateAccounting metrics report the amount of time the server spends in each state and the number of transitions into that state. 

A StatsD reporting bug that reports gauges as counters was also fixed in this PR. 