### PR TITLE
[TRIVIAL] Adjust frequency of mtENDPOINTS messages

### DIFF
--- a/src/ripple/peerfinder/impl/Tuning.h
+++ b/src/ripple/peerfinder/impl/Tuning.h
@@ -129,7 +129,8 @@ enum {
 };
 
 // How often we send or accept mtENDPOINTS messages per peer
-static std::chrono::seconds const secondsPerMessage(5);
+// (we use a prime number of purpose)
+static std::chrono::seconds const secondsPerMessage(61);
 
 // How long an Endpoint will stay in the cache
 // This should be a small multiple of the broadcast frequency


### PR DESCRIPTION
Previously servers would send their peers `mtENDPOINTS` messages every 5 seconds. This is too often and for no real reason. Increase the frequency to 61 seconds (a prime number).