### PR TITLE
Improve reporting of unusual unit test failure conditions:

### DIFF
--- a/bin/ci/ubuntu/build-and-test.sh
+++ b/bin/ci/ubuntu/build-and-test.sh
@@ -139,7 +139,6 @@ else
         'ripple.ripple_data.reduce_relay_simulate'
         'ripple.ripple_data.digest'
         'ripple.tx.Offer_manual'
-        'ripple.app.PayStrandAllPairs'
         'ripple.tx.CrossingLimits'
         'ripple.tx.PlumpBook'
         'ripple.app.Flow_manual'

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -271,8 +271,8 @@ runUnitTests(
         multi_runner_child child_runner{num_jobs, quiet, log};
         child_runner.arg(argument);
         multi_selector pred(pattern);
-        auto const any_failed =
-            child_runner.run_multi(pred) || anyMissing(child_runner, pred);
+        auto any_failed = child_runner.run_multi(pred);
+        any_failed = anyMissing(child_runner, pred) || any_failed;
 
         if (any_failed)
             return EXIT_FAILURE;

--- a/src/test/unit_test/multi_runner.cpp
+++ b/src/test/unit_test/multi_runner.cpp
@@ -183,6 +183,22 @@ multi_runner_base<IsParent>::inner::any_failed(bool v)
 }
 
 template <bool IsParent>
+std::size_t
+multi_runner_base<IsParent>::inner::tests() const
+{
+    std::lock_guard l{m_};
+    return results_.total;
+}
+
+template <bool IsParent>
+std::size_t
+multi_runner_base<IsParent>::inner::suites() const
+{
+    std::lock_guard l{m_};
+    return results_.suites;
+}
+
+template <bool IsParent>
 void
 multi_runner_base<IsParent>::inner::inc_keep_alive_count()
 {
@@ -349,6 +365,30 @@ multi_runner_base<IsParent>::message_queue_send(
 }
 
 template <bool IsParent>
+std::size_t
+multi_runner_base<IsParent>::tests() const
+{
+    return inner_->tests();
+}
+
+template <bool IsParent>
+std::size_t
+multi_runner_base<IsParent>::suites() const
+{
+    return inner_->suites();
+}
+
+template <bool IsParent>
+void
+multi_runner_base<IsParent>::add_failures(std::size_t failures)
+{
+    results results;
+    results.failed += failures;
+    add(results);
+    any_failed(failures != 0);
+}
+
+template <bool IsParent>
 constexpr const char* multi_runner_base<IsParent>::shared_mem_name_;
 template <bool IsParent>
 constexpr const char* multi_runner_base<IsParent>::message_queue_name_;
@@ -445,6 +485,24 @@ multi_runner_parent::any_failed() const
     return multi_runner_base<true>::any_failed();
 }
 
+std::size_t
+multi_runner_parent::tests() const
+{
+    return multi_runner_base<true>::tests();
+}
+
+std::size_t
+multi_runner_parent::suites() const
+{
+    return multi_runner_base<true>::suites();
+}
+
+void
+multi_runner_parent::add_failures(std::size_t failures)
+{
+    multi_runner_base<true>::add_failures(failures);
+}
+
 //------------------------------------------------------------------------------
 
 multi_runner_child::multi_runner_child(
@@ -499,6 +557,25 @@ multi_runner_child::~multi_runner_child()
     }
 
     add(results_);
+}
+
+std::size_t
+multi_runner_child::tests() const
+{
+    return results_.total;
+}
+
+std::size_t
+multi_runner_child::suites() const
+{
+    return results_.suites;
+}
+
+void
+multi_runner_child::add_failures(std::size_t failures)
+{
+    results_.failed += failures;
+    any_failed(failures != 0);
 }
 
 void

--- a/src/test/unit_test/multi_runner.cpp
+++ b/src/test/unit_test/multi_runner.cpp
@@ -382,10 +382,13 @@ template <bool IsParent>
 void
 multi_runner_base<IsParent>::add_failures(std::size_t failures)
 {
-    results results;
-    results.failed += failures;
-    add(results);
-    any_failed(failures != 0);
+    if (failures != 0)
+    {
+        results results;
+        results.failed = failures;
+        add(results);
+        any_failed(true);
+    }
 }
 
 template <bool IsParent>

--- a/src/test/unit_test/multi_runner.h
+++ b/src/test/unit_test/multi_runner.h
@@ -131,6 +131,12 @@ class multi_runner_base
         void
         any_failed(bool v);
 
+        std::size_t
+        tests() const;
+
+        std::size_t
+        suites() const;
+
         void
         inc_keep_alive_count();
 
@@ -192,6 +198,15 @@ public:
 
     bool
     any_failed() const;
+
+    std::size_t
+    tests() const;
+
+    std::size_t
+    suites() const;
+
+    void
+    add_failures(std::size_t failures);
 };
 
 }  // namespace detail
@@ -220,6 +235,15 @@ public:
 
     bool
     any_failed() const;
+
+    std::size_t
+    tests() const;
+
+    std::size_t
+    suites() const;
+
+    void
+    add_failures(std::size_t failures);
 };
 
 //------------------------------------------------------------------------------
@@ -248,6 +272,15 @@ public:
 
     multi_runner_child(std::size_t num_jobs, bool quiet, bool print_log);
     ~multi_runner_child();
+
+    std::size_t
+    tests() const;
+
+    std::size_t
+    suites() const;
+
+    void
+    add_failures(std::size_t failures);
 
     template <class Pred>
     bool


### PR DESCRIPTION
## High Level Overview of Change

* Jobs with no unit tests are counted as failures. Resolves #3474
* Crashed processes are counted as failures. Resolves #3600
* Any tests specified on the command line test do not have matching
  suites are counted as failures.
* Remove unused CI manual test.

This is another "scratching an itch" PR that is the result of debugging / tracking down another problem, in this case, a test crash. In the process, Travis CI found an entry in manual unit test list that no longer exists.

### Context of Change

Enhances unit test code to improve reporting, and catch more "failure" situations. Other than removing a manual test, all changes were made to testing code, including the test running code in Main.cpp.

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3602)
<!-- Reviewable:end -->
