### PR TITLE
Adds new 'ledgers' RPC command - return multiple ledgers with one request

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -578,6 +578,7 @@ target_sources (rippled PRIVATE
   src/ripple/rpc/handlers/LedgerData.cpp
   src/ripple/rpc/handlers/LedgerEntry.cpp
   src/ripple/rpc/handlers/LedgerHandler.cpp
+  src/ripple/rpc/handlers/LedgersHandler.cpp
   src/ripple/rpc/handlers/LedgerHeader.cpp
   src/ripple/rpc/handlers/LedgerRequest.cpp
   src/ripple/rpc/handlers/LogLevel.cpp

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -297,6 +297,7 @@ JSS ( last_refresh_message );       // out: ValidatorSite
 JSS ( ledger );                     // in: NetworkOPs, LedgerCleaner,
                                     //     RPCHelpers
                                     // out: NetworkOPs, PeerImp
+JSS ( ledgers );
 JSS ( ledger_current_index );       // out: NetworkOPs, RPCHelpers,
                                     //      LedgerCurrent, LedgerAccept,
                                     //      AccountLines
@@ -307,8 +308,11 @@ JSS ( ledger_hash );                // in: RPCHelpers, LedgerRequest,
                                     // out: NetworkOPs, RPCHelpers,
                                     //      LedgerClosed, LedgerData,
                                     //      AccountLines
+JSS ( ledger_hashes );              // in: RPCHelpers, LedgerRequest
 JSS ( ledger_hit_rate );            // out: GetCounts
 JSS ( ledger_index );               // in/out: many
+JSS ( ledger_indexes );             // in: RPCHelpers, LedgerRequest
+JSS ( ledger_index_range );         // in: RPCHelpers, LedgerRequest
 JSS ( ledger_index_max );           // in, out: AccountTx*
 JSS ( ledger_index_min );           // in, out: AccountTx*
 JSS ( ledger_max );                 // in, out: AccountTx*

--- a/src/ripple/rpc/handlers/Handlers.h
+++ b/src/ripple/rpc/handlers/Handlers.h
@@ -21,6 +21,7 @@
 #define RIPPLE_RPC_HANDLERS_HANDLERS_H_INCLUDED
 
 #include <ripple/rpc/handlers/LedgerHandler.h>
+#include <ripple/rpc/handlers/LedgersHandler.h>
 
 namespace ripple {
 

--- a/src/ripple/rpc/handlers/LedgersHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgersHandler.cpp
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Dev Null Productions, LLC
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/rpc/handlers/LedgersHandler.h>
+#include <ripple/app/ledger/LedgerToJson.h>
+#include <ripple/app/main/Application.h>
+#include <ripple/app/misc/LoadFeeTrack.h>
+#include <ripple/json/Object.h>
+#include <ripple/protocol/ErrorCodes.h>
+#include <ripple/protocol/jss.h>
+#include <ripple/resource/Fees.h>
+#include <ripple/rpc/impl/RPCHelpers.h>
+#include <ripple/rpc/Role.h>
+
+namespace ripple {
+namespace RPC {
+
+LedgersHandler::LedgersHandler (JsonContext& context) : context_ (context)
+{
+}
+
+Status LedgersHandler::check()
+{
+    auto const& params = context_.params;
+    bool needsLedger =
+            params.isMember (jss::ledger_hashes) ||
+            params.isMember (jss::ledger_indexes) ||
+            params.isMember (jss::ledger_index_range);
+    if (! needsLedger)
+        return Status::OK;
+
+    if (auto s = lookupLedgers (ledgers_, context_))
+        return s;
+
+    bool const full = params[jss::full].asBool();
+    bool const transactions = params[jss::transactions].asBool();
+    bool const accounts = params[jss::accounts].asBool();
+    bool const expand = params[jss::expand].asBool();
+    bool const binary = params[jss::binary].asBool();
+    bool const owner_funds = params[jss::owner_funds].asBool();
+
+    options_ = (full ? LedgerFill::full : 0)
+            | (expand ? LedgerFill::expand : 0)
+            | (transactions ? LedgerFill::dumpTxrp : 0)
+            | (accounts ? LedgerFill::dumpState : 0)
+            | (binary ? LedgerFill::binary : 0)
+            | (owner_funds ? LedgerFill::ownerFunds : 0);
+
+    if (full || accounts)
+    {
+        // Until some sane way to get full ledgers has been implemented,
+        // disallow retrieving all state nodes.
+        if (! isUnlimited (context_.role))
+            return rpcNO_PERMISSION;
+
+        if (context_.app.getFeeTrack().isLoadedLocal() &&
+            ! isUnlimited (context_.role))
+        {
+            return rpcTOO_BUSY;
+        }
+        context_.loadType = binary ? Resource::feeMediumBurdenRPC :
+            Resource::feeHighBurdenRPC;
+    }
+
+    return Status::OK;
+}
+
+} // RPC
+} // ripple

--- a/src/ripple/rpc/handlers/LedgersHandler.h
+++ b/src/ripple/rpc/handlers/LedgersHandler.h
@@ -1,0 +1,102 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Dev Null Productions, LLC
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_RPC_HANDLERS_LEDGERS_H_INCLUDED
+#define RIPPLE_RPC_HANDLERS_LEDGERS_H_INCLUDED
+
+#include <ripple/app/main/Application.h>
+#include <ripple/app/ledger/LedgerToJson.h>
+#include <ripple/ledger/ReadView.h>
+#include <ripple/json/Object.h>
+#include <ripple/protocol/jss.h>
+#include <ripple/rpc/Context.h>
+#include <ripple/rpc/Status.h>
+#include <ripple/rpc/impl/Handler.h>
+#include <ripple/rpc/Role.h>
+
+namespace Json {
+class Object;
+}
+
+namespace ripple {
+namespace RPC {
+
+struct JsonContext;
+
+// ledgers [ids|indexes|index_range] [full]
+// {
+//    ledger: 'current' | 'closed' | <uint256> | <number>,  // optional
+//    full: true | false    // optional, defaults to false.
+// }
+
+class LedgersHandler {
+public:
+    explicit LedgersHandler (JsonContext&);
+
+    Status check ();
+
+    template <class Object>
+    void writeResult (Object&);
+
+    static char const* name()
+    {
+        return "ledgers";
+    }
+
+    static Role role()
+    {
+        return Role::USER;
+    }
+
+    static Condition condition()
+    {
+        return NO_CONDITION;
+    }
+
+private:
+    JsonContext& context_;
+    std::vector<std::shared_ptr<ReadView const>> ledgers_;
+    int options_ = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+//
+// Implementation.
+
+// TODO support multiple-ledgers, range of ledgers
+
+template <class Object>
+void LedgersHandler::writeResult (Object& value)
+{
+    Json::Value array(Json::arrayValue);
+
+    for(uint l = 0; l < ledgers_.size(); ++l){
+        Json::Value lvalue;
+        addJson(lvalue, {*ledgers_[l], options_});
+        array.append(lvalue);
+    }
+
+    value[jss::ledgers] = array;
+}
+
+} // RPC
+} // ripple
+
+#endif

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -145,6 +145,7 @@ class HandlerTable {
             // This is where the new-style handlers are added.
             // This is also where different versions of handlers are added.
             addHandler<LedgerHandler>(v);
+            addHandler<LedgersHandler>(v);
             addHandler<VersionHandler>(v);
         }
     }

--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -130,6 +130,9 @@ lookupLedger (std::shared_ptr<ReadView const>&, JsonContext&);
 Status
 lookupLedger (std::shared_ptr<ReadView const>&, JsonContext&, Json::Value& result);
 
+Status
+lookupLedgers (std::vector<std::shared_ptr<ReadView const>>&, JsonContext&);
+
 template <class T>
 Status
 ledgerFromRequest(


### PR DESCRIPTION
Ledgers to be retrieved can be specified via the following params:

- ledger_hashes: array of specific hashes to retrieve
- ledger_indexes: array of specific indexes to retrieve
- ledger_index_range: range of indexes specified by first/last

This would be of use in the "ledgers" section in [xrp1ntel](https://xrp1ntel.com/ledgers) where we would use it to render statistics pertaining to a range of ledgers in a terse manner.