### PR TITLE
[TRIVIAL] document the 'devnet' network identifier setting

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -746,6 +746,7 @@
 #
 #   main    -> 0
 #   testnet -> 1
+#   devnet  -> 2
 #
 #   If this value is not specified the server is not explicitly configured
 #   to track a particular network.


### PR DESCRIPTION
The [network_id] option allows three string values: "main", "testnet", and "devnet" in addition to unsigned integers.