### PR TITLE
[TRIVIAL] Fix a typo in the [sqlite] section description

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1170,7 +1170,7 @@
 #       ...
 #
 #   Example 1:
-#       sync_level=low
+#       safety_level=low
 #
 #   Example 2:
 #       journal_mode=off


### PR DESCRIPTION
## High Level Overview of Change

I spotted a typo in the `[sqlite]` tuning section documentation in the example config file. The example uses `sync_level`, when the option is called `safety_level`.

### Type of Change

- [X ] Documentation Updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3765)
<!-- Reviewable:end -->
