### PR TITLE
Handle build directories for specific versions of gcc/clang:

### DIFF
--- a/Builds/Test.py
+++ b/Builds/Test.py
@@ -272,9 +272,17 @@ def run_cmake(directory, cmake_dir, args):
         args += ( '-DCMAKE_BUILD_TYPE=Debug', )
     if re.search('release', cmake_dir):
         args += ( '-DCMAKE_BUILD_TYPE=Release', )
-    if re.search('gcc', cmake_dir):
+    m = re.search('gcc(-[^.]*)', cmake_dir)
+    if m:
+        args += ( '-DCMAKE_C_COMPILER=' + m.group(0),
+          '-DCMAKE_CXX_COMPILER=g++' + m.group(1), )
+    elif re.search('gcc', cmake_dir):
         args += ( '-DCMAKE_C_COMPILER=gcc', '-DCMAKE_CXX_COMPILER=g++', )
-    if re.search('clang', cmake_dir):
+    m = re.search('clang(-[^.]*)', cmake_dir)
+    if m:
+        args += ( '-DCMAKE_C_COMPILER=' + m.group(0),
+          '-DCMAKE_CXX_COMPILER=clang++' + m.group(1), )
+    elif re.search('clang', cmake_dir):
         args += ( '-DCMAKE_C_COMPILER=clang', '-DCMAKE_CXX_COMPILER=clang++', )
 
     args += ( os.path.join('..', '..', '..'), )


### PR DESCRIPTION
* Example: gcc.Debug will use the the default version of gcc installed on the
  system. gcc-9.Debug will use version 9, regardless of the default. This will
  be most useful when the default is older than required or desired.

This was a quick "scratch an itch" change because recent changes upped the required version of clang, and I didn't feel like upgrading the OS on my dogfood machine from Ubuntu 18.04 LTS.