### PR TITLE
[TRIVIAL] Add list of dependencies for building reporting mode

### DIFF
--- a/Builds/linux/README.md
+++ b/Builds/linux/README.md
@@ -22,6 +22,11 @@ $ apt-get update
 $ apt-get install -y gcc g++ wget git cmake pkg-config protobuf-compiler libprotobuf-dev libssl-dev
 ```
 
+To build the software in reporting mode, install these additional dependencies:
+```
+$ apt-get install -y autoconf flex bison
+```
+
 Advanced users can choose to install newer versions of gcc, or the clang compiler.
 At this time, rippled only supports protobuf version 2. Using version 3 of 
 protobuf will give errors.


### PR DESCRIPTION
Call out the 3 dependencies that must be installed via package manager to build the software in reporting mode. Somehow this information was deleted from the original PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3777)
<!-- Reviewable:end -->
