### PR TITLE
Use boost::circular_buffer:

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1961,9 +1961,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMHaveTransactionSet> const& m)
             return;
         }
 
-        if (recentTxSets_.size() == 128)
-            recentTxSets_.pop_front();
-
         recentTxSets_.push_back(hash);
     }
 }
@@ -2323,11 +2320,6 @@ PeerImp::addLedger(
     if (std::find(recentLedgers_.begin(), recentLedgers_.end(), hash) !=
         recentLedgers_.end())
         return;
-
-    // VFALCO TODO See if a sorted vector would be better.
-
-    if (recentLedgers_.size() == 128)
-        recentLedgers_.pop_front();
 
     recentLedgers_.push_back(hash);
 }

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -37,7 +37,6 @@
 #include <boost/endian/conversion.hpp>
 #include <boost/optional.hpp>
 #include <cstdint>
-#include <deque>
 #include <queue>
 #include <shared_mutex>
 
@@ -134,8 +133,9 @@ private:
     LedgerIndex maxLedger_ = 0;
     uint256 closedLedgerHash_;
     uint256 previousLedgerHash_;
-    std::deque<uint256> recentLedgers_;
-    std::deque<uint256> recentTxSets_;
+
+    boost::circular_buffer<uint256> recentLedgers_{128};
+    boost::circular_buffer<uint256> recentTxSets_{128};
 
     boost::optional<std::chrono::milliseconds> latency_;
     boost::optional<std::uint32_t> lastPingSeq_;
@@ -495,13 +495,6 @@ public:
     //
     //--------------------------------------------------------------------------
 
-    static error_code
-    invalid_argument_error()
-    {
-        return boost::system::errc::make_error_code(
-            boost::system::errc::invalid_argument);
-    }
-
     void
     onMessageUnknown(std::uint16_t type);
 
@@ -565,9 +558,6 @@ private:
     }
 
     //--------------------------------------------------------------------------
-    void
-    setLedgerState();
-
     // lockedRecentLock is passed as a reminder to callers that recentLock_
     // must be locked.
     void


### PR DESCRIPTION
The existing code used `std::deque` along with a size check to constrain the size of a buffer and, effectively, "hand rolled" a circular buffer. This change simply migrates directly to `boost::circular_buffer`.