### PR TITLE
Account channels RPC bug fixes

### DIFF
--- a/src/ripple/rpc/handlers/AccountChannels.cpp
+++ b/src/ripple/rpc/handlers/AccountChannels.cpp
@@ -148,14 +148,13 @@ Json::Value doAccountChannels (RPC::JsonContext& context)
 
     if (!forEachItemAfter(*ledger, accountID, startAfter, startHint,
                           limit-visitData.items.size()+1,
-        [&visitData](std::shared_ptr<SLE const> const& sleCur)
-        {
-
-            if (sleCur && sleCur->getType () == ltPAYCHAN &&
-                (! visitData.hasDst ||
+        [&visitData, &accountID](std::shared_ptr<SLE const> const& sleCur) {
+            if (sleCur && sleCur->getType() == ltPAYCHAN &&
+                (*sleCur)[sfAccount] == accountID &&
+                (!visitData.hasDst ||
                  visitData.raDstAccount == (*sleCur)[sfDestination]))
             {
-                visitData.items.emplace_back (sleCur);
+                visitData.items.emplace_back(sleCur);
                 return true;
             }
 

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -887,7 +887,6 @@ struct PayChan_test : public beast::unit_test::suite
         env(create(alice, bob, channelFunds, settleDelay, pk));
         env.close();
         auto const chan1Str = to_string(channel(*env.current(), alice, bob));
-        std::string chan1PkStr;
         {
             auto const r =
                 env.rpc("account_channels", alice.human(), bob.human());
@@ -895,8 +894,6 @@ struct PayChan_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 r[jss::result][jss::channels][0u][jss::channel_id] == chan1Str);
             BEAST_EXPECT(r[jss::result][jss::validated]);
-            chan1PkStr =
-                r[jss::result][jss::channels][0u][jss::public_key].asString();
         }
         {
             auto const r = env.rpc("account_channels", alice.human());
@@ -904,8 +901,6 @@ struct PayChan_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 r[jss::result][jss::channels][0u][jss::channel_id] == chan1Str);
             BEAST_EXPECT(r[jss::result][jss::validated]);
-            chan1PkStr =
-                r[jss::result][jss::channels][0u][jss::public_key].asString();
         }
         {
             auto const r =


### PR DESCRIPTION
This PR fixes two bugs in the `account_channels` RPC command:

1) The marker functionality did not work at all
2) This command returns the channels where a given account is the channel's source. With the new amendment that adds channels to the owner account of the channel's destination, this command would have returned channels where the account was either the source of destination. This patch fixes the command so it behaves as originally intended.