### PR TITLE
[Trivial] Convert warn-level log to trace level.  Closes #3153

### DIFF
--- a/src/ripple/app/rdb/impl/RelationalDBInterface_nodes.cpp
+++ b/src/ripple/app/rdb/impl/RelationalDBInterface_nodes.cpp
@@ -317,12 +317,14 @@ saveValidatedLedger(
                     JLOG(j.trace()) << "ActTx: " << sql;
                     *db << sql;
                 }
-                else
+                else if (auto const sleTxn = acceptedLedgerTx->getTxn();
+                         !isPseudoTx(*sleTxn))
                 {
+                    // It's okay for pseudo transactions to not affect any
+                    // accounts.  But otherwise...
                     JLOG(j.warn()) << "Transaction in ledger " << seq
                                    << " affects no accounts";
-                    JLOG(j.warn()) << acceptedLedgerTx->getTxn()->getJson(
-                        JsonOptions::none);
+                    JLOG(j.warn()) << sleTxn->getJson(JsonOptions::none);
                 }
 
                 *db

--- a/src/ripple/app/rdb/impl/RelationalDBInterface_shards.cpp
+++ b/src/ripple/app/rdb/impl/RelationalDBInterface_shards.cpp
@@ -150,8 +150,10 @@ updateLedgerDBs(
                     JLOG(j.trace())
                         << "shard " << index << " account transaction: " << sql;
                 }
-                else
+                else if (!isPseudoTx(*item.first))
                 {
+                    // It's okay for pseudo transactions to not affect any
+                    // accounts.  But otherwise...
                     JLOG(j.warn())
                         << "shard " << index << " transaction in ledger "
                         << sSeq << " affects no accounts";


### PR DESCRIPTION
## High Level Overview of Change

There are a couple of places in the code that log at warning level about transactions that affect no accounts.  However there are pseudo transactions that can occur every flag ledger, and these pseudo transactions affect no accounts (directly).  Seeing the warning generated has been shown to cause concern for at least one user.

This pull request leaves the logging messages in place, but reduces their threshold to trace level, so they are less likely to be seen by the average user.

### Context of Change

The messages of concern were first reported in https://github.com/ripple/rippled/issues/3153.  This change will close that issue.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

Since the change only affects logging levels, there's really no reason to include this change in the release notes.
