### PR TITLE
Fix idle peer deletion timer

### DIFF
--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -100,7 +100,7 @@ OverlayImpl::Timer::on_timer(error_code ec)
     overlay_.sendEndpoints();
     overlay_.autoConnect();
 
-    if ((overlay_.timer_count_ % Tuning::checkIdlePeers) == 0)
+    if ((++overlay_.timer_count_ % Tuning::checkIdlePeers) == 0)
         overlay_.deleteIdlePeers();
 
     timer_.expires_from_now(std::chrono::seconds(1));


### PR DESCRIPTION
## High Level Overview of Change

Increments OverlayImpl::timer_count_, so that idle peer deletion is checked once every 4 seconds.

### Context of Change

This PR fixes #3754, which was introduced in 1.7.0-b5.

### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
