### PR TITLE
Use dirInsert instead of deprecated dirAdd

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -3774,8 +3774,7 @@ NetworkOPsImp::getBookPage(
                     uTipIndex,
                     sleOfferDir,
                     uBookEntry,
-                    offerIndex,
-                    viewJ);
+                    offerIndex);
 
                 JLOG(m_journal.trace())
                     << "getBookPage:   uTipIndex=" << uTipIndex;
@@ -3900,8 +3899,7 @@ NetworkOPsImp::getBookPage(
                     uTipIndex,
                     sleOfferDir,
                     uBookEntry,
-                    offerIndex,
-                    viewJ))
+                    offerIndex))
             {
                 bDirectAdvance = true;
             }

--- a/src/ripple/app/tx/impl/BookTip.cpp
+++ b/src/ripple/app/tx/impl/BookTip.cpp
@@ -53,9 +53,9 @@ BookTip::step(beast::Journal j)
             return false;
 
         unsigned int di = 0;
-        std::shared_ptr<SLE> dir;
+        std::shared_ptr<SLE const> dir;
 
-        if (dirFirst(view_, *first_page, dir, di, m_index, j))
+        if (cdirFirst(view_, *first_page, dir, di, m_index))
         {
             m_dir = dir->key();
             m_entry = view_.peek(keylet::offer(m_index));

--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -209,13 +209,10 @@ CreateCheck::doApply()
     // destination's owner directory.
     if (dstAccountId != account_)
     {
-        auto const page = dirAdd(
-            view(),
+        auto const page = view().dirInsert(
             keylet::ownerDir(dstAccountId),
             sleCheck->key(),
-            false,
-            describeOwnerDir(dstAccountId),
-            viewJ);
+            describeOwnerDir(dstAccountId));
 
         JLOG(j_.trace()) << "Adding Check to destination directory "
                          << to_string(sleCheck->key()) << ": "
@@ -228,13 +225,10 @@ CreateCheck::doApply()
     }
 
     {
-        auto const page = dirAdd(
-            view(),
+        auto const page = view().dirInsert(
             keylet::ownerDir(account_),
             sleCheck->key(),
-            false,
-            describeOwnerDir(account_),
-            viewJ);
+            describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Adding Check to owner directory "
                          << to_string(sleCheck->key()) << ": "

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -125,13 +125,10 @@ CreateTicket::doApply()
         sleTicket->setFieldU32(sfTicketSequence, curTicketSeq);
         view().insert(sleTicket);
 
-        auto const page = dirAdd(
-            view(),
+        auto const page = view().dirInsert(
             keylet::ownerDir(account_),
             sleTicket->key(),
-            false,
-            describeOwnerDir(account_),
-            viewJ);
+            describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Creating ticket " << to_string(sleTicket->key())
                          << ": " << (page ? "success" : "failure");

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -202,8 +202,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
             ownerDirKeylet.key,
             sleDirNode,
             uDirEntry,
-            dirEntry,
-            ctx.j))
+            dirEntry))
         // Account has no directory at all.  Looks good.
         return tesSUCCESS;
 
@@ -236,7 +235,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
             return tefTOO_BIG;
 
     } while (cdirNext(
-        ctx.view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry, ctx.j));
+        ctx.view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));
 
     return tesSUCCESS;
 }
@@ -255,13 +254,13 @@ DeleteAccount::doApply()
 
     // Delete all of the entries in the account directory.
     Keylet const ownerDirKeylet{keylet::ownerDir(account_)};
-    std::shared_ptr<SLE> sleDirNode{};
+    std::shared_ptr<SLE const> sleDirNode{};
     unsigned int uDirEntry{0};
     uint256 dirEntry{beast::zero};
 
     if (view().exists(ownerDirKeylet) &&
-        dirFirst(
-            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry, j_))
+        cdirFirst(
+            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry))
     {
         do
         {
@@ -322,8 +321,8 @@ DeleteAccount::doApply()
             }
             uDirEntry = 0;
 
-        } while (dirNext(
-            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry, j_));
+        } while (cdirNext(
+            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));
     }
 
     // Transfer any XRP remaining after the fee is paid to the destination:

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -246,13 +246,10 @@ EscrowCreate::doApply()
 
     // Add escrow to sender's owner directory
     {
-        auto page = dirAdd(
-            ctx_.view(),
+        auto page = ctx_.view().dirInsert(
             keylet::ownerDir(account),
             slep->key(),
-            false,
-            describeOwnerDir(account),
-            ctx_.app.journal("View"));
+            describeOwnerDir(account));
         if (!page)
             return tecDIR_FULL;
         (*slep)[sfOwnerNode] = *page;
@@ -261,13 +258,10 @@ EscrowCreate::doApply()
     // If it's not a self-send, add escrow to recipient's owner directory.
     if (auto const dest = ctx_.tx[sfDestination]; dest != ctx_.tx[sfAccount])
     {
-        auto page = dirAdd(
-            ctx_.view(),
+        auto page = ctx_.view().dirInsert(
             keylet::ownerDir(dest),
             slep->key(),
-            false,
-            describeOwnerDir(dest),
-            ctx_.app.journal("View"));
+            describeOwnerDir(dest));
         if (!page)
             return tecDIR_FULL;
         (*slep)[sfDestinationNode] = *page;

--- a/src/ripple/app/tx/impl/PayChan.cpp
+++ b/src/ripple/app/tx/impl/PayChan.cpp
@@ -264,13 +264,10 @@ PayChanCreate::doApply()
 
     // Add PayChan to owner directory
     {
-        auto const page = dirAdd(
-            ctx_.view(),
+        auto const page = ctx_.view().dirInsert(
             keylet::ownerDir(account),
             slep->key(),
-            false,
-            describeOwnerDir(account),
-            ctx_.app.journal("View"));
+            describeOwnerDir(account));
         if (!page)
             return tecDIR_FULL;
         (*slep)[sfOwnerNode] = *page;
@@ -279,13 +276,10 @@ PayChanCreate::doApply()
     // Add PayChan to the recipient's owner directory
     if (ctx_.view().rules().enabled(fixPayChanRecipientOwnerDir))
     {
-        auto const page = dirAdd(
-            ctx_.view(),
+        auto const page = ctx_.view().dirInsert(
             keylet::ownerDir(dst),
             slep->key(),
-            false,
-            describeOwnerDir(dst),
-            ctx_.app.journal("View"));
+            describeOwnerDir(dst));
         if (!page)
             return tecDIR_FULL;
         (*slep)[sfDestinationNode] = *page;

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -342,13 +342,10 @@ SetSignerList::replaceSignerList()
 
     auto viewJ = ctx_.app.journal("View");
     // Add the signer list to the account's directory.
-    auto const page = dirAdd(
-        ctx_.view(),
+    auto const page = ctx_.view().dirInsert(
         ownerDirKeylet,
         signerListKeylet.key,
-        false,
-        describeOwnerDir(account_),
-        viewJ);
+        describeOwnerDir(account_));
 
     JLOG(j_.trace()) << "Create signer list for account " << toBase58(account_)
                      << ": " << (page ? "success" : "failure");

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -135,8 +135,7 @@ cdirFirst(
     uint256 const& uRootIndex,            // --> Root of directory.
     std::shared_ptr<SLE const>& sleNode,  // <-> current node
     unsigned int& uDirEntry,              // <-- next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
+    uint256& uEntryIndex);  // <-- The entry, if available. Otherwise, zero.
 
 // Return the current entry and advance uDirEntry.
 // <-- true, if had a next entry.
@@ -147,8 +146,7 @@ cdirNext(
     uint256 const& uRootIndex,            // --> Root of directory
     std::shared_ptr<SLE const>& sleNode,  // <-> current node
     unsigned int& uDirEntry,              // <-> next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
+    uint256& uEntryIndex);  // <-- The entry, if available. Otherwise, zero.
 
 // Return the list of enabled amendments
 [[nodiscard]] std::set<uint256>
@@ -223,42 +221,8 @@ adjustOwnerCount(
     std::int32_t amount,
     beast::Journal j);
 
-// Return the first entry and advance uDirEntry.
-// <-- true, if had a next entry.
-// VFALCO Fix these clumsy routines with an iterator
-bool
-dirFirst(
-    ApplyView& view,
-    uint256 const& uRootIndex,      // --> Root of directory.
-    std::shared_ptr<SLE>& sleNode,  // <-> current node
-    unsigned int& uDirEntry,        // <-- next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
-
-// Return the current entry and advance uDirEntry.
-// <-- true, if had a next entry.
-// VFALCO Fix these clumsy routines with an iterator
-bool
-dirNext(
-    ApplyView& view,
-    uint256 const& uRootIndex,      // --> Root of directory
-    std::shared_ptr<SLE>& sleNode,  // <-> current node
-    unsigned int& uDirEntry,        // <-> next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
-
 [[nodiscard]] std::function<void(SLE::ref)>
 describeOwnerDir(AccountID const& account);
-
-// deprecated
-boost::optional<std::uint64_t>
-dirAdd(
-    ApplyView& view,
-    Keylet const& uRootIndex,
-    uint256 const& uLedgerIndex,
-    bool strictOrder,
-    std::function<void(SLE::ref)> fDescriber,
-    beast::Journal j);
 
 // VFALCO NOTE Both STAmount parameters should just
 //             be "Amount", a unit-less number.

--- a/src/ripple/ledger/impl/BookDirs.cpp
+++ b/src/ripple/ledger/impl/BookDirs.cpp
@@ -38,8 +38,7 @@ BookDirs::BookDirs(ReadView const& view, Book const& book)
                 key_,
                 sle_,
                 entry_,
-                index_,
-                beast::Journal{beast::Journal::getNullSink()}))
+                index_))
         {
             assert(false);
         }
@@ -96,7 +95,7 @@ BookDirs::const_iterator::operator++()
     using beast::zero;
 
     assert(index_ != zero);
-    if (!cdirNext(*view_, cur_key_, sle_, entry_, index_, j_))
+    if (!cdirNext(*view_, cur_key_, sle_, entry_, index_))
     {
         if (index_ != 0 ||
             (cur_key_ =
@@ -106,7 +105,7 @@ BookDirs::const_iterator::operator++()
             entry_ = 0;
             index_ = zero;
         }
-        else if (!cdirFirst(*view_, cur_key_, sle_, entry_, index_, j_))
+        else if (!cdirFirst(*view_, cur_key_, sle_, entry_, index_))
         {
             assert(false);
         }

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -45,8 +45,7 @@ class Book_test : public beast::unit_test::suite
                 sleOfferDir->key(),
                 sleOfferDir,
                 bookEntry,
-                offerIndex,
-                env.journal);
+                offerIndex);
             auto sleOffer = view->read(keylet::offer(offerIndex));
             dir = to_string(sleOffer->getFieldH256(sfBookDirectory));
         }


### PR DESCRIPTION
Removes some legacy code in favor of newer APIs and eliminates a pair of duplicated functions that provided `const` and non-`const` variants.

This commit also eliminates some logging. Most of it is unhelpful, but some of it _could_ be useful in exceptional situations, but would be buried. One thing to think about is how such errors are surfaced to server operators and the network as a whole so that they can be evaluated and, if needed, addressed.