### PR TITLE
Improve online_delete configuration and DB tuning:

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -975,7 +975,11 @@
 #   particularly in failure scenarios. It is strongly recommended that they
 #   be left at their defaults unless the server is having performance issues
 #   during normal operation or during automatic purging (online_delete)
-#   operations.
+#   operations. A warning will be logged on startup if 'ledger_history'
+#   is configured to store more than 10,000,000 ledgers and any of these
+#   settings are less safe than the default. This is due to the inordinate
+#   amount of time and bandwidth it will take to safely rebuild a corrupted
+#   database from other peers.
 #
 #   Optional keys:
 #

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -36,7 +36,7 @@
 #   For more information on where the rippled server instance searches for the
 #   file, visit:
 #
-#     https://developers.ripple.com/commandline-usage.html#generic-options
+#     https://xrpl.org/commandline-usage.html#generic-options
 #
 #   This file should be named rippled.cfg. This file is UTF-8 with DOS, UNIX,
 #   or Mac style end of lines. Blank lines and lines beginning with '#' are
@@ -939,7 +939,7 @@
 #   [import_db]     Settings for performing a one-time import (optional)
 #   [database_path]   Path to the book-keeping databases.
 #
-#   There are 4 or 5 bookkeeping SQLite database that the server creates and
+#   There are 4 or 5 bookkeeping SQLite databases that the server creates and
 #   maintains. If you omit this configuration setting, it will default to
 #   creating a directory called "db" located in the same place as your
 #   rippled.cfg file. Partial pathnames will be considered relative to
@@ -1335,7 +1335,7 @@ advisory_delete=0
 # This is the persistent datastore for shards. It is important for the health
 # of the ripple network that rippled operators shard as much as practical.
 # NuDB requires SSD storage. Helpful information can be found at
-# https://ripple.com/build/history-sharding
+# https://xrpl.org/history-sharding.html
 #[shard_db]
 #path=/var/lib/rippled/db/shards/nudb
 #max_size_gb=500
@@ -1354,7 +1354,8 @@ time.apple.com
 time.nist.gov
 pool.ntp.org
 
-# To use the XRP test network (see https://ripple.com/build/xrp-test-net/),
+# To use the XRP test network
+# (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),
 # use the following [ips] section:
 # [ips]
 # r.altnet.rippletest.net 51235

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -917,13 +917,16 @@
 #                           The online delete process checks periodically
 #                           that rippled is still in sync with the network,
 #                           and that the validated ledger is less than
-#                           *age_threshold_seconds* old. By default, if it
+#                           'age_threshold_seconds' old. By default, if it
 #                           is not the online delete process aborts and
-#                           tries again later. If *recovery_buffer_seconds*
-#                           is set, online delete will wait this number of
-#                           seconds for rippled to recover before it aborts.
+#                           tries again later. If 'recovery_buffer_seconds'
+#                           is set and rippled is out of sync, but likely to
+#                           recover quickly, then online delete will wait
+#                           this number of seconds for rippled to get back
+#                           into sync before it aborts.
 #                           Set this value if the node is otherwise staying
-#                           in sync, or recovering quickly.
+#                           in sync, or recovering quickly, but the online
+#                           delete process is unable to finish.
 #                           Default is unset.
 #
 #   Notes:

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -913,13 +913,13 @@
 #                           number of seconds.
 #                           Default is 60.
 #
-#       recovery_buffer_seconds
+#       recovery_wait_seconds
 #                           The online delete process checks periodically
 #                           that rippled is still in sync with the network,
 #                           and that the validated ledger is less than
 #                           'age_threshold_seconds' old. By default, if it
 #                           is not the online delete process aborts and
-#                           tries again later. If 'recovery_buffer_seconds'
+#                           tries again later. If 'recovery_wait_seconds'
 #                           is set and rippled is out of sync, but likely to
 #                           recover quickly, then online delete will wait
 #                           this number of seconds for rippled to get back
@@ -967,30 +967,37 @@
 #       <key> '=' <value>
 #       ...
 #
-#   Example:
+#   Example 1:
 #       sync_level=low
+#
+#   Example 2:
 #       journal_mode=off
+#       synchronous=off
 #
 #   WARNING: These settings can have significant effects on data integrity,
-#   particularly in failure scenarios. It is strongly recommended that they
-#   be left at their defaults unless the server is having performance issues
-#   during normal operation or during automatic purging (online_delete)
-#   operations. A warning will be logged on startup if 'ledger_history'
-#   is configured to store more than 10,000,000 ledgers and any of these
-#   settings are less safe than the default. This is due to the inordinate
-#   amount of time and bandwidth it will take to safely rebuild a corrupted
-#   database from other peers.
+#   particularly in systemic failure scenarios. It is strongly recommended
+#   that they be left at their defaults unless the server is having
+#   performance issues during normal operation or during automatic purging
+#   (online_delete) operations. A warning will be logged on startup if
+#   'ledger_history' is configured to store more than 10,000,000 ledgers and
+#   any of these settings are less safe than the default. This is due to the
+#   inordinate amount of time and bandwidth it will take to safely rebuild a
+#   corrupted database of that size from other peers.
 #
 #   Optional keys:
 #
 #       safety_level        Valid values: high, low
-#                           The default is "high", and tunes the SQLite
-#                           databases in the most reliable mode. "low"
-#                           is equivalent to
+#                           The default is "high", which tunes the SQLite
+#                           databases in the most reliable mode, and is
+#                           equivalent to:
+#                             journal_mode=wal
+#                             synchronous=normal
+#                             temp_store=file
+#                           "low" is equivalent to:
 #                             journal_mode=memory
 #                             synchronous=off
 #                             temp_store=memory
-#                           These settings trade speed and reduced I/O
+#                           These "low" settings trade speed and reduced I/O
 #                           for a higher risk of data loss. See the
 #                           individual settings below for more information.
 #                           This setting may not be combined with any of the

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -869,18 +869,62 @@
 #
 #       These keys are possible for any type of backend:
 #
+#       earliest_seq        The default is 32570 to match the XRP ledger
+#                           network's earliest allowed sequence. Alternate
+#                           networks may set this value. Minimum value of 1.
+#                           If a [shard_db] section is defined, and this
+#                           value is present either [node_db] or [shard_db],
+#                           it must be defined with the same value in both
+#                           sections.
+#
 #       online_delete       Minimum value of 256. Enable automatic purging
 #                           of older ledger information. Maintain at least this
 #                           number of ledger records online. Must be greater
 #                           than or equal to ledger_history.
 #
-#       advisory_delete     0 for disabled, 1 for enabled. If set, then
-#                           require administrative RPC call "can_delete"
-#                           to enable online deletion of ledger records.
+#       These keys modify the behavior of online_delete, and thus are only
+#       relevant if online_delete is defined and non-zero:
 #
-#       earliest_seq        The default is 32570 to match the XRP ledger
-#                           network's earliest allowed sequence. Alternate
-#                           networks may set this value. Minimum value of 1.
+#       advisory_delete     0 for disabled, 1 for enabled. If set, the
+#                           administrative RPC call "can_delete" is required
+#                           to enable online deletion of ledger records.
+#                           Online deletion does not run automatically if
+#                           non-zero and the last deletion was on a ledger
+#                           greater than the current "can_delete" setting.
+#                           Default is 0.
+#
+#       delete_batch        When automatically purging, SQLite database
+#                           records are deleted in batches. This value
+#                           controls the maximum size of each batch. Larger
+#                           batches keep the databases locked for more time,
+#                           which may cause other functions to fall behind,
+#                           and thus cause the node to lose sync.
+#                           Default is 100.
+#
+#       back_off_milliseconds
+#                           Number of milliseconds to wait between
+#                           online_delete batches to allow other functions
+#                           to catch up.
+#                           Default is 100.
+#
+#       age_threshold_seconds
+#                           The online delete process will only run if the
+#                           latest validated ledger is younger than this
+#                           number of seconds.
+#                           Default is 60.
+#
+#       recovery_buffer_seconds
+#                           The online delete process checks periodically
+#                           that rippled is still in sync with the network,
+#                           and that the validated ledger is less than
+#                           *age_threshold_seconds* old. By default, if it
+#                           is not the online delete process aborts and
+#                           tries again later. If *recovery_buffer_seconds*
+#                           is set, online delete will wait this number of
+#                           seconds for rippled to recover before it aborts.
+#                           Set this value if the node is otherwise staying
+#                           in sync, or recovering quickly.
+#                           Default is unset.
 #
 #   Notes:
 #       The 'node_db' entry configures the primary, persistent storage.
@@ -891,6 +935,12 @@
 #
 #   [import_db]     Settings for performing a one-time import (optional)
 #   [database_path]   Path to the book-keeping databases.
+#
+#   There are 4 or 5 bookkeeping SQLite database that the server creates and
+#   maintains. If you omit this configuration setting, it will default to
+#   creating a directory called "db" located in the same place as your
+#   rippled.cfg file. Partial pathnames will be considered relative to
+#   the location of the rippled executable.
 #
 #   [shard_db]      Settings for the Shard Database (optional)
 #
@@ -907,12 +957,64 @@
 #
 #       max_size_gb         Maximum disk space the database will utilize (in gigabytes)
 #
+#   [sqlite]       Tuning settings for the SQLite databases (optional)
 #
-#   There are 4 bookkeeping SQLite database that the server creates and
-#   maintains. If you omit this configuration setting, it will default to
-#   creating a directory called "db" located in the same place as your
-#   rippled.cfg file. Partial pathnames will be considered relative to
-#   the location of the rippled executable.
+#   Format (without spaces):
+#       One or more lines of case-insensitive key / value pairs:
+#       <key> '=' <value>
+#       ...
+#
+#   Example:
+#       sync_level=low
+#       journal_mode=off
+#
+#   WARNING: These settings can have significant effects on data integrity,
+#   particularly in failure scenarios. It is strongly recommended that they
+#   be left at their defaults unless the server is having performance issues
+#   during normal operation or during automatic purging (online_delete)
+#   operations.
+#
+#   Optional keys:
+#
+#       safety_level        Valid values: high, low
+#                           The default is "high", and tunes the SQLite
+#                           databases in the most reliable mode. "low"
+#                           is equivalent to
+#                             journal_mode=memory
+#                             synchronous=off
+#                             temp_store=memory
+#                           These settings trade speed and reduced I/O
+#                           for a higher risk of data loss. See the
+#                           individual settings below for more information.
+#
+#       journal_mode        Valid values: delete, truncate, persist, memory, wal, off
+#                           The default is "wal", which uses a write-ahead
+#                           log to implement database transactions.
+#                           Alternately, "memory" saves disk I/O, but if
+#                           rippled crashes during a transaction, the
+#                           database is likely to be corrupted.
+#                           See https://www.sqlite.org/pragma.html#pragma_journal_mode
+#                           for more details about the available options.
+#
+#       synchronous         Valid values: off, normal, full, extra
+#                           The default is "normal", which works well with
+#                           the "wal" journal mode. Alternatively, "off"
+#                           allows rippled to continue as soon as data is
+#                           passed to the OS, which can significantly
+#                           increase speed, but risks data corruption if
+#                           the host computer crashes before writing that
+#                           data to disk.
+#                           See https://www.sqlite.org/pragma.html#pragma_synchronous
+#                           for more details about the available options.
+#
+#       temp_store          Valid values: default, file, memory
+#                           The default is "file", which will use files
+#                           for temporary database tables and indices.
+#                           Alternatively, "memory" may save I/O, but
+#                           rippled does not currently use many, if any,
+#                           of these temporary objects.
+#                           See https://www.sqlite.org/pragma.html#pragma_temp_store
+#                           for more details about the available options.
 #
 #
 #
@@ -1212,23 +1314,24 @@ medium
 
 # This is primary persistent datastore for rippled.  This includes transaction
 # metadata, account states, and ledger headers.  Helpful information can be
-# found here: https://ripple.com/wiki/NodeBackEnd
-# delete old ledgers while maintaining at least 2000. Do not require an
-# external administrative command to initiate deletion.
+# found at https://xrpl.org/capacity-planning.html#node-db-type
+# type=NuDB is recommended for non-validators with fast SSDs. Validators or
+#    slow / spinning disks should use RocksDB.
+# online_delete=512 is recommended to delete old ledgers while maintaining at
+#    least 512.
+# advisory_delete=0 allows the online delete process to run automatically
+#    when the node has approximately two times the "online_delete" value of
+#    ledgers. No external administrative command is required to initiate
+#    deletion.
 [node_db]
-type=RocksDB
-path=/var/lib/rippled/db/rocksdb
-open_files=2000
-filter_bits=12
-cache_mb=256
-file_size_mb=8
-file_size_mult=2
-online_delete=2000
+type=NuDB
+path=/var/lib/rippled/db/nudb
+online_delete=512
 advisory_delete=0
 
 # This is the persistent datastore for shards. It is important for the health
 # of the ripple network that rippled operators shard as much as practical.
-# NuDB requires SSD storage. Helpful information can be found here
+# NuDB requires SSD storage. Helpful information can be found at
 # https://ripple.com/build/history-sharding
 #[shard_db]
 #path=/var/lib/rippled/db/shards/nudb

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -993,6 +993,9 @@
 #                           These settings trade speed and reduced I/O
 #                           for a higher risk of data loss. See the
 #                           individual settings below for more information.
+#                           This setting may not be combined with any of the
+#                           other tuning settings: "journal_mode",
+#                           "synchronous", or "temp_store".
 #
 #       journal_mode        Valid values: delete, truncate, persist, memory, wal, off
 #                           The default is "wal", which uses a write-ahead
@@ -1002,6 +1005,8 @@
 #                           database is likely to be corrupted.
 #                           See https://www.sqlite.org/pragma.html#pragma_journal_mode
 #                           for more details about the available options.
+#                           This setting may not be combined with the
+#                           "safety_level" setting.
 #
 #       synchronous         Valid values: off, normal, full, extra
 #                           The default is "normal", which works well with
@@ -1013,6 +1018,8 @@
 #                           data to disk.
 #                           See https://www.sqlite.org/pragma.html#pragma_synchronous
 #                           for more details about the available options.
+#                           This setting may not be combined with the
+#                           "safety_level" setting.
 #
 #       temp_store          Valid values: default, file, memory
 #                           The default is "file", which will use files
@@ -1022,6 +1029,8 @@
 #                           of these temporary objects.
 #                           See https://www.sqlite.org/pragma.html#pragma_temp_store
 #                           for more details about the available options.
+#                           This setting may not be combined with the
+#                           "safety_level" setting.
 #
 #
 #

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -939,11 +939,11 @@
 #   [import_db]     Settings for performing a one-time import (optional)
 #   [database_path]   Path to the book-keeping databases.
 #
-#   There are 4 or 5 bookkeeping SQLite databases that the server creates and
-#   maintains. If you omit this configuration setting, it will default to
-#   creating a directory called "db" located in the same place as your
-#   rippled.cfg file. Partial pathnames will be considered relative to
-#   the location of the rippled executable.
+#   The server creates and maintains 4 to 5 bookkeeping SQLite databases in
+#   the 'database_path' location. If you omit this configuration setting,
+#   the server creates a directory called "db" located in the same place as
+#   your rippled.cfg file.
+#   Partial pathnames are relative to the location of the rippled executable.
 #
 #   [shard_db]      Settings for the Shard Database (optional)
 #
@@ -1339,7 +1339,9 @@ medium
 # metadata, account states, and ledger headers.  Helpful information can be
 # found at https://xrpl.org/capacity-planning.html#node-db-type
 # type=NuDB is recommended for non-validators with fast SSDs. Validators or
-#    slow / spinning disks should use RocksDB.
+#    slow / spinning disks should use RocksDB. Caution: Spinning disks are
+#    not recommended. They do not perform well enough to consistently remain
+#    synced to the network.
 # online_delete=512 is recommended to delete old ledgers while maintaining at
 #    least 512.
 # advisory_delete=0 allows the online delete process to run automatically

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -1001,7 +1001,9 @@ void
 RCLConsensus::Adaptor::updateOperatingMode(std::size_t const positions) const
 {
     if (!positions && app_.getOPs().isFull())
+    {
         app_.getOPs().setMode(OperatingMode::CONNECTED);
+    }
 }
 
 void

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -1001,9 +1001,7 @@ void
 RCLConsensus::Adaptor::updateOperatingMode(std::size_t const positions) const
 {
     if (!positions && app_.getOPs().isFull())
-    {
         app_.getOPs().setMode(OperatingMode::CONNECTED);
-    }
 }
 
 void

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -228,14 +228,14 @@ Ledger::Ledger(
         !txMap_->fetchRoot(SHAMapHash{info_.txHash}, nullptr))
     {
         loaded = false;
-        JLOG(j.warn()) << "Don't have TX root for ledger";
+        JLOG(j.warn()) << "Don't have TX root for ledger" << info_.seq;
     }
 
     if (info_.accountHash.isNonZero() &&
         !stateMap_->fetchRoot(SHAMapHash{info_.accountHash}, nullptr))
     {
         loaded = false;
-        JLOG(j.warn()) << "Don't have AS root for ledger";
+        JLOG(j.warn()) << "Don't have AS root for ledger" << info_.seq;
     }
 
     txMap_->setImmutable();

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -228,14 +228,14 @@ Ledger::Ledger(
         !txMap_->fetchRoot(SHAMapHash{info_.txHash}, nullptr))
     {
         loaded = false;
-        JLOG(j.warn()) << "Don't have TX root for ledger" << info_.seq;
+        JLOG(j.warn()) << "Don't have transaction root for ledger" << info_.seq;
     }
 
     if (info_.accountHash.isNonZero() &&
         !stateMap_->fetchRoot(SHAMapHash{info_.accountHash}, nullptr))
     {
         loaded = false;
-        JLOG(j.warn()) << "Don't have AS root for ledger" << info_.seq;
+        JLOG(j.warn()) << "Don't have state data root for ledger" << info_.seq;
     }
 
     txMap_->setImmutable();

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -54,6 +54,10 @@ class Transaction;
 class LedgerMaster : public Stoppable, public AbstractFetchPackContainer
 {
 public:
+    // Age for last validated ledger if the process has yet to validate.
+    static constexpr std::chrono::seconds NO_VALIDATED_LEDGER_AGE =
+        std::chrono::hours{24 * 14};
+
     explicit LedgerMaster(
         Application& app,
         Stopwatch& stopwatch,

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -269,7 +269,7 @@ LedgerMaster::getValidatedLedgerAge()
     if (valClose == 0s)
     {
         JLOG(m_journal.debug()) << "No validated ledger";
-        return weeks{2};
+        return NO_VALIDATED_LEDGER_AGE;
     }
 
     std::chrono::seconds ret = app_.timeKeeper().closeTime().time_since_epoch();

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1072,7 +1072,7 @@ public:
             mLedgerDB->setupCheckpointing(m_jobQueue.get(), logs());
 
             // wallet database
-            setup.noPragma();
+            setup.useGlobalPragma = false;
             mWalletDB = std::make_unique<DatabaseCon>(
                 setup,
                 WalletDBName,

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1026,7 +1026,7 @@ public:
 
             // transaction database
             mTxnDB = std::make_unique<DatabaseCon>(
-                setup, TxDBName, TxDBPragma, TxDBInit);
+                setup, TxDBName, true, TxDBPragma, TxDBInit);
             mTxnDB->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(config_->getValueFor(SizedItem::txnDBCache)));
@@ -1065,7 +1065,7 @@ public:
 
             // ledger database
             mLedgerDB = std::make_unique<DatabaseCon>(
-                setup, LgrDBName, LgrDBPragma, LgrDBInit);
+                setup, LgrDBName, true, LgrDBPragma, LgrDBInit);
             mLedgerDB->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(config_->getValueFor(SizedItem::lgrDBCache)));
@@ -1075,6 +1075,7 @@ public:
             mWalletDB = std::make_unique<DatabaseCon>(
                 setup,
                 WalletDBName,
+                false,
                 std::array<char const*, 0>(),
                 WalletDBInit);
         }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1022,7 +1022,7 @@ public:
 
         try
         {
-            auto setup = setup_DatabaseCon(*config_);
+            auto setup = setup_DatabaseCon(*config_, m_journal);
 
             // transaction database
             mTxnDB = std::make_unique<DatabaseCon>(

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1022,11 +1022,11 @@ public:
 
         try
         {
-            auto const setup = setup_DatabaseCon(*config_);
+            auto setup = setup_DatabaseCon(*config_);
 
             // transaction database
             mTxnDB = std::make_unique<DatabaseCon>(
-                setup, TxDBName, true, TxDBPragma, TxDBInit);
+                setup, TxDBName, TxDBPragma, TxDBInit);
             mTxnDB->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(config_->getValueFor(SizedItem::txnDBCache)));
@@ -1065,17 +1065,17 @@ public:
 
             // ledger database
             mLedgerDB = std::make_unique<DatabaseCon>(
-                setup, LgrDBName, true, LgrDBPragma, LgrDBInit);
+                setup, LgrDBName, LgrDBPragma, LgrDBInit);
             mLedgerDB->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(config_->getValueFor(SizedItem::lgrDBCache)));
             mLedgerDB->setupCheckpointing(m_jobQueue.get(), logs());
 
             // wallet database
+            setup.noPragma();
             mWalletDB = std::make_unique<DatabaseCon>(
                 setup,
                 WalletDBName,
-                false,
                 std::array<char const*, 0>(),
                 WalletDBInit);
         }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1364,7 +1364,7 @@ public:
                 JLOG(m_journal.fatal())
                     << "Free SQLite space for transaction db is less than "
                        "512MB. To fix this, rippled must be executed with the "
-                       "vacuum <sqlitetmpdir> parameter before restarting. "
+                       "\"--vacuum\" parameter before restarting. "
                        "Note that this activity can take multiple days, "
                        "depending on database size.";
                 signalStop();

--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -71,21 +71,13 @@ inline constexpr std::array<char const*, 5> LgrDBInit{
 // Transaction database holds transactions and public keys
 inline constexpr auto TxDBName{"transaction.db"};
 
-inline constexpr
-#if (ULONG_MAX > UINT_MAX) && !defined(NO_SQLITE_MMAP)
-    std::array<char const*, 4>
-        TxDBPragma
+inline constexpr std::array TxDBPragma
 {
-    {
-#else
-    std::array<char const*, 3> TxDBPragma {{
-#endif
-        "PRAGMA page_size=4096;", "PRAGMA journal_size_limit=1582080;",
-            "PRAGMA max_page_count=2147483646;",
+    "PRAGMA page_size=4096;", "PRAGMA journal_size_limit=1582080;",
+        "PRAGMA max_page_count=2147483646;",
 #if (ULONG_MAX > UINT_MAX) && !defined(NO_SQLITE_MMAP)
-            "PRAGMA mmap_size=17179869184;"
+        "PRAGMA mmap_size=17179869184;"
 #endif
-    }
 };
 
 inline constexpr std::array<char const*, 8> TxDBInit{

--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -26,13 +26,23 @@ namespace ripple {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// These pragmas are built at startup and applied to all database
+// connections, unless otherwise noted.
+inline constexpr char const* CommonDBPragmaJournal{"PRAGMA journal_mode=%s;"};
+inline constexpr char const* CommonDBPragmaSync{"PRAGMA synchronous=%s;"};
+inline constexpr char const* CommonDBPragmaTemp{"PRAGMA temp_store=%s;"};
+// Default values will always be used for the common pragmas if
+// at least this much ledger history is configured. This includes
+// full history nodes. This is because such a large amount of data will
+// be more difficult to recover if a rare failure occurs, which are
+// more likely with some of the other available tuning settings.
+inline constexpr std::uint32_t SQLITE_TUNING_CUTOFF = 100'000'000;
+
 // Ledger database holds ledgers and ledger confirmations
 inline constexpr auto LgrDBName{"ledger.db"};
 
-inline constexpr std::array<char const*, 3> LgrDBPragma{
-    {"PRAGMA synchronous=NORMAL;",
-     "PRAGMA journal_mode=WAL;",
-     "PRAGMA journal_size_limit=1582080;"}};
+inline constexpr std::array<char const*, 1> LgrDBPragma{
+    {"PRAGMA journal_size_limit=1582080;"}};
 
 inline constexpr std::array<char const*, 5> LgrDBInit{
     {"BEGIN TRANSACTION;",
@@ -63,15 +73,14 @@ inline constexpr auto TxDBName{"transaction.db"};
 
 inline constexpr
 #if (ULONG_MAX > UINT_MAX) && !defined(NO_SQLITE_MMAP)
-    std::array<char const*, 6>
+    std::array<char const*, 4>
         TxDBPragma
 {
     {
 #else
-    std::array<char const*, 5> TxDBPragma {{
+    std::array<char const*, 3> TxDBPragma {{
 #endif
-        "PRAGMA page_size=4096;", "PRAGMA synchronous=NORMAL;",
-            "PRAGMA journal_mode=WAL;", "PRAGMA journal_size_limit=1582080;",
+        "PRAGMA page_size=4096;", "PRAGMA journal_size_limit=1582080;",
             "PRAGMA max_page_count=2147483646;",
 #if (ULONG_MAX > UINT_MAX) && !defined(NO_SQLITE_MMAP)
             "PRAGMA mmap_size=17179869184;"
@@ -115,10 +124,8 @@ inline constexpr std::array<char const*, 8> TxDBInit{
 // Temporary database used with an incomplete shard that is being acquired
 inline constexpr auto AcquireShardDBName{"acquire.db"};
 
-inline constexpr std::array<char const*, 3> AcquireShardDBPragma{
-    {"PRAGMA synchronous=NORMAL;",
-     "PRAGMA journal_mode=WAL;",
-     "PRAGMA journal_size_limit=1582080;"}};
+inline constexpr std::array<char const*, 1> AcquireShardDBPragma{
+    {"PRAGMA journal_size_limit=1582080;"}};
 
 inline constexpr std::array<char const*, 1> AcquireShardDBInit{
     {"CREATE TABLE IF NOT EXISTS Shard (             \
@@ -130,6 +137,7 @@ inline constexpr std::array<char const*, 1> AcquireShardDBInit{
 ////////////////////////////////////////////////////////////////////////////////
 
 // Pragma for Ledger and Transaction databases with complete shards
+// These override the CommonDBPragma values defined above.
 inline constexpr std::array<char const*, 2> CompleteShardDBPragma{
     {"PRAGMA synchronous=OFF;", "PRAGMA journal_mode=OFF;"}};
 
@@ -172,6 +180,7 @@ inline constexpr std::array<char const*, 6> WalletDBInit{
 
 static constexpr auto stateDBName{"state.db"};
 
+// These override the CommonDBPragma values defined above.
 static constexpr std::array<char const*, 2> DownloaderDBPragma{
     {"PRAGMA synchronous=FULL;", "PRAGMA journal_mode=DELETE;"}};
 

--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -31,12 +31,12 @@ namespace ripple {
 inline constexpr char const* CommonDBPragmaJournal{"PRAGMA journal_mode=%s;"};
 inline constexpr char const* CommonDBPragmaSync{"PRAGMA synchronous=%s;"};
 inline constexpr char const* CommonDBPragmaTemp{"PRAGMA temp_store=%s;"};
-// Default values will always be used for the common pragmas if
-// at least this much ledger history is configured. This includes
-// full history nodes. This is because such a large amount of data will
-// be more difficult to recover if a rare failure occurs, which are
-// more likely with some of the other available tuning settings.
-inline constexpr std::uint32_t SQLITE_TUNING_CUTOFF = 100'000'000;
+// A warning will be logged if any lower-safety sqlite tuning settings
+// are used and at least this much ledger history is configured. This
+// includes full history nodes. This is because such a large amount of
+// data will be more difficult to recover if a rare failure occurs,
+// which are more likely with some of the other available tuning settings.
+inline constexpr std::uint32_t SQLITE_TUNING_CUTOFF = 10'000'000;
 
 // Ledger database holds ledgers and ledger confirmations
 inline constexpr auto LgrDBName{"ledger.db"};

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -541,8 +541,9 @@ run(int argc, char** argv)
                 return -1;
             }
 
+            dbSetup.noPragma();
             auto txnDB = std::make_unique<DatabaseCon>(
-                dbSetup, TxDBName, false, TxDBPragma, TxDBInit);
+                dbSetup, TxDBName, TxDBPragma, TxDBInit);
             auto& session = txnDB->getSession();
             std::uint32_t pageSize;
 
@@ -555,8 +556,8 @@ run(int argc, char** argv)
             session << "PRAGMA temp_store_directory=\"" << tmpPath.string()
                     << "\";";
             session << "VACUUM;";
-            assert(dbSetup.CommonPragma);
-            for (auto const& p : *dbSetup.CommonPragma)
+            assert(dbSetup.globalPragma);
+            for (auto const& p : *dbSetup.globalPragma)
                 session << p;
             session << "PRAGMA page_size;", soci::into(pageSize);
 

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -542,7 +542,7 @@ run(int argc, char** argv)
             }
 
             auto txnDB = std::make_unique<DatabaseCon>(
-                dbSetup, TxDBName, TxDBPragma, TxDBInit);
+                dbSetup, TxDBName, false, TxDBPragma, TxDBInit);
             auto& session = txnDB->getSession();
             std::uint32_t pageSize;
 
@@ -555,7 +555,9 @@ run(int argc, char** argv)
             session << "PRAGMA temp_store_directory=\"" << tmpPath.string()
                     << "\";";
             session << "VACUUM;";
-            session << "PRAGMA journal_mode=WAL;";
+            assert(dbSetup.CommonPragma);
+            for (auto const& p : *dbSetup.CommonPragma)
+                session << p;
             session << "PRAGMA page_size;", soci::into(pageSize);
 
             std::cout << "VACUUM finished. page_size: " << pageSize

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2757,12 +2757,12 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             if (std::abs(closeOffset.count()) >= 60)
                 l[jss::close_time_offset] = closeOffset.count();
 
-            constexpr std::chrono::seconds HIGH_AGE_THRESHOLD{1000000};
+            constexpr std::chrono::seconds highAgeThreshold{1000000};
             if (m_ledgerMaster.haveValidated())
             {
                 auto const age = m_ledgerMaster.getValidatedLedgerAge();
                 l[jss::age] =
-                    Json::UInt(age < HIGH_AGE_THRESHOLD ? age.count() : 0);
+                    Json::UInt(age < highAgeThreshold ? age.count() : 0);
             }
             else
             {
@@ -2773,7 +2773,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                     using namespace std::chrono_literals;
                     auto age = closeTime - lCloseTime;
                     l[jss::age] =
-                        Json::UInt(age < HIGH_AGE_THRESHOLD ? age.count() : 0);
+                        Json::UInt(age < highAgeThreshold ? age.count() : 0);
                 }
             }
         }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2757,16 +2757,24 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             if (std::abs(closeOffset.count()) >= 60)
                 l[jss::close_time_offset] = closeOffset.count();
 
-            auto lCloseTime = lpClosed->info().closeTime;
-            auto closeTime = app_.timeKeeper().closeTime();
-            if (lCloseTime <= closeTime)
+            constexpr std::chrono::seconds HIGH_AGE_THRESHOLD{1000000};
+            if (m_ledgerMaster.haveValidated())
             {
-                using namespace std::chrono_literals;
-                auto age = closeTime - lCloseTime;
-                if (age < 1000000s)
-                    l[jss::age] = Json::UInt(age.count());
-                else
-                    l[jss::age] = 0;
+                auto const age = m_ledgerMaster.getValidatedLedgerAge();
+                l[jss::age] =
+                    Json::UInt(age < HIGH_AGE_THRESHOLD ? age.count() : 0);
+            }
+            else
+            {
+                auto lCloseTime = lpClosed->info().closeTime;
+                auto closeTime = app_.timeKeeper().closeTime();
+                if (lCloseTime <= closeTime)
+                {
+                    using namespace std::chrono_literals;
+                    auto age = closeTime - lCloseTime;
+                    l[jss::age] =
+                        Json::UInt(age < HIGH_AGE_THRESHOLD ? age.count() : 0);
+                }
             }
         }
 

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -648,9 +648,6 @@ SHAMapStoreImp::freshenCaches()
 void
 SHAMapStoreImp::clearPrior(LedgerIndex lastRotated)
 {
-    if (health())
-        return;
-
     // Do not allow ledgers to be acquired from the network
     // that are about to be deleted.
     minimumOnline_ = lastRotated + 1;

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -180,13 +180,24 @@ SHAMapStoreImp::SHAMapStoreImp(
             section.set("filter_bits", "10");
     }
 
-    get_if_exists(section, "delete_batch", deleteBatch_);
-    get_if_exists(section, "backOff", backOff_);
-    get_if_exists(section, "age_threshold", ageThreshold_);
     get_if_exists(section, "online_delete", deleteInterval_);
 
     if (deleteInterval_)
     {
+        // Configuration that affects the behavior of online delete
+        get_if_exists(section, "delete_batch", deleteBatch_);
+        std::uint32_t temp;
+        if (get_if_exists(section, "back_off_milliseconds", temp) ||
+            // Included for backward compaibility with an undocumented setting
+            get_if_exists(section, "backOff", temp))
+        {
+            backOff_ = std::chrono::milliseconds{temp};
+        }
+        if (get_if_exists(section, "age_threshold_seconds", temp))
+            ageThreshold_ = std::chrono::seconds{temp};
+        if (get_if_exists(section, "recovery_buffer_seconds", temp))
+            recoveryBuffer_.emplace(std::chrono::seconds{temp});
+
         get_if_exists(section, "advisory_delete", advisoryDelete_);
 
         auto const minInterval = config.standalone()
@@ -348,23 +359,14 @@ SHAMapStoreImp::run()
 
         // will delete up to (not including) lastRotated
         if (validatedSeq >= lastRotated + deleteInterval_ &&
-            canDelete_ >= lastRotated - 1)
+            canDelete_ >= lastRotated - 1 && !health())
         {
             JLOG(journal_.warn())
                 << "rotating  validatedSeq " << validatedSeq << " lastRotated "
                 << lastRotated << " deleteInterval " << deleteInterval_
-                << " canDelete_ " << canDelete_;
-
-            switch (health())
-            {
-                case Health::stopping:
-                    stopped();
-                    return;
-                case Health::unhealthy:
-                    continue;
-                case Health::ok:
-                default:;
-            }
+                << " canDelete_ " << canDelete_ << " state "
+                << app_.getOPs().strOperatingMode(false) << " age "
+                << ledgerMaster_->getValidatedLedgerAge().count() << 's';
 
             clearPrior(lastRotated);
             switch (health())
@@ -378,27 +380,29 @@ SHAMapStoreImp::run()
                 default:;
             }
 
+            JLOG(journal_.trace()) << "copying ledger " << validatedSeq;
             std::uint64_t nodeCount = 0;
             validatedLedger->stateMap().snapShot(false)->visitNodes(std::bind(
                 &SHAMapStoreImp::copyNode,
                 this,
                 std::ref(nodeCount),
                 std::placeholders::_1));
+            switch (health())
+            {
+                case Health::stopping:
+                    stopped();
+                    return;
+                case Health::unhealthy:
+                    continue;
+                case Health::ok:
+                default:;
+            }
+            // Only log if we completed without a "health" abort
             JLOG(journal_.debug()) << "copied ledger " << validatedSeq
                                    << " nodecount " << nodeCount;
-            switch (health())
-            {
-                case Health::stopping:
-                    stopped();
-                    return;
-                case Health::unhealthy:
-                    continue;
-                case Health::ok:
-                default:;
-            }
 
+            JLOG(journal_.trace()) << "freshening caches";
             freshenCaches();
-            JLOG(journal_.debug()) << validatedSeq << " freshened caches";
             switch (health())
             {
                 case Health::stopping:
@@ -409,7 +413,10 @@ SHAMapStoreImp::run()
                 case Health::ok:
                 default:;
             }
+            // Only log if we completed without a "health" abort
+            JLOG(journal_.debug()) << validatedSeq << " freshened caches";
 
+            JLOG(journal_.trace()) << "Making a new backend";
             auto newBackend = makeBackendRotating();
             JLOG(journal_.debug())
                 << validatedSeq << " new backend " << newBackend->getName();
@@ -566,12 +573,21 @@ SHAMapStoreImp::clearSql(
     std::string const& minQuery,
     std::string const& deleteQuery)
 {
+    assert(deleteInterval_);
     LedgerIndex min = std::numeric_limits<LedgerIndex>::max();
 
     {
-        auto db = database.checkoutDb();
         boost::optional<std::uint64_t> m;
-        *db << minQuery, soci::into(m);
+        JLOG(journal_.trace())
+            << "Begin: Look up lowest value of: " << minQuery;
+        if (auto db = database.checkoutDb())
+            *db << minQuery, soci::into(m);
+        else
+        {
+            assert(false);
+            return false;
+        }
+        JLOG(journal_.trace()) << "End: Look up lowest value of: " << minQuery;
         if (!m)
             return false;
         min = *m;
@@ -579,6 +595,12 @@ SHAMapStoreImp::clearSql(
 
     if (min > lastRotated || health() != Health::ok)
         return false;
+    if (min == lastRotated)
+    {
+        // Micro-optimization mainly to clarify logs
+        JLOG(journal_.trace()) << "Nothing to delete from " << deleteQuery;
+        return true;
+    }
 
     boost::format formattedDeleteQuery(deleteQuery);
 
@@ -587,14 +609,27 @@ SHAMapStoreImp::clearSql(
     while (min < lastRotated)
     {
         min = std::min(lastRotated, min + deleteBatch_);
+        JLOG(journal_.trace()) << "Begin: Delete up to " << deleteBatch_
+                               << " rows with LedgerSeq < " << min
+                               << " using query: " << deleteQuery;
+        if (auto db = database.checkoutDb())
         {
-            auto db = database.checkoutDb();
             *db << boost::str(formattedDeleteQuery % min);
         }
+        else
+        {
+            assert(false);
+            return false;
+        }
+        JLOG(journal_.trace())
+            << "End: Delete up to " << deleteBatch_ << " rows with LedgerSeq < "
+            << min << " using query: " << deleteQuery;
         if (health())
             return true;
         if (min < lastRotated)
-            std::this_thread::sleep_for(std::chrono::milliseconds(backOff_));
+            std::this_thread::sleep_for(backOff_);
+        if (health())
+            return true;
     }
     JLOG(journal_.debug()) << "finished: " << deleteQuery;
     return true;
@@ -627,7 +662,11 @@ SHAMapStoreImp::clearPrior(LedgerIndex lastRotated)
     // Do not allow ledgers to be acquired from the network
     // that are about to be deleted.
     minimumOnline_ = lastRotated + 1;
+    JLOG(journal_.trace()) << "Begin: Clear internal ledgers up to "
+                           << lastRotated;
     ledgerMaster_->clearPriorLedgers(lastRotated);
+    JLOG(journal_.trace()) << "End: Clear internal ledgers up to "
+                           << lastRotated;
     if (health())
         return;
 
@@ -666,16 +705,32 @@ SHAMapStoreImp::health()
     }
     if (!netOPs_)
         return Health::ok;
+    assert(deleteInterval_);
 
-    constexpr static std::chrono::seconds age_threshold(60);
-    auto age = ledgerMaster_->getValidatedLedgerAge();
-    OperatingMode mode = netOPs_->getOperatingMode();
-    if (mode != OperatingMode::FULL || age > age_threshold)
+    if (healthy_)
     {
-        JLOG(journal_.warn()) << "Not deleting. state: "
-                              << app_.getOPs().strOperatingMode(mode, false)
-                              << ". age " << age.count() << 's';
-        healthy_ = false;
+        auto age = ledgerMaster_->getValidatedLedgerAge();
+        OperatingMode mode = netOPs_->getOperatingMode();
+        if (recoveryBuffer_ && mode == OperatingMode::SYNCING &&
+            age < ageThreshold_)
+        {
+            JLOG(journal_.warn())
+                << "Waiting " << recoveryBuffer_->count()
+                << "s for node to get back into sync with network. state: "
+                << app_.getOPs().strOperatingMode(mode, false) << ". age "
+                << age.count() << 's';
+            std::this_thread::sleep_for(*recoveryBuffer_);
+
+            age = ledgerMaster_->getValidatedLedgerAge();
+            mode = netOPs_->getOperatingMode();
+        }
+        if (mode != OperatingMode::FULL || age > ageThreshold_)
+        {
+            JLOG(journal_.warn()) << "Not deleting. state: "
+                                  << app_.getOPs().strOperatingMode(mode, false)
+                                  << ". age " << age.count() << 's';
+            healthy_ = false;
+        }
     }
 
     if (healthy_)

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -25,6 +25,7 @@
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/nodestore/DatabaseRotating.h>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <thread>
 
@@ -106,8 +107,9 @@ private:
     std::uint32_t deleteInterval_ = 0;
     bool advisoryDelete_ = false;
     std::uint32_t deleteBatch_ = 100;
-    std::uint32_t backOff_ = 100;
-    std::int32_t ageThreshold_ = 60;
+    std::chrono::milliseconds backOff_{100};
+    std::chrono::seconds ageThreshold_{60};
+    boost::optional<std::chrono::seconds> recoveryBuffer_{};
 
     // these do not exist upon SHAMapStore creation, but do exist
     // as of onPrepare() or before

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -220,7 +220,7 @@ private:
      *  @return true if any deletable rows were found (though not
      *      necessarily deleted.
      */
-    bool
+    void
     clearSql(
         DatabaseCon& database,
         LedgerIndex lastRotated,

--- a/src/ripple/core/DatabaseCon.h
+++ b/src/ripple/core/DatabaseCon.h
@@ -113,7 +113,6 @@ public:
         std::array<char const*, M> const& initSQL)
         // Use temporary files or regular DB files?
         : DatabaseCon(
-              {},
               setup.standAlone && setup.startUp != Config::LOAD &&
                       setup.startUp != Config::LOAD_FILE &&
                       setup.startUp != Config::REPLAY
@@ -131,7 +130,7 @@ public:
         std::string const& DBName,
         std::array<char const*, N> const& pragma,
         std::array<char const*, M> const& initSQL)
-        : DatabaseCon({}, dataDir / DBName, {}, pragma, initSQL)
+        : DatabaseCon(dataDir / DBName, nullptr, pragma, initSQL)
     {
     }
 
@@ -151,13 +150,8 @@ public:
     setupCheckpointing(JobQueue*, Logs&);
 
 private:
-    class Base
-    {
-    };
-
     template <std::size_t N, std::size_t M>
     DatabaseCon(
-        Base,
         boost::filesystem::path const& pPath,
         std::vector<std::string> const* commonPragma,
         std::array<char const*, N> const& pragma,

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -442,7 +442,7 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_LEDGER_HISTORY, strTemp, j_))
     {
         if (boost::iequals(strTemp, "full"))
-            LEDGER_HISTORY = 1000000000u;
+            LEDGER_HISTORY = 1'000'000'000u;
         else if (boost::iequals(strTemp, "none"))
             LEDGER_HISTORY = 0;
         else
@@ -454,7 +454,7 @@ Config::loadFromString(std::string const& fileContents)
         if (boost::iequals(strTemp, "none"))
             FETCH_DEPTH = 0;
         else if (boost::iequals(strTemp, "full"))
-            FETCH_DEPTH = 1000000000u;
+            FETCH_DEPTH = 1'000'000'000u;
         else
             FETCH_DEPTH = beast::lexicalCastThrow<std::uint32_t>(strTemp);
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -442,7 +442,8 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_LEDGER_HISTORY, strTemp, j_))
     {
         if (boost::iequals(strTemp, "full"))
-            LEDGER_HISTORY = 1'000'000'000u;
+            LEDGER_HISTORY =
+                std::numeric_limits<decltype(LEDGER_HISTORY)>::max();
         else if (boost::iequals(strTemp, "none"))
             LEDGER_HISTORY = 0;
         else
@@ -454,7 +455,7 @@ Config::loadFromString(std::string const& fileContents)
         if (boost::iequals(strTemp, "none"))
             FETCH_DEPTH = 0;
         else if (boost::iequals(strTemp, "full"))
-            FETCH_DEPTH = 1'000'000'000u;
+            FETCH_DEPTH = std::numeric_limits<decltype(FETCH_DEPTH)>::max();
         else
             FETCH_DEPTH = beast::lexicalCastThrow<std::uint32_t>(strTemp);
 

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -28,7 +28,7 @@
 namespace ripple {
 
 DatabaseCon::Setup
-setup_DatabaseCon(Config const& c)
+setup_DatabaseCon(Config const& c, boost::optional<beast::Journal> j)
 {
     DatabaseCon::Setup setup;
 
@@ -40,9 +40,9 @@ setup_DatabaseCon(Config const& c)
         Throw<std::runtime_error>("database_path must be set.");
     }
 
-    if (!setup.CommonPragma)
+    if (!setup.globalPragma)
     {
-        setup.CommonPragma = [&c]() {
+        setup.globalPragma = [&c, &j]() {
             auto const& sqlite = c.section("sqlite");
             auto result = std::make_unique<std::vector<std::string>>();
             result->reserve(3);
@@ -53,8 +53,8 @@ setup_DatabaseCon(Config const& c)
             std::string synchronous = "normal";
             std::string temp_store = "file";
 
-            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF &&
-                set(safety_level, "safety_level", sqlite))
+            bool showWarning = false;
+            if (set(safety_level, "safety_level", sqlite))
             {
                 if (boost::iequals(safety_level, "low"))
                 {
@@ -62,6 +62,7 @@ setup_DatabaseCon(Config const& c)
                     journal_mode = "memory";
                     synchronous = "off";
                     temp_store = "memory";
+                    showWarning = true;
                 }
                 else if (!boost::iequals(safety_level, "high"))
                 {
@@ -70,70 +71,87 @@ setup_DatabaseCon(Config const& c)
                 }
             }
 
-            // #journal_mode Valid values : delete, truncate, persist, memory,
-            // wal, off
-            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
-                set(journal_mode, "journal_mode", sqlite);
-            if (boost::iequals(journal_mode, "delete") ||
-                boost::iequals(journal_mode, "truncate") ||
-                boost::iequals(journal_mode, "persist") ||
-                boost::iequals(journal_mode, "memory") ||
-                boost::iequals(journal_mode, "wal") ||
-                boost::iequals(journal_mode, "off"))
             {
-                result->emplace_back(boost::str(
-                    boost::format(CommonDBPragmaJournal) % journal_mode));
-            }
-            else
-            {
-                Throw<std::runtime_error>(
-                    "Invalid journal_mode value: " + journal_mode);
-            }
-
-            //#synchronous Valid values : off, normal, full, extra
-            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
-                set(synchronous, "synchronous", sqlite);
-            if (boost::iequals(synchronous, "off") ||
-                boost::iequals(synchronous, "normal") ||
-                boost::iequals(synchronous, "full") ||
-                boost::iequals(synchronous, "extra"))
-            {
-                result->emplace_back(boost::str(
-                    boost::format(CommonDBPragmaSync) % synchronous));
-            }
-            else
-            {
-                Throw<std::runtime_error>(
-                    "Invalid synchronous value: " + synchronous);
+                // #journal_mode Valid values : delete, truncate, persist,
+                // memory, wal, off
+                if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
+                    set(journal_mode, "journal_mode", sqlite);
+                bool higherRisk = boost::iequals(journal_mode, "memory") ||
+                    boost::iequals(journal_mode, "off");
+                showWarning = showWarning || higherRisk;
+                if (higherRisk || boost::iequals(journal_mode, "delete") ||
+                    boost::iequals(journal_mode, "truncate") ||
+                    boost::iequals(journal_mode, "persist") ||
+                    boost::iequals(journal_mode, "wal"))
+                {
+                    result->emplace_back(boost::str(
+                        boost::format(CommonDBPragmaJournal) % journal_mode));
+                }
+                else
+                {
+                    Throw<std::runtime_error>(
+                        "Invalid journal_mode value: " + journal_mode);
+                }
             }
 
-            // #temp_store Valid values : default, file, memory
-            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
-                set(temp_store, "temp_store", sqlite);
-            if (boost::iequals(temp_store, "default") ||
-                boost::iequals(temp_store, "file") ||
-                boost::iequals(temp_store, "memory"))
             {
-                result->emplace_back(
-                    boost::str(boost::format(CommonDBPragmaTemp) % temp_store));
-            }
-            else
-            {
-                Throw<std::runtime_error>(
-                    "Invalid temp_store value: " + temp_store);
+                //#synchronous Valid values : off, normal, full, extra
+                if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
+                    set(synchronous, "synchronous", sqlite);
+                bool higherRisk = boost::iequals(synchronous, "off");
+                showWarning = showWarning || higherRisk;
+                if (higherRisk || boost::iequals(synchronous, "normal") ||
+                    boost::iequals(synchronous, "full") ||
+                    boost::iequals(synchronous, "extra"))
+                {
+                    result->emplace_back(boost::str(
+                        boost::format(CommonDBPragmaSync) % synchronous));
+                }
+                else
+                {
+                    Throw<std::runtime_error>(
+                        "Invalid synchronous value: " + synchronous);
+                }
             }
 
+            {
+                // #temp_store Valid values : default, file, memory
+                if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
+                    set(temp_store, "temp_store", sqlite);
+                bool higherRisk = boost::iequals(temp_store, "memory");
+                showWarning = showWarning || higherRisk;
+                if (higherRisk || boost::iequals(temp_store, "default") ||
+                    boost::iequals(temp_store, "file"))
+                {
+                    result->emplace_back(boost::str(
+                        boost::format(CommonDBPragmaTemp) % temp_store));
+                }
+                else
+                {
+                    Throw<std::runtime_error>(
+                        "Invalid temp_store value: " + temp_store);
+                }
+            }
+
+            if (showWarning && j && c.LEDGER_HISTORY > SQLITE_TUNING_CUTOFF)
+            {
+                JLOG(j->warn())
+                    << "reducing the data integrity guarantees from the "
+                       "default [sqlite] behavior is not recommended for "
+                       "nodes storing large amounts of history, because of the "
+                       "difficulty inherent in rebuilding corrupted data.";
+            }
             assert(result->size() == 3);
             return result;
         }();
     }
+    setup.commonPragma = setup.globalPragma;
 
     return setup;
 }
 
-std::unique_ptr<std::vector<std::string> const>
-    DatabaseCon::Setup::CommonPragma;
-const std::vector<std::string> DatabaseCon::Setup::NoCommonPragma;
+std::shared_ptr<std::vector<std::string> const>
+    DatabaseCon::Setup::globalPragma;
 
 void
 DatabaseCon::setupCheckpointing(JobQueue* q, Logs& l)

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -21,6 +21,8 @@
 #include <ripple/basics/contract.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/core/SociDB.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 #include <memory>
 
 namespace ripple {
@@ -38,8 +40,100 @@ setup_DatabaseCon(Config const& c)
         Throw<std::runtime_error>("database_path must be set.");
     }
 
+    if (!setup.CommonPragma)
+    {
+        setup.CommonPragma = [&c]() {
+            auto const& sqlite = c.section("sqlite");
+            auto result = std::make_unique<std::vector<std::string>>();
+            result->reserve(3);
+
+            // defaults
+            std::string safety_level = "high";
+            std::string journal_mode = "wal";
+            std::string synchronous = "normal";
+            std::string temp_store = "file";
+
+            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF &&
+                set(safety_level, "safety_level", sqlite))
+            {
+                if (boost::iequals(safety_level, "low"))
+                {
+                    // low safety defaults
+                    journal_mode = "memory";
+                    synchronous = "off";
+                    temp_store = "memory";
+                }
+                else if (!boost::iequals(safety_level, "high"))
+                {
+                    Throw<std::runtime_error>(
+                        "Invalid safety_level value: " + safety_level);
+                }
+            }
+
+            // #journal_mode Valid values : delete, truncate, persist, memory,
+            // wal, off
+            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
+                set(journal_mode, "journal_mode", sqlite);
+            if (boost::iequals(journal_mode, "delete") ||
+                boost::iequals(journal_mode, "truncate") ||
+                boost::iequals(journal_mode, "persist") ||
+                boost::iequals(journal_mode, "memory") ||
+                boost::iequals(journal_mode, "wal") ||
+                boost::iequals(journal_mode, "off"))
+            {
+                result->emplace_back(boost::str(
+                    boost::format(CommonDBPragmaJournal) % journal_mode));
+            }
+            else
+            {
+                Throw<std::runtime_error>(
+                    "Invalid journal_mode value: " + journal_mode);
+            }
+
+            //#synchronous Valid values : off, normal, full, extra
+            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
+                set(synchronous, "synchronous", sqlite);
+            if (boost::iequals(synchronous, "off") ||
+                boost::iequals(synchronous, "normal") ||
+                boost::iequals(synchronous, "full") ||
+                boost::iequals(synchronous, "extra"))
+            {
+                result->emplace_back(boost::str(
+                    boost::format(CommonDBPragmaSync) % synchronous));
+            }
+            else
+            {
+                Throw<std::runtime_error>(
+                    "Invalid synchronous value: " + synchronous);
+            }
+
+            // #temp_store Valid values : default, file, memory
+            if (c.LEDGER_HISTORY < SQLITE_TUNING_CUTOFF)
+                set(temp_store, "temp_store", sqlite);
+            if (boost::iequals(temp_store, "default") ||
+                boost::iequals(temp_store, "file") ||
+                boost::iequals(temp_store, "memory"))
+            {
+                result->emplace_back(
+                    boost::str(boost::format(CommonDBPragmaTemp) % temp_store));
+            }
+            else
+            {
+                Throw<std::runtime_error>(
+                    "Invalid temp_store value: " + temp_store);
+            }
+
+            assert(result->size() == 3);
+            return result;
+        }();
+    }
+
     return setup;
 }
+
+std::unique_ptr<std::vector<std::string> const>
+    DatabaseCon::Setup::CommonPragma;
+const std::vector<std::string> DatabaseCon::Setup::NoCommonPragma;
 
 void
 DatabaseCon::setupCheckpointing(JobQueue* q, Logs& l)

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -56,13 +56,13 @@ setup_DatabaseCon(Config const& c, boost::optional<beast::Journal> j)
 
             if (set(safety_level, "safety_level", sqlite))
             {
-                showRiskWarning = boost::iequals(safety_level, "low");
-                if (showRiskWarning)
+                if (boost::iequals(safety_level, "low"))
                 {
                     // low safety defaults
                     journal_mode = "memory";
                     synchronous = "off";
                     temp_store = "memory";
+                    showRiskWarning = true;
                 }
                 else if (!boost::iequals(safety_level, "high"))
                 {
@@ -160,12 +160,12 @@ setup_DatabaseCon(Config const& c, boost::optional<beast::Journal> j)
             return result;
         }();
     }
-    setup.commonPragma = setup.globalPragma;
+    setup.useGlobalPragma = true;
 
     return setup;
 }
 
-std::shared_ptr<std::vector<std::string> const>
+std::unique_ptr<std::vector<std::string> const>
     DatabaseCon::Setup::globalPragma;
 
 void

--- a/src/ripple/net/impl/DatabaseBody.ipp
+++ b/src/ripple/net/impl/DatabaseBody.ipp
@@ -50,7 +50,7 @@ DatabaseBody::value_type::open(
 
     auto setup = setup_DatabaseCon(config);
     setup.dataDir = path.parent_path();
-    setup.noPragma();
+    setup.useGlobalPragma = false;
 
     // Downloader ignores the "CommonPragma"
     conn_ = std::make_unique<DatabaseCon>(

--- a/src/ripple/net/impl/DatabaseBody.ipp
+++ b/src/ripple/net/impl/DatabaseBody.ipp
@@ -50,10 +50,11 @@ DatabaseBody::value_type::open(
 
     auto setup = setup_DatabaseCon(config);
     setup.dataDir = path.parent_path();
+    setup.noPragma();
 
     // Downloader ignores the "CommonPragma"
     conn_ = std::make_unique<DatabaseCon>(
-        setup, "Download", false, DownloaderDBPragma, DatabaseBodyDBInit);
+        setup, "Download", DownloaderDBPragma, DatabaseBodyDBInit);
 
     path_ = path;
 

--- a/src/ripple/net/impl/DatabaseBody.ipp
+++ b/src/ripple/net/impl/DatabaseBody.ipp
@@ -51,8 +51,9 @@ DatabaseBody::value_type::open(
     auto setup = setup_DatabaseCon(config);
     setup.dataDir = path.parent_path();
 
+    // Downloader ignores the "CommonPragma"
     conn_ = std::make_unique<DatabaseCon>(
-        setup, "Download", DownloaderDBPragma, DatabaseBodyDBInit);
+        setup, "Download", false, DownloaderDBPragma, DatabaseBodyDBInit);
 
     path_ = path;
 

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -128,6 +128,7 @@ Shard::open(Scheduler& scheduler, nudb::context& ctx)
         acquireInfo_->SQLiteDB = std::make_unique<DatabaseCon>(
             setup,
             AcquireShardDBName,
+            true,
             AcquireShardDBPragma,
             AcquireShardDBInit);
         acquireInfo_->SQLiteDB->setupCheckpointing(
@@ -684,14 +685,14 @@ Shard::initSQLite(std::lock_guard<std::recursive_mutex> const&)
         if (backendComplete_)
         {
             lgrSQLiteDB_ = std::make_unique<DatabaseCon>(
-                setup, LgrDBName, CompleteShardDBPragma, LgrDBInit);
+                setup, LgrDBName, false, CompleteShardDBPragma, LgrDBInit);
             lgrSQLiteDB_->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(
                     config.getValueFor(SizedItem::lgrDBCache, boost::none)));
 
             txSQLiteDB_ = std::make_unique<DatabaseCon>(
-                setup, TxDBName, CompleteShardDBPragma, TxDBInit);
+                setup, TxDBName, false, CompleteShardDBPragma, TxDBInit);
             txSQLiteDB_->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(
@@ -701,14 +702,14 @@ Shard::initSQLite(std::lock_guard<std::recursive_mutex> const&)
         {
             // The incomplete shard uses a Write Ahead Log for performance
             lgrSQLiteDB_ = std::make_unique<DatabaseCon>(
-                setup, LgrDBName, LgrDBPragma, LgrDBInit);
+                setup, LgrDBName, true, LgrDBPragma, LgrDBInit);
             lgrSQLiteDB_->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(config.getValueFor(SizedItem::lgrDBCache)));
             lgrSQLiteDB_->setupCheckpointing(&app_.getJobQueue(), app_.logs());
 
             txSQLiteDB_ = std::make_unique<DatabaseCon>(
-                setup, TxDBName, TxDBPragma, TxDBInit);
+                setup, TxDBName, true, TxDBPragma, TxDBInit);
             txSQLiteDB_->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(config.getValueFor(SizedItem::txnDBCache)));

--- a/src/test/app/LedgerHistory_test.cpp
+++ b/src/test/app/LedgerHistory_test.cpp
@@ -100,7 +100,7 @@ public:
             Env env{
                 *this,
                 envconfig(),
-                std::make_unique<CheckMessageLogs>("MISMATCH ", found)};
+                std::make_unique<CheckMessageLogs>("MISMATCH ", &found)};
             LedgerHistory lh{beast::insight::NullCollector::New(), env.app()};
             auto const genesis = makeLedger({}, env, lh, 0s);
             uint256 const dummyTxHash{1};
@@ -117,7 +117,7 @@ public:
                 *this,
                 envconfig(),
                 std::make_unique<CheckMessageLogs>(
-                    "MISMATCH on close time", found)};
+                    "MISMATCH on close time", &found)};
             LedgerHistory lh{beast::insight::NullCollector::New(), env.app()};
             auto const genesis = makeLedger({}, env, lh, 0s);
             auto const ledgerA = makeLedger(genesis, env, lh, 4s);
@@ -137,7 +137,7 @@ public:
                 *this,
                 envconfig(),
                 std::make_unique<CheckMessageLogs>(
-                    "MISMATCH on prior ledger", found)};
+                    "MISMATCH on prior ledger", &found)};
             LedgerHistory lh{beast::insight::NullCollector::New(), env.app()};
             auto const genesis = makeLedger({}, env, lh, 0s);
             auto const ledgerA = makeLedger(genesis, env, lh, 4s);
@@ -163,7 +163,7 @@ public:
             Env env{
                 *this,
                 envconfig(),
-                std::make_unique<CheckMessageLogs>(msg, found)};
+                std::make_unique<CheckMessageLogs>(msg, &found)};
             LedgerHistory lh{beast::insight::NullCollector::New(), env.app()};
 
             Account alice{"A1"};

--- a/src/test/app/LedgerHistory_test.cpp
+++ b/src/test/app/LedgerHistory_test.cpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <sstream>
 #include <test/jtx.h>
+#include <test/jtx/CheckMessageLogs.h>
 
 namespace ripple {
 namespace test {
@@ -34,56 +35,6 @@ namespace test {
 class LedgerHistory_test : public beast::unit_test::suite
 {
 public:
-    /** Log manager that searches for a specific message substring
-     */
-    class CheckMessageLogs : public Logs
-    {
-        std::string msg_;
-        bool& found_;
-
-        class CheckMessageSink : public beast::Journal::Sink
-        {
-            CheckMessageLogs& owner_;
-
-        public:
-            CheckMessageSink(
-                beast::severities::Severity threshold,
-                CheckMessageLogs& owner)
-                : beast::Journal::Sink(threshold, false), owner_(owner)
-            {
-            }
-
-            void
-            write(beast::severities::Severity level, std::string const& text)
-                override
-            {
-                if (text.find(owner_.msg_) != std::string::npos)
-                    owner_.found_ = true;
-            }
-        };
-
-    public:
-        /** Constructor
-
-            @param msg The message string to search for
-            @param found The variable to set to true if the message is found
-        */
-        CheckMessageLogs(std::string msg, bool& found)
-            : Logs{beast::severities::kDebug}
-            , msg_{std::move(msg)}
-            , found_{found}
-        {
-        }
-
-        std::unique_ptr<beast::Journal::Sink>
-        makeSink(
-            std::string const& partition,
-            beast::severities::Severity threshold) override
-        {
-            return std::make_unique<CheckMessageSink>(threshold, *this);
-        }
-    };
-
     /** Generate a new ledger by hand, applying a specific close time offset
         and optionally inserting a transaction.
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -259,6 +259,7 @@ public:
             DatabaseCon dbCon(
                 setup,
                 dbName.data(),
+                false,
                 std::array<char const*, 0>(),
                 WalletDBInit);
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -256,10 +256,10 @@ public:
         {
             DatabaseCon::Setup setup;
             setup.dataDir = getDatabasePath();
+            BEAST_EXPECT(!setup.commonPragma);
             DatabaseCon dbCon(
                 setup,
                 dbName.data(),
-                false,
                 std::array<char const*, 0>(),
                 WalletDBInit);
 

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -256,7 +256,7 @@ public:
         {
             DatabaseCon::Setup setup;
             setup.dataDir = getDatabasePath();
-            BEAST_EXPECT(!setup.commonPragma);
+            BEAST_EXPECT(!setup.useGlobalPragma);
             DatabaseCon dbCon(
                 setup,
                 dbName.data(),

--- a/src/test/jtx/CaptureLogs.h
+++ b/src/test/jtx/CaptureLogs.h
@@ -31,7 +31,7 @@ namespace test {
 class CaptureLogs : public Logs
 {
     std::stringstream strm_;
-    std::string& result_;
+    std::string* pResult_;
 
     /**
      * @brief sink for writing all log messages to a stringstream
@@ -57,14 +57,14 @@ class CaptureLogs : public Logs
     };
 
 public:
-    explicit CaptureLogs(std::string& result)
-        : Logs(beast::severities::kInfo), result_(result)
+    explicit CaptureLogs(std::string* pResult)
+        : Logs(beast::severities::kInfo), pResult_(pResult)
     {
     }
 
     ~CaptureLogs() override
     {
-        result_ = strm_.str();
+        *pResult_ = strm_.str();
     }
 
     std::unique_ptr<beast::Journal::Sink>

--- a/src/test/jtx/CaptureLogs.h
+++ b/src/test/jtx/CaptureLogs.h
@@ -1,0 +1,80 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/basics/Log.h>
+
+namespace ripple {
+namespace test {
+
+/**
+ * @brief Log manager for CaptureSinks. This class holds the stream
+ * instance that is written to by the sinks. Upon destruction, all
+ * contents of the stream are assigned to the string specified in the
+ * ctor
+ */
+class CaptureLogs : public Logs
+{
+    std::stringstream strm_;
+    std::string& result_;
+
+    /**
+     * @brief sink for writing all log messages to a stringstream
+     */
+    class CaptureSink : public beast::Journal::Sink
+    {
+        std::stringstream& strm_;
+
+    public:
+        CaptureSink(
+            beast::severities::Severity threshold,
+            std::stringstream& strm)
+            : beast::Journal::Sink(threshold, false), strm_(strm)
+        {
+        }
+
+        void
+        write(beast::severities::Severity level, std::string const& text)
+            override
+        {
+            strm_ << text;
+        }
+    };
+
+public:
+    explicit CaptureLogs(std::string& result)
+        : Logs(beast::severities::kInfo), result_(result)
+    {
+    }
+
+    ~CaptureLogs() override
+    {
+        result_ = strm_.str();
+    }
+
+    std::unique_ptr<beast::Journal::Sink>
+    makeSink(
+        std::string const& partition,
+        beast::severities::Severity threshold) override
+    {
+        return std::make_unique<CaptureSink>(threshold, strm_);
+    }
+};
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/jtx/CheckMessageLogs.h
+++ b/src/test/jtx/CheckMessageLogs.h
@@ -27,7 +27,7 @@ namespace test {
 class CheckMessageLogs : public Logs
 {
     std::string msg_;
-    bool& found_;
+    bool* pFound_;
 
     class CheckMessageSink : public beast::Journal::Sink
     {
@@ -46,7 +46,7 @@ class CheckMessageLogs : public Logs
             override
         {
             if (text.find(owner_.msg_) != std::string::npos)
-                owner_.found_ = true;
+                *owner_.pFound_ = true;
         }
     };
 
@@ -54,10 +54,11 @@ public:
     /** Constructor
 
         @param msg The message string to search for
-        @param found The variable to set to true if the message is found
+        @param pFound Pointer to the variable to set to true if the message is
+       found
     */
-    CheckMessageLogs(std::string msg, bool& found)
-        : Logs{beast::severities::kDebug}, msg_{std::move(msg)}, found_{found}
+    CheckMessageLogs(std::string msg, bool* pFound)
+        : Logs{beast::severities::kDebug}, msg_{std::move(msg)}, pFound_{pFound}
     {
     }
 

--- a/src/test/jtx/CheckMessageLogs.h
+++ b/src/test/jtx/CheckMessageLogs.h
@@ -1,0 +1,74 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/basics/Log.h>
+
+namespace ripple {
+namespace test {
+
+/** Log manager that searches for a specific message substring
+ */
+class CheckMessageLogs : public Logs
+{
+    std::string msg_;
+    bool& found_;
+
+    class CheckMessageSink : public beast::Journal::Sink
+    {
+        CheckMessageLogs& owner_;
+
+    public:
+        CheckMessageSink(
+            beast::severities::Severity threshold,
+            CheckMessageLogs& owner)
+            : beast::Journal::Sink(threshold, false), owner_(owner)
+        {
+        }
+
+        void
+        write(beast::severities::Severity level, std::string const& text)
+            override
+        {
+            if (text.find(owner_.msg_) != std::string::npos)
+                owner_.found_ = true;
+        }
+    };
+
+public:
+    /** Constructor
+
+        @param msg The message string to search for
+        @param found The variable to set to true if the message is found
+    */
+    CheckMessageLogs(std::string msg, bool& found)
+        : Logs{beast::severities::kDebug}, msg_{std::move(msg)}, found_{found}
+    {
+    }
+
+    std::unique_ptr<beast::Journal::Sink>
+    makeSink(
+        std::string const& partition,
+        beast::severities::Severity threshold) override
+    {
+        return std::make_unique<CheckMessageSink>(threshold, *this);
+    }
+};
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -168,11 +168,7 @@ public:
         std::unique_ptr<Logs> logs = nullptr,
         beast::severities::Severity thresh = beast::severities::kError)
         : test(suite_)
-        , bundle_(
-              suite_,
-              std::move(config),
-              logs ? std::move(logs) : std::make_unique<SuiteLogs>(suite_),
-              thresh)
+        , bundle_(suite_, std::move(config), std::move(logs), thresh)
         , journal{bundle_.app->journal("Env")}
     {
         memoize(Account::master);

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -27,6 +27,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/chrono.h>
 #include <ripple/beast/cxx17/type_traits.h>  // <type_traits>
+#include <ripple/beast/utility/Journal.h>
 #include <ripple/core/Config.h>
 #include <ripple/json/json_value.h>
 #include <ripple/json/to_string.h>
@@ -131,7 +132,8 @@ private:
         AppBundle(
             beast::unit_test::suite& suite,
             std::unique_ptr<Config> config,
-            std::unique_ptr<Logs> logs);
+            std::unique_ptr<Logs> logs,
+            beast::severities::Severity thresh);
         ~AppBundle();
     };
 
@@ -163,12 +165,14 @@ public:
     Env(beast::unit_test::suite& suite_,
         std::unique_ptr<Config> config,
         FeatureBitset features,
-        std::unique_ptr<Logs> logs = nullptr)
+        std::unique_ptr<Logs> logs = nullptr,
+        beast::severities::Severity thresh = beast::severities::kError)
         : test(suite_)
         , bundle_(
               suite_,
               std::move(config),
-              logs ? std::move(logs) : std::make_unique<SuiteLogs>(suite_))
+              logs ? std::move(logs) : std::make_unique<SuiteLogs>(suite_),
+              thresh)
         , journal{bundle_.app->journal("Env")}
     {
         memoize(Account::master);
@@ -211,11 +215,13 @@ public:
      */
     Env(beast::unit_test::suite& suite_,
         std::unique_ptr<Config> config,
-        std::unique_ptr<Logs> logs = nullptr)
+        std::unique_ptr<Logs> logs = nullptr,
+        beast::severities::Severity thresh = beast::severities::kError)
         : Env(suite_,
               std::move(config),
               supported_amendments(),
-              std::move(logs))
+              std::move(logs),
+              thresh)
     {
     }
 

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -59,7 +59,8 @@ namespace jtx {
 Env::AppBundle::AppBundle(
     beast::unit_test::suite& suite,
     std::unique_ptr<Config> config,
-    std::unique_ptr<Logs> logs)
+    std::unique_ptr<Logs> logs,
+    beast::severities::Severity thresh)
     : AppBundle()
 {
     using namespace beast::severities;
@@ -72,7 +73,7 @@ Env::AppBundle::AppBundle(
     owned = make_Application(
         std::move(config), std::move(logs), std::move(timeKeeper_));
     app = owned.get();
-    app->logs().threshold(kError);
+    app->logs().threshold(thresh);
     if (!app->setup())
         Throw<std::runtime_error>("Env::AppBundle: setup failed");
     timeKeeper->set(app->getLedgerMaster().getClosedLedger()->info().closeTime);

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -64,8 +64,17 @@ Env::AppBundle::AppBundle(
     : AppBundle()
 {
     using namespace beast::severities;
-    // Use kFatal threshold to reduce noise from STObject.
-    setDebugLogSink(std::make_unique<SuiteJournalSink>("Debug", kFatal, suite));
+    if (logs)
+    {
+        setDebugLogSink(logs->makeSink("Debug", kFatal));
+    }
+    else
+    {
+        logs = std::make_unique<SuiteLogs>(suite);
+        // Use kFatal threshold to reduce noise from STObject.
+        setDebugLogSink(
+            std::make_unique<SuiteJournalSink>("Debug", kFatal, suite));
+    }
     auto timeKeeper_ = std::make_unique<ManualTimeKeeper>();
     timeKeeper = timeKeeper_.get();
     // Hack so we don't have to call Config::setup

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -51,19 +51,19 @@ public:
 
             auto const s = setup_DatabaseCon(env.app().config());
 
-            if (BEAST_EXPECT(s.CommonPragma->size() == 3))
+            if (BEAST_EXPECT(s.globalPragma->size() == 3))
             {
                 BEAST_EXPECT(
-                    s.CommonPragma->at(0) == "PRAGMA journal_mode=wal;");
+                    s.globalPragma->at(0) == "PRAGMA journal_mode=wal;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(1) == "PRAGMA synchronous=normal;");
+                    s.globalPragma->at(1) == "PRAGMA synchronous=normal;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(2) == "PRAGMA temp_store=file;");
+                    s.globalPragma->at(2) == "PRAGMA temp_store=file;");
             }
         }
         {
             // Low safety level
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             Env env = [&]() {
                 auto p = test::jtx::envconfig();
@@ -76,19 +76,19 @@ public:
             }();
 
             auto const s = setup_DatabaseCon(env.app().config());
-            if (BEAST_EXPECT(s.CommonPragma->size() == 3))
+            if (BEAST_EXPECT(s.globalPragma->size() == 3))
             {
                 BEAST_EXPECT(
-                    s.CommonPragma->at(0) == "PRAGMA journal_mode=memory;");
+                    s.globalPragma->at(0) == "PRAGMA journal_mode=memory;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(1) == "PRAGMA synchronous=off;");
+                    s.globalPragma->at(1) == "PRAGMA synchronous=off;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(2) == "PRAGMA temp_store=memory;");
+                    s.globalPragma->at(2) == "PRAGMA temp_store=memory;");
             }
         }
         {
             // Override individual settings
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             Env env = [&]() {
                 auto p = test::jtx::envconfig();
@@ -103,20 +103,20 @@ public:
             }();
 
             auto const s = setup_DatabaseCon(env.app().config());
-            if (BEAST_EXPECT(s.CommonPragma->size() == 3))
+            if (BEAST_EXPECT(s.globalPragma->size() == 3))
             {
                 BEAST_EXPECT(
-                    s.CommonPragma->at(0) == "PRAGMA journal_mode=off;");
+                    s.globalPragma->at(0) == "PRAGMA journal_mode=off;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(1) == "PRAGMA synchronous=extra;");
+                    s.globalPragma->at(1) == "PRAGMA synchronous=extra;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(2) == "PRAGMA temp_store=default;");
+                    s.globalPragma->at(2) == "PRAGMA temp_store=default;");
             }
         }
         {
             // Override individual settings with low safety level
             // (Low doesn't force the other settings)
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             Env env = [&]() {
                 auto p = test::jtx::envconfig();
@@ -132,19 +132,19 @@ public:
             }();
 
             auto const s = setup_DatabaseCon(env.app().config());
-            if (BEAST_EXPECT(s.CommonPragma->size() == 3))
+            if (BEAST_EXPECT(s.globalPragma->size() == 3))
             {
                 BEAST_EXPECT(
-                    s.CommonPragma->at(0) == "PRAGMA journal_mode=off;");
+                    s.globalPragma->at(0) == "PRAGMA journal_mode=off;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(1) == "PRAGMA synchronous=extra;");
+                    s.globalPragma->at(1) == "PRAGMA synchronous=extra;");
                 BEAST_EXPECT(
-                    s.CommonPragma->at(2) == "PRAGMA temp_store=default;");
+                    s.globalPragma->at(2) == "PRAGMA temp_store=default;");
             }
         }
         {
             // Errors
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             auto p = test::jtx::envconfig();
             {
@@ -164,7 +164,7 @@ public:
         }
         {
             // Errors
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             auto p = test::jtx::envconfig();
             {
@@ -184,7 +184,7 @@ public:
         }
         {
             // Errors
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             auto p = test::jtx::envconfig();
             {
@@ -204,7 +204,7 @@ public:
         }
         {
             // Errors
-            DatabaseCon::Setup::CommonPragma.reset();
+            DatabaseCon::Setup::globalPragma.reset();
 
             auto p = test::jtx::envconfig();
             {

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -157,7 +157,7 @@ public:
                 Env env(*this, std::move(p));
                 fail();
             }
-            catch (std::exception const& e)
+            catch (...)
             {
                 pass();
             }
@@ -177,7 +177,7 @@ public:
                 Env env(*this, std::move(p));
                 fail();
             }
-            catch (std::exception const& e)
+            catch (...)
             {
                 pass();
             }
@@ -197,7 +197,7 @@ public:
                 Env env(*this, std::move(p));
                 fail();
             }
-            catch (std::exception const& e)
+            catch (...)
             {
                 pass();
             }
@@ -217,7 +217,7 @@ public:
                 Env env(*this, std::move(p));
                 fail();
             }
-            catch (std::exception const& e)
+            catch (...)
             {
                 pass();
             }

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -84,7 +84,8 @@ public:
                 return Env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(integrityWarning, found),
+                    std::make_unique<CheckMessageLogs>(
+                        integrityWarning, &found),
                     beast::severities::kWarning);
             }();
 
@@ -116,7 +117,8 @@ public:
                 return Env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(integrityWarning, found),
+                    std::make_unique<CheckMessageLogs>(
+                        integrityWarning, &found),
                     beast::severities::kWarning);
             }();
 
@@ -149,7 +151,8 @@ public:
                 return Env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(integrityWarning, found),
+                    std::make_unique<CheckMessageLogs>(
+                        integrityWarning, &found),
                     beast::severities::kWarning);
             }();
 
@@ -185,7 +188,8 @@ public:
                 return Env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(integrityWarning, found),
+                    std::make_unique<CheckMessageLogs>(
+                        integrityWarning, &found),
                     beast::severities::kWarning);
             }();
 
@@ -226,7 +230,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -255,7 +259,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -284,7 +288,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -313,7 +317,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -341,7 +345,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -369,7 +373,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -397,7 +401,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }
@@ -425,7 +429,7 @@ public:
                 Env env(
                     *this,
                     std::move(p),
-                    std::make_unique<CheckMessageLogs>(expected, found),
+                    std::make_unique<CheckMessageLogs>(expected, &found),
                     beast::severities::kWarning);
                 fail();
             }

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <stdexcept>
 #include <test/jtx.h>
+#include <test/jtx/CaptureLogs.h>
 #include <test/jtx/envconfig.h>
 #include <test/unit_test/SuiteJournal.h>
 #include <thread>
@@ -374,60 +375,6 @@ public:
         }
         pass();
     }
-
-    /**
-     * @brief sink for writing all log messages to a stringstream
-     */
-    class CaptureSink : public beast::Journal::Sink
-    {
-        std::stringstream& strm_;
-
-    public:
-        CaptureSink(
-            beast::severities::Severity threshold,
-            std::stringstream& strm)
-            : beast::Journal::Sink(threshold, false), strm_(strm)
-        {
-        }
-
-        void
-        write(beast::severities::Severity level, std::string const& text)
-            override
-        {
-            strm_ << text;
-        }
-    };
-
-    /**
-     * @brief Log manager for CaptureSinks. This class holds the stream
-     * instance that is written to by the sinks. Upon destruction, all
-     * contents of the stream are assigned to the string specified in the
-     * ctor
-     */
-    class CaptureLogs : public Logs
-    {
-        std::stringstream strm_;
-        std::string& result_;
-
-    public:
-        explicit CaptureLogs(std::string& result)
-            : Logs(beast::severities::kInfo), result_(result)
-        {
-        }
-
-        ~CaptureLogs() override
-        {
-            result_ = strm_.str();
-        }
-
-        std::unique_ptr<beast::Journal::Sink>
-        makeSink(
-            std::string const& partition,
-            beast::severities::Severity threshold) override
-        {
-            return std::make_unique<CaptureSink>(threshold, strm_);
-        }
-    };
 
     void
     testBadConfig()

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -391,7 +391,7 @@ public:
                     (*cfg).deprecatedClearSection("port_rpc");
                     return cfg;
                 }),
-                std::make_unique<CaptureLogs>(messages)};
+                std::make_unique<CaptureLogs>(&messages)};
         });
         BEAST_EXPECT(
             messages.find("Missing 'ip' in [port_rpc]") != std::string::npos);
@@ -404,7 +404,7 @@ public:
                     (*cfg)["port_rpc"].set("ip", getEnvLocalhostAddr());
                     return cfg;
                 }),
-                std::make_unique<CaptureLogs>(messages)};
+                std::make_unique<CaptureLogs>(&messages)};
         });
         BEAST_EXPECT(
             messages.find("Missing 'port' in [port_rpc]") != std::string::npos);
@@ -418,7 +418,7 @@ public:
                     (*cfg)["port_rpc"].set("port", "0");
                     return cfg;
                 }),
-                std::make_unique<CaptureLogs>(messages)};
+                std::make_unique<CaptureLogs>(&messages)};
         });
         BEAST_EXPECT(
             messages.find("Invalid value '0' for key 'port' in [port_rpc]") !=
@@ -434,7 +434,7 @@ public:
                     (*cfg)["port_rpc"].set("protocol", "");
                     return cfg;
                 }),
-                std::make_unique<CaptureLogs>(messages)};
+                std::make_unique<CaptureLogs>(&messages)};
         });
         BEAST_EXPECT(
             messages.find("Missing 'protocol' in [port_rpc]") !=
@@ -469,7 +469,7 @@ public:
                         (*cfg)["port_ws"].set("admin", getEnvLocalhostAddr());
                         return cfg;
                     }),
-                    std::make_unique<CaptureLogs>(messages)};
+                    std::make_unique<CaptureLogs>(&messages)};
             });
         BEAST_EXPECT(
             messages.find("Required section [server] is missing") !=
@@ -495,7 +495,7 @@ public:
                            (*cfg)["server"].append("port_ws");
                            return cfg;
                        }),
-                       std::make_unique<CaptureLogs>(messages)};
+                       std::make_unique<CaptureLogs>(&messages)};
                });
         BEAST_EXPECT(
             messages.find("Missing section: [port_peer]") != std::string::npos);


### PR DESCRIPTION
* Document delete_batch, back_off_milliseconds, age_threshold_seconds.
* Convert those time values to chrono types.
* Fix bug that ignored age_threshold_seconds.
* Add a "recovery buffer" to the config that gives the node a chance to
  recover before aborting online delete.
* Add begin/end log messages around the SQL queries.
* Add a new configuration section: [sqlite] to allow tuning the sqlite
  database operations. Ignored on full/large history servers.
* Update documentation of [node_db] and [sqlite] in the
  rippled-example.cfg file.
* Resolves ripple#3321

I added the "recovery buffer" function that wasn't described in the original issue to scratch my own itch, because my local machine was losing sync for a fraction of a second while the ledger was being copied over. This resolved that issue. I defaulted it to not run, so it doesn't cause unexpected behavior.

Note this includes two commits, one from @mtrippled . Both need to be reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3429)
<!-- Reviewable:end -->
