### PR TITLE
Database downloader fix

### DIFF
--- a/src/ripple/net/DatabaseDownloader.h
+++ b/src/ripple/net/DatabaseDownloader.h
@@ -28,12 +28,14 @@ namespace ripple {
 class DatabaseDownloader : public HTTPDownloader
 {
 public:
-    DatabaseDownloader(
-        boost::asio::io_service& io_service,
-        beast::Journal j,
-        Config const& config);
+    virtual ~DatabaseDownloader() = default;
 
 private:
+    DatabaseDownloader(
+        boost::asio::io_service& io_service,
+        Config const& config,
+        beast::Journal j);
+
     static const std::uint8_t MAX_PATH_LEN =
         std::numeric_limits<std::uint8_t>::max();
 
@@ -54,7 +56,20 @@ private:
 
     Config const& config_;
     boost::asio::io_service& io_service_;
+
+    friend std::shared_ptr<DatabaseDownloader>
+    make_DatabaseDownloader(
+        boost::asio::io_service& io_service,
+        Config const& config,
+        beast::Journal j);
 };
+
+// DatabaseDownloader must be a shared_ptr because it uses shared_from_this
+std::shared_ptr<DatabaseDownloader>
+make_DatabaseDownloader(
+    boost::asio::io_service& io_service,
+    Config const& config,
+    beast::Journal j);
 
 }  // namespace ripple
 

--- a/src/ripple/net/impl/DatabaseDownloader.cpp
+++ b/src/ripple/net/impl/DatabaseDownloader.cpp
@@ -21,11 +21,21 @@
 
 namespace ripple {
 
+std::shared_ptr<DatabaseDownloader>
+make_DatabaseDownloader(
+    boost::asio::io_service& io_service,
+    Config const& config,
+    beast::Journal j)
+{
+    return std::shared_ptr<DatabaseDownloader>(
+        new DatabaseDownloader(io_service, config, j));
+}
+
 DatabaseDownloader::DatabaseDownloader(
     boost::asio::io_service& io_service,
-    beast::Journal j,
-    Config const& config)
-    : HTTPDownloader(io_service, j, config)
+    Config const& config,
+    beast::Journal j)
+    : HTTPDownloader(io_service, config, j)
     , config_(config)
     , io_service_(io_service)
 {
@@ -42,11 +52,9 @@ DatabaseDownloader::getParser(
     auto p = std::make_shared<http::response_parser<DatabaseBody>>();
     p->body_limit(std::numeric_limits<std::uint64_t>::max());
     p->get().body().open(dstPath, config_, io_service_, ec);
+
     if (ec)
-    {
         p->get().body().close();
-        fail(dstPath, complete, ec, "open", nullptr);
-    }
 
     return p;
 }

--- a/src/ripple/rpc/ShardArchiveHandler.h
+++ b/src/ripple/rpc/ShardArchiveHandler.h
@@ -130,7 +130,7 @@ private:
     // destroying sqliteDB_.
     /////////////////////////////////////////////////
     std::mutex mutable m_;
-    std::unique_ptr<DatabaseDownloader> downloader_;
+    std::shared_ptr<DatabaseDownloader> downloader_;
     std::map<std::uint32_t, parsedURL> archives_;
     bool process_;
     std::unique_ptr<DatabaseCon> sqliteDB_;

--- a/src/test/net/DatabaseDownloader_test.cpp
+++ b/src/test/net/DatabaseDownloader_test.cpp
@@ -80,17 +80,20 @@ class DatabaseDownloader_test : public beast::unit_test::suite
     {
         test::StreamSink sink_;
         beast::Journal journal_;
-        // The DatabaseDownloader must be created as shared_ptr
-        // because it uses shared_from_this
         std::shared_ptr<DatabaseDownloader> ptr_;
 
         Downloader(jtx::Env& env)
             : journal_{sink_}
-            , ptr_{std::make_shared<DatabaseDownloader>(
+            , ptr_{make_DatabaseDownloader(
                   env.app().getIOService(),
-                  journal_,
-                  env.app().config())}
+                  env.app().config(),
+                  journal_)}
         {
+        }
+
+        ~Downloader()
+        {
+            ptr_->onStop();
         }
 
         DatabaseDownloader*


### PR DESCRIPTION
This PR implements a fix for an issue discovered by @seelabs and @ximinez wherein the `DatabaseDownloader` unit test crashes when a `boost::asio` coroutine is invoked for an object (namely an instance of `DatabaseDownloader`) that has already been destroyed.

The problem was solved by delaying destruction of the object until the coroutine has completed. This was achieved by calling `SSLHTTPDownloader::onStop` from the `DatabaseDownloader` desctructor.

To trigger the crash, I modified the following line in the unit test:

`auto constexpr timeout = 2s;`

I changed the timeout value to `10us` in order to consistently produce a crash. Each time the crash occurred, the offending line was inside of `SSLHTTPDownloader::do_session` and the downloader had already been destroyed, which is consistent with the stack trace from the crash observed by Scott. Naturally, I was able to use this miniature timeout value to confirm the fix.

**FYI:** This PR is stacked on two unmerged PRs. The relevant code is in commit 56c0224.