### PR TITLE
Remove remaining runtime conditionals from amendments enabled in 2016

### DIFF
--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -563,9 +563,6 @@ TxQ::tryClearAccountQueue(Application& app, OpenView& view,
 
 /*
     How the decision to apply, queue, or reject is made:
-    0. Is `featureFeeEscalation` enabled?
-        Yes: Continue to next step.
-        No: Fallback to `ripple::apply`. Stop.
     1. Does `preflight` indicate that the tx is valid?
         No: Return the `TER` from `preflight`. Stop.
         Yes: Continue to next step.
@@ -1170,9 +1167,6 @@ TxQ::apply(Application& app, OpenView& view,
 }
 
 /*
-    0. Is `featureFeeEscalation` enabled?
-        Yes: Continue to next step.
-        No: Stop.
     1. Update the fee metrics based on the fee levels of the
         txs in the validated ledger and whether consensus is
         slow.
@@ -1229,9 +1223,6 @@ TxQ::processClosedLedger(Application& app,
 /*
     How the txs are moved from the queue to the new open ledger.
 
-    0. Is `featureFeeEscalation` enabled?
-        Yes: Continue to next step.
-        No: Don't do anything to the open ledger. Stop.
     1. Iterate over the txs from highest fee level to lowest.
         For each tx:
         a) Is this the first tx in the queue for this account?

--- a/src/ripple/app/tx/impl/SetAccount.cpp
+++ b/src/ripple/app/tx/impl/SetAccount.cpp
@@ -295,12 +295,7 @@ SetAccount::doApply ()
             (!view().peek (keylet::signers (account_))))
         {
             // Account has no regular key or multi-signer signer list.
-
-            // Prevent transaction changes until we're ready.
-            if (view().rules().enabled(featureMultiSign))
-                return tecNO_ALTERNATIVE_KEY;
-
-            return tecNO_REGULAR_KEY;
+            return tecNO_ALTERNATIVE_KEY;
         }
 
         JLOG(j_.trace()) << "Set lsfDisableMaster.";

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -74,9 +74,6 @@ SetSignerList::determineOperation(STTx const& tx,
 NotTEC
 SetSignerList::preflight (PreflightContext const& ctx)
 {
-    if (! ctx.rules.enabled(featureMultiSign))
-        return temDISABLED;
-
     auto const ret = preflight1 (ctx);
     if (!isTesSuccess (ret))
         return ret;

--- a/src/ripple/app/tx/impl/SetTrust.cpp
+++ b/src/ripple/app/tx/impl/SetTrust.cpp
@@ -444,7 +444,7 @@ SetTrust::doApply ()
     else if (! saLimitAmount &&                          // Setting default limit.
         (! bQualityIn || ! uQualityIn) &&           // Not setting quality in or setting default quality in.
         (! bQualityOut || ! uQualityOut) &&         // Not setting quality out or setting default quality out.
-        (! (view().rules().enabled(featureTrustSetAuth)) || ! bSetAuth))
+        (! bSetAuth))
     {
         JLOG(j_.trace()) <<
             "Redundant: Setting non-existent ripple line to defaults.";

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -331,13 +331,9 @@ TER Transactor::apply ()
 NotTEC
 Transactor::checkSign (PreclaimContext const& ctx)
 {
-    // Make sure multisigning is enabled before we check for multisignatures.
-    if (ctx.view.rules().enabled(featureMultiSign))
-    {
-        // If the pk is empty, then we must be multi-signing.
-        if (ctx.tx.getSigningPubKey().empty ())
-            return checkMultiSign (ctx);
-    }
+    // If the pk is empty, then we must be multi-signing.
+    if (ctx.tx.getSigningPubKey().empty ())
+        return checkMultiSign (ctx);
 
     return checkSingleSign (ctx);
 }

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -38,9 +38,6 @@ checkValidity(HashRouter& router,
     STTx const& tx, Rules const& rules,
         Config const& config)
 {
-    auto const allowMultiSign =
-        rules.enabled(featureMultiSign);
-
     auto const id = tx.getTransactionID();
     auto const flags = router.getFlags(id);
     if (flags & SF_SIGBAD)
@@ -50,7 +47,7 @@ checkValidity(HashRouter& router,
     if (!(flags & SF_SIGGOOD))
     {
         // Don't know signature state. Check it.
-        auto const sigVerify = tx.checkSign(allowMultiSign);
+        auto const sigVerify = tx.checkSign();
         if (! sigVerify.first)
         {
             router.setFlags(id, SF_SIGBAD);

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -52,7 +52,7 @@ class FeatureCollections
     {
         "MultiSign",                   // Unconditionally supported.
         "Tickets",
-        "TrustSetAuth",
+        "TrustSetAuth",                // Unconditionally supported.
         "FeeEscalation",               // Unconditionally supported.
         "OwnerPaysFee",
         "CompareFlowV1V2",
@@ -340,7 +340,6 @@ foreachFeature(FeatureBitset bs, F&& f)
 }
 
 extern uint256 const featureTickets;
-extern uint256 const featureTrustSetAuth;
 extern uint256 const featureOwnerPaysFee;
 extern uint256 const featureCompareFlowV1V2;
 extern uint256 const featurePayChan;

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -50,7 +50,7 @@ class FeatureCollections
 {
     static constexpr char const* const featureNames[] =
     {
-        "MultiSign",
+        "MultiSign",                   // Unconditionally supported.
         "Tickets",
         "TrustSetAuth",
         "FeeEscalation",               // Unconditionally supported.
@@ -339,7 +339,6 @@ foreachFeature(FeatureBitset bs, F&& f)
             f(bitsetIndexToFeature(i));
 }
 
-extern uint256 const featureMultiSign;
 extern uint256 const featureTickets;
 extern uint256 const featureTrustSetAuth;
 extern uint256 const featureOwnerPaysFee;

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -53,7 +53,7 @@ class FeatureCollections
         "MultiSign",
         "Tickets",
         "TrustSetAuth",
-        "FeeEscalation",
+        "FeeEscalation",               // Unconditionally supported.
         "OwnerPaysFee",
         "CompareFlowV1V2",
         "PayChan",

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -133,7 +133,7 @@ public:
         @return `true` if valid signature. If invalid, the error message string.
     */
     std::pair<bool, std::string>
-    checkSign(bool allowMultiSign) const;
+    checkSign() const;
 
     // SQL Functions with metadata.
     static

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -82,12 +82,20 @@ detail::supportedAmendments ()
 {
     // Commented out amendments will be supported in a future release (and
     // uncommented at that time).
+    //
+    // There are also unconditionally supported amendments in the list.
+    // Those are amendments that were enabled some time ago and the
+    // amendment conditional code has been removed.
+    //
+    // ** WARNING **
+    // Unconditionally supported amendments need to remain in the list.
+    // Removing them will cause servers to become amendment blocked.
     static std::vector<std::string> const supported
     {
         "MultiSign",
 //        "Tickets",
         "TrustSetAuth",
-        "FeeEscalation", // Looks unused, but do not remove; Servers will be amendment blocked.
+        "FeeEscalation",               // Unconditionally supported.
 //        "OwnerPaysFee",
         "PayChan",
         "Flow",

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -94,7 +94,7 @@ detail::supportedAmendments ()
     {
         "MultiSign",                   // Unconditionally supported.
 //        "Tickets",
-        "TrustSetAuth",
+        "TrustSetAuth",                // Unconditionally supported.
         "FeeEscalation",               // Unconditionally supported.
 //        "OwnerPaysFee",
         "PayChan",
@@ -152,7 +152,6 @@ uint256 bitsetIndexToFeature(size_t i)
 
 
 uint256 const featureTickets = *getRegisteredFeature("Tickets");
-uint256 const featureTrustSetAuth = *getRegisteredFeature("TrustSetAuth");
 uint256 const featureOwnerPaysFee = *getRegisteredFeature("OwnerPaysFee");
 uint256 const featureCompareFlowV1V2 = *getRegisteredFeature("CompareFlowV1V2");
 uint256 const featurePayChan = *getRegisteredFeature("PayChan");

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -92,7 +92,7 @@ detail::supportedAmendments ()
     // Removing them will cause servers to become amendment blocked.
     static std::vector<std::string> const supported
     {
-        "MultiSign",
+        "MultiSign",                   // Unconditionally supported.
 //        "Tickets",
         "TrustSetAuth",
         "FeeEscalation",               // Unconditionally supported.
@@ -151,7 +151,6 @@ uint256 bitsetIndexToFeature(size_t i)
 }
 
 
-uint256 const featureMultiSign = *getRegisteredFeature("MultiSign");
 uint256 const featureTickets = *getRegisteredFeature("Tickets");
 uint256 const featureTrustSetAuth = *getRegisteredFeature("TrustSetAuth");
 uint256 const featureOwnerPaysFee = *getRegisteredFeature("OwnerPaysFee");

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -177,24 +177,16 @@ void STTx::sign (
     tid_ = getHash(HashPrefix::transactionID);
 }
 
-std::pair<bool, std::string> STTx::checkSign(bool allowMultiSign) const
+std::pair<bool, std::string> STTx::checkSign() const
 {
     std::pair<bool, std::string> ret {false, ""};
     try
     {
-        if (allowMultiSign)
-        {
-            // Determine whether we're single- or multi-signing by looking
-            // at the SigningPubKey.  It it's empty we must be
-            // multi-signing.  Otherwise we're single-signing.
-            Blob const& signingPubKey = getFieldVL (sfSigningPubKey);
-            ret = signingPubKey.empty () ?
-                checkMultiSign () : checkSingleSign ();
-        }
-        else
-        {
-            ret = checkSingleSign ();
-        }
+        // Determine whether we're single- or multi-signing by looking
+        // at the SigningPubKey.  It it's empty we must be
+        // multi-signing.  Otherwise we're single-signing.
+        Blob const& signingPubKey = getFieldVL (sfSigningPubKey);
+        ret = signingPubKey.empty () ? checkMultiSign () : checkSingleSign ();
     }
     catch (std::exception const&)
     {

--- a/src/ripple/rpc/handlers/SignFor.cpp
+++ b/src/ripple/rpc/handlers/SignFor.cpp
@@ -39,13 +39,6 @@ Json::Value doSignFor (RPC::JsonContext& context)
             "Signing is not supported by this server.");
     }
 
-    // Bail if multisign is not enabled.
-    if (! context.app.getLedgerMaster().getValidatedRules().
-        enabled (featureMultiSign))
-    {
-        RPC::inject_error (rpcNOT_ENABLED, context.params);
-        return context.params;
-    }
     context.loadType = Resource::feeHighBurdenRPC;
     auto const failHard = context.params[jss::fail_hard].asBool();
     auto const failType = NetworkOPs::doFailHard (failHard);

--- a/src/ripple/rpc/handlers/SubmitMultiSigned.cpp
+++ b/src/ripple/rpc/handlers/SubmitMultiSigned.cpp
@@ -32,13 +32,6 @@ namespace ripple {
 // }
 Json::Value doSubmitMultiSigned (RPC::JsonContext& context)
 {
-    // Bail if multisign is not enabled.
-    if (! context.app.getLedgerMaster().getValidatedRules().
-        enabled (featureMultiSign))
-    {
-        RPC::inject_error (rpcNOT_ENABLED, context.params);
-        return context.params;
-    }
     context.loadType = Resource::feeHighBurdenRPC;
     auto const failHard = context.params[jss::fail_hard].asBool();
     auto const failType = NetworkOPs::doFailHard (failHard);

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -892,7 +892,7 @@ class Check_test : public beast::unit_test::suite
         }
 
         // Use a regular key and also multisign to cash a check.
-        // featureMultiSign changes the reserve on a SignerList, so
+        // featureMultiSignReserve changes the reserve on a SignerList, so
         // check both before and after.
         FeatureBitset const allSupported {supported_amendments()};
         for (auto const features :
@@ -1541,7 +1541,7 @@ class Check_test : public beast::unit_test::suite
         Account const zoe {"zoe"};
         IOU const USD {gw["USD"]};
 
-        // featureMultiSign changes the reserve on a SignerList, so
+        // featureMultiSignReserve changes the reserve on a SignerList, so
         // check both before and after.
         FeatureBitset const allSupported {supported_amendments()};
         for (auto const features :

--- a/src/test/app/SetAuth_test.cpp
+++ b/src/test/app/SetAuth_test.cpp
@@ -47,43 +47,33 @@ struct SetAuth_test : public beast::unit_test::suite
 
     void testAuth(FeatureBitset features)
     {
-        // featureTrustSetAuth should always be reset by the caller.
-        BEAST_EXPECT(!features[featureTrustSetAuth]);
-
         using namespace jtx;
         auto const gw = Account("gw");
         auto const USD = gw["USD"];
-        {
-            Env env(*this, features);
-            env.fund(XRP(100000), "alice", gw);
-            env(fset(gw, asfRequireAuth));
-            env(auth(gw, "alice", "USD"),       ter(tecNO_LINE_REDUNDANT));
-        }
-        {
-            Env env(*this, features | featureTrustSetAuth);
 
-            env.fund(XRP(100000), "alice", "bob", gw);
-            env(fset(gw, asfRequireAuth));
-            env(auth(gw, "alice", "USD"));
-            BEAST_EXPECT(env.le(
-                keylet::line(Account("alice").id(),
-                    gw.id(), USD.currency)));
-            env(trust("alice", USD(1000)));
-            env(trust("bob", USD(1000)));
-            env(pay(gw, "alice", USD(100)));
-            env(pay(gw, "bob", USD(100)),       ter(tecPATH_DRY)); // Should be terNO_AUTH
-            env(pay("alice", "bob", USD(50)),   ter(tecPATH_DRY)); // Should be terNO_AUTH
-        }
+        Env env(*this);
+
+        env.fund(XRP(100000), "alice", "bob", gw);
+        env(fset(gw, asfRequireAuth));
+        env(auth(gw, "alice", "USD"));
+        BEAST_EXPECT(env.le(
+            keylet::line(Account("alice").id(),
+                gw.id(), USD.currency)));
+        env(trust("alice", USD(1000)));
+        env(trust("bob", USD(1000)));
+        env(pay(gw, "alice", USD(100)));
+        env(pay(gw, "bob", USD(100)),       ter(tecPATH_DRY)); // Should be terNO_AUTH
+        env(pay("alice", "bob", USD(50)),   ter(tecPATH_DRY)); // Should be terNO_AUTH
     }
 
     void run() override
     {
         using namespace jtx;
         auto const sa = supported_amendments();
-        testAuth(sa - featureTrustSetAuth - featureFlow - fix1373 - featureFlowCross);
-        testAuth(sa - featureTrustSetAuth - fix1373 - featureFlowCross);
-        testAuth(sa - featureTrustSetAuth - featureFlowCross);
-        testAuth(sa - featureTrustSetAuth);
+        testAuth(sa - featureFlow - fix1373 - featureFlowCross);
+        testAuth(sa               - fix1373 - featureFlowCross);
+        testAuth(sa                         - featureFlowCross);
+        testAuth(sa);
     }
 };
 

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1478,7 +1478,7 @@ public:
             });
         j.sign (keypair.first, keypair.second);
 
-        unexpected (!j.checkSign (true).first, "Transaction fails signature test");
+        unexpected (!j.checkSign().first, "Transaction fails signature test");
 
         Serializer rawTxn;
         j.add (rawTxn);

--- a/src/test/rpc/AccountSet_test.cpp
+++ b/src/test/rpc/AccountSet_test.cpp
@@ -376,12 +376,10 @@ public:
         }
     }
 
-    void testBadInputs(bool withFeatures)
+    void testBadInputs()
     {
         using namespace test::jtx;
-        std::unique_ptr<Env> penv {
-            withFeatures ?  new Env(*this) : new Env(*this, FeatureBitset{})};
-        Env& env = *penv;
+        Env env (*this);
         Account const alice ("alice");
         env.fund(XRP(10000), alice);
 
@@ -415,7 +413,7 @@ public:
 
         env(fset (alice, asfDisableMaster),
             sig(alice),
-            ter(withFeatures ? tecNO_ALTERNATIVE_KEY : tecNO_REGULAR_KEY));
+            ter(tecNO_ALTERNATIVE_KEY));
     }
 
     void testRequireAuthWithDir()
@@ -450,13 +448,10 @@ public:
         testMessageKey();
         testWalletID();
         testEmailHash();
-        testBadInputs(true);
-        testBadInputs(false);
+        testBadInputs();
         testRequireAuthWithDir();
         testTransferRate();
     }
-
-
 };
 
 BEAST_DEFINE_TESTSUITE(AccountSet,app,ripple);


### PR DESCRIPTION
There were four amendments enabled in 2016.  They are:

- FeeEscalation: 19 May 2016
- MultiSign: 27 June 2016
- TrustSetAuth: 19 July 2016
- Flow: 21 Oct 2016

There's a different pull request that removes run-time conditionals for Flow.

This pull request deals with the remaining three by removing their runtime conditionals.  Each amendment is unconditionalized in its own commit.  My intention is that the commits _not_ be squashed if the branch is merged to develop.

The conditionals for featureFeeEscalation had been removed previously, but a few comments remained where it was referenced.  Those comments are fixed up.

None of these amendments can be _completely_ removed yet.  If the server doesn't recognize the amendments then it becomes amendment blocked.  So, for now, we have to leave the amendments in the Feature files.  That problem should be addressed in a different pull request.