### PR TITLE
Shard download space fix

### DIFF
--- a/src/ripple/net/HTTPStream.h
+++ b/src/ripple/net/HTTPStream.h
@@ -38,24 +38,14 @@ public:
 
     virtual ~HTTPStream() = default;
 
-    template <class T>
-    static std::unique_ptr<HTTPStream>
-    makeUnique(
-        Config const& config,
-        boost::asio::io_service::strand& strand,
-        beast::Journal j)
-    {
-        return std::make_unique<T>(config, strand, j);
-    }
-
     [[nodiscard]] virtual boost::asio::ip::tcp::socket&
     getStream() = 0;
 
     [[nodiscard]] virtual bool
     connect(
         std::string& errorOut,
-        std::string const host,
-        std::string const port,
+        std::string const& host,
+        std::string const& port,
         boost::asio::yield_context& yield) = 0;
 
     virtual void
@@ -68,7 +58,13 @@ public:
     asyncRead(
         boost::beast::flat_buffer& buf,
         parser& p,
-        bool readSome,
+        boost::asio::yield_context& yield,
+        boost::system::error_code& ec) = 0;
+
+    virtual void
+    asyncReadSome(
+        boost::beast::flat_buffer& buf,
+        parser& p,
         boost::asio::yield_context& yield,
         boost::system::error_code& ec) = 0;
 };
@@ -89,8 +85,8 @@ public:
     bool
     connect(
         std::string& errorOut,
-        std::string const host,
-        std::string const port,
+        std::string const& host,
+        std::string const& port,
         boost::asio::yield_context& yield) override;
 
     void
@@ -103,7 +99,13 @@ public:
     asyncRead(
         boost::beast::flat_buffer& buf,
         parser& p,
-        bool readSome,
+        boost::asio::yield_context& yield,
+        boost::system::error_code& ec) override;
+
+    void
+    asyncReadSome(
+        boost::beast::flat_buffer& buf,
+        parser& p,
         boost::asio::yield_context& yield,
         boost::system::error_code& ec) override;
 
@@ -117,10 +119,7 @@ private:
 class RawStream : public HTTPStream
 {
 public:
-    RawStream(
-        Config const& config,
-        boost::asio::io_service::strand& strand,
-        beast::Journal j);
+    RawStream(boost::asio::io_service::strand& strand);
 
     virtual ~RawStream() = default;
 
@@ -130,8 +129,8 @@ public:
     bool
     connect(
         std::string& errorOut,
-        std::string const host,
-        std::string const port,
+        std::string const& host,
+        std::string const& port,
         boost::asio::yield_context& yield) override;
 
     void
@@ -144,7 +143,13 @@ public:
     asyncRead(
         boost::beast::flat_buffer& buf,
         parser& p,
-        bool readSome,
+        boost::asio::yield_context& yield,
+        boost::system::error_code& ec) override;
+
+    void
+    asyncReadSome(
+        boost::beast::flat_buffer& buf,
+        parser& p,
         boost::asio::yield_context& yield,
         boost::system::error_code& ec) override;
 

--- a/src/ripple/nodestore/DatabaseShard.h
+++ b/src/ripple/nodestore/DatabaseShard.h
@@ -78,13 +78,13 @@ public:
     virtual boost::optional<std::uint32_t>
     prepareLedger(std::uint32_t validLedgerSeq) = 0;
 
-    /** Prepare a shard index to be imported into the database
+    /** Prepare one or more shard indexes to be imported into the database
 
-        @param shardIndex Shard index to be prepared for import
-        @return true if shard index successfully prepared for import
+        @param shardIndexes Shard indexes to be prepared for import
+        @return true if all shard indexes successfully prepared for import
     */
     virtual bool
-    prepareShard(std::uint32_t shardIndex) = 0;
+    prepareShards(std::vector<std::uint32_t> const& shardIndexes) = 0;
 
     /** Remove a previously prepared shard index for import
 

--- a/src/ripple/nodestore/impl/DatabaseShardImp.h
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.h
@@ -55,7 +55,7 @@ public:
     prepareLedger(std::uint32_t validLedgerSeq) override;
 
     bool
-    prepareShard(std::uint32_t shardIndex) override;
+    prepareShards(std::vector<std::uint32_t> const& shardIndexes) override;
 
     void
     removePreShard(std::uint32_t shardIndex) override;

--- a/src/ripple/rpc/impl/ShardArchiveHandler.cpp
+++ b/src/ripple/rpc/impl/ShardArchiveHandler.cpp
@@ -247,9 +247,6 @@ ShardArchiveHandler::add(
     if (it != archives_.end())
         return url == it->second;
 
-    if (!app_.getShardStore()->prepareShard(shardIndex))
-        return false;
-
     archives_.emplace(shardIndex, std::move(url));
 
     return true;
@@ -274,6 +271,16 @@ ShardArchiveHandler::start()
         JLOG(j_.warn()) << "No archives to process";
         return false;
     }
+
+    std::vector<std::uint32_t> shardIndexes(archives_.size());
+    std::transform(
+        archives_.begin(),
+        archives_.end(),
+        shardIndexes.begin(),
+        [](auto const& entry) { return entry.first; });
+
+    if (!app_.getShardStore()->prepareShards(shardIndexes))
+        return false;
 
     try
     {

--- a/src/test/nodestore/DatabaseShard_test.cpp
+++ b/src/test/nodestore/DatabaseShard_test.cpp
@@ -647,9 +647,9 @@ class DatabaseShard_test : public TestBase
     }
 
     void
-    testPrepareShard(std::uint64_t const seedValue)
+    testPrepareShards(std::uint64_t const seedValue)
     {
-        testcase("Prepare shard");
+        testcase("Prepare shards");
 
         using namespace test::jtx;
 
@@ -675,7 +675,7 @@ class DatabaseShard_test : public TestBase
             }
             else
             {
-                db->prepareShard(n);
+                db->prepareShards({n});
                 bitMask |= 1ll << n;
             }
             BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
@@ -683,11 +683,11 @@ class DatabaseShard_test : public TestBase
 
         // test illegal cases
         // adding shards with too large number
-        db->prepareShard(0);
+        db->prepareShards({0});
         BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
-        db->prepareShard(nTestShards + 1);
+        db->prepareShards({nTestShards + 1});
         BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
-        db->prepareShard(nTestShards + 2);
+        db->prepareShards({nTestShards + 2});
         BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
 
         // create shards which are not prepared for import
@@ -753,7 +753,7 @@ class DatabaseShard_test : public TestBase
             if (!BEAST_EXPECT(data.makeLedgers(env)))
                 return;
 
-            db->prepareShard(1);
+            db->prepareShards({1});
             BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(2));
 
             using namespace boost::filesystem;
@@ -1338,7 +1338,7 @@ public:
         testCreateShard(seedValue);
         testReopenDatabase(seedValue + 10);
         testGetCompleteShards(seedValue + 20);
-        testPrepareShard(seedValue + 30);
+        testPrepareShards(seedValue + 30);
         testImportShard(seedValue + 40);
         testCorruptedDatabase(seedValue + 50);
         testIllegalFinalKey(seedValue + 60);


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

With this change, the `DatabaseShardImp` will confirm that sufficient space is available to store _all_ the shards queued for download, instead of confirming that each shard will fit without considering the additional space required by the others.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

This PR is stacked on two unmerged PRs. The relevant code starts with commit 6e1b74e.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ X] Bug fix (non-breaking change which fixes an issue)