### PR TITLE
Maximum Transactions in JobQueue read from Config

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -453,6 +453,13 @@
 #
 #
 #
+# [max_transactions]
+#
+#   Configure the maximum number of transactions to have in the job queue
+#
+#   Must be a number between 100 and 1000, defaults to 250
+# 
+#
 # [overlay]
 #
 #   Controls settings related to the peer to peer overlay.

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -173,6 +173,11 @@ public:
     // Compression
     bool COMPRESSION = false;
 
+    // Work queue limits
+    int MAX_TRANSACTIONS = 250;
+    static constexpr int MAX_JOB_QUEUE_TX = 1000;
+    static constexpr int MIN_JOB_QUEUE_TX = 100;
+
     // Amendment majority time
     std::chrono::seconds AMENDMENT_MAJORITY_TIME = defaultAmendmentMajorityTime;
 

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -61,6 +61,7 @@ struct ConfigSection
 #define SECTION_IPS "ips"
 #define SECTION_IPS_FIXED "ips_fixed"
 #define SECTION_AMENDMENT_MAJORITY_TIME "amendment_majority_time"
+#define SECTION_MAX_TRANSACTIONS "max_transactions"
 #define SECTION_NETWORK_QUORUM "network_quorum"
 #define SECTION_NODE_SEED "node_seed"
 #define SECTION_NODE_SIZE "node_size"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -481,6 +481,14 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_COMPRESSION, strTemp, j_))
         COMPRESSION = beast::lexicalCastThrow<bool>(strTemp);
 
+    if (getSingleSection(secConfig, SECTION_MAX_TRANSACTIONS, strTemp, j_))
+    {
+        MAX_TRANSACTIONS = std::clamp(
+            beast::lexicalCastThrow<int>(strTemp),
+            MIN_JOB_QUEUE_TX,
+            MAX_JOB_QUEUE_TX);
+    }
+
     if (getSingleSection(
             secConfig, SECTION_AMENDMENT_MAJORITY_TIME, strTemp, j_))
     {

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1507,9 +1507,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMTransaction> const& m)
             }
         }
 
-        // The maximum number of transactions to have in the job queue.
-        constexpr int max_transactions = 250;
-        if (app_.getJobQueue().getJobCount(jtTRANSACTION) > max_transactions)
+        if (app_.getJobQueue().getJobCount(jtTRANSACTION) >
+            app_.config().MAX_TRANSACTIONS)
         {
             overlay_.incJqTransOverflow();
             JLOG(p_journal_.info()) << "Transaction queue is full";


### PR DESCRIPTION
## High Level Overview of Change
Fixes #3556. max_transactions is now read from the `rippled.cfg` instead of hardcoded.

### Context of Change
The maximum capacity of `JobQueue` was hardcoded in `PeerImp.cpp`. Now the maximum capacity is read from the configuration file. `max_transactions` defaults to 250, and has a hardcoded minimum of 100 and a hardcoded maximum of 1000, as suggested in the issue description. 

This option is added to the configuration with: 
```
[max_transactions]
    500
```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before/After
**Before:**
max_transactions was hardcoded.

**After:**
`MAX_TRANSACTIONS` is read from `rippled.cfg` in `Config.cpp`. `std::clamp` is used to ensure the configuration value is between 100 and 1000. Member variable `max_transactions_` was created in `PeerImp`, and initialized to the value read by the configuration.

## Test Plan
All unit tests pass. No tests added.