### PR TITLE
Replace dirAdd() calls with dirAppend() or dirInsert()

### DIFF
--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -183,7 +183,7 @@ CreateCheck::doApply()
             return tecINSUFFICIENT_RESERVE;
     }
 
-    // Note that we we use the value from the sequence or ticket as the
+    // Note that we use the value from the sequence or ticket as the
     // Check sequence.  For more explanation see comments in SeqProxy.h.
     std::uint32_t const seq = ctx_.tx.getSeqProxy().value();
     Keylet const checkKeylet = keylet::check(account_, seq);
@@ -216,7 +216,7 @@ CreateCheck::doApply()
             describeOwnerDir(dstAccountId));
 
         JLOG(j_.trace()) << "Adding Check to destination directory "
-                         << to_string(sleCheck->key()) << ": "
+                         << to_string(checkKeylet.key) << ": "
                          << (page ? "success" : "failure");
 
         if (!page)
@@ -232,7 +232,7 @@ CreateCheck::doApply()
             describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Adding Check to owner directory "
-                         << to_string(sleCheck->key()) << ": "
+                         << to_string(checkKeylet.key) << ": "
                          << (page ? "success" : "failure");
 
         if (!page)

--- a/src/ripple/app/tx/impl/CreateCheck.cpp
+++ b/src/ripple/app/tx/impl/CreateCheck.cpp
@@ -186,7 +186,8 @@ CreateCheck::doApply()
     // Note that we we use the value from the sequence or ticket as the
     // Check sequence.  For more explanation see comments in SeqProxy.h.
     std::uint32_t const seq = ctx_.tx.getSeqProxy().value();
-    auto sleCheck = std::make_shared<SLE>(keylet::check(account_, seq));
+    Keylet const checkKeylet = keylet::check(account_, seq);
+    auto sleCheck = std::make_shared<SLE>(checkKeylet);
 
     sleCheck->setAccountID(sfAccount, account_);
     AccountID const dstAccountId = ctx_.tx[sfDestination];
@@ -209,13 +210,10 @@ CreateCheck::doApply()
     // destination's owner directory.
     if (dstAccountId != account_)
     {
-        auto const page = dirAdd(
-            view(),
+        auto const page = view().dirInsert(
             keylet::ownerDir(dstAccountId),
-            sleCheck->key(),
-            false,
-            describeOwnerDir(dstAccountId),
-            viewJ);
+            checkKeylet,
+            describeOwnerDir(dstAccountId));
 
         JLOG(j_.trace()) << "Adding Check to destination directory "
                          << to_string(sleCheck->key()) << ": "
@@ -228,13 +226,10 @@ CreateCheck::doApply()
     }
 
     {
-        auto const page = dirAdd(
-            view(),
+        auto const page = view().dirInsert(
             keylet::ownerDir(account_),
-            sleCheck->key(),
-            false,
-            describeOwnerDir(account_),
-            viewJ);
+            checkKeylet,
+            describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Adding Check to owner directory "
                          << to_string(sleCheck->key()) << ": "

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -129,7 +129,7 @@ CreateTicket::doApply()
             ticketKeylet,
             describeOwnerDir(account_));
 
-        JLOG(j_.trace()) << "Creating ticket " << to_string(sleTicket->key())
+        JLOG(j_.trace()) << "Creating ticket " << to_string(ticketKeylet.key)
                          << ": " << (page ? "success" : "failure");
 
         if (!page)

--- a/src/ripple/app/tx/impl/CreateTicket.cpp
+++ b/src/ripple/app/tx/impl/CreateTicket.cpp
@@ -117,21 +117,17 @@ CreateTicket::doApply()
     for (std::uint32_t i = 0; i < ticketCount; ++i)
     {
         std::uint32_t const curTicketSeq = firstTicketSeq + i;
-
-        SLE::pointer sleTicket = std::make_shared<SLE>(
-            ltTICKET, getTicketIndex(account_, curTicketSeq));
+        Keylet const ticketKeylet = keylet::ticket(account_, curTicketSeq);
+        SLE::pointer sleTicket = std::make_shared<SLE>(ticketKeylet);
 
         sleTicket->setAccountID(sfAccount, account_);
         sleTicket->setFieldU32(sfTicketSequence, curTicketSeq);
         view().insert(sleTicket);
 
-        auto const page = dirAdd(
-            view(),
+        auto const page = view().dirInsert(
             keylet::ownerDir(account_),
-            sleTicket->key(),
-            false,
-            describeOwnerDir(account_),
-            viewJ);
+            ticketKeylet,
+            describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Creating ticket " << to_string(sleTicket->key())
                          << ": " << (page ? "success" : "failure");

--- a/src/ripple/app/tx/impl/DepositPreauth.cpp
+++ b/src/ripple/app/tx/impl/DepositPreauth.cpp
@@ -127,8 +127,8 @@ DepositPreauth::doApply()
         // Preclaim already verified that the Preauth entry does not yet exist.
         // Create and populate the Preauth entry.
         AccountID const auth{ctx_.tx[sfAuthorize]};
-        auto slePreauth =
-            std::make_shared<SLE>(keylet::depositPreauth(account_, auth));
+        Keylet const preauthKeylet = keylet::depositPreauth(account_, auth);
+        auto slePreauth = std::make_shared<SLE>(preauthKeylet);
 
         slePreauth->setAccountID(sfAccount, account_);
         slePreauth->setAccountID(sfAuthorize, auth);
@@ -137,7 +137,7 @@ DepositPreauth::doApply()
         auto viewJ = ctx_.app.journal("View");
         auto const page = view().dirInsert(
             keylet::ownerDir(account_),
-            slePreauth->key(),
+            preauthKeylet,
             describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Adding DepositPreauth to owner directory "

--- a/src/ripple/app/tx/impl/DepositPreauth.cpp
+++ b/src/ripple/app/tx/impl/DepositPreauth.cpp
@@ -141,7 +141,7 @@ DepositPreauth::doApply()
             describeOwnerDir(account_));
 
         JLOG(j_.trace()) << "Adding DepositPreauth to owner directory "
-                         << to_string(slePreauth->key()) << ": "
+                         << to_string(preauthKeylet.key) << ": "
                          << (page ? "success" : "failure");
 
         if (!page)

--- a/src/ripple/app/tx/impl/Escrow.cpp
+++ b/src/ripple/app/tx/impl/Escrow.cpp
@@ -231,8 +231,9 @@ EscrowCreate::doApply()
 
     // Create escrow in ledger.  Note that we we use the value from the
     // sequence or ticket.  For more explanation see comments in SeqProxy.h.
-    auto const slep = std::make_shared<SLE>(
-        keylet::escrow(account, ctx_.tx.getSeqProxy().value()));
+    Keylet const escrowKeylet =
+        keylet::escrow(account, ctx_.tx.getSeqProxy().value());
+    auto const slep = std::make_shared<SLE>(escrowKeylet);
     (*slep)[sfAmount] = ctx_.tx[sfAmount];
     (*slep)[sfAccount] = account;
     (*slep)[~sfCondition] = ctx_.tx[~sfCondition];
@@ -246,13 +247,8 @@ EscrowCreate::doApply()
 
     // Add escrow to sender's owner directory
     {
-        auto page = dirAdd(
-            ctx_.view(),
-            keylet::ownerDir(account),
-            slep->key(),
-            false,
-            describeOwnerDir(account),
-            ctx_.app.journal("View"));
+        auto page = ctx_.view().dirInsert(
+            keylet::ownerDir(account), escrowKeylet, describeOwnerDir(account));
         if (!page)
             return tecDIR_FULL;
         (*slep)[sfOwnerNode] = *page;
@@ -261,13 +257,8 @@ EscrowCreate::doApply()
     // If it's not a self-send, add escrow to recipient's owner directory.
     if (auto const dest = ctx_.tx[sfDestination]; dest != ctx_.tx[sfAccount])
     {
-        auto page = dirAdd(
-            ctx_.view(),
-            keylet::ownerDir(dest),
-            slep->key(),
-            false,
-            describeOwnerDir(dest),
-            ctx_.app.journal("View"));
+        auto page = ctx_.view().dirInsert(
+            keylet::ownerDir(dest), escrowKeylet, describeOwnerDir(dest));
         if (!page)
             return tecDIR_FULL;
         (*slep)[sfDestinationNode] = *page;

--- a/src/ripple/app/tx/impl/SetSignerList.cpp
+++ b/src/ripple/app/tx/impl/SetSignerList.cpp
@@ -342,13 +342,8 @@ SetSignerList::replaceSignerList()
 
     auto viewJ = ctx_.app.journal("View");
     // Add the signer list to the account's directory.
-    auto const page = dirAdd(
-        ctx_.view(),
-        ownerDirKeylet,
-        signerListKeylet.key,
-        false,
-        describeOwnerDir(account_),
-        viewJ);
+    auto const page = ctx_.view().dirInsert(
+        ownerDirKeylet, signerListKeylet, describeOwnerDir(account_));
 
     JLOG(j_.trace()) << "Create signer list for account " << toBase58(account_)
                      << ": " << (page ? "success" : "failure");

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -276,19 +276,16 @@ public:
     std::optional<std::uint64_t>
     dirAppend(
         Keylet const& directory,
-        uint256 const& key,
-        std::function<void(std::shared_ptr<SLE> const&)> const& describe)
-    {
-        return dirAdd(true, directory, key, describe);
-    }
-
-    std::optional<std::uint64_t>
-    dirAppend(
-        Keylet const& directory,
         Keylet const& key,
         std::function<void(std::shared_ptr<SLE> const&)> const& describe)
     {
-        return dirAppend(directory, key.key, describe);
+        if (key.type != ltOFFER)
+        {
+            assert(!"Only Offers are appended to book directories.  "
+                "Call dirInsert() instead.");
+            return std::nullopt;
+        }
+        return dirAdd(true, directory, key.key, describe);
     }
     /** @} */
 
@@ -325,7 +322,7 @@ public:
         Keylet const& key,
         std::function<void(std::shared_ptr<SLE> const&)> const& describe)
     {
-        return dirInsert(directory, key.key, describe);
+        return dirAdd(false, directory, key.key, describe);
     }
     /** @} */
 

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -249,16 +249,6 @@ dirNext(
 [[nodiscard]] std::function<void(SLE::ref)>
 describeOwnerDir(AccountID const& account);
 
-// deprecated
-std::optional<std::uint64_t>
-dirAdd(
-    ApplyView& view,
-    Keylet const& uRootIndex,
-    uint256 const& uLedgerIndex,
-    bool strictOrder,
-    std::function<void(SLE::ref)> fDescriber,
-    beast::Journal j);
-
 // VFALCO NOTE Both STAmount parameters should just
 //             be "Amount", a unit-less number.
 //

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -721,21 +721,6 @@ describeOwnerDir(AccountID const& account)
     };
 }
 
-std::optional<std::uint64_t>
-dirAdd(
-    ApplyView& view,
-    Keylet const& dir,
-    uint256 const& uLedgerIndex,
-    bool strictOrder,
-    std::function<void(SLE::ref)> fDescriber,
-    beast::Journal j)
-{
-    if (strictOrder)
-        return view.dirAppend(dir, uLedgerIndex, fDescriber);
-
-    return view.dirInsert(dir, uLedgerIndex, fDescriber);
-}
-
 TER
 trustCreate(
     ApplyView& view,
@@ -765,24 +750,18 @@ trustCreate(
     auto const sleRippleState = std::make_shared<SLE>(ltRIPPLE_STATE, uIndex);
     view.insert(sleRippleState);
 
-    auto lowNode = dirAdd(
-        view,
+    auto lowNode = view.dirInsert(
         keylet::ownerDir(uLowAccountID),
         sleRippleState->key(),
-        false,
-        describeOwnerDir(uLowAccountID),
-        j);
+        describeOwnerDir(uLowAccountID));
 
     if (!lowNode)
         return tecDIR_FULL;
 
-    auto highNode = dirAdd(
-        view,
+    auto highNode = view.dirInsert(
         keylet::ownerDir(uHighAccountID),
         sleRippleState->key(),
-        false,
-        describeOwnerDir(uHighAccountID),
-        j);
+        describeOwnerDir(uHighAccountID));
 
     if (!highNode)
         return tecDIR_FULL;


### PR DESCRIPTION
## High Level Overview of Change

Just tidying up some unfinished business here: https://github.com/ripple/rippled/issues/2516

Calls to `dirDelete()` had been removed in a previous commit.  Now that the `SortedDirectories` amendment is unconditionally enabled, it's okay to remove the calls to `dirAdd()`.  Once all `dirAdd()` calls are removed, then `dirAdd()` itself can be removed.  That's what we do here.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)

This change is purely a refactor and should have no effect on functionality.  So the change should not need any mention in the release notes.
