### PR TITLE
Remove some "Env::close" noise from unit test output

### DIFF
--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -136,9 +136,15 @@ Env::close(
         auto resp = rpc("ledger_accept");
         if (resp["result"]["status"] != std::string("success"))
         {
-            JLOG(journal.error())
-                << "Env::close() failed: " << resp["result"]["status"]
-                << std::endl;
+            std::string reason = "internal error";
+            if (resp.isMember("error_what"))
+                reason = resp["error_what"].asString();
+            else if (resp.isMember("error_message"))
+                reason = resp["error_message"].asString();
+            else if (resp.isMember("error"))
+                reason = resp["error"].asString();
+
+            JLOG(journal.error()) << "Env::close() failed: " << reason;
             res = false;
         }
     }

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -1670,12 +1670,17 @@ public:
         Env env{*this, asAdmin ? envconfig() : envconfig(no_admin)};
         Account gw{"gw"};
         env.fund(XRP(200000), gw);
-        env.close();
+        // Note that calls to env.close() fail without admin permission.
+        if (asAdmin)
+            env.close();
+
         auto USD = gw["USD"];
 
         for (auto i = 0; i <= RPC::Tuning::bookOffers.rmax; i++)
             env(offer(gw, XRP(50 + 1 * i), USD(1.0 + 0.1 * i)));
-        env.close();
+
+        if (asAdmin)
+            env.close();
 
         Json::Value jvParams;
         jvParams[jss::limit] = 1;

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -58,7 +58,9 @@ public:
             Account const bob{std::string("bob") + std::to_string(i)};
             env.fund(XRP(1000), bob);
         }
-        env.close();
+        // Note that calls to env.close() fail without admin permission.
+        if (asAdmin)
+            env.close();
 
         // with no limit specified, we get the max_limit if the total number of
         // accounts is greater than max, which it is here
@@ -107,7 +109,6 @@ public:
             Account const bob{std::string("bob") + std::to_string(i)};
             env.fund(XRP(1000), bob);
         }
-        env.close();
 
         // with no limit specified, we should get all of our fund entries
         // plus three more related to the gateway setup
@@ -212,7 +213,6 @@ public:
             Account const bob{std::string("bob") + std::to_string(i)};
             env.fund(XRP(1000), bob);
         }
-        env.close();
 
         // with no limit specified, we should get all of our fund entries
         // plus three more related to the gateway setup

--- a/src/test/rpc/LedgerRequestRPC_test.cpp
+++ b/src/test/rpc/LedgerRequestRPC_test.cpp
@@ -360,7 +360,6 @@ public:
         Account const gw{"gateway"};
         auto const USD = gw["USD"];
         env.fund(XRP(100000), gw);
-        env.close();
 
         auto const result = env.rpc("ledger_request", "1")[jss::result];
         // The current HTTP/S ServerHandler returns an HTTP 403 error code here


### PR DESCRIPTION
## `Env::close()` calls fail without admin privileges

### Context of Change

The unit tests have been echoing something about `Env.close()` for a long time.  But it was not obvious why that was or if anything should be done about it.  I investigated and found a couple of problems:

1. There were a few unit tests calling `Env::close()` when the test was set up without admin privileges.
2. The complaint coming out of `Env` echoed `resp["result"]["status"]` which was `NULL`.  So the user was not informed about the reason for the complaint.

This change fixes both of those problems:

1. It modifies the unit tests that were calling `Env::close()` without admin privileges.  They no longer call `Env::close()`.
2. It modifies the log write from `Env` to include the reason that the `Env::close()` call failed.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (fixes pre-existing tests for better behavior)

Unless we're documenting the output of the unit tests, I don't think there's any reason to include this change in the release notes.

This change only affects unit test code.  Other than running the unit tests, no further testing should be required.
