### PR TITLE
Command line parser issues

### DIFF
--- a/Builds/CMake/deps/Protobuf.cmake
+++ b/Builds/CMake/deps/Protobuf.cmake
@@ -10,6 +10,7 @@ if (static)
 endif ()
 find_package (Protobuf 3.8)
 if (local_protobuf OR NOT Protobuf_FOUND)
+  include (GNUInstallDirs)
   message (STATUS "using local protobuf build.")
   if (WIN32)
     # protobuf prepends lib even on windows
@@ -56,10 +57,10 @@ if (local_protobuf OR NOT Protobuf_FOUND)
     INSTALL_COMMAND
       ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --config $<CONFIG> --target install
     BUILD_BYPRODUCTS
-      <BINARY_DIR>/_installed_/lib/${pbuf_lib_pre}protobuf${ep_lib_suffix}
-      <BINARY_DIR>/_installed_/lib/${pbuf_lib_pre}protobuf_d${ep_lib_suffix}
-      <BINARY_DIR>/_installed_/lib/${pbuf_lib_pre}protoc${ep_lib_suffix}
-      <BINARY_DIR>/_installed_/lib/${pbuf_lib_pre}protoc_d${ep_lib_suffix}
+      <BINARY_DIR>/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protobuf${ep_lib_suffix}
+      <BINARY_DIR>/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protobuf_d${ep_lib_suffix}
+      <BINARY_DIR>/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protoc${ep_lib_suffix}
+      <BINARY_DIR>/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protoc_d${ep_lib_suffix}
       <BINARY_DIR>/_installed_/bin/protoc${CMAKE_EXECUTABLE_SUFFIX}
   )
   ExternalProject_Get_Property (protobuf_src BINARY_DIR)
@@ -75,9 +76,9 @@ if (local_protobuf OR NOT Protobuf_FOUND)
   file (MAKE_DIRECTORY ${BINARY_DIR}/_installed_/include)
   set_target_properties (protobuf::libprotobuf PROPERTIES
     IMPORTED_LOCATION_DEBUG
-      ${BINARY_DIR}/_installed_/lib/${pbuf_lib_pre}protobuf_d${ep_lib_suffix}
+      ${BINARY_DIR}/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protobuf_d${ep_lib_suffix}
     IMPORTED_LOCATION_RELEASE
-      ${BINARY_DIR}/_installed_/lib/${pbuf_lib_pre}protobuf${ep_lib_suffix}
+      ${BINARY_DIR}/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protobuf${ep_lib_suffix}
     INTERFACE_INCLUDE_DIRECTORIES
       ${BINARY_DIR}/_installed_/include)
   add_dependencies (protobuf::libprotobuf protobuf_src)
@@ -88,9 +89,9 @@ if (local_protobuf OR NOT Protobuf_FOUND)
   endif ()
   set_target_properties (protobuf::libprotoc PROPERTIES
     IMPORTED_LOCATION_DEBUG
-      ${BINARY_DIR}/_installed_/lib/${pbuf_lib_pre}protoc_d${ep_lib_suffix}
+      ${BINARY_DIR}/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protoc_d${ep_lib_suffix}
     IMPORTED_LOCATION_RELEASE
-      ${BINARY_DIR}/_installed_/lib/${pbuf_lib_pre}protoc${ep_lib_suffix}
+      ${BINARY_DIR}/_installed_/${CMAKE_INSTALL_LIBDIR}/${pbuf_lib_pre}protoc${ep_lib_suffix}
     INTERFACE_INCLUDE_DIRECTORIES
       ${BINARY_DIR}/_installed_/include)
   add_dependencies (protobuf::libprotoc protobuf_src)

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -133,7 +133,7 @@ void printHelp (const po::options_description& desc)
            "     account_lines <account> <account>|\"\" [<ledger>]\n"
            "     account_channels <account> <account>|\"\" [<ledger>]\n"
            "     account_objects <account> [<ledger>] [strict]\n"
-           "     account_offers <account>|<account_public_key> [<ledger>]\n"
+           "     account_offers <account>|<account_public_key> [<ledger>] [strict]\n"
            "     account_tx accountID [ledger_min [ledger_max [limit [offset]]]] [binary] [count] [descending]\n"
            "     book_offers <taker_pays> <taker_gets> [<taker [<ledger> [<limit> [<proof> [<marker>]]]]]\n"
            "     can_delete [<ledgerid>|<ledgerhash>|now|always|never]\n"

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -691,11 +691,11 @@ private:
         return jvRequest;
     }
 
-    // owner_info <account>|<account_public_key>
-    // owner_info <seed>|<pass_phrase>|<key> [<ledfer>]
-    // account_info <account>|<account_public_key>
-    // account_info <seed>|<pass_phrase>|<key> [<ledger>]
-    // account_offers <account>|<account_public_key> [<ledger>]
+    // owner_info <account>|<account_public_key> [strict]
+    // owner_info <seed>|<pass_phrase>|<key> [<ledger>] [strict]
+    // account_info <account>|<account_public_key> [strict]
+    // account_info <seed>|<pass_phrase>|<key> [<ledger>] [strict]
+    // account_offers <account>|<account_public_key> [<ledger>] [strict]
     Json::Value parseAccountItems (Json::Value const& jvParams)
     {
         return parseAccountRaw1 (jvParams);

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1141,8 +1141,8 @@ public:
             // Request-response methods
             // - Returns an error, or the request.
             // - To modify the method, provide a new method in the request.
-            {   "account_currencies",   &RPCParser::parseAccountCurrencies,     1,  2   },
-            {   "account_info",         &RPCParser::parseAccountItems,          1,  2   },
+            {   "account_currencies",   &RPCParser::parseAccountCurrencies,     1,  3   },
+            {   "account_info",         &RPCParser::parseAccountItems,          1,  3   },
             {   "account_lines",        &RPCParser::parseAccountLines,          1,  5   },
             {   "account_channels",     &RPCParser::parseAccountChannels,       1,  3   },
             {   "account_objects",      &RPCParser::parseAccountItems,          1,  5   },
@@ -1171,7 +1171,7 @@ public:
             {   "ledger_request",       &RPCParser::parseLedgerId,              1,  1   },
             {   "log_level",            &RPCParser::parseLogLevel,              0,  2   },
             {   "logrotate",            &RPCParser::parseAsIs,                  0,  0   },
-            {   "owner_info",           &RPCParser::parseAccountItems,          1,  2   },
+            {   "owner_info",           &RPCParser::parseAccountItems,          1,  3   },
             {   "peers",                &RPCParser::parseAsIs,                  0,  0   },
             {   "ping",                 &RPCParser::parseAsIs,                  0,  0   },
             {   "print",                &RPCParser::parseAsIs,                  0,  1   },

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1559,8 +1559,7 @@ int fromCommandLine (
 {
     auto const result = rpcClient(vCmd, config, logs);
 
-    if (result.first != rpcBAD_SYNTAX)
-        std::cout << result.second.toStyledString ();
+    std::cout << result.second.toStyledString ();
 
     return result.first;
 }

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -334,7 +334,7 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    "account_currencies: too many arguments.", __LINE__,
+    "account_currencies: current ledger.", __LINE__,
     {
         "account_currencies",
         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -346,9 +346,9 @@ static RPCCallTestData const rpcCallTestArray [] =
     "method" : "account_currencies",
     "params" : [
       {
-         "error" : "badSyntax",
-         "error_code" : 1,
-         "error_message" : "Syntax error."
+         "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "ledger_index" : "current",
+         "strict" : 1
       }
     ]
     })"
@@ -486,7 +486,6 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    // Note: this works, but it doesn't match the documentation.
     "account_info: strict.", __LINE__,
     {
         "account_info",
@@ -506,7 +505,6 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    // Note: Somewhat according to the docs, this is should be valid syntax.
     "account_info: with ledger index and strict.", __LINE__,
     {
         "account_info",
@@ -519,9 +517,9 @@ static RPCCallTestData const rpcCallTestArray [] =
     "method" : "account_info",
     "params" : [
       {
-         "error" : "badSyntax",
-         "error_code" : 1,
-         "error_message" : "Syntax error."
+         "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "ledger_index" : "validated",
+         "strict" : 1
       }
     ]
     })"
@@ -904,7 +902,6 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    // Note: this works, but it doesn't match the documentation.
     "account_objects: strict.", __LINE__,
     {
         "account_objects",
@@ -1168,7 +1165,6 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    // Note: this works, but it doesn't match the documentation.
     "account_offers: strict.", __LINE__,
     {
         "account_offers",
@@ -1188,7 +1184,6 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    // Note: this works, but doesn't match the documentation.
     "account_offers: with ledger index and strict.", __LINE__,
     {
         "account_offers",
@@ -4994,7 +4989,6 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    // Note: this works, but it doesn't match the documentation.
     "owner_info: strict.", __LINE__,
     {
         "owner_info",
@@ -5026,9 +5020,9 @@ static RPCCallTestData const rpcCallTestArray [] =
     "method" : "owner_info",
     "params" : [
       {
-         "error" : "badSyntax",
-         "error_code" : 1,
-         "error_message" : "Syntax error."
+         "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "ledger_index" : "validated",
+         "strict" : 1
       }
     ]
     })"
@@ -5092,7 +5086,7 @@ static RPCCallTestData const rpcCallTestArray [] =
 {
     // Note: there is code in place to return rpcLGR_IDX_MALFORMED.  That
     // cannot currently occur because jvParseLedger() always returns true.
-    "owner_info: invalid ledger selection 1.", __LINE__,
+    "owner_info: invalid ledger selection.", __LINE__,
     {
         "owner_info",
         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -5113,7 +5107,7 @@ static RPCCallTestData const rpcCallTestArray [] =
 {
     // Note: there is code in place to return rpcLGR_IDX_MALFORMED.  That
     // cannot currently occur because jvParseLedger() always returns true.
-    "owner_info: invalid ledger selection 2.", __LINE__,
+    "owner_info: invalid ledger selection and strict.", __LINE__,
     {
         "owner_info",
         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -5125,9 +5119,9 @@ static RPCCallTestData const rpcCallTestArray [] =
     "method" : "owner_info",
     "params" : [
        {
-         "error" : "badSyntax",
-         "error_code" : 1,
-         "error_message" : "Syntax error."
+         "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "ledger_index" : 0,
+         "strict" : 1
        }
     ]
     })",

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -330,6 +330,7 @@ static RPCCallTestData const rpcCallTestArray [] =
     "params" : [
       {
          "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "api_version" : %MAX_API_VER%,
          "ledger_index" : "current",
          "strict" : 1
       }
@@ -539,6 +540,7 @@ static RPCCallTestData const rpcCallTestArray [] =
     "params" : [
       {
          "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "api_version" : %MAX_API_VER%,
          "ledger_index" : "validated",
          "strict" : 1
       }
@@ -5042,6 +5044,7 @@ static RPCCallTestData const rpcCallTestArray [] =
     "params" : [
       {
          "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "api_version" : %MAX_API_VER%,
          "ledger_index" : "validated",
          "strict" : 1
       }
@@ -5141,6 +5144,7 @@ static RPCCallTestData const rpcCallTestArray [] =
     "params" : [
        {
          "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "api_version" : %MAX_API_VER%,
          "ledger_index" : 0,
          "strict" : 1
        }

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -317,6 +317,26 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
+    "account_currencies: current ledger.", __LINE__,
+    {
+        "account_currencies",
+        "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        "current",
+        "strict"
+    },
+    RPCCallTestData::no_exception,
+    R"({
+    "method" : "account_currencies",
+    "params" : [
+      {
+         "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+         "ledger_index" : "current",
+         "strict" : 1
+      }
+    ]
+    })"
+},
+{
     "account_currencies: too few arguments.", __LINE__,
     {
         "account_currencies",
@@ -334,21 +354,22 @@ static RPCCallTestData const rpcCallTestArray [] =
     })"
 },
 {
-    "account_currencies: current ledger.", __LINE__,
+    "account_currencies: too many arguments.", __LINE__,
     {
         "account_currencies",
         "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
         "current",
-        "strict"
+        "strict",
+        "spare"
     },
     RPCCallTestData::no_exception,
     R"({
     "method" : "account_currencies",
     "params" : [
       {
-         "account" : "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
-         "ledger_index" : "current",
-         "strict" : 1
+         "error" : "badSyntax",
+         "error_code" : 1,
+         "error_message" : "Syntax error."
       }
     ]
     })"


### PR DESCRIPTION
This pull request addresses issue #2983 with the following changes:

- Expand the signatures of cli commands corresponding to parseAccountItems and parseAccountCurrencies to accept a 3rd 'strict' parameter
- Remove the edge case omitting output in the case of bad syntax, now output is always produced

As far as the 2nd bullet point in issue #2983, the aforementioned commands were inspected and found to output documentation pertaining to the 'strict' parameter as expected (see attached screenshot). If I missed something please let me know and I can look into further.

![rippled-commands-strict](https://user-images.githubusercontent.com/166845/71566094-8e50da80-2a82-11ea-93f4-0fad5263cd16.png)
