### PR TITLE
[TRIVIAL] Fixes for gcc 10

### DIFF
--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -177,7 +177,7 @@ parseLedgerArgs(Json::Value const& params)
     {
         LedgerSpecifier ledger;
         if (params[jss::ledger_index].isNumeric())
-            ledger = params[jss::ledger_index].asInt();
+            ledger = params[jss::ledger_index].asUInt();
         else
         {
             std::string ledgerStr = params[jss::ledger_index].asString();


### PR DESCRIPTION
Gcc 10 fails to compile rippled without this change.