### PR TITLE
Travis CI Windows fix

### DIFF
--- a/Builds/CMake/deps/Sqlite.cmake
+++ b/Builds/CMake/deps/Sqlite.cmake
@@ -21,6 +21,7 @@ if(sqlite3)
 else()
   ExternalProject_Add (sqlite3
     PREFIX ${nih_cache_path}
+    TLS_VERIFY OFF
     # sqlite doesn't use git, but it provides versioned tarballs
     URL https://www.sqlite.org/2018/sqlite-amalgamation-3260000.zip
     # ^^^ version is apparent in the URL:  3260000 => 3.26.0

--- a/Builds/containers/shared/install_boost.sh
+++ b/Builds/containers/shared/install_boost.sh
@@ -19,12 +19,15 @@ fi
 #fetch/unpack:
 fn=$(basename -- "$BOOST_URL")
 ext="${fn##*.}"
-wget --quiet $BOOST_URL -O /tmp/boost.tar.${ext}
+#todo - TravisCI is unable to check the cert, this is a workaround
+#delete --no-check-certificate once TravisCI fixes their issue
+wget --no-check-certificate $BOOST_URL -O /tmp/boost.tar.${ext}
 cd $(dirname $BOOST_ROOT)
 rm -fr ${BOOST_ROOT}
 mkdir ${BOOST_ROOT}
 tar xf /tmp/boost.tar.${ext} -C ${BOOST_ROOT} --strip-components 1
 cd $BOOST_ROOT
+
 
 BLDARGS=()
 if [[ ${BOOST_BUILD_ALL:-false} == "true" ]]; then


### PR DESCRIPTION
This fix allows Travis CI Windows to pass. Previously, `wget` on Windows instance cannot verify some of the certificates and therefore causing the download of Boost to fail. This workaround bypasses the checks for cert. This is not a security issue because it only bypasses on windows CI and not the actual build process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3465)
<!-- Reviewable:end -->
