### PR TITLE
Reduce Validation and Proposal message relaying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -390,8 +390,6 @@ matrix:
         - mkdir -p build.ms && cd build.ms
         - cmake -G Ninja ${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=${BLD_CONFIG} ..
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose
-        # override num procs to force single unit test job
-        - export NUM_PROCESSORS=1
         - travis_wait ${MAX_TIME_MIN} ./rippled.exe --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows-bld
       name: windows, release
@@ -404,8 +402,6 @@ matrix:
         - cmake -G "Visual Studio 15 2017 Win64" ${CMAKE_EXTRA_ARGS} ..
         - export DESTDIR=${PWD}/_installed_
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose --config ${BLD_CONFIG} --target install
-        # override num procs to force single unit test job
-        - export NUM_PROCESSORS=1
         - >-
           travis_wait ${MAX_TIME_MIN} "./_installed_/Program Files/rippled/bin/rippled.exe" --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows-bld

--- a/.travis.yml
+++ b/.travis.yml
@@ -390,6 +390,8 @@ matrix:
         - mkdir -p build.ms && cd build.ms
         - cmake -G Ninja ${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=${BLD_CONFIG} ..
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose
+        # override num procs to force single unit test job
+        - export NUM_PROCESSORS=1
         - travis_wait ${MAX_TIME_MIN} ./rippled.exe --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows-bld
       name: windows, release
@@ -402,6 +404,8 @@ matrix:
         - cmake -G "Visual Studio 15 2017 Win64" ${CMAKE_EXTRA_ARGS} ..
         - export DESTDIR=${PWD}/_installed_
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose --config ${BLD_CONFIG} --target install
+        # override num procs to force single unit test job
+        - export NUM_PROCESSORS=1
         - >-
           travis_wait ${MAX_TIME_MIN} "./_installed_/Program Files/rippled/bin/rippled.exe" --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows-bld

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -867,6 +867,7 @@ target_sources (rippled PRIVATE
   src/test/overlay/cluster_test.cpp
   src/test/overlay/short_read_test.cpp
   src/test/overlay/compression_test.cpp
+  src/test/overlay/reduce_relay_test.cpp
   #[===============================[
      test sources:
        subdir: peerfinder

--- a/bin/ci/ubuntu/build-and-test.sh
+++ b/bin/ci/ubuntu/build-and-test.sh
@@ -136,6 +136,7 @@ else
     # ORDER matters here...sorted in approximately
     # descending execution time (longest running tests at top)
     declare -a manual_tests=(
+        'ripple.ripple_data.reduce_relay_simulate'
         'ripple.ripple_data.digest'
         'ripple.tx.Offer_manual'
         'ripple.app.PayStrandAllPairs'

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -157,7 +157,7 @@ RCLConsensus::Adaptor::share(RCLCxPeerPos const& peerPos)
     auto const sig = peerPos.signature();
     prop.set_signature(sig.data(), sig.size());
 
-    app_.overlay().relay(prop, peerPos.suppressionID());
+    app_.overlay().relay(prop, peerPos.suppressionID(), peerPos.publicKey());
 }
 
 void

--- a/src/ripple/app/misc/HashRouter.cpp
+++ b/src/ripple/app/misc/HashRouter.cpp
@@ -50,8 +50,7 @@ HashRouter::addSuppression(uint256 const& key)
 bool
 HashRouter::addSuppressionPeer(uint256 const& key, PeerShortID peer)
 {
-    auto [added, _] = addSuppressionPeerWithStatus(key, peer);
-    return added;
+    return addSuppressionPeerWithStatus(key, peer).first;
 }
 
 std::pair<bool, std::optional<Stopwatch::time_point>>

--- a/src/ripple/app/misc/HashRouter.cpp
+++ b/src/ripple/app/misc/HashRouter.cpp
@@ -50,11 +50,18 @@ HashRouter::addSuppression(uint256 const& key)
 bool
 HashRouter::addSuppressionPeer(uint256 const& key, PeerShortID peer)
 {
+    auto [added, _] = addSuppressionPeerWithStatus(key, peer);
+    return added;
+}
+
+std::pair<bool, std::optional<Stopwatch::time_point>>
+HashRouter::addSuppressionPeerWithStatus(const uint256& key, PeerShortID peer)
+{
     std::lock_guard lock(mutex_);
 
     auto result = emplace(key);
     result.first.addPeer(peer);
-    return result.second;
+    return {result.second, result.first.relayed()};
 }
 
 bool
@@ -110,14 +117,14 @@ HashRouter::setFlags(uint256 const& key, int flags)
 
 auto
 HashRouter::shouldRelay(uint256 const& key)
-    -> boost::optional<std::set<PeerShortID>>
+    -> std::optional<std::set<PeerShortID>>
 {
     std::lock_guard lock(mutex_);
 
     auto& s = emplace(key).first;
 
     if (!s.shouldRelay(suppressionMap_.clock().now(), holdTime_))
-        return boost::none;
+        return {};
 
     return s.releasePeerSet();
 }

--- a/src/ripple/app/misc/HashRouter.h
+++ b/src/ripple/app/misc/HashRouter.h
@@ -97,6 +97,13 @@ private:
             return std::move(peers_);
         }
 
+        /** Return seated relay time point if the message has been relayed */
+        std::optional<Stopwatch::time_point>
+        relayed() const
+        {
+            return relayed_;
+        }
+
         /** Determines if this item should be relayed.
 
             Checks whether the item has been recently relayed.
@@ -142,8 +149,8 @@ private:
         std::set<PeerShortID> peers_;
         // This could be generalized to a map, if more
         // than one flag needs to expire independently.
-        boost::optional<Stopwatch::time_point> relayed_;
-        boost::optional<Stopwatch::time_point> processed_;
+        std::optional<Stopwatch::time_point> relayed_;
+        std::optional<Stopwatch::time_point> processed_;
         std::uint32_t recoveries_ = 0;
     };
 
@@ -185,6 +192,14 @@ public:
     bool
     addSuppressionPeer(uint256 const& key, PeerShortID peer);
 
+    /** Add a suppression peer and get message's relay status.
+     * Return pair:
+     * element 1: true if the peer is added.
+     * element 2: optional is seated to the relay time point or
+     * is unseated if has not relayed yet. */
+    std::pair<bool, std::optional<Stopwatch::time_point>>
+    addSuppressionPeerWithStatus(uint256 const& key, PeerShortID peer);
+
     bool
     addSuppressionPeer(uint256 const& key, PeerShortID peer, int& flags);
 
@@ -214,11 +229,11 @@ public:
             return `true` again until the hold time has expired.
             The internal set of peers will also be reset.
 
-        @return A `boost::optional` set of peers which do not need to be
+        @return A `std::optional` set of peers which do not need to be
             relayed to. If the result is uninitialized, the item should
             _not_ be relayed.
     */
-    boost::optional<std::set<PeerShortID>>
+    std::optional<std::set<PeerShortID>>
     shouldRelay(uint256 const& key);
 
     /** Determines whether the hashed item should be recovered

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -179,7 +179,7 @@ public:
     // Thread pool configuration
     std::size_t WORKERS = 0;
 
-    // Reduce-relay
+    // Reduce-relay - these parameters are experimental.
     // Enable reduce-relay functionality
     bool REDUCE_RELAY_ENABLE = false;
     // Send squelch message to peers

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -179,6 +179,12 @@ public:
     // Thread pool configuration
     std::size_t WORKERS = 0;
 
+    // Reduce-relay
+    // Enable reduce-relay functionality
+    bool REDUCE_RELAY_ENABLE = false;
+    // Send squelch message to peers
+    bool REDUCE_RELAY_SQUELCH = false;
+
     // These override the command line client settings
     boost::optional<beast::IP::Endpoint> rpc_ip;
 

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -70,6 +70,7 @@ struct ConfigSection
 #define SECTION_PATH_SEARCH_MAX "path_search_max"
 #define SECTION_PEER_PRIVATE "peer_private"
 #define SECTION_PEERS_MAX "peers_max"
+#define SECTION_REDUCE_RELAY "reduce_relay"
 #define SECTION_RELAY_PROPOSALS "relay_proposals"
 #define SECTION_RELAY_VALIDATIONS "relay_validations"
 #define SECTION_RPC_STARTUP "rpc_startup"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -481,6 +481,13 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_COMPRESSION, strTemp, j_))
         COMPRESSION = beast::lexicalCastThrow<bool>(strTemp);
 
+    if (exists(SECTION_REDUCE_RELAY))
+    {
+        auto sec = section(SECTION_REDUCE_RELAY);
+        REDUCE_RELAY_ENABLE = sec.value_or("enable", false);
+        REDUCE_RELAY_SQUELCH = sec.value_or("squelch", false);
+    }
+
     if (getSingleSection(
             secConfig, SECTION_AMENDMENT_MAJORITY_TIME, strTemp, j_))
     {

--- a/src/ripple/overlay/Message.h
+++ b/src/ripple/overlay/Message.h
@@ -21,6 +21,7 @@
 #define RIPPLE_OVERLAY_MESSAGE_H_INCLUDED
 
 #include <ripple/overlay/Compression.h>
+#include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/messages.h>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/buffers_iterator.hpp>
@@ -55,8 +56,13 @@ public:
     /** Constructor
      * @param message Protocol message to serialize
      * @param type Protocol message type
+     * @param validator Public Key of the source validator for Validation or
+     * Proposal message. Used to check if the message should be squelched.
      */
-    Message(::google::protobuf::Message const& message, int type);
+    Message(
+        ::google::protobuf::Message const& message,
+        int type,
+        boost::optional<PublicKey> const& validator = {});
 
     /** Retrieve the packed message data. If compressed message is requested but
      * the message is not compressible then the uncompressed buffer is returned.
@@ -74,11 +80,19 @@ public:
         return category_;
     }
 
+    /** Get the validator's key */
+    boost::optional<PublicKey> const&
+    getValidatorKey() const
+    {
+        return validatorKey_;
+    }
+
 private:
     std::vector<uint8_t> buffer_;
     std::vector<uint8_t> bufferCompressed_;
     std::size_t category_;
     std::once_flag once_flag_;
+    boost::optional<PublicKey> validatorKey_;
 
     /** Set the payload header
      * @param in Pointer to the payload

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -133,7 +133,7 @@ public:
 
     /** Returns the peer with the matching short id, or null. */
     virtual std::shared_ptr<Peer>
-    findPeerByShortID(Peer::id_t const& id) = 0;
+    findPeerByShortID(Peer::id_t const& id) const = 0;
 
     /** Returns the peer with the matching public key, or null. */
     virtual std::shared_ptr<Peer>
@@ -147,13 +147,27 @@ public:
     virtual void
     broadcast(protocol::TMValidation& m) = 0;
 
-    /** Relay a proposal. */
-    virtual void
-    relay(protocol::TMProposeSet& m, uint256 const& uid) = 0;
+    /** Relay a proposal. Return set
+     * of peers, which have already seen the
+     * message; i.e. the message has been
+     * received from these peers and added
+     * to the hash router */
+    virtual std::set<Peer::id_t>
+    relay(
+        protocol::TMProposeSet& m,
+        uint256 const& uid,
+        PublicKey const& validator) = 0;
 
-    /** Relay a validation. */
-    virtual void
-    relay(protocol::TMValidation& m, uint256 const& uid) = 0;
+    /** Relay a validation. Return set
+     * of peers, which have already seen the
+     * message; i.e. the message has been
+     * received from these peers and added
+     * to the hash router */
+    virtual std::set<Peer::id_t>
+    relay(
+        protocol::TMValidation& m,
+        uint256 const& uid,
+        PublicKey const& validator) = 0;
 
     /** Visit every active peer.
      *

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -147,22 +147,24 @@ public:
     virtual void
     broadcast(protocol::TMValidation& m) = 0;
 
-    /** Relay a proposal. Return set
-     * of peers, which have already seen the
-     * message; i.e. the message has been
-     * received from these peers and added
-     * to the hash router */
+    /** Relay a proposal.
+     * @param m the serialized proposal
+     * @param uid the id used to identify this proposal
+     * @param validator The pubkey of the validator that issued this proposal
+     * @return the set of peers which have already sent us this proposal
+     */
     virtual std::set<Peer::id_t>
     relay(
         protocol::TMProposeSet& m,
         uint256 const& uid,
         PublicKey const& validator) = 0;
 
-    /** Relay a validation. Return set
-     * of peers, which have already seen the
-     * message; i.e. the message has been
-     * received from these peers and added
-     * to the hash router */
+    /** Relay a validation.
+     * @param m the serialized validation
+     * @param uid the id used to identify this validation
+     * @param validator The pubkey of the validator that issued this validation
+     * @return the set of peers which have already sent us this validation
+     */
     virtual std::set<Peer::id_t>
     relay(
         protocol::TMValidation& m,

--- a/src/ripple/overlay/Slot.h
+++ b/src/ripple/overlay/Slot.h
@@ -430,7 +430,10 @@ void
 Slot<clock_type>::resetCounts()
 {
     for (auto& [_, peer] : peers_)
+    {
+        (void)_;
         peer.count = 0;
+    }
 }
 
 template <typename clock_type>
@@ -685,8 +688,11 @@ Slots<clock_type>::updateSlotAndSquelch(
     {
         JLOG(journal_.debug())
             << "updateSlotAndSquelch: new slot " << Slice(validator);
-        auto [it, _] = slots_.emplace(std::make_pair(
-            validator, Slot<clock_type>(handler_, app_.journal("Slot"))));
+        auto it = slots_
+                      .emplace(std::make_pair(
+                          validator,
+                          Slot<clock_type>(handler_, app_.journal("Slot"))))
+                      .first;
         it->second.update(validator, id, type);
     }
     else

--- a/src/ripple/overlay/Slot.h
+++ b/src/ripple/overlay/Slot.h
@@ -1,0 +1,728 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_OVERLAY_SLOT_H_INCLUDED
+#define RIPPLE_OVERLAY_SLOT_H_INCLUDED
+
+#include <ripple/app/main/Application.h>
+#include <ripple/basics/chrono.h>
+#include <ripple/beast/container/aged_unordered_map.h>
+#include <ripple/beast/utility/Journal.h>
+#include <ripple/overlay/Peer.h>
+#include <ripple/overlay/Squelch.h>
+#include <ripple/overlay/SquelchCommon.h>
+#include <ripple/protocol/PublicKey.h>
+#include <ripple.pb.h>
+
+#include <algorithm>
+#include <memory>
+#include <optional>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace ripple {
+
+namespace squelch {
+
+template <typename clock_type>
+class Slots;
+
+/** Peer's State */
+enum class PeerState : uint8_t {
+    Counting,   // counting messages
+    Selected,   // selected to relay, counting if Slot in Counting
+    Squelched,  // squelched, doesn't relay
+};
+/** Slot's State */
+enum class SlotState : uint8_t {
+    Counting,  // counting messages
+    Selected,  // peers selected, stop counting
+};
+
+template <typename Unit, typename TP>
+Unit
+epoch(TP const& t)
+{
+    return duration_cast<Unit>(t.time_since_epoch());
+}
+
+/** Abstract class. Declares squelch and unsquelch handlers.
+ * OverlayImpl inherits from this class. Motivation is
+ * for easier unit tests to facilitate on the fly
+ * changing callbacks. */
+class SquelchHandler
+{
+public:
+    virtual ~SquelchHandler()
+    {
+    }
+    /** Squelch handler
+     * @param validator Public key of the source validator
+     * @param id Peer's id to squelch
+     * @param duration Squelch duration in seconds
+     */
+    virtual void
+    squelch(PublicKey const& validator, Peer::id_t id, std::uint32_t duration)
+        const = 0;
+    /** Unsquelch handler
+     * @param validator Public key of the source validator
+     * @param id Peer's id to unsquelch
+     */
+    virtual void
+    unsquelch(PublicKey const& validator, Peer::id_t id) const = 0;
+};
+
+/**
+ * Slot is associated with a specific validator via validator's public key.
+ * Slot counts messages from a validator, selects peers to be the source
+ * of the messages, and communicates the peers to be squelched. Slot can be
+ * in the following states: 1) Counting. This is the peer selection state
+ * when Slot counts the messages and selects the peers; 2) Selected. Slot
+ * doesn't count messages in Selected state. A message received from
+ * unsquelched, disconnected peer, or idling peer may transition Slot to
+ * Counting state.
+ */
+template <typename clock_type>
+class Slot final
+{
+private:
+    friend class Slots<clock_type>;
+    using id_t = Peer::id_t;
+    using time_point = typename clock_type::time_point;
+
+    /** Constructor
+     * @param journal Journal for logging
+     * @param handler Squelch/Unsquelch implementation
+     */
+    Slot(SquelchHandler const& handler, beast::Journal journal)
+        : reachedThreshold_(0)
+        , lastSelected_(clock_type::now())
+        , state_(SlotState::Counting)
+        , handler_(handler)
+        , journal_(journal)
+    {
+    }
+
+    /** Update peer info. If the message is from a new
+     * peer or from a previously expired squelched peer then switch
+     * the peer's and slot's state to Counting. If time of last
+     * selection round is > 2 * MAX_UNSQUELCH_EXPIRE then switch the slot's
+     * state to Counting. If the number of messages for the peer
+     * is > MIN_MESSAGE_THRESHOLD then add peer to considered peers pool.
+     * If the number of considered peers who reached MAX_MESSAGE_THRESHOLD is
+     * MAX_SELECTED_PEERS then randomly select MAX_SELECTED_PEERS from
+     * considered peers, and call squelch handler for each peer, which is not
+     * selected and not already in Squelched state. Set the state for those
+     * peers to Squelched and reset the count of all peers. Set slot's state to
+     * Selected. Message count is not updated when the slot is in Selected
+     * state.
+     * @param validator Public key of the source validator
+     * @param id Peer id which received the message
+     * @param type  Message type (Validation and Propose Set only,
+     *     others are ignored, future use)
+     */
+    void
+    update(PublicKey const& validator, id_t id, protocol::MessageType type);
+
+    /** Handle peer deletion when a peer disconnects.
+     * If the peer is in Selected state then
+     * call unsquelch handler for every peer in squelched state and reset
+     * every peer's state to Counting. Switch Slot's state to Counting.
+     * @param validator Public key of the source validator
+     * @param id Deleted peer id
+     * @param erase If true then erase the peer. The peer is not erased
+     *      when the peer when is idled. The peer is deleted when it
+     *      disconnects
+     */
+    void
+    deletePeer(PublicKey const& validator, id_t id, bool erase);
+
+    /** Get the time of the last peer selection round */
+    const time_point&
+    getLastSelected() const
+    {
+        return lastSelected_;
+    }
+
+    /** Return number of peers in state */
+    std::uint16_t
+    inState(PeerState state) const;
+
+    /** Return number of peers not in state */
+    std::uint16_t
+    notInState(PeerState state) const;
+
+    /** Return Slot's state */
+    SlotState
+    getState() const
+    {
+        return state_;
+    }
+
+    /** Return selected peers */
+    std::set<id_t>
+    getSelected() const;
+
+    /** Get peers info. Return map of peer's state, count, squelch
+     * expiration milsec, and last message time milsec.
+     */
+    std::
+        unordered_map<id_t, std::tuple<PeerState, uint16_t, uint32_t, uint32_t>>
+        getPeers() const;
+
+    /** Check if peers stopped relaying messages. If a peer is
+     * selected peer then call unsquelch handler for all
+     * currently squelched peers and switch the slot to
+     * Counting state.
+     * @param validator Public key of the source validator
+     */
+    void
+    deleteIdlePeer(PublicKey const& validator);
+
+private:
+    /** Reset counts of peers in Selected or Counting state */
+    void
+    resetCounts();
+
+    /** Initialize slot to Counting state */
+    void
+    initCounting();
+
+    /** Data maintained for each peer */
+    struct PeerInfo
+    {
+        PeerState state;         // peer's state
+        std::size_t count;       // message count
+        time_point expire;       // squelch expiration time
+        time_point lastMessage;  // time last message received
+    };
+    std::unordered_map<id_t, PeerInfo> peers_;  // peer's data
+    // pool of peers considered as the source of messages
+    // from validator - peers that reached MIN_MESSAGE_THRESHOLD
+    std::unordered_set<id_t> considered_;
+    // number of peers that reached MAX_MESSAGE_THRESHOLD
+    std::uint16_t reachedThreshold_;
+    // last time peers were selected, used to age the slot
+    typename clock_type::time_point lastSelected_;
+    SlotState state_;                // slot's state
+    SquelchHandler const& handler_;  // squelch/unsquelch handler
+    beast::Journal const journal_;   // logging
+};
+
+template <typename clock_type>
+void
+Slot<clock_type>::deleteIdlePeer(PublicKey const& validator)
+{
+    auto now = clock_type::now();
+    for (auto it = peers_.begin(); it != peers_.end();)
+    {
+        auto& peer = it->second;
+        auto id = it->first;
+        ++it;
+        if (now - peer.lastMessage > IDLED)
+        {
+            JLOG(journal_.debug())
+                << "deleteIdlePeer: " << Slice(validator) << " " << id
+                << " idled "
+                << duration_cast<seconds>(now - peer.lastMessage).count()
+                << " selected " << (peer.state == PeerState::Selected);
+            deletePeer(validator, id, false);
+        }
+    }
+}
+
+template <typename clock_type>
+void
+Slot<clock_type>::update(
+    PublicKey const& validator,
+    id_t id,
+    protocol::MessageType type)
+{
+    auto now = clock_type::now();
+    auto it = peers_.find(id);
+    // First message from this peer
+    if (it == peers_.end())
+    {
+        JLOG(journal_.debug())
+            << "update: adding peer " << Slice(validator) << " " << id;
+        peers_.emplace(
+            std::make_pair(id, PeerInfo{PeerState::Counting, 0, now, now}));
+        initCounting();
+        return;
+    }
+    // Message from a peer with expired squelch
+    if (it->second.state == PeerState::Squelched && now > it->second.expire)
+    {
+        JLOG(journal_.debug())
+            << "update: squelch expired " << Slice(validator) << " " << id;
+        it->second.state = PeerState::Counting;
+        it->second.lastMessage = now;
+        initCounting();
+        return;
+    }
+
+    auto& peer = it->second;
+
+    JLOG(journal_.debug())
+        << "update: existing peer " << Slice(validator) << " " << id
+        << " slot state " << static_cast<int>(state_) << " peer state "
+        << static_cast<int>(peer.state) << " count " << peer.count << " last "
+        << duration_cast<milliseconds>(now - peer.lastMessage).count()
+        << " pool " << considered_.size() << " threshold " << reachedThreshold_
+        << " " << (type == protocol::mtVALIDATION ? "validation" : "proposal");
+
+    peer.lastMessage = now;
+
+    if (state_ != SlotState::Counting || peer.state == PeerState::Squelched)
+        return;
+
+    if (++peer.count > MIN_MESSAGE_THRESHOLD)
+        considered_.insert(id);
+    if (peer.count == (MAX_MESSAGE_THRESHOLD + 1))
+        ++reachedThreshold_;
+
+    if (now - lastSelected_ > 2 * MAX_UNSQUELCH_EXPIRE)
+    {
+        JLOG(journal_.debug())
+            << "update: resetting due to inactivity " << Slice(validator) << " "
+            << id << " " << duration_cast<seconds>(now - lastSelected_).count();
+        initCounting();
+        return;
+    }
+
+    if (reachedThreshold_ == MAX_SELECTED_PEERS)
+    {
+        // Randomly select MAX_SELECTED_PEERS peers from considered.
+        // Exclude peers that have been idling > IDLED -
+        // it's possible that deleteIdlePeer() has not been called yet.
+        // If number of remaining peers != MAX_SELECTED_PEERS
+        // then reset the Counting state and let deleteIdlePeer() handle
+        // idled peers.
+        std::unordered_set<id_t> selected;
+        auto const consideredPoolSize = considered_.size();
+        while (selected.size() != MAX_SELECTED_PEERS && considered_.size() != 0)
+        {
+            auto i =
+                considered_.size() == 1 ? 0 : rand_int(considered_.size() - 1);
+            auto it = std::next(considered_.begin(), i);
+            auto id = *it;
+            considered_.erase(it);
+            auto const& itpeers = peers_.find(id);
+            if (itpeers == peers_.end())
+            {
+                JLOG(journal_.error()) << "update: peer not found "
+                                       << Slice(validator) << " " << id;
+                continue;
+            }
+            if (now - itpeers->second.lastMessage < IDLED)
+                selected.insert(id);
+        }
+
+        if (selected.size() != MAX_SELECTED_PEERS)
+        {
+            JLOG(journal_.debug())
+                << "update: selection failed " << Slice(validator) << " " << id;
+            initCounting();
+            return;
+        }
+
+        lastSelected_ = now;
+
+        auto s = selected.begin();
+        JLOG(journal_.debug())
+            << "update: " << Slice(validator) << " " << id << " pool size "
+            << consideredPoolSize << " selected " << *s << " "
+            << *std::next(s, 1) << " " << *std::next(s, 2);
+
+        // squelch peers which are not selected and
+        // not already squelched
+        std::stringstream str;
+        for (auto& [k, v] : peers_)
+        {
+            v.count = 0;
+
+            if (selected.find(k) != selected.end())
+                v.state = PeerState::Selected;
+            else if (v.state != PeerState::Squelched)
+            {
+                if (journal_.debug())
+                    str << k << " ";
+                v.state = PeerState::Squelched;
+                auto duration = Squelch<clock_type>::getSquelchDuration();
+                v.expire = now + duration;
+                handler_.squelch(
+                    validator,
+                    k,
+                    duration_cast<milliseconds>(duration).count());
+            }
+        }
+        JLOG(journal_.debug()) << "update: squelching " << Slice(validator)
+                               << " " << id << " " << str.str();
+        considered_.clear();
+        reachedThreshold_ = 0;
+        state_ = SlotState::Selected;
+    }
+}
+
+template <typename clock_type>
+void
+Slot<clock_type>::deletePeer(PublicKey const& validator, id_t id, bool erase)
+{
+    auto it = peers_.find(id);
+    if (it != peers_.end())
+    {
+        JLOG(journal_.debug())
+            << "deletePeer: " << Slice(validator) << " " << id << " selected "
+            << (it->second.state == PeerState::Selected) << " considered "
+            << (considered_.find(id) != considered_.end()) << " erase "
+            << erase;
+        auto now = clock_type::now();
+        if (it->second.state == PeerState::Selected)
+        {
+            for (auto& [k, v] : peers_)
+            {
+                if (v.state == PeerState::Squelched)
+                    handler_.unsquelch(validator, k);
+                v.state = PeerState::Counting;
+                v.count = 0;
+                v.expire = now;
+            }
+
+            considered_.clear();
+            reachedThreshold_ = 0;
+            state_ = SlotState::Counting;
+        }
+        else if (considered_.find(id) != considered_.end())
+        {
+            if (it->second.count > MAX_MESSAGE_THRESHOLD)
+                --reachedThreshold_;
+            considered_.erase(id);
+        }
+
+        it->second.lastMessage = now;
+        it->second.count = 0;
+
+        if (erase)
+            peers_.erase(it);
+    }
+}
+
+template <typename clock_type>
+void
+Slot<clock_type>::resetCounts()
+{
+    for (auto& [_, peer] : peers_)
+        peer.count = 0;
+}
+
+template <typename clock_type>
+void
+Slot<clock_type>::initCounting()
+{
+    state_ = SlotState::Counting;
+    considered_.clear();
+    reachedThreshold_ = 0;
+    resetCounts();
+}
+
+template <typename clock_type>
+std::uint16_t
+Slot<clock_type>::inState(PeerState state) const
+{
+    return std::count_if(peers_.begin(), peers_.end(), [&](auto const& it) {
+        return (it.second.state == state);
+    });
+}
+
+template <typename clock_type>
+std::uint16_t
+Slot<clock_type>::notInState(PeerState state) const
+{
+    return std::count_if(peers_.begin(), peers_.end(), [&](auto const& it) {
+        return (it.second.state != state);
+    });
+}
+
+template <typename clock_type>
+std::set<typename Peer::id_t>
+Slot<clock_type>::getSelected() const
+{
+    std::set<id_t> init;
+    return std::accumulate(
+        peers_.begin(), peers_.end(), init, [](auto& init, auto const& it) {
+            if (it.second.state == PeerState::Selected)
+            {
+                init.insert(it.first);
+                return init;
+            }
+            return init;
+        });
+}
+
+template <typename clock_type>
+std::unordered_map<
+    typename Peer::id_t,
+    std::tuple<PeerState, uint16_t, uint32_t, uint32_t>>
+Slot<clock_type>::getPeers() const
+{
+    auto init = std::unordered_map<
+        id_t,
+        std::tuple<PeerState, std::uint16_t, std::uint32_t, std::uint32_t>>();
+    return std::accumulate(
+        peers_.begin(), peers_.end(), init, [](auto& init, auto const& it) {
+            init.emplace(std::make_pair(
+                it.first,
+                std::move(std::make_tuple(
+                    it.second.state,
+                    it.second.count,
+                    epoch<milliseconds>(it.second.expire).count(),
+                    epoch<milliseconds>(it.second.lastMessage).count()))));
+            return init;
+        });
+}
+
+/** Slots is a container for validator's Slot and handles Slot update
+ * when a message is received from a validator. It also handles Slot aging
+ * and checks for peers which are disconnected or stopped relaying the messages.
+ */
+template <typename clock_type>
+class Slots final
+{
+    using time_point = typename clock_type::time_point;
+    using id_t = typename Peer::id_t;
+    using messages = beast::aged_unordered_map<
+        uint256,
+        std::unordered_set<Peer::id_t>,
+        clock_type,
+        hardened_hash<strong_hash>>;
+
+public:
+    /**
+     * @param app Applicaton reference
+     * @param handler Squelch/unsquelch implementation
+     */
+    Slots(Application& app, SquelchHandler const& handler)
+        : handler_(handler), app_(app), journal_(app.journal("Slots"))
+    {
+    }
+    ~Slots() = default;
+    /** Calls Slot::update of Slot associated with the validator.
+     * @param key Message's hash
+     * @param validator Validator's public key
+     * @param id Peer's id which received the message
+     * @param id Peer's pointer which received the message
+     * @param type Received protocol message type
+     */
+    void
+    updateSlotAndSquelch(
+        uint256 const& key,
+        PublicKey const& validator,
+        id_t id,
+        protocol::MessageType type);
+
+    /** Check if peers stopped relaying messages
+     * and if slots stopped receiving messages from the validator.
+     */
+    void
+    deleteIdlePeers();
+
+    /** Return number of peers in state */
+    std::optional<std::uint16_t>
+    inState(PublicKey const& validator, PeerState state) const
+    {
+        auto const& it = slots_.find(validator);
+        if (it != slots_.end())
+            return it->second.inState(state);
+        return {};
+    }
+
+    /** Return number of peers not in state */
+    std::optional<std::uint16_t>
+    notInState(PublicKey const& validator, PeerState state) const
+    {
+        auto const& it = slots_.find(validator);
+        if (it != slots_.end())
+            return it->second.notInState(state);
+        return {};
+    }
+
+    /** Return true if Slot is in state */
+    bool
+    inState(PublicKey const& validator, SlotState state) const
+    {
+        auto const& it = slots_.find(validator);
+        if (it != slots_.end())
+            return it->second.state_ == state;
+        return false;
+    }
+
+    /** Get selected peers */
+    std::set<id_t>
+    getSelected(PublicKey const& validator)
+    {
+        auto const& it = slots_.find(validator);
+        if (it != slots_.end())
+            return it->second.getSelected();
+        return {};
+    }
+
+    /** Get peers info. Return map of peer's state, count, and squelch
+     * expiration milliseconds.
+     */
+    std::unordered_map<
+        typename Peer::id_t,
+        std::tuple<PeerState, uint16_t, uint32_t, std::uint32_t>>
+    getPeers(PublicKey const& validator)
+    {
+        auto const& it = slots_.find(validator);
+        if (it != slots_.end())
+            return it->second.getPeers();
+        return {};
+    }
+
+    /** Get Slot's state */
+    std::optional<SlotState>
+    getState(PublicKey const& validator)
+    {
+        auto const& it = slots_.find(validator);
+        if (it != slots_.end())
+            return it->second.getState();
+        return {};
+    }
+
+    /** Called when a peer is deleted. If the peer was selected to be the
+     * source of messages from the validator then squelched peers have to be
+     * unsquelched.
+     * @param id Peer's id
+     * @param erase If true then erase the peer
+     */
+    void
+    deletePeer(id_t id, bool erase);
+
+private:
+    /** Add message/peer if have not seen this message
+     * from the peer. A message is aged after IDLED seconds.
+     * Return true if added */
+    bool
+    addPeerMessage(uint256 const& key, id_t id);
+
+    hash_map<PublicKey, Slot<clock_type>> slots_;
+    SquelchHandler const& handler_;  // squelch/unsquelch handler
+    Application& app_;
+    beast::Journal const journal_;
+    // Maintain aged container of message/peers. This is required
+    // to discard duplicate message from the same peer. A message
+    // is aged after IDLED seconds. A message received IDLED seconds
+    // after it was relayed is ignored by PeerImp.
+    inline static messages peersWithMessage_{
+        beast::get_abstract_clock<clock_type>()};
+};
+
+template <typename clock_type>
+bool
+Slots<clock_type>::addPeerMessage(uint256 const& key, id_t id)
+{
+    beast::expire(peersWithMessage_, squelch::IDLED);
+
+    if (key.isNonZero())
+    {
+        auto it = peersWithMessage_.find(key);
+        if (it == peersWithMessage_.end())
+        {
+            JLOG(journal_.trace())
+                << "addPeerMessage: new " << to_string(key) << " " << id;
+            peersWithMessage_.emplace(key, std::unordered_set<id_t>{id});
+            return true;
+        }
+
+        if (it->second.find(id) != it->second.end())
+        {
+            JLOG(journal_.trace()) << "addPeerMessage: duplicate message "
+                                   << to_string(key) << " " << id;
+            return false;
+        }
+
+        JLOG(journal_.trace())
+            << "addPeerMessage: added " << to_string(key) << " " << id;
+
+        it->second.insert(id);
+    }
+
+    return true;
+}
+
+template <typename clock_type>
+void
+Slots<clock_type>::updateSlotAndSquelch(
+    uint256 const& key,
+    PublicKey const& validator,
+    id_t id,
+    protocol::MessageType type)
+{
+    if (!addPeerMessage(key, id))
+        return;
+
+    auto it = slots_.find(validator);
+    if (it == slots_.end())
+    {
+        JLOG(journal_.debug())
+            << "updateSlotAndSquelch: new slot " << Slice(validator);
+        auto [it, _] = slots_.emplace(std::make_pair(
+            validator, Slot<clock_type>(handler_, app_.journal("Slot"))));
+        it->second.update(validator, id, type);
+    }
+    else
+        it->second.update(validator, id, type);
+}
+
+template <typename clock_type>
+void
+Slots<clock_type>::deletePeer(id_t id, bool erase)
+{
+    for (auto& [validator, slot] : slots_)
+        slot.deletePeer(validator, id, erase);
+}
+
+template <typename clock_type>
+void
+Slots<clock_type>::deleteIdlePeers()
+{
+    auto now = clock_type::now();
+
+    for (auto it = slots_.begin(); it != slots_.end();)
+    {
+        it->second.deleteIdlePeer(it->first);
+        if (now - it->second.getLastSelected() > MAX_UNSQUELCH_EXPIRE)
+        {
+            JLOG(journal_.debug())
+                << "deleteIdlePeers: deleting idle slot " << Slice(it->first);
+            it = slots_.erase(it);
+        }
+        else
+            ++it;
+    }
+}
+
+}  // namespace squelch
+
+}  // namespace ripple
+
+#endif  // RIPPLE_OVERLAY_SLOT_H_INCLUDED

--- a/src/ripple/overlay/Squelch.h
+++ b/src/ripple/overlay/Squelch.h
@@ -1,0 +1,122 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_OVERLAY_SQUELCH_H_INCLUDED
+#define RIPPLE_OVERLAY_SQUELCH_H_INCLUDED
+
+#include <ripple/basics/random.h>
+#include <ripple/overlay/SquelchCommon.h>
+#include <ripple/protocol/PublicKey.h>
+
+#include <chrono>
+#include <functional>
+
+namespace ripple {
+
+namespace squelch {
+
+/** Maintains squelching of relaying messages from validators */
+template <typename clock_type>
+class Squelch
+{
+    using time_point = typename clock_type::time_point;
+
+public:
+    Squelch() = default;
+    virtual ~Squelch() = default;
+
+    /** Squelch/Unsquelch relaying for the validator
+     * @param validator The validator's public key
+     * @param squelch Squelch/unsquelch flag
+     * @param squelchDuration Squelch duration time if squelch is true
+     */
+    void
+    squelch(PublicKey const& validator, bool squelch, uint64_t squelchDuration);
+
+    /** Are the messages to this validator squelched
+     * @param validator Validator's public key
+     * @return true if squelched
+     */
+    bool
+    isSquelched(PublicKey const& validator);
+
+    /** Get random squelch duration between MIN_UNSQUELCH_EXPIRE and
+     * MAX_UNSQUELCH_EXPIRE */
+    static seconds
+    getSquelchDuration();
+
+private:
+    /** Maintains the list of squelched relaying to downstream peers.
+     * Expiration time is included in the TMSquelch message. */
+    hash_map<PublicKey, time_point> squelched_;
+};
+
+template <typename clock_type>
+void
+Squelch<clock_type>::squelch(
+    PublicKey const& validator,
+    bool squelch,
+    uint64_t squelchDuration)
+{
+    if (squelch)
+    {
+        squelched_[validator] = [squelchDuration]() {
+            seconds duration = seconds(squelchDuration);
+            return clock_type::now() +
+                ((duration >= MIN_UNSQUELCH_EXPIRE &&
+                  duration <= MAX_UNSQUELCH_EXPIRE)
+                     ? duration
+                     : getSquelchDuration());
+        }();
+    }
+    else
+        squelched_.erase(validator);
+}
+
+template <typename clock_type>
+bool
+Squelch<clock_type>::isSquelched(PublicKey const& validator)
+{
+    auto now = clock_type::now();
+
+    auto const& it = squelched_.find(validator);
+    if (it == squelched_.end())
+        return false;
+    else if (it->second > now)
+        return true;
+
+    squelched_.erase(it);
+
+    return false;
+}
+
+template <typename clock_type>
+seconds
+Squelch<clock_type>::getSquelchDuration()
+{
+    auto d = seconds(ripple::rand_int(
+        MIN_UNSQUELCH_EXPIRE.count(), MAX_UNSQUELCH_EXPIRE.count()));
+    return d;
+}
+
+}  // namespace squelch
+
+}  // namespace ripple
+
+#endif  // RIPPLED_SQUELCH_H

--- a/src/ripple/overlay/SquelchCommon.h
+++ b/src/ripple/overlay/SquelchCommon.h
@@ -1,0 +1,52 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_OVERLAY_SQUELCHCOMMON_H_INCLUDED
+#define RIPPLE_OVERLAY_SQUELCHCOMMON_H_INCLUDED
+#include <chrono>
+
+namespace ripple {
+
+namespace squelch {
+
+using namespace std::chrono;
+
+// Peer's squelch is limited in time to
+// rand{MIN_UNSQUELCH_EXPIRE, MAX_UNSQUELCH_EXPIRE}
+static constexpr seconds MIN_UNSQUELCH_EXPIRE = seconds{300};
+static constexpr seconds MAX_UNSQUELCH_EXPIRE = seconds{600};
+// No message received threshold before identifying a peer as idled
+static constexpr seconds IDLED = seconds{8};
+// Message count threshold to start selecting peers as the source
+// of messages from the validator. We add peers who reach
+// MIN_MESSAGE_THRESHOLD to considered pool once MAX_SELECTED_PEERS
+// reach MAX_MESSAGE_THRESHOLD.
+static constexpr uint16_t MIN_MESSAGE_THRESHOLD = 9;
+static constexpr uint16_t MAX_MESSAGE_THRESHOLD = 10;
+// Max selected peers to choose as the source of messages from validator
+static constexpr uint16_t MAX_SELECTED_PEERS = 3;
+// Wait before reduce-relay feature is enabled on boot up to let
+// the server establish peer connections
+static constexpr minutes WAIT_ON_BOOTUP = minutes{10};
+
+}  // namespace squelch
+
+}  // namespace ripple
+
+#endif  // RIPPLED_SQUELCHCOMMON_H

--- a/src/ripple/overlay/impl/Message.cpp
+++ b/src/ripple/overlay/impl/Message.cpp
@@ -23,8 +23,12 @@
 
 namespace ripple {
 
-Message::Message(::google::protobuf::Message const& message, int type)
+Message::Message(
+    ::google::protobuf::Message const& message,
+    int type,
+    boost::optional<PublicKey> const& validator)
     : category_(TrafficCount::categorize(message, type, false))
+    , validatorKey_(validator)
 {
     using namespace ripple::compression;
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -99,10 +99,12 @@ OverlayImpl::Timer::on_timer(error_code ec)
     overlay_.m_peerFinder->once_per_second();
     overlay_.sendEndpoints();
     overlay_.autoConnect();
-    overlay_.deleteIdlePeers();
 
     if ((++overlay_.timer_count_ % Tuning::checkSeconds) == 0)
         overlay_.check();
+
+    if ((overlay_.timer_count_ % Tuning::checkIdlePeers) == 0)
+        overlay_.deleteIdlePeers();
 
     timer_.expires_from_now(std::chrono::seconds(1));
     timer_.async_wait(overlay_.strand_.wrap(std::bind(

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -2358,14 +2358,14 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMSquelch> const& m)
 {
     if (!m->has_validatorpubkey())
     {
-        JLOG(p_journal_.debug()) << "onMessage: TMSquelch, missing public key";
+        charge(Resource::feeBadData);
         return;
     }
     auto validator = m->validatorpubkey();
     auto const slice{makeSlice(validator)};
     if (!publicKeyType(slice))
     {
-        JLOG(p_journal_.debug()) << "onMessage: TMSquelch, invalid public key";
+        charge(Resource::feeBadData);
         return;
     }
     PublicKey key(slice);

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -24,6 +24,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/RangeSet.h>
 #include <ripple/beast/utility/WrappedSink.h>
+#include <ripple/overlay/Squelch.h>
 #include <ripple/overlay/impl/OverlayImpl.h>
 #include <ripple/overlay/impl/ProtocolMessage.h>
 #include <ripple/overlay/impl/ProtocolVersion.h>
@@ -141,6 +142,8 @@ private:
     boost::optional<std::uint32_t> lastPingSeq_;
     clock_type::time_point lastPingTime_;
     clock_type::time_point const creationTime_;
+
+    squelch::Squelch<UptimeClock> squelch_;
 
     // Notes on thread locking:
     //
@@ -549,6 +552,8 @@ public:
     onMessage(std::shared_ptr<protocol::TMValidation> const& m);
     void
     onMessage(std::shared_ptr<protocol::TMGetObjectByHash> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMSquelch> const& m);
 
 private:
     State

--- a/src/ripple/overlay/impl/ProtocolMessage.h
+++ b/src/ripple/overlay/impl/ProtocolMessage.h
@@ -77,6 +77,8 @@ protocolMessageName(int type)
             return "validation";
         case protocol::mtGET_OBJECTS:
             return "get_objects";
+        case protocol::mtSQUELCH:
+            return "squelch";
         default:
             break;
     }
@@ -374,6 +376,10 @@ invokeProtocolMessage(Buffers const& buffers, Handler& handler)
         case protocol::mtGET_OBJECTS:
             success = detail::invoke<protocol::TMGetObjectByHash>(
                 *header, buffers, handler);
+            break;
+        case protocol::mtSQUELCH:
+            success =
+                detail::invoke<protocol::TMSquelch>(*header, buffers, handler);
             break;
         default:
             handler.onMessageUnknown(header->message_type);

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -71,6 +71,9 @@ enum {
 
     /** How often to log send queue size */
     sendQueueLogFreq = 64,
+
+    /** How often we check for idle peers (seconds) */
+    checkIdlePeers = 4,
 };
 
 /** The threshold above which we treat a peer connection as high latency */

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -23,6 +23,7 @@ enum MessageType
     mtGET_PEER_SHARD_INFO   = 52;
     mtPEER_SHARD_INFO       = 53;
     mtVALIDATORLIST         = 54;
+    mtSQUELCH               = 55;
 }
 
 // token, iterations, target, challenge = issue demand for proof of work
@@ -354,5 +355,12 @@ message TMPing
     optional uint32 seq         = 2; // detect stale replies, ensure other side is reading
     optional uint64 pingTime    = 3; // know when we think we sent the ping
     optional uint64 netTime     = 4;
+}
+
+message TMSquelch
+{
+    required bool squelch           = 1; // squelch if true, otherwise unsquelch
+    required bytes validatorPubKey  = 2; // validator's public key
+    optional uint32 squelchDuration = 3; // squelch duration in milliseconds
 }
 

--- a/src/test/app/HashRouter_test.cpp
+++ b/src/test/app/HashRouter_test.cpp
@@ -191,7 +191,7 @@ class HashRouter_test : public beast::unit_test::suite
 
         uint256 const key1(1);
 
-        boost::optional<std::set<HashRouter::PeerShortID>> peers;
+        std::optional<std::set<HashRouter::PeerShortID>> peers;
 
         peers = router.shouldRelay(key1);
         BEAST_EXPECT(peers && peers->empty());

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -1392,7 +1392,8 @@ public:
         testSelectedPeerDisconnects(log);
         testSelectedPeerStopsRelaying(log);
         testInternalHashRouter(log);
-        testRandom(log);
+        if (arg() == "simulate")
+            testRandom(log);
     }
 };
 

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -1,0 +1,1399 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#include <ripple/basics/random.h>
+#include <ripple/beast/unit_test.h>
+#include <ripple/overlay/Message.h>
+#include <ripple/overlay/Peer.h>
+#include <ripple/overlay/Slot.h>
+#include <ripple/protocol/SecretKey.h>
+#include <ripple.pb.h>
+#include <test/jtx/Env.h>
+
+#include <boost/optional.hpp>
+#include <boost/thread.hpp>
+
+#include <numeric>
+#include <optional>
+
+namespace ripple {
+
+namespace test {
+
+using namespace std::chrono;
+
+class Link;
+
+using MessageSPtr = std::shared_ptr<Message>;
+using LinkSPtr = std::shared_ptr<Link>;
+using PeerSPtr = std::shared_ptr<Peer>;
+using PeerWPtr = std::weak_ptr<Peer>;
+using SquelchCB =
+    std::function<void(PublicKey const&, PeerWPtr const&, std::uint32_t)>;
+using UnsquelchCB = std::function<void(PublicKey const&, PeerWPtr const&)>;
+using LinkIterCB = std::function<void(Link&, MessageSPtr)>;
+
+static constexpr std::uint32_t MAX_PEERS = 10;
+static constexpr std::uint32_t MAX_VALIDATORS = 10;
+static constexpr std::uint32_t MAX_MESSAGES = 200000;
+
+/** Simulate two entities - peer directly connected to the server
+ * (via squelch in PeerSim) and PeerImp (via Overlay)
+ */
+class PeerPartial : public Peer
+{
+public:
+    virtual ~PeerPartial()
+    {
+    }
+    virtual void
+    onMessage(MessageSPtr const& m, SquelchCB f) = 0;
+    virtual void
+    onMessage(protocol::TMSquelch const& squelch) = 0;
+    void
+    send(protocol::TMSquelch const& squelch)
+    {
+        onMessage(squelch);
+    }
+
+    // dummy implementation
+    void
+    send(std::shared_ptr<Message> const& m) override
+    {
+    }
+    beast::IP::Endpoint
+    getRemoteAddress() const override
+    {
+        return {};
+    }
+    void
+    charge(Resource::Charge const& fee) override
+    {
+    }
+    bool
+    cluster() const override
+    {
+        return false;
+    }
+    bool
+    isHighLatency() const override
+    {
+        return false;
+    }
+    int
+    getScore(bool) const override
+    {
+        return 0;
+    }
+    PublicKey const&
+    getNodePublic() const override
+    {
+        static PublicKey key{};
+        return key;
+    }
+    Json::Value
+    json() override
+    {
+        return {};
+    }
+    bool
+    supportsFeature(ProtocolFeature f) const override
+    {
+        return false;
+    }
+    boost::optional<std::size_t>
+    publisherListSequence(PublicKey const&) const override
+    {
+        return {};
+    }
+    void
+    setPublisherListSequence(PublicKey const&, std::size_t const) override
+    {
+    }
+    uint256 const&
+    getClosedLedgerHash() const override
+    {
+        static uint256 hash{};
+        return hash;
+    }
+    bool
+    hasLedger(uint256 const& hash, std::uint32_t seq) const override
+    {
+        return false;
+    }
+    void
+    ledgerRange(std::uint32_t& minSeq, std::uint32_t& maxSeq) const override
+    {
+    }
+    bool
+    hasShard(std::uint32_t shardIndex) const override
+    {
+        return false;
+    }
+    bool
+    hasTxSet(uint256 const& hash) const override
+    {
+        return false;
+    }
+    void
+    cycleStatus() override
+    {
+    }
+    bool
+    hasRange(std::uint32_t uMin, std::uint32_t uMax) override
+    {
+        return false;
+    }
+    bool
+    compressionEnabled() const override
+    {
+        return false;
+    }
+};
+
+/** Manually advanced clock. */
+class ManualClock
+{
+public:
+    typedef uint64_t rep;
+    typedef std::milli period;
+    typedef std::chrono::duration<std::uint32_t, period> duration;
+    typedef std::chrono::time_point<ManualClock> time_point;
+    inline static const bool is_steady = false;
+
+    static void
+    advance(duration d) noexcept
+    {
+        now_ += d;
+    }
+
+    static void
+    randAdvance(milliseconds min, milliseconds max)
+    {
+        now_ += randDuration(min, max);
+    }
+
+    static void
+    reset() noexcept
+    {
+        now_ = time_point(seconds(0));
+    }
+
+    static time_point
+    now() noexcept
+    {
+        return now_;
+    }
+
+    static duration
+    randDuration(milliseconds min, milliseconds max)
+    {
+        return duration(milliseconds(rand_int(min.count(), max.count())));
+    }
+
+    explicit ManualClock() = default;
+
+private:
+    inline static time_point now_ = time_point(seconds(0));
+};
+
+/** Simulate server's OverlayImpl */
+class Overlay
+{
+public:
+    Overlay() = default;
+    virtual ~Overlay() = default;
+
+    virtual void
+    updateSlotAndSquelch(
+        uint256 const& key,
+        PublicKey const& validator,
+        Peer::id_t id,
+        SquelchCB f,
+        protocol::MessageType type = protocol::mtVALIDATION) = 0;
+
+    virtual void deleteIdlePeers(UnsquelchCB) = 0;
+
+    virtual void deletePeer(Peer::id_t, UnsquelchCB) = 0;
+};
+
+class Validator;
+
+/** Simulate link from a validator to a peer directly connected
+ * to the server.
+ */
+class Link
+{
+    using Latency = std::pair<milliseconds, milliseconds>;
+
+public:
+    Link(
+        Validator& validator,
+        PeerSPtr peer,
+        Latency const& latency = {milliseconds(5), milliseconds(15)})
+        : validator_(validator), peer_(peer), latency_(latency), up_(true)
+    {
+        auto sp = peer_.lock();
+        assert(sp);
+    }
+    ~Link() = default;
+    void
+    send(MessageSPtr const& m, SquelchCB f)
+    {
+        if (!up_)
+            return;
+        auto sp = peer_.lock();
+        assert(sp);
+        auto peer = std::dynamic_pointer_cast<PeerPartial>(sp);
+        peer->onMessage(m, f);
+    }
+    Validator&
+    validator()
+    {
+        return validator_;
+    }
+    void
+    up(bool linkUp)
+    {
+        up_ = linkUp;
+    }
+    Peer::id_t
+    peerId()
+    {
+        auto p = peer_.lock();
+        assert(p);
+        return p->id();
+    }
+    PeerSPtr
+    getPeer()
+    {
+        auto p = peer_.lock();
+        assert(p);
+        return p;
+    }
+
+private:
+    Validator& validator_;
+    PeerWPtr peer_;
+    Latency latency_;
+    bool up_;
+};
+
+/** Simulate Validator */
+class Validator
+{
+    using Links = std::unordered_map<Peer::id_t, LinkSPtr>;
+
+public:
+    Validator()
+    {
+        pkey_ = std::get<0>(randomKeyPair(KeyType::ed25519));
+        protocol::TMValidation v;
+        v.set_validation("validation");
+        message_ = std::make_shared<Message>(v, protocol::mtVALIDATION, pkey_);
+        id_ = sid_++;
+    }
+    Validator(Validator const&) = default;
+    Validator(Validator&&) = default;
+    Validator&
+    operator=(Validator const&) = default;
+    Validator&
+    operator=(Validator&&) = default;
+    ~Validator()
+    {
+        clear();
+    }
+
+    void
+    clear()
+    {
+        links_.clear();
+    }
+
+    static void
+    resetId()
+    {
+        sid_ = 0;
+    }
+
+    PublicKey const&
+    key()
+    {
+        return pkey_;
+    }
+
+    operator PublicKey() const
+    {
+        return pkey_;
+    }
+
+    void
+    addPeer(PeerSPtr peer)
+    {
+        links_.emplace(
+            std::make_pair(peer->id(), std::make_shared<Link>(*this, peer)));
+    }
+
+    void
+    deletePeer(Peer::id_t id)
+    {
+        links_.erase(id);
+    }
+
+    void
+    for_links(std::vector<Peer::id_t> peers, LinkIterCB f)
+    {
+        for (auto id : peers)
+        {
+            assert(links_.find(id) != links_.end());
+            f(*links_[id], message_);
+        }
+    }
+
+    void
+    for_links(LinkIterCB f, bool simulateSlow = false)
+    {
+        std::vector<LinkSPtr> v;
+        std::transform(
+            links_.begin(), links_.end(), std::back_inserter(v), [](auto& kv) {
+                return kv.second;
+            });
+        std::random_device d;
+        std::mt19937 g(d());
+        std::shuffle(v.begin(), v.end(), g);
+
+        for (auto& link : v)
+        {
+            f(*link, message_);
+        }
+    }
+
+    /** Send to specific peers */
+    void
+    send(std::vector<Peer::id_t> peers, SquelchCB f)
+    {
+        for_links(peers, [&](Link& link, MessageSPtr m) { link.send(m, f); });
+    }
+
+    /** Send to all peers */
+    void
+    send(SquelchCB f)
+    {
+        for_links([&](Link& link, MessageSPtr m) { link.send(m, f); });
+    }
+
+    MessageSPtr
+    message()
+    {
+        return message_;
+    }
+
+    std::uint16_t
+    id()
+    {
+        return id_;
+    }
+
+    void
+    linkUp(Peer::id_t id)
+    {
+        auto it = links_.find(id);
+        assert(it != links_.end());
+        it->second->up(true);
+    }
+
+    void
+    linkDown(Peer::id_t id)
+    {
+        auto it = links_.find(id);
+        assert(it != links_.end());
+        it->second->up(false);
+    }
+
+private:
+    Links links_;
+    PublicKey pkey_{};
+    MessageSPtr message_ = nullptr;
+    inline static std::uint16_t sid_ = 0;
+    std::uint16_t id_ = 0;
+};
+
+class PeerSim : public PeerPartial, public std::enable_shared_from_this<PeerSim>
+{
+public:
+    using id_t = Peer::id_t;
+    PeerSim(Overlay& overlay) : overlay_(overlay)
+    {
+        id_ = sid_++;
+    }
+
+    ~PeerSim() = default;
+
+    id_t
+    id() const override
+    {
+        return id_;
+    }
+
+    static void
+    resetId()
+    {
+        sid_ = 0;
+    }
+
+    /** Local Peer (PeerImp) */
+    void
+    onMessage(MessageSPtr const& m, SquelchCB f) override
+    {
+        auto validator = m->getValidatorKey();
+        assert(validator);
+        if (squelch_.isSquelched(*validator))
+            return;
+
+        overlay_.updateSlotAndSquelch({}, *validator, id(), f);
+    }
+
+    /** Remote Peer (Directly connected Peer) */
+    virtual void
+    onMessage(protocol::TMSquelch const& squelch) override
+    {
+        auto validator = squelch.validatorpubkey();
+        PublicKey key(Slice(validator.data(), validator.size()));
+        squelch_.squelch(key, squelch.squelch(), squelch.squelchduration());
+    }
+
+private:
+    inline static id_t sid_ = 0;
+    id_t id_;
+    Overlay& overlay_;
+    squelch::Squelch<ManualClock> squelch_;
+};
+
+class OverlaySim : public Overlay, public squelch::SquelchHandler
+{
+    using Peers = std::unordered_map<Peer::id_t, PeerSPtr>;
+
+public:
+    using id_t = Peer::id_t;
+    using clock_type = ManualClock;
+    OverlaySim(Application& app) : slots_(app, *this)
+    {
+    }
+
+    ~OverlaySim() = default;
+
+    void
+    clear()
+    {
+        peers_.clear();
+        ManualClock::advance(hours(1));
+        slots_.deleteIdlePeers();
+    }
+
+    std::uint16_t
+    inState(PublicKey const& validator, squelch::PeerState state)
+    {
+        auto res = slots_.inState(validator, state);
+        return res ? *res : 0;
+    }
+
+    void
+    updateSlotAndSquelch(
+        uint256 const& key,
+        PublicKey const& validator,
+        Peer::id_t id,
+        SquelchCB f,
+        protocol::MessageType type = protocol::mtVALIDATION) override
+    {
+        squelch_ = f;
+        slots_.updateSlotAndSquelch(key, validator, id, type);
+    }
+
+    void
+    deletePeer(id_t id, UnsquelchCB f) override
+    {
+        unsquelch_ = f;
+        slots_.deletePeer(id, true);
+    }
+
+    void
+    deleteIdlePeers(UnsquelchCB f) override
+    {
+        unsquelch_ = f;
+        slots_.deleteIdlePeers();
+    }
+
+    PeerSPtr
+    addPeer(bool useCache = true)
+    {
+        PeerSPtr peer{};
+        Peer::id_t id;
+        if (peersCache_.empty() || !useCache)
+        {
+            peer = std::make_shared<PeerSim>(*this);
+            id = peer->id();
+        }
+        else
+        {
+            auto it = peersCache_.begin();
+            peer = it->second;
+            id = it->first;
+            peersCache_.erase(it);
+        }
+        peers_.emplace(std::make_pair(id, peer));
+        return peer;
+    }
+
+    void
+    deletePeer(Peer::id_t id, bool useCache = true)
+    {
+        auto it = peers_.find(id);
+        assert(it != peers_.end());
+        deletePeer(id, [&](PublicKey const&, PeerWPtr) {});
+        if (useCache)
+            peersCache_.emplace(std::make_pair(id, it->second));
+        peers_.erase(it);
+    }
+
+    void
+    resetPeers()
+    {
+        while (!peers_.empty())
+            deletePeer(peers_.begin()->first);
+        while (!peersCache_.empty())
+            addPeer();
+    }
+
+    std::optional<Peer::id_t>
+    deleteLastPeer()
+    {
+        if (peers_.empty())
+            return {};
+
+        std::uint8_t maxId = 0;
+
+        for (auto& [id, _] : peers_)
+        {
+            if (id > maxId)
+                maxId = id;
+        }
+
+        deletePeer(maxId, false);
+
+        return maxId;
+    }
+
+    bool
+    isCountingState(PublicKey const& validator)
+    {
+        return slots_.inState(validator, squelch::SlotState::Counting);
+    }
+
+    std::set<id_t>
+    getSelected(PublicKey const& validator)
+    {
+        return slots_.getSelected(validator);
+    }
+
+    bool
+    isSelected(PublicKey const& validator, Peer::id_t peer)
+    {
+        auto selected = slots_.getSelected(validator);
+        return selected.find(peer) != selected.end();
+    }
+
+    id_t
+    getSelectedPeer(PublicKey const& validator)
+    {
+        auto selected = slots_.getSelected(validator);
+        assert(selected.size());
+        return *selected.begin();
+    }
+
+    std::unordered_map<
+        id_t,
+        std::tuple<
+            squelch::PeerState,
+            std::uint16_t,
+            std::uint32_t,
+            std::uint32_t>>
+    getPeers(PublicKey const& validator)
+    {
+        return slots_.getPeers(validator);
+    }
+
+    std::uint16_t
+    getNumPeers() const
+    {
+        return peers_.size();
+    }
+
+private:
+    void
+    squelch(
+        PublicKey const& validator,
+        Peer::id_t id,
+        std::uint32_t squelchDuration) const override
+    {
+        if (auto it = peers_.find(id); it != peers_.end())
+            squelch_(validator, it->second, squelchDuration);
+    }
+    void
+    unsquelch(PublicKey const& validator, Peer::id_t id) const override
+    {
+        if (auto it = peers_.find(id); it != peers_.end())
+            unsquelch_(validator, it->second);
+    }
+    SquelchCB squelch_;
+    UnsquelchCB unsquelch_;
+    Peers peers_;
+    Peers peersCache_;
+    squelch::Slots<ManualClock> slots_;
+};
+
+class Network
+{
+public:
+    Network(Application& app) : overlay_(app)
+    {
+        init();
+    }
+
+    void
+    init()
+    {
+        validators_.resize(MAX_VALIDATORS);
+        for (int p = 0; p < MAX_PEERS; p++)
+        {
+            auto peer = overlay_.addPeer();
+            for (auto& v : validators_)
+                v.addPeer(peer);
+        }
+    }
+
+    ~Network() = default;
+
+    void
+    reset()
+    {
+        validators_.clear();
+        overlay_.clear();
+        PeerSim::resetId();
+        Validator::resetId();
+        init();
+    }
+
+    Peer::id_t
+    addPeer()
+    {
+        auto peer = overlay_.addPeer();
+        for (auto& v : validators_)
+            v.addPeer(peer);
+        return peer->id();
+    }
+
+    void
+    deleteLastPeer()
+    {
+        auto id = overlay_.deleteLastPeer();
+
+        if (!id)
+            return;
+
+        for (auto& validator : validators_)
+            validator.deletePeer(*id);
+    }
+
+    void
+    purgePeers()
+    {
+        while (overlay_.getNumPeers() > MAX_PEERS)
+            deleteLastPeer();
+    }
+
+    Validator&
+    validator(std::uint16_t v)
+    {
+        assert(v < validators_.size());
+        return validators_[v];
+    }
+
+    OverlaySim&
+    overlay()
+    {
+        return overlay_;
+    }
+
+    void
+    enableLink(std::uint16_t validatorId, Peer::id_t peer, bool enable)
+    {
+        auto it =
+            std::find_if(validators_.begin(), validators_.end(), [&](auto& v) {
+                return v.id() == validatorId;
+            });
+        assert(it != validators_.end());
+        if (enable)
+            it->linkUp(peer);
+        else
+            it->linkDown(peer);
+    }
+
+    void
+    onDisconnectPeer(Peer::id_t peer)
+    {
+        // Send unsquelch to the Peer on all links. This way when
+        // the Peer "reconnects" it starts sending messages on the link.
+        // We expect that if a Peer disconnects and then reconnects, it's
+        // unsquelched.
+        protocol::TMSquelch squelch;
+        squelch.set_squelch(false);
+        for (auto& v : validators_)
+        {
+            PublicKey key = v;
+            squelch.clear_validatorpubkey();
+            squelch.set_validatorpubkey(key.data(), key.size());
+            v.for_links({peer}, [&](Link& l, MessageSPtr) {
+                std::dynamic_pointer_cast<PeerSim>(l.getPeer())->send(squelch);
+            });
+        }
+    }
+
+    void
+    for_rand(
+        std::uint32_t min,
+        std::uint32_t max,
+        std::function<void(std::uint32_t)> f)
+    {
+        auto size = max - min;
+        std::vector<std::uint32_t> s(size);
+        std::iota(s.begin(), s.end(), min);
+        std::random_device d;
+        std::mt19937 g(d());
+        std::shuffle(s.begin(), s.end(), g);
+        for (auto v : s)
+            f(v);
+    }
+
+    void
+    propagate(
+        LinkIterCB link,
+        std::uint16_t nValidators = MAX_VALIDATORS,
+        std::uint32_t nMessages = MAX_MESSAGES,
+        bool purge = true,
+        bool resetClock = true)
+    {
+        if (resetClock)
+            ManualClock::reset();
+
+        if (purge)
+        {
+            purgePeers();
+            overlay_.resetPeers();
+        }
+
+        for (int m = 0; m < nMessages; ++m)
+        {
+            ManualClock::randAdvance(milliseconds(1800), milliseconds(2200));
+            for_rand(0, nValidators, [&](std::uint32_t v) {
+                validators_[v].for_links(link);
+            });
+        }
+    }
+
+    /** Is peer in Selected state in any of the slots */
+    bool
+    isSelected(Peer::id_t id)
+    {
+        for (auto& v : validators_)
+        {
+            if (overlay_.isSelected(v, id))
+                return true;
+        }
+        return false;
+    }
+
+    /** Check if there are peers to unsquelch - peer is in Selected
+     * state in any of the slots and there are peers in Squelched state
+     * in those slots.
+     */
+    bool
+    allCounting(Peer::id_t peer)
+    {
+        for (auto& v : validators_)
+        {
+            if (!overlay_.isSelected(v, peer))
+                continue;
+            auto peers = overlay_.getPeers(v);
+            for (auto& [_, v] : peers)
+                if (std::get<squelch::PeerState>(v) ==
+                    squelch::PeerState::Squelched)
+                    return false;
+        }
+        return true;
+    }
+
+private:
+    OverlaySim overlay_;
+    std::vector<Validator> validators_;
+};
+
+class reduce_relay_test : public beast::unit_test::suite
+{
+    using Slot = squelch::Slot<ManualClock>;
+    using id_t = Peer::id_t;
+
+    void
+    printPeers(const std::string& msg, std::uint16_t validator = 0)
+    {
+        auto peers = network_.overlay().getPeers(network_.validator(validator));
+        std::cout << msg << " "
+                  << "num peers " << (int)network_.overlay().getNumPeers()
+                  << std::endl;
+        for (auto& [k, v] : peers)
+            std::cout << k << ":" << (int)std::get<squelch::PeerState>(v)
+                      << " ";
+        std::cout << std::endl;
+    }
+
+    /** Send squelch (if duration is set) or unsquelch (if duration not set) */
+    Peer::id_t
+    sendSquelch(
+        PublicKey const& validator,
+        PeerWPtr const& peerPtr,
+        std::optional<std::uint32_t> duration)
+    {
+        protocol::TMSquelch squelch;
+        bool res = duration ? true : false;
+        squelch.set_squelch(res);
+        squelch.set_validatorpubkey(validator.data(), validator.size());
+        if (res)
+            squelch.set_squelchduration(*duration);
+        auto sp = peerPtr.lock();
+        assert(sp);
+        std::dynamic_pointer_cast<PeerSim>(sp)->send(squelch);
+        return sp->id();
+    }
+
+    enum State { On, Off, WaitReset };
+    enum EventType { LinkDown = 0, PeerDisconnected = 1 };
+    // Link down or Peer disconnect event
+    // TBD - add new peer event
+    // TBD - add overlapping type of events at any
+    //       time in any quantity
+    struct Event
+    {
+        State state_ = State::Off;
+        std::uint32_t cnt_ = 0;
+        std::uint32_t handledCnt_ = 0;
+        bool isSelected_ = false;
+        Peer::id_t peer_;
+        std::uint16_t validator_;
+        PublicKey key_;
+        time_point<ManualClock> time_;
+        bool handled_ = false;
+    };
+
+    /** Randomly brings the link between a validator and a peer down.
+     * Randomly disconnects a peer. Those events are generated one at a time.
+     */
+    void
+    random(bool log)
+    {
+        std::unordered_map<EventType, Event> events{
+            {LinkDown, {}}, {PeerDisconnected, {}}};
+        time_point<ManualClock> lastCheck = ManualClock::now();
+
+        network_.reset();
+        network_.propagate([&](Link& link, MessageSPtr m) {
+            auto& validator = link.validator();
+            auto now = ManualClock::now();
+
+            bool squelched = false;
+            std::stringstream str;
+
+            link.send(
+                m,
+                [&](PublicKey const& key,
+                    PeerWPtr const& peerPtr,
+                    std::uint32_t duration) {
+                    assert(key == validator);
+                    auto p = sendSquelch(key, peerPtr, duration);
+                    squelched = true;
+                    str << p << " ";
+                });
+
+            if (squelched)
+            {
+                auto selected = network_.overlay().getSelected(validator);
+                str << " selected: ";
+                for (auto s : selected)
+                    str << s << " ";
+                if (log)
+                    std::cout
+                        << (double)squelch::epoch<milliseconds>(now).count() /
+                            1000.
+                        << " random, squelched, validator: " << validator.id()
+                        << " peers: " << str.str() << std::endl;
+                auto countingState =
+                    network_.overlay().isCountingState(validator);
+                BEAST_EXPECT(
+                    countingState == false &&
+                    selected.size() == squelch::MAX_SELECTED_PEERS);
+            }
+
+            // Trigger Link Down or Peer Disconnect event
+            // Only one Link Down at a time
+            if (events[EventType::LinkDown].state_ == State::Off)
+            {
+                auto update = [&](EventType event) {
+                    events[event].cnt_++;
+                    events[event].validator_ = validator.id();
+                    events[event].key_ = validator;
+                    events[event].peer_ = link.peerId();
+                    events[event].state_ = State::On;
+                    events[event].time_ = now;
+                    if (event == EventType::LinkDown)
+                    {
+                        network_.enableLink(
+                            validator.id(), link.peerId(), false);
+                        events[event].isSelected_ =
+                            network_.overlay().isSelected(
+                                validator, link.peerId());
+                    }
+                    else
+                        events[event].isSelected_ =
+                            network_.isSelected(link.peerId());
+                };
+                auto r = rand_int(0, 1000);
+                if (r == (int)EventType::LinkDown ||
+                    r == (int)EventType::PeerDisconnected)
+                {
+                    update(static_cast<EventType>(r));
+                }
+            }
+
+            if (events[EventType::PeerDisconnected].state_ == State::On)
+            {
+                auto& event = events[EventType::PeerDisconnected];
+                bool allCounting = network_.allCounting(event.peer_);
+                network_.overlay().deletePeer(
+                    event.peer_,
+                    [&](PublicKey const& v, PeerWPtr const& peerPtr) {
+                        if (event.isSelected_)
+                            sendSquelch(v, peerPtr, {});
+                        event.handled_ = true;
+                    });
+                // Should only be unsquelched if the peer is in Selected state
+                // If in Selected state it's possible unsquelching didn't
+                // take place because there is no peers in Squelched state in
+                // any of the slots where the peer is in Selected state
+                // (allCounting is true)
+                bool handled =
+                    (event.isSelected_ == false && !event.handled_) ||
+                    (event.isSelected_ == true &&
+                     (event.handled_ || allCounting));
+                BEAST_EXPECT(handled);
+                event.state_ = State::Off;
+                event.isSelected_ = false;
+                event.handledCnt_ += handled;
+                event.handled_ = false;
+                network_.onDisconnectPeer(event.peer_);
+            }
+
+            auto& event = events[EventType::LinkDown];
+            // Check every sec for idled peers. Idled peers are
+            // created by Link Down event.
+            if (now - lastCheck > milliseconds(1000))
+            {
+                lastCheck = now;
+                // Check if Link Down event must be handled by
+                // deleteIdlePeer(): 1) the peer is in Selected state;
+                // 2) the peer has not received any messages for IDLED time;
+                // 3) there are peers in Squelched state in the slot.
+                // 4) peer is in Slot's peers_ (if not then it is deleted
+                //    by Slots::deleteIdlePeers())
+                bool mustHandle = false;
+                if (event.state_ == State::On)
+                {
+                    event.isSelected_ =
+                        network_.overlay().isSelected(event.key_, event.peer_);
+                    auto peers = network_.overlay().getPeers(event.key_);
+                    auto d = squelch::epoch<milliseconds>(now).count() -
+                        std::get<3>(peers[event.peer_]);
+                    mustHandle = event.isSelected_ &&
+                        d > milliseconds(squelch::IDLED).count() &&
+                        network_.overlay().inState(
+                            event.key_, squelch::PeerState::Squelched) > 0 &&
+                        peers.find(event.peer_) != peers.end();
+                }
+                network_.overlay().deleteIdlePeers(
+                    [&](PublicKey const& v, PeerWPtr const& ptr) {
+                        event.handled_ = true;
+                        if (mustHandle && v == event.key_)
+                        {
+                            event.state_ = State::WaitReset;
+                            sendSquelch(validator, ptr, {});
+                        }
+                    });
+                bool handled =
+                    (event.handled_ && event.state_ == State::WaitReset) ||
+                    (!event.handled_ && !mustHandle);
+                BEAST_EXPECT(handled);
+            }
+            if (event.state_ == State::WaitReset ||
+                (event.state_ == State::On &&
+                 (now - event.time_ > (squelch::IDLED + seconds(2)))))
+            {
+                bool handled =
+                    event.state_ == State::WaitReset || !event.handled_;
+                BEAST_EXPECT(handled);
+                event.state_ = State::Off;
+                event.isSelected_ = false;
+                event.handledCnt_ += handled;
+                event.handled_ = false;
+                network_.enableLink(event.validator_, event.peer_, true);
+            }
+        });
+
+        auto& down = events[EventType::LinkDown];
+        auto& disconnected = events[EventType::PeerDisconnected];
+        // It's possible the last Down Link event is not handled
+        BEAST_EXPECT(down.handledCnt_ >= down.cnt_ - 1);
+        // All Peer Disconnect events must be handled
+        BEAST_EXPECT(disconnected.cnt_ == disconnected.handledCnt_);
+        if (log)
+            std::cout << "link down count: " << down.cnt_ << "/"
+                      << down.handledCnt_
+                      << " peer disconnect count: " << disconnected.cnt_ << "/"
+                      << disconnected.handledCnt_;
+    }
+
+    bool
+    checkCounting(PublicKey const& validator, bool isCountingState)
+    {
+        auto countingState = network_.overlay().isCountingState(validator);
+        BEAST_EXPECT(countingState == isCountingState);
+        return countingState == isCountingState;
+    }
+
+    void
+    doTest(const std::string& msg, bool log, std::function<void(bool)> f)
+    {
+        testcase(msg);
+        f(log);
+    }
+
+    /** Initial counting round: three peers receive message "faster" then
+     * others. Once the message count for the three peers reaches threshold
+     * the rest of the peers are squelched and the slot for the given validator
+     * is in Selected state.
+     */
+    void
+    testInitialRound(bool log)
+    {
+        doTest("Initial Round", log, [this](bool log) {
+            BEAST_EXPECT(propagateAndSquelch(log));
+        });
+    }
+
+    /** Receiving message from squelched peer too soon should not change the
+     * slot's state to Counting.
+     */
+    void
+    testPeerUnsquelchedTooSoon(bool log)
+    {
+        doTest("Peer Unsquelched Too Soon", log, [this](bool log) {
+            BEAST_EXPECT(propagateNoSquelch(log, 1, false, false, false));
+        });
+    }
+
+    /** Receiving message from squelched peer should change the
+     * slot's state to Counting.
+     */
+    void
+    testPeerUnsquelched(bool log)
+    {
+        ManualClock::advance(seconds(601));
+        doTest("Peer Unsquelched", log, [this](bool log) {
+            BEAST_EXPECT(propagateNoSquelch(log, 2, true, true, false));
+        });
+    }
+
+    /** Propagate enough messages to generate one squelch event */
+    bool
+    propagateAndSquelch(bool log, bool purge = true, bool resetClock = true)
+    {
+        int n = 0;
+        network_.propagate(
+            [&](Link& link, MessageSPtr message) {
+                std::uint16_t squelched = 0;
+                link.send(
+                    message,
+                    [&](PublicKey const& key,
+                        PeerWPtr const& peerPtr,
+                        std::uint32_t duration) {
+                        squelched++;
+                        sendSquelch(key, peerPtr, duration);
+                    });
+                if (squelched)
+                {
+                    BEAST_EXPECT(
+                        squelched == MAX_PEERS - squelch::MAX_SELECTED_PEERS);
+                    n++;
+                }
+            },
+            1,
+            squelch::MAX_MESSAGE_THRESHOLD + 2,
+            purge,
+            resetClock);
+        auto selected = network_.overlay().getSelected(network_.validator(0));
+        BEAST_EXPECT(selected.size() == squelch::MAX_SELECTED_PEERS);
+        BEAST_EXPECT(n == 1);  // only one selection round
+        auto res = checkCounting(network_.validator(0), false);
+        BEAST_EXPECT(res);
+        return n == 1 && res;
+    }
+
+    /** Send fewer message so that squelch event is not generated */
+    bool
+    propagateNoSquelch(
+        bool log,
+        std::uint16_t nMessages,
+        bool countingState,
+        bool purge = true,
+        bool resetClock = true)
+    {
+        bool squelched = false;
+        network_.propagate(
+            [&](Link& link, MessageSPtr message) {
+                link.send(
+                    message,
+                    [&](PublicKey const& key,
+                        PeerWPtr const& peerPtr,
+                        std::uint32_t duration) {
+                        squelched = true;
+                        BEAST_EXPECT(false);
+                    });
+            },
+            1,
+            nMessages,
+            purge,
+            resetClock);
+        auto res = checkCounting(network_.validator(0), countingState);
+        return !squelched && res;
+    }
+
+    /** Receiving a message from new peer should change the
+     * slot's state to Counting.
+     */
+    void
+    testNewPeer(bool log)
+    {
+        doTest("New Peer", log, [this](bool log) {
+            BEAST_EXPECT(propagateAndSquelch(log, true, false));
+            network_.addPeer();
+            BEAST_EXPECT(propagateNoSquelch(log, 1, true, false, false));
+        });
+    }
+
+    /** Selected peer disconnects. Should change the state to counting and
+     * unsquelch squelched peers. */
+    void
+    testSelectedPeerDisconnects(bool log)
+    {
+        doTest("Selected Peer Disconnects", log, [this](bool log) {
+            ManualClock::advance(seconds(601));
+            BEAST_EXPECT(propagateAndSquelch(log, true, false));
+            auto id = network_.overlay().getSelectedPeer(network_.validator(0));
+            std::uint16_t unsquelched = 0;
+            network_.overlay().deletePeer(
+                id, [&](PublicKey const& key, PeerWPtr const& peer) {
+                    unsquelched++;
+                });
+            BEAST_EXPECT(
+                unsquelched == MAX_PEERS - squelch::MAX_SELECTED_PEERS);
+            BEAST_EXPECT(checkCounting(network_.validator(0), true));
+        });
+    }
+
+    /** Selected peer stops relaying. Should change the state to counting and
+     * unsquelch squelched peers. */
+    void
+    testSelectedPeerStopsRelaying(bool log)
+    {
+        doTest("Selected Peer Stops Relaying", log, [this](bool log) {
+            ManualClock::advance(seconds(601));
+            BEAST_EXPECT(propagateAndSquelch(log, true, false));
+            ManualClock::advance(squelch::IDLED + seconds(1));
+            std::uint16_t unsquelched = 0;
+            network_.overlay().deleteIdlePeers(
+                [&](PublicKey const& key, PeerWPtr const& peer) {
+                    unsquelched++;
+                });
+            auto peers = network_.overlay().getPeers(network_.validator(0));
+            BEAST_EXPECT(
+                unsquelched == MAX_PEERS - squelch::MAX_SELECTED_PEERS);
+            BEAST_EXPECT(checkCounting(network_.validator(0), true));
+        });
+    }
+
+    /** Squelched peer disconnects. Should not change the state to counting.
+     */
+    void
+    testSquelchedPeerDisconnects(bool log)
+    {
+        doTest("Squelched Peer Disconnects", log, [this](bool log) {
+            ManualClock::advance(seconds(601));
+            BEAST_EXPECT(propagateAndSquelch(log, true, false));
+            auto peers = network_.overlay().getPeers(network_.validator(0));
+            auto it = std::find_if(peers.begin(), peers.end(), [&](auto it) {
+                return std::get<squelch::PeerState>(it.second) ==
+                    squelch::PeerState::Squelched;
+            });
+            assert(it != peers.end());
+            std::uint16_t unsquelched = 0;
+            network_.overlay().deletePeer(
+                it->first, [&](PublicKey const& key, PeerWPtr const& peer) {
+                    unsquelched++;
+                });
+            BEAST_EXPECT(unsquelched == 0);
+            BEAST_EXPECT(checkCounting(network_.validator(0), false));
+        });
+    }
+
+    void
+    testRandom(bool log)
+    {
+        doTest("Random Test", log, [&](bool log) { random(log); });
+    }
+
+    void
+    testConfig(bool log)
+    {
+        doTest("Config Test", log, [&](bool log) {
+            Config c;
+
+            std::string toLoad(R"rippleConfig(
+[reduce_relay]
+enable=1
+squelch=1
+)rippleConfig");
+
+            c.loadFromString(toLoad);
+            BEAST_EXPECT(c.REDUCE_RELAY_ENABLE == true);
+            BEAST_EXPECT(c.REDUCE_RELAY_SQUELCH == true);
+
+            Config c1;
+
+            toLoad = (R"rippleConfig(
+[reduce_relay]
+enable=0
+squelch=0
+)rippleConfig");
+
+            c1.loadFromString(toLoad);
+            BEAST_EXPECT(c1.REDUCE_RELAY_ENABLE == false);
+            BEAST_EXPECT(c1.REDUCE_RELAY_SQUELCH == false);
+
+            Config c2;
+
+            toLoad = R"rippleConfig(
+[reduce_relay]
+enabled=1
+squelched=1
+)rippleConfig";
+
+            c2.loadFromString(toLoad);
+            BEAST_EXPECT(c2.REDUCE_RELAY_ENABLE == false);
+            BEAST_EXPECT(c2.REDUCE_RELAY_SQUELCH == false);
+        });
+    }
+
+    void
+    testInternalHashRouter(bool log)
+    {
+        doTest("Duplicate Message", log, [&](bool log) {
+            network_.reset();
+            // update message count for the same peer/validator
+            std::int16_t nMessages = 5;
+            for (int i = 0; i < nMessages; i++)
+            {
+                uint256 key(i);
+                network_.overlay().updateSlotAndSquelch(
+                    key,
+                    network_.validator(0),
+                    0,
+                    [&](PublicKey const&, PeerWPtr, std::uint32_t) {});
+            }
+            auto peers = network_.overlay().getPeers(network_.validator(0));
+            // first message changes Slot state to Counting and is not counted,
+            // hence '-1'.
+            BEAST_EXPECT(std::get<1>(peers[0]) == (nMessages - 1));
+            // add duplicate
+            uint256 key(nMessages - 1);
+            network_.overlay().updateSlotAndSquelch(
+                key,
+                network_.validator(0),
+                0,
+                [&](PublicKey const&, PeerWPtr, std::uint32_t) {});
+            // confirm the same number of messages
+            peers = network_.overlay().getPeers(network_.validator(0));
+            BEAST_EXPECT(std::get<1>(peers[0]) == (nMessages - 1));
+            // advance the clock
+            ManualClock::advance(squelch::IDLED + seconds(1));
+            network_.overlay().updateSlotAndSquelch(
+                key,
+                network_.validator(0),
+                0,
+                [&](PublicKey const&, PeerWPtr, std::uint32_t) {});
+            peers = network_.overlay().getPeers(network_.validator(0));
+            // confirm message number increased
+            BEAST_EXPECT(std::get<1>(peers[0]) == nMessages);
+        });
+    }
+
+    jtx::Env env_;
+    Network network_;
+
+public:
+    reduce_relay_test() : env_(*this), network_(env_.app())
+    {
+    }
+
+    void
+    run() override
+    {
+        bool log = false;
+        testConfig(log);
+        testInitialRound(log);
+        testPeerUnsquelchedTooSoon(log);
+        testPeerUnsquelched(log);
+        testNewPeer(log);
+        testSquelchedPeerDisconnects(log);
+        testSelectedPeerDisconnects(log);
+        testSelectedPeerStopsRelaying(log);
+        testInternalHashRouter(log);
+        testRandom(log);
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(reduce_relay, ripple_data, ripple);
+
+}  // namespace test
+
+}  // namespace ripple

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -861,6 +861,7 @@ class reduce_relay_test : public beast::unit_test::suite
     using Slot = squelch::Slot<ManualClock>;
     using id_t = Peer::id_t;
 
+protected:
     void
     printPeers(const std::string& msg, std::uint16_t validator = 0)
     {
@@ -1281,12 +1282,6 @@ class reduce_relay_test : public beast::unit_test::suite
     }
 
     void
-    testRandom(bool log)
-    {
-        doTest("Random Test", log, [&](bool log) { random(log); });
-    }
-
-    void
     testConfig(bool log)
     {
         doTest("Config Test", log, [&](bool log) {
@@ -1392,12 +1387,27 @@ public:
         testSelectedPeerDisconnects(log);
         testSelectedPeerStopsRelaying(log);
         testInternalHashRouter(log);
-        if (arg() == "simulate")
-            testRandom(log);
+    }
+};
+
+class reduce_relay_simulate_test : public reduce_relay_test
+{
+    void
+    testRandom(bool log)
+    {
+        doTest("Random Test", log, [&](bool log) { random(log); });
+    }
+
+    void
+    run() override
+    {
+        bool log = false;
+        testRandom(log);
     }
 };
 
 BEAST_DEFINE_TESTSUITE(reduce_relay, ripple_data, ripple);
+BEAST_DEFINE_TESTSUITE_MANUAL(reduce_relay_simulate, ripple_data, ripple);
 
 }  // namespace test
 

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -589,6 +589,7 @@ public:
 
         for (auto& [id, _] : peers_)
         {
+            (void)_;
             if (id > maxId)
                 maxId = id;
         }
@@ -840,9 +841,12 @@ public:
                 continue;
             auto peers = overlay_.getPeers(v);
             for (auto& [_, v] : peers)
+            {
+                (void)_;
                 if (std::get<squelch::PeerState>(v) ==
                     squelch::PeerState::Squelched)
                     return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
- The motivation for the reduce relay is to reduce CPU and bandwidth cost and improve link latency.
- Every node independently goes through the peer selection rounds at some random intervals.
- MAX_PEERS are randomly selected from the pool of directly connected peers with the Validation and Proposal message count from a validator in {MESSAGE_LOW_THRESHOLD,MESSAGE_UPPER_THRESHOLD}. The peers are chosen to be the source of Validation and Proposal messages from this validator. Protocol message is sent to the rest of directly connected peers instructing them to squelch (stop relaying) the message for some random period of time in {MAX_UNSQUELCH_EXPIRE,MIN_UNSQUELCH_EXPIRE}.
- When the squelch expires or when a new peer connects to the node, another peer selection round starts.
- When a peer, which is selected to be the source of the messages for the given validator disconnects, or is idled then unsquelch message is sent to all squelched peers and another peer selection round starts.