### PR TITLE
Add delivered amount to GetAccountTransactionHistory responses

### DIFF
--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -373,19 +373,21 @@ populateProtoResponse(
                             closeTime->time_since_epoch().count());
                     if (txnMeta)
                     {
-                        if (!txnMeta->hasDeliveredAmount())
+                        RPC::convert(*txnProto->mutable_meta(), txnMeta);
+                        if (!txnProto->meta().has_delivered_amount())
                         {
-                            std::optional<STAmount> amount = getDeliveredAmount(
-                                context,
-                                txn->getSTransaction(),
-                                *txnMeta,
-                                txn->getLedger());
-                            if (amount)
+                            if (auto amt = getDeliveredAmount(
+                                    context,
+                                    txn->getSTransaction(),
+                                    *txnMeta,
+                                    txn->getLedger()))
                             {
-                                txnMeta->setDeliveredAmount(*amount);
+                                RPC::convert(
+                                    *txnProto->mutable_meta()
+                                         ->mutable_delivered_amount(),
+                                    *amt);
                             }
                         }
-                        RPC::convert(*txnProto->mutable_meta(), txnMeta);
                     }
                 }
             }

--- a/src/ripple/rpc/impl/GRPCHelpers.cpp
+++ b/src/ripple/rpc/impl/GRPCHelpers.cpp
@@ -1567,6 +1567,9 @@ convert(org::xrpl::rpc::v1::Meta& to, std::shared_ptr<TxMeta> const& from)
     to.mutable_transaction_result()->set_result(
         transToken(from->getResultTER()));
 
+    if (from->hasDeliveredAmount())
+        convert(*to.mutable_delivered_amount(), from->getDeliveredAmount());
+
     STArray& nodes = from->getNodes();
     for (auto it = nodes.begin(); it != nodes.end(); ++it)
     {


### PR DESCRIPTION
The delivered_amount field was not being populated when calling GetAccountTransactionHistory. In contrast, the delivered_amount field was being populated when calling GetTransaction. This change populates delivered_amount in the response to GetAccountTransactionHistory, and adds a unit test to make sure the results delivered by GetTransaction and GetAccountTransactionHistory match each other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3370)
<!-- Reviewable:end -->
