### PR TITLE
Prevent deadlock when notifying shard of ledger

### DIFF
--- a/src/ripple/app/main/DBInit.h
+++ b/src/ripple/app/main/DBInit.h
@@ -129,9 +129,9 @@ inline constexpr std::array<char const*, 1> AcquireShardDBInit{
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Pragma for Ledger and Transaction databases with complete shards
+// Pragma for Ledger and Transaction databases with final shards
 // These override the CommonDBPragma values defined above.
-inline constexpr std::array<char const*, 2> CompleteShardDBPragma{
+inline constexpr std::array<char const*, 2> FinalShardDBPragma{
     {"PRAGMA synchronous=OFF;", "PRAGMA journal_mode=OFF;"}};
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/ripple/nodestore/impl/Shard.h
+++ b/src/ripple/nodestore/impl/Shard.h
@@ -31,7 +31,6 @@
 #include <nudb/nudb.hpp>
 
 #include <atomic>
-#include <tuple>
 
 namespace ripple {
 namespace NodeStore {
@@ -253,6 +252,7 @@ private:
     Application& app_;
     beast::Journal const j_;
     mutable std::mutex mutex_;
+    mutable std::mutex storedMutex_;
 
     // Shard Index
     std::uint32_t const index_;
@@ -316,11 +316,8 @@ private:
     initSQLite(std::lock_guard<std::mutex> const&);
 
     // Write SQLite entries for this ledger
-    // Lock over mutex_ required
     [[nodiscard]] bool
-    storeSQLite(
-        std::shared_ptr<Ledger const> const& ledger,
-        std::lock_guard<std::mutex> const&);
+    storeSQLite(std::shared_ptr<Ledger const> const& ledger);
 
     // Set storage and file descriptor usage stats
     // Lock over mutex_ required


### PR DESCRIPTION
## High Level Overview of Change

This change is primarily about preventing a potential thread deadlock when notifying shards on ledger completions.

### Context of Change

Shards are notified by the inbound ledger process when pertaining ledgers have been acquired. Upon notification, the SQLite database is populated with ledger data. If the ledger data resides in the same shard, it is possible to encounter a deadlock when shard fetch calls are made while storing to the SQLite database.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change that only restructures code)
