### PR TITLE
Add vl.xrplf.org to validators.txt

### DIFF
--- a/cfg/validators-example.txt
+++ b/cfg/validators-example.txt
@@ -54,9 +54,13 @@
 
 [validator_list_sites]
 https://vl.ripple.com
+https://vl.xrplf.org
 
 [validator_list_keys]
+#vl.ripple.com
 ED2677ABFFD1B33AC6FBC3062B71F1E8397C1505E1C42C64D11AD1B28FF73F4734
+# vl.xrplf.org
+ED45D1840EE724BE327ABE9146503D5848EFD5F38B6D5FEDE71E80ACCE5E6E738B
 
 # To use the test network (see https://xrpl.org/connect-your-rippled-to-the-xrp-test-net.html),
 # use the following configuration instead:


### PR DESCRIPTION
Add the list provider vl.xrplf.org (XRP Ledger Foundation) to validators.txt and include the keys.