### PR TITLE
Replace std::pmr with boost::pmr:

### DIFF
--- a/src/ripple/shamap/SHAMapInnerNode.h
+++ b/src/ripple/shamap/SHAMapInnerNode.h
@@ -103,7 +103,7 @@ private:
 public:
     explicit SHAMapInnerNode(
         std::uint32_t cowid,
-        std::uint8_t numAllocatedChildren = branchFactor);
+        std::uint8_t numAllocatedChildren = 2);
 
     SHAMapInnerNode(SHAMapInnerNode const&) = delete;
     SHAMapInnerNode&


### PR DESCRIPTION
## High Level Overview of Change

gcc's implementation of `prm::synchronized_pool_resource` showed extremely poor performance compared with `boost::synchronized_pool_resouece`. Boost's implementation of pmr is now used in all cases (previously it was only used when a standard lib, like clang's, lacked an implementation of pmr).

This patch also makes a minor change where inner nodes are constructed with sparse arrays, unless "dense" is explicitly requested.

### Context of Change

We observed a performance regression with the "SHAMapInnerNode" changes. The regression was traced back to the pmr allocators.

### Type of Change

- [ x] Code optimization


