### PR TITLE
Remove ReadViewFwdRange `end` iterator cache:

### DIFF
--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -204,7 +204,7 @@ public:
         explicit sles_type(ReadView const& view);
         iterator
         begin() const;
-        iterator const&
+        iterator
         end() const;
         iterator
         upper_bound(key_type const& key) const;
@@ -217,7 +217,7 @@ public:
         empty() const;
         iterator
         begin() const;
-        iterator const&
+        iterator
         end() const;
     };
 

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -147,7 +147,6 @@ public:
 
 protected:
     ReadView const* view_;
-    boost::optional<iterator> mutable end_;
 };
 
 }  // namespace detail

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -135,11 +135,9 @@ ReadView::sles_type::begin() const -> iterator
 }
 
 auto
-ReadView::sles_type::end() const -> iterator const&
+ReadView::sles_type::end() const -> iterator
 {
-    if (!end_)
-        end_ = iterator(view_, view_->slesEnd());
-    return *end_;
+    return iterator(view_, view_->slesEnd());
 }
 
 auto
@@ -165,11 +163,9 @@ ReadView::txs_type::begin() const -> iterator
 }
 
 auto
-ReadView::txs_type::end() const -> iterator const&
+ReadView::txs_type::end() const -> iterator
 {
-    if (!end_)
-        end_ = iterator(view_, view_->txsEnd());
-    return *end_;
+    return iterator(view_, view_->txsEnd());
 }
 
 }  // namespace ripple


### PR DESCRIPTION
## High Level Overview of Change

ReadViewFwdRange was storing a cached `end_` iterator that was lazily
created in an iterators `end()` function. When the cache is empty, and
the range it iterated from multiple threads, this creates a race
condition.

This change has performance consequences for "old style" for loops.
For example:

```
 // don't do this
for(auto i = tx_range.begin(); i != tx_range.end(); ++i)

```

Can call the now expensive `end()` function more often than needed.
Range-based for loop (I.e. `for(auto const& t : tx_range)`) should be
used instead.



### Type of Change


- [ x] Bug fix (non-breaking change which fixes an issue)



## Future Tasks

We may want consider a `for_each` style interface with a lamba in the future, to prevent people for writing old-style for loops.