### PR TITLE
Allow 100 signers

### DIFF
--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -113,7 +113,8 @@ class FeatureCollections
                     // payment check
         "HardenedValidations",
         "fixAmendmentMajorityCalc",  // Fix Amendment majority calculation
-        "NegativeUNL"};
+        "NegativeUNL",
+        "increaseMaxSignersTo100"};
     std::vector<uint256> features;
     boost::container::flat_map<uint256, std::size_t> featureToIndex;
     boost::container::flat_map<std::string, uint256> nameToFeature;
@@ -370,6 +371,7 @@ extern uint256 const fix1781;
 extern uint256 const featureHardenedValidations;
 extern uint256 const fixAmendmentMajorityCalc;
 extern uint256 const featureNegativeUNL;
+extern uint256 const increaseMaxSignersTo100;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -191,6 +191,6 @@ sterilize(STTx const& stx);
 bool
 isPseudoTx(STObject const& tx);
 
-}  // namespace ripple
+}  // namespace ripple 
 
 #endif

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -191,6 +191,6 @@ sterilize(STTx const& stx);
 bool
 isPseudoTx(STObject const& tx);
 
-}  // namespace ripple 
+}  // namespace ripple
 
 #endif

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -49,7 +49,7 @@ public:
     }
 
     static std::size_t const minMultiSigners = 1;
-    static std::size_t const maxMultiSigners = 8;
+    static std::size_t const maxMultiSigners = 100;
 
 public:
     STTx() = delete;

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -132,6 +132,7 @@ detail::supportedAmendments()
         "fix1781",
         "HardenedValidations",
         "fixAmendmentMajorityCalc",
+        "increaseMaxSignersTo100",
         //"NegativeUNL"      // Commented out to prevent automatic enablement
     };
     return supported;
@@ -187,6 +188,7 @@ uint256 const
     featureHardenedValidations      = *getRegisteredFeature("HardenedValidations"),
     fixAmendmentMajorityCalc        = *getRegisteredFeature("fixAmendmentMajorityCalc"),
     featureNegativeUNL              = *getRegisteredFeature("NegativeUNL");
+    featureincreaseMaxSignersTo100  = *getRegisteredFeature("increaseMaxSignersTo100");
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.


### PR DESCRIPTION
Kava's bridge use case requires them to be able to set quorums of 67 on signer lists with 100 members. This PR would increase the max size of the signer list from 8 to 100.