### PR TITLE
[TRIVIAL] Add missing cstdint include:

### DIFF
--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -21,6 +21,7 @@
 #define RIPPLE_APP_DATA_DBINIT_H_INCLUDED
 
 #include <array>
+#include <cstdint>
 
 namespace ripple {
 


### PR DESCRIPTION
The gcc non-unity build breaks without this include.