### PR TITLE
Load transaction and meta-data from SQLite

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -954,8 +954,6 @@ saveValidatedLedger(
             (void)_;
             uint256 transactionID = acceptedLedgerTx->getTransactionID();
 
-            app.getMasterTransaction().inLedger(transactionID, seq);
-
             std::string const txnId(to_string(transactionID));
             std::string const txnSeq(
                 std::to_string(acceptedLedgerTx->getTxnSeq()));
@@ -1012,6 +1010,8 @@ saveValidatedLedger(
                     acceptedLedgerTx->getTxn()->getMetaSQL(
                         seq, acceptedLedgerTx->getEscMeta()) +
                     ";");
+
+            app.getMasterTransaction().inLedger(transactionID, seq);
         }
 
         tr.commit();

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -53,10 +53,10 @@ public:
      * Fetch transaction from the cache or database.
      *
      * @return A std::variant that contains either a
-     *         shared_pointer to the retrieved transaction or a
-     *         bool indicating whether or not the all ledgers in
-     *         the provided range were present in the database
-     *         while the search was conducted.
+     *         pair of shared_pointer to the retrieved transaction
+     *         and its metadata or an enum indicating whether or not
+     *         the all ledgers in the provided range were present in
+     *         the database while the search was conducted.
      */
     std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -46,7 +46,7 @@ public:
 
     std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        TxSearchedAll>
+        TxSearched>
     fetch(uint256 const&, error_code_i& ec);
 
     /**
@@ -60,7 +60,7 @@ public:
      */
     std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        TxSearchedAll>
+        TxSearched>
     fetch(
         uint256 const&,
         ClosedInterval<uint32_t> const& range,

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -46,7 +46,7 @@ public:
 
     std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        SearchedAll>
+        TxSearchedAll>
     fetch(uint256 const&, error_code_i& ec);
 
     /**
@@ -60,7 +60,7 @@ public:
      */
     std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        SearchedAll>
+        TxSearchedAll>
     fetch(
         uint256 const&,
         ClosedInterval<uint32_t> const& range,

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -44,19 +44,22 @@ public:
     std::shared_ptr<Transaction>
     fetch_from_cache(uint256 const&);
 
-    std::shared_ptr<Transaction>
+    std::optional<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>>
     fetch(uint256 const&, error_code_i& ec);
 
     /**
      * Fetch transaction from the cache or database.
      *
-     * @return A boost::variant that contains either a
+     * @return A std::variant that contains either a
      *         shared_pointer to the retrieved transaction or a
      *         bool indicating whether or not the all ledgers in
      *         the provided range were present in the database
      *         while the search was conducted.
      */
-    boost::variant<Transaction::pointer, bool>
+    std::optional<std::variant<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
+        bool>>
     fetch(
         uint256 const&,
         ClosedInterval<uint32_t> const& range,

--- a/src/ripple/app/ledger/TransactionMaster.h
+++ b/src/ripple/app/ledger/TransactionMaster.h
@@ -44,8 +44,9 @@ public:
     std::shared_ptr<Transaction>
     fetch_from_cache(uint256 const&);
 
-    std::optional<
-        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>>
+    std::variant<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
+        SearchedAll>
     fetch(uint256 const&, error_code_i& ec);
 
     /**
@@ -57,9 +58,9 @@ public:
      *         the provided range were present in the database
      *         while the search was conducted.
      */
-    std::optional<std::variant<
+    std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        bool>>
+        SearchedAll>
     fetch(
         uint256 const&,
         ClosedInterval<uint32_t> const& range,

--- a/src/ripple/app/ledger/impl/TransactionMaster.cpp
+++ b/src/ripple/app/ledger/impl/TransactionMaster.cpp
@@ -56,7 +56,7 @@ TransactionMaster::fetch_from_cache(uint256 const& txnID)
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    SearchedAll>
+    TxSearchedAll>
 TransactionMaster::fetch(uint256 const& txnID, error_code_i& ec)
 {
     using TxPair =
@@ -68,7 +68,7 @@ TransactionMaster::fetch(uint256 const& txnID, error_code_i& ec)
 
     auto v = Transaction::load(txnID, mApp, ec);
 
-    if (auto e = std::get_if<SearchedAll>(&v))
+    if (auto e = std::get_if<TxSearchedAll>(&v))
         return *e;
 
     auto [txn, txnMeta] = std::get<TxPair>(v);
@@ -81,7 +81,7 @@ TransactionMaster::fetch(uint256 const& txnID, error_code_i& ec)
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    SearchedAll>
+    TxSearchedAll>
 TransactionMaster::fetch(
     uint256 const& txnID,
     ClosedInterval<uint32_t> const& range,
@@ -96,7 +96,7 @@ TransactionMaster::fetch(
 
     auto v = Transaction::load(txnID, mApp, range, ec);
 
-    if (auto e = std::get_if<SearchedAll>(&v))
+    if (auto e = std::get_if<TxSearchedAll>(&v))
         return *e;
 
     auto [txn, txnMeta] = std::get<TxPair>(v);

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -53,7 +53,7 @@ enum TransStatus {
     INCOMPLETE = 8   // needs more signatures
 };
 
-enum class SearchedAll { no, yes, unknown };
+enum class TxSearchedAll { no, yes, unknown };
 
 // This class is for constructing and examining transactions.
 // Transactions are static so manipulation functions are unnecessary.
@@ -305,12 +305,12 @@ public:
 
     static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        SearchedAll>
+        TxSearchedAll>
     load(uint256 const& id, Application& app, error_code_i& ec);
 
     static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        SearchedAll>
+        TxSearchedAll>
     load(
         uint256 const& id,
         Application& app,
@@ -320,7 +320,7 @@ public:
 private:
     static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        SearchedAll>
+        TxSearchedAll>
     load(
         uint256 const& id,
         Application& app,

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -53,7 +53,7 @@ enum TransStatus {
     INCOMPLETE = 8   // needs more signatures
 };
 
-enum class TxSearchedAll { no, yes, unknown };
+enum class TxSearched { all, some, unknown };
 
 // This class is for constructing and examining transactions.
 // Transactions are static so manipulation functions are unnecessary.
@@ -101,6 +101,12 @@ public:
     getLedger() const
     {
         return mInLedger;
+    }
+
+    bool
+    isValidated() const
+    {
+        return mInLedger != 0;
     }
 
     TransStatus
@@ -305,12 +311,12 @@ public:
 
     static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        TxSearchedAll>
+        TxSearched>
     load(uint256 const& id, Application& app, error_code_i& ec);
 
     static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        TxSearchedAll>
+        TxSearched>
     load(
         uint256 const& id,
         Application& app,
@@ -320,7 +326,7 @@ public:
 private:
     static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        TxSearchedAll>
+        TxSearched>
     load(
         uint256 const& id,
         Application& app,

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -53,6 +53,8 @@ enum TransStatus {
     INCOMPLETE = 8   // needs more signatures
 };
 
+enum class SearchedAll { no, yes, unknown };
+
 // This class is for constructing and examining transactions.
 // Transactions are static so manipulation functions are unnecessary.
 class Transaction : public std::enable_shared_from_this<Transaction>,
@@ -301,13 +303,14 @@ public:
     Json::Value
     getJson(JsonOptions options, bool binary = false) const;
 
-    static std::optional<
-        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>>
+    static std::variant<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
+        SearchedAll>
     load(uint256 const& id, Application& app, error_code_i& ec);
 
-    static std::optional<std::variant<
+    static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        bool>>
+        SearchedAll>
     load(
         uint256 const& id,
         Application& app,
@@ -315,9 +318,9 @@ public:
         error_code_i& ec);
 
 private:
-    static std::optional<std::variant<
+    static std::variant<
         std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-        bool>>
+        SearchedAll>
     load(
         uint256 const& id,
         Application& app,

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -22,6 +22,7 @@
 
 #include <ripple/basics/RangeSet.h>
 #include <ripple/beast/utility/Journal.h>
+#include <ripple/ledger/TxMeta.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STTx.h>
@@ -300,10 +301,13 @@ public:
     Json::Value
     getJson(JsonOptions options, bool binary = false) const;
 
-    static pointer
+    static std::optional<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>>
     load(uint256 const& id, Application& app, error_code_i& ec);
 
-    static boost::variant<Transaction::pointer, bool>
+    static std::optional<std::variant<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
+        bool>>
     load(
         uint256 const& id,
         Application& app,
@@ -311,7 +315,9 @@ public:
         error_code_i& ec);
 
 private:
-    static boost::variant<Transaction::pointer, bool>
+    static std::optional<std::variant<
+        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
+        bool>>
     load(
         uint256 const& id,
         Application& app,

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -110,9 +110,6 @@ std::variant<
     TxSearchedAll>
 Transaction::load(uint256 const& id, Application& app, error_code_i& ec)
 {
-    using TxPair =
-        std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>;
-
     return load(id, app, boost::none, ec);
 }
 
@@ -148,14 +145,11 @@ Transaction::load(
 
     boost::optional<std::uint64_t> ledgerSeq;
     boost::optional<std::string> status;
-    Blob rawTxn;
-    Blob rawMeta;
+    Blob rawTxn, rawMeta;
     {
         auto db = app.getTxnDB().checkoutDb();
-        soci::blob sociRawTxnBlob(*db);
-        soci::blob sociRawMetaBlob(*db);
-        soci::indicator txn;
-        soci::indicator meta;
+        soci::blob sociRawTxnBlob(*db), sociRawMetaBlob(*db);
+        soci::indicator txn, meta;
 
         *db << sql, soci::into(ledgerSeq), soci::into(status),
             soci::into(sociRawTxnBlob, txn), soci::into(sociRawMetaBlob, meta);

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -107,7 +107,7 @@ Transaction::transactionFromSQL(
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    SearchedAll>
+    TxSearchedAll>
 Transaction::load(uint256 const& id, Application& app, error_code_i& ec)
 {
     using TxPair =
@@ -118,7 +118,7 @@ Transaction::load(uint256 const& id, Application& app, error_code_i& ec)
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    SearchedAll>
+    TxSearchedAll>
 Transaction::load(
     uint256 const& id,
     Application& app,
@@ -132,7 +132,7 @@ Transaction::load(
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    SearchedAll>
+    TxSearchedAll>
 Transaction::load(
     uint256 const& id,
     Application& app,
@@ -163,7 +163,7 @@ Transaction::load(
         auto const got_data = db->got_data();
 
         if ((!got_data || txn != soci::i_ok || meta != soci::i_ok) && !range)
-            return SearchedAll::unknown;
+            return TxSearchedAll::unknown;
 
         if (!got_data)
         {
@@ -176,11 +176,11 @@ Transaction::load(
                 soci::into(count, rti);
 
             if (!db->got_data() || rti != soci::i_ok)
-                return SearchedAll::no;
+                return TxSearchedAll::no;
 
             return count == (range->last() - range->first() + 1)
-                ? SearchedAll::yes
-                : SearchedAll::no;
+                ? TxSearchedAll::yes
+                : TxSearchedAll::no;
         }
 
         convert(sociRawTxnBlob, rawTxn);
@@ -211,7 +211,7 @@ Transaction::load(
         ec = rpcDB_DESERIALIZATION;
     }
 
-    return SearchedAll::unknown;
+    return TxSearchedAll::unknown;
 }
 
 // options 1 to include the date of the transaction

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -107,7 +107,7 @@ Transaction::transactionFromSQL(
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    TxSearchedAll>
+    TxSearched>
 Transaction::load(uint256 const& id, Application& app, error_code_i& ec)
 {
     return load(id, app, boost::none, ec);
@@ -115,7 +115,7 @@ Transaction::load(uint256 const& id, Application& app, error_code_i& ec)
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    TxSearchedAll>
+    TxSearched>
 Transaction::load(
     uint256 const& id,
     Application& app,
@@ -129,7 +129,7 @@ Transaction::load(
 
 std::variant<
     std::pair<std::shared_ptr<Transaction>, std::shared_ptr<TxMeta>>,
-    TxSearchedAll>
+    TxSearched>
 Transaction::load(
     uint256 const& id,
     Application& app,
@@ -157,7 +157,7 @@ Transaction::load(
         auto const got_data = db->got_data();
 
         if ((!got_data || txn != soci::i_ok || meta != soci::i_ok) && !range)
-            return TxSearchedAll::unknown;
+            return TxSearched::unknown;
 
         if (!got_data)
         {
@@ -170,11 +170,11 @@ Transaction::load(
                 soci::into(count, rti);
 
             if (!db->got_data() || rti != soci::i_ok)
-                return TxSearchedAll::no;
+                return TxSearched::some;
 
             return count == (range->last() - range->first() + 1)
-                ? TxSearchedAll::yes
-                : TxSearchedAll::no;
+                ? TxSearched::all
+                : TxSearched::some;
         }
 
         convert(sociRawTxnBlob, rawTxn);
@@ -205,7 +205,7 @@ Transaction::load(
         ec = rpcDB_DESERIALIZATION;
     }
 
-    return TxSearchedAll::unknown;
+    return TxSearched::unknown;
 }
 
 // options 1 to include the date of the transaction

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -117,8 +117,6 @@ doTxHelp(RPC::Context& context, TxArgs const& args)
             args.ledgerRange->first, args.ledgerRange->second);
     }
 
-    std::shared_ptr<Transaction> txn;
-    std::shared_ptr<TxMeta> meta;
     auto ec{rpcSUCCESS};
 
     using TxPair =
@@ -141,10 +139,8 @@ doTxHelp(RPC::Context& context, TxArgs const& args)
         result.searchedAll = *e;
         return {result, rpcTXN_NOT_FOUND};
     }
-    else
-    {
-        std::tie(txn, meta) = std::get<TxPair>(v);
-    }
+
+    auto [txn, meta] = std::get<TxPair>(v);
 
     if (ec == rpcDB_DESERIALIZATION)
     {

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -196,7 +196,7 @@ populateProtoResponse(
                 "txn not found. searched_all = " +
                     to_string(
                         (result.searchedAll == TxSearchedAll::yes ? "true"
-                                                                : "false"))};
+                                                                  : "false"))};
         }
         else
         {


### PR DESCRIPTION
## High Level Overview of Change
The Tx RPC call now fetches both the transaction and transaction meta-data from SQLite.

### Context of Change
Previously, the Tx RPC call was querying SQLite for the Transaction, and then querying the key-value store for transaction metadata. Tx now queries SQLite for both transaction and meta-data, since the meta-data was already stored in SQLite along with the transaction. 

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before/After
**Before:**
`doTxHelp()` queries `TransactionMaster::Fetch` to get Transaction, then queries the key-value store to get the meta-data. `Transaction::Load()` only fetches `txn` from SQLite.

**After**
`doTxHelp()` queries `TransactionMaster::fetch` for both Transaction and meta-data. TransactionMaster::fetch checks the cache for transaction, if it exists and is validated, the meta-data is queried from SQLite, otherwise only the transaction is fetched.  `Transaction::Load()` returns both `txn` and `txnMeta` from SQLite.

## Test Plan
All unit tests pass. No new tests added.