### PR TITLE
Harden validations, report server version & deprecate TTL fields

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -32,6 +32,7 @@
 #include <ripple/app/misc/TxQ.h>
 #include <ripple/app/misc/ValidatorKeys.h>
 #include <ripple/app/misc/ValidatorList.h>
+#include <ripple/basics/random.h>
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/consensus/LedgerTiming.h>
 #include <ripple/nodestore/DatabaseShard.h>
@@ -85,7 +86,14 @@ RCLConsensus::Adaptor::Adaptor(
     , nodeID_{validatorKeys.nodeID}
     , valPublic_{validatorKeys.publicKey}
     , valSecret_{validatorKeys.secretKey}
+    , valCookie_{
+          rand_int<std::uint64_t>(1, std::numeric_limits<std::uint64_t>::max())}
 {
+    assert(valCookie_ != 0);
+
+    JLOG(j_.info()) << "Consensus engine started"
+                    << " (Node: " << to_string(nodeID_)
+                    << ", Cookie: " << valCookie_ << ")";
 }
 
 boost::optional<RCLCxLedger>
@@ -753,41 +761,63 @@ RCLConsensus::Adaptor::validate(
     bool proposing)
 {
     using namespace std::chrono_literals;
+
     auto validationTime = app_.timeKeeper().closeTime();
     if (validationTime <= lastValidationTime_)
         validationTime = lastValidationTime_ + 1s;
     lastValidationTime_ = validationTime;
 
-    STValidation::FeeSettings fees;
-    std::vector<uint256> amendments;
-
-    auto const& feeTrack = app_.getFeeTrack();
-    std::uint32_t fee =
-        std::max(feeTrack.getLocalFee(), feeTrack.getClusterFee());
-
-    if (fee > feeTrack.getLoadBase())
-        fees.loadFee = fee;
-
-    // next ledger is flag ledger
-    if (((ledger.seq() + 1) % 256) == 0)
-    {
-        // Suggest fee changes and new features
-        feeVote_->doValidation(ledger.ledger_, fees);
-        amendments = app_.getAmendmentTable().doValidation(
-            getEnabledAmendments(*ledger.ledger_));
-    }
-
     auto v = std::make_shared<STValidation>(
-        ledger.id(),
-        ledger.seq(),
-        txns.id(),
-        validationTime,
+        lastValidationTime_,
         valPublic_,
         valSecret_,
         nodeID_,
-        proposing /* full if proposed */,
-        fees,
-        amendments);
+        [&](STValidation& v) {
+            v.setFieldH256(sfLedgerHash, ledger.id());
+            v.setFieldH256(sfConsensusHash, txns.id());
+
+            v.setFieldU32(sfLedgerSequence, ledger.seq());
+
+            if (proposing)
+                v.setFlag(vfFullValidation);
+
+            if (ledger.ledger_->rules().enabled(featureHardenedValidations))
+            {
+                // Attest to the hash of what we consider to be the last fully
+                // validated ledger. This may be the hash of the ledger we are
+                // validating here, and that's fine.
+                if (auto const vl = ledgerMaster_.getValidatedLedger())
+                    v.setFieldH256(sfValidatedHash, vl->info().hash);
+
+                v.setFieldU64(sfCookie, valCookie_);
+            }
+
+            // Report our load
+            {
+                auto const& ft = app_.getFeeTrack();
+                auto const fee = std::max(ft.getLocalFee(), ft.getClusterFee());
+                if (fee > ft.getLoadBase())
+                    v.setFieldU32(sfLoadFee, fee);
+            }
+
+            // If the next ledger is a flag ledger, suggest fee changes and
+            // new features:
+            if ((ledger.seq() + 1) % 256 == 0)
+            {
+                // Fees:
+                feeVote_->doValidation(ledger.ledger_->fees(), v);
+
+                // Amendments
+                // FIXME: pass `v` and have the function insert the array
+                // directly?
+                auto const amendments = app_.getAmendmentTable().doValidation(
+                    getEnabledAmendments(*ledger.ledger_));
+
+                if (!amendments.empty())
+                    v.setFieldV256(
+                        sfAmendments, STVector256(sfAmendments, amendments));
+            }
+        });
 
     // suppress it if we receive it
     app_.getHashRouter().addSuppression(

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -38,6 +38,7 @@
 #include <ripple/nodestore/DatabaseShard.h>
 #include <ripple/overlay/Overlay.h>
 #include <ripple/overlay/predicates.h>
+#include <ripple/protocol/BuildInfo.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/digest.h>
 
@@ -790,6 +791,11 @@ RCLConsensus::Adaptor::validate(
                     v.setFieldH256(sfValidatedHash, vl->info().hash);
 
                 v.setFieldU64(sfCookie, valCookie_);
+
+                // Report our server version every flag ledger:
+                if ((ledger.seq() + 1) % 256 == 0)
+                    v.setFieldU64(
+                        sfServerVersion, BuildInfo::getEncodedVersion());
             }
 
             // Report our load

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -66,6 +66,9 @@ class RCLConsensus
         PublicKey const valPublic_;
         SecretKey const valSecret_;
 
+        // A randomly selected non-zero value used to tag our validations
+        std::uint64_t const valCookie_;
+
         // Ledger we most recently needed to acquire
         LedgerHash acquiringLedger_;
         ConsensusParms parms_;

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -33,12 +33,11 @@ class Application;
 
 /** Wrapper over STValidation for generic Validation code
 
-    Wraps an STValidation::pointer for compatibility with the generic validation
-    code.
+    Wraps an STValidation for compatibility with the generic validation code.
 */
 class RCLValidation
 {
-    STValidation::pointer val_;
+    std::shared_ptr<STValidation> val_;
 
 public:
     using NodeKey = ripple::PublicKey;
@@ -48,7 +47,7 @@ public:
 
         @param v The validation to wrap.
     */
-    RCLValidation(STValidation::pointer const& v) : val_{v}
+    RCLValidation(std::shared_ptr<STValidation> const& v) : val_{v}
     {
     }
 
@@ -127,8 +126,15 @@ public:
         return ~(*val_)[~sfLoadFee];
     }
 
+    /// Get the cookie specified in the validation (0 if not set)
+    std::uint64_t
+    cookie() const
+    {
+        return (*val_)[sfCookie];
+    }
+
     /// Extract the underlying STValidation being wrapped
-    STValidation::pointer
+    std::shared_ptr<STValidation>
     unwrap() const
     {
         return val_;
@@ -243,7 +249,7 @@ using RCLValidations = Validations<RCLValidationsAdaptor>;
 bool
 handleNewValidation(
     Application& app,
-    STValidation::ref val,
+    std::shared_ptr<STValidation> const& val,
     std::string const& source);
 
 }  // namespace ripple

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -103,7 +103,7 @@ public:
         NetClock::time_point closeTime,
         std::set<uint256> const& enabledAmendments,
         majorityAmendments_t const& majorityAmendments,
-        std::vector<STValidation::pointer> const& valSet) = 0;
+        std::vector<std::shared_ptr<STValidation>> const& valSet) = 0;
 
     // Called by the consensus code when we need to
     // add feature entries to a validation
@@ -126,7 +126,7 @@ public:
     void
     doVoting(
         std::shared_ptr<ReadView const> const& lastClosedLedger,
-        std::vector<STValidation::pointer> const& parentValidations,
+        std::vector<std::shared_ptr<STValidation>> const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition)
     {
         // Ask implementation what to do

--- a/src/ripple/app/misc/FeeVote.h
+++ b/src/ripple/app/misc/FeeVote.h
@@ -60,9 +60,7 @@ public:
         @param baseValidation
     */
     virtual void
-    doValidation(
-        std::shared_ptr<ReadView const> const& lastClosedLedger,
-        STValidation::FeeSettings& fees) = 0;
+    doValidation(Fees const& lastFees, STValidation& val) = 0;
 
     /** Cast our local vote on the fee.
 
@@ -72,7 +70,7 @@ public:
     virtual void
     doVoting(
         std::shared_ptr<ReadView const> const& lastClosedLedger,
-        std::vector<STValidation::pointer> const& parentValidations,
+        std::vector<std::shared_ptr<STValidation>> const& parentValidations,
         std::shared_ptr<SHAMap> const& initialPosition) = 0;
 };
 

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -362,7 +362,9 @@ public:
         std::shared_ptr<protocol::TMProposeSet> set) override;
 
     bool
-    recvValidation(STValidation::ref val, std::string const& source) override;
+    recvValidation(
+        std::shared_ptr<STValidation> const& val,
+        std::string const& source) override;
 
     std::shared_ptr<SHAMap>
     getTXMap(uint256 const& hash);
@@ -550,7 +552,7 @@ public:
         std::shared_ptr<STTx const> const& stTxn,
         TER terResult) override;
     void
-    pubValidation(STValidation::ref val) override;
+    pubValidation(std::shared_ptr<STValidation> const& val) override;
 
     //--------------------------------------------------------------------------
     //
@@ -2047,7 +2049,7 @@ NetworkOPsImp::pubConsensus(ConsensusPhase phase)
 }
 
 void
-NetworkOPsImp::pubValidation(STValidation::ref val)
+NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
 {
     // VFALCO consider std::shared_mutex
     std::lock_guard sl(mSubLock);
@@ -2473,7 +2475,9 @@ NetworkOPsImp::getTxsAccountB(
 }
 
 bool
-NetworkOPsImp::recvValidation(STValidation::ref val, std::string const& source)
+NetworkOPsImp::recvValidation(
+    std::shared_ptr<STValidation> const& val,
+    std::string const& source)
 {
     JLOG(m_journal.debug())
         << "recvValidation " << val->getLedgerHash() << " from " << source;

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -175,7 +175,9 @@ public:
         std::shared_ptr<protocol::TMProposeSet> set) = 0;
 
     virtual bool
-    recvValidation(STValidation::ref val, std::string const& source) = 0;
+    recvValidation(
+        std::shared_ptr<STValidation> const& val,
+        std::string const& source) = 0;
 
     virtual void
     mapComplete(std::shared_ptr<SHAMap> const& map, bool fromAcquire) = 0;
@@ -309,7 +311,7 @@ public:
         std::shared_ptr<STTx const> const& stTxn,
         TER terResult) = 0;
     virtual void
-    pubValidation(STValidation::ref val) = 0;
+    pubValidation(std::shared_ptr<STValidation> const& val) = 0;
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -232,7 +232,7 @@ public:
         NetClock::time_point closeTime,
         std::set<uint256> const& enabledAmendments,
         majorityAmendments_t const& majorityAmendments,
-        std::vector<STValidation::pointer> const& validations) override;
+        std::vector<std::shared_ptr<STValidation>> const& validations) override;
 };
 
 //------------------------------------------------------------------------------
@@ -455,7 +455,7 @@ AmendmentTableImpl::doVoting(
     NetClock::time_point closeTime,
     std::set<uint256> const& enabledAmendments,
     majorityAmendments_t const& majorityAmendments,
-    std::vector<STValidation::pointer> const& valSet)
+    std::vector<std::shared_ptr<STValidation>> const& valSet)
 {
     JLOG(j_.trace()) << "voting at " << closeTime.time_since_epoch().count()
                      << ": " << enabledAmendments.size() << ", "

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -72,7 +72,6 @@ public:
         explicit Setup() = default;
 
         std::shared_ptr<boost::asio::ssl::context> context;
-        bool expire = false;
         beast::IP::Address public_ip;
         int ipLimit = 0;
         std::uint32_t crawlOptions = 0;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -1186,16 +1186,12 @@ OverlayImpl::findPeerByPublicKey(PublicKey const& pubKey)
 void
 OverlayImpl::send(protocol::TMProposeSet& m)
 {
-    if (setup_.expire)
-        m.set_hops(0);
     auto const sm = std::make_shared<Message>(m, protocol::mtPROPOSE_LEDGER);
     for_each([&](std::shared_ptr<PeerImp>&& p) { p->send(sm); });
 }
 void
 OverlayImpl::send(protocol::TMValidation& m)
 {
-    if (setup_.expire)
-        m.set_hops(0);
     auto const sm = std::make_shared<Message>(m, protocol::mtVALIDATION);
     for_each([&](std::shared_ptr<PeerImp>&& p) { p->send(sm); });
 
@@ -1212,8 +1208,6 @@ OverlayImpl::send(protocol::TMValidation& m)
 void
 OverlayImpl::relay(protocol::TMProposeSet& m, uint256 const& uid)
 {
-    if (m.has_hops() && m.hops() >= maxTTL)
-        return;
     if (auto const toSkip = app_.getHashRouter().shouldRelay(uid))
     {
         auto const sm =
@@ -1228,8 +1222,6 @@ OverlayImpl::relay(protocol::TMProposeSet& m, uint256 const& uid)
 void
 OverlayImpl::relay(protocol::TMValidation& m, uint256 const& uid)
 {
-    if (m.has_hops() && m.hops() >= maxTTL)
-        return;
     if (auto const toSkip = app_.getHashRouter().shouldRelay(uid))
     {
         auto const sm = std::make_shared<Message>(m, protocol::mtVALIDATION);
@@ -1335,7 +1327,6 @@ setup_Overlay(BasicConfig const& config)
     {
         auto const& section = config.section("overlay");
         setup.context = make_SSLContext("");
-        setup.expire = get<bool>(section, "expire", false);
 
         set(setup.ipLimit, "ip_limit", section);
         if (setup.ipLimit < 0)

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -52,8 +52,6 @@ namespace ripple {
 class PeerImp;
 class BasicConfig;
 
-constexpr std::uint32_t maxTTL = 2;
-
 class OverlayImpl : public Overlay
 {
 public:

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1605,9 +1605,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
 {
     protocol::TMProposeSet& set = *m;
 
-    if (set.has_hops() && !cluster())
-        set.set_hops(set.hops() + 1);
-
     auto const sig = makeSlice(set.signature());
 
     // Preliminary check for the validity of the signature: A DER encoded
@@ -2110,9 +2107,6 @@ void
 PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
 {
     auto const closeTime = app_.timeKeeper().closeTime();
-
-    if (m->has_hops() && !cluster())
-        m->set_hops(m->hops() + 1);
 
     if (m->validation().size() < 50)
     {

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -2117,7 +2117,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
 
     try
     {
-        STValidation::pointer val;
+        std::shared_ptr<STValidation> val;
         {
             SerialIter sit(makeSlice(m->validation()));
             val = std::make_shared<STValidation>(
@@ -2453,7 +2453,6 @@ PeerImp::checkPropose(
         << "Checking " << (isTrusted ? "trusted" : "UNTRUSTED") << " proposal";
 
     assert(packet);
-    protocol::TMProposeSet& set = *packet;
 
     if (!cluster() && !peerPos.checkSign())
     {
@@ -2474,7 +2473,7 @@ PeerImp::checkPropose(
         {
             // relay untrusted proposal
             JLOG(p_journal_.trace()) << "relaying UNTRUSTED proposal";
-            overlay_.relay(set, peerPos.suppressionID());
+            overlay_.relay(*packet, peerPos.suppressionID());
         }
         else
         {
@@ -2485,7 +2484,7 @@ PeerImp::checkPropose(
 
 void
 PeerImp::checkValidation(
-    STValidation::pointer val,
+    std::shared_ptr<STValidation> const& val,
     std::shared_ptr<protocol::TMValidation> const& packet)
 {
     try

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -592,7 +592,7 @@ private:
 
     void
     checkValidation(
-        STValidation::pointer val,
+        std::shared_ptr<STValidation> const& val,
         std::shared_ptr<protocol::TMValidation> const& packet);
 
     void

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -179,10 +179,14 @@ message TMProposeSet
     required uint32 closeTime           = 4;
     required bytes signature            = 5;    // signature of above fields
     required bytes previousledger       = 6;
-    optional bool checkedSignature      = 7;    // node vouches signature is correct
     repeated bytes addedTransactions    = 10;   // not required if number is large
     repeated bytes removedTransactions  = 11;   // not required if number is large
-    optional uint32 hops                = 12;   // Number of hops traveled
+
+    // node vouches signature is correct
+    optional bool checkedSignature      = 7     [deprecated=true];
+
+    // Number of hops traveled
+    optional uint32 hops                = 12    [deprecated=true];
 }
 
 enum TxSetStatus
@@ -210,9 +214,14 @@ message TMValidatorList
 // Used to sign a final closed ledger after reprocessing
 message TMValidation
 {
-    required bytes validation       = 1;    // in STValidation signed form
-    optional bool checkedSignature  = 2;    // node vouches signature is correct
-    optional uint32 hops            = 3;    // Number of hops traveled
+    // The serialized validation
+    required bytes validation = 1;
+
+    // node vouches signature is correct
+    optional bool checkedSignature = 2 [deprecated = true];
+
+    // Number of hops traveled
+    optional uint32 hops = 3           [deprecated = true];
 }
 
 message TMIPv4Endpoint

--- a/src/ripple/protocol/BuildInfo.h
+++ b/src/ripple/protocol/BuildInfo.h
@@ -43,6 +43,31 @@ getVersionString();
 std::string const&
 getFullVersionString();
 
+/** Returns the server version packed in a 64-bit integer.
+
+    The general format is:
+
+    ........-........-........-........-........-........-........-........
+    XXXXXXXX-XXXXXXXX-YYYYYYYY-YYYYYYYY-YYYYYYYY-YYYYYYYY-YYYYYYYY-YYYYYYYY
+
+    X: 16 bits identifying the particular implementation
+    Y: 48 bits of data specific to the implementation
+
+    The rippled-specific format (implementation ID is: 0x18 0x3B) is:
+
+    00011000-00111011-MMMMMMMM-mmmmmmmm-pppppppp-TTNNNNNN-00000000-00000000
+
+        M: 8-bit major version (0-255)
+        m: 8-bit minor version (0-255)
+        p: 8-bit patch version (0-255)
+        T: 11 if neither an RC nor a beta
+           10 if an RC
+           01 if a beta
+        N: 6-bit rc/beta number (1-63)
+*/
+std::uint64_t
+getEncodedVersion();
+
 }  // namespace BuildInfo
 
 }  // namespace ripple

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -111,7 +111,7 @@ class FeatureCollections
         "RequireFullyCanonicalSig",
         "fix1781",  // XRPEndpointSteps should be included in the circular
                     // payment check
-    };
+        "HardenedValidations"};
 
     std::vector<uint256> features;
     boost::container::flat_map<uint256, std::size_t> featureToIndex;
@@ -366,6 +366,7 @@ extern uint256 const featureDeletableAccounts;
 extern uint256 const fixQualityUpperBound;
 extern uint256 const featureRequireFullyCanonicalSig;
 extern uint256 const fix1781;
+extern uint256 const featureHardenedValidations;
 
 // The following amendments have been active for at least two years.
 // Their pre-amendment code has been removed.

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -401,6 +401,7 @@ extern SF_U64 const sfLowNode;
 extern SF_U64 const sfHighNode;
 extern SF_U64 const sfDestinationNode;
 extern SF_U64 const sfCookie;
+extern SF_U64 const sfServerVersion;
 
 // 128-bit
 extern SF_U128 const sfEmailHash;

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -432,6 +432,7 @@ extern SF_U256 const sfDigest;
 extern SF_U256 const sfPayChannel;
 extern SF_U256 const sfConsensusHash;
 extern SF_U256 const sfCheckID;
+extern SF_U256 const sfValidatedHash;
 
 // currency amount (common)
 extern SF_Amount const sfAmount;

--- a/src/ripple/protocol/SOTemplate.h
+++ b/src/ripple/protocol/SOTemplate.h
@@ -50,7 +50,13 @@ public:
         : sField_(fieldName), style_(style)
     {
         if (!sField_.get().isUseful())
-            Throw<std::runtime_error>("SField in SOElement must be useful.");
+        {
+            auto nm = std::to_string(fieldName.getCode());
+            if (fieldName.hasName())
+                nm += ": '" + fieldName.getName() + "'";
+            Throw<std::runtime_error>(
+                "SField (" + nm + ") in SOElement must be useful.");
+        }
     }
 
     SField const&

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -130,7 +130,7 @@ detail::supportedAmendments()
         "fixQualityUpperBound",
         "RequireFullyCanonicalSig",
         "fix1781",
-    };
+        "HardenedValidations"};
     return supported;
 }
 
@@ -187,6 +187,8 @@ uint256 const fixQualityUpperBound =
 uint256 const featureRequireFullyCanonicalSig =
     *getRegisteredFeature("RequireFullyCanonicalSig");
 uint256 const fix1781 = *getRegisteredFeature("fix1781");
+uint256 const featureHardenedValidations =
+    *getRegisteredFeature("HardenedValidations");
 
 // The following amendments have been active for at least two years.
 // Their pre-amendment code has been removed.

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -168,6 +168,7 @@ SF_U256 const sfDigest(access, STI_HASH256, 21, "Digest");
 SF_U256 const sfPayChannel(access, STI_HASH256, 22, "Channel");
 SF_U256 const sfConsensusHash(access, STI_HASH256, 23, "ConsensusHash");
 SF_U256 const sfCheckID(access, STI_HASH256, 24, "CheckID");
+SF_U256 const sfValidatedHash(access, STI_HASH256, 25, "ValidatedHash");
 
 // currency amount (common)
 SF_Amount const sfAmount(access, STI_AMOUNT, 1, "Amount");

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -131,6 +131,7 @@ SF_U64 const sfLowNode(access, STI_UINT64, 7, "LowNode");
 SF_U64 const sfHighNode(access, STI_UINT64, 8, "HighNode");
 SF_U64 const sfDestinationNode(access, STI_UINT64, 9, "DestinationNode");
 SF_U64 const sfCookie(access, STI_UINT64, 10, "Cookie");
+SF_U64 const sfServerVersion(access, STI_UINT64, 11, "ServerVersion");
 
 // 128-bit
 SF_U128 const sfEmailHash(access, STI_HASH128, 1, "EmailHash");

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -47,6 +47,7 @@ STValidation::validationFormat()
         {sfConsensusHash, soeOPTIONAL},
         {sfCookie, soeDEFAULT},
         {sfValidatedHash, soeOPTIONAL},
+        {sfServerVersion, soeOPTIONAL},
     };
 
     return format;

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -35,16 +35,11 @@ class RCLValidations_test : public beast::unit_test::suite
         testcase("Change validation trusted status");
         auto keys = randomKeyPair(KeyType::secp256k1);
         auto v = std::make_shared<STValidation>(
-            uint256(),
-            1,
-            uint256(),
-            NetClock::time_point(),
+            ripple::NetClock::time_point{},
             keys.first,
             keys.second,
             calcNodeID(keys.first),
-            true,
-            STValidation::FeeSettings{},
-            std::vector<uint256>{});
+            [&](STValidation& v) {});
 
         BEAST_EXPECT(v->isTrusted());
         v->setUntrusted();

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -54,7 +54,7 @@ class Validations_test : public beast::unit_test::suite
         clock_type const& c_;
         PeerID nodeID_;
         bool trusted_ = true;
-        std::size_t signIdx_ = 1;
+        std::size_t signIdx_{1};
         boost::optional<std::uint32_t> loadFee_;
 
     public:
@@ -394,7 +394,7 @@ class Validations_test : public beast::unit_test::suite
 
                 // If we advance far enough for AB to expire, we can fully
                 // validate or partially validate that sequence number again
-                BEAST_EXPECT(ValStatus::badSeq == process(ledgerAZ));
+                BEAST_EXPECT(ValStatus::conflicting == process(ledgerAZ));
                 harness.clock().advance(
                     harness.parms().validationSET_EXPIRES + 1ms);
                 BEAST_EXPECT(ValStatus::current == process(ledgerAZ));
@@ -683,8 +683,10 @@ class Validations_test : public beast::unit_test::suite
                 trustedValidations[val.ledgerID()].emplace_back(val);
         }
         // d now thinks ledger 1, but cannot re-issue a previously used seq
+        // and attempting it should generate a conflict.
         {
-            BEAST_EXPECT(ValStatus::badSeq == harness.add(d.partial(ledgerA)));
+            BEAST_EXPECT(
+                ValStatus::conflicting == harness.add(d.partial(ledgerA)));
         }
         // e only issues partials
         {

--- a/src/test/csf/Validation.h
+++ b/src/test/csf/Validation.h
@@ -55,6 +55,7 @@ class Validation
     bool trusted_ = false;
     bool full_ = false;
     boost::optional<std::uint32_t> loadFee_;
+    std::uint64_t cookie_{0};
 
 public:
     using NodeKey = PeerKey;
@@ -68,7 +69,8 @@ public:
         PeerKey key,
         PeerID nodeID,
         bool full,
-        boost::optional<std::uint32_t> loadFee = boost::none)
+        boost::optional<std::uint32_t> loadFee = boost::none,
+        std::uint64_t cookie = 0)
         : ledgerID_{id}
         , seq_{seq}
         , signTime_{sign}
@@ -77,6 +79,7 @@ public:
         , nodeID_{nodeID}
         , full_{full}
         , loadFee_{loadFee}
+        , cookie_{cookie}
     {
     }
 
@@ -126,6 +129,12 @@ public:
     full() const
     {
         return full_;
+    }
+
+    std::uint64_t
+    cookie() const
+    {
+        return cookie_;
     }
 
     boost::optional<std::uint32_t>
@@ -191,4 +200,5 @@ public:
 }  // namespace csf
 }  // namespace test
 }  // namespace ripple
+
 #endif

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -370,6 +370,7 @@ public:
 
             // Check stream update
             using namespace std::chrono_literals;
+
             BEAST_EXPECT(wsc->findMsg(5s, [&](auto const& jv) {
                 return jv[jss::type] == "validationReceived" &&
                     jv[jss::validation_public_key].asString() == valPublicKey &&
@@ -378,7 +379,7 @@ public:
                     jv[jss::ledger_index] ==
                     std::to_string(env.closed()->info().seq) &&
                     jv[jss::flags] ==
-                    (vfFullyCanonicalSig | STValidation::kFullFlag) &&
+                    (vfFullyCanonicalSig | vfFullValidation) &&
                     jv[jss::full] == true && !jv.isMember(jss::load_fee) &&
                     jv[jss::signature] && jv[jss::signing_time];
             }));


### PR DESCRIPTION
This PR contains three separate commits:

### Remove obsolete TTL fields
Proposals and validations include a TTL field. This was part of an earlier idea which never really materialized. The fields were never really used in practice (a TTL value is not set by default). This change simply makes this official: the fields are deprecated, should not be used and are not coming back.

Ripple engineers will be implementing the system outlined by @JoelKatz in this [post](https://www.xrpchat.com/topic/33075-suggestion-reduce-relaying/).

### Include version in validations

Currently, it is impossible to know what version of the software a given validator is running. This information is useful for server operators, for developing who are putting together dashboards, and the community at large.

This change adds a "packed" version in a validation message. The message will, by default, only be sent every 256 ledgers.

### Harden validations

Several changes are included in this PR.

1. Track how many validations a given server publishes for a given ledger. This should be precisely one. When such validations are detected, the server will now log a message to notify server operators of this issue.
2. The commit adds a 64-bit "cookie" in every validation which can be used to _attempt_ to decipher whether multiple validations are the result of accidental misconfiguration vs. outright byzantine behavior. It is important to note that a malicious validator operator can manipulate the cookie.
3. Adds the hash of the last ledger a validator considers to be fully validated in the validation message.