### PR TITLE
Currently, the ledger command only takes int for ledger_index - update the logic to allow string as well.

### DIFF
--- a/src/ripple/json/json_value.h
+++ b/src/ripple/json/json_value.h
@@ -136,7 +136,7 @@ operator!=(StaticString x, std::string const& y)
  * The sequence of an #arrayValue will be automatically resize and initialized
  * with #nullValue. resize() can be used to enlarge or truncate an #arrayValue.
  *
- * The get() methods can be used to obtanis default value in the case the
+ * The get() methods can be used to obtain a default value in the case the
  * required element does not exist.
  *
  * It is possible to iterate over the list of a #objectValue values using

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -228,31 +228,23 @@ ledgerFromRequest(T& ledger, JsonContext& context)
             return {rpcINVALID_PARAMS, "ledgerHashMalformed"};
         return getLedger(ledger, ledgerHash, context);
     }
-    else if (indexValue.isNumeric())
-    {
-        return getLedger(ledger, indexValue.asInt(), context);
-    }
-    else
-    {
-        auto const index = indexValue.asString();
-        if (index == "validated")
-        {
-            return getLedger(ledger, LedgerShortcut::VALIDATED, context);
-        }
-        else
-        {
-            if (index.empty() || index == "current")
-                return getLedger(ledger, LedgerShortcut::CURRENT, context);
-            else if (index == "closed")
-                return getLedger(ledger, LedgerShortcut::CLOSED, context);
-            else
-            {
-                return {rpcINVALID_PARAMS, "ledgerIndexMalformed"};
-            }
-        }
-    }
 
-    return Status::OK;
+    auto const index = indexValue.asString();
+
+    if (index.empty() || index == "current")
+        return getLedger(ledger, LedgerShortcut::CURRENT, context);
+
+    if (index == "validated")
+        return getLedger(ledger, LedgerShortcut::VALIDATED, context);
+
+    if (index == "closed")
+        return getLedger(ledger, LedgerShortcut::CLOSED, context);
+
+    std::uint32_t iVal;
+    if (beast::lexicalCastChecked(iVal, index))
+        return getLedger(ledger, iVal, context);
+
+    return {rpcINVALID_PARAMS, "ledgerIndexMalformed"};
 }
 }  // namespace
 

--- a/src/test/rpc/DepositAuthorized_test.cpp
+++ b/src/test/rpc/DepositAuthorized_test.cpp
@@ -228,10 +228,17 @@ public:
         }
         {
             // Request an invalid ledger.
-            Json::Value args{depositAuthArgs(alice, becky, "17")};
+            Json::Value args{depositAuthArgs(alice, becky, "-1")};
             Json::Value const result{
                 env.rpc("json", "deposit_authorized", args.toStyledString())};
             verifyErr(result, "invalidParams", "ledgerIndexMalformed");
+        }
+        {
+            // Request a ledger that doesn't exist yet as a string.
+            Json::Value args{depositAuthArgs(alice, becky, "17")};
+            Json::Value const result{
+                env.rpc("json", "deposit_authorized", args.toStyledString())};
+            verifyErr(result, "lgrNotFound", "ledgerNotFound");
         }
         {
             // Request a ledger that doesn't exist yet.


### PR DESCRIPTION
Assume ledger_index is quoted int if it is not "current", "closed", or "validated".

FIXES #3533