### PR TITLE
Use ephemeral validator public keys in lag ratchet:

### DIFF
--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -151,7 +151,12 @@ class ValidatorList
     hash_map<PublicKey, std::size_t> keyListings_;
 
     // The current list of trusted master keys
-    hash_set<PublicKey> trustedKeys_;
+    hash_set<PublicKey> trustedMasterKeys_;
+
+    // The current list of trusted signing keys. For those validators using
+    // a manifest, the signing key is the ephemeral key. For the ones using
+    // a seed, the signing key is the same as the master key.
+    hash_set<PublicKey> trustedSigningKeys_;
 
     PublicKey localPubKey_;
 
@@ -503,7 +508,7 @@ public:
     getQuorumKeys() const
     {
         std::shared_lock<std::shared_timed_mutex> read_lock{mutex_};
-        return {quorum_, trustedKeys_};
+        return {quorum_, trustedSigningKeys_};
     }
 
 

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -1173,7 +1173,7 @@ Consensus<Adaptor>::shouldPause() const
         !adaptor_.haveValidated() ||
         result_->roundTime.read() > parms.ledgerMAX_CONSENSUS)
     {
-        j_.debug() << "not pausing" << vars.str();
+        j_.debug() << "not pausing (early)" << vars.str();
         return false;
     }
 


### PR DESCRIPTION
A review of the lag ratchet code revealed that we were using the long-term master public keys of trusted validators, when we should have been using the ephemeral public keys instead.

As a result, the lag ratchet code would be effectively inoperable.