### PR TITLE
[Trivial] Use jtx::offer_cancel more places

### DIFF
--- a/src/test/app/AccountTxPaging_test.cpp
+++ b/src/test/app/AccountTxPaging_test.cpp
@@ -584,13 +584,7 @@ class AccountTxPaging_test : public beast::unit_test::suite
         txns.emplace_back(env.tx());
         env.close();
 
-        {
-            Json::Value cancelOffer;
-            cancelOffer[jss::Account] = alice.human();
-            cancelOffer[jss::OfferSequence] = offerSeq;
-            cancelOffer[jss::TransactionType] = jss::OfferCancel;
-            env(cancelOffer, sig(alie));
-        }
+        env(offer_cancel(alice, offerSeq), sig(alie));
         env.close();
 
         txns.emplace_back(env.tx());

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -1026,11 +1026,7 @@ public:
         // Now multisign a ttOFFER_CANCEL canceling the offer we just created.
         {
             aliceSeq = env.seq(alice);
-            Json::Value cancelOffer;
-            cancelOffer[jss::Account] = alice.human();
-            cancelOffer[jss::OfferSequence] = offerSeq;
-            cancelOffer[jss::TransactionType] = jss::OfferCancel;
-            env(cancelOffer,
+            env(offer_cancel(alice, offerSeq),
                 seq(aliceSeq),
                 msig(becky, bogie),
                 fee(3 * baseFee));

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -2308,11 +2308,7 @@ public:
         env.memoize("bob");
         env.memoize("carol");
         {
-            Json::Value cancelOffer;
-            cancelOffer[jss::Account] = alice.human();
-            cancelOffer[jss::OfferSequence] = 3;
-            cancelOffer[jss::TransactionType] = jss::OfferCancel;
-            auto const jtx = env.jt(cancelOffer, seq(5), fee(10));
+            auto const jtx = env.jt(offer_cancel(alice, 3), seq(5), fee(10));
             auto const pf = preflight(
                 env.app(),
                 env.current()->rules(),

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -279,12 +279,8 @@ struct Directory_test : public beast::unit_test::suite
         {
             for (int i = 0; i < dirNodeMaxEntries; ++i)
             {
-                Json::Value cancelOffer;
-                cancelOffer[jss::Account] = alice.human();
-                cancelOffer[jss::OfferSequence] =
-                    Json::UInt(firstOfferSeq + page * dirNodeMaxEntries + i);
-                cancelOffer[jss::TransactionType] = jss::OfferCancel;
-                env(cancelOffer);
+                env(offer_cancel(
+                    alice, firstOfferSeq + page * dirNodeMaxEntries + i));
                 env.close();
             }
         }

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -277,13 +277,7 @@ class AccountTx_test : public beast::unit_test::suite
         env(offer(alice, USD(50), XRP(150)), sig(alie));
         env.close();
 
-        {
-            Json::Value cancelOffer;
-            cancelOffer[jss::Account] = alice.human();
-            cancelOffer[jss::OfferSequence] = offerSeq;
-            cancelOffer[jss::TransactionType] = jss::OfferCancel;
-            env(cancelOffer, sig(alie));
-        }
+        env(offer_cancel(alice, offerSeq), sig(alie));
         env.close();
 
         // SignerListSet


### PR DESCRIPTION
## High Level Overview of Change

Replace manual construction of OfferCancel transactions in unit tests with calls to jtx::offer_cancel().

### Context of Change

While working on other unit tests I noticed a number of places where a `Json:Value` was used to manually construct an `OfferCancel` transaction.  That's fine, but there's a convenience function, `jtx::offer_cancel()`, that does the same work with less boiler plate.

I looked for all places in the unit tests that manually construct an `OfferCancel` transaction and switched them over to use `jtx::offer_cancel()`.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

This change only affects unit tests.  There is no need to include this change in release notes.
