### PR TITLE
Add featureRetire2017Amendments:

### DIFF
--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -37,7 +37,7 @@ public:
     virtual ~AmendmentTable() = default;
 
     virtual uint256
-    find(std::string const& name) = 0;
+    find(std::string const& name) const = 0;
 
     virtual bool
     veto(uint256 const& amendment) = 0;
@@ -46,13 +46,17 @@ public:
 
     virtual bool
     enable(uint256 const& amendment) = 0;
+
+    // Only retire enabled unconditional amendments!
+    // Returns true if amendment removed,
+    // false if amendment already gone or not enabled.
     virtual bool
-    disable(uint256 const& amendment) = 0;
+    retire(uint256 const& amendment) = 0;
 
     virtual bool
-    isEnabled(uint256 const& amendment) = 0;
+    isEnabled(uint256 const& amendment) const = 0;
     virtual bool
-    isSupported(uint256 const& amendment) = 0;
+    isSupported(uint256 const& amendment) const = 0;
 
     /**
      * @brief returns true if one or more amendments on the network
@@ -61,16 +65,17 @@ public:
      * @return true if an unsupported feature is enabled on the network
      */
     virtual bool
-    hasUnsupportedEnabled() = 0;
+    hasUnsupportedEnabled() const = 0;
+
     virtual boost::optional<NetClock::time_point>
-    firstUnsupportedExpected() = 0;
+    firstUnsupportedExpected() const = 0;
 
     virtual Json::Value
-    getJson(int) = 0;
+    getJson() const = 0;
 
     /** Returns a Json::objectValue. */
     virtual Json::Value
-    getJson(uint256 const&) = 0;
+    getJson(uint256 const& amendment) const = 0;
 
     /** Called when a new fully-validated ledger is accepted. */
     void
@@ -81,20 +86,22 @@ public:
             doValidatedLedger(
                 lastValidatedLedger->seq(),
                 getEnabledAmendments(*lastValidatedLedger),
-                getMajorityAmendments(*lastValidatedLedger));
+                getMajorityAmendments(*lastValidatedLedger),
+                lastValidatedLedger->rules());
     }
 
     /** Called to determine whether the amendment logic needs to process
         a new validated ledger. (If it could have changed things.)
     */
     virtual bool
-    needValidatedLedger(LedgerIndex seq) = 0;
+    needValidatedLedger(LedgerIndex seq) const = 0;
 
     virtual void
     doValidatedLedger(
         LedgerIndex ledgerSeq,
         std::set<uint256> const& enabled,
-        majorityAmendments_t const& majority) = 0;
+        majorityAmendments_t const& majority,
+        Rules const& rules) = 0;
 
     // Called by the consensus code when we need to
     // inject pseudo-transactions
@@ -108,14 +115,14 @@ public:
     // Called by the consensus code when we need to
     // add feature entries to a validation
     virtual std::vector<uint256>
-    doValidation(std::set<uint256> const& enabled) = 0;
+    doValidation(std::set<uint256> const& enabled) const = 0;
 
     // The set of amendments to enable in the genesis ledger
     // This will return all known, non-vetoed amendments.
     // If we ever have two amendments that should not both be
     // enabled at the same time, we should ensure one is vetoed.
     virtual std::vector<uint256>
-    getDesired() = 0;
+    getDesired() const = 0;
 
     // The function below adapts the API callers expect to the
     // internal amendment table API. This allows the amendment

--- a/src/ripple/app/misc/README.md
+++ b/src/ripple/app/misc/README.md
@@ -62,32 +62,32 @@ of the administrator to set these values.
 
 # Amendment
 
-An Amendment is a new or proposed change to a ledger rule. Ledger rules affect 
-transaction processing and consensus; peers must use the same set of rules for 
-consensus to succeed, otherwise different instances of rippled will get 
-different results. Amendments can be almost anything but they must be accepted 
-by a network majority through a consensus process before they are utilized. An 
-Amendment must receive at least an 80% approval rate from validating nodes for 
-a period of two weeks before being accepted. The following example outlines the 
-process of an Amendment from its conception to approval and usage. 
+An Amendment is a new or proposed change to a ledger rule. Ledger rules affect
+transaction processing and consensus; peers must use the same set of rules for
+consensus to succeed, otherwise different instances of rippled will get
+different results. Amendments can be almost anything but they must be accepted
+by a network majority through a consensus process before they are utilized. An
+Amendment must receive at least an 80% approval rate from validating nodes for
+a period of two weeks before being accepted. The following example outlines the
+process of an Amendment from its conception to approval and usage.
 
-*  A community member makes proposes to change transaction processing in some 
-  way. The proposal is discussed amongst the community and receives its support 
-  creating a community or human consensus. 
+*  A community member proposes to change transaction processing in some way.
+  The proposal is discussed amongst the community and receives its support
+  creating a community or human consensus.
 
 *  Some members contribute their time and work to develop the Amendment.
 
-*  A pull request is created and the new code is folded into a rippled build 
+*  A pull request is created and the new code is folded into a rippled build
   and made available for use.
 
 *  The consensus process begins with the validating nodes.
 
-*  If the Amendment holds an 80% majority for a two week period, nodes will begin 
+*  If the Amendment holds an 80% majority for a two week period, nodes will begin
   including the transaction to enable it in their initial sets.
 
-Nodes may veto Amendments they consider undesirable by never announcing their 
-support for those Amendments. Just a few nodes vetoing an Amendment will normally 
-keep it from being accepted. Nodes could also vote yes on an Amendments even 
+Nodes may veto Amendments they consider undesirable by never announcing their
+support for those Amendments. Just a few nodes vetoing an Amendment will normally
+keep it from being accepted. Nodes could also vote yes on an Amendments even
 before it obtains a super-majority. This might make sense for a critical bug fix.
 
 Validators that support an amendment that is not yet enabled announce their
@@ -101,7 +101,7 @@ the majority status from the ledger.
 If an amendment holds majority status for two weeks, validators will
 introduce a pseudo-transaction to enable the amendment.
 
-All amednements are assumed to be critical and irreversible. Thus there
+All amendments are assumed to be critical and irreversible. Thus there
 is no mechanism to disable or revoke an amendment, nor is there a way
 for a server to operate while an amendment it does not understand is
 enabled.

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -69,29 +69,30 @@ namespace detail {
 
 class FeatureCollections
 {
+    // clang-format off
     static constexpr char const* const featureNames[] = {
-        "MultiSign",  // Unconditionally supported.
+        "MultiSign",            // Retired
         "Tickets",
-        "TrustSetAuth",   // Unconditionally supported.
-        "FeeEscalation",  // Unconditionally supported.
+        "TrustSetAuth",         // Retired
+        "FeeEscalation",        // Retired
         "OwnerPaysFee",
-        "PayChan",
-        "Flow",  // Unconditionally supported.
+        "PayChan",              // Retired
+        "Flow",                 // Retired
         "CompareTakerFlowCross",
         "FlowCross",
-        "CryptoConditions",
-        "TickSize",
-        "fix1368",
-        "Escrow",
+        "CryptoConditions",     // Retired
+        "TickSize",             // Retired
+        "fix1368",              // Retired
+        "Escrow",               // Retired
         "CryptoConditionsSuite",
-        "fix1373",
-        "EnforceInvariants",
-        "SortedDirectories",
-        "fix1201",
-        "fix1512",
+        "fix1373",              // Retired
+        "EnforceInvariants",    // Retired
+        "SortedDirectories",    // Retired
+        "fix1201",              // Retired
+        "fix1512",              // Retired
         "fix1513",
-        "fix1523",
-        "fix1528",
+        "fix1523",              // Retired
+        "fix1528",              // Retired
         "DepositAuth",
         "Checks",
         "fix1571",
@@ -106,12 +107,12 @@ class FeatureCollections
         "fixCheckThreading",
         "fixPayChanRecipientOwnerDir",
         "DeletableAccounts",
-        // fixQualityUpperBound should be activated before FlowCross
-        "fixQualityUpperBound",
+        "fixQualityUpperBound",   // Should be activated before FlowCross
         "RequireFullyCanonicalSig",
-        "fix1781",  // XRPEndpointSteps should be included in the circular
-                    // payment check
+        "fix1781",  // Include XRPEndpointSteps in the circular payment check
+        "Retire2017Amendments",
     };
+    // clang-format on
 
     std::vector<uint256> features;
     boost::container::flat_map<uint256, std::size_t> featureToIndex;
@@ -139,6 +140,11 @@ public:
 /** Amendments that this server supports, but doesn't enable by default */
 std::vector<std::string> const&
 supportedAmendments();
+
+// Enabled Amendments that this server unconditionally supports, and
+// are in the process of being retired.
+std::initializer_list<uint256> const&
+retiringAmendments();
 
 }  // namespace detail
 
@@ -366,21 +372,7 @@ extern uint256 const featureDeletableAccounts;
 extern uint256 const fixQualityUpperBound;
 extern uint256 const featureRequireFullyCanonicalSig;
 extern uint256 const fix1781;
-
-// The following amendments have been active for at least two years.
-// Their pre-amendment code has been removed.
-extern uint256 const retiredPayChan;
-extern uint256 const retiredCryptoConditions;
-extern uint256 const retiredTickSize;
-extern uint256 const retiredFix1368;
-extern uint256 const retiredEscrow;
-extern uint256 const retiredFix1373;
-extern uint256 const retiredEnforceInvariants;
-extern uint256 const retiredSortedDirectories;
-extern uint256 const retiredFix1201;
-extern uint256 const retiredFix1512;
-extern uint256 const retiredFix1523;
-extern uint256 const retiredFix1528;
+extern uint256 const featureRetire2017Amendments;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -80,6 +80,7 @@ static detail::FeatureCollections const featureCollections;
 std::vector<std::string> const&
 detail::supportedAmendments()
 {
+    // clang-format off
     // Commented out amendments will be supported in a future release (and
     // uncommented at that time).
     //
@@ -92,10 +93,10 @@ detail::supportedAmendments()
     // Removing them will cause servers to become amendment blocked.
     static std::vector<std::string> const supported{
         "MultiSign",      // Unconditionally supported.
-                          //        "Tickets",
+//        "Tickets",
         "TrustSetAuth",   // Unconditionally supported.
         "FeeEscalation",  // Unconditionally supported.
-                          //        "OwnerPaysFee",
+//        "OwnerPaysFee",
         "PayChan",
         "Flow",
         "CryptoConditions",
@@ -130,7 +131,9 @@ detail::supportedAmendments()
         "fixQualityUpperBound",
         "RequireFullyCanonicalSig",
         "fix1781",
+        "Retire2017Amendments",
     };
+    // clang-format on
     return supported;
 }
 
@@ -140,6 +143,21 @@ boost::optional<uint256>
 getRegisteredFeature(std::string const& name)
 {
     return featureCollections.getRegisteredFeature(name);
+}
+
+// Used for static initialization.  It's a LogicError if the named feature
+// is missing
+static uint256
+getMandatoryFeature(std::string const& name)
+{
+    boost::optional<uint256> const optFeatureId = getRegisteredFeature(name);
+    if (!optFeatureId)
+    {
+        LogicError(
+            std::string("Requested feature \"") + name +
+            "\" is not registered in FeatureCollections::featureName.");
+    }
+    return *optFeatureId;
 }
 
 size_t
@@ -154,56 +172,93 @@ bitsetIndexToFeature(size_t i)
     return featureCollections.bitsetIndexToFeature(i);
 }
 
-uint256 const featureTickets = *getRegisteredFeature("Tickets");
-uint256 const featureOwnerPaysFee = *getRegisteredFeature("OwnerPaysFee");
-uint256 const featureFlow = *getRegisteredFeature("Flow");
-uint256 const featureCompareTakerFlowCross =
-    *getRegisteredFeature("CompareTakerFlowCross");
-uint256 const featureFlowCross = *getRegisteredFeature("FlowCross");
-uint256 const featureCryptoConditionsSuite =
-    *getRegisteredFeature("CryptoConditionsSuite");
-uint256 const fix1513 = *getRegisteredFeature("fix1513");
-uint256 const featureDepositAuth = *getRegisteredFeature("DepositAuth");
-uint256 const featureChecks = *getRegisteredFeature("Checks");
-uint256 const fix1571 = *getRegisteredFeature("fix1571");
-uint256 const fix1543 = *getRegisteredFeature("fix1543");
-uint256 const fix1623 = *getRegisteredFeature("fix1623");
-uint256 const featureDepositPreauth = *getRegisteredFeature("DepositPreauth");
-uint256 const fix1515 = *getRegisteredFeature("fix1515");
-uint256 const fix1578 = *getRegisteredFeature("fix1578");
-uint256 const featureMultiSignReserve =
-    *getRegisteredFeature("MultiSignReserve");
-uint256 const fixTakerDryOfferRemoval =
-    *getRegisteredFeature("fixTakerDryOfferRemoval");
-uint256 const fixMasterKeyAsRegularKey =
-    *getRegisteredFeature("fixMasterKeyAsRegularKey");
-uint256 const fixCheckThreading = *getRegisteredFeature("fixCheckThreading");
-uint256 const fixPayChanRecipientOwnerDir =
-    *getRegisteredFeature("fixPayChanRecipientOwnerDir");
-uint256 const featureDeletableAccounts =
-    *getRegisteredFeature("DeletableAccounts");
-uint256 const fixQualityUpperBound =
-    *getRegisteredFeature("fixQualityUpperBound");
-uint256 const featureRequireFullyCanonicalSig =
-    *getRegisteredFeature("RequireFullyCanonicalSig");
-uint256 const fix1781 = *getRegisteredFeature("fix1781");
+// clang-format off
+uint256 const featureTickets = getMandatoryFeature("Tickets");
+uint256 const featureOwnerPaysFee = getMandatoryFeature("OwnerPaysFee");
+uint256 const featurePayChan = getMandatoryFeature("PayChan");
+uint256 const featureFlow = getMandatoryFeature("Flow");
+uint256 const featureCompareTakerFlowCross = getMandatoryFeature("CompareTakerFlowCross");
+uint256 const featureFlowCross = getMandatoryFeature("FlowCross");
+uint256 const featureCryptoConditions = getMandatoryFeature("CryptoConditions");
+uint256 const featureTickSize = getMandatoryFeature("TickSize");
+uint256 const fix1368 = getMandatoryFeature("fix1368");
+uint256 const featureEscrow = getMandatoryFeature("Escrow");
+uint256 const featureCryptoConditionsSuite = getMandatoryFeature("CryptoConditionsSuite");
+uint256 const fix1373 = getMandatoryFeature("fix1373");
+uint256 const featureEnforceInvariants = getMandatoryFeature("EnforceInvariants");
+uint256 const featureSortedDirectories = getMandatoryFeature("SortedDirectories");
+uint256 const fix1201 = getMandatoryFeature("fix1201");
+uint256 const fix1512 = getMandatoryFeature("fix1512");
+uint256 const fix1513 = getMandatoryFeature("fix1513");
+uint256 const fix1523 = getMandatoryFeature("fix1523");
+uint256 const fix1528 = getMandatoryFeature("fix1528");
+uint256 const featureDepositAuth = getMandatoryFeature("DepositAuth");
+uint256 const featureChecks = getMandatoryFeature("Checks");
+uint256 const fix1571 = getMandatoryFeature("fix1571");
+uint256 const fix1543 = getMandatoryFeature("fix1543");
+uint256 const fix1623 = getMandatoryFeature("fix1623");
+uint256 const featureDepositPreauth = getMandatoryFeature("DepositPreauth");
+uint256 const fix1515 = getMandatoryFeature("fix1515");
+uint256 const fix1578 = getMandatoryFeature("fix1578");
+uint256 const featureMultiSignReserve = getMandatoryFeature("MultiSignReserve");
+uint256 const fixTakerDryOfferRemoval = getMandatoryFeature("fixTakerDryOfferRemoval");
+uint256 const fixMasterKeyAsRegularKey = getMandatoryFeature("fixMasterKeyAsRegularKey");
+uint256 const fixCheckThreading = getMandatoryFeature("fixCheckThreading");
+uint256 const fixPayChanRecipientOwnerDir = getMandatoryFeature("fixPayChanRecipientOwnerDir");
+uint256 const featureDeletableAccounts = getMandatoryFeature("DeletableAccounts");
+uint256 const fixQualityUpperBound = getMandatoryFeature("fixQualityUpperBound");
+uint256 const featureRequireFullyCanonicalSig = getMandatoryFeature("RequireFullyCanonicalSig");
+uint256 const fix1781 = getMandatoryFeature("fix1781");
+uint256 const featureRetire2017Amendments = getMandatoryFeature("Retire2017Amendments");
 
 // The following amendments have been active for at least two years.
 // Their pre-amendment code has been removed.
-uint256 const retiredPayChan = *getRegisteredFeature("PayChan");
-uint256 const retiredCryptoConditions =
-    *getRegisteredFeature("CryptoConditions");
-uint256 const retiredTickSize = *getRegisteredFeature("TickSize");
-uint256 const retiredFix1368 = *getRegisteredFeature("fix1368");
-uint256 const retiredEscrow = *getRegisteredFeature("Escrow");
-uint256 const retiredFix1373 = *getRegisteredFeature("fix1373");
-uint256 const retiredEnforceInvariants =
-    *getRegisteredFeature("EnforceInvariants");
-uint256 const retiredSortedDirectories =
-    *getRegisteredFeature("SortedDirectories");
-uint256 const retiredFix1201 = *getRegisteredFeature("fix1201");
-uint256 const retiredFix1512 = *getRegisteredFeature("fix1512");
-uint256 const retiredFix1523 = *getRegisteredFeature("fix1523");
-uint256 const retiredFix1528 = *getRegisteredFeature("fix1528");
+//
+// The static retired amendments could hypothetically be moved so they are only
+// inside the detail::retiringAmendments() implementation.  However doing so
+// would postpone the discovery of any construction problems until the first
+// call to retiringAmendments().  By leaving these definitions at file
+// scope any run-time build problems will be revealed before main() is called.
+static uint256 const retiredFeeEscalation = getMandatoryFeature("FeeEscalation");
+static uint256 const retiredMultiSign = getMandatoryFeature("MultiSign");
+static uint256 const retiredTrustSetAuth = getMandatoryFeature("TrustSetAuth");
+static uint256 const retiredFlow = getMandatoryFeature("Flow");
+static uint256 const retiredCryptoConditions = getMandatoryFeature("CryptoConditions");
+static uint256 const retiredTickSize = getMandatoryFeature("TickSize");
+static uint256 const retiredPayChan = getMandatoryFeature("PayChan");
+static uint256 const retiredFix1368 = getMandatoryFeature("fix1368");
+static uint256 const retiredEscrow = getMandatoryFeature("Escrow");
+static uint256 const retiredFix1373 = getMandatoryFeature("fix1373");
+static uint256 const retiredEnforceInvariants = getMandatoryFeature("EnforceInvariants");
+static uint256 const retiredSortedDirectories = getMandatoryFeature("SortedDirectories");
+static uint256 const retiredFix1528 = getMandatoryFeature("fix1528");
+static uint256 const retiredFix1523 = getMandatoryFeature("fix1523");
+static uint256 const retiredFix1512 = getMandatoryFeature("fix1512");
+static uint256 const retiredFix1201 = getMandatoryFeature("fix1201");
+// clang-format on
+
+std::initializer_list<uint256> const&
+detail::retiringAmendments()
+{
+    static std::initializer_list<uint256> const retiring{
+        retiredFeeEscalation,
+        retiredMultiSign,
+        retiredTrustSetAuth,
+        retiredFlow,
+        retiredCryptoConditions,
+        retiredTickSize,
+        retiredPayChan,
+        retiredFix1368,
+        retiredEscrow,
+        retiredFix1373,
+        retiredEnforceInvariants,
+        retiredSortedDirectories,
+        retiredFix1528,
+        retiredFix1523,
+        retiredFix1512,
+        retiredFix1201,
+    };
+    return retiring;
+};
 
 }  // namespace ripple

--- a/src/ripple/rpc/handlers/Feature1.cpp
+++ b/src/ripple/rpc/handlers/Feature1.cpp
@@ -45,7 +45,7 @@ doFeature(RPC::JsonContext& context)
 
     if (!context.params.isMember(jss::feature))
     {
-        auto features = table.getJson(0);
+        auto features = table.getJson();
 
         for (auto const& [h, t] : majorities)
         {
@@ -67,9 +67,9 @@ doFeature(RPC::JsonContext& context)
     if (context.params.isMember(jss::vetoed))
     {
         if (context.params[jss::vetoed].asBool())
-            context.app.getAmendmentTable().veto(feature);
+            table.veto(feature);
         else
-            context.app.getAmendmentTable().unVeto(feature);
+            table.unVeto(feature);
     }
 
     Json::Value jvReply = table.getJson(feature);


### PR DESCRIPTION
If the Retire2017Amendments amendment is activated, then those amendments that are ...

1. Enabled,
2. No longer dependent on runtime amendment checks, and
3. Listed in detail::retiringAmendments() ...

will be removed from the Amendment ledger object and the AmendmentTable.

The motivation for this change is to reduce the number of amendments stored in the Amendment ledger object.  It also reduces noise in the feature RPC command (and source code) regarding amendments that have been enabled for a long time.