### PR TITLE
Added GRPCServer to Stoppable Hierarchy

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -439,7 +439,7 @@ public:
               logs_->journal("Application"),
               std::chrono::milliseconds(100),
               get_io_service())
-        , grpcServer_(std::make_unique<GRPCServer>(*this))
+        , grpcServer_(std::make_unique<GRPCServer>(*this, *m_jobQueue))
     {
         add(m_resourceManager.get());
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1310,7 +1310,6 @@ ApplicationImp::setup()
     logs_->silent(config_->silent());
 
     m_jobQueue->setThreadCount(config_->WORKERS, config_->standalone());
-    grpcServer_->run();
 
     if (!config_->standalone())
         timeKeeper_->run(config_->SNTP_SERVERS);

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -441,10 +441,11 @@ void
 GRPCServer::onStart()
 {
     // Start the server and setup listeners
-    if ((running_ = impl_.start()))
+    if (running_ = impl_.start(); running_)
     {
         thread_ = std::thread([this]() {
             // Start the event loop and begin handling requests
+            beast::setCurrentThreadName("rippled: grpc");
             this->impl_.handleRpcs();
         });
     }
@@ -457,9 +458,15 @@ GRPCServer::onStop()
     {
         impl_.shutdown();
         thread_.join();
+        running_ = false;
     }
 
     stopped();
+}
+
+GRPCServer::~GRPCServer()
+{
+    assert(!running_);
 }
 
 }  // namespace ripple

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -450,13 +450,16 @@ GRPCServer::run()
     }
 }
 
-GRPCServer::~GRPCServer()
+void
+GRPCServer::onStop() 
 {
     if (running_)
     {
         impl_.shutdown();
         thread_.join();
     }
+
+    stopped();
 }
 
 }  // namespace ripple

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -438,7 +438,7 @@ GRPCServerImpl::start()
 }
 
 void
-GRPCServer::run()
+GRPCServer::onStart()
 {
     // Start the server and setup listeners
     if ((running_ = impl_.start()))

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -451,7 +451,7 @@ GRPCServer::onStart()
 }
 
 void
-GRPCServer::onStop() 
+GRPCServer::onStop()
 {
     if (running_)
     {

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/app/main/GRPCServer.h>
+#include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/resource/Fees.h>
 
 namespace ripple {

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -254,7 +254,7 @@ public:
     void
     onStop() override;
 
-    ~GRPCServer(){};
+    ~GRPCServer() = default;
 
 private:
     GRPCServerImpl impl_;

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -15,7 +15,7 @@
     ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
-//======================================================å========================
+//==============================================================================
 
 #ifndef RIPPLE_CORE_GRPCSERVER_H_INCLUDED
 #define RIPPLE_CORE_GRPCSERVER_H_INCLUDED

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -22,6 +22,7 @@
 
 #include <ripple/app/main/Application.h>
 #include <ripple/core/JobQueue.h>
+#include <ripple/core/Stoppable.h>
 #include <ripple/net/InfoSub.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/resource/Charge.h>
@@ -234,10 +235,16 @@ private:
 
 };  // GRPCServerImpl
 
-class GRPCServer
+class GRPCServer : public Stoppable
 {
 public:
-    explicit GRPCServer(Application& app) : impl_(app){};
+    explicit GRPCServer(
+        Application& app, 
+        Stoppable& parent) 
+        : Stoppable("GRPCServer", parent)
+        , impl_(app) 
+        {
+        }
 
     GRPCServer(const GRPCServer&) = delete;
 
@@ -247,7 +254,12 @@ public:
     void
     run();
 
-    ~GRPCServer();
+    void
+    onStop() override;
+
+    ~GRPCServer() 
+    {
+    };
 
 private:
     GRPCServerImpl impl_;

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -252,7 +252,7 @@ public:
     operator=(const GRPCServer&) = delete;
 
     void
-    run();
+    onStart() override;
 
     void
     onStop() override;

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -21,6 +21,7 @@
 #define RIPPLE_CORE_GRPCSERVER_H_INCLUDED
 
 #include <ripple/app/main/Application.h>
+#include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/core/JobQueue.h>
 #include <ripple/core/Stoppable.h>
 #include <ripple/net/InfoSub.h>
@@ -254,12 +255,12 @@ public:
     void
     onStop() override;
 
-    ~GRPCServer() = default;
+    ~GRPCServer() override;
 
 private:
     GRPCServerImpl impl_;
     std::thread thread_;
-    bool running_;
+    bool running_ = false;
 };
 }  // namespace ripple
 #endif

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -238,13 +238,10 @@ private:
 class GRPCServer : public Stoppable
 {
 public:
-    explicit GRPCServer(
-        Application& app, 
-        Stoppable& parent) 
-        : Stoppable("GRPCServer", parent)
-        , impl_(app) 
-        {
-        }
+    explicit GRPCServer(Application& app, Stoppable& parent)
+        : Stoppable("GRPCServer", parent), impl_(app)
+    {
+    }
 
     GRPCServer(const GRPCServer&) = delete;
 
@@ -257,9 +254,7 @@ public:
     void
     onStop() override;
 
-    ~GRPCServer() 
-    {
-    };
+    ~GRPCServer(){};
 
 private:
     GRPCServerImpl impl_;

--- a/src/ripple/app/main/GRPCServer.h
+++ b/src/ripple/app/main/GRPCServer.h
@@ -15,13 +15,12 @@
     ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
-//==============================================================================
+//======================================================å========================
 
 #ifndef RIPPLE_CORE_GRPCSERVER_H_INCLUDED
 #define RIPPLE_CORE_GRPCSERVER_H_INCLUDED
 
 #include <ripple/app/main/Application.h>
-#include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/core/JobQueue.h>
 #include <ripple/core/Stoppable.h>
 #include <ripple/net/InfoSub.h>

--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -186,9 +186,9 @@ class RootStoppable;
                                                              |
                                                          JobQueue
                                                              |
-        +--------+-----------+-----------+-----------+-------+---+----------+
-        |        |           |           |           |           |          |
-        |    NetworkOPs      |     InboundLedgers    |      OrderbookDB     |
+        +--------+-----------+-----------+-----------+-------+---+----------+----------+
+        |        |           |           |           |           |          |          |
+        |    NetworkOPs      |     InboundLedgers    |      OrderbookDB     |     GRPCServer
         |                    |                       |                      |
      Overlay        InboundTransactions        LedgerMaster             Database
         |                                            |                      |

--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -186,14 +186,14 @@ class RootStoppable;
                                                              |
                                                          JobQueue
                                                              |
-        +--------+-----------+---------+------------+---+----+---------+---+
-        |        |           |         |            |   |              |   |
-        |    NetworkOPs      |    InboundLedgers    |   |      OrderbookDB |
-        |                    |                      |  GRPCServer          |
-        |                    |                      |                  Database
-     Overlay        InboundTransactions        LedgerMaster                |
-        |                                           |                      |
-    PeerFinder                                LedgerCleaner           TaskQueue
+        +------+---------+--------+----------+---+----+---------+---+
+        |      |         |        |          |   |              |   |
+        |  NetworkOPs    |   InboundLedgers  |   |      OrderbookDB |
+        |                |                   |  GRPCServer          |
+        |                |                   |                  Database
+     Overlay    InboundTransactions     LedgerMaster                |
+        |                                    |                      |
+    PeerFinder                          LedgerCleaner          TaskQueue
 
     @endcode
 */

--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -173,7 +173,7 @@ class RootStoppable;
     @note A Stoppable may not be restarted.
 
     The form of the Stoppable tree in the rippled application evolves as
-    the source code changes and reacts to new demands.  As of March in 2017
+    the source code changes and reacts to new demands. As of July in 2020
     the Stoppable tree had this form:
 
     @code
@@ -186,13 +186,14 @@ class RootStoppable;
                                                              |
                                                          JobQueue
                                                              |
-        +--------+-----------+-----------+-----------+-------+---+----------+----------+
-        |        |           |           |           |           |          |          |
-        |    NetworkOPs      |     InboundLedgers    |      OrderbookDB     |     GRPCServer
-        |                    |                       |                      |
-     Overlay        InboundTransactions        LedgerMaster             Database
-        |                                            |                      |
-    PeerFinder                                LedgerCleaner            TaskQueue
+        +--------+-----------+---------+------------+---+----+---------+---+
+        |        |           |         |            |   |              |   |
+        |    NetworkOPs      |    InboundLedgers    |   |      OrderbookDB |
+        |                    |                      |  GRPCServer          |
+        |                    |                      |                  Database
+     Overlay        InboundTransactions        LedgerMaster                |
+        |                                           |                      |
+    PeerFinder                                LedgerCleaner           TaskQueue
 
     @endcode
 */

--- a/src/ripple/core/Stoppable.h
+++ b/src/ripple/core/Stoppable.h
@@ -186,7 +186,7 @@ class RootStoppable;
                                                              |
                                                          JobQueue
                                                              |
-        +------+---------+--------+----------+---+----+---------+---+
+        +------+---------+--------+----------+---+-----------+--+---+
         |      |         |        |          |   |              |   |
         |  NetworkOPs    |   InboundLedgers  |   |      OrderbookDB |
         |                |                   |  GRPCServer          |


### PR DESCRIPTION
## High Level Overview of Change
* Fixes #3359, adding `GRPCServer` class to `Stoppable` Hierarchy.

### Context of Change
* Started `GRPCServer` using `onStart` that is triggered by `Application::doStart()`, instead of directly calling `GRPCServer::run()` in `Application::setup()`
* Removed `~GRPCServer`, and instead tear down the server in `GRPCServer::onStop()`
* Make `JobQueue` parent to `GRPCServer`

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Passes all existing unit test. When messages were logged in `onStop` in both `JobQueue` and `GRPCServer`, the GRPC Server is stopped before the JobQueue, as is expected.