### PR TITLE
Getledger refactor

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.h
+++ b/src/ripple/overlay/impl/PeerImp.h
@@ -46,6 +46,7 @@
 namespace ripple {
 
 struct ValidatorBlobInfo;
+class SHAMap;
 
 class PeerImp : public Peer,
                 public std::enable_shared_from_this<PeerImp>,
@@ -564,7 +565,18 @@ private:
         std::shared_ptr<protocol::TMValidation> const& packet);
 
     void
-    getLedger(std::shared_ptr<protocol::TMGetLedger> const& packet);
+    sendLedgerBase(
+        std::shared_ptr<Ledger const> const& ledger,
+        protocol::TMLedgerData& ledgerData);
+
+    std::shared_ptr<Ledger const>
+    getLedger(std::shared_ptr<protocol::TMGetLedger> const& m);
+
+    std::shared_ptr<SHAMap const>
+    getTxSet(std::shared_ptr<protocol::TMGetLedger> const& m) const;
+
+    void
+    processLedgerRequest(std::shared_ptr<protocol::TMGetLedger> const& m);
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/overlay/impl/Tuning.h
+++ b/src/ripple/overlay/impl/Tuning.h
@@ -54,6 +54,9 @@ enum {
 
     /** How often we check for idle peers (seconds) */
     checkIdlePeers = 4,
+
+    /** The maximum number of levels to search */
+    maxQueryDepth = 3,
 };
 
 /** Size of buffer used to read from the socket. */


### PR DESCRIPTION
This PR refactors the TMGetLedger and TMLedgerData message protocols. Both handler functions now verify the message fields before processing them. The TMGetLedger handler was broken into smaller functions.

Note: The branch was rebased with the "Extend peer shard info" branch to resolve a non-related unit test failure. Please review only the commit titled **"Refactor GetLedger and LedgerData message handlers"**
