### PR TITLE
Serialize metadata as blob in tx RPC when binary flag is true

### DIFF
--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -236,7 +236,14 @@ doTxHelp(RPC::Context& context, TxArgs const& args)
 
     if (ledger && meta)
     {
-        result.meta = meta;
+        if (args.binary)
+        {
+            result.meta = meta->getAsObject().getSerializer().getData();
+        }
+        else
+        {
+            result.meta = meta;
+        }
         result.validated = isValidated(
             context.ledgerMaster, ledger->info().seq, ledger->info().hash);
     }


### PR DESCRIPTION
In the `tx` command, transaction metadata is always returned in expanded JSON form, even if `binary` is set to true in the request. The transaction itself is encoded as a blob if `binary` is set to true, just not the metadata. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3791)
<!-- Reviewable:end -->
