### PR TITLE
[Trivial] Future proof rippled by changing variable name 'requires' to 'require'

### DIFF
--- a/src/test/jtx/JTx.h
+++ b/src/test/jtx/JTx.h
@@ -42,7 +42,7 @@ class Env;
 struct JTx
 {
     Json::Value jv;
-    requires_t requires;
+    requires_t require;
     std::optional<TER> ter = TER{tesSUCCESS};
     bool fill_fee = true;
     bool fill_seq = true;

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -356,7 +356,7 @@ Env::postconditions(JTx const& jt, TER ter, bool didApply)
             --trace_;
         test.log << pretty(jt.jv) << std::endl;
     }
-    for (auto const& f : jt.requires)
+    for (auto const& f : jt.require)
         f(*this);
 }
 

--- a/src/test/jtx/require.h
+++ b/src/test/jtx/require.h
@@ -74,7 +74,7 @@ public:
     void
     operator()(Env&, JTx& jt) const
     {
-        jt.requires.emplace_back(cond_);
+        jt.require.emplace_back(cond_);
     }
 };
 


### PR DESCRIPTION
'requires' is a keyword in C++20.

https://en.cppreference.com/w/cpp/keyword/requires

This is the least intrusive change. Another option is to rename the require class (and the associated variable name) to something else. If the latter is desired, I will make the change. Please let me know what you think. Thanks!
