### PR TITLE
Improve Windows and MacOS test performance in Travis CI:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -438,9 +438,7 @@ cache:
     - $CACHE_DIR
 
 before_install:
-  # NUM_PROCESSORS was restricted due to problems in parallel launch of
-  # unit tests on Mac platform
-  - if [ "$(uname)" = "Darwin" ] ; then export NUM_PROCESSORS=2; else export NUM_PROCESSORS=$(nproc); fi
+  - export NUM_PROCESSORS=$(nproc)
   - echo "NUM PROC is ${NUM_PROCESSORS}"
   - if [ "$(uname)" = "Linux" ] ; then docker pull ${DOCKER_IMAGE}; fi
   - if [ "${MATRIX_EVAL}" != "" ] ; then eval "${MATRIX_EVAL}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -438,7 +438,8 @@ cache:
     - $CACHE_DIR
 
 before_install:
-  # NUM_PROCESSORS was set to 1 due to problems in parallel launch of unit tests on Mac platform
+  # NUM_PROCESSORS was restricted due to problems in parallel launch of
+  # unit tests on Mac platform
   - if [ "$(uname)" = "Darwin" ] ; then export NUM_PROCESSORS=2; else export NUM_PROCESSORS=$(nproc); fi
   - echo "NUM PROC is ${NUM_PROCESSORS}"
   - if [ "$(uname)" = "Linux" ] ; then docker pull ${DOCKER_IMAGE}; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -390,8 +390,8 @@ matrix:
         - mkdir -p build.ms && cd build.ms
         - cmake -G Ninja ${CMAKE_EXTRA_ARGS} -DCMAKE_BUILD_TYPE=${BLD_CONFIG} ..
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose
-        # override num procs to force single unit test job
-        - export NUM_PROCESSORS=1
+        # override num procs to force fewer unit test jobs
+        - export NUM_PROCESSORS=2
         - travis_wait ${MAX_TIME_MIN} ./rippled.exe --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows-bld
       name: windows, release
@@ -404,8 +404,8 @@ matrix:
         - cmake -G "Visual Studio 15 2017 Win64" ${CMAKE_EXTRA_ARGS} ..
         - export DESTDIR=${PWD}/_installed_
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose --config ${BLD_CONFIG} --target install
-        # override num procs to force single unit test job
-        - export NUM_PROCESSORS=1
+        # override num procs to force fewer unit test jobs
+        - export NUM_PROCESSORS=2
         - >-
           travis_wait ${MAX_TIME_MIN} "./_installed_/Program Files/rippled/bin/rippled.exe" --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS}
     - <<: *windows-bld
@@ -439,7 +439,7 @@ cache:
 
 before_install:
   # NUM_PROCESSORS was set to 1 due to problems in parallel launch of unit tests on Mac platform
-  - if [ "$(uname)" = "Darwin" ] ; then export NUM_PROCESSORS=1; else export NUM_PROCESSORS=$(nproc); fi
+  - if [ "$(uname)" = "Darwin" ] ; then export NUM_PROCESSORS=2; else export NUM_PROCESSORS=$(nproc); fi
   - echo "NUM PROC is ${NUM_PROCESSORS}"
   - if [ "$(uname)" = "Linux" ] ; then docker pull ${DOCKER_IMAGE}; fi
   - if [ "${MATRIX_EVAL}" != "" ] ; then eval "${MATRIX_EVAL}"; fi


### PR DESCRIPTION
* Increases hard-coded number of parallel unit test processes for
  Windows and MacOS builds from 1 to 2.
* Reduces Travis job time to well under the timeout value of 1.5 hours.
* Continue using a hard-coded value rather than `nprocs` because higher
  values cause some jobs to run out of memory.

## High Level Overview of Change

Windows debug builds in Travis timeout more and more often, especially in personal branches. Prior to this change, the Windows and MacOS builds override the number of parallel test jobs (`--unittest-jobs`) to only use 1, instead of the number of available processors (`nproc`). This PR changes the override to 2 jobs, which decreases the job time enough to not time out, and have a decent amount of time left over. (Though we do need to put some work into decreasing our unit test run times, that's a separate issue.)

More than 2 test processes causes these same Windows debug jobs to have OOM issues and fail for that reason, so 2 "threads the needle" or is in the "Goldilocks zone" to keep everything working for now.

### Context of Change

Travis CI is resource limited, and has a maximum job time that Windows debug builds, especially in personal branches, frequently runs in to.

### Type of Change

- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

Compare
* https://travis-ci.com/github/ximinez/rippled/builds/183923361
which failed because two of the test jobs timed out after 1 hour 30 minutes and
* https://travis-ci.com/github/ximinez/rippled/builds/184732255
which succeeded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3610)
<!-- Reviewable:end -->
