### PR TITLE
Fix telBAD_PUBLIC_KEY message:

### DIFF
--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -105,7 +105,7 @@ transResults()
         MAKE_ERROR(telLOCAL_ERROR,            "Local failure."),
         MAKE_ERROR(telBAD_DOMAIN,             "Domain too long."),
         MAKE_ERROR(telBAD_PATH_COUNT,         "Malformed: Too many paths."),
-        MAKE_ERROR(telBAD_PUBLIC_KEY,         "Public key too long."),
+        MAKE_ERROR(telBAD_PUBLIC_KEY,         "Public key is not valid."),
         MAKE_ERROR(telFAILED_PROCESSING,      "Failed to correctly process transaction."),
         MAKE_ERROR(telINSUF_FEE_P,            "Fee insufficient."),
         MAKE_ERROR(telNO_DST_PARTIAL,         "Partial payment to create account not allowed."),


### PR DESCRIPTION
The previous error description was focused on keys that are too long,
but this error can occur if the key is too short or does not contain
the correct prefix.

## High Level Overview of Change

Changes the error message for `telBAD_PUBLIC_KEY` to be more accurate.

### Context of Change

See https://github.com/ripple/xrpl-dev-portal/pull/952 for the related documentation update.

### Type of Change

- [x] Documentation Updates

Transaction error descriptions are reported to users in the API but are not part of the consensus process, and the documentation [explicitly calls out that these messages are subject to change without notice](https://xrpl.org/transaction-results.html#immediate-response), so this is a non-breaking, non-amendment change.