### PR TITLE
Add instructions for resolving validation failures:

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,31 +23,38 @@ jobs:
     - name: Format src/test
       run: find src/test -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-${CLANG_VERSION} -i
     - name: Check for differences
-      shell: bash
+      id: assert
       run: |
         set -o pipefail
-        echo "If you are reading this, you are probably looking at a failed"
-        echo "Github Actions job. That means you pushed a file that did not"
-        echo "conform to the formatting specified in .clang-format. That may"
-        echo "be because you neglected to run 'git clang-format' or "
-        echo "'clang-format' before committing, or that your version of"
-        echo "clang-format has an incompatibility with the one on this"
-        echo "machine, which is:"
-        clang-format-${CLANG_VERSION} --version
-        echo
-        echo "To fix it, you can do one of two things:"
-        echo "1. (The hard way): Download and apply the patch generated as an"
-        echo "   artifact of this job to your repo, commit, and push."
-        echo "2. (The easy way): Run "
-        echo "   'git-clang-format --extensions c,cpp,h,cxx,ipp develop'"
-        echo "   in your repo, commit, and push."
-        git diff --exit-code | tee "${{ github.sha }}.patch"
-    - name: Publish patch
-      if: failure()
+        git diff --exit-code | tee "clang-format.patch"
+    - name: Upload patch
+      if: failure() && steps.assert.outcome == 'failure'
       uses: actions/upload-artifact@v2
       continue-on-error: true
       with:
-        name: ${{ github.sha }}.patch
+        name: clang-format.patch
         if-no-files-found: ignore
-        path: ${{ github.sha }}.patch
+        path: clang-format.patch
+    - name: What happened?
+      if: failure() && steps.assert.outcome == 'failure'
+      env:
+        PREAMBLE: |
+          If you are reading this, you are looking at a failed Github Actions
+          job.  That means you pushed one or more files that did not conform
+          to the formatting specified in .clang-format. That may be because
+          you neglected to run 'git clang-format' or 'clang-format' before
+          committing, or that your version of clang-format has an
+          incompatibility with the one on this
+          machine, which is:
+        SUGGESTION: |
 
+          To fix it, you can do one of two things:
+          1. Download and apply the patch generated as an artifact of this
+             job to your repo, commit, and push.
+          2. Run 'git-clang-format --extensions c,cpp,h,cxx,ipp develop'
+             in your repo, commit, and push.
+      run: |
+        echo "${PREAMBLE}"
+        clang-format-${CLANG_VERSION} --version
+        echo "${SUGGESTION}"
+        exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,5 +23,31 @@ jobs:
     - name: Format src/test
       run: find src/test -type f \( -name '*.cpp' -o -name '*.h' -o -name '*.ipp' \) -print0 | xargs -0 clang-format-${CLANG_VERSION} -i
     - name: Check for differences
-      run: git diff --exit-code
+      shell: bash
+      run: |
+        set -o pipefail
+        echo "If you are reading this, you are probably looking at a failed"
+        echo "Github Actions job. That means you pushed a file that did not"
+        echo "conform to the formatting specified in .clang-format. That may"
+        echo "be because you neglected to run 'git clang-format' or "
+        echo "'clang-format' before committing, or that your version of"
+        echo "clang-format has an incompatibility with the one on this"
+        echo "machine, which is:"
+        clang-format-${CLANG_VERSION} --version
+        echo
+        echo "To fix it, you can do one of two things:"
+        echo "1. (The hard way): Download and apply the patch generated as an"
+        echo "   artifact of this job to your repo, commit, and push."
+        echo "2. (The easy way): Run "
+        echo "   'git-clang-format --extensions c,cpp,h,cxx,ipp develop'"
+        echo "   in your repo, commit, and push."
+        git diff --exit-code | tee "${{ github.sha }}.patch"
+    - name: Publish patch
+      if: failure()
+      uses: actions/upload-artifact@v2
+      continue-on-error: true
+      with:
+        name: ${{ github.sha }}.patch
+        if-no-files-found: ignore
+        path: ${{ github.sha }}.patch
 

--- a/.github/workflows/levelization.yml
+++ b/.github/workflows/levelization.yml
@@ -12,7 +12,34 @@ jobs:
     - name: Check levelization
       run: Builds/levelization/levelization.sh
     - name: Check for differences
-      run: git diff --exit-code
-      # If this workflow fails, and you have improved levelization, run
-      # Builds/levelization/levelization.sh, and commit the changes to
-      # loops.txt.
+      shell: bash
+      run: |
+        set -o pipefail
+        echo "If you are reading this, you are probably looking at a failed"
+        echo "Github Actions job. That means you changed the dependency"
+        echo "relationships between the modules in rippled. That may be an"
+        echo "improvement or a regression. This check doesn't judge."
+        echo
+        echo "A rule of thumb, though, is that if you removed something from"
+        echo "loops.txt, that's probably an improvement. If you added"
+        echo "something, it's probably a regression."
+        echo
+        echo "To fix it, you can do one of two things:"
+        echo "1. (The hard way): Download and apply the patch generated as an"
+        echo "   artifact of this job to your repo, commit, and push."
+        echo "2. (The easy way): Run './Builds/levelization/levelization.sh'"
+        echo "   in your repo, commit, and push."
+        echo
+        echo "See Builds/levelization/README.md for more info."
+        git diff --exit-code | tee "${{ github.sha }}.patch"
+        # If this workflow fails, and you have improved levelization, run
+        # Builds/levelization/levelization.sh, and commit the changes to
+        # loops.txt.
+    - name: Publish patch
+      if: failure()
+      uses: actions/upload-artifact@v2
+      continue-on-error: true
+      with:
+        name: ${{ github.sha }}.patch
+        if-no-files-found: ignore
+        path: ${{ github.sha }}.patch

--- a/.github/workflows/levelization.yml
+++ b/.github/workflows/levelization.yml
@@ -12,34 +12,38 @@ jobs:
     - name: Check levelization
       run: Builds/levelization/levelization.sh
     - name: Check for differences
-      shell: bash
+      id: assert
       run: |
         set -o pipefail
-        echo "If you are reading this, you are probably looking at a failed"
-        echo "Github Actions job. That means you changed the dependency"
-        echo "relationships between the modules in rippled. That may be an"
-        echo "improvement or a regression. This check doesn't judge."
-        echo
-        echo "A rule of thumb, though, is that if you removed something from"
-        echo "loops.txt, that's probably an improvement. If you added"
-        echo "something, it's probably a regression."
-        echo
-        echo "To fix it, you can do one of two things:"
-        echo "1. (The hard way): Download and apply the patch generated as an"
-        echo "   artifact of this job to your repo, commit, and push."
-        echo "2. (The easy way): Run './Builds/levelization/levelization.sh'"
-        echo "   in your repo, commit, and push."
-        echo
-        echo "See Builds/levelization/README.md for more info."
-        git diff --exit-code | tee "${{ github.sha }}.patch"
-        # If this workflow fails, and you have improved levelization, run
-        # Builds/levelization/levelization.sh, and commit the changes to
-        # loops.txt.
-    - name: Publish patch
-      if: failure()
+        git diff --exit-code | tee "levelization.patch"
+    - name: Upload patch
+      if: failure() && steps.assert.outcome == 'failure'
       uses: actions/upload-artifact@v2
       continue-on-error: true
       with:
-        name: ${{ github.sha }}.patch
+        name: levelization.patch
         if-no-files-found: ignore
-        path: ${{ github.sha }}.patch
+        path: levelization.patch
+    - name: What happened?
+      if: failure() && steps.assert.outcome == 'failure'
+      env:
+        MESSAGE: |
+          If you are reading this, you are looking at a failed Github
+          Actions job. That means you changed the dependency relationships
+          between the modules in rippled. That may be an improvement or a
+          regression. This check doesn't judge.
+
+          A rule of thumb, though, is that if your changes caused
+          something to be removed from loops.txt, that's probably an
+          improvement. If something was added, it's probably a regression.
+
+          To fix it, you can do one of two things:
+          1. Download and apply the patch generated as an artifact of this
+             job to your repo, commit, and push.
+          2. Run './Builds/levelization/levelization.sh' in your repo,
+             commit, and push.
+
+          See Builds/levelization/README.md for more info.
+      run: |
+        echo "${MESSAGE}"
+        exit 1

--- a/Builds/levelization/README.md
+++ b/Builds/levelization/README.md
@@ -16,10 +16,14 @@ reflect these rules. Whenever possible, developers should refactor any
 levelization violations they find (by moving files or individual
 classes). At the very least, don't make things worse.
 
-The table below summarizes the _desired_ division of modules. The levels
-are numbered from the bottom up with the lower level, lower numbered,
-more independent modules listed first, and the higher level, higher
-numbered modules with more dependencies listed later.
+The table below summarizes the _desired_ division of modules, based on the
+state of the rippled code when it was created. The levels are numbered from
+the bottom up with the lower level, lower numbered, more independent
+modules listed first, and the higher level, higher numbered modules with
+more dependencies listed later.
+
+**tl;dr:** The modules listed first are more independent than the modules
+listed later.
 
 | Level / Tier | Module(s)                                     |
 |--------------|-----------------------------------------------|

--- a/Builds/levelization/results/loops.txt
+++ b/Builds/levelization/results/loops.txt
@@ -4,11 +4,10 @@ Loop: ripple.app ripple.core
 Loop: ripple.app ripple.ledger
   ripple.app > ripple.ledger
 
-Loop: ripple.app ripple.net
-  ripple.app > ripple.net
-
 Loop: ripple.app ripple.nodestore
   ripple.app > ripple.nodestore
+
+This line shouldn't be here
 
 Loop: ripple.app ripple.overlay
   ripple.overlay ~= ripple.app

--- a/Builds/levelization/results/ordering.txt
+++ b/Builds/levelization/results/ordering.txt
@@ -5,10 +5,6 @@ ripple.app > ripple.consensus
 ripple.app > ripple.crypto
 ripple.app > ripple.json
 ripple.app > ripple.protocol
-ripple.app > ripple.resource
-ripple.app > test.unit_test
-ripple.basics > ripple.beast
-ripple.conditions > ripple.basics
 ripple.conditions > ripple.protocol
 ripple.consensus > ripple.basics
 ripple.consensus > ripple.beast
@@ -16,6 +12,7 @@ ripple.consensus > ripple.json
 ripple.consensus > ripple.protocol
 ripple.core > ripple.beast
 ripple.core > ripple.json
+This line shouldn't be here
 ripple.core > ripple.protocol
 ripple.crypto > ripple.basics
 ripple.json > ripple.beast

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -118,69 +118,7 @@ adjustDescriptorLimit(int needed, beast::Journal j)
 
 void
 printHelp(const po::options_description& desc)
-{
-    std::cerr
-        << systemName() << "d [options] <command> <params>\n"
-        << desc << std::endl
-        << "Commands: \n"
-           "     account_currencies <account> [<ledger>] [strict]\n"
-           "     account_info <account>|<seed>|<pass_phrase>|<key> [<ledger>] "
-           "[strict]\n"
-           "     account_lines <account> <account>|\"\" [<ledger>]\n"
-           "     account_channels <account> <account>|\"\" [<ledger>]\n"
-           "     account_objects <account> [<ledger>] [strict]\n"
-           "     account_offers <account>|<account_public_key> [<ledger>] "
-           "[strict]\n"
-           "     account_tx accountID [ledger_min [ledger_max [limit "
-           "[offset]]]] [binary] [count] [descending]\n"
-           "     book_offers <taker_pays> <taker_gets> [<taker [<ledger> "
-           "[<limit> [<proof> [<marker>]]]]]\n"
-           "     can_delete [<ledgerid>|<ledgerhash>|now|always|never]\n"
-           "     channel_authorize <private_key> <channel_id> <drops>\n"
-           "     channel_verify <public_key> <channel_id> <drops> <signature>\n"
-           "     connect <ip> [<port>]\n"
-           "     consensus_info\n"
-           "     deposit_authorized <source_account> <destination_account> "
-           "[<ledger>]\n"
-           "     download_shard [[<index> <url>]]\n"
-           "     feature [<feature> [accept|reject]]\n"
-           "     fetch_info [clear]\n"
-           "     gateway_balances [<ledger>] <issuer_account> [ <hotwallet> [ "
-           "<hotwallet> ]]\n"
-           "     get_counts\n"
-           "     json <method> <json>\n"
-           "     ledger [<id>|current|closed|validated] [full]\n"
-           "     ledger_accept\n"
-           "     ledger_cleaner\n"
-           "     ledger_closed\n"
-           "     ledger_current\n"
-           "     ledger_request <ledger>\n"
-           "     log_level [[<partition>] <severity>]\n"
-           "     logrotate \n"
-           "     peers\n"
-           "     ping\n"
-           "     random\n"
-           "     peer_reservations_add <public_key> [<description>]\n"
-           "     peer_reservations_del <public_key>\n"
-           "     peer_reservations_list\n"
-           "     ripple ...\n"
-           "     ripple_path_find <json> [<ledger>]\n"
-           "     server_info [counters]\n"
-           "     server_state [counters]\n"
-           "     sign <private_key> <tx_json> [offline]\n"
-           "     sign_for <signer_address> <signer_private_key> <tx_json> "
-           "[offline]\n"
-           "     stop\n"
-           "     submit <tx_blob>|[<private_key> <tx_json>]\n"
-           "     submit_multisigned <tx_json>\n"
-           "     tx <id>\n"
-           "     validation_create [<seed>|<pass_phrase>|<key>]\n"
-           "     validators\n"
-           "     validator_list_sites\n"
-           "     version\n"
-           "     wallet_propose [<passphrase>]\n";
-}
-
+{ std::cerr << systemName() << "d [options] <command> <params>\n" << desc << std::endl << "Commands: \n" "     account_currencies <account> [<ledger>] [strict]\n" "     account_info <account>|<seed>|<pass_phrase>|<key> [<ledger>] " "[strict]\n" "     account_lines <account> <account>|\"\" [<ledger>]\n" "     account_channels <account> <account>|\"\" [<ledger>]\n" "     account_objects <account> [<ledger>] [strict]\n" "     account_offers <account>|<account_public_key> [<ledger>] " "[strict]\n" "     account_tx accountID [ledger_min [ledger_max [limit " "[offset]]]] [binary] [count] [descending]\n" "     book_offers <taker_pays> <taker_gets> [<taker [<ledger> " "[<limit> [<proof> [<marker>]]]]]\n" "     can_delete [<ledgerid>|<ledgerhash>|now|always|never]\n" "     channel_authorize <private_key> <channel_id> <drops>\n" "     channel_verify <public_key> <channel_id> <drops> <signature>\n" "     connect <ip> [<port>]\n" "     consensus_info\n" "     deposit_authorized <source_account> <destination_account> " "[<ledger>]\n" "     download_shard [[<index> <url>]]\n" "     feature [<feature> [accept|reject]]\n" "     fetch_info [clear]\n" "     gateway_balances [<ledger>] <issuer_account> [ <hotwallet> [ " "<hotwallet> ]]\n" "     get_counts\n" "     json <method> <json>\n" "     ledger [<id>|current|closed|validated] [full]\n" "     ledger_accept\n" "     ledger_cleaner\n" "     ledger_closed\n" "     ledger_current\n" "     ledger_request <ledger>\n" "     log_level [[<partition>] <severity>]\n" "     logrotate \n" "     peers\n" "     ping\n" "     random\n" "     peer_reservations_add <public_key> [<description>]\n" "     peer_reservations_del <public_key>\n" "     peer_reservations_list\n" "     ripple ...\n" "     ripple_path_find <json> [<ledger>]\n" "     server_info [counters]\n" "     server_state [counters]\n" "     sign <private_key> <tx_json> [offline]\n" "     sign_for <signer_address> <signer_private_key> <tx_json> " "[offline]\n" "     stop\n" "     submit <tx_blob>|[<private_key> <tx_json>]\n" "     submit_multisigned <tx_json>\n" "     tx <id>\n" "     validation_create [<seed>|<pass_phrase>|<key>]\n" "     validators\n" "     validator_list_sites\n" "     version\n" "     wallet_propose [<passphrase>]\n"; }
 //------------------------------------------------------------------------------
 
 /* simple unit test selector that allows a comma separated list


### PR DESCRIPTION
## High Level Overview of Change

The non-build ~CI jobs~ Github Actions are not always clear about what is going on or how to fix their issues when they fail. These changes, if merged, will put instructions at the site of the failure, which should ease resolving those issues.

* Add instructions to the workflow at the point where the failure would
  occur, which is where someone experiencing a failure is most likely to
  look. To keep things simple, the instructions are always printed. The
  assumption is that if the job succeeds, nobody is likely to look
  anyway.
* Provides the diff of the failure as an artifact, so the user can apply
  it directly to their repo.
* Also update the levelization/README.md to clarify the levels a little
  bit.

### Type of Change

- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [X] Documentation Updates

## Test Plan

These changes can be verified by viewing the Github Actions results for this PR (levelization and clang-format). Drill down into the job, then to the "Check for differences" step. The instructions will be displayed.

To test that they show as expected for failures, clone this branch to your own repo, make some changes to the levelization files (`Builds/levelization/results/*.txt`) and/or make changes to a source code file that messes up the formatting. Then commit and push to your own repo. The relevant jobs should fail, and clicking through the errors should lead to the instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3752)
<!-- Reviewable:end -->
