### PR TITLE
[TRIVIAL] Do not use __func__ inside lambdas

### DIFF
--- a/src/ripple/app/reporting/ETLSource.cpp
+++ b/src/ripple/app/reporting/ETLSource.cpp
@@ -110,9 +110,9 @@ ETLSource::reconnect(boost::beast::error_code ec)
     size_t waitTime = std::min(pow(2, numFailures_), 30.0);
     numFailures_++;
     timer_.expires_after(boost::asio::chrono::seconds(waitTime));
-    timer_.async_wait([this](auto ec) {
+    timer_.async_wait([this, fname = __func__](auto ec) {
         bool startAgain = (ec != boost::asio::error::operation_aborted);
-        JLOG(journal_.trace()) << __func__ << " async_wait : ec = " << ec;
+        JLOG(journal_.trace()) << fname << " async_wait : ec = " << ec;
         close(startAgain);
     });
 }
@@ -133,11 +133,11 @@ ETLSource::close(bool startAgain)
             closing_ = true;
             ws_->async_close(
                 boost::beast::websocket::close_code::normal,
-                [this, startAgain](auto ec) {
+                [this, startAgain, fname = __func__](auto ec) {
                     if (ec)
                     {
                         JLOG(journal_.error())
-                            << __func__ << " async_close : "
+                            << fname << " async_close : "
                             << "error code = " << ec << " - " << toString();
                     }
                     closing_ = false;

--- a/src/ripple/app/reporting/ReportingETL.cpp
+++ b/src/ripple/app/reporting/ReportingETL.cpp
@@ -333,11 +333,11 @@ ReportingETL::publishLedger(uint32_t ledgerSequence, uint32_t maxAttempts)
             continue;
         }
 
-        publishStrand_.post([this, ledger]() {
+        publishStrand_.post([this, ledger, fname = __func__]() {
             app_.getOPs().pubLedger(ledger);
             setLastPublish();
             JLOG(journal_.info())
-                << __func__ << " : "
+                << fname << " : "
                 << "Published ledger. " << detail::toString(ledger->info());
         });
         return true;

--- a/src/ripple/nodestore/impl/Database.cpp
+++ b/src/ripple/nodestore/impl/Database.cpp
@@ -107,14 +107,14 @@ Database::importInternal(Backend& dstBackend, Database& srcDB)
 {
     Batch batch;
     batch.reserve(batchWritePreallocationSize);
-    auto storeBatch = [&]() {
+    auto storeBatch = [&, fname = __func__]() {
         try
         {
             dstBackend.storeBatch(batch);
         }
         catch (std::exception const& e)
         {
-            JLOG(j_.error()) << "Exception caught in function " << __func__
+            JLOG(j_.error()) << "Exception caught in function " << fname
                              << ". Error: " << e.what();
             return;
         }
@@ -188,7 +188,7 @@ Database::storeLedger(
 
     Batch batch;
     batch.reserve(batchWritePreallocationSize);
-    auto storeBatch = [&]() {
+    auto storeBatch = [&, fname = __func__]() {
         std::uint64_t sz{0};
         for (auto const& nodeObject : batch)
             sz += nodeObject->getData().size();
@@ -200,7 +200,7 @@ Database::storeLedger(
         catch (std::exception const& e)
         {
             fail(
-                std::string("Exception caught in function ") + __func__ +
+                std::string("Exception caught in function ") + fname +
                 ". Error: " + e.what());
             return false;
         }

--- a/src/ripple/nodestore/impl/DatabaseShardImp.cpp
+++ b/src/ripple/nodestore/impl/DatabaseShardImp.cpp
@@ -495,7 +495,7 @@ DatabaseShardImp::importShard(
     }
     dstDir /= std::to_string(shardIndex);
 
-    auto renameDir = [&](path const& src, path const& dst) {
+    auto renameDir = [&, fname = __func__](path const& src, path const& dst) {
         try
         {
             rename(src, dst);
@@ -503,7 +503,7 @@ DatabaseShardImp::importShard(
         catch (std::exception const& e)
         {
             return fail(
-                std::string(". Exception caught in function ") + __func__ +
+                std::string(". Exception caught in function ") + fname +
                     ". Error: " + e.what(),
                 std::lock_guard(mutex_));
         }


### PR DESCRIPTION

## High Level Overview of Change

Using `__func__` inside a lambda with output `operator()`. The intended functionality is to output the enclosing function name. To do this, we capture `__func__` outside the lambda.
### Context of Change

### Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)


## Before / After

Before
```
foo(){
[]{
    std::cout << __func__ << '\n'; //prints "operator()"
}
}
```

After
```
foo(){
[fname = __func__]{
    std::cout << fname << '\n'; //prints "foo"
}
}
```