### PR TITLE
Fix a couple of unusual startup and connection issues

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1480,8 +1480,6 @@ ApplicationImp::setup()
             return false;
     }
 
-    validatorSites_->start();
-
     // start first consensus round
     if (!m_networkOPs->beginConsensus(
             m_ledgerMaster->getClosedLedger()->info().hash))
@@ -1595,6 +1593,7 @@ ApplicationImp::setup()
         }
     }
 
+    RPC::ShardArchiveHandler* shardArchiveHandler = nullptr;
     if (shardStore_)
     {
         try
@@ -1606,15 +1605,7 @@ ApplicationImp::setup()
 
             // Recovery is needed.
             if (handler)
-            {
-                if (!handler->start())
-                {
-                    JLOG(m_journal.fatal())
-                        << "Failed to start ShardArchiveHandler.";
-
-                    return false;
-                }
-            }
+                shardArchiveHandler = handler;
         }
         catch (std::exception const& e)
         {
@@ -1626,6 +1617,15 @@ ApplicationImp::setup()
             return false;
         }
     }
+
+    if (shardArchiveHandler && !shardArchiveHandler->start())
+    {
+        JLOG(m_journal.fatal()) << "Failed to start ShardArchiveHandler.";
+
+        return false;
+    }
+
+    validatorSites_->start();
 
     return true;
 }

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -253,7 +253,6 @@ PeerImp::send(std::shared_ptr<Message> const& m)
     if (sendq_size != 0)
         return;
 
-    assert(send_queue_.front());
     boost::asio::async_write(
         stream_,
         boost::asio::buffer(
@@ -778,7 +777,6 @@ PeerImp::doAccept()
             strand_,
             [this, write_buffer, self = shared_from_this()](
                 error_code ec, std::size_t bytes_transferred) {
-                assert(strand_.running_in_this_thread());
                 if (!socket_.is_open())
                     return;
                 if (ec == boost::asio::error::operation_aborted)
@@ -933,7 +931,6 @@ PeerImp::onWriteMessage(error_code ec, std::size_t bytes_transferred)
     if (!send_queue_.empty())
     {
         // Timeout on writes only
-        assert(send_queue_.front());
         return boost::asio::async_write(
             stream_,
             boost::asio::buffer(

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -410,9 +410,6 @@ private:
     fail(std::string const& name, error_code ec);
 
     void
-    failinstrand(std::string const& name, error_code ec);
-
-    void
     gracefulClose();
 
     void

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -410,6 +410,9 @@ private:
     fail(std::string const& name, error_code ec);
 
     void
+    failinstrand(std::string const& name, error_code ec);
+
+    void
     gracefulClose();
 
     void


### PR DESCRIPTION
## High Level Overview of Change

1. Ensure that the `PeerImp::doAccept` incoming connection handler call to `async_write` has it's callback run on the strand.
2. Move all peer post-connection messages to `doProtocolStart`.
3. Also, only send validator list on incoming connection instead of both incoming and outgoing.
4. Move the `ShardArchiveHandler` and `ValidatorSites` startup calls to the end of `setup`.

### Context of Change

For number 1, it's possible, though unlikely for a `async_write` to be called while the `async_write` for the response is in progress. This asserts in beast. 2 and 3 are just cleanups that made sense with this change.

Number 4, fixes an unusual startup race condition. With a stopped rippled still open in gdb, attempting to start another rippled fails because the ports are still locked up, but the failed rippled doesn't cleanly exit. This can be a separate commit once the other commits are squashed.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

I'll be running this code on my dogfood machine, which accepts incoming connections, indefinitely to see if it doesn't assert.

Additionally, a test network consisting of only nodes which include this change should continue to function normally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3712)
<!-- Reviewable:end -->
