### PR TITLE
Add load_factor to server_info in reporting mode

### DIFF
--- a/src/ripple/rpc/handlers/ServerInfo.cpp
+++ b/src/ripple/rpc/handlers/ServerInfo.cpp
@@ -17,7 +17,9 @@
 */
 //==============================================================================
 
+#include <ripple/app/main/Application.h>
 #include <ripple/app/misc/NetworkOPs.h>
+#include <ripple/app/reporting/P2pProxy.h>
 #include <ripple/json/json_value.h>
 #include <ripple/net/RPCErr.h>
 #include <ripple/protocol/jss.h>
@@ -38,6 +40,15 @@ doServerInfo(RPC::JsonContext& context)
         context.params.isMember(jss::counters) &&
             context.params[jss::counters].asBool());
 
+    if (context.app.config().reporting())
+    {
+        Json::Value proxied = forwardToP2p(context);
+        if (proxied.isMember(jss::result) &&
+            proxied[jss::result].isMember(jss::info) &&
+            proxied[jss::result][jss::info].isMember(jss::load_factor))
+            ret[jss::info][jss::load_factor] =
+                proxied[jss::result][jss::info][jss::load_factor];
+    }
     return ret;
 }
 

--- a/src/ripple/rpc/handlers/ServerInfo.cpp
+++ b/src/ripple/rpc/handlers/ServerInfo.cpp
@@ -42,14 +42,9 @@ doServerInfo(RPC::JsonContext& context)
 
     if (context.app.config().reporting())
     {
-        Json::Value proxied = forwardToP2p(context);
-        if (proxied.isMember(jss::result) &&
-            proxied[jss::result].isMember(jss::info) &&
-            proxied[jss::result][jss::info].isMember(jss::load_factor))
-            ret[jss::info][jss::load_factor] =
-                proxied[jss::result][jss::info][jss::load_factor];
-        else
-            ret[jss::info][jss::load_factor] = 1;
+        Json::Value const proxied = forwardToP2p(context);
+        auto const lf = proxied[jss::result][jss::info][jss::load_factor];
+        ret[jss::info][jss::load_factor] = lf.isNull() ? 1 : lf;
     }
     return ret;
 }

--- a/src/ripple/rpc/handlers/ServerInfo.cpp
+++ b/src/ripple/rpc/handlers/ServerInfo.cpp
@@ -48,6 +48,8 @@ doServerInfo(RPC::JsonContext& context)
             proxied[jss::result][jss::info].isMember(jss::load_factor))
             ret[jss::info][jss::load_factor] =
                 proxied[jss::result][jss::info][jss::load_factor];
+        else
+            ret[jss::info][jss::load_factor] = 1;
     }
     return ret;
 }


### PR DESCRIPTION
load_factor was missing from server_info when the server was running in reporting mode. This commit fixes that by querying the p2p node for the load_factor, and propagating that info back to the client. If the p2p node is unavailable or returns an error, load_factor is set to 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ripple/rippled/3817)
<!-- Reviewable:end -->
