### PR TITLE
Internal amendment vetoes:

### DIFF
--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -36,9 +36,15 @@
  * 2) add a uint256 declaration for the feature to the bottom of this file
  * 3) add a uint256 definition for the feature to the corresponding source
  *    file (Feature.cpp)
- * 4) if the feature is going to be supported in the near future, add its
- *    sha512half value and name (matching exactly the featureName here) to
- *    the supportedAmendments in Feature.cpp.
+ * 4) use the uint256 as the parameter to `view.rules.enabled()` to
+ *    control flow into new code that this feature limits.
+ * 5) if the feature development is COMPLETE, and the feature is ready to be
+ *    SUPPORTED, add its name (matching exactly the featureName here) to the
+ *    supportedAmendments in Feature.cpp.
+ * 6) if the feature is not ready to be ENABLED, add its name (matching exactly
+ *    the featureName here) to the downVotedAmendments in Feature.cpp.
+ * In general, any new amendments added to supportedAmendments should also be
+ * added to downVotedAmendments for at least one full release cycle.
  *
  */
 
@@ -136,11 +142,21 @@ public:
 
     uint256 const&
     bitsetIndexToFeature(size_t i) const;
+
+    std::string
+    featureToName(uint256 const& f) const;
 };
 
-/** Amendments that this server supports, but doesn't enable by default */
+/** Amendments that this server supports and will vote for by default.
+   Whether they are enabled depends on the Rules defined in the validated
+   ledger */
 std::vector<std::string> const&
 supportedAmendments();
+
+/** Amendments that this server won't vote for by default. Overrides the default
+   vote behavior of `supportedAmendments()` */
+std::vector<std::string> const&
+downVotedAmendments();
 
 }  // namespace detail
 
@@ -152,6 +168,9 @@ featureToBitsetIndex(uint256 const& f);
 
 uint256
 bitsetIndexToFeature(size_t i);
+
+std::string
+featureToName(uint256 const& f);
 
 class FeatureBitset
     : private std::bitset<detail::FeatureCollections::numFeatures()>

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -273,20 +273,19 @@ public:
 
         std::unique_ptr<AmendmentTable> table = makeTable(weeks(2));
 
-        // Note which entries are pre-enabled.
+        // Note which entries are pre-enabled
         std::set<uint256> allEnabled;
-        for (std::string const& a : enabled_)
+        for (auto const& a : enabled_)
             allEnabled.insert(amendmentId(a));
 
         // Subset of amendments to late-enable
         std::set<uint256> lateEnabled;
         lateEnabled.insert(amendmentId(supported_[0]));
-        lateEnabled.insert(amendmentId(enabled_[0]));
         lateEnabled.insert(amendmentId(vetoed_[0]));
 
         // Do the late enabling.
         for (uint256 const& a : lateEnabled)
-            table->enable(a);
+            BEAST_EXPECT(table->enable(a));
 
         // So far all enabled amendments are supported.
         BEAST_EXPECT(!table->hasUnsupportedEnabled());
@@ -314,14 +313,14 @@ public:
             // Unveto an amendment that is already not vetoed.  Shouldn't
             // hurt anything, but the values returned by getDesired()
             // shouldn't change.
-            table->unVeto(amendmentId(supported_[1]));
+            BEAST_EXPECT(!table->unVeto(amendmentId(supported_[1])));
             BEAST_EXPECT(desired == table->getDesired());
         }
 
         // UnVeto one of the vetoed amendments.  It should now be desired.
         {
             uint256 const unvetoedID = amendmentId(vetoed_[0]);
-            table->unVeto(unvetoedID);
+            BEAST_EXPECT(table->unVeto(unvetoedID));
 
             std::vector<uint256> const desired = table->getDesired();
             BEAST_EXPECT(

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -141,9 +141,12 @@ class TxQ_test : public beast::unit_test::suite
         // fee (1) and amendment (supportedAmendments().size())
         // pseudotransactions. The queue treats the fees on these
         // transactions as though they are ordinary transactions.
-        auto const flagPerLedger =
-            1 + ripple::detail::supportedAmendments().size();
+        auto const flagPerLedger = 1 +
+            ripple::detail::supportedAmendments().size() -
+            ripple::detail::downVotedAmendments().size();
         auto const flagMaxQueue = ledgersInQueue * flagPerLedger;
+        // If this check fails, check that all the entries in
+        // downVotedAmendments are also in supportedAmendments.
         checkMetrics(env, 0, flagMaxQueue, 0, flagPerLedger, 256);
 
         // Pad a couple of txs with normal fees so the median comes
@@ -4173,8 +4176,8 @@ public:
             if (!getMajorityAmendments(*env.closed()).empty())
                 break;
         }
-        auto expectedPerLedger =
-            ripple::detail::supportedAmendments().size() + 1;
+        auto expectedPerLedger = ripple::detail::supportedAmendments().size() -
+            ripple::detail::downVotedAmendments().size() + 1;
         checkMetrics(env, 0, 5 * expectedPerLedger, 0, expectedPerLedger, 256);
 
         // Now wait 2 weeks modulo 256 ledgers for the amendments to be


### PR DESCRIPTION
| [Spec](https://github.com/ripple/rippled-specs/tree/master/0013-DefaultAmendmentDownvotes) |
| - |

* Allows a version to have the code to support a given amendment, but
  not vote for it by default. This allows the amendment to be enabled in
  a future version without necessarily amendment blocking these older
  versions.
* ~Provides a new configuration file section: [unveto_amendments], which
  can be used to override the hard-coded veto list, and is intended for
  use on test networks (testnet, devnet). Will also override
  [veto_amendments], but since that's in the same configuration file,
  that would be silly.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3458)
<!-- Reviewable:end -->
