### PR TITLE
enable testing experimental API versions in unit tests

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1502,6 +1502,15 @@
 #       Enable or disable access to /vl requests. Default is '1' which
 #       enables access.
 #
+# [beta_rpc_api]
+#
+#   0 or 1.
+#
+#   0: Disable the beta API version for JSON-RPC and WebSocket [default]
+#   1: Enable the beta API version for testing. The beta API version
+#      contains breaking changes that require a new API version number.
+#      They are not ready for public consumption.
+#
 #-------------------------------------------------------------------------------
 #
 # 10. Example Settings

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1515,7 +1515,7 @@ ApplicationImp::setup()
              Role::ADMIN,
              {},
              {},
-             RPC::ApiMaximumSupportedVersion},
+             RPC::apiMaximumSupportedVersion},
             jvCommand};
 
         Json::Value jvResult;

--- a/src/ripple/app/reporting/P2pProxy.cpp
+++ b/src/ripple/app/reporting/P2pProxy.cpp
@@ -54,7 +54,8 @@ shouldForwardToP2p(RPC::JsonContext& context)
 
     JLOG(context.j.trace()) << "COMMAND:" << strCommand;
     JLOG(context.j.trace()) << "REQUEST:" << params;
-    auto handler = RPC::getHandler(context.apiVersion, strCommand);
+    auto handler = RPC::getHandler(
+        context.apiVersion, context.app.config().BETA_RPC_API, strCommand);
     if (!handler)
     {
         JLOG(context.j.error())

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -226,6 +226,9 @@ public:
     // How long can a peer remain in the "diverged" state
     std::chrono::seconds MAX_DIVERGED_TIME{300};
 
+    // Enable the beta API version
+    bool BETA_RPC_API = false;
+
 public:
     Config() : j_{beast::Journal::getNullSink()}
     {

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -98,6 +98,7 @@ struct ConfigSection
 #define SECTION_VETO_AMENDMENTS "veto_amendments"
 #define SECTION_WORKERS "workers"
 #define SECTION_LEDGER_REPLAY "ledger_replay"
+#define SECTION_BETA_RPC_API "beta_rpc_api"
 
 }  // namespace ripple
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -635,6 +635,9 @@ Config::loadFromString(std::string const& fileContents)
                 "majority is 15 minutes");
     }
 
+    if (getSingleSection(secConfig, SECTION_BETA_RPC_API, strTemp, j_))
+        BETA_RPC_API = beast::lexicalCastThrow<bool>(strTemp);
+
     // Do not load trusted validator configuration for standalone mode
     if (!RUN_STANDALONE)
     {

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -315,8 +315,8 @@ private:
 
             if (uLedgerMax != -1 && uLedgerMax < uLedgerMin)
             {
-                // The command line always follows ApiMaximumSupportedVersion
-                if (RPC::ApiMaximumSupportedVersion == 1)
+                // The command line always follows apiMaximumSupportedVersion
+                if (RPC::apiMaximumSupportedVersion == 1)
                     return rpcError(rpcLGR_IDXS_INVALID);
                 return rpcError(rpcNOT_SYNCED);
             }
@@ -388,8 +388,8 @@ private:
 
             if (uLedgerMax != -1 && uLedgerMax < uLedgerMin)
             {
-                // The command line always follows ApiMaximumSupportedVersion
-                if (RPC::ApiMaximumSupportedVersion == 1)
+                // The command line always follows apiMaximumSupportedVersion
+                if (RPC::apiMaximumSupportedVersion == 1)
                     return rpcError(rpcLGR_IDXS_INVALID);
                 return rpcError(rpcNOT_SYNCED);
             }
@@ -1401,7 +1401,8 @@ struct RPCCallImp
 
             // Parse reply
             JLOG(j.debug()) << "RPC reply: " << strData << std::endl;
-            if (strData.find("Unable to parse request") == 0)
+            if (strData.find("Unable to parse request") == 0 ||
+                strData.find(jss::invalid_API_version.c_str()) == 0)
                 Throw<RequestNotParseable>(strData);
             Json::Reader reader;
             Json::Value jvReply;
@@ -1472,7 +1473,7 @@ rpcCmdLineToJson(
         if (jr.isObject() && !jr.isMember(jss::error) &&
             !jr.isMember(jss::api_version))
         {
-            jr[jss::api_version] = RPC::ApiMaximumSupportedVersion;
+            jr[jss::api_version] = RPC::apiMaximumSupportedVersion;
         }
     };
 

--- a/src/ripple/rpc/RPCHandler.h
+++ b/src/ripple/rpc/RPCHandler.h
@@ -35,7 +35,7 @@ Status
 doCommand(RPC::JsonContext&, Json::Value&);
 
 Role
-roleRequired(unsigned int version, std::string const& method);
+roleRequired(unsigned int version, bool betaEnabled, std::string const& method);
 
 }  // namespace RPC
 }  // namespace ripple

--- a/src/ripple/rpc/handlers/Version.h
+++ b/src/ripple/rpc/handlers/Version.h
@@ -28,7 +28,8 @@ namespace RPC {
 class VersionHandler
 {
 public:
-    explicit VersionHandler(JsonContext&)
+    explicit VersionHandler(JsonContext& c)
+        : apiVersion_(c.apiVersion), betaEnabled_(c.app.config().BETA_RPC_API)
     {
     }
 
@@ -42,7 +43,7 @@ public:
     void
     writeResult(Object& obj)
     {
-        setVersion(obj);
+        setVersion(obj, apiVersion_, betaEnabled_);
     }
 
     static char const*
@@ -62,6 +63,10 @@ public:
     {
         return NO_CONDITION;
     }
+
+private:
+    unsigned int apiVersion_;
+    bool betaEnabled_;
 };
 
 }  // namespace RPC

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -166,23 +166,16 @@ private:
     template <std::size_t N>
     explicit HandlerTable(const Handler (&entries)[N])
     {
-        for (auto v = RPC::ApiMinimumSupportedVersion;
-             v <= RPC::ApiMaximumSupportedVersion;
-             ++v)
+        for (std::size_t i = 0; i < N; ++i)
         {
-            for (std::size_t i = 0; i < N; ++i)
-            {
-                auto& innerTable = table_[versionToIndex(v)];
-                auto const& entry = entries[i];
-                assert(innerTable.find(entry.name_) == innerTable.end());
-                innerTable[entry.name_] = entry;
-            }
-
-            // This is where the new-style handlers are added.
-            // This is also where different versions of handlers are added.
-            addHandler<LedgerHandler>(v);
-            addHandler<VersionHandler>(v);
+            auto const& entry = entries[i];
+            assert(table_.find(entry.name_) == table_.end());
+            table_[entry.name_] = entry;
         }
+
+        // This is where the new-style handlers are added.
+        addHandler<LedgerHandler>();
+        addHandler<VersionHandler>();
     }
 
 public:
@@ -194,43 +187,34 @@ public:
     }
 
     Handler const*
-    getHandler(unsigned version, std::string name) const
+    getHandler(unsigned version, bool betaEnabled, std::string name) const
     {
-        if (version > RPC::ApiMaximumSupportedVersion ||
-            version < RPC::ApiMinimumSupportedVersion)
+        if (version < RPC::apiMinimumSupportedVersion ||
+            version > (betaEnabled ? RPC::apiBetaVersion
+                                   : RPC::apiMaximumSupportedVersion))
             return nullptr;
-        auto& innerTable = table_[versionToIndex(version)];
-        auto i = innerTable.find(name);
-        return i == innerTable.end() ? nullptr : &i->second;
+        auto i = table_.find(name);
+        return i == table_.end() ? nullptr : &i->second;
     }
 
     std::vector<char const*>
     getHandlerNames() const
     {
-        std::unordered_set<char const*> name_set;
-        for (int index = 0; index < table_.size(); ++index)
-        {
-            for (auto const& h : table_[index])
-            {
-                name_set.insert(h.second.name_);
-            }
-        }
-        return std::vector<char const*>(name_set.begin(), name_set.end());
+        std::vector<char const*> ret;
+        ret.reserve(table_.size());
+        for (auto const& i : table_)
+            ret.push_back(i.second.name_);
+        return ret;
     }
 
 private:
-    std::array<std::map<std::string, Handler>, APINumberVersionSupported>
-        table_;
+    std::map<std::string, Handler> table_;
 
     template <class HandlerImpl>
     void
-    addHandler(unsigned version)
+    addHandler()
     {
-        assert(
-            version >= RPC::ApiMinimumSupportedVersion &&
-            version <= RPC::ApiMaximumSupportedVersion);
-        auto& innerTable = table_[versionToIndex(version)];
-        assert(innerTable.find(HandlerImpl::name()) == innerTable.end());
+        assert(table_.find(HandlerImpl::name()) == table_.end());
 
         Handler h;
         h.name_ = HandlerImpl::name();
@@ -238,22 +222,16 @@ private:
         h.role_ = HandlerImpl::role();
         h.condition_ = HandlerImpl::condition();
 
-        innerTable[HandlerImpl::name()] = h;
-    }
-
-    inline unsigned
-    versionToIndex(unsigned version) const
-    {
-        return version - RPC::ApiMinimumSupportedVersion;
+        table_[HandlerImpl::name()] = h;
     }
 };
 
 }  // namespace
 
 Handler const*
-getHandler(unsigned version, std::string const& name)
+getHandler(unsigned version, bool betaEnabled, std::string const& name)
 {
-    return HandlerTable::instance().getHandler(version, name);
+    return HandlerTable::instance().getHandler(version, betaEnabled, name);
 }
 
 std::vector<char const*>

--- a/src/ripple/rpc/impl/Handler.h
+++ b/src/ripple/rpc/impl/Handler.h
@@ -55,7 +55,7 @@ struct Handler
 };
 
 Handler const*
-getHandler(unsigned int version, std::string const&);
+getHandler(unsigned int version, bool betaEnabled, std::string const&);
 
 /** Return a Json::objectValue with a single entry. */
 template <class Value>

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -156,7 +156,8 @@ fillHandler(JsonContext& context, Handler const*& result)
 
     JLOG(context.j.trace()) << "COMMAND:" << strCommand;
     JLOG(context.j.trace()) << "REQUEST:" << context.params;
-    auto handler = getHandler(context.apiVersion, strCommand);
+    auto handler = getHandler(
+        context.apiVersion, context.app.config().BETA_RPC_API, strCommand);
 
     if (!handler)
         return rpcUNKNOWN_COMMAND;
@@ -289,9 +290,9 @@ doCommand(RPC::JsonContext& context, Json::Value& result)
 }
 
 Role
-roleRequired(unsigned int version, std::string const& method)
+roleRequired(unsigned int version, bool betaEnabled, std::string const& method)
 {
-    auto handler = RPC::getHandler(version, method);
+    auto handler = RPC::getHandler(version, betaEnabled, method);
 
     if (!handler)
         return Role::FORBID;

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -886,13 +886,14 @@ beast::SemanticVersion const goodVersion("1.0.0");
 beast::SemanticVersion const lastVersion("1.0.0");
 
 unsigned int
-getAPIVersionNumber(Json::Value const& jv)
+getAPIVersionNumber(Json::Value const& jv, bool betaEnabled)
 {
-    static Json::Value const minVersion(RPC::ApiMinimumSupportedVersion);
-    static Json::Value const maxVersion(RPC::ApiMaximumSupportedVersion);
-    static Json::Value const invalidVersion(RPC::APIInvalidVersion);
+    static Json::Value const minVersion(RPC::apiMinimumSupportedVersion);
+    static Json::Value const invalidVersion(RPC::apiInvalidVersion);
 
-    Json::Value requestedVersion(RPC::APIVersionIfUnspecified);
+    Json::Value const maxVersion(
+        betaEnabled ? RPC::apiBetaVersion : RPC::apiMaximumSupportedVersion);
+    Json::Value requestedVersion(RPC::apiVersionIfUnspecified);
     if (jv.isObject())
     {
         requestedVersion = jv.get(jss::api_version, requestedVersion);

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -389,8 +389,9 @@ ServerHandlerImp::processSession(
     Resource::Charge loadType = Resource::feeReferenceRPC;
     try
     {
-        auto apiVersion = RPC::getAPIVersionNumber(jv);
-        if (apiVersion == RPC::APIInvalidVersion ||
+        auto apiVersion =
+            RPC::getAPIVersionNumber(jv, app_.config().BETA_RPC_API);
+        if (apiVersion == RPC::apiInvalidVersion ||
             (!jv.isMember(jss::command) && !jv.isMember(jss::method)) ||
             (jv.isMember(jss::command) && !jv[jss::command].isString()) ||
             (jv.isMember(jss::method) && !jv[jss::method].isString()) ||
@@ -399,7 +400,7 @@ ServerHandlerImp::processSession(
         {
             jr[jss::type] = jss::response;
             jr[jss::status] = jss::error;
-            jr[jss::error] = apiVersion == RPC::APIInvalidVersion
+            jr[jss::error] = apiVersion == RPC::apiInvalidVersion
                 ? jss::invalid_API_version
                 : jss::missingCommand;
             jr[jss::request] = jv;
@@ -418,6 +419,7 @@ ServerHandlerImp::processSession(
 
         auto required = RPC::roleRequired(
             apiVersion,
+            app_.config().BETA_RPC_API,
             jv.isMember(jss::command) ? jv[jss::command].asString()
                                       : jv[jss::method].asString());
         auto role = requestRole(
@@ -609,22 +611,24 @@ ServerHandlerImp::processRequest(
             continue;
         }
 
-        auto apiVersion = RPC::APIVersionIfUnspecified;
+        auto apiVersion = RPC::apiVersionIfUnspecified;
         if (jsonRPC.isMember(jss::params) && jsonRPC[jss::params].isArray() &&
             jsonRPC[jss::params].size() > 0 &&
             jsonRPC[jss::params][0u].isObject())
         {
-            apiVersion =
-                RPC::getAPIVersionNumber(jsonRPC[jss::params][Json::UInt(0)]);
+            apiVersion = RPC::getAPIVersionNumber(
+                jsonRPC[jss::params][Json::UInt(0)],
+                app_.config().BETA_RPC_API);
         }
 
-        if (apiVersion == RPC::APIVersionIfUnspecified && batch)
+        if (apiVersion == RPC::apiVersionIfUnspecified && batch)
         {
             // for batch request, api_version may be at a different level
-            apiVersion = RPC::getAPIVersionNumber(jsonRPC);
+            apiVersion =
+                RPC::getAPIVersionNumber(jsonRPC, app_.config().BETA_RPC_API);
         }
 
-        if (apiVersion == RPC::APIInvalidVersion)
+        if (apiVersion == RPC::apiInvalidVersion)
         {
             if (!batch)
             {
@@ -643,8 +647,10 @@ ServerHandlerImp::processRequest(
         auto role = Role::FORBID;
         auto required = Role::FORBID;
         if (jsonRPC.isMember(jss::method) && jsonRPC[jss::method].isString())
-            required =
-                RPC::roleRequired(apiVersion, jsonRPC[jss::method].asString());
+            required = RPC::roleRequired(
+                apiVersion,
+                app_.config().BETA_RPC_API,
+                jsonRPC[jss::method].asString());
 
         if (jsonRPC.isMember(jss::params) && jsonRPC[jss::params].isArray() &&
             jsonRPC[jss::params].size() > 0 &&

--- a/src/ripple/rpc/impl/TransactionSign.cpp
+++ b/src/ripple/rpc/impl/TransactionSign.cpp
@@ -388,7 +388,7 @@ transactionPreProcessImpl(
         validatedLedgerAge,
         app.config(),
         app.getFeeTrack(),
-        getAPIVersionNumber(params));
+        getAPIVersionNumber(params, app.config().BETA_RPC_API));
 
     if (RPC::contains_error(txJsonResult))
         return std::move(txJsonResult);
@@ -1066,7 +1066,7 @@ transactionSubmitMultiSigned(
         validatedLedgerAge,
         app.config(),
         app.getFeeTrack(),
-        getAPIVersionNumber(jvRequest));
+        getAPIVersionNumber(jvRequest, app.config().BETA_RPC_API));
 
     if (RPC::contains_error(txJsonResult))
         return std::move(txJsonResult);

--- a/src/test/app/Path_test.cpp
+++ b/src/test/app/Path_test.cpp
@@ -226,7 +226,7 @@ public:
              Role::USER,
              {},
              {},
-             RPC::APIVersionIfUnspecified},
+             RPC::apiVersionIfUnspecified},
             {},
             {}};
 
@@ -334,7 +334,7 @@ public:
              Role::USER,
              {},
              {},
-             RPC::APIVersionIfUnspecified},
+             RPC::apiVersionIfUnspecified},
             {},
             {}};
         Json::Value result;

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -176,7 +176,7 @@ class AccountTx_test : public beast::unit_test::suite
             p[jss::ledger_index_max] = 1;
             BEAST_EXPECT(isErr(
                 env.rpc("json", "account_tx", to_string(p)),
-                (RPC::ApiMaximumSupportedVersion == 1 ? rpcLGR_IDXS_INVALID
+                (RPC::apiMaximumSupportedVersion == 1 ? rpcLGR_IDXS_INVALID
                                                       : rpcINVALID_LGR_RANGE)));
         }
 
@@ -192,7 +192,7 @@ class AccountTx_test : public beast::unit_test::suite
             p[jss::ledger_index_min] = env.current()->info().seq;
             BEAST_EXPECT(isErr(
                 env.rpc("json", "account_tx", to_string(p)),
-                (RPC::ApiMaximumSupportedVersion == 1 ? rpcLGR_IDXS_INVALID
+                (RPC::apiMaximumSupportedVersion == 1 ? rpcLGR_IDXS_INVALID
                                                       : rpcINVALID_LGR_RANGE)));
         }
 

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -299,7 +299,7 @@ public:
         env.timeKeeper().adjustCloseTime(weeks{3});
         result = env.rpc("ledger_request", "1")[jss::result];
         BEAST_EXPECT(result[jss::status] == "error");
-        if (RPC::ApiMaximumSupportedVersion == 1)
+        if (RPC::apiMaximumSupportedVersion == 1)
         {
             BEAST_EXPECT(result[jss::error] == "noCurrent");
             BEAST_EXPECT(

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -1437,7 +1437,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
         __LINE__,
         {"account_tx", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", "580", "579"},
         RPCCallTestData::no_exception,
-        RPC::ApiMaximumSupportedVersion == 1 ?
+        RPC::apiMaximumSupportedVersion == 1 ?
                                              R"({
     "method" : "account_tx",
     "params" : [
@@ -5917,7 +5917,7 @@ static RPCCallTestData const rpcCallTestArray[] = {
         __LINE__,
         {"tx_account", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", "580", "579"},
         RPCCallTestData::no_exception,
-        RPC::ApiMaximumSupportedVersion == 1 ?
+        RPC::apiMaximumSupportedVersion == 1 ?
                                              R"({
     "method" : "tx_account",
     "params" : [
@@ -6410,7 +6410,7 @@ std::string
 updateAPIVersionString(const char* const req)
 {
     static std::string version_str =
-        std::to_string(RPC::ApiMaximumSupportedVersion);
+        std::to_string(RPC::apiMaximumSupportedVersion);
     static auto place_holder = "%MAX_API_VER%";
     std::string jr(req);
     boost::replace_all(jr, place_holder, version_str);


### PR DESCRIPTION
### Motivation
As discussed in https://github.com/ripple/rippled/pull/3770, we need a way to unit test API version 2 RPC calls. 

### Context of Change
The API version that is available for public consumption is 1. But for unit tests, the API version 2 can be enabled.
To show how it works, a version 2 `Version` RPC call is also added.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
