### PR TITLE
Replaces peers_max with peers_in_max and peers_out_max configuration.

### DIFF
--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -148,8 +148,6 @@ public:
     // the new configuration. if peers_max is configured then peers_in_max and
     // peers_out_max are ignored.
     std::size_t PEERS_MAX = 0;
-    // is true if peers_max is configured
-    bool legacyPeersMax_ = false;
     std::size_t PEERS_OUT_MAX = 0;
     std::size_t PEERS_IN_MAX = 0;
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -142,7 +142,16 @@ public:
 
     // True to ask peers not to relay current IP.
     bool PEER_PRIVATE = false;
+    // peers_max is a legacy configuration, which is going to be replaced
+    // with individual inbound peers peers_in_max and outbound peers
+    // peers_out_max configuration. for now we support both the legacy and
+    // the new configuration. if peers_max is configured then peers_in_max and
+    // peers_out_max are ignored.
     std::size_t PEERS_MAX = 0;
+    // is true if peers_max is configured
+    bool legacyPeersMax_ = false;
+    std::size_t PEERS_OUT_MAX = 0;
+    std::size_t PEERS_IN_MAX = 0;
 
     std::chrono::seconds WEBSOCKET_PING_FREQ = std::chrono::minutes{5};
 

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -72,6 +72,8 @@ struct ConfigSection
 #define SECTION_PATH_SEARCH_MAX "path_search_max"
 #define SECTION_PEER_PRIVATE "peer_private"
 #define SECTION_PEERS_MAX "peers_max"
+#define SECTION_PEERS_IN_MAX "peers_in_max"
+#define SECTION_PEERS_OUT_MAX "peers_out_max"
 #define SECTION_REDUCE_RELAY "reduce_relay"
 #define SECTION_RELAY_PROPOSALS "relay_proposals"
 #define SECTION_RELAY_VALIDATIONS "relay_validations"

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -367,7 +367,7 @@ Config::loadFromString(std::string const& fileContents)
     }
     else
     {
-        std::optional<int> peers_in_max{};
+        std::optional<std::size_t> peers_in_max{};
         if (getSingleSection(secConfig, SECTION_PEERS_IN_MAX, strTemp, j_))
         {
             peers_in_max = beast::lexicalCastThrow<std::size_t>(strTemp);
@@ -377,7 +377,7 @@ Config::loadFromString(std::string const& fileContents)
                     "] section; the value must be less or equal than 1000");
         }
 
-        std::optional<int> peers_out_max{};
+        std::optional<std::size_t> peers_out_max{};
         if (getSingleSection(secConfig, SECTION_PEERS_OUT_MAX, strTemp, j_))
         {
             peers_out_max = beast::lexicalCastThrow<std::size_t>(strTemp);

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -364,7 +364,6 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_PEERS_MAX, strTemp, j_))
     {
         PEERS_MAX = beast::lexicalCastThrow<std::size_t>(strTemp);
-        legacyPeersMax_ = true;
     }
     else
     {
@@ -395,12 +394,8 @@ Config::loadFromString(std::string const& fileContents)
                                       "]"
                                       "and [" SECTION_PEERS_OUT_MAX
                                       "] must be configured");
-        // if none is configured then we assume the legacy path
-        if (!peers_in_max && !peers_out_max)
-        {
-            legacyPeersMax_ = true;
-        }
-        else
+
+        if (peers_in_max && peers_out_max)
         {
             PEERS_IN_MAX = *peers_in_max;
             PEERS_OUT_MAX = *peers_out_max;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -499,37 +499,11 @@ OverlayImpl::checkStopped()
 void
 OverlayImpl::onPrepare()
 {
-    PeerFinder::Config config;
-
-    if (app_.config().PEERS_MAX != 0)
-        config.maxPeers = app_.config().PEERS_MAX;
-
-    config.outPeers = config.calcOutPeers();
-
-    auto const port = serverHandler_.setup().overlay.port;
-
-    config.peerPrivate = app_.config().PEER_PRIVATE;
-
-    // Servers with peer privacy don't want to allow incoming connections
-    config.wantIncoming = (!config.peerPrivate) && (port != 0);
-
-    // This will cause servers configured as validators to request that
-    // peers they connect to never report their IP address. We set this
-    // after we set the 'wantIncoming' because we want a "soft" version
-    // of peer privacy unless the operator explicitly asks for it.
-    if (!app_.getValidationPublicKey().empty())
-        config.peerPrivate = true;
-
-    // if it's a private peer or we are running as standalone
-    // automatic connections would defeat the purpose.
-    config.autoConnect =
-        !app_.config().standalone() && !app_.config().PEER_PRIVATE;
-    config.listeningPort = port;
-    config.features = "";
-    config.ipLimit = setup_.ipLimit;
-
-    // Enforce business rules
-    config.applyTuning();
+    PeerFinder::Config config = PeerFinder::Config::makeConfig(
+        app_.config(),
+        serverHandler_.setup().overlay.port,
+        !app_.getValidationPublicKey().empty(),
+        setup_.ipLimit);
 
     m_peerFinder->setConfig(config);
 

--- a/src/ripple/peerfinder/PeerfinderManager.h
+++ b/src/ripple/peerfinder/PeerfinderManager.h
@@ -46,9 +46,6 @@ struct Config
     */
     int maxPeers;
 
-    /** Legacy config if peers_max is set. */
-    bool legacyConfig;
-
     /** The number of automatic outbound connections to maintain.
         Outbound connections are only maintained if autoConnect
         is `true`.

--- a/src/ripple/peerfinder/PeerfinderManager.h
+++ b/src/ripple/peerfinder/PeerfinderManager.h
@@ -22,6 +22,7 @@
 
 #include <ripple/beast/clock/abstract_clock.h>
 #include <ripple/beast/utility/PropertyStream.h>
+#include <ripple/core/Config.h>
 #include <ripple/core/Stoppable.h>
 #include <ripple/peerfinder/Slot.h>
 #include <boost/asio/ip/tcp.hpp>
@@ -45,17 +46,20 @@ struct Config
     */
     int maxPeers;
 
+    /** Legacy config if peers_max is set. */
+    bool legacyConfig;
+
     /** The number of automatic outbound connections to maintain.
         Outbound connections are only maintained if autoConnect
-        is `true`. The value can be fractional; The decision to round up
-        or down will be made using a per-process pseudorandom number and
-        a probability proportional to the fractional part.
-        Example:
-            If outPeers is 9.3, then 30% of nodes will maintain 9 outbound
-            connections, while 70% of nodes will maintain 10 outbound
-            connections.
+        is `true`.
     */
-    double outPeers;
+    int outPeers;
+
+    /** The number of automatic inbound connections to maintain.
+        Inbound connections are only maintained if wantIncoming
+        is `true`.
+    */
+    int inPeers;
 
     /** `true` if we want our IP address kept private. */
     bool peerPrivate = true;
@@ -81,7 +85,7 @@ struct Config
     Config();
 
     /** Returns a suitable value for outPeers according to the rules. */
-    double
+    std::size_t
     calcOutPeers() const;
 
     /** Adjusts the values so they follow the business rules. */
@@ -91,6 +95,20 @@ struct Config
     /** Write the configuration into a property stream */
     void
     onWrite(beast::PropertyStream::Map& map);
+
+    /** Make PeerFinder::Config from configuration parameters
+     * @param config server's configuration
+     * @param port server's listening port
+     * @param validationPublicKey true if validation public key is not empty
+     * @param ipLimit limit of incoming connections per IP
+     * @return PeerFinder::Config
+     */
+    static Config
+    makeConfig(
+        ripple::Config const& config,
+        std::uint16_t port,
+        bool validationPublicKey,
+        int ipLimit);
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/peerfinder/PeerfinderManager.h
+++ b/src/ripple/peerfinder/PeerfinderManager.h
@@ -44,19 +44,19 @@ struct Config
         This includes both inbound and outbound, but does not include
         fixed peers.
     */
-    int maxPeers;
+    std::size_t maxPeers;
 
     /** The number of automatic outbound connections to maintain.
         Outbound connections are only maintained if autoConnect
         is `true`.
     */
-    int outPeers;
+    std::size_t outPeers;
 
     /** The number of automatic inbound connections to maintain.
         Inbound connections are only maintained if wantIncoming
         is `true`.
     */
-    int inPeers;
+    std::size_t inPeers;
 
     /** `true` if we want our IP address kept private. */
     bool peerPrivate = true;

--- a/src/ripple/peerfinder/impl/Counts.h
+++ b/src/ripple/peerfinder/impl/Counts.h
@@ -48,8 +48,6 @@ public:
         , m_acceptCount(0)
         , m_closingCount(0)
     {
-        m_roundingThreshold =
-            std::generate_canonical<double, 10>(default_prng());
     }
 
     //--------------------------------------------------------------------------
@@ -136,28 +134,28 @@ public:
     void
     onConfig(Config const& config)
     {
-        // Calculate the number of outbound peers we want. If we dont want or
-        // can't accept incoming, this will simply be equal to maxPeers.
-        // Otherwise we calculate a fractional amount based on percentages and
-        // pseudo-randomly round up or down.
-        //
-        if (config.wantIncoming)
+        if (config.legacyConfig)
         {
-            // Round outPeers upwards using a Bernoulli distribution
-            m_out_max = std::floor(config.outPeers);
-            if (m_roundingThreshold < (config.outPeers - m_out_max))
-                ++m_out_max;
-        }
-        else
-        {
-            m_out_max = config.maxPeers;
-        }
+            // Calculate the number of outbound peers we want. If we dont want
+            // or can't accept incoming, this will simply be equal to maxPeers.
+            if (config.wantIncoming)
+                m_out_max = config.outPeers;
+            else
+                m_out_max = config.maxPeers;
 
-        // Calculate the largest number of inbound connections we could take.
-        if (config.maxPeers >= m_out_max)
-            m_in_max = config.maxPeers - m_out_max;
+            // Calculate the largest number of inbound connections we could
+            // take.
+            if (config.maxPeers >= m_out_max)
+                m_in_max = config.maxPeers - m_out_max;
+            else
+                m_in_max = 0;
+        }
         else
-            m_in_max = 0;
+        {
+            m_out_max = config.outPeers;
+            if (config.wantIncoming)
+                m_in_max = config.inPeers;
+        }
     }
 
     /** Returns the number of accepted connections that haven't handshaked. */
@@ -350,13 +348,6 @@ private:
 
     // Number of connections that are gracefully closing.
     int m_closingCount;
-
-    /** Fractional threshold below which we round down.
-        This is used to round the value of Config::outPeers up or down in
-        such a way that the network-wide average number of outgoing
-        connections approximates the recommended, fractional value.
-    */
-    double m_roundingThreshold;
 };
 
 }  // namespace PeerFinder

--- a/src/ripple/peerfinder/impl/Counts.h
+++ b/src/ripple/peerfinder/impl/Counts.h
@@ -134,28 +134,9 @@ public:
     void
     onConfig(Config const& config)
     {
-        if (config.legacyConfig)
-        {
-            // Calculate the number of outbound peers we want. If we dont want
-            // or can't accept incoming, this will simply be equal to maxPeers.
-            if (config.wantIncoming)
-                m_out_max = config.outPeers;
-            else
-                m_out_max = config.maxPeers;
-
-            // Calculate the largest number of inbound connections we could
-            // take.
-            if (config.maxPeers >= m_out_max)
-                m_in_max = config.maxPeers - m_out_max;
-            else
-                m_in_max = 0;
-        }
-        else
-        {
-            m_out_max = config.outPeers;
-            if (config.wantIncoming)
-                m_in_max = config.inPeers;
-        }
+        m_out_max = config.outPeers;
+        if (config.wantIncoming)
+            m_in_max = config.inPeers;
     }
 
     /** Returns the number of accepted connections that haven't handshaked. */

--- a/src/ripple/peerfinder/impl/PeerfinderConfig.cpp
+++ b/src/ripple/peerfinder/impl/PeerfinderConfig.cpp
@@ -25,7 +25,9 @@ namespace PeerFinder {
 
 Config::Config()
     : maxPeers(Tuning::defaultMaxPeers)
+    , legacyConfig(false)
     , outPeers(calcOutPeers())
+    , inPeers(0)
     , wantIncoming(true)
     , autoConnect(true)
     , listeningPort(0)
@@ -33,21 +35,28 @@ Config::Config()
 {
 }
 
-double
+std::size_t
 Config::calcOutPeers() const
 {
-    return std::max(
-        maxPeers * Tuning::outPercent * 0.01, double(Tuning::minOutCount));
+    return std::round(std::max(
+        maxPeers * Tuning::outPercent * 0.01, double(Tuning::minOutCount)));
 }
 
 void
 Config::applyTuning()
 {
-    if (maxPeers < Tuning::minOutCount)
-        maxPeers = Tuning::minOutCount;
-    outPeers = calcOutPeers();
+    if (legacyConfig)
+    {
+        if (maxPeers < Tuning::minOutCount)
+            maxPeers = Tuning::minOutCount;
+        outPeers = calcOutPeers();
 
-    auto const inPeers = maxPeers - outPeers;
+        inPeers = maxPeers - outPeers;
+    }
+    else
+    {
+        maxPeers = 0;
+    }
 
     if (ipLimit == 0)
     {
@@ -76,6 +85,54 @@ Config::onWrite(beast::PropertyStream::Map& map)
     map["port"] = listeningPort;
     map["features"] = features;
     map["ip_limit"] = ipLimit;
+}
+
+Config
+Config::makeConfig(
+    ripple::Config const& cfg,
+    std::uint16_t port,
+    bool validationPublicKey,
+    int ipLimit)
+{
+    PeerFinder::Config config;
+
+    config.legacyConfig = cfg.legacyPeersMax_;
+    if (config.legacyConfig)
+    {
+        if (cfg.PEERS_MAX != 0)
+            config.maxPeers = cfg.PEERS_MAX;
+
+        config.outPeers = config.calcOutPeers();
+    }
+    else
+    {
+        config.outPeers = cfg.PEERS_OUT_MAX;
+        config.inPeers = cfg.PEERS_IN_MAX;
+    }
+
+    config.peerPrivate = cfg.PEER_PRIVATE;
+
+    // Servers with peer privacy don't want to allow incoming connections
+    config.wantIncoming = (!config.peerPrivate) && (port != 0);
+
+    // This will cause servers configured as validators to request that
+    // peers they connect to never report their IP address. We set this
+    // after we set the 'wantIncoming' because we want a "soft" version
+    // of peer privacy unless the operator explicitly asks for it.
+    if (validationPublicKey)
+        config.peerPrivate = true;
+
+    // if it's a private peer or we are running as standalone
+    // automatic connections would defeat the purpose.
+    config.autoConnect = !cfg.standalone() && !cfg.PEER_PRIVATE;
+    config.listeningPort = port;
+    config.features = "";
+    config.ipLimit = ipLimit;
+
+    // Enforce business rules
+    config.applyTuning();
+
+    return config;
 }
 
 }  // namespace PeerFinder

--- a/src/ripple/peerfinder/impl/PeerfinderConfig.cpp
+++ b/src/ripple/peerfinder/impl/PeerfinderConfig.cpp
@@ -37,8 +37,9 @@ Config::Config()
 std::size_t
 Config::calcOutPeers() const
 {
-    return std::round(std::max(
-        maxPeers * Tuning::outPercent * 0.01, double(Tuning::minOutCount)));
+    return std::max(
+        (maxPeers * Tuning::outPercent + 50) / 100,
+        std::size_t(Tuning::minOutCount));
 }
 
 void
@@ -95,8 +96,6 @@ Config::makeConfig(
         if (config.maxPeers < Tuning::minOutCount)
             config.maxPeers = Tuning::minOutCount;
         config.outPeers = config.calcOutPeers();
-
-        config.inPeers = config.maxPeers - config.outPeers;
 
         // Calculate the number of outbound peers we want. If we dont want
         // or can't accept incoming, this will simply be equal to maxPeers.

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -251,6 +251,10 @@ public:
 100
 )rippleConfig");
         run(R"rippleConfig(
+[peers_out_max]
+100
+)rippleConfig");
+        run(R"rippleConfig(
 [peers_in_max]
 100
 [peers_out_max]

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -180,8 +180,8 @@ public:
             {
                 max = maxPeers.value();
                 toLoad += "[peers_max]\n" + std::to_string(max) + "\n" +
-                    "[peers_in_max]\n" + std::to_string(*maxIn) + "\n" +
-                    "[peers_out_max]\n" + std::to_string(*maxOut) + "\n";
+                    "[peers_in_max]\n" + std::to_string(maxIn.value_or(0)) + "\n" +
+                    "[peers_out_max]\n" + std::to_string(maxOut.value_or(0)) + "\n";
             }
             else if (maxIn && maxOut)
             {
@@ -191,9 +191,9 @@ public:
 
             c.loadFromString(toLoad);
             BEAST_EXPECT(
-                (c.legacyPeersMax_ && c.PEERS_MAX == max &&
+                (c.PEERS_MAX == max &&
                  c.PEERS_IN_MAX == 0 && c.PEERS_OUT_MAX == 0) ||
-                (!c.legacyPeersMax_ && c.PEERS_IN_MAX == *maxIn &&
+                (c.PEERS_IN_MAX == *maxIn &&
                  c.PEERS_OUT_MAX == *maxOut));
 
             Config config = Config::makeConfig(c, port, false, 0);
@@ -221,7 +221,7 @@ public:
         run("legacy max_peers 5", 5, 100, 10, 4000, 10, 0, 1);
         run("legacy max_peers 20", 20, 100, 10, 4000, 10, 10, 2);
         run("legacy max_peers 100", 100, 100, 10, 4000, 15, 85, 6);
-        run("legacy max_peers 20, private", 20, 100, 10, 0, 20, 0, 2);
+        run("legacy max_peers 20, private", 20, 100, 10, 0, 20, 0, 1);
 
         // test with max_in_peers and max_out_peers
         run("new in 100/out 10", {}, 100, 10, 4000, 10, 100, 6);
@@ -248,10 +248,6 @@ public:
         };
         run(R"rippleConfig(
 [peers_in_max]
-100
-)rippleConfig");
-        run(R"rippleConfig(
-[peers_out_max]
 100
 )rippleConfig");
         run(R"rippleConfig(

--- a/src/test/peerfinder/PeerFinder_test.cpp
+++ b/src/test/peerfinder/PeerFinder_test.cpp
@@ -180,8 +180,9 @@ public:
             {
                 max = maxPeers.value();
                 toLoad += "[peers_max]\n" + std::to_string(max) + "\n" +
-                    "[peers_in_max]\n" + std::to_string(maxIn.value_or(0)) + "\n" +
-                    "[peers_out_max]\n" + std::to_string(maxOut.value_or(0)) + "\n";
+                    "[peers_in_max]\n" + std::to_string(maxIn.value_or(0)) +
+                    "\n" + "[peers_out_max]\n" +
+                    std::to_string(maxOut.value_or(0)) + "\n";
             }
             else if (maxIn && maxOut)
             {
@@ -191,10 +192,9 @@ public:
 
             c.loadFromString(toLoad);
             BEAST_EXPECT(
-                (c.PEERS_MAX == max &&
-                 c.PEERS_IN_MAX == 0 && c.PEERS_OUT_MAX == 0) ||
-                (c.PEERS_IN_MAX == *maxIn &&
-                 c.PEERS_OUT_MAX == *maxOut));
+                (c.PEERS_MAX == max && c.PEERS_IN_MAX == 0 &&
+                 c.PEERS_OUT_MAX == 0) ||
+                (c.PEERS_IN_MAX == *maxIn && c.PEERS_OUT_MAX == *maxOut));
 
             Config config = Config::makeConfig(c, port, false, 0);
 


### PR DESCRIPTION
## High Level Overview of Change

Replaces peers_max maximum peer connections and outbound/inbound connections
calculation with a user configured individual outbound/inbound configuration.

### Context of Change

Replaces peers_max with individual inbound and
outbound configuration of peers_in_max and peers_out_max, which
makes the peer's configuration less confusing.
If peers_max is configured then outbound and inbound connections 
are derived as prior to this change. If no configuration is set
then the legacy path is assumed; i.e. peers_max. Otherwise the new
configuration is used. Config::outPeers is no longer
adjusted up or down.

### Type of Change

- [ x] New feature (non-breaking change which adds functionality)

## Test Plan

Added unit-tests to PeerFinder tests to verify valid configuration settings.
