### PR TITLE
Report additional fields in validation stream

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2009,6 +2009,15 @@ NetworkOPsImp::pubValidation(std::shared_ptr<STValidation> const& val)
         jvObj[jss::signing_time] = *(*val)[~sfSigningTime];
         jvObj[jss::data] = strHex(val->getSerializer().slice());
 
+        if (auto version = (*val)[~sfServerVersion])
+            jvObj[jss::server_version] = std::to_string(*version);
+
+        if (auto cookie = (*val)[~sfCookie])
+            jvObj[jss::cookie] = std::to_string(*cookie);
+
+        if (auto hash = (*val)[~sfValidatedHash])
+            jvObj[jss::validated_hash] = strHex(*hash);
+
         auto const masterKey =
             app_.validatorManifests().getMasterKey(signerPublic);
 

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -178,6 +178,7 @@ JSS(complete_shards);        // out: OverlayImpl, PeerImp
 JSS(consensus);              // out: NetworkOPs, LedgerConsensus
 JSS(converge_time);          // out: NetworkOPs
 JSS(converge_time_s);        // out: NetworkOPs
+JSS(cookie);                 // out: NetworkOPs
 JSS(count);                  // in: AccountTx*, ValidatorList
 JSS(counters);               // in/out: retrieve counters
 JSS(currentShard);           // out: NodeToShardStatus
@@ -498,6 +499,7 @@ JSS(server_domain);             // out: NetworkOPs
 JSS(server_state);              // out: NetworkOPs
 JSS(server_state_duration_us);  // out: NetworkOPs
 JSS(server_status);             // out: NetworkOPs
+JSS(server_version);            // out: NetworkOPs
 JSS(settle_delay);              // out: AccountChannels
 JSS(severity);                  // in: LogLevel
 JSS(shards);                    // in/out: GetCounts, DownloadShard
@@ -587,6 +589,7 @@ JSS(validated);               // out: NetworkOPs, RPCHelpers, AccountTx*
 JSS(validator_list_expires);  // out: NetworkOps, ValidatorList
 JSS(validator_list);          // out: NetworkOps, ValidatorList
 JSS(validators);
+JSS(validated_hash);          // out: NetworkOPs
 JSS(validated_ledger);        // out: NetworkOPs
 JSS(validated_ledger_index);  // out: SubmitTransaction
 JSS(validated_ledgers);       // out: NetworkOPs


### PR DESCRIPTION
This branch was initially created by @nbougalis, who is currently too busy to shepherd the pull request through the review.  So I'm re-opening the pull request in a form where I can easily handle any requests for changes.

### Overview

The HardenedValidations amendment introduces additional fields in validations:

- `sfValidatedHash`, if present, is the hash the of last ledger that the validator considers to be fully validated.
- `sfCookie`, if present, is a 64-bit cookie (the default implementation selects it randomly at startup but other implementations are possible), which can be used to improve the detection and classification of duplicate validations.
- `sfServerVersion`, if present, reports the version of the software that the validator is running. By surfacing this information, server operators gain additional insight about variety of software on the network.

If merged, this commit fixes #3797 by adding the fields to the `validations` stream as shown below:

- `sfValidateHash` as `validated_hash`: a 256-bit hex string;
- `sfCookie` as `cookie`: a 64-bit integer as a string; and
- `sfServerVersion` as `server_version`: a 64-bit integer as a string.


### Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [X] Documentation updates are required

Tagging @wilsonianb who originally opened #3797.