### PR TITLE
[TRIVIAL] Remove assert from Keylet:

### DIFF
--- a/src/ripple/protocol/impl/Keylet.cpp
+++ b/src/ripple/protocol/impl/Keylet.cpp
@@ -34,7 +34,6 @@ Keylet::check(SLE const& sle) const
         assert(sle.getType() != ltDIR_NODE);
         return sle.getType() != ltDIR_NODE;
     }
-    assert(sle.getType() == type);
     return sle.getType() == type;
 }
 


### PR DESCRIPTION
Some transactions specify a keylet directly (Checks, for example). In those
cases, the assert will trigger even though there is no error.