### PR TITLE
unwrap result.result when forwarding RPCs

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -304,6 +304,25 @@ bool
 LedgerMaster::isCaughtUp(std::string& reason)
 {
     using namespace std::chrono_literals;
+
+#ifdef RIPPLED_REPORTING
+    if (app_.config().reporting())
+    {
+        auto age = PgQuery(app_.getPgPool())("SELECT age()");
+        if (!age || age.isNull())
+        {
+            reason = "No ledgers in database";
+            return false;
+        }
+        if (std::chrono::seconds{age.asInt()} > 3min)
+        {
+            reason = "No recently-published ledger";
+            return false;
+        }
+        return true;
+    }
+#endif
+
     if (getPublishedLedgerAge() > 3min)
     {
         reason = "No recently-published ledger";

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -906,7 +906,11 @@ ServerHandlerImp::processRequest(
 
         if (reply.isMember(jss::result) &&
             reply[jss::result].isMember(jss::result))
+        {
             reply = reply[jss::result];
+            reply[jss::result][jss::status] = reply[jss::status];
+            reply.removeMember(jss::status);
+        }
     }
     auto response = to_string(reply);
 

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -908,8 +908,11 @@ ServerHandlerImp::processRequest(
             reply[jss::result].isMember(jss::result))
         {
             reply = reply[jss::result];
-            reply[jss::result][jss::status] = reply[jss::status];
-            reply.removeMember(jss::status);
+            if (reply.isMember(jss::status))
+            {
+                reply[jss::result][jss::status] = reply[jss::status];
+                reply.removeMember(jss::status);
+            }
         }
     }
     auto response = to_string(reply);

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -903,6 +903,10 @@ ServerHandlerImp::processRequest(
             reply.append(std::move(r));
         else
             reply = std::move(r);
+
+        if (reply.isMember(jss::result) &&
+            reply[jss::result].isMember(jss::result))
+            reply = reply[jss::result];
     }
     auto response = to_string(reply);
 


### PR DESCRIPTION
## High Level Overview of Change

When forwarding JSON-RPC requests from a reporting node to a p2p node, the returned JSON had a double nesting of "result". See before and after section for an example. This PR removes the first result, so there is only one field named result in the response. This bug did not affect Websocket responses. This bug was a breaking change, so the fix reverts a breaking change.

### Context of Change

### Type of Change


- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
Before (JSON-RPC):
```
{
   "result" : {
      "api_version" : 1,
      "forwarded" : true,
      "result" : {
         "current_ledger_size" : "41",
         "current_queue_size" : "0",
         "drops" : {
            "base_fee" : "10",
            "median_fee" : "5000",
            "minimum_fee" : "10",
            "open_ledger_fee" : "10"
         },
         "expected_ledger_size" : "81",
         "ledger_current_index" : 62544876,
         "levels" : {
            "median_level" : "128000",
            "minimum_level" : "256",
            "open_ledger_level" : "256",
            "reference_level" : "256"
         },
         "max_queue_size" : "2000"
      },
      "status" : "success",
      "type" : "response",
      "warnings" : [
         {
            "id" : 1004,
            "message" : "This is a reporting server.  The default behavior of a reporting server is to only return validated data. If you are looking for not yet validated data, include \"ledger_index : current\" in your request, which will cause this server to forward the request to a p2p node. If the forward is successful the response will include \"forwarded\" : \"true\""
         }
      ]
   }
}


```
After (JSON-RPC):
```
{
   "api_version" : 1,
   "forwarded" : true,
   "result" : {
      "current_ledger_size" : "92",
      "current_queue_size" : "0",
      "drops" : {
         "base_fee" : "10",
         "median_fee" : "5000",
         "minimum_fee" : "10",
         "open_ledger_fee" : "10"
      },
      "expected_ledger_size" : "94",
      "ledger_current_index" : 62544768,
      "levels" : {
         "median_level" : "128000",
         "minimum_level" : "256",
         "open_ledger_level" : "256",
         "reference_level" : "256"
      },
      "max_queue_size" : "2000",
      "status" : "success"
   },
   "type" : "response",
   "warnings" : [
      {
         "id" : 1004,
         "message" : "This is a reporting server.  The default behavior of a reporting server is to only return validated data. If you are looking for not yet validated data, include \"ledger_index : current\" in your request, which will cause this server to forward the request to a p2p node. If the forward is successful the response will include \"forwarded\" : \"true\""
      }
   ]
}

```
Websocket Before _and_ After (websocket responses were not affected by this bug):
```
{
    "forwarded": true,
    "result": {
        "current_ledger_size": "31",
        "current_queue_size": "0",
        "drops": {
            "base_fee": "10",
            "median_fee": "5000",
            "minimum_fee": "10",
            "open_ledger_fee": "10"
        },
        "expected_ledger_size": "75",
        "ledger_current_index": 62565455,
        "levels": {
            "median_level": "128000",
            "minimum_level": "256",
            "open_ledger_level": "256",
            "reference_level": "256"
        },
        "max_queue_size": "2000"
    },
    "status": "success",
    "type": "response",
    "warnings": [
        {
            "id": 1004,
            "message": "This is a reporting server.  The default behavior of a reporting server is to only return validated data. If you are looking for not yet validated data, include \"ledger_index : current\" in your request, which will cause this server to forward the request to a p2p node. If the forward is successful the response will include \"forwarded\" : \"true\""
        }
    ]
}

```

## Test Plan
I tested the code before and after the fix with command line RPC as well as curl. I also verified that the Websocket responses are unaffected. I used `fee` as the test command, since `fee` is always forwarded. I also tested the case where the p2p node returns an error, which is correctly propagated to the reporting node. I also lastly tested the case where the p2p node is unavailable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3804)
<!-- Reviewable:end -->
