### PR TITLE
Fix "sign" & "submit" Sequence field autofill with Tickets

### DIFF
--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -115,9 +115,10 @@ enum TEMcodes : TERUnderlyingType {
     temCANNOT_PREAUTH_SELF,
     temINVALID_COUNT,
 
-    // An intermediate result used internally, should never be returned.
-    temUNCERTAIN,
-    temUNKNOWN,
+    temUNCERTAIN,  // An internal intermediate result; should never be returned.
+    temUNKNOWN,    // An internal intermediate result; should never be returned.
+
+    temSEQ_AND_TICKET,
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -152,6 +152,7 @@ transResults()
         MAKE_ERROR(temINVALID_ACCOUNT_ID,     "Malformed: A field contains an invalid account ID."),
         MAKE_ERROR(temCANNOT_PREAUTH_SELF,    "Malformed: An account may not preauthorize itself."),
         MAKE_ERROR(temINVALID_COUNT,          "Malformed: Count field outside valid range."),
+        MAKE_ERROR(temSEQ_AND_TICKET,         "Transaction contains a TicketSequence and a non-zero Sequence."),
 
         MAKE_ERROR(terRETRY,                  "Retry transaction."),
         MAKE_ERROR(terFUNDS_SPENT,            "DEPRECATED."),

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -441,7 +441,9 @@ transactionPreProcessImpl(
     {
         if (!tx_json.isMember(jss::Sequence))
         {
-            if (!sle)
+            bool const hasTicketSeq =
+                tx_json.isMember(sfTicketSequence.jsonName);
+            if (!hasTicketSeq && !sle)
             {
                 JLOG(j.debug())
                     << "transactionSign: Failed to find source account "
@@ -449,7 +451,8 @@ transactionPreProcessImpl(
 
                 return rpcError(rpcSRC_ACT_NOT_FOUND);
             }
-            tx_json[jss::Sequence] = app.getTxQ().nextQueuableSeq(sle).value();
+            tx_json[jss::Sequence] =
+                hasTicketSeq ? 0 : app.getTxQ().nextQueuableSeq(sle).value();
         }
 
         if (!tx_json.isMember(jss::Flags))


### PR DESCRIPTION
## High Level Overview of Change

@manojsdoshi found a bug in the handling of `Sequence` autofill by the "sign" and "submit" RPC commands when a `TicketSequence` is part of the transaction.

As it stands, if the `Sequence` field is missing, then the next usable sequence number associated with the account is filled in.  This leads to unexpected behavior.  The non-zero `Sequence` field takes precedent over the `TicketSequence`, so the associated `Ticket` is not consumed.

The fix is for "sign" and "submit" to check the transaction for a `TicketSequence`.  If a `TicketSequence` is present and a `Sequence` field is not, then the commands fill in `'Sequence': 0` which is what is required for the `TicketSequence` to be used.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Test (added unit test to verify fix).

## Test Plan
Using the "sign" or "submit" RPC commands, submit a transaction with a `TicketSequence` but no `Sequence` field.

Before the fix you should observe the transaction returned by the command has a non-zero `Sequence` field filled in.  If the transaction is submitted then the `TicketSequence` will not be consumed.

After the fix you should observe the transaction returned by the command has a `'Sequence': 0` field filled in.  If the transaction is submitted then the `TicketSequence` is consumed if the transaction returns a `tec` or `tesSUCCESS` code.