### PR TITLE
Improve shard finalize memory utilization

### DIFF
--- a/src/ripple/nodestore/impl/Shard.h
+++ b/src/ripple/nodestore/impl/Shard.h
@@ -229,11 +229,6 @@ private:
     // Determines if the shard directory should be removed in the destructor
     std::atomic<bool> removeOnDestroy_{false};
 
-    // Set the backend cache
-    // Lock over mutex_ required
-    void
-    setBackendCache(std::lock_guard<std::recursive_mutex> const& lock);
-
     // Open/Create SQLite databases
     // Lock over mutex_ required
     bool

--- a/src/ripple/shamap/impl/ShardFamily.cpp
+++ b/src/ripple/shamap/impl/ShardFamily.cpp
@@ -38,8 +38,8 @@ ShardFamily::ShardFamily(Application& app, CollectorManager& cm)
     , db_(getShardStore(app))
     , cm_(cm)
     , j_(app.journal("ShardFamily"))
-    , tnTargetSize_(app.config().getValueFor(SizedItem::treeCacheSize))
-    , tnTargetAge_(app.config().getValueFor(SizedItem::treeCacheAge))
+    , tnTargetSize_(app.config().getValueFor(SizedItem::treeCacheSize, 0))
+    , tnTargetAge_(app.config().getValueFor(SizedItem::treeCacheAge, 0))
 {
 }
 


### PR DESCRIPTION
This pull request addresses memory utilization during the finalization stage of a shard. The current process visits the SHAmaps nodes of every ledger in a shard causing the family shard and backend tagged caches to grow quicker than they are pruned. The proposed solution resets the appropriate caches between ledgers to drastically reduce memory usage.