### PR TITLE
Support boost 1.76:

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2230,8 +2230,8 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
 
     info[jss::server_state] = strOperatingMode(admin);
 
-    info[jss::time] = to_string(
-        floor<std::chrono::microseconds>(std::chrono::system_clock::now()));
+    info[jss::time] = to_string(std::chrono::floor<std::chrono::microseconds>(
+        std::chrono::system_clock::now()));
 
     if (needNetworkLedger_)
         info[jss::network_ledger] = "waiting";

--- a/src/ripple/app/reporting/ETLSource.h
+++ b/src/ripple/app/reporting/ETLSource.h
@@ -238,7 +238,7 @@ public:
         auto last = getLastMsgTime();
         if (last.time_since_epoch().count() != 0)
             result["last_message_arrival_time"] =
-                to_string(floor<std::chrono::microseconds>(last));
+                to_string(std::chrono::floor<std::chrono::microseconds>(last));
         return result;
     }
 

--- a/src/ripple/app/reporting/ReportingETL.h
+++ b/src/ripple/app/reporting/ReportingETL.h
@@ -317,7 +317,8 @@ public:
         auto last = getLastPublish();
         if (last.time_since_epoch().count() != 0)
             result["last_publish_time"] =
-                to_string(floor<std::chrono::microseconds>(getLastPublish()));
+                to_string(std::chrono::floor<std::chrono::microseconds>(
+                    getLastPublish()));
         return result;
     }
 

--- a/src/ripple/basics/impl/PerfLogImp.cpp
+++ b/src/ripple/basics/impl/PerfLogImp.cpp
@@ -288,7 +288,7 @@ PerfLogImp::report()
     lastLog_ = present;
 
     Json::Value report(Json::objectValue);
-    report[jss::time] = to_string(floor<microseconds>(present));
+    report[jss::time] = to_string(std::chrono::floor<microseconds>(present));
     {
         std::lock_guard lock{counters_.jobsMutex_};
         report[jss::workers] =

--- a/src/ripple/beast/net/IPAddress.h
+++ b/src/ripple/beast/net/IPAddress.h
@@ -100,20 +100,6 @@ hash_append(Hasher& h, beast::IP::Address const& addr) noexcept
 }
 }  // namespace beast
 
-namespace std {
-template <>
-struct hash<beast::IP::Address>
-{
-    explicit hash() = default;
-
-    std::size_t
-    operator()(beast::IP::Address const& addr) const
-    {
-        return beast::uhash<>{}(addr);
-    }
-};
-}  // namespace std
-
 namespace boost {
 template <>
 struct hash<::beast::IP::Address>

--- a/src/test/unit_test/multi_runner.cpp
+++ b/src/test/unit_test/multi_runner.cpp
@@ -27,6 +27,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 namespace ripple {
 namespace test {


### PR DESCRIPTION
* remove unused `std::hash` specialization
* Use `std::chrono::floor` instead of `floor`

This patch was tested against boost 1.76-rc1. We should wait to merge it until boost 1.76 is officially released.

