### PR TITLE
[TRIVIAL] Qualify tolower with std:: and remove obsolete comments

### DIFF
--- a/src/ripple/beast/core/LexicalCast.h
+++ b/src/ripple/beast/core/LexicalCast.h
@@ -193,7 +193,7 @@ struct LexicalCast <Out, std::string>
         std::transform(in.begin (), in.end (), in.begin (),
             [](auto c)
             {
-                return ::tolower(static_cast<unsigned char>(c));
+                return std::tolower(static_cast<unsigned char>(c));
             });
 
         if (in == "1" || in == "true")

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -237,7 +237,6 @@ Json::Output makeOutput (Session& session)
     };
 }
 
-// HACK!
 static
 std::map<std::string, std::string>
 build_map(boost::beast::http::fields const& h)
@@ -246,11 +245,10 @@ build_map(boost::beast::http::fields const& h)
     for (auto const& e : h)
     {
         auto key (e.name_string().to_string());
-        // TODO Replace with safe C++14 version
         std::transform (key.begin(), key.end(), key.begin(),
                         [](auto kc)
                         {
-                            return ::tolower(static_cast<unsigned char>(kc));
+                            return std::tolower(static_cast<unsigned char>(kc));
                         });
         c [key] = e.value().to_string();
     }


### PR DESCRIPTION
* Fixes RIPD-1759