### PR TITLE
NegativeUNL SField Changes

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -604,9 +604,9 @@ Ledger::negativeUNL() const
 {
     hash_set<PublicKey> negUnl;
     if (auto sle = read(keylet::negativeUNL());
-        sle && sle->isFieldPresent(sfNegativeUNL))
+        sle && sle->isFieldPresent(sfDisabledValidators))
     {
-        auto const& nUnlData = sle->getFieldArray(sfNegativeUNL);
+        auto const& nUnlData = sle->getFieldArray(sfDisabledValidators);
         for (auto const& n : nUnlData)
         {
             if (n.isFieldPresent(sfPublicKey))
@@ -669,9 +669,9 @@ Ledger::updateNegativeUNL()
         return;
 
     STArray newNUnl;
-    if (sle->isFieldPresent(sfNegativeUNL))
+    if (sle->isFieldPresent(sfDisabledValidators))
     {
-        auto const& oldNUnl = sle->getFieldArray(sfNegativeUNL);
+        auto const& oldNUnl = sle->getFieldArray(sfDisabledValidators);
         for (auto v : oldNUnl)
         {
             if (hasToReEnable && v.isFieldPresent(sfPublicKey) &&
@@ -692,7 +692,7 @@ Ledger::updateNegativeUNL()
 
     if (!newNUnl.empty())
     {
-        sle->setFieldArray(sfNegativeUNL, newNUnl);
+        sle->setFieldArray(sfDisabledValidators, newNUnl);
         if (hasToReEnable)
             sle->makeFieldAbsent(sfValidatorToReEnable);
         if (hasToDisable)

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -600,7 +600,7 @@ Ledger::peek(Keylet const& k) const
 }
 
 hash_set<PublicKey>
-Ledger::negativeUnl() const
+Ledger::negativeUNL() const
 {
     hash_set<PublicKey> negUnl;
     if (auto sle = read(keylet::negativeUNL());
@@ -626,12 +626,12 @@ Ledger::negativeUnl() const
 }
 
 boost::optional<PublicKey>
-Ledger::negativeUnlToDisable() const
+Ledger::validatorToDisable() const
 {
     if (auto sle = read(keylet::negativeUNL());
-        sle && sle->isFieldPresent(sfNegativeUNLToDisable))
+        sle && sle->isFieldPresent(sfValidatorToDisable))
     {
-        auto d = sle->getFieldVL(sfNegativeUNLToDisable);
+        auto d = sle->getFieldVL(sfValidatorToDisable);
         auto s = makeSlice(d);
         if (publicKeyType(s))
             return PublicKey(s);
@@ -641,12 +641,12 @@ Ledger::negativeUnlToDisable() const
 }
 
 boost::optional<PublicKey>
-Ledger::negativeUnlToReEnable() const
+Ledger::validatorToReEnable() const
 {
     if (auto sle = read(keylet::negativeUNL());
-        sle && sle->isFieldPresent(sfNegativeUNLToReEnable))
+        sle && sle->isFieldPresent(sfValidatorToReEnable))
     {
-        auto d = sle->getFieldVL(sfNegativeUNLToReEnable);
+        auto d = sle->getFieldVL(sfValidatorToReEnable);
         auto s = makeSlice(d);
         if (publicKeyType(s))
             return PublicKey(s);
@@ -662,8 +662,8 @@ Ledger::updateNegativeUNL()
     if (!sle)
         return;
 
-    bool const hasToDisable = sle->isFieldPresent(sfNegativeUNLToDisable);
-    bool const hasToReEnable = sle->isFieldPresent(sfNegativeUNLToReEnable);
+    bool const hasToDisable = sle->isFieldPresent(sfValidatorToDisable);
+    bool const hasToReEnable = sle->isFieldPresent(sfValidatorToReEnable);
 
     if (!hasToDisable && !hasToReEnable)
         return;
@@ -676,7 +676,7 @@ Ledger::updateNegativeUNL()
         {
             if (hasToReEnable && v.isFieldPresent(sfPublicKey) &&
                 v.getFieldVL(sfPublicKey) ==
-                    sle->getFieldVL(sfNegativeUNLToReEnable))
+                    sle->getFieldVL(sfValidatorToReEnable))
                 continue;
             newNUnl.push_back(v);
         }
@@ -684,9 +684,9 @@ Ledger::updateNegativeUNL()
 
     if (hasToDisable)
     {
-        newNUnl.emplace_back(sfNegativeUNLEntry);
+        newNUnl.emplace_back(sfDisabledValidator);
         newNUnl.back().setFieldVL(
-            sfPublicKey, sle->getFieldVL(sfNegativeUNLToDisable));
+            sfPublicKey, sle->getFieldVL(sfValidatorToDisable));
         newNUnl.back().setFieldU32(sfFirstLedgerSequence, seq());
     }
 
@@ -694,9 +694,9 @@ Ledger::updateNegativeUNL()
     {
         sle->setFieldArray(sfNegativeUNL, newNUnl);
         if (hasToReEnable)
-            sle->makeFieldAbsent(sfNegativeUNLToReEnable);
+            sle->makeFieldAbsent(sfValidatorToReEnable);
         if (hasToDisable)
-            sle->makeFieldAbsent(sfNegativeUNLToDisable);
+            sle->makeFieldAbsent(sfValidatorToDisable);
         rawReplace(sle);
     }
     else

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -335,7 +335,7 @@ public:
      * @return the public keys
      */
     hash_set<PublicKey>
-    negativeUnl() const;
+    negativeUNL() const;
 
     /**
      * get the to be disabled validator's master public key if any
@@ -343,7 +343,7 @@ public:
      * @return the public key if any
      */
     boost::optional<PublicKey>
-    negativeUnlToDisable() const;
+    validatorToDisable() const;
 
     /**
      * get the to be re-enabled validator's master public key if any
@@ -351,7 +351,7 @@ public:
      * @return the public key if any
      */
     boost::optional<PublicKey>
-    negativeUnlToReEnable() const;
+    validatorToReEnable() const;
 
     /**
      * update the Negative UNL ledger component.

--- a/src/ripple/app/misc/NegativeUNLVote.cpp
+++ b/src/ripple/app/misc/NegativeUNLVote.cpp
@@ -57,9 +57,9 @@ NegativeUNLVote::doVoting(
             buildScoreTable(prevLedger, unlNodeIDs, validations))
     {
         // build next negUnl
-        auto negUnlKeys = prevLedger->negativeUnl();
-        auto negUnlToDisable = prevLedger->negativeUnlToDisable();
-        auto negUnlToReEnable = prevLedger->negativeUnlToReEnable();
+        auto negUnlKeys = prevLedger->negativeUNL();
+        auto negUnlToDisable = prevLedger->validatorToDisable();
+        auto negUnlToReEnable = prevLedger->validatorToReEnable();
         if (negUnlToDisable)
             negUnlKeys.insert(*negUnlToDisable);
         if (negUnlToReEnable)
@@ -211,7 +211,7 @@ NegativeUNLVote::buildScoreTable(
             return it->second;
         return 0;
     }();
-    if (myValidationCount < negativeUnlMinLocalValsToVote)
+    if (myValidationCount < negativeUNLMinLocalValsToVote)
     {
         JLOG(j_.debug()) << "N-UNL: ledger " << seq
                          << ". Local node only issued " << myValidationCount
@@ -221,7 +221,7 @@ NegativeUNLVote::buildScoreTable(
         return {};
     }
     else if (
-        myValidationCount > negativeUnlMinLocalValsToVote &&
+        myValidationCount > negativeUNLMinLocalValsToVote &&
         myValidationCount <= FLAG_LEDGER_INTERVAL)
     {
         return scoreTable;
@@ -246,7 +246,7 @@ NegativeUNLVote::findAllCandidates(
     // Compute if need to find more validators to disable
     auto const canAdd = [&]() -> bool {
         auto const maxNegativeListed = static_cast<std::size_t>(
-            std::ceil(unl.size() * negativeUnlMaxListed));
+            std::ceil(unl.size() * negativeUNLMaxListed));
         std::size_t negativeListed = 0;
         for (auto const& n : unl)
         {
@@ -255,8 +255,8 @@ NegativeUNLVote::findAllCandidates(
         }
         bool const result = negativeListed < maxNegativeListed;
         JLOG(j_.trace()) << "N-UNL: nodeId " << myId_ << " lowWaterMark "
-                         << negativeUnlLowWaterMark << " highWaterMark "
-                         << negativeUnlHighWaterMark << " canAdd " << result
+                         << negativeUNLLowWaterMark << " highWaterMark "
+                         << negativeUNLHighWaterMark << " canAdd " << result
                          << " negativeListed " << negativeListed
                          << " maxNegativeListed " << maxNegativeListed;
         return result;
@@ -269,10 +269,10 @@ NegativeUNLVote::findAllCandidates(
 
         // Find toDisable Candidates: check if
         //  (1) canAdd,
-        //  (2) has less than negativeUnlLowWaterMark validations,
+        //  (2) has less than negativeUNLLowWaterMark validations,
         //  (3) is not in negUnl, and
         //  (4) is not a new validator.
-        if (canAdd && score < negativeUnlLowWaterMark &&
+        if (canAdd && score < negativeUNLLowWaterMark &&
             !negUnl.count(nodeId) && !newValidators_.count(nodeId))
         {
             JLOG(j_.trace()) << "N-UNL: toDisable candidate " << nodeId;
@@ -280,9 +280,9 @@ NegativeUNLVote::findAllCandidates(
         }
 
         // Find toReEnable Candidates: check if
-        //  (1) has more than negativeUnlHighWaterMark validations,
+        //  (1) has more than negativeUNLHighWaterMark validations,
         //  (2) is in negUnl
-        if (score > negativeUnlHighWaterMark && negUnl.count(nodeId))
+        if (score > negativeUNLHighWaterMark && negUnl.count(nodeId))
         {
             JLOG(j_.trace()) << "N-UNL: toReEnable candidate " << nodeId;
             candidates.toReEnableCandidates.push_back(nodeId);

--- a/src/ripple/app/misc/NegativeUNLVote.h
+++ b/src/ripple/app/misc/NegativeUNLVote.h
@@ -48,23 +48,23 @@ class NegativeUNLVote final
 public:
     /**
      * A validator is considered unreliable if its validations is less than
-     * negativeUnlLowWaterMark in the last flag ledger period.
+     * negativeUNLLowWaterMark in the last flag ledger period.
      * An unreliable validator is a candidate to be disabled by the NegativeUNL
      * protocol.
      */
-    static constexpr size_t negativeUnlLowWaterMark =
+    static constexpr size_t negativeUNLLowWaterMark =
         FLAG_LEDGER_INTERVAL * 50 / 100;
     /**
-     * An unreliable validator must have more than negativeUnlHighWaterMark
+     * An unreliable validator must have more than negativeUNLHighWaterMark
      * validations in the last flag ledger period to be re-enabled.
      */
-    static constexpr size_t negativeUnlHighWaterMark =
+    static constexpr size_t negativeUNLHighWaterMark =
         FLAG_LEDGER_INTERVAL * 80 / 100;
     /**
      * The minimum number of validations of the local node for it to
      * participate in the voting.
      */
-    static constexpr size_t negativeUnlMinLocalValsToVote =
+    static constexpr size_t negativeUNLMinLocalValsToVote =
         FLAG_LEDGER_INTERVAL * 90 / 100;
     /**
      * We don't want to disable new validators immediately after adding them.
@@ -74,7 +74,7 @@ public:
     /**
      * We only want to put 25% of the UNL on the NegativeUNL.
      */
-    static constexpr float negativeUnlMaxListed = 0.25;
+    static constexpr float negativeUNLMaxListed = 0.25;
 
     /**
      * A flag indicating whether a UNLModify Tx is to disable or to re-enable

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1751,7 +1751,7 @@ NetworkOPsImp::beginConsensus(uint256 const& networkClosed)
         m_ledgerMaster.getClosedLedger()->info().hash);
 
     if (prevLedger->rules().enabled(featureNegativeUNL))
-        app_.validators().setNegativeUnl(prevLedger->negativeUnl());
+        app_.validators().setNegativeUNL(prevLedger->negativeUNL());
     TrustChanges const changes = app_.validators().updateTrusted(
         app_.getValidations().getCurrentNodeIDs());
 

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -161,7 +161,7 @@ class ValidatorList
     PublicKey localPubKey_;
 
     // The master public keys of the current negative UNL
-    hash_set<PublicKey> negativeUnl_;
+    hash_set<PublicKey> negativeUNL_;
 
     // Currently supported version of publisher list format
     static constexpr std::uint32_t requiredListVersion = 1;
@@ -521,14 +521,14 @@ public:
      * @return the master public keys
      */
     hash_set<PublicKey>
-    getNegativeUnl() const;
+    getNegativeUNL() const;
 
     /**
      * set the Negative UNL with validators' master public keys
      * @param negUnl the public keys
      */
     void
-    setNegativeUnl(hash_set<PublicKey> const& negUnl);
+    setNegativeUNL(hash_set<PublicKey> const& negUnl);
 
     /**
      * Remove validations that are from validators on the negative UNL.

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -748,10 +748,10 @@ ValidatorList::getJson() const
     });
 
     // Negative UNL
-    if (!negativeUnl_.empty())
+    if (!negativeUNL_.empty())
     {
         Json::Value& jNegativeUNL = (res[jss::NegativeUNL] = Json::arrayValue);
-        for (auto const& k : negativeUnl_)
+        for (auto const& k : negativeUNL_)
         {
             jNegativeUNL.append(toBase58(TokenType::NodePublic, k));
         }
@@ -944,15 +944,15 @@ ValidatorList::updateTrusted(hash_set<NodeID> const& seenValidators)
     auto unlSize = trustedMasterKeys_.size();
     auto effectiveUnlSize = unlSize;
     auto seenSize = seenValidators.size();
-    if (!negativeUnl_.empty())
+    if (!negativeUNL_.empty())
     {
         for (auto const& k : trustedMasterKeys_)
         {
-            if (negativeUnl_.count(k))
+            if (negativeUNL_.count(k))
                 --effectiveUnlSize;
         }
         hash_set<NodeID> negUnlNodeIDs;
-        for (auto const& k : negativeUnl_)
+        for (auto const& k : negativeUNL_)
         {
             negUnlNodeIDs.emplace(calcNodeID(k));
         }
@@ -987,17 +987,17 @@ ValidatorList::getTrustedMasterKeys() const
 }
 
 hash_set<PublicKey>
-ValidatorList::getNegativeUnl() const
+ValidatorList::getNegativeUNL() const
 {
     std::shared_lock lock{mutex_};
-    return negativeUnl_;
+    return negativeUNL_;
 }
 
 void
-ValidatorList::setNegativeUnl(hash_set<PublicKey> const& negUnl)
+ValidatorList::setNegativeUNL(hash_set<PublicKey> const& negUnl)
 {
     std::lock_guard lock{mutex_};
-    negativeUnl_ = negUnl;
+    negativeUNL_ = negUnl;
 }
 
 std::vector<std::shared_ptr<STValidation>>
@@ -1008,7 +1008,7 @@ ValidatorList::negativeUNLFilter(
     auto ret = std::move(validations);
 
     std::shared_lock lock{mutex_};
-    if (!negativeUnl_.empty())
+    if (!negativeUNL_.empty())
     {
         ret.erase(
             std::remove_if(
@@ -1019,7 +1019,7 @@ ValidatorList::negativeUNLFilter(
                             getTrustedKey(v->getSignerPublic());
                         masterKey)
                     {
-                        return negativeUnl_.count(*masterKey);
+                        return negativeUNL_.count(*masterKey);
                     }
                     else
                     {

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -290,9 +290,10 @@ Change::applyUNLModify()
     }
 
     bool const found = [&] {
-        if (negUnlObject->isFieldPresent(sfNegativeUNL))
+        if (negUnlObject->isFieldPresent(sfDisabledValidators))
         {
-            auto const& negUnl = negUnlObject->getFieldArray(sfNegativeUNL);
+            auto const& negUnl =
+                negUnlObject->getFieldArray(sfDisabledValidators);
             for (auto const& v : negUnl)
             {
                 if (v.isFieldPresent(sfPublicKey) &&

--- a/src/ripple/app/tx/impl/Change.cpp
+++ b/src/ripple/app/tx/impl/Change.cpp
@@ -306,16 +306,16 @@ Change::applyUNLModify()
     if (disabling)
     {
         // cannot have more than one toDisable
-        if (negUnlObject->isFieldPresent(sfNegativeUNLToDisable))
+        if (negUnlObject->isFieldPresent(sfValidatorToDisable))
         {
             JLOG(j_.warn()) << "N-UNL: applyUNLModify, already has ToDisable";
             return tefFAILURE;
         }
 
         // cannot be the same as toReEnable
-        if (negUnlObject->isFieldPresent(sfNegativeUNLToReEnable))
+        if (negUnlObject->isFieldPresent(sfValidatorToReEnable))
         {
-            if (negUnlObject->getFieldVL(sfNegativeUNLToReEnable) == validator)
+            if (negUnlObject->getFieldVL(sfValidatorToReEnable) == validator)
             {
                 JLOG(j_.warn())
                     << "N-UNL: applyUNLModify, ToDisable is same as ToReEnable";
@@ -331,21 +331,21 @@ Change::applyUNLModify()
             return tefFAILURE;
         }
 
-        negUnlObject->setFieldVL(sfNegativeUNLToDisable, validator);
+        negUnlObject->setFieldVL(sfValidatorToDisable, validator);
     }
     else
     {
         // cannot have more than one toReEnable
-        if (negUnlObject->isFieldPresent(sfNegativeUNLToReEnable))
+        if (negUnlObject->isFieldPresent(sfValidatorToReEnable))
         {
             JLOG(j_.warn()) << "N-UNL: applyUNLModify, already has ToReEnable";
             return tefFAILURE;
         }
 
         // cannot be the same as toDisable
-        if (negUnlObject->isFieldPresent(sfNegativeUNLToDisable))
+        if (negUnlObject->isFieldPresent(sfValidatorToDisable))
         {
-            if (negUnlObject->getFieldVL(sfNegativeUNLToDisable) == validator)
+            if (negUnlObject->getFieldVL(sfValidatorToDisable) == validator)
             {
                 JLOG(j_.warn())
                     << "N-UNL: applyUNLModify, ToReEnable is same as ToDisable";
@@ -361,7 +361,7 @@ Change::applyUNLModify()
             return tefFAILURE;
         }
 
-        negUnlObject->setFieldVL(sfNegativeUNLToReEnable, validator);
+        negUnlObject->setFieldVL(sfValidatorToReEnable, validator);
     }
 
     view().update(negUnlObject);

--- a/src/ripple/proto/org/xrpl/rpc/v1/common.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/common.proto
@@ -356,12 +356,12 @@ message TransactionSignature
     bytes value = 1;
 }
 
-message NegativeUnlToDisable
+message ValidatorToDisable
 {
     bytes value = 1;
 }
 
-message NegativeUnlToReEnable
+message ValidatorToReEnable
 {
     bytes value = 1;
 }
@@ -490,7 +490,7 @@ message SignerEntry
 }
 
 // Next field: 3
-message NegativeUnlEntry
+message DisabledValidator
 {
     PublicKey public_key = 1;
 

--- a/src/ripple/proto/org/xrpl/rpc/v1/ledger_objects.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/ledger_objects.proto
@@ -23,7 +23,7 @@ message LedgerObject
         PayChannel pay_channel = 10;
         RippleState ripple_state = 11;
         SignerList signer_list = 12;
-        NegativeUnl negative_unl = 13;
+        NegativeUNL negative_unl = 13;
     }
 }
 
@@ -333,11 +333,11 @@ message SignerList
 }
 
 // Next field: 4
-message NegativeUnl
+message NegativeUNL
 {
-    repeated NegativeUnlEntry negative_unl_entries = 1;
+    repeated DisabledValidator disabled_validators = 1;
 
-    NegativeUnlToDisable validator_to_disable = 2;
+    ValidatorToDisable validator_to_disable = 2;
 
-    NegativeUnlToReEnable validator_to_re_enable = 3;
+    ValidatorToReEnable validator_to_re_enable = 3;
 }

--- a/src/ripple/proto/org/xrpl/rpc/v1/ledger_objects.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/ledger_objects.proto
@@ -332,7 +332,7 @@ message SignerList
     SignerQuorum signer_quorum = 7;
 }
 
-// Next field: 4
+// Next field: 5
 message NegativeUNL
 {
     repeated DisabledValidator disabled_validators = 1;
@@ -340,4 +340,6 @@ message NegativeUNL
     ValidatorToDisable validator_to_disable = 2;
 
     ValidatorToReEnable validator_to_re_enable = 3;
+
+    Flags flags = 4;
 }

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -85,7 +85,7 @@ skip(LedgerIndex ledger) noexcept;
 Keylet const&
 fees() noexcept;
 
-/** The (fixed) index of the object containing the ledger negativeUnl. */
+/** The (fixed) index of the object containing the ledger negativeUNL. */
 Keylet const&
 negativeUNL() noexcept;
 

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -521,7 +521,7 @@ extern SField const sfSufficient;
 extern SField const sfAffectedNodes;
 extern SField const sfMemos;
 extern SField const sfMajorities;
-extern SField const sfNegativeUNL;
+extern SField const sfDisabledValidators;
 //------------------------------------------------------------------------------
 
 }  // namespace ripple

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -473,8 +473,8 @@ extern SF_Blob const sfFulfillment;
 extern SF_Blob const sfCondition;
 extern SF_Blob const sfMasterSignature;
 extern SF_Blob const sfUNLModifyValidator;
-extern SF_Blob const sfNegativeUNLToDisable;
-extern SF_Blob const sfNegativeUNLToReEnable;
+extern SF_Blob const sfValidatorToDisable;
+extern SF_Blob const sfValidatorToReEnable;
 
 // account
 extern SF_Account const sfAccount;
@@ -508,7 +508,7 @@ extern SField const sfMemo;
 extern SField const sfSignerEntry;
 extern SField const sfSigner;
 extern SField const sfMajority;
-extern SField const sfNegativeUNLEntry;
+extern SField const sfDisabledValidator;
 
 // array of objects
 // ARRAY/1 is reserved for end of array

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -228,7 +228,7 @@ LedgerFormats::LedgerFormats()
     add(jss::NegativeUNL,
         ltNEGATIVE_UNL,
         {
-            {sfNegativeUNL, soeOPTIONAL},
+            {sfDisabledValidators, soeOPTIONAL},
             {sfValidatorToDisable, soeOPTIONAL},
             {sfValidatorToReEnable, soeOPTIONAL},
         },

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -229,8 +229,8 @@ LedgerFormats::LedgerFormats()
         ltNEGATIVE_UNL,
         {
             {sfNegativeUNL, soeOPTIONAL},
-            {sfNegativeUNLToDisable, soeOPTIONAL},
-            {sfNegativeUNLToReEnable, soeOPTIONAL},
+            {sfValidatorToDisable, soeOPTIONAL},
+            {sfValidatorToReEnable, soeOPTIONAL},
         },
         commonFields);
 }

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -286,7 +286,7 @@ SField const sfMemos(access, STI_ARRAY, 9, "Memos");
 
 // array of objects (uncommon)
 SField const sfMajorities(access, STI_ARRAY, 16, "Majorities");
-SField const sfNegativeUNL(access, STI_ARRAY, 17, "NegativeUNL");
+SField const sfDisabledValidators(access, STI_ARRAY, 17, "DisabledValidators");
 
 SField::SField(
     private_access_tag_t,

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -224,9 +224,8 @@ SF_Blob const sfMasterSignature(
     SField::sMD_Default,
     SField::notSigning);
 SF_Blob const sfUNLModifyValidator(access, STI_VL, 19, "UNLModifyValidator");
-SF_Blob const sfNegativeUNLToDisable(access, STI_VL, 20, "ValidatorToDisable");
-SF_Blob const
-    sfNegativeUNLToReEnable(access, STI_VL, 21, "ValidatorToReEnable");
+SF_Blob const sfValidatorToDisable(access, STI_VL, 20, "ValidatorToDisable");
+SF_Blob const sfValidatorToReEnable(access, STI_VL, 21, "ValidatorToReEnable");
 
 // account
 SF_Account const sfAccount(access, STI_ACCOUNT, 1, "Account");
@@ -265,7 +264,7 @@ SField const sfSignerEntry(access, STI_OBJECT, 11, "SignerEntry");
 SField const sfSigner(access, STI_OBJECT, 16, "Signer");
 //                                                                                 17 has not been used yet...
 SField const sfMajority(access, STI_OBJECT, 18, "Majority");
-SField const sfNegativeUNLEntry(access, STI_OBJECT, 19, "DisabledValidator");
+SField const sfDisabledValidator(access, STI_OBJECT, 19, "DisabledValidator");
 
 // array of objects
 // ARRAY/1 is reserved for end of array

--- a/src/ripple/rpc/impl/GRPCHelpers.cpp
+++ b/src/ripple/rpc/impl/GRPCHelpers.cpp
@@ -887,7 +887,7 @@ populateDisabledValidators(T& to, STObject const& from)
             populateFirstLedgerSequence(innerProto, innerObj);
         },
         from,
-        sfNegativeUNL,
+        sfDisabledValidators,
         sfDisabledValidator);
 }
 
@@ -1470,6 +1470,8 @@ convert(org::xrpl::rpc::v1::NegativeUNL& to, STObject const& from)
     populateValidatorToDisable(to, from);
 
     populateValidatorToReEnable(to, from);
+
+    populateFlags(to, from);
 }
 
 void

--- a/src/ripple/rpc/impl/GRPCHelpers.cpp
+++ b/src/ripple/rpc/impl/GRPCHelpers.cpp
@@ -497,22 +497,22 @@ populateFirstLedgerSequence(T& to, STObject const& from)
 
 template <class T>
 void
-populateNegativeUNLToDisable(T& to, STObject const& from)
+populateValidatorToDisable(T& to, STObject const& from)
 {
     populateProtoPrimitive(
         [&to]() { return to.mutable_validator_to_disable(); },
         from,
-        sfNegativeUNLToDisable);
+        sfValidatorToDisable);
 }
 
 template <class T>
 void
-populateNegativeUNLToReEnable(T& to, STObject const& from)
+populateValidatorToReEnable(T& to, STObject const& from)
 {
     populateProtoPrimitive(
         [&to]() { return to.mutable_validator_to_re_enable(); },
         from,
-        sfNegativeUNLToReEnable);
+        sfValidatorToReEnable);
 }
 
 template <class T>
@@ -878,17 +878,17 @@ populateSignerEntries(T& to, STObject const& from)
 
 template <class T>
 void
-populateNegativeUNLEntries(T& to, STObject const& from)
+populateDisabledValidators(T& to, STObject const& from)
 {
     populateProtoArray(
-        [&to]() { return to.add_negative_unl_entries(); },
+        [&to]() { return to.add_disabled_validators(); },
         [](auto& innerObj, auto& innerProto) {
             populatePublicKey(innerProto, innerObj);
             populateFirstLedgerSequence(innerProto, innerObj);
         },
         from,
         sfNegativeUNL,
-        sfNegativeUNLEntry);
+        sfDisabledValidator);
 }
 
 template <class T>
@@ -1463,13 +1463,13 @@ convert(org::xrpl::rpc::v1::SignerList& to, STObject const& from)
 }
 
 void
-convert(org::xrpl::rpc::v1::NegativeUnl& to, STObject const& from)
+convert(org::xrpl::rpc::v1::NegativeUNL& to, STObject const& from)
 {
-    populateNegativeUNLEntries(to, from);
+    populateDisabledValidators(to, from);
 
-    populateNegativeUNLToDisable(to, from);
+    populateValidatorToDisable(to, from);
 
-    populateNegativeUNLToReEnable(to, from);
+    populateValidatorToReEnable(to, from);
 }
 
 void

--- a/src/ripple/rpc/impl/GRPCHelpers.h
+++ b/src/ripple/rpc/impl/GRPCHelpers.h
@@ -59,7 +59,7 @@ void
 convert(org::xrpl::rpc::v1::SignerList& to, STObject const& from);
 
 void
-convert(org::xrpl::rpc::v1::NegativeUnl& to, STObject const& from);
+convert(org::xrpl::rpc::v1::NegativeUNL& to, STObject const& from);
 
 template <class T>
 void

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -1342,7 +1342,7 @@ private:
                             nUnl.insert(*it);
                             ++it;
                         }
-                        validators->setNegativeUnl(nUnl);
+                        validators->setNegativeUNL(nUnl);
                         validators->updateTrusted(activeValidators);
                         BEAST_EXPECT(
                             validators->quorum() ==
@@ -1374,8 +1374,8 @@ private:
                             nUnl.insert(*it);
                             ++it;
                         }
-                        validators->setNegativeUnl(nUnl);
-                        auto nUnl_temp = validators->getNegativeUnl();
+                        validators->setNegativeUNL(nUnl);
+                        auto nUnl_temp = validators->getNegativeUNL();
                         if (nUnl_temp.size() == nUnl.size())
                         {
                             for (auto& n : nUnl_temp)
@@ -1396,7 +1396,7 @@ private:
 
                 {
                     // nUNL overlap: |nUNL - UNL| = 5, with nUNL size: 18
-                    auto nUnl = validators->getNegativeUnl();
+                    auto nUnl = validators->getNegativeUNL();
                     BEAST_EXPECT(nUnl.size() == 12);
                     std::size_t ss = 33;
                     std::vector<uint8_t> data(ss, 0);
@@ -1407,7 +1407,7 @@ private:
                         data[1]++;
                         nUnl.emplace(s);
                     }
-                    validators->setNegativeUnl(nUnl);
+                    validators->setNegativeUNL(nUnl);
                     validators->updateTrusted(activeValidators);
                     BEAST_EXPECT(validators->quorum() == 39);
                 }
@@ -1439,7 +1439,7 @@ private:
                     nUnl.insert(*it);
                     ++it;
                 }
-                validators->setNegativeUnl(nUnl);
+                validators->setNegativeUNL(nUnl);
                 validators->updateTrusted(activeValidators);
                 BEAST_EXPECT(validators->quorum() == 30);
             }

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -1911,6 +1911,10 @@ class NegativeUNLgRPC_test : public beast::unit_test::suite
 
             org::xrpl::rpc::v1::NegativeUNL to;
             ripple::RPC::convert(to, *negUnlObject);
+            if (!to.has_flags() ||
+                to.flags().value() != negUnlObject->getFlags())
+                return false;
+
             bool goodSize = to.disabled_validators_size() == negUnlSize &&
                 to.has_validator_to_disable() == hasToDisable &&
                 to.has_validator_to_re_enable() == hasToReEnable;
@@ -1919,10 +1923,10 @@ class NegativeUNLgRPC_test : public beast::unit_test::suite
 
             if (negUnlSize)
             {
-                if (!negUnlObject->isFieldPresent(sfNegativeUNL))
+                if (!negUnlObject->isFieldPresent(sfDisabledValidators))
                     return false;
                 auto const& nUnlData =
-                    negUnlObject->getFieldArray(sfNegativeUNL);
+                    negUnlObject->getFieldArray(sfDisabledValidators);
                 if (nUnlData.size() != negUnlSize)
                     return false;
                 int idx = 0;
@@ -2036,10 +2040,10 @@ VerifyPubKeyAndSeq(
     auto sle = l->read(keylet::negativeUNL());
     if (!sle)
         return false;
-    if (!sle->isFieldPresent(sfNegativeUNL))
+    if (!sle->isFieldPresent(sfDisabledValidators))
         return false;
 
-    auto const& nUnlData = sle->getFieldArray(sfNegativeUNL);
+    auto const& nUnlData = sle->getFieldArray(sfDisabledValidators);
     if (nUnlData.size() != nUnlLedgerSeq.size())
         return false;
 

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -282,7 +282,7 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnlToDisable() == publicKeys[0]);
+                BEAST_EXPECT(l->validatorToDisable() == publicKeys[0]);
                 //++ first ToDisable Tx in ledger's TxSet
                 uint256 txID = txDisable_0.getTransactionID();
                 BEAST_EXPECT(l->txExists(txID));
@@ -296,7 +296,7 @@ class NegativeUNL_test : public beast::unit_test::suite
                 auto good_size = negUnlSizeTest(l, 0, true, false);
                 BEAST_EXPECT(good_size);
                 if (good_size)
-                    BEAST_EXPECT(l->negativeUnlToDisable() == publicKeys[0]);
+                    BEAST_EXPECT(l->validatorToDisable() == publicKeys[0]);
                 l = std::make_shared<Ledger>(
                     *l, env.app().timeKeeper().closeTime());
             }
@@ -309,7 +309,7 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(*(l->negativeUnl().begin()) == publicKeys[0]);
+                BEAST_EXPECT(*(l->negativeUNL().begin()) == publicKeys[0]);
                 nUnlLedgerSeq.emplace(publicKeys[0], l->seq());
             }
 
@@ -330,9 +330,9 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[0]));
-                BEAST_EXPECT(l->negativeUnlToDisable() == publicKeys[1]);
-                BEAST_EXPECT(l->negativeUnlToReEnable() == publicKeys[0]);
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[0]));
+                BEAST_EXPECT(l->validatorToDisable() == publicKeys[1]);
+                BEAST_EXPECT(l->validatorToReEnable() == publicKeys[0]);
                 // test sfFirstLedgerSequence
                 BEAST_EXPECT(VerifyPubKeyAndSeq(l, nUnlLedgerSeq));
             }
@@ -346,9 +346,9 @@ class NegativeUNL_test : public beast::unit_test::suite
                 BEAST_EXPECT(good_size);
                 if (good_size)
                 {
-                    BEAST_EXPECT(l->negativeUnl().count(publicKeys[0]));
-                    BEAST_EXPECT(l->negativeUnlToDisable() == publicKeys[1]);
-                    BEAST_EXPECT(l->negativeUnlToReEnable() == publicKeys[0]);
+                    BEAST_EXPECT(l->negativeUNL().count(publicKeys[0]));
+                    BEAST_EXPECT(l->validatorToDisable() == publicKeys[1]);
+                    BEAST_EXPECT(l->validatorToReEnable() == publicKeys[0]);
                 }
                 l = std::make_shared<Ledger>(
                     *l, env.app().timeKeeper().closeTime());
@@ -362,7 +362,7 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
             }
 
             auto txDisable_0 = createTx(true, l->seq(), publicKeys[0]);
@@ -374,8 +374,8 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
-                BEAST_EXPECT(l->negativeUnlToDisable() == publicKeys[0]);
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
+                BEAST_EXPECT(l->validatorToDisable() == publicKeys[0]);
                 nUnlLedgerSeq.emplace(publicKeys[1], l->seq());
                 nUnlLedgerSeq.erase(publicKeys[0]);
                 BEAST_EXPECT(VerifyPubKeyAndSeq(l, nUnlLedgerSeq));
@@ -390,8 +390,8 @@ class NegativeUNL_test : public beast::unit_test::suite
                 BEAST_EXPECT(good_size);
                 if (good_size)
                 {
-                    BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
-                    BEAST_EXPECT(l->negativeUnlToDisable() == publicKeys[0]);
+                    BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
+                    BEAST_EXPECT(l->validatorToDisable() == publicKeys[0]);
                 }
                 l = std::make_shared<Ledger>(
                     *l, env.app().timeKeeper().closeTime());
@@ -405,8 +405,8 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[0]));
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[0]));
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
                 nUnlLedgerSeq.emplace(publicKeys[0], l->seq());
                 BEAST_EXPECT(VerifyPubKeyAndSeq(l, nUnlLedgerSeq));
             }
@@ -424,9 +424,9 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[0]));
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
-                BEAST_EXPECT(l->negativeUnlToReEnable() == publicKeys[0]);
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[0]));
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
+                BEAST_EXPECT(l->validatorToReEnable() == publicKeys[0]);
                 BEAST_EXPECT(VerifyPubKeyAndSeq(l, nUnlLedgerSeq));
             }
         }
@@ -439,9 +439,9 @@ class NegativeUNL_test : public beast::unit_test::suite
                 BEAST_EXPECT(good_size);
                 if (good_size)
                 {
-                    BEAST_EXPECT(l->negativeUnl().count(publicKeys[0]));
-                    BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
-                    BEAST_EXPECT(l->negativeUnlToReEnable() == publicKeys[0]);
+                    BEAST_EXPECT(l->negativeUNL().count(publicKeys[0]));
+                    BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
+                    BEAST_EXPECT(l->validatorToReEnable() == publicKeys[0]);
                 }
                 l = std::make_shared<Ledger>(
                     *l, env.app().timeKeeper().closeTime());
@@ -455,7 +455,7 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
                 nUnlLedgerSeq.erase(publicKeys[0]);
                 BEAST_EXPECT(VerifyPubKeyAndSeq(l, nUnlLedgerSeq));
             }
@@ -469,8 +469,8 @@ class NegativeUNL_test : public beast::unit_test::suite
             BEAST_EXPECT(good_size);
             if (good_size)
             {
-                BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
-                BEAST_EXPECT(l->negativeUnlToReEnable() == publicKeys[1]);
+                BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
+                BEAST_EXPECT(l->validatorToReEnable() == publicKeys[1]);
                 BEAST_EXPECT(VerifyPubKeyAndSeq(l, nUnlLedgerSeq));
             }
         }
@@ -483,8 +483,8 @@ class NegativeUNL_test : public beast::unit_test::suite
                 BEAST_EXPECT(good_size);
                 if (good_size)
                 {
-                    BEAST_EXPECT(l->negativeUnl().count(publicKeys[1]));
-                    BEAST_EXPECT(l->negativeUnlToReEnable() == publicKeys[1]);
+                    BEAST_EXPECT(l->negativeUNL().count(publicKeys[1]));
+                    BEAST_EXPECT(l->validatorToReEnable() == publicKeys[1]);
                 }
                 l = std::make_shared<Ledger>(
                     *l, env.app().timeKeeper().closeTime());
@@ -633,14 +633,14 @@ struct NetworkHistory
             {
                 l->updateNegativeUNL();
                 OpenView accum(&*l);
-                if (l->negativeUnl().size() < param.negUNLSize)
+                if (l->negativeUNL().size() < param.negUNLSize)
                 {
                     auto tx = createTx(true, l->seq(), UNLKeys[nidx]);
                     if (!applyAndTestResult(env, accum, tx, true))
                         break;
                     ++nidx;
                 }
-                else if (l->negativeUnl().size() == param.negUNLSize)
+                else if (l->negativeUNL().size() == param.negUNLSize)
                 {
                     if (param.hasToDisable)
                     {
@@ -1030,7 +1030,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
         // build a good scoreTable to use, or copy and modify
         hash_map<NodeID, std::uint32_t> goodScoreTable;
         for (auto const& n : history.UNLNodeIDs)
-            goodScoreTable[n] = NegativeUNLVote::negativeUnlHighWaterMark + 1;
+            goodScoreTable[n] = NegativeUNLVote::negativeUNLHighWaterMark + 1;
 
         NegativeUNLVote vote(history.UNLNodeIDs[0], history.env.journal);
 
@@ -1043,7 +1043,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
             // all bad scores
             hash_map<NodeID, std::uint32_t> scoreTable;
             for (auto& n : history.UNLNodeIDs)
-                scoreTable[n] = NegativeUNLVote::negativeUnlLowWaterMark - 1;
+                scoreTable[n] = NegativeUNLVote::negativeUNLLowWaterMark - 1;
             BEAST_EXPECT(checkCandidateSizes(
                 vote, history.UNLNodeIDSet, negUnl_012, scoreTable, 35 - 3, 0));
         }
@@ -1051,7 +1051,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
             // all between watermarks
             hash_map<NodeID, std::uint32_t> scoreTable;
             for (auto& n : history.UNLNodeIDs)
-                scoreTable[n] = NegativeUNLVote::negativeUnlLowWaterMark + 1;
+                scoreTable[n] = NegativeUNLVote::negativeUNLLowWaterMark + 1;
             BEAST_EXPECT(checkCandidateSizes(
                 vote, history.UNLNodeIDSet, negUnl_012, scoreTable, 0, 0));
         }
@@ -1060,7 +1060,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
             // 2 good scorers in negUnl
             auto scoreTable = goodScoreTable;
             scoreTable[*negUnl_012.begin()] =
-                NegativeUNLVote::negativeUnlLowWaterMark + 1;
+                NegativeUNLVote::negativeUNLLowWaterMark + 1;
             BEAST_EXPECT(checkCandidateSizes(
                 vote, history.UNLNodeIDSet, negUnl_012, scoreTable, 0, 2));
         }
@@ -1069,9 +1069,9 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
             // 2 bad scorers not in negUnl
             auto scoreTable = goodScoreTable;
             scoreTable[history.UNLNodeIDs[11]] =
-                NegativeUNLVote::negativeUnlLowWaterMark - 1;
+                NegativeUNLVote::negativeUNLLowWaterMark - 1;
             scoreTable[history.UNLNodeIDs[12]] =
-                NegativeUNLVote::negativeUnlLowWaterMark - 1;
+                NegativeUNLVote::negativeUNLLowWaterMark - 1;
             BEAST_EXPECT(checkCandidateSizes(
                 vote, history.UNLNodeIDSet, negUnl_012, scoreTable, 2, 3));
         }
@@ -1092,7 +1092,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
             scoreTable.erase(history.UNLNodeIDs[0]);
             scoreTable.erase(history.UNLNodeIDs[1]);
             scoreTable[history.UNLNodeIDs[2]] =
-                NegativeUNLVote::negativeUnlLowWaterMark + 1;
+                NegativeUNLVote::negativeUNLLowWaterMark + 1;
             hash_set<NodeID> UNL_temp = history.UNLNodeIDSet;
             UNL_temp.erase(history.UNLNodeIDs[0]);
             UNL_temp.erase(history.UNLNodeIDs[1]);
@@ -1113,9 +1113,9 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
                 // 2 new validators have good scores, already in negUnl
                 auto scoreTable = goodScoreTable;
                 scoreTable[new_1] =
-                    NegativeUNLVote::negativeUnlHighWaterMark + 1;
+                    NegativeUNLVote::negativeUNLHighWaterMark + 1;
                 scoreTable[new_2] =
-                    NegativeUNLVote::negativeUnlHighWaterMark + 1;
+                    NegativeUNLVote::negativeUNLHighWaterMark + 1;
                 hash_set<NodeID> negUnl_temp = negUnl_012;
                 negUnl_temp.insert(new_1);
                 negUnl_temp.insert(new_2);
@@ -1151,16 +1151,16 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
          * == combination 1:
          * -- unl size: 34, 35, 80
          * -- nUnl size: 0, 50%, all
-         * -- score pattern: all 0, all negativeUnlLowWaterMark & +1 & -1, all
-         * negativeUnlHighWaterMark & +1 & -1, all 100%
+         * -- score pattern: all 0, all negativeUNLLowWaterMark & +1 & -1, all
+         * negativeUNLHighWaterMark & +1 & -1, all 100%
          *
          * == combination 2:
          * -- unl size: 34, 35, 80
-         * -- negativeUnl size: 0, all
+         * -- negativeUNL size: 0, all
          * -- nUnl size: one on, one off, one on, one off,
-         * -- score pattern: 2*(negativeUnlLowWaterMark, +1, -1) &
-         * 2*(negativeUnlHighWaterMark, +1, -1) & rest
-         * negativeUnlMinLocalValsToVote
+         * -- score pattern: 2*(negativeUNLLowWaterMark, +1, -1) &
+         * 2*(negativeUNLHighWaterMark, +1, -1) & rest
+         * negativeUNLMinLocalValsToVote
          */
 
         jtx::Env env(*this);
@@ -1172,13 +1172,13 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
         std::array<std::uint32_t, 3> nUnlPercent = {0, 50, 100};
         std::array<std::uint32_t, 8> scores = {
             0,
-            NegativeUNLVote::negativeUnlLowWaterMark - 1,
-            NegativeUNLVote::negativeUnlLowWaterMark,
-            NegativeUNLVote::negativeUnlLowWaterMark + 1,
-            NegativeUNLVote::negativeUnlHighWaterMark - 1,
-            NegativeUNLVote::negativeUnlHighWaterMark,
-            NegativeUNLVote::negativeUnlHighWaterMark + 1,
-            NegativeUNLVote::negativeUnlMinLocalValsToVote};
+            NegativeUNLVote::negativeUNLLowWaterMark - 1,
+            NegativeUNLVote::negativeUNLLowWaterMark,
+            NegativeUNLVote::negativeUNLLowWaterMark + 1,
+            NegativeUNLVote::negativeUNLHighWaterMark - 1,
+            NegativeUNLVote::negativeUNLHighWaterMark,
+            NegativeUNLVote::negativeUNLHighWaterMark + 1,
+            NegativeUNLVote::negativeUNLMinLocalValsToVote};
 
         //== combination 1:
         {
@@ -1221,7 +1221,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
                         if (np == 0)
                         {
                             if (score <
-                                NegativeUNLVote::negativeUnlLowWaterMark)
+                                NegativeUNLVote::negativeUNLLowWaterMark)
                             {
                                 toDisable_expect = us;
                             }
@@ -1229,7 +1229,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
                         else if (np == 50)
                         {
                             if (score >
-                                NegativeUNLVote::negativeUnlHighWaterMark)
+                                NegativeUNLVote::negativeUNLHighWaterMark)
                             {
                                 toReEnable_expect = us * np / 100;
                             }
@@ -1237,7 +1237,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::suite
                         else
                         {
                             if (score >
-                                NegativeUNLVote::negativeUnlHighWaterMark)
+                                NegativeUNLVote::negativeUNLHighWaterMark)
                             {
                                 toReEnable_expect = us;
                             }
@@ -1523,7 +1523,7 @@ class NegativeUNLVoteScoreTable_test : public beast::unit_test::suite
  *
  * == 2 nodes offline including me, not in nUnl
  * -- txSet.size = 0
- * == 2 nodes offline, not in negativeUnl, but I'm not a validator
+ * == 2 nodes offline, not in negativeUNL, but I'm not a validator
  * -- txSet.size = 0
  * == 2 in nUnl, but not in unl, no other remove candidates
  * -- txSet.size = 1
@@ -1542,7 +1542,7 @@ class NegativeUNLVoteGoodScore_test : public beast::unit_test::suite
         testcase("Do Voting");
 
         {
-            //== all good score, negativeUnl empty
+            //== all good score, negativeUNL empty
             //-- txSet.size = 0
             NetworkHistory history = {*this, {51, 0, false, false, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1556,7 +1556,7 @@ class NegativeUNLVoteGoodScore_test : public beast::unit_test::suite
         }
 
         {
-            // all good score, negativeUnl not empty (use hasToDisable)
+            // all good score, negativeUNL not empty (use hasToDisable)
             //-- txSet.size = 1
             NetworkHistory history = {*this, {37, 0, true, false, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1585,7 +1585,7 @@ class NegativeUNLVoteOffline_test : public beast::unit_test::suite
         testcase("Do Voting");
 
         {
-            //== 2 nodes offline, negativeUnl empty (use hasToReEnable)
+            //== 2 nodes offline, negativeUNL empty (use hasToReEnable)
             //-- txSet.size = 1
             NetworkHistory history = {*this, {29, 1, false, true, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1603,16 +1603,16 @@ class NegativeUNLVoteOffline_test : public beast::unit_test::suite
         }
 
         {
-            // 2 nodes offline, in negativeUnl
+            // 2 nodes offline, in negativeUNL
             //-- txSet.size = 0
             NetworkHistory history = {*this, {30, 1, true, false, {}}};
             BEAST_EXPECT(history.goodHistory);
             if (history.goodHistory)
             {
                 NodeID n1 =
-                    calcNodeID(*history.lastLedger()->negativeUnl().begin());
+                    calcNodeID(*history.lastLedger()->negativeUNL().begin());
                 NodeID n2 =
-                    calcNodeID(*history.lastLedger()->negativeUnlToDisable());
+                    calcNodeID(*history.lastLedger()->validatorToDisable());
                 history.walkHistoryAndAddValidations(
                     [&](std::shared_ptr<Ledger const> const& l,
                         std::size_t idx) -> bool {
@@ -1641,7 +1641,7 @@ class NegativeUNLVoteMaxListed_test : public beast::unit_test::suite
         testcase("Do Voting");
 
         {
-            // 2 nodes offline, not in negativeUnl, but maxListed
+            // 2 nodes offline, not in negativeUNL, but maxListed
             //-- txSet.size = 0
             NetworkHistory history = {*this, {32, 8, true, true, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1674,7 +1674,7 @@ class NegativeUNLVoteRetiredValidator_test : public beast::unit_test::suite
         testcase("Do Voting");
 
         {
-            //== 2 nodes offline including me, not in negativeUnl
+            //== 2 nodes offline including me, not in negativeUNL
             //-- txSet.size = 0
             NetworkHistory history = {*this, {35, 0, false, false, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1688,7 +1688,7 @@ class NegativeUNLVoteRetiredValidator_test : public beast::unit_test::suite
         }
 
         {
-            // 2 nodes offline, not in negativeUnl, but I'm not a validator
+            // 2 nodes offline, not in negativeUNL, but I'm not a validator
             //-- txSet.size = 0
             NetworkHistory history = {*this, {40, 0, false, false, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1702,7 +1702,7 @@ class NegativeUNLVoteRetiredValidator_test : public beast::unit_test::suite
         }
 
         {
-            //== 2 in negativeUnl, but not in unl, no other remove candidates
+            //== 2 in negativeUNL, but not in unl, no other remove candidates
             //-- txSet.size = 1
             NetworkHistory history = {*this, {25, 2, false, false, {}}};
             BEAST_EXPECT(history.goodHistory);
@@ -1862,8 +1862,8 @@ class NegativeUNLVoteFilterValidations_test : public beast::unit_test::suite
         validators.load(local, cfgKeys, cfgPublishers);
         validators.updateTrusted(activeValidators);
         BEAST_EXPECT(validators.getTrustedMasterKeys().size() == numNodes);
-        validators.setNegativeUnl(nUnlKeys);
-        BEAST_EXPECT(validators.getNegativeUnl().size() == negUnlSize);
+        validators.setNegativeUNL(nUnlKeys);
+        BEAST_EXPECT(validators.getNegativeUNL().size() == negUnlSize);
 
         // test the filter
         BEAST_EXPECT(vals.size() == numNodes);
@@ -1909,9 +1909,9 @@ class NegativeUNLgRPC_test : public beast::unit_test::suite
             if (!negUnlObject)
                 return false;
 
-            org::xrpl::rpc::v1::NegativeUnl to;
+            org::xrpl::rpc::v1::NegativeUNL to;
             ripple::RPC::convert(to, *negUnlObject);
-            bool goodSize = to.negative_unl_entries_size() == negUnlSize &&
+            bool goodSize = to.disabled_validators_size() == negUnlSize &&
                 to.has_validator_to_disable() == hasToDisable &&
                 to.has_validator_to_re_enable() == hasToReEnable;
             if (!goodSize)
@@ -1932,17 +1932,16 @@ class NegativeUNLgRPC_test : public beast::unit_test::suite
                         !n.isFieldPresent(sfFirstLedgerSequence))
                         return false;
 
-                    if (!to.negative_unl_entries(idx).has_ledger_sequence() ||
-                        !to.negative_unl_entries(idx).has_public_key())
+                    if (!to.disabled_validators(idx).has_ledger_sequence() ||
+                        !to.disabled_validators(idx).has_public_key())
                         return false;
 
-                    if (to.negative_unl_entries(idx).public_key().value() !=
+                    if (to.disabled_validators(idx).public_key().value() !=
                         toByteString(n.getFieldVL(sfPublicKey)))
                         return false;
 
-                    if (to.negative_unl_entries(idx)
-                            .ledger_sequence()
-                            .value() != n.getFieldU32(sfFirstLedgerSequence))
+                    if (to.disabled_validators(idx).ledger_sequence().value() !=
+                        n.getFieldU32(sfFirstLedgerSequence))
                         return false;
 
                     ++idx;
@@ -1951,21 +1950,21 @@ class NegativeUNLgRPC_test : public beast::unit_test::suite
 
             if (hasToDisable)
             {
-                if (!negUnlObject->isFieldPresent(sfNegativeUNLToDisable))
+                if (!negUnlObject->isFieldPresent(sfValidatorToDisable))
                     return false;
                 if (to.validator_to_disable().value() !=
                     toByteString(
-                        negUnlObject->getFieldVL(sfNegativeUNLToDisable)))
+                        negUnlObject->getFieldVL(sfValidatorToDisable)))
                     return false;
             }
 
             if (hasToReEnable)
             {
-                if (!negUnlObject->isFieldPresent(sfNegativeUNLToReEnable))
+                if (!negUnlObject->isFieldPresent(sfValidatorToReEnable))
                     return false;
                 if (to.validator_to_re_enable().value() !=
                     toByteString(
-                        negUnlObject->getFieldVL(sfNegativeUNLToReEnable)))
+                        negUnlObject->getFieldVL(sfValidatorToReEnable)))
                     return false;
             }
 
@@ -2010,11 +2009,11 @@ negUnlSizeTest(
     bool hasToDisable,
     bool hasToReEnable)
 {
-    bool sameSize = l->negativeUnl().size() == size;
+    bool sameSize = l->negativeUNL().size() == size;
     bool sameToDisable =
-        (l->negativeUnlToDisable() != boost::none) == hasToDisable;
+        (l->validatorToDisable() != boost::none) == hasToDisable;
     bool sameToReEnable =
-        (l->negativeUnlToReEnable() != boost::none) == hasToReEnable;
+        (l->validatorToReEnable() != boost::none) == hasToReEnable;
 
     return sameSize && sameToDisable && sameToReEnable;
 }

--- a/src/test/rpc/ValidatorRPC_test.cpp
+++ b/src/test/rpc/ValidatorRPC_test.cpp
@@ -146,7 +146,7 @@ public:
             auto k2 = randomKeyPair(KeyType::ed25519).first;
             disabledKeys.insert(k1);
             disabledKeys.insert(k2);
-            env.app().validators().setNegativeUnl(disabledKeys);
+            env.app().validators().setNegativeUNL(disabledKeys);
 
             auto const jrr = env.rpc("validators")[jss::result];
             auto& jrrnUnl = jrr[jss::NegativeUNL];
@@ -163,7 +163,7 @@ public:
             }
 
             disabledKeys.clear();
-            env.app().validators().setNegativeUnl(disabledKeys);
+            env.app().validators().setNegativeUNL(disabledKeys);
             auto const jrrUpdated = env.rpc("validators")[jss::result];
             BEAST_EXPECT(jrrUpdated[jss::NegativeUNL].isNull());
         }


### PR DESCRIPTION
Several declarations in SField are changed so that the symbolic names and the text representations are consistent. 
-- the SField declarations are sfDisabledValidator, sfValidatorToDisable, and sfValidatorToReEnable
-- their corresponding gRPC declarations are also changed
-- the related function names are also changed
-- changed negativeUnl to negativeUNL too

Tested with unit test and local network tests.