### PR TITLE
Set version to 1.7.0-b7

### DIFF
--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -33,7 +33,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "1.7.0-b6"
+char const* const versionString = "1.7.0-b7"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
I merged PR #3692 (**1.7.0-b6**) using the fancy green button in the PR, which resulted in a rebase and caused the tip of **develop** (434e2f4cbf28a66adad49101842aa649e66fccea) to not be signed.

This stacks a new commit that sets the version and is properly signed. 