### PR TITLE
Fix CMake check for Windows platform

### DIFF
--- a/Builds/CMake/RippledSanity.cmake
+++ b/Builds/CMake/RippledSanity.cmake
@@ -73,9 +73,9 @@ if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif ()
 
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio" AND
-    NOT ("${CMAKE_GENERATOR}" MATCHES .*Win64.*))
+    NOT ("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64"))
   message (FATAL_ERROR
-    "Visual Studio 32-bit build is not supported. Use -G\"${CMAKE_GENERATOR} Win64\"")
+    "Visual Studio 32-bit build is not supported. Use `-A x64`")
 endif ()
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
Unlike [previous Visual Studio generators](https://cmake.org/cmake/help/git-stage/generator/Visual%20Studio%2015%202017.html), the [`Visual Studio 16 2019` generator for CMake](https://cmake.org/cmake/help/git-stage/generator/Visual%20Studio%2016%202019.html) does not have a `Win64` variant. Instead, users are expected to pass the platform argument through the `-A` option.