### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!--
+This PR template helps you to write a good pull request description.
+Please feel free to include additional useful information even beyond what is requested below.
+-->
+
 ## High Level Overview of Change
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+## High Level Overview of Change
+
+<!--
+Please include a summary/list of the changes.
+If too broad, please consider splitting into multiple PRs.
+If a relevant task or issue, please link it here.
+-->
+
+### Context of Change
+
+<!--
+Please include the context of a change.
+If a bug fix, when was the bug introduced? What was the behavior?
+If a new feature, why was this architecture chosen? What were the alternatives?
+If a refactor, how is this better than the previous implementation?
+
+If there is a spec or design document for this feature, please link it here.
+-->
+
+### Type of Change
+
+<!--
+Please check [x] relevant options, delete irrelevant ones.
+-->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor (non-breaking change that only restructures code)
+- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
+- [ ] Documentation Updates
+- [ ] Release
+
+## Before / After
+
+<!--
+If just refactoring / back-end changes, this can be just an English description of the change at a technical level.
+If an API change, examples should be included.
+-->
+
+## Test Plan
+
+<!--
+Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
+-->
+
+<!--
+## Future Tasks
+For future tasks related to PR.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 ## High Level Overview of Change
 
 <!--
-Please include a summary/list of the changes.
+Please include a summary of the changes.
+This may be a direct input to the release notes.
 If too broad, please consider splitting into multiple PRs.
 If a relevant task or issue, please link it here.
 -->
@@ -31,17 +32,16 @@ Please check [x] relevant options, delete irrelevant ones.
 - [ ] Documentation Updates
 - [ ] Release
 
-## Before / After
-
 <!--
-If just refactoring / back-end changes, this can be just an English description of the change at a technical level.
-If an API change, examples should be included.
+## Before / After
+If relevant, use this section for an English description of the change at a technical level.
+If this change affects an API, examples should be included here.
 -->
 
-## Test Plan
-
 <!--
-Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
+## Test Plan
+If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
+This section may not be needed if your change includes thoroughly commented unit tests.
 -->
 
 <!--


### PR DESCRIPTION
## High Level Overview of Change

Add a pull request template for this GitHub repository.

[GitHub documentation about PR templates](https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)

### Context of Change

This was inspired by the development team's conversation about how it is sometimes difficult for PR reviewers to get the necessary context to effectively review the main part of a PR. We feel that more descriptive PRs may help reviewers and QA testers to quickly understand the "big picture" of each PR.

This is functionally similar to the issue templates that were added earlier: https://github.com/ripple/rippled/pull/3246

The difference is that this is tailored for pull requests.

### Type of Change

- [x] New feature (non-breaking change which adds functionality) - adds template when creating new GitHub PR
- [x] Documentation Updates

## Before / After

When creating a new PR, you currently get a blank text field. This encourages short PR descriptions, which often lack in helpful detail.

Now, the text field is pre-populated with a template that inspires PR authors to write helpful content for code reviewers and other stakeholders.

## Test Plan

Aside from a couple minor edits to make it more relevant to rippled, this template is substantially the same as the one used by `xpring-eng`:

https://raw.githubusercontent.com/xpring-eng/.github/master/.github/pull_request_template.md

Here are a few random examples of PRs that used this template:
- https://github.com/xpring-eng/Xpring-SDK-Demo/pull/34
- https://github.com/xpring-eng/xpring.io/pull/101
- https://github.com/payid-org/payid/pull/568
