### PR TITLE
Boost 1.74

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -128,6 +128,7 @@ target_include_directories (xrpl_core
 
 target_compile_definitions(xrpl_core
   PUBLIC
+    BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT
     HAS_UNCAUGHT_EXCEPTIONS=1)
 target_compile_options (xrpl_core
   PUBLIC

--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -125,6 +125,10 @@ target_include_directories (xrpl_core
     # this one is for beast/legacy files:
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/beast/extras>
     $<INSTALL_INTERFACE:include>)
+
+target_compile_definitions(xrpl_core
+  PUBLIC
+    HAS_UNCAUGHT_EXCEPTIONS=1)
 target_compile_options (xrpl_core
   PUBLIC
     $<$<BOOL:${is_gcc}>:-Wno-maybe-uninitialized>)

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -360,7 +360,11 @@ OverlayImpl::makeRedirectResponse(
     msg.version(request.version());
     msg.result(boost::beast::http::status::service_unavailable);
     msg.insert("Server", BuildInfo::getFullVersionString());
-    msg.insert("Remote-Address", remote_address);
+    {
+        std::ostringstream ostr;
+        ostr << remote_address;
+        msg.insert("Remote-Address", ostr.str());
+    }
     msg.insert("Content-Type", "application/json");
     msg.insert(boost::beast::http::field::connection, "close");
     msg.body() = Json::objectValue;

--- a/src/ripple/server/impl/BaseWSPeer.h
+++ b/src/ripple/server/impl/BaseWSPeer.h
@@ -198,13 +198,14 @@ BaseWSPeer<Handler, Impl>::run()
     impl().ws_.control_callback(control_callback_);
     start_timer();
     close_on_timer_ = true;
-    impl().ws_.async_accept_ex(
-        request_,
-        [](auto& res) {
+    impl().ws_.set_option(
+        boost::beast::websocket::stream_base::decorator([](auto& res) {
             res.set(
                 boost::beast::http::field::server,
                 BuildInfo::getFullVersionString());
-        },
+        }));
+    impl().ws_.async_accept(
+        request_,
         bind_executor(
             strand_,
             std::bind(

--- a/src/test/jtx/impl/JSONRPCClient.cpp
+++ b/src/test/jtx/impl/JSONRPCClient.cpp
@@ -107,7 +107,11 @@ public:
         req.target("/");
         req.version(11);
         req.insert("Content-Type", "application/json; charset=UTF-8");
-        req.insert("Host", ep_);
+        {
+            std::ostringstream ostr;
+            ostr << ep_;
+            req.insert("Host", ostr.str());
+        }
         {
             Json::Value jr;
             jr[jss::method] = cmd;

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -141,13 +141,14 @@ public:
         {
             auto const ep = getEndpoint(cfg, v2);
             stream_.connect(ep);
-            ws_.handshake_ex(
-                ep.address().to_string() + ":" + std::to_string(ep.port()),
-                "/",
+            ws_.set_option(boost::beast::websocket::stream_base::decorator(
                 [&](boost::beast::websocket::request_type& req) {
                     for (auto const& h : headers)
                         req.set(h.first, h.second);
-                });
+                }));
+            ws_.handshake(
+                ep.address().to_string() + ":" + std::to_string(ep.port()),
+                "/");
             ws_.async_read(
                 rb_,
                 strand_.wrap(std::bind(


### PR DESCRIPTION
Tested on boost 1.74 beta 1. Note that there appears to be an issue in 1.74 b1, the file `boost/asio/ts/netfwd.hpp` needed to be modified to change line 61 from `typedef execution any_io_executor;` to `typedef executor any_io_executor;` (note: executor, not execution). We should not merge this PR until boost 1.74 is officially released.

This PR also includes another trivial patch to resolve some warnings from Howard's date library (not an issue with the date library itself).