### PR TITLE
Extend peer shard info

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -521,6 +521,7 @@ target_sources (rippled PRIVATE
   src/ripple/nodestore/impl/ManagerImp.cpp
   src/ripple/nodestore/impl/NodeObject.cpp
   src/ripple/nodestore/impl/Shard.cpp
+  src/ripple/nodestore/impl/ShardInfo.cpp
   src/ripple/nodestore/impl/TaskQueue.cpp
   #[===============================[
      main sources:

--- a/Builds/levelization/results/loops.txt
+++ b/Builds/levelization/results/loops.txt
@@ -8,7 +8,7 @@ Loop: ripple.app ripple.net
   ripple.app > ripple.net
 
 Loop: ripple.app ripple.nodestore
-  ripple.app > ripple.nodestore
+  ripple.nodestore ~= ripple.app
 
 Loop: ripple.app ripple.overlay
   ripple.overlay ~= ripple.app
@@ -41,7 +41,7 @@ Loop: ripple.net ripple.rpc
   ripple.rpc > ripple.net
 
 Loop: ripple.nodestore ripple.overlay
-  ripple.overlay == ripple.nodestore
+  ripple.overlay ~= ripple.nodestore
 
 Loop: ripple.overlay ripple.rpc
   ripple.rpc ~= ripple.overlay

--- a/src/ripple/basics/RangeSet.h
+++ b/src/ripple/basics/RangeSet.h
@@ -98,18 +98,15 @@ template <class T>
 std::string
 to_string(RangeSet<T> const& rs)
 {
-    using ripple::to_string;
-
     if (rs.empty())
         return "empty";
-    std::string res = "";
+
+    std::string s;
     for (auto const& interval : rs)
-    {
-        if (!res.empty())
-            res += ",";
-        res += to_string(interval);
-    }
-    return res;
+        s += ripple::to_string(interval) + ",";
+    s.pop_back();
+
+    return s;
 }
 
 /** Convert the given styled string to a RangeSet.
@@ -122,13 +119,14 @@ to_string(RangeSet<T> const& rs)
     @return True on successfully converting styled string
 */
 template <class T>
-bool
+[[nodiscard]] bool
 from_string(RangeSet<T>& rs, std::string const& s)
 {
     std::vector<std::string> intervals;
     std::vector<std::string> tokens;
     bool result{true};
 
+    rs.clear();
     boost::split(tokens, s, boost::algorithm::is_any_of(","));
     for (auto const& t : tokens)
     {

--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -226,13 +226,78 @@ public:
     void
     onChildrenStopped() override;
 
+    /** @return The maximum number of ledgers stored in a shard
+     */
+    [[nodiscard]] std::uint32_t
+    ledgersPerShard() const noexcept
+    {
+        return ledgersPerShard_;
+    }
+
     /** @return The earliest ledger sequence allowed
      */
-    std::uint32_t
-    earliestLedgerSeq() const
+    [[nodiscard]] std::uint32_t
+    earliestLedgerSeq() const noexcept
     {
         return earliestLedgerSeq_;
     }
+
+    /** @return The earliest shard index
+     */
+    [[nodiscard]] std::uint32_t
+    earliestShardIndex() const noexcept
+    {
+        return earliestShardIndex_;
+    }
+
+    /** Calculates the first ledger sequence for a given shard index
+
+        @param shardIndex The shard index considered
+        @return The first ledger sequence pertaining to the shard index
+    */
+    [[nodiscard]] std::uint32_t
+    firstLedgerSeq(std::uint32_t shardIndex) const noexcept
+    {
+        assert(shardIndex >= earliestShardIndex_);
+        if (shardIndex <= earliestShardIndex_)
+            return earliestLedgerSeq_;
+        return 1 + (shardIndex * ledgersPerShard_);
+    }
+
+    /** Calculates the last ledger sequence for a given shard index
+
+        @param shardIndex The shard index considered
+        @return The last ledger sequence pertaining to the shard index
+    */
+    [[nodiscard]] std::uint32_t
+    lastLedgerSeq(std::uint32_t shardIndex) const noexcept
+    {
+        assert(shardIndex >= earliestShardIndex_);
+        return (shardIndex + 1) * ledgersPerShard_;
+    }
+
+    /** Calculates the shard index for a given ledger sequence
+
+        @param ledgerSeq ledger sequence
+        @return The shard index of the ledger sequence
+    */
+    [[nodiscard]] std::uint32_t
+    seqToShardIndex(std::uint32_t ledgerSeq) const noexcept
+    {
+        assert(ledgerSeq >= earliestLedgerSeq_);
+        return (ledgerSeq - 1) / ledgersPerShard_;
+    }
+
+    /** Calculates the maximum ledgers for a given shard index
+
+        @param shardIndex The shard index considered
+        @return The maximum ledgers pertaining to the shard index
+
+        @note The earliest shard may store less if the earliest ledger
+        sequence truncates its beginning
+    */
+    [[nodiscard]] std::uint32_t
+    maxLedgers(std::uint32_t shardIndex) const noexcept;
 
 protected:
     beast::Journal const j_;
@@ -241,6 +306,25 @@ protected:
 
     std::atomic<std::uint32_t> fetchHitCount_{0};
     std::atomic<std::uint32_t> fetchSz_{0};
+
+    // The default is DEFAULT_LEDGERS_PER_SHARD (16384) to match the XRP ledger
+    // network. Can be set through the configuration file using the
+    // 'ledgers_per_shard' field under the 'node_db' and 'shard_db' stanzas.
+    // If specified, the value must be a multiple of 256 and equally assigned
+    // in both stanzas. Only unit tests or alternate networks should change
+    // this value.
+    std::uint32_t const ledgersPerShard_;
+
+    // The default is XRP_LEDGER_EARLIEST_SEQ (32570) to match the XRP ledger
+    // network's earliest allowed ledger sequence. Can be set through the
+    // configuration file using the 'earliest_seq' field under the 'node_db'
+    // and 'shard_db' stanzas. If specified, the value must be greater than zero
+    // and equally assigned in both stanzas. Only unit tests or alternate
+    // networks should change this value.
+    std::uint32_t const earliestLedgerSeq_;
+
+    // The earliest shard index
+    std::uint32_t const earliestShardIndex_;
 
     void
     stopReadThreads();
@@ -292,10 +376,6 @@ private:
 
     std::vector<std::thread> readThreads_;
     bool readShut_{false};
-
-    // The default is 32570 to match the XRP ledger network's earliest
-    // allowed sequence. Alternate networks may set this value.
-    std::uint32_t const earliestLedgerSeq_;
 
     virtual std::shared_ptr<NodeObject>
     fetchNodeObject(

--- a/src/ripple/nodestore/DatabaseShard.h
+++ b/src/ripple/nodestore/DatabaseShard.h
@@ -21,9 +21,9 @@
 #define RIPPLE_NODESTORE_DATABASESHARD_H_INCLUDED
 
 #include <ripple/app/ledger/Ledger.h>
-#include <ripple/basics/RangeSet.h>
-#include <ripple/core/DatabaseCon.h>
+#include <ripple/core/SociDB.h>
 #include <ripple/nodestore/Database.h>
+#include <ripple/nodestore/ShardInfo.h>
 #include <ripple/nodestore/Types.h>
 
 #include <memory>
@@ -61,7 +61,7 @@ public:
 
         @return `true` if the database initialized without error
     */
-    virtual bool
+    [[nodiscard]] virtual bool
     init() = 0;
 
     /** Prepare to store a new ledger in the shard being acquired
@@ -76,7 +76,7 @@ public:
                 between requests.
         @implNote adds a new writable shard if necessary
     */
-    virtual std::optional<std::uint32_t>
+    [[nodiscard]] virtual std::optional<std::uint32_t>
     prepareLedger(std::uint32_t validLedgerSeq) = 0;
 
     /** Prepare one or more shard indexes to be imported into the database
@@ -84,7 +84,7 @@ public:
         @param shardIndexes Shard indexes to be prepared for import
         @return true if all shard indexes successfully prepared for import
     */
-    virtual bool
+    [[nodiscard]] virtual bool
     prepareShards(std::vector<std::uint32_t> const& shardIndexes) = 0;
 
     /** Remove a previously prepared shard index for import
@@ -98,7 +98,7 @@ public:
 
         @return a string representing the shards prepared for import
     */
-    virtual std::string
+    [[nodiscard]] virtual std::string
     getPreShards() = 0;
 
     /** Import a shard into the shard database
@@ -108,7 +108,7 @@ public:
         @return true If the shard was successfully imported
         @implNote if successful, srcDir is moved to the database directory
     */
-    virtual bool
+    [[nodiscard]] virtual bool
     importShard(
         std::uint32_t shardIndex,
         boost::filesystem::path const& srcDir) = 0;
@@ -119,7 +119,7 @@ public:
         @param seq The sequence of the ledger
         @return The ledger if found, nullptr otherwise
     */
-    virtual std::shared_ptr<Ledger>
+    [[nodiscard]] virtual std::shared_ptr<Ledger>
     fetchLedger(uint256 const& hash, std::uint32_t seq) = 0;
 
     /** Notifies the database that the given ledger has been
@@ -129,13 +129,6 @@ public:
     */
     virtual void
     setStored(std::shared_ptr<Ledger const> const& ledger) = 0;
-
-    /** Query which complete shards are stored
-
-        @return the indexes of complete shards
-    */
-    virtual std::string
-    getCompleteShards() = 0;
 
     /**
      * @brief callForLedgerSQL Checkouts ledger database for shard
@@ -233,56 +226,23 @@ public:
         std::function<bool(soci::session& session, std::uint32_t index)> const&
             callback) = 0;
 
-    /** @return The maximum number of ledgers stored in a shard
-     */
-    virtual std::uint32_t
-    ledgersPerShard() const = 0;
+    /** Query information about shards held
 
-    /** @return The earliest shard index
-     */
-    virtual std::uint32_t
-    earliestShardIndex() const = 0;
-
-    /** Calculates the shard index for a given ledger sequence
-
-        @param seq ledger sequence
-        @return The shard index of the ledger sequence
+        @return Information about shards held by this node
     */
-    virtual std::uint32_t
-    seqToShardIndex(std::uint32_t seq) const = 0;
-
-    /** Calculates the first ledger sequence for a given shard index
-
-        @param shardIndex The shard index considered
-        @return The first ledger sequence pertaining to the shard index
-    */
-    virtual std::uint32_t
-    firstLedgerSeq(std::uint32_t shardIndex) const = 0;
-
-    /** Calculates the last ledger sequence for a given shard index
-
-        @param shardIndex The shard index considered
-        @return The last ledger sequence pertaining to the shard index
-    */
-    virtual std::uint32_t
-    lastLedgerSeq(std::uint32_t shardIndex) const = 0;
+    [[nodiscard]] virtual std::unique_ptr<ShardInfo>
+    getShardInfo() const = 0;
 
     /** Returns the root database directory
      */
-    virtual boost::filesystem::path const&
+    [[nodiscard]] virtual boost::filesystem::path const&
     getRootDir() const = 0;
 
-    /** The number of ledgers in a shard */
-    static constexpr std::uint32_t ledgersPerShardDefault{16384u};
+    /** Returns the number of queued tasks
+     */
+    [[nodiscard]] virtual size_t
+    getNumTasks() const = 0;
 };
-
-constexpr std::uint32_t
-seqToShardIndex(
-    std::uint32_t ledgerSeq,
-    std::uint32_t ledgersPerShard = DatabaseShard::ledgersPerShardDefault)
-{
-    return (ledgerSeq - 1) / ledgersPerShard;
-}
 
 extern std::unique_ptr<DatabaseShard>
 make_ShardStore(

--- a/src/ripple/nodestore/ShardInfo.h
+++ b/src/ripple/nodestore/ShardInfo.h
@@ -1,0 +1,122 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_NODESTORE_SHARDINFO_H_INCLUDED
+#define RIPPLE_NODESTORE_SHARDINFO_H_INCLUDED
+
+#include <ripple/basics/RangeSet.h>
+#include <ripple/nodestore/Types.h>
+#include <ripple/protocol/messages.h>
+
+namespace ripple {
+namespace NodeStore {
+
+/* Contains information on the status of shards for a node
+ */
+class ShardInfo
+{
+private:
+    class Incomplete
+    {
+    public:
+        Incomplete() = delete;
+        Incomplete(ShardState state, std::uint32_t percentProgress)
+            : state_(state), percentProgress_(percentProgress)
+        {
+        }
+
+        [[nodiscard]] ShardState
+        state() const noexcept
+        {
+            return state_;
+        }
+
+        [[nodiscard]] std::uint32_t
+        percentProgress() const noexcept
+        {
+            return percentProgress_;
+        }
+
+    private:
+        ShardState state_;
+        std::uint32_t percentProgress_;
+    };
+
+public:
+    [[nodiscard]] NetClock::time_point const&
+    msgTimestamp() const
+    {
+        return msgTimestamp_;
+    }
+
+    void
+    setMsgTimestamp(NetClock::time_point const& timestamp)
+    {
+        msgTimestamp_ = timestamp;
+    }
+
+    [[nodiscard]] std::string
+    finalizedToString() const;
+
+    [[nodiscard]] bool
+    setFinalizedFromString(std::string const& str)
+    {
+        return from_string(finalized_, str);
+    }
+
+    [[nodiscard]] RangeSet<std::uint32_t> const&
+    finalized() const
+    {
+        return finalized_;
+    }
+
+    [[nodiscard]] std::string
+    incompleteToString() const;
+
+    [[nodiscard]] std::map<std::uint32_t, Incomplete> const&
+    incomplete() const
+    {
+        return incomplete_;
+    }
+
+    // Returns true if successful or false because of a duplicate index
+    bool
+    update(
+        std::uint32_t shardIndex,
+        ShardState state,
+        std::uint32_t percentProgress);
+
+    [[nodiscard]] protocol::TMPeerShardInfoV2
+    makeMessage(Application& app);
+
+private:
+    // Finalized immutable shards
+    RangeSet<std::uint32_t> finalized_;
+
+    // Incomplete shards being acquired or finalized
+    std::map<std::uint32_t, Incomplete> incomplete_;
+
+    // Message creation time
+    NetClock::time_point msgTimestamp_;
+};
+
+}  // namespace NodeStore
+}  // namespace ripple
+
+#endif

--- a/src/ripple/nodestore/Types.h
+++ b/src/ripple/nodestore/Types.h
@@ -55,6 +55,16 @@ enum Status {
 using Batch = std::vector<std::shared_ptr<NodeObject>>;
 
 }  // namespace NodeStore
+
+/** Shard states. */
+enum class ShardState : std::uint32_t {
+    acquire,     // Acquiring ledgers
+    complete,    // Backend is ledger complete, database is unverified
+    finalizing,  // Verifying database
+    finalized,   // Database verified, shard is immutable
+    queued       // Queued to be finalized
+};
+
 }  // namespace ripple
 
 #endif

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -22,6 +22,7 @@
 #include <ripple/app/misc/NetworkOPs.h>
 #include <ripple/app/rdb/backend/RelationalDBInterfaceSqlite.h>
 #include <ripple/basics/ByteUtilities.h>
+#include <ripple/basics/RangeSet.h>
 #include <ripple/basics/chrono.h>
 #include <ripple/basics/random.h>
 #include <ripple/core/ConfigSections.h>
@@ -30,6 +31,7 @@
 #include <ripple/overlay/Overlay.h>
 #include <ripple/overlay/predicates.h>
 #include <ripple/protocol/HashPrefix.h>
+#include <ripple/protocol/digest.h>
 
 #include <boost/algorithm/string/predicate.hpp>
 
@@ -58,7 +60,6 @@ DatabaseShardImp::DatabaseShardImp(
     , app_(app)
     , parent_(parent)
     , taskQueue_(std::make_unique<TaskQueue>(*this))
-    , earliestShardIndex_(seqToShardIndex(earliestLedgerSeq()))
     , avgShardFileSz_(ledgersPerShard_ * kilobytes(192ull))
     , openFinalLimit_(
           app.config().getValueFor(SizedItem::openFinalLimit, std::nullopt))
@@ -118,7 +119,7 @@ DatabaseShardImp::init()
             if (!app_.config().standalone() && !historicalPaths_.empty())
             {
                 // Check historical paths for duplicated file systems
-                if (!checkHistoricalPaths())
+                if (!checkHistoricalPaths(lock))
                     return false;
             }
 
@@ -148,12 +149,12 @@ DatabaseShardImp::init()
 
                     // Ignore values below the earliest shard index
                     auto const shardIndex{std::stoul(dirName)};
-                    if (shardIndex < earliestShardIndex())
+                    if (shardIndex < earliestShardIndex_)
                     {
                         JLOG(j_.debug())
                             << "shard " << shardIndex
                             << " ignored, comes before earliest shard index "
-                            << earliestShardIndex();
+                            << earliestShardIndex_;
                         continue;
                     }
 
@@ -182,13 +183,13 @@ DatabaseShardImp::init()
 
                     switch (shard->getState())
                     {
-                        case Shard::final:
+                        case ShardState::finalized:
                             if (++openFinals > openFinalLimit_)
                                 shard->tryClose();
                             shards_.emplace(shardIndex, std::move(shard));
                             break;
 
-                        case Shard::complete:
+                        case ShardState::complete:
                             finalizeShard(
                                 shards_.emplace(shardIndex, std::move(shard))
                                     .first->second,
@@ -196,7 +197,7 @@ DatabaseShardImp::init()
                                 std::nullopt);
                             break;
 
-                        case Shard::acquire:
+                        case ShardState::acquire:
                             if (acquireIndex_ != 0)
                             {
                                 JLOG(j_.error())
@@ -223,12 +224,11 @@ DatabaseShardImp::init()
             return false;
         }
 
-        updateStatus(lock);
         setParent(parent_);
         init_ = true;
     }
 
-    setFileStats();
+    updateFileStats();
     return true;
 }
 
@@ -296,7 +296,9 @@ DatabaseShardImp::prepareLedger(std::uint32_t validLedgerSeq)
         std::lock_guard lock(mutex_);
         shards_.emplace(*shardIndex, std::move(shard));
         acquireIndex_ = *shardIndex;
+        updatePeers(lock);
     }
+
     return ledgerSeq;
 }
 
@@ -319,13 +321,14 @@ DatabaseShardImp::prepareShards(std::vector<std::uint32_t> const& shardIndexes)
                 boost::algorithm::join(indexesAsString, ", ");
         };
 
-        std::string const prequel = shardIndex
-            ? "shard " + std::to_string(*shardIndex)
-            : multipleIndexPrequel();
-
-        JLOG(j.error()) << prequel << " " << msg;
+        JLOG(j.error()) << (shardIndex ? "shard " + std::to_string(*shardIndex)
+                                       : multipleIndexPrequel())
+                        << " " << msg;
         return false;
     };
+
+    if (shardIndexes.empty())
+        return fail("invalid shard indexes");
 
     std::lock_guard lock(mutex_);
     assert(init_);
@@ -337,18 +340,18 @@ DatabaseShardImp::prepareShards(std::vector<std::uint32_t> const& shardIndexes)
 
     for (auto const shardIndex : shardIndexes)
     {
-        if (shardIndex < earliestShardIndex())
+        if (shardIndex < earliestShardIndex_)
         {
             return fail(
                 "comes before earliest shard index " +
-                    std::to_string(earliestShardIndex()),
+                    std::to_string(earliestShardIndex_),
                 shardIndex);
         }
 
         // If we are synced to the network, check if the shard index is
         // greater or equal to the current or validated shard index.
         auto seqCheck = [&](std::uint32_t ledgerSeq) {
-            if (ledgerSeq >= earliestLedgerSeq() &&
+            if (ledgerSeq >= earliestLedgerSeq_ &&
                 shardIndex >= seqToShardIndex(ledgerSeq))
             {
                 return fail("invalid index", shardIndex);
@@ -398,14 +401,9 @@ DatabaseShardImp::prepareShards(std::vector<std::uint32_t> const& shardIndexes)
     }
 
     for (auto const shardIndex : shardIndexes)
-    {
-        auto const prepareSuccessful =
-            preparedIndexes_.emplace(shardIndex).second;
+        preparedIndexes_.emplace(shardIndex);
 
-        (void)prepareSuccessful;
-        assert(prepareSuccessful);
-    }
-
+    updatePeers(lock);
     return true;
 }
 
@@ -415,7 +413,8 @@ DatabaseShardImp::removePreShard(std::uint32_t shardIndex)
     std::lock_guard lock(mutex_);
     assert(init_);
 
-    preparedIndexes_.erase(shardIndex);
+    if (preparedIndexes_.erase(shardIndex))
+        updatePeers(lock);
 }
 
 std::string
@@ -433,7 +432,7 @@ DatabaseShardImp::getPreShards()
     if (rs.empty())
         return {};
 
-    return to_string(rs);
+    return ripple::to_string(rs);
 };
 
 bool
@@ -447,6 +446,7 @@ DatabaseShardImp::importShard(
 
         // Remove the failed import shard index so it can be retried
         preparedIndexes_.erase(shardIndex);
+        updatePeers(lock);
         return false;
     };
 
@@ -518,7 +518,8 @@ DatabaseShardImp::importShard(
     auto shard{std::make_unique<Shard>(
         app_, *this, shardIndex, dstDir.parent_path(), j_)};
 
-    if (!shard->init(scheduler_, *ctx_) || shard->getState() != Shard::complete)
+    if (!shard->init(scheduler_, *ctx_) ||
+        shard->getState() != ShardState::complete)
     {
         shard.reset();
         renameDir(dstDir, srcDir);
@@ -561,9 +562,9 @@ DatabaseShardImp::fetchLedger(uint256 const& hash, std::uint32_t ledgerSeq)
         // Ledger must be stored in a final or acquiring shard
         switch (shard->getState())
         {
-            case Shard::final:
+            case ShardState::finalized:
                 break;
-            case Shard::acquire:
+            case ShardState::acquire:
                 if (shard->containsLedger(ledgerSeq))
                     break;
                 [[fallthrough]];
@@ -682,13 +683,11 @@ DatabaseShardImp::setStored(std::shared_ptr<Ledger const> const& ledger)
     setStoredInShard(shard, ledger);
 }
 
-std::string
-DatabaseShardImp::getCompleteShards()
+std::unique_ptr<ShardInfo>
+DatabaseShardImp::getShardInfo() const
 {
     std::lock_guard lock(mutex_);
-    assert(init_);
-
-    return status_;
+    return getShardInfo(lock);
 }
 
 void
@@ -718,12 +717,12 @@ DatabaseShardImp::onChildrenStopped()
     }
 
     // All shards should be expired at this point
-    for (auto const& e : shards)
+    for (auto const& weak : shards)
     {
-        if (!e.expired())
+        if (!weak.expired())
         {
             std::string shardIndex;
-            if (auto const shard{e.lock()}; shard)
+            if (auto const shard{weak.lock()}; shard)
                 shardIndex = std::to_string(shard->index());
 
             JLOG(j_.warn()) << " shard " << shardIndex << " unexpired";
@@ -856,13 +855,10 @@ DatabaseShardImp::import(Database& source)
                 auto const firstSeq{firstLedgerSeq(shardIndex)};
                 auto const lastSeq{
                     std::max(firstSeq, lastLedgerSeq(shardIndex))};
-                auto const numLedgers{
-                    shardIndex == earliestShardIndex() ? lastSeq - firstSeq + 1
-                                                       : ledgersPerShard_};
                 auto ledgerHashes{
                     app_.getRelationalDBInterface().getHashesByIndex(
                         firstSeq, lastSeq)};
-                if (ledgerHashes.size() != numLedgers)
+                if (ledgerHashes.size() != maxLedgers(shardIndex))
                     continue;
 
                 bool valid{true};
@@ -930,7 +926,7 @@ DatabaseShardImp::import(Database& source)
 
             using namespace boost::filesystem;
             bool success{false};
-            if (lastLedgerHash && shard->getState() == Shard::complete)
+            if (lastLedgerHash && shard->getState() == ShardState::complete)
             {
                 // Store shard final key
                 Serializer s;
@@ -977,11 +973,9 @@ DatabaseShardImp::import(Database& source)
                 shard->removeOnDestroy();
             }
         }
-
-        updateStatus(lock);
     }
 
-    setFileStats();
+    updateFileStats();
 }
 
 std::int32_t
@@ -1086,13 +1080,11 @@ DatabaseShardImp::sweep()
     std::vector<std::shared_ptr<Shard>> openFinals;
     openFinals.reserve(openFinalLimit_);
 
-    for (auto const& e : shards)
+    for (auto const& weak : shards)
     {
-        if (auto const shard{e.lock()}; shard && shard->isOpen())
+        if (auto const shard{weak.lock()}; shard && shard->isOpen())
         {
-            shard->sweep();
-
-            if (shard->getState() == Shard::final)
+            if (shard->getState() == ShardState::finalized)
                 openFinals.emplace_back(std::move(shard));
         }
     }
@@ -1135,30 +1127,30 @@ DatabaseShardImp::initConfig(std::lock_guard<std::mutex> const&)
     Config const& config{app_.config()};
     Section const& section{config.section(ConfigSection::shardDatabase())};
 
+    auto compare = [&](std::string const& name, std::uint32_t defaultValue) {
+        std::uint32_t shardDBValue{defaultValue};
+        get_if_exists<std::uint32_t>(section, name, shardDBValue);
+
+        std::uint32_t nodeDBValue{defaultValue};
+        get_if_exists<std::uint32_t>(
+            config.section(ConfigSection::nodeDatabase()), name, nodeDBValue);
+
+        return shardDBValue == nodeDBValue;
+    };
+
+    // If ledgers_per_shard or earliest_seq are specified,
+    // they must be equally assigned in 'node_db'
+    if (!compare("ledgers_per_shard", DEFAULT_LEDGERS_PER_SHARD))
     {
-        // The earliest ledger sequence defaults to XRP_LEDGER_EARLIEST_SEQ.
-        // A custom earliest ledger sequence can be set through the
-        // configuration file using the 'earliest_seq' field under the
-        // 'node_db' and 'shard_db' stanzas. If specified, this field must
-        // have a value greater than zero and be equally assigned in
-        // both stanzas.
-
-        std::uint32_t shardDBEarliestSeq{0};
-        get_if_exists<std::uint32_t>(
-            section, "earliest_seq", shardDBEarliestSeq);
-
-        std::uint32_t nodeDBEarliestSeq{0};
-        get_if_exists<std::uint32_t>(
-            config.section(ConfigSection::nodeDatabase()),
-            "earliest_seq",
-            nodeDBEarliestSeq);
-
-        if (shardDBEarliestSeq != nodeDBEarliestSeq)
-        {
-            return fail(
-                "and [" + ConfigSection::nodeDatabase() +
-                "] define different 'earliest_seq' values");
-        }
+        return fail(
+            "and [" + ConfigSection::nodeDatabase() + "] define different '" +
+            "ledgers_per_shard" + "' values");
+    }
+    if (!compare("earliest_seq", XRP_LEDGER_EARLIEST_SEQ))
+    {
+        return fail(
+            "and [" + ConfigSection::nodeDatabase() + "] define different '" +
+            "earliest_seq" + "' values");
     }
 
     using namespace boost::filesystem;
@@ -1188,20 +1180,6 @@ DatabaseShardImp::initConfig(std::lock_guard<std::mutex> const&)
 
             historicalPaths_.push_back(s);
         }
-    }
-
-    if (section.exists("ledgers_per_shard"))
-    {
-        // To be set only in standalone for testing
-        if (!config.standalone())
-            return fail("'ledgers_per_shard' only honored in stand alone");
-
-        ledgersPerShard_ = get<std::uint32_t>(section, "ledgers_per_shard");
-        if (ledgersPerShard_ == 0 || ledgersPerShard_ % 256 != 0)
-            return fail("'ledgers_per_shard' must be a multiple of 256");
-
-        earliestShardIndex_ = seqToShardIndex(earliestLedgerSeq());
-        avgShardFileSz_ = ledgersPerShard_ * kilobytes(192);
     }
 
     // NuDB is the default and only supported permanent storage backend
@@ -1236,7 +1214,7 @@ DatabaseShardImp::findAcquireIndex(
     std::uint32_t validLedgerSeq,
     std::lock_guard<std::mutex> const&)
 {
-    if (validLedgerSeq < earliestLedgerSeq())
+    if (validLedgerSeq < earliestLedgerSeq_)
         return std::nullopt;
 
     auto const maxShardIndex{[this, validLedgerSeq]() {
@@ -1245,7 +1223,7 @@ DatabaseShardImp::findAcquireIndex(
             --shardIndex;
         return shardIndex;
     }()};
-    auto const maxNumShards{maxShardIndex - earliestShardIndex() + 1};
+    auto const maxNumShards{maxShardIndex - earliestShardIndex_ + 1};
 
     // Check if the shard store has all shards
     if (shards_.size() >= maxNumShards)
@@ -1259,8 +1237,7 @@ DatabaseShardImp::findAcquireIndex(
         std::vector<std::uint32_t> available;
         available.reserve(maxNumShards - shards_.size());
 
-        for (auto shardIndex = earliestShardIndex();
-             shardIndex <= maxShardIndex;
+        for (auto shardIndex = earliestShardIndex_; shardIndex <= maxShardIndex;
              ++shardIndex)
         {
             if (shards_.find(shardIndex) == shards_.end() &&
@@ -1285,7 +1262,7 @@ DatabaseShardImp::findAcquireIndex(
     // chances of running more than 30 times is less than 1 in a billion
     for (int i = 0; i < 40; ++i)
     {
-        auto const shardIndex{rand_int(earliestShardIndex(), maxShardIndex)};
+        auto const shardIndex{rand_int(earliestShardIndex_, maxShardIndex)};
         if (shards_.find(shardIndex) == shards_.end() &&
             preparedIndexes_.find(shardIndex) == preparedIndexes_.end())
         {
@@ -1332,9 +1309,7 @@ DatabaseShardImp::finalizeShard(
 
         {
             auto const boundaryIndex{shardBoundaryIndex()};
-
             std::lock_guard lock(mutex_);
-            updateStatus(lock);
 
             if (shard->index() < boundaryIndex)
             {
@@ -1347,19 +1322,17 @@ DatabaseShardImp::finalizeShard(
                                     << " is not stored at a historical path";
                 }
             }
-
             else
             {
                 // Not a historical shard. Shift recent shards if necessary
-                relocateOutdatedShards(lock);
                 assert(!boundaryIndex || shard->index() - boundaryIndex <= 1);
-
-                auto& recentShard = shard->index() == boundaryIndex
-                    ? secondLatestShardIndex_
-                    : latestShardIndex_;
+                relocateOutdatedShards(lock);
 
                 // Set the appropriate recent shard index
-                recentShard = shard->index();
+                if (shard->index() == boundaryIndex)
+                    secondLatestShardIndex_ = shard->index();
+                else
+                    latestShardIndex_ = shard->index();
 
                 if (shard->getDir().parent_path() != dir_)
                 {
@@ -1367,26 +1340,16 @@ DatabaseShardImp::finalizeShard(
                                     << " is not stored at the path";
                 }
             }
+
+            updatePeers(lock);
         }
 
-        setFileStats();
-
-        // Update peers with new shard index
-        if (!app_.config().standalone() &&
-            app_.getOPs().getOperatingMode() != OperatingMode::DISCONNECTED)
-        {
-            protocol::TMPeerShardInfo message;
-            PublicKey const& publicKey{app_.nodeIdentity().first};
-            message.set_nodepubkey(publicKey.data(), publicKey.size());
-            message.set_shardindexes(std::to_string(shard->index()));
-            app_.overlay().foreach(send_always(std::make_shared<Message>(
-                message, protocol::mtPEER_SHARD_INFO)));
-        }
+        updateFileStats();
     });
 }
 
 void
-DatabaseShardImp::setFileStats()
+DatabaseShardImp::updateFileStats()
 {
     std::vector<std::weak_ptr<Shard>> shards;
     {
@@ -1402,9 +1365,9 @@ DatabaseShardImp::setFileStats()
     std::uint64_t sumSz{0};
     std::uint32_t sumFd{0};
     std::uint32_t numShards{0};
-    for (auto const& e : shards)
+    for (auto const& weak : shards)
     {
-        if (auto const shard{e.lock()}; shard)
+        if (auto const shard{weak.lock()}; shard)
         {
             auto const [sz, fd] = shard->getFileInfo();
             sumSz += sz;
@@ -1444,21 +1407,6 @@ DatabaseShardImp::setFileStats()
 
         canAdd_ = false;
     }
-}
-
-void
-DatabaseShardImp::updateStatus(std::lock_guard<std::mutex> const&)
-{
-    if (!shards_.empty())
-    {
-        RangeSet<std::uint32_t> rs;
-        for (auto const& e : shards_)
-            if (e.second->getState() == Shard::final)
-                rs.insert(e.second->index());
-        status_ = to_string(rs);
-    }
-    else
-        status_.clear();
 }
 
 bool
@@ -1528,7 +1476,7 @@ DatabaseShardImp::setStoredInShard(
         return false;
     }
 
-    if (shard->getState() == Shard::complete)
+    if (shard->getState() == ShardState::complete)
     {
         std::lock_guard lock(mutex_);
         if (auto const it{shards_.find(shard->index())}; it != shards_.end())
@@ -1545,7 +1493,7 @@ DatabaseShardImp::setStoredInShard(
         }
     }
 
-    setFileStats();
+    updateFileStats();
     return true;
 }
 
@@ -1563,12 +1511,6 @@ DatabaseShardImp::removeFailedShard(std::shared_ptr<Shard>& shard)
 
         if (shard->index() == secondLatestShardIndex_)
             secondLatestShardIndex_ = std::nullopt;
-
-        if ((shards_.erase(shard->index()) > 0) &&
-            shard->getState() == Shard::final)
-        {
-            updateStatus(lock);
-        }
     }
 
     shard->removeOnDestroy();
@@ -1576,7 +1518,7 @@ DatabaseShardImp::removeFailedShard(std::shared_ptr<Shard>& shard)
     // Reset the shared_ptr to invoke the shard's
     // destructor and remove it from the server
     shard.reset();
-    setFileStats();
+    updateFileStats();
 }
 
 std::uint32_t
@@ -1584,7 +1526,7 @@ DatabaseShardImp::shardBoundaryIndex() const
 {
     auto const validIndex = app_.getLedgerMaster().getValidLedgerIndex();
 
-    if (validIndex < earliestLedgerSeq())
+    if (validIndex < earliestLedgerSeq_)
         return 0;
 
     // Shards with an index earlier than the recent shard boundary index
@@ -1610,151 +1552,135 @@ void
 DatabaseShardImp::relocateOutdatedShards(
     std::lock_guard<std::mutex> const& lock)
 {
-    if (auto& cur = latestShardIndex_, &prev = secondLatestShardIndex_;
-        cur || prev)
-    {
-        auto const latestShardIndex =
-            seqToShardIndex(app_.getLedgerMaster().getValidLedgerIndex());
+    auto& cur{latestShardIndex_};
+    auto& prev{secondLatestShardIndex_};
+    if (!cur && !prev)
+        return;
 
-        auto const separateHistoricalPath = !historicalPaths_.empty();
+    auto const latestShardIndex =
+        seqToShardIndex(app_.getLedgerMaster().getValidLedgerIndex());
+    auto const separateHistoricalPath = !historicalPaths_.empty();
 
-        auto const removeShard =
-            [this](std::uint32_t const shardIndex) -> void {
-            canAdd_ = false;
+    auto const removeShard = [this](std::uint32_t const shardIndex) -> void {
+        canAdd_ = false;
 
-            if (auto it = shards_.find(shardIndex); it != shards_.end())
-            {
-                if (it->second)
-                    removeFailedShard(it->second);
-                else
-                {
-                    JLOG(j_.warn()) << "can't find shard to remove";
-                }
-            }
+        if (auto it = shards_.find(shardIndex); it != shards_.end())
+        {
+            if (it->second)
+                removeFailedShard(it->second);
             else
             {
                 JLOG(j_.warn()) << "can't find shard to remove";
             }
-        };
+        }
+        else
+        {
+            JLOG(j_.warn()) << "can't find shard to remove";
+        }
+    };
 
-        auto const keepShard =
-            [this, &lock, removeShard, separateHistoricalPath](
-                std::uint32_t const shardIndex) -> bool {
-            if (numHistoricalShards(lock) >= maxHistoricalShards_)
-            {
-                JLOG(j_.error())
-                    << "maximum number of historical shards reached";
+    auto const keepShard = [this, &lock, removeShard, separateHistoricalPath](
+                               std::uint32_t const shardIndex) -> bool {
+        if (numHistoricalShards(lock) >= maxHistoricalShards_)
+        {
+            JLOG(j_.error()) << "maximum number of historical shards reached";
+            removeShard(shardIndex);
+            return false;
+        }
+        if (separateHistoricalPath &&
+            !sufficientStorage(1, PathDesignation::historical, lock))
+        {
+            JLOG(j_.error()) << "insufficient storage space available";
+            removeShard(shardIndex);
+            return false;
+        }
 
-                removeShard(shardIndex);
-                return false;
-            }
-            if (separateHistoricalPath &&
-                !sufficientStorage(1, PathDesignation::historical, lock))
-            {
-                JLOG(j_.error()) << "insufficient storage space available";
+        return true;
+    };
 
-                removeShard(shardIndex);
-                return false;
-            }
+    // Move a shard from the main shard path to a historical shard
+    // path by copying the contents, and creating a new shard.
+    auto const moveShard = [this,
+                            &lock](std::uint32_t const shardIndex) -> void {
+        auto it{shards_.find(shardIndex)};
+        if (it == shards_.end())
+        {
+            JLOG(j_.warn()) << "can't find shard to move to historical path";
+            return;
+        }
 
-            return true;
-        };
+        auto& shard{it->second};
 
-        // Move a shard from the main shard path to a historical shard
-        // path by copying the contents, and creating a new shard.
-        auto const moveShard = [this,
-                                &lock](std::uint32_t const shardIndex) -> void {
-            auto const dst = chooseHistoricalPath(lock);
+        // Close any open file descriptors before moving the shard
+        // directory. Don't call removeOnDestroy since that would
+        // attempt to close the fds after the directory has been moved.
+        if (!shard->tryClose())
+        {
+            JLOG(j_.warn()) << "can't close shard to move to historical path";
+            return;
+        }
 
-            if (auto it = shards_.find(shardIndex); it != shards_.end())
-            {
-                auto& shard{it->second};
+        auto const dst{chooseHistoricalPath(lock)};
+        try
+        {
+            // Move the shard directory to the new path
+            boost::filesystem::rename(
+                shard->getDir().string(), dst / std::to_string(shardIndex));
+        }
+        catch (...)
+        {
+            JLOG(j_.error()) << "shard " << shardIndex
+                             << " failed to move to historical storage";
+            return;
+        }
 
-                // Close any open file descriptors before moving the shard
-                // directory. Don't call removeOnDestroy since that would
-                // attempt to close the fds after the directory has been moved.
-                if (!shard->tryClose())
-                {
-                    JLOG(j_.warn())
-                        << "can't close shard to move to historical path";
-                    return;
-                }
+        // Create a shard instance at the new location
+        shard = std::make_shared<Shard>(app_, *this, shardIndex, dst, j_);
 
-                try
-                {
-                    // Move the shard directory to the new path
-                    boost::filesystem::rename(
-                        shard->getDir().string(),
-                        dst / std::to_string(shardIndex));
-                }
-                catch (...)
-                {
-                    JLOG(j_.error()) << "shard " << shardIndex
-                                     << " failed to move to historical storage";
-                    return;
-                }
+        // Open the new shard
+        if (!shard->init(scheduler_, *ctx_))
+        {
+            JLOG(j_.error()) << "shard " << shardIndex
+                             << " failed to open in historical storage";
+            shard->removeOnDestroy();
+            shard.reset();
+        }
+    };
 
-                // Create a shard instance at the new location
-                shard =
-                    std::make_shared<Shard>(app_, *this, shardIndex, dst, j_);
+    // See if either of the recent shards needs to be updated
+    bool const curNotSynched =
+        latestShardIndex_ && *latestShardIndex_ != latestShardIndex;
+    bool const prevNotSynched = secondLatestShardIndex_ &&
+        *secondLatestShardIndex_ != latestShardIndex - 1;
 
-                // Open the new shard
-                if (!shard->init(scheduler_, *ctx_))
-                {
-                    JLOG(j_.error()) << "shard " << shardIndex
-                                     << " failed to open in historical storage";
-                    shard->removeOnDestroy();
-                    shard.reset();
-                }
-            }
+    // A new shard has been published. Move outdated
+    // shards to historical storage as needed
+    if (curNotSynched || prevNotSynched)
+    {
+        if (prev)
+        {
+            // Move the formerly second latest shard to historical storage
+            if (keepShard(*prev) && separateHistoricalPath)
+                moveShard(*prev);
+
+            prev = std::nullopt;
+        }
+
+        if (cur)
+        {
+            // The formerly latest shard is now the second latest
+            if (cur == latestShardIndex - 1)
+                prev = cur;
+
+            // The formerly latest shard is no longer a 'recent' shard
             else
             {
-                JLOG(j_.warn())
-                    << "can't find shard to move to historical path";
-            }
-        };
-
-        // See if either of the recent shards needs to be updated
-        bool const curNotSynched =
-            latestShardIndex_ && *latestShardIndex_ != latestShardIndex;
-        bool const prevNotSynched = secondLatestShardIndex_ &&
-            *secondLatestShardIndex_ != latestShardIndex - 1;
-
-        // A new shard has been published. Move outdated
-        // shards to historical storage as needed
-        if (curNotSynched || prevNotSynched)
-        {
-            if (prev)
-            {
-                // Move the formerly second latest shard to historical storage
-                if (keepShard(*prev) && separateHistoricalPath)
-                {
-                    moveShard(*prev);
-                }
-
-                prev = std::nullopt;
+                // Move the formerly latest shard to historical storage
+                if (keepShard(*cur) && separateHistoricalPath)
+                    moveShard(*cur);
             }
 
-            if (cur)
-            {
-                // The formerly latest shard is now the second latest
-                if (cur == latestShardIndex - 1)
-                {
-                    prev = cur;
-                }
-
-                // The formerly latest shard is no longer a 'recent' shard
-                else
-                {
-                    // Move the formerly latest shard to historical storage
-                    if (keepShard(*cur) && separateHistoricalPath)
-                    {
-                        moveShard(*cur);
-                    }
-                }
-
-                cur = std::nullopt;
-            }
+            cur = std::nullopt;
         }
     }
 }
@@ -1824,7 +1750,7 @@ DatabaseShardImp::chooseHistoricalPath(std::lock_guard<std::mutex> const&) const
 }
 
 bool
-DatabaseShardImp::checkHistoricalPaths() const
+DatabaseShardImp::checkHistoricalPaths(std::lock_guard<std::mutex> const&) const
 {
 #if BOOST_OS_LINUX
     // Each historical shard path must correspond
@@ -1914,7 +1840,7 @@ DatabaseShardImp::callForLedgerSQL(
     auto shardIndex = seqToShardIndex(ledgerSeq);
 
     if (shards_.count(shardIndex) &&
-        shards_[shardIndex]->getState() == Shard::State::final)
+        shards_[shardIndex]->getState() == ShardState::finalized)
     {
         return shards_[shardIndex]->callForLedgerSQL(callback);
     }
@@ -1932,7 +1858,7 @@ DatabaseShardImp::callForTransactionSQL(
     auto shardIndex = seqToShardIndex(ledgerSeq);
 
     if (shards_.count(shardIndex) &&
-        shards_[shardIndex]->getState() == Shard::State::final)
+        shards_[shardIndex]->getState() == ShardState::finalized)
     {
         return shards_[shardIndex]->callForTransactionSQL(callback);
     }
@@ -1958,7 +1884,7 @@ DatabaseShardImp::iterateShardsForward(
 
     for (; it != eit; it++)
     {
-        if (it->second->getState() == Shard::State::final)
+        if (it->second->getState() == ShardState::finalized)
         {
             if (!visit(*it->second))
                 return false;
@@ -2009,7 +1935,7 @@ DatabaseShardImp::iterateShardsBack(
 
     for (; it != eit; it++)
     {
-        if (it->second->getState() == Shard::State::final &&
+        if (it->second->getState() == ShardState::finalized &&
             (!maxShardIndex || it->first <= *maxShardIndex))
         {
             if (!visit(*it->second))
@@ -2040,6 +1966,41 @@ DatabaseShardImp::iterateTransactionSQLsBack(
     return iterateShardsBack(maxShardIndex, [&callback](Shard& shard) -> bool {
         return shard.callForTransactionSQL(callback);
     });
+}
+
+std::unique_ptr<ShardInfo>
+DatabaseShardImp::getShardInfo(std::lock_guard<std::mutex> const&) const
+{
+    auto shardInfo{std::make_unique<ShardInfo>()};
+    for (auto const& [_, shard] : shards_)
+    {
+        shardInfo->update(
+            shard->index(), shard->getState(), shard->getPercentProgress());
+    }
+
+    for (auto const shardIndex : preparedIndexes_)
+        shardInfo->update(shardIndex, ShardState::queued, 0);
+
+    return shardInfo;
+}
+
+size_t
+DatabaseShardImp::getNumTasks() const
+{
+    std::lock_guard lock(mutex_);
+    return taskQueue_->size();
+}
+
+void
+DatabaseShardImp::updatePeers(std::lock_guard<std::mutex> const& lock) const
+{
+    if (!app_.config().standalone() &&
+        app_.getOPs().getOperatingMode() != OperatingMode::DISCONNECTED)
+    {
+        auto const message{getShardInfo(lock)->makeMessage(app_)};
+        app_.overlay().foreach(send_always(std::make_shared<Message>(
+            message, protocol::mtPEER_SHARD_INFO_V2)));
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -56,9 +56,7 @@ Shard::Shard(
     , index_(index)
     , firstSeq_(db.firstLedgerSeq(index))
     , lastSeq_(std::max(firstSeq_, db.lastLedgerSeq(index)))
-    , maxLedgers_(
-          index == db.earliestShardIndex() ? lastSeq_ - firstSeq_ + 1
-                                           : db.ledgersPerShard())
+    , maxLedgers_(db.maxLedgers(index))
     , dir_((dir.empty() ? db.getRootDir() : dir) / std::to_string(index_))
 {
 }
@@ -146,7 +144,7 @@ bool
 Shard::tryClose()
 {
     // Keep database open if being acquired or finalized
-    if (state_ != final)
+    if (state_ != ShardState::finalized)
         return false;
 
     std::lock_guard lock(mutex_);
@@ -189,7 +187,7 @@ Shard::tryClose()
 std::optional<std::uint32_t>
 Shard::prepare()
 {
-    if (state_ != acquire)
+    if (state_ != ShardState::acquire)
     {
         JLOG(j_.warn()) << "shard " << index_
                         << " prepare called when not acquiring";
@@ -212,7 +210,7 @@ Shard::prepare()
 bool
 Shard::storeNodeObject(std::shared_ptr<NodeObject> const& nodeObject)
 {
-    if (state_ != acquire)
+    if (state_ != ShardState::acquire)
     {
         // The import node store case is an exception
         if (nodeObject->getHash() != finalKey)
@@ -296,7 +294,7 @@ Shard::storeLedger(
     std::shared_ptr<Ledger const> const& next)
 {
     StoreLedgerResult result;
-    if (state_ != acquire)
+    if (state_ != ShardState::acquire)
     {
         // Ignore residual calls from InboundLedgers
         JLOG(j_.trace()) << "shard " << index_ << ". Not acquiring";
@@ -418,20 +416,21 @@ Shard::storeLedger(
 bool
 Shard::setLedgerStored(std::shared_ptr<Ledger const> const& ledger)
 {
-    if (state_ != acquire)
+    if (state_ != ShardState::acquire)
     {
         // Ignore residual calls from InboundLedgers
         JLOG(j_.trace()) << "shard " << index_ << " not acquiring";
         return false;
     }
 
+    auto fail = [&](std::string const& msg) {
+        JLOG(j_.error()) << "shard " << index_ << ". " << msg;
+        return false;
+    };
+
     auto const ledgerSeq{ledger->info().seq};
     if (ledgerSeq < firstSeq_ || ledgerSeq > lastSeq_)
-    {
-        JLOG(j_.error()) << "shard " << index_ << " invalid ledger sequence "
-                         << ledgerSeq;
-        return false;
-    }
+        return fail("Invalid ledger sequence " + std::to_string(ledgerSeq));
 
     auto const scopedCount{makeBackendCount()};
     if (!scopedCount)
@@ -444,11 +443,8 @@ Shard::setLedgerStored(std::shared_ptr<Ledger const> const& ledger)
     {
         std::lock_guard lock(mutex_);
         if (!acquireInfo_)
-        {
-            JLOG(j_.error())
-                << "shard " << index_ << " missing acquire SQLite database";
-            return false;
-        }
+            return fail("Missing acquire SQLite database");
+
         if (boost::icl::contains(acquireInfo_->storedSeqs, ledgerSeq))
         {
             // Ignore redundant calls
@@ -459,7 +455,7 @@ Shard::setLedgerStored(std::shared_ptr<Ledger const> const& ledger)
     }
 
     if (!storeSQLite(ledger))
-        return false;
+        return fail("Failed to store ledger");
 
     std::lock_guard lock(mutex_);
 
@@ -491,15 +487,16 @@ Shard::setLedgerStored(std::shared_ptr<Ledger const> const& ledger)
     }
     catch (std::exception const& e)
     {
-        JLOG(j_.fatal()) << "shard " << index_
-                         << ". Exception caught in function " << __func__
-                         << ". Error: " << e.what();
         acquireInfo_->storedSeqs.erase(ledgerSeq);
-        return false;
+        return fail(
+            std::string(". Exception caught in function ") + __func__ +
+            ". Error: " + e.what());
     }
 
-    if (boost::icl::length(acquireInfo_->storedSeqs) >= maxLedgers_)
-        state_ = complete;
+    // Update progress
+    progress_ = boost::icl::length(acquireInfo_->storedSeqs);
+    if (progress_ == maxLedgers_)
+        state_ = ShardState::complete;
 
     setFileStats(lock);
     JLOG(j_.trace()) << "shard " << index_ << " stored ledger sequence "
@@ -512,7 +509,7 @@ Shard::containsLedger(std::uint32_t ledgerSeq) const
 {
     if (ledgerSeq < firstSeq_ || ledgerSeq > lastSeq_)
         return false;
-    if (state_ != acquire)
+    if (state_ != ShardState::acquire)
         return true;
 
     std::lock_guard lock(mutex_);
@@ -523,12 +520,6 @@ Shard::containsLedger(std::uint32_t ledgerSeq) const
         return false;
     }
     return boost::icl::contains(acquireInfo_->storedSeqs, ledgerSeq);
-}
-
-void
-Shard::sweep()
-{
-    // nothing to do
 }
 
 std::chrono::steady_clock::time_point
@@ -568,8 +559,6 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
     if (!scopedCount)
         return false;
 
-    state_ = finalizing;
-
     uint256 hash{0};
     std::uint32_t ledgerSeq{0};
     auto fail = [&](std::string const& msg) {
@@ -579,12 +568,17 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
                          << (ledgerSeq == 0 ? ""
                                             : ". Ledger sequence " +
                                      std::to_string(ledgerSeq));
-        state_ = finalizing;
+        state_ = ShardState::finalizing;
+        progress_ = 0;
+        busy_ = false;
         return false;
     };
 
     try
     {
+        state_ = ShardState::finalizing;
+        progress_ = 0;
+
         /*
         TODO MP
         A lock is required when calling the NuDB verify function. Because
@@ -727,6 +721,10 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
 
         hash = ledger->info().parentHash;
         next = std::move(ledger);
+
+        // Update progress
+        progress_ = maxLedgers_ - (ledgerSeq - firstSeq_);
+
         --ledgerSeq;
 
         fullBelowCache->reset();
@@ -813,7 +811,9 @@ Shard::finalize(bool writeSQLite, std::optional<uint256> const& referenceHash)
 
         // Re-open deterministic shard
         if (!open(lock))
-            return false;
+            return fail("failed to open");
+
+        assert(state_ == ShardState::finalized);
 
         // Allow all other threads work with the shard
         busy_ = false;
@@ -840,7 +840,8 @@ Shard::open(std::lock_guard<std::mutex> const& lock)
         txSQLiteDB_.reset();
         acquireInfo_.reset();
 
-        state_ = acquire;
+        state_ = ShardState::acquire;
+        progress_ = 0;
 
         if (!preexist)
             remove_all(dir_);
@@ -852,18 +853,19 @@ Shard::open(std::lock_guard<std::mutex> const& lock)
         return false;
     };
     auto createAcquireInfo = [this, &config]() {
-        acquireInfo_ = std::make_unique<AcquireInfo>();
-
         DatabaseCon::Setup setup;
         setup.startUp = config.standalone() ? config.LOAD : config.START_UP;
         setup.standAlone = config.standalone();
         setup.dataDir = dir_;
         setup.useGlobalPragma = true;
 
+        acquireInfo_ = std::make_unique<AcquireInfo>();
         acquireInfo_->SQLiteDB = makeAcquireDB(
             setup,
             DatabaseCon::CheckpointerSetup{&app_.getJobQueue(), &app_.logs()});
-        state_ = acquire;
+
+        state_ = ShardState::acquire;
+        progress_ = 0;
     };
 
     try
@@ -901,14 +903,14 @@ Shard::open(std::lock_guard<std::mutex> const& lock)
                 }
 
                 // Check if backend is complete
-                if (boost::icl::length(storedSeqs) == maxLedgers_)
-                    state_ = complete;
+                progress_ = boost::icl::length(storedSeqs);
+                if (progress_ == maxLedgers_)
+                    state_ = ShardState::complete;
             }
         }
         else
         {
-            // A shard that is final or its backend is complete
-            // and ready to be finalized
+            // A shard with a finalized or complete state
             std::shared_ptr<NodeObject> nodeObject;
             if (backend_->fetch(finalKey.data(), &nodeObject) != Status::ok)
             {
@@ -931,10 +933,12 @@ Shard::open(std::lock_guard<std::mutex> const& lock)
             if (exists(dir_ / LgrDBName) && exists(dir_ / TxDBName))
             {
                 lastAccess_ = std::chrono::steady_clock::now();
-                state_ = final;
+                state_ = ShardState::finalized;
             }
             else
-                state_ = complete;
+                state_ = ShardState::complete;
+
+            progress_ = maxLedgers_;
         }
     }
     catch (std::exception const& e)
@@ -960,7 +964,7 @@ Shard::initSQLite(std::lock_guard<std::mutex> const&)
         setup.startUp = config.standalone() ? config.LOAD : config.START_UP;
         setup.standAlone = config.standalone();
         setup.dataDir = dir_;
-        setup.useGlobalPragma = (state_ != complete);
+        setup.useGlobalPragma = (state_ != ShardState::complete);
         return setup;
     }();
 
@@ -972,21 +976,48 @@ Shard::initSQLite(std::lock_guard<std::mutex> const&)
         if (txSQLiteDB_)
             txSQLiteDB_.reset();
 
-        if (state_ == final)
+        switch (state_)
         {
-            auto [lgr, tx] = makeShardCompleteLedgerDBs(config, setup);
-            txSQLiteDB_ = std::move(tx);
-            lgrSQLiteDB_ = std::move(lgr);
-        }
-        else
-        {
-            auto [lgr, tx] = makeShardIncompleteLedgerDBs(
-                config,
-                setup,
-                DatabaseCon::CheckpointerSetup{
-                    &app_.getJobQueue(), &app_.logs()});
-            txSQLiteDB_ = std::move(tx);
-            lgrSQLiteDB_ = std::move(lgr);
+            case ShardState::complete:
+            case ShardState::finalizing:
+            case ShardState::finalized: {
+                auto [lgr, tx] = makeShardCompleteLedgerDBs(config, setup);
+
+                lgrSQLiteDB_ = std::move(lgr);
+                lgrSQLiteDB_->getSession() << boost::str(
+                    boost::format("PRAGMA cache_size=-%d;") %
+                    kilobytes(config.getValueFor(
+                        SizedItem::lgrDBCache, std::nullopt)));
+
+                txSQLiteDB_ = std::move(tx);
+                txSQLiteDB_->getSession() << boost::str(
+                    boost::format("PRAGMA cache_size=-%d;") %
+                    kilobytes(config.getValueFor(
+                        SizedItem::txnDBCache, std::nullopt)));
+                break;
+            }
+
+            // case ShardState::acquire:
+            // case ShardState::queued:
+            default: {
+                // Incomplete shards use a Write Ahead Log for performance
+                auto [lgr, tx] = makeShardIncompleteLedgerDBs(
+                    config,
+                    setup,
+                    DatabaseCon::CheckpointerSetup{
+                        &app_.getJobQueue(), &app_.logs()});
+
+                lgrSQLiteDB_ = std::move(lgr);
+                lgrSQLiteDB_->getSession() << boost::str(
+                    boost::format("PRAGMA cache_size=-%d;") %
+                    kilobytes(config.getValueFor(SizedItem::lgrDBCache)));
+
+                txSQLiteDB_ = std::move(tx);
+                txSQLiteDB_->getSession() << boost::str(
+                    boost::format("PRAGMA cache_size=-%d;") %
+                    kilobytes(config.getValueFor(SizedItem::txnDBCache)));
+                break;
+            }
         }
     }
     catch (std::exception const& e)
@@ -1211,7 +1242,7 @@ Shard::makeBackendCount()
         if (!open(lock))
             return {nullptr};
     }
-    else if (state_ == final)
+    else if (state_ == ShardState::finalized)
         lastAccess_ = std::chrono::steady_clock::now();
 
     return Shard::Count(&backendCount_);

--- a/src/ripple/nodestore/impl/Shard.h
+++ b/src/ripple/nodestore/impl/Shard.h
@@ -23,6 +23,7 @@
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/app/rdb/RelationalDBInterface.h>
 #include <ripple/basics/BasicConfig.h>
+#include <ripple/basics/MathUtilities.h>
 #include <ripple/basics/RangeSet.h>
 #include <ripple/core/DatabaseCon.h>
 #include <ripple/nodestore/NodeObject.h>
@@ -52,17 +53,19 @@ class DatabaseShard;
 class Shard final
 {
 public:
-    enum class State {
-        acquire,     // Being acquired
-        complete,    // Backend contains all ledgers but is not yet final
-        finalizing,  // Being finalized
-        final        // Database verified, shard is immutable
-    };
+    /// Copy constructor (disallowed)
+    Shard(Shard const&) = delete;
 
-    static constexpr State acquire = State::acquire;
-    static constexpr State complete = State::complete;
-    static constexpr State finalizing = State::finalizing;
-    static constexpr State final = State::final;
+    /// Move constructor (disallowed)
+    Shard(Shard&&) = delete;
+
+    // Copy assignment (disallowed)
+    Shard&
+    operator=(Shard const&) = delete;
+
+    // Move assignment (disallowed)
+    Shard&
+    operator=(Shard&&) = delete;
 
     Shard(
         Application& app,
@@ -102,7 +105,7 @@ public:
     /** Notify shard to prepare for shutdown.
      */
     void
-    stop()
+    stop() noexcept
     {
         stop_ = true;
     }
@@ -140,17 +143,14 @@ public:
     [[nodiscard]] bool
     containsLedger(std::uint32_t ledgerSeq) const;
 
-    void
-    sweep();
-
     [[nodiscard]] std::uint32_t
-    index() const
+    index() const noexcept
     {
         return index_;
     }
 
     [[nodiscard]] boost::filesystem::path const&
-    getDir() const
+    getDir() const noexcept
     {
         return dir_;
     }
@@ -164,10 +164,19 @@ public:
     [[nodiscard]] std::pair<std::uint64_t, std::uint32_t>
     getFileInfo() const;
 
-    [[nodiscard]] State
-    getState() const
+    [[nodiscard]] ShardState
+    getState() const noexcept
     {
         return state_;
+    }
+
+    /** Returns a percent signifying how complete
+        the current state of the shard is.
+     */
+    [[nodiscard]] std::uint32_t
+    getPercentProgress() const noexcept
+    {
+        return calculatePercent(progress_, maxLedgers_);
     }
 
     [[nodiscard]] std::int32_t
@@ -192,7 +201,7 @@ public:
     /** Enables removal of the shard directory on destruction.
      */
     void
-    removeOnDestroy()
+    removeOnDestroy() noexcept
     {
         removeOnDestroy_ = true;
     }
@@ -235,28 +244,28 @@ private:
     public:
         Count(Count const&) = delete;
         Count&
-        operator=(Count&&) = delete;
-        Count&
         operator=(Count const&) = delete;
+        Count&
+        operator=(Count&&) = delete;
 
-        Count(Count&& other) : counter_(other.counter_)
+        Count(Count&& other) noexcept : counter_(other.counter_)
         {
             other.counter_ = nullptr;
         }
 
-        Count(std::atomic<std::uint32_t>* counter) : counter_(counter)
+        Count(std::atomic<std::uint32_t>* counter) noexcept : counter_(counter)
         {
             if (counter_)
                 ++(*counter_);
         }
 
-        ~Count()
+        ~Count() noexcept
         {
             if (counter_)
                 --(*counter_);
         }
 
-        operator bool() const
+        operator bool() const noexcept
         {
             return counter_ != nullptr;
         }
@@ -313,7 +322,7 @@ private:
     std::unique_ptr<DatabaseCon> txSQLiteDB_;
 
     // Tracking information used only when acquiring a shard from the network.
-    // If the shard is final, this member will be null.
+    // If the shard is finalized, this member will be null.
     std::unique_ptr<AcquireInfo> acquireInfo_;
 
     // Older shard without an acquire database or final key
@@ -326,12 +335,16 @@ private:
     // Determines if the shard busy with replacing by deterministic one
     std::atomic<bool> busy_{false};
 
-    std::atomic<State> state_{State::acquire};
+    // State of the shard
+    std::atomic<ShardState> state_{ShardState::acquire};
+
+    // Number of ledgers processed for the current shard state
+    std::atomic<std::uint32_t> progress_{0};
 
     // Determines if the shard directory should be removed in the destructor
     std::atomic<bool> removeOnDestroy_{false};
 
-    // The time of the last access of a shard that has a final state
+    // The time of the last access of a shard with a finalized state
     std::chrono::steady_clock::time_point lastAccess_;
 
     // Open shard databases

--- a/src/ripple/nodestore/impl/ShardInfo.cpp
+++ b/src/ripple/nodestore/impl/ShardInfo.cpp
@@ -1,0 +1,138 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2020 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/main/Application.h>
+#include <ripple/core/TimeKeeper.h>
+#include <ripple/nodestore/ShardInfo.h>
+#include <ripple/protocol/SecretKey.h>
+#include <ripple/protocol/digest.h>
+
+#include <boost/algorithm/clamp.hpp>
+
+namespace ripple {
+namespace NodeStore {
+
+std::string
+ShardInfo::finalizedToString() const
+{
+    if (!finalized_.empty())
+        return ripple::to_string(finalized_);
+    return {};
+}
+
+std::string
+ShardInfo::incompleteToString() const
+{
+    std::string result;
+    if (!incomplete_.empty())
+    {
+        for (auto const& [shardIndex, incomplete] : incomplete_)
+        {
+            result += std::to_string(shardIndex) + ":" +
+                std::to_string(incomplete.percentProgress()) + ",";
+        }
+        result.pop_back();
+    }
+
+    return result;
+}
+
+bool
+ShardInfo::update(
+    std::uint32_t shardIndex,
+    ShardState state,
+    std::uint32_t percentProgress)
+{
+    if (state == ShardState::finalized)
+    {
+        if (boost::icl::contains(finalized_, shardIndex))
+            return false;
+
+        finalized_.insert(shardIndex);
+        return true;
+    }
+
+    return incomplete_.emplace(shardIndex, Incomplete(state, percentProgress))
+        .second;
+}
+
+protocol::TMPeerShardInfoV2
+ShardInfo::makeMessage(Application& app)
+{
+    protocol::TMPeerShardInfoV2 message;
+    Serializer s;
+    s.add32(HashPrefix::shardInfo);
+
+    // Set the message creation time
+    msgTimestamp_ = app.timeKeeper().now();
+    {
+        auto const timestamp{msgTimestamp_.time_since_epoch().count()};
+        message.set_timestamp(timestamp);
+        s.add32(timestamp);
+    }
+
+    if (!incomplete_.empty())
+    {
+        message.mutable_incomplete()->Reserve(incomplete_.size());
+        for (auto const& [shardIndex, incomplete] : incomplete_)
+        {
+            auto tmIncomplete{message.add_incomplete()};
+
+            tmIncomplete->set_shardindex(shardIndex);
+            s.add32(shardIndex);
+
+            static_assert(std::is_same_v<
+                          std::underlying_type_t<decltype(incomplete.state())>,
+                          std::uint32_t>);
+            auto const state{static_cast<std::uint32_t>(incomplete.state())};
+            tmIncomplete->set_state(state);
+            s.add32(state);
+
+            // Set progress if greater than zero
+            auto const percentProgress{incomplete.percentProgress()};
+            if (percentProgress > 0)
+            {
+                tmIncomplete->set_progress(percentProgress);
+                s.add32(percentProgress);
+            }
+        }
+    }
+
+    if (!finalized_.empty())
+    {
+        auto const str{ripple::to_string(finalized_)};
+        message.set_finalized(str);
+        s.addRaw(str.data(), str.size());
+    }
+
+    // Set the public key
+    auto const& publicKey{app.nodeIdentity().first};
+    message.set_publickey(publicKey.data(), publicKey.size());
+
+    // Create a digital signature using the node private key
+    auto const signature{sign(publicKey, app.nodeIdentity().second, s.slice())};
+
+    // Set the digital signature
+    message.set_signature(signature.data(), signature.size());
+
+    return message;
+}
+
+}  // namespace NodeStore
+}  // namespace ripple

--- a/src/ripple/nodestore/impl/TaskQueue.cpp
+++ b/src/ripple/nodestore/impl/TaskQueue.cpp
@@ -46,6 +46,13 @@ TaskQueue::addTask(std::function<void()> task)
     workers_.addTask();
 }
 
+size_t
+TaskQueue::size() const
+{
+    std::lock_guard lock{mutex_};
+    return tasks_.size() + processing_;
+}
+
 void
 TaskQueue::processTask(int instance)
 {
@@ -53,13 +60,18 @@ TaskQueue::processTask(int instance)
 
     {
         std::lock_guard lock{mutex_};
-        assert(!tasks_.empty());
 
+        assert(!tasks_.empty());
         task = std::move(tasks_.front());
         tasks_.pop();
+
+        ++processing_;
     }
 
     task();
+
+    std::lock_guard lock{mutex_};
+    --processing_;
 }
 
 }  // namespace NodeStore

--- a/src/ripple/nodestore/impl/TaskQueue.h
+++ b/src/ripple/nodestore/impl/TaskQueue.h
@@ -44,10 +44,16 @@ public:
     void
     addTask(std::function<void()> task);
 
+    /** Return the queue size
+     */
+    [[nodiscard]] size_t
+    size() const;
+
 private:
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     Workers workers_;
     std::queue<std::function<void()>> tasks_;
+    std::uint64_t processing_{0};
 
     void
     processTask(int instance) override;

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -201,11 +201,12 @@ public:
 
     /** Returns information reported to the crawl shard RPC command.
 
+        @param includePublicKey include peer public keys in the result.
         @param hops the maximum jumps the crawler will attempt.
         The number of hops achieved is not guaranteed.
     */
     virtual Json::Value
-    crawlShards(bool pubKey, std::uint32_t hops) = 0;
+    crawlShards(bool includePublicKey, std::uint32_t hops) = 0;
 
     /** Returns the ID of the network this server is configured for, if any.
 

--- a/src/ripple/overlay/Peer.h
+++ b/src/ripple/overlay/Peer.h
@@ -32,8 +32,8 @@ namespace Resource {
 class Charge;
 }
 
-// Maximum hops to attempt when crawling shards. cs = crawl shards
-static constexpr std::uint32_t csHopLimit = 3;
+// Maximum hops to relay the peer shard info request
+static constexpr std::uint32_t relayLimit = 3;
 
 enum class ProtocolFeature {
     ValidatorListPropagation,
@@ -112,8 +112,6 @@ public:
     hasLedger(uint256 const& hash, std::uint32_t seq) const = 0;
     virtual void
     ledgerRange(std::uint32_t& minSeq, std::uint32_t& maxSeq) const = 0;
-    virtual bool
-    hasShard(std::uint32_t shardIndex) const = 0;
     virtual bool
     hasTxSet(uint256 const& hash) const = 0;
     virtual void

--- a/src/ripple/overlay/impl/Message.cpp
+++ b/src/ripple/overlay/impl/Message.cpp
@@ -93,13 +93,13 @@ Message::compress()
             case protocol::mtSTATUS_CHANGE:
             case protocol::mtHAVE_SET:
             case protocol::mtVALIDATION:
-            case protocol::mtGET_SHARD_INFO:
-            case protocol::mtSHARD_INFO:
             case protocol::mtGET_PEER_SHARD_INFO:
             case protocol::mtPEER_SHARD_INFO:
             case protocol::mtPROOF_PATH_REQ:
             case protocol::mtPROOF_PATH_RESPONSE:
             case protocol::mtREPLAY_DELTA_REQ:
+            case protocol::mtGET_PEER_SHARD_INFO_V2:
+            case protocol::mtPEER_SHARD_INFO_V2:
                 break;
         }
         return false;

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -717,98 +717,99 @@ OverlayImpl::reportTraffic(
 }
 
 Json::Value
-OverlayImpl::crawlShards(bool pubKey, std::uint32_t hops)
+OverlayImpl::crawlShards(bool includePublicKey, std::uint32_t relays)
 {
     using namespace std::chrono;
-    using namespace std::chrono_literals;
 
     Json::Value jv(Json::objectValue);
-    auto const numPeers{size()};
-    if (numPeers == 0)
+
+    // Add shard info from this server to json result
+    if (auto shardStore = app_.getShardStore())
+    {
+        if (includePublicKey)
+            jv[jss::public_key] =
+                toBase58(TokenType::NodePublic, app_.nodeIdentity().first);
+
+        auto const shardInfo{shardStore->getShardInfo()};
+        if (!shardInfo->finalized().empty())
+            jv[jss::complete_shards] = shardInfo->finalizedToString();
+        if (!shardInfo->incomplete().empty())
+            jv[jss::incomplete_shards] = shardInfo->incompleteToString();
+    }
+
+    if (relays == 0 || size() == 0)
         return jv;
 
-    // If greater than a hop away, we may need to gather or freshen data
-    if (hops > 0)
     {
-        // Prevent crawl spamming
-        clock_type::time_point const last(csLast_.load());
-        if ((clock_type::now() - last) > 60s)
+        protocol::TMGetPeerShardInfoV2 tmGPS;
+        tmGPS.set_relays(relays);
+
+        // Wait if a request is in progress
+        std::unique_lock<std::mutex> csLock{csMutex_};
+        if (!csIDs_.empty())
+            csCV_.wait(csLock);
+
         {
-            auto const timeout(seconds((hops * hops) * 10));
-            std::unique_lock<std::mutex> l{csMutex_};
+            std::lock_guard lock{mutex_};
+            for (auto const& id : ids_)
+                csIDs_.emplace(id.first);
+        }
 
-            // Check if already requested
-            if (csIDs_.empty())
-            {
-                {
-                    std::lock_guard lock{mutex_};
-                    for (auto& id : ids_)
-                        csIDs_.emplace(id.first);
-                }
+        // Request peer shard info
+        foreach(send_always(std::make_shared<Message>(
+            tmGPS, protocol::mtGET_PEER_SHARD_INFO_V2)));
 
-                // Relay request to active peers
-                protocol::TMGetPeerShardInfo tmGPS;
-                tmGPS.set_hops(hops);
-                foreach(send_always(std::make_shared<Message>(
-                    tmGPS, protocol::mtGET_PEER_SHARD_INFO)));
-
-                if (csCV_.wait_for(l, timeout) == std::cv_status::timeout)
-                {
-                    csIDs_.clear();
-                    csCV_.notify_all();
-                }
-                csLast_ = duration_cast<seconds>(
-                    clock_type::now().time_since_epoch());
-            }
-            else
-                csCV_.wait_for(l, timeout);
+        if (csCV_.wait_for(csLock, seconds(60)) == std::cv_status::timeout)
+        {
+            csIDs_.clear();
+            csCV_.notify_all();
         }
     }
 
-    // Combine the shard info from peers and their sub peers
-    hash_map<PublicKey, PeerImp::ShardInfo> peerShardInfo;
-    for_each([&](std::shared_ptr<PeerImp> const& peer) {
-        if (auto psi = peer->getPeerShardInfo())
+    // Combine shard info from peers
+    hash_map<PublicKey, NodeStore::ShardInfo> peerShardInfo;
+    for_each([&](std::shared_ptr<PeerImp>&& peer) {
+        auto const psi{peer->getPeerShardInfos()};
+        for (auto const& [publicKey, shardInfo] : psi)
         {
-            // e is non-const so it may be moved from
-            for (auto& e : *psi)
-            {
-                auto it{peerShardInfo.find(e.first)};
-                if (it != peerShardInfo.end())
-                    // The key exists so join the shard indexes.
-                    it->second.shardIndexes += e.second.shardIndexes;
-                else
-                    peerShardInfo.emplace(std::move(e));
-            }
+            auto const it{peerShardInfo.find(publicKey)};
+            if (it == peerShardInfo.end())
+                peerShardInfo.emplace(publicKey, shardInfo);
+            else if (shardInfo.msgTimestamp() > it->second.msgTimestamp())
+                it->second = shardInfo;
         }
     });
 
-    // Prepare json reply
-    auto& av = jv[jss::peers] = Json::Value(Json::arrayValue);
-    for (auto const& e : peerShardInfo)
+    // Add shard info to json result
+    if (!peerShardInfo.empty())
     {
-        auto& pv{av.append(Json::Value(Json::objectValue))};
-        if (pubKey)
-            pv[jss::public_key] = toBase58(TokenType::NodePublic, e.first);
+        auto& av = jv[jss::peers] = Json::Value(Json::arrayValue);
+        for (auto const& [publicKey, shardInfo] : peerShardInfo)
+        {
+            auto& pv{av.append(Json::Value(Json::objectValue))};
+            if (includePublicKey)
+            {
+                pv[jss::public_key] =
+                    toBase58(TokenType::NodePublic, publicKey);
+            }
 
-        auto const& address{e.second.endpoint.address()};
-        if (!address.is_unspecified())
-            pv[jss::ip] = address.to_string();
-
-        pv[jss::complete_shards] = to_string(e.second.shardIndexes);
+            if (!shardInfo.finalized().empty())
+                pv[jss::complete_shards] = shardInfo.finalizedToString();
+            if (!shardInfo.incomplete().empty())
+                pv[jss::incomplete_shards] = shardInfo.incompleteToString();
+        }
     }
 
     return jv;
 }
 
 void
-OverlayImpl::lastLink(std::uint32_t id)
+OverlayImpl::endOfPeerChain(std::uint32_t id)
 {
-    // Notify threads when every peer has received a last link.
-    // This doesn't account for every node that might reply but
-    // it is adequate.
-    std::lock_guard l{csMutex_};
-    if (csIDs_.erase(id) && csIDs_.empty())
+    // Notify threads if all peers have received a reply from all peer chains
+    std::lock_guard csLock{csMutex_};
+    csIDs_.erase(id);
+    if (csIDs_.empty())
         csCV_.notify_all();
 }
 
@@ -870,8 +871,16 @@ OverlayImpl::getOverlayInfo()
             pv[jss::complete_ledgers] =
                 std::to_string(minSeq) + "-" + std::to_string(maxSeq);
 
-        if (auto shardIndexes = sp->getShardIndexes())
-            pv[jss::complete_shards] = to_string(*shardIndexes);
+        auto const peerShardInfos{sp->getPeerShardInfos()};
+        auto const it{peerShardInfos.find(sp->getNodePublic())};
+        if (it != peerShardInfos.end())
+        {
+            auto const& shardInfo{it->second};
+            if (!shardInfo.finalized().empty())
+                pv[jss::complete_shards] = shardInfo.finalizedToString();
+            if (!shardInfo.incomplete().empty())
+                pv[jss::incomplete_shards] = shardInfo.incompleteToString();
+        }
     });
 
     return jv;

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -117,8 +117,7 @@ private:
     std::atomic<uint64_t> peerDisconnects_{0};
     std::atomic<uint64_t> peerDisconnectsCharges_{0};
 
-    // Last time we crawled peers for shard info. 'cs' = crawl shards
-    std::atomic<std::chrono::seconds> csLast_{std::chrono::seconds{0}};
+    // 'cs' = crawl shards
     std::mutex csMutex_;
     std::condition_variable csCV_;
     // Peer IDs expecting to receive a last link notification
@@ -372,14 +371,14 @@ public:
     }
 
     Json::Value
-    crawlShards(bool pubKey, std::uint32_t hops) override;
+    crawlShards(bool includePublicKey, std::uint32_t relays) override;
 
-    /** Called when the last link from a peer chain is received.
+    /** Called when the reply from the last peer in a peer chain is received.
 
         @param id peer id that received the shard info.
     */
     void
-    lastLink(std::uint32_t id);
+    endOfPeerChain(std::uint32_t id);
 
     /** Updates message count for validator/peer. Sends TMSquelch if the number
      * of messages for N peers reaches threshold T. A message is counted

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -25,6 +25,7 @@
 #include <ripple/basics/Log.h>
 #include <ripple/basics/RangeSet.h>
 #include <ripple/beast/utility/WrappedSink.h>
+#include <ripple/nodestore/ShardInfo.h>
 #include <ripple/overlay/Squelch.h>
 #include <ripple/overlay/impl/OverlayImpl.h>
 #include <ripple/overlay/impl/ProtocolMessage.h>
@@ -53,12 +54,6 @@ class PeerImp : public Peer,
 public:
     /** Whether the peer's view of the ledger converges or diverges from ours */
     enum class Tracking { diverged, unknown, converged };
-
-    struct ShardInfo
-    {
-        beast::IP::Endpoint endpoint;
-        RangeSet<std::uint32_t> shardIndexes;
-    };
 
 private:
     using clock_type = std::chrono::steady_clock;
@@ -166,8 +161,9 @@ private:
     // been sent to or received from this peer.
     hash_map<PublicKey, std::size_t> publisherListSequences_;
 
+    // Any known shard info from this peer and its sub peers
+    hash_map<PublicKey, NodeStore::ShardInfo> shardInfos_;
     std::mutex mutable shardInfoMutex_;
-    hash_map<PublicKey, ShardInfo> shardInfo_;
 
     Compressed compressionEnabled_ = Compressed::Off;
     // true if validation/proposal reduce-relay feature is enabled
@@ -376,9 +372,6 @@ public:
     ledgerRange(std::uint32_t& minSeq, std::uint32_t& maxSeq) const override;
 
     bool
-    hasShard(std::uint32_t shardIndex) const override;
-
-    bool
     hasTxSet(uint256 const& hash) const override;
 
     void
@@ -397,13 +390,9 @@ public:
     void
     fail(std::string const& reason);
 
-    /** Return a range set of known shard indexes from this peer. */
-    std::optional<RangeSet<std::uint32_t>>
-    getShardIndexes() const;
-
-    /** Return any known shard info from this peer and its sub peers. */
-    std::optional<hash_map<PublicKey, ShardInfo>>
-    getPeerShardInfo() const;
+    // Return any known shard info from this peer and its sub peers
+    [[nodiscard]] hash_map<PublicKey, NodeStore::ShardInfo> const
+    getPeerShardInfos() const;
 
     bool
     compressionEnabled() const override
@@ -501,13 +490,13 @@ public:
     void
     onMessage(std::shared_ptr<protocol::TMCluster> const& m);
     void
-    onMessage(std::shared_ptr<protocol::TMGetShardInfo> const& m);
-    void
-    onMessage(std::shared_ptr<protocol::TMShardInfo> const& m);
-    void
     onMessage(std::shared_ptr<protocol::TMGetPeerShardInfo> const& m);
     void
     onMessage(std::shared_ptr<protocol::TMPeerShardInfo> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMGetPeerShardInfoV2> const& m);
+    void
+    onMessage(std::shared_ptr<protocol::TMPeerShardInfoV2> const& m);
     void
     onMessage(std::shared_ptr<protocol::TMEndpoints> const& m);
     void

--- a/src/ripple/overlay/impl/ProtocolMessage.h
+++ b/src/ripple/overlay/impl/ProtocolMessage.h
@@ -69,14 +69,6 @@ protocolMessageName(int type)
             return "ping";
         case protocol::mtCLUSTER:
             return "cluster";
-        case protocol::mtGET_SHARD_INFO:
-            return "get_shard_info";
-        case protocol::mtSHARD_INFO:
-            return "shard_info";
-        case protocol::mtGET_PEER_SHARD_INFO:
-            return "get_peer_shard_info";
-        case protocol::mtPEER_SHARD_INFO:
-            return "peer_shard_info";
         case protocol::mtENDPOINTS:
             return "endpoints";
         case protocol::mtTRANSACTION:
@@ -97,6 +89,10 @@ protocolMessageName(int type)
             return "validator_list_collection";
         case protocol::mtVALIDATION:
             return "validation";
+        case protocol::mtGET_PEER_SHARD_INFO:
+            return "get_peer_shard_info";
+        case protocol::mtPEER_SHARD_INFO:
+            return "peer_shard_info";
         case protocol::mtGET_OBJECTS:
             return "get_objects";
         case protocol::mtSQUELCH:
@@ -109,6 +105,10 @@ protocolMessageName(int type)
             return "replay_delta_request";
         case protocol::mtREPLAY_DELTA_RESPONSE:
             return "replay_delta_response";
+        case protocol::mtGET_PEER_SHARD_INFO_V2:
+            return "get_peer_shard_info_v2";
+        case protocol::mtPEER_SHARD_INFO_V2:
+            return "peer_shard_info_v2";
         default:
             break;
     }
@@ -401,22 +401,6 @@ invokeProtocolMessage(
             success =
                 detail::invoke<protocol::TMCluster>(*header, buffers, handler);
             break;
-        case protocol::mtGET_SHARD_INFO:
-            success = detail::invoke<protocol::TMGetShardInfo>(
-                *header, buffers, handler);
-            break;
-        case protocol::mtSHARD_INFO:
-            success = detail::invoke<protocol::TMShardInfo>(
-                *header, buffers, handler);
-            break;
-        case protocol::mtGET_PEER_SHARD_INFO:
-            success = detail::invoke<protocol::TMGetPeerShardInfo>(
-                *header, buffers, handler);
-            break;
-        case protocol::mtPEER_SHARD_INFO:
-            success = detail::invoke<protocol::TMPeerShardInfo>(
-                *header, buffers, handler);
-            break;
         case protocol::mtENDPOINTS:
             success = detail::invoke<protocol::TMEndpoints>(
                 *header, buffers, handler);
@@ -449,6 +433,14 @@ invokeProtocolMessage(
             success = detail::invoke<protocol::TMValidation>(
                 *header, buffers, handler);
             break;
+        case protocol::mtGET_PEER_SHARD_INFO:
+            success = detail::invoke<protocol::TMGetPeerShardInfo>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtPEER_SHARD_INFO:
+            success = detail::invoke<protocol::TMPeerShardInfo>(
+                *header, buffers, handler);
+            break;
         case protocol::mtVALIDATORLIST:
             success = detail::invoke<protocol::TMValidatorList>(
                 *header, buffers, handler);
@@ -479,6 +471,14 @@ invokeProtocolMessage(
             break;
         case protocol::mtREPLAY_DELTA_RESPONSE:
             success = detail::invoke<protocol::TMReplayDeltaResponse>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtGET_PEER_SHARD_INFO_V2:
+            success = detail::invoke<protocol::TMGetPeerShardInfoV2>(
+                *header, buffers, handler);
+            break;
+        case protocol::mtPEER_SHARD_INFO_V2:
+            success = detail::invoke<protocol::TMPeerShardInfoV2>(
                 *header, buffers, handler);
             break;
         default:

--- a/src/ripple/overlay/impl/TrafficCount.cpp
+++ b/src/ripple/overlay/impl/TrafficCount.cpp
@@ -39,10 +39,10 @@ TrafficCount::categorize(
     if (type == protocol::mtENDPOINTS)
         return TrafficCount::category::overlay;
 
-    if ((type == protocol::mtGET_SHARD_INFO) ||
-        (type == protocol::mtSHARD_INFO) ||
-        (type == protocol::mtGET_PEER_SHARD_INFO) ||
-        (type == protocol::mtPEER_SHARD_INFO))
+    if ((type == protocol::mtGET_PEER_SHARD_INFO) ||
+        (type == protocol::mtPEER_SHARD_INFO) ||
+        (type == protocol::mtGET_PEER_SHARD_INFO_V2) ||
+        (type == protocol::mtPEER_SHARD_INFO_V2))
         return TrafficCount::category::shards;
 
     if (type == protocol::mtTRANSACTION)

--- a/src/ripple/proto/ripple.proto
+++ b/src/ripple/proto/ripple.proto
@@ -6,29 +6,31 @@ package protocol;
 // conflict. Even if you're sure, it's probably best to assign a new type.
 enum MessageType
 {
-    mtMANIFESTS             = 2;
-    mtPING                  = 3;
-    mtCLUSTER               = 5;
-    mtENDPOINTS             = 15;
-    mtTRANSACTION           = 30;
-    mtGET_LEDGER            = 31;
-    mtLEDGER_DATA           = 32;
-    mtPROPOSE_LEDGER        = 33;
-    mtSTATUS_CHANGE         = 34;
-    mtHAVE_SET              = 35;
-    mtVALIDATION            = 41;
-    mtGET_OBJECTS           = 42;
-    mtGET_SHARD_INFO        = 50;
-    mtSHARD_INFO            = 51;
-    mtGET_PEER_SHARD_INFO   = 52;
-    mtPEER_SHARD_INFO       = 53;
-    mtVALIDATORLIST         = 54;
-    mtSQUELCH               = 55;
-    mtVALIDATORLISTCOLLECTION = 56;
-    mtPROOF_PATH_REQ        = 57;
-    mtPROOF_PATH_RESPONSE   = 58;
-    mtREPLAY_DELTA_REQ      = 59;
-    mtREPLAY_DELTA_RESPONSE = 60;
+    mtMANIFESTS                 = 2;
+    mtPING                      = 3;
+    mtCLUSTER                   = 5;
+    mtENDPOINTS                 = 15;
+    mtTRANSACTION               = 30;
+    mtGET_LEDGER                = 31;
+    mtLEDGER_DATA               = 32;
+    mtPROPOSE_LEDGER            = 33;
+    mtSTATUS_CHANGE             = 34;
+    mtHAVE_SET                  = 35;
+    mtVALIDATION                = 41;
+    mtGET_OBJECTS               = 42;
+    mtGET_SHARD_INFO            = 50;
+    mtSHARD_INFO                = 51;
+    mtGET_PEER_SHARD_INFO       = 52;
+    mtPEER_SHARD_INFO           = 53;
+    mtVALIDATORLIST             = 54;
+    mtSQUELCH                   = 55;
+    mtVALIDATORLISTCOLLECTION   = 56;
+    mtPROOF_PATH_REQ            = 57;
+    mtPROOF_PATH_RESPONSE       = 58;
+    mtREPLAY_DELTA_REQ          = 59;
+    mtREPLAY_DELTA_RESPONSE     = 60;
+    mtGET_PEER_SHARD_INFO_V2    = 61;
+    mtPEER_SHARD_INFO_V2        = 62;
 }
 
 // token, iterations, target, challenge = issue demand for proof of work
@@ -79,46 +81,75 @@ message TMCluster
     repeated TMLoadSource    loadSources     = 2;
 }
 
-// Request info on shards held
-message TMGetShardInfo
-{
-    required uint32 hops            = 1 [deprecated=true]; // number of hops to travel
-    optional bool lastLink          = 2 [deprecated=true]; // true if last link in the peer chain
-    repeated uint32 peerchain       = 3 [deprecated=true]; // IDs used to route messages
-}
-
-// Info about shards held
-message TMShardInfo
-{
-    required string shardIndexes    = 1 [deprecated=true]; // rangeSet of shard indexes
-    optional bytes nodePubKey       = 2 [deprecated=true]; // The node's public key
-    optional string endpoint        = 3 [deprecated=true]; // ipv6 or ipv4 address
-    optional bool lastLink          = 4 [deprecated=true]; // true if last link in the peer chain
-    repeated uint32 peerchain       = 5 [deprecated=true]; // IDs used to route messages
-}
-
 // Node public key
 message TMLink
 {
-    required bytes nodePubKey       = 1; // node public key
+    required bytes nodePubKey       = 1 [deprecated=true]; // node public key
 }
 
 // Request info on shards held
 message TMGetPeerShardInfo
 {
-    required uint32 hops            = 1; // number of hops to travel
-    optional bool lastLink          = 2; // true if last link in the peer chain
-    repeated TMLink peerChain       = 3; // public keys used to route messages
+    required uint32 hops            = 1 [deprecated=true]; // number of hops to travel
+    optional bool lastLink          = 2 [deprecated=true]; // true if last link in the peer chain
+    repeated TMLink peerChain       = 3 [deprecated=true]; // public keys used to route messages
 }
 
 // Info about shards held
 message TMPeerShardInfo
 {
-    required string shardIndexes    = 1; // rangeSet of shard indexes
-    optional bytes nodePubKey       = 2; // node public key
-    optional string endpoint        = 3; // ipv6 or ipv4 address
-    optional bool lastLink          = 4; // true if last link in the peer chain
-    repeated TMLink peerChain       = 5; // public keys used to route messages
+    required string shardIndexes    = 1 [deprecated=true]; // rangeSet of shard indexes
+    optional bytes nodePubKey       = 2 [deprecated=true]; // node public key
+    optional string endpoint        = 3 [deprecated=true]; // ipv6 or ipv4 address
+    optional bool lastLink          = 4 [deprecated=true]; // true if last link in the peer chain
+    repeated TMLink peerChain       = 5 [deprecated=true]; // public keys used to route messages
+}
+
+// Peer public key
+message TMPublicKey
+{
+    required bytes publicKey = 1;
+}
+
+// Request peer shard information
+message TMGetPeerShardInfoV2
+{
+    // Peer public keys used to route messages
+    repeated TMPublicKey peerChain = 1;
+
+    // Remaining times to relay
+    required uint32 relays = 2;
+}
+
+// Peer shard information
+message TMPeerShardInfoV2
+{
+    message TMIncomplete
+    {
+        required uint32 shardIndex = 1;
+        required uint32 state = 2;
+
+        // State completion percent, 1 - 100
+        optional uint32 progress = 3;
+    }
+
+    // Message creation time
+    required uint32 timestamp = 1;
+
+    // Incomplete shards being acquired or verified
+    repeated TMIncomplete incomplete = 2;
+
+    // Verified immutable shards (RangeSet)
+    optional string finalized = 3;
+
+    // Public key of node that authored the shard info
+    required bytes publicKey = 4;
+
+    // Digital signature of node that authored the shard info
+    required bytes signature = 5;
+
+    // Peer public keys used to route messages
+    repeated TMPublicKey peerChain = 6;
 }
 
 // A transaction can have only one input and one output.

--- a/src/ripple/protocol/HashPrefix.h
+++ b/src/ripple/protocol/HashPrefix.h
@@ -84,6 +84,9 @@ enum class HashPrefix : std::uint32_t {
 
     /** Payment Channel Claim */
     paymentChannelClaim = detail::make_hash_prefix('C', 'L', 'M'),
+
+    /** shard info for signing */
+    shardInfo = detail::make_hash_prefix('S', 'H', 'D'),
 };
 
 template <class Hasher>

--- a/src/ripple/protocol/SystemParameters.h
+++ b/src/ripple/protocol/SystemParameters.h
@@ -58,7 +58,10 @@ systemCurrencyCode()
 }
 
 /** The XRP ledger network's earliest allowed sequence */
-static std::uint32_t constexpr XRP_LEDGER_EARLIEST_SEQ{32570};
+static constexpr std::uint32_t XRP_LEDGER_EARLIEST_SEQ{32570u};
+
+/** The number of ledgers in a shard */
+static constexpr std::uint32_t DEFAULT_LEDGERS_PER_SHARD{16384u};
 
 /** The minimum amount of support an amendment should have.
 

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -65,6 +65,7 @@ JSS(EscrowFinish);           // transaction type.
 JSS(Fee);                    // in/out: TransactionSign; field.
 JSS(FeeSettings);            // ledger type.
 JSS(Flags);                  // in/out: TransactionSign; field.
+JSS(incomplete_shards);      // out: OverlayImpl, PeerImp
 JSS(Invalid);                //
 JSS(LastLedgerSequence);     // in: TransactionSign; field
 JSS(LedgerHashes);           // ledger type.

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -271,11 +271,6 @@ public:
     {
     }
     bool
-    hasShard(std::uint32_t shardIndex) const override
-    {
-        return false;
-    }
-    bool
     hasTxSet(uint256 const& hash) const override
     {
         return false;

--- a/src/test/basics/RangeSet_test.cpp
+++ b/src/test/basics/RangeSet_test.cpp
@@ -96,22 +96,18 @@ public:
         BEAST_EXPECT(!from_string(set, "1,,2"));
         BEAST_EXPECT(boost::icl::length(set) == 0);
 
-        set.clear();
         BEAST_EXPECT(from_string(set, "1"));
         BEAST_EXPECT(boost::icl::length(set) == 1);
         BEAST_EXPECT(boost::icl::first(set) == 1);
 
-        set.clear();
         BEAST_EXPECT(from_string(set, "1,1"));
         BEAST_EXPECT(boost::icl::length(set) == 1);
         BEAST_EXPECT(boost::icl::first(set) == 1);
 
-        set.clear();
         BEAST_EXPECT(from_string(set, "1-1"));
         BEAST_EXPECT(boost::icl::length(set) == 1);
         BEAST_EXPECT(boost::icl::first(set) == 1);
 
-        set.clear();
         BEAST_EXPECT(from_string(set, "1,4-6"));
         BEAST_EXPECT(boost::icl::length(set) == 4);
         BEAST_EXPECT(boost::icl::first(set) == 1);
@@ -121,7 +117,6 @@ public:
         BEAST_EXPECT(boost::icl::contains(set, 5));
         BEAST_EXPECT(boost::icl::last(set) == 6);
 
-        set.clear();
         BEAST_EXPECT(from_string(set, "1-2,4-6"));
         BEAST_EXPECT(boost::icl::length(set) == 5);
         BEAST_EXPECT(boost::icl::first(set) == 1);
@@ -129,7 +124,6 @@ public:
         BEAST_EXPECT(boost::icl::contains(set, 4));
         BEAST_EXPECT(boost::icl::last(set) == 6);
 
-        set.clear();
         BEAST_EXPECT(from_string(set, "1-2,6"));
         BEAST_EXPECT(boost::icl::length(set) == 3);
         BEAST_EXPECT(boost::icl::first(set) == 1);

--- a/src/test/nodestore/DatabaseShard_test.cpp
+++ b/src/test/nodestore/DatabaseShard_test.cpp
@@ -19,6 +19,8 @@
 
 #include <ripple/app/ledger/LedgerMaster.h>
 #include <ripple/app/ledger/LedgerToJson.h>
+#include <ripple/basics/Slice.h>
+#include <ripple/basics/random.h>
 #include <ripple/beast/hash/hash_append.h>
 #include <ripple/beast/utility/temp_dir.h>
 #include <ripple/core/ConfigSections.h>
@@ -27,14 +29,15 @@
 #include <ripple/nodestore/impl/DecodedBlob.h>
 #include <ripple/nodestore/impl/Shard.h>
 #include <ripple/protocol/digest.h>
+#include <test/jtx.h>
+#include <test/nodestore/TestBase.h>
+
 #include <boost/algorithm/hex.hpp>
 #include <chrono>
 #include <fstream>
 #include <iostream>
 #include <numeric>
 #include <openssl/ripemd.h>
-#include <test/jtx.h>
-#include <test/nodestore/TestBase.h>
 
 namespace ripple {
 namespace NodeStore {
@@ -177,7 +180,7 @@ class DatabaseShard_test : public TestBase
         /* ring used to generate pseudo-random sequence */
         beast::xor_shift_engine rng_;
         /* number of shards to generate */
-        int nShards_;
+        int numShards_;
         /* vector of accounts used to send test transactions */
         std::vector<test::jtx::Account> accounts_;
         /* nAccounts_[i] is the number of these accounts existed before i-th
@@ -196,11 +199,11 @@ class DatabaseShard_test : public TestBase
         TestData(
             std::uint64_t const seedValue,
             int dataSize = dataSizeMax,
-            int nShards = 1)
-            : rng_(seedValue), nShards_(nShards)
+            int numShards = 1)
+            : rng_(seedValue), numShards_(numShards)
         {
             std::uint32_t n = 0;
-            std::uint32_t nLedgers = ledgersPerShard * nShards;
+            std::uint32_t nLedgers = ledgersPerShard * numShards;
 
             nAccounts_.reserve(nLedgers);
             payAccounts_.reserve(nLedgers);
@@ -285,7 +288,7 @@ class DatabaseShard_test : public TestBase
                 }
             }
 
-            for (std::uint32_t i = 0; i < ledgersPerShard * nShards_; ++i)
+            for (std::uint32_t i = 0; i < ledgersPerShard * numShards_; ++i)
             {
                 auto const index = i + (startIndex * ledgersPerShard);
 
@@ -545,8 +548,8 @@ class DatabaseShard_test : public TestBase
         }
 
         RangeSet<std::uint32_t> rs;
-        from_string(rs, set);
-        return to_string(rs);
+        BEAST_EXPECT(from_string(rs, set));
+        return ripple::to_string(rs);
     }
 
     std::unique_ptr<Config>
@@ -575,74 +578,77 @@ class DatabaseShard_test : public TestBase
             // Node store configuration
             cfg->overwrite(
                 ConfigSection::nodeDatabase(),
-                "earliest_seq",
-                std::to_string(earliestSeq));
-            cfg->overwrite(
-                ConfigSection::nodeDatabase(),
                 "path",
                 nodeDir.empty() ? defNodeDir.path() : nodeDir);
+            cfg->overwrite(
+                ConfigSection::nodeDatabase(),
+                "ledgers_per_shard",
+                std::to_string(ledgersPerShard));
+            cfg->overwrite(
+                ConfigSection::nodeDatabase(),
+                "earliest_seq",
+                std::to_string(earliestSeq));
             return cfg;
         });
     }
 
-    std::optional<int>
+    std::optional<std::uint32_t>
     waitShard(
-        DatabaseShard& db,
-        int shardIndex,
+        DatabaseShard& shardStore,
+        std::uint32_t shardIndex,
         std::chrono::seconds timeout = shardStoreTimeout)
     {
-        RangeSet<std::uint32_t> rs;
-        auto start = std::chrono::system_clock::now();
-        auto end = start + timeout;
-        while (!from_string(rs, db.getCompleteShards()) ||
-               !boost::icl::contains(rs, shardIndex))
+        auto const end{std::chrono::system_clock::now() + timeout};
+        while (shardStore.getNumTasks() ||
+               !boost::icl::contains(
+                   shardStore.getShardInfo()->finalized(), shardIndex))
         {
             if (!BEAST_EXPECT(std::chrono::system_clock::now() < end))
-                return {};
-            std::this_thread::yield();
+                return std::nullopt;
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 
         return shardIndex;
     }
 
-    std::optional<int>
+    std::optional<std::uint32_t>
     createShard(
         TestData& data,
-        DatabaseShard& db,
-        int maxShardNumber = 1,
-        int ledgerOffset = 0)
+        DatabaseShard& shardStore,
+        int maxShardIndex = 1,
+        int shardOffset = 0)
     {
         int shardIndex{-1};
 
         for (std::uint32_t i = 0; i < ledgersPerShard; ++i)
         {
-            auto const ledgerSeq{
-                db.prepareLedger((maxShardNumber + 1) * ledgersPerShard)};
+            auto const ledgerSeq{shardStore.prepareLedger(
+                (maxShardIndex + 1) * ledgersPerShard)};
             if (!BEAST_EXPECT(ledgerSeq != std::nullopt))
-                return {};
+                return std::nullopt;
 
-            shardIndex = db.seqToShardIndex(*ledgerSeq);
+            shardIndex = shardStore.seqToShardIndex(*ledgerSeq);
 
-            int const arrInd = *ledgerSeq - (ledgersPerShard * ledgerOffset) -
+            int const arrInd = *ledgerSeq - (ledgersPerShard * shardOffset) -
                 ledgersPerShard - 1;
             BEAST_EXPECT(
-                arrInd >= 0 && arrInd < maxShardNumber * ledgersPerShard);
-            BEAST_EXPECT(saveLedger(db, *data.ledgers_[arrInd]));
+                arrInd >= 0 && arrInd < maxShardIndex * ledgersPerShard);
+            BEAST_EXPECT(saveLedger(shardStore, *data.ledgers_[arrInd]));
             if (arrInd % ledgersPerShard == (ledgersPerShard - 1))
             {
                 uint256 const finalKey_{0};
                 Serializer s;
                 s.add32(Shard::version);
-                s.add32(db.firstLedgerSeq(shardIndex));
-                s.add32(db.lastLedgerSeq(shardIndex));
+                s.add32(shardStore.firstLedgerSeq(shardIndex));
+                s.add32(shardStore.lastLedgerSeq(shardIndex));
                 s.addRaw(data.ledgers_[arrInd]->info().hash.data(), 256 / 8);
-                db.store(
+                shardStore.store(
                     hotUNKNOWN, std::move(s.modData()), finalKey_, *ledgerSeq);
             }
-            db.setStored(data.ledgers_[arrInd]);
+            shardStore.setStored(data.ledgers_[arrInd]);
         }
 
-        return waitShard(db, shardIndex);
+        return waitShard(shardStore, shardIndex);
     }
 
     void
@@ -653,25 +659,47 @@ class DatabaseShard_test : public TestBase
         using namespace test::jtx;
 
         beast::temp_dir shardDir;
-        Env env{*this, testConfig(shardDir.path())};
         DummyScheduler scheduler;
         RootStoppable parent("TestRootStoppable");
+        {
+            Env env{*this, testConfig(shardDir.path())};
+            std::unique_ptr<DatabaseShard> shardStore{
+                make_ShardStore(env.app(), parent, scheduler, 2, journal_)};
 
-        std::unique_ptr<DatabaseShard> db =
-            make_ShardStore(env.app(), parent, scheduler, 2, journal_);
+            BEAST_EXPECT(shardStore);
+            BEAST_EXPECT(shardStore->init());
+            BEAST_EXPECT(shardStore->ledgersPerShard() == ledgersPerShard);
+            BEAST_EXPECT(shardStore->seqToShardIndex(ledgersPerShard + 1) == 1);
+            BEAST_EXPECT(shardStore->seqToShardIndex(2 * ledgersPerShard) == 1);
+            BEAST_EXPECT(
+                shardStore->seqToShardIndex(2 * ledgersPerShard + 1) == 2);
+            BEAST_EXPECT(
+                shardStore->earliestShardIndex() ==
+                (earliestSeq - 1) / ledgersPerShard);
+            BEAST_EXPECT(shardStore->firstLedgerSeq(1) == ledgersPerShard + 1);
+            BEAST_EXPECT(shardStore->lastLedgerSeq(1) == 2 * ledgersPerShard);
+            BEAST_EXPECT(shardStore->getRootDir().string() == shardDir.path());
+        }
 
-        BEAST_EXPECT(db);
-        BEAST_EXPECT(db->ledgersPerShard() == db->ledgersPerShardDefault);
-        BEAST_EXPECT(db->init());
-        BEAST_EXPECT(db->ledgersPerShard() == ledgersPerShard);
-        BEAST_EXPECT(db->seqToShardIndex(ledgersPerShard + 1) == 1);
-        BEAST_EXPECT(db->seqToShardIndex(2 * ledgersPerShard) == 1);
-        BEAST_EXPECT(db->seqToShardIndex(2 * ledgersPerShard + 1) == 2);
-        BEAST_EXPECT(
-            db->earliestShardIndex() == (earliestSeq - 1) / ledgersPerShard);
-        BEAST_EXPECT(db->firstLedgerSeq(1) == ledgersPerShard + 1);
-        BEAST_EXPECT(db->lastLedgerSeq(1) == 2 * ledgersPerShard);
-        BEAST_EXPECT(db->getRootDir().string() == shardDir.path());
+        {
+            Env env{*this, testConfig(shardDir.path())};
+            std::unique_ptr<DatabaseShard> shardStore{
+                make_ShardStore(env.app(), parent, scheduler, 2, journal_)};
+
+            env.app().config().overwrite(
+                ConfigSection::shardDatabase(), "ledgers_per_shard", "512");
+            BEAST_EXPECT(!shardStore->init());
+        }
+
+        Env env{*this, testConfig(shardDir.path())};
+        std::unique_ptr<DatabaseShard> shardStore{
+            make_ShardStore(env.app(), parent, scheduler, 2, journal_)};
+
+        env.app().config().overwrite(
+            ConfigSection::shardDatabase(),
+            "earliest_seq",
+            std::to_string(std::numeric_limits<std::uint32_t>::max()));
+        BEAST_EXPECT(!shardStore->init());
     }
 
     void
@@ -714,9 +742,11 @@ class DatabaseShard_test : public TestBase
             if (!BEAST_EXPECT(data.makeLedgers(env)))
                 return;
 
-            for (std::uint32_t i = 0; i < 2; ++i)
+            for (auto i = 0; i < 2; ++i)
+            {
                 if (!createShard(data, *db, 2))
                     return;
+            }
         }
         {
             Env env{*this, testConfig(shardDir.path())};
@@ -736,9 +766,9 @@ class DatabaseShard_test : public TestBase
     }
 
     void
-    testGetCompleteShards(std::uint64_t const seedValue)
+    testGetFinalShards(std::uint64_t const seedValue)
     {
-        testcase("Get complete shards");
+        testcase("Get final shards");
 
         using namespace test::jtx;
 
@@ -751,17 +781,20 @@ class DatabaseShard_test : public TestBase
         if (!BEAST_EXPECT(data.makeLedgers(env)))
             return;
 
-        BEAST_EXPECT(db->getCompleteShards() == "");
+        BEAST_EXPECT(db->getShardInfo()->finalized().empty());
 
-        std::uint64_t bitMask = 0;
-
-        for (std::uint32_t i = 0; i < nTestShards; ++i)
+        for (auto i = 0; i < nTestShards; ++i)
         {
-            auto n = createShard(data, *db, nTestShards);
-            if (!BEAST_EXPECT(n && *n >= 1 && *n <= nTestShards))
+            auto const shardIndex{createShard(data, *db, nTestShards)};
+            if (!BEAST_EXPECT(
+                    shardIndex && *shardIndex >= 1 &&
+                    *shardIndex <= nTestShards))
+            {
                 return;
-            bitMask |= 1ll << *n;
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(bitMask));
+            }
+
+            BEAST_EXPECT(boost::icl::contains(
+                db->getShardInfo()->finalized(), *shardIndex));
         }
     }
 
@@ -781,47 +814,54 @@ class DatabaseShard_test : public TestBase
         if (!BEAST_EXPECT(data.makeLedgers(env)))
             return;
 
-        std::uint64_t bitMask = 0;
         BEAST_EXPECT(db->getPreShards() == "");
+        BEAST_EXPECT(!db->prepareShards({}));
 
+        std::uint64_t bitMask = 0;
         for (std::uint32_t i = 0; i < nTestShards * 2; ++i)
         {
-            std::uint32_t n = randInt(data.rng_, nTestShards - 1) + 1;
-            if (bitMask & (1ll << n))
+            std::uint32_t const shardIndex{
+                randInt(data.rng_, nTestShards - 1) + 1};
+            if (bitMask & (1ll << shardIndex))
             {
-                db->removePreShard(n);
-                bitMask &= ~(1ll << n);
+                db->removePreShard(shardIndex);
+                bitMask &= ~(1ll << shardIndex);
             }
             else
             {
-                db->prepareShards({n});
-                bitMask |= 1ll << n;
+                BEAST_EXPECT(db->prepareShards({shardIndex}));
+                bitMask |= 1ll << shardIndex;
             }
             BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
         }
 
         // test illegal cases
         // adding shards with too large number
-        db->prepareShards({0});
+        BEAST_EXPECT(!db->prepareShards({0}));
         BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
-        db->prepareShards({nTestShards + 1});
+        BEAST_EXPECT(!db->prepareShards({nTestShards + 1}));
         BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
-        db->prepareShards({nTestShards + 2});
+        BEAST_EXPECT(!db->prepareShards({nTestShards + 2}));
         BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
 
         // create shards which are not prepared for import
-        BEAST_EXPECT(db->getCompleteShards() == "");
+        BEAST_EXPECT(db->getShardInfo()->finalized().empty());
 
         std::uint64_t bitMask2 = 0;
-
-        for (std::uint32_t i = 0; i < nTestShards; ++i)
+        for (auto i = 0; i < nTestShards; ++i)
         {
-            auto n = createShard(data, *db, nTestShards);
-            if (!BEAST_EXPECT(n && *n >= 1 && *n <= nTestShards))
+            auto const shardIndex{createShard(data, *db, nTestShards)};
+            if (!BEAST_EXPECT(
+                    shardIndex && *shardIndex >= 1 &&
+                    *shardIndex <= nTestShards))
+            {
                 return;
-            bitMask2 |= 1ll << *n;
-            BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(bitMask));
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(bitMask2));
+            }
+
+            BEAST_EXPECT(boost::icl::contains(
+                db->getShardInfo()->finalized(), *shardIndex));
+
+            bitMask2 |= 1ll << *shardIndex;
             BEAST_EXPECT((bitMask & bitMask2) == 0);
             if ((bitMask | bitMask2) == ((1ll << nTestShards) - 1) << 1)
                 break;
@@ -872,8 +912,9 @@ class DatabaseShard_test : public TestBase
             if (!BEAST_EXPECT(data.makeLedgers(env)))
                 return;
 
-            db->prepareShards({1});
-            BEAST_EXPECT(db->getPreShards() == bitmask2Rangeset(2));
+            BEAST_EXPECT(!db->importShard(1, importPath / "not_exist"));
+            BEAST_EXPECT(db->prepareShards({1}));
+            BEAST_EXPECT(db->getPreShards() == "1");
 
             using namespace boost::filesystem;
             remove_all(importPath / LgrDBName);
@@ -911,9 +952,11 @@ class DatabaseShard_test : public TestBase
                 if (!BEAST_EXPECT(data.makeLedgers(env)))
                     return;
 
-                for (std::uint32_t i = 0; i < 2; ++i)
+                for (auto i = 0; i < 2; ++i)
+                {
                     if (!BEAST_EXPECT(createShard(data, *db, 2)))
                         return;
+                }
             }
 
             boost::filesystem::path path = shardDir.path();
@@ -937,10 +980,10 @@ class DatabaseShard_test : public TestBase
         if (!BEAST_EXPECT(data.makeLedgers(env)))
             return;
 
-        for (std::uint32_t i = 1; i <= 1; ++i)
-            waitShard(*db, i);
+        for (std::uint32_t shardIndex = 1; shardIndex <= 1; ++shardIndex)
+            waitShard(*db, shardIndex);
 
-        BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0x2));
+        BEAST_EXPECT(boost::icl::contains(db->getShardInfo()->finalized(), 1));
 
         for (std::uint32_t i = 0; i < 1 * ledgersPerShard; ++i)
             checkLedger(data, *db, *data.ledgers_[i]);
@@ -999,7 +1042,11 @@ class DatabaseShard_test : public TestBase
                 }
 
                 if (i == 2)
+                {
                     waitShard(*db, shardIndex);
+                    BEAST_EXPECT(boost::icl::contains(
+                        db->getShardInfo()->finalized(), 1));
+                }
                 else
                 {
                     boost::filesystem::path path(shardDir.path());
@@ -1012,11 +1059,9 @@ class DatabaseShard_test : public TestBase
                     {
                         std::this_thread::yield();
                     }
-                }
 
-                BEAST_EXPECT(
-                    db->getCompleteShards() ==
-                    bitmask2Rangeset(i == 2 ? 2 : 0));
+                    BEAST_EXPECT(db->getShardInfo()->finalized().empty());
+                }
             }
 
             {
@@ -1029,23 +1074,22 @@ class DatabaseShard_test : public TestBase
                     return;
 
                 if (i == 2)
-                    waitShard(*db, 1);
-
-                BEAST_EXPECT(
-                    db->getCompleteShards() ==
-                    bitmask2Rangeset(i == 2 ? 2 : 0));
-
-                if (i == 2)
                 {
+                    waitShard(*db, 1);
+                    BEAST_EXPECT(boost::icl::contains(
+                        db->getShardInfo()->finalized(), 1));
+
                     for (std::uint32_t j = 0; j < ledgersPerShard; ++j)
                         checkLedger(data, *db, *data.ledgers_[j]);
                 }
+                else
+                    BEAST_EXPECT(db->getShardInfo()->finalized().empty());
             }
         }
     }
 
     void
-    testImport(std::uint64_t const seedValue)
+    testImportNodeStore(std::uint64_t const seedValue)
     {
         testcase("Import node store");
 
@@ -1066,11 +1110,15 @@ class DatabaseShard_test : public TestBase
             for (std::uint32_t i = 0; i < 2 * ledgersPerShard; ++i)
                 BEAST_EXPECT(saveLedger(ndb, *data.ledgers_[i]));
 
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0));
+            BEAST_EXPECT(db->getShardInfo()->finalized().empty());
             db->import(ndb);
+
             for (std::uint32_t i = 1; i <= 2; ++i)
                 waitShard(*db, i);
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0x6));
+
+            auto const finalShards{std::move(db->getShardInfo()->finalized())};
+            for (std::uint32_t shardIndex : {1, 2})
+                BEAST_EXPECT(boost::icl::contains(finalShards, shardIndex));
         }
         {
             Env env{*this, testConfig(shardDir.path())};
@@ -1084,7 +1132,9 @@ class DatabaseShard_test : public TestBase
             for (std::uint32_t i = 1; i <= 2; ++i)
                 waitShard(*db, i);
 
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0x6));
+            auto const finalShards{std::move(db->getShardInfo()->finalized())};
+            for (std::uint32_t shardIndex : {1, 2})
+                BEAST_EXPECT(boost::icl::contains(finalShards, shardIndex));
 
             for (std::uint32_t i = 0; i < 2 * ledgersPerShard; ++i)
                 checkLedger(data, *db, *data.ledgers_[i]);
@@ -1120,8 +1170,10 @@ class DatabaseShard_test : public TestBase
 
         using namespace test::jtx;
 
-        std::string ripemd160Key("B2F9DB61F714A82889966F097CD615C36DB2B01D"),
-            ripemd160Dat("6DB1D02CD019F09198FE80DB5A7D707F0C6BFF4C");
+        std::string const ripemd160Key(
+            "B23490F7830707E8BEEFBFD78D76F437AE9DDE72");
+        std::string const ripemd160Dat(
+            "8DCF2DA184D8DEC0E3D2716D7BF6C56641B6DA3B");
 
         for (int i = 0; i < 2; i++)
         {
@@ -1155,18 +1207,10 @@ class DatabaseShard_test : public TestBase
 
             boost::filesystem::path path(shardDir.path());
             path /= "1";
-            boost::filesystem::path keypath = path / "nudb.key";
-            std::string key = ripemd160File(keypath.string());
-            boost::filesystem::path datpath = path / "nudb.dat";
-            std::string dat = ripemd160File(datpath.string());
-
-            std::cerr << "Iteration " << i << ": RIPEMD160[nudb.key] = " << key
-                      << std::endl;
-            std::cerr << "Iteration " << i << ": RIPEMD160[nudb.dat] = " << dat
-                      << std::endl;
-
-            BEAST_EXPECT(key == ripemd160Key);
-            BEAST_EXPECT(dat == ripemd160Dat);
+            BEAST_EXPECT(
+                ripemd160File((path / "nudb.key").string()) == ripemd160Key);
+            BEAST_EXPECT(
+                ripemd160File((path / "nudb.dat").string()) == ripemd160Dat);
         }
     }
 
@@ -1177,8 +1221,7 @@ class DatabaseShard_test : public TestBase
 
         using namespace test::jtx;
 
-        // Test importing with multiple historical
-        // paths
+        // Test importing with multiple historical paths
         {
             beast::temp_dir shardDir;
             std::array<beast::temp_dir, 4> historicalDirs;
@@ -1214,13 +1257,15 @@ class DatabaseShard_test : public TestBase
             for (std::uint32_t i = 0; i < ledgerCount * ledgersPerShard; ++i)
                 BEAST_EXPECT(saveLedger(ndb, *data.ledgers_[i]));
 
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0));
+            BEAST_EXPECT(db->getShardInfo()->finalized().empty());
 
             db->import(ndb);
             for (std::uint32_t i = 1; i <= ledgerCount; ++i)
                 waitShard(*db, i);
 
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0b11110));
+            auto const final{std::move(db->getShardInfo()->finalized())};
+            for (std::uint32_t shardIndex : {1, 2, 3, 4})
+                BEAST_EXPECT(boost::icl::contains(final, shardIndex));
 
             auto const mainPathCount = std::distance(
                 boost::filesystem::directory_iterator(shardDir.path()),
@@ -1246,8 +1291,7 @@ class DatabaseShard_test : public TestBase
             BEAST_EXPECT(historicalPathCount == ledgerCount - 2);
         }
 
-        // Test importing with a single historical
-        // path
+        // Test importing with a single historical path
         {
             beast::temp_dir shardDir;
             beast::temp_dir historicalDir;
@@ -1272,13 +1316,15 @@ class DatabaseShard_test : public TestBase
             for (std::uint32_t i = 0; i < ledgerCount * ledgersPerShard; ++i)
                 BEAST_EXPECT(saveLedger(ndb, *data.ledgers_[i]));
 
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0));
+            BEAST_EXPECT(db->getShardInfo()->finalized().empty());
 
             db->import(ndb);
             for (std::uint32_t i = 1; i <= ledgerCount; ++i)
                 waitShard(*db, i);
 
-            BEAST_EXPECT(db->getCompleteShards() == bitmask2Rangeset(0b11110));
+            auto const finalShards{std::move(db->getShardInfo()->finalized())};
+            for (std::uint32_t shardIndex : {1, 2, 3, 4})
+                BEAST_EXPECT(boost::icl::contains(finalShards, shardIndex));
 
             auto const mainPathCount = std::distance(
                 boost::filesystem::directory_iterator(shardDir.path()),
@@ -1305,170 +1351,114 @@ class DatabaseShard_test : public TestBase
 
         using namespace test::jtx;
 
-        // Test importing with multiple historical
-        // paths
+        // Create the primary shard directory
+        beast::temp_dir primaryDir;
+        auto config{testConfig(primaryDir.path())};
+
+        // Create four historical directories
+        std::array<beast::temp_dir, 4> historicalDirs;
         {
-            beast::temp_dir shardDir;
-            std::array<beast::temp_dir, 4> historicalDirs;
-            std::array<boost::filesystem::path, 4> historicalPaths;
+            auto& paths{config->section(SECTION_HISTORICAL_SHARD_PATHS)};
+            for (auto const& dir : historicalDirs)
+                paths.append(dir.path());
+        }
 
-            std::transform(
-                historicalDirs.begin(),
-                historicalDirs.end(),
-                historicalPaths.begin(),
-                [](const beast::temp_dir& dir) { return dir.path(); });
+        Env env{*this, std::move(config)};
 
-            beast::temp_dir nodeDir;
-            auto c = testConfig(shardDir.path());
+        // Create some shards
+        std::uint32_t constexpr numShards{4};
+        TestData data(seedValue, 4, numShards);
+        if (!BEAST_EXPECT(data.makeLedgers(env)))
+            return;
 
-            auto& historyPaths = c->section(SECTION_HISTORICAL_SHARD_PATHS);
-            historyPaths.append(
-                {historicalPaths[0].string(),
-                 historicalPaths[1].string(),
-                 historicalPaths[2].string(),
-                 historicalPaths[3].string()});
+        auto shardStore{env.app().getShardStore()};
+        BEAST_EXPECT(shardStore);
 
-            Env env{*this, std::move(c)};
-            DatabaseShard* db = env.app().getShardStore();
-            BEAST_EXPECT(db);
-
-            auto const ledgerCount = 4;
-
-            TestData data(seedValue, 4, ledgerCount);
-            if (!BEAST_EXPECT(data.makeLedgers(env)))
-                return;
-
-            BEAST_EXPECT(db->getCompleteShards() == "");
-            std::uint64_t bitMask = 0;
-
-            // Add ten shards to the Shard Database
-            for (std::uint32_t i = 0; i < ledgerCount; ++i)
+        for (auto i = 0; i < numShards; ++i)
+        {
+            auto const shardIndex{createShard(data, *shardStore, numShards)};
+            if (!BEAST_EXPECT(
+                    shardIndex && *shardIndex >= 1 && *shardIndex <= numShards))
             {
-                auto n = createShard(data, *db, ledgerCount);
-                if (!BEAST_EXPECT(n && *n >= 1 && *n <= ledgerCount))
-                    return;
-                bitMask |= 1ll << *n;
-                BEAST_EXPECT(
-                    db->getCompleteShards() == bitmask2Rangeset(bitMask));
-            }
-
-            auto mainPathCount = std::distance(
-                boost::filesystem::directory_iterator(shardDir.path()),
-                boost::filesystem::directory_iterator());
-
-            // Only the two most recent shards
-            // should be stored at the main path
-            BEAST_EXPECT(mainPathCount == 2);
-
-            // Confirm recent shard locations
-            std::set<boost::filesystem::path> mainPathShards{
-                shardDir.path() / boost::filesystem::path("3"),
-                shardDir.path() / boost::filesystem::path("4")};
-            std::set<boost::filesystem::path> actual(
-                boost::filesystem::directory_iterator(shardDir.path()),
-                boost::filesystem::directory_iterator());
-
-            BEAST_EXPECT(mainPathShards == actual);
-
-            const auto generateHistoricalStems = [&historicalPaths, &actual] {
-                for (auto const& path : historicalPaths)
-                {
-                    for (auto const& shard :
-                         boost::filesystem::directory_iterator(path))
-                    {
-                        actual.insert(boost::filesystem::path(shard).stem());
-                    }
-                }
-            };
-
-            // Confirm historical shard locations
-            std::set<boost::filesystem::path> historicalPathShards;
-            std::generate_n(
-                std::inserter(
-                    historicalPathShards, historicalPathShards.begin()),
-                2,
-                [n = 1]() mutable { return std::to_string(n++); });
-            actual.clear();
-            generateHistoricalStems();
-
-            BEAST_EXPECT(historicalPathShards == actual);
-
-            auto historicalPathCount = std::accumulate(
-                historicalPaths.begin(),
-                historicalPaths.end(),
-                0,
-                [](int const sum, boost::filesystem::path const& path) {
-                    return sum +
-                        std::distance(
-                               boost::filesystem::directory_iterator(path),
-                               boost::filesystem::directory_iterator());
-                });
-
-            // All historical shards should be stored
-            // at historical paths
-            BEAST_EXPECT(historicalPathCount == ledgerCount - 2);
-
-            data = TestData(seedValue * 2, 4, ledgerCount);
-            if (!BEAST_EXPECT(data.makeLedgers(env, ledgerCount)))
                 return;
-
-            // Add ten more shards to the Shard Database
-            // to exercise recent shard rotation
-            for (std::uint32_t i = 0; i < ledgerCount; ++i)
-            {
-                auto n = createShard(data, *db, ledgerCount * 2, ledgerCount);
-                if (!BEAST_EXPECT(
-                        n && *n >= 1 + ledgerCount && *n <= ledgerCount * 2))
-                    return;
-                bitMask |= 1ll << *n;
-                BEAST_EXPECT(
-                    db->getCompleteShards() == bitmask2Rangeset(bitMask));
             }
+        }
 
-            mainPathCount = std::distance(
-                boost::filesystem::directory_iterator(shardDir.path()),
-                boost::filesystem::directory_iterator());
+        {
+            // Confirm finalized shards are in the shard store
+            auto const finalized{shardStore->getShardInfo()->finalized()};
+            BEAST_EXPECT(boost::icl::length(finalized) == numShards);
+            BEAST_EXPECT(boost::icl::first(finalized) == 1);
+            BEAST_EXPECT(boost::icl::last(finalized) == numShards);
+        }
 
-            // Only the two most recent shards
-            // should be stored at the main path
-            BEAST_EXPECT(mainPathCount == 2);
+        using namespace boost::filesystem;
+        auto const dirContains = [](beast::temp_dir const& dir,
+                                    std::uint32_t shardIndex) {
+            boost::filesystem::path const path(std::to_string(shardIndex));
+            for (auto const& it : directory_iterator(dir.path()))
+                if (boost::filesystem::path(it).stem() == path)
+                    return true;
+            return false;
+        };
+        auto const historicalDirsContains = [&](std::uint32_t shardIndex) {
+            for (auto const& dir : historicalDirs)
+                if (dirContains(dir, shardIndex))
+                    return true;
+            return false;
+        };
 
-            // Confirm recent shard locations
-            mainPathShards = {
-                shardDir.path() / boost::filesystem::path("7"),
-                shardDir.path() / boost::filesystem::path("8")};
-            actual = {
-                boost::filesystem::directory_iterator(shardDir.path()),
-                boost::filesystem::directory_iterator()};
+        // Confirm two most recent shards are in the primary shard directory
+        for (auto const shardIndex : {numShards - 1, numShards})
+        {
+            BEAST_EXPECT(dirContains(primaryDir, shardIndex));
+            BEAST_EXPECT(!historicalDirsContains(shardIndex));
+        }
 
-            BEAST_EXPECT(mainPathShards == actual);
+        // Confirm remaining shards are in the historical shard directories
+        for (auto shardIndex = 1; shardIndex < numShards - 1; ++shardIndex)
+        {
+            BEAST_EXPECT(!dirContains(primaryDir, shardIndex));
+            BEAST_EXPECT(historicalDirsContains(shardIndex));
+        }
 
-            // Confirm historical shard locations
-            historicalPathShards.clear();
-            std::generate_n(
-                std::inserter(
-                    historicalPathShards, historicalPathShards.begin()),
-                6,
-                [n = 1]() mutable { return std::to_string(n++); });
-            actual.clear();
-            generateHistoricalStems();
+        // Create some more shards to exercise recent shard rotation
+        data = TestData(seedValue * 2, 4, numShards);
+        if (!BEAST_EXPECT(data.makeLedgers(env, numShards)))
+            return;
 
-            BEAST_EXPECT(historicalPathShards == actual);
+        for (auto i = 0; i < numShards; ++i)
+        {
+            auto const shardIndex{
+                createShard(data, *shardStore, numShards * 2, numShards)};
+            if (!BEAST_EXPECT(
+                    shardIndex && *shardIndex >= numShards + 1 &&
+                    *shardIndex <= numShards * 2))
+            {
+                return;
+            }
+        }
 
-            historicalPathCount = std::accumulate(
-                historicalPaths.begin(),
-                historicalPaths.end(),
-                0,
-                [](int const sum, boost::filesystem::path const& path) {
-                    return sum +
-                        std::distance(
-                               boost::filesystem::directory_iterator(path),
-                               boost::filesystem::directory_iterator());
-                });
+        {
+            // Confirm finalized shards are in the shard store
+            auto const finalized{shardStore->getShardInfo()->finalized()};
+            BEAST_EXPECT(boost::icl::length(finalized) == numShards * 2);
+            BEAST_EXPECT(boost::icl::first(finalized) == 1);
+            BEAST_EXPECT(boost::icl::last(finalized) == numShards * 2);
+        }
 
-            // All historical shards should be stored
-            // at historical paths
-            BEAST_EXPECT(historicalPathCount == (ledgerCount * 2) - 2);
+        // Confirm two most recent shards are in the primary shard directory
+        for (auto const shardIndex : {numShards * 2 - 1, numShards * 2})
+        {
+            BEAST_EXPECT(dirContains(primaryDir, shardIndex));
+            BEAST_EXPECT(!historicalDirsContains(shardIndex));
+        }
+
+        // Confirm remaining shards are in the historical shard directories
+        for (auto shardIndex = 1; shardIndex < numShards * 2 - 1; ++shardIndex)
+        {
+            BEAST_EXPECT(!dirContains(primaryDir, shardIndex));
+            BEAST_EXPECT(historicalDirsContains(shardIndex));
         }
     }
 
@@ -1494,18 +1484,20 @@ class DatabaseShard_test : public TestBase
         if (!BEAST_EXPECT(data.makeLedgers(env)))
             return;
 
-        BEAST_EXPECT(shardStore->getCompleteShards().empty());
+        BEAST_EXPECT(shardStore->getShardInfo()->finalized().empty());
 
         int oldestShardIndex{-1};
-        std::uint64_t bitMask{0};
         for (auto i = 0; i < numShards; ++i)
         {
             auto shardIndex{createShard(data, *shardStore, numShards)};
             if (!BEAST_EXPECT(
                     shardIndex && *shardIndex >= 1 && *shardIndex <= numShards))
+            {
                 return;
+            }
 
-            bitMask |= (1ll << *shardIndex);
+            BEAST_EXPECT(boost::icl::contains(
+                shardStore->getShardInfo()->finalized(), *shardIndex));
 
             if (oldestShardIndex == -1)
                 oldestShardIndex = *shardIndex;
@@ -1522,6 +1514,137 @@ class DatabaseShard_test : public TestBase
             data.ledgers_[index]->info().hash, ledgerSeq));
     }
 
+    void
+    testShardInfo(std::uint64_t const seedValue)
+    {
+        testcase("Shard info");
+
+        using namespace test::jtx;
+        beast::temp_dir shardDir;
+        Env env{*this, testConfig(shardDir.path())};
+
+        auto shardStore{env.app().getShardStore()};
+        BEAST_EXPECT(shardStore);
+
+        // Check shard store is empty
+        {
+            auto const shardInfo{shardStore->getShardInfo()};
+            BEAST_EXPECT(
+                shardInfo->msgTimestamp().time_since_epoch().count() == 0);
+            BEAST_EXPECT(shardInfo->finalizedToString().empty());
+            BEAST_EXPECT(shardInfo->finalized().empty());
+            BEAST_EXPECT(shardInfo->incompleteToString().empty());
+            BEAST_EXPECT(shardInfo->incomplete().empty());
+        }
+
+        // Create an incomplete shard with index 1
+        TestData data(seedValue, dataSizeMax, 2);
+        if (!BEAST_EXPECT(data.makeLedgers(env)))
+            return;
+        if (!BEAST_EXPECT(shardStore->prepareLedger(2 * ledgersPerShard)))
+            return;
+
+        // Check shard is incomplete
+        {
+            auto const shardInfo{shardStore->getShardInfo()};
+            BEAST_EXPECT(shardInfo->finalizedToString().empty());
+            BEAST_EXPECT(shardInfo->finalized().empty());
+            BEAST_EXPECT(shardInfo->incompleteToString() == "1:0");
+            BEAST_EXPECT(
+                shardInfo->incomplete().find(1) !=
+                shardInfo->incomplete().end());
+        }
+
+        // Finalize the shard
+        {
+            auto shardIndex{createShard(data, *shardStore)};
+            if (!BEAST_EXPECT(shardIndex && *shardIndex == 1))
+                return;
+        }
+
+        // Check shard is finalized
+        {
+            auto const shardInfo{shardStore->getShardInfo()};
+            BEAST_EXPECT(shardInfo->finalizedToString() == "1");
+            BEAST_EXPECT(boost::icl::contains(shardInfo->finalized(), 1));
+            BEAST_EXPECT(shardInfo->incompleteToString().empty());
+            BEAST_EXPECT(shardInfo->incomplete().empty());
+            BEAST_EXPECT(!shardInfo->update(1, ShardState::finalized, 0));
+            BEAST_EXPECT(shardInfo->setFinalizedFromString("2"));
+            BEAST_EXPECT(shardInfo->finalizedToString() == "2");
+            BEAST_EXPECT(boost::icl::contains(shardInfo->finalized(), 2));
+        }
+
+        // Create an incomplete shard with index 2
+        if (!BEAST_EXPECT(shardStore->prepareLedger(3 * ledgersPerShard)))
+            return;
+
+        // Store 10 percent of the ledgers
+        for (std::uint32_t i = 0; i < (ledgersPerShard / 10); ++i)
+        {
+            auto const ledgerSeq{
+                shardStore->prepareLedger(3 * ledgersPerShard)};
+            if (!BEAST_EXPECT(ledgerSeq != std::nullopt))
+                return;
+
+            auto const arrInd{*ledgerSeq - ledgersPerShard - 1};
+            if (!BEAST_EXPECT(saveLedger(*shardStore, *data.ledgers_[arrInd])))
+                return;
+
+            shardStore->setStored(data.ledgers_[arrInd]);
+        }
+
+        auto const shardInfo{shardStore->getShardInfo()};
+        BEAST_EXPECT(shardInfo->incompleteToString() == "2:10");
+        BEAST_EXPECT(
+            shardInfo->incomplete().find(2) != shardInfo->incomplete().end());
+
+        auto const timeStamp{env.app().timeKeeper().now()};
+        shardInfo->setMsgTimestamp(timeStamp);
+        BEAST_EXPECT(timeStamp == shardInfo->msgTimestamp());
+
+        // Check message
+        auto const msg{shardInfo->makeMessage(env.app())};
+        Serializer s;
+        s.add32(HashPrefix::shardInfo);
+
+        BEAST_EXPECT(msg.timestamp() != 0);
+        s.add32(msg.timestamp());
+
+        // Verify incomplete shard
+        {
+            BEAST_EXPECT(msg.incomplete_size() == 1);
+
+            auto const& incomplete{msg.incomplete(0)};
+            BEAST_EXPECT(incomplete.shardindex() == 2);
+            s.add32(incomplete.shardindex());
+
+            BEAST_EXPECT(
+                static_cast<ShardState>(incomplete.state()) ==
+                ShardState::acquire);
+            s.add32(incomplete.state());
+
+            BEAST_EXPECT(incomplete.has_progress());
+            BEAST_EXPECT(incomplete.progress() == 10);
+            s.add32(incomplete.progress());
+        }
+
+        // Verify finalized shard
+        BEAST_EXPECT(msg.has_finalized());
+        BEAST_EXPECT(msg.finalized() == "1");
+        s.addRaw(msg.finalized().data(), msg.finalized().size());
+
+        // Verify public key
+        auto slice{makeSlice(msg.publickey())};
+        BEAST_EXPECT(publicKeyType(slice));
+
+        // Verify signature
+        BEAST_EXPECT(verify(
+            PublicKey(slice), s.slice(), makeSlice(msg.signature()), false));
+
+        BEAST_EXPECT(msg.peerchain_size() == 0);
+    }
+
 public:
     DatabaseShard_test() : journal_("DatabaseShard_test", *this)
     {
@@ -1531,20 +1654,20 @@ public:
     run() override
     {
         std::uint64_t const seedValue = 51;
-
         testStandalone();
         testCreateShard(seedValue);
         testReopenDatabase(seedValue + 10);
-        testGetCompleteShards(seedValue + 20);
+        testGetFinalShards(seedValue + 20);
         testPrepareShards(seedValue + 30);
         testImportShard(seedValue + 40);
         testCorruptedDatabase(seedValue + 50);
         testIllegalFinalKey(seedValue + 60);
-        testImport(seedValue + 70);
+        testImportNodeStore(seedValue + 70);
         testDeterministicShard(seedValue + 80);
         testImportWithHistoricalPaths(seedValue + 90);
         testPrepareWithHistoricalPaths(seedValue + 100);
         testOpenShardManagement(seedValue + 110);
+        testShardInfo(seedValue + 120);
     }
 };
 

--- a/src/test/nodestore/Database_test.cpp
+++ b/src/test/nodestore/Database_test.cpp
@@ -598,9 +598,8 @@ public:
 
         if (type == "memory")
         {
-            // Earliest ledger sequence tests
+            // Verify default earliest ledger sequence
             {
-                // Verify default earliest ledger sequence
                 std::unique_ptr<Database> db =
                     Manager::instance().make_Database(
                         "test",
@@ -673,6 +672,55 @@ public:
                     std::strcmp(e.what(), "earliest_seq set more than once") ==
                     0);
             }
+
+            // Verify default ledgers per shard
+            {
+                std::unique_ptr<Database> db =
+                    Manager::instance().make_Database(
+                        "test",
+                        megabytes(4),
+                        scheduler,
+                        2,
+                        parent,
+                        nodeParams,
+                        journal_);
+                BEAST_EXPECT(
+                    db->ledgersPerShard() == DEFAULT_LEDGERS_PER_SHARD);
+            }
+
+            // Set an invalid ledgers per shard
+            try
+            {
+                nodeParams.set("ledgers_per_shard", "100");
+                std::unique_ptr<Database> db =
+                    Manager::instance().make_Database(
+                        "test",
+                        megabytes(4),
+                        scheduler,
+                        2,
+                        parent,
+                        nodeParams,
+                        journal_);
+            }
+            catch (std::runtime_error const& e)
+            {
+                BEAST_EXPECT(
+                    std::strcmp(e.what(), "Invalid ledgers_per_shard") == 0);
+            }
+
+            // Set a valid ledgers per shard
+            nodeParams.set("ledgers_per_shard", "256");
+            std::unique_ptr<Database> db = Manager::instance().make_Database(
+                "test",
+                megabytes(4),
+                scheduler,
+                2,
+                parent,
+                nodeParams,
+                journal_);
+
+            // Verify database uses the ledgers per shard
+            BEAST_EXPECT(db->ledgersPerShard() == 256);
         }
     }
 

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -141,11 +141,6 @@ public:
     {
     }
     bool
-    hasShard(std::uint32_t shardIndex) const override
-    {
-        return false;
-    }
-    bool
     hasTxSet(uint256 const& hash) const override
     {
         return false;

--- a/src/test/rpc/ShardArchiveHandler_test.cpp
+++ b/src/test/rpc/ShardArchiveHandler_test.cpp
@@ -159,13 +159,18 @@ public:
         beast::temp_dir tempDir;
 
         auto c = jtx::envconfig();
-        auto& section = c->section(ConfigSection::shardDatabase());
-        section.set("path", tempDir.path());
-        section.set("max_historical_shards", "20");
-        section.set("ledgers_per_shard", "256");
-        section.set("earliest_seq", "257");
-        auto& sectionNode = c->section(ConfigSection::nodeDatabase());
-        sectionNode.set("earliest_seq", "257");
+        {
+            auto& section{c->section(ConfigSection::shardDatabase())};
+            section.set("path", tempDir.path());
+            section.set("max_historical_shards", "20");
+            section.set("ledgers_per_shard", "256");
+            section.set("earliest_seq", "257");
+        }
+        {
+            auto& section{c->section(ConfigSection::nodeDatabase())};
+            section.set("ledgers_per_shard", "256");
+            section.set("earliest_seq", "257");
+        }
         c->setupControl(true, true, true);
 
         jtx::Env env(*this, std::move(c));
@@ -257,13 +262,18 @@ public:
 
         {
             auto c = jtx::envconfig();
-            auto& section = c->section(ConfigSection::shardDatabase());
-            section.set("path", tempDir.path());
-            section.set("max_historical_shards", "20");
-            section.set("ledgers_per_shard", "256");
-            section.set("earliest_seq", "257");
-            auto& sectionNode = c->section(ConfigSection::nodeDatabase());
-            sectionNode.set("earliest_seq", "257");
+            {
+                auto& section{c->section(ConfigSection::shardDatabase())};
+                section.set("path", tempDir.path());
+                section.set("max_historical_shards", "20");
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
+            {
+                auto& section{c->section(ConfigSection::nodeDatabase())};
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
             c->setupControl(true, true, true);
 
             jtx::Env env(*this, std::move(c));
@@ -354,19 +364,23 @@ public:
         }
 
         auto c = jtx::envconfig();
-        auto& section = c->section(ConfigSection::shardDatabase());
-        section.set("path", tempDir.path());
-        section.set("max_historical_shards", "20");
-        section.set("ledgers_per_shard", "256");
-        section.set("shard_verification_retry_interval", "1");
-        section.set("shard_verification_max_attempts", "10000");
-        section.set("earliest_seq", "257");
-        auto& sectionNode = c->section(ConfigSection::nodeDatabase());
-        sectionNode.set("earliest_seq", "257");
+        {
+            auto& section{c->section(ConfigSection::shardDatabase())};
+            section.set("path", tempDir.path());
+            section.set("max_historical_shards", "20");
+            section.set("shard_verification_retry_interval", "1");
+            section.set("shard_verification_max_attempts", "10000");
+            section.set("ledgers_per_shard", "256");
+            section.set("earliest_seq", "257");
+        }
+        {
+            auto& section{c->section(ConfigSection::nodeDatabase())};
+            section.set("ledgers_per_shard", "256");
+            section.set("earliest_seq", "257");
+        }
         c->setupControl(true, true, true);
 
         jtx::Env env(*this, std::move(c));
-
         std::uint8_t const numberOfDownloads = 10;
 
         // Create some ledgers so that the ShardArchiveHandler
@@ -422,13 +436,18 @@ public:
             beast::temp_dir tempDir;
 
             auto c = jtx::envconfig();
-            auto& section = c->section(ConfigSection::shardDatabase());
-            section.set("path", tempDir.path());
-            section.set("max_historical_shards", "1");
-            section.set("ledgers_per_shard", "256");
-            section.set("earliest_seq", "257");
-            auto& sectionNode = c->section(ConfigSection::nodeDatabase());
-            sectionNode.set("earliest_seq", "257");
+            {
+                auto& section{c->section(ConfigSection::shardDatabase())};
+                section.set("path", tempDir.path());
+                section.set("max_historical_shards", "1");
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
+            {
+                auto& section{c->section(ConfigSection::nodeDatabase())};
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
             c->setupControl(true, true, true);
 
             std::unique_ptr<Logs> logs(new CaptureLogs(&capturedLogs));
@@ -496,13 +515,18 @@ public:
             beast::temp_dir tempDir;
 
             auto c = jtx::envconfig();
-            auto& section = c->section(ConfigSection::shardDatabase());
-            section.set("path", tempDir.path());
-            section.set("max_historical_shards", "0");
-            section.set("ledgers_per_shard", "256");
-            section.set("earliest_seq", "257");
-            auto& sectionNode = c->section(ConfigSection::nodeDatabase());
-            sectionNode.set("earliest_seq", "257");
+            {
+                auto& section{c->section(ConfigSection::shardDatabase())};
+                section.set("path", tempDir.path());
+                section.set("max_historical_shards", "0");
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
+            {
+                auto& section{c->section(ConfigSection::nodeDatabase())};
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
             c->setupControl(true, true, true);
 
             std::unique_ptr<Logs> logs(new CaptureLogs(&capturedLogs));
@@ -579,13 +603,18 @@ public:
             beast::temp_dir tempDir;
 
             auto c = jtx::envconfig();
-            auto& section = c->section(ConfigSection::shardDatabase());
-            section.set("path", tempDir.path());
-            section.set("max_historical_shards", "1");
-            section.set("ledgers_per_shard", "256");
-            section.set("earliest_seq", "257");
-            auto& sectionNode = c->section(ConfigSection::nodeDatabase());
-            sectionNode.set("earliest_seq", "257");
+            {
+                auto& section{c->section(ConfigSection::shardDatabase())};
+                section.set("path", tempDir.path());
+                section.set("max_historical_shards", "1");
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
+            {
+                auto& section{c->section(ConfigSection::nodeDatabase())};
+                section.set("ledgers_per_shard", "256");
+                section.set("earliest_seq", "257");
+            }
             c->setupControl(true, true, true);
 
             std::unique_ptr<Logs> logs(new CaptureLogs(&capturedLogs));
@@ -607,7 +636,7 @@ public:
                 env.close();
             }
 
-            env.app().getShardStore()->prepareShards({1});
+            BEAST_EXPECT(env.app().getShardStore()->prepareShards({1}));
 
             auto handler = env.app().getShardArchiveHandler();
             BEAST_EXPECT(handler);


### PR DESCRIPTION
This pull request is a refactoring and improvement of the shard information shared between peers with messages. Notably, the data shared now includes shard states, their progress, and a digital signature of the message data. The information is also visible via the crawl_shards command. Please note that the protocol message for the shard info has changed and the new message will only be visible to rippled nodes running 1.7.0-b10 or higher.

The introduction of the ShardInfo class disrupts levelization. The class resides in /nodestore, and is included from /overlay/impl/Peerimp.h and /nodestore/DataBaseShard.h. Since this cycle already exists, the levelization files will be updated with the change.