### PR TITLE
Fix double counting unit test failures:

### DIFF
--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -297,6 +297,7 @@ runUnitTests(
                 boost::process::exe = exe_name, boost::process::args = args);
 
         int bad_child_exits = 0;
+        int terminated_child_exits = 0;
         for (auto& c : children)
         {
             try
@@ -309,10 +310,11 @@ runUnitTests(
             {
                 // wait throws if process was terminated with a signal
                 ++bad_child_exits;
+                ++terminated_child_exits;
             }
         }
 
-        parent_runner.add_failures(bad_child_exits);
+        parent_runner.add_failures(terminated_child_exits);
         anyMissing(parent_runner, multi_selector(pattern));
 
         if (parent_runner.any_failed() || bad_child_exits)


### PR DESCRIPTION

## High Level Overview of Change

Unit tests are counting test failures, process crashes, and process exit code
failures in the count. Since a failing tests causes the process exit code to
return failure, we get extra counts. This patch removes process exit code
failures from the count.


### Type of Change


- [ x] Bug fix (non-breaking change which fixes an issue)

