### PR TITLE
Fix nested locks in ValidatorList:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -234,10 +234,28 @@ matrix:
         - BUILD_TYPE=Debug
     - <<: *linux
       compiler: clang-9
-      name: clang-9
+      name: clang-9, debug
       env:
         - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
         - BUILD_TYPE=Debug
+    - <<: *linux
+      compiler: clang-9
+      name: clang-9, release
+      env:
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
+        - BUILD_TYPE=Release
+    - <<: *linux
+      compiler: clang-10
+      name: clang-10, debug ?
+      env:
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
+        - BUILD_TYPE=Debug
+    - <<: *linux
+      compiler: clang-10
+      name: clang-10, release ?
+      env:
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
+        - BUILD_TYPE=Release
     # verify build with min version of cmake
     - <<: *linux
       compiler: gcc-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,18 +244,6 @@ matrix:
       env:
         - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
         - BUILD_TYPE=Release
-    - <<: *linux
-      compiler: clang-10
-      name: clang-10, debug ?
-      env:
-        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
-        - BUILD_TYPE=Debug
-    - <<: *linux
-      compiler: clang-10
-      name: clang-10, release ?
-      env:
-        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
-        - BUILD_TYPE=Release
     # verify build with min version of cmake
     - <<: *linux
       compiler: gcc-8

--- a/src/ripple/shamap/SHAMapInnerNode.h
+++ b/src/ripple/shamap/SHAMapInnerNode.h
@@ -108,6 +108,7 @@ public:
     SHAMapInnerNode(SHAMapInnerNode const&) = delete;
     SHAMapInnerNode&
     operator=(SHAMapInnerNode const&) = delete;
+    ~SHAMapInnerNode();
 
     std::shared_ptr<SHAMapTreeNode>
     clone(std::uint32_t cowid) const override;

--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -49,9 +49,7 @@ SHAMapInnerNode::SHAMapInnerNode(
 {
 }
 
-SHAMapInnerNode::~SHAMapInnerNode()
-{
-}
+SHAMapInnerNode::~SHAMapInnerNode() = default;
 
 template <class F>
 void

--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -49,6 +49,10 @@ SHAMapInnerNode::SHAMapInnerNode(
 {
 }
 
+SHAMapInnerNode::~SHAMapInnerNode()
+{
+}
+
 template <class F>
 void
 SHAMapInnerNode::iterChildren(F&& f) const

--- a/src/ripple/shamap/impl/TaggedPointer.h
+++ b/src/ripple/shamap/impl/TaggedPointer.h
@@ -217,11 +217,6 @@ public:
     getChildIndex(std::uint16_t isBranch, int i) const;
 };
 
-inline TaggedPointer::~TaggedPointer()
-{
-    destroyHashesAndChildren();
-}
-
 }  // namespace ripple
 
 #endif

--- a/src/ripple/shamap/impl/TaggedPointer.ipp
+++ b/src/ripple/shamap/impl/TaggedPointer.ipp
@@ -636,4 +636,9 @@ TaggedPointer::getChildren() const
     return result;
 };
 
+inline TaggedPointer::~TaggedPointer()
+{
+    destroyHashesAndChildren();
+}
+
 }  // namespace ripple


### PR DESCRIPTION
## High Level Overview of Change

* Found several functions called under lock that take a lock. Refactor
  to require a lock as a parameter instead.
* Found several functions called under lock that don't take a lock, but
  should. Refactored those as well to require a lock as a parameter.

### Context of Change

Due to a change in 1.7.0-b5 that changed mutex type, so UB behavior went from being harmless to causing deadlocks.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change that only restructures code)

## Test Plan

Run rippled with a loop making frequent requests to the `crawl/` endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3698)
<!-- Reviewable:end -->
