### PR TITLE
[Trivial] Fix clang warnings about copies vs references:

### DIFF
--- a/src/ripple/app/misc/impl/ValidatorList.cpp
+++ b/src/ripple/app/misc/impl/ValidatorList.cpp
@@ -99,7 +99,7 @@ void
 ValidatorList::PublisherListStats::mergeDispositions(
     PublisherListStats const& src)
 {
-    for (auto const [disp, count] : src.dispositions)
+    for (auto const& [disp, count] : src.dispositions)
     {
         dispositions[disp] += count;
     }

--- a/src/ripple/app/misc/impl/ValidatorSite.cpp
+++ b/src/ripple/app/misc/impl/ValidatorSite.cpp
@@ -408,7 +408,7 @@ ValidatorSite::parseJsonResponse(
     sites_[siteIdx].lastRefreshStatus.emplace(
         Site::Status{clock_type::now(), applyResult.bestDisposition(), ""});
 
-    for (auto const [disp, count] : applyResult.dispositions)
+    for (auto const& [disp, count] : applyResult.dispositions)
     {
         switch (disp)
         {

--- a/src/ripple/overlay/impl/ConnectAttempt.cpp
+++ b/src/ripple/overlay/impl/ConnectAttempt.cpp
@@ -293,7 +293,7 @@ ConnectAttempt::processResponse()
         Json::Reader r;
         std::string s;
         s.reserve(boost::asio::buffer_size(response_.body().data()));
-        for (auto const& buffer : response_.body().data())
+        for (auto const buffer : response_.body().data())
             s.append(
                 boost::asio::buffer_cast<char const*>(buffer),
                 boost::asio::buffer_size(buffer));

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -2111,7 +2111,7 @@ PeerImp::onValidatorListMessage(
     }
 
     // Log based on all the results.
-    for (auto const [disp, count] : applyResult.dispositions)
+    for (auto const& [disp, count] : applyResult.dispositions)
     {
         switch (disp)
         {

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -258,7 +258,9 @@ buffers_to_string(ConstBufferSequence const& bs)
     using boost::asio::buffer_size;
     std::string s;
     s.reserve(buffer_size(bs));
-    for (auto const& b : bs)
+    // Use auto&& so the right thing happens whether bs returns a copy or
+    // a reference
+    for (auto&& b : bs)
         s.append(buffer_cast<char const*>(b), buffer_size(b));
     return s;
 }

--- a/src/ripple/server/SimpleWriter.h
+++ b/src/ripple/server/SimpleWriter.h
@@ -66,7 +66,7 @@ public:
         auto const& buf = sb_.data();
         std::vector<boost::asio::const_buffer> result;
         result.reserve(std::distance(buf.begin(), buf.end()));
-        for (auto const& b : buf)
+        for (auto const b : buf)
             result.push_back(b);
         return result;
     }

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -865,7 +865,7 @@ class Check_test : public beast::unit_test::suite
         // featureMultiSignReserve changes the reserve on a SignerList, so
         // check both before and after.
         FeatureBitset const allSupported{supported_amendments()};
-        for (auto const features :
+        for (auto const& features :
              {allSupported - featureMultiSignReserve,
               allSupported | featureMultiSignReserve})
         {
@@ -1514,7 +1514,7 @@ class Check_test : public beast::unit_test::suite
         // featureMultiSignReserve changes the reserve on a SignerList, so
         // check both before and after.
         FeatureBitset const allSupported{supported_amendments()};
-        for (auto const features :
+        for (auto const& features :
              {allSupported - featureMultiSignReserve,
               allSupported | featureMultiSignReserve})
         {

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -568,7 +568,7 @@ public:
         //
         // fix1578 changes the return code.  Verify expected behavior
         // without and with fix1578.
-        for (auto const tweakedFeatures :
+        for (auto const& tweakedFeatures :
              {features - fix1578, features | fix1578})
         {
             Env env{*this, tweakedFeatures};

--- a/src/test/csf/BasicNetwork_test.cpp
+++ b/src/test/csf/BasicNetwork_test.cpp
@@ -49,7 +49,7 @@ public:
             auto t = scheduler.in(1s, [&] { set.insert(0); });
             if (id == 0)
             {
-                for (auto const& link : net.links(this))
+                for (auto const link : net.links(this))
                     net.send(this, link.target, [&, to = link.target] {
                         to->receive(net, this, 1);
                     });
@@ -68,7 +68,7 @@ public:
             ++m;
             if (m < 5)
             {
-                for (auto const& link : net.links(this))
+                for (auto const link : net.links(this))
                     net.send(this, link.target, [&, mm = m, to = link.target] {
                         to->receive(net, this, mm);
                     });

--- a/src/test/csf/Peer.h
+++ b/src/test/csf/Peer.h
@@ -344,7 +344,7 @@ struct Peer
     bool
     trusts(PeerID const& oId)
     {
-        for (auto const& p : trustGraph.trustedPeers(this))
+        for (auto const p : trustGraph.trustedPeers(this))
             if (p->id == oId)
                 return true;
         return false;
@@ -404,7 +404,7 @@ struct Peer
 
         using namespace std::chrono_literals;
         SimDuration minDuration{10s};
-        for (auto const& link : net.links(this))
+        for (auto const link : net.links(this))
         {
             minDuration = std::min(minDuration, link.data.delay);
 
@@ -451,7 +451,7 @@ struct Peer
 
         using namespace std::chrono_literals;
         SimDuration minDuration{10s};
-        for (auto const& link : net.links(this))
+        for (auto const link : net.links(this))
         {
             minDuration = std::min(minDuration, link.data.delay);
             // Send a message to neighbors to find the tx set
@@ -741,7 +741,7 @@ struct Peer
     void
     send(BroadcastMesg<M> const& bm, PeerID from)
     {
-        for (auto const& link : net.links(this))
+        for (auto const link : net.links(this))
         {
             if (link.target->id != from && link.target->id != bm.origin)
             {
@@ -848,7 +848,7 @@ struct Peer
     getQuorumKeys()
     {
         hash_set<NodeKey_t> keys;
-        for (auto const& p : trustGraph.trustedPeers(this))
+        for (auto const p : trustGraph.trustedPeers(this))
             keys.insert(p->key);
         return {quorum, keys};
     }

--- a/src/test/csf/TrustGraph.h
+++ b/src/test/csf/TrustGraph.h
@@ -126,7 +126,7 @@ public:
 
         using UNL = std::set<Peer>;
         std::set<UNL> unique;
-        for (Peer const& peer : graph_.outVertices())
+        for (Peer const peer : graph_.outVertices())
         {
             unique.emplace(
                 std::begin(trustedPeers(peer)), std::end(trustedPeers(peer)));

--- a/src/test/ledger/Invariants_test.cpp
+++ b/src/test/ledger/Invariants_test.cpp
@@ -75,7 +75,7 @@ class Invariants_test : public beast::unit_test::suite
             return;
 
         TER terActual = tesSUCCESS;
-        for (TER const terExpect : ters)
+        for (TER const& terExpect : ters)
         {
             terActual = ac.checkInvariants(terActual, fee);
             BEAST_EXPECT(terExpect == terActual);

--- a/src/test/rpc/NoRipple_test.cpp
+++ b/src/test/rpc/NoRipple_test.cpp
@@ -84,7 +84,7 @@ public:
 
         // fix1578 changes the return code.  Verify expected behavior
         // without and with fix1578.
-        for (auto const tweakedFeatures :
+        for (auto const& tweakedFeatures :
              {features - fix1578, features | fix1578})
         {
             Env env(*this, tweakedFeatures);


### PR DESCRIPTION
## High Level Overview of Change

Fix warnings identified by a recent version of clang.

### Context of Change

A recent version of clang warns regarding several ranged for loops where the code base was either:

- making unnecessary copies or
- was extending life times of temporaries referred to by `const` lvalue references.

This fixes the places that clang identified.

The warning are raised by `Apple clang version 12.0.0 (clang-1200.0.32.21)`.  I can't tell you which trunk version of clang it is, since Apple has their own clang versioning scheme.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

This change does not affect functionality, so there is no need for it to be mentioned in the release notes.

But it will allow me to build using clang while warnings-as-errors is set, so I hope it merges to develop soon... 😄 
