### PR TITLE
[Trivial] Reduce strand re-execute log message severity from error to warning:

### DIFF
--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -964,7 +964,7 @@ BookStep<TIn, TOut, TDerived>::validFwd (
     if (!(checkNear (savCache.in, cache_->in) &&
             checkNear (savCache.out, cache_->out)))
     {
-        JLOG (j_.error()) <<
+        JLOG (j_.warn()) <<
             "Strand re-execute check failed." <<
             " ExpectedIn: " << to_string (savCache.in) <<
             " CachedIn: " << to_string (cache_->in) <<

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -725,7 +725,7 @@ DirectStepI<TDerived>::validFwd (
 
     if (maxSrcToDst < cache_->srcToDst)
     {
-        JLOG (j_.error()) <<
+        JLOG (j_.warn()) <<
             "DirectStepI: Strand re-execute check failed." <<
             " Exceeded max src->dst limit" <<
             " max src->dst: " << to_string (maxSrcToDst) <<
@@ -736,7 +736,7 @@ DirectStepI<TDerived>::validFwd (
     if (!(checkNear (savCache.in, cache_->in) &&
           checkNear (savCache.out, cache_->out)))
     {
-        JLOG (j_.error()) <<
+        JLOG (j_.warn()) <<
             "DirectStepI: Strand re-execute check failed." <<
             " ExpectedIn: " << to_string (savCache.in) <<
             " CachedIn: " << to_string (cache_->in) <<

--- a/src/ripple/app/paths/impl/StrandFlow.h
+++ b/src/ripple/app/paths/impl/StrandFlow.h
@@ -251,7 +251,7 @@ flow (
                     strand[i]->validFwd (checkSB, checkAfView, stepIn);
                 if (!valid)
                 {
-                    JLOG (j.error())
+                    JLOG (j.warn())
                         << "Strand re-execute check failed. Step: " << i;
                     break;
                 }

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -315,7 +315,7 @@ XRPEndpointStep<TDerived>::validFwd (
 
     if (!isLast_ && balance < xrpIn)
     {
-        JLOG (j_.error()) << "XRPEndpointStep: Strand re-execute check failed."
+        JLOG (j_.warn()) << "XRPEndpointStep: Strand re-execute check failed."
             << " Insufficient balance: " << to_string (balance)
             << " Requested: " << to_string (xrpIn);
         return {false, EitherAmount (balance)};
@@ -323,7 +323,7 @@ XRPEndpointStep<TDerived>::validFwd (
 
     if (xrpIn != *cache_)
     {
-        JLOG (j_.error()) << "XRPEndpointStep: Strand re-execute check failed."
+        JLOG (j_.warn()) << "XRPEndpointStep: Strand re-execute check failed."
             << " ExpectedIn: " << to_string (*cache_)
             << " CachedIn: " << to_string (xrpIn);
     }


### PR DESCRIPTION
Historically strand re-execute log messages have been treated as errors.  However in the vast majority of cases these log messages are caused by well understood mechanics in the payment engine.  So usually these log messages should be treated as warnings.