### PR TITLE
Changed default node_size to huge and default online_delete to 30000

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1158,7 +1158,7 @@ protocol = ws
 #-------------------------------------------------------------------------------
 
 [node_size]
-medium
+huge
 
 # This is primary persistent datastore for rippled.  This includes transaction
 # metadata, account states, and ledger headers.  Helpful information can be
@@ -1173,7 +1173,7 @@ filter_bits=12
 cache_mb=256
 file_size_mb=8
 file_size_mult=2
-online_delete=2000
+online_delete=30000
 advisory_delete=0
 
 # This is the persistent datastore for shards. It is important for the health


### PR DESCRIPTION
The node_size setting should be `huge` by default so that those who run production servers don't have to worry about changing it. An `online_delete` setting of `2000` is too small and system resources are used to complete deletion too frequently. Setting this to 30000 is more reasonable. Reference ranges for these settings can be found [here](https://xrpl.org/capacity-planning.html#node-size).