### PR TITLE
Move signer_list in JSON response for api_version 2

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,10 @@ This document contains the release notes for `rippled`, the reference server imp
  
 Have new ideas? Need help with setting up your node? Come visit us [here](https://github.com/ripple/rippled/issues/new/choose)
 
+# Change log
+
+- API version 2 will now return `signer_lists` in the root of the `account_info` response, no longer nested under `account_data`.
+
 # Releases
 
 ## Version 1.7.2

--- a/src/ripple/rpc/handlers/AccountInfo.cpp
+++ b/src/ripple/rpc/handlers/AccountInfo.cpp
@@ -109,8 +109,19 @@ doAccountInfo(RPC::JsonContext& context)
             if (sleSigners)
                 jvSignerList.append(sleSigners->getJson(JsonOptions::none));
 
-            result[jss::account_data][jss::signer_lists] =
-                std::move(jvSignerList);
+            // Documentation states this is returned as part of the account_info
+            // response, but previously the code put it under account_data. We
+            // can move this to the documentated location from apiVersion 2
+            // onwards.
+            if (context.apiVersion == 1)
+            {
+                result[jss::account_data][jss::signer_lists] =
+                    std::move(jvSignerList);
+            }
+            else
+            {
+                result[jss::signer_lists] = std::move(jvSignerList);
+            }
         }
         // Return queue info if that is requested
         if (queue)


### PR DESCRIPTION
## High Level Overview of Change

`signer_lists` is returned in the root of the `account_info` response, no longer nested under `account_data`.

### Context of Change

See https://github.com/ripple/xrpl-dev-portal/issues/938 for context.

### Type of Change

- [X] New feature (non-breaking change which adds functionality)