### PR TITLE
Reduce log level of xrp/xrp offer payment step

### DIFF
--- a/src/ripple/app/paths/impl/PaySteps.cpp
+++ b/src/ripple/app/paths/impl/PaySteps.cpp
@@ -117,7 +117,7 @@ toStep (
 
     if (isXRP (curIssue.currency) && isXRP (outCurrency))
     {
-        JLOG (j.warn()) << "Found xrp/xrp offer payment step";
+        JLOG (j.info()) << "Found xrp/xrp offer payment step";
         return {temBAD_PATH, std::unique_ptr<Step>{}};
     }
 


### PR DESCRIPTION
Reduced log level of `Found xrp/xrp offer payment step` from WRN to NFO. This fixes #3181