### PR TITLE
Improve unit test coverage of AccountDelete transactor

### DIFF
--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -204,7 +204,8 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
             uDirEntry,
             dirEntry,
             ctx.j))
-        // Account has no directory at all.  Looks good.
+        // Account has no directory at all.  This _should_ have been caught
+        // by the dirIsEmpty() check earlier, but it's okay to catch it here.
         return tesSUCCESS;
 
     std::int32_t deletableDirEntryCount{0};


### PR DESCRIPTION
## High Level Overview of Change

Adds unit tests for the `AccountDelete` transactor to improve coverage.

### Context of Change

While reading through the `AccountDelete` transactor source code for other reasons, I thought I spotted a potential bug.  And I saw, when running code coverage locally, that the case I was wondering about was not exercised by the unit tests.

So I added a unit test to cover the case I was wondering about (it ended up the there was no bug).  Then I added more unit tests to try and make the `AccountDelete` code coverage as complete as is reasonable.

### Type of Change

- [x] Tests (added tests for code that already exists)

This change only adds unit tests, so there's no reason to mention the changes in the release notes.
