### PR TITLE
Fix compression enable flag and compression algorithm fetching

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -100,8 +100,9 @@ PeerImp::PeerImp(
     , request_(std::move(request))
     , headers_(request_)
     , compressionEnabled_(
-          headers_["X-Offer-Compression"] == "lz4" ? Compressed::On
-                                                   : Compressed::Off)
+          headers_["X-Offer-Compression"] == "lz4" && app_.config().COMPRESSION
+              ? Compressed::On
+              : Compressed::Off)
 {
 }
 


### PR DESCRIPTION
## High Level Overview of Change

Fixes compressionEnabled_ flag in the inbound peer.
Fixes compression algorithm fetching on protocol message receive.

### Context of Change

Both issues are introduced in 1.6.0.

First fix adds configuration compression flag check when setting compressionEnabled_ in the PeerImp constructor.
Previously the compressionEnabled_ of the inbound peer was set to true if the connected peer supported compression even though the node didn't support the compression.

Second fix adds 0xF0 mask when fetching the compression algorithm from a received message. Previously the compression algorithm used the whole byte. Since the algorithm occupies high four bits, when a payload size is large then the low four bits could be set resulting in an invalid algorithm.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue), fixes #3624 

## Test Plan

Added log messages to PeerImp::PeerImp() to verify the compressionEnabled_ flag for different compression configurations. Added log messages to PeerImp::onMessageBegin() to output received message compressed flag and peer's remote address.