### PR TITLE
Improve handling of peers that aren't synced

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -489,6 +489,23 @@
 #       single host from consuming all inbound slots. If the value is not
 #       present the server will autoconfigure an appropriate limit.
 #
+#   max_unknown_time = <number>
+#
+#       The maximum amount of time, in seconds, that an outbound connection
+#       is allowed to stay in the "unknown" tracking state. This option can
+#       take any value between 300 and 1800 seconds, inclusive. If the option
+#       is not present the server will autoconfigure an appropriate limit.
+#
+#       The current default (which is subject to change) is 600 seconds.
+#
+#   max_diverged_time = <number>
+#
+#       The maximum amount of time, in seconds, that an outbound connection
+#       is allowed to stay in the "diverged" tracking state. The option can
+#       take any value between 60 and 900 seconds, inclusive. If the option
+#       is not present the server will autoconfigure an appropriate limit.
+#
+#       The current default (which is subject to change) is 300 seconds.
 #
 #
 # [transaction_queue] EXPERIMENTAL
@@ -590,13 +607,13 @@
 #
 #-------------------------------------------------------------------------------
 #
-# 3. Ripple Protocol
+# 3. Protocol
 #
 #-------------------
 #
 #   These settings affect the behavior of the server instance with respect
-#   to Ripple payment protocol level activities such as validating and
-#   closing ledgers or adjusting fees in response to server overloads.
+#   to protocol level activities such as validating and closing ledgers
+#   adjusting fees in response to server overloads.
 #
 #
 #
@@ -617,12 +634,6 @@
 #   Legal values are: "trusted" and "all". The default is "all".
 #
 #
-# [node_size]
-#
-#   Tunes the servers based on the expected load and available memory. Legal
-#   sizes are "tiny", "small", "medium", "large", and "huge". We recommend
-#   you start at the default and raise the setting if you have extra memory.
-#   The default is "tiny".
 #
 #
 #
@@ -1190,6 +1201,14 @@
 # 8. Misc Settings
 #
 #-----------------
+#
+# [node_size]
+#
+#   Tunes the servers based on the expected load and available memory. Legal
+#   sizes are "tiny", "small", "medium", "large", and "huge". We recommend
+#   you start at the default and raise the setting if you have extra memory.
+#   If no value is specified, the code assumes the proper size is "tiny". The
+#   default configuration file explicitly specifies "medium" as the size.
 #
 # [signing_support]
 #

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -755,7 +755,7 @@ Ledger::walkLedger(beast::Journal j) const
 }
 
 bool
-Ledger::assertSane(beast::Journal ledgerJ) const
+Ledger::assertSensible(beast::Journal ledgerJ) const
 {
     if (info_.hash.isNonZero() && info_.accountHash.isNonZero() && stateMap_ &&
         txMap_ && (info_.accountHash == stateMap_->getHash().as_uint256()) &&
@@ -769,7 +769,7 @@ Ledger::assertSane(beast::Journal ledgerJ) const
     j[jss::accountTreeHash] = to_string(info_.accountHash);
     j[jss::transTreeHash] = to_string(info_.txHash);
 
-    JLOG(ledgerJ.fatal()) << "ledger is not sane" << j;
+    JLOG(ledgerJ.fatal()) << "ledger is not sensible" << j;
 
     assert(false);
 

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -322,7 +322,7 @@ public:
     walkLedger(beast::Journal j) const;
 
     bool
-    assertSane(beast::Journal ledgerJ) const;
+    assertSensible(beast::Journal ledgerJ) const;
 
     void
     invariants() const;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -404,8 +404,8 @@ LedgerMaster::addHeldTransaction(
 }
 
 // Validate a ledger's close time and sequence number if we're considering
-// jumping to that ledger. This helps defend agains some rare hostile or
-// insane majority scenarios.
+// jumping to that ledger. This helps defend against some rare hostile or
+// diverged majority scenarios.
 bool
 LedgerMaster::canBeCurrent(std::shared_ptr<Ledger const> const& ledger)
 {
@@ -964,9 +964,9 @@ LedgerMaster::checkAccept(uint256 const& hash, std::uint32_t seq)
     {
         if ((seq != 0) && (getValidLedgerIndex() == 0))
         {
-            // Set peers sane early if we can
+            // Set peers converged early if we can
             if (valCount >= app_.validators().quorum())
-                app_.overlay().checkSanity(seq);
+                app_.overlay().checkTracking(seq);
         }
 
         // FIXME: We may not want to fetch a ledger with just one

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -2041,9 +2041,9 @@ ApplicationImp::loadOldLedger(
             return false;
         }
 
-        if (!loadLedger->assertSane(journal("Ledger")))
+        if (!loadLedger->assertSensible(journal("Ledger")))
         {
-            JLOG(m_journal.fatal()) << "Ledger is not sane.";
+            JLOG(m_journal.fatal()) << "Ledger is not sensible.";
             assert(false);
             return false;
         }

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -197,6 +197,12 @@ public:
 
     std::string SERVER_DOMAIN;
 
+    // How long can a peer remain in the "unknown" state
+    std::chrono::seconds MAX_UNKNOWN_TIME{600};
+
+    // How long can a peer remain in the "diverged" state
+    std::chrono::seconds MAX_DIVERGED_TIME{300};
+
 public:
     Config() : j_{beast::Journal::getNullSink()}
     {

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -66,6 +66,7 @@ struct ConfigSection
 #define SECTION_NETWORK_QUORUM "network_quorum"
 #define SECTION_NODE_SEED "node_seed"
 #define SECTION_NODE_SIZE "node_size"
+#define SECTION_OVERLAY "overlay"
 #define SECTION_PATH_SEARCH_OLD "path_search_old"
 #define SECTION_PATH_SEARCH "path_search"
 #define SECTION_PATH_SEARCH_FAST "path_search_fast"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -425,8 +425,7 @@ Config::loadFromString(std::string const& fileContents)
 
     if (exists(SECTION_VALIDATION_SEED) && exists(SECTION_VALIDATOR_TOKEN))
         Throw<std::runtime_error>("Cannot have both [" SECTION_VALIDATION_SEED
-                                  "] "
-                                  "and [" SECTION_VALIDATOR_TOKEN
+                                  "] and [" SECTION_VALIDATOR_TOKEN
                                   "] config sections");
 
     if (getSingleSection(secConfig, SECTION_NETWORK_QUORUM, strTemp, j_))
@@ -508,6 +507,51 @@ Config::loadFromString(std::string const& fileContents)
         }
 
         SERVER_DOMAIN = strTemp;
+    }
+
+    if (exists(SECTION_OVERLAY))
+    {
+        auto const sec = section(SECTION_OVERLAY);
+
+        using namespace std::chrono;
+
+        try
+        {
+            if (auto val = sec.get<std::string>("max_unknown_time"))
+                MAX_UNKNOWN_TIME =
+                    seconds{beast::lexicalCastThrow<std::uint32_t>(*val)};
+        }
+        catch (...)
+        {
+            Throw<std::runtime_error>(
+                "Invalid value 'max_unknown_time' in " SECTION_OVERLAY
+                ": must be of the form '<number>' representing seconds.");
+        }
+
+        if (MAX_UNKNOWN_TIME < seconds{300} || MAX_UNKNOWN_TIME > seconds{1800})
+            Throw<std::runtime_error>(
+                "Invalid value 'max_unknown_time' in " SECTION_OVERLAY
+                ": the time must be between 300 and 1800 seconds, inclusive.");
+
+        try
+        {
+            if (auto val = sec.get<std::string>("max_diverged_time"))
+                MAX_DIVERGED_TIME =
+                    seconds{beast::lexicalCastThrow<std::uint32_t>(*val)};
+        }
+        catch (...)
+        {
+            Throw<std::runtime_error>(
+                "Invalid value 'max_diverged_time' in " SECTION_OVERLAY
+                ": must be of the form '<number>' representing seconds.");
+        }
+
+        if (MAX_DIVERGED_TIME < seconds{60} || MAX_DIVERGED_TIME > seconds{900})
+        {
+            Throw<std::runtime_error>(
+                "Invalid value 'max_diverged_time' in " SECTION_OVERLAY
+                ": the time must be between 60 and 900 seconds, inclusive.");
+        }
     }
 
     if (getSingleSection(

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -126,11 +126,6 @@ public:
     virtual void
     checkTracking(std::uint32_t index) = 0;
 
-    /** Calls the check function on each peer
-     */
-    virtual void
-    check() = 0;
-
     /** Returns the peer with the matching short id, or null. */
     virtual std::shared_ptr<Peer>
     findPeerByShortID(Peer::id_t const& id) const = 0;

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -120,11 +120,11 @@ public:
     virtual PeerSequence
     getActivePeers() const = 0;
 
-    /** Calls the checkSanity function on each peer
-        @param index the value to pass to the peer's checkSanity function
+    /** Calls the checkTracking function on each peer
+        @param index the value to pass to the peer's checkTracking function
     */
     virtual void
-    checkSanity(std::uint32_t index) = 0;
+    checkTracking(std::uint32_t index) = 0;
 
     /** Calls the check function on each peer
      */

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -1207,10 +1207,10 @@ OverlayImpl::getActivePeers() const
 }
 
 void
-OverlayImpl::checkSanity(std::uint32_t index)
+OverlayImpl::checkTracking(std::uint32_t index)
 {
     for_each(
-        [index](std::shared_ptr<PeerImp>&& sp) { sp->checkSanity(index); });
+        [index](std::shared_ptr<PeerImp>&& sp) { sp->checkTracking(index); });
 }
 
 void

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -100,9 +100,6 @@ OverlayImpl::Timer::on_timer(error_code ec)
     overlay_.sendEndpoints();
     overlay_.autoConnect();
 
-    if ((++overlay_.timer_count_ % Tuning::checkSeconds) == 0)
-        overlay_.check();
-
     if ((overlay_.timer_count_ % Tuning::checkIdlePeers) == 0)
         overlay_.deleteIdlePeers();
 
@@ -1211,12 +1208,6 @@ OverlayImpl::checkTracking(std::uint32_t index)
 {
     for_each(
         [index](std::shared_ptr<PeerImp>&& sp) { sp->checkTracking(index); });
-}
-
-void
-OverlayImpl::check()
-{
-    for_each([](std::shared_ptr<PeerImp>&& sp) { sp->check(); });
 }
 
 std::shared_ptr<Peer>

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -195,7 +195,7 @@ public:
     void
     check() override;
 
-    void checkSanity(std::uint32_t) override;
+    void checkTracking(std::uint32_t) override;
 
     std::shared_ptr<Peer>
     findPeerByShortID(Peer::id_t const& id) const override;

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -192,9 +192,6 @@ public:
     PeerSequence
     getActivePeers() const override;
 
-    void
-    check() override;
-
     void checkTracking(std::uint32_t) override;
 
     std::shared_ptr<Peer>

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -90,7 +90,7 @@ private:
     // These are up here to prevent warnings about order of initializations
     //
     OverlayImpl& overlay_;
-    bool const m_inbound;
+    bool const inbound_;
 
     // Protocol version to use for this link
     ProtocolVersion protocol_;
@@ -144,9 +144,6 @@ private:
     //
     // o name_
     // o last_status_
-    // o lastPingSeq_
-    // o lastPingTime_
-    // o no_ping_
     //
     // June 2019
 
@@ -163,7 +160,6 @@ private:
     std::queue<std::shared_ptr<Message>> send_queue_;
     bool gracefulClose_ = false;
     int large_sendq_ = 0;
-    int no_ping_ = 0;
     std::unique_ptr<LoadEvent> load_event_;
     // The highest sequence of each PublisherList that has
     // been sent to or received from this peer.
@@ -593,11 +589,12 @@ PeerImp::PeerImp(
     , timer_(waitable_timer{socket_.get_executor()})
     , remote_address_(slot->remote_endpoint())
     , overlay_(overlay)
-    , m_inbound(false)
+    , inbound_(false)
     , protocol_(protocol)
     , tracking_(Tracking::unknown)
     , trackingTime_(clock_type::now())
     , publicKey_(publicKey)
+    , lastPingTime_(clock_type::now())
     , creationTime_(clock_type::now())
     , usage_(usage)
     , fee_(Resource::feeLightPeer)

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -30,21 +30,13 @@ enum {
     /** Size of buffer used to read from the socket. */
     readBufferBytes = 4096,
 
-    /** How long a server can remain insane before we
-        disconnected it (if outbound) */
-    maxInsaneTime = 60,
-
-    /** How long a server can remain unknown before we
-        disconnect it (if outbound) */
-    maxUnknownTime = 300,
-
     /** How many ledgers off a server can be and we will
-        still consider it sane */
-    saneLedgerLimit = 24,
+        still consider it converged */
+    convergedLedgerLimit = 24,
 
     /** How many ledgers off a server has to be before we
-        consider it insane */
-    insaneLedgerLimit = 128,
+        consider it diverged */
+    divergedLedgerLimit = 128,
 
     /** The maximum number of ledger entries in a single
         reply */

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -42,18 +42,9 @@ enum {
         reply */
     maxReplyNodes = 8192,
 
-    /** How often we check connections (seconds) */
-    checkSeconds = 32,
-
-    /** How often we latency/sendq probe connections */
-    timerSeconds = 8,
-
     /** How many timer intervals a sendq has to stay large before we disconnect
      */
     sendqIntervals = 4,
-
-    /** How many timer intervals we can go without a ping reply */
-    noPing = 10,
 
     /** How many messages on a send queue before we refuse queries */
     dropSendQueue = 192,
@@ -67,9 +58,6 @@ enum {
     /** How often we check for idle peers (seconds) */
     checkIdlePeers = 4,
 };
-
-/** The threshold above which we treat a peer connection as high latency */
-std::chrono::milliseconds constexpr peerHighLatency{300};
 
 }  // namespace Tuning
 

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -459,7 +459,6 @@ JSS(role);                  // out: Ping.cpp
 JSS(rpc);
 JSS(rt_accounts);  // in: Subscribe, Unsubscribe
 JSS(running_duration_us);
-JSS(sanity);                    // out: PeerImp
 JSS(search_depth);              // in: RipplePathFind
 JSS(searched_all);              // out: Tx
 JSS(secret);                    // in: TransactionSign,
@@ -520,6 +519,7 @@ JSS(ticket_count);        // out: AccountInfo
 JSS(ticket_seq);          // in: LedgerEntry
 JSS(time);
 JSS(timeouts);                // out: InboundLedger
+JSS(track);                   // out: PeerImp
 JSS(traffic);                 // out: Overlay
 JSS(total);                   // out: counters
 JSS(totalCoins);              // out: LedgerToJson

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -707,7 +707,7 @@ struct Peer
 
     // Basic Sequence number router
     //   A message that will be flooded across the network is tagged with a
-    //   seqeuence number by the origin node in a BroadcastMesg. Receivers will
+    //   sequence number by the origin node in a BroadcastMesg. Receivers will
     //   ignore a message as stale if they've already processed a newer sequence
     //   number, or will process and potentially relay the message along.
     //


### PR DESCRIPTION
When evaluating the fitness and usefulness of an outbound peer, the code would incorrectly calculate the amount of time that the peer spent in a non-useful state.

This commit, if merged, corrects the calculation and makes the timeout values configurable by server operators.

Two new options are introduced in the 'overlay' stanza of the config file. The default values are:

```
[overlay]
max_unknown_time = 5 minutes
max_insane_time = 90 seconds
```