### PR TITLE
Fix compilation of krb5 dependency with GCC 10 and Clang 10

### DIFF
--- a/Builds/CMake/deps/cassandra.cmake
+++ b/Builds/CMake/deps/cassandra.cmake
@@ -47,7 +47,7 @@ if(reporting)
                 GIT_REPOSITORY https://github.com/krb5/krb5.git
                 GIT_TAG master
                 UPDATE_COMMAND ""
-                CONFIGURE_COMMAND autoreconf src && ./src/configure --enable-static --disable-shared > /dev/null
+                CONFIGURE_COMMAND autoreconf src && CFLAGS=-fcommon ./src/configure --enable-static --disable-shared > /dev/null
                 BUILD_IN_SOURCE 1
                 BUILD_COMMAND make
                 INSTALL_COMMAND ""


### PR DESCRIPTION
[This is the problem](https://github.com/cockroachdb/cockroach/issues/49734#issuecomment-758389602) and [this is the fix](https://github.com/cockroachdb/cockroach/pull/58895/files).