### PR TITLE
Travis workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -419,6 +419,8 @@ before_cache:
   - cd ${TRAVIS_HOME}
   - if [ -f cache_ignore.tar ] ; then $SUDO tar xvf cache_ignore.tar; fi
   - cd ${TRAVIS_BUILD_DIR}
+  # Display what changed in the cache before updating the cache
+  - find $CACHE_DIR -mmin -30 -ls
 
 cache:
   timeout: 900

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ services:
   - docker
 
 stages:
-  - windep-ssl
-  - windep-grpc
-  - windep-libarchive
+  - windep-vcpkg
   - windep-boost
   - build
 
@@ -51,6 +49,14 @@ env:
     - CCACHE_NOHASHDIR=true
     - CCACHE_DIR=${CACHE_DIR}/ccache
 
+before_install:
+  - export NUM_PROCESSORS=$(nproc)
+  - echo "NUM PROC is ${NUM_PROCESSORS}"
+  - if [ "$(uname)" = "Linux" ] ; then docker pull ${DOCKER_IMAGE}; fi
+  - if [ "${MATRIX_EVAL}" != "" ] ; then eval "${MATRIX_EVAL}"; fi
+  - if [ "${CMAKE_ADD}" != "" ] ; then export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} ${CMAKE_ADD}"; fi
+  - bin/ci/ubuntu/travis-cache-start.sh
+
 matrix:
   fast_finish: true
   allow_failures:
@@ -64,11 +70,10 @@ matrix:
     # allow the rest of the builds to continue. They may succeed if the
     # dependency is already cached. These do not need to be retried if
     # _any_ of the Windows builds succeed.
-    - stage: windep-ssl
-    - stage: windep-grpc
-    - stage: windep-libarchive
+    - stage: windep-vcpkg
     - stage: windep-boost
 
+  # https://docs.travis-ci.com/user/build-config-yaml#usage-of-yaml-anchors-and-aliases
   include:
     # debug builds
     - &linux
@@ -335,23 +340,16 @@ matrix:
           -DCMAKE_VERBOSE_MAKEFILE=ON
           -DCMAKE_TOOLCHAIN_FILE=${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake
           -DVCPKG_TARGET_TRIPLET=x64-windows-static"
-      stage: windep-ssl
-      name: prereq-ssl
+      stage: windep-vcpkg
+      name: prereq-vcpkg
       install:
         - choco upgrade cmake.install
         - choco install ninja visualstudio2017-workload-vctools -y
       script:
         - df -h
+        - env
         - travis_wait ${MAX_TIME_MIN} bin/sh/install-vcpkg.sh openssl
-    - <<: *windows
-      stage: windep-grpc
-      name: prereq-grpc
-      script:
         - travis_wait ${MAX_TIME_MIN} bin/sh/install-vcpkg.sh grpc
-    - <<: *windows
-      stage: windep-libarchive
-      name: prereq-libarchive
-      script:
         - travis_wait ${MAX_TIME_MIN} bin/sh/install-vcpkg.sh libarchive[lz4]
         # TBD consider rocksdb via vcpkg if/when we can build with the
         # vcpkg version
@@ -426,14 +424,6 @@ cache:
   timeout: 900
   directories:
     - $CACHE_DIR
-
-before_install:
-  - export NUM_PROCESSORS=$(nproc)
-  - echo "NUM PROC is ${NUM_PROCESSORS}"
-  - if [ "$(uname)" = "Linux" ] ; then docker pull ${DOCKER_IMAGE}; fi
-  - if [ "${MATRIX_EVAL}" != "" ] ; then eval "${MATRIX_EVAL}"; fi
-  - if [ "${CMAKE_ADD}" != "" ] ; then export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} ${CMAKE_ADD}"; fi
-  - bin/ci/ubuntu/travis-cache-start.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -356,7 +356,7 @@ matrix:
         # - travis_wait ${MAX_TIME_MIN} bin/sh/install-vcpkg.sh rocksdb[snappy,lz4,zlib]
     - <<: *windows
       stage: windep-boost
-      name: prereq-boost
+      name: prereq-keep-boost
       install:
         - choco upgrade cmake.install
         - choco install ninja visualstudio2017-workload-vctools -y

--- a/bin/ci/ubuntu/build-and-test.sh
+++ b/bin/ci/ubuntu/build-and-test.sh
@@ -95,8 +95,32 @@ fi
 mkdir -p "build/${BUILD_DIR}"
 pushd "build/${BUILD_DIR}"
 
+# cleanup possible artifacts
+rm -fv CMakeFiles/CMakeOutput.log CMakeFiles/CMakeError.log
+# Clean up NIH directories which should be git repos, but aren't
+for nih_path in ${NIH_CACHE_ROOT}/*/*/*/src ${NIH_CACHE_ROOT}/*/*/src
+do
+  for dir in lz4 snappy rocksdb
+  do
+    if [ -e ${nih_path}/${dir} -a \! -e ${nih_path}/${dir}/.git ]
+    then
+      ls -la ${nih_path}/${dir}*
+      rm -rfv ${nih_path}/${dir}*
+    fi
+  done
+done
+
 # generate
 ${time} cmake ../.. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${CMAKE_EXTRA_ARGS}
+# Display the cmake output, to help with debugging if something fails
+for file in CMakeOutput.log CMakeError.log
+do
+  if [ -f CMakeFiles/${file} ]
+  then
+    ls -l CMakeFiles/${file}
+    cat CMakeFiles/${file}
+  fi
+done
 # build
 export DESTDIR=$(pwd)/_INSTALLED_
 

--- a/bin/ci/ubuntu/travis-cache-start.sh
+++ b/bin/ci/ubuntu/travis-cache-start.sh
@@ -2,6 +2,21 @@
 # some cached files create churn, so save them here for
 # later restoration before packing the cache
 set -eux
+clean_cache="travis_clean_cache"
+if [[ ! ( "${TRAVIS_JOB_NAME}" =~ "windows" || \
+    "${TRAVIS_JOB_NAME}" =~ "prereq-keep" ) ]] && \
+    ( [[ "${TRAVIS_COMMIT_MESSAGE}" =~ "${clean_cache}" ]] || \
+        ( [[ -v TRAVIS_PULL_REQUEST_SHA && \
+            "${TRAVIS_PULL_REQUEST_SHA}" != "" ]] && \
+          git log -1 "${TRAVIS_PULL_REQUEST_SHA}" | grep -cq "${clean_cache}" -
+        )
+    )
+then
+    find ${TRAVIS_HOME}/_cache -maxdepth 2 -type d
+    rm -rf ${TRAVIS_HOME}/_cache
+    mkdir -p ${TRAVIS_HOME}/_cache
+fi
+
 pushd ${TRAVIS_HOME}
 if [ -f cache_ignore.tar ] ; then
     rm -f cache_ignore.tar


### PR DESCRIPTION
## High Level Overview of Change

Several other branches and pull requests have had many of their Travis CI jobs fail with errors that look related to the Travis CI cache, despite the relevant caches (or all caches in some cases) being deleted. These commits attempt to work around these apparent Travis failures.

It is currently split into 3 commits:
1. `Reset corrupt / inconsistent dependency source folders` works automatically. It looks at several `nih_c` folders which are expected to be git repos and deletes them, along with their cmake-related tracking folders, if they aren't. This will trigger cmake to make a fresh clone of the repos. It also dumps the contents of the cmake log files after the generation step so that they can be examined for more information when there are failures, and shows which files and dirs are modified in the cache folder before the cache is pushed, so this may possibly be optimized in the future.
2. `Simplify travis config` moves a couple of things around for readability and squashes several of the windows prerequisite steps into one. By itself, this doesn't resolve any errors, but it should speed up the build because the combined prereq step only needs to spin up one machine, read and write the cache once, etc. instead of three times. It also prepares the code for the third commit.
3. `Force wipe the travis caches with "travis_clean_cache"` AKA "drop back and punt" adds some logic to completely wipe (`rm -rf`) the cache directory before building if the top commit message on the branch or PR contains the string "travis_clean_cache". (That includes this commit.) In cases where the automated cleanups don't work, any developer can put this string in their branch's last commit to force everything to reset. 

Until this is merged, developers that are having unexplained Travis build issues can make use of these changes in one of the following ways:
* Rebase their branch on top of this branch, and either let the automatic checks take care of things _or_ add / change their top commit to include the magic "travis_clean_cache" string. I will make my best efforts to keep this branch up to date with develop, but feel free to nudge me if not.
* Cherry pick the relevant commits on top of their changes. If their build appears to be failing with errors that look like a corrupted git repo (e.g. https://travis-ci.com/github/ripple/rippled/jobs/454113921#L743), the `Reset corrupt / inconsistent dependency source folders` should be sufficient. (Sufficiency not guaranteed 😁 .) Otherwise, cherry pick the last two together - if the last commit is the head of your branch, the reset will occur automatically.
In principal, once the issue is resolved, these commits can be _removed_ from the other branch for further development and/or merging.

### Context of Change

This appears to be a problem on the side of Travis CI, and these changes are an attempt at a workaround.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)

## Test Plan

* Push a normal commit when a cache is not expected. Expected result: Travis CI succeeds.
* Push a commit when a cache is expected, or restart the job from step one. Travis CI may succeed or fail. 🤷‍♂️ 
* Push a commit containing the string "travis_clean_cache". Expected result: Regardless of the result from step two, Travis CI should succeed.

## Future Tasks
I noticed that Travis updates the cache on almost every job, even when the dependencies are up to date. At some point I'd like to determine what's changing, and trying to find ways to prevent them from changing or move them out of the cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3694)
<!-- Reviewable:end -->
