### PR TITLE
Check XRP endpoints for circular paths (RIPD-1781):

### DIFF
--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -111,6 +111,7 @@ class FeatureCollections
         // fixQualityUpperBound should be activated before FlowCross
         "fixQualityUpperBound",
         "RequireFullyCanonicalSig",
+        "fix1781", // XRPEndpointSteps should be included in the circular payment check
     };
 
     std::vector<uint256> features;
@@ -399,6 +400,7 @@ extern uint256 const fixPayChanRecipientOwnerDir;
 extern uint256 const featureDeletableAccounts;
 extern uint256 const fixQualityUpperBound;
 extern uint256 const featureRequireFullyCanonicalSig;
+extern uint256 const fix1781;
 
 } // ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -130,6 +130,7 @@ detail::supportedAmendments ()
         "DeletableAccounts",
         "fixQualityUpperBound",
         "RequireFullyCanonicalSig",
+        "fix1781",
     };
     return supported;
 }
@@ -189,5 +190,6 @@ uint256 const fixPayChanRecipientOwnerDir = *getRegisteredFeature("fixPayChanRec
 uint256 const featureDeletableAccounts = *getRegisteredFeature("DeletableAccounts");
 uint256 const fixQualityUpperBound = *getRegisteredFeature("fixQualityUpperBound");
 uint256 const featureRequireFullyCanonicalSig = *getRegisteredFeature("RequireFullyCanonicalSig");
+uint256 const fix1781 = *getRegisteredFeature("fix1781");
 
 } // ripple

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -703,7 +703,7 @@ struct PayStrand_test : public beast::unit_test::suite
                     alice,
                     /*deliver*/ xrpIssue(),
                     /*limitQuality*/ boost::none,
-                    /*sendMaxIssue*/ xrpIssue(),
+                    /*sendMaxIssue*/ EUR.issue(),
                     path,
                     true,
                     false,


### PR DESCRIPTION
The payment engine restricts payment paths so two steps do not input the same
Currency/Issuer or output the same Currency/Issuer. This check was skipped when
the path started or ended with XRP. An example of a path that was incorrectly
accepted was: XRP -> //USD -> //XRP -> EUR

This patch enables the path loop check for paths that start or end with XRP.