### PR TITLE
Create comparator wrapper classes for MSVC 2019 build issues:

### DIFF
--- a/src/ripple/basics/comparators.h
+++ b/src/ripple/basics/comparators.h
@@ -1,0 +1,76 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2021 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_BASICS_COMPARATORS_H_INCLUDED
+#define RIPPLE_BASICS_COMPARATORS_H_INCLUDED
+
+#include <functional>
+
+namespace ripple {
+
+#ifdef _MSC_VER
+
+/*
+ * MSVC 2019 version 16.9.0 added [[nodiscard]] to the std comparison
+ * operator() functions. boost::bimap checks that the comparitor is a
+ * BinaryFunction, in part by calling the function and ignoring the value.
+ * These two things don't play well together. These wrapper classes simply
+ * strip [[nodiscard]] from operator() for use in boost::bimap.
+ *
+ * See also:
+ *  https://www.boost.org/doc/libs/1_75_0/libs/bimap/doc/html/boost_bimap/the_tutorial/controlling_collection_types.html
+ */
+
+template <class T = void>
+struct less
+{
+    using result_type = bool;
+
+    constexpr bool
+    operator()(const T& left, const T& right) const
+    {
+        return std::less<T>()(left, right);
+    }
+};
+
+template <class T = void>
+struct equal_to
+{
+    using result_type = bool;
+
+    constexpr bool
+    operator()(const T& left, const T& right) const
+    {
+        return std::equal_to<T>()(left, right);
+    }
+};
+
+#else
+
+template <class T = void>
+using less = std::less<T>;
+
+template <class T = void>
+using equal_to = std::equal_to<T>;
+
+#endif
+
+}  // namespace ripple
+
+#endif

--- a/src/ripple/peerfinder/impl/Bootcache.h
+++ b/src/ripple/peerfinder/impl/Bootcache.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_PEERFINDER_BOOTCACHE_H_INCLUDED
 #define RIPPLE_PEERFINDER_BOOTCACHE_H_INCLUDED
 
+#include <ripple/basics/comparators.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/beast/utility/PropertyStream.h>
 #include <ripple/peerfinder/PeerfinderManager.h>
@@ -81,8 +82,11 @@ private:
         int m_valence;
     };
 
-    using left_t = boost::bimaps::unordered_set_of<beast::IP::Endpoint>;
-    using right_t = boost::bimaps::multiset_of<Entry>;
+    using left_t = boost::bimaps::unordered_set_of<
+        beast::IP::Endpoint,
+        boost::hash<beast::IP::Endpoint>,
+        ripple::equal_to<beast::IP::Endpoint>>;
+    using right_t = boost::bimaps::multiset_of<Entry, ripple::less<Entry>>;
     using map_type = boost::bimap<left_t, right_t>;
     using value_type = map_type::value_type;
 

--- a/src/test/csf/ledgers.h
+++ b/src/test/csf/ledgers.h
@@ -21,6 +21,7 @@
 
 #include <ripple/basics/UnorderedContainers.h>
 #include <ripple/basics/chrono.h>
+#include <ripple/basics/comparators.h>
 #include <ripple/basics/tagged_integer.h>
 #include <ripple/consensus/LedgerTiming.h>
 #include <ripple/json/json_value.h>
@@ -242,7 +243,9 @@ private:
  */
 class LedgerOracle
 {
-    using InstanceMap = boost::bimaps::bimap<Ledger::Instance, Ledger::ID>;
+    using InstanceMap = boost::bimaps::bimap<
+        boost::bimaps::set_of<Ledger::Instance, ripple::less<Ledger::Instance>>,
+        boost::bimaps::set_of<Ledger::ID, ripple::less<Ledger::ID>>>;
     using InstanceEntry = InstanceMap::value_type;
 
     // Set of all known ledgers; note this is never pruned


### PR DESCRIPTION
## High Level Overview of Change

Travis CI builds started failing for Visual Studio 2019 builds. [Example 1](https://travis-ci.com/github/ripple/rippled/builds/219024792), [example 2](https://travis-ci.com/github/ripple/rippled/builds/219024792).

@scottschurr , @miguelportilla , and I tracked the problem down to a recent update to VS 2019. The unaltered current develop branch fails with this version, so it is definitely not due to changes in rippled code.

The underlying cause is that the `std::less` and `std::equal_to` comparators have added the `[[nodiscard]]` attribute, which conflicts with `boost::bimap` type validations, which call the functions without capturing the result.

This fix adds classes to exactly wrap the comparators, removing `[[nodiscard]]` attributes.

### Type of Change

- [X ] Refactor (non-breaking change that only restructures code)

## Future Tasks

The new wrapper classes can be removed when either:
* A Boost update fixes this issue.
* A VS 2019 update fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3786)
<!-- Reviewable:end -->
