### PR TITLE
Remove legacy protocol version (1.2)

### DIFF
--- a/src/ripple/overlay/README.md
+++ b/src/ripple/overlay/README.md
@@ -152,8 +152,7 @@ appropriate HTTP error code (e.g. by sending an HTTP 400 "Bad Request" response)
 
 Protocol versions are string of the form `XRPL/` followed by a dotted major
 and minor protocol version number, where the major number is greater than or
-equal to 2 and the minor is greater than or equal to 0. The legacy version
-`RTXP/1.2` is also supported at this time and is an alias for `XRPL/2.0`.
+equal to 2 and the minor is greater than or equal to 0.
 
 See [RFC 2616 &sect;14.42](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.42)
 

--- a/src/ripple/overlay/impl/ProtocolVersion.cpp
+++ b/src/ripple/overlay/impl/ProtocolVersion.cpp
@@ -36,7 +36,6 @@ namespace ripple {
 // clang-format off
 constexpr ProtocolVersion const supportedProtocolList[]
 {
-    {1, 2},
     {2, 0},
     {2, 1},
     {2, 2}
@@ -73,11 +72,6 @@ static_assert(
 std::string
 to_string(ProtocolVersion const& p)
 {
-    // The legacy protocol uses a different name. This can be removed when we
-    // migrate away from it and require 2.0 or later.
-    if (p == ProtocolVersion{1, 2})
-        return "RTXP/1.2";
-
     return "XRPL/" + std::to_string(p.first) + "." + std::to_string(p.second);
 }
 
@@ -100,12 +94,6 @@ parseProtocolVersions(boost::beast::string_view const& value)
 
     for (auto const& s : beast::rfc2616::split_commas(value))
     {
-        if (s == "RTXP/1.2")
-        {
-            result.push_back(make_protocol(1, 2));
-            continue;
-        }
-
         boost::smatch m;
 
         if (boost::regex_match(s, m, re))

--- a/src/ripple/overlay/impl/ProtocolVersion.h
+++ b/src/ripple/overlay/impl/ProtocolVersion.h
@@ -49,9 +49,8 @@ to_string(ProtocolVersion const& p);
 /** Parse a set of protocol versions.
 
     Given a comma-separated string, extract and return all those that look
-    like valid protocol versions (i.e. RTXP/1.2 and XRPL/2.0 and later). Any
-    strings that are not parseable as valid protocol strings are excluded
-    from the result set.
+    like valid protocol versions (i.e. XRPL/2.0 and later). Strings that are
+    not parseable as valid protocol strings are excluded from the result set.
 
     @return A list of all apparently valid protocol versions.
 

--- a/src/test/overlay/ProtocolVersion_test.cpp
+++ b/src/test/overlay/ProtocolVersion_test.cpp
@@ -50,7 +50,6 @@ public:
     run() override
     {
         testcase("Convert protocol version to string");
-        BEAST_EXPECT(to_string(make_protocol(1, 2)) == "RTXP/1.2");
         BEAST_EXPECT(to_string(make_protocol(1, 3)) == "XRPL/1.3");
         BEAST_EXPECT(to_string(make_protocol(2, 0)) == "XRPL/2.0");
         BEAST_EXPECT(to_string(make_protocol(2, 1)) == "XRPL/2.1");
@@ -62,16 +61,16 @@ public:
             // Empty string
             check("", "");
             check(
-                "RTXP/1.1,RTXP/1.3,XRPL/2.1,RTXP/1.2,XRPL/2.0",
-                "RTXP/1.2,XRPL/2.0,XRPL/2.1");
+                "RTXP/1.1,RTXP/1.2,RTXP/1.3,XRPL/2.1,XRPL/2.0",
+                "XRPL/2.0,XRPL/2.1");
             check(
                 "RTXP/0.9,RTXP/1.01,XRPL/0.3,XRPL/2.01,XRPL/19.04,Oscar/"
                 "123,NIKB",
                 "");
             check(
-                "RTXP/1.2,XRPL/2.0,RTXP/1.2,XRPL/2.0,XRPL/19.4,XRPL/7.89,XRPL/"
+                "XRPL/2.0,RTXP/1.2,XRPL/2.0,XRPL/19.4,XRPL/7.89,XRPL/"
                 "A.1,XRPL/2.01",
-                "RTXP/1.2,XRPL/2.0,XRPL/7.89,XRPL/19.4");
+                "XRPL/2.0,XRPL/7.89,XRPL/19.4");
             check(
                 "XRPL/2.0,XRPL/3.0,XRPL/4,XRPL/,XRPL,OPT XRPL/2.2,XRPL/5.67",
                 "XRPL/2.0,XRPL/3.0,XRPL/5.67");
@@ -80,8 +79,7 @@ public:
         {
             testcase("Protocol version negotiation");
 
-            BEAST_EXPECT(
-                negotiateProtocolVersion("RTXP/1.2") == make_protocol(1, 2));
+            BEAST_EXPECT(negotiateProtocolVersion("RTXP/1.2") == std::nullopt);
             BEAST_EXPECT(
                 negotiateProtocolVersion("RTXP/1.2, XRPL/2.0") ==
                 make_protocol(2, 0));


### PR DESCRIPTION
This pull request removes support for the legacy protocol. It has been observed that nodes running versions as low as 0.60 occupy peer slots. From the perspective of hubs, not accepting connections from legacy protocol peers, will free up both slots and bandwidth consumption.