### PR TITLE
Fix ledger sequence on copynode

### DIFF
--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -302,8 +302,7 @@ SHAMapStoreImp::copyNode(
     SHAMapAbstractNode const& node)
 {
     // Copy a single record from node to dbRotating_
-    dbRotating_->fetchNodeObject(
-        node.getNodeHash().as_uint256(), node.getSeq());
+    dbRotating_->fetchNodeObject(node.getNodeHash().as_uint256());
     if (!(++nodeCount % checkHealthInterval_))
     {
         if (health())

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -211,7 +211,7 @@ private:
 
         for (auto const& key : cache.getKeys())
         {
-            dbRotating_->fetchNodeObject(key, 0);
+            dbRotating_->fetchNodeObject(key);
             if (!(++check % checkHealthInterval_) && health())
                 return true;
         }

--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -128,7 +128,7 @@ public:
     std::shared_ptr<NodeObject>
     fetchNodeObject(
         uint256 const& hash,
-        std::uint32_t ledgerSeq,
+        std::uint32_t ledgerSeq = 0,
         FetchType fetchType = FetchType::synchronous);
 
     /** Fetch an object without waiting.
@@ -139,7 +139,8 @@ public:
 
         @note This can be called concurrently.
         @param hash The key of the object to retrieve
-        @param ledgerSeq The sequence of the ledger where the object is stored.
+        @param ledgerSeq The sequence of the ledger where the
+                object is stored, used by the shard store.
         @param nodeObject The object retrieved
         @return Whether the operation completed
     */


### PR DESCRIPTION
## High Level Overview of Change

SHAMapStoreImp::copyNode is incorrectly passing the identifier
of node object where a ledger sequence is expected. 

### Context of Change

This bug was introduced with the first version of shards. Fortunately,
the parameter is ignored with the node store and the error did
not cause an adverse effect.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)