### PR TITLE
Warn operators about upcoming unknown amendments:

### DIFF
--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -54,6 +54,8 @@ public:
      * @return true if an unsupported feature is enabled on the network
      */
     virtual bool hasUnsupportedEnabled () = 0;
+    virtual boost::optional<NetClock::time_point>
+    firstUnsupportedExpected() = 0;
 
     virtual Json::Value getJson (int) = 0;
 
@@ -61,11 +63,15 @@ public:
     virtual Json::Value getJson (uint256 const& ) = 0;
 
     /** Called when a new fully-validated ledger is accepted. */
-    void doValidatedLedger (std::shared_ptr<ReadView const> const& lastValidatedLedger)
+    void
+    doValidatedLedger(
+        std::shared_ptr<ReadView const> const& lastValidatedLedger)
     {
-        if (needValidatedLedger (lastValidatedLedger->seq ()))
-            doValidatedLedger (lastValidatedLedger->seq (),
-                getEnabledAmendments (*lastValidatedLedger));
+        if (needValidatedLedger(lastValidatedLedger->seq()))
+            doValidatedLedger(
+                lastValidatedLedger->seq(),
+                getEnabledAmendments(*lastValidatedLedger),
+                getMajorityAmendments(*lastValidatedLedger));
     }
 
     /** Called to determine whether the amendment logic needs to process
@@ -77,7 +83,8 @@ public:
     virtual void
     doValidatedLedger (
         LedgerIndex ledgerSeq,
-        std::set <uint256> const& enabled) = 0;
+        std::set <uint256> const& enabled,
+        majorityAmendments_t const& majority) = 0;
 
     // Called by the consensus code when we need to
     // inject pseudo-transactions

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -185,6 +185,9 @@ public:
     virtual void setMode(OperatingMode om) = 0;
     virtual bool isAmendmentBlocked () = 0;
     virtual void setAmendmentBlocked () = 0;
+    virtual bool isAmendmentWarned() = 0;
+    virtual void setAmendmentWarned() = 0;
+    virtual void clearAmendmentWarned() = 0;
     virtual void consensusViewChange () = 0;
 
     virtual Json::Value getConsensusInfo () = 0;

--- a/src/ripple/protocol/ErrorCodes.h
+++ b/src/ripple/protocol/ErrorCodes.h
@@ -138,6 +138,16 @@ enum error_code_i
     rpcLAST = rpcINVALID_LGR_RANGE // rpcLAST should always equal the last code.=
 };
 
+/** Codes returned in the `warnings` array of certain RPC commands.
+
+    These values need to remain stable.
+*/
+enum warning_code_i
+{
+    warnRPC_UNSUPPORTED_MAJORITY    = 1001,
+    warnRPC_AMENDMENT_BLOCKED       = 1002,
+};
+
 //------------------------------------------------------------------------------
 
 // VFALCO NOTE these should probably not be in the RPC namespace.

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -202,6 +202,7 @@ JSS ( destination_amount );         // in: PathRequest, RipplePathFind
 JSS ( destination_currencies );     // in: PathRequest, RipplePathFind
 JSS ( destination_tag );            // in: PathRequest
                                     // out: AccountChannels
+JSS ( details );                    // out: any (warnings)
 JSS ( dir_entry );                  // out: DirectoryEntryIterator
 JSS ( dir_index );                  // out: DirectoryEntryIterator
 JSS ( dir_root );                   // out: DirectoryEntryIterator
@@ -219,6 +220,8 @@ JSS ( error_exception );            // out: Submit
 JSS ( error_message );              // out: error
 JSS ( escrow );                     // in: LedgerEntry
 JSS ( expand );                     // in: handler/Ledger
+JSS ( expected_date );              // out: any (warnings)
+JSS ( expected_date_UTC );          // out: any (warnings)
 JSS ( expected_ledger_size );       // out: TxQ
 JSS ( expiration );                 // out: AccountOffers, AccountChannels,
                                     //      ValidatorList
@@ -563,6 +566,7 @@ JSS ( version );                    // out: RPCVersion
 JSS ( vetoed );                     // out: AmendmentTableImpl
 JSS ( vote );                       // in: Feature
 JSS ( warning );                    // rpc:
+JSS ( warnings );                   // out: server_info, server_state
 JSS ( workers );
 JSS ( write_load );                 // out: GetCounts
 

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -189,38 +189,6 @@ Status callMethod (
     }
 }
 
-template <class Method, class Object>
-void getResult (
-    JsonContext& context, Method method, Object& object, std::string const& name)
-{
-    auto&& result = Json::addObject (object, jss::result);
-    if (auto status = callMethod (context, method, name, result))
-    {
-        JLOG (context.j.debug()) << "rpcError: " << status.toString();
-        result[jss::status] = jss::error;
-
-        auto rq = context.params;
-
-        if (rq.isObject())
-        {
-            if (rq.isMember(jss::passphrase.c_str()))
-                rq[jss::passphrase.c_str()] = "<masked>";
-            if (rq.isMember(jss::secret.c_str()))
-                rq[jss::secret.c_str()] = "<masked>";
-            if (rq.isMember(jss::seed.c_str()))
-                rq[jss::seed.c_str()] = "<masked>";
-            if (rq.isMember(jss::seed_hex.c_str()))
-                rq[jss::seed_hex.c_str()] = "<masked>";
-        }
-
-        result[jss::request] = rq;
-    }
-    else
-    {
-        result[jss::status] = jss::success;
-    }
-}
-
 } // namespace
 
 Status doCommand (


### PR DESCRIPTION
* When an unknown amendment reaches majority, log an error-level
  message, and return a `warnings` stanza on all successful
  admin-level RPC calls with a message describing the problem, and
  the expected deadline.
* Check on every flag ledger to see if the amendment(s) lose majority.
  Logs again if they don't, resumes normal operations if they did.
* The intention is to give operators earlier warning that their
  instances are in danger of being amendment blocked, which will
  hopefully motivate them to update ahead of time.