### PR TITLE
Fix inbound peer's compression enabled flag, fixes 3624

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -91,8 +91,9 @@ PeerImp::PeerImp(
     , request_(std::move(request))
     , headers_(request_)
     , compressionEnabled_(
-          headers_["X-Offer-Compression"] == "lz4" ? Compressed::On
-                                                   : Compressed::Off)
+          headers_["X-Offer-Compression"] == "lz4" && app_.config().COMPRESSION
+              ? Compressed::On
+              : Compressed::Off)
 {
 }
 


### PR DESCRIPTION
## High Level Overview of Change

Add compression configuration enable flag check when enabling compression flag for an inbound peer.

### Context of Change

The bug was introduced when compression was implemented. It's part of the new compression code.

### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)

Current code checks if a http request header includes compression header when enabling `PeerImp::compressionEnabled_`. If the request contains a valid http request `X-Offer-Compression: lz4` then the `compressionEnabled_` flag for the peer is enabled. This is not correct because the server might not have the compression enabled. In which case the `compressionEnabled_` should be disabled. To fix this, check compression configuration setting - `app_.config().COMPRESSION` in addition to the http request check.
