### PR TITLE
Always check the sequence when adding to the transaction queue

### DIFF
--- a/src/ripple/app/tx/applySteps.h
+++ b/src/ripple/app/tx/applySteps.h
@@ -284,29 +284,6 @@ preclaim(
     Application& app,
     OpenView const& view);
 
-// There are two special entry points that are only intended for use by the
-// TxQ.  To help enforce that this class contains the two functions as
-// static members.
-class ForTxQ
-{
-private:
-    friend TxQ;
-
-    // This entry point runs all of the preclaim checks with the lone exception
-    // of verifying Sequence or Ticket validity.  This allows the TxQ to
-    // perform its own similar checks without needing to construct a bogus view.
-    static PreclaimResult
-    preclaimWithoutSeqCheck(
-        PreflightResult const& preflightResult,
-        Application& app,
-        OpenView const& view);
-
-    // Checks the sequence number explicitly.  Used by the TxQ in the case
-    // where the preclaim sequence number check was skipped earlier.
-    static TER
-    seqCheck(OpenView& view, STTx const& tx, beast::Journal j);
-};
-
 /** Compute only the expected base fee for a transaction.
 
     Base fees are transaction specific, so any calculation

--- a/src/ripple/app/tx/impl/CancelOffer.cpp
+++ b/src/ripple/app/tx/impl/CancelOffer.cpp
@@ -40,8 +40,7 @@ CancelOffer::preflight(PreflightContext const& ctx)
         return temINVALID_FLAG;
     }
 
-    auto const seq = ctx.tx.getFieldU32(sfOfferSequence);
-    if (!seq)
+    if (!ctx.tx[sfOfferSequence])
     {
         JLOG(ctx.j.trace()) << "CancelOffer::preflight: missing sequence";
         return temBAD_SEQUENCE;

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -75,9 +75,8 @@ CreateOffer::preflight(PreflightContext const& ctx)
         return temBAD_EXPIRATION;
     }
 
-    bool const bHaveCancel(tx.isFieldPresent(sfOfferSequence));
-
-    if (bHaveCancel && (tx.getFieldU32(sfOfferSequence) == 0))
+    if (auto const cancelSequence = tx[~sfOfferSequence];
+        cancelSequence && *cancelSequence == 0)
     {
         JLOG(j.debug()) << "Malformed offer: bad cancel sequence";
         return temBAD_SEQUENCE;

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -247,7 +247,7 @@ Transactor::checkSeqProxy(
     {
         JLOG(j.trace())
             << "applyTransaction: delay: source account does not exist "
-            << toBase58(tx.getAccountID(sfAccount));
+            << toBase58(id);
         return terNO_ACCOUNT;
     }
 
@@ -305,7 +305,7 @@ Transactor::checkPriorTxAndLastLedger(PreclaimContext const& ctx)
     {
         JLOG(ctx.j.trace())
             << "applyTransaction: delay: source account does not exist "
-            << toBase58(ctx.tx.getAccountID(sfAccount));
+            << toBase58(id);
         return terNO_ACCOUNT;
     }
 

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -477,31 +477,35 @@ public:
     const STArray&
     getFieldArray(SField const& field) const;
 
-    /** Return the value of a field.
-
-        Throws:
-
-            STObject::FieldErr if the field is
-            not present.
+    /** Get the value of a field.
+        @param A TypedField built from an SField value representing the desired
+            object field. In typical use, the TypedField will be implicitly
+            constructed.
+        @return The value of the specified field.
+        @throws STObject::FieldErr if the field is not present.
     */
     template <class T>
     typename T::value_type
     operator[](TypedField<T> const& f) const;
 
-    /** Return the value of a field as boost::optional
+    /** Get the value of a field as boost::optional
 
-        @return boost::none if the field is not present.
+        @param An OptionaledField built from an SField value representing the
+           desired object field. In typical use, the OptionaledField will be
+           constructed by using the ~ operator on an SField.
+        @return boost::none if the field is not present, else the value of the
+           specified field.
     */
     template <class T>
     boost::optional<std::decay_t<typename T::value_type>>
     operator[](OptionaledField<T> const& of) const;
 
-    /** Return a modifiable field value.
-
-        Throws:
-
-            STObject::FieldErr if the field is
-            not present.
+    /** Get a modifiable field value.
+        @param A TypedField built from an SField value representing the desired
+            object field. In typical use, the TypedField will be implicitly
+            constructed.
+        @return A modifiable reference to the value of the specified field.
+        @throws STObject::FieldErr if the field is not present.
     */
     template <class T>
     ValueProxy<T>
@@ -509,12 +513,63 @@ public:
 
     /** Return a modifiable field value as boost::optional
 
-        The return value equals boost::none if the
-        field is not present.
+        @param An OptionaledField built from an SField value representing the
+            desired object field. In typical use, the OptionaledField will be
+            constructed by using the ~ operator on an SField.
+        @return Transparent proxy object to an `optional` holding a modifiable
+            reference to the value of the specified field. Returns boost::none
+            if the field is not present.
     */
     template <class T>
     OptionalProxy<T>
     operator[](OptionaledField<T> const& of);
+
+    /** Get the value of a field.
+        @param A TypedField built from an SField value representing the desired
+            object field. In typical use, the TypedField will be implicitly
+            constructed.
+        @return The value of the specified field.
+        @throws STObject::FieldErr if the field is not present.
+    */
+    template <class T>
+    typename T::value_type
+    at(TypedField<T> const& f) const;
+
+    /** Get the value of a field as boost::optional
+
+        @param An OptionaledField built from an SField value representing the
+           desired object field. In typical use, the OptionaledField will be
+           constructed by using the ~ operator on an SField.
+        @return boost::none if the field is not present, else the value of the
+           specified field.
+    */
+    template <class T>
+    boost::optional<std::decay_t<typename T::value_type>>
+    at(OptionaledField<T> const& of) const;
+
+    /** Get a modifiable field value.
+        @param A TypedField built from an SField value representing the desired
+            object field. In typical use, the TypedField will be implicitly
+            constructed.
+        @return A modifiable reference to the value of the specified field.
+        @throws STObject::FieldErr if the field is not present.
+    */
+    template <class T>
+    ValueProxy<T>
+    at(TypedField<T> const& f);
+
+    /** Return a modifiable field value as boost::optional
+
+        @param An OptionaledField built from an SField value representing the
+            desired object field. In typical use, the OptionaledField will be
+            constructed by using the ~ operator on an SField.
+        @return Transparent proxy object to an `optional` holding a modifiable
+            reference to the value of the specified field. Returns boost::none
+            if the field is not present.
+    */
+    template <class T>
+    OptionalProxy<T>
+    at(OptionaledField<T> const& of);
 
     /** Set a field.
         if the field already exists, it is replaced.
@@ -927,6 +982,34 @@ template <class T>
 typename T::value_type
 STObject::operator[](TypedField<T> const& f) const
 {
+    return at(f);
+}
+
+template <class T>
+boost::optional<std::decay_t<typename T::value_type>>
+STObject::operator[](OptionaledField<T> const& of) const
+{
+    return at(of);
+}
+
+template <class T>
+inline auto
+STObject::operator[](TypedField<T> const& f) -> ValueProxy<T>
+{
+    return at(f);
+}
+
+template <class T>
+inline auto
+STObject::operator[](OptionaledField<T> const& of) -> OptionalProxy<T>
+{
+    return at(of);
+}
+
+template <class T>
+typename T::value_type
+STObject::at(TypedField<T> const& f) const
+{
     auto const b = peekAtPField(f);
     if (!b)
         // This is a free object (no constraints)
@@ -951,7 +1034,7 @@ STObject::operator[](TypedField<T> const& f) const
 
 template <class T>
 boost::optional<std::decay_t<typename T::value_type>>
-STObject::operator[](OptionaledField<T> const& of) const
+STObject::at(OptionaledField<T> const& of) const
 {
     auto const b = peekAtPField(*of.f);
     if (!b)
@@ -971,14 +1054,14 @@ STObject::operator[](OptionaledField<T> const& of) const
 
 template <class T>
 inline auto
-STObject::operator[](TypedField<T> const& f) -> ValueProxy<T>
+STObject::at(TypedField<T> const& f) -> ValueProxy<T>
 {
     return ValueProxy<T>(this, &f);
 }
 
 template <class T>
 inline auto
-STObject::operator[](OptionaledField<T> const& of) -> OptionalProxy<T>
+STObject::at(OptionaledField<T> const& of) -> OptionalProxy<T>
 {
     return OptionalProxy<T>(this, of.f);
 }

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -164,8 +164,7 @@ transResults()
         MAKE_ERROR(terPRE_SEQ,                "Missing/inapplicable prior transaction."),
         MAKE_ERROR(terOWNERS,                 "Non-zero owner count."),
         MAKE_ERROR(terQUEUED,                 "Held until escalated fee drops."),
-        {terPRE_TICKET, {"terPRE_TICKET", "Ticket is not yet in ledger."}},
-
+        MAKE_ERROR(terPRE_TICKET,             "Ticket is not yet in ledger."),
         MAKE_ERROR(tesSUCCESS,                "The transaction was applied. Only final in a validated ledger."),
     };
     // clang-format on


### PR DESCRIPTION
## High Level Overview of Change

#3271 made a change to transaction processing in the Transaction Queue (`TxQ`) for transactions that are being considered for queuing, to validate the sequence/ticket on the `TxQ` side, and bypass the sequence check in the `Transactor`. Because the sequence didn't need to be checked, it was thought no longer necessary to "bump" the account's sequence number if there were multiple transactions queued, so that code was removed. Unfortunately, there are cases in `OfferCreate` and `OfferCancel` where the `OfferSequence` field is checked against the account sequence number. If the offer to be cancelled is in the queue, and the account sequence doesn't get bumped, then when the transaction is processed it will return `temBAD_SEQUENCE` from `preflight`. Worse, because that's a `tem` code, the transaction is cached as "bad" and won't be reconsidered unless the transaction is in a validated ledger (fortunately, no validators are currently running 1.7, so that's fine).

This PR accomplishes three separate things, left for now as three separate commits. When it's ready to be merged, we may want to squash them into a single commit, or only squash the first two (more on that below).
1. The first commit adds a unit test reproducing the problem. It also add a new engine result code `terTICKET`, which indicates that the transaction can't be processed until the ticket it refers to is consumed. No code outside of the test refers to this new code, so I think it's safe.
2. Is the actual fix. First, and most importantly, it changes the `TxQ` logic to go back to the old behavior of "bumping" the account's sequence number, and always checks the sequence in `preflight`. Second, it checks all transactions that refer to another transaction using its sequence number (including `OfferCreate`, `OfferCancel`, `EscrowFinish`, and `EscrowCancel`, but the check is generalized to all transactions that have the right fields) for an existing ticket in the ledger for that sequence. If a pending ticket is found, the new `terTICKET` result is returned. As long as this PR is included in 1.7 release, this does not need a new amendment because ticket functionality is new with 1.7 and without the `TicketBatch` amendment, tickets can not exist in the ledger. It also adds a `STObject::at()` which functions identically to `STObject::operator[]`, and splits the `TxQ` unit tests into two suites to improve speed.
3. This one is a little more optional. The original symptom of the problem was because `temBAD_SEQUENCE` was returned by `preclaim` based on data in the ledger. IMHO, that check can and should be done in `preflight` based just on the data in the transaction. This adds a new amendment `fixOfferSequence`. If the amendment is enabled and the `OfferSequence` is not smaller than the `Sequence`, `preflight` returns `temBAD_SEQUENCE`. This is the exact same behavior, only the check is sooner in the process. I only put it behind an amendment because they changed order may have some unexpected consequences (and it _did_ require updating a unit test). I still think it's useful because catching this malformation earlier will save time and resources.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

### Test the `temBAD_SEQUENCE` fix

With version 1.6.0 and the version that contains this PR.
1. Get enough transactions into the ledger to cause fee to escalate.
2. Submit several `OfferCreate` and `OfferCancel` transactions with low fees (e.g. 10 drops) in short order (before the ledger closes). Each transaction except the first should cancel the prior. The first must be an `OfferCreate`. The others can be some kind of mix.
3. Verify that all the transactions return `terQUEUED`.
4. Verify that all the transactions eventually make it into a validated ledger.

With a beta of 1.7 before this is merged, all of the transactions submitted after the first will return `temBAD_SEQUENCE`.

### Test `terTICKET`

1. Enable the "TicketBatch" amendment.
2. Create an arbitrary number of tickets using `TicketCreate`.
3. Submit an `OfferCreate`, `OfferCancel`, `EscrowFinish`, and/or `EscrowCancel` that use the sequence number of one of the just created tickets as the `OfferSequence`. For the escrow transactions, you can either use the same account in the `Owner` field, or even better, submit those from an account different than the one that created the tickets and use the ticket creator as `Owner`.
4. All of the transactions in step 2 should return `terTICKET`.
5. Submit _any_ kind of transaction to consume the tickets that the transactions from step 2 referred to. Some of them can be `EscrowCreate`, but that is not necessary.
6. Resubmit all of the transactions from step 2.
7. All of the offer-related transaction should succeed. The escrow-related transactions should only succeed if a corresponding escrow was created in step 4, otherwise, they should return `tecNO_TARGET`.

### Test `fixOfferSequence`

1. Without the amendment, submit an `OfferCreate` or `OfferCancel` where the `Sequence` field is smaller or equal to the `OfferSequence` field. Note that `OfferSequence` is optional in the `OfferCreate` transaction. It will return `temBAD_SEQUENCE`.
2. With the amendment, submit an `OfferCreate` or `OfferCancel` where the `Sequence` field is smaller or equal to the `OfferSequence` field. Note that `OfferSequence` is optional in the `OfferCreate` transaction. It will also return `temBAD_SEQUENCE`.

## Future Tasks

Only `preflight` should return `tem` engine results. It should not require referring to the ledger (except the `Rules` which is provided to `preflight`) to determine if a transaction is properly formed. Similar to the `NotTEC` type, consider a `NotTEM` type that is returned from `preclaim` and `doApply`. Once the `fixOfferSequence` is enabled, it should be safe to remove the check in `preflight` that first triggered this issue (or return a different result). Any other `tem` codes returned by `preclaim` or `doApply` will probably need similar amendments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3632)
<!-- Reviewable:end -->
