### PR TITLE
Refactor AccountLinesRPC defaultRipple response

### DIFF
--- a/src/ripple/app/paths/RippleState.h
+++ b/src/ripple/app/paths/RippleState.h
@@ -88,6 +88,12 @@ public:
     }
 
     bool
+    getDefaultRipple() const
+    {
+        return mFlags & lsfDefaultRipple;
+    }
+
+    bool
     getNoRipple() const
     {
         return mFlags & (mViewLowest ? lsfLowNoRipple : lsfHighNoRipple);

--- a/src/ripple/rpc/handlers/AccountLines.cpp
+++ b/src/ripple/rpc/handlers/AccountLines.cpp
@@ -62,10 +62,10 @@ addLine(Json::Value& jsonLines, RippleState const& line)
         jPeer[jss::authorized] = true;
     if (line.getAuthPeer())
         jPeer[jss::peer_authorized] = true;
-    if (line.getNoRipple())
-        jPeer[jss::no_ripple] = true;
-    if (line.getNoRipplePeer())
-        jPeer[jss::no_ripple_peer] = true;
+    if (line.getNoRipple() || !line.getDefaultRipple())
+        jPeer[jss::no_ripple] = line.getNoRipple();
+    if (line.getNoRipplePeer() || !line.getDefaultRipple())
+        jPeer[jss::no_ripple_peer] = line.getNoRipplePeer();
     if (line.getFreeze())
         jPeer[jss::freeze] = true;
     if (line.getFreezePeer())

--- a/src/test/rpc/NoRipple_test.cpp
+++ b/src/test/rpc/NoRipple_test.cpp
@@ -135,12 +135,12 @@ public:
             {
                 auto const aliceLines = getAccountLines(alice);
                 BEAST_EXPECT(aliceLines.size() == 1);
-                BEAST_EXPECT(!aliceLines[0u].isMember(jss::no_ripple));
+                BEAST_EXPECT(aliceLines[0u][jss::no_ripple].asBool() == false);
 
                 auto const bobLines = getAccountLines(bob);
                 BEAST_EXPECT(bobLines.size() == 2);
-                BEAST_EXPECT(!bobLines[0u].isMember(jss::no_ripple));
-                BEAST_EXPECT(!bobLines[1u].isMember(jss::no_ripple));
+                BEAST_EXPECT(bobLines[0u][jss::no_ripple].asBool() == false);
+                BEAST_EXPECT(bobLines[1u][jss::no_ripple].asBool() == false);
             }
 
             // Now carol sends the 50 USD back to alice.  Then alice and


### PR DESCRIPTION
## High Level Overview of Change
Fixes #3245. The AccountLinesRPC takes default no_ripple into the API response.

### Context of Change
The API will return the `no_ripple` field when `no_ripple: true` or when `no_ripple: false` and defaultRipple is disabled.

From issue #3245: 
For a trust line between accounts A and B, where A is the "perspective account" used in the API request's account field and B is the "peer account" for a given trust line:

    1) If A's side of the trust line has NoRipple enabled, return "no_ripple": true always.
    2) Else, if A has DefaultRipple disabled, explicitly return "no_ripple": false. 
    3) Else, omit no_ripple. (NoRipple is off and that's the default.)


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
**Before:**
The API only returns `no_ripple` when it is `true`

**After:**
The API only returns `no_ripple` when it is `true`. It also returns `no_ripple: false` when defaultRipple disabled. This is the case where `false` is the non-default value.

## Test Plan
Modified three tests to expect `no_ripple` field to be `false`.