### PR TITLE
Temper excessive warnings about historical shard

### DIFF
--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -1579,7 +1579,7 @@ DatabaseShardImp::shardBoundaryIndex() const
     auto const validIndex = app_.getLedgerMaster().getValidLedgerIndex();
 
     if (validIndex < earliestLedgerSeq())
-        return validIndex;
+        return 0;
 
     // Shards with an index earlier than the recent shard boundary index
     // are considered historical. The three shards at or later than

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -891,6 +891,9 @@ DatabaseShardImp::import(Database& source)
                             true,
                             boost::none);
                         success = true;
+
+                        if (shardIndex < shardBoundaryIndex())
+                            ++numHistShards;
                     }
                     catch (std::exception const& e)
                     {
@@ -1409,10 +1412,20 @@ DatabaseShardImp::setFileStats()
     fdRequired_ = sumFd;
     avgShardFileSz_ = (numShards == 0 ? fileSz_ : fileSz_ / numShards);
 
+    if (!canAdd_)
+        return;
+
     if (auto const count = numHistoricalShards(lock);
         count >= maxHistoricalShards_)
     {
-        JLOG(j_.warn()) << "maximum number of historical shards reached";
+        if (maxHistoricalShards_)
+        {
+            // In order to avoid excessive output, don't produce
+            // this warning if the server isn't configured to
+            // store historical shards.
+            JLOG(j_.warn()) << "maximum number of historical shards reached";
+        }
+
         canAdd_ = false;
     }
     else if (!sufficientStorage(
@@ -1422,6 +1435,8 @@ DatabaseShardImp::setFileStats()
     {
         JLOG(j_.warn())
             << "maximum shard store size exceeds available storage space";
+
+        canAdd_ = false;
     }
 }
 
@@ -1561,14 +1576,17 @@ DatabaseShardImp::removeFailedShard(std::shared_ptr<Shard>& shard)
 std::uint32_t
 DatabaseShardImp::shardBoundaryIndex() const
 {
+    auto const validIndex = app_.getLedgerMaster().getValidLedgerIndex();
+
+    if (validIndex < earliestLedgerSeq())
+        return validIndex;
+
     // Shards with an index earlier than the recent shard boundary index
     // are considered historical. The three shards at or later than
     // this index consist of the two most recently validated shards
     // and the shard still in the process of being built by live
     // transactions.
-    return NodeStore::seqToShardIndex(
-               app_.getLedgerMaster().getValidLedgerIndex(), ledgersPerShard_) -
-        1;
+    return seqToShardIndex(validIndex) - 1;
 }
 
 std::uint32_t


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

When a node already has historical shards stored, but is subsequently configured to not store historical shards, the shard database produces excessive warnings about the historical shard limit being exceeded. This PR fixes this issue, and also replaces several calls to a `Nodestore` function with roughly equivalent calls to a `DatabaseShardImp` function.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] Refactor (non-breaking change that only restructures code)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
