### PR TITLE
Correct handling of corner-cases involving custom iterators:

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -100,8 +100,9 @@ public:
     bool
     equal(base_type const& impl) const override
     {
-        auto const& other = dynamic_cast<sles_iter_impl const&>(impl);
-        return iter_ == other.iter_;
+        if (auto const p = dynamic_cast<sles_iter_impl const*>(&impl))
+            return iter_ == p->iter_;
+        return false;
     }
 
     void
@@ -148,8 +149,9 @@ public:
     bool
     equal(base_type const& impl) const override
     {
-        auto const& other = dynamic_cast<txs_iter_impl const&>(impl);
-        return iter_ == other.iter_;
+        if (auto const p = dynamic_cast<txs_iter_impl const*>(&impl))
+            return iter_ == p->iter_;
+        return false;
     }
 
     void

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -126,7 +126,7 @@ public:
     private:
         ReadView const* view_ = nullptr;
         std::unique_ptr<iter_base> impl_;
-        boost::optional<value_type> mutable cache_;
+        std::optional<value_type> mutable cache_;
     };
 
     static_assert(std::is_nothrow_move_constructible<iterator>{}, "");

--- a/src/ripple/ledger/detail/ReadViewFwdRange.ipp
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.ipp
@@ -52,11 +52,12 @@ auto
 ReadViewFwdRange<ValueType>::iterator::operator=(iterator const& other)
     -> iterator&
 {
-    if (this == &other)
-        return *this;
-    view_ = other.view_;
-    impl_ = other.impl_ ? other.impl_->copy() : nullptr;
-    cache_ = other.cache_;
+    if (this != &other)
+    {
+        view_ = other.view_;
+        impl_ = other.impl_ ? other.impl_->copy() : nullptr;
+        cache_ = other.cache_;
+    }
     return *this;
 }
 
@@ -65,9 +66,13 @@ auto
 ReadViewFwdRange<ValueType>::iterator::operator=(iterator&& other) noexcept
     -> iterator&
 {
-    view_ = other.view_;
-    impl_ = std::move(other.impl_);
-    cache_ = std::move(other.cache_);
+    if (this != &other)
+    {
+        view_ = other.view_;
+        impl_ = std::move(other.impl_);
+        cache_ = std::move(other.cache_);
+    }
+
     return *this;
 }
 
@@ -76,7 +81,11 @@ bool
 ReadViewFwdRange<ValueType>::iterator::operator==(iterator const& other) const
 {
     assert(view_ == other.view_);
-    return impl_->equal(*other.impl_);
+
+    if (impl_ != nullptr && other.impl_ != nullptr)
+        return impl_->equal(*other.impl_);
+
+    return impl_ == other.impl_;
 }
 
 template <class ValueType>
@@ -107,7 +116,7 @@ auto
 ReadViewFwdRange<ValueType>::iterator::operator++() -> iterator&
 {
     impl_->increment();
-    cache_ = boost::none;
+    cache_.reset();
     return *this;
 }
 

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -45,8 +45,9 @@ public:
     bool
     equal(base_type const& impl) const override
     {
-        auto const& other = dynamic_cast<txs_iter_impl const&>(impl);
-        return iter_ == other.iter_;
+        if (auto const p = dynamic_cast<txs_iter_impl const*>(&impl))
+            return iter_ == p->iter_;
+        return false;
     }
 
     void

--- a/src/ripple/ledger/impl/RawStateTable.cpp
+++ b/src/ripple/ledger/impl/RawStateTable.cpp
@@ -61,9 +61,13 @@ public:
     bool
     equal(base_type const& impl) const override
     {
-        auto const& other = dynamic_cast<sles_iter_impl const&>(impl);
-        assert(end1_ == other.end1_ && end0_ == other.end0_);
-        return iter1_ == other.iter1_ && iter0_ == other.iter0_;
+        if (auto const p = dynamic_cast<sles_iter_impl const*>(&impl))
+        {
+            assert(end1_ == p->end1_ && end0_ == p->end0_);
+            return iter1_ == p->iter1_ && iter0_ == p->iter0_;
+        }
+
+        return false;
     }
 
     void

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -589,8 +589,7 @@ private:
     friend class SHAMap;
 };
 
-inline SHAMap::const_iterator::const_iterator(SHAMap const* map)
-    : map_(map)
+inline SHAMap::const_iterator::const_iterator(SHAMap const* map) : map_(map)
 {
     assert(map_ != nullptr);
 

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -564,7 +564,10 @@ private:
     pointer item_ = nullptr;
 
 public:
-    const_iterator() = default;
+    const_iterator() = delete;
+    const_iterator(const_iterator const& other) = default;
+
+    ~const_iterator() = default;
 
     reference
     operator*() const;
@@ -578,7 +581,7 @@ public:
 
 private:
     explicit const_iterator(SHAMap const* map);
-    const_iterator(SHAMap const* map, pointer item);
+    const_iterator(SHAMap const* map, std::nullptr_t);
     const_iterator(SHAMap const* map, pointer item, SharedPtrNodeStack&& stack);
 
     friend bool
@@ -587,15 +590,16 @@ private:
 };
 
 inline SHAMap::const_iterator::const_iterator(SHAMap const* map)
-    : map_(map), item_(nullptr)
+    : map_(map)
 {
-    auto temp = map_->peekFirstItem(stack_);
-    if (temp)
+    assert(map_ != nullptr);
+
+    if (auto temp = map_->peekFirstItem(stack_))
         item_ = temp->peekItem().get();
 }
 
-inline SHAMap::const_iterator::const_iterator(SHAMap const* map, pointer item)
-    : map_(map), item_(item)
+inline SHAMap::const_iterator::const_iterator(SHAMap const* map, std::nullptr_t)
+    : map_(map)
 {
 }
 
@@ -622,8 +626,7 @@ SHAMap::const_iterator::operator->() const
 inline SHAMap::const_iterator&
 SHAMap::const_iterator::operator++()
 {
-    auto temp = map_->peekNextItem(item_->key(), stack_);
-    if (temp)
+    if (auto temp = map_->peekNextItem(item_->key(), stack_))
         item_ = temp->peekItem().get();
     else
         item_ = nullptr;

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -37,7 +37,6 @@ static_assert(!std::is_move_constructible<SHAMap>{}, "");
 static_assert(!std::is_move_assignable<SHAMap>{}, "");
 
 static_assert(std::is_nothrow_destructible<SHAMap::const_iterator>{}, "");
-static_assert(std::is_default_constructible<SHAMap::const_iterator>{}, "");
 static_assert(std::is_copy_constructible<SHAMap::const_iterator>{}, "");
 static_assert(std::is_copy_assignable<SHAMap::const_iterator>{}, "");
 static_assert(std::is_move_constructible<SHAMap::const_iterator>{}, "");


### PR DESCRIPTION
## High Level Overview of Change

This commit, if merged, corrects the handling of corner-cases involving custom iterators:

- Under some conditions, comparing `ReadViewFwdRange::iterators` for equality could result in derefencing an empty `std::unique_ptr` which will result in a crash.
- The `OpenView::txs_iter_impl::equal` function could throw an `std::bad_cast` exception which was unexpected.


### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)