### PR TITLE
Improve online delete backend lock

### DIFF
--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -427,13 +427,14 @@ SHAMapStoreImp::run()
             }
 
             lastRotated_ = validatedSeq;
-            state_db_.setState(SavedState {
-                newBackend->getName(),
-                dbRotating_->getName(),
-                lastRotated_});
-
             clearCaches(validatedSeq);
-            dbRotating_->rotateBackends(std::move(newBackend));
+
+            SavedState savedState;
+            savedState.writableDb = newBackend->getName();
+            savedState.archiveDb = dbRotating_->rotateBackends(
+                std::move(newBackend));
+            savedState.lastRotated = lastRotated_;
+            state_db_.setState(savedState);
 
             JLOG(journal_.warn()) << "finished rotation " << validatedSeq;
         }

--- a/src/ripple/nodestore/DatabaseRotating.h
+++ b/src/ripple/nodestore/DatabaseRotating.h
@@ -47,11 +47,13 @@ public:
     virtual TaggedCache<uint256, NodeObject> const&
     getPositiveCache() = 0;
 
-    /** Returns the name of the rotated backend.
+    /** Rotates the backends.
+
+        @param f A function executed before the rotation and under the same lock
     */
-    virtual
-    std::string
-    rotateBackends(std::shared_ptr<Backend> newBackend) = 0;
+    virtual void
+    rotateWithLock(std::function<std::unique_ptr<NodeStore::Backend>(
+                       std::string const& writableBackendName)> const& f) = 0;
 };
 
 }  // namespace NodeStore

--- a/src/ripple/nodestore/DatabaseRotating.h
+++ b/src/ripple/nodestore/DatabaseRotating.h
@@ -47,16 +47,9 @@ public:
     virtual TaggedCache<uint256, NodeObject> const&
     getPositiveCache() = 0;
 
-    virtual std::mutex&
-    peekMutex() const = 0;
-
-    virtual std::shared_ptr<Backend> const&
-    getWritableBackend() const = 0;
-
-    virtual std::shared_ptr<Backend>
-    rotateBackends(
-        std::shared_ptr<Backend> newBackend,
-        std::lock_guard<std::mutex> const&) = 0;
+    virtual
+    void
+    rotateBackends(std::shared_ptr<Backend> newBackend) = 0;
 };
 
 }  // namespace NodeStore

--- a/src/ripple/nodestore/DatabaseRotating.h
+++ b/src/ripple/nodestore/DatabaseRotating.h
@@ -47,8 +47,10 @@ public:
     virtual TaggedCache<uint256, NodeObject> const&
     getPositiveCache() = 0;
 
+    /** Returns the name of the rotated backend.
+    */
     virtual
-    void
+    std::string
     rotateBackends(std::shared_ptr<Backend> newBackend) = 0;
 };
 

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -49,8 +49,10 @@ public:
         stopThreads();
     }
 
-    std::string
-    rotateBackends(std::shared_ptr<Backend> newBackend) override;
+    void
+    rotateWithLock(
+        std::function<std::unique_ptr<NodeStore::Backend>(
+            std::string const& writableBackendName)> const& f) override;
 
     std::string
     getName() const override;
@@ -125,7 +127,7 @@ private:
     fetchFrom(uint256 const& hash, std::uint32_t seq) override;
 
     void
-    for_each(std::function <void(std::shared_ptr<NodeObject>)> f) override;
+    for_each(std::function<void(std::shared_ptr<NodeObject>)> f) override;
 };
 
 }  // namespace NodeStore

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -49,7 +49,7 @@ public:
         stopThreads();
     }
 
-    void
+    std::string
     rotateBackends(std::shared_ptr<Backend> newBackend) override;
 
     std::string

--- a/src/ripple/nodestore/impl/DatabaseRotatingImp.h
+++ b/src/ripple/nodestore/impl/DatabaseRotatingImp.h
@@ -49,41 +49,17 @@ public:
         stopThreads();
     }
 
-    std::shared_ptr<Backend> const&
-    getWritableBackend() const override
-    {
-        std::lock_guard lock(rotateMutex_);
-        return writableBackend_;
-    }
-
-    std::shared_ptr<Backend>
-    rotateBackends(
-        std::shared_ptr<Backend> newBackend,
-        std::lock_guard<std::mutex> const&) override;
-
-    std::mutex&
-    peekMutex() const override
-    {
-        return rotateMutex_;
-    }
+    void
+    rotateBackends(std::shared_ptr<Backend> newBackend) override;
 
     std::string
-    getName() const override
-    {
-        return getWritableBackend()->getName();
-    }
+    getName() const override;
 
     std::int32_t
-    getWriteLoad() const override
-    {
-        return getWritableBackend()->getWriteLoad();
-    }
+    getWriteLoad() const override;
 
     void
-    import(Database& source) override
-    {
-        importInternal(*getWritableBackend(), source);
-    }
+    import(Database& source) override;
 
     void
     store(
@@ -105,11 +81,7 @@ public:
         std::shared_ptr<NodeObject>& object) override;
 
     bool
-    storeLedger(std::shared_ptr<Ledger const> const& srcLedger) override
-    {
-        return Database::storeLedger(
-            *srcLedger, getWritableBackend(), pCache_, nCache_, nullptr);
-    }
+    storeLedger(std::shared_ptr<Ledger const> const& srcLedger) override;
 
     int
     getDesiredAsyncReadCount(std::uint32_t seq) override
@@ -147,31 +119,13 @@ private:
 
     std::shared_ptr<Backend> writableBackend_;
     std::shared_ptr<Backend> archiveBackend_;
-    mutable std::mutex rotateMutex_;
-
-    struct Backends
-    {
-        std::shared_ptr<Backend> const& writableBackend;
-        std::shared_ptr<Backend> const& archiveBackend;
-    };
-
-    Backends
-    getBackends() const
-    {
-        std::lock_guard lock(rotateMutex_);
-        return Backends{writableBackend_, archiveBackend_};
-    }
+    mutable std::mutex mutex_;
 
     std::shared_ptr<NodeObject>
     fetchFrom(uint256 const& hash, std::uint32_t seq) override;
 
     void
-    for_each(std::function<void(std::shared_ptr<NodeObject>)> f) override
-    {
-        Backends b = getBackends();
-        b.archiveBackend->for_each(f);
-        b.writableBackend->for_each(f);
-    }
+    for_each(std::function <void(std::shared_ptr<NodeObject>)> f) override;
 };
 
 }  // namespace NodeStore


### PR DESCRIPTION
Addresses a possibility in the online delete process where one or more backend shared pointer references may become invalid during rotation.