### PR TITLE
Remove legacy support for endpoint dissemination:

### DIFF
--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -21,6 +21,7 @@
 #define RIPPLE_APP_DATA_DBINIT_H_INCLUDED
 
 #include <array>
+#include <cstdint>
 
 namespace ripple {
 

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1376,13 +1376,11 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMEndpoints> const& m)
 
     for (auto const& tm : m->endpoints_v2())
     {
-        auto result =
-            beast::IP::Endpoint::from_string_checked(tm.endpoint());
+        auto result = beast::IP::Endpoint::from_string_checked(tm.endpoint());
         if (!result)
         {
-            JLOG(p_journal_.error())
-                << "failed to parse incoming endpoint: {" << tm.endpoint()
-                << "}";
+            JLOG(p_journal_.error()) << "failed to parse incoming endpoint: {"
+                                     << tm.endpoint() << "}";
             continue;
         }
 
@@ -1394,8 +1392,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMEndpoints> const& m)
         // take the address/port we were given
 
         endpoints.emplace_back(
-            tm.hops() > 0 ? *result
-                          : remote_address_.at_port(result->port()),
+            tm.hops() > 0 ? *result : remote_address_.at_port(result->port()),
             tm.hops());
     }
 

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -593,13 +593,6 @@ private:
 
     void
     getLedger(std::shared_ptr<protocol::TMGetLedger> const& packet);
-
-    // Called when we receive tx set data.
-    void
-    peerTXData(
-        uint256 const& hash,
-        std::shared_ptr<protocol::TMLedgerData> const& pPacket,
-        beast::Journal journal);
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -656,24 +656,13 @@ void
 PeerImp::sendEndpoints(FwdIt first, FwdIt last)
 {
     protocol::TMEndpoints tm;
-    for (; first != last; ++first)
-    {
-        auto const& ep = *first;
-        // eventually remove endpoints and just keep endpoints_v2
-        // (once we are sure the entire network understands endpoints_v2)
-        protocol::TMEndpoint& tme(*tm.add_endpoints());
-        if (ep.address.is_v4())
-            tme.mutable_ipv4()->set_ipv4(boost::endian::native_to_big(
-                static_cast<std::uint32_t>(ep.address.to_v4().to_ulong())));
-        else
-            tme.mutable_ipv4()->set_ipv4(0);
-        tme.mutable_ipv4()->set_ipv4port(ep.address.port());
-        tme.set_hops(ep.hops);
 
-        // add v2 endpoints (strings)
+    while (first != last)
+    {
         auto& tme2(*tm.add_endpoints_v2());
-        tme2.set_endpoint(ep.address.to_string());
-        tme2.set_hops(ep.hops);
+        tme2.set_endpoint(first->address.to_string());
+        tme2.set_hops(first->hops);
+        first++;
     }
     tm.set_version(2);
 

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -224,31 +224,15 @@ message TMValidation
     optional uint32 hops = 3           [deprecated = true];
 }
 
-message TMIPv4Endpoint
-{
-    required uint32 ipv4            = 1;
-
-    // VFALCO NOTE There is no uint16 in google protocol buffers,
-    //             so we use a uint32 to represent the port.
-    //
-    required uint32 ipv4Port        = 2;
-}
-
-// An Endpoint describes a network peer that can accept incoming connections
-message TMEndpoint
-{
-    required TMIPv4Endpoint ipv4    = 1;
-    required uint32         hops    = 2;
-}
-
 // An array of Endpoint messages
 message TMEndpoints
 {
+    // Previously used - don't reuse.
+    reserved 2;
+
     // This field is used to allow the TMEndpoints message format to be
     // modified as necessary in the future.
     required uint32         version = 1;
-
-    repeated TMEndpoint     endpoints = 2;
 
     // An update to the Endpoint type that uses a string
     // to represent endpoints, thus allowing ipv6 or ipv4 addresses

--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -180,15 +180,12 @@ public:
     buildEndpoints(int n)
     {
         auto endpoints = std::make_shared<protocol::TMEndpoints>();
-        endpoints->mutable_endpoints()->Reserve(n);
+        endpoints->mutable_endpoints_v2()->Reserve(n);
         for (int i = 0; i < n; i++)
         {
-            auto* endpoint = endpoints->add_endpoints();
-            endpoint->set_hops(i);
-            std::string addr = std::string("10.0.1.") + std::to_string(i);
-            endpoint->mutable_ipv4()->set_ipv4(boost::endian::native_to_big(
-                boost::asio::ip::address_v4::from_string(addr).to_uint()));
-            endpoint->mutable_ipv4()->set_ipv4port(i);
+            auto ep = endpoints->add_endpoints_v2();
+            ep->set_endpoint(std::string("10.0.1.") + std::to_string(i));
+            ep->set_hops(i);
         }
         endpoints->set_version(2);
 


### PR DESCRIPTION
Support for IPv6 messages was added with commit 08382d866b116e3ec9d50193bcf45caea8ca09a2
and version 1.1.0. No peer presently connected to the network in a useful capacity fails
to understand v2 messages.

This commit removes the code that generates and processes v1 messages and deletes legacy
messages from the protocol buffer definition file.