### PR TITLE
Protocol Amendment: Always Require Fully-Canonical Signatures

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -750,6 +750,7 @@ else ()
     src/test/app/ValidatorKeys_test.cpp
     src/test/app/ValidatorList_test.cpp
     src/test/app/ValidatorSite_test.cpp
+    src/test/app/tx/apply_test.cpp
     #[===============================[
        nounity, test sources:
          subdir: basics

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -47,7 +47,7 @@ checkValidity(HashRouter& router,
     if (!(flags & SF_SIGGOOD))
     {
         // Don't know signature state. Check it.
-        auto const sigVerify = tx.checkSign();
+        auto const sigVerify = tx.checkSign(rules);
         if (! sigVerify.first)
         {
             router.setFlags(id, SF_SIGBAD);

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -47,7 +47,7 @@ checkValidity(HashRouter& router,
     if (!(flags & SF_SIGGOOD))
     {
         // Don't know signature state. Check it.
-        STTx::RequireFullyCanonicalSig const requireCanonicalSig =
+        auto const requireCanonicalSig =
             rules.enabled(featureRequireFullyCanonicalSig) ?
             STTx::RequireFullyCanonicalSig::yes :
             STTx::RequireFullyCanonicalSig::no;

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -47,7 +47,12 @@ checkValidity(HashRouter& router,
     if (!(flags & SF_SIGGOOD))
     {
         // Don't know signature state. Check it.
-        auto const sigVerify = tx.checkSign(rules);
+        STTx::RequireFullyCanonicalSig const requireCanonicalSig =
+            rules.enabled(featureRequireFullyCanonicalSig) ?
+            STTx::RequireFullyCanonicalSig::yes :
+            STTx::RequireFullyCanonicalSig::no;
+
+        auto const sigVerify = tx.checkSign(requireCanonicalSig);
         if (! sigVerify.first)
         {
             router.setFlags(id, SF_SIGBAD);

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -110,6 +110,7 @@ class FeatureCollections
         "DeletableAccounts",
         // fixQualityUpperBound should be activated before FlowCross
         "fixQualityUpperBound",
+        "RequireFullyCanonicalSig"
     };
 
     std::vector<uint256> features;
@@ -397,6 +398,7 @@ extern uint256 const fixCheckThreading;
 extern uint256 const fixPayChanRecipientOwnerDir;
 extern uint256 const featureDeletableAccounts;
 extern uint256 const fixQualityUpperBound;
+extern uint256 const featureRequireFullyCanonicalSig;
 
 } // ripple
 

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -30,6 +30,8 @@
 
 namespace ripple {
 
+class Rules;
+
 enum TxnSql : char
 {
     txnSqlNew = 'N',
@@ -133,7 +135,7 @@ public:
         @return `true` if valid signature. If invalid, the error message string.
     */
     std::pair<bool, std::string>
-    checkSign() const;
+    checkSign(Rules const& rules) const;
 
     // SQL Functions with metadata.
     static
@@ -150,8 +152,8 @@ public:
         std::string const& escapedMetaData) const;
 
 private:
-    std::pair<bool, std::string> checkSingleSign () const;
-    std::pair<bool, std::string> checkMultiSign () const;
+    std::pair<bool, std::string> checkSingleSign (Rules const& rules) const;
+    std::pair<bool, std::string> checkMultiSign (Rules const& rules) const;
 
     uint256 tid_;
     TxType tx_type_;

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -152,8 +152,8 @@ public:
         std::string const& escapedMetaData) const;
 
 private:
-    std::pair<bool, std::string> checkSingleSign (Rules const& rules) const;
-    std::pair<bool, std::string> checkMultiSign (Rules const& rules) const;
+    std::pair<bool, std::string> checkSingleSign (bool require_fully_canonical) const;
+    std::pair<bool, std::string> checkMultiSign (bool require_fully_canonical) const;
 
     uint256 tid_;
     TxType tx_type_;

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -30,8 +30,6 @@
 
 namespace ripple {
 
-class Rules;
-
 enum TxnSql : char
 {
     txnSqlNew = 'N',
@@ -134,8 +132,13 @@ public:
     /** Check the signature.
         @return `true` if valid signature. If invalid, the error message string.
     */
+    enum class RequireFullyCanonicalSig : bool
+    {
+        no,
+        yes
+    };
     std::pair<bool, std::string>
-    checkSign(Rules const& rules) const;
+    checkSign(RequireFullyCanonicalSig requireCanonicalSig) const;
 
     // SQL Functions with metadata.
     static
@@ -152,8 +155,11 @@ public:
         std::string const& escapedMetaData) const;
 
 private:
-    std::pair<bool, std::string> checkSingleSign (bool require_fully_canonical) const;
-    std::pair<bool, std::string> checkMultiSign (bool require_fully_canonical) const;
+    std::pair<bool, std::string>
+    checkSingleSign (RequireFullyCanonicalSig requireCanonicalSig) const;
+
+    std::pair<bool, std::string>
+    checkMultiSign (RequireFullyCanonicalSig requireCanonicalSig) const;
 
     uint256 tid_;
     TxType tx_type_;

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -129,6 +129,7 @@ detail::supportedAmendments ()
         "fixPayChanRecipientOwnerDir",
         "DeletableAccounts",
         "fixQualityUpperBound",
+        "RequireFullyCanonicalSig"
     };
     return supported;
 }
@@ -187,5 +188,6 @@ uint256 const fixCheckThreading = *getRegisteredFeature("fixCheckThreading");
 uint256 const fixPayChanRecipientOwnerDir = *getRegisteredFeature("fixPayChanRecipientOwnerDir");
 uint256 const featureDeletableAccounts = *getRegisteredFeature("DeletableAccounts");
 uint256 const fixQualityUpperBound = *getRegisteredFeature("fixQualityUpperBound");
+uint256 const featureRequireFullyCanonicalSig = *getRegisteredFeature("RequireFullyCanonicalSig");
 
 } // ripple

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -268,7 +268,7 @@ STTx::checkSingleSign (RequireFullyCanonicalSig requireCanonicalSig) const
     {
         bool const fullyCanonical =
             (getFlags() & tfFullyCanonicalSig) ||
-            (requireCanonicalSig != RequireFullyCanonicalSig::no);
+            (requireCanonicalSig == RequireFullyCanonicalSig::yes);
 
         auto const spk = getFieldVL (sfSigningPubKey);
 
@@ -325,7 +325,7 @@ STTx::checkMultiSign (RequireFullyCanonicalSig requireCanonicalSig) const
     // Determine whether signatures must be full canonical.
     bool const fullyCanonical =
         (getFlags() & tfFullyCanonicalSig) ||
-        (requireCanonicalSig != RequireFullyCanonicalSig::no);
+        (requireCanonicalSig == RequireFullyCanonicalSig::yes);
 
     // Signers must be in sorted order by AccountID.
     AccountID lastAccountID (beast::zero);

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -23,6 +23,7 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/basics/StringUtilities.h>
 #include <ripple/ledger/ReadView.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/HashPrefix.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/protocol/Protocol.h>

--- a/src/test/app/tx/apply_test.cpp
+++ b/src/test/app/tx/apply_test.cpp
@@ -1,0 +1,83 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Dev Null Productions
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/tx/apply.h>
+#include <ripple/basics/StringUtilities.h>
+#include <ripple/protocol/Feature.h>
+#include <test/jtx/Env.h>
+
+namespace ripple {
+
+class Apply_test : public beast::unit_test::suite
+{
+public:
+    void run() override
+    {
+        testcase ("Require Fully Canonicial Signature");
+        testFullyCanonicalSigs();
+    }
+
+    void testFullyCanonicalSigs()
+    {
+        // Construct a payments w/out a fully-canonical tx
+        const std::string non_fully_canonical_tx =
+            "12000022000000002400000001201B00497D9C6140000000000F6950684000000"
+            "00000000C732103767C7B2C13AD90050A4263745E4BAB2B975417FA22E87780E1"
+            "506DDAF21139BE74483046022100E95670988A34C4DB0FA73A8BFD6383872AF43"
+            "8C147A62BC8387406298C3EADC1022100A7DC80508ED5A4750705C702A81CBF9D"
+            "2C2DC3AFEDBED37BBCCD97BC8C40E08F8114E25A26437D923EEF4D6D815DF9336"
+            "8B62E6440848314BB85996936E4F595287774684DC2AC6266024BEF";
+
+        auto ret = strUnHex (non_fully_canonical_tx);
+        SerialIter sitTrans (makeSlice(*ret));
+        STTx const tx = *std::make_shared<STTx const> (std::ref (sitTrans));
+
+        {
+            test::jtx::Env no_fully_canonical (*this,
+                test::jtx::supported_amendments() -
+                featureRequireFullyCanonicalSig);
+
+            Validity valid = checkValidity(no_fully_canonical.app().getHashRouter(),
+                                           tx,
+                                           no_fully_canonical.current()->rules(),
+                                           no_fully_canonical.app().config()).first;
+
+            if(valid != Validity::Valid)
+                fail("Non-Fully canoncial signature was not permitted");
+        }
+
+        {
+            test::jtx::Env fully_canonical (*this,
+                test::jtx::supported_amendments());
+
+            Validity valid = checkValidity(fully_canonical.app().getHashRouter(),
+                                           tx,
+                                           fully_canonical.current()->rules(),
+                                           fully_canonical.app().config()).first;
+            if(valid == Validity::Valid)
+                fail("Non-Fully canoncial signature was permitted");
+        }
+
+        pass();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(Apply,app,ripple);
+
+} // ripple

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1467,6 +1467,7 @@ public:
 
     void testSTTx(KeyType keyType)
     {
+        test::jtx::Env env(*this);
         auto const keypair = randomKeyPair (keyType);
 
         STTx j (ttACCOUNT_SET,
@@ -1478,7 +1479,7 @@ public:
             });
         j.sign (keypair.first, keypair.second);
 
-        unexpected (!j.checkSign().first, "Transaction fails signature test");
+        unexpected (!j.checkSign(env.current()->rules()).first, "Transaction fails signature test");
 
         Serializer rawTxn;
         j.add (rawTxn);

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -29,7 +29,6 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/protocol/messages.h>
-#include <test/jtx/Env.h>
 
 #include <memory>
 
@@ -1622,17 +1621,13 @@ public:
         STTx const tx = *std::make_shared<STTx const> (std::ref (sitTrans));
 
         {
-            test::jtx::Env no_fully_canonical (*this, test::jtx::supported_amendments() - featureRequireFullyCanonicalSig);
-
-            bool valid = tx.checkSign(no_fully_canonical.current()->rules()).first;
+            bool valid = tx.checkSign(STTx::RequireFullyCanonicalSig::no).first;
             if(!valid)
               fail("Non-Fully canoncial signature was not permitted");
         }
 
         {
-            test::jtx::Env fully_canonical (*this, test::jtx::supported_amendments());
-
-            bool valid = tx.checkSign(fully_canonical.current()->rules()).first;
+            bool valid = tx.checkSign(STTx::RequireFullyCanonicalSig::yes).first;
             if(valid)
               fail("Non-Fully canoncial signature was permitted");
         }

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -1473,7 +1473,6 @@ public:
 
     void testSTTx(KeyType keyType)
     {
-        test::jtx::Env env(*this);
         auto const keypair = randomKeyPair (keyType);
 
         STTx j (ttACCOUNT_SET,
@@ -1485,7 +1484,8 @@ public:
             });
         j.sign (keypair.first, keypair.second);
 
-        unexpected (!j.checkSign(env.current()->rules()).first, "Transaction fails signature test");
+        unexpected (!j.checkSign(STTx::RequireFullyCanonicalSig::yes).first,
+            "Transaction fails signature test");
 
         Serializer rawTxn;
         j.add (rawTxn);

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -27,6 +27,7 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/basics/Slice.h>
 #include <ripple/protocol/messages.h>
+#include <test/jtx/Env.h>
 
 #include <memory>
 

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -17,6 +17,8 @@
 */
 //==============================================================================
 
+#include <ripple/basics/StringUtilities.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/STTx.h>
@@ -48,6 +50,9 @@ public:
 
         testcase ("STObject constructor errors");
         testObjectCtorErrors();
+
+        testcase ("Require Fully Canonicial Signature");
+        testFullyCanonicalSigs();
     }
 
     void testMalformedSerializedForm()
@@ -1604,6 +1609,35 @@ public:
             BEAST_EXPECT (
                 got == "Field 'Fee' is required but missing.");
         }
+    }
+
+    void testFullyCanonicalSigs()
+    {
+        // Construct a payments w/out a fully-canonical tx
+        const std::string non_fully_canonical_tx =
+          "12000022000000002400000001201B00497D9C6140000000000F695068400000000000000C732103767C7B2C13AD90050A4263745E4BAB2B975417FA22E87780E1506DDAF21139BE74483046022100E95670988A34C4DB0FA73A8BFD6383872AF438C147A62BC8387406298C3EADC1022100A7DC80508ED5A4750705C702A81CBF9D2C2DC3AFEDBED37BBCCD97BC8C40E08F8114E25A26437D923EEF4D6D815DF93368B62E6440848314BB85996936E4F595287774684DC2AC6266024BEF";
+
+        auto ret = strUnHex (non_fully_canonical_tx);
+        SerialIter sitTrans (makeSlice(*ret));
+        STTx const tx = *std::make_shared<STTx const> (std::ref (sitTrans));
+
+        {
+            test::jtx::Env no_fully_canonical (*this, test::jtx::supported_amendments() - featureRequireFullyCanonicalSig);
+
+            bool valid = tx.checkSign(no_fully_canonical.current()->rules()).first;
+            if(!valid)
+              fail("Non-Fully canoncial signature was not permitted");
+        }
+
+        {
+            test::jtx::Env fully_canonical (*this, test::jtx::supported_amendments());
+
+            bool valid = tx.checkSign(fully_canonical.current()->rules()).first;
+            if(valid)
+              fail("Non-Fully canoncial signature was permitted");
+        }
+
+        pass();
     }
 };
 

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -17,8 +17,6 @@
 */
 //==============================================================================
 
-#include <ripple/basics/StringUtilities.h>
-#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/STTx.h>
@@ -49,9 +47,6 @@ public:
 
         testcase ("STObject constructor errors");
         testObjectCtorErrors();
-
-        testcase ("Require Fully Canonicial Signature");
-        testFullyCanonicalSigs();
     }
 
     void testMalformedSerializedForm()
@@ -1608,31 +1603,6 @@ public:
             BEAST_EXPECT (
                 got == "Field 'Fee' is required but missing.");
         }
-    }
-
-    void testFullyCanonicalSigs()
-    {
-        // Construct a payments w/out a fully-canonical tx
-        const std::string non_fully_canonical_tx =
-          "12000022000000002400000001201B00497D9C6140000000000F695068400000000000000C732103767C7B2C13AD90050A4263745E4BAB2B975417FA22E87780E1506DDAF21139BE74483046022100E95670988A34C4DB0FA73A8BFD6383872AF438C147A62BC8387406298C3EADC1022100A7DC80508ED5A4750705C702A81CBF9D2C2DC3AFEDBED37BBCCD97BC8C40E08F8114E25A26437D923EEF4D6D815DF93368B62E6440848314BB85996936E4F595287774684DC2AC6266024BEF";
-
-        auto ret = strUnHex (non_fully_canonical_tx);
-        SerialIter sitTrans (makeSlice(*ret));
-        STTx const tx = *std::make_shared<STTx const> (std::ref (sitTrans));
-
-        {
-            bool valid = tx.checkSign(STTx::RequireFullyCanonicalSig::no).first;
-            if(!valid)
-              fail("Non-Fully canoncial signature was not permitted");
-        }
-
-        {
-            bool valid = tx.checkSign(STTx::RequireFullyCanonicalSig::yes).first;
-            if(valid)
-              fail("Non-Fully canoncial signature was permitted");
-        }
-
-        pass();
     }
 };
 

--- a/src/test/unity/app_test_unity2.cpp
+++ b/src/test/unity/app_test_unity2.cpp
@@ -38,3 +38,4 @@
 #include <test/app/ValidatorKeys_test.cpp>
 #include <test/app/ValidatorList_test.cpp>
 #include <test/app/ValidatorSite_test.cpp>
+#include <test/app/tx/apply_test.cpp>


### PR DESCRIPTION
Addresses #3042 by adding an amendment which if enabled would require full-canonical signatures regardless of whether or not the **tfFullyCanonicalSig** flag is set. Existing functionality will be preserved if amendment is not enabled. 

