### PR TITLE
TrustedPublisherServer race condition fix:

### DIFF
--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -164,7 +164,7 @@ private:
             publisher(FetchListConfig const& c) : cfg{c}
             {
             }
-            std::unique_ptr<TrustedPublisherServer> server;
+            std::shared_ptr<TrustedPublisherServer> server;
             std::vector<Validator> list;
             std::string uri;
             FetchListConfig const& cfg;
@@ -184,7 +184,7 @@ private:
             while (item.list.size() < listSize)
                 item.list.push_back(TrustedPublisherServer::randomValidator());
 
-            item.server = std::make_unique<TrustedPublisherServer>(
+            item.server = make_TrustedPublisherServer(
                 env.app().getIOService(),
                 item.list,
                 env.timeKeeper().now() + cfg.expiresFromNow,

--- a/src/test/net/DatabaseDownloader_test.cpp
+++ b/src/test/net/DatabaseDownloader_test.cpp
@@ -31,16 +31,16 @@ namespace test {
 
 class DatabaseDownloader_test : public beast::unit_test::suite
 {
-    TrustedPublisherServer
+    std::shared_ptr<TrustedPublisherServer>
     createServer(jtx::Env& env, bool ssl = true)
     {
         std::vector<TrustedPublisherServer::Validator> list;
         list.push_back(TrustedPublisherServer::randomValidator());
-        return TrustedPublisherServer{
+        return make_TrustedPublisherServer(
             env.app().getIOService(),
             list,
             env.timeKeeper().now() + std::chrono::seconds{3600},
-            ssl};
+            ssl);
     }
 
     struct DownloadCompleter
@@ -129,8 +129,8 @@ class DatabaseDownloader_test : public beast::unit_test::suite
         // initiate the download and wait for the callback
         // to be invoked
         auto stat = downloader->download(
-            server.local_endpoint().address().to_string(),
-            std::to_string(server.local_endpoint().port()),
+            server->local_endpoint().address().to_string(),
+            std::to_string(server->local_endpoint().port()),
             "/textfile",
             11,
             data.file(),
@@ -196,9 +196,9 @@ class DatabaseDownloader_test : public beast::unit_test::suite
             ripple::test::detail::FileDirGuard const datafile{
                 *this, "downloads", "data", "", false, false};
             auto server = createServer(env);
-            auto host = server.local_endpoint().address().to_string();
-            auto port = std::to_string(server.local_endpoint().port());
-            server.stop();
+            auto host = server->local_endpoint().address().to_string();
+            auto port = std::to_string(server->local_endpoint().port());
+            server->stop();
             BEAST_EXPECT(dl->download(
                 host,
                 port,
@@ -220,8 +220,8 @@ class DatabaseDownloader_test : public beast::unit_test::suite
                 *this, "downloads", "data", "", false, false};
             auto server = createServer(env, false);
             BEAST_EXPECT(dl->download(
-                server.local_endpoint().address().to_string(),
-                std::to_string(server.local_endpoint().port()),
+                server->local_endpoint().address().to_string(),
+                std::to_string(server->local_endpoint().port()),
                 "",
                 11,
                 datafile.file(),
@@ -240,8 +240,8 @@ class DatabaseDownloader_test : public beast::unit_test::suite
                 *this, "downloads", "data", "", false, false};
             auto server = createServer(env);
             BEAST_EXPECT(dl->download(
-                server.local_endpoint().address().to_string(),
-                std::to_string(server.local_endpoint().port()),
+                server->local_endpoint().address().to_string(),
+                std::to_string(server->local_endpoint().port()),
                 "/textfile/huge",
                 11,
                 datafile.file(),

--- a/src/test/rpc/ShardArchiveHandler_test.cpp
+++ b/src/test/rpc/ShardArchiveHandler_test.cpp
@@ -36,16 +36,16 @@ class ShardArchiveHandler_test : public beast::unit_test::suite
 {
     using Downloads = std::vector<std::pair<std::uint32_t, std::string>>;
 
-    TrustedPublisherServer
+    std::shared_ptr<TrustedPublisherServer>
     createServer(jtx::Env& env, bool ssl = true)
     {
         std::vector<TrustedPublisherServer::Validator> list;
         list.push_back(TrustedPublisherServer::randomValidator());
-        return TrustedPublisherServer{
+        return make_TrustedPublisherServer(
             env.app().getIOService(),
             list,
             env.timeKeeper().now() + std::chrono::seconds{3600},
-            ssl};
+            ssl);
     }
 
 public:
@@ -191,9 +191,9 @@ public:
         BEAST_EXPECT(dynamic_cast<RPC::RecoveryHandler*>(handler) == nullptr);
 
         auto server = createServer(env);
-        auto host = server.local_endpoint().address().to_string();
-        auto port = std::to_string(server.local_endpoint().port());
-        server.stop();
+        auto host = server->local_endpoint().address().to_string();
+        auto port = std::to_string(server->local_endpoint().port());
+        server->stop();
 
         Downloads const dl = [count = numberOfDownloads, &host, &port] {
             Downloads ret;
@@ -290,9 +290,9 @@ public:
                 dynamic_cast<RPC::RecoveryHandler*>(handler) == nullptr);
 
             auto server = createServer(env);
-            auto host = server.local_endpoint().address().to_string();
-            auto port = std::to_string(server.local_endpoint().port());
-            server.stop();
+            auto host = server->local_endpoint().address().to_string();
+            auto port = std::to_string(server->local_endpoint().port());
+            server->stop();
 
             Downloads const dl = [count = numberOfDownloads, &host, &port] {
                 Downloads ret;

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -190,8 +190,8 @@ public:
         BasicApp worker{1};
         using namespace std::chrono_literals;
         NetClock::time_point const expiration{3600s};
-        TrustedPublisherServer server{
-            worker.get_io_service(), validators, expiration, false, 1, false};
+        auto server = make_TrustedPublisherServer(
+            worker.get_io_service(), validators, expiration, false, 1, false);
 
         //----------------------------------------------------------------------
         // Publisher list site unavailable
@@ -206,7 +206,7 @@ public:
                 envconfig([&](std::unique_ptr<Config> cfg) {
                     cfg->section(SECTION_VALIDATOR_LIST_SITES).append(siteURI);
                     cfg->section(SECTION_VALIDATOR_LIST_KEYS)
-                        .append(strHex(server.publisherPublic()));
+                        .append(strHex(server->publisherPublic()));
                     return cfg;
                 }),
             };
@@ -245,7 +245,7 @@ public:
                     BEAST_EXPECT(!jp.isMember(jss::version));
                     BEAST_EXPECT(
                         jp[jss::pubkey_publisher] ==
-                        strHex(server.publisherPublic()));
+                        strHex(server->publisherPublic()));
                 }
                 BEAST_EXPECT(jrr[jss::signing_keys].size() == 0);
             }
@@ -264,10 +264,10 @@ public:
         //----------------------------------------------------------------------
         // Publisher list site available
         {
-            server.start();
+            server->start();
 
             std::stringstream uri;
-            uri << "http://" << server.local_endpoint() << "/validators";
+            uri << "http://" << server->local_endpoint() << "/validators";
             auto siteURI = uri.str();
 
             Env env{
@@ -275,7 +275,7 @@ public:
                 envconfig([&](std::unique_ptr<Config> cfg) {
                     cfg->section(SECTION_VALIDATOR_LIST_SITES).append(siteURI);
                     cfg->section(SECTION_VALIDATOR_LIST_KEYS)
-                        .append(strHex(server.publisherPublic()));
+                        .append(strHex(server->publisherPublic()));
                     return cfg;
                 }),
             };
@@ -333,7 +333,7 @@ public:
                     BEAST_EXPECT(jp[jss::seq].asUInt() == 1);
                     BEAST_EXPECT(
                         jp[jss::pubkey_publisher] ==
-                        strHex(server.publisherPublic()));
+                        strHex(server->publisherPublic()));
                     BEAST_EXPECT(jp[jss::expiration] == to_string(expiration));
                     BEAST_EXPECT(jp[jss::version] == 1);
                 }


### PR DESCRIPTION
There was a race condition in `on_accept` where the object's destructor could
run while `on_accept` was called. This patch ensures that if `on_accept` is
called then the object is valid for the whole call.