### PR TITLE
Travis CI VS2019 build error fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -344,7 +344,9 @@ matrix:
       install:
         - choco upgrade cmake.install
         - choco install ninja visualstudio2017-workload-vctools -y
-        - choco install visualstudio2019buildtools visualstudio2019community visualstudio2019-workload-vctools -y
+        #Force install 14.24 to fix build issue. TODO - this should be deleted when rocksdb fixes their issue with the new compiler.
+        - choco install visualstudio2019buildtools visualstudio2019community -y
+        - choco install visualstudio2019-workload-vctools --package-parameters "--add Microsoft.VisualStudio.Component.VC.14.24.x86.x64" -y
       script:
         - export BOOST_TOOLSET=msvc-14.1
         - travis_wait ${MAX_TIME_MIN} Builds/containers/shared/install_boost.sh
@@ -383,7 +385,9 @@ matrix:
       install:
         - choco upgrade cmake.install
         - choco install ninja -y
-        - choco install visualstudio2019buildtools visualstudio2019community visualstudio2019-workload-vctools -y
+        #Force install 14.24 to fix build issue. TODO - this should be deleted when rocksdb fixes their issue with the new compiler.
+        - choco install visualstudio2019buildtools visualstudio2019community -y
+        - choco install visualstudio2019-workload-vctools --package-parameters "--add Microsoft.VisualStudio.Component.VC.14.24.x86.x64" -y
       before_script:
         - export BLD_CONFIG=Release
         # we want to use the boost build from cache, which was built using the

--- a/bin/sh/setup-msvc.sh
+++ b/bin/sh/setup-msvc.sh
@@ -22,6 +22,10 @@ while read line ; do
     fi
   fi
 done <<EOL
+"C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64 -vcvars_ver=14.24
+"C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64 -vcvars_ver=14.24
+"C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64 -vcvars_ver=14.24
+"C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64 -vcvars_ver=14.24
 "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
 "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
 "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build/vcvarsall.bat" x86_amd64
@@ -32,6 +36,8 @@ done <<EOL
 "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/vcvarsall.bat" amd64
 EOL
 # TODO: update the list above as needed to support newer versions of msvc tools
+# MSVC 19.25.28610.4 causes the rocksdb's compilation to fail, for VS2019, we will choose 14.24 VCTools for now
+# TODO: Delete lines with -vcars_ver=14.24 once rocksdb becomes compatible with newer compiler version.
 
 rm -f getenv.bat
 


### PR DESCRIPTION
vs_buildtools.exe automatically downloads the newest compiler and the most recent release of MSVC 19.25.28610.4 fails to build rocksdb. This fix forces choco (windows package manager) to download MSVC 19.24.28314.0 for VS2019 builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3303)
<!-- Reviewable:end -->
