### PR TITLE
Clarify the safety of NetClock::time_point arithmetic:

### DIFF
--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -638,7 +638,7 @@ CreateOffer::takerCross(
     Sandbox& sbCancel,
     Amounts const& takerAmount)
 {
-    NetClock::time_point const when{ctx_.view().parentCloseTime()};
+    NetClock::time_point const when = ctx_.view().parentCloseTime();
 
     beast::WrappedSink takerSink(j_, "Taker ");
 

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -151,7 +151,9 @@ isCurrent(
     // Because this can be called on untrusted, possibly
     // malicious validations, we do our math in a way
     // that avoids any chance of overflowing or underflowing
-    // the signing time.
+    // the signing time.  All of the expressions below are
+    // promoted from unsigned 32 bit to signed 64 bit prior
+    // to computation.
 
     return (signTime > (now - p.validationCURRENT_EARLY)) &&
         (signTime < (now + p.validationCURRENT_WALL)) &&

--- a/src/ripple/overlay/impl/Handshake.cpp
+++ b/src/ripple/overlay/impl/Handshake.cpp
@@ -268,7 +268,6 @@ verifyHandshake(
         // We can't blindly "return a-b;" because TimeKeeper::time_point
         // uses an unsigned integer for representing durations, which is
         // a problem when trying to subtract time points.
-        // FIXME: @HowardHinnant, should we migrate to using std::int64_t?
         auto calculateOffset = [](TimeKeeper::time_point a,
                                   TimeKeeper::time_point b) {
             if (a > b)


### PR DESCRIPTION
* NetClock::rep is uint32_t and can be error-prone when
  used with subtraction.
* Fixes #3656

## High Level Overview of Change

To address #3656 a comprehensive survey of all uses of `NetClock::time_point` in rippled was made.  Only two minor were found.

1. src/ripple/consensus/Validations.h has this expression:
```c++
signTime > (now - p.validationCURRENT_EARLY)
```
This is the expression #3656 refers to as being vulnerable to unsigned overflow.  However it turns out this expression is fine because `p.validationCURRENT_EARLY` is a 64 bit signed integral type.  Thus the 32 but unsigned `now` is losslessly converted to signed 64 bit prior to the conversion.  Additionally the 32 but unsigned `signTime` is converted to signed 64 bit prior to the comparison.

The expression is correct and bullet-proof as is.  A comment to this effect has been added.

2.  src/ripple/app/tx/impl/CreateOffer.cpp has this expression:
```c++
NetClock::time_point const when{ctx_.view().parentCloseTime()};
```
While correct, using explicit conversion syntax for implicit construction is error-prone because one might accidentally choose an unwanted explicit constructor.  This code is safer using implicit syntax to ensure that only an implicit constructor is chosen:
```c++
NetClock::time_point const when = ctx_.view().parentCloseTime();
```