### PR TITLE
[TRIVIAL] Document secure_gateway for gRPC

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -942,7 +942,7 @@
 #   Each ETL source specified must have gRPC enabled (by adding a [port_grpc]
 #   section to the config). It is recommended to add a secure_gateway entry to
 #   the gRPC section, in order to bypass the server's rate limiting mechanism.
-#   Note, this section needs to be added to the config of the ETL source, not
+#   This section needs to be added to the config of the ETL source, not
 #   the config of the reporting node. In the example below, the
 #   reporting server is running at 127.0.0.1. Multiple IPs can be
 #   specified in secure_gateway via a comma separated list.

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -941,7 +941,7 @@
 #
 #   Each ETL source specified must have gRPC enabled (by adding a [port_grpc]
 #   section to the config). It is recommended to add a secure_gateway entry to
-#   the gRPC section, in order to bypass the server's rate limiting mechanism.
+#   the gRPC section, in order to bypass the server's rate limiting.
 #   This section needs to be added to the config of the ETL source, not
 #   the config of the reporting node. In the example below, the
 #   reporting server is running at 127.0.0.1. Multiple IPs can be

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -939,6 +939,19 @@
 #   connection info is specified under the [ledger_tx_tables] config section;
 #   see the Database section for further documentation.
 #
+#   Each ETL source specified must have gRPC enabled (by adding a [grpc_port]
+#   section to the config). It is recommended to add a secure_gateway entry to
+#   the gRPC section, in order to bypass the server's rate limiting mechanism.
+#   Note, this section needs to be added to the config of the ETL source, not
+#   the config of the reporting node. An example is listed below, where the
+#   reporting server is running at 127.0.0.1. Note, multiple IPs can be
+#   specified in secure_gateway via a comma separated list.
+#
+#   [port_grpc]
+#   ip = 0.0.0.0
+#   port = 50051
+#   secure_gateway = 127.0.0.1
+#
 #
 #-------------------------------------------------------------------------------
 #
@@ -1567,6 +1580,7 @@ protocol = ws
 #[port_grpc]
 #port = 50051
 #ip = 0.0.0.0
+#secure_gateway = 127.0.0.1
 
 #[port_ws_public]
 #port = 6005

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -944,7 +944,7 @@
 #   the gRPC section, in order to bypass the server's rate limiting mechanism.
 #   Note, this section needs to be added to the config of the ETL source, not
 #   the config of the reporting node. An example is listed below, where the
-#   reporting server is running at 127.0.0.1. Note, multiple IPs can be
+#   reporting server is running at 127.0.0.1. Multiple IPs can be
 #   specified in secure_gateway via a comma separated list.
 #
 #   [port_grpc]

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -939,7 +939,7 @@
 #   connection info is specified under the [ledger_tx_tables] config section;
 #   see the Database section for further documentation.
 #
-#   Each ETL source specified must have gRPC enabled (by adding a [grpc_port]
+#   Each ETL source specified must have gRPC enabled (by adding a [port_grpc]
 #   section to the config). It is recommended to add a secure_gateway entry to
 #   the gRPC section, in order to bypass the server's rate limiting mechanism.
 #   Note, this section needs to be added to the config of the ETL source, not
@@ -1684,4 +1684,3 @@ validators.txt
 # source_grpc_port=50051
 # source_ws_port=6005
 # source_ip=127.0.0.1
-

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -943,7 +943,7 @@
 #   section to the config). It is recommended to add a secure_gateway entry to
 #   the gRPC section, in order to bypass the server's rate limiting mechanism.
 #   Note, this section needs to be added to the config of the ETL source, not
-#   the config of the reporting node. An example is listed below, where the
+#   the config of the reporting node. In the example below, the
 #   reporting server is running at 127.0.0.1. Multiple IPs can be
 #   specified in secure_gateway via a comma separated list.
 #


### PR DESCRIPTION
It is recommended to add a `secure_gateway` section to `[port_grpc]` when the server is an ETL source for a reporting mode server. This commit adds a few lines to the example config to explain such. There are no code changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3762)
<!-- Reviewable:end -->
