### PR TITLE
Replace most uses of `boost::optional` with `std::optional

### DIFF
--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -101,7 +101,7 @@ RCLConsensus::Adaptor::Adaptor(
                     << ", Cookie: " << valCookie_ << ")";
 }
 
-boost::optional<RCLCxLedger>
+std::optional<RCLCxLedger>
 RCLConsensus::Adaptor::acquireLedger(LedgerHash const& hash)
 {
     // we need to switch the ledger we're working from
@@ -124,7 +124,7 @@ RCLConsensus::Adaptor::acquireLedger(LedgerHash const& hash)
                         id, 0, InboundLedger::Reason::CONSENSUS);
                 });
         }
-        return boost::none;
+        return std::nullopt;
     }
 
     assert(!built->open() && built->isImmutable());
@@ -230,14 +230,14 @@ RCLConsensus::Adaptor::share(RCLTxSet const& txns)
     inboundTransactions_.giveSet(txns.id(), txns.map_, false);
 }
 
-boost::optional<RCLTxSet>
+std::optional<RCLTxSet>
 RCLConsensus::Adaptor::acquireTxSet(RCLTxSet::ID const& setId)
 {
     if (auto txns = inboundTransactions_.getSet(setId, true))
     {
         return RCLTxSet{std::move(txns)};
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 bool
@@ -620,7 +620,7 @@ RCLConsensus::Adaptor::doAccept(
         std::lock(lock, sl);
 
         auto const lastVal = ledgerMaster_.getValidatedLedger();
-        boost::optional<Rules> rules;
+        std::optional<Rules> rules;
         if (lastVal)
             rules.emplace(*lastVal, app_.config().features);
         else
@@ -925,7 +925,7 @@ RCLConsensus::gotTxSet(NetClock::time_point const& now, RCLTxSet const& txSet)
 void
 RCLConsensus::simulate(
     NetClock::time_point const& now,
-    boost::optional<std::chrono::milliseconds> consensusDelay)
+    std::optional<std::chrono::milliseconds> consensusDelay)
 {
     std::lock_guard _{mutex_};
     consensus_.simulate(now, consensusDelay);

--- a/src/ripple/app/consensus/RCLConsensus.h
+++ b/src/ripple/app/consensus/RCLConsensus.h
@@ -200,7 +200,7 @@ class RCLConsensus
             @param hash The ID/hash of the ledger acquire
             @return Optional ledger, will be seated if we locally had the ledger
         */
-        boost::optional<RCLCxLedger>
+        std::optional<RCLCxLedger>
         acquireLedger(LedgerHash const& hash);
 
         /** Share the given proposal with all peers
@@ -227,7 +227,7 @@ class RCLConsensus
             @param setId The transaction set ID associated with the proposal
             @return Optional set of transactions, seated if available.
        */
-        boost::optional<RCLTxSet>
+        std::optional<RCLTxSet>
         acquireTxSet(RCLTxSet::ID const& setId);
 
         /** Whether the open ledger has any transactions
@@ -507,7 +507,7 @@ public:
     void
     simulate(
         NetClock::time_point const& now,
-        boost::optional<std::chrono::milliseconds> consensusDelay);
+        std::optional<std::chrono::milliseconds> consensusDelay);
 
     //! @see Consensus::proposal
     bool

--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -123,7 +123,7 @@ RCLValidationsAdaptor::now() const
     return app_.timeKeeper().closeTime();
 }
 
-boost::optional<RCLValidatedLedger>
+std::optional<RCLValidatedLedger>
 RCLValidationsAdaptor::acquire(LedgerHash const& hash)
 {
     auto ledger = app_.getLedgerMaster().getLedgerByHash(hash);
@@ -139,7 +139,7 @@ RCLValidationsAdaptor::acquire(LedgerHash const& hash)
                 pApp->getInboundLedgers().acquire(
                     hash, 0, InboundLedger::Reason::CONSENSUS);
             });
-        return boost::none;
+        return std::nullopt;
     }
 
     assert(!ledger->open() && ledger->isImmutable());

--- a/src/ripple/app/consensus/RCLValidations.h
+++ b/src/ripple/app/consensus/RCLValidations.h
@@ -120,7 +120,7 @@ public:
     }
 
     /// Get the load fee of the validation if it exists
-    boost::optional<std::uint32_t>
+    std::optional<std::uint32_t>
     loadFee() const
     {
         return ~(*val_)[~sfLoadFee];
@@ -218,7 +218,7 @@ public:
     now() const;
 
     /** Attempt to acquire the ledger with given id from the network */
-    boost::optional<RCLValidatedLedger>
+    std::optional<RCLValidatedLedger>
     acquire(LedgerHash const& id);
 
     beast::Journal

--- a/src/ripple/app/ledger/AbstractFetchPackContainer.h
+++ b/src/ripple/app/ledger/AbstractFetchPackContainer.h
@@ -22,7 +22,7 @@
 
 #include <ripple/basics/Blob.h>
 #include <ripple/basics/base_uint.h>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace ripple {
 
@@ -37,10 +37,10 @@ public:
     /** Retrieves partial ledger data of the coresponding hash from peers.`
 
         @param nodeHash The 256-bit hash of the data to fetch.
-        @return `boost::none` if the hash isn't cached,
+        @return `std::nullopt` if the hash isn't cached,
             otherwise, the hash associated data.
     */
-    virtual boost::optional<Blob>
+    virtual std::optional<Blob>
     getFetchPack(uint256 const& nodeHash) = 0;
 };
 

--- a/src/ripple/app/ledger/AccountStateSF.cpp
+++ b/src/ripple/app/ledger/AccountStateSF.cpp
@@ -33,7 +33,7 @@ AccountStateSF::gotNode(
         hotACCOUNT_NODE, std::move(nodeData), nodeHash.as_uint256(), ledgerSeq);
 }
 
-boost::optional<Blob>
+std::optional<Blob>
 AccountStateSF::getNode(SHAMapHash const& nodeHash) const
 {
     return fp_.getFetchPack(nodeHash.as_uint256());

--- a/src/ripple/app/ledger/AccountStateSF.h
+++ b/src/ripple/app/ledger/AccountStateSF.h
@@ -44,7 +44,7 @@ public:
         Blob&& nodeData,
         SHAMapNodeType type) const override;
 
-    boost::optional<Blob>
+    std::optional<Blob>
     getNode(SHAMapHash const& nodeHash) const override;
 
 private:

--- a/src/ripple/app/ledger/ConsensusTransSetSF.cpp
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.cpp
@@ -74,7 +74,7 @@ ConsensusTransSetSF::gotNode(
     }
 }
 
-boost::optional<Blob>
+std::optional<Blob>
 ConsensusTransSetSF::getNode(SHAMapHash const& nodeHash) const
 {
     Blob nodeData;
@@ -96,7 +96,7 @@ ConsensusTransSetSF::getNode(SHAMapHash const& nodeHash) const
         return nodeData;
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
 }  // namespace ripple

--- a/src/ripple/app/ledger/ConsensusTransSetSF.h
+++ b/src/ripple/app/ledger/ConsensusTransSetSF.h
@@ -47,7 +47,7 @@ public:
         Blob&& nodeData,
         SHAMapNodeType type) const override;
 
-    boost::optional<Blob>
+    std::optional<Blob>
     getNode(SHAMapHash const& nodeHash) const override;
 
 private:

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -416,14 +416,14 @@ Ledger::exists(uint256 const& key) const
     return stateMap_->hasItem(key);
 }
 
-boost::optional<uint256>
-Ledger::succ(uint256 const& key, boost::optional<uint256> const& last) const
+std::optional<uint256>
+Ledger::succ(uint256 const& key, std::optional<uint256> const& last) const
 {
     auto item = stateMap_->upper_bound(key);
     if (item == stateMap_->end())
-        return boost::none;
+        return std::nullopt;
     if (last && item->key() >= last)
-        return boost::none;
+        return std::nullopt;
     return item->key();
 }
 
@@ -500,13 +500,13 @@ Ledger::txRead(key_type const& key) const -> tx_type
 }
 
 auto
-Ledger::digest(key_type const& key) const -> boost::optional<digest_type>
+Ledger::digest(key_type const& key) const -> std::optional<digest_type>
 {
     SHAMapHash digest;
     // VFALCO Unfortunately this loads the item
     //        from the NodeStore needlessly.
     if (!stateMap_->peekItem(key, digest))
-        return boost::none;
+        return std::nullopt;
     return digest.as_uint256();
 }
 
@@ -680,7 +680,7 @@ Ledger::negativeUNL() const
     return negUnl;
 }
 
-boost::optional<PublicKey>
+std::optional<PublicKey>
 Ledger::validatorToDisable() const
 {
     if (auto sle = read(keylet::negativeUNL());
@@ -692,10 +692,10 @@ Ledger::validatorToDisable() const
             return PublicKey(s);
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<PublicKey>
+std::optional<PublicKey>
 Ledger::validatorToReEnable() const
 {
     if (auto sle = read(keylet::negativeUNL());
@@ -707,7 +707,7 @@ Ledger::validatorToReEnable() const
             return PublicKey(s);
     }
 
-    return boost::none;
+    return std::nullopt;
 }
 
 void
@@ -1205,6 +1205,7 @@ loadLedgerHelper(std::string const& sqlSuffix, Application& app, bool acquire)
 
     auto db = app.getLedgerDB().checkoutDb();
 
+    // SOCI requires boost::optional (not std::optional) as parameters.
     boost::optional<std::string> sLedgerHash, sPrevHash, sAccountHash,
         sTransHash;
     boost::optional<std::uint64_t> totDrops, closingTime, prevClosingTime,
@@ -1619,6 +1620,7 @@ getHashByIndex(std::uint32_t ledgerIndex, Application& app)
     {
         auto db = app.getLedgerDB().checkoutDb();
 
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<std::string> lh;
         *db << sql, soci::into(lh);
 
@@ -1646,6 +1648,7 @@ getHashesByIndex(
             ledgerIndex, ledgerHash, parentHash, app);
     auto db = app.getLedgerDB().checkoutDb();
 
+    // SOCI requires boost::optional (not std::optional) as parameters.
     boost::optional<std::string> lhO, phO;
 
     *db << "SELECT LedgerHash,PrevHash FROM Ledgers "
@@ -1680,6 +1683,8 @@ getHashesByIndex(std::uint32_t minSeq, std::uint32_t maxSeq, Application& app)
 
     std::uint64_t ls;
     std::string lh;
+
+    // SOCI requires boost::optional (not std::optional) as the parameter.
     boost::optional<std::string> ph;
     soci::statement st =
         (db->prepare << sql, soci::into(ls), soci::into(lh), soci::into(ph));

--- a/src/ripple/app/ledger/Ledger.h
+++ b/src/ripple/app/ledger/Ledger.h
@@ -31,7 +31,6 @@
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/Serializer.h>
 #include <ripple/shamap/SHAMap.h>
-#include <boost/optional.hpp>
 #include <mutex>
 
 namespace ripple {
@@ -175,8 +174,8 @@ public:
     bool
     exists(uint256 const& key) const;
 
-    boost::optional<uint256>
-    succ(uint256 const& key, boost::optional<uint256> const& last = boost::none)
+    std::optional<uint256>
+    succ(uint256 const& key, std::optional<uint256> const& last = std::nullopt)
         const override;
 
     std::shared_ptr<SLE const>
@@ -207,7 +206,7 @@ public:
     // DigestAwareReadView
     //
 
-    boost::optional<digest_type>
+    std::optional<digest_type>
     digest(key_type const& key) const override;
 
     //
@@ -361,7 +360,7 @@ public:
      *
      * @return the public key if any
      */
-    boost::optional<PublicKey>
+    std::optional<PublicKey>
     validatorToDisable() const;
 
     /**
@@ -369,7 +368,7 @@ public:
      *
      * @return the public key if any
      */
-    boost::optional<PublicKey>
+    std::optional<PublicKey>
     validatorToReEnable() const;
 
     /**

--- a/src/ripple/app/ledger/LedgerHistory.cpp
+++ b/src/ripple/app/ledger/LedgerHistory.cpp
@@ -323,8 +323,8 @@ void
 LedgerHistory::handleMismatch(
     LedgerHash const& built,
     LedgerHash const& valid,
-    boost::optional<uint256> const& builtConsensusHash,
-    boost::optional<uint256> const& validatedConsensusHash,
+    std::optional<uint256> const& builtConsensusHash,
+    std::optional<uint256> const& validatedConsensusHash,
     Json::Value const& consensus)
 {
     assert(built != valid);
@@ -444,14 +444,14 @@ LedgerHistory::builtLedger(
 
     if (entry->validated && !entry->built)
     {
-        if (entry->validated.get() != hash)
+        if (entry->validated.value() != hash)
         {
-            JLOG(j_.error())
-                << "MISMATCH: seq=" << index
-                << " validated:" << entry->validated.get() << " then:" << hash;
+            JLOG(j_.error()) << "MISMATCH: seq=" << index
+                             << " validated:" << entry->validated.value()
+                             << " then:" << hash;
             handleMismatch(
                 hash,
-                entry->validated.get(),
+                entry->validated.value(),
                 consensusHash,
                 entry->validatedConsensusHash,
                 consensus);
@@ -471,7 +471,7 @@ LedgerHistory::builtLedger(
 void
 LedgerHistory::validatedLedger(
     std::shared_ptr<Ledger const> const& ledger,
-    boost::optional<uint256> const& consensusHash)
+    std::optional<uint256> const& consensusHash)
 {
     LedgerIndex index = ledger->info().seq;
     LedgerHash hash = ledger->info().hash;
@@ -484,17 +484,17 @@ LedgerHistory::validatedLedger(
 
     if (entry->built && !entry->validated)
     {
-        if (entry->built.get() != hash)
+        if (entry->built.value() != hash)
         {
             JLOG(j_.error())
-                << "MISMATCH: seq=" << index << " built:" << entry->built.get()
-                << " then:" << hash;
+                << "MISMATCH: seq=" << index
+                << " built:" << entry->built.value() << " then:" << hash;
             handleMismatch(
-                entry->built.get(),
+                entry->built.value(),
                 hash,
                 entry->builtConsensusHash,
                 consensusHash,
-                entry->consensus.get());
+                entry->consensus.value());
         }
         else
         {

--- a/src/ripple/app/ledger/LedgerHistory.h
+++ b/src/ripple/app/ledger/LedgerHistory.h
@@ -26,6 +26,8 @@
 #include <ripple/beast/insight/Event.h>
 #include <ripple/protocol/RippleLedgerHash.h>
 
+#include <optional>
+
 namespace ripple {
 
 // VFALCO TODO Rename to OldLedgers ?
@@ -95,7 +97,7 @@ public:
     void
     validatedLedger(
         std::shared_ptr<Ledger const> const&,
-        boost::optional<uint256> const& consensusHash);
+        std::optional<uint256> const& consensusHash);
 
     /** Repair a hash to index mapping
         @param ledgerIndex The index whose mapping is to be repaired
@@ -123,8 +125,8 @@ private:
     handleMismatch(
         LedgerHash const& built,
         LedgerHash const& valid,
-        boost::optional<uint256> const& builtConsensusHash,
-        boost::optional<uint256> const& validatedConsensusHash,
+        std::optional<uint256> const& builtConsensusHash,
+        std::optional<uint256> const& validatedConsensusHash,
         Json::Value const& consensus);
 
     Application& app_;
@@ -140,15 +142,15 @@ private:
     struct cv_entry
     {
         // Hash of locally built ledger
-        boost::optional<LedgerHash> built;
+        std::optional<LedgerHash> built;
         // Hash of the validated ledger
-        boost::optional<LedgerHash> validated;
+        std::optional<LedgerHash> validated;
         // Hash of locally accepted consensus transaction set
-        boost::optional<uint256> builtConsensusHash;
+        std::optional<uint256> builtConsensusHash;
         // Hash of validated consensus transaction set
-        boost::optional<uint256> validatedConsensusHash;
+        std::optional<uint256> validatedConsensusHash;
         // Consensus metadata of built ledger
-        boost::optional<Json::Value> consensus;
+        std::optional<Json::Value> consensus;
     };
     using ConsensusValidated = TaggedCache<LedgerIndex, cv_entry>;
     ConsensusValidated m_consensus_validated;

--- a/src/ripple/app/ledger/LedgerMaster.h
+++ b/src/ripple/app/ledger/LedgerMaster.h
@@ -39,7 +39,7 @@
 #include <ripple/protocol/RippleLedgerHash.h>
 #include <ripple/protocol/STValidation.h>
 #include <ripple/protocol/messages.h>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <mutex>
 
@@ -181,7 +181,7 @@ public:
     getHashBySeq(std::uint32_t index);
 
     /** Walk to a ledger's hash using the skip list */
-    boost::optional<LedgerHash>
+    std::optional<LedgerHash>
     walkHashBySeq(std::uint32_t index, InboundLedger::Reason reason);
 
     /** Walk the chain of ledger hashes to determine the hash of the
@@ -191,7 +191,7 @@ public:
         from the reference ledger or any prior ledger are not present
         in the node store.
     */
-    boost::optional<LedgerHash>
+    std::optional<LedgerHash>
     walkHashBySeq(
         std::uint32_t index,
         std::shared_ptr<ReadView const> const& referenceLedger,
@@ -206,10 +206,10 @@ public:
     void
     setLedgerRangePresent(std::uint32_t minV, std::uint32_t maxV);
 
-    boost::optional<NetClock::time_point>
+    std::optional<NetClock::time_point>
     getCloseTimeBySeq(LedgerIndex ledgerIndex);
 
-    boost::optional<NetClock::time_point>
+    std::optional<NetClock::time_point>
     getCloseTimeByHash(LedgerHash const& ledgerHash, LedgerIndex ledgerIndex);
 
     void
@@ -284,7 +284,7 @@ public:
     void
     addFetchPack(uint256 const& hash, std::shared_ptr<Blob> data);
 
-    boost::optional<Blob>
+    std::optional<Blob>
     getFetchPack(uint256 const& hash) override;
 
     void
@@ -305,7 +305,7 @@ public:
     }
 
     // Returns the minimum ledger sequence in SQL database, if any.
-    boost::optional<LedgerIndex>
+    std::optional<LedgerIndex>
     minSqlSeq();
 
 private:
@@ -320,7 +320,7 @@ private:
     void
     getFetchPack(LedgerIndex missing, InboundLedger::Reason reason);
 
-    boost::optional<LedgerHash>
+    std::optional<LedgerHash>
     getLedgerHashForHistory(LedgerIndex index, InboundLedger::Reason reason);
 
     std::size_t

--- a/src/ripple/app/ledger/TransactionStateSF.cpp
+++ b/src/ripple/app/ledger/TransactionStateSF.cpp
@@ -38,7 +38,7 @@ TransactionStateSF::gotNode(
         ledgerSeq);
 }
 
-boost::optional<Blob>
+std::optional<Blob>
 TransactionStateSF::getNode(SHAMapHash const& nodeHash) const
 {
     return fp_.getFetchPack(nodeHash.as_uint256());

--- a/src/ripple/app/ledger/TransactionStateSF.h
+++ b/src/ripple/app/ledger/TransactionStateSF.h
@@ -44,7 +44,7 @@ public:
         Blob&& nodeData,
         SHAMapNodeType type) const override;
 
-    boost::optional<Blob>
+    std::optional<Blob>
     getNode(SHAMapHash const& nodeHash) const override;
 
 private:

--- a/src/ripple/app/ledger/impl/LedgerCleaner.cpp
+++ b/src/ripple/app/ledger/impl/LedgerCleaner.cpp
@@ -260,11 +260,11 @@ private:
         stopped();
     }
 
-    // VFALCO TODO This should return boost::optional<uint256>
+    // VFALCO TODO This should return std::optional<uint256>
     LedgerHash
     getLedgerHash(std::shared_ptr<ReadView const>& ledger, LedgerIndex index)
     {
-        boost::optional<LedgerHash> hash;
+        std::optional<LedgerHash> hash;
         try
         {
             hash = hashOfSeq(*ledger, index, j_);

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -81,6 +81,7 @@
 #include <iostream>
 #include <limits>
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <variant>
 
@@ -173,7 +174,7 @@ public:
     std::unique_ptr<SHAMapStore> m_shaMapStore;
     PendingSaves pendingSaves_;
     AccountIDCache accountIDCache_;
-    boost::optional<OpenLedger> openLedger_;
+    std::optional<OpenLedger> openLedger_;
 
     // These are not Stoppable-derived
     NodeCache m_tempNodeCache;
@@ -1006,7 +1007,7 @@ public:
                 NodeStore::Manager::instance().make_Database(
                     "NodeStore.import",
                     megabytes(config_->getValueFor(
-                        SizedItem::burstSize, boost::none)),
+                        SizedItem::burstSize, std::nullopt)),
                     dummyScheduler,
                     0,
                     dummyRoot,
@@ -1220,7 +1221,7 @@ public:
                 DatabaseCon::Setup dbSetup = setup_DatabaseCon(*config_);
                 boost::filesystem::path dbPath = dbSetup.dataDir / TxDBName;
                 boost::system::error_code ec;
-                boost::optional<std::uint64_t> dbSize =
+                std::optional<std::uint64_t> dbSize =
                     boost::filesystem::file_size(dbPath, ec);
                 if (ec)
                 {
@@ -2278,6 +2279,7 @@ ApplicationImp::setMaxDisallowedLedger()
     }
     else
     {
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<LedgerIndex> seq;
         {
             auto db = getLedgerDB().checkoutDb();

--- a/src/ripple/app/main/BasicApp.cpp
+++ b/src/ripple/app/main/BasicApp.cpp
@@ -37,7 +37,7 @@ BasicApp::BasicApp(std::size_t numberOfThreads)
 
 BasicApp::~BasicApp()
 {
-    work_ = boost::none;
+    work_.reset();
 
     for (auto& t : threads_)
         t.join();

--- a/src/ripple/app/main/BasicApp.h
+++ b/src/ripple/app/main/BasicApp.h
@@ -21,7 +21,7 @@
 #define RIPPLE_APP_BASICAPP_H_INCLUDED
 
 #include <boost/asio/io_service.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -29,7 +29,7 @@
 class BasicApp
 {
 private:
-    boost::optional<boost::asio::io_service::work> work_;
+    std::optional<boost::asio::io_service::work> work_;
     std::vector<std::thread> threads_;
     boost::asio::io_service io_service_;
 

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -43,7 +43,7 @@ getEndpoint(std::string const& peer)
             peerClean = peer.substr(first + 1);
         }
 
-        boost::optional<beast::IP::Endpoint> endpoint =
+        std::optional<beast::IP::Endpoint> endpoint =
             beast::IP::Endpoint::from_string_checked(peerClean);
         if (endpoint)
             return beast::IP::to_asio_endpoint(endpoint.value());

--- a/src/ripple/app/main/NodeIdentity.cpp
+++ b/src/ripple/app/main/NodeIdentity.cpp
@@ -48,12 +48,13 @@ loadNodeIdentity(Application& app)
     }
 
     // Try to load a node identity from the database:
-    boost::optional<PublicKey> publicKey;
-    boost::optional<SecretKey> secretKey;
+    std::optional<PublicKey> publicKey;
+    std::optional<SecretKey> secretKey;
 
     auto db = app.getWalletDB().checkoutDb();
 
     {
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<std::string> pubKO, priKO;
         soci::statement st =
             (db->prepare << "SELECT PublicKey, PrivateKey FROM NodeIdentity;",

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -25,6 +25,8 @@
 #include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STValidation.h>
 
+#include <optional>
+
 namespace ripple {
 
 /** The amendment table stores the list of enabled and potential amendments.
@@ -61,7 +63,7 @@ public:
     virtual bool
     hasUnsupportedEnabled() const = 0;
 
-    virtual boost::optional<NetClock::time_point>
+    virtual std::optional<NetClock::time_point>
     firstUnsupportedExpected() const = 0;
 
     virtual Json::Value

--- a/src/ripple/app/misc/HashRouter.h
+++ b/src/ripple/app/misc/HashRouter.h
@@ -25,7 +25,8 @@
 #include <ripple/basics/base_uint.h>
 #include <ripple/basics/chrono.h>
 #include <ripple/beast/container/aged_unordered_map.h>
-#include <boost/optional.hpp>
+
+#include <optional>
 
 namespace ripple {
 

--- a/src/ripple/app/misc/Manifest.h
+++ b/src/ripple/app/misc/Manifest.h
@@ -24,7 +24,7 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace ripple {
@@ -113,7 +113,7 @@ struct Manifest
     revoked() const;
 
     /// Returns manifest signature
-    boost::optional<Blob>
+    std::optional<Blob>
     getSignature() const;
 
     /// Returns manifest master key signature
@@ -125,16 +125,16 @@ struct Manifest
 
     @param s Serialized manifest string
 
-    @return `boost::none` if string is invalid
+    @return `std::nullopt` if string is invalid
 
     @note This does not verify manifest signatures.
           `Manifest::verify` should be called after constructing manifest.
 */
 /** @{ */
-boost::optional<Manifest>
+std::optional<Manifest>
 deserializeManifest(Slice s);
 
-inline boost::optional<Manifest>
+inline std::optional<Manifest>
 deserializeManifest(std::string const& s)
 {
     return deserializeManifest(makeSlice(s));
@@ -144,7 +144,7 @@ template <
     class T,
     class = std::enable_if_t<
         std::is_same<T, char>::value || std::is_same<T, unsigned char>::value>>
-boost::optional<Manifest>
+std::optional<Manifest>
 deserializeManifest(std::vector<T> const& v)
 {
     return deserializeManifest(makeSlice(v));
@@ -173,7 +173,7 @@ struct ValidatorToken
     SecretKey validationSecret;
 };
 
-boost::optional<ValidatorToken>
+std::optional<ValidatorToken>
 loadValidatorToken(std::vector<std::string> const& blob);
 
 enum class ManifestDisposition {
@@ -264,25 +264,25 @@ public:
     /** Returns master key's current manifest sequence.
 
         @return sequence corresponding to Master public key
-          if configured or boost::none otherwise
+          if configured or std::nullopt otherwise
     */
-    boost::optional<std::uint32_t>
+    std::optional<std::uint32_t>
     getSequence(PublicKey const& pk) const;
 
     /** Returns domain claimed by a given public key
 
         @return domain corresponding to Master public key
-          if present, otherwise boost::none
+          if present, otherwise std::nullopt
     */
-    boost::optional<std::string>
+    std::optional<std::string>
     getDomain(PublicKey const& pk) const;
 
     /** Returns mainfest corresponding to a given public key
 
         @return manifest corresponding to Master public key
-          if present, otherwise boost::none
+          if present, otherwise std::nullopt
     */
-    boost::optional<std::string>
+    std::optional<std::string>
     getManifest(PublicKey const& pk) const;
 
     /** Returns `true` if master key has been revoked in a manifest.

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -211,7 +211,7 @@ class NetworkOPsImp final : public NetworkOPs
         std::uint32_t loadFactorServer = 256;
         std::uint32_t loadBaseServer = 256;
         XRPAmount baseFee{10};
-        boost::optional<TxQ::Metrics> em = boost::none;
+        std::optional<TxQ::Metrics> em = std::nullopt;
     };
 
 public:
@@ -440,7 +440,7 @@ public:
     getLedgerFetchInfo() override;
     std::uint32_t
     acceptLedger(
-        boost::optional<std::chrono::milliseconds> consensusDelay) override;
+        std::optional<std::chrono::milliseconds> consensusDelay) override;
     uint256
     getConsensusLCL() override;
     void
@@ -1302,7 +1302,7 @@ NetworkOPsImp::apply(std::unique_lock<std::mutex>& batchLock)
         if (changed)
             reportFeeChange();
 
-        boost::optional<LedgerIndex> validatedLedgerIndex;
+        std::optional<LedgerIndex> validatedLedgerIndex;
         if (auto const l = m_ledgerMaster.getValidatedLedger())
             validatedLedgerIndex = l->info().seq;
 
@@ -1714,7 +1714,7 @@ NetworkOPsImp::switchLastClosedLedger(
 
         auto retries = m_localTX->getTxSet();
         auto const lastVal = app_.getLedgerMaster().getValidatedLedger();
-        boost::optional<Rules> rules;
+        std::optional<Rules> rules;
         if (lastVal)
             rules.emplace(*lastVal, app_.config().features);
         else
@@ -1959,7 +1959,7 @@ NetworkOPsImp::ServerFeeSummary::operator!=(
 {
     if (loadFactorServer != b.loadFactorServer ||
         loadBaseServer != b.loadBaseServer || baseFee != b.baseFee ||
-        em.is_initialized() != b.em.is_initialized())
+        em.has_value() != b.em.has_value())
         return true;
 
     if (em && b.em)
@@ -2311,6 +2311,7 @@ NetworkOPsImp::getAccountTxs(
     {
         auto db = app_.getTxnDB().checkoutDb();
 
+        // SOCI requires boost::optional (not std::optional) as parameters.
         boost::optional<std::uint64_t> ledgerSeq;
         boost::optional<std::string> status;
         soci::blob sociTxnBlob(*db), sociTxnMetaBlob(*db);
@@ -2391,6 +2392,7 @@ NetworkOPsImp::getAccountTxsB(
     {
         auto db = app_.getTxnDB().checkoutDb();
 
+        // SOCI requires boost::optional (not std::optional) as parameters.
         boost::optional<std::uint64_t> ledgerSeq;
         boost::optional<std::string> status;
         soci::blob sociTxnBlob(*db), sociTxnMetaBlob(*db);
@@ -3455,7 +3457,7 @@ NetworkOPsImp::unsubBook(std::uint64_t uSeq, Book const& book)
 
 std::uint32_t
 NetworkOPsImp::acceptLedger(
-    boost::optional<std::chrono::milliseconds> consensusDelay)
+    std::optional<std::chrono::milliseconds> consensusDelay)
 {
     // This code-path is exclusively used when the server is in standalone
     // mode via `ledger_accept`

--- a/src/ripple/app/misc/NetworkOPs.h
+++ b/src/ripple/app/misc/NetworkOPs.h
@@ -27,12 +27,11 @@
 #include <ripple/ledger/ReadView.h>
 #include <ripple/net/InfoSub.h>
 #include <ripple/protocol/STValidation.h>
+#include <ripple/protocol/messages.h>
 #include <boost/asio.hpp>
 #include <deque>
 #include <memory>
 #include <tuple>
-
-#include <ripple/protocol/messages.h>
 
 namespace ripple {
 
@@ -238,8 +237,8 @@ public:
     */
     virtual std::uint32_t
     acceptLedger(
-        boost::optional<std::chrono::milliseconds> consensusDelay =
-            boost::none) = 0;
+        std::optional<std::chrono::milliseconds> consensusDelay =
+            std::nullopt) = 0;
 
     virtual uint256
     getConsensusLCL() = 0;

--- a/src/ripple/app/misc/SHAMapStore.h
+++ b/src/ripple/app/misc/SHAMapStore.h
@@ -23,7 +23,7 @@
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/nodestore/Manager.h>
 #include <ripple/protocol/ErrorCodes.h>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace ripple {
 
@@ -90,7 +90,7 @@ public:
         @return The minimum ledger sequence to keep online based on the
             description above. If not set, then an unseated optional.
     */
-    virtual boost::optional<LedgerIndex>
+    virtual std::optional<LedgerIndex>
     minimumOnline() const = 0;
 };
 

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -53,6 +53,7 @@ SHAMapStoreImp::SavedStateDB::init(
 
     std::int64_t count = 0;
     {
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<std::int64_t> countO;
         session_ << "SELECT COUNT(Key) FROM DbState WHERE Key = 1;",
             soci::into(countO);
@@ -68,6 +69,7 @@ SHAMapStoreImp::SavedStateDB::init(
     }
 
     {
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<std::int64_t> countO;
         session_ << "SELECT COUNT(Key) FROM CanDelete WHERE Key = 1;",
             soci::into(countO);
@@ -275,7 +277,7 @@ SHAMapStoreImp::makeNodeStore(std::string const& name, std::int32_t readThreads)
         db = NodeStore::Manager::instance().make_Database(
             name,
             megabytes(
-                app_.config().getValueFor(SizedItem::burstSize, boost::none)),
+                app_.config().getValueFor(SizedItem::burstSize, std::nullopt)),
             scheduler_,
             readThreads,
             app_.getJobQueue(),
@@ -584,7 +586,8 @@ SHAMapStoreImp::makeBackendRotating(std::string path)
 
     auto backend{NodeStore::Manager::instance().make_Backend(
         section,
-        megabytes(app_.config().getValueFor(SizedItem::burstSize, boost::none)),
+        megabytes(
+            app_.config().getValueFor(SizedItem::burstSize, std::nullopt)),
         scheduler_,
         app_.logs().journal(nodeStoreName_))};
     backend->open();
@@ -602,6 +605,7 @@ SHAMapStoreImp::clearSql(
     LedgerIndex min = std::numeric_limits<LedgerIndex>::max();
 
     {
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<std::uint64_t> m;
         JLOG(journal_.trace())
             << "Begin: Look up lowest value of: " << minQuery;
@@ -781,7 +785,7 @@ SHAMapStoreImp::onStop()
     }
 }
 
-boost::optional<LedgerIndex>
+std::optional<LedgerIndex>
 SHAMapStoreImp::minimumOnline() const
 {
     // minimumOnline_ with 0 value is equivalent to unknown/not set.

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -115,7 +115,7 @@ private:
     /// for this time and check again so the node can
     /// recover.
     /// See also: "recovery_wait_seconds" in rippled-example.cfg
-    boost::optional<std::chrono::seconds> recoveryWaitTime_;
+    std::optional<std::chrono::seconds> recoveryWaitTime_;
 
     // these do not exist upon SHAMapStore creation, but do exist
     // as of run() or before
@@ -189,7 +189,7 @@ public:
     int
     fdRequired() const override;
 
-    boost::optional<LedgerIndex>
+    std::optional<LedgerIndex>
     minimumOnline() const override;
 
 private:

--- a/src/ripple/app/misc/Transaction.h
+++ b/src/ripple/app/misc/Transaction.h
@@ -30,6 +30,8 @@
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
+#include <optional>
+
 namespace ripple {
 
 //
@@ -69,6 +71,8 @@ public:
         std::string&,
         Application&) noexcept;
 
+    // The two boost::optional parameters are because SOCI requires
+    // boost::optional (not std::optional) parameters.
     static Transaction::pointer
     transactionFromSQL(
         boost::optional<std::uint64_t> const& ledgerSeq,
@@ -76,6 +80,8 @@ public:
         Blob const& rawTxn,
         Application& app);
 
+    // The boost::optional parameter is because SOCI requires
+    // boost::optional (not std::optional) parameters.
     static TransStatus
     sqlTransactionStatus(boost::optional<std::string> const& status);
 
@@ -276,7 +282,7 @@ public:
      * @brief getCurrentLedgerState Get current ledger state of transaction
      * @return Current ledger state
      */
-    boost::optional<CurrentLedgerState>
+    std::optional<CurrentLedgerState>
     getCurrentLedgerState() const
     {
         return currentLedgerState_;
@@ -376,7 +382,7 @@ private:
     load(
         uint256 const& id,
         Application& app,
-        boost::optional<ClosedInterval<uint32_t>> const& range,
+        std::optional<ClosedInterval<uint32_t>> const& range,
         error_code_i& ec);
 
     uint256 mTransactionID;
@@ -389,7 +395,7 @@ private:
     /** different ways for transaction to be accepted */
     SubmitResult submitResult_;
 
-    boost::optional<CurrentLedgerState> currentLedgerState_;
+    std::optional<CurrentLedgerState> currentLedgerState_;
 
     std::shared_ptr<STTx const> mTransaction;
     Application& mApp;

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -28,6 +28,7 @@
 #include <ripple/protocol/TER.h>
 #include <boost/circular_buffer.hpp>
 #include <boost/intrusive/set.hpp>
+#include <optional>
 
 namespace ripple {
 
@@ -112,7 +113,7 @@ public:
             @todo eahennis. This setting seems to go against our goals and
                 values. Can it be removed?
         */
-        boost::optional<std::uint32_t> maximumTxnInLedger;
+        std::optional<std::uint32_t> maximumTxnInLedger;
         /** When the ledger has more transactions than "expected", and
             performance is humming along nicely, the expected ledger size
             is updated to the previous ledger size plus this percentage.
@@ -164,7 +165,7 @@ public:
         /// Number of transactions in the queue
         std::size_t txCount;
         /// Max transactions currently allowed in queue
-        boost::optional<std::size_t> txQMaxSize;
+        std::optional<std::size_t> txQMaxSize;
         /// Number of transactions currently in the open ledger
         std::size_t txInLedger;
         /// Number of transactions expected per ledger
@@ -191,14 +192,14 @@ public:
         /// Full initialization
         TxDetails(
             FeeLevel64 feeLevel_,
-            boost::optional<LedgerIndex> const& lastValid_,
+            std::optional<LedgerIndex> const& lastValid_,
             TxConsequences const& consequences_,
             AccountID const& account_,
             SeqProxy seqProxy_,
             std::shared_ptr<STTx const> const& txn_,
             int retriesRemaining_,
             TER preflightResult_,
-            boost::optional<TER> lastResult_)
+            std::optional<TER> lastResult_)
             : feeLevel(feeLevel_)
             , lastValid(lastValid_)
             , consequences(consequences_)
@@ -214,7 +215,7 @@ public:
         /// Fee level of the queued transaction
         FeeLevel64 feeLevel;
         /// LastValidLedger field of the queued transaction, if any
-        boost::optional<LedgerIndex> lastValid;
+        std::optional<LedgerIndex> lastValid;
         /** Potential @ref TxConsequences of applying the queued transaction
             to the open ledger.
         */
@@ -247,7 +248,7 @@ public:
             `tem`, or `tesSUCCESS`, because those results cause the
             transaction to be removed from the queue.
         */
-        boost::optional<TER> lastResult;
+        std::optional<TER> lastResult;
     };
 
     /// Constructor
@@ -378,7 +379,7 @@ private:
         /// towards".
         std::size_t const targetTxnCount_;
         /// Maximum value of txnsExpected
-        boost::optional<std::size_t> const maximumTxnCount_;
+        std::optional<std::size_t> const maximumTxnCount_;
         /// Number of transactions expected per ledger.
         /// One more than this value will be accepted
         /// before escalation kicks in.
@@ -407,7 +408,7 @@ private:
                       ? *setup.maximumTxnInLedger < targetTxnCount_
                           ? targetTxnCount_
                           : *setup.maximumTxnInLedger
-                      : boost::optional<std::size_t>(boost::none))
+                      : std::optional<std::size_t>(std::nullopt))
             , txnsExpected_(minimumTxnCount_)
             , recentTxnCounts_(setup.ledgersInQueue)
             , escalationMultiplier_(setup.minimumEscalationMultiplier)
@@ -524,7 +525,7 @@ private:
         AccountID const account;
         /// Expiration ledger for the transaction
         /// (`sfLastLedgerSequence` field).
-        boost::optional<LedgerIndex> const lastValid;
+        std::optional<LedgerIndex> const lastValid;
         /// Transaction SeqProxy number
         /// (`sfSequence` or `sfTicketSequence` field).
         SeqProxy const seqProxy;
@@ -547,16 +548,16 @@ private:
             `tem`, or `tesSUCCESS`, because those results cause the
             transaction to be removed from the queue.
         */
-        boost::optional<TER> lastResult;
+        std::optional<TER> lastResult;
         /** Cached result of the `preflight` operation. Because
             `preflight` is expensive, minimize the number of times
             it needs to be done.
             @invariant `pfresult` is never allowed to be empty. The
-                `boost::optional` is leveraged to allow `emplace`d
+                `std::optional` is leveraged to allow `emplace`d
                 construction and replacement without a copy
                 assignment operation.
         */
-        boost::optional<PreflightResult const> pfresult;
+        std::optional<PreflightResult const> pfresult;
 
         /** Starting retry count for newly queued transactions.
 
@@ -710,9 +711,9 @@ private:
         beast::Journal j);
 
     // Helper function that removes a replaced entry in _byFee.
-    boost::optional<TxQAccount::TxMap::iterator>
+    std::optional<TxQAccount::TxMap::iterator>
     removeFromByFee(
-        boost::optional<TxQAccount::TxMap::iterator> const& replacedTxIter,
+        std::optional<TxQAccount::TxMap::iterator> const& replacedTxIter,
         std::shared_ptr<STTx const> const& tx);
 
     using FeeHook = boost::intrusive::member_hook<
@@ -754,7 +755,7 @@ private:
         @note This member must always and only be accessed under
         locked mutex_
     */
-    boost::optional<size_t> maxSize_;
+    std::optional<size_t> maxSize_;
 
     /** Most queue operations are done under the master lock,
         but use this mutex for the RPC "fee" command, which isn't.
@@ -777,7 +778,7 @@ private:
         OpenView const&,
         std::shared_ptr<SLE const> const& sleAccount,
         AccountMap::iterator const&,
-        boost::optional<TxQAccount::TxMap::iterator> const&,
+        std::optional<TxQAccount::TxMap::iterator> const&,
         std::lock_guard<std::mutex> const& lock);
 
     /// Erase and return the next entry in byFee_ (lower fee level)

--- a/src/ripple/app/misc/ValidatorList.h
+++ b/src/ripple/app/misc/ValidatorList.h
@@ -121,7 +121,7 @@ struct ValidatorBlobInfo
     std::string signature;
     // base-64 or hex-encoded manifest containing the publisher's master and
     // signing public keys
-    boost::optional<std::string> manifest;
+    std::optional<std::string> manifest;
 };
 
 /**
@@ -187,7 +187,7 @@ class ValidatorList
         std::string rawSignature;
         // base-64 or hex-encoded manifest containing the publisher's master and
         // signing public keys
-        boost::optional<std::string> rawManifest;
+        std::optional<std::string> rawManifest;
         uint256 hash;
     };
 
@@ -214,7 +214,7 @@ class ValidatorList
         date.
         */
         std::map<std::size_t, PublisherList> remaining;
-        boost::optional<std::size_t> maxSequence;
+        std::optional<std::size_t> maxSequence;
         // The hash of the full set if sent in a single message
         uint256 fullHash;
         std::string rawManifest;
@@ -231,7 +231,7 @@ class ValidatorList
     using shared_lock = std::shared_lock<decltype(mutex_)>;
 
     std::atomic<std::size_t> quorum_;
-    boost::optional<std::size_t> minimumQuorum_;
+    std::optional<std::size_t> minimumQuorum_;
 
     // Published lists stored by publisher master public key
     hash_map<PublicKey, PublisherListCollection> publisherLists_;
@@ -267,7 +267,7 @@ public:
         TimeKeeper& timeKeeper,
         std::string const& databasePath,
         beast::Journal j,
-        boost::optional<std::size_t> minimumQuorum = boost::none);
+        std::optional<std::size_t> minimumQuorum = std::nullopt);
     ~ValidatorList() = default;
 
     /** Describes the result of processing a Validator List (UNL),
@@ -295,7 +295,7 @@ public:
         // Tracks the dispositions of each processed list and how many times it
         // occurred
         std::map<ListDisposition, std::size_t> dispositions;
-        boost::optional<PublicKey> publisherKey;
+        std::optional<PublicKey> publisherKey;
         PublisherStatus status = PublisherStatus::unavailable;
         std::size_t sequence = 0;
     };
@@ -438,7 +438,7 @@ public:
         std::uint32_t version,
         std::vector<ValidatorBlobInfo> const& blobs,
         std::string siteUri,
-        boost::optional<uint256> const& hash = {});
+        std::optional<uint256> const& hash = {});
 
     /* Attempt to read previously stored list files. Expected to only be
        called when loading from URL fails.
@@ -520,26 +520,26 @@ public:
 
         @param identity Validation public key
 
-        @return `boost::none` if key is not trusted
+        @return `std::nullopt` if key is not trusted
 
         @par Thread Safety
 
         May be called concurrently
     */
-    boost::optional<PublicKey>
+    std::optional<PublicKey>
     getTrustedKey(PublicKey const& identity) const;
 
     /** Returns listed master public if public key is included on any lists
 
         @param identity Validation public key
 
-        @return `boost::none` if key is not listed
+        @return `std::nullopt` if key is not listed
 
         @par Thread Safety
 
         May be called concurrently
     */
-    boost::optional<PublicKey>
+    std::optional<PublicKey>
     getListedKey(PublicKey const& identity) const;
 
     /** Returns `true` if public key is a trusted publisher
@@ -620,10 +620,10 @@ public:
     /** Returns the current valid list for the given publisher key,
         if available, as a Json object.
     */
-    boost::optional<Json::Value>
+    std::optional<Json::Value>
     getAvailable(
         boost::beast::string_view const& pubKey,
-        boost::optional<std::uint32_t> forceVersion = {});
+        std::optional<std::uint32_t> forceVersion = {});
 
     /** Return the number of configured validator list sites. */
     std::size_t
@@ -632,13 +632,13 @@ public:
     /** Return the time when the validator list will expire
 
         @note This may be a time in the past if a published list has not
-        been updated since its validUntil. It will be boost::none if any
+        been updated since its validUntil. It will be std::nullopt if any
         configured published list has not been fetched.
 
         @par Thread Safety
         May be called concurrently
     */
-    boost::optional<TimeKeeper::time_point>
+    std::optional<TimeKeeper::time_point>
     expires() const;
 
     /** Return a JSON representation of the state of the validator list
@@ -712,25 +712,25 @@ private:
 
     @param identity Validation public key
 
-    @return `boost::none` if key is not trusted
+    @return `std::nullopt` if key is not trusted
 
     @par Thread Safety
 
     May be called concurrently
     */
-    boost::optional<PublicKey>
+    std::optional<PublicKey>
     getTrustedKey(shared_lock const&, PublicKey const& identity) const;
 
     /** Return the time when the validator list will expire
 
     @note This may be a time in the past if a published list has not
-    been updated since its expiration. It will be boost::none if any
+    been updated since its expiration. It will be std::nullopt if any
     configured published list has not been fetched.
 
     @par Thread Safety
     May be called concurrently
     */
-    boost::optional<TimeKeeper::time_point>
+    std::optional<TimeKeeper::time_point>
     expires(shared_lock const&) const;
 
     /** Apply published list of public keys
@@ -758,12 +758,12 @@ private:
     PublisherListStats
     applyList(
         std::string const& globalManifest,
-        boost::optional<std::string> const& localManifest,
+        std::optional<std::string> const& localManifest,
         std::string const& blob,
         std::string const& signature,
         std::uint32_t version,
         std::string siteUri,
-        boost::optional<uint256> const& hash,
+        std::optional<uint256> const& hash,
         lock_guard const&);
 
     void
@@ -825,7 +825,7 @@ private:
     buildFileData(
         std::string const& pubKey,
         PublisherListCollection const& pubCollection,
-        boost::optional<std::uint32_t> forceVersion,
+        std::optional<std::uint32_t> forceVersion,
         beast::Journal j);
 
     template <class Hasher>

--- a/src/ripple/app/misc/impl/AccountTxPaging.cpp
+++ b/src/ripple/app/misc/impl/AccountTxPaging.cpp
@@ -194,6 +194,7 @@ accountTxPage(
         Blob rawData;
         Blob rawMeta;
 
+        // SOCI requires boost::optional (not std::optional) as parameters.
         boost::optional<std::uint64_t> ledgerSeq;
         boost::optional<std::uint32_t> txnSeq;
         boost::optional<std::string> status;

--- a/src/ripple/app/misc/impl/AmendmentTable.cpp
+++ b/src/ripple/app/misc/impl/AmendmentTable.cpp
@@ -216,7 +216,7 @@ private:
     // Unset if no unsupported amendments reach majority,
     // else set to the earliest time an unsupported amendment
     // will be enabled.
-    boost::optional<NetClock::time_point> firstUnsupportedExpected_;
+    std::optional<NetClock::time_point> firstUnsupportedExpected_;
 
     beast::Journal const j_;
 
@@ -276,7 +276,7 @@ public:
     bool
     hasUnsupportedEnabled() const override;
 
-    boost::optional<NetClock::time_point>
+    std::optional<NetClock::time_point>
     firstUnsupportedExpected() const override;
 
     Json::Value
@@ -332,6 +332,7 @@ AmendmentTableImpl::AmendmentTableImpl(
         std::string sql =
             "SELECT count(*) FROM sqlite_master "
             "WHERE type='table' AND name='FeatureVotes'";
+        // SOCI requires boost::optional (not std::optional) as the parameter.
         boost::optional<int> featureVotesCount;
         *db << sql, soci::into(featureVotesCount);
         bool exists = static_cast<bool>(*featureVotesCount);
@@ -410,6 +411,7 @@ AmendmentTableImpl::AmendmentTableImpl(
     soci::transaction tr(*db);
     std::string sql =
         "SELECT AmendmentHash, AmendmentName, Veto FROM FeatureVotes";
+    // SOCI requires boost::optional (not std::optional) as parameters.
     boost::optional<std::string> amendment_hash;
     boost::optional<std::string> amendment_name;
     boost::optional<int> vote_to_veto;
@@ -588,7 +590,7 @@ AmendmentTableImpl::hasUnsupportedEnabled() const
     return unsupportedEnabled_;
 }
 
-boost::optional<NetClock::time_point>
+std::optional<NetClock::time_point>
 AmendmentTableImpl::firstUnsupportedExpected() const
 {
     std::lock_guard sl(mutex_);

--- a/src/ripple/app/misc/impl/Transaction.cpp
+++ b/src/ripple/app/misc/impl/Transaction.cpp
@@ -30,7 +30,6 @@
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/jss.h>
-#include <boost/optional.hpp>
 
 namespace ripple {
 
@@ -112,7 +111,7 @@ std::variant<
     TxSearched>
 Transaction::load(uint256 const& id, Application& app, error_code_i& ec)
 {
-    return load(id, app, boost::none, ec);
+    return load(id, app, std::nullopt, ec);
 }
 
 std::variant<
@@ -124,7 +123,7 @@ Transaction::load(
     ClosedInterval<uint32_t> const& range,
     error_code_i& ec)
 {
-    using op = boost::optional<ClosedInterval<uint32_t>>;
+    using op = std::optional<ClosedInterval<uint32_t>>;
 
     return load(id, app, op{range}, ec);
 }
@@ -211,7 +210,7 @@ std::variant<
 Transaction::load(
     uint256 const& id,
     Application& app,
-    boost::optional<ClosedInterval<uint32_t>> const& range,
+    std::optional<ClosedInterval<uint32_t>> const& range,
     error_code_i& ec)
 {
     std::string sql =
@@ -221,6 +220,7 @@ Transaction::load(
     sql.append(to_string(id));
     sql.append("';");
 
+    // SOCI requires boost::optional (not std::optional) as parameters.
     boost::optional<std::uint64_t> ledgerSeq;
     boost::optional<std::string> status;
     Blob rawTxn, rawMeta;

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -63,11 +63,11 @@ getFeeLevelPaid(ReadView const& view, STTx const& tx)
     return FeeLevel64(std::numeric_limits<std::uint64_t>::max());
 }
 
-static boost::optional<LedgerIndex>
+static std::optional<LedgerIndex>
 getLastLedgerSequence(STTx const& tx)
 {
     if (!tx.isFieldPresent(sfLastLedgerSequence))
-        return boost::none;
+        return std::nullopt;
     return tx.getFieldU32(sfLastLedgerSequence);
 }
 
@@ -348,7 +348,7 @@ TxQ::TxQAccount::remove(SeqProxy seqProx)
 //////////////////////////////////////////////////////////////////////////
 
 TxQ::TxQ(Setup const& setup, beast::Journal j)
-    : setup_(setup), j_(j), feeMetrics_(setup, j), maxSize_(boost::none)
+    : setup_(setup), j_(j), feeMetrics_(setup, j), maxSize_(std::nullopt)
 {
 }
 
@@ -373,7 +373,7 @@ TxQ::canBeHeld(
     OpenView const& view,
     std::shared_ptr<SLE const> const& sleAccount,
     AccountMap::iterator const& accountIter,
-    boost::optional<TxQAccount::TxMap::iterator> const& replacementIter,
+    std::optional<TxQAccount::TxMap::iterator> const& replacementIter,
     std::lock_guard<std::mutex> const& lock)
 {
     // PreviousTxnID is deprecated and should never be used.
@@ -801,10 +801,10 @@ TxQ::apply(
         TxQAccount::TxMap::iterator end;
     };
 
-    boost::optional<TxIter> const txIter =
+    std::optional<TxIter> const txIter =
         [accountIter,
          accountIsInQueue,
-         acctSeqProx]() -> boost::optional<TxIter> {
+         acctSeqProx]() -> std::optional<TxIter> {
         if (!accountIsInQueue)
             return {};
 
@@ -853,7 +853,7 @@ TxQ::apply(
     // If the transaction is intending to replace a transaction in the queue
     // identify the one that might be replaced.
     auto replacedTxIter = [accountIsInQueue, &accountIter, txSeqProx]()
-        -> boost::optional<TxQAccount::TxMap::iterator> {
+        -> std::optional<TxQAccount::TxMap::iterator> {
         if (accountIsInQueue)
         {
             TxQAccount& txQAcct = accountIter->second;
@@ -936,7 +936,7 @@ TxQ::apply(
         }
     };
 
-    boost::optional<MultiTxn> multiTxn;
+    std::optional<MultiTxn> multiTxn;
 
     if (acctTxCount == 0)
     {
@@ -1178,7 +1178,7 @@ TxQ::apply(
             conditions change, but don't waste the effort to clear).
     */
     if (!(flags & tapPREFER_QUEUE) && txSeqProx.isSeq() && txIter &&
-        multiTxn.is_initialized() &&
+        multiTxn.has_value() &&
         txIter->first->second.retriesRemaining == MaybeTx::retriesAllowed &&
         feeLevelPaid > requiredFeeLevel && requiredFeeLevel > baseLevel)
     {
@@ -1693,9 +1693,9 @@ TxQ::tryDirectApply(
     return {};
 }
 
-boost::optional<TxQ::TxQAccount::TxMap::iterator>
+std::optional<TxQ::TxQAccount::TxMap::iterator>
 TxQ::removeFromByFee(
-    boost::optional<TxQAccount::TxMap::iterator> const& replacedTxIter,
+    std::optional<TxQAccount::TxMap::iterator> const& replacedTxIter,
     std::shared_ptr<STTx const> const& tx)
 {
     if (replacedTxIter && tx)
@@ -1710,7 +1710,7 @@ TxQ::removeFromByFee(
 
         erase(deleteIter);
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 TxQ::Metrics

--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -123,7 +123,7 @@ ValidatorList::ValidatorList(
     TimeKeeper& timeKeeper,
     std::string const& databasePath,
     beast::Journal j,
-    boost::optional<std::size_t> minimumQuorum)
+    std::optional<std::size_t> minimumQuorum)
     : validatorManifests_(validatorManifests)
     , publisherManifests_(publisherManifests)
     , timeKeeper_(timeKeeper)
@@ -271,7 +271,7 @@ Json::Value
 ValidatorList::buildFileData(
     std::string const& pubKey,
     ValidatorList::PublisherListCollection const& pubCollection,
-    boost::optional<std::uint32_t> forceVersion,
+    std::optional<std::uint32_t> forceVersion,
     beast::Journal j)
 {
     Json::Value value(Json::objectValue);
@@ -508,7 +508,7 @@ splitMessageParts(
     }
     else
     {
-        boost::optional<protocol::TMValidatorListCollection> smallMsg;
+        std::optional<protocol::TMValidatorListCollection> smallMsg;
         smallMsg.emplace();
         smallMsg->set_version(largeMsg.version());
         smallMsg->set_manifest(largeMsg.manifest());
@@ -926,7 +926,7 @@ ValidatorList::applyLists(
     std::uint32_t version,
     std::vector<ValidatorBlobInfo> const& blobs,
     std::string siteUri,
-    boost::optional<uint256> const& hash /* = {} */)
+    std::optional<uint256> const& hash /* = {} */)
 {
     if (std::count(
             std::begin(supportedListVersions),
@@ -1061,12 +1061,12 @@ ValidatorList::updatePublisherList(
 ValidatorList::PublisherListStats
 ValidatorList::applyList(
     std::string const& globalManifest,
-    boost::optional<std::string> const& localManifest,
+    std::optional<std::string> const& localManifest,
     std::string const& blob,
     std::string const& signature,
     std::uint32_t version,
     std::string siteUri,
-    boost::optional<uint256> const& hash,
+    std::optional<uint256> const& hash,
     ValidatorList::lock_guard const& lock)
 {
     using namespace std::string_literals;
@@ -1159,7 +1159,7 @@ ValidatorList::applyList(
             if (val.isObject() && val.isMember(jss::validation_public_key) &&
                 val[jss::validation_public_key].isString())
             {
-                boost::optional<Blob> const ret =
+                std::optional<Blob> const ret =
                     strUnHex(val[jss::validation_public_key].asString());
 
                 if (!ret || !publicKeyType(makeSlice(*ret)))
@@ -1372,7 +1372,7 @@ ValidatorList::trusted(PublicKey const& identity) const
     return trusted(read_lock, identity);
 }
 
-boost::optional<PublicKey>
+std::optional<PublicKey>
 ValidatorList::getListedKey(PublicKey const& identity) const
 {
     std::shared_lock read_lock{mutex_};
@@ -1380,10 +1380,10 @@ ValidatorList::getListedKey(PublicKey const& identity) const
     auto const pubKey = validatorManifests_.getMasterKey(identity);
     if (keyListings_.find(pubKey) != keyListings_.end())
         return pubKey;
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<PublicKey>
+std::optional<PublicKey>
 ValidatorList::getTrustedKey(
     ValidatorList::shared_lock const&,
     PublicKey const& identity) const
@@ -1391,10 +1391,10 @@ ValidatorList::getTrustedKey(
     auto const pubKey = validatorManifests_.getMasterKey(identity);
     if (trustedMasterKeys_.find(pubKey) != trustedMasterKeys_.end())
         return pubKey;
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<PublicKey>
+std::optional<PublicKey>
 ValidatorList::getTrustedKey(PublicKey const& identity) const
 {
     std::shared_lock read_lock{mutex_};
@@ -1464,17 +1464,17 @@ ValidatorList::count() const
     return count(read_lock);
 }
 
-boost::optional<TimeKeeper::time_point>
+std::optional<TimeKeeper::time_point>
 ValidatorList::expires(ValidatorList::shared_lock const&) const
 {
-    boost::optional<TimeKeeper::time_point> res{boost::none};
+    std::optional<TimeKeeper::time_point> res{};
     for (auto const& [pubKey, collection] : publisherLists_)
     {
         (void)pubKey;
         // Unfetched
         auto const& current = collection.current;
         if (current.validUntil == TimeKeeper::time_point{})
-            return boost::none;
+            return std::nullopt;
 
         // Find the latest validUntil in a chain where the next validFrom
         // overlaps with the previous validUntil. applyLists has already cleaned
@@ -1498,7 +1498,7 @@ ValidatorList::expires(ValidatorList::shared_lock const&) const
     return res;
 }
 
-boost::optional<TimeKeeper::time_point>
+std::optional<TimeKeeper::time_point>
 ValidatorList::expires() const
 {
     std::shared_lock read_lock{mutex_};
@@ -1676,10 +1676,10 @@ ValidatorList::for_each_available(
     }
 }
 
-boost::optional<Json::Value>
+std::optional<Json::Value>
 ValidatorList::getAvailable(
     boost::beast::string_view const& pubKey,
-    boost::optional<std::uint32_t> forceVersion /* = {} */)
+    std::optional<std::uint32_t> forceVersion /* = {} */)
 {
     std::shared_lock read_lock{mutex_};
 

--- a/src/ripple/app/paths/Flow.cpp
+++ b/src/ripple/app/paths/Flow.cpp
@@ -65,8 +65,8 @@ flow(
     bool partialPayment,
     bool ownerPaysTransferFee,
     bool offerCrossing,
-    boost::optional<Quality> const& limitQuality,
-    boost::optional<STAmount> const& sendMax,
+    std::optional<Quality> const& limitQuality,
+    std::optional<STAmount> const& sendMax,
     beast::Journal j,
     path::detail::FlowDebugInfo* flowDebugInfo)
 {
@@ -80,7 +80,7 @@ flow(
 
     Issue const dstIssue = deliver.issue();
 
-    boost::optional<Issue> sendMaxIssue;
+    std::optional<Issue> sendMaxIssue;
     if (sendMax)
         sendMaxIssue = sendMax->issue();
 

--- a/src/ripple/app/paths/Flow.h
+++ b/src/ripple/app/paths/Flow.h
@@ -63,8 +63,8 @@ flow(
     bool partialPayment,
     bool ownerPaysTransferFee,
     bool offerCrossing,
-    boost::optional<Quality> const& limitQuality,
-    boost::optional<STAmount> const& sendMax,
+    std::optional<Quality> const& limitQuality,
+    std::optional<STAmount> const& sendMax,
     beast::Journal j,
     path::detail::FlowDebugInfo* flowDebugInfo = nullptr);
 

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -34,7 +34,7 @@
 
 #include <ripple/rpc/impl/Tuning.h>
 #include <boost/algorithm/clamp.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <tuple>
 
@@ -474,7 +474,7 @@ PathRequest::getPathFinder(
         *raSrcAccount,
         *raDstAccount,
         currency,
-        boost::none,
+        std::nullopt,
         dst_amount,
         saSendMax,
         app_);

--- a/src/ripple/app/paths/PathRequest.h
+++ b/src/ripple/app/paths/PathRequest.h
@@ -26,9 +26,9 @@
 #include <ripple/json/json_value.h>
 #include <ripple/net/InfoSub.h>
 #include <ripple/protocol/UintTypes.h>
-#include <boost/optional.hpp>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <utility>
 
@@ -139,10 +139,10 @@ private:
     Json::Value jvStatus;  // Last result
 
     // Client request parameters
-    boost::optional<AccountID> raSrcAccount;
-    boost::optional<AccountID> raDstAccount;
+    std::optional<AccountID> raSrcAccount;
+    std::optional<AccountID> raDstAccount;
     STAmount saDstAmount;
-    boost::optional<STAmount> saSendMax;
+    std::optional<STAmount> saSendMax;
 
     std::set<Issue> sciSourceCurrencies;
     std::map<Issue, STPathSet> mContext;

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -159,9 +159,9 @@ Pathfinder::Pathfinder(
     AccountID const& uSrcAccount,
     AccountID const& uDstAccount,
     Currency const& uSrcCurrency,
-    boost::optional<AccountID> const& uSrcIssuer,
+    std::optional<AccountID> const& uSrcIssuer,
     STAmount const& saDstAmount,
-    boost::optional<STAmount> const& srcAmount,
+    std::optional<STAmount> const& srcAmount,
     Application& app)
     : mSrcAccount(uSrcAccount)
     , mDstAccount(uDstAccount)
@@ -184,7 +184,7 @@ Pathfinder::Pathfinder(
     , app_(app)
     , j_(app.journal("Pathfinder"))
 {
-    assert(!uSrcIssuer || isXRP(uSrcCurrency) == isXRP(uSrcIssuer.get()));
+    assert(!uSrcIssuer || isXRP(uSrcCurrency) == isXRP(uSrcIssuer.value()));
 }
 
 bool

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -43,9 +43,9 @@ public:
         AccountID const& srcAccount,
         AccountID const& dstAccount,
         Currency const& uSrcCurrency,
-        boost::optional<AccountID> const& uSrcIssuer,
+        std::optional<AccountID> const& uSrcIssuer,
         STAmount const& dstAmount,
-        boost::optional<STAmount> const& srcAmount,
+        std::optional<STAmount> const& srcAmount,
         Application& app);
     Pathfinder(Pathfinder const&) = delete;
     Pathfinder&
@@ -185,7 +185,7 @@ private:
     AccountID mEffectiveDst;  // The account the paths need to end at
     STAmount mDstAmount;
     Currency mSrcCurrency;
-    boost::optional<AccountID> mSrcIssuer;
+    std::optional<AccountID> mSrcIssuer;
     STAmount mSrcAmount;
     /** The amount remaining from mSrcAccount after the default liquidity has
         been removed. */

--- a/src/ripple/app/paths/RippleCalc.cpp
+++ b/src/ripple/app/paths/RippleCalc.cpp
@@ -76,21 +76,21 @@ RippleCalc::rippleCalculate(
         bool const partialPayment =
             !pInputs ? false : pInputs->partialPaymentAllowed;
 
-        auto const limitQuality = [&]() -> boost::optional<Quality> {
+        auto const limitQuality = [&]() -> std::optional<Quality> {
             if (pInputs && pInputs->limitQuality &&
                 saMaxAmountReq > beast::zero)
                 return Quality{Amounts(saMaxAmountReq, saDstAmountReq)};
-            return boost::none;
+            return std::nullopt;
         }();
 
-        auto const sendMax = [&]() -> boost::optional<STAmount> {
+        auto const sendMax = [&]() -> std::optional<STAmount> {
             if (saMaxAmountReq >= beast::zero ||
                 saMaxAmountReq.getCurrency() != saDstAmountReq.getCurrency() ||
                 saMaxAmountReq.getIssuer() != uSrcAccountID)
             {
                 return saMaxAmountReq;
             }
-            return boost::none;
+            return std::nullopt;
         }();
 
         bool const ownerPaysTransferFee =

--- a/src/ripple/app/paths/impl/AmountSpec.h
+++ b/src/ripple/app/paths/impl/AmountSpec.h
@@ -24,6 +24,8 @@
 #include <ripple/basics/XRPAmount.h>
 #include <ripple/protocol/STAmount.h>
 
+#include <optional>
+
 namespace ripple {
 
 struct AmountSpec
@@ -36,8 +38,8 @@ struct AmountSpec
         XRPAmount xrp;
         IOUAmount iou;
     };
-    boost::optional<AccountID> issuer;
-    boost::optional<Currency> currency;
+    std::optional<AccountID> issuer;
+    std::optional<Currency> currency;
 
     friend std::ostream&
     operator<<(std::ostream& stream, AmountSpec const& amt)
@@ -192,7 +194,7 @@ toEitherAmount(STAmount const& amt)
 }
 
 inline AmountSpec
-toAmountSpec(EitherAmount const& ea, boost::optional<Currency> const& c)
+toAmountSpec(EitherAmount const& ea, std::optional<Currency> const& c)
 {
     AmountSpec r;
     r.native = (!c || isXRP(*c));

--- a/src/ripple/app/paths/impl/BookStep.cpp
+++ b/src/ripple/app/paths/impl/BookStep.cpp
@@ -72,7 +72,7 @@ protected:
         }
     };
 
-    boost::optional<Cache> cache_;
+    std::optional<Cache> cache_;
 
     static uint32_t
     getMaxOffersToConsume(StrandContext const& ctx)
@@ -100,19 +100,19 @@ public:
         return book_;
     }
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cachedIn() const override
     {
         if (!cache_)
-            return boost::none;
+            return std::nullopt;
         return EitherAmount(cache_->in);
     }
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cachedOut() const override
     {
         if (!cache_)
-            return boost::none;
+            return std::nullopt;
         return EitherAmount(cache_->out);
     }
 
@@ -123,13 +123,13 @@ public:
                                      : DebtDirection::redeems;
     }
 
-    boost::optional<Book>
+    std::optional<Book>
     bookStepBook() const override
     {
         return book_;
     }
 
-    std::pair<boost::optional<Quality>, DebtDirection>
+    std::pair<std::optional<Quality>, DebtDirection>
     qualityUpperBound(ReadView const& v, DebtDirection prevStepDir)
         const override;
 
@@ -239,7 +239,7 @@ public:
         AccountID const&,
         AccountID const&,
         TOffer<TIn, TOut> const& offer,
-        boost::optional<Quality>&,
+        std::optional<Quality>&,
         FlowOfferStream<TIn, TOut>&,
         bool) const
     {
@@ -319,7 +319,7 @@ private:
     // Helper function that throws if the optional passed to the constructor
     // is none.
     static Quality
-    getQuality(boost::optional<Quality> const& limitQuality)
+    getQuality(std::optional<Quality> const& limitQuality)
     {
         // It's really a programming error if the quality is missing.
         assert(limitQuality);
@@ -344,7 +344,7 @@ public:
         AccountID const& strandSrc,
         AccountID const& strandDst,
         TOffer<TIn, TOut> const& offer,
-        boost::optional<Quality>& ofrQ,
+        std::optional<Quality>& ofrQ,
         FlowOfferStream<TIn, TOut>& offers,
         bool const offerAttempted) const
     {
@@ -386,7 +386,7 @@ public:
             // If no offers have been attempted yet then it's okay to move to
             // a different quality.
             if (!offerAttempted)
-                ofrQ = boost::none;
+                ofrQ = std::nullopt;
 
             // Return true so the current offer will be deleted.
             return true;
@@ -411,7 +411,7 @@ public:
         std::uint32_t trIn) const
     {
         auto const srcAcct =
-            prevStep ? prevStep->directStepSrcAcct() : boost::none;
+            prevStep ? prevStep->directStepSrcAcct() : std::nullopt;
 
         return                             // If offer crossing
             srcAcct &&                     // && prevStep is DirectI
@@ -473,7 +473,7 @@ BookStep<TIn, TOut, TDerived>::equal(Step const& rhs) const
 }
 
 template <class TIn, class TOut, class TDerived>
-std::pair<boost::optional<Quality>, DebtDirection>
+std::pair<std::optional<Quality>, DebtDirection>
 BookStep<TIn, TOut, TDerived>::qualityUpperBound(
     ReadView const& v,
     DebtDirection prevStepDir) const
@@ -484,7 +484,7 @@ BookStep<TIn, TOut, TDerived>::qualityUpperBound(
     Sandbox sb(&v, tapNONE);
     BookTip bt(sb, book_);
     if (!bt.step(j_))
-        return {boost::none, dir};
+        return {std::nullopt, dir};
 
     Quality const q = static_cast<TDerived const*>(this)->adjustQualityWithFees(
         v, bt.quality(), prevStepDir);
@@ -579,7 +579,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
 
     bool const flowCross = afView.rules().enabled(featureFlowCross);
     bool offerAttempted = false;
-    boost::optional<Quality> ofrQ;
+    std::optional<Quality> ofrQ;
     while (offers.step())
     {
         auto& offer = offers.tip();
@@ -619,7 +619,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
                     offers.permRmOffer(offer.key());
                     if (!offerAttempted)
                         // Change quality only if no previous offers were tried.
-                        ofrQ = boost::none;
+                        ofrQ = std::nullopt;
                     // This continue causes offers.step() to delete the offer.
                     continue;
                 }

--- a/src/ripple/app/paths/impl/DirectStep.cpp
+++ b/src/ripple/app/paths/impl/DirectStep.cpp
@@ -27,7 +27,6 @@
 #include <ripple/protocol/Quality.h>
 
 #include <boost/container/flat_set.hpp>
-#include <boost/optional.hpp>
 
 #include <numeric>
 #include <sstream>
@@ -64,7 +63,7 @@ protected:
         }
     };
 
-    boost::optional<Cache> cache_;
+    std::optional<Cache> cache_;
 
     // Compute the maximum value that can flow from src->dst at
     // the best available quality.
@@ -120,29 +119,29 @@ public:
         return currency_;
     }
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cachedIn() const override
     {
         if (!cache_)
-            return boost::none;
+            return std::nullopt;
         return EitherAmount(cache_->in);
     }
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cachedOut() const override
     {
         if (!cache_)
-            return boost::none;
+            return std::nullopt;
         return EitherAmount(cache_->out);
     }
 
-    boost::optional<AccountID>
+    std::optional<AccountID>
     directStepSrcAcct() const override
     {
         return src_;
     }
 
-    boost::optional<std::pair<AccountID, AccountID>>
+    std::optional<std::pair<AccountID, AccountID>>
     directStepAccts() const override
     {
         return std::make_pair(src_, dst_);
@@ -154,7 +153,7 @@ public:
     std::uint32_t
     lineQualityIn(ReadView const& v) const override;
 
-    std::pair<boost::optional<Quality>, DebtDirection>
+    std::pair<std::optional<Quality>, DebtDirection>
     qualityUpperBound(ReadView const& v, DebtDirection dir) const override;
 
     std::pair<IOUAmount, IOUAmount>
@@ -831,7 +830,7 @@ DirectStepI<TDerived>::lineQualityIn(ReadView const& v) const
 }
 
 template <class TDerived>
-std::pair<boost::optional<Quality>, DebtDirection>
+std::pair<std::optional<Quality>, DebtDirection>
 DirectStepI<TDerived>::qualityUpperBound(
     ReadView const& v,
     DebtDirection prevStepDir) const

--- a/src/ripple/app/paths/impl/FlowDebugInfo.h
+++ b/src/ripple/app/paths/impl/FlowDebugInfo.h
@@ -26,9 +26,9 @@
 #include <ripple/ledger/PaymentSandbox.h>
 
 #include <boost/container/flat_map.hpp>
-#include <boost/optional.hpp>
 
 #include <chrono>
+#include <optional>
 #include <sstream>
 
 namespace ripple {
@@ -357,7 +357,7 @@ balanceDiffs(PaymentSandbox const& sb, ReadView const& rv)
 }
 
 inline std::string
-balanceDiffsToString(boost::optional<BalanceDiffs> const& bd)
+balanceDiffsToString(std::optional<BalanceDiffs> const& bd)
 {
     if (!bd)
         return std::string{};

--- a/src/ripple/app/paths/impl/PaySteps.cpp
+++ b/src/ripple/app/paths/impl/PaySteps.cpp
@@ -137,8 +137,8 @@ toStrand(
     AccountID const& src,
     AccountID const& dst,
     Issue const& deliver,
-    boost::optional<Quality> const& limitQuality,
-    boost::optional<Issue> const& sendMaxIssue,
+    std::optional<Quality> const& limitQuality,
+    std::optional<Issue> const& sendMaxIssue,
     STPath const& path,
     bool ownerPaysTransferFee,
     bool offerCrossing,
@@ -209,7 +209,7 @@ toStrand(
              path[0].getAccountID() != sendMaxIssue->account))
         {
             normPath.emplace_back(
-                sendMaxIssue->account, boost::none, boost::none);
+                sendMaxIssue->account, std::nullopt, std::nullopt);
         }
 
         for (auto const& i : path)
@@ -225,7 +225,7 @@ toStrand(
                  lastCurrency.getIssuerID() != deliver.account))
             {
                 normPath.emplace_back(
-                    boost::none, deliver.currency, deliver.account);
+                    std::nullopt, deliver.currency, deliver.account);
             }
         }
 
@@ -233,13 +233,13 @@ toStrand(
                normPath.back().getAccountID() == deliver.account) ||
               (dst == deliver.account)))
         {
-            normPath.emplace_back(deliver.account, boost::none, boost::none);
+            normPath.emplace_back(deliver.account, std::nullopt, std::nullopt);
         }
 
         if (!normPath.back().isAccount() ||
             normPath.back().getAccountID() != dst)
         {
-            normPath.emplace_back(dst, boost::none, boost::none);
+            normPath.emplace_back(dst, std::nullopt, std::nullopt);
         }
     }
 
@@ -290,7 +290,7 @@ toStrand(
            account then no step is created, as a step has already been created
            for that offer.
         */
-        boost::optional<STPathElement> impliedPE;
+        std::optional<STPathElement> impliedPE;
         auto cur = &normPath[i];
         auto const next = &normPath[i + 1];
 
@@ -468,8 +468,8 @@ toStrands(
     AccountID const& src,
     AccountID const& dst,
     Issue const& deliver,
-    boost::optional<Quality> const& limitQuality,
-    boost::optional<Issue> const& sendMax,
+    std::optional<Quality> const& limitQuality,
+    std::optional<Issue> const& sendMax,
     STPathSet const& paths,
     bool addDefaultPath,
     bool ownerPaysTransferFee,
@@ -580,7 +580,7 @@ StrandContext::StrandContext(
     AccountID const& strandSrc_,
     AccountID const& strandDst_,
     Issue const& strandDeliver_,
-    boost::optional<Quality> const& limitQuality_,
+    std::optional<Quality> const& limitQuality_,
     bool isLast_,
     bool ownerPaysTransferFee_,
     bool offerCrossing_,

--- a/src/ripple/app/paths/impl/Steps.h
+++ b/src/ripple/app/paths/impl/Steps.h
@@ -27,7 +27,7 @@
 #include <ripple/protocol/TER.h>
 
 #include <boost/container/flat_set.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace ripple {
 class PaymentSandbox;
@@ -121,32 +121,32 @@ public:
        Amount of currency computed coming into the Step the last time the
        step ran in reverse.
     */
-    virtual boost::optional<EitherAmount>
+    virtual std::optional<EitherAmount>
     cachedIn() const = 0;
 
     /**
        Amount of currency computed coming out of the Step the last time the
        step ran in reverse.
     */
-    virtual boost::optional<EitherAmount>
+    virtual std::optional<EitherAmount>
     cachedOut() const = 0;
 
     /**
        If this step is DirectStepI (IOU->IOU direct step), return the src
        account. This is needed for checkNoRipple.
     */
-    virtual boost::optional<AccountID>
+    virtual std::optional<AccountID>
     directStepSrcAcct() const
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     // for debugging. Return the src and dst accounts for a direct step
     // For XRP endpoints, one of src or dst will be the root account
-    virtual boost::optional<std::pair<AccountID, AccountID>>
+    virtual std::optional<std::pair<AccountID, AccountID>>
     directStepAccts() const
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     /**
@@ -175,7 +175,7 @@ public:
 
        @param v view to query the ledger state from
        @param prevStepDir Set to DebtDirection::redeems if the previous step redeems.
-       @return A pair. The first element is the upper bound of quality for the step, or boost::none if the
+       @return A pair. The first element is the upper bound of quality for the step, or std::nullopt if the
        step is dry. The second element will be set to DebtDirection::redeems if this steps redeems,
        DebtDirection:issues if this step issues.
        @note it is an upper bound because offers on the books may be unfunded.
@@ -185,7 +185,7 @@ public:
        it should be a good estimate for the actual quality.
      */
     // clang-format on
-    virtual std::pair<boost::optional<Quality>, DebtDirection>
+    virtual std::pair<std::optional<Quality>, DebtDirection>
     qualityUpperBound(ReadView const& v, DebtDirection prevStepDir) const = 0;
 
     /** Return the number of offers consumed or partially consumed the last time
@@ -204,10 +204,10 @@ public:
     /**
        If this step is a BookStep, return the book.
     */
-    virtual boost::optional<Book>
+    virtual std::optional<Book>
     bookStepBook() const
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     /**
@@ -339,7 +339,7 @@ normalizePath(
     AccountID const& src,
     AccountID const& dst,
     Issue const& deliver,
-    boost::optional<Issue> const& sendMaxIssue,
+    std::optional<Issue> const& sendMaxIssue,
     STPath const& path);
 
 /**
@@ -370,8 +370,8 @@ toStrand(
     AccountID const& src,
     AccountID const& dst,
     Issue const& deliver,
-    boost::optional<Quality> const& limitQuality,
-    boost::optional<Issue> const& sendMaxIssue,
+    std::optional<Quality> const& limitQuality,
+    std::optional<Issue> const& sendMaxIssue,
     STPath const& path,
     bool ownerPaysTransferFee,
     bool offerCrossing,
@@ -407,8 +407,8 @@ toStrands(
     AccountID const& src,
     AccountID const& dst,
     Issue const& deliver,
-    boost::optional<Quality> const& limitQuality,
-    boost::optional<Issue> const& sendMax,
+    std::optional<Quality> const& limitQuality,
+    std::optional<Issue> const& sendMax,
     STPathSet const& paths,
     bool addDefaultPath,
     bool ownerPaysTransferFee,
@@ -496,11 +496,11 @@ checkNear(XRPAmount const& expected, XRPAmount const& actual);
  */
 struct StrandContext
 {
-    ReadView const& view;       ///< Current ReadView
-    AccountID const strandSrc;  ///< Strand source account
-    AccountID const strandDst;  ///< Strand destination account
-    Issue const strandDeliver;  ///< Issue strand delivers
-    boost::optional<Quality> const limitQuality;  ///< Worst accepted quality
+    ReadView const& view;                       ///< Current ReadView
+    AccountID const strandSrc;                  ///< Strand source account
+    AccountID const strandDst;                  ///< Strand destination account
+    Issue const strandDeliver;                  ///< Issue strand delivers
+    std::optional<Quality> const limitQuality;  ///< Worst accepted quality
     bool const isFirst;               ///< true if Step is first in Strand
     bool const isLast = false;        ///< true if Step is last in Strand
     bool const ownerPaysTransferFee;  ///< true if owner, not sender, pays fee
@@ -532,7 +532,7 @@ struct StrandContext
         AccountID const& strandSrc_,
         AccountID const& strandDst_,
         Issue const& strandDeliver_,
-        boost::optional<Quality> const& limitQuality_,
+        std::optional<Quality> const& limitQuality_,
         bool isLast_,
         bool ownerPaysTransferFee_,
         bool offerCrossing_,

--- a/src/ripple/app/paths/impl/XRPEndpointStep.cpp
+++ b/src/ripple/app/paths/impl/XRPEndpointStep.cpp
@@ -47,13 +47,13 @@ private:
     // Since this step will always be an endpoint in a strand
     // (either the first or last step) the same cache is used
     // for cachedIn and cachedOut and only one will ever be used
-    boost::optional<XRPAmount> cache_;
+    std::optional<XRPAmount> cache_;
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cached() const
     {
         if (!cache_)
-            return boost::none;
+            return std::nullopt;
         return EitherAmount(*cache_);
     }
 
@@ -69,7 +69,7 @@ public:
         return acc_;
     }
 
-    boost::optional<std::pair<AccountID, AccountID>>
+    std::optional<std::pair<AccountID, AccountID>>
     directStepAccts() const override
     {
         if (isLast_)
@@ -77,13 +77,13 @@ public:
         return std::make_pair(acc_, xrpAccount());
     }
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cachedIn() const override
     {
         return cached();
     }
 
-    boost::optional<EitherAmount>
+    std::optional<EitherAmount>
     cachedOut() const override
     {
         return cached();
@@ -95,7 +95,7 @@ public:
         return DebtDirection::issues;
     }
 
-    std::pair<boost::optional<Quality>, DebtDirection>
+    std::pair<std::optional<Quality>, DebtDirection>
     qualityUpperBound(ReadView const& v, DebtDirection prevStepDir)
         const override;
 
@@ -242,7 +242,7 @@ operator==(
 }
 
 template <class TDerived>
-std::pair<boost::optional<Quality>, DebtDirection>
+std::pair<std::optional<Quality>, DebtDirection>
 XRPEndpointStep<TDerived>::qualityUpperBound(
     ReadView const& v,
     DebtDirection prevStepDir) const

--- a/src/ripple/app/tx/impl/ApplyContext.h
+++ b/src/ripple/app/tx/impl/ApplyContext.h
@@ -26,7 +26,7 @@
 #include <ripple/core/Config.h>
 #include <ripple/ledger/ApplyViewImpl.h>
 #include <ripple/protocol/STTx.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include <utility>
 
 namespace ripple {
@@ -123,7 +123,7 @@ private:
 
     OpenView& base_;
     ApplyFlags flags_;
-    boost::optional<ApplyViewImpl> view_;
+    std::optional<ApplyViewImpl> view_;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/tx/impl/CashCheck.cpp
+++ b/src/ripple/app/tx/impl/CashCheck.cpp
@@ -357,7 +357,7 @@ CashCheck::doApply()
                 static_cast<bool>(optDeliverMin),  // partial payment
                 true,                              // owner pays transfer fee
                 false,                             // offer crossing
-                boost::none,
+                std::nullopt,
                 sleCheck->getFieldAmount(sfSendMax),
                 viewJ);
 

--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -740,7 +740,7 @@ CreateOffer::flowCross(
         if (!takerAmount.in.native() & !takerAmount.out.native())
         {
             STPath path;
-            path.emplace_back(boost::none, xrpCurrency(), boost::none);
+            path.emplace_back(std::nullopt, xrpCurrency(), std::nullopt);
             paths.emplace_back(std::move(path));
         }
         // Special handling for the tfSell flag.

--- a/src/ripple/app/tx/impl/OfferStream.cpp
+++ b/src/ripple/app/tx/impl/OfferStream.cpp
@@ -144,7 +144,7 @@ TOfferStreamBase<TIn, TOut>::step()
 
     for (;;)
     {
-        ownerFunds_ = boost::none;
+        ownerFunds_ = std::nullopt;
         // BookTip::step deletes the current offer from the view before
         // advancing to the next (unless the ledger entry is missing).
         if (!tip_.step(j_))

--- a/src/ripple/app/tx/impl/OfferStream.h
+++ b/src/ripple/app/tx/impl/OfferStream.h
@@ -76,7 +76,7 @@ protected:
     NetClock::time_point const expire_;
     BookTip tip_;
     TOffer<TIn, TOut> offer_;
-    boost::optional<TOut> ownerFunds_;
+    std::optional<TOut> ownerFunds_;
     StepCounter& counter_;
 
     void

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -541,7 +541,7 @@ PayChanClaim::doApply()
     {
         if (src != txAccount)
             return tecNO_PERMISSION;
-        (*slep)[~sfExpiration] = boost::none;
+        (*slep)[~sfExpiration] = std::nullopt;
         ctx_.view().update(slep);
     }
 

--- a/src/ripple/app/tx/impl/Transactor.h
+++ b/src/ripple/app/tx/impl/Transactor.h
@@ -24,7 +24,6 @@
 #include <ripple/app/tx/impl/ApplyContext.h>
 #include <ripple/basics/XRPAmount.h>
 #include <ripple/beast/utility/Journal.h>
-#include <boost/optional.hpp>
 
 namespace ripple {
 

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -440,7 +440,7 @@ preclaim(
     Application& app,
     OpenView const& view)
 {
-    boost::optional<PreclaimContext const> ctx;
+    std::optional<PreclaimContext const> ctx;
     if (preflightResult.rules != view.rules())
     {
         auto secondFlight = preflight(

--- a/src/ripple/basics/BasicConfig.h
+++ b/src/ripple/basics/BasicConfig.h
@@ -23,10 +23,10 @@
 #include <ripple/basics/contract.h>
 #include <boost/beast/core/string.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 #include <algorithm>
 #include <beast/unit_test/detail/const_container.hpp>
 #include <map>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -139,12 +139,12 @@ public:
     find(std::string const& name) const;
 
     template <class T>
-    boost::optional<T>
+    std::optional<T>
     get(std::string const& name) const
     {
         auto const iter = cont().find(name);
         if (iter == cont().end())
-            return boost::none;
+            return std::nullopt;
         return boost::lexical_cast<T>(iter->second);
     }
 
@@ -154,7 +154,7 @@ public:
     value_or(std::string const& name, T const& other) const
     {
         auto const v = get<T>(name);
-        return v.is_initialized() ? *v : other;
+        return v.has_value() ? *v : other;
     }
 
     // indicates if trailing comments were seen
@@ -279,7 +279,7 @@ set(T& target, std::string const& name, Section const& section)
     try
     {
         auto const val = section.get<T>(name);
-        if ((found_and_valid = val.is_initialized()))
+        if ((found_and_valid = val.has_value()))
             target = *val;
     }
     catch (boost::bad_lexical_cast&)
@@ -333,7 +333,7 @@ get(Section const& section, std::string const& name, const char* defaultValue)
     try
     {
         auto const val = section.get<std::string>(name);
-        if (val.is_initialized())
+        if (val.has_value())
             return *val;
     }
     catch (boost::bad_lexical_cast&)

--- a/src/ripple/basics/FileUtilities.h
+++ b/src/ripple/basics/FileUtilities.h
@@ -21,8 +21,9 @@
 #define RIPPLE_BASICS_FILEUTILITIES_H_INCLUDED
 
 #include <boost/filesystem.hpp>
-#include <boost/optional.hpp>
 #include <boost/system/error_code.hpp>
+
+#include <optional>
 
 namespace ripple {
 
@@ -30,7 +31,7 @@ std::string
 getFileContents(
     boost::system::error_code& ec,
     boost::filesystem::path const& sourcePath,
-    boost::optional<std::size_t> maxSize = boost::none);
+    std::optional<std::size_t> maxSize = std::nullopt);
 
 void
 writeFileContents(

--- a/src/ripple/basics/RangeSet.h
+++ b/src/ripple/basics/RangeSet.h
@@ -25,8 +25,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/icl/closed_interval.hpp>
 #include <boost/icl/interval_set.hpp>
-#include <boost/optional.hpp>
 
+#include <optional>
 #include <string>
 
 namespace ripple {
@@ -177,18 +177,18 @@ from_string(RangeSet<T>& rs, std::string const& s)
     @param t The value that must be larger than the result
     @param minVal (Default is 0) The smallest allowed value
     @return The largest v such that minV <= v < t and !contains(rs, v) or
-            boost::none if no such v exists.
+            std::nullopt if no such v exists.
 */
 template <class T>
-boost::optional<T>
+std::optional<T>
 prevMissing(RangeSet<T> const& rs, T t, T minVal = 0)
 {
     if (rs.empty() || t == minVal)
-        return boost::none;
+        return std::nullopt;
     RangeSet<T> tgt{ClosedInterval<T>{minVal, t - 1}};
     tgt -= rs;
     if (tgt.empty())
-        return boost::none;
+        return std::nullopt;
     return boost::icl::last(tgt);
 }
 

--- a/src/ripple/basics/StringUtilities.h
+++ b/src/ripple/basics/StringUtilities.h
@@ -24,8 +24,8 @@
 #include <ripple/basics/strHex.h>
 
 #include <boost/format.hpp>
-#include <boost/optional.hpp>
 #include <boost/utility/string_view.hpp>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -45,7 +45,7 @@ std::string
 sqlBlobLiteral(Blob const& blob);
 
 template <class Iterator>
-boost::optional<Blob>
+std::optional<Blob>
 strUnHex(std::size_t strSize, Iterator begin, Iterator end)
 {
     Blob out;
@@ -85,13 +85,13 @@ strUnHex(std::size_t strSize, Iterator begin, Iterator end)
     return {std::move(out)};
 }
 
-inline boost::optional<Blob>
+inline std::optional<Blob>
 strUnHex(std::string const& strSrc)
 {
     return strUnHex(strSrc.size(), strSrc.cbegin(), strSrc.cend());
 }
 
-inline boost::optional<Blob>
+inline std::optional<Blob>
 strViewUnHex(boost::string_view const& strSrc)
 {
     return strUnHex(strSrc.size(), strSrc.cbegin(), strSrc.cend());
@@ -105,7 +105,7 @@ struct parsedURL
     std::string username;
     std::string password;
     std::string domain;
-    boost::optional<std::uint16_t> port;
+    std::optional<std::uint16_t> port;
     std::string path;
 
     bool
@@ -122,7 +122,7 @@ parseUrl(parsedURL& pUrl, std::string const& strUrl);
 std::string
 trim_whitespace(std::string str);
 
-boost::optional<std::uint64_t>
+std::optional<std::uint64_t>
 to_uint64(std::string const& s);
 
 /** Determines if the given string looks like a TOML-file hosting domain.

--- a/src/ripple/basics/XRPAmount.h
+++ b/src/ripple/basics/XRPAmount.h
@@ -27,9 +27,9 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/operators.hpp>
-#include <boost/optional.hpp>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -178,7 +178,7 @@ public:
     decimalXRP() const;
 
     template <class Dest>
-    boost::optional<Dest>
+    std::optional<Dest>
     dropsAs() const
     {
         if ((drops_ > std::numeric_limits<Dest>::max()) ||
@@ -186,7 +186,7 @@ public:
             (std::numeric_limits<Dest>::is_signed &&
              drops_ < std::numeric_limits<Dest>::lowest()))
         {
-            return boost::none;
+            return std::nullopt;
         }
         return static_cast<Dest>(drops_);
     }

--- a/src/ripple/basics/impl/FileUtilities.cpp
+++ b/src/ripple/basics/impl/FileUtilities.cpp
@@ -25,7 +25,7 @@ std::string
 getFileContents(
     boost::system::error_code& ec,
     boost::filesystem::path const& sourcePath,
-    boost::optional<std::size_t> maxSize)
+    std::optional<std::size_t> maxSize)
 {
     using namespace boost::filesystem;
     using namespace boost::system::errc;

--- a/src/ripple/basics/impl/PerfLogImp.cpp
+++ b/src/ripple/basics/impl/PerfLogImp.cpp
@@ -24,13 +24,13 @@
 #include <ripple/core/JobTypes.h>
 #include <ripple/json/json_writer.h>
 #include <ripple/json/to_string.h>
-#include <boost/optional.hpp>
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <iterator>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -103,13 +103,13 @@ trim_whitespace(std::string str)
     return str;
 }
 
-boost::optional<std::uint64_t>
+std::optional<std::uint64_t>
 to_uint64(std::string const& s)
 {
     std::uint64_t result;
     if (beast::lexicalCastChecked(result, s))
         return result;
-    return boost::none;
+    return std::nullopt;
 }
 
 bool

--- a/src/ripple/beast/insight/impl/StatsDCollector.cpp
+++ b/src/ripple/beast/insight/impl/StatsDCollector.cpp
@@ -26,12 +26,12 @@
 #include <ripple/beast/insight/StatsDCollector.h>
 #include <ripple/beast/net/IPAddressConversion.h>
 #include <boost/asio/ip/tcp.hpp>
-#include <boost/optional.hpp>
 #include <cassert>
 #include <climits>
 #include <deque>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <thread>
@@ -224,7 +224,7 @@ private:
     IP::Endpoint m_address;
     std::string m_prefix;
     boost::asio::io_service m_io_service;
-    boost::optional<boost::asio::io_service::work> m_work;
+    std::optional<boost::asio::io_service::work> m_work;
     boost::asio::io_service::strand m_strand;
     boost::asio::basic_waitable_timer<std::chrono::steady_clock> m_timer;
     boost::asio::ip::udp::socket m_socket;
@@ -262,7 +262,7 @@ public:
         boost::system::error_code ec;
         m_timer.cancel(ec);
 
-        m_work = boost::none;
+        m_work.reset();
         m_thread.join();
     }
 

--- a/src/ripple/beast/net/IPEndpoint.h
+++ b/src/ripple/beast/net/IPEndpoint.h
@@ -24,10 +24,9 @@
 #include <ripple/beast/hash/uhash.h>
 #include <ripple/beast/net/IPAddress.h>
 
-#include <boost/optional.hpp>
-
 #include <cstdint>
 #include <ios>
+#include <optional>
 #include <string>
 
 namespace beast {
@@ -47,9 +46,9 @@ public:
 
     /** Create an Endpoint from a string.
         If the port is omitted, the endpoint will have a zero port.
-        @return An optional endpoint; will be `boost::none` on failure
+        @return An optional endpoint; will be `std::nullopt` on failure
     */
-    static boost::optional<Endpoint>
+    static std::optional<Endpoint>
     from_string_checked(std::string const& s);
     static Endpoint
     from_string(std::string const& s);

--- a/src/ripple/beast/net/impl/IPEndpoint.cpp
+++ b/src/ripple/beast/net/impl/IPEndpoint.cpp
@@ -31,7 +31,7 @@ Endpoint::Endpoint(Address const& addr, Port port) : m_addr(addr), m_port(port)
 {
 }
 
-boost::optional<Endpoint>
+std::optional<Endpoint>
 Endpoint::from_string_checked(std::string const& s)
 {
     std::stringstream is(boost::trim_copy(s));
@@ -45,7 +45,7 @@ Endpoint::from_string_checked(std::string const& s)
 Endpoint
 Endpoint::from_string(std::string const& s)
 {
-    if (boost::optional<Endpoint> const result = from_string_checked(s))
+    if (std::optional<Endpoint> const result = from_string_checked(s))
         return *result;
     return Endpoint{};
 }

--- a/src/ripple/conditions/Fulfillment.h
+++ b/src/ripple/conditions/Fulfillment.h
@@ -24,7 +24,6 @@
 #include <ripple/basics/Slice.h>
 #include <ripple/conditions/Condition.h>
 #include <ripple/conditions/impl/utils.h>
-#include <boost/optional.hpp>
 
 namespace ripple {
 namespace cryptoconditions {

--- a/src/ripple/conditions/impl/Condition.cpp
+++ b/src/ripple/conditions/impl/Condition.cpp
@@ -22,7 +22,6 @@
 #include <ripple/conditions/Fulfillment.h>
 #include <ripple/conditions/impl/PreimageSha256.h>
 #include <ripple/conditions/impl/utils.h>
-#include <boost/optional.hpp>
 #include <boost/regex.hpp>
 #include <iostream>
 #include <vector>

--- a/src/ripple/conditions/impl/Fulfillment.cpp
+++ b/src/ripple/conditions/impl/Fulfillment.cpp
@@ -22,7 +22,6 @@
 #include <ripple/conditions/Fulfillment.h>
 #include <ripple/conditions/impl/PreimageSha256.h>
 #include <ripple/conditions/impl/utils.h>
-#include <boost/optional.hpp>
 #include <boost/regex.hpp>
 #include <type_traits>
 #include <vector>

--- a/src/ripple/consensus/Consensus.h
+++ b/src/ripple/consensus/Consensus.h
@@ -30,6 +30,7 @@
 #include <ripple/consensus/LedgerTiming.h>
 #include <ripple/json/json_writer.h>
 #include <boost/logic/tribool.hpp>
+#include <optional>
 #include <sstream>
 
 namespace ripple {
@@ -214,10 +215,10 @@ checkConsensus(
       //-----------------------------------------------------------------------
       //
       // Attempt to acquire a specific ledger.
-      boost::optional<Ledger> acquireLedger(Ledger::ID const & ledgerID);
+      std::optional<Ledger> acquireLedger(Ledger::ID const & ledgerID);
 
       // Acquire the transaction set associated with a proposed position.
-      boost::optional<TxSet> acquireTxSet(TxSet::ID const & setID);
+      std::optional<TxSet> acquireTxSet(TxSet::ID const & setID);
 
       // Whether any transactions are in the open ledger
       bool hasOpenTransactions() const;
@@ -398,7 +399,7 @@ public:
     void
     simulate(
         NetClock::time_point const& now,
-        boost::optional<std::chrono::milliseconds> consensusDelay);
+        std::optional<std::chrono::milliseconds> consensusDelay);
 
     /** Get the previous ledger ID.
 
@@ -577,7 +578,7 @@ private:
     // Transaction Sets, indexed by hash of transaction tree
     hash_map<typename TxSet_t::ID, const TxSet_t> acquired_;
 
-    boost::optional<Result> result_;
+    std::optional<Result> result_;
     ConsensusCloseTimes rawCloseTimes_;
 
     //-------------------------------------------------------------------------
@@ -792,7 +793,7 @@ Consensus<Adaptor>::peerProposalInternal(
         if (ait == acquired_.end())
         {
             // acquireTxSet will return the set if it is available, or
-            // spawn a request for it and return none/nullptr.  It will call
+            // spawn a request for it and return nullopt/nullptr.  It will call
             // gotTxSet once it arrives
             if (auto set = adaptor_.acquireTxSet(newPeerProp.position()))
                 gotTxSet(now_, *set);
@@ -881,7 +882,7 @@ template <class Adaptor>
 void
 Consensus<Adaptor>::simulate(
     NetClock::time_point const& now,
-    boost::optional<std::chrono::milliseconds> consensusDelay)
+    std::optional<std::chrono::milliseconds> consensusDelay)
 {
     using namespace std::chrono_literals;
     JLOG(j_.info()) << "Simulating consensus";
@@ -1388,11 +1389,11 @@ Consensus<Adaptor>::updateOurPositions()
     }
 
     // This will stay unseated unless there are any changes
-    boost::optional<TxSet_t> ourNewSet;
+    std::optional<TxSet_t> ourNewSet;
 
     // Update votes on disputed transactions
     {
-        boost::optional<typename TxSet_t::MutableTxSet> mutableSet;
+        std::optional<typename TxSet_t::MutableTxSet> mutableSet;
         for (auto& [txId, dispute] : result_->disputes)
         {
             // Because the threshold for inclusion increases,

--- a/src/ripple/consensus/LedgerTrie.h
+++ b/src/ripple/consensus/LedgerTrie.h
@@ -23,9 +23,9 @@
 #include <ripple/basics/ToString.h>
 #include <ripple/basics/tagged_integer.h>
 #include <ripple/json/json_value.h>
-#include <boost/optional.hpp>
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <stack>
 #include <vector>
@@ -116,14 +116,14 @@ public:
     }
 
     // Return the Span from [spot,end_) or none if no such valid span
-    boost::optional<Span>
+    std::optional<Span>
     from(Seq spot) const
     {
         return sub(spot, end_);
     }
 
     // Return the Span from [start_,spot) or none if no such valid span
-    boost::optional<Span>
+    std::optional<Span>
     before(Seq spot) const
     {
         return sub(start_, spot);
@@ -167,14 +167,14 @@ private:
     }
 
     // Return a span of this over the half-open interval [from,to)
-    boost::optional<Span>
+    std::optional<Span>
     sub(Seq from, Seq to) const
     {
         Seq newFrom = clamp(from);
         Seq newTo = clamp(to);
         if (newFrom < newTo)
             return Span(newFrom, newTo, ledger_);
-        return boost::none;
+        return std::nullopt;
     }
 
     friend std::ostream&
@@ -469,9 +469,9 @@ public:
         //  a b c  | g h i
         //  prefix | newSuffix
 
-        boost::optional<Span> prefix = loc->span.before(diffSeq);
-        boost::optional<Span> oldSuffix = loc->span.from(diffSeq);
-        boost::optional<Span> newSuffix = Span{ledger}.from(diffSeq);
+        std::optional<Span> prefix = loc->span.before(diffSeq);
+        std::optional<Span> oldSuffix = loc->span.from(diffSeq);
+        std::optional<Span> newSuffix = Span{ledger}.from(diffSeq);
 
         if (oldSuffix)
         {
@@ -672,13 +672,13 @@ public:
         @param largestIssued The sequence number of the largest validation
                              issued by this node.
         @return Pair with the sequence number and ID of the preferred ledger or
-                boost::none if no preferred ledger exists
+                std::nullopt if no preferred ledger exists
     */
-    boost::optional<SpanTip<Ledger>>
+    std::optional<SpanTip<Ledger>>
     getPreferred(Seq const largestIssued) const
     {
         if (empty())
-            return boost::none;
+            return std::nullopt;
 
         Node* curr = root.get();
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -27,8 +27,8 @@
 #include <ripple/beast/container/aged_unordered_map.h>
 #include <ripple/consensus/LedgerTrie.h>
 #include <ripple/protocol/PublicKey.h>
-#include <boost/optional.hpp>
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -272,7 +272,7 @@ to_string(ValStatus m)
         NetClock::time_point now() const;
 
         // Attempt to acquire a specific ledger.
-        boost::optional<Ledger> acquire(Ledger::ID const & ledgerID);
+        std::optional<Ledger> acquire(Ledger::ID const & ledgerID);
 
         // ... implementation specific
     };
@@ -323,7 +323,7 @@ class Validations
         bySequence_;
 
     // Sequence of the earliest validation to keep from expire
-    boost::optional<Seq> toKeep_;
+    std::optional<Seq> toKeep_;
 
     // Represents the ancestry of validated ledgers
     LedgerTrie<Ledger> trie_;
@@ -376,7 +376,7 @@ private:
     {
         for (auto it = acquiring_.begin(); it != acquiring_.end();)
         {
-            if (boost::optional<Ledger> ledger =
+            if (std::optional<Ledger> ledger =
                     adaptor_.acquire(it->first.second))
             {
                 for (NodeID const& nodeID : it->second)
@@ -423,7 +423,7 @@ private:
         std::lock_guard<Mutex> const& lock,
         NodeID const& nodeID,
         Validation const& val,
-        boost::optional<std::pair<Seq, ID>> prior)
+        std::optional<std::pair<Seq, ID>> prior)
     {
         assert(val.trusted());
 
@@ -449,8 +449,7 @@ private:
         }
         else
         {
-            if (boost::optional<Ledger> ledger =
-                    adaptor_.acquire(val.ledgerID()))
+            if (std::optional<Ledger> ledger = adaptor_.acquire(val.ledgerID()))
                 updateTrie(lock, nodeID, *ledger);
             else
                 acquiring_[valPair].insert(nodeID);
@@ -682,7 +681,7 @@ public:
             }
             else if (val.trusted())
             {
-                updateTrie(lock, nodeID, val, boost::none);
+                updateTrie(lock, nodeID, val, std::nullopt);
             }
         }
 
@@ -753,7 +752,7 @@ public:
             if (added.find(nodeId) != added.end())
             {
                 validation.setTrusted();
-                updateTrie(lock, nodeId, validation, boost::none);
+                updateTrie(lock, nodeId, validation, std::nullopt);
             }
             else if (removed.find(nodeId) != removed.end())
             {
@@ -795,14 +794,14 @@ public:
         @param curr The local node's current working ledger
 
         @return The sequence and id of the preferred working ledger,
-                or boost::none if no trusted validations are available to
+                or std::nullopt if no trusted validations are available to
                 determine the preferred ledger.
     */
-    boost::optional<std::pair<Seq, ID>>
+    std::optional<std::pair<Seq, ID>>
     getPreferred(Ledger const& curr)
     {
         std::lock_guard lock{mutex_};
-        boost::optional<SpanTip<Ledger>> preferred =
+        std::optional<SpanTip<Ledger>> preferred =
             withTrie(lock, [this](LedgerTrie<Ledger>& trie) {
                 return trie.getPreferred(localSeqEnforcer_.largest());
             });
@@ -827,7 +826,7 @@ public:
                 });
             if (it != acquiring_.end())
                 return it->first;
-            return boost::none;
+            return std::nullopt;
         }
 
         // If we are the parent of the preferred ledger, stick with our
@@ -862,7 +861,7 @@ public:
     ID
     getPreferred(Ledger const& curr, Seq minValidSeq)
     {
-        boost::optional<std::pair<Seq, ID>> preferred = getPreferred(curr);
+        std::optional<std::pair<Seq, ID>> preferred = getPreferred(curr);
         if (preferred && preferred->first >= minValidSeq)
             return preferred->second;
         return curr.id();
@@ -890,7 +889,7 @@ public:
         Seq minSeq,
         hash_map<ID, std::uint32_t> const& peerCounts)
     {
-        boost::optional<std::pair<Seq, ID>> preferred = getPreferred(lcl);
+        std::optional<std::pair<Seq, ID>> preferred = getPreferred(lcl);
 
         // Trusted validations exist, but stick with local preferred ledger if
         // preferred is in the past
@@ -1041,7 +1040,7 @@ public:
             [&](NodeID const&, Validation const& v) {
                 if (v.trusted() && v.full())
                 {
-                    boost::optional<std::uint32_t> loadFee = v.loadFee();
+                    std::optional<std::uint32_t> loadFee = v.loadFee();
                     if (loadFee)
                         res.push_back(*loadFee);
                     else

--- a/src/ripple/core/ClosureCounter.h
+++ b/src/ripple/core/ClosureCounter.h
@@ -21,10 +21,10 @@
 #define RIPPLE_CORE_CLOSURE_COUNTER_H_INCLUDED
 
 #include <ripple/basics/Log.h>
-#include <boost/optional.hpp>
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <type_traits>
 
 namespace ripple {
@@ -169,15 +169,15 @@ public:
     /** Wrap the passed closure with a reference counter.
 
         @param closure Closure that accepts Args_t parameters and returns Ret_t.
-        @return If join() has been called returns boost::none.  Otherwise
-                returns a boost::optional that wraps closure with a
+        @return If join() has been called returns std::nullopt.  Otherwise
+                returns a std::optional that wraps closure with a
                 reference counter.
     */
     template <class Closure>
-    boost::optional<Wrapper<Closure>>
+    std::optional<Wrapper<Closure>>
     wrap(Closure&& closure)
     {
-        boost::optional<Wrapper<Closure>> ret;
+        std::optional<Wrapper<Closure>> ret;
 
         std::lock_guard lock{mutex_};
         if (!waitForClosures_)

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -29,11 +29,11 @@
 #include <boost/beast/core/string.hpp>
 #include <boost/filesystem.hpp>  // VFALCO FIX: This include should not be here
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
@@ -165,7 +165,7 @@ public:
     int PATH_SEARCH_MAX = 10;
 
     // Validation
-    boost::optional<std::size_t>
+    std::optional<std::size_t>
         VALIDATION_QUORUM;  // validations to consider ledger authoritative
 
     XRPAmount FEE_DEFAULT{10};
@@ -214,7 +214,7 @@ public:
     bool VP_REDUCE_RELAY_SQUELCH = false;
 
     // These override the command line client settings
-    boost::optional<beast::IP::Endpoint> rpc_ip;
+    std::optional<beast::IP::Endpoint> rpc_ip;
 
     std::unordered_set<uint256, beast::uhash<>> features;
 
@@ -314,7 +314,7 @@ public:
               defaults in the code for every case.
     */
     int
-    getValueFor(SizedItem item, boost::optional<std::size_t> node = boost::none)
+    getValueFor(SizedItem item, std::optional<std::size_t> node = std::nullopt)
         const;
 };
 

--- a/src/ripple/core/DatabaseCon.h
+++ b/src/ripple/core/DatabaseCon.h
@@ -24,8 +24,8 @@
 #include <ripple/core/Config.h>
 #include <ripple/core/SociDB.h>
 #include <boost/filesystem/path.hpp>
-#include <boost/optional.hpp>
 #include <mutex>
+#include <optional>
 #include <string>
 
 namespace soci {
@@ -234,7 +234,7 @@ checkpointerFromId(std::uintptr_t id);
 DatabaseCon::Setup
 setup_DatabaseCon(
     Config const& c,
-    boost::optional<beast::Journal> j = boost::none);
+    std::optional<beast::Journal> j = std::nullopt);
 
 }  // namespace ripple
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -821,7 +821,7 @@ Config::getDebugLogFile() const
 }
 
 int
-Config::getValueFor(SizedItem item, boost::optional<std::size_t> node) const
+Config::getValueFor(SizedItem item, std::optional<std::size_t> node) const
 {
     auto const index = static_cast<std::underlying_type_t<SizedItem>>(item);
     assert(index < sizedItems.size());

--- a/src/ripple/core/impl/DatabaseCon.cpp
+++ b/src/ripple/core/impl/DatabaseCon.cpp
@@ -103,7 +103,7 @@ DatabaseCon::~DatabaseCon()
 }
 
 DatabaseCon::Setup
-setup_DatabaseCon(Config const& c, boost::optional<beast::Journal> j)
+setup_DatabaseCon(Config const& c, std::optional<beast::Journal> j)
 {
     DatabaseCon::Setup setup;
 

--- a/src/ripple/core/impl/SNTPClock.cpp
+++ b/src/ripple/core/impl/SNTPClock.cpp
@@ -22,12 +22,12 @@
 #include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/core/impl/SNTPClock.h>
 #include <boost/asio.hpp>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <thread>
 
 namespace ripple {
@@ -90,7 +90,7 @@ private:
     std::mutex mutable mutex_;
     std::thread thread_;
     boost::asio::io_service io_service_;
-    boost::optional<boost::asio::io_service::work> work_;
+    std::optional<boost::asio::io_service::work> work_;
 
     std::map<boost::asio::ip::udp::endpoint, Query> queries_;
     boost::asio::ip::udp::socket socket_;
@@ -125,7 +125,7 @@ public:
             error_code ec;
             timer_.cancel(ec);
             socket_.cancel(ec);
-            work_ = boost::none;
+            work_ = std::nullopt;
             thread_.join();
         }
     }

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -23,7 +23,6 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/ledger/RawView.h>
 #include <ripple/ledger/ReadView.h>
-#include <boost/optional.hpp>
 
 namespace ripple {
 
@@ -141,7 +140,7 @@ class ApplyView : public ReadView
 {
 private:
     /** Add an entry to a directory using the specified insert strategy */
-    boost::optional<std::uint64_t>
+    std::optional<std::uint64_t>
     dirAdd(
         bool preserveOrder,
         Keylet const& directory,
@@ -265,7 +264,7 @@ public:
         @param key the entry to insert
         @param describe callback to add required entries to a new page
 
-        @return a \c boost::optional which, if insertion was successful,
+        @return a \c std::optional which, if insertion was successful,
                 will contain the page number in which the item was stored.
 
         @note this function may create a page (including a root page), if no
@@ -274,7 +273,7 @@ public:
               allowable pages.
     */
     /** @{ */
-    boost::optional<std::uint64_t>
+    std::optional<std::uint64_t>
     dirAppend(
         Keylet const& directory,
         uint256 const& key,
@@ -283,7 +282,7 @@ public:
         return dirAdd(true, directory, key, describe);
     }
 
-    boost::optional<std::uint64_t>
+    std::optional<std::uint64_t>
     dirAppend(
         Keylet const& directory,
         Keylet const& key,
@@ -302,7 +301,7 @@ public:
         @param key the entry to insert
         @param describe callback to add required entries to a new page
 
-        @return a \c boost::optional which, if insertion was successful,
+        @return a \c std::optional which, if insertion was successful,
                 will contain the page number in which the item was stored.
 
         @note this function may create a page (including a root page), if no
@@ -311,7 +310,7 @@ public:
               allowable pages.
     */
     /** @{ */
-    boost::optional<std::uint64_t>
+    std::optional<std::uint64_t>
     dirInsert(
         Keylet const& directory,
         uint256 const& key,
@@ -320,7 +319,7 @@ public:
         return dirAdd(false, directory, key, describe);
     }
 
-    boost::optional<std::uint64_t>
+    std::optional<std::uint64_t>
     dirInsert(
         Keylet const& directory,
         Keylet const& key,

--- a/src/ripple/ledger/ApplyViewImpl.h
+++ b/src/ripple/ledger/ApplyViewImpl.h
@@ -24,7 +24,6 @@
 #include <ripple/ledger/detail/ApplyViewBase.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/TER.h>
-#include <boost/optional.hpp>
 
 namespace ripple {
 
@@ -86,7 +85,7 @@ public:
             std::shared_ptr<SLE const> const& after)> const& func);
 
 private:
-    boost::optional<STAmount> deliver_;
+    std::optional<STAmount> deliver_;
 };
 
 }  // namespace ripple

--- a/src/ripple/ledger/BookDirs.h
+++ b/src/ripple/ledger/BookDirs.h
@@ -102,7 +102,7 @@ private:
     std::shared_ptr<SLE const> sle_;
     unsigned int entry_ = 0;
     uint256 index_;
-    boost::optional<value_type> mutable cache_;
+    std::optional<value_type> mutable cache_;
 
     static beast::Journal j_;
 };

--- a/src/ripple/ledger/CachedView.h
+++ b/src/ripple/ledger/CachedView.h
@@ -88,10 +88,10 @@ public:
         return base_.rules();
     }
 
-    boost::optional<key_type>
+    std::optional<key_type>
     succ(
         key_type const& key,
-        boost::optional<key_type> const& last = boost::none) const override
+        std::optional<key_type> const& last = std::nullopt) const override
     {
         return base_.succ(key, last);
     }
@@ -142,7 +142,7 @@ public:
     // DigestAwareReadView
     //
 
-    boost::optional<digest_type>
+    std::optional<digest_type>
     digest(key_type const& key) const override
     {
         return base_.digest(key);

--- a/src/ripple/ledger/Directory.h
+++ b/src/ripple/ledger/Directory.h
@@ -103,7 +103,7 @@ private:
     Keylet root_;
     Keylet page_;
     uint256 index_;
-    boost::optional<value_type> mutable cache_;
+    std::optional<value_type> mutable cache_;
     std::shared_ptr<SLE const> sle_;
     STVector256 const* indexes_ = nullptr;
     std::vector<uint256>::const_iterator it_;

--- a/src/ripple/ledger/OpenView.h
+++ b/src/ripple/ledger/OpenView.h
@@ -203,10 +203,10 @@ public:
     bool
     exists(Keylet const& k) const override;
 
-    boost::optional<key_type>
+    std::optional<key_type>
     succ(
         key_type const& key,
-        boost::optional<key_type> const& last = boost::none) const override;
+        std::optional<key_type> const& last = std::nullopt) const override;
 
     std::shared_ptr<SLE const>
     read(Keylet const& k) const override;

--- a/src/ripple/ledger/PaymentSandbox.h
+++ b/src/ripple/ledger/PaymentSandbox.h
@@ -49,7 +49,7 @@ public:
 
     // Get the adjustments for the balance between main and other.
     // Returns the debits, credits and the original balance
-    boost::optional<Adjustment>
+    std::optional<Adjustment>
     adjustments(
         AccountID const& main,
         AccountID const& other,
@@ -68,7 +68,7 @@ public:
     // Get the adjusted owner count. Since DeferredCredits is meant to be used
     // in payments, and payments only decrease owner counts, return the max
     // remembered owner count.
-    boost::optional<std::uint32_t>
+    std::optional<std::uint32_t>
     ownerCount(AccountID const& id) const;
 
     void

--- a/src/ripple/ledger/RawView.h
+++ b/src/ripple/ledger/RawView.h
@@ -23,7 +23,6 @@
 #include <ripple/ledger/ReadView.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/Serializer.h>
-#include <boost/optional.hpp>
 #include <cstdint>
 #include <memory>
 #include <utility>

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -32,10 +32,10 @@
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/STTx.h>
-#include <boost/optional.hpp>
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <unordered_set>
 
 namespace ripple {
@@ -284,16 +284,16 @@ public:
 
         This returns the key of the first state item
         whose key is greater than the specified key. If
-        no such key is present, boost::none is returned.
+        no such key is present, std::nullopt is returned.
 
-        If `last` is engaged, returns boost::none when
+        If `last` is engaged, returns std::nullopt when
         the key returned would be outside the open
         interval (key, last).
     */
-    virtual boost::optional<key_type>
+    virtual std::optional<key_type>
     succ(
         key_type const& key,
-        boost::optional<key_type> const& last = boost::none) const = 0;
+        std::optional<key_type> const& last = std::nullopt) const = 0;
 
     /** Return the state item associated with a key.
 
@@ -403,9 +403,9 @@ public:
 
     /** Return the digest associated with the key.
 
-        @return boost::none if the item does not exist.
+        @return std::nullopt if the item does not exist.
     */
-    virtual boost::optional<digest_type>
+    virtual std::optional<digest_type>
     digest(key_type const& key) const = 0;
 };
 

--- a/src/ripple/ledger/TxMeta.h
+++ b/src/ripple/ledger/TxMeta.h
@@ -25,7 +25,7 @@
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/TER.h>
 #include <boost/container/flat_set.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace ripple {
 
@@ -105,7 +105,7 @@ public:
     void
     setDeliveredAmount(STAmount const& delivered)
     {
-        mDelivered.reset(delivered);
+        mDelivered = delivered;
     }
 
     STAmount
@@ -127,7 +127,7 @@ private:
     std::uint32_t mIndex;
     int mResult;
 
-    boost::optional<STAmount> mDelivered;
+    std::optional<STAmount> mDelivered;
 
     STArray mNodes;
 };

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -33,7 +33,6 @@
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/Serializer.h>
 #include <ripple/protocol/TER.h>
-#include <boost/optional.hpp>
 #include <functional>
 #include <map>
 #include <memory>
@@ -164,11 +163,11 @@ getMajorityAmendments(ReadView const& view);
     in the passed ledger. As the skip list is limited
     in size, if the requested ledger sequence number is
     out of the range of ledgers represented in the skip
-    list, then boost::none is returned.
+    list, then std::nullopt is returned.
     @return The hash of the ledger with the
-            given sequence number or boost::none.
+            given sequence number or std::nullopt.
 */
-[[nodiscard]] boost::optional<uint256>
+[[nodiscard]] std::optional<uint256>
 hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal);
 
 /** Find a ledger index from which we could easily get the requested ledger
@@ -251,7 +250,7 @@ dirNext(
 describeOwnerDir(AccountID const& account);
 
 // deprecated
-boost::optional<std::uint64_t>
+std::optional<std::uint64_t>
 dirAdd(
     ApplyView& view,
     Keylet const& uRootIndex,

--- a/src/ripple/ledger/detail/ApplyStateTable.h
+++ b/src/ripple/ledger/detail/ApplyStateTable.h
@@ -69,17 +69,17 @@ public:
         OpenView& to,
         STTx const& tx,
         TER ter,
-        boost::optional<STAmount> const& deliver,
+        std::optional<STAmount> const& deliver,
         beast::Journal j);
 
     bool
     exists(ReadView const& base, Keylet const& k) const;
 
-    boost::optional<key_type>
+    std::optional<key_type>
     succ(
         ReadView const& base,
         key_type const& key,
-        boost::optional<key_type> const& last) const;
+        std::optional<key_type> const& last) const;
 
     std::shared_ptr<SLE const>
     read(ReadView const& base, Keylet const& k) const;

--- a/src/ripple/ledger/detail/ApplyViewBase.h
+++ b/src/ripple/ledger/detail/ApplyViewBase.h
@@ -60,10 +60,10 @@ public:
     bool
     exists(Keylet const& k) const override;
 
-    boost::optional<key_type>
+    std::optional<key_type>
     succ(
         key_type const& key,
-        boost::optional<key_type> const& last = boost::none) const override;
+        std::optional<key_type> const& last = std::nullopt) const override;
 
     std::shared_ptr<SLE const>
     read(Keylet const& k) const override;

--- a/src/ripple/ledger/detail/RawStateTable.h
+++ b/src/ripple/ledger/detail/RawStateTable.h
@@ -68,11 +68,11 @@ public:
     bool
     exists(ReadView const& base, Keylet const& k) const;
 
-    boost::optional<key_type>
+    std::optional<key_type>
     succ(
         ReadView const& base,
         key_type const& key,
-        boost::optional<key_type> const& last) const;
+        std::optional<key_type> const& last) const;
 
     void
     erase(std::shared_ptr<SLE> const& sle);

--- a/src/ripple/ledger/detail/ReadViewFwdRange.h
+++ b/src/ripple/ledger/detail/ReadViewFwdRange.h
@@ -20,10 +20,10 @@
 #ifndef RIPPLE_LEDGER_READVIEWFWDRANGE_H_INCLUDED
 #define RIPPLE_LEDGER_READVIEWFWDRANGE_H_INCLUDED
 
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <iterator>
 #include <memory>
+#include <optional>
 
 namespace ripple {
 

--- a/src/ripple/ledger/impl/ApplyStateTable.cpp
+++ b/src/ripple/ledger/impl/ApplyStateTable.cpp
@@ -114,7 +114,7 @@ ApplyStateTable::apply(
     OpenView& to,
     STTx const& tx,
     TER ter,
-    boost::optional<STAmount> const& deliver,
+    std::optional<STAmount> const& deliver,
     beast::Journal j)
 {
     // Build metadata and insert
@@ -290,9 +290,9 @@ auto
 ApplyStateTable::succ(
     ReadView const& base,
     key_type const& key,
-    boost::optional<key_type> const& last) const -> boost::optional<key_type>
+    std::optional<key_type> const& last) const -> std::optional<key_type>
 {
-    boost::optional<key_type> next = key;
+    std::optional<key_type> next = key;
     items_t::const_iterator iter;
     // Find base successor that is
     // not also deleted in our list
@@ -317,7 +317,7 @@ ApplyStateTable::succ(
     // Nothing in our list, return
     // what we got from the parent.
     if (last && next >= last)
-        return boost::none;
+        return std::nullopt;
     return next;
 }
 

--- a/src/ripple/ledger/impl/ApplyView.cpp
+++ b/src/ripple/ledger/impl/ApplyView.cpp
@@ -24,7 +24,7 @@
 
 namespace ripple {
 
-boost::optional<std::uint64_t>
+std::optional<std::uint64_t>
 ApplyView::dirAdd(
     bool preserveOrder,
     Keylet const& directory,
@@ -93,7 +93,7 @@ ApplyView::dirAdd(
 
     // Check whether we're out of pages.
     if (++page >= dirNodeMaxPages)
-        return boost::none;
+        return std::nullopt;
 
     // We are about to create a new node; we'll link it to
     // the chain first:

--- a/src/ripple/ledger/impl/ApplyViewBase.cpp
+++ b/src/ripple/ledger/impl/ApplyViewBase.cpp
@@ -62,8 +62,8 @@ ApplyViewBase::exists(Keylet const& k) const
 }
 
 auto
-ApplyViewBase::succ(key_type const& key, boost::optional<key_type> const& last)
-    const -> boost::optional<key_type>
+ApplyViewBase::succ(key_type const& key, std::optional<key_type> const& last)
+    const -> std::optional<key_type>
 {
     return items_.succ(*base_, key, last);
 }

--- a/src/ripple/ledger/impl/BookDirs.cpp
+++ b/src/ripple/ledger/impl/BookDirs.cpp
@@ -112,7 +112,7 @@ BookDirs::const_iterator::operator++()
         }
     }
 
-    cache_ = boost::none;
+    cache_ = std::nullopt;
     return *this;
 }
 

--- a/src/ripple/ledger/impl/CashDiff.cpp
+++ b/src/ripple/ledger/impl/CashDiff.cpp
@@ -23,6 +23,7 @@
 #include <boost/container/static_vector.hpp>
 #include <cassert>
 #include <cstdlib>  // std::abs()
+#include <optional>
 
 namespace ripple {
 namespace detail {
@@ -299,7 +300,7 @@ private:
     std::size_t commonKeys_ = 0;  // Number of keys common to both rhs and lhs.
     std::size_t lhsKeys_ = 0;     // Number of keys in lhs but not rhs.
     std::size_t rhsKeys_ = 0;     // Number of keys in rhs but not lhs.
-    boost::optional<DropsGone> dropsGone_;
+    std::optional<DropsGone> dropsGone_;
     detail::CashSummary lhsDiffs_;
     detail::CashSummary rhsDiffs_;
 
@@ -337,7 +338,7 @@ public:
     bool
     hasDiff() const
     {
-        return dropsGone_ != boost::none || lhsDiffs_.hasDiff() ||
+        return dropsGone_ != std::nullopt || lhsDiffs_.hasDiff() ||
             rhsDiffs_.hasDiff();
     }
 

--- a/src/ripple/ledger/impl/Directory.cpp
+++ b/src/ripple/ledger/impl/Directory.cpp
@@ -108,7 +108,7 @@ const_iterator::operator++()
         }
     }
 
-    cache_ = boost::none;
+    cache_ = std::nullopt;
     return *this;
 }
 

--- a/src/ripple/ledger/impl/OpenView.cpp
+++ b/src/ripple/ledger/impl/OpenView.cpp
@@ -161,8 +161,8 @@ OpenView::exists(Keylet const& k) const
 }
 
 auto
-OpenView::succ(key_type const& key, boost::optional<key_type> const& last) const
-    -> boost::optional<key_type>
+OpenView::succ(key_type const& key, std::optional<key_type> const& last) const
+    -> std::optional<key_type>
 {
     return items_.succ(*base_, key, last);
 }

--- a/src/ripple/ledger/impl/PaymentSandbox.cpp
+++ b/src/ripple/ledger/impl/PaymentSandbox.cpp
@@ -23,7 +23,6 @@
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/STAccount.h>
-#include <boost/optional.hpp>
 
 #include <cassert>
 
@@ -100,13 +99,13 @@ DeferredCredits::ownerCount(
     }
 }
 
-boost::optional<std::uint32_t>
+std::optional<std::uint32_t>
 DeferredCredits::ownerCount(AccountID const& id) const
 {
     auto i = ownerCounts_.find(id);
     if (i != ownerCounts_.end())
         return i->second;
-    return boost::none;
+    return std::nullopt;
 }
 
 // Get the adjustments for the balance between main and other.
@@ -114,9 +113,9 @@ auto
 DeferredCredits::adjustments(
     AccountID const& main,
     AccountID const& other,
-    Currency const& currency) const -> boost::optional<Adjustment>
+    Currency const& currency) const -> std::optional<Adjustment>
 {
-    boost::optional<Adjustment> result;
+    std::optional<Adjustment> result;
 
     Key const k = makeKey(main, other, currency);
     auto i = credits_.find(k);

--- a/src/ripple/ledger/impl/RawStateTable.cpp
+++ b/src/ripple/ledger/impl/RawStateTable.cpp
@@ -199,9 +199,9 @@ auto
 RawStateTable::succ(
     ReadView const& base,
     key_type const& key,
-    boost::optional<key_type> const& last) const -> boost::optional<key_type>
+    std::optional<key_type> const& last) const -> std::optional<key_type>
 {
-    boost::optional<key_type> next = key;
+    std::optional<key_type> next = key;
     items_t::const_iterator iter;
     // Find base successor that is
     // not also deleted in our list
@@ -226,7 +226,7 @@ RawStateTable::succ(
     // Nothing in our list, return
     // what we got from the parent.
     if (last && next >= last)
-        return boost::none;
+        return std::nullopt;
     return next;
 }
 

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -18,7 +18,6 @@
 //==============================================================================
 
 #include <ripple/ledger/ReadView.h>
-#include <boost/optional.hpp>
 
 namespace ripple {
 
@@ -26,7 +25,7 @@ class Rules::Impl
 {
 private:
     std::unordered_set<uint256, hardened_hash<>> set_;
-    boost::optional<uint256> digest_;
+    std::optional<uint256> digest_;
     std::unordered_set<uint256, beast::uhash<>> const& presets_;
 
 public:

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -30,6 +30,7 @@
 #include <ripple/protocol/st.h>
 #include <boost/algorithm/string.hpp>
 #include <cassert>
+#include <optional>
 
 namespace ripple {
 
@@ -173,14 +174,14 @@ accountFunds(
 // Prevent ownerCount from wrapping under error conditions.
 //
 // adjustment allows the ownerCount to be adjusted up or down in multiple steps.
-// If id != boost.none, then do error reporting.
+// If id != std::nullopt, then do error reporting.
 //
 // Returns adjusted owner count.
 static std::uint32_t
 confineOwnerCount(
     std::uint32_t current,
     std::int32_t adjustment,
-    boost::optional<AccountID> const& id = boost::none,
+    std::optional<AccountID> const& id = std::nullopt,
     beast::Journal j = beast::Journal{beast::Journal::getNullSink()})
 {
     std::uint32_t adjusted{current + adjustment};
@@ -572,7 +573,7 @@ getMajorityAmendments(ReadView const& view)
     return ret;
 }
 
-boost::optional<uint256>
+std::optional<uint256>
 hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal)
 {
     // Easy cases...
@@ -580,7 +581,7 @@ hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal)
     {
         JLOG(journal.warn())
             << "Can't get seq " << seq << " from " << ledger.seq() << " future";
-        return boost::none;
+        return std::nullopt;
     }
     if (seq == ledger.seq())
         return ledger.info().hash;
@@ -615,7 +616,7 @@ hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal)
     {
         JLOG(journal.debug())
             << "Can't get seq " << seq << " from " << ledger.seq() << " past";
-        return boost::none;
+        return std::nullopt;
     }
 
     // in skiplist
@@ -632,7 +633,7 @@ hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal)
     }
     JLOG(journal.warn()) << "Can't get seq " << seq << " from " << ledger.seq()
                          << " error";
-    return boost::none;
+    return std::nullopt;
 }
 
 //------------------------------------------------------------------------------
@@ -720,7 +721,7 @@ describeOwnerDir(AccountID const& account)
     };
 }
 
-boost::optional<std::uint64_t>
+std::optional<std::uint64_t>
 dirAdd(
     ApplyView& view,
     Keylet const& dir,

--- a/src/ripple/net/DatabaseBody.h
+++ b/src/ripple/net/DatabaseBody.h
@@ -145,6 +145,9 @@ public:
     // the payload size (`content_length`) which we can
     // optionally use for optimization.
     //
+    // Note: boost::Beast calls init() and requires a
+    // boost::optional (not a std::optional) as the
+    // parameter.
     void
     init(boost::optional<std::uint64_t> const&, boost::system::error_code& ec);
 

--- a/src/ripple/net/HTTPStream.h
+++ b/src/ripple/net/HTTPStream.h
@@ -28,6 +28,8 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 
+#include <optional>
+
 namespace ripple {
 
 class HTTPStream
@@ -111,7 +113,7 @@ public:
 
 private:
     HTTPClientSSLContext ssl_ctx_;
-    boost::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>
+    std::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>
         stream_;
     boost::asio::io_service::strand& strand_;
 };
@@ -154,7 +156,7 @@ public:
         boost::system::error_code& ec) override;
 
 private:
-    boost::optional<boost::asio::ip::tcp::socket> stream_;
+    std::optional<boost::asio::ip::tcp::socket> stream_;
     boost::asio::io_service::strand& strand_;
 };
 

--- a/src/ripple/net/impl/DatabaseBody.ipp
+++ b/src/ripple/net/impl/DatabaseBody.ipp
@@ -60,6 +60,7 @@ DatabaseBody::value_type::open(
 
     auto db = conn_->checkoutDb();
 
+    // SOCI requires boost::optional (not std::optional) as the parameter.
     boost::optional<std::string> pathFromDb;
 
     *db << "SELECT Path FROM Download WHERE Part=0;", soci::into(pathFromDb);
@@ -78,6 +79,7 @@ DatabaseBody::value_type::open(
         // Continuing a file download.
         else
         {
+            // SOCI requires boost::optional (not std::optional) parameter.
             boost::optional<std::uint64_t> size;
 
             *db << "SELECT SUM(LENGTH(Data)) FROM Download;", soci::into(size);

--- a/src/ripple/net/impl/HTTPClient.cpp
+++ b/src/ripple/net/impl/HTTPClient.cpp
@@ -27,12 +27,12 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/optional.hpp>
 #include <boost/regex.hpp>
+#include <optional>
 
 namespace ripple {
 
-boost::optional<HTTPClientSSLContext> httpClientSSLContext;
+static std::optional<HTTPClientSSLContext> httpClientSSLContext;
 
 void
 HTTPClient::initializeSSLContext(Config const& config, beast::Journal j)

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -42,7 +42,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/streambuf.hpp>
 #include <boost/beast/core/string.hpp>
-#include <boost/optional.hpp>
 #include <boost/regex.hpp>
 
 #include <array>

--- a/src/ripple/nodestore/DatabaseShard.h
+++ b/src/ripple/nodestore/DatabaseShard.h
@@ -25,9 +25,8 @@
 #include <ripple/nodestore/Database.h>
 #include <ripple/nodestore/Types.h>
 
-#include <boost/optional.hpp>
-
 #include <memory>
+#include <optional>
 
 namespace ripple {
 namespace NodeStore {
@@ -68,14 +67,15 @@ public:
 
         @param validLedgerSeq The sequence of the maximum valid ledgers
         @return If a ledger should be fetched and stored, then returns the
-        ledger sequence of the ledger to request. Otherwise returns boost::none.
-                Some reasons this may return boost::none are: all shards are
+        ledger sequence of the ledger to request. Otherwise returns
+        std::nullopt.
+                Some reasons this may return std::nullopt are: all shards are
                 stored and full, max allowed disk space would be exceeded, or a
                 ledger was recently requested and not enough time has passed
                 between requests.
         @implNote adds a new writable shard if necessary
     */
-    virtual boost::optional<std::uint32_t>
+    virtual std::optional<std::uint32_t>
     prepareLedger(std::uint32_t validLedgerSeq) = 0;
 
     /** Prepare one or more shard indexes to be imported into the database

--- a/src/ripple/nodestore/README.md
+++ b/src/ripple/nodestore/README.md
@@ -48,7 +48,7 @@ contains. The fields are as follows:
 |0...7  |unused               |                          |
 |8      |type                 |NodeObjectType enumeration|
 |9...end|data                 |body of the object data   |
----    
+---
 The `NodeStore` provides an interface that stores, in a persistent database, a
 collection of NodeObjects that rippled uses as its primary representation of
 ledger entries. All ledger entries are stored as NodeObjects and as such, need
@@ -200,7 +200,7 @@ skip list by calling `LedgerMaster::walkHashBySeq` and providing the sequence of
 a shard's last ledger:
 
 ```C++
-boost::optional<uint256> expectedHash;
+std::optional<uint256> expectedHash;
 expectedHash =
     app_.getLedgerMaster().walkHashBySeq(lastLedgerSeq(shardIndex));
 ```

--- a/src/ripple/nodestore/impl/DatabaseShardImp.h
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.h
@@ -51,7 +51,7 @@ public:
     [[nodiscard]] bool
     init() override;
 
-    [[nodiscard]] boost::optional<std::uint32_t>
+    [[nodiscard]] std::optional<std::uint32_t>
     prepareLedger(std::uint32_t validLedgerSeq) override;
 
     bool
@@ -230,10 +230,10 @@ private:
     // values are not updated in real time and are modified only
     // when adding shards to the database, in order to determine where
     // pending shards will be stored on the filesystem. A value of
-    // boost::none indicates that the corresponding shard is not held
+    // std::nullopt indicates that the corresponding shard is not held
     // by the database.
-    boost::optional<std::uint32_t> latestShardIndex_;
-    boost::optional<std::uint32_t> secondLatestShardIndex_;
+    std::optional<std::uint32_t> latestShardIndex_;
+    std::optional<std::uint32_t> secondLatestShardIndex_;
 
     // Initialize settings from the configuration file
     // Lock must be held
@@ -254,7 +254,7 @@ private:
 
     // Randomly select a shard index not stored
     // Lock must be held
-    boost::optional<std::uint32_t>
+    std::optional<std::uint32_t>
     findAcquireIndex(
         std::uint32_t validLedgerSeq,
         std::lock_guard<std::mutex> const&);
@@ -265,7 +265,7 @@ private:
     finalizeShard(
         std::shared_ptr<Shard>& shard,
         bool writeSQLite,
-        boost::optional<uint256> const& expectedHash);
+        std::optional<uint256> const& expectedHash);
 
     // Set storage and file descriptor usage stats
     void
@@ -312,11 +312,11 @@ private:
 
     // Checks whether the shard can be stored. If
     // the new shard can't be stored, returns
-    // boost::none. Otherwise returns an enum
+    // std::nullopt. Otherwise returns an enum
     // indicating whether the new shard should be
     // placed in a separate directory for historical
     // shards.
-    boost::optional<PathDesignation>
+    std::optional<PathDesignation>
     prepareForNewShard(
         std::uint32_t shardIndex,
         std::uint32_t numHistoricalShards,

--- a/src/ripple/nodestore/impl/Shard.cpp
+++ b/src/ripple/nodestore/impl/Shard.cpp
@@ -117,7 +117,8 @@ Shard::init(Scheduler& scheduler, nudb::context& context)
     backend_ = factory->createInstance(
         NodeObject::keyBytes,
         section,
-        megabytes(app_.config().getValueFor(SizedItem::burstSize, boost::none)),
+        megabytes(
+            app_.config().getValueFor(SizedItem::burstSize, std::nullopt)),
         scheduler,
         context,
         j_);
@@ -182,14 +183,14 @@ Shard::tryClose()
     return true;
 }
 
-boost::optional<std::uint32_t>
+std::optional<std::uint32_t>
 Shard::prepare()
 {
     if (state_ != acquire)
     {
         JLOG(j_.warn()) << "shard " << index_
                         << " prepare called when not acquiring";
-        return boost::none;
+        return std::nullopt;
     }
 
     std::lock_guard lock(mutex_);
@@ -197,7 +198,7 @@ Shard::prepare()
     {
         JLOG(j_.error()) << "shard " << index_
                          << " missing acquire SQLite database";
-        return boost::none;
+        return std::nullopt;
     }
 
     if (acquireInfo_->storedSeqs.empty())
@@ -560,7 +561,7 @@ Shard::isLegacy() const
 bool
 Shard::finalize(
     bool const writeSQLite,
-    boost::optional<uint256> const& expectedHash)
+    std::optional<uint256> const& expectedHash)
 {
     uint256 hash{0};
     std::uint32_t ledgerSeq{0};
@@ -617,6 +618,8 @@ Shard::finalize(
             if (!acquireInfo_)
                 return fail("missing acquire SQLite database");
 
+            // index and sHash must be boost::optional (not std) because that's
+            // what SOCI expects in its interface.
             auto session{acquireInfo_->SQLiteDB->checkoutDb()};
             boost::optional<std::uint32_t> index;
             boost::optional<std::string> sHash;
@@ -864,6 +867,8 @@ Shard::open(std::lock_guard<std::mutex> const& lock)
             // A shard being acquired, backend is likely incomplete
             createAcquireInfo();
 
+            // index and must be boost::optional (not std) because that's
+            // what SOCI expects in its interface.
             auto& session{acquireInfo_->SQLiteDB->getSession()};
             boost::optional<std::uint32_t> index;
             soci::blob sociBlob(session);
@@ -970,14 +975,14 @@ Shard::initSQLite(std::lock_guard<std::mutex> const&)
             lgrSQLiteDB_->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(
-                    config.getValueFor(SizedItem::lgrDBCache, boost::none)));
+                    config.getValueFor(SizedItem::lgrDBCache, std::nullopt)));
 
             txSQLiteDB_ = std::make_unique<DatabaseCon>(
                 setup, TxDBName, FinalShardDBPragma, TxDBInit);
             txSQLiteDB_->getSession() << boost::str(
                 boost::format("PRAGMA cache_size=-%d;") %
                 kilobytes(
-                    config.getValueFor(SizedItem::txnDBCache, boost::none)));
+                    config.getValueFor(SizedItem::txnDBCache, std::nullopt)));
         }
         else
         {

--- a/src/ripple/nodestore/impl/Shard.h
+++ b/src/ripple/nodestore/impl/Shard.h
@@ -105,7 +105,7 @@ public:
         stop_ = true;
     }
 
-    [[nodiscard]] boost::optional<std::uint32_t>
+    [[nodiscard]] std::optional<std::uint32_t>
     prepare();
 
     [[nodiscard]] bool
@@ -186,7 +186,7 @@ public:
     [[nodiscard]] bool
     finalize(
         bool const writeSQLite,
-        boost::optional<uint256> const& referenceHash);
+        std::optional<uint256> const& referenceHash);
 
     /** Enables removal of the shard directory on destruction.
      */

--- a/src/ripple/overlay/Cluster.h
+++ b/src/ripple/overlay/Cluster.h
@@ -71,11 +71,11 @@ public:
     Cluster(beast::Journal j);
 
     /** Determines whether a node belongs in the cluster
-        @return boost::none if the node isn't a member,
+        @return std::nullopt if the node isn't a member,
                 otherwise, the comment associated with the
                 node (which may be an empty string).
     */
-    boost::optional<std::string>
+    std::optional<std::string>
     member(PublicKey const& node) const;
 
     /** The number of nodes in the cluster list. */

--- a/src/ripple/overlay/Message.h
+++ b/src/ripple/overlay/Message.h
@@ -65,7 +65,7 @@ public:
     Message(
         ::google::protobuf::Message const& message,
         int type,
-        boost::optional<PublicKey> const& validator = {});
+        std::optional<PublicKey> const& validator = {});
 
     /** Retrieve the size of the packed but uncompressed message data. */
     std::size_t
@@ -94,7 +94,7 @@ public:
     }
 
     /** Get the validator's key */
-    boost::optional<PublicKey> const&
+    std::optional<PublicKey> const&
     getValidatorKey() const
     {
         return validatorKey_;
@@ -105,7 +105,7 @@ private:
     std::vector<uint8_t> bufferCompressed_;
     std::size_t category_;
     std::once_flag once_flag_;
-    boost::optional<PublicKey> validatorKey_;
+    std::optional<PublicKey> validatorKey_;
 
     /** Set the payload header
      * @param in Pointer to the payload

--- a/src/ripple/overlay/Overlay.h
+++ b/src/ripple/overlay/Overlay.h
@@ -33,9 +33,9 @@
 #include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
-#include <boost/optional.hpp>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 namespace boost {
@@ -215,7 +215,7 @@ public:
         @return The numerical identifier configured by the administrator of the
                 server. An unseated optional, otherwise.
     */
-    virtual boost::optional<std::uint32_t>
+    virtual std::optional<std::uint32_t>
     networkID() const = 0;
 };
 

--- a/src/ripple/overlay/Peer.h
+++ b/src/ripple/overlay/Peer.h
@@ -96,7 +96,7 @@ public:
     virtual bool
     supportsFeature(ProtocolFeature f) const = 0;
 
-    virtual boost::optional<std::size_t>
+    virtual std::optional<std::size_t>
     publisherListSequence(PublicKey const&) const = 0;
 
     virtual void

--- a/src/ripple/overlay/PeerReservationTable.h
+++ b/src/ripple/overlay/PeerReservationTable.h
@@ -27,10 +27,10 @@
 #include <ripple/protocol/PublicKey.h>
 
 #define SOCI_USE_BOOST
-#include <boost/optional.hpp>
 #include <soci/soci.h>
 
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -104,15 +104,14 @@ public:
      * @return the replaced reservation if it existed
      * @throw soci::soci_error
      */
-    auto
-    insert_or_assign(PeerReservation const& reservation)
-        -> boost::optional<PeerReservation>;
+    std::optional<PeerReservation>
+    insert_or_assign(PeerReservation const& reservation);
 
     /**
      * @return the erased reservation if it existed
      */
-    auto
-    erase(PublicKey const& nodeId) -> boost::optional<PeerReservation>;
+    std::optional<PeerReservation>
+    erase(PublicKey const& nodeId);
 
 private:
     beast::Journal mutable journal_;

--- a/src/ripple/overlay/impl/Cluster.cpp
+++ b/src/ripple/overlay/impl/Cluster.cpp
@@ -35,14 +35,14 @@ Cluster::Cluster(beast::Journal j) : j_(j)
 {
 }
 
-boost::optional<std::string>
+std::optional<std::string>
 Cluster::member(PublicKey const& identity) const
 {
     std::lock_guard lock(mutex_);
 
     auto iter = nodes_.find(identity);
     if (iter == nodes_.end())
-        return boost::none;
+        return std::nullopt;
     return iter->name();
 }
 

--- a/src/ripple/overlay/impl/ConnectAttempt.cpp
+++ b/src/ripple/overlay/impl/ConnectAttempt.cpp
@@ -333,7 +333,7 @@ ConnectAttempt::processResponse()
 
     // Just because our peer selected a particular protocol version doesn't
     // mean that it's acceptable to us. Check that it is:
-    boost::optional<ProtocolVersion> negotiatedProtocol;
+    std::optional<ProtocolVersion> negotiatedProtocol;
 
     {
         auto const pvs = parseProtocolVersions(response_["Upgrade"]);

--- a/src/ripple/overlay/impl/Message.cpp
+++ b/src/ripple/overlay/impl/Message.cpp
@@ -26,7 +26,7 @@ namespace ripple {
 Message::Message(
     ::google::protobuf::Message const& message,
     int type,
-    boost::optional<PublicKey> const& validator)
+    std::optional<PublicKey> const& validator)
     : category_(TrafficCount::categorize(message, type, false))
     , validatorKey_(validator)
 {

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -123,7 +123,7 @@ OverlayImpl::OverlayImpl(
     : Overlay(parent)
     , app_(app)
     , io_service_(io_service)
-    , work_(boost::in_place(std::ref(io_service_)))
+    , work_(std::in_place, std::ref(io_service_))
     , strand_(io_service_)
     , setup_(setup)
     , journal_(app_.journal("Overlay"))
@@ -1325,7 +1325,7 @@ OverlayImpl::stop()
         std::lock_guard lock(mutex_);
         if (!work_)
             return;
-        work_ = boost::none;
+        work_ = std::nullopt;
 
         children.reserve(list_.size());
         for (auto const& element : list_)

--- a/src/ripple/overlay/impl/OverlayImpl.h
+++ b/src/ripple/overlay/impl/OverlayImpl.h
@@ -39,7 +39,6 @@
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/container/flat_map.hpp>
-#include <boost/optional.hpp>
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -47,6 +46,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 
 namespace ripple {
@@ -96,7 +96,7 @@ private:
 
     Application& app_;
     boost::asio::io_service& io_service_;
-    boost::optional<boost::asio::io_service::work> work_;
+    std::optional<boost::asio::io_service::work> work_;
     boost::asio::io_service::strand strand_;
     mutable std::recursive_mutex mutex_;  // VFALCO use std::mutex
     std::condition_variable_any cond_;
@@ -124,7 +124,7 @@ private:
     // Peer IDs expecting to receive a last link notification
     std::set<std::uint32_t> csIDs_;
 
-    boost::optional<std::uint32_t> networkID_;
+    std::optional<std::uint32_t> networkID_;
 
     reduce_relay::Slots<UptimeClock> slots_;
 
@@ -365,7 +365,7 @@ public:
         return peerDisconnectsCharges_;
     }
 
-    boost::optional<std::uint32_t>
+    std::optional<std::uint32_t>
     networkID() const override
     {
         return networkID_;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -154,18 +154,18 @@ PeerImp::run()
         return post(strand_, std::bind(&PeerImp::run, shared_from_this()));
 
     auto parseLedgerHash =
-        [](std::string const& value) -> boost::optional<uint256> {
+        [](std::string const& value) -> std::optional<uint256> {
         if (uint256 ret; ret.parseHex(value))
             return ret;
 
         if (auto const s = base64_decode(value); s.size() == uint256::size())
             return uint256{s};
 
-        return boost::none;
+        return std::nullopt;
     };
 
-    boost::optional<uint256> closed;
-    boost::optional<uint256> previous;
+    std::optional<uint256> closed;
+    std::optional<uint256> previous;
 
     if (auto const iter = headers_.find("Closed-Ledger");
         iter != headers_.end())
@@ -575,23 +575,23 @@ PeerImp::fail(std::string const& name, error_code ec)
     close();
 }
 
-boost::optional<RangeSet<std::uint32_t>>
+std::optional<RangeSet<std::uint32_t>>
 PeerImp::getShardIndexes() const
 {
     std::lock_guard l{shardInfoMutex_};
     auto it{shardInfo_.find(publicKey_)};
     if (it != shardInfo_.end())
         return it->second.shardIndexes;
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<hash_map<PublicKey, PeerImp::ShardInfo>>
+std::optional<hash_map<PublicKey, PeerImp::ShardInfo>>
 PeerImp::getPeerShardInfo() const
 {
     std::lock_guard l{shardInfoMutex_};
     if (!shardInfo_.empty())
         return shardInfo_;
-    return boost::none;
+    return std::nullopt;
 }
 
 void
@@ -1262,7 +1262,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMPeerShardInfo> const& m)
             return badData("Invalid shard indexes");
 
         std::uint32_t earliestShard;
-        boost::optional<std::uint32_t> latestShard;
+        std::optional<std::uint32_t> latestShard;
         {
             auto const curLedgerSeq{
                 app_.getLedgerMaster().getCurrentLedgerIndex()};
@@ -3127,7 +3127,7 @@ PeerImp::getScore(bool haveItem) const
     if (haveItem)
         score += spHaveItem;
 
-    boost::optional<std::chrono::milliseconds> latency;
+    std::optional<std::chrono::milliseconds> latency;
     {
         std::lock_guard sl(recentLock_);
         latency = latency_;

--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -37,9 +37,9 @@
 
 #include <boost/circular_buffer.hpp>
 #include <boost/endian/conversion.hpp>
-#include <boost/optional.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <cstdint>
+#include <optional>
 #include <queue>
 
 namespace ripple {
@@ -114,8 +114,8 @@ private:
     boost::circular_buffer<uint256> recentLedgers_{128};
     boost::circular_buffer<uint256> recentTxSets_{128};
 
-    boost::optional<std::chrono::milliseconds> latency_;
-    boost::optional<std::uint32_t> lastPingSeq_;
+    std::optional<std::chrono::milliseconds> latency_;
+    std::optional<std::uint32_t> lastPingSeq_;
     clock_type::time_point lastPingTime_;
     clock_type::time_point const creationTime_;
 
@@ -339,7 +339,7 @@ public:
     bool
     supportsFeature(ProtocolFeature f) const override;
 
-    boost::optional<std::size_t>
+    std::optional<std::size_t>
     publisherListSequence(PublicKey const& pubKey) const override
     {
         std::lock_guard<std::mutex> sl(recentLock_);
@@ -398,11 +398,11 @@ public:
     fail(std::string const& reason);
 
     /** Return a range set of known shard indexes from this peer. */
-    boost::optional<RangeSet<std::uint32_t>>
+    std::optional<RangeSet<std::uint32_t>>
     getShardIndexes() const;
 
     /** Return any known shard info from this peer and its sub peers. */
-    boost::optional<hash_map<PublicKey, ShardInfo>>
+    std::optional<hash_map<PublicKey, ShardInfo>>
     getPeerShardInfo() const;
 
     bool

--- a/src/ripple/overlay/impl/PeerReservationTable.cpp
+++ b/src/ripple/overlay/impl/PeerReservationTable.cpp
@@ -74,6 +74,8 @@ PeerReservationTable::load(DatabaseCon& connection)
     connection_ = &connection;
     auto db = connection_->checkoutDb();
 
+    // These values must be boost::optionals (not std) because SOCI expects
+    // boost::optionals.
     boost::optional<std::string> valPubKey, valDesc;
     // We should really abstract the table and column names into constants,
     // but no one else does. Because it is too tedious? It would be easy if we
@@ -104,11 +106,10 @@ PeerReservationTable::load(DatabaseCon& connection)
     return true;
 }
 
-auto
+std::optional<PeerReservation>
 PeerReservationTable::insert_or_assign(PeerReservation const& reservation)
-    -> boost::optional<PeerReservation>
 {
-    boost::optional<PeerReservation> previous;
+    std::optional<PeerReservation> previous;
 
     std::lock_guard lock(mutex_);
 
@@ -144,11 +145,10 @@ PeerReservationTable::insert_or_assign(PeerReservation const& reservation)
     return previous;
 }
 
-auto
+std::optional<PeerReservation>
 PeerReservationTable::erase(PublicKey const& nodeId)
-    -> boost::optional<PeerReservation>
 {
-    boost::optional<PeerReservation> previous;
+    std::optional<PeerReservation> previous;
 
     std::lock_guard lock(mutex_);
 

--- a/src/ripple/overlay/impl/ProtocolVersion.cpp
+++ b/src/ripple/overlay/impl/ProtocolVersion.cpp
@@ -134,10 +134,10 @@ parseProtocolVersions(boost::beast::string_view const& value)
     return result;
 }
 
-boost::optional<ProtocolVersion>
+std::optional<ProtocolVersion>
 negotiateProtocolVersion(std::vector<ProtocolVersion> const& versions)
 {
-    boost::optional<ProtocolVersion> result;
+    std::optional<ProtocolVersion> result;
 
     // The protocol version we want to negotiate is the largest item in the
     // intersection of the versions supported by us and the peer. Since the
@@ -157,7 +157,7 @@ negotiateProtocolVersion(std::vector<ProtocolVersion> const& versions)
     return result;
 }
 
-boost::optional<ProtocolVersion>
+std::optional<ProtocolVersion>
 negotiateProtocolVersion(boost::beast::string_view const& versions)
 {
     auto const them = parseProtocolVersions(versions);

--- a/src/ripple/overlay/impl/ProtocolVersion.h
+++ b/src/ripple/overlay/impl/ProtocolVersion.h
@@ -21,8 +21,8 @@
 #define RIPPLE_OVERLAY_PROTOCOLVERSION_H_INCLUDED
 
 #include <boost/beast/core/string.hpp>
-#include <boost/optional.hpp>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -62,11 +62,11 @@ std::vector<ProtocolVersion>
 parseProtocolVersions(boost::beast::string_view const& s);
 
 /** Given a list of supported protocol versions, choose the one we prefer. */
-boost::optional<ProtocolVersion>
+std::optional<ProtocolVersion>
 negotiateProtocolVersion(std::vector<ProtocolVersion> const& versions);
 
 /** Given a list of supported protocol versions, choose the one we prefer. */
-boost::optional<ProtocolVersion>
+std::optional<ProtocolVersion>
 negotiateProtocolVersion(boost::beast::string_view const& versions);
 
 /** The list of all the protocol versions we support. */

--- a/src/ripple/peerfinder/Slot.h
+++ b/src/ripple/peerfinder/Slot.h
@@ -22,8 +22,8 @@
 
 #include <ripple/beast/net/IPEndpoint.h>
 #include <ripple/protocol/PublicKey.h>
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace ripple {
 namespace PeerFinder {
@@ -65,16 +65,16 @@ public:
     remote_endpoint() const = 0;
 
     /** The local endpoint of the socket, when known. */
-    virtual boost::optional<beast::IP::Endpoint> const&
+    virtual std::optional<beast::IP::Endpoint> const&
     local_endpoint() const = 0;
 
-    virtual boost::optional<std::uint16_t>
+    virtual std::optional<std::uint16_t>
     listening_port() const = 0;
 
     /** The peer's public key, when known.
         The public key is established when the handshake is complete.
     */
-    virtual boost::optional<PublicKey> const&
+    virtual std::optional<PublicKey> const&
     public_key() const = 0;
 };
 

--- a/src/ripple/peerfinder/impl/Logic.h
+++ b/src/ripple/peerfinder/impl/Logic.h
@@ -852,7 +852,7 @@ public:
             slots_.erase(iter);
         }
         // Remove the key if present
-        if (slot->public_key() != boost::none)
+        if (slot->public_key() != std::nullopt)
         {
             auto const iter = keys_.find(*slot->public_key());
             // Key must exist
@@ -1109,7 +1109,7 @@ public:
         {
             beast::PropertyStream::Map item(set);
             SlotImp const& slot(*entry.second);
-            if (slot.local_endpoint() != boost::none)
+            if (slot.local_endpoint() != std::nullopt)
                 item["local_address"] = to_string(*slot.local_endpoint());
             item["remote_address"] = to_string(slot.remote_endpoint());
             if (slot.inbound())

--- a/src/ripple/peerfinder/impl/PeerfinderManager.cpp
+++ b/src/ripple/peerfinder/impl/PeerfinderManager.cpp
@@ -24,9 +24,9 @@
 #include <ripple/peerfinder/impl/SourceStrings.h>
 #include <ripple/peerfinder/impl/StoreSqdb.h>
 #include <boost/asio/io_service.hpp>
-#include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 #include <memory>
+#include <optional>
 #include <thread>
 
 namespace ripple {
@@ -36,7 +36,7 @@ class ManagerImp : public Manager
 {
 public:
     boost::asio::io_service& io_service_;
-    boost::optional<boost::asio::io_service::work> work_;
+    std::optional<boost::asio::io_service::work> work_;
     clock_type& m_clock;
     beast::Journal m_journal;
     StoreSqdb m_store;
@@ -55,7 +55,7 @@ public:
         beast::insight::Collector::ptr const& collector)
         : Manager(stoppable)
         , io_service_(io_service)
-        , work_(boost::in_place(std::ref(io_service_)))
+        , work_(std::in_place, std::ref(io_service_))
         , m_clock(clock)
         , m_journal(journal)
         , m_store(journal)
@@ -76,7 +76,7 @@ public:
     {
         if (work_)
         {
-            work_ = boost::none;
+            work_.reset();
             checker_.stop();
             m_logic.stop();
         }

--- a/src/ripple/peerfinder/impl/SlotImp.h
+++ b/src/ripple/peerfinder/impl/SlotImp.h
@@ -24,8 +24,8 @@
 #include <ripple/beast/container/aged_unordered_map.h>
 #include <ripple/peerfinder/PeerfinderManager.h>
 #include <ripple/peerfinder/Slot.h>
-#include <boost/optional.hpp>
 #include <atomic>
+#include <optional>
 
 namespace ripple {
 namespace PeerFinder {
@@ -81,24 +81,24 @@ public:
         return m_remote_endpoint;
     }
 
-    boost::optional<beast::IP::Endpoint> const&
+    std::optional<beast::IP::Endpoint> const&
     local_endpoint() const override
     {
         return m_local_endpoint;
     }
 
-    boost::optional<PublicKey> const&
+    std::optional<PublicKey> const&
     public_key() const override
     {
         return m_public_key;
     }
 
-    boost::optional<std::uint16_t>
+    std::optional<std::uint16_t>
     listening_port() const override
     {
         std::uint32_t const value = m_listening_port;
         if (value == unknownPort)
-            return boost::none;
+            return std::nullopt;
         return value;
     }
 
@@ -181,8 +181,8 @@ private:
     bool m_reserved;
     State m_state;
     beast::IP::Endpoint m_remote_endpoint;
-    boost::optional<beast::IP::Endpoint> m_local_endpoint;
-    boost::optional<PublicKey> m_public_key;
+    std::optional<beast::IP::Endpoint> m_local_endpoint;
+    std::optional<PublicKey> m_public_key;
 
     static std::int32_t constexpr unknownPort = -1;
     std::atomic<std::int32_t> m_listening_port;

--- a/src/ripple/peerfinder/impl/StoreSqdb.h
+++ b/src/ripple/peerfinder/impl/StoreSqdb.h
@@ -140,6 +140,7 @@ public:
         // get version
         int version(0);
         {
+            // SOCI requires a boost::optional (not std::optional) parameter.
             boost::optional<int> vO;
             m_session << "SELECT "
                          "  version "

--- a/src/ripple/protocol/AccountID.h
+++ b/src/ripple/protocol/AccountID.h
@@ -26,9 +26,9 @@
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/basics/base_uint.h>
 #include <ripple/json/json_value.h>
-#include <boost/optional.hpp>
 #include <cstddef>
 #include <mutex>
+#include <optional>
 #include <string>
 
 namespace ripple {
@@ -51,10 +51,10 @@ std::string
 toBase58(AccountID const& v);
 
 /** Parse AccountID from checked, base58 string.
-    @return boost::none if a parse error occurs
+    @return std::nullopt if a parse error occurs
 */
 template <>
-boost::optional<AccountID>
+std::optional<AccountID>
 parseBase58(std::string const& s);
 
 /** Compute AccountID from public key.

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -22,9 +22,9 @@
 
 #include <ripple/basics/base_uint.h>
 #include <boost/container/flat_map.hpp>
-#include <boost/optional.hpp>
 #include <array>
 #include <bitset>
+#include <optional>
 #include <string>
 
 /**
@@ -131,7 +131,7 @@ public:
         return sizeof(featureNames) / sizeof(featureNames[0]);
     }
 
-    boost::optional<uint256>
+    std::optional<uint256>
     getRegisteredFeature(std::string const& name) const;
 
     std::size_t
@@ -147,7 +147,7 @@ supportedAmendments();
 
 }  // namespace detail
 
-boost::optional<uint256>
+std::optional<uint256>
 getRegisteredFeature(std::string const& name);
 
 size_t

--- a/src/ripple/protocol/KeyType.h
+++ b/src/ripple/protocol/KeyType.h
@@ -20,7 +20,7 @@
 #ifndef RIPPLE_PROTOCOL_KEYTYPE_H_INCLUDED
 #define RIPPLE_PROTOCOL_KEYTYPE_H_INCLUDED
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace ripple {
@@ -30,7 +30,7 @@ enum class KeyType {
     ed25519 = 1,
 };
 
-inline boost::optional<KeyType>
+inline std::optional<KeyType>
 keyTypeFromString(std::string const& s)
 {
     if (s == "secp256k1")

--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -25,10 +25,10 @@
 #include <ripple/protocol/STExchange.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/tokens.h>
-#include <boost/optional.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 #include <ostream>
 #include <utility>
 
@@ -73,7 +73,7 @@ public:
     /** Create a public key.
 
         Preconditions:
-            publicKeyType(slice) != boost::none
+            publicKeyType(slice) != std::nullopt
     */
     explicit PublicKey(Slice const& slice);
 
@@ -168,7 +168,7 @@ struct STExchange<STBlob, PublicKey>
     using value_type = PublicKey;
 
     static void
-    get(boost::optional<value_type>& t, STBlob const& u)
+    get(std::optional<value_type>& t, STBlob const& u)
     {
         t.emplace(Slice(u.data(), u.size()));
     }
@@ -189,7 +189,7 @@ toBase58(TokenType type, PublicKey const& pk)
 }
 
 template <>
-boost::optional<PublicKey>
+std::optional<PublicKey>
 parseBase58(TokenType type, std::string const& s);
 
 enum class ECDSACanonicality { canonical, fullyCanonical };
@@ -209,29 +209,29 @@ enum class ECDSACanonicality { canonical, fullyCanonical };
 
     where G is the curve order.
 
-    This routine returns boost::none if the format
+    This routine returns std::nullopt if the format
     of the signature is invalid (for example, the
     points are encoded incorrectly).
 
-    @return boost::none if the signature fails
+    @return std::nullopt if the signature fails
             validity checks.
 
     @note Only the format of the signature is checked,
           no verification cryptography is performed.
 */
-boost::optional<ECDSACanonicality>
+std::optional<ECDSACanonicality>
 ecdsaCanonicality(Slice const& sig);
 
 /** Returns the type of public key.
 
-    @return boost::none If the public key does not
+    @return std::nullopt If the public key does not
             represent a known type.
 */
 /** @{ */
-boost::optional<KeyType>
+std::optional<KeyType>
 publicKeyType(Slice const& slice);
 
-inline boost::optional<KeyType>
+inline std::optional<KeyType>
 publicKeyType(PublicKey const& publicKey)
 {
     return publicKeyType(publicKey.slice());

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -292,7 +292,7 @@ struct TypedField : SField
     }
 };
 
-/** Indicate boost::optional field semantics. */
+/** Indicate std::optional field semantics. */
 template <class T>
 struct OptionaledField
 {

--- a/src/ripple/protocol/STExchange.h
+++ b/src/ripple/protocol/STExchange.h
@@ -28,8 +28,8 @@
 #include <ripple/protocol/STBlob.h>
 #include <ripple/protocol/STInteger.h>
 #include <ripple/protocol/STObject.h>
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -48,7 +48,7 @@ struct STExchange<STInteger<U>, T>
     using value_type = U;
 
     static void
-    get(boost::optional<T>& t, STInteger<U> const& u)
+    get(std::optional<T>& t, STInteger<U> const& u)
     {
         t = u.value();
     }
@@ -68,7 +68,7 @@ struct STExchange<STBlob, Slice>
     using value_type = Slice;
 
     static void
-    get(boost::optional<value_type>& t, STBlob const& u)
+    get(std::optional<value_type>& t, STBlob const& u)
     {
         t.emplace(u.data(), u.size());
     }
@@ -88,7 +88,7 @@ struct STExchange<STBlob, Buffer>
     using value_type = Buffer;
 
     static void
-    get(boost::optional<Buffer>& t, STBlob const& u)
+    get(std::optional<Buffer>& t, STBlob const& u)
     {
         t.emplace(u.data(), u.size());
     }
@@ -111,10 +111,10 @@ struct STExchange<STBlob, Buffer>
 /** Return the value of a field in an STObject as a given type. */
 /** @{ */
 template <class T, class U>
-boost::optional<T>
+std::optional<T>
 get(STObject const& st, TypedField<U> const& f)
 {
-    boost::optional<T> t;
+    std::optional<T> t;
     STBase const* const b = st.peekAtPField(f);
     if (!b)
         return t;
@@ -130,7 +130,7 @@ get(STObject const& st, TypedField<U> const& f)
 }
 
 template <class U>
-boost::optional<typename STExchange<U, typename U::value_type>::value_type>
+std::optional<typename STExchange<U, typename U::value_type>::value_type>
 get(STObject const& st, TypedField<U> const& f)
 {
     return get<typename U::value_type>(st, f);

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -32,8 +32,8 @@
 #include <ripple/protocol/STVector256.h>
 #include <ripple/protocol/impl/STVar.h>
 #include <boost/iterator/transform_iterator.hpp>
-#include <boost/optional.hpp>
 #include <cassert>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
@@ -104,7 +104,7 @@ private:
         using value_type = typename T::value_type;
 
         using optional_type =
-            boost::optional<typename std::decay<value_type>::type>;
+            std::optional<typename std::decay<value_type>::type>;
 
     public:
         OptionalProxy(OptionalProxy const&) = default;
@@ -129,20 +129,20 @@ private:
 
         operator optional_type() const;
 
-        /** Explicit conversion to boost::optional */
+        /** Explicit conversion to std::optional */
         optional_type
         operator~() const;
 
         friend bool
-        operator==(OptionalProxy const& lhs, boost::none_t) noexcept
+        operator==(OptionalProxy const& lhs, std::nullopt_t) noexcept
         {
             return !lhs.engaged();
         }
 
         friend bool
-        operator==(boost::none_t, OptionalProxy const& rhs) noexcept
+        operator==(std::nullopt_t, OptionalProxy const& rhs) noexcept
         {
-            return rhs == boost::none;
+            return rhs == std::nullopt;
         }
 
         friend bool
@@ -170,15 +170,15 @@ private:
         }
 
         friend bool
-        operator!=(OptionalProxy const& lhs, boost::none_t) noexcept
+        operator!=(OptionalProxy const& lhs, std::nullopt_t) noexcept
         {
-            return !(lhs == boost::none);
+            return !(lhs == std::nullopt);
         }
 
         friend bool
-        operator!=(boost::none_t, OptionalProxy const& rhs) noexcept
+        operator!=(std::nullopt_t, OptionalProxy const& rhs) noexcept
         {
-            return !(rhs == boost::none);
+            return !(rhs == std::nullopt);
         }
 
         friend bool
@@ -199,7 +199,7 @@ private:
             return !(lhs == rhs);
         }
 
-        // Emulate boost::optional::value_or
+        // Emulate std::optional::value_or
         value_type
         value_or(value_type val) const
         {
@@ -207,7 +207,7 @@ private:
         }
 
         OptionalProxy&
-        operator=(boost::none_t const&);
+        operator=(std::nullopt_t const&);
         OptionalProxy&
         operator=(optional_type&& v);
         OptionalProxy&
@@ -482,16 +482,16 @@ public:
     typename T::value_type
     operator[](TypedField<T> const& f) const;
 
-    /** Get the value of a field as boost::optional
+    /** Get the value of a field as a std::optional
 
         @param An OptionaledField built from an SField value representing the
            desired object field. In typical use, the OptionaledField will be
            constructed by using the ~ operator on an SField.
-        @return boost::none if the field is not present, else the value of the
-           specified field.
+        @return std::nullopt if the field is not present, else the value of
+           the specified field.
     */
     template <class T>
-    boost::optional<std::decay_t<typename T::value_type>>
+    std::optional<std::decay_t<typename T::value_type>>
     operator[](OptionaledField<T> const& of) const;
 
     /** Get a modifiable field value.
@@ -505,14 +505,14 @@ public:
     ValueProxy<T>
     operator[](TypedField<T> const& f);
 
-    /** Return a modifiable field value as boost::optional
+    /** Return a modifiable field value as std::optional
 
         @param An OptionaledField built from an SField value representing the
             desired object field. In typical use, the OptionaledField will be
             constructed by using the ~ operator on an SField.
         @return Transparent proxy object to an `optional` holding a modifiable
-            reference to the value of the specified field. Returns boost::none
-            if the field is not present.
+            reference to the value of the specified field. Returns
+            std::nullopt if the field is not present.
     */
     template <class T>
     OptionalProxy<T>
@@ -529,16 +529,16 @@ public:
     typename T::value_type
     at(TypedField<T> const& f) const;
 
-    /** Get the value of a field as boost::optional
+    /** Get the value of a field as std::optional
 
         @param An OptionaledField built from an SField value representing the
            desired object field. In typical use, the OptionaledField will be
            constructed by using the ~ operator on an SField.
-        @return boost::none if the field is not present, else the value of the
-           specified field.
+        @return std::nullopt if the field is not present, else the value of
+           the specified field.
     */
     template <class T>
-    boost::optional<std::decay_t<typename T::value_type>>
+    std::optional<std::decay_t<typename T::value_type>>
     at(OptionaledField<T> const& of) const;
 
     /** Get a modifiable field value.
@@ -552,14 +552,14 @@ public:
     ValueProxy<T>
     at(TypedField<T> const& f);
 
-    /** Return a modifiable field value as boost::optional
+    /** Return a modifiable field value as std::optional
 
         @param An OptionaledField built from an SField value representing the
             desired object field. In typical use, the OptionaledField will be
             constructed by using the ~ operator on an SField.
         @return Transparent proxy object to an `optional` holding a modifiable
-            reference to the value of the specified field. Returns boost::none
-            if the field is not present.
+            reference to the value of the specified field. Returns
+            std::nullopt if the field is not present.
     */
     template <class T>
     OptionalProxy<T>
@@ -901,7 +901,7 @@ STObject::OptionalProxy<T>::operator~() const
 
 template <class T>
 auto
-STObject::OptionalProxy<T>::operator=(boost::none_t const&) -> OptionalProxy&
+STObject::OptionalProxy<T>::operator=(std::nullopt_t const&) -> OptionalProxy&
 {
     disengage();
     return *this;
@@ -969,7 +969,7 @@ auto
 STObject::OptionalProxy<T>::optional_value() const -> optional_type
 {
     if (!engaged())
-        return boost::none;
+        return std::nullopt;
     return this->value();
 }
 
@@ -983,7 +983,7 @@ STObject::operator[](TypedField<T> const& f) const
 }
 
 template <class T>
-boost::optional<std::decay_t<typename T::value_type>>
+std::optional<std::decay_t<typename T::value_type>>
 STObject::operator[](OptionaledField<T> const& of) const
 {
     return at(of);
@@ -1030,19 +1030,19 @@ STObject::at(TypedField<T> const& f) const
 }
 
 template <class T>
-boost::optional<std::decay_t<typename T::value_type>>
+std::optional<std::decay_t<typename T::value_type>>
 STObject::at(OptionaledField<T> const& of) const
 {
     auto const b = peekAtPField(*of.f);
     if (!b)
-        return boost::none;
+        return std::nullopt;
     auto const u = dynamic_cast<T const*>(b);
     if (!u)
     {
         assert(mType);
         assert(b->getSType() == STI_NOTPRESENT);
         if (mType->style(*of.f) == soeOPTIONAL)
-            return boost::none;
+            return std::nullopt;
         assert(mType->style(*of.f) == soeDEFAULT);
         return typename T::value_type{};
     }

--- a/src/ripple/protocol/STParsedJSON.h
+++ b/src/ripple/protocol/STParsedJSON.h
@@ -21,7 +21,7 @@
 #define RIPPLE_PROTOCOL_STPARSEDJSON_H_INCLUDED
 
 #include <ripple/protocol/STArray.h>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace ripple {
 
@@ -47,7 +47,7 @@ public:
     ~STParsedJSONObject() = default;
 
     /** The STObject if the parse was successful. */
-    boost::optional<STObject> object;
+    std::optional<STObject> object;
 
     /** On failure, an appropriate set of error values. */
     Json::Value error;
@@ -75,7 +75,7 @@ public:
     ~STParsedJSONArray() = default;
 
     /** The STArray if the parse was successful. */
-    boost::optional<STArray> array;
+    std::optional<STArray> array;
 
     /** On failure, an appropriate set of error values. */
     Json::Value error;

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -24,9 +24,9 @@
 #include <ripple/protocol/SField.h>
 #include <ripple/protocol/STBase.h>
 #include <ripple/protocol/UintTypes.h>
-#include <boost/optional.hpp>
 #include <cassert>
 #include <cstddef>
+#include <optional>
 
 namespace ripple {
 
@@ -50,9 +50,9 @@ private:
 
 public:
     STPathElement(
-        boost::optional<AccountID> const& account,
-        boost::optional<Currency> const& currency,
-        boost::optional<AccountID> const& issuer)
+        std::optional<AccountID> const& account,
+        std::optional<Currency> const& currency,
+        std::optional<AccountID> const& issuer)
         : mType(typeNone)
     {
         if (!account)

--- a/src/ripple/protocol/SecretKey.h
+++ b/src/ripple/protocol/SecretKey.h
@@ -113,7 +113,7 @@ operator!=(SecretKey const& lhs, SecretKey const& rhs)
 
 /** Parse a secret key */
 template <>
-boost::optional<SecretKey>
+std::optional<SecretKey>
 parseBase58(TokenType type, std::string const& s);
 
 inline std::string

--- a/src/ripple/protocol/Seed.h
+++ b/src/ripple/protocol/Seed.h
@@ -23,8 +23,8 @@
 #include <ripple/basics/Slice.h>
 #include <ripple/basics/base_uint.h>
 #include <ripple/protocol/tokens.h>
-#include <boost/optional.hpp>
 #include <array>
+#include <optional>
 
 namespace ripple {
 
@@ -113,11 +113,11 @@ generateSeed(std::string const& passPhrase);
 
 /** Parse a Base58 encoded string into a seed */
 template <>
-boost::optional<Seed>
+std::optional<Seed>
 parseBase58(std::string const& s);
 
 /** Attempt to parse a string as a seed */
-boost::optional<Seed>
+std::optional<Seed>
 parseGenericSeed(std::string const& str);
 
 /** Encode a Seed in RFC1751 format */

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -23,7 +23,7 @@
 #include <ripple/basics/safe_cast.h>
 #include <ripple/json/json_value.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <ostream>
 #include <string>
 
@@ -598,7 +598,7 @@ transToken(TER code);
 std::string
 transHuman(TER code);
 
-boost::optional<TER>
+std::optional<TER>
 transCode(std::string const& token);
 
 }  // namespace ripple

--- a/src/ripple/protocol/impl/AccountID.cpp
+++ b/src/ripple/protocol/impl/AccountID.cpp
@@ -32,12 +32,12 @@ toBase58(AccountID const& v)
 }
 
 template <>
-boost::optional<AccountID>
+std::optional<AccountID>
 parseBase58(std::string const& s)
 {
     auto const result = decodeBase58Token(s, TokenType::AccountID);
     if (result.size() != AccountID::bytes)
-        return boost::none;
+        return std::nullopt;
     return AccountID{result};
 }
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -48,12 +48,12 @@ detail::FeatureCollections::FeatureCollections()
     }
 }
 
-boost::optional<uint256>
+std::optional<uint256>
 detail::FeatureCollections::getRegisteredFeature(std::string const& name) const
 {
     auto const i = nameToFeature.find(name);
     if (i == nameToFeature.end())
-        return boost::none;
+        return std::nullopt;
     return i->second;
 }
 
@@ -141,7 +141,7 @@ detail::supportedAmendments()
 
 //------------------------------------------------------------------------------
 
-boost::optional<uint256>
+std::optional<uint256>
 getRegisteredFeature(std::string const& name)
 {
     return featureCollections.getRegisteredFeature(name);

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -23,7 +23,6 @@
 #include <ripple/basics/strHex.h>
 #include <ripple/protocol/STPathSet.h>
 #include <ripple/protocol/jss.h>
-#include <cstddef>
 
 namespace ripple {
 

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -167,8 +167,7 @@ STTx::getSeqProxy() const
     if (seq != 0)
         return SeqProxy::sequence(seq);
 
-    boost::optional<std::uint32_t> const ticketSeq{operator[](
-        ~sfTicketSequence)};
+    std::optional<std::uint32_t> const ticketSeq{operator[](~sfTicketSequence)};
     if (!ticketSeq)
         // No TicketSequence specified.  Return the Sequence, whatever it is.
         return SeqProxy::sequence(seq);

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -264,14 +264,14 @@ randomKeyPair(KeyType type)
 }
 
 template <>
-boost::optional<SecretKey>
+std::optional<SecretKey>
 parseBase58(TokenType type, std::string const& s)
 {
     auto const result = decodeBase58Token(s, type);
     if (result.empty())
-        return boost::none;
+        return std::nullopt;
     if (result.size() != 32)
-        return boost::none;
+        return std::nullopt;
     return SecretKey(makeSlice(result));
 }
 

--- a/src/ripple/protocol/impl/Seed.cpp
+++ b/src/ripple/protocol/impl/Seed.cpp
@@ -75,22 +75,22 @@ generateSeed(std::string const& passPhrase)
 }
 
 template <>
-boost::optional<Seed>
+std::optional<Seed>
 parseBase58(std::string const& s)
 {
     auto const result = decodeBase58Token(s, TokenType::FamilySeed);
     if (result.empty())
-        return boost::none;
+        return std::nullopt;
     if (result.size() != 16)
-        return boost::none;
+        return std::nullopt;
     return Seed(makeSlice(result));
 }
 
-boost::optional<Seed>
+std::optional<Seed>
 parseGenericSeed(std::string const& str)
 {
     if (str.empty())
-        return boost::none;
+        return std::nullopt;
 
     if (parseBase58<AccountID>(str) ||
         parseBase58<PublicKey>(TokenType::NodePublic, str) ||
@@ -98,7 +98,7 @@ parseGenericSeed(std::string const& str)
         parseBase58<SecretKey>(TokenType::NodePrivate, str) ||
         parseBase58<SecretKey>(TokenType::AccountSecret, str))
     {
-        return boost::none;
+        return std::nullopt;
     }
 
     {

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -210,7 +210,7 @@ transHuman(TER code)
     return transResultInfo(code, token, text) ? text : "-";
 }
 
-boost::optional<TER>
+std::optional<TER>
 transCode(std::string const& token)
 {
     static auto const results = [] {
@@ -227,7 +227,7 @@ transCode(std::string const& token)
     auto const r = results.find(token);
 
     if (r == results.end())
-        return boost::none;
+        return std::nullopt;
 
     return TER::fromInt(r->second);
 }

--- a/src/ripple/protocol/tokens.h
+++ b/src/ripple/protocol/tokens.h
@@ -20,8 +20,8 @@
 #ifndef RIPPLE_PROTOCOL_TOKENS_H_INCLUDED
 #define RIPPLE_PROTOCOL_TOKENS_H_INCLUDED
 
-#include <boost/optional.hpp>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace ripple {
@@ -38,11 +38,11 @@ enum class TokenType : std::uint8_t {
 };
 
 template <class T>
-boost::optional<T>
+std::optional<T>
 parseBase58(std::string const& s);
 
 template <class T>
-boost::optional<T>
+std::optional<T>
 parseBase58(TokenType type, std::string const& s);
 
 /** Encode data in Base58Check format using XRPL alphabet

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -129,10 +129,10 @@ doAccountInfo(RPC::JsonContext& context)
 
                 std::uint32_t seqCount = 0;
                 std::uint32_t ticketCount = 0;
-                boost::optional<std::uint32_t> lowestSeq;
-                boost::optional<std::uint32_t> highestSeq;
-                boost::optional<std::uint32_t> lowestTicket;
-                boost::optional<std::uint32_t> highestTicket;
+                std::optional<std::uint32_t> lowestSeq;
+                std::optional<std::uint32_t> highestSeq;
+                std::optional<std::uint32_t> lowestTicket;
+                std::optional<std::uint32_t> highestTicket;
                 bool anyAuthChanged = false;
                 XRPAmount totalSpend(0);
 

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -73,7 +73,7 @@ doAccountObjects(RPC::JsonContext& context)
     if (!ledger->exists(keylet::account(accountID)))
         return rpcError(rpcACT_NOT_FOUND);
 
-    boost::optional<std::vector<LedgerEntryType>> typeFilter;
+    std::optional<std::vector<LedgerEntryType>> typeFilter;
 
     if (params.isMember(jss::deletion_blockers_only) &&
         params[jss::deletion_blockers_only].asBool())

--- a/src/ripple/rpc/handlers/BookOffers.cpp
+++ b/src/ripple/rpc/handlers/BookOffers.cpp
@@ -159,7 +159,7 @@ doBookOffers(RPC::JsonContext& context)
             rpcDST_ISR_MALFORMED,
             "Invalid field 'taker_gets.issuer', expected non-XRP issuer.");
 
-    boost::optional<AccountID> takerID;
+    std::optional<AccountID> takerID;
     if (context.params.isMember(jss::taker))
     {
         if (!context.params[jss::taker].isString())

--- a/src/ripple/rpc/handlers/PayChanClaim.cpp
+++ b/src/ripple/rpc/handlers/PayChanClaim.cpp
@@ -30,7 +30,7 @@
 #include <ripple/rpc/impl/RPCHelpers.h>
 #include <ripple/rpc/impl/Tuning.h>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace ripple {
 
@@ -63,10 +63,9 @@ doChannelAuthorize(RPC::JsonContext& context)
     if (!channelId.parseHex(params[jss::channel_id].asString()))
         return rpcError(rpcCHANNEL_MALFORMED);
 
-    boost::optional<std::uint64_t> const optDrops =
-        params[jss::amount].isString()
+    std::optional<std::uint64_t> const optDrops = params[jss::amount].isString()
         ? to_uint64(params[jss::amount].asString())
-        : boost::none;
+        : std::nullopt;
 
     if (!optDrops)
         return rpcError(rpcCHANNEL_AMT_MALFORMED);
@@ -104,7 +103,7 @@ doChannelVerify(RPC::JsonContext& context)
         if (!params.isMember(p))
             return RPC::missing_field_error(p);
 
-    boost::optional<PublicKey> pk;
+    std::optional<PublicKey> pk;
     {
         std::string const strPk = params[jss::public_key].asString();
         pk = parseBase58<PublicKey>(TokenType::AccountPublic, strPk);
@@ -125,10 +124,9 @@ doChannelVerify(RPC::JsonContext& context)
     if (!channelId.parseHex(params[jss::channel_id].asString()))
         return rpcError(rpcCHANNEL_MALFORMED);
 
-    boost::optional<std::uint64_t> const optDrops =
-        params[jss::amount].isString()
+    std::optional<std::uint64_t> const optDrops = params[jss::amount].isString()
         ? to_uint64(params[jss::amount].asString())
-        : boost::none;
+        : std::nullopt;
 
     if (!optDrops)
         return rpcError(rpcCHANNEL_AMT_MALFORMED);

--- a/src/ripple/rpc/handlers/Reservations.cpp
+++ b/src/ripple/rpc/handlers/Reservations.cpp
@@ -25,8 +25,7 @@
 #include <ripple/rpc/Context.h>
 #include <ripple/rpc/handlers/Handlers.h>
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -71,7 +70,7 @@ doPeerReservationsAdd(RPC::JsonContext& context)
 
     // channel_verify takes a key in both base58 and hex.
     // @nikb prefers that we take only base58.
-    boost::optional<PublicKey> optPk = parseBase58<PublicKey>(
+    std::optional<PublicKey> optPk = parseBase58<PublicKey>(
         TokenType::NodePublic, params[jss::public_key].asString());
     if (!optPk)
         return rpcError(rpcPUBLIC_MALFORMED);
@@ -102,7 +101,7 @@ doPeerReservationsDel(RPC::JsonContext& context)
     if (!params[jss::public_key].isString())
         return RPC::expected_field_error(jss::public_key, "a string");
 
-    boost::optional<PublicKey> optPk = parseBase58<PublicKey>(
+    std::optional<PublicKey> optPk = parseBase58<PublicKey>(
         TokenType::NodePublic, params[jss::public_key].asString());
     if (!optPk)
         return rpcError(rpcPUBLIC_MALFORMED);

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -273,7 +273,7 @@ doSubscribe(RPC::JsonContext& context)
                 return rpcError(rpcBAD_MARKET);
             }
 
-            boost::optional<AccountID> takerID;
+            std::optional<AccountID> takerID;
 
             if (j.isMember(jss::taker))
             {

--- a/src/ripple/rpc/handlers/TxHistory.cpp
+++ b/src/ripple/rpc/handlers/TxHistory.cpp
@@ -176,6 +176,7 @@ doTxHistory(RPC::JsonContext& context)
     {
         auto db = context.app.getTxnDB().checkoutDb();
 
+        // SOCI requires boost::optional (not std::optional) as parameters.
         boost::optional<std::uint64_t> ledgerSeq;
         boost::optional<std::string> status;
         soci::blob sociRawTxnBlob(*db);

--- a/src/ripple/rpc/handlers/ValidationCreate.cpp
+++ b/src/ripple/rpc/handlers/ValidationCreate.cpp
@@ -26,7 +26,7 @@
 
 namespace ripple {
 
-static boost::optional<Seed>
+static std::optional<Seed>
 validationSeed(Json::Value const& params)
 {
     if (!params.isMember(jss::secret))

--- a/src/ripple/rpc/handlers/WalletPropose.cpp
+++ b/src/ripple/rpc/handlers/WalletPropose.cpp
@@ -28,7 +28,6 @@
 #include <ripple/rpc/Context.h>
 #include <ripple/rpc/handlers/WalletPropose.h>
 #include <ripple/rpc/impl/RPCHelpers.h>
-#include <boost/optional.hpp>
 #include <cmath>
 #include <ed25519-donna/ed25519.h>
 #include <map>
@@ -73,8 +72,8 @@ doWalletPropose(RPC::JsonContext& context)
 Json::Value
 walletPropose(Json::Value const& params)
 {
-    boost::optional<KeyType> keyType;
-    boost::optional<Seed> seed;
+    std::optional<KeyType> keyType;
+    std::optional<Seed> seed;
     bool rippleLibSeed = false;
 
     if (params.isMember(jss::key_type))

--- a/src/ripple/rpc/impl/DeliveredAmount.cpp
+++ b/src/ripple/rpc/impl/DeliveredAmount.cpp
@@ -41,7 +41,7 @@ namespace RPC {
 
   GetLedgerIndex is a callable that returns a LedgerIndex
   GetCloseTime is a callable that returns a
-               boost::optional<NetClock::time_point>
+               std::optional<NetClock::time_point>
  */
 template <class GetLedgerIndex, class GetCloseTime>
 std::optional<STAmount>
@@ -174,7 +174,7 @@ insertDeliveredAmount(
 }
 
 template <class GetLedgerIndex>
-std::optional<STAmount>
+static std::optional<STAmount>
 getDeliveredAmount(
     RPC::Context const& context,
     std::shared_ptr<STTx const> const& serializedTx,
@@ -185,7 +185,7 @@ getDeliveredAmount(
     {
         auto const getCloseTime =
             [&context,
-             &getLedgerIndex]() -> boost::optional<NetClock::time_point> {
+             &getLedgerIndex]() -> std::optional<NetClock::time_point> {
             return context.ledgerMaster.getCloseTimeBySeq(getLedgerIndex());
         };
         return getDeliveredAmount(

--- a/src/ripple/rpc/impl/GRPCHelpers.cpp
+++ b/src/ripple/rpc/impl/GRPCHelpers.cpp
@@ -1756,10 +1756,10 @@ convert(
 
         std::uint32_t seqCount = 0;
         std::uint32_t ticketCount = 0;
-        boost::optional<std::uint32_t> lowestSeq;
-        boost::optional<std::uint32_t> highestSeq;
-        boost::optional<std::uint32_t> lowestTicket;
-        boost::optional<std::uint32_t> highestTicket;
+        std::optional<std::uint32_t> lowestSeq;
+        std::optional<std::uint32_t> highestSeq;
+        std::optional<std::uint32_t> lowestTicket;
+        std::optional<std::uint32_t> highestTicket;
         bool anyAuthChanged = false;
         XRPAmount totalSpend(0);
 

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -34,10 +34,10 @@
 namespace ripple {
 namespace RPC {
 
-boost::optional<AccountID>
+std::optional<AccountID>
 accountFromStringStrict(std::string const& account)
 {
-    boost::optional<AccountID> result;
+    std::optional<AccountID> result;
 
     auto const publicKey =
         parseBase58<PublicKey>(TokenType::AccountPublic, account);
@@ -92,7 +92,7 @@ bool
 getAccountObjects(
     ReadView const& ledger,
     AccountID const& account,
-    boost::optional<std::vector<LedgerEntryType>> const& typeFilter,
+    std::optional<std::vector<LedgerEntryType>> const& typeFilter,
     uint256 dirIndex,
     uint256 const& entryIndex,
     std::uint32_t const limit,
@@ -608,7 +608,7 @@ injectSLE(Json::Value& jv, SLE const& sle)
     }
 }
 
-boost::optional<Json::Value>
+std::optional<Json::Value>
 readLimitField(
     unsigned int& limit,
     Tuning::LimitRange const& range,
@@ -624,17 +624,17 @@ readLimitField(
         if (!isUnlimited(context.role))
             limit = std::max(range.rmin, std::min(range.rmax, limit));
     }
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<Seed>
+std::optional<Seed>
 parseRippleLibSeed(Json::Value const& value)
 {
     // ripple-lib encodes seed used to generate an Ed25519 wallet in a
     // non-standard way. While rippled never encode seeds that way, we
     // try to detect such keys to avoid user confusion.
     if (!value.isString())
-        return boost::none;
+        return std::nullopt;
 
     auto const result = decodeBase58Token(value.asString(), TokenType::None);
 
@@ -643,10 +643,10 @@ parseRippleLibSeed(Json::Value const& value)
         static_cast<std::uint8_t>(result[1]) == std::uint8_t(0x4B))
         return Seed(makeSlice(result.substr(2)));
 
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<Seed>
+std::optional<Seed>
 getSeedFromRPC(Json::Value const& params, Json::Value& error)
 {
     // The array should be constexpr, but that makes Visual Studio unhappy.
@@ -671,20 +671,20 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
             "Exactly one of the following must be specified: " +
             std::string(jss::passphrase) + ", " + std::string(jss::seed) +
             " or " + std::string(jss::seed_hex));
-        return boost::none;
+        return std::nullopt;
     }
 
     // Make sure a string is present
     if (!params[seedType].isString())
     {
         error = RPC::expected_field_error(seedType, "string");
-        return boost::none;
+        return std::nullopt;
     }
 
     auto const fieldContents = params[seedType].asString();
 
     // Convert string to seed.
-    boost::optional<Seed> seed;
+    std::optional<Seed> seed;
 
     if (seedType == jss::seed.c_str())
         seed = parseBase58<Seed>(fieldContents);
@@ -745,8 +745,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
         return {};
     }
 
-    boost::optional<KeyType> keyType;
-    boost::optional<Seed> seed;
+    std::optional<KeyType> keyType;
+    std::optional<Seed> seed;
 
     if (has_key_type)
     {

--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -29,7 +29,7 @@
 #include <ripple/rpc/Context.h>
 #include <ripple/rpc/Status.h>
 #include <ripple/rpc/impl/Tuning.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include <org/xrpl/rpc/v1/xrp_ledger.pb.h>
 
 namespace Json {
@@ -46,7 +46,7 @@ namespace RPC {
 struct JsonContext;
 
 /** Get an AccountID from an account ID or public key. */
-boost::optional<AccountID>
+std::optional<AccountID>
 accountFromStringStrict(std::string const&);
 
 // --> strIdent: public key, account ID, or regular seed.
@@ -84,7 +84,7 @@ bool
 getAccountObjects(
     ReadView const& ledger,
     AccountID const& account,
-    boost::optional<std::vector<LedgerEntryType>> const& typeFilter,
+    std::optional<std::vector<LedgerEntryType>> const& typeFilter,
     uint256 dirIndex,
     uint256 const& entryIndex,
     std::uint32_t const limit,
@@ -174,16 +174,16 @@ injectSLE(Json::Value& jv, SLE const& sle);
 
     If there is an error, return it as JSON.
 */
-boost::optional<Json::Value>
+std::optional<Json::Value>
 readLimitField(
     unsigned int& limit,
     Tuning::LimitRange const&,
     JsonContext const&);
 
-boost::optional<Seed>
+std::optional<Seed>
 getSeedFromRPC(Json::Value const& params, Json::Value& error);
 
-boost::optional<Seed>
+std::optional<Seed>
 parseRippleLibSeed(Json::Value const& params);
 
 std::pair<PublicKey, SecretKey>

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -45,7 +45,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/beast/http/fields.hpp>
 #include <boost/beast/http/string_body.hpp>
-#include <boost/optional.hpp>
 #include <boost/regex.hpp>
 #include <boost/type_traits.hpp>
 #include <algorithm>

--- a/src/ripple/rpc/impl/ShardArchiveHandler.cpp
+++ b/src/ripple/rpc/impl/ShardArchiveHandler.cpp
@@ -330,7 +330,7 @@ ShardArchiveHandler::next(std::lock_guard<std::mutex> const& l)
     // that comes after the last ledger in this shard. A
     // later ledger must be present in order to reliably
     // retrieve the hash of the shard's last ledger.
-    boost::optional<uint256> expectedHash;
+    std::optional<uint256> expectedHash;
     bool shouldHaveHash = false;
     if (auto const seq = app_.getShardStore()->lastLedgerSeq(shardIndex);
         (shouldHaveHash = app_.getLedgerMaster().getValidLedgerIndex() > seq))
@@ -387,7 +387,7 @@ ShardArchiveHandler::next(std::lock_guard<std::mutex> const& l)
 
         if (!downloader_->download(
                 url.domain,
-                std::to_string(url.port.get_value_or(defaultPort)),
+                std::to_string(url.port.value_or(defaultPort)),
                 url.path,
                 11,
                 dstDir / "archive.tar.lz4",

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -229,7 +229,7 @@ checkPayment(
                     sendMax.issue().currency,
                     sendMax.issue().account,
                     amount,
-                    boost::none,
+                    std::nullopt,
                     app);
                 if (pf.findPaths(app.config().PATH_SEARCH_OLD))
                 {
@@ -496,7 +496,7 @@ transactionPreProcessImpl(
     }
 
     STParsedJSONObject parsed(std::string(jss::tx_json), tx_json);
-    if (parsed.object == boost::none)
+    if (!parsed.object.has_value())
     {
         Json::Value err;
         err[jss::error] = parsed.error[jss::error];
@@ -514,7 +514,7 @@ transactionPreProcessImpl(
             sfSigningPubKey,
             signingArgs.isMultiSigning() ? Slice(nullptr, 0) : pk.slice());
 
-        stpTrans = std::make_shared<STTx>(std::move(parsed.object.get()));
+        stpTrans = std::make_shared<STTx>(std::move(parsed.object.value()));
     }
     catch (STObject::FieldErr& err)
     {
@@ -1118,7 +1118,7 @@ transactionSubmitMultiSigned(
         try
         {
             stpTrans =
-                std::make_shared<STTx>(std::move(parsedTx_json.object.get()));
+                std::make_shared<STTx>(std::move(parsedTx_json.object.value()));
         }
         catch (STObject::FieldErr& err)
         {

--- a/src/ripple/rpc/json_body.h
+++ b/src/ripple/rpc/json_body.h
@@ -62,6 +62,8 @@ struct json_body
         {
         }
 
+        // get() must return a boost::optional (not a std::optional) to meet
+        // requirements of a boost::beast::BodyReader.
         boost::optional<std::pair<const_buffers_type, bool>>
         get(boost::beast::error_code& ec)
         {
@@ -95,6 +97,8 @@ struct json_body
             ec.assign(0, ec.category());
         }
 
+        // get() must return a boost::optional (not a std::optional) to meet
+        // requirements of a boost::beast::BodyWriter.
         boost::optional<std::pair<const_buffers_type, bool>>
         get(boost::beast::error_code& ec)
         {

--- a/src/ripple/server/Port.h
+++ b/src/ripple/server/Port.h
@@ -27,6 +27,7 @@
 #include <boost/beast/websocket/option.hpp>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 
@@ -105,10 +106,10 @@ struct ParsedPort
     int limit = 0;
     std::uint16_t ws_queue_limit;
 
-    boost::optional<boost::asio::ip::address> ip;
-    boost::optional<std::uint16_t> port;
-    boost::optional<std::vector<beast::IP::Address>> admin_ip;
-    boost::optional<std::vector<beast::IP::Address>> secure_gateway_ip;
+    std::optional<boost::asio::ip::address> ip;
+    std::optional<std::uint16_t> port;
+    std::optional<std::vector<beast::IP::Address>> admin_ip;
+    std::optional<std::vector<beast::IP::Address>> secure_gateway_ip;
 };
 
 void

--- a/src/ripple/server/impl/Port.cpp
+++ b/src/ripple/server/impl/Port.cpp
@@ -72,7 +72,7 @@ populate(
     Section const& section,
     std::string const& field,
     std::ostream& log,
-    boost::optional<std::vector<beast::IP::Address>>& ips,
+    std::optional<std::vector<beast::IP::Address>>& ips,
     bool allowAllIps,
     std::vector<beast::IP::Address> const& admin_ip)
 {
@@ -240,7 +240,7 @@ parse_Port(ParsedPort& port, Section const& section, std::ostream& log)
         log,
         port.secure_gateway_ip,
         false,
-        port.admin_ip.get_value_or({}));
+        port.admin_ip.value_or(std::vector<beast::IP::Address>{}));
 
     set(port.user, "user", section);
     set(port.password, "password", section);

--- a/src/ripple/server/impl/ServerImpl.h
+++ b/src/ripple/server/impl/ServerImpl.h
@@ -26,10 +26,10 @@
 #include <ripple/server/impl/Door.h>
 #include <ripple/server/impl/io_list.h>
 #include <boost/asio.hpp>
-#include <boost/optional.hpp>
 #include <array>
 #include <chrono>
 #include <mutex>
+#include <optional>
 
 namespace ripple {
 
@@ -84,7 +84,7 @@ private:
     beast::Journal const j_;
     boost::asio::io_service& io_service_;
     boost::asio::io_service::strand strand_;
-    boost::optional<boost::asio::io_service::work> work_;
+    std::optional<boost::asio::io_service::work> work_;
 
     std::mutex m_;
     std::vector<Port> ports_;
@@ -151,7 +151,7 @@ template <class Handler>
 ServerImpl<Handler>::~ServerImpl()
 {
     // Handler::onStopped will not be called
-    work_ = boost::none;
+    work_ = std::nullopt;
     ios_.close();
     ios_.join();
 }
@@ -184,7 +184,7 @@ void
 ServerImpl<Handler>::close()
 {
     ios_.close([&] {
-        work_ = boost::none;
+        work_ = std::nullopt;
         handler_.onStopped(*this);
     });
 }

--- a/src/ripple/shamap/SHAMapSyncFilter.h
+++ b/src/ripple/shamap/SHAMapSyncFilter.h
@@ -22,7 +22,7 @@
 
 #include <ripple/shamap/SHAMapNodeID.h>
 #include <ripple/shamap/SHAMapTreeNode.h>
-#include <boost/optional.hpp>
+#include <optional>
 
 /** Callback for filtering SHAMap during sync. */
 namespace ripple {
@@ -45,7 +45,7 @@ public:
         Blob&& nodeData,
         SHAMapNodeType type) const = 0;
 
-    virtual boost::optional<Blob>
+    virtual std::optional<Blob>
     getNode(SHAMapHash const& nodeHash) const = 0;
 };
 

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -482,7 +482,7 @@ struct Flow_test : public beast::unit_test::suite
                     false,
                     true,
                     false,
-                    boost::none,
+                    std::nullopt,
                     smax,
                     flowJournal);
             }();

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -245,7 +245,7 @@ public:
             return true;
         return false;
     }
-    boost::optional<std::size_t>
+    std::optional<std::size_t>
     publisherListSequence(PublicKey const&) const override
     {
         return {};

--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -486,8 +486,8 @@ public:
         BEAST_EXPECT(cache.getMasterKey(kp1.first) == pk);
         BEAST_EXPECT(cache.getMasterKey(kp0.first) == kp0.first);
 
-        // getSigningKey should return boost::none for a revoked master public
-        // key getMasterKey should return boost::none for an ephemeral public
+        // getSigningKey should return std::nullopt for a revoked master public
+        // key getMasterKey should return std::nullopt for an ephemeral public
         // key from a revoked master public key
         BEAST_EXPECT(
             ManifestDisposition::accepted ==
@@ -645,7 +645,7 @@ public:
 
                 auto buildManifestObject =
                     [&](std::uint32_t seq,
-                        boost::optional<std::string> domain,
+                        std::optional<std::string> domain,
                         bool noSigningPublic = false,
                         bool noSignature = false) {
                         STObject st(sfGeneric);
@@ -678,7 +678,7 @@ public:
 
                     {  // valid manifest without domain
                         auto const st =
-                            buildManifestObject(++sequence, boost::none);
+                            buildManifestObject(++sequence, std::nullopt);
 
                         auto const m = toString(st);
                         auto const manifest = deserializeManifest(m);
@@ -814,7 +814,7 @@ public:
                     {
                         auto const st = buildManifestObject(
                             std::numeric_limits<std::uint32_t>::max(),
-                            boost::none,
+                            std::nullopt,
                             true,
                             true);
 
@@ -833,7 +833,7 @@ public:
                     {  // can't specify an ephemeral signing key
                         auto const st = buildManifestObject(
                             std::numeric_limits<std::uint32_t>::max(),
-                            boost::none,
+                            std::nullopt,
                             true,
                             false);
 
@@ -842,7 +842,7 @@ public:
                     {  // can't specify an ephemeral signature
                         auto const st = buildManifestObject(
                             std::numeric_limits<std::uint32_t>::max(),
-                            boost::none,
+                            std::nullopt,
                             false,
                             true);
 
@@ -851,7 +851,7 @@ public:
                     {  // can't specify an ephemeral key & signature
                         auto const st = buildManifestObject(
                             std::numeric_limits<std::uint32_t>::max(),
-                            boost::none,
+                            std::nullopt,
                             false,
                             false);
 

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -47,7 +47,7 @@ namespace detail {
 void
 stpath_append_one(STPath& st, jtx::Account const& account)
 {
-    st.push_back(STPathElement({account.id(), boost::none, boost::none}));
+    st.push_back(STPathElement({account.id(), std::nullopt, std::nullopt}));
 }
 
 template <class T>
@@ -60,7 +60,7 @@ stpath_append_one(STPath& st, T const& t)
 void
 stpath_append_one(STPath& st, jtx::IOU const& iou)
 {
-    st.push_back(STPathElement({iou.account.id(), iou.currency, boost::none}));
+    st.push_back(STPathElement({iou.account.id(), iou.currency, std::nullopt}));
 }
 
 void
@@ -72,7 +72,7 @@ stpath_append_one(STPath& st, STPathElement const& pe)
 void
 stpath_append_one(STPath& st, jtx::BookSpec const& book)
 {
-    st.push_back(STPathElement({boost::none, book.currency, book.account}));
+    st.push_back(STPathElement({std::nullopt, book.currency, book.account}));
 }
 
 template <class T, class... Args>
@@ -207,8 +207,8 @@ public:
         jtx::Account const& src,
         jtx::Account const& dst,
         STAmount const& saDstAmount,
-        boost::optional<STAmount> const& saSendMax = boost::none,
-        boost::optional<Currency> const& saSrcCurrency = boost::none)
+        std::optional<STAmount> const& saSendMax = std::nullopt,
+        std::optional<Currency> const& saSrcCurrency = std::nullopt)
     {
         using namespace jtx;
 
@@ -268,8 +268,8 @@ public:
         jtx::Account const& src,
         jtx::Account const& dst,
         STAmount const& saDstAmount,
-        boost::optional<STAmount> const& saSendMax = boost::none,
-        boost::optional<Currency> const& saSrcCurrency = boost::none)
+        std::optional<STAmount> const& saSendMax = std::nullopt,
+        std::optional<Currency> const& saSrcCurrency = std::nullopt)
     {
         Json::Value result = find_paths_request(
             env, src, dst, saDstAmount, saSendMax, saSrcCurrency);
@@ -516,14 +516,14 @@ public:
                 "alice",
                 "bob",
                 Account("bob")["AUD"](-1),
-                boost::optional<STAmount>(XRP(100000000)));
+                std::optional<STAmount>(XRP(100000000)));
             BEAST_EXPECT(st.empty());
             std::tie(st, sa, da) = find_paths(
                 env,
                 "alice",
                 "bob",
                 Account("bob")["USD"](-1),
-                boost::optional<STAmount>(XRP(100000000)));
+                std::optional<STAmount>(XRP(100000000)));
             BEAST_EXPECT(sa == XRP(100));
             BEAST_EXPECT(equal(da, Account("bob")["USD"](100)));
         }
@@ -970,7 +970,7 @@ public:
         {
             auto const& send_amt = XRP(10);
             std::tie(st, sa, da) =
-                find_paths(env, A1, A2, send_amt, boost::none, xrpCurrency());
+                find_paths(env, A1, A2, send_amt, std::nullopt, xrpCurrency());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(st.empty());
         }
@@ -980,7 +980,7 @@ public:
             // does not exist.
             auto const& send_amt = XRP(200);
             std::tie(st, sa, da) = find_paths(
-                env, A1, Account{"A0"}, send_amt, boost::none, xrpCurrency());
+                env, A1, Account{"A0"}, send_amt, std::nullopt, xrpCurrency());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(st.empty());
         }
@@ -988,7 +988,7 @@ public:
         {
             auto const& send_amt = G3["ABC"](10);
             std::tie(st, sa, da) =
-                find_paths(env, A2, G3, send_amt, boost::none, xrpCurrency());
+                find_paths(env, A2, G3, send_amt, std::nullopt, xrpCurrency());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, XRP(100)));
             BEAST_EXPECT(same(st, stpath(IPE(G3["ABC"]))));
@@ -997,7 +997,7 @@ public:
         {
             auto const& send_amt = A2["ABC"](1);
             std::tie(st, sa, da) =
-                find_paths(env, A1, A2, send_amt, boost::none, xrpCurrency());
+                find_paths(env, A1, A2, send_amt, std::nullopt, xrpCurrency());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, XRP(10)));
             BEAST_EXPECT(same(st, stpath(IPE(G3["ABC"]), G3)));
@@ -1006,7 +1006,7 @@ public:
         {
             auto const& send_amt = A3["ABC"](1);
             std::tie(st, sa, da) =
-                find_paths(env, A1, A3, send_amt, boost::none, xrpCurrency());
+                find_paths(env, A1, A3, send_amt, std::nullopt, xrpCurrency());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, XRP(10)));
             BEAST_EXPECT(same(st, stpath(IPE(G3["ABC"]), G3, A2)));
@@ -1044,7 +1044,7 @@ public:
 
         auto const& send_amt = XRP(10);
         std::tie(st, sa, da) =
-            find_paths(env, A1, A2, send_amt, boost::none, A2["ABC"].currency);
+            find_paths(env, A1, A2, send_amt, std::nullopt, A2["ABC"].currency);
         BEAST_EXPECT(equal(da, send_amt));
         BEAST_EXPECT(equal(sa, A1["ABC"](1)));
         BEAST_EXPECT(same(st, stpath(G3, IPE(xrpIssue()))));
@@ -1087,7 +1087,7 @@ public:
         {
             auto const& send_amt = A2["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A1, A2, send_amt, boost::none, A2["HKD"].currency);
+                env, A1, A2, send_amt, std::nullopt, A2["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A1["HKD"](10)));
             BEAST_EXPECT(same(st, stpath(G1BS, M1, G2SW)));
@@ -1096,7 +1096,7 @@ public:
         {
             auto const& send_amt = A1["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A2, A1, send_amt, boost::none, A1["HKD"].currency);
+                env, A2, A1, send_amt, std::nullopt, A1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A2["HKD"](10)));
             BEAST_EXPECT(same(st, stpath(G2SW, M1, G1BS)));
@@ -1105,7 +1105,7 @@ public:
         {
             auto const& send_amt = A2["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, G1BS, A2, send_amt, boost::none, A1["HKD"].currency);
+                env, G1BS, A2, send_amt, std::nullopt, A1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, G1BS["HKD"](10)));
             BEAST_EXPECT(same(st, stpath(M1, G2SW)));
@@ -1114,7 +1114,7 @@ public:
         {
             auto const& send_amt = M1["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, M1, G1BS, send_amt, boost::none, A1["HKD"].currency);
+                env, M1, G1BS, send_amt, std::nullopt, A1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, M1["HKD"](10)));
             BEAST_EXPECT(st.empty());
@@ -1123,7 +1123,7 @@ public:
         {
             auto const& send_amt = A1["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, G2SW, A1, send_amt, boost::none, A1["HKD"].currency);
+                env, G2SW, A1, send_amt, std::nullopt, A1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, G2SW["HKD"](10)));
             BEAST_EXPECT(same(st, stpath(M1, G1BS)));
@@ -1182,7 +1182,7 @@ public:
             //  Source -> Destination (repay source issuer)
             auto const& send_amt = G1["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A1, G1, send_amt, boost::none, G1["HKD"].currency);
+                env, A1, G1, send_amt, std::nullopt, G1["HKD"].currency);
             BEAST_EXPECT(st.empty());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A1["HKD"](10)));
@@ -1193,7 +1193,7 @@ public:
             //  Source -> Destination (repay destination issuer)
             auto const& send_amt = A1["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A1, G1, send_amt, boost::none, G1["HKD"].currency);
+                env, A1, G1, send_amt, std::nullopt, G1["HKD"].currency);
             BEAST_EXPECT(st.empty());
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A1["HKD"](10)));
@@ -1204,7 +1204,7 @@ public:
             //  Source -> AC -> Destination
             auto const& send_amt = A3["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A1, A3, send_amt, boost::none, G1["HKD"].currency);
+                env, A1, A3, send_amt, std::nullopt, G1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A1["HKD"](10)));
             BEAST_EXPECT(same(st, stpath(G1)));
@@ -1215,7 +1215,7 @@ public:
             //  Source -> OB -> Destination
             auto const& send_amt = G2["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, G1, G2, send_amt, boost::none, G1["HKD"].currency);
+                env, G1, G2, send_amt, std::nullopt, G1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, G1["HKD"](10)));
             BEAST_EXPECT(same(
@@ -1231,7 +1231,7 @@ public:
             //  Source -> AC -> OB -> Destination
             auto const& send_amt = G2["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A1, G2, send_amt, boost::none, G1["HKD"].currency);
+                env, A1, G2, send_amt, std::nullopt, G1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A1["HKD"](10)));
             BEAST_EXPECT(same(
@@ -1247,7 +1247,7 @@ public:
             //  Source -> AC -> OB to XRP -> OB from XRP -> AC -> Destination
             auto const& send_amt = A2["HKD"](10);
             std::tie(st, sa, da) = find_paths(
-                env, A1, A2, send_amt, boost::none, G1["HKD"].currency);
+                env, A1, A2, send_amt, std::nullopt, G1["HKD"].currency);
             BEAST_EXPECT(equal(da, send_amt));
             BEAST_EXPECT(equal(sa, A1["HKD"](10)));
             BEAST_EXPECT(same(
@@ -1297,7 +1297,7 @@ public:
         STPathSet st;
         STAmount sa, da;
         std::tie(st, sa, da) =
-            find_paths(env, G1, A2, send_amt, boost::none, G1["HKD"].currency);
+            find_paths(env, G1, A2, send_amt, std::nullopt, G1["HKD"].currency);
         BEAST_EXPECT(equal(da, send_amt));
         BEAST_EXPECT(equal(sa, G1["HKD"](10)));
         BEAST_EXPECT(same(st, stpath(M1, G2), stpath(IPE(G2["HKD"]), G2)));

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -92,15 +92,15 @@ struct PayChan_test : public beast::unit_test::suite
         return (*slep)[sfAmount];
     }
 
-    static boost::optional<std::int64_t>
+    static std::optional<std::int64_t>
     channelExpiration(ReadView const& view, uint256 const& chan)
     {
         auto const slep = view.read({ltPAYCHAN, chan});
         if (!slep)
-            return boost::none;
+            return std::nullopt;
         if (auto const r = (*slep)[~sfExpiration])
             return r.value();
-        return boost::none;
+        return std::nullopt;
     }
 
     static Json::Value
@@ -110,8 +110,8 @@ struct PayChan_test : public beast::unit_test::suite
         STAmount const& amount,
         NetClock::duration const& settleDelay,
         PublicKey const& pk,
-        boost::optional<NetClock::time_point> const& cancelAfter = boost::none,
-        boost::optional<std::uint32_t> const& dstTag = boost::none)
+        std::optional<NetClock::time_point> const& cancelAfter = std::nullopt,
+        std::optional<std::uint32_t> const& dstTag = std::nullopt)
     {
         using namespace jtx;
         Json::Value jv;
@@ -134,7 +134,7 @@ struct PayChan_test : public beast::unit_test::suite
         jtx::Account const& account,
         uint256 const& channel,
         STAmount const& amount,
-        boost::optional<NetClock::time_point> const& expiration = boost::none)
+        std::optional<NetClock::time_point> const& expiration = std::nullopt)
     {
         using namespace jtx;
         Json::Value jv;
@@ -152,10 +152,10 @@ struct PayChan_test : public beast::unit_test::suite
     claim(
         jtx::Account const& account,
         uint256 const& channel,
-        boost::optional<STAmount> const& balance = boost::none,
-        boost::optional<STAmount> const& amount = boost::none,
-        boost::optional<Slice> const& signature = boost::none,
-        boost::optional<PublicKey> const& pk = boost::none)
+        std::optional<STAmount> const& balance = std::nullopt,
+        std::optional<STAmount> const& amount = std::nullopt,
+        std::optional<Slice> const& signature = std::nullopt,
+        std::optional<PublicKey> const& pk = std::nullopt)
     {
         using namespace jtx;
         Json::Value jv;
@@ -604,7 +604,7 @@ struct PayChan_test : public beast::unit_test::suite
             assert(reqBal <= chanAmt);
             auto const sig =
                 signClaimAuth(alice.pk(), alice.sk(), chan, reqBal);
-            env(claim(bob, chan, reqBal, boost::none, Slice(sig), alice.pk()));
+            env(claim(bob, chan, reqBal, std::nullopt, Slice(sig), alice.pk()));
             BEAST_EXPECT(channelBalance(*env.current(), chan) == reqBal);
             auto const feeDrops = env.current()->fees().base;
             BEAST_EXPECT(env.balance(bob) == preBob + delta - feeDrops);
@@ -621,7 +621,7 @@ struct PayChan_test : public beast::unit_test::suite
             assert(reqBal <= chanAmt);
             auto const sig =
                 signClaimAuth(alice.pk(), alice.sk(), chan, reqBal);
-            env(claim(bob, chan, reqBal, boost::none, Slice(sig), alice.pk()));
+            env(claim(bob, chan, reqBal, std::nullopt, Slice(sig), alice.pk()));
             BEAST_EXPECT(channelBalance(*env.current(), chan) == reqBal);
             auto const feeDrops = env.current()->fees().base;
             BEAST_EXPECT(env.balance(bob) == preBob + delta - feeDrops);
@@ -714,7 +714,7 @@ struct PayChan_test : public beast::unit_test::suite
         {
             auto const chan = channel(alice, bob, env.seq(alice));
             env(create(
-                alice, bob, channelFunds, settleDelay, pk, boost::none, 1));
+                alice, bob, channelFunds, settleDelay, pk, std::nullopt, 1));
             BEAST_EXPECT(channelExists(*env.current(), chan));
         }
     }
@@ -961,10 +961,10 @@ struct PayChan_test : public beast::unit_test::suite
 
         auto testLimit = [](test::jtx::Env& env,
                             test::jtx::Account const& src,
-                            boost::optional<int> limit = boost::none,
+                            std::optional<int> limit = std::nullopt,
                             Json::Value const& marker = Json::nullValue,
-                            boost::optional<test::jtx::Account> const& dst =
-                                boost::none) {
+                            std::optional<test::jtx::Account> const& dst =
+                                std::nullopt) {
             Json::Value jvc;
             jvc[jss::account] = src.human();
             if (dst)
@@ -1431,7 +1431,7 @@ struct PayChan_test : public beast::unit_test::suite
         auto const settleDelay = 3600s;
         auto const channelFunds = XRP(1000);
 
-        boost::optional<NetClock::time_point> cancelAfter;
+        std::optional<NetClock::time_point> cancelAfter;
 
         {
             auto const chan = to_string(channel(alice, bob, env.seq(alice)));

--- a/src/test/app/PayStrand_test.cpp
+++ b/src/test/app/PayStrand_test.cpp
@@ -286,24 +286,24 @@ public:
         AccFactory&& accF,
         IssFactory&& issF,
         CurrencyFactory&& currencyF,
-        boost::optional<AccountID> const& existingAcc,
-        boost::optional<Currency> const& existingCur,
-        boost::optional<AccountID> const& existingIss)
+        std::optional<AccountID> const& existingAcc,
+        std::optional<Currency> const& existingCur,
+        std::optional<AccountID> const& existingIss)
     {
         assert(!has(SB::last));
 
-        auto const acc = [&]() -> boost::optional<AccountID> {
+        auto const acc = [&]() -> std::optional<AccountID> {
             if (!has(SB::acc))
-                return boost::none;
+                return std::nullopt;
             if (has(SB::rootAcc))
                 return xrpAccount();
             if (has(SB::existingAcc) && existingAcc)
                 return existingAcc;
             return accF().id();
         }();
-        auto const iss = [&]() -> boost::optional<AccountID> {
+        auto const iss = [&]() -> std::optional<AccountID> {
             if (!has(SB::iss))
-                return boost::none;
+                return std::nullopt;
             if (has(SB::rootIss))
                 return xrpAccount();
             if (has(SB::sameAccIss))
@@ -312,9 +312,9 @@ public:
                 return *existingIss;
             return issF().id();
         }();
-        auto const cur = [&]() -> boost::optional<Currency> {
+        auto const cur = [&]() -> std::optional<Currency> {
             if (!has(SB::cur))
-                return boost::none;
+                return std::nullopt;
             if (has(SB::xrp))
                 return xrpCurrency();
             if (has(SB::existingCur) && existingCur)
@@ -395,7 +395,7 @@ struct ExistingElementPool
         jtx::Env& env,
         size_t numAct,
         size_t numCur,
-        boost::optional<size_t> const& offererIndex)
+        std::optional<size_t> const& offererIndex)
     {
         using namespace jtx;
 
@@ -582,9 +582,9 @@ struct ExistingElementPool
         STAmount const& deliver,
         std::vector<STPathElement> const& prefix,
         std::vector<STPathElement> const& suffix,
-        boost::optional<AccountID> const& existingAcc,
-        boost::optional<Currency> const& existingCur,
-        boost::optional<AccountID> const& existingIss,
+        std::optional<AccountID> const& existingAcc,
+        std::optional<Currency> const& existingCur,
+        std::optional<AccountID> const& existingIss,
         F&& f)
     {
         auto accF = [&] { return this->getAvailAccount(); };
@@ -660,7 +660,7 @@ struct PayStrand_test : public beast::unit_test::suite
         auto test = [&, this](
                         jtx::Env& env,
                         Issue const& deliver,
-                        boost::optional<Issue> const& sendMaxIssue,
+                        std::optional<Issue> const& sendMaxIssue,
                         STPath const& path,
                         TER expTer,
                         auto&&... expSteps) {
@@ -669,7 +669,7 @@ struct PayStrand_test : public beast::unit_test::suite
                 alice,
                 bob,
                 deliver,
-                boost::none,
+                std::nullopt,
                 sendMaxIssue,
                 path,
                 true,
@@ -696,7 +696,7 @@ struct PayStrand_test : public beast::unit_test::suite
                     alice,
                     alice,
                     /*deliver*/ xrpIssue(),
-                    /*limitQuality*/ boost::none,
+                    /*limitQuality*/ std::nullopt,
                     /*sendMaxIssue*/ EUR.issue(),
                     path,
                     true,
@@ -713,7 +713,7 @@ struct PayStrand_test : public beast::unit_test::suite
                     alice,
                     alice,
                     /*deliver*/ xrpIssue(),
-                    /*limitQuality*/ boost::none,
+                    /*limitQuality*/ std::nullopt,
                     /*sendMaxIssue*/ EUR.issue(),
                     path,
                     true,
@@ -730,10 +730,10 @@ struct PayStrand_test : public beast::unit_test::suite
             Env env(*this, features);
             env.fund(XRP(10000), alice, bob, carol, gw);
 
-            test(env, USD, boost::none, STPath(), terNO_LINE);
+            test(env, USD, std::nullopt, STPath(), terNO_LINE);
 
             env.trust(USD(1000), alice, bob, carol);
-            test(env, USD, boost::none, STPath(), tecPATH_DRY);
+            test(env, USD, std::nullopt, STPath(), tecPATH_DRY);
 
             env(pay(gw, alice, USD(100)));
             env(pay(gw, carol, USD(100)));
@@ -742,7 +742,7 @@ struct PayStrand_test : public beast::unit_test::suite
             test(
                 env,
                 USD,
-                boost::none,
+                std::nullopt,
                 STPath(),
                 tesSUCCESS,
                 D{alice, gw, usdC},
@@ -818,7 +818,7 @@ struct PayStrand_test : public beast::unit_test::suite
                 D{gw, bob, eurC});
 
             // XRP -> XRP transaction can't include a path
-            test(env, XRP, boost::none, STPath({ape(carol)}), temBAD_PATH);
+            test(env, XRP, std::nullopt, STPath({ape(carol)}), temBAD_PATH);
 
             {
                 // The root account can't be the src or dst
@@ -830,7 +830,7 @@ struct PayStrand_test : public beast::unit_test::suite
                         alice,
                         xrpAccount(),
                         XRP,
-                        boost::none,
+                        std::nullopt,
                         USD.issue(),
                         STPath(),
                         true,
@@ -845,8 +845,8 @@ struct PayStrand_test : public beast::unit_test::suite
                         xrpAccount(),
                         alice,
                         XRP,
-                        boost::none,
-                        boost::none,
+                        std::nullopt,
+                        std::nullopt,
                         STPath(),
                         true,
                         false,
@@ -860,8 +860,8 @@ struct PayStrand_test : public beast::unit_test::suite
                         noAccount(),
                         bob,
                         USD,
-                        boost::none,
-                        boost::none,
+                        std::nullopt,
+                        std::nullopt,
                         STPath(),
                         true,
                         false,
@@ -882,7 +882,7 @@ struct PayStrand_test : public beast::unit_test::suite
             test(
                 env,
                 USD,
-                boost::none,
+                std::nullopt,
                 STPath({STPathElement(
                     0, xrpAccount(), xrpCurrency(), xrpAccount())}),
                 temBAD_PATH);
@@ -893,7 +893,7 @@ struct PayStrand_test : public beast::unit_test::suite
             test(
                 env,
                 USD,
-                boost::none,
+                std::nullopt,
                 STPath({ape(gw), ape(carol)}),
                 temBAD_PATH_LOOP);
 
@@ -936,7 +936,7 @@ struct PayStrand_test : public beast::unit_test::suite
             env.fund(XRP(10000), alice, bob, noripple(gw));
             env.trust(USD(1000), alice, bob);
             env(pay(gw, alice, USD(100)));
-            test(env, USD, boost::none, STPath(), terNO_RIPPLE);
+            test(env, USD, std::nullopt, STPath(), terNO_RIPPLE);
         }
 
         {
@@ -948,21 +948,21 @@ struct PayStrand_test : public beast::unit_test::suite
 
             // Account can still issue payments
             env(fset(alice, asfGlobalFreeze));
-            test(env, USD, boost::none, STPath(), tesSUCCESS);
+            test(env, USD, std::nullopt, STPath(), tesSUCCESS);
             env(fclear(alice, asfGlobalFreeze));
-            test(env, USD, boost::none, STPath(), tesSUCCESS);
+            test(env, USD, std::nullopt, STPath(), tesSUCCESS);
 
             // Account can not issue funds
             env(fset(gw, asfGlobalFreeze));
-            test(env, USD, boost::none, STPath(), terNO_LINE);
+            test(env, USD, std::nullopt, STPath(), terNO_LINE);
             env(fclear(gw, asfGlobalFreeze));
-            test(env, USD, boost::none, STPath(), tesSUCCESS);
+            test(env, USD, std::nullopt, STPath(), tesSUCCESS);
 
             // Account can not receive funds
             env(fset(bob, asfGlobalFreeze));
-            test(env, USD, boost::none, STPath(), terNO_LINE);
+            test(env, USD, std::nullopt, STPath(), terNO_LINE);
             env(fclear(bob, asfGlobalFreeze));
-            test(env, USD, boost::none, STPath(), tesSUCCESS);
+            test(env, USD, std::nullopt, STPath(), tesSUCCESS);
         }
         {
             // Freeze between gw and alice
@@ -970,10 +970,10 @@ struct PayStrand_test : public beast::unit_test::suite
             env.fund(XRP(10000), alice, bob, gw);
             env.trust(USD(1000), alice, bob);
             env(pay(gw, alice, USD(100)));
-            test(env, USD, boost::none, STPath(), tesSUCCESS);
+            test(env, USD, std::nullopt, STPath(), tesSUCCESS);
             env(trust(gw, alice["USD"](0), tfSetFreeze));
             BEAST_EXPECT(getTrustFlag(env, gw, alice, usdC, TrustFlag::freeze));
-            test(env, USD, boost::none, STPath(), terNO_LINE);
+            test(env, USD, std::nullopt, STPath(), terNO_LINE);
         }
         {
             // check no auth
@@ -988,7 +988,7 @@ struct PayStrand_test : public beast::unit_test::suite
             BEAST_EXPECT(getTrustFlag(env, gw, alice, usdC, TrustFlag::auth));
             env(pay(gw, alice, USD(100)));
             env.require(balance(alice, USD(100)));
-            test(env, USD, boost::none, STPath(), terNO_AUTH);
+            test(env, USD, std::nullopt, STPath(), terNO_AUTH);
 
             // Check pure issue redeem still works
             auto [ter, strand] = toStrand(
@@ -996,8 +996,8 @@ struct PayStrand_test : public beast::unit_test::suite
                 alice,
                 gw,
                 USD,
-                boost::none,
-                boost::none,
+                std::nullopt,
+                std::nullopt,
                 STPath(),
                 true,
                 false,
@@ -1029,15 +1029,15 @@ struct PayStrand_test : public beast::unit_test::suite
 
             // alice -> USD/XRP -> bob
             STPath path;
-            path.emplace_back(boost::none, USD.currency, USD.account.id());
-            path.emplace_back(boost::none, xrpCurrency(), boost::none);
+            path.emplace_back(std::nullopt, USD.currency, USD.account.id());
+            path.emplace_back(std::nullopt, xrpCurrency(), std::nullopt);
 
             auto [ter, strand] = toStrand(
                 *env.current(),
                 alice,
                 bob,
                 XRP,
-                boost::none,
+                std::nullopt,
                 USD.issue(),
                 path,
                 false,

--- a/src/test/app/TheoreticalQuality_test.cpp
+++ b/src/test/app/TheoreticalQuality_test.cpp
@@ -40,7 +40,7 @@ struct RippleCalcTestParams
     AccountID dstAccount;
 
     STAmount dstAmt;
-    boost::optional<STAmount> sendMax;
+    std::optional<STAmount> sendMax;
 
     STPathSet paths;
 
@@ -69,22 +69,22 @@ struct RippleCalcTestParams
                         p.emplace_back(
                             *parseBase58<AccountID>(
                                 pe[jss::account].asString()),
-                            boost::none,
-                            boost::none);
+                            std::nullopt,
+                            std::nullopt);
                     }
                     else if (
                         pe.isMember(jss::currency) && pe.isMember(jss::issuer))
                     {
                         auto const currency =
                             to_currency(pe[jss::currency].asString());
-                        boost::optional<AccountID> issuer;
+                        std::optional<AccountID> issuer;
                         if (!isXRP(currency))
                             issuer = *parseBase58<AccountID>(
                                 pe[jss::issuer].asString());
                         else
                             assert(isXRP(*parseBase58<AccountID>(
                                 pe[jss::issuer].asString())));
-                        p.emplace_back(boost::none, currency, issuer);
+                        p.emplace_back(std::nullopt, currency, issuer);
                     }
                     else
                     {
@@ -242,14 +242,14 @@ class TheoreticalQuality_test : public beast::unit_test::suite
     testCase(
         RippleCalcTestParams const& rcp,
         std::shared_ptr<ReadView const> closed,
-        boost::optional<Quality> const& expectedQ = {})
+        std::optional<Quality> const& expectedQ = {})
     {
         PaymentSandbox sb(closed.get(), tapNONE);
 
-        auto const sendMaxIssue = [&rcp]() -> boost::optional<Issue> {
+        auto const sendMaxIssue = [&rcp]() -> std::optional<Issue> {
             if (rcp.sendMax)
                 return rcp.sendMax->issue();
-            return boost::none;
+            return std::nullopt;
         }();
 
         beast::Journal dummyJ{beast::Journal::getNullSink()};
@@ -259,7 +259,7 @@ class TheoreticalQuality_test : public beast::unit_test::suite
             rcp.srcAccount,
             rcp.dstAccount,
             rcp.dstAmt.issue(),
-            /*limitQuality*/ boost::none,
+            /*limitQuality*/ std::nullopt,
             sendMaxIssue,
             rcp.paths,
             /*defaultPaths*/ rcp.paths.empty(),
@@ -312,7 +312,7 @@ class TheoreticalQuality_test : public beast::unit_test::suite
 
 public:
     void
-    testDirectStep(boost::optional<int> const& reqNumIterations)
+    testDirectStep(std::optional<int> const& reqNumIterations)
     {
         testcase("Direct Step");
 
@@ -404,7 +404,7 @@ public:
     }
 
     void
-    testBookStep(boost::optional<int> const& reqNumIterations)
+    testBookStep(std::optional<int> const& reqNumIterations)
     {
         testcase("Book Step");
         using namespace jtx;
@@ -527,20 +527,20 @@ public:
     {
         // Use the command line argument `--unittest-arg=500 ` to change the
         // number of iterations to 500
-        auto const numIterations = [s = arg()]() -> boost::optional<int> {
+        auto const numIterations = [s = arg()]() -> std::optional<int> {
             if (s.empty())
-                return boost::none;
+                return std::nullopt;
             try
             {
                 std::size_t pos;
                 auto const r = stoi(s, &pos);
                 if (pos != s.size())
-                    return boost::none;
+                    return std::nullopt;
                 return r;
             }
             catch (...)
             {
-                return boost::none;
+                return std::nullopt;
             }
         }();
         testRelativeQDistance();

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -792,7 +792,7 @@ class Ticket_test : public beast::unit_test::suite
                                  uint256 const& txID,
                                  std::uint32_t ledgerSeq,
                                  std::uint32_t txSeq,
-                                 boost::optional<std::uint32_t> ticketSeq,
+                                 std::optional<std::uint32_t> ticketSeq,
                                  TxType txType) {
             error_code_i txErrCode{rpcSUCCESS};
 

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -26,7 +26,6 @@
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/jss.h>
 #include <ripple/protocol/st.h>
-#include <boost/optional.hpp>
 #include <test/jtx.h>
 #include <test/jtx/TestSuite.h>
 #include <test/jtx/WSClient.h>
@@ -43,7 +42,7 @@ class TxQ1_test : public beast::unit_test::suite
     checkMetrics(
         jtx::Env& env,
         std::size_t expectedCount,
-        boost::optional<std::size_t> expectedMaxCount,
+        std::optional<std::size_t> expectedMaxCount,
         std::size_t expectedInLedger,
         std::size_t expectedPerLedger,
         std::uint64_t expectedMinFeeLevel,
@@ -188,23 +187,23 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         // Create several accounts while the fee is cheap so they all apply.
         env.fund(XRP(50000), noripple(alice, bob, charlie, daria));
-        checkMetrics(env, 0, boost::none, 4, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
         // Alice - price starts exploding: held
         env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 4, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 4, 3, 256);
 
         // Bob with really high fee - applies
         env(noop(bob), openLedgerFee(env));
-        checkMetrics(env, 1, boost::none, 5, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 5, 3, 256);
 
         // Daria with low fee: hold
         env(noop(daria), fee(1000), queued);
-        checkMetrics(env, 2, boost::none, 5, 3, 256);
+        checkMetrics(env, 2, std::nullopt, 5, 3, 256);
 
         env.close();
         // Verify that the held transactions got applied
@@ -390,14 +389,14 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         // Fund alice and then fill the ledger.
         env.fund(XRP(50000), noripple(alice));
         env(noop(alice));
         env(noop(alice));
         env(noop(alice));
-        checkMetrics(env, 0, boost::none, 4, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
         //////////////////////////////////////////////////////////////////
 
@@ -409,7 +408,7 @@ public:
         env(noop(alice), ticket::use(tkt1 - 2), ter(tefNO_TICKET));
         env(noop(alice), ticket::use(tkt1 - 1), ter(terPRE_TICKET));
         env.require(owners(alice, 0), tickets(alice, 0));
-        checkMetrics(env, 1, boost::none, 4, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 4, 3, 256);
 
         env.close();
         env.require(owners(alice, 250), tickets(alice, 250));
@@ -645,11 +644,11 @@ public:
         auto gw = Account("gw");
         auto USD = gw["USD"];
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 2, 256);
 
         // Create accounts
         env.fund(XRP(50000), noripple(alice, gw));
-        checkMetrics(env, 0, boost::none, 2, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 2, 256);
         env.close();
         checkMetrics(env, 0, 4, 0, 2, 256);
 
@@ -686,38 +685,38 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 2, 256);
 
         // Create several accounts while the fee is cheap so they all apply.
         env.fund(XRP(50000), noripple(alice, bob, charlie));
-        checkMetrics(env, 0, boost::none, 3, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 3, 2, 256);
 
         // Future transaction for Alice - fails
         env(noop(alice),
             openLedgerFee(env),
             seq(env.seq(alice) + 1),
             ter(terPRE_SEQ));
-        checkMetrics(env, 0, boost::none, 3, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 3, 2, 256);
 
         // Current transaction for Alice: held
         env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 3, 2, 256);
+        checkMetrics(env, 1, std::nullopt, 3, 2, 256);
 
         // Alice - sequence is too far ahead, so won't queue.
         env(noop(alice), seq(env.seq(alice) + 2), ter(telCAN_NOT_QUEUE));
-        checkMetrics(env, 1, boost::none, 3, 2, 256);
+        checkMetrics(env, 1, std::nullopt, 3, 2, 256);
 
         // Bob with really high fee - applies
         env(noop(bob), openLedgerFee(env));
-        checkMetrics(env, 1, boost::none, 4, 2, 256);
+        checkMetrics(env, 1, std::nullopt, 4, 2, 256);
 
         // Daria with low fee: hold
         env(noop(charlie), fee(1000), queued);
-        checkMetrics(env, 2, boost::none, 4, 2, 256);
+        checkMetrics(env, 2, std::nullopt, 4, 2, 256);
 
         // Alice with normal fee: hold
         env(noop(alice), seq(env.seq(alice) + 1), queued);
-        checkMetrics(env, 3, boost::none, 4, 2, 256);
+        checkMetrics(env, 3, std::nullopt, 4, 2, 256);
 
         env.close();
         // Verify that the held transactions got applied
@@ -744,7 +743,7 @@ public:
 
         auto queued = ter(terQUEUED);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 2, 256);
 
         // Fund across several ledgers so the TxQ metrics stay restricted.
         env.fund(XRP(1000), noripple(alice, bob));
@@ -754,11 +753,11 @@ public:
         env.fund(XRP(1000), noripple(edgar, felicia));
         env.close(env.now() + 5s, 10000ms);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 2, 256);
         env(noop(bob));
         env(noop(charlie));
         env(noop(daria));
-        checkMetrics(env, 0, boost::none, 3, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 3, 2, 256);
 
         BEAST_EXPECT(env.current()->info().seq == 6);
         // Fail to queue an item with a low LastLedgerSeq
@@ -773,7 +772,7 @@ public:
         env(noop(charlie), fee(7000), queued);
         env(noop(daria), fee(7000), queued);
         env(noop(edgar), fee(7000), queued);
-        checkMetrics(env, 5, boost::none, 3, 2, 256);
+        checkMetrics(env, 5, std::nullopt, 3, 2, 256);
         {
             auto& txQ = env.app().getTxQ();
             auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
@@ -852,7 +851,7 @@ public:
 
         auto queued = ter(terQUEUED);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 2, 256);
 
         // Fund across several ledgers so the TxQ metrics stay restricted.
         env.fund(XRP(1000), noripple(alice, bob));
@@ -864,14 +863,14 @@ public:
         env(noop(alice));
         env(noop(alice));
         env(noop(alice));
-        checkMetrics(env, 0, boost::none, 3, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 3, 2, 256);
 
         env(noop(bob), queued);
-        checkMetrics(env, 1, boost::none, 3, 2, 256);
+        checkMetrics(env, 1, std::nullopt, 3, 2, 256);
 
         // Since Alice's queue is empty this blocker can go into her queue.
         env(regkey(alice, bob), fee(0), queued);
-        checkMetrics(env, 2, boost::none, 3, 2, 256);
+        checkMetrics(env, 2, std::nullopt, 3, 2, 256);
 
         // Close out this ledger so we can get a maxsize
         env.close();
@@ -971,19 +970,19 @@ public:
 
         auto queued = ter(terQUEUED);
 
-        checkMetrics(env, 0, boost::none, 0, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 2, 256);
 
         env.fund(XRP(1000), noripple(alice, bob));
 
-        checkMetrics(env, 0, boost::none, 2, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 2, 256);
 
         // Fill the ledger
         env(noop(alice));
-        checkMetrics(env, 0, boost::none, 3, 2, 256);
+        checkMetrics(env, 0, std::nullopt, 3, 2, 256);
 
         // Put a transaction in the queue
         env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 3, 2, 256);
+        checkMetrics(env, 1, std::nullopt, 3, 2, 256);
 
         // Now cheat, and bypass the queue.
         {
@@ -1001,7 +1000,7 @@ public:
                 });
             env.postconditions(jt, ter, didApply);
         }
-        checkMetrics(env, 1, boost::none, 4, 2, 256);
+        checkMetrics(env, 1, std::nullopt, 4, 2, 256);
 
         env.close();
         // Alice's queued transaction failed in TxQ::accept
@@ -1030,7 +1029,7 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         // ledgers in queue is 2 because of makeConfig
         auto const initQueueMax = initFee(env, 3, 2, 10, 10, 200, 50);
@@ -1300,11 +1299,11 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 4, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 4, 256);
 
         // Create several accounts while the fee is cheap so they all apply.
         env.fund(XRP(50000), noripple(alice, bob, charlie, daria));
-        checkMetrics(env, 0, boost::none, 4, 4, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 4, 256);
 
         env.close();
         checkMetrics(env, 0, 8, 0, 4, 256);
@@ -1429,13 +1428,13 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 1, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 1, 256);
 
         env.fund(XRP(50000), noripple(alice));
-        checkMetrics(env, 0, boost::none, 1, 1, 256);
+        checkMetrics(env, 0, std::nullopt, 1, 1, 256);
 
         env(fset(alice, asfAccountTxnID));
-        checkMetrics(env, 0, boost::none, 2, 1, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 1, 256);
 
         // Immediately after the fset, the sfAccountTxnID field
         // is still uninitialized, so preflight succeeds here,
@@ -1444,7 +1443,7 @@ public:
             json(R"({"AccountTxnID": "0"})"),
             ter(telCAN_NOT_QUEUE));
 
-        checkMetrics(env, 0, boost::none, 2, 1, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 1, 256);
         env.close();
         // The failed transaction is retried from LocalTx
         // and succeeds.
@@ -1473,15 +1472,15 @@ public:
 
             auto alice = Account("alice");
 
-            checkMetrics(env, 0, boost::none, 0, 2, 256);
+            checkMetrics(env, 0, std::nullopt, 0, 2, 256);
 
             env.fund(XRP(50000), noripple(alice));
-            checkMetrics(env, 0, boost::none, 1, 2, 256);
+            checkMetrics(env, 0, std::nullopt, 1, 2, 256);
 
             for (int i = 0; i < 10; ++i)
                 env(noop(alice), openLedgerFee(env));
 
-            checkMetrics(env, 0, boost::none, 11, 2, 256);
+            checkMetrics(env, 0, std::nullopt, 11, 2, 256);
 
             env.close();
             // If not for the maximum, the per ledger would be 11.
@@ -1667,11 +1666,11 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         env.fund(XRP(50000), noripple(alice, bob));
         env.memoize(charlie);
-        checkMetrics(env, 0, boost::none, 2, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 3, 256);
         {
             // Cannot put a blocker in an account's queue if that queue
             // already holds two or more (non-blocker) entries.
@@ -1680,7 +1679,7 @@ public:
             env(noop(alice));
             // Set a regular key just to clear the password spent flag
             env(regkey(alice, charlie));
-            checkMetrics(env, 0, boost::none, 4, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
             // Put two "normal" txs in the queue
             auto const aliceSeq = env.seq(alice);
@@ -1706,7 +1705,7 @@ public:
 
             // Other accounts are not affected
             env(noop(bob), queued);
-            checkMetrics(env, 3, boost::none, 4, 3, 256);
+            checkMetrics(env, 3, std::nullopt, 4, 3, 256);
 
             // Drain the queue.
             env.close();
@@ -1797,12 +1796,12 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         env.fund(XRP(50000), noripple(alice, bob));
         env.memoize(charlie);
 
-        checkMetrics(env, 0, boost::none, 2, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 3, 256);
 
         std::uint32_t tkt{env.seq(alice) + 1};
         {
@@ -1813,7 +1812,7 @@ public:
             env(ticket::create(alice, 250), seq(tkt - 1));
             // Set a regular key just to clear the password spent flag
             env(regkey(alice, charlie));
-            checkMetrics(env, 0, boost::none, 4, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
             // Put two "normal" txs in the queue
             auto const aliceSeq = env.seq(alice);
@@ -1843,7 +1842,7 @@ public:
 
             // Other accounts are not affected
             env(noop(bob), queued);
-            checkMetrics(env, 3, boost::none, 4, 3, 256);
+            checkMetrics(env, 3, std::nullopt, 4, 3, 256);
 
             // Drain the queue and local transactions.
             env.close();
@@ -2382,23 +2381,23 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         // Fund accounts while the fee is cheap so they all apply.
         env.fund(XRP(50000), noripple(alice, bob, charlie));
-        checkMetrics(env, 0, boost::none, 3, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 3, 3, 256);
 
         // Alice - no fee change yet
         env(noop(alice));
-        checkMetrics(env, 0, boost::none, 4, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
         // Bob with really high fee - applies
         env(noop(bob), openLedgerFee(env));
-        checkMetrics(env, 0, boost::none, 5, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 5, 3, 256);
 
         // Charlie with low fee: queued
         env(noop(charlie), fee(1000), queued);
-        checkMetrics(env, 1, boost::none, 5, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 5, 3, 256);
 
         env.close();
         // Verify that the queued transaction was applied
@@ -2556,7 +2555,7 @@ public:
         auto const bob = Account("bob");
 
         env.fund(XRP(500000), noripple(alice, bob));
-        checkMetrics(env, 0, boost::none, 2, 1, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 1, 256);
 
         auto const aliceSeq = env.seq(alice);
         BEAST_EXPECT(env.current()->info().seq == 3);
@@ -2576,7 +2575,7 @@ public:
             seq(aliceSeq + 3),
             json(R"({"LastLedgerSequence":11})"),
             ter(terQUEUED));
-        checkMetrics(env, 4, boost::none, 2, 1, 256);
+        checkMetrics(env, 4, std::nullopt, 2, 1, 256);
         auto const bobSeq = env.seq(bob);
         // Ledger 4 gets 3,
         // Ledger 5 gets 4,
@@ -2585,7 +2584,7 @@ public:
         {
             env(noop(bob), seq(bobSeq + i), fee(200), ter(terQUEUED));
         }
-        checkMetrics(env, 4 + 3 + 4 + 5, boost::none, 2, 1, 256);
+        checkMetrics(env, 4 + 3 + 4 + 5, std::nullopt, 2, 1, 256);
         // Close ledger 3
         env.close();
         checkMetrics(env, 4 + 4 + 5, 20, 3, 2, 256);
@@ -2650,7 +2649,7 @@ public:
         auto const bob = Account("bob");
 
         env.fund(XRP(500000), noripple(alice, bob));
-        checkMetrics(env, 0, boost::none, 2, 1, 256);
+        checkMetrics(env, 0, std::nullopt, 2, 1, 256);
 
         auto const aliceSeq = env.seq(alice);
         BEAST_EXPECT(env.current()->info().seq == 3);
@@ -2697,7 +2696,7 @@ public:
             seq(aliceSeq + 19),
             json(R"({"LastLedgerSequence":11})"),
             ter(terQUEUED));
-        checkMetrics(env, 10, boost::none, 2, 1, 256);
+        checkMetrics(env, 10, std::nullopt, 2, 1, 256);
 
         auto const bobSeq = env.seq(bob);
         // Ledger 4 gets 2 from bob and 1 from alice,
@@ -2707,7 +2706,7 @@ public:
         {
             env(noop(bob), seq(bobSeq + i), fee(200), ter(terQUEUED));
         }
-        checkMetrics(env, 10 + 2 + 4 + 5, boost::none, 2, 1, 256);
+        checkMetrics(env, 10 + 2 + 4 + 5, std::nullopt, 2, 1, 256);
         // Close ledger 3
         env.close();
         checkMetrics(env, 9 + 4 + 5, 20, 3, 2, 256);
@@ -2801,7 +2800,7 @@ public:
         env.fund(XRP(100000), alice, bob);
 
         fillQueue(env, alice);
-        checkMetrics(env, 0, boost::none, 7, 6, 256);
+        checkMetrics(env, 0, std::nullopt, 7, 6, 256);
 
         // Queue up several transactions for alice sign-and-submit
         auto const aliceSeq = env.seq(alice);
@@ -2821,7 +2820,7 @@ public:
                 envs(noop(alice), fee(1000), seq(none), ter(terQUEUED))(
                     submitParams);
         }
-        checkMetrics(env, 5, boost::none, 7, 6, 256);
+        checkMetrics(env, 5, std::nullopt, 7, 6, 256);
         {
             auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
             SeqProxy seq = SeqProxy::sequence(aliceSeq);
@@ -2846,7 +2845,7 @@ public:
         // Give them a higher fee so they'll beat alice's.
         for (int i = 0; i < 8; ++i)
             envs(noop(bob), fee(2000), seq(none), ter(terQUEUED))();
-        checkMetrics(env, 13, boost::none, 7, 6, 256);
+        checkMetrics(env, 13, std::nullopt, 7, 6, 256);
 
         env.close();
         checkMetrics(env, 5, 14, 8, 7, 256);
@@ -3479,7 +3478,7 @@ public:
 
         // Fund the first few accounts at non escalated fee
         env.fund(XRP(50000), noripple(a, b, c, d));
-        checkMetrics(env, 0, boost::none, 4, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
         // First transaction establishes the messaging
         using namespace std::chrono_literals;
@@ -3612,14 +3611,14 @@ public:
         auto alice = Account("alice");
         auto bob = Account("bob");
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
         env.fund(XRP(50000000), alice, bob);
 
         fillQueue(env, alice);
 
         auto calcTotalFee = [&](std::int64_t alreadyPaid,
-                                boost::optional<std::size_t> numToClear =
-                                    boost::none) -> std::uint64_t {
+                                std::optional<std::size_t> numToClear =
+                                    std::nullopt) -> std::uint64_t {
             auto totalFactor = 0;
             auto const metrics = env.app().getTxQ().getMetrics(*env.current());
             if (!numToClear)
@@ -3658,7 +3657,7 @@ public:
                 seq(aliceSeq++),
                 ter(terQUEUED));
 
-            checkMetrics(env, 3, boost::none, 4, 3, 256);
+            checkMetrics(env, 3, std::nullopt, 4, 3, 256);
 
             // Figure out how much it would cost to cover all the
             // queued txs + itself
@@ -3671,7 +3670,7 @@ public:
             // the edge case test.
             env(noop(alice), fee(totalFee1), seq(aliceSeq++), ter(terQUEUED));
 
-            checkMetrics(env, 4, boost::none, 4, 3, 256);
+            checkMetrics(env, 4, std::nullopt, 4, 3, 256);
 
             // Now repeat the process including the new tx
             // and avoiding the rounding error
@@ -3681,7 +3680,7 @@ public:
             // Submit a transaction with that fee. It will succeed.
             env(noop(alice), fee(totalFee2), seq(aliceSeq++));
 
-            checkMetrics(env, 0, boost::none, 9, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 9, 3, 256);
         }
 
         testcase("replace last tx with enough to clear queue");
@@ -3701,7 +3700,7 @@ public:
                 seq(aliceSeq++),
                 ter(terQUEUED));
 
-            checkMetrics(env, 3, boost::none, 9, 3, 256);
+            checkMetrics(env, 3, std::nullopt, 9, 3, 256);
 
             // Figure out how much it would cost to cover all the
             // queued txs + itself
@@ -3714,7 +3713,7 @@ public:
             env(noop(alice), fee(totalFee), seq(aliceSeq++));
 
             // The queue is clear
-            checkMetrics(env, 0, boost::none, 12, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 12, 3, 256);
 
             env.close();
             checkMetrics(env, 0, 24, 0, 12, 256);
@@ -3826,16 +3825,16 @@ public:
                      {"maximum_txn_per_account", "200"}}));
             auto alice = Account("alice");
 
-            checkMetrics(env, 0, boost::none, 0, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 0, 3, 256);
             env.fund(XRP(50000000), alice);
 
             fillQueue(env, alice);
-            checkMetrics(env, 0, boost::none, 4, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 4, 3, 256);
             auto seqAlice = env.seq(alice);
             auto txCount = 140;
             for (int i = 0; i < txCount; ++i)
                 env(noop(alice), seq(seqAlice++), ter(terQUEUED));
-            checkMetrics(env, txCount, boost::none, 4, 3, 256);
+            checkMetrics(env, txCount, std::nullopt, 4, 3, 256);
 
             // Close a few ledgers successfully, so the limit grows
 
@@ -3912,16 +3911,16 @@ public:
                      {"maximum_txn_per_account", "200"}}));
             auto alice = Account("alice");
 
-            checkMetrics(env, 0, boost::none, 0, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 0, 3, 256);
             env.fund(XRP(50000000), alice);
 
             fillQueue(env, alice);
-            checkMetrics(env, 0, boost::none, 4, 3, 256);
+            checkMetrics(env, 0, std::nullopt, 4, 3, 256);
             auto seqAlice = env.seq(alice);
             auto txCount = 43;
             for (int i = 0; i < txCount; ++i)
                 env(noop(alice), seq(seqAlice++), ter(terQUEUED));
-            checkMetrics(env, txCount, boost::none, 4, 3, 256);
+            checkMetrics(env, txCount, std::nullopt, 4, 3, 256);
 
             // Close a few ledgers successfully, so the limit grows
 
@@ -3970,19 +3969,19 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         // Create account
         env.fund(XRP(50000), noripple(alice));
-        checkMetrics(env, 0, boost::none, 1, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 1, 3, 256);
 
         fillQueue(env, alice);
-        checkMetrics(env, 0, boost::none, 4, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
         // Queue a transaction
         auto const aliceSeq = env.seq(alice);
         env(noop(alice), queued);
-        checkMetrics(env, 1, boost::none, 4, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 4, 3, 256);
 
         // Now, apply a (different) transaction directly
         // to the open ledger, bypassing the queue
@@ -3998,18 +3997,18 @@ public:
             return result.second;
         });
         // the queued transaction is still there
-        checkMetrics(env, 1, boost::none, 5, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 5, 3, 256);
 
         // The next transaction should be able to go into the open
         // ledger, even though aliceSeq is queued.  In earlier incarnations
         // of the TxQ this would cause an assert.
         env(noop(alice), seq(aliceSeq + 1), openLedgerFee(env));
-        checkMetrics(env, 1, boost::none, 6, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 6, 3, 256);
         // Now queue a couple more transactions to make sure
         // they succeed despite aliceSeq being queued
         env(noop(alice), seq(aliceSeq + 2), queued);
         env(noop(alice), seq(aliceSeq + 3), queued);
-        checkMetrics(env, 3, boost::none, 6, 3, 256);
+        checkMetrics(env, 3, std::nullopt, 6, 3, 256);
 
         // Now close the ledger. One of the queued transactions
         // (aliceSeq) should be dropped.
@@ -4037,11 +4036,11 @@ public:
 
         BEAST_EXPECT(env.current()->fees().base == 10);
 
-        checkMetrics(env, 0, boost::none, 0, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 0, 3, 256);
 
         // Create account
         env.fund(XRP(50000), noripple(alice));
-        checkMetrics(env, 0, boost::none, 1, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 1, 3, 256);
 
         // Create tickets
         std::uint32_t const tktSeq0{env.seq(alice) + 1};
@@ -4049,12 +4048,12 @@ public:
 
         // Fill the queue so the next transaction will be queued.
         fillQueue(env, alice);
-        checkMetrics(env, 0, boost::none, 4, 3, 256);
+        checkMetrics(env, 0, std::nullopt, 4, 3, 256);
 
         // Queue a transaction with a ticket.  Leave an unused ticket
         // on either side.
         env(noop(alice), ticket::use(tktSeq0 + 1), queued);
-        checkMetrics(env, 1, boost::none, 4, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 4, 3, 256);
 
         // Now, apply a (different) transaction directly
         // to the open ledger, bypassing the queue
@@ -4070,25 +4069,25 @@ public:
             return result.second;
         });
         // the queued transaction is still there
-        checkMetrics(env, 1, boost::none, 5, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 5, 3, 256);
 
         // The next (sequence-based) transaction should be able to go into
         // the open ledger, even though tktSeq0 is queued.  Note that this
         // sequence-based transaction goes in front of the queued
         // transaction, so the queued transaction is left in the queue.
         env(noop(alice), openLedgerFee(env));
-        checkMetrics(env, 1, boost::none, 6, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 6, 3, 256);
 
         // We should be able to do the same thing with a ticket that goes
         // if front of the queued transaction.  This one too will leave
         // the queued transaction in place.
         env(noop(alice), ticket::use(tktSeq0 + 0), openLedgerFee(env));
-        checkMetrics(env, 1, boost::none, 7, 3, 256);
+        checkMetrics(env, 1, std::nullopt, 7, 3, 256);
 
         // We have one ticketed transaction in the queue.  We should able
         // to add another to the queue.
         env(noop(alice), ticket::use(tktSeq0 + 2), queued);
-        checkMetrics(env, 2, boost::none, 7, 3, 256);
+        checkMetrics(env, 2, std::nullopt, 7, 3, 256);
 
         // Here we try to force the queued transactions into the ledger by
         // adding one more queued (ticketed) transaction that pays enough
@@ -4104,7 +4103,7 @@ public:
         // transaction is equally capable of going into the ledger independent
         // of all other ticket- or sequence-based transactions.
         env(noop(alice), ticket::use(tktSeq0 + 3), fee(XRP(1)));
-        checkMetrics(env, 2, boost::none, 8, 3, 256);
+        checkMetrics(env, 2, std::nullopt, 8, 3, 256);
 
         // Now close the ledger. One of the queued transactions
         // (the one with tktSeq0 + 1) should be dropped.

--- a/src/test/app/ValidatorList_test.cpp
+++ b/src/test/app/ValidatorList_test.cpp
@@ -130,7 +130,7 @@ private:
         std::vector<Validator> const& validators,
         std::size_t sequence,
         std::size_t validUntil,
-        boost::optional<std::size_t> validFrom = {})
+        std::optional<std::size_t> validFrom = {})
     {
         std::string data = "{\"sequence\":" + std::to_string(sequence) +
             ",\"expiration\":" + std::to_string(validUntil);
@@ -1635,7 +1635,7 @@ private:
                 env.journal);
 
             // Empty list has no expiration
-            BEAST_EXPECT(trustedKeys->expires() == boost::none);
+            BEAST_EXPECT(trustedKeys->expires() == std::nullopt);
 
             // Config listed keys have maximum expiry
             PublicKey emptyLocalKey;
@@ -1643,7 +1643,7 @@ private:
             trustedKeys->load(emptyLocalKey, {toStr(localCfgListed)}, {});
             BEAST_EXPECT(
                 trustedKeys->expires() &&
-                trustedKeys->expires().get() == NetClock::time_point::max());
+                trustedKeys->expires().value() == NetClock::time_point::max());
             BEAST_EXPECT(trustedKeys->listed(localCfgListed));
         }
 
@@ -1726,7 +1726,7 @@ private:
             PreparedList prep2 = addPublishedList();
 
             // Initially, no list has been published, so no known expiration
-            BEAST_EXPECT(trustedKeys->expires() == boost::none);
+            BEAST_EXPECT(trustedKeys->expires() == std::nullopt);
 
             // Apply first list
             checkResult(
@@ -1738,7 +1738,7 @@ private:
 
             // One list still hasn't published, so expiration is still
             // unknown
-            BEAST_EXPECT(trustedKeys->expires() == boost::none);
+            BEAST_EXPECT(trustedKeys->expires() == std::nullopt);
 
             // Apply second list
             checkResult(
@@ -1750,7 +1750,7 @@ private:
             // We now have loaded both lists, so expiration is known
             BEAST_EXPECT(
                 trustedKeys->expires() &&
-                trustedKeys->expires().get() == prep1.expirations.back());
+                trustedKeys->expires().value() == prep1.expirations.back());
 
             // Advance past the first list's LAST validFrom date. It remains
             // the earliest validUntil, while rotating in the second list
@@ -1764,7 +1764,7 @@ private:
                     env.app().getHashRouter());
                 BEAST_EXPECT(
                     trustedKeys->expires() &&
-                    trustedKeys->expires().get() == prep1.expirations.back());
+                    trustedKeys->expires().value() == prep1.expirations.back());
                 BEAST_EXPECT(!changes.added.empty());
                 BEAST_EXPECT(changes.removed.empty());
             }
@@ -1781,7 +1781,7 @@ private:
                     env.app().getHashRouter());
                 BEAST_EXPECT(
                     trustedKeys->expires() &&
-                    trustedKeys->expires().get() == prep1.expirations.back());
+                    trustedKeys->expires().value() == prep1.expirations.back());
                 BEAST_EXPECT(changes.added.empty());
                 BEAST_EXPECT(changes.removed.empty());
             }
@@ -1798,7 +1798,7 @@ private:
 
         auto createValidatorList =
             [&](std::uint32_t vlSize,
-                boost::optional<std::size_t> minimumQuorum = {})
+                std::optional<std::size_t> minimumQuorum = {})
             -> std::shared_ptr<ValidatorList> {
             auto trustedKeys = std::make_shared<ValidatorList>(
                 manifests,

--- a/src/test/basics/RangeSet_test.cpp
+++ b/src/test/basics/RangeSet_test.cpp
@@ -41,7 +41,7 @@ public:
 
         for (std::uint32_t i = 1; i < 100; ++i)
         {
-            boost::optional<std::uint32_t> expected;
+            std::optional<std::uint32_t> expected;
             // no prev missing in domain for i <= 6
             if (i > 6)
             {

--- a/src/test/beast/beast_io_latency_probe_test.cpp
+++ b/src/test/beast/beast_io_latency_probe_test.cpp
@@ -18,15 +18,18 @@
 //==============================================================================
 #include <ripple/beast/asio/io_latency_probe.h>
 #include <ripple/beast/unit_test.h>
+
+#include <beast/test/yield_to.hpp>
+
 #include <boost/asio/basic_waitable_timer.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_service.hpp>
-#include <boost/optional.hpp>
+
 #include <algorithm>
-#include <beast/test/yield_to.hpp>
 #include <chrono>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -60,7 +63,7 @@ class io_latency_probe_test : public beast::unit_test::suite,
         {
             using namespace std::chrono;
             boost::asio::io_service ios;
-            boost::optional<boost::asio::io_service::work> work{ios};
+            std::optional<boost::asio::io_service::work> work{ios};
             std::thread worker{[&] { ios.run(); }};
             boost::asio::basic_waitable_timer<Clock> timer{ios};
             elapsed_times_.reserve(num_samples);
@@ -86,7 +89,7 @@ class io_latency_probe_test : public beast::unit_test::suite,
                 });
                 cv.wait(mainlock, [&done] { return done; });
             }
-            work = boost::none;
+            work.reset();
             worker.join();
             if (wait_err)
                 boost::asio::detail::throw_error(wait_err, "wait");

--- a/src/test/consensus/LedgerTrie_test.cpp
+++ b/src/test/consensus/LedgerTrie_test.cpp
@@ -362,8 +362,8 @@ class LedgerTrie_test : public beast::unit_test::suite
         // Empty
         {
             LedgerTrie<Ledger> t;
-            BEAST_EXPECT(t.getPreferred(Seq{0}) == boost::none);
-            BEAST_EXPECT(t.getPreferred(Seq{2}) == boost::none);
+            BEAST_EXPECT(t.getPreferred(Seq{0}) == std::nullopt);
+            BEAST_EXPECT(t.getPreferred(Seq{2}) == std::nullopt);
         }
         // Genesis support is NOT empty
         {
@@ -373,7 +373,7 @@ class LedgerTrie_test : public beast::unit_test::suite
             t.insert(genesis);
             BEAST_EXPECT(t.getPreferred(Seq{0})->id == genesis.id());
             BEAST_EXPECT(t.remove(genesis));
-            BEAST_EXPECT(t.getPreferred(Seq{0}) == boost::none);
+            BEAST_EXPECT(t.getPreferred(Seq{0}) == std::nullopt);
             BEAST_EXPECT(!t.remove(genesis));
         }
         // Single node no children

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -2020,9 +2020,9 @@ negUnlSizeTest(
 {
     bool sameSize = l->negativeUNL().size() == size;
     bool sameToDisable =
-        (l->validatorToDisable() != boost::none) == hasToDisable;
+        (l->validatorToDisable() != std::nullopt) == hasToDisable;
     bool sameToReEnable =
-        (l->validatorToReEnable() != boost::none) == hasToReEnable;
+        (l->validatorToReEnable() != std::nullopt) == hasToReEnable;
 
     return sameSize && sameToDisable && sameToReEnable;
 }

--- a/src/test/consensus/Validations_test.cpp
+++ b/src/test/consensus/Validations_test.cpp
@@ -55,7 +55,7 @@ class Validations_test : public beast::unit_test::suite
         PeerID nodeID_;
         bool trusted_ = true;
         std::size_t signIdx_{1};
-        boost::optional<std::uint32_t> loadFee_;
+        std::optional<std::uint32_t> loadFee_;
 
     public:
         Node(PeerID nodeID, clock_type const& c) : c_(c), nodeID_(nodeID)
@@ -200,7 +200,7 @@ class Validations_test : public beast::unit_test::suite
             return toNetClock(c_);
         }
 
-        boost::optional<Ledger>
+        std::optional<Ledger>
         acquire(Ledger::ID const& id)
         {
             return oracle_.lookup(id);
@@ -443,7 +443,7 @@ class Validations_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 harness.vals().getNodesAfter(ledgerA, ledgerA.id()) == 0);
             BEAST_EXPECT(
-                harness.vals().getPreferred(genesisLedger) == boost::none);
+                harness.vals().getPreferred(genesisLedger) == std::nullopt);
         }
     }
 
@@ -780,7 +780,7 @@ class Validations_test : public beast::unit_test::suite
         };
 
         // Empty (no ledgers)
-        BEAST_EXPECT(harness.vals().getPreferred(ledgerA) == boost::none);
+        BEAST_EXPECT(harness.vals().getPreferred(ledgerA) == std::nullopt);
 
         // Single ledger
         BEAST_EXPECT(ValStatus::current == harness.add(a.validate(ledgerB)));
@@ -1014,7 +1014,7 @@ class Validations_test : public beast::unit_test::suite
                 trustedVals.size());
             if (trustedVals.empty())
                 BEAST_EXPECT(
-                    vals.getPreferred(this->genesisLedger) == boost::none);
+                    vals.getPreferred(this->genesisLedger) == std::nullopt);
             else
                 BEAST_EXPECT(
                     vals.getPreferred(this->genesisLedger)->second == testID);
@@ -1083,7 +1083,7 @@ class Validations_test : public beast::unit_test::suite
             // make acquiring ledger available
             h["ab"];
             BEAST_EXPECT(vals.currentTrusted() == trustedVals);
-            BEAST_EXPECT(vals.getPreferred(genesisLedger) == boost::none);
+            BEAST_EXPECT(vals.getPreferred(genesisLedger) == std::nullopt);
             BEAST_EXPECT(
                 vals.getNodesAfter(genesisLedger, genesisLedger.id()) == 0);
         }

--- a/src/test/core/ClosureCounter_test.cpp
+++ b/src/test/core/ClosureCounter_test.cpp
@@ -58,7 +58,7 @@ class ClosureCounter_test : public beast::unit_test::suite
             BEAST_EXPECT(evidence == 2);
 
             // Destroying the contents of wrapped should decrement voidCounter.
-            wrapped = boost::none;
+            wrapped = std::nullopt;
             BEAST_EXPECT(voidCounter.count() == 0);
         }
         {
@@ -82,7 +82,7 @@ class ClosureCounter_test : public beast::unit_test::suite
             BEAST_EXPECT(evidence == 11);
 
             // Destroying the contents of wrapped should decrement setCounter.
-            wrapped = boost::none;
+            wrapped = std::nullopt;
             BEAST_EXPECT(setCounter.count() == 0);
         }
         {
@@ -102,7 +102,7 @@ class ClosureCounter_test : public beast::unit_test::suite
             BEAST_EXPECT((*wrapped)(2, -8) == -6);
 
             // Destroying the contents of wrapped should decrement sumCounter.
-            wrapped = boost::none;
+            wrapped = std::nullopt;
             BEAST_EXPECT(sumCounter.count() == 0);
         }
     }
@@ -274,8 +274,8 @@ class ClosureCounter_test : public beast::unit_test::suite
         using namespace std::chrono_literals;
         voidCounter.join("testWrap", 1ms, j);
 
-        // Wrapping a closure after join() should return boost::none.
-        BEAST_EXPECT(voidCounter.wrap([]() {}) == boost::none);
+        // Wrapping a closure after join() should return std::nullopt.
+        BEAST_EXPECT(voidCounter.wrap([]() {}) == std::nullopt);
     }
 
     void
@@ -310,7 +310,7 @@ class ClosureCounter_test : public beast::unit_test::suite
 
         // Destroy the contents of wrapped and expect the thread to exit
         // (asynchronously).
-        wrapped = boost::none;
+        wrapped = std::nullopt;
         BEAST_EXPECT(voidCounter.count() == 0);
 
         // Wait for the thread to exit.

--- a/src/test/core/Config_test.cpp
+++ b/src/test/core/Config_test.cpp
@@ -810,11 +810,11 @@ trustthesevalidators.gov
         ParsedPort rpc;
         if (!unexcept([&]() { parse_Port(rpc, conf["port_rpc"], log); }))
             return;
-        BEAST_EXPECT(rpc.admin_ip && (rpc.admin_ip.get().size() == 2));
+        BEAST_EXPECT(rpc.admin_ip && (rpc.admin_ip.value().size() == 2));
         ParsedPort wss;
         if (!unexcept([&]() { parse_Port(wss, conf["port_wss_admin"], log); }))
             return;
-        BEAST_EXPECT(wss.admin_ip && (wss.admin_ip.get().size() == 1));
+        BEAST_EXPECT(wss.admin_ip && (wss.admin_ip.value().size() == 1));
     }
 
     void
@@ -991,7 +991,7 @@ r.ripple.com 51235
             BEAST_EXPECT(!get_if_exists(s, "a_string", val_10));
             BEAST_EXPECT(val_10 == 10);
 
-            BEAST_EXPECT(s.get<int>("not_a_key") == boost::none);
+            BEAST_EXPECT(s.get<int>("not_a_key") == std::nullopt);
             try
             {
                 s.get<int>("a_string");

--- a/src/test/core/SociDB_test.cpp
+++ b/src/test/core/SociDB_test.cpp
@@ -223,6 +223,8 @@ public:
             }
             try
             {
+                // SOCI requires boost::optional (not std::optional) as
+                // parameters.
                 boost::optional<std::int32_t> ig;
                 boost::optional<std::uint32_t> uig;
                 boost::optional<std::int64_t> big;

--- a/src/test/csf/Digraph.h
+++ b/src/test/csf/Digraph.h
@@ -21,10 +21,11 @@
 #define RIPPLE_TEST_CSF_DIGRAPH_H_INCLUDED
 
 #include <boost/container/flat_map.hpp>
-#include <boost/optional.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/iterator_range.hpp>
+
 #include <fstream>
+#include <optional>
 #include <type_traits>
 #include <unordered_map>
 
@@ -111,10 +112,10 @@ public:
 
         @param source The source vertex
         @param target The target vertex
-        @return optional<Edge> which is boost::none if no edge exists
+        @return optional<Edge> which is std::nullopt if no edge exists
 
     */
-    boost::optional<EdgeData>
+    std::optional<EdgeData>
     edge(Vertex source, Vertex target) const
     {
         auto it = graph_.find(source);
@@ -124,7 +125,7 @@ public:
             if (edgeIt != it->second.end())
                 return edgeIt->second;
         }
-        return boost::none;
+        return std::nullopt;
     }
 
     /** Check if two vertices are connected
@@ -136,7 +137,7 @@ public:
     bool
     connected(Vertex source, Vertex target) const
     {
-        return edge(source, target) != boost::none;
+        return edge(source, target) != std::nullopt;
     }
 
     /** Range over vertices in the graph

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -144,12 +144,12 @@ struct Peer
             return p_.now();
         }
 
-        boost::optional<Ledger>
+        std::optional<Ledger>
         acquire(Ledger::ID const& lId)
         {
             if (Ledger const* ledger = p_.acquireLedger(lId))
                 return *ledger;
-            return boost::none;
+            return std::nullopt;
         }
     };
 

--- a/src/test/csf/TrustGraph.h
+++ b/src/test/csf/TrustGraph.h
@@ -21,11 +21,11 @@
 #define RIPPLE_TEST_CSF_UNL_H_INCLUDED
 
 #include <boost/container/flat_set.hpp>
-#include <boost/optional.hpp>
+#include <test/csf/random.h>
+
 #include <chrono>
 #include <numeric>
 #include <random>
-#include <test/csf/random.h>
 #include <vector>
 
 namespace ripple {

--- a/src/test/csf/Validation.h
+++ b/src/test/csf/Validation.h
@@ -20,9 +20,10 @@
 #define RIPPLE_TEST_CSF_VALIDATION_H_INCLUDED
 
 #include <ripple/basics/tagged_integer.h>
-#include <boost/optional.hpp>
-#include <memory>
 #include <test/csf/ledgers.h>
+
+#include <memory>
+#include <optional>
 #include <utility>
 
 namespace ripple {
@@ -54,7 +55,7 @@ class Validation
     PeerID nodeID_{0};
     bool trusted_ = false;
     bool full_ = false;
-    boost::optional<std::uint32_t> loadFee_;
+    std::optional<std::uint32_t> loadFee_;
     std::uint64_t cookie_{0};
 
 public:
@@ -69,7 +70,7 @@ public:
         PeerKey key,
         PeerID nodeID,
         bool full,
-        boost::optional<std::uint32_t> loadFee = boost::none,
+        std::optional<std::uint32_t> loadFee = std::nullopt,
         std::uint64_t cookie = 0)
         : ledgerID_{id}
         , seq_{seq}
@@ -137,7 +138,7 @@ public:
         return cookie_;
     }
 
-    boost::optional<std::uint32_t>
+    std::optional<std::uint32_t>
     loadFee() const
     {
         return loadFee_;

--- a/src/test/csf/collectors.h
+++ b/src/test/csf/collectors.h
@@ -20,12 +20,13 @@
 #define RIPPLE_TEST_CSF_COLLECTORS_H_INCLUDED
 
 #include <ripple/basics/UnorderedContainers.h>
-#include <boost/optional.hpp>
-#include <chrono>
-#include <ostream>
 #include <test/csf/Histogram.h>
 #include <test/csf/SimTime.h>
 #include <test/csf/events.h>
+
+#include <chrono>
+#include <optional>
+#include <ostream>
 #include <tuple>
 
 namespace ripple {
@@ -180,8 +181,8 @@ struct TxCollector
     {
         Tx tx;
         SimTime submitted;
-        boost::optional<SimTime> accepted;
-        boost::optional<SimTime> validated;
+        std::optional<SimTime> accepted;
+        std::optional<SimTime> validated;
 
         Tracker(Tx tx_, SimTime submitted_) : tx{tx_}, submitted{submitted_}
         {
@@ -453,7 +454,7 @@ struct LedgerCollector
     struct Tracker
     {
         SimTime accepted;
-        boost::optional<SimTime> fullyValidated;
+        std::optional<SimTime> fullyValidated;
 
         Tracker(SimTime accepted_) : accepted{accepted_}
         {

--- a/src/test/csf/impl/ledgers.cpp
+++ b/src/test/csf/impl/ledgers.cpp
@@ -125,7 +125,7 @@ LedgerOracle::accept(
     return Ledger(it->second, &(it->first));
 }
 
-boost::optional<Ledger>
+std::optional<Ledger>
 LedgerOracle::lookup(Ledger::ID const& id) const
 {
     auto const it = instances_.right.find(id);
@@ -133,7 +133,7 @@ LedgerOracle::lookup(Ledger::ID const& id) const
     {
         return Ledger(it->first, &(it->second));
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 std::size_t

--- a/src/test/csf/ledgers.h
+++ b/src/test/csf/ledgers.h
@@ -25,7 +25,7 @@
 #include <ripple/consensus/LedgerTiming.h>
 #include <ripple/json/json_value.h>
 #include <boost/bimap/bimap.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <set>
 #include <test/csf/Tx.h>
 
@@ -256,7 +256,7 @@ public:
     LedgerOracle();
 
     /** Find the ledger with the given ID */
-    boost::optional<Ledger>
+    std::optional<Ledger>
     lookup(Ledger::ID const& id) const;
 
     /** Accept the given txs and generate a new ledger

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -333,8 +333,7 @@ public:
     bool
     close(
         NetClock::time_point closeTime,
-        boost::optional<std::chrono::milliseconds> consensusDelay =
-            boost::none);
+        std::optional<std::chrono::milliseconds> consensusDelay = std::nullopt);
 
     /** Close and advance the ledger.
 

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -25,9 +25,10 @@
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/TxFlags.h>
 #include <ripple/protocol/jss.h>
-#include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 #include <test/jtx.h>
+
+#include <boost/lexical_cast.hpp>
+#include <optional>
 #include <utility>
 
 namespace ripple {
@@ -765,13 +766,13 @@ public:
         // the supported amendments list and tests that it can be
         // enabled explicitly
 
-        auto const neverSupportedFeat = [&]() -> boost::optional<uint256> {
+        auto const neverSupportedFeat = [&]() -> std::optional<uint256> {
             auto const n = supported.size();
             for (size_t i = 0; i < n; ++i)
                 if (!supported[i])
                     return bitsetIndexToFeature(i);
 
-            return boost::none;
+            return std::nullopt;
         }();
 
         if (!neverSupportedFeat)

--- a/src/test/jtx/JTx.h
+++ b/src/test/jtx/JTx.h
@@ -23,10 +23,11 @@
 #include <ripple/json/json_value.h>
 #include <ripple/protocol/STTx.h>
 #include <ripple/protocol/TER.h>
-#include <functional>
-#include <memory>
 #include <test/jtx/basic_prop.h>
 #include <test/jtx/requires.h>
+
+#include <functional>
+#include <memory>
 #include <vector>
 
 namespace ripple {
@@ -42,7 +43,7 @@ struct JTx
 {
     Json::Value jv;
     requires_t requires;
-    boost::optional<TER> ter = TER{tesSUCCESS};
+    std::optional<TER> ter = TER{tesSUCCESS};
     bool fill_fee = true;
     bool fill_seq = true;
     bool fill_sig = true;

--- a/src/test/jtx/TrustedPublisherServer.h
+++ b/src/test/jtx/TrustedPublisherServer.h
@@ -546,7 +546,7 @@ private:
         socket_type sock(std::move(s));
         flat_buffer sb;
         error_code ec;
-        boost::optional<ssl_stream<ip::tcp::socket&>> ssl_stream;
+        std::optional<ssl_stream<ip::tcp::socket&>> ssl_stream;
 
         if (ssl)
         {

--- a/src/test/jtx/WSClient.h
+++ b/src/test/jtx/WSClient.h
@@ -21,10 +21,11 @@
 #define RIPPLE_TEST_WSCLIENT_H_INCLUDED
 
 #include <ripple/core/Config.h>
-#include <boost/optional.hpp>
+#include <test/jtx/AbstractClient.h>
+
 #include <chrono>
 #include <memory>
-#include <test/jtx/AbstractClient.h>
+#include <optional>
 
 namespace ripple {
 namespace test {
@@ -33,13 +34,13 @@ class WSClient : public AbstractClient
 {
 public:
     /** Retrieve a message. */
-    virtual boost::optional<Json::Value>
+    virtual std::optional<Json::Value>
     getMsg(
         std::chrono::milliseconds const& timeout = std::chrono::milliseconds{
             0}) = 0;
 
     /** Retrieve a message that meets the predicate criteria. */
-    virtual boost::optional<Json::Value>
+    virtual std::optional<Json::Value>
     findMsg(
         std::chrono::milliseconds const& timeout,
         std::function<bool(Json::Value const&)> pred) = 0;

--- a/src/test/jtx/fee.h
+++ b/src/test/jtx/fee.h
@@ -22,9 +22,10 @@
 
 #include <ripple/basics/contract.h>
 #include <ripple/protocol/STAmount.h>
-#include <boost/optional.hpp>
 #include <test/jtx/Env.h>
 #include <test/jtx/tags.h>
+
+#include <optional>
 
 namespace ripple {
 namespace test {
@@ -35,7 +36,7 @@ class fee
 {
 private:
     bool manual_ = true;
-    boost::optional<STAmount> amount_;
+    std::optional<STAmount> amount_;
 
 public:
     explicit fee(autofill_t) : manual_(false)

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -120,7 +120,7 @@ Env::closed()
 bool
 Env::close(
     NetClock::time_point closeTime,
-    boost::optional<std::chrono::milliseconds> consensusDelay)
+    std::optional<std::chrono::milliseconds> consensusDelay)
 {
     // Round up to next distinguishable value
     using namespace std::chrono_literals;
@@ -422,7 +422,7 @@ Env::st(JTx const& jt)
 {
     // The parse must succeed, since we
     // generated the JSON ourselves.
-    boost::optional<STObject> obj;
+    std::optional<STObject> obj;
     try
     {
         obj = jtx::parse(jt.jv);

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -88,7 +88,7 @@ class WSClientImpl : public WSClient
     }
 
     boost::asio::io_service ios_;
-    boost::optional<boost::asio::io_service::work> work_;
+    std::optional<boost::asio::io_service::work> work_;
     boost::asio::io_service::strand strand_;
     std::thread thread_;
     boost::asio::ip::tcp::socket stream_;
@@ -120,7 +120,7 @@ class WSClientImpl : public WSClient
                 }));
             }
         }));
-        work_ = boost::none;
+        work_ = std::nullopt;
         thread_.join();
     }
 
@@ -212,21 +212,21 @@ public:
         return {};
     }
 
-    boost::optional<Json::Value>
+    std::optional<Json::Value>
     getMsg(std::chrono::milliseconds const& timeout) override
     {
         std::shared_ptr<msg> m;
         {
             std::unique_lock<std::mutex> lock(m_);
             if (!cv_.wait_for(lock, timeout, [&] { return !msgs_.empty(); }))
-                return boost::none;
+                return std::nullopt;
             m = std::move(msgs_.back());
             msgs_.pop_back();
         }
         return std::move(m->jv);
     }
 
-    boost::optional<Json::Value>
+    std::optional<Json::Value>
     findMsg(
         std::chrono::milliseconds const& timeout,
         std::function<bool(Json::Value const&)> pred) override
@@ -247,7 +247,7 @@ public:
                     return false;
                 }))
             {
-                return boost::none;
+                return std::nullopt;
             }
         }
         return std::move(m->jv);

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -79,7 +79,7 @@ msig::operator()(Env& env, JTx& jt) const
     auto const mySigners = signers;
     jt.signer = [mySigners, &env](Env&, JTx& jtx) {
         jtx[sfSigningPubKey.getJsonName()] = "";
-        boost::optional<STObject> st;
+        std::optional<STObject> st;
         try
         {
             st = parse(jtx.jv);

--- a/src/test/jtx/impl/paths.cpp
+++ b/src/test/jtx/impl/paths.cpp
@@ -39,7 +39,7 @@ paths::operator()(Env& env, JTx& jt) const
         in_.currency,
         in_.account,
         amount,
-        boost::none,
+        std::nullopt,
         env.app());
     if (!pf.findPaths(depth_))
         return;

--- a/src/test/jtx/memo.h
+++ b/src/test/jtx/memo.h
@@ -20,7 +20,6 @@
 #ifndef RIPPLE_TEST_JTX_MEMO_H_INCLUDED
 #define RIPPLE_TEST_JTX_MEMO_H_INCLUDED
 
-#include <boost/optional.hpp>
 #include <test/jtx/Env.h>
 
 namespace ripple {

--- a/src/test/jtx/seq.h
+++ b/src/test/jtx/seq.h
@@ -20,9 +20,10 @@
 #ifndef RIPPLE_TEST_JTX_SEQ_H_INCLUDED
 #define RIPPLE_TEST_JTX_SEQ_H_INCLUDED
 
-#include <boost/optional.hpp>
 #include <test/jtx/Env.h>
 #include <test/jtx/tags.h>
+
+#include <optional>
 
 namespace ripple {
 namespace test {
@@ -33,7 +34,7 @@ struct seq
 {
 private:
     bool manual_ = true;
-    boost::optional<std::uint32_t> num_;
+    std::optional<std::uint32_t> num_;
 
 public:
     explicit seq(autofill_t) : manual_(false)

--- a/src/test/jtx/sig.h
+++ b/src/test/jtx/sig.h
@@ -20,8 +20,9 @@
 #ifndef RIPPLE_TEST_JTX_SIG_H_INCLUDED
 #define RIPPLE_TEST_JTX_SIG_H_INCLUDED
 
-#include <boost/optional.hpp>
 #include <test/jtx/Env.h>
+
+#include <optional>
 
 namespace ripple {
 namespace test {
@@ -34,7 +35,7 @@ class sig
 {
 private:
     bool manual_ = true;
-    boost::optional<Account> account_;
+    std::optional<Account> account_;
 
 public:
     explicit sig(autofill_t) : manual_(false)

--- a/src/test/jtx/ter.h
+++ b/src/test/jtx/ter.h
@@ -33,7 +33,7 @@ namespace jtx {
 class ter
 {
 private:
-    boost::optional<TER> v_;
+    std::optional<TER> v_;
 
 public:
     explicit ter(decltype(std::ignore))

--- a/src/test/jtx/ticket.h
+++ b/src/test/jtx/ticket.h
@@ -20,11 +20,11 @@
 #ifndef RIPPLE_TEST_JTX_TICKET_H_INCLUDED
 #define RIPPLE_TEST_JTX_TICKET_H_INCLUDED
 
-#include <boost/optional.hpp>
-#include <cstdint>
 #include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
 #include <test/jtx/owners.h>
+
+#include <cstdint>
 
 namespace ripple {
 namespace test {

--- a/src/test/ledger/SkipList_test.cpp
+++ b/src/test/ledger/SkipList_test.cpp
@@ -55,15 +55,14 @@ class SkipList_test : public beast::unit_test::suite
             auto l = *(std::next(std::begin(history)));
             BEAST_EXPECT((*std::begin(history))->info().seq < l->info().seq);
             BEAST_EXPECT(
-                hashOfSeq(*l, l->info().seq + 1, env.journal) == boost::none);
+                !hashOfSeq(*l, l->info().seq + 1, env.journal).has_value());
             BEAST_EXPECT(
                 hashOfSeq(*l, l->info().seq, env.journal) == l->info().hash);
             BEAST_EXPECT(
                 hashOfSeq(*l, l->info().seq - 1, env.journal) ==
                 l->info().parentHash);
-            BEAST_EXPECT(
-                hashOfSeq(*history.back(), l->info().seq, env.journal) ==
-                boost::none);
+            BEAST_EXPECT(!hashOfSeq(*history.back(), l->info().seq, env.journal)
+                              .has_value());
         }
 
         // ledger skip lists store up to the previous 256 hashes
@@ -79,9 +78,8 @@ class SkipList_test : public beast::unit_test::suite
             }
 
             // edge case accessing beyond 256
-            BEAST_EXPECT(
-                hashOfSeq(**i, (*i)->info().seq - 258, env.journal) ==
-                boost::none);
+            BEAST_EXPECT(!hashOfSeq(**i, (*i)->info().seq - 258, env.journal)
+                              .has_value());
         }
 
         // every 256th hash beyond the first 256 is stored

--- a/src/test/ledger/View_test.cpp
+++ b/src/test/ledger/View_test.cpp
@@ -70,7 +70,7 @@ class View_test : public beast::unit_test::suite
     {
         openLedger.modify([](OpenView& view, beast::Journal) {
             // HACK!
-            boost::optional<uint256> next;
+            std::optional<uint256> next;
             next.emplace(0);
             for (;;)
             {
@@ -88,7 +88,7 @@ class View_test : public beast::unit_test::suite
     wipe(Ledger& ledger)
     {
         // HACK!
-        boost::optional<uint256> next;
+        std::optional<uint256> next;
         next.emplace(0);
         for (;;)
         {
@@ -105,7 +105,7 @@ class View_test : public beast::unit_test::suite
     succ(
         ReadView const& v,
         std::uint32_t id,
-        boost::optional<std::uint32_t> answer)
+        std::optional<std::uint32_t> answer)
     {
         auto const next = v.succ(k(id).key);
         if (answer)
@@ -142,12 +142,12 @@ class View_test : public beast::unit_test::suite
             *genesis, env.app().timeKeeper().closeTime());
         wipe(*ledger);
         ReadView& v = *ledger;
-        succ(v, 0, boost::none);
+        succ(v, 0, std::nullopt);
         ledger->rawInsert(sle(1, 1));
         BEAST_EXPECT(v.exists(k(1)));
         BEAST_EXPECT(seq(v.read(k(1))) == 1);
         succ(v, 0, 1);
-        succ(v, 1, boost::none);
+        succ(v, 1, std::nullopt);
         ledger->rawInsert(sle(2, 2));
         BEAST_EXPECT(seq(v.read(k(2))) == 2);
         ledger->rawInsert(sle(3, 3));
@@ -170,13 +170,13 @@ class View_test : public beast::unit_test::suite
         wipe(env.app().openLedger());
         auto const open = env.current();
         ApplyViewImpl v(&*open, tapNONE);
-        succ(v, 0, boost::none);
+        succ(v, 0, std::nullopt);
         v.insert(sle(1));
         BEAST_EXPECT(v.exists(k(1)));
         BEAST_EXPECT(seq(v.read(k(1))) == 1);
         BEAST_EXPECT(seq(v.peek(k(1))) == 1);
         succ(v, 0, 1);
-        succ(v, 1, boost::none);
+        succ(v, 1, std::nullopt);
         v.insert(sle(2, 2));
         BEAST_EXPECT(seq(v.read(k(2))) == 2);
         v.insert(sle(3, 3));
@@ -221,7 +221,7 @@ class View_test : public beast::unit_test::suite
             succ(v0, 4, 7);
             succ(v0, 5, 7);
             succ(v0, 6, 7);
-            succ(v0, 7, boost::none);
+            succ(v0, 7, std::nullopt);
 
             succ(v1, 0, 1);
             succ(v1, 1, 2);
@@ -230,7 +230,7 @@ class View_test : public beast::unit_test::suite
             succ(v1, 4, 5);
             succ(v1, 5, 6);
             succ(v1, 6, 7);
-            succ(v1, 7, boost::none);
+            succ(v1, 7, std::nullopt);
 
             v1.erase(v1.peek(k(4)));
             succ(v1, 3, 5);
@@ -254,7 +254,7 @@ class View_test : public beast::unit_test::suite
         succ(v0, 4, 5);
         succ(v0, 5, 7);
         succ(v0, 6, 7);
-        succ(v0, 7, boost::none);
+        succ(v0, 7, std::nullopt);
     }
 
     void

--- a/src/test/nodestore/DatabaseShard_test.cpp
+++ b/src/test/nodestore/DatabaseShard_test.cpp
@@ -495,7 +495,7 @@ class DatabaseShard_test : public TestBase
         {
             auto const ledgerSeq{
                 db.prepareLedger((maxShardNumber + 1) * ledgersPerShard)};
-            if (!BEAST_EXPECT(ledgerSeq != boost::none))
+            if (!BEAST_EXPECT(ledgerSeq != std::nullopt))
                 return {};
 
             shardIndex = db.seqToShardIndex(*ledgerSeq);
@@ -707,7 +707,7 @@ class DatabaseShard_test : public TestBase
         // try to create another shard
         BEAST_EXPECT(
             db->prepareLedger((nTestShards + 1) * ledgersPerShard) ==
-            boost::none);
+            std::nullopt);
     }
 
     void
@@ -847,7 +847,7 @@ class DatabaseShard_test : public TestBase
                 {
                     auto const ledgerSeq{
                         db->prepareLedger(2 * ledgersPerShard)};
-                    if (!BEAST_EXPECT(ledgerSeq != boost::none))
+                    if (!BEAST_EXPECT(ledgerSeq != std::nullopt))
                         return;
 
                     shardIndex = db->seqToShardIndex(*ledgerSeq);
@@ -1285,7 +1285,7 @@ class DatabaseShard_test : public TestBase
 
         // Create one shard more than the open final limit
         auto const openFinalLimit{env.app().config().getValueFor(
-            SizedItem::openFinalLimit, boost::none)};
+            SizedItem::openFinalLimit, std::nullopt)};
         auto const numShards{openFinalLimit + 1};
 
         TestData data(seedValue, 2, numShards);

--- a/src/test/overlay/ProtocolVersion_test.cpp
+++ b/src/test/overlay/ProtocolVersion_test.cpp
@@ -92,8 +92,8 @@ public:
                 make_protocol(2, 0));
             BEAST_EXPECT(
                 negotiateProtocolVersion("XRPL/999.999, WebSocket/1.0") ==
-                boost::none);
-            BEAST_EXPECT(negotiateProtocolVersion("") == boost::none);
+                std::nullopt);
+            BEAST_EXPECT(negotiateProtocolVersion("") == std::nullopt);
         }
     }
 };

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -26,7 +26,6 @@
 #include <ripple.pb.h>
 #include <test/jtx/Env.h>
 
-#include <boost/optional.hpp>
 #include <boost/thread.hpp>
 
 #include <numeric>
@@ -117,7 +116,7 @@ public:
     {
         return false;
     }
-    boost::optional<std::size_t>
+    std::optional<std::size_t>
     publisherListSequence(PublicKey const&) const override
     {
         return {};

--- a/src/test/overlay/short_read_test.cpp
+++ b/src/test/overlay/short_read_test.cpp
@@ -20,15 +20,17 @@
 #include <ripple/basics/make_SSLContext.h>
 #include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/beast/unit_test.h>
+#include <test/jtx/envconfig.h>
+
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
+
 #include <cassert>
 #include <condition_variable>
 #include <functional>
 #include <memory>
-#include <test/jtx/envconfig.h>
+#include <optional>
 #include <thread>
 #include <utility>
 
@@ -60,7 +62,7 @@ private:
     using address_type = boost::asio::ip::address;
 
     io_context_type io_context_;
-    boost::optional<boost::asio::executor_work_guard<boost::asio::executor>>
+    std::optional<boost::asio::executor_work_guard<boost::asio::executor>>
         work_;
     std::thread thread_;
     std::shared_ptr<boost::asio::ssl::context> context_;
@@ -639,7 +641,7 @@ public:
 
     ~short_read_test()
     {
-        work_ = boost::none;
+        work_.reset();
         thread_.join();
     }
 

--- a/src/test/protocol/InnerObjectFormats_test.cpp
+++ b/src/test/protocol/InnerObjectFormats_test.cpp
@@ -186,7 +186,7 @@ public:
                     "Internal InnerObjectFormatsParsedJSON error.  Bad JSON.");
             }
             STParsedJSONObject parsed("request", req);
-            bool const noObj = parsed.object == boost::none;
+            bool const noObj = !parsed.object.has_value();
             if (noObj == test.expectFail)
             {
                 pass();

--- a/src/test/protocol/PublicKey_test.cpp
+++ b/src/test/protocol/PublicKey_test.cpp
@@ -73,7 +73,7 @@ public:
     }
 
     bool
-    check(boost::optional<ECDSACanonicality> answer, std::string const& s)
+    check(std::optional<ECDSACanonicality> answer, std::string const& s)
     {
         return ecdsaCanonicality(makeSlice(sig(s))) == answer;
     }
@@ -179,126 +179,126 @@ public:
             "b6ba"));
 
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3005"
             "0201FF"
             "0200"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020101"
             "020202"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020701"
             "020102"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020401"
             "020102"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020501"
             "020102"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020201"
             "020102"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020301"
             "020202"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3006"
             "020401"
             "020202"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3047"
             "0221005990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba"
             "6105"
             "022200002d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e56"
             "6695ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3144"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3045"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "301F"
             "01205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3045"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed00"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3044"
             "01205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3024"
             "0200"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3044"
             "02208990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3045"
             "0221005990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba"
             "6105"
             "02202d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3044"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05012"
             "02d5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695e"
             "d"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3024"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "0200"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3044"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"
             "0220fd5876262c288beb511d061691bf26777344b702b00f8fe28621fe4e566695"
             "ed"));
         BEAST_EXPECT(check(
-            boost::none,
+            std::nullopt,
             "3045"
             "02205990e0584b2b238e1dfaad8d6ed69ecc1a4a13ac85fc0b31d0df395eb1ba61"
             "05"

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -415,7 +415,7 @@ public:
             except<STObject::FieldErr>([&]() { st[sf3Outer]; });
             BEAST_EXPECT(*st[~sf1Outer] == 1);
             BEAST_EXPECT(*st[~sf2Outer] == 2);
-            BEAST_EXPECT(st[~sf3Outer] == boost::none);
+            BEAST_EXPECT(st[~sf3Outer] == std::nullopt);
             BEAST_EXPECT(!!st[~sf1Outer]);
             BEAST_EXPECT(!!st[~sf2Outer]);
             BEAST_EXPECT(!st[~sf3Outer]);
@@ -457,14 +457,14 @@ public:
             STObject st(sfGeneric);
             unexcept([&]() { st[sf1Outer]; });
             except([&]() { return st[sf1Outer] == 0; });
-            BEAST_EXPECT(st[~sf1Outer] == boost::none);
-            BEAST_EXPECT(st[~sf1Outer] == boost::optional<std::uint32_t>{});
-            BEAST_EXPECT(st[~sf1Outer] != boost::optional<std::uint32_t>(1));
+            BEAST_EXPECT(st[~sf1Outer] == std::nullopt);
+            BEAST_EXPECT(st[~sf1Outer] == std::optional<std::uint32_t>{});
+            BEAST_EXPECT(st[~sf1Outer] != std::optional<std::uint32_t>(1));
             BEAST_EXPECT(!st[~sf1Outer]);
             st[sf1Outer] = 2;
             BEAST_EXPECT(st[sf1Outer] == 2);
-            BEAST_EXPECT(st[~sf1Outer] != boost::none);
-            BEAST_EXPECT(st[~sf1Outer] == boost::optional<std::uint32_t>(2));
+            BEAST_EXPECT(st[~sf1Outer] != std::nullopt);
+            BEAST_EXPECT(st[~sf1Outer] == std::optional<std::uint32_t>(2));
             BEAST_EXPECT(!!st[~sf1Outer]);
             st[sf1Outer] = 1;
             BEAST_EXPECT(st[sf1Outer] == 1);
@@ -473,11 +473,11 @@ public:
             st[sf1Outer] = 0;
             BEAST_EXPECT(!st[sf1Outer]);
             BEAST_EXPECT(!!st[~sf1Outer]);
-            st[~sf1Outer] = boost::none;
+            st[~sf1Outer] = std::nullopt;
             BEAST_EXPECT(!st[~sf1Outer]);
-            BEAST_EXPECT(st[~sf1Outer] == boost::none);
-            BEAST_EXPECT(st[~sf1Outer] == boost::optional<std::uint32_t>{});
-            st[~sf1Outer] = boost::none;
+            BEAST_EXPECT(st[~sf1Outer] == std::nullopt);
+            BEAST_EXPECT(st[~sf1Outer] == std::optional<std::uint32_t>{});
+            st[~sf1Outer] = std::nullopt;
             BEAST_EXPECT(!st[~sf1Outer]);
             except([&]() { return st[sf1Outer] == 0; });
             except([&]() { return *st[~sf1Outer]; });
@@ -502,16 +502,16 @@ public:
         {
             STObject st(sotOuter, sfGeneric);
             BEAST_EXPECT(!!st[~sf1Outer]);
-            BEAST_EXPECT(st[~sf1Outer] != boost::none);
+            BEAST_EXPECT(st[~sf1Outer] != std::nullopt);
             BEAST_EXPECT(st[sf1Outer] == 0);
             BEAST_EXPECT(*st[~sf1Outer] == 0);
             BEAST_EXPECT(!st[~sf2Outer]);
-            BEAST_EXPECT(st[~sf2Outer] == boost::none);
+            BEAST_EXPECT(st[~sf2Outer] == std::nullopt);
             except([&]() { return st[sf2Outer] == 0; });
             BEAST_EXPECT(!!st[~sf3Outer]);
-            BEAST_EXPECT(st[~sf3Outer] != boost::none);
+            BEAST_EXPECT(st[~sf3Outer] != std::nullopt);
             BEAST_EXPECT(st[sf3Outer] == 0);
-            except([&]() { st[~sf1Outer] = boost::none; });
+            except([&]() { st[~sf1Outer] = std::nullopt; });
             st[sf1Outer] = 1;
             BEAST_EXPECT(st[sf1Outer] == 1);
             BEAST_EXPECT(*st[~sf1Outer] == 1);
@@ -524,7 +524,7 @@ public:
             BEAST_EXPECT(st[sf2Outer] == 2);
             BEAST_EXPECT(*st[~sf2Outer] == 2);
             BEAST_EXPECT(!!st[~sf2Outer]);
-            st[~sf2Outer] = boost::none;
+            st[~sf2Outer] = std::nullopt;
             except([&]() { return *st[~sf2Outer]; });
             BEAST_EXPECT(!st[~sf2Outer]);
             st[sf3Outer] = 3;
@@ -539,13 +539,13 @@ public:
             BEAST_EXPECT(st[sf3Outer] == 0);
             BEAST_EXPECT(*st[~sf3Outer] == 0);
             BEAST_EXPECT(!!st[~sf3Outer]);
-            except([&]() { st[~sf3Outer] = boost::none; });
+            except([&]() { st[~sf3Outer] = std::nullopt; });
             BEAST_EXPECT(st[sf3Outer] == 0);
             BEAST_EXPECT(*st[~sf3Outer] == 0);
             BEAST_EXPECT(!!st[~sf3Outer]);
         }
 
-        // coercion operator to boost::optional
+        // coercion operator to std::optional
 
         {
             STObject st(sfGeneric);
@@ -553,7 +553,7 @@ public:
             static_assert(
                 std::is_same<
                     std::decay_t<decltype(v)>,
-                    boost::optional<std::uint32_t>>::value,
+                    std::optional<std::uint32_t>>::value,
                 "");
         }
 
@@ -577,7 +577,7 @@ public:
         st[sf4] = std::move(b);
         BEAST_EXPECT(b.empty());
         BEAST_EXPECT(Slice(st[sf4]).size() == 1);
-        st[~sf4] = boost::none;
+        st[~sf4] = std::nullopt;
         BEAST_EXPECT(!~st[~sf4]);
         b = Buffer{2};
         st[sf4] = Slice(b);
@@ -596,7 +596,7 @@ public:
         st[sf5] = std::move(b);
         BEAST_EXPECT(b.empty());
         BEAST_EXPECT(Slice(st[sf5]).size() == 1);
-        st[~sf4] = boost::none;
+        st[~sf4] = std::nullopt;
         BEAST_EXPECT(!~st[~sf4]);
     }
 }
@@ -610,7 +610,7 @@ public:
         generateKeyPair(KeyType::secp256k1, generateSeed("masterpassphrase"));
     st[sf5] = kp.first;
     BEAST_EXPECT(st[sf5] != PublicKey{});
-    st[~sf5] = boost::none;
+    st[~sf5] = std::nullopt;
 #if 0
             pk = st[sf5];
             BEAST_EXPECT(pk.size() == 0);
@@ -663,7 +663,7 @@ public:
     st[sf2] = v;
     BEAST_EXPECT(cst[sf2].size() == 1);
     BEAST_EXPECT(cst[sf2][0] == uint256{1});
-    st[~sf2] = boost::none;
+    st[~sf2] = std::nullopt;
     BEAST_EXPECT(!st[~sf2]);
     st[sf3] = v;
     BEAST_EXPECT(cst[sf3].size() == 1);

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -93,7 +93,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
         auto const gw = Account{"gateway"};
         env.fund(XRP(10000), alice, gw);
         char currencySuffix{'A'};
-        std::vector<boost::optional<IOU>> gwCurrencies(26);  // A - Z
+        std::vector<std::optional<IOU>> gwCurrencies(26);  // A - Z
         std::generate(gwCurrencies.begin(), gwCurrencies.end(), [&]() {
             auto gwc = gw[std::string("US") + currencySuffix++];
             env(trust(alice, gwc(100)));
@@ -111,7 +111,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
         auto arrayCheck =
             [&result](
                 Json::StaticString const& fld,
-                std::vector<boost::optional<IOU>> const& expected) -> bool {
+                std::vector<std::optional<IOU>> const& expected) -> bool {
             bool stat = result.isMember(fld) && result[fld].isArray() &&
                 result[fld].size() == expected.size();
             for (size_t i = 0; stat && i < expected.size(); ++i)

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1157,7 +1157,7 @@ public:
             t[jss::TakerPays] != takerPays.value().getJson(JsonOptions::none))
             return false;
         // Make sure no other message is waiting
-        return wsc->getMsg(timeout) == boost::none;
+        return wsc->getMsg(timeout) == std::nullopt;
     }
 
     void

--- a/src/test/rpc/KeyGeneration_test.cpp
+++ b/src/test/rpc/KeyGeneration_test.cpp
@@ -97,7 +97,7 @@ class WalletPropose_test : public ripple::TestSuite
 {
 public:
     void
-    testRandomWallet(boost::optional<std::string> const& keyType)
+    testRandomWallet(std::optional<std::string> const& keyType)
     {
         Json::Value params;
         if (keyType)
@@ -146,7 +146,7 @@ public:
 
     void
     testSeed(
-        boost::optional<std::string> const& keyType,
+        std::optional<std::string> const& keyType,
         key_strings const& strings)
     {
         testcase("seed");
@@ -162,7 +162,7 @@ public:
 
     void
     testSeedHex(
-        boost::optional<std::string> const& keyType,
+        std::optional<std::string> const& keyType,
         key_strings const& strings)
     {
         testcase("seed_hex");
@@ -179,7 +179,7 @@ public:
     void
     testLegacyPassphrase(
         char const* value,
-        boost::optional<std::string> const& keyType,
+        std::optional<std::string> const& keyType,
         key_strings const& strings)
     {
         Json::Value params;
@@ -196,7 +196,7 @@ public:
 
     void
     testLegacyPassphrase(
-        boost::optional<std::string> const& keyType,
+        std::optional<std::string> const& keyType,
         key_strings const& strings)
     {
         testcase("passphrase");
@@ -209,7 +209,7 @@ public:
 
     void
     testKeyType(
-        boost::optional<std::string> const& keyType,
+        std::optional<std::string> const& keyType,
         key_strings const& strings)
     {
         testcase(keyType ? *keyType : "no key_type");
@@ -318,7 +318,7 @@ public:
 
     void
     testKeypairForSignature(
-        boost::optional<std::string> keyType,
+        std::optional<std::string> keyType,
         key_strings const& strings)
     {
         testcase(
@@ -852,13 +852,13 @@ public:
     void
     run() override
     {
-        testKeyType(boost::none, secp256k1_strings);
+        testKeyType(std::nullopt, secp256k1_strings);
         testKeyType(std::string("secp256k1"), secp256k1_strings);
         testKeyType(std::string("ed25519"), ed25519_strings);
         testKeyType(std::string("secp256k1"), strong_brain_strings);
         testBadInput();
 
-        testKeypairForSignature(boost::none, secp256k1_strings);
+        testKeypairForSignature(std::nullopt, secp256k1_strings);
         testKeypairForSignature(std::string("secp256k1"), secp256k1_strings);
         testKeypairForSignature(std::string("ed25519"), ed25519_strings);
         testKeypairForSignature(std::string("secp256k1"), strong_brain_strings);

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -98,7 +98,7 @@ public:
 
             // Check stream update
             auto jvo = wsc->getMsg(10ms);
-            BEAST_EXPECTS(!jvo, "getMsg: " + to_string(jvo.get()));
+            BEAST_EXPECTS(!jvo, "getMsg: " + to_string(jvo.value()));
         }
     }
 

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -23,17 +23,20 @@
 #include <ripple/core/ConfigSections.h>
 #include <ripple/server/Server.h>
 #include <ripple/server/Session.h>
-#include <boost/asio.hpp>
-#include <boost/beast/core/tcp_stream.hpp>
-#include <boost/beast/ssl/ssl_stream.hpp>
-#include <boost/optional.hpp>
-#include <boost/utility/in_place_factory.hpp>
-#include <chrono>
-#include <stdexcept>
+
 #include <test/jtx.h>
 #include <test/jtx/CaptureLogs.h>
 #include <test/jtx/envconfig.h>
 #include <test/unit_test/SuiteJournal.h>
+
+#include <boost/asio.hpp>
+#include <boost/beast/core/tcp_stream.hpp>
+#include <boost/beast/ssl/ssl_stream.hpp>
+#include <boost/utility/in_place_factory.hpp>
+
+#include <chrono>
+#include <optional>
+#include <stdexcept>
 #include <thread>
 
 namespace ripple {
@@ -49,19 +52,19 @@ public:
     {
     private:
         boost::asio::io_service io_service_;
-        boost::optional<boost::asio::io_service::work> work_;
+        std::optional<boost::asio::io_service::work> work_;
         std::thread thread_;
 
     public:
         TestThread()
-            : work_(boost::in_place(std::ref(io_service_)))
+            : work_(std::in_place, std::ref(io_service_))
             , thread_([&]() { this->io_service_.run(); })
         {
         }
 
         ~TestThread()
         {
-            work_ = boost::none;
+            work_.reset();
             thread_.join();
         }
 

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -69,14 +69,14 @@ public:
         {
         }
 
-        boost::optional<Blob>
+        std::optional<Blob>
         getNode(SHAMapHash const& nodeHash) const override
         {
             Map::iterator it = mMap.find(nodeHash);
             if (it == mMap.end())
             {
                 JLOG(mJournal.fatal()) << "Test filter missing node";
-                return boost::none;
+                return std::nullopt;
             }
             return it->second;
         }


### PR DESCRIPTION
## High Level Overview of Change
The rippled code base makes heavy use of `optional`.  It started with `boost::optional`.  That's what was available at the time.  Since the code base now requires C++17, we have `std::optional` available.  This pull request converts most uses of `boost::optional` to `std::optional`.

There are two situations that could not be converted:

- If the `optional` is passed as a parameter to SOCI, then the parameter must be a `boost::optional`.
- If the `optional` is passed to as a parameter to `boost::beast`, then the parameter must be a `boost::optional`.

In all of those places comments were added about why a `boost::optional` was being used.

### Context of Change
Using two types of `optional` indiscriminately in the code base was messy and confusing.  Preferring `std::optional` when it is viable seems like a reasonable approach to reducing the confusion.

### Type of Change

- [x ] Refactor (non-breaking change that only restructures code)

The change was addressed piecemeal.  One comparatively small area was changed and all of the fallout breakage was fixed.  That set of changes was committed.  Then another small set of changes was attempted.  Each commit builds and passes unit tests on its own.

That approach is preserved in the pull request commits.  So there are a ton of commits.  If the pull request passes review I'll squash all of the commits down to a single commit.

If I were reviewing this pull request I'd probably do it commit-by-commit.  But reviewers should feel free to take their favorite approach.

## Future Tasks
There may be other `boost` library types that we wish to convert over to `std`.  Possibly `string_view`?  `filesystem`?

## Release Notes
This change has no user impact, so no release notes are required.