### PR TITLE
Discard non-validator TMSquelch message

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -2489,6 +2489,16 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMSquelch> const& m)
     }
     PublicKey key(slice);
 
+    // Ignore non-validator squelch
+    if (!app_.validators().listed(key))
+    {
+        charge(Resource::feeBadData);
+        JLOG(p_journal_.debug())
+            << "onMessage: TMSquelch discarding non-validator squelch "
+            << slice;
+        return;
+    }
+
     // Ignore the squelch for validator's own messages.
     if (key == app_.getValidationPublicKey())
     {


### PR DESCRIPTION
## High Level Overview of Change

Discard TMSquelch message with a non-validator public key

### Context of Change

Introduced in 1.7.0.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
