### PR TITLE
Report server domain to other servers:

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -351,6 +351,14 @@
 #   connection is no longer available.
 #
 #
+# [server_domain]
+#
+#   domain name
+#
+#   The domain under which a TOML file applicable to this server can be
+#   found. A server may lie about its domain so the TOML should contain
+#   a reference to this server by pubkey in the [nodes] array.
+#
 #
 #-------------------------------------------------------------------------------
 #

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2532,6 +2532,10 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     if (human)
         info[jss::hostid] = getHostId(admin);
 
+    // domain: if configured with a domain, report it:
+    if (!app_.config().SERVER_DOMAIN.empty())
+        info[jss::server_domain] = app_.config().SERVER_DOMAIN;
+
     if (auto const netid = app_.overlay().networkID())
         info[jss::network_id] = static_cast<Json::UInt>(*netid);
 

--- a/src/ripple/app/misc/impl/Manifest.cpp
+++ b/src/ripple/app/misc/impl/Manifest.cpp
@@ -90,30 +90,9 @@ deserializeManifest(Slice s)
         {
             auto const d = st.getFieldVL(sfDomain);
 
-            // The domain must be between 4 and 128 characters long
-            if (boost::algorithm::clamp(d.size(), 4, 128) != d.size())
-                return boost::none;
-
             m.domain.assign(reinterpret_cast<char const*>(d.data()), d.size());
 
-            // This regular expression should do a decent job of weeding out
-            // obviously wrong domain names but it isn't perfect. It does not
-            // really support IDNs. If this turns out to be an issue, a more
-            // thorough regex can be used or this check can just be removed.
-            static boost::regex const re(
-                "^"                   // Beginning of line
-                "("                   // Beginning of a segment
-                "(?!-)"               //  - must not begin with '-'
-                "[a-zA-Z0-9-]{1,63}"  //  - only alphanumeric and '-'
-                "(?<!-)"              //  - must not end with '-'
-                "\\."                 // segment separator
-                ")+"                  // 1 or more segments
-                "[A-Za-z]{2,63}"      // TLD
-                "$"                   // End of line
-                ,
-                boost::regex_constants::optimize);
-
-            if (!boost::regex_match(m.domain, re))
+            if (!isProperlyFormedTomlDomain(m.domain))
                 return boost::none;
         }
 

--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -148,6 +148,15 @@ trim_whitespace(std::string str);
 boost::optional<std::uint64_t>
 to_uint64(std::string const& s);
 
+/** Determines if the given string looks like a TOML-file hosting domain.
+
+    Do not use this function to determine if a particular string is a valid
+    domain, as this function may reject domains that are otherwise valid and
+    doesn't check whether the TLD is valid.
+ */
+bool
+isProperlyFormedTomlDomain(std::string const& domain);
+
 }  // namespace ripple
 
 #endif

--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -120,4 +120,31 @@ to_uint64(std::string const& s)
     return boost::none;
 }
 
+bool
+isProperlyFormedTomlDomain(std::string const& domain)
+{
+    // The domain must be between 4 and 128 characters long
+    if (domain.size() < 4 || domain.size() > 128)
+        return false;
+
+    // This regular expression should do a decent job of weeding out
+    // obviously wrong domain names but it isn't perfect. It does not
+    // really support IDNs. If this turns out to be an issue, a more
+    // thorough regex can be used or this check can just be removed.
+    static boost::regex const re(
+        "^"                   // Beginning of line
+        "("                   // Beginning of a segment
+        "(?!-)"               //  - must not begin with '-'
+        "[a-zA-Z0-9-]{1,63}"  //  - only alphanumeric and '-'
+        "(?<!-)"              //  - must not end with '-'
+        "\\."                 // segment separator
+        ")+"                  // 1 or more segments
+        "[A-Za-z]{2,63}"      // TLD
+        "$"                   // End of line
+        ,
+        boost::regex_constants::optimize);
+
+    return boost::regex_match(domain, re);
+}
+
 }  // namespace ripple

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -195,6 +195,8 @@ public:
 
     std::unordered_set<uint256, beast::uhash<>> features;
 
+    std::string SERVER_DOMAIN;
+
 public:
     Config() : j_{beast::Journal::getNullSink()}
     {

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -81,6 +81,7 @@ struct ConfigSection
 #define SECTION_SSL_VERIFY "ssl_verify"
 #define SECTION_SSL_VERIFY_FILE "ssl_verify_file"
 #define SECTION_SSL_VERIFY_DIR "ssl_verify_dir"
+#define SECTION_SERVER_DOMAIN "server_domain"
 #define SECTION_VALIDATORS_FILE "validators_file"
 #define SECTION_VALIDATION_SEED "validation_seed"
 #define SECTION_WEBSOCKET_PING_FREQ "websocket_ping_frequency"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -19,8 +19,8 @@
 
 #include <ripple/basics/FileUtilities.h>
 #include <ripple/basics/Log.h>
-#include <ripple/basics/contract.h>
 #include <ripple/basics/StringUtilities.h>
+#include <ripple/basics/contract.h>
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/FileUtilities.h>
 #include <ripple/basics/Log.h>
 #include <ripple/basics/contract.h>
+#include <ripple/basics/StringUtilities.h>
 #include <ripple/beast/core/LexicalCast.h>
 #include <ripple/core/Config.h>
 #include <ripple/core/ConfigSections.h>
@@ -494,6 +495,18 @@ Config::loadFromString(std::string const& fileContents)
             beast::lexicalCastThrow<int>(strTemp),
             MIN_JOB_QUEUE_TX,
             MAX_JOB_QUEUE_TX);
+    }
+
+    if (getSingleSection(secConfig, SECTION_SERVER_DOMAIN, strTemp, j_))
+    {
+        if (!isProperlyFormedTomlDomain(strTemp))
+        {
+            Throw<std::runtime_error>(
+                "Invalid " SECTION_SERVER_DOMAIN
+                ": the domain name does not appear to meet the requirements.");
+        }
+
+        SERVER_DOMAIN = strTemp;
     }
 
     if (getSingleSection(

--- a/src/ripple/overlay/README.md
+++ b/src/ripple/overlay/README.md
@@ -243,6 +243,24 @@ encoded in base58 using the standard encoding for node public keys.
 
 See: https://xrpl.org/base58-encodings.html
 
+
+| Field Name          	|  Request          	| Response          	|
+|---------------------	|:-----------------:	|:-----------------:	|
+| `Server-Domain`   	| :white_check_mark: 	| :white_check_mark: 	|
+
+The optional `Server-Domain` field allows a server to report the domain that
+it is operating under. The value is configured by the server administrator in
+the configuration file using the `[server_domain]` key.
+
+The value is advisory and is not used by the code at this time, except for
+reporting purposes. External tools should verify this value prior to using
+it by attempting to locate a [TOML file](https://xrpl.org/xrp-ledger-toml.html)
+under the specified domain and locating the public key of this server under the
+`[NODES]` key.
+
+Sending a malformed domain will prevent a connection from being established.
+
+
 | Field Name          	|  Request          	| Response          	|
 |---------------------	|:-----------------:	|:-----------------:	|
 | `Session-Signature` 	| :heavy_check_mark: 	| :heavy_check_mark: 	|
@@ -254,7 +272,8 @@ The value is presently encoded using **Base64** encoding, but implementations
 should support both **Base64** and **HEX** encoding for this value.
 
 For more details on this field, please see **Session Signature** below.
-    
+
+
 | Field Name          	|  Request          	| Response          	|
 |---------------------	|:-----------------:	|:-----------------:	|
 | `Crawl`             	| :white_check_mark: 	| :white_check_mark: 	|

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -477,9 +477,14 @@ private:
     void
     onWriteResponse(error_code ec, std::size_t bytes_transferred);
 
-    // A thread-safe way of getting the name.
     std::string
-    getName() const;
+    name() const;
+
+    std::string
+    domain() const;
+
+    std::optional<std::uint32_t>
+    networkID() const;
 
     //
     // protocol message loop

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -474,6 +474,7 @@ JSS(seq);                       // in: LedgerEntry;
                                 //      ValidatorList, ValidatorInfo, Manifest
 JSS(seqNum);                    // out: LedgerToJson
 JSS(sequence_count);            // out: AccountInfo
+JSS(server_domain);             // out: NetworkOPs
 JSS(server_state);              // out: NetworkOPs
 JSS(server_state_duration_us);  // out: NetworkOPs
 JSS(server_status);             // out: NetworkOPs


### PR DESCRIPTION
This commit introduces a new configuration option that server operators can set. The value is communicated to other servers and is also reported via the `server_info` API.

The value is meant to allow third-party applications or tools to group servers together. For example, a tool that visualizes the network's topology can group servers together.

Similar to the `Domain` field in validator manifests, an operator can claim any domain. Prior to relying on the value returned, the domain should be verified by retrieving the xrp-ledger.toml file from the domain and looking for the server's public key in the`nodes` array.