### PR TITLE
Improve manifest relaying:

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1913,6 +1913,8 @@ NetworkOPsImp::pubManifest(Manifest const& mo)
         if (auto sig = mo.getSignature())
             jvObj[jss::signature] = strHex(*sig);
         jvObj[jss::master_signature] = strHex(mo.getMasterSignature());
+        if (!mo.domain.empty())
+            jvObj[jss::domain] = mo.domain;
 
         for (auto i = mStreamMaps[sManifests].begin();
              i != mStreamMaps[sManifests].end();)

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1915,6 +1915,7 @@ NetworkOPsImp::pubManifest(Manifest const& mo)
         jvObj[jss::master_signature] = strHex(mo.getMasterSignature());
         if (!mo.domain.empty())
             jvObj[jss::domain] = mo.domain;
+        jvObj[jss::manifest] = strHex(mo.serialized);
 
         for (auto i = mStreamMaps[sManifests].begin();
              i != mStreamMaps[sManifests].end();)

--- a/src/ripple/app/misc/impl/Manifest.cpp
+++ b/src/ripple/app/misc/impl/Manifest.cpp
@@ -304,9 +304,11 @@ boost::optional<std::string>
 ManifestCache::getDomain(PublicKey const& pk) const
 {
     std::lock_guard lock{read_mutex_};
+
     auto const iter = map_.find(pk);
 
-    if (iter != map_.end() && !iter->second.revoked())
+    if (iter != map_.end() && !iter->second.revoked() &&
+        !iter->second.domain.empty())
         return iter->second.domain;
 
     return boost::none;

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -151,9 +151,11 @@ private:
     }
 
     static bool
-    validPublicKey(std::string const& strPk)
+    validPublicKey(
+        std::string const& strPk,
+        TokenType type = TokenType::AccountPublic)
     {
-        if (parseBase58<PublicKey>(TokenType::AccountPublic, strPk))
+        if (parseBase58<PublicKey>(type, strPk))
             return true;
 
         auto pkHex = strUnHex(strPk);
@@ -235,7 +237,7 @@ private:
             Json::Value jvRequest(Json::objectValue);
 
             std::string const strPk = jvParams[0u].asString();
-            if (!validPublicKey(strPk))
+            if (!validPublicKey(strPk, TokenType::NodePublic))
                 return rpcError(rpcPUBLIC_MALFORMED);
 
             jvRequest[jss::public_key] = strPk;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -710,8 +710,14 @@ OverlayImpl::onManifests(
     }
 
     if (!relay.list().empty())
-        for_each([m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS)](
-                     std::shared_ptr<PeerImp>&& p) { p->send(m2); });
+    {
+        auto const m2 = std::make_shared<Message>(relay, protocol::mtMANIFESTS);
+
+        for_each([&m2, sender = from->id()](std::shared_ptr<PeerImp>&& p) {
+            if (p->id() != sender)
+                p->send(m2);
+        });
+    }
 }
 
 void

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -991,6 +991,17 @@ PeerImp::onMessageEnd(
 void
 PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
 {
+    auto const s = m->list_size();
+
+    if (s == 0)
+    {
+        fee_ = Resource::feeUnwantedData;
+        return;
+    }
+
+    if (s > 100)
+        fee_ = Resource::feeMediumBurdenPeer;
+
     // VFALCO What's the right job type?
     auto that = shared_from_this();
     app_.getJobQueue().addJob(

--- a/src/test/rpc/ValidatorInfo_test.cpp
+++ b/src/test/rpc/ValidatorInfo_test.cpp
@@ -106,7 +106,6 @@ public:
             BEAST_EXPECT(info[jss::result][jss::manifest] == manifest);
             BEAST_EXPECT(
                 info[jss::result][jss::ephemeral_key] == ephemeral_key);
-            BEAST_EXPECT(info[jss::result][jss::domain] == "");
         }
     }
 


### PR DESCRIPTION
The manifest relay code would only ever relay manifests from validators on a server's UNL which means that the manifests of validators that are not broadly trusted can fail to propagate across the network, which can make it difficult to detect and track such validators.
    
This commit, if merged, propagates all manifests on a best-effort basis resulting in broader availability of manifests on the network and avoid the need to introduce on-ledger manifest storage or to establish one or more manifest repositories.
