### PR TITLE
Update to RocksDB 6.20.3

### DIFF
--- a/Builds/CMake/deps/Rocksdb.cmake
+++ b/Builds/CMake/deps/Rocksdb.cmake
@@ -8,7 +8,7 @@ set_target_properties (rocksdb_lib
 
 option (local_rocksdb "use local build of rocksdb." OFF)
 if (NOT local_rocksdb)
-  find_package (RocksDB 6.7 QUIET CONFIG)
+  find_package (RocksDB 6.20 QUIET CONFIG)
   if (TARGET RocksDB::rocksdb)
     message (STATUS "Found RocksDB using config.")
     get_target_property (_rockslib_l RocksDB::rocksdb IMPORTED_LOCATION_DEBUG)
@@ -40,7 +40,7 @@ if (NOT local_rocksdb)
       # TBD if there is some way to extract transitive deps..then:
       #set (RocksDB_USE_STATIC ON)
     else ()
-      find_package (RocksDB 6.7 MODULE)
+      find_package (RocksDB 6.20 MODULE)
       if (ROCKSDB_FOUND)
         if (RocksDB_LIBRARY_DEBUG)
           set_target_properties (rocksdb_lib PROPERTIES IMPORTED_LOCATION_DEBUG ${RocksDB_LIBRARY_DEBUG})
@@ -60,7 +60,7 @@ if (local_rocksdb)
   ExternalProject_Add (rocksdb
     PREFIX ${nih_cache_path}
     GIT_REPOSITORY https://github.com/facebook/rocksdb.git
-    GIT_TAG v6.7.3
+    GIT_TAG v6.20.3
     PATCH_COMMAND
       # only used by windows build
       ${CMAKE_COMMAND} -E copy

--- a/Builds/CMake/rocksdb_build_version.cc.in
+++ b/Builds/CMake/rocksdb_build_version.cc.in
@@ -1,4 +1,70 @@
-#include "build_version.h"
-const char* rocksdb_build_git_sha = "rocksdb_build_git_sha: N/A";
-const char* rocksdb_build_git_date = "rocksdb_build_git_date: N/A";
-const char* rocksdb_build_compile_date = "N/A";
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+#include <memory>
+
+#include "rocksdb/version.h"
+#include "util/string_util.h"
+
+// The build script may replace these values with real values based
+// on whether or not GIT is available and the platform settings
+static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:@GIT_SHA@";
+static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:@GIT_TAG@";
+#define HAS_GIT_CHANGES @GIT_MOD@
+#if HAS_GIT_CHANGES == 0
+// If HAS_GIT_CHANGES is 0, the GIT date is used.
+// Use the time the branch/tag was last modified
+static const std::string rocksdb_build_date = "rocksdb_build_date:@GIT_DATE@";
+#else
+// If HAS_GIT_CHANGES is > 0, the branch/tag has modifications.
+// Use the time the build was created.
+static const std::string rocksdb_build_date = "rocksdb_build_date:@BUILD_DATE@";
+#endif
+
+namespace ROCKSDB_NAMESPACE {
+static void AddProperty(std::unordered_map<std::string, std::string> *props, const std::string& name) {
+  size_t colon = name.find(":");
+  if (colon != std::string::npos && colon > 0 && colon < name.length() - 1) {
+    // If we found a "@:", then this property was a build-time substitution that failed.  Skip it
+    size_t at = name.find("@", colon);
+    if (at != colon + 1) {
+      // Everything before the colon is the name, after is the value
+      (*props)[name.substr(0, colon)] = name.substr(colon + 1);
+    }
+  }
+}
+
+static std::unordered_map<std::string, std::string>* LoadPropertiesSet() {
+  auto * properties = new std::unordered_map<std::string, std::string>();
+  AddProperty(properties, rocksdb_build_git_sha);
+  AddProperty(properties, rocksdb_build_git_tag);
+  AddProperty(properties, rocksdb_build_date);
+  return properties;
+}
+
+const std::unordered_map<std::string, std::string>& GetRocksBuildProperties() {
+  static std::unique_ptr<std::unordered_map<std::string, std::string>> props(LoadPropertiesSet());
+  return *props;
+}
+
+std::string GetRocksVersionAsString(bool with_patch) {
+  std::string version = ToString(ROCKSDB_MAJOR) + "." + ToString(ROCKSDB_MINOR);
+  if (with_patch) {
+    return version + "." + ToString(ROCKSDB_PATCH);
+  } else {
+    return version;
+  }
+}
+
+std::string GetRocksBuildInfoAsString(const std::string& program, bool verbose) {
+  std::string info = program + " (RocksDB) " + GetRocksVersionAsString(true);
+  if (verbose) {
+    for (const auto& it : GetRocksBuildProperties()) {
+      info.append("\n    ");
+      info.append(it.first);
+      info.append(": ");
+      info.append(it.second);
+    }
+  }
+  return info;
+}
+} // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
## High Level Overview of Change

Was not able to build rippled on an M1 Mac (Apple Silicon).

In order to build on Apple Silicon (e.g. M1 processors) we need RocksDB v6.16.3 or higher:

https://github.com/facebook/rocksdb/pull/7714

`rocksdb_build_version.cc.in` is copy-pasted from `build_version.cc.in` here: https://github.com/facebook/rocksdb/commit/0a9a05ae12943b1529ef1eabbca5ce5a71c986bf

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

I was getting a build error that looked a bit like this:
```
make[3]: warning: -jN forced in submake: disabling jobserver mode.
/Users/user/ripple/rippled/.nih_c/unix_makefiles/AppleClang_12.0.5.12050022/Debug/src/rocksdb/util/crc32c.cc:500:18: error: use of undeclared identifier 'isSSE42'
  has_fast_crc = isSSE42();
                 ^
```

## Test Plan

Unit tests passed, but I have NOT done any other testing.

<!--
## Future Tasks
For future tasks related to PR.
-->
