### PR TITLE
Remove time based switches

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1987,6 +1987,20 @@ bool ApplicationImp::loadOldLedger (
                 }
             }
         }
+        using namespace std::chrono_literals;
+        using namespace date;
+        static constexpr NetClock::time_point ledgerWarnTimePoint{
+                          sys_days{January/1/2018} - sys_days{January/1/2000}};
+        if (loadLedger->info().closeTime < ledgerWarnTimePoint)
+        {
+            JLOG(m_journal.fatal()) <<
+                "\n\n***  WARNING   ***\n"
+                "You are replaying a ledger from before " <<
+                to_string(ledgerWarnTimePoint) << " UTC.\n"
+                "This replay will not handle your ledger as it was originally "
+                "handled.\nConsider running an earlier version of rippled to "
+                "get the older rules.\n*** CONTINUING ***\n";
+        }
 
         JLOG(m_journal.info()) <<
             "Loading ledger " << loadLedger->info().hash <<

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -278,9 +278,6 @@ TxQ::MaybeTx::MaybeTx(
 std::pair<TER, bool>
 TxQ::MaybeTx::apply(Application& app, OpenView& view, beast::Journal j)
 {
-    boost::optional<STAmountSO> saved;
-    if (view.rules().enabled(fix1513))
-        saved.emplace(view.info().parentCloseTime);
     // If the rules or flags change, preflight again
     assert(pfresult);
     if (pfresult->rules != view.rules() ||
@@ -539,13 +536,7 @@ TxQ::tryClearAccountQueue(Application& app, OpenView& view,
     }
     // Apply the current tx. Because the state of the view has been changed
     // by the queued txs, we also need to preclaim again.
-    auto txResult = [&]{
-        boost::optional<STAmountSO> saved;
-        if (view.rules().enabled(fix1513))
-            saved.emplace(view.info().parentCloseTime);
-        auto const pcresult = preclaim(pfresult, app, view);
-        return doApply(pcresult, app, view);
-    }();
+    auto const txResult = doApply (preclaim (pfresult, app, view), app, view);
 
     if (txResult.second)
     {
@@ -633,11 +624,6 @@ TxQ::apply(Application& app, OpenView& view,
     auto const account = (*tx)[sfAccount];
     auto const transactionID = tx->getTransactionID();
     auto const tSeq = tx->getSequence();
-
-    boost::optional<STAmountSO> saved;
-    if (view.rules().enabled(fix1513))
-        saved.emplace(view.info().parentCloseTime);
-
     // See if the transaction is valid, properly formed,
     // etc. before doing potentially expensive queue
     // replace and multi-transaction operations.

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -332,7 +332,6 @@ TER RippleCalc::rippleCalculate (detail::FlowDebugInfo* flowDebugInfo)
     boost::container::flat_set<uint256> unfundedOffersFromBestPaths;
 
     int iPass = 0;
-    auto const dcSwitch = fix1141(view.info().parentCloseTime);
 
     while (resultCode == temUNCERTAIN)
     {
@@ -351,10 +350,8 @@ TER RippleCalc::rippleCalculate (detail::FlowDebugInfo* flowDebugInfo)
             {
                 // If computing the only non-dry path, and not limiting quality,
                 // compute multi-quality.
-                multiQuality = dcSwitch
-                    ? !inputFlags.limitQuality &&
-                        ((pathStateList_.size () - iDry) == 1)
-                    : ((pathStateList_.size () - iDry) == 1);
+                multiQuality = !inputFlags.limitQuality &&
+                    ((pathStateList_.size() - iDry) == 1);
 
                 // Update to current amount processed.
                 pathState->reset (actualAmountIn_, actualAmountOut_);
@@ -378,7 +375,6 @@ TER RippleCalc::rippleCalculate (detail::FlowDebugInfo* flowDebugInfo)
                 if (!pathState->quality())
                 {
                     // Path was dry.
-
                     ++iDry;
                 }
                 else if (pathState->outPass() == beast::zero)

--- a/src/ripple/app/paths/cursor/AdvanceNode.cpp
+++ b/src/ripple/app/paths/cursor/AdvanceNode.cpp
@@ -26,9 +26,8 @@ namespace path {
 
 TER PathCursor::advanceNode (STAmount const& amount, bool reverse, bool callerHasLiquidity) const
 {
-    bool const multi = fix1141 (view ().info ().parentCloseTime)
-        ? (multiQuality_ || (!callerHasLiquidity && amount == beast::zero))
-        : (multiQuality_ || amount == beast::zero);
+    bool const multi =
+        (multiQuality_ || (!callerHasLiquidity && amount == beast::zero));
 
     // If the multiQuality_ is unchanged, use the PathCursor we're using now.
     if (multi == multiQuality_)

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -238,15 +238,12 @@ TER PathCursor::deliverNodeReverseImpl (
                 saInPassAct,
                 saOutAct > beast::zero);
 
-            if (fix1141(view().info().parentCloseTime))
+            // The recursive call is dry this time, but we have liquidity
+            // from previous calls
+            if (resultCode == tecPATH_DRY && saOutAct > beast::zero)
             {
-                // The recursive call is dry this time, but we have liquidity
-                // from previous calls
-                if (resultCode == tecPATH_DRY && saOutAct > beast::zero)
-                {
-                    resultCode = tesSUCCESS;
-                    break;
-                }
+                resultCode = tesSUCCESS;
+                break;
             }
 
             JLOG (j_.trace())

--- a/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
+++ b/src/ripple/app/paths/cursor/DeliverNodeReverse.cpp
@@ -185,14 +185,6 @@ TER PathCursor::deliverNodeReverseImpl (
         // Compute portion of input needed to cover actual output.
         auto outputFee = mulRound (
             saOutPassAct, node().saOfrRate, node().saTakerPays.issue (), true);
-        if (*stAmountCalcSwitchover == false && ! outputFee)
-        {
-            JLOG (j_.fatal())
-                << "underflow computing outputFee "
-                << "saOutPassAct: " << saOutPassAct
-                << " saOfrRate: " << node ().saOfrRate;
-            return telFAILED_PROCESSING;
-        }
         STAmount saInPassReq = std::min (node().saTakerPays, outputFee);
         STAmount saInPassAct;
 

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -714,14 +714,12 @@ BookStep<TIn, TOut, TDerived>::revImp (
             result.out = out;
             this->consumeOffer (sb, offer, ofrAdjAmt, stpAdjAmt, ownerGivesAdj);
 
-            // When the mantissas of two iou amounts differ by less than ten, then
-            // subtracting them leaves a result of zero. This can cause the check for
-            // (stpAmt.out > remainingOut) to incorrectly think an offer will be funded
-            // after subtracting remainingIn.
-            if (fix1298(sb.parentCloseTime()))
-                return offer.fully_consumed();
-            else
-                return false;
+            // Explicitly check whether the offer is funded.  Given that we have
+            // (stpAmt.out > remainingOut), it's natural to assume the offer
+            // will still be funded after consuming remainingOut but that is
+            // not always the case.  If the mantissas of two IOU amounts differ
+            // by less than ten, then subtracting them leaves a zero.
+            return offer.fully_consumed();
         }
     };
 
@@ -884,10 +882,7 @@ BookStep<TIn, TOut, TDerived>::fwdImp (
         // subtracting them leaves a result of zero. This can cause the check for
         // (stpAmt.in > remainingIn) to incorrectly think an offer will be funded
         // after subtracting remainingIn.
-        if (fix1298(sb.parentCloseTime()))
-            processMore = processMore || offer.fully_consumed();
-
-        return processMore;
+        return processMore || offer.fully_consumed();
     };
 
     {

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -1015,23 +1015,20 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
         return tecNO_ISSUER;
     }
 
-    if (fix1443(ctx.view.info().parentCloseTime))
+    if (ctx.prevStep)
     {
-        if (ctx.prevStep)
+        if (auto const prev = ctx.prevStep->directStepSrcAcct())
         {
-            if (auto const prev = ctx.prevStep->directStepSrcAcct())
-            {
-                auto const& view = ctx.view;
-                auto const& cur = book_.in.account;
+            auto const& view = ctx.view;
+            auto const& cur = book_.in.account;
 
-                auto sle =
-                    view.read(keylet::line(*prev, cur, book_.in.currency));
-                if (!sle)
-                    return terNO_LINE;
-                if ((*sle)[sfFlags] &
-                    ((cur > *prev) ? lsfHighNoRipple : lsfLowNoRipple))
-                    return terNO_RIPPLE;
-            }
+            auto sle =
+                view.read(keylet::line(*prev, cur, book_.in.currency));
+            if (!sle)
+                return terNO_LINE;
+            if ((*sle)[sfFlags] &
+                ((cur > *prev) ? lsfHighNoRipple : lsfLowNoRipple))
+                return terNO_RIPPLE;
         }
     }
 

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -425,8 +425,7 @@ DirectIPaymentStep::check (
             return terNO_AUTH;
         }
 
-        if (ctx.prevStep &&
-            fix1449(ctx.view.info().parentCloseTime))
+        if (ctx.prevStep)
         {
             if (ctx.prevStep->bookStepBook())
             {

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -107,7 +107,6 @@ apply (Application& app, OpenView& view,
     STTx const& tx, ApplyFlags flags,
         beast::Journal j)
 {
-    STAmountSO saved(view.info().parentCloseTime);
     auto pfresult = preflight(app, view.rules(), tx, flags, j);
     auto pcresult = preclaim(pfresult, app, view);
     return doApply(pcresult, app, view);

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,9 +328,6 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
-[[nodiscard]] NetClock::time_point const& fix1141Time ();
-[[nodiscard]] bool fix1141 (NetClock::time_point const closeTime);
-
 [[nodiscard]] NetClock::time_point const& fix1274Time ();
 [[nodiscard]] bool fix1274 (NetClock::time_point const closeTime);
 

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,9 +328,6 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
-[[nodiscard]] NetClock::time_point const& fix1443Time ();
-[[nodiscard]] bool fix1443 (NetClock::time_point const closeTime);
-
 [[nodiscard]] NetClock::time_point const& fix1449Time ();
 [[nodiscard]] bool fix1449 (NetClock::time_point const closeTime);
 

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,9 +328,6 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
-[[nodiscard]] NetClock::time_point const& fix1298Time ();
-[[nodiscard]] bool fix1298 (NetClock::time_point const closeTime);
-
 [[nodiscard]] NetClock::time_point const& fix1443Time ();
 [[nodiscard]] bool fix1443 (NetClock::time_point const closeTime);
 

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,9 +328,6 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
-[[nodiscard]] NetClock::time_point const& fix1449Time ();
-[[nodiscard]] bool fix1449 (NetClock::time_point const closeTime);
-
 } // ripple
 
 #endif

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -328,9 +328,6 @@ transferXRP (ApplyView& view,
             STAmount const& amount,
                 beast::Journal j);
 
-[[nodiscard]] NetClock::time_point const& fix1274Time ();
-[[nodiscard]] bool fix1274 (NetClock::time_point const closeTime);
-
 [[nodiscard]] NetClock::time_point const& fix1298Time ();
 [[nodiscard]] bool fix1298 (NetClock::time_point const closeTime);
 

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -204,8 +204,7 @@ PaymentSandbox::balanceHook (AccountID const& account,
         adjustedAmt = std::min(adjustedAmt, minBal);
     }
 
-    if (fix1274 (info ().parentCloseTime))
-        adjustedAmt.setIssuer(amount.getIssuer());
+    adjustedAmt.setIssuer(amount.getIssuer());
 
     if (isXRP(issuer) && adjustedAmt < beast::zero)
         // A calculated negative XRP balance is not an error case. Consider a

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -33,20 +33,6 @@
 
 namespace ripple {
 
-NetClock::time_point const& fix1449Time ()
-{
-    using namespace std::chrono_literals;
-    // Thurs, Mar 30, 2017 20:00:00 UTC
-    static NetClock::time_point const soTime{544219200s};
-
-    return soTime;
-}
-
-bool fix1449 (NetClock::time_point const closeTime)
-{
-    return closeTime > fix1449Time();
-}
-
 //------------------------------------------------------------------------------
 //
 // Observers

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -33,20 +33,6 @@
 
 namespace ripple {
 
-NetClock::time_point const& fix1274Time ()
-{
-    using namespace std::chrono_literals;
-    // Fri Sep 30, 2016 17:00:00 UTC
-    static NetClock::time_point const soTime{528570000s};
-
-    return soTime;
-}
-
-bool fix1274 (NetClock::time_point const closeTime)
-{
-    return closeTime > fix1274Time();
-}
-
 NetClock::time_point const& fix1298Time ()
 {
     using namespace std::chrono_literals;

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -33,20 +33,6 @@
 
 namespace ripple {
 
-NetClock::time_point const& fix1298Time ()
-{
-    using namespace std::chrono_literals;
-    // Wed Dec 21, 2016 18:00:00 UTC
-    static NetClock::time_point const soTime{535658400s};
-
-    return soTime;
-}
-
-bool fix1298 (NetClock::time_point const closeTime)
-{
-    return closeTime > fix1298Time();
-}
-
 NetClock::time_point const& fix1443Time ()
 {
     using namespace std::chrono_literals;

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -33,20 +33,6 @@
 
 namespace ripple {
 
-NetClock::time_point const& fix1443Time ()
-{
-    using namespace std::chrono_literals;
-    // Sun Mar 12, 2017 01:00:00 UTC
-    static NetClock::time_point const soTime{542595600s};
-
-    return soTime;
-}
-
-bool fix1443 (NetClock::time_point const closeTime)
-{
-    return closeTime > fix1443Time();
-}
-
 NetClock::time_point const& fix1449Time ()
 {
     using namespace std::chrono_literals;

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -46,6 +46,27 @@ namespace ripple {
 
 namespace detail {
 
+// *NOTE*
+//
+// Features, or Amendments as they are called elsewhere, are enabled on the
+// network at some specific time based on Validator voting.  Features are
+// enabled using run-time conditionals based on the state of the amendment.
+// There is value in retaining that conditional code for some time after
+// the amendment is enabled to make it simple to replay old transactions.
+// However, once an Amendment has been enabled for, say, more than two years
+// then retaining that conditional code has less value since it is
+// uncommon to replay such old transactions.
+//
+// Starting in January of 2020 Amendment conditionals from before January
+// 2018 are being removed.  So replaying any ledger from before January
+// 2018 needs to happen on an older version of the server code.  There's
+// a log message in Application.cpp that warns about replaying old ledgers.
+//
+// At some point in the future someone may wish to remove Amendment
+// conditional code for Amendments that were enabled after January 2018.
+// When that happens then the log message in Application.cpp should be
+// updated.
+
 class FeatureCollections
 {
     static constexpr char const* const featureNames[] =

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -20,15 +20,12 @@
 #ifndef RIPPLE_PROTOCOL_STAMOUNT_H_INCLUDED
 #define RIPPLE_PROTOCOL_STAMOUNT_H_INCLUDED
 
-#include <ripple/basics/chrono.h>
 #include <ripple/basics/IOUAmount.h>
-#include <ripple/basics/LocalValue.h>
 #include <ripple/basics/XRPAmount.h>
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/Serializer.h>
 #include <ripple/protocol/STBase.h>
 #include <ripple/protocol/Issue.h>
-#include <memory>
 
 namespace ripple {
 
@@ -405,38 +402,6 @@ inline bool isXRP(STAmount const& amount)
 {
     return isXRP (amount.issue().currency);
 }
-
-extern LocalValue<bool> stAmountCalcSwitchover;
-extern LocalValue<bool> stAmountCalcSwitchover2;
-
-/** RAII class to set and restore the STAmount calc switchover.*/
-class STAmountSO
-{
-public:
-    explicit STAmountSO(NetClock::time_point const closeTime)
-        : saved_(*stAmountCalcSwitchover)
-        , saved2_(*stAmountCalcSwitchover2)
-    {
-        *stAmountCalcSwitchover = closeTime > soTime;
-        *stAmountCalcSwitchover2 = closeTime > soTime2;
-    }
-
-    ~STAmountSO()
-    {
-        *stAmountCalcSwitchover = saved_;
-        *stAmountCalcSwitchover2 = saved2_;
-    }
-
-    // Mon Dec 28, 2015 18:00:00 UTC
-    static NetClock::time_point const soTime;
-
-    // Sat Feb 27, 2016 05:00:00 UTC
-    static NetClock::time_point const soTime2;
-
-private:
-    bool saved_;
-    bool saved2_;
-};
 
 } // ripple
 

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -35,17 +35,6 @@
 
 namespace ripple {
 
-LocalValue<bool> stAmountCalcSwitchover(true);
-LocalValue<bool> stAmountCalcSwitchover2(true);
-
-using namespace std::chrono_literals;
-
-// Mon Dec 28, 2015 18:00:00 UTC
-const NetClock::time_point STAmountSO::soTime{504640800s};
-
-// Sat Feb 27, 2016 05:00:00 UTC
-const NetClock::time_point STAmountSO::soTime2{509864400s};
-
 static const std::uint64_t tenTo14 = 100000000000000ull;
 static const std::uint64_t tenTo14m1 = tenTo14 - 1;
 static const std::uint64_t tenTo17 = tenTo14 * 1000;
@@ -1246,10 +1235,9 @@ mulRound (STAmount const& v1, STAmount const& v2, Issue const& issue,
         canonicalizeRound (xrp, amount, offset);
     STAmount result (issue, amount, offset, resultNegative);
 
-    // Control when bugfixes that require switchover dates are enabled
-    if (roundUp && !resultNegative && !result && *stAmountCalcSwitchover)
+    if (roundUp && !resultNegative && !result)
     {
-        if (xrp && *stAmountCalcSwitchover2)
+        if (xrp)
         {
             // return the smallest value above zero
             amount = 1;
@@ -1318,10 +1306,9 @@ divRound (STAmount const& num, STAmount const& den,
         canonicalizeRound (isXRP (issue), amount, offset);
 
     STAmount result (issue, amount, offset, resultNegative);
-    // Control when bugfixes that require switchover dates are enabled
-    if (roundUp && !resultNegative && !result && *stAmountCalcSwitchover)
+    if (roundUp && !resultNegative && !result)
     {
-        if (isXRP(issue) && *stAmountCalcSwitchover2)
+        if (isXRP(issue))
         {
             // return the smallest value above zero
             amount = 1;

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -166,9 +166,6 @@ class Check_test : public beast::unit_test::suite
             // If the Checks amendment is not enabled, you should not be able
             // to create, cash, or cancel checks.
             Env env {*this, supported_amendments() - featureChecks};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), alice);
 
@@ -189,9 +186,6 @@ class Check_test : public beast::unit_test::suite
             // If the Checks amendment is enabled all check-related
             // facilities should be available.
             Env env {*this};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), alice);
 
@@ -226,9 +220,6 @@ class Check_test : public beast::unit_test::suite
         IOU const USD {gw["USD"]};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         STAmount const startBalance {XRP(1000).value()};
         env.fund (startBalance, gw, alice, bob);
@@ -327,9 +318,6 @@ class Check_test : public beast::unit_test::suite
         IOU const USD {gw1["USD"]};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         STAmount const startBalance {XRP(1000).value()};
         env.fund (startBalance, gw1, gwF, alice, bob);
@@ -507,9 +495,6 @@ class Check_test : public beast::unit_test::suite
         Account const bob {"bob"};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         XRPAmount const baseFeeDrops {env.current()->fees().base};
         STAmount const startBalance {XRP(300).value()};
@@ -632,9 +617,6 @@ class Check_test : public beast::unit_test::suite
         {
             // Simple IOU check cashed with Amount (with failures).
             Env env {*this};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), gw, alice, bob);
 
@@ -754,9 +736,6 @@ class Check_test : public beast::unit_test::suite
         {
             // Simple IOU check cashed with DeliverMin (with failures).
             Env env {*this};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), gw, alice, bob);
 
@@ -840,9 +819,6 @@ class Check_test : public beast::unit_test::suite
         {
             // Examine the effects of the asfRequireAuth flag.
             Env env {*this};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), gw, alice, bob);
             env (fset (gw, asfRequireAuth));
@@ -900,9 +876,6 @@ class Check_test : public beast::unit_test::suite
                 allSupported | featureMultiSignReserve})
         {
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), gw, alice, bob);
 
@@ -973,9 +946,6 @@ class Check_test : public beast::unit_test::suite
         IOU const USD {gw["USD"]};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000), gw, alice, bob);
 
@@ -1045,9 +1015,6 @@ class Check_test : public beast::unit_test::suite
         IOU const USD {gw["USD"]};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000), gw, alice, bob);
 
@@ -1245,9 +1212,6 @@ class Check_test : public beast::unit_test::suite
         IOU const USD {gw["USD"]};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000), gw, alice, bob, zoe);
 
@@ -1550,10 +1514,6 @@ class Check_test : public beast::unit_test::suite
         {
             Env env {*this, features};
 
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
-
             env.fund (XRP(1000), gw, alice, bob, zoe);
 
             // alice creates her checks ahead of time.
@@ -1708,9 +1668,6 @@ class Check_test : public beast::unit_test::suite
         Account const bob {"bob"};
 
         Env env {*this};
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000), alice, bob);
 
@@ -1745,9 +1702,6 @@ class Check_test : public beast::unit_test::suite
             Account const bob {"bob"};
 
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP(1000), alice, bob);
             env.close();

--- a/src/test/app/CrossingLimits_test.cpp
+++ b/src/test/app/CrossingLimits_test.cpp
@@ -52,10 +52,6 @@ public:
 
         using namespace jtx;
         Env env(*this, features);
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gateway");
         auto const USD = gw["USD"];
@@ -96,10 +92,6 @@ public:
 
         using namespace jtx;
         Env env(*this, features);
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gateway");
         auto const USD = gw["USD"];
@@ -140,10 +132,6 @@ public:
 
         using namespace jtx;
         Env env(*this, features);
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gateway");
         auto const USD = gw["USD"];
@@ -208,10 +196,6 @@ public:
 
         using namespace jtx;
         Env env(*this, features);
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gateway");
         auto const USD = gw["USD"];
@@ -329,9 +313,6 @@ public:
         // strand dry until the liquidity is actually used)
         {
             Env env(*this, features);
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close(closeTime);
 
             env.fund(XRP(100000000), gw, alice, bob, carol);
 
@@ -400,9 +381,6 @@ public:
         }
         {
             Env env(*this, features);
-            auto const closeTime =
-                fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-            env.close(closeTime);
 
             env.fund(XRP(100000000), gw, alice, bob, carol);
 
@@ -508,9 +486,6 @@ public:
         auto const USD = gw["USD"];
 
         Env env(*this, features);
-        auto const closeTime =
-            fix1449Time() + 100 * env.closed()->info().closeTimeResolution;
-        env.close(closeTime);
 
         env.fund(XRP(100000000), gw, alice, bob);
 

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1024,9 +1024,7 @@ struct Flow_test : public beast::unit_test::suite
         auto const usdC = USD.currency;
 
         env.fund(XRP(10000), alice, bob, gw);
-        // Need to be past this time to see the bug
-        env.close(fix1274Time() +
-            100 * env.closed()->info().closeTimeResolution);
+        env.close();
         env(trust(alice, USD(100)));
         env.close();
 

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -935,21 +935,14 @@ struct Flow_test : public beast::unit_test::suite
             txflags(tfPartialPayment | tfNoRippleDirect));
     }
 
-    void testUnfundedOffer (bool withFix, FeatureBitset features)
+    void testUnfundedOffer (FeatureBitset features)
     {
-        testcase(std::string("Unfunded Offer ") +
-            (withFix ? "with fix" : "without fix"));
+        testcase("Unfunded Offer");
 
         using namespace jtx;
         {
             // Test reverse
             Env env(*this, features);
-            auto closeTime = fix1298Time();
-            if (withFix)
-                closeTime += env.closed()->info().closeTimeResolution;
-            else
-                closeTime -= env.closed()->info().closeTimeResolution;
-            env.close(closeTime);
 
             auto const alice = Account("alice");
             auto const bob = Account("bob");
@@ -968,20 +961,11 @@ struct Flow_test : public beast::unit_test::suite
             env(pay(alice, bob, tinyAmt1), path(~USD),
                 sendmax(drops(9000000000)), txflags(tfNoRippleDirect));
 
-            if (withFix)
-                BEAST_EXPECT(!isOffer(env, gw, XRP(0), USD(0)));
-            else
-                BEAST_EXPECT(isOffer(env, gw, XRP(0), USD(0)));
+            BEAST_EXPECT(!isOffer(env, gw, XRP(0), USD(0)));
         }
         {
             // Test forward
             Env env(*this, features);
-            auto closeTime = fix1298Time();
-            if (withFix)
-                closeTime += env.closed()->info().closeTimeResolution;
-            else
-                closeTime -= env.closed()->info().closeTimeResolution;
-            env.close(closeTime);
 
             auto const alice = Account("alice");
             auto const bob = Account("bob");
@@ -1002,10 +986,7 @@ struct Flow_test : public beast::unit_test::suite
             env(pay(alice, bob, drops(9000000000)), path(~XRP),
                 sendmax(USD(1)), txflags(tfNoRippleDirect));
 
-            if (withFix)
-                BEAST_EXPECT(!isOffer(env, gw, USD(0), XRP(0)));
-            else
-                BEAST_EXPECT(isOffer(env, gw, USD(0), XRP(0)));
+            BEAST_EXPECT(!isOffer(env, gw, USD(0), XRP(0)));
         }
     }
 
@@ -1232,8 +1213,7 @@ struct Flow_test : public beast::unit_test::suite
         testSelfPayment2(features);
         testSelfFundedXRPEndpoint(false, features);
         testSelfFundedXRPEndpoint(true, features);
-        testUnfundedOffer(true, features);
-        testUnfundedOffer(false, features);
+        testUnfundedOffer(features);
         testReexecuteDirectStep(features | fix1368);
         testSelfPayLowQualityOffer(features);
     }

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -492,11 +492,6 @@ struct Flow_test : public beast::unit_test::suite
             // pass. This test checks that the payment produces 1 EUR, as expected.
 
             Env env (*this, features);
-
-            auto const closeTime = STAmountSO::soTime2 +
-                100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
-
             env.fund (XRP (10000), alice, bob, carol, gw);
             env.trust (USD (1000), alice, bob, carol);
             env.trust (EUR (1000), alice, bob, carol);
@@ -1249,40 +1244,6 @@ struct Flow_test : public beast::unit_test::suite
             ter(temBAD_PATH));
     }
 
-    void
-    testZeroOutputStep()
-    {
-        testcase("Zero Output Step");
-
-        using namespace jtx;
-        auto const alice = Account("alice");
-        auto const bob = Account("bob");
-        auto const carol = Account("carol");
-        auto const gw = Account("gw");
-        auto const USD = gw["USD"];
-        auto const EUR = gw["EUR"];
-
-        auto const features = supported_amendments();
-        Env env(*this, features);
-        env.fund(XRP(10000), alice, bob, carol, gw);
-        env.trust(USD(1000), alice, bob, carol);
-        env.trust(EUR(1000), alice, bob, carol);
-        env(pay(gw, alice, USD(100)));
-        env(pay(gw, bob, USD(100)));
-        env(pay(gw, bob, EUR(100)));
-        env.close();
-
-        env(offer(bob, USD(100), EUR(100)));
-        env(offer(bob, EUR(100), XRP(0.000001)));
-        env.close();
-
-        env(pay(alice, carol, XRP(1)),
-            path(~EUR, ~XRP),
-            sendmax(USD(1)),
-            txflags(tfPartialPayment),
-            ter(tecPATH_DRY));
-    }
-
     void testWithFeats(FeatureBitset features)
     {
         using namespace jtx;
@@ -1311,7 +1272,6 @@ struct Flow_test : public beast::unit_test::suite
     void run() override
     {
         testLimitQuality();
-        testZeroOutputStep();
         testRIPD1443(true);
         testRIPD1443(false);
         testRIPD1449(true);

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1090,16 +1090,12 @@ struct Flow_test : public beast::unit_test::suite
     }
 
     void
-    testRIPD1449(bool withFix)
+    testRIPD1449()
     {
         testcase("ripd1449");
 
         using namespace jtx;
         Env env(*this);
-        auto const timeDelta = env.closed ()->info ().closeTimeResolution;
-        auto const d = withFix ? 100*timeDelta : -100*timeDelta;
-        auto closeTime = fix1449Time() + d;
-        env.close(closeTime);
 
         // pay alice -> xrp -> USD/bob -> bob -> gw -> alice
         // set no ripple on bob's side of the bob/gw trust line
@@ -1128,7 +1124,7 @@ struct Flow_test : public beast::unit_test::suite
 
         env(pay(alice, alice, USD(1000)), path(~bob["USD"], bob, gw),
             sendmax(XRP(1)), txflags(tfNoRippleDirect),
-            ter(withFix ? TER {tecPATH_DRY} : TER {tesSUCCESS}));
+            ter(tecPATH_DRY));
         env.close();
     }
 
@@ -1214,8 +1210,7 @@ struct Flow_test : public beast::unit_test::suite
     {
         testLimitQuality();
         testRIPD1443();
-        testRIPD1449(true);
-        testRIPD1449(false);
+        testRIPD1449();
 
         using namespace jtx;
         auto const sa = supported_amendments();

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1045,17 +1045,12 @@ struct Flow_test : public beast::unit_test::suite
     }
 
     void
-    testRIPD1443(bool withFix)
+    testRIPD1443()
     {
         testcase("ripd1443");
 
         using namespace jtx;
         Env env(*this);
-        auto const timeDelta = env.closed ()->info ().closeTimeResolution;
-        auto const d = withFix ? 100*timeDelta : -100*timeDelta;
-        auto closeTime = fix1443Time() + d;
-        env.close(closeTime);
-
         auto const alice = Account("alice");
         auto const bob = Account("bob");
         auto const carol = Account("carol");
@@ -1077,21 +1072,18 @@ struct Flow_test : public beast::unit_test::suite
 
         env(pay(alice, alice, XRP(1)), path(gw, bob, ~XRP),
             sendmax(gw["USD"](1000)), txflags(tfNoRippleDirect),
-            ter(withFix ? TER {tecPATH_DRY} : TER {tesSUCCESS}));
+            ter(tecPATH_DRY));
         env.close();
 
-        if (withFix)
-        {
-            env.trust(bob["USD"](10000), alice);
-            env(pay(bob, alice, bob["USD"](1000)));
-        }
+        env.trust(bob["USD"](10000), alice);
+        env(pay(bob, alice, bob["USD"](1000)));
 
         env(offer(alice, XRP(1000), bob["USD"](1000)));
         env.close();
 
         env(pay (carol, carol, gw["USD"](1000)), path(~bob["USD"], gw),
             sendmax(XRP(100000)), txflags(tfNoRippleDirect),
-            ter(withFix ? TER {tecPATH_DRY} : TER {tesSUCCESS}));
+            ter(tecPATH_DRY));
         env.close();
 
         pass();
@@ -1221,8 +1213,7 @@ struct Flow_test : public beast::unit_test::suite
     void run() override
     {
         testLimitQuality();
-        testRIPD1443(true);
-        testRIPD1443(false);
+        testRIPD1443();
         testRIPD1449(true);
         testRIPD1449(false);
 

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -331,7 +331,7 @@ public:
         // needed for this offer, it will incorrectly compute zero in both
         // the forward and reverse passes (when the stAmountCalcSwitchover2
         // is inactive.)
-        env (offer (erin, drops (1), USD (1)));
+        env (offer (erin, drops (2), USD (2)));
 
         env (pay (alice, bob, USD (1)), path (~USD),
             sendmax (XRP (102)),

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -112,10 +112,6 @@ public:
 
         using namespace jtx;
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const USD = gw["USD"];
@@ -163,10 +159,6 @@ public:
 
         using namespace jtx;
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -366,10 +358,6 @@ public:
         {
             // No ripple with an implied account step after an offer
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             auto const gw1 = Account {"gw1"};
             auto const USD1 = gw1["USD"];
@@ -395,10 +383,6 @@ public:
         {
             // Make sure payment works with default flags
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             auto const gw1 = Account {"gw1"};
             auto const USD1 = gw1["USD"];
@@ -450,10 +434,6 @@ public:
         // No crossing:
         {
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP (1000000), gw);
 
@@ -475,10 +455,6 @@ public:
         // Partial cross:
         {
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP (1000000), gw);
 
@@ -509,10 +485,6 @@ public:
         // buy XRP. If it fully crosses, we succeed.
         {
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (XRP (1000000), gw);
 
@@ -581,10 +553,6 @@ public:
             {features - fix1578, features | fix1578})
         {
             Env env {*this, tweakedFeatures};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             auto const f = env.current ()->fees ().base;
 
@@ -647,10 +615,6 @@ public:
         // and add nothing on the books:
         {
             Env env {*this, features};
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             auto const f = env.current ()->fees ().base;
 
@@ -703,10 +667,6 @@ public:
         // tfPassive -- place the offer without crossing it.
         {
             Env env (*this, features);
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (startBalance, gw, alice, bob);
             env.close();
@@ -760,10 +720,6 @@ public:
         // tfPassive -- cross only offers of better quality.
         {
             Env env (*this, features);
-            auto const closeTime =
-                fix1449Time () +
-                    100 * env.closed ()->info ().closeTimeResolution;
-            env.close (closeTime);
 
             env.fund (startBalance, gw, "alice", "bob");
             env.close();
@@ -812,10 +768,6 @@ public:
         auto const USD = gw["USD"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (startBalance, gw, alice);
 
@@ -913,10 +865,6 @@ public:
         auto const xrpOffer = XRP (1000);
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (startBalance, gw, alice, bob);
         env.close();
@@ -992,10 +940,6 @@ public:
         auto const xrpOffer = XRP (1000);
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000000), gw);
 
@@ -1058,10 +1002,7 @@ public:
         auto const BTC = gw["BTC"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
+        env.close();
 
         env.fund (XRP (10000), gw);
         if (use_partner)
@@ -1176,10 +1117,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1262,10 +1199,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1322,10 +1255,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1372,10 +1301,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const USD = env.master["USD"];
 
@@ -1405,10 +1330,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const alice = Account {"alice"};
 
@@ -1439,10 +1360,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1505,10 +1422,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const alice = Account {"alice"};
         auto const bob = Account {"bob"};
@@ -1538,10 +1451,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1631,10 +1540,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1676,10 +1581,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1729,10 +1630,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw1 = Account {"gateway_1"};
         auto const gw2 = Account {"gateway_2"};
@@ -1802,10 +1699,6 @@ public:
 
         using namespace jtx;
         Env env(*this, features);
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         Account const alice {"alice"};
         Account const bob {"bob"};
@@ -1875,10 +1768,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw1 = Account {"gateway_1"};
         auto const gw2 = Account {"gateway_2"};
@@ -1933,10 +1822,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -1973,10 +1858,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -2019,10 +1900,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -2067,10 +1944,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account {"gateway"};
         auto const alice = Account {"alice"};
@@ -2180,10 +2053,6 @@ public:
         auto const USD = gw["USD"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(10000000), gw);
 
@@ -2344,10 +2213,6 @@ public:
         auto const xrpOffer = XRP(1000);
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000000), gw, bob);
         env.close();
@@ -2429,10 +2294,6 @@ public:
         auto const eurOffer = EUR(1000);
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000000), gw);
         env.close();
@@ -2554,10 +2415,6 @@ public:
         auto const eurOffer = EUR(1000);
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000000), gw, alice, bob, carol);
         env.close();
@@ -2652,10 +2509,6 @@ public:
         auto const USD = gw["USD"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(10000000), gw);
 
@@ -2829,10 +2682,6 @@ public:
         auto const USD   = gw["USD"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(10000000), gw, alice, bob);
 
@@ -2914,10 +2763,6 @@ public:
         auto const USD = gw1["USD"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         // The fee that's charged for transactions.
         auto const fee = env.current ()->fees ().base;
@@ -3239,10 +3084,6 @@ public:
         auto const USD = gw["USD"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         // The fee that's charged for transactions.
         auto const fee = env.current ()->fees ().base;
@@ -3302,10 +3143,6 @@ public:
         auto const EUR = gw2["EUR"];
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         env.fund (XRP(1000000), gw1, gw2);
         env.close();
@@ -3423,10 +3260,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const alice = Account("alice");
         auto const bob = Account("bob");
@@ -3475,10 +3308,6 @@ public:
         // The problem was identified when featureOwnerPaysFee was enabled,
         // so make sure that gets included.
         Env env {*this, features | featureOwnerPaysFee};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         // The fee that's charged for transactions.
         auto const fee = env.current ()->fees ().base;
@@ -3553,10 +3382,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const ann = Account("ann");
         auto const bob = Account("bob");
@@ -3608,10 +3433,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const ann = Account("ann");
         auto const gw = Account("gateway");
@@ -3648,10 +3469,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gateway");
         auto const alice = Account("alice");
@@ -3697,10 +3514,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gateway");
         auto const alice = Account("alice");
@@ -3751,10 +3564,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw1 = Account("gw1");
         auto const gw2 = Account("gw2");
@@ -3810,10 +3619,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gw");
         auto const alice = Account("alice");
@@ -3893,10 +3698,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gw");
         auto const BTC = gw["BTC"];
@@ -4045,10 +3846,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gw");
         auto const BTC = gw["BTC"];
@@ -4173,10 +3970,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gw");
         auto const alice = Account("alice");
@@ -4245,10 +4038,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gw");
         auto const alice = Account("alice");
@@ -4367,10 +4156,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         // This test mimics the payment flow used in the Ripple Connect
         // smoke test.  The players:
@@ -4460,10 +4245,6 @@ public:
         using namespace jtx;
 
         Env env {*this, features};
-        auto const closeTime =
-            fix1449Time() +
-                100 * env.closed()->info().closeTimeResolution;
-        env.close (closeTime);
 
         auto const gw = Account("gw");
         auto const alice = Account("alice");

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -635,9 +635,6 @@ struct PayStrandAllPairs_test : public beast::unit_test::suite
         ExistingElementPool eep;
         Env env(*this, features);
 
-        auto const closeTime = fix1298Time() +
-            100 * env.closed()->info().closeTimeResolution;
-        env.close(closeTime);
         eep.setupEnv(env, /*numAcc*/ 9, /*numCur*/ 6, boost::none);
         env.close();
 

--- a/src/test/ledger/PaymentSandbox_test.cpp
+++ b/src/test/ledger/PaymentSandbox_test.cpp
@@ -333,10 +333,6 @@ class PaymentSandbox_test : public beast::unit_test::suite
         auto const USD = gw["USD"];
         Account const alice ("alice");
 
-        auto const closeTime = fix1274Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
-
         ApplyViewImpl av (&*env.current (), tapNONE);
         PaymentSandbox sb (&av);
 

--- a/src/test/ledger/PaymentSandbox_test.cpp
+++ b/src/test/ledger/PaymentSandbox_test.cpp
@@ -277,19 +277,10 @@ class PaymentSandbox_test : public beast::unit_test::suite
         STAmount hugeAmt (issue, STAmount::cMaxValue, STAmount::cMaxOffset - 1,
             false, false, STAmount::unchecked{});
 
-        for (auto d : {-1, 1})
-        {
-            auto const closeTime = fix1141Time () +
-                d * env.closed()->info().closeTimeResolution;
-            env.close (closeTime);
-            ApplyViewImpl av (&*env.current (), tapNONE);
-            PaymentSandbox pv (&av);
-            pv.creditHook (gw, alice, hugeAmt, -tinyAmt);
-            if (closeTime > fix1141Time ())
-                BEAST_EXPECT(pv.balanceHook (alice, gw, hugeAmt) == tinyAmt);
-            else
-                BEAST_EXPECT(pv.balanceHook (alice, gw, hugeAmt) != tinyAmt);
-        }
+        ApplyViewImpl av (&*env.current (), tapNONE);
+        PaymentSandbox pv (&av);
+        pv.creditHook (gw, alice, hugeAmt, -tinyAmt);
+        BEAST_EXPECT(pv.balanceHook (alice, gw, hugeAmt) == tinyAmt);
     }
 
     void testReserve(FeatureBitset features)
@@ -314,9 +305,7 @@ class PaymentSandbox_test : public beast::unit_test::suite
         Account const alice ("alice");
         env.fund (reserve(env, 1), alice);
 
-        auto const closeTime = fix1141Time () +
-                100 * env.closed ()->info ().closeTimeResolution;
-        env.close (closeTime);
+        env.close();
         ApplyViewImpl av (&*env.current (), tapNONE);
         PaymentSandbox sb (&av);
         {


### PR DESCRIPTION
Some of the earliest amendment-like things were time-based switches that enabled a particular new behavior once a parent ledger had passed a particular date and time.  The most recent time-based switch was enabled on March 30, 2017.  Well over 2 years ago.

If merged this pull request will have two effects:

1. If someone is replaying a ledger that is from before January 1 2018, a warning (at `FTL` level) is printed to the log.

2. All of the conditional execution based on time-based switches is removed. In effect, the ledger now presumes that the threshold time is passed.  As a consequence all of the time-based switches are removed.

The first commit adds the log message.  Each remaining commit removes an individual time-based switch.  My preference is that the commits be merged independently (not squashed) since each change really is independent of the others.

Thanks for the help.