### PR TITLE
Revise "[workers]" description in the example config.

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -766,8 +766,8 @@
 #
 #   Configures the number of threads for processing work submitted by peers
 #   and clients. If not specified, then the value is automatically set to the
-#   number of processor cores plus 2 for networked nodes or 1 for nodes running
-#   in stand alone mode.
+#   number of processor threads plus 2 for networked nodes. Nodes running in
+#   stand alone mode default to 1 worker.
 #
 #
 #

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -765,9 +765,9 @@
 # [workers]
 #
 #   Configures the number of threads for processing work submitted by peers
-#   and clients. If not specified, then the value is automatically determined
-#   by factors including the number of system processors and whether this
-#   node is a validator.
+#   and clients. If not specified, then the value is automatically set to the
+#   number of processor cores plus 2 for networked nodes or 1 for nodes running
+#   in stand alone mode.
 #
 #
 #


### PR DESCRIPTION
## High Level Overview of Change
The description of how the default number of workers is calculated is not currently accurate, and having validation enabled is irrelevant to the default number of workers.

Unless specified in the configuration file, thread count is determined by adding 2 to the response from `hardware_concurrency()`:

`threads = hardware_concurrency() + 2`

https://github.com/ripple/rippled/blob/develop/src/ripple/core/impl/JobQueue.cpp#L166


### Type of Change
- [x] Documentation Updates