### PR TITLE
Add constexpr constructor for `base_uint`

### DIFF
--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -1512,8 +1512,6 @@ loadByHashPostgres(uint256 const& ledgerHash, Application& app)
 static uint256
 getHashByIndexPostgres(std::uint32_t ledgerIndex, Application& app)
 {
-    uint256 ret;
-
     auto infos = loadLedgerInfosPostgres(ledgerIndex, app);
     assert(infos.size() <= 1);
     if (infos.size())

--- a/src/ripple/app/ledger/impl/InboundLedgers.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedgers.cpp
@@ -231,7 +231,6 @@ public:
     void
     gotStaleData(std::shared_ptr<protocol::TMLedgerData> packet_ptr) override
     {
-        const uint256 uZero;
         Serializer s;
         try
         {

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -96,12 +96,8 @@ getBookBase(Book const& book)
 uint256
 getQualityNext(uint256 const& uBase)
 {
-    static uint256 const nextq = []() {
-        uint256 x;
-        (void)x.parseHex(
-            "0000000000000000000000000000000000000000000000010000000000000000");
-        return x;
-    }();
+    static constexpr uint256 nextq(
+        "0000000000000000000000000000000000000000000000010000000000000000");
     return uBase + nextq;
 }
 

--- a/src/ripple/protocol/impl/UintTypes.cpp
+++ b/src/ripple/protocol/impl/UintTypes.cpp
@@ -55,11 +55,8 @@ to_string(Currency const& currency)
     if (currency == noCurrency())
         return "1";
 
-    static Currency const sIsoBits = []() {
-        Currency c;
-        (void)c.parseHex("FFFFFFFFFFFFFFFFFFFFFFFF000000FFFFFFFFFF");
-        return c;
-    }();
+    static constexpr Currency sIsoBits(
+        "FFFFFFFFFFFFFFFFFFFFFFFF000000FFFFFFFFFF");
 
     if ((currency & sIsoBits).isZero())
     {

--- a/src/ripple/shamap/impl/SHAMapSync.cpp
+++ b/src/ripple/shamap/impl/SHAMapSync.cpp
@@ -56,7 +56,6 @@ SHAMap::visitNodes(std::function<bool(SHAMapTreeNode&)> const& function) const
     {
         while (pos < 16)
         {
-            uint256 childHash;
             if (!node->isEmptyBranch(pos))
             {
                 std::shared_ptr<SHAMapTreeNode> child =

--- a/src/test/basics/base_uint_test.cpp
+++ b/src/test/basics/base_uint_test.cpp
@@ -195,6 +195,60 @@ struct base_uint_test : beast::unit_test::suite
             BEAST_EXPECT(tmp.parseHex(s1));
             BEAST_EXPECT(to_string(tmp) == s1);
         }
+
+        // Constexpr constructors
+        {
+            static_assert(test96{}.signum() == 0);
+            static_assert(test96("0").signum() == 0);
+            static_assert(test96("000000000000000000000000").signum() == 0);
+            static_assert(test96("000000000000000000000001").signum() == 1);
+            static_assert(test96("800000000000000000000000").signum() == 1);
+
+// Everything within the #if should fail during compilation.
+#if 0
+            // Too few characters
+            static_assert(test96("00000000000000000000000").signum() == 0);
+
+            // Too many characters
+            static_assert(test96("0000000000000000000000000").signum() == 0);
+
+            // Non-hex characters
+            static_assert(test96("00000000000000000000000 ").signum() == 1);
+            static_assert(test96("00000000000000000000000/").signum() == 1);
+            static_assert(test96("00000000000000000000000:").signum() == 1);
+            static_assert(test96("00000000000000000000000@").signum() == 1);
+            static_assert(test96("00000000000000000000000G").signum() == 1);
+            static_assert(test96("00000000000000000000000`").signum() == 1);
+            static_assert(test96("00000000000000000000000g").signum() == 1);
+            static_assert(test96("00000000000000000000000~").signum() == 1);
+#endif  // 0
+
+            // Verify that constexpr base_uints interpret a string the same
+            // way parseHex() does.
+            struct StrBaseUint
+            {
+                char const* const str;
+                test96 tst;
+
+                constexpr StrBaseUint(char const* s) : str(s), tst(s)
+                {
+                }
+            };
+            constexpr StrBaseUint testCases[] = {
+                "000000000000000000000000",
+                "000000000000000000000001",
+                "fedcba9876543210ABCDEF91",
+                "19FEDCBA0123456789abcdef",
+                "800000000000000000000000",
+                "fFfFfFfFfFfFfFfFfFfFfFfF"};
+
+            for (StrBaseUint const& t : testCases)
+            {
+                test96 t96;
+                BEAST_EXPECT(t96.parseHex(t.str));
+                BEAST_EXPECT(t96 == t.tst);
+            }
+        }
     }
 };
 

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -325,12 +325,10 @@ struct Directory_test : public beast::unit_test::suite
         env.fund(XRP(10000), alice);
         env.close();
 
-        uint256 base;
-        (void)base.parseHex(
+        constexpr uint256 base(
             "fb71c9aa3310141da4b01d6c744a98286af2d72ab5448d5adc0910ca0c910880");
 
-        uint256 item;
-        (void)item.parseHex(
+        constexpr uint256 item(
             "bad0f021aa3b2f6754a8fe82a5779730aa0bbbab82f17201ef24900efc2c7312");
 
         {

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -116,7 +116,6 @@ class AccountCurrencies_test : public beast::unit_test::suite
                 result[fld].size() == expected.size();
             for (size_t i = 0; stat && i < expected.size(); ++i)
             {
-                Currency foo;
                 stat &=
                     (to_string(expected[i].value().currency) ==
                      result[fld][i].asString());

--- a/src/test/shamap/SHAMap_test.cpp
+++ b/src/test/shamap/SHAMap_test.cpp
@@ -141,16 +141,15 @@ public:
         tests::TestNodeFamily f(journal);
 
         // h3 and h4 differ only in the leaf, same terminal node (level 19)
-        uint256 h1, h2, h3, h4, h5;
-        (void)h1.parseHex(
+        constexpr uint256 h1(
             "092891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7");
-        (void)h2.parseHex(
+        constexpr uint256 h2(
             "436ccbac3347baa1f1e53baeef1f43334da88f1f6d70d963b833afd6dfa289fe");
-        (void)h3.parseHex(
+        constexpr uint256 h3(
             "b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6ca8");
-        (void)h4.parseHex(
+        constexpr uint256 h4(
             "b92891fe4ef6cee585fdc6fda2e09eb4d386363158ec3321b8123e5a772c6ca8");
-        (void)h5.parseHex(
+        constexpr uint256 h5(
             "a92891fe4ef6cee585fdc6fda0e09eb4d386363158ec3321b8123e5a772c6ca7");
 
         SHAMap sMap(SHAMapType::FREE, f);
@@ -225,57 +224,41 @@ public:
         else
             testcase("build/tear unbacked");
         {
-            std::vector<uint256> keys(8);
-            (void)keys[0].parseHex(
-                "b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[1].parseHex(
-                "b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[2].parseHex(
-                "b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[3].parseHex(
-                "b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[4].parseHex(
-                "b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[5].parseHex(
-                "b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[6].parseHex(
-                "f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[7].parseHex(
-                "292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
+            constexpr std::array keys{
+                uint256("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8")};
 
-            std::vector<uint256> hashes(8);
-            (void)hashes[0].parseHex(
-                "B7387CFEA0465759ADC718E8C42B52D2309D179B326E239EB5075C64B6281F"
-                "7F");
-            (void)hashes[1].parseHex(
-                "FBC195A9592A54AB44010274163CB6BA95F497EC5BA0A8831845467FB2ECE2"
-                "66");
-            (void)hashes[2].parseHex(
-                "4E7D2684B65DFD48937FFB775E20175C43AF0C94066F7D5679F51AE756795B"
-                "75");
-            (void)hashes[3].parseHex(
-                "7A2F312EB203695FFD164E038E281839EEF06A1B99BFC263F3CECC6C74F93E"
-                "07");
-            (void)hashes[4].parseHex(
-                "395A6691A372387A703FB0F2C6D2C405DAF307D0817F8F0E207596462B0E3A"
-                "3E");
-            (void)hashes[5].parseHex(
-                "D044C0A696DE3169CC70AE216A1564D69DE96582865796142CE7D98A84D9DD"
-                "E4");
-            (void)hashes[6].parseHex(
-                "76DCC77C4027309B5A91AD164083264D70B77B5E43E08AEDA5EBF943611436"
-                "15");
-            (void)hashes[7].parseHex(
-                "DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA02BBE7230"
-                "E5");
+            constexpr std::array hashes{
+                uint256("B7387CFEA0465759ADC718E8C42B52D2309D179B326E239EB5075C"
+                        "64B6281F7F"),
+                uint256("FBC195A9592A54AB44010274163CB6BA95F497EC5BA0A883184546"
+                        "7FB2ECE266"),
+                uint256("4E7D2684B65DFD48937FFB775E20175C43AF0C94066F7D5679F51A"
+                        "E756795B75"),
+                uint256("7A2F312EB203695FFD164E038E281839EEF06A1B99BFC263F3CECC"
+                        "6C74F93E07"),
+                uint256("395A6691A372387A703FB0F2C6D2C405DAF307D0817F8F0E207596"
+                        "462B0E3A3E"),
+                uint256("D044C0A696DE3169CC70AE216A1564D69DE96582865796142CE7D9"
+                        "8A84D9DDE4"),
+                uint256("76DCC77C4027309B5A91AD164083264D70B77B5E43E08AEDA5EBF9"
+                        "4361143615"),
+                uint256("DF4220E93ADC6F5569063A01B4DC79F8DB9553B6A3222ADE23DEA0"
+                        "2BBE7230E5")};
 
             SHAMap map(SHAMapType::FREE, f);
             if (!backed)
@@ -305,31 +288,23 @@ public:
             testcase("iterate unbacked");
 
         {
-            std::vector<uint256> keys(8);
-            (void)keys[0].parseHex(
-                "f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[1].parseHex(
-                "b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[2].parseHex(
-                "b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[3].parseHex(
-                "b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[4].parseHex(
-                "b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[5].parseHex(
-                "b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[6].parseHex(
-                "b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
-            (void)keys[7].parseHex(
-                "292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e5a772c6c"
-                "a8");
+            constexpr std::array keys{
+                uint256("f22891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b99891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92881fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92791fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b92691fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("b91891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8"),
+                uint256("292891fe4ef6cee585fdc6fda1e09eb4d386363158ec3321b8123e"
+                        "5a772c6ca8")};
 
             tests::TestNodeFamily tf{journal};
             SHAMap map{SHAMapType::FREE, tf};


### PR DESCRIPTION
## High Level Overview of Change
Adds the capability of building a `base_uint`, specifying the specific value, at compile time.

### Context of Change
There are a few places in the code where `base_unit` values are known at compile time, but the values could not be built until runtime.  Adding this constructor allows those values to be built at compile time.  Benefits include:

- There are no race conditions regarding the value's construction.
- The compiler does not emit any executable code to produce the values.
- Code executed during `constexpr` evaluation is guaranteed by the compiler to not exhibit undefined behavior.
- It's kinda fun to see what you can get the compiler to do at compile time

There are not a lot of these compile-time values, so this is not an earth shattering change.

### Type of Change
- [ x] Refactor (non-breaking change that only restructures code)
- [ x] Tests (tests were added for this feature)

## Before / After
Before:
```
    static uint256 const nextq = []() {
        uint256 x;
        (void)x.parseHex(		
            "0000000000000000000000000000000000000000000000010000000000000000");		
        return x;		
    }();
```
After:
```
    static constexpr uint256 nextq(
        "0000000000000000000000000000000000000000000000010000000000000000");
```

## Future Tasks
We can consider `constexpr` enabling more stuff.

## Release notes
This change has no user impact, so no release notes are required.