### PR TITLE
[TRIVIAL?] Tweak the unity build to fix a linker memory problem

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -984,5 +984,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
     # these two seem to produce conflicts in beast teardown template methods
     src/test/rpc/ValidatorRPC_test.cpp
     src/test/rpc/ShardArchiveHandler_test.cpp
+    # This file is so big it makes the Windows linker run out of memory
+    src/test/server/ServerStatus_test.cpp
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 endif ()


### PR DESCRIPTION
I've been having trouble doing unity builds from the command line on my well-provisioned Windows box (16-core i7, 32Gb RAM, etc.) recently. I tried turning down the `CMAKE_UNITY_BUILD_BATCH_SIZE`, but the problem recurred with batches as small as 10, and it seems like single digits start defeating the purpose. I finally tracked it down to a specific file causing whichever unity file it's in to be so large that the linker runs out of memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3460)
<!-- Reviewable:end -->
