### PR TITLE
Redistribute unit test priorities based on current measurements

### DIFF
--- a/src/beast/extras/beast/unit_test/suite.hpp
+++ b/src/beast/extras/beast/unit_test/suite.hpp
@@ -670,6 +670,11 @@ run(runner& r)
     @endcode
 
     The macro invocation must appear in the same namespace as the test class.
+
+    Unit test priorities were introduced so parallel unit_test::suites would
+    execute faster. Suites with longer running times have higher priorities
+    than unit tests with shorter running times.  Suites with no priorities
+    are assumed to run most quickly, so they run last.
 */
 
 #if BEAST_NO_UNIT_TEST_INLINE

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -924,7 +924,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountDelete, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(AccountDelete, app, ripple, 2);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -1572,7 +1572,7 @@ struct LedgerReplayerLong_test : public beast::unit_test::suite
 };
 
 BEAST_DEFINE_TESTSUITE(LedgerReplay, app, ripple);
-BEAST_DEFINE_TESTSUITE(LedgerReplayer, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(LedgerReplayer, app, ripple, 1);
 BEAST_DEFINE_TESTSUITE(LedgerReplayerTimeout, app, ripple);
 BEAST_DEFINE_TESTSUITE_MANUAL(LedgerReplayerLong, app, ripple);
 

--- a/src/test/app/TheoreticalQuality_test.cpp
+++ b/src/test/app/TheoreticalQuality_test.cpp
@@ -549,7 +549,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(TheoreticalQuality, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(TheoreticalQuality, app, ripple, 3);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/app/TrustAndBalance_test.cpp
+++ b/src/test/app/TrustAndBalance_test.cpp
@@ -505,6 +505,6 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE_PRIO(TrustAndBalance, app, ripple, 1);
+BEAST_DEFINE_TESTSUITE(TrustAndBalance, app, ripple);
 
 }  // namespace ripple

--- a/src/test/app/ValidatorSite_test.cpp
+++ b/src/test/app/ValidatorSite_test.cpp
@@ -659,7 +659,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(ValidatorSite, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(ValidatorSite, app, ripple, 2);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -1997,14 +1997,14 @@ BEAST_DEFINE_TESTSUITE(NegativeUNLNoAmendment, ledger, ripple);
 BEAST_DEFINE_TESTSUITE(NegativeUNLVoteInternal, consensus, ripple);
 BEAST_DEFINE_TESTSUITE_MANUAL(NegativeUNLVoteScoreTable, consensus, ripple);
 BEAST_DEFINE_TESTSUITE_PRIO(NegativeUNLVoteGoodScore, consensus, ripple, 1);
-BEAST_DEFINE_TESTSUITE_PRIO(NegativeUNLVoteOffline, consensus, ripple, 1);
-BEAST_DEFINE_TESTSUITE_PRIO(NegativeUNLVoteMaxListed, consensus, ripple, 1);
+BEAST_DEFINE_TESTSUITE(NegativeUNLVoteOffline, consensus, ripple);
+BEAST_DEFINE_TESTSUITE(NegativeUNLVoteMaxListed, consensus, ripple);
 BEAST_DEFINE_TESTSUITE_PRIO(
     NegativeUNLVoteRetiredValidator,
     consensus,
     ripple,
     1);
-BEAST_DEFINE_TESTSUITE_PRIO(NegativeUNLVoteNewValidator, consensus, ripple, 1);
+BEAST_DEFINE_TESTSUITE(NegativeUNLVoteNewValidator, consensus, ripple);
 BEAST_DEFINE_TESTSUITE(NegativeUNLVoteFilterValidations, consensus, ripple);
 BEAST_DEFINE_TESTSUITE(NegativeUNLgRPC, ledger, ripple);
 

--- a/src/test/rpc/AccountSet_test.cpp
+++ b/src/test/rpc/AccountSet_test.cpp
@@ -555,6 +555,6 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(AccountSet, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(AccountSet, app, ripple, 1);
 
 }  // namespace ripple

--- a/src/test/rpc/ReportingETL_test.cpp
+++ b/src/test/rpc/ReportingETL_test.cpp
@@ -1031,7 +1031,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(ReportingETL, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(ReportingETL, app, ripple, 2);
 
 }  // namespace test
 }  // namespace ripple

--- a/src/test/rpc/ShardArchiveHandler_test.cpp
+++ b/src/test/rpc/ShardArchiveHandler_test.cpp
@@ -696,7 +696,7 @@ public:
     }
 };
 
-BEAST_DEFINE_TESTSUITE(ShardArchiveHandler, app, ripple);
+BEAST_DEFINE_TESTSUITE_PRIO(ShardArchiveHandler, app, ripple, 3);
 
 }  // namespace test
 }  // namespace ripple


### PR DESCRIPTION
## High Level Overview of Change

Unit test priorities were introduced so parallel unit tests would execute faster.  Unit tests with longer running times have higher priorities than unit tests with shorter running times.

As tests have changed, the amount of time that unit tests take to execute has changed.  Some unit tests that currently have long running times did not have priorities.  Some unit tests that used to have long running times run faster than they used to.

This pull request adds priorities to tests that currently have long running times but did not have priorities assigned.  Some unit tests that had a priority have their priority removed, since they do not run for very long.

Comparative unit test execution times were measured using my Mac mini.  Other platforms may have different results.

### Type of Change

- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)

Since this pull request only affects the order in which unit tests execute it does not need to be mentioned in the release notes.

I've requested review from @ximinez and @thejohnfreeman, since they seem to be paying the most attention to continuous integration these days. 