### PR TITLE
Add higher bound to validations to keep

### DIFF
--- a/src/ripple/app/misc/NegativeUNLVote.cpp
+++ b/src/ripple/app/misc/NegativeUNLVote.cpp
@@ -167,7 +167,7 @@ NegativeUNLVote::buildScoreTable(
     // Ask the validation container to keep enough validation message history
     // for next time.
     auto const seq = prevLedger->info().seq + 1;
-    validations.setSeqToKeep(seq - 1);
+    validations.setSeqToKeep(seq - 1, seq + FLAG_LEDGER_INTERVAL);
 
     // Find FLAG_LEDGER_INTERVAL (i.e. 256) previous ledger hashes
     auto const hashIndex = prevLedger->read(keylet::skip());

--- a/src/ripple/consensus/Validations.h
+++ b/src/ripple/consensus/Validations.h
@@ -743,7 +743,7 @@ public:
                     if (!validationMap.empty())
                     {
                         auto const seq = validationMap.begin()->second.seq();
-                        if (seq >= toKeep_->low_ && seq < toKeep_->high_)
+                        if (toKeep_->low_ <= seq && seq < toKeep_->high_)
                         {
                             byLedger_.touch(i);
                         }
@@ -752,7 +752,7 @@ public:
 
                 for (auto i = bySequence_.begin(); i != bySequence_.end(); ++i)
                 {
-                    if (i->first >= toKeep_->low_ && i->first < toKeep_->high_)
+                    if (toKeep_->low_ <= i->first && i->first < toKeep_->high_)
                     {
                         bySequence_.touch(i);
                     }


### PR DESCRIPTION
## High Level Overview of Change
Change `toKeep_` in the validations container to a range of `seq` with lower and higher bounds instead of just the lower bound. With the added higher bound of the range, validations with crazy high `seq` outside of the range can expire.

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
- Unit tests
- A network test, connected a node (a validator but was not on the UNL) to the Devnet for about a day. The number of validations kept by the node (from `get_counts` reply) did not grow overtime. 