### PR TITLE
Added public_key to ValidatorList::getAvailable response

### DIFF
--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -820,6 +820,7 @@ ValidatorList::getAvailable(boost::beast::string_view const& pubKey)
 
     Json::Value value(Json::objectValue);
 
+    value["public_key"] = std::string{pubKey};
     value["manifest"] = iter->second.rawManifest;
     value["blob"] = iter->second.rawBlob;
     value["signature"] = iter->second.rawSignature;

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -820,11 +820,11 @@ ValidatorList::getAvailable(boost::beast::string_view const& pubKey)
 
     Json::Value value(Json::objectValue);
 
-    value["public_key"] = std::string{pubKey};
-    value["manifest"] = iter->second.rawManifest;
-    value["blob"] = iter->second.rawBlob;
-    value["signature"] = iter->second.rawSignature;
-    value["version"] = iter->second.rawVersion;
+    value[jss::public_key] = std::string{pubKey};
+    value[jss::manifest] = iter->second.rawManifest;
+    value[jss::blob] = iter->second.rawBlob;
+    value[jss::signature] = iter->second.rawSignature;
+    value[jss::version] = iter->second.rawVersion;
 
     return value;
 }

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -143,6 +143,7 @@ JSS(base_fee_xrp);           // out: NetworkOPs
 JSS(bids);                   // out: Subscribe
 JSS(binary);                 // in: AccountTX, LedgerEntry,
                              //     AccountTxOld, Tx LedgerData
+JSS(blob);                   // out: ValidatorList
 JSS(books);                  // in: Subscribe, Unsubscribe
 JSS(both);                   // in: Subscribe, Unsubscribe
 JSS(both_sides);             // in: Subscribe, Unsubscribe

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -570,6 +570,25 @@ private:
             BEAST_EXPECT(trustedKeys->listed(val.signingPublic));
         }
 
+        const auto hexPublic =
+            strHex(publisherPublic.begin(), publisherPublic.end());
+
+        const auto available = trustedKeys->getAvailable(hexPublic);
+
+        BEAST_EXPECT(available);
+        if (available)
+        {
+            BEAST_EXPECT(
+                available->get(jss::public_key, Json::nullValue) == hexPublic);
+            BEAST_EXPECT(available->get(jss::blob, Json::nullValue) == blob2);
+            BEAST_EXPECT(
+                available->get(jss::manifest, Json::nullValue) == manifest1);
+            BEAST_EXPECT(
+                available->get(jss::version, Json::nullValue) == version);
+            BEAST_EXPECT(
+                available->get(jss::signature, Json::nullValue) == sig2);
+        }
+
         // do not re-apply lists with past or current sequence numbers
         BEAST_EXPECT(
             ListDisposition::stale ==

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -26,6 +26,7 @@
 #include <ripple/protocol/SecretKey.h>
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/digest.h>
+#include <ripple/protocol/jss.h>
 #include <test/jtx.h>
 
 namespace ripple {
@@ -575,18 +576,13 @@ private:
 
         const auto available = trustedKeys->getAvailable(hexPublic);
 
-        BEAST_EXPECT(available);
-        if (available)
-        {
-            BEAST_EXPECT(
-                available->get(jss::public_key, Json::nullValue) == hexPublic);
-            BEAST_EXPECT(available->get(jss::blob, Json::nullValue) == blob2);
-            BEAST_EXPECT(
-                available->get(jss::manifest, Json::nullValue) == manifest1);
-            BEAST_EXPECT(
-                available->get(jss::version, Json::nullValue) == version);
-            BEAST_EXPECT(
-                available->get(jss::signature, Json::nullValue) == sig2);
+        if (BEAST_EXPECT(available)) {
+            auto const& a = *available;
+            BEAST_EXPECT(a[jss::public_key] == hexPublic);
+            BEAST_EXPECT(a[jss::blob] == blob2);
+            BEAST_EXPECT(a[jss::manifest] == manifest1);
+            BEAST_EXPECT(a[jss::version] == version);
+            BEAST_EXPECT(a[jss::signature] == sig2);
         }
 
         // do not re-apply lists with past or current sequence numbers

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -576,7 +576,8 @@ private:
 
         const auto available = trustedKeys->getAvailable(hexPublic);
 
-        if (BEAST_EXPECT(available)) {
+        if (BEAST_EXPECT(available))
+        {
             auto const& a = *available;
             BEAST_EXPECT(a[jss::public_key] == hexPublic);
             BEAST_EXPECT(a[jss::blob] == blob2);


### PR DESCRIPTION
## High Level Overview of Change
Public key from the `/vl/` request URL is now copied back in rippled's response.

### Context of Change
API change Fixes #3392, vl method should return public key (Version: 1.5.0). The response from rippled at the endpoint `/vl/<public_key>` now includes the public_key.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
Request: `https://localhost:51235/vl/ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734`
Response:
**Before**
`{
    "blob": "eyJzZ...J9XX0=",
    "manifest": "JAAAA....sAg==",
    "signature": "4C59F...883E03",
    "version": 1
}`
**After**
`{
    "blob": "eyJzZ...J9XX0=",
    "manifest": "JAAAA....sAg==",
    "public_key": "ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734",
    "signature": "4C59F...883E03",
    "version": 1
}`

## Test Plan
None currently, and am open to suggestions for how to go about writing tests.