### PR TITLE
Update LZ4 library to 1.9.2

### DIFF
--- a/Builds/CMake/deps/Findlz4.cmake
+++ b/Builds/CMake/deps/Findlz4.cmake
@@ -1,6 +1,6 @@
 find_package (PkgConfig)
 if (PKG_CONFIG_FOUND)
-  pkg_search_module (lz4_PC QUIET liblz4>=1.8)
+  pkg_search_module (lz4_PC QUIET liblz4>=1.9)
 endif ()
 
 if(static)

--- a/Builds/CMake/deps/Lz4.cmake
+++ b/Builds/CMake/deps/Lz4.cmake
@@ -21,7 +21,7 @@ else()
   ExternalProject_Add (lz4
     PREFIX ${nih_cache_path}
     GIT_REPOSITORY https://github.com/lz4/lz4.git
-    GIT_TAG v1.8.2
+    GIT_TAG v1.9.2
     SOURCE_SUBDIR contrib/cmake_unofficial
     CMAKE_ARGS
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/src/ripple/nodestore/impl/codec.h
+++ b/src/ripple/nodestore/impl/codec.h
@@ -51,13 +51,12 @@ lz4_decompress(void const* in, std::size_t in_size, BufferFactory&& bf)
         Throw<std::runtime_error>("lz4 decompress: n == 0");
     void* const out = bf(result.second);
     result.first = out;
-    if (LZ4_decompress_fast(
+    if (LZ4_decompress_safe(
             reinterpret_cast<char const*>(in) + n,
             reinterpret_cast<char*>(out),
-            result.second) +
-            n !=
-        in_size)
-        Throw<std::runtime_error>("lz4 decompress: LZ4_decompress_fast");
+            in_size - n,
+            result.second) != result.second)
+        Throw<std::runtime_error>("lz4 decompress: LZ4_decompress_safe");
     return result;
 }
 


### PR DESCRIPTION
* Update the LZ4 library from 1.8.2 to 1.9.2
* Use `LZ4_decompress_safe` instead of `LZ4_decompress_fast` which is unsafe and deprecated.