### PR TITLE
Automatically determine the node size:

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1426,8 +1426,20 @@
 #   Tunes the servers based on the expected load and available memory. Legal
 #   sizes are "tiny", "small", "medium", "large", and "huge". We recommend
 #   you start at the default and raise the setting if you have extra memory.
-#   If no value is specified, the code assumes the proper size is "tiny". The
-#   default configuration file explicitly specifies "medium" as the size.
+#
+#   The code attempts to automatically determine the appropriate size for
+#   this parameter based on the amount of RAM and the number of execution
+#   cores availabe to the server. The current decision matrix is:
+#
+#   |         |         Cores          |
+#   |---------|------------------------|
+#   |   RAM   |   1  | 2 or 3 |   ≥ 4  |
+#   |---------|------|--------|--------|
+#   |  < ~8GB | tiny |   tiny |   tiny |
+#   | < ~12GB | tiny |  small |  small |
+#   | < ~16GB | tiny |  small | medium |
+#   | < ~24GB | tiny |  small |  large |
+#   | < ~32GB | tiny |  small |   huge |
 #
 # [signing_support]
 #
@@ -1588,9 +1600,6 @@ protocol = ws
 #protocol = wss
 
 #-------------------------------------------------------------------------------
-
-[node_size]
-medium
 
 # This is primary persistent datastore for rippled.  This includes transaction
 # metadata, account states, and ledger headers.  Helpful information can be

--- a/src/ripple/app/main/Main.cpp
+++ b/src/ripple/app/main/Main.cpp
@@ -745,8 +745,6 @@ run(int argc, char** argv)
 
 }  // namespace ripple
 
-// Must be outside the namespace for obvious reasons
-//
 int
 main(int argc, char** argv)
 {
@@ -770,7 +768,5 @@ main(int argc, char** argv)
 
     atexit(&google::protobuf::ShutdownProtobufLibrary);
 
-    auto const result(ripple::run(argc, argv));
-
-    return result;
+    return ripple::run(argc, argv);
 }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2241,6 +2241,25 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
 
     if (admin)
     {
+        switch (app_.config().NODE_SIZE)
+        {
+            case 0:
+                info[jss::node_size] = "tiny";
+                break;
+            case 1:
+                info[jss::node_size] = "small";
+                break;
+            case 2:
+                info[jss::node_size] = "medium";
+                break;
+            case 3:
+                info[jss::node_size] = "large";
+                break;
+            case 4:
+                info[jss::node_size] = "huge";
+                break;
+        }
+
         auto when = app_.validators().expires();
 
         if (!human)

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -56,7 +56,8 @@ enum class SizedItem : std::size_t {
     txnDBCache,
     lgrDBCache,
     openFinalLimit,
-    burstSize
+    burstSize,
+    ramSizeGB
 };
 
 //  This entire derived class is deprecated.
@@ -116,6 +117,9 @@ private:
     */
     bool signingEnabled_ = false;
 
+    // The amount of RAM, in bytes, that we detected on this system.
+    std::uint64_t const ramSize_;
+
 public:
     bool doImport = false;
     bool nodeToShard = false;
@@ -156,8 +160,6 @@ public:
     std::size_t PEERS_OUT_MAX = 0;
     std::size_t PEERS_IN_MAX = 0;
 
-    std::chrono::seconds WEBSOCKET_PING_FREQ = std::chrono::minutes{5};
-
     // Path searching
     int PATH_SEARCH_OLD = 7;
     int PATH_SEARCH = 7;
@@ -176,6 +178,9 @@ public:
     std::uint32_t LEDGER_HISTORY = 256;
     std::uint32_t FETCH_DEPTH = 1000000000;
 
+    // Tunable that adjusts various parameters, typically associated
+    // with hardware parameters (RAM size and CPU cores). The default
+    // is 'tiny'.
     std::size_t NODE_SIZE = 0;
 
     bool SSL_VERIFY = true;
@@ -227,9 +232,7 @@ public:
     std::chrono::seconds MAX_DIVERGED_TIME{300};
 
 public:
-    Config() : j_{beast::Journal::getNullSink()}
-    {
-    }
+    Config();
 
     /* Be very careful to make sure these bool params
         are in the right order. */

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -88,7 +88,6 @@ struct ConfigSection
 #define SECTION_SERVER_DOMAIN "server_domain"
 #define SECTION_VALIDATORS_FILE "validators_file"
 #define SECTION_VALIDATION_SEED "validation_seed"
-#define SECTION_WEBSOCKET_PING_FREQ "websocket_ping_frequency"
 #define SECTION_VALIDATOR_KEYS "validator_keys"
 #define SECTION_VALIDATOR_KEY_REVOCATION "validator_key_revocation"
 #define SECTION_VALIDATOR_LIST_KEYS "validator_list_keys"

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -388,6 +388,7 @@ JSS(node_read_retries);          // out: GetCounts
 JSS(node_reads_hit);             // out: GetCounts
 JSS(node_reads_total);           // out: GetCounts
 JSS(node_reads_duration_us);     // out: GetCounts
+JSS(node_size);                  // out: server_info
 JSS(nodestore);                  // out: GetCounts
 JSS(node_writes);                // out: GetCounts
 JSS(node_written_bytes);         // out: GetCounts


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Allows the `node_size` parameter to be automatically adjusted based on the hardware that the server is running on.

### Context of Change

The `[node_size]` configuration parameter is used to tune various parameters based on the hardware that the code is running on. The parameter can take five distinct values: `tiny`, `small`, `medium`, `large` and `huge`.

The default value in the code is `tiny` but the default configuration file sets the value to `medium`. This commit attempts to detect the amount of RAM on the system and adjusts the node size default value based on the amount of RAM and the number of hardware execution threads on the system.

The decision matrix currently used is:

|         |   1  | 2 or 3 |   ≥ 4  |
|:-------:|:----:|:------:|:------:|
|  < ~8GB | tiny |   tiny |   tiny |
| < ~12GB | tiny |  small |  small |
| < ~16GB | tiny |  small | medium |
| < ~24GB | tiny |  small |  large |
| < ~32GB | tiny |  small |   huge |

The node size will now be reported in the `server_info` API when invoked in 'admin' mode in the `node_size` field.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [X] Documentation Updates
- [ ] Release

