### PR TITLE
[TRIVIAL] Remove all uses of the name scoped_lock

### DIFF
--- a/src/ripple/core/impl/semaphore.h
+++ b/src/ripple/core/impl/semaphore.h
@@ -29,8 +29,6 @@ template <class Mutex, class CondVar>
 class basic_semaphore
 {
 private:
-    using scoped_lock = std::unique_lock <Mutex>;
-
     Mutex m_mutex;
     CondVar m_cond;
     std::size_t m_count;
@@ -49,7 +47,7 @@ public:
     /** Increment the count and unblock one waiting thread. */
     void notify ()
     {
-        scoped_lock lock (m_mutex);
+        std::lock_guard lock{m_mutex};
         ++m_count;
         m_cond.notify_one ();
     }
@@ -57,7 +55,7 @@ public:
     /** Block until notify is called. */
     void wait ()
     {
-        scoped_lock lock (m_mutex);
+        std::unique_lock lock{m_mutex};
         while (m_count == 0)
             m_cond.wait (lock);
         --m_count;
@@ -68,7 +66,7 @@ public:
     */
     bool try_wait ()
     {
-        scoped_lock lock (m_mutex);
+        std::lock_guard lock{m_mutex};
         if (m_count == 0)
             return false;
         --m_count;


### PR DESCRIPTION
*  scoped_lock is now a std name with subtly different semantics
   compared to lock_guard.  Namely it can be used to lock 0 or
   more mutexes.  This is valuable, but can also be accidentally
   used to lock 0 mutexes when 1 was intended, creating a
   run-time error.

   Therefore, if and when we use scoped_lock, extra care needs to
   be taken in reviewing that code to ensure it doesn't
   accidentally lock 0 mutexes when 1 was intended.  To aid in
   such careful reviewing, the use of the name scoped_lock should
   be limited to those cases where the number of mutexes is not
   exactly one.

More in-depth rationale is here: https://stackoverflow.com/a/60172828/576911