### PR TITLE
[TRIVIAL] Fix a build issue caused by the latest Docker version

### DIFF
--- a/Builds/containers/gitlab-ci/pkgbuild.yml
+++ b/Builds/containers/gitlab-ci/pkgbuild.yml
@@ -282,7 +282,7 @@ tag_bld_images:
   variables:
     docker_driver: overlay2
   image:
-    name: docker:latest
+    name: docker:19.03.8
   services:
     # workaround for TLS issues - consider going back
     # back to unversioned `dind` when issues are resolved


### PR DESCRIPTION
The latest docker version is not supported by artifactory
which causes the package build to fail. Setting the docker
version to 19.03.8 fixes the issue.