### PR TITLE
Add ledger_cleaner command to rippled cmd line help

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -150,6 +150,7 @@ void printHelp (const po::options_description& desc)
            "     json <method> <json>\n"
            "     ledger [<id>|current|closed|validated] [full]\n"
            "     ledger_accept\n"
+           "     ledger_cleaner\n"
            "     ledger_closed\n"
            "     ledger_current\n"
            "     ledger_request <ledger>\n"


### PR DESCRIPTION
Resolves #3277 by adding the ledger_cleaner command to the rippled help.

Because there is no [command parser](https://github.com/ripple/rippled/blob/develop/src/ripple/net/impl/RPCCall.cpp#L1158) which maps ledger_cleaner command line parameters to RPC Call params, the command is always invoked w/ the default params. This can be changed with a subsequent PR.