### PR TITLE
crawl_shards comment fix

### DIFF
--- a/src/ripple/rpc/handlers/CrawlShards.cpp
+++ b/src/ripple/rpc/handlers/CrawlShards.cpp
@@ -32,7 +32,7 @@ namespace ripple {
     {
         // Determines if the result includes node public key.
         // optional, default is false
-        pubkey: <bool>
+        public_key: <bool>
 
         // The maximum number of peer hops to attempt.
         // optional, default is zero, maximum is 3


### PR DESCRIPTION
Corrects the public_key parameter name in the comment.
See https://github.com/ripple/xrpl-dev-portal/pull/854 for context.