### PR TITLE
[TRIVIAL] Add instructions to use 64-bit Windows build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -400,6 +400,7 @@ matrix:
       name: windows, visual studio, debug
       script:
         - mkdir -p build.ms && cd build.ms
+        - export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_GENERATOR_TOOLSET=host=x64"
         - cmake -G "Visual Studio 15 2017 Win64" ${CMAKE_EXTRA_ARGS} ..
         - export DESTDIR=${PWD}/_installed_
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose --config ${BLD_CONFIG} --target install

--- a/Builds/VisualStudio2017/README.md
+++ b/Builds/VisualStudio2017/README.md
@@ -214,7 +214,7 @@ execute the following commands within your `rippled` cloned repository:
 ```
 mkdir build\cmake
 cd build\cmake
-cmake ..\.. -G"Visual Studio 15 2017 Win64" -DBOOST_ROOT="C:\lib\boost_1_70_0" -DOPENSSL_ROOT="C:\lib\OpenSSL-Win64"
+cmake ..\.. -G"Visual Studio 15 2017 Win64" -DBOOST_ROOT="C:\lib\boost_1_70_0" -DOPENSSL_ROOT="C:\lib\OpenSSL-Win64" -DCMAKE_GENERATOR_TOOLSET=host=x64
 ```
 Now launch Visual Studio 2017 and select **File | Open | Project/Solution**.
 Navigate to the `build\cmake` folder created above and select the `rippled.sln`


### PR DESCRIPTION
## High Level Overview of Change

I finally, accidentally figured out why my Windows command line builds (using msbuild) will fail every once in a while to link because a file memory mapping fails, or a plain old out of memory. By default, the 32-bit versions of these tools are used, so the system has ample memory available, the process does not. This change adds instructions to use the `CMAKE_GENERATOR_TOOLSET` to use the 64-bit versions of the tools. The [cmake docs](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_TOOLSET.html) are clear that "The value of this variable should never be modified by project code.".

Note that this has never happened to me in the IDE, presumably because the default settings use the 64-bit tools.

I also updated Travis to use this option, though I'll only know if it works when that finishes. I'll remove the second commit if not.

### Type of Change

- [X ] Documentation Updates

## Test Plan

No code changes to test. If CI works, it works, and the other change is to documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3725)
<!-- Reviewable:end -->
