### PR TITLE
Persist API-configured voting settings

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1360,6 +1360,7 @@ ApplicationImp::setup()
         Section enabledAmendments = config_->section(SECTION_AMENDMENTS);
 
         m_amendmentTable = make_AmendmentTable(
+            *this,
             config().AMENDMENT_MAJORITY_TIME,
             supportedAmendments,
             enabledAmendments,

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -164,6 +164,7 @@ public:
 
 std::unique_ptr<AmendmentTable>
 make_AmendmentTable(
+    Application& app,
     std::chrono::seconds majorityTime,
     Section const& supported,
     Section const& enabled,

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -421,7 +421,12 @@ AmendmentTableImpl::AmendmentTableImpl(
     st.execute();
     while (st.fetch())
     {
-        uint256 amend_hash = from_hex_text<uint256>(*amendment_hash);
+        uint256 amend_hash;
+        if (!amend_hash.parseHex(*amendment_hash))
+        {
+            Throw<std::runtime_error>(
+                "Invalid amendment ID '" + *amendment_hash + " in wallet.db");
+        }
         if (*vote_to_veto)
         {
             // Unknown amendments are effectively vetoed already

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -398,9 +398,9 @@ AmendmentTableImpl::AmendmentTableImpl(
             else
             {
                 JLOG(j_.warn())
-                    << "[veto_amendments] section in config has ammendment "
-                    << a.first
-                    << " both [veto_amendments] and [amendments].";
+                    << "[veto_amendments] section in config has amendment "
+                    << '(' << a.first << ", " << a.second
+                    << ") both [veto_amendments] and [amendments].";
             }
         }
     }

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -313,33 +313,28 @@ public:
         test::jtx::Env env{*this, makeConfig()};
         std::unique_ptr<AmendmentTable> table = makeTable(env, weeks(2));
 
-        // Note which entries are pre-enabled.
+        // Note which entries are enabled.
         std::set<uint256> allEnabled;
-        for (std::string const& a : enabled_)
-            allEnabled.insert(amendmentId(a));
 
-        // Subset of amendments to late-enable
-        std::set<uint256> lateEnabled;
-        lateEnabled.insert(amendmentId(supported_[0]));
-        lateEnabled.insert(amendmentId(enabled_[0]));
-        lateEnabled.insert(amendmentId(vetoed_[0]));
+        // Subset of amendments to enable
+        allEnabled.insert(amendmentId(supported_[0]));
+        allEnabled.insert(amendmentId(enabled_[0]));
+        allEnabled.insert(amendmentId(vetoed_[0]));
 
-        // Do the late enabling.
-        for (uint256 const& a : lateEnabled)
+        for (uint256 const& a : allEnabled)
             table->enable(a);
 
         // So far all enabled amendments are supported.
         BEAST_EXPECT(!table->hasUnsupportedEnabled());
 
-        // Verify all pre- and late-enables are enabled and nothing else.
-        //         allEnabled.insert(lateEnabled.begin(), lateEnabled.end());
-        //         for (std::string const& a : supported_)
-        //         {
-        //             uint256 const supportedID = amendmentId(a);
-        //             BEAST_EXPECT(
-        //                 table->isEnabled(supportedID) ==
-        //                 (allEnabled.find(supportedID) != allEnabled.end()));
-        //         }
+        // Verify all enables are enabled and nothing else.
+        for (std::string const& a : supported_)
+        {
+            uint256 const supportedID = amendmentId(a);
+            BEAST_EXPECT(
+                table->isEnabled(supportedID) ==
+                (allEnabled.find(supportedID) != allEnabled.end()));
+        }
 
         // All supported and unVetoed amendments should be returned as desired.
         {

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -332,14 +332,14 @@ public:
         BEAST_EXPECT(!table->hasUnsupportedEnabled());
 
         // Verify all pre- and late-enables are enabled and nothing else.
-//         allEnabled.insert(lateEnabled.begin(), lateEnabled.end());
-//         for (std::string const& a : supported_)
-//         {
-//             uint256 const supportedID = amendmentId(a);
-//             BEAST_EXPECT(
-//                 table->isEnabled(supportedID) ==
-//                 (allEnabled.find(supportedID) != allEnabled.end()));
-//         }
+        //         allEnabled.insert(lateEnabled.begin(), lateEnabled.end());
+        //         for (std::string const& a : supported_)
+        //         {
+        //             uint256 const supportedID = amendmentId(a);
+        //             BEAST_EXPECT(
+        //                 table->isEnabled(supportedID) ==
+        //                 (allEnabled.find(supportedID) != allEnabled.end()));
+        //         }
 
         // All supported and unVetoed amendments should be returned as desired.
         {

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -112,25 +112,23 @@ public:
     makeTable(
         Application& app,
         std::chrono::seconds majorityTime,
-        Section const supported,
-        Section const enabled,
-        Section const vetoed)
+        Section const& supported,
+        Section const& enabled,
+        Section const& vetoed)
     {
-        auto t = make_AmendmentTable(
+        return make_AmendmentTable(
             app, majorityTime, supported, enabled, vetoed, journal);
-        return t;
     }
 
     std::unique_ptr<AmendmentTable>
     makeTable(
         test::jtx::Env& env,
         std::chrono::seconds majorityTime,
-        Section const supported,
-        Section const enabled,
-        Section const vetoed)
+        Section const& supported,
+        Section const& enabled,
+        Section const& vetoed)
     {
-        return make_AmendmentTable(
-            env.app(), majorityTime, supported, enabled, vetoed, journal);
+        return makeTable(env.app(), majorityTime, supported, enabled, vetoed);
     }
 
     std::unique_ptr<AmendmentTable>

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -159,7 +159,6 @@ public:
         for (auto const& a : enabled_)
         {
             BEAST_EXPECT(table->isSupported(amendmentId(a)));
-            BEAST_EXPECT(table->isEnabled(amendmentId(a)));
         }
 
         for (auto const& a : vetoed_)
@@ -333,14 +332,14 @@ public:
         BEAST_EXPECT(!table->hasUnsupportedEnabled());
 
         // Verify all pre- and late-enables are enabled and nothing else.
-        allEnabled.insert(lateEnabled.begin(), lateEnabled.end());
-        for (std::string const& a : supported_)
-        {
-            uint256 const supportedID = amendmentId(a);
-            BEAST_EXPECT(
-                table->isEnabled(supportedID) ==
-                (allEnabled.find(supportedID) != allEnabled.end()));
-        }
+//         allEnabled.insert(lateEnabled.begin(), lateEnabled.end());
+//         for (std::string const& a : supported_)
+//         {
+//             uint256 const supportedID = amendmentId(a);
+//             BEAST_EXPECT(
+//                 table->isEnabled(supportedID) ==
+//                 (allEnabled.find(supportedID) != allEnabled.end()));
+//         }
 
         // All supported and unVetoed amendments should be returned as desired.
         {


### PR DESCRIPTION
Fixes #3366

## High Level Overview of Change

This change follows the procedure outlined by @nbougalis in #3366 

1. On startup, parse the configuration file.
2. If the [veto_amendments] or [amendments] section is present, check if the FeatureVotes table is present in wallet.db.
3. If it is not, create the FeatureVotes table and transfer the settings from the config file.
4. Proceed normally but only reference the FeatureVotes table instead of the config file.
5. Warns if the voting table already exists in wallet.db and there exists voting sections in the config file.  The config file is ignored in this case.

### Context of Change

See #3366 for further discussion on the design of this feature.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates are still needed.

