### PR TITLE
[Trivial] Add time zone abbreviation to all time point streaming

### DIFF
--- a/src/ripple/basics/chrono.h
+++ b/src/ripple/basics/chrono.h
@@ -59,7 +59,7 @@ template <class Duration>
 std::string
 to_string(date::sys_time<Duration> tp)
 {
-    return date::format("%Y-%b-%d %T", tp);
+    return date::format("%Y-%b-%d %T %Z", tp);
 }
 
 inline


### PR DESCRIPTION
Fixes RIPD-1658.

Add time-zone abbreviation when streaming out time_points.  This will always be "UTC".  Another possibility is to stream out the UTC offset: "+0000".  I chose the abbreviation instead to indicate the distinction between UTC, and some other time zone such as "Europe/London" which has an offset of +0000 about half the year.  Rippled timestamp output will _never_ vary from +0000, and UTC communicates that more precisely than does +0000.