### PR TITLE
reserve 22 as ttHOOK_SET

### DIFF
--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -274,6 +274,7 @@ enum TECcodes : TERUnderlyingType {
     tecKILLED = 150,
     tecHAS_OBLIGATIONS = 151,
     tecTOO_SOON = 152,
+    tecHOOK_ERROR [[maybe_unused]] = 153
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/TxFormats.h
+++ b/src/ripple/protocol/TxFormats.h
@@ -56,6 +56,8 @@ enum TxType {
     ttTRUST_SET = 20,
     ttACCOUNT_DELETE = 21,
 
+    ttHOOK_SET [[maybe_unused]] = 22,
+
     ttAMENDMENT = 100,
     ttFEE = 101,
     ttUNL_MODIFY = 102,


### PR DESCRIPTION
We'd like to reserve 22 as SetHook transaction type. This tt will eventually allow configurable behaviour on accounts for send and receive events.