### PR TITLE
Improve amendment management and default votes

### DIFF
--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1250,28 +1250,22 @@ ApplicationImp::setup()
 
     // Configure the amendments the server supports
     {
-        auto buildAmendmentList =
-            [](Section section, std::vector<std::string> const& amendments) {
-                std::vector<std::string> hashes;
-                hashes.reserve(amendments.size());
-                for (auto const& name : amendments)
-                {
-                    auto const f = getRegisteredFeature(name);
-                    assert(f);
-                    if (f)
-                        hashes.push_back(to_string(*f) + " " + name);
-                }
-                section.append(hashes);
-                return section;
-            };
-        Section const supportedAmendments = buildAmendmentList(
-            Section("Supported Amendments"), detail::supportedAmendments());
+        auto const supportedAmendments = []() {
+            auto const& amendments = detail::supportedAmendments();
+            std::vector<AmendmentTable::FeatureInfo> hashes;
+            for (auto const& [a, vote] : amendments)
+            {
+                auto const f = ripple::getRegisteredFeature(a);
+                assert(f);
+                if (f)
+                    hashes.emplace_back(a, *f, vote);
+            }
+            return hashes;
+        }();
+        Section const& downVotedAmendments =
+            config_->section(SECTION_VETO_AMENDMENTS);
 
-        Section const downVotedAmendments = buildAmendmentList(
-            config_->section(SECTION_VETO_AMENDMENTS),
-            detail::downVotedAmendments());
-
-        Section const enabledAmendments = config_->section(SECTION_AMENDMENTS);
+        Section const& enabledAmendments = config_->section(SECTION_AMENDMENTS);
 
         m_amendmentTable = make_AmendmentTable(
             *this,

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -1250,27 +1250,35 @@ ApplicationImp::setup()
 
     // Configure the amendments the server supports
     {
-        auto const& sa = detail::supportedAmendments();
-        std::vector<std::string> saHashes;
-        saHashes.reserve(sa.size());
-        for (auto const& name : sa)
-        {
-            auto const f = getRegisteredFeature(name);
-            BOOST_ASSERT(f);
-            if (f)
-                saHashes.push_back(to_string(*f) + " " + name);
-        }
-        Section supportedAmendments("Supported Amendments");
-        supportedAmendments.append(saHashes);
+        auto buildAmendmentList =
+            [](Section section, std::vector<std::string> const& amendments) {
+                std::vector<std::string> hashes;
+                hashes.reserve(amendments.size());
+                for (auto const& name : amendments)
+                {
+                    auto const f = getRegisteredFeature(name);
+                    assert(f);
+                    if (f)
+                        hashes.push_back(to_string(*f) + " " + name);
+                }
+                section.append(hashes);
+                return section;
+            };
+        Section const supportedAmendments = buildAmendmentList(
+            Section("Supported Amendments"), detail::supportedAmendments());
 
-        Section enabledAmendments = config_->section(SECTION_AMENDMENTS);
+        Section const downVotedAmendments = buildAmendmentList(
+            config_->section(SECTION_VETO_AMENDMENTS),
+            detail::downVotedAmendments());
+
+        Section const enabledAmendments = config_->section(SECTION_AMENDMENTS);
 
         m_amendmentTable = make_AmendmentTable(
             *this,
             config().AMENDMENT_MAJORITY_TIME,
             supportedAmendments,
             enabledAmendments,
-            config_->section(SECTION_VETO_AMENDMENTS),
+            downVotedAmendments,
             logs_->journal("Amendments"));
     }
 

--- a/src/ripple/app/misc/AmendmentTable.h
+++ b/src/ripple/app/misc/AmendmentTable.h
@@ -22,6 +22,7 @@
 
 #include <ripple/app/ledger/Ledger.h>
 #include <ripple/core/ConfigSections.h>
+#include <ripple/protocol/Feature.h>
 #include <ripple/protocol/Protocol.h>
 #include <ripple/protocol/STValidation.h>
 
@@ -36,6 +37,19 @@ namespace ripple {
 class AmendmentTable
 {
 public:
+    struct FeatureInfo
+    {
+        FeatureInfo() = delete;
+        FeatureInfo(std::string const& n, uint256 const& f, DefaultVote v)
+            : name(n), feature(f), vote(v)
+        {
+        }
+
+        std::string const name;
+        uint256 const feature;
+        DefaultVote const vote;
+    };
+
     virtual ~AmendmentTable() = default;
 
     virtual uint256
@@ -168,7 +182,7 @@ std::unique_ptr<AmendmentTable>
 make_AmendmentTable(
     Application& app,
     std::chrono::seconds majorityTime,
-    Section const& supported,
+    std::vector<AmendmentTable::FeatureInfo> const& supported,
     Section const& enabled,
     Section const& vetoed,
     beast::Journal journal);

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -36,7 +36,7 @@
  *    for the feature at the bottom
  * 2) Add a uint256 definition for the feature to the corresponding source
  *    file (Feature.cpp). Use `registerFeature` to create the feature with
- *    the feature's name, `Supported::no`, and `DefaultVote::no`. This
+ *    the feature's name, `Supported::no`, and `DefaultVote::abstain`. This
  *    should be the only place the feature's name appears in code as a string.
  * 3) Use the uint256 as the parameter to `view.rules.enabled()` to
  *    control flow into new code that this feature limits.
@@ -45,8 +45,8 @@
  * 5) When the feature is ready to be ENABLED, change the `registerFeature`
  *    parameter to `DefaultVote::yes`.
  * In general, any newly supported amendments (`Supported::yes`) should have
- * a `DefaultVote::no` for at least one full release cycle. High priority bug
- * fixes can be an exception to this rule of thumb.
+ * a `DefaultVote::abstain` for at least one full release cycle. High priority
+ * bug fixes can be an exception to this rule of thumb.
  *
  * When a feature has been enabled for several years, the conditional code
  * may be removed, and the feature "retired". To retire a feature:
@@ -55,7 +55,7 @@
  *    section at the end of the file.
  * 3) CHANGE the name of the variable to start with "retired".
  * 4) CHANGE the parameters of the `registerFeature` call to `Supported::yes`
- *    and `DefaultVote::no`.
+ *    and `DefaultVote::abstain`.
  * The feature must remain registered and supported indefinitely because it
  * still exists in the ledger, but there is no need to vote for it because
  * there's nothing to vote for. If it is removed completely from the code, any
@@ -66,6 +66,8 @@
 
 namespace ripple {
 
+enum class DefaultVote : bool { abstain = false, yes };
+
 namespace detail {
 
 // This value SHOULD be equal to the number of amendments registered in
@@ -74,19 +76,19 @@ namespace detail {
 // the actual number of amendments. An assert on startup will verify this.
 static constexpr std::size_t numFeatures = 45;
 
-/** Amendments that this server supports and will vote for by default.
+/** Amendments that this server supports and the default voting behavior.
    Whether they are enabled depends on the Rules defined in the validated
    ledger */
-std::vector<std::string> const&
+std::map<std::string, DefaultVote> const&
 supportedAmendments();
 
 /** Amendments that this server won't vote for by default. */
-std::vector<std::string> const&
-downVotedAmendments();
+std::size_t
+numDownVotedAmendments();
 
 /** Amendments that this server will vote for by default. */
-std::vector<std::string> const&
-upVotedAmendments();
+std::size_t
+numUpVotedAmendments();
 
 }  // namespace detail
 

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -32,19 +32,35 @@
  *
  * Steps required to add new features to the code:
  *
- * 1) add the new feature name to the featureNames array below
- * 2) add a uint256 declaration for the feature to the bottom of this file
- * 3) add a uint256 definition for the feature to the corresponding source
- *    file (Feature.cpp)
- * 4) use the uint256 as the parameter to `view.rules.enabled()` to
+ * 1) In this file, increment `numFeatures` and add a uint256 declaration
+ *    for the feature at the bottom
+ * 2) Add a uint256 definition for the feature to the corresponding source
+ *    file (Feature.cpp). Use `registerFeature` to create the feature with
+ *    the feature's name, `Supported::no`, and `DefaultVote::no`. This
+ *    should be the only place the feature's name appears in code as a string.
+ * 3) Use the uint256 as the parameter to `view.rules.enabled()` to
  *    control flow into new code that this feature limits.
- * 5) if the feature development is COMPLETE, and the feature is ready to be
- *    SUPPORTED, add its name (matching exactly the featureName here) to the
- *    supportedAmendments in Feature.cpp.
- * 6) if the feature is not ready to be ENABLED, add its name (matching exactly
- *    the featureName here) to the downVotedAmendments in Feature.cpp.
- * In general, any new amendments added to supportedAmendments should also be
- * added to downVotedAmendments for at least one full release cycle.
+ * 4) If the feature development is COMPLETE, and the feature is ready to be
+ *    SUPPORTED, change the `registerFeature` parameter to Supported::yes.
+ * 5) When the feature is ready to be ENABLED, change the `registerFeature`
+ *    parameter to `DefaultVote::yes`.
+ * In general, any newly supported amendments (`Supported::yes`) should have
+ * a `DefaultVote::no` for at least one full release cycle. High priority bug
+ * fixes can be an exception to this rule of thumb.
+ *
+ * When a feature has been enabled for several years, the conditional code
+ * may be removed, and the feature "retired". To retire a feature:
+ * 1) Remove the uint256 declaration from this file.
+ * 2) MOVE the uint256 definition in Feature.cpp to the "retired features"
+ *    section at the end of the file.
+ * 3) CHANGE the name of the variable to start with "retired".
+ * 4) CHANGE the parameters of the `registerFeature` call to `Supported::yes`
+ *    and `DefaultVote::no`.
+ * The feature must remain registered and supported indefinitely because it
+ * still exists in the ledger, but there is no need to vote for it because
+ * there's nothing to vote for. If it is removed completely from the code, any
+ * instances running that code will get amendment blocked. Removing the
+ * feature from the ledger is beyond the scope of these instructions.
  *
  */
 
@@ -52,104 +68,11 @@ namespace ripple {
 
 namespace detail {
 
-// *NOTE*
-//
-// Features, or Amendments as they are called elsewhere, are enabled on the
-// network at some specific time based on Validator voting.  Features are
-// enabled using run-time conditionals based on the state of the amendment.
-// There is value in retaining that conditional code for some time after
-// the amendment is enabled to make it simple to replay old transactions.
-// However, once an Amendment has been enabled for, say, more than two years
-// then retaining that conditional code has less value since it is
-// uncommon to replay such old transactions.
-//
-// Starting in January of 2020 Amendment conditionals from before January
-// 2018 are being removed.  So replaying any ledger from before January
-// 2018 needs to happen on an older version of the server code.  There's
-// a log message in Application.cpp that warns about replaying old ledgers.
-//
-// At some point in the future someone may wish to remove Amendment
-// conditional code for Amendments that were enabled after January 2018.
-// When that happens then the log message in Application.cpp should be
-// updated.
-
-class FeatureCollections
-{
-    static constexpr char const* const featureNames[] = {
-        "MultiSign",      // Unconditionally supported.
-        "TrustSetAuth",   // Unconditionally supported.
-        "FeeEscalation",  // Unconditionally supported.
-        "OwnerPaysFee",
-        "PayChan",
-        "Flow",  // Unconditionally supported.
-        "CompareTakerFlowCross",
-        "FlowCross",
-        "CryptoConditions",
-        "TickSize",
-        "fix1368",
-        "Escrow",
-        "CryptoConditionsSuite",
-        "fix1373",
-        "EnforceInvariants",
-        "SortedDirectories",
-        "fix1201",
-        "fix1512",
-        "fix1513",
-        "fix1523",
-        "fix1528",
-        "DepositAuth",
-        "Checks",
-        "fix1571",
-        "fix1543",
-        "fix1623",
-        "DepositPreauth",
-        "fix1515",
-        "fix1578",
-        "MultiSignReserve",
-        "fixTakerDryOfferRemoval",
-        "fixMasterKeyAsRegularKey",
-        "fixCheckThreading",
-        "fixPayChanRecipientOwnerDir",
-        "DeletableAccounts",
-        // fixQualityUpperBound should be activated before FlowCross
-        "fixQualityUpperBound",
-        "RequireFullyCanonicalSig",
-        "fix1781",  // XRPEndpointSteps should be included in the circular
-                    // payment check
-        "HardenedValidations",
-        "fixAmendmentMajorityCalc",  // Fix Amendment majority calculation
-        "NegativeUNL",
-        "TicketBatch",
-        "FlowSortStrands",
-        "fixSTAmountCanonicalize",
-        "fixRmSmallIncreasedQOffers",
-    };
-
-    std::vector<uint256> features;
-    boost::container::flat_map<uint256, std::size_t> featureToIndex;
-    boost::container::flat_map<std::string, uint256> nameToFeature;
-
-public:
-    FeatureCollections();
-
-    static constexpr std::size_t
-    numFeatures()
-    {
-        return sizeof(featureNames) / sizeof(featureNames[0]);
-    }
-
-    std::optional<uint256>
-    getRegisteredFeature(std::string const& name) const;
-
-    std::size_t
-    featureToBitsetIndex(uint256 const& f) const;
-
-    uint256 const&
-    bitsetIndexToFeature(size_t i) const;
-
-    std::string
-    featureToName(uint256 const& f) const;
-};
+// This value SHOULD be equal to the number of amendments registered in
+// Feature.cpp. Because it's only used to reserve storage, and determine how
+// large to make the FeatureBitset, it MAY be larger. It MUST NOT be less than
+// the actual number of amendments. An assert on startup will verify this.
+static constexpr std::size_t numFeatures = 45;
 
 /** Amendments that this server supports and will vote for by default.
    Whether they are enabled depends on the Rules defined in the validated
@@ -157,10 +80,13 @@ public:
 std::vector<std::string> const&
 supportedAmendments();
 
-/** Amendments that this server won't vote for by default. Overrides the default
-   vote behavior of `supportedAmendments()` */
+/** Amendments that this server won't vote for by default. */
 std::vector<std::string> const&
 downVotedAmendments();
+
+/** Amendments that this server will vote for by default. */
+std::vector<std::string> const&
+upVotedAmendments();
 
 }  // namespace detail
 
@@ -176,10 +102,9 @@ bitsetIndexToFeature(size_t i);
 std::string
 featureToName(uint256 const& f);
 
-class FeatureBitset
-    : private std::bitset<detail::FeatureCollections::numFeatures()>
+class FeatureBitset : private std::bitset<detail::numFeatures>
 {
-    using base = std::bitset<detail::FeatureCollections::numFeatures()>;
+    using base = std::bitset<detail::numFeatures>;
 
     template <class... Fs>
     void
@@ -213,12 +138,14 @@ public:
 
     explicit FeatureBitset(base const& b) : base(b)
     {
+        assert(b.count() == count());
     }
 
     template <class... Fs>
     explicit FeatureBitset(uint256 const& f, Fs&&... fs)
     {
         initFromFeatures(f, std::forward<Fs>(fs)...);
+        assert(count() == (sizeof...(fs) + 1));
     }
 
     template <class Col>
@@ -226,6 +153,7 @@ public:
     {
         for (auto const& f : fs)
             set(featureToBitsetIndex(f));
+        assert(fs.size() == count());
     }
 
     auto

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -36,9 +36,15 @@
  * 2) add a uint256 declaration for the feature to the bottom of this file
  * 3) add a uint256 definition for the feature to the corresponding source
  *    file (Feature.cpp)
- * 4) if the feature is going to be supported in the near future, add its
- *    sha512half value and name (matching exactly the featureName here) to
- *    the supportedAmendments in Feature.cpp.
+ * 4) use the uint256 as the parameter to `view.rules.enabled()` to
+ *    control flow into new code that this feature limits.
+ * 5) if the feature development is COMPLETE, and the feature is ready to be
+ *    SUPPORTED, add its name (matching exactly the featureName here) to the
+ *    supportedAmendments in Feature.cpp.
+ * 6) if the feature is not ready to be ENABLED, add its name (matching exactly
+ *    the featureName here) to the downVotedAmendments in Feature.cpp.
+ * In general, any new amendments added to supportedAmendments should also be
+ * added to downVotedAmendments for at least one full release cycle.
  *
  */
 
@@ -140,11 +146,21 @@ public:
 
     uint256 const&
     bitsetIndexToFeature(size_t i) const;
+
+    std::string
+    featureToName(uint256 const& f) const;
 };
 
-/** Amendments that this server supports, but doesn't enable by default */
+/** Amendments that this server supports and will vote for by default.
+   Whether they are enabled depends on the Rules defined in the validated
+   ledger */
 std::vector<std::string> const&
 supportedAmendments();
+
+/** Amendments that this server won't vote for by default. Overrides the default
+   vote behavior of `supportedAmendments()` */
+std::vector<std::string> const&
+downVotedAmendments();
 
 }  // namespace detail
 
@@ -156,6 +172,9 @@ featureToBitsetIndex(uint256 const& f);
 
 uint256
 bitsetIndexToFeature(size_t i);
+
+std::string
+featureToName(uint256 const& f);
 
 class FeatureBitset
     : private std::bitset<detail::FeatureCollections::numFeatures()>

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -17,6 +17,7 @@
 */
 //==============================================================================
 
+#include <ripple/basics/Slice.h>
 #include <ripple/basics/contract.h>
 #include <ripple/protocol/Feature.h>
 #include <ripple/protocol/digest.h>
@@ -25,41 +26,184 @@
 
 namespace ripple {
 
-//------------------------------------------------------------------------------
+enum class Supported : bool { no = false, yes };
 
-constexpr char const* const detail::FeatureCollections::featureNames[];
+enum class DefaultVote : bool { no = false, yes };
+
+namespace detail {
+// *NOTE*
+//
+// Features, or Amendments as they are called elsewhere, are enabled on the
+// network at some specific time based on Validator voting.  Features are
+// enabled using run-time conditionals based on the state of the amendment.
+// There is value in retaining that conditional code for some time after
+// the amendment is enabled to make it simple to replay old transactions.
+// However, once an Amendment has been enabled for, say, more than two years
+// then retaining that conditional code has less value since it is
+// uncommon to replay such old transactions.
+//
+// Starting in January of 2020 Amendment conditionals from before January
+// 2018 are being removed.  So replaying any ledger from before January
+// 2018 needs to happen on an older version of the server code.  There's
+// a log message in Application.cpp that warns about replaying old ledgers.
+//
+// At some point in the future someone may wish to remove Amendment
+// conditional code for Amendments that were enabled after January 2018.
+// When that happens then the log message in Application.cpp should be
+// updated.
+
+class FeatureCollections
+{
+    struct Feature
+    {
+        std::string name;
+        uint256 feature;
+        std::size_t index;
+
+        explicit Feature() = default;
+        explicit Feature(
+            std::string const& name_,
+            uint256 const& feature_,
+            std::size_t index_)
+            : name(name_), feature(feature_), index(index_)
+        {
+        }
+    };
+    std::vector<Feature> features;
+    boost::container::flat_map<uint256, std::size_t> featureToIndex;
+    boost::container::flat_map<std::string, uint256> nameToFeature;
+    std::vector<std::string> supported;
+    std::vector<std::string> upVote;
+    std::vector<std::string> downVote;
+    mutable std::atomic<bool> readOnly = false;
+
+public:
+    FeatureCollections();
+
+    std::optional<uint256>
+    getRegisteredFeature(std::string const& name) const;
+
+    uint256
+    registerFeature(
+        std::string const& name,
+        Supported support,
+        DefaultVote vote);
+
+    std::size_t
+    featureToBitsetIndex(uint256 const& f) const;
+
+    uint256 const&
+    bitsetIndexToFeature(size_t i) const;
+
+    std::string
+    featureToName(uint256 const& f) const;
+
+    /** Amendments that this server supports.
+    Whether they are enabled depends on the Rules defined in the validated
+    ledger */
+    std::vector<std::string> const&
+    supportedAmendments() const
+    {
+        return supported;
+    }
+
+    /** Amendments that this server WON'T vote for by default. */
+    std::vector<std::string> const&
+    downVotedAmendments() const
+    {
+        return downVote;
+    }
+
+    /** Amendments that this server WILL vote for by default. */
+    std::vector<std::string> const&
+    upVotedAmendments() const
+    {
+        return upVote;
+    }
+};
+
+}  // namespace detail
+
+//------------------------------------------------------------------------------
 
 detail::FeatureCollections::FeatureCollections()
 {
-    features.reserve(numFeatures());
-    featureToIndex.reserve(numFeatures());
-    nameToFeature.reserve(numFeatures());
-
-    for (std::size_t i = 0; i < numFeatures(); ++i)
-    {
-        auto const name = featureNames[i];
-        sha512_half_hasher h;
-        h(name, std::strlen(name));
-        auto const f = static_cast<uint256>(h);
-
-        features.push_back(f);
-        featureToIndex[f] = i;
-        nameToFeature[name] = f;
-    }
+    features.reserve(ripple::detail::numFeatures);
+    featureToIndex.reserve(ripple::detail::numFeatures);
+    nameToFeature.reserve(ripple::detail::numFeatures);
+    supported.reserve(ripple::detail::numFeatures);
+    upVote.reserve(ripple::detail::numFeatures);
+    downVote.reserve(ripple::detail::numFeatures);
 }
 
 std::optional<uint256>
 detail::FeatureCollections::getRegisteredFeature(std::string const& name) const
 {
+    readOnly = true;
     auto const i = nameToFeature.find(name);
     if (i == nameToFeature.end())
         return std::nullopt;
     return i->second;
 }
 
+uint256
+detail::FeatureCollections::registerFeature(
+    std::string const& name,
+    Supported support,
+    DefaultVote vote)
+{
+    assert(!readOnly);
+    auto const i = nameToFeature.find(name);
+    // Each feature should only be registered once
+    assert(i == nameToFeature.end());
+    if (i == nameToFeature.end())
+    {
+        // If this assertion fails, and you just added a feature, increase the
+        // numFeatures value in Feature.h
+        assert(features.size() < numFeatures);
+
+        auto const f = sha512Half(Slice(name.data(), name.size()));
+#if DEBUG
+        {
+            // remove this before publishing
+            sha512_half_hasher h;
+            h(name.data(), name.size());
+            auto const fOld = static_cast<uint256>(h);
+            assert(f == fOld);
+        }
+#endif
+
+        auto const& feature = features.emplace_back(name, f, features.size());
+        featureToIndex[f] = feature.index;
+        nameToFeature[name] = f;
+
+        assert(features.size() == featureToIndex.size());
+        assert(features.size() == nameToFeature.size());
+
+        assert(features[featureToIndex[f]].name == name);
+        assert(features[featureToIndex[f]].feature == f);
+
+        if (support == Supported::yes)
+        {
+            supported.emplace_back(name);
+
+            if (vote == DefaultVote::yes)
+                upVote.emplace_back(name);
+            else
+                downVote.emplace_back(name);
+        }
+        assert(upVote.size() + downVote.size() == supported.size());
+        assert(supported.size() <= features.size());
+        return f;
+    }
+    else
+        return i->second;
+}
+
 size_t
 detail::FeatureCollections::featureToBitsetIndex(uint256 const& f) const
 {
+    readOnly = true;
     auto const i = featureToIndex.find(f);
     if (i == featureToIndex.end())
         LogicError("Invalid Feature ID");
@@ -69,125 +213,43 @@ detail::FeatureCollections::featureToBitsetIndex(uint256 const& f) const
 uint256 const&
 detail::FeatureCollections::bitsetIndexToFeature(size_t i) const
 {
+    readOnly = true;
     if (i >= features.size())
         LogicError("Invalid FeatureBitset index");
-    return features[i];
+    return features[i].feature;
 }
 
 std::string
 detail::FeatureCollections::featureToName(uint256 const& f) const
 {
+    readOnly = true;
     auto const i = featureToIndex.find(f);
-    assert(featureToIndex.size() == numFeatures());
-    return i == featureToIndex.end() ? to_string(f) : featureNames[i->second];
+    return i == featureToIndex.end() ? to_string(f) : features[i->second].name;
 }
 
-static detail::FeatureCollections const featureCollections;
+static detail::FeatureCollections featureCollections;
 
-/** Amendments that this server supports and will vote for by default.
+/** Amendments that this server supports.
    Whether they are enabled depends on the Rules defined in the validated
    ledger */
 std::vector<std::string> const&
 detail::supportedAmendments()
 {
-    // Commented out amendments will be supported in a future release (and
-    // uncommented at that time). Including an amendment here indicates
-    // that development of the feature is complete. Any future behavior
-    // changes will require another amendment.
-    //
-    // In general, any new non-fix amendments added to this list should also be
-    // added to downVotedAmendments for at least one full release cycle to
-    // prevent rippled from automatically voting to enable that amendment by
-    // default for some time. Fix amendments should be carefully considered
-    // based on the risk and severity of the thing they are fixing.
-    //
-    // There are also unconditionally supported amendments in the list.
-    // Those are amendments that were enabled some time ago and the
-    // amendment conditional code has been removed.
-    //
-    // ** WARNING **
-    // Unconditionally supported amendments need to remain in the list.
-    // Removing them will cause servers to become amendment blocked.
-    static std::vector<std::string> const supported{
-        "MultiSign",      // Unconditionally supported.
-        "TrustSetAuth",   // Unconditionally supported.
-        "FeeEscalation",  // Unconditionally supported.
-                          //        "OwnerPaysFee",
-        "PayChan",
-        "Flow",
-        "CryptoConditions",
-        "TickSize",
-        "fix1368",
-        "Escrow",
-        "CryptoConditionsSuite",
-        "fix1373",
-        "EnforceInvariants",
-        "FlowCross",
-        "SortedDirectories",
-        "fix1201",
-        "fix1512",
-        "fix1513",
-        "fix1523",
-        "fix1528",
-        "DepositAuth",
-        "Checks",
-        "fix1571",
-        "fix1543",
-        "fix1623",
-        "DepositPreauth",
-        // Use liquidity from strands that consume max offers, but mark as dry
-        "fix1515",
-        "fix1578",
-        "MultiSignReserve",
-        "fixTakerDryOfferRemoval",
-        "fixMasterKeyAsRegularKey",
-        "fixCheckThreading",
-        "fixPayChanRecipientOwnerDir",
-        "DeletableAccounts",
-        "fixQualityUpperBound",
-        "RequireFullyCanonicalSig",
-        "fix1781",
-        "HardenedValidations",
-        "fixAmendmentMajorityCalc",
-        //"NegativeUNL",      // Commented out to prevent automatic enablement
-        "TicketBatch",
-        "FlowSortStrands",
-        "fixSTAmountCanonicalize",
-        "fixRmSmallIncreasedQOffers",
-    };
-    return supported;
+    return featureCollections.supportedAmendments();
 }
 
-/** Amendments that this server won't vote for by default. Overrides the default
-   vote behavior of `supportedAmendments()` */
+/** Amendments that this server won't vote for by default. */
 std::vector<std::string> const&
 detail::downVotedAmendments()
 {
-    // Amendment names included in this list should also be present and
-    // uncommented in supportedAmendments above. This allows a particular
-    // version of rippled to be able to understand the amendment if it gets
-    // enabled, but not vote for the amendment by default. Additionally, some
-    // tests will fail if an entry in this list is not in supportedAmendments.
-    //
-    // Note that this list can be overridden by the "feature" admin RPC command.
-    //
-    // For example, if amendment FOO is first complete and released in 2.1, but
-    // down voted (included in this list) until 2.3 when it is removed from this
-    // list, then when it is finally enabled by receiving votes from the
-    // majority of UNL validators some time after 2.3 is released, versions 2.1
-    // and later will know how to handle the new behavior and will NOT be
-    // amendment blocked.
-    //
-    // Suggested format for entries in the string vector:
-    //  "AmendmentName",   // Added in 2.1, planned to enable in 2.3
-    //
-    // To enable automatically voting for the amendment, simply remove it from
-    // this list. There should never be a need to comment entries out aside from
-    // testing.
-    static std::vector<std::string> const vetoed{
-        "CryptoConditionsSuite",  // Added in 0.60.0, incomplete, do not enable
-    };
-    return vetoed;
+    return featureCollections.downVotedAmendments();
+}
+
+/** Amendments that this server will vote for by default. */
+std::vector<std::string> const&
+detail::upVotedAmendments()
+{
+    return featureCollections.upVotedAmendments();
 }
 
 //------------------------------------------------------------------------------
@@ -196,6 +258,12 @@ std::optional<uint256>
 getRegisteredFeature(std::string const& name)
 {
     return featureCollections.getRegisteredFeature(name);
+}
+
+uint256
+registerFeature(std::string const& name, Supported support, DefaultVote vote)
+{
+    return featureCollections.registerFeature(name, support, vote);
 }
 
 size_t
@@ -218,54 +286,64 @@ featureToName(uint256 const& f)
 
 // clang-format off
 
+// All known amendments must be registered either here or below with the
+// "retired" amendments
 uint256 const
-    featureOwnerPaysFee             = *getRegisteredFeature("OwnerPaysFee"),
-    featureFlow                     = *getRegisteredFeature("Flow"),
-    featureCompareTakerFlowCross    = *getRegisteredFeature("CompareTakerFlowCross"),
-    featureFlowCross                = *getRegisteredFeature("FlowCross"),
-    featureCryptoConditionsSuite    = *getRegisteredFeature("CryptoConditionsSuite"),
-    fix1513                         = *getRegisteredFeature("fix1513"),
-    featureDepositAuth              = *getRegisteredFeature("DepositAuth"),
-    featureChecks                   = *getRegisteredFeature("Checks"),
-    fix1571                         = *getRegisteredFeature("fix1571"),
-    fix1543                         = *getRegisteredFeature("fix1543"),
-    fix1623                         = *getRegisteredFeature("fix1623"),
-    featureDepositPreauth           = *getRegisteredFeature("DepositPreauth"),
-    fix1515                         = *getRegisteredFeature("fix1515"),
-    fix1578                         = *getRegisteredFeature("fix1578"),
-    featureMultiSignReserve         = *getRegisteredFeature("MultiSignReserve"),
-    fixTakerDryOfferRemoval         = *getRegisteredFeature("fixTakerDryOfferRemoval"),
-    fixMasterKeyAsRegularKey        = *getRegisteredFeature("fixMasterKeyAsRegularKey"),
-    fixCheckThreading               = *getRegisteredFeature("fixCheckThreading"),
-    fixPayChanRecipientOwnerDir     = *getRegisteredFeature("fixPayChanRecipientOwnerDir"),
-    featureDeletableAccounts        = *getRegisteredFeature("DeletableAccounts"),
-    fixQualityUpperBound            = *getRegisteredFeature("fixQualityUpperBound"),
-    featureRequireFullyCanonicalSig = *getRegisteredFeature("RequireFullyCanonicalSig"),
-    fix1781                         = *getRegisteredFeature("fix1781"),
-    featureHardenedValidations      = *getRegisteredFeature("HardenedValidations"),
-    fixAmendmentMajorityCalc        = *getRegisteredFeature("fixAmendmentMajorityCalc"),
-    featureNegativeUNL              = *getRegisteredFeature("NegativeUNL"),
-    featureTicketBatch              = *getRegisteredFeature("TicketBatch"),
-    featureFlowSortStrands          = *getRegisteredFeature("FlowSortStrands"),
-    fixSTAmountCanonicalize         = *getRegisteredFeature("fixSTAmountCanonicalize"),
-    fixRmSmallIncreasedQOffers      = *getRegisteredFeature("fixRmSmallIncreasedQOffers");
+    featureOwnerPaysFee             = registerFeature("OwnerPaysFee", Supported::no, DefaultVote::no),
+    featureFlow                     = registerFeature("Flow", Supported::yes, DefaultVote::yes),
+    featureCompareTakerFlowCross    = registerFeature("CompareTakerFlowCross", Supported::no, DefaultVote::no),
+    featureFlowCross                = registerFeature("FlowCross", Supported::yes, DefaultVote::yes),
+    featureCryptoConditionsSuite    = registerFeature("CryptoConditionsSuite", Supported::yes, DefaultVote::no),
+    fix1513                         = registerFeature("fix1513", Supported::yes, DefaultVote::yes),
+    featureDepositAuth              = registerFeature("DepositAuth", Supported::yes, DefaultVote::yes),
+    featureChecks                   = registerFeature("Checks", Supported::yes, DefaultVote::yes),
+    fix1571                         = registerFeature("fix1571", Supported::yes, DefaultVote::yes),
+    fix1543                         = registerFeature("fix1543", Supported::yes, DefaultVote::yes),
+    fix1623                         = registerFeature("fix1623", Supported::yes, DefaultVote::yes),
+    featureDepositPreauth           = registerFeature("DepositPreauth", Supported::yes, DefaultVote::yes),
+    // Use liquidity from strands that consume max offers, but mark as dry
+    fix1515                         = registerFeature("fix1515", Supported::yes, DefaultVote::yes),
+    fix1578                         = registerFeature("fix1578", Supported::yes, DefaultVote::yes),
+    featureMultiSignReserve         = registerFeature("MultiSignReserve", Supported::yes, DefaultVote::yes),
+    fixTakerDryOfferRemoval         = registerFeature("fixTakerDryOfferRemoval", Supported::yes, DefaultVote::yes),
+    fixMasterKeyAsRegularKey        = registerFeature("fixMasterKeyAsRegularKey", Supported::yes, DefaultVote::yes),
+    fixCheckThreading               = registerFeature("fixCheckThreading", Supported::yes, DefaultVote::yes),
+    fixPayChanRecipientOwnerDir     = registerFeature("fixPayChanRecipientOwnerDir", Supported::yes, DefaultVote::yes),
+    featureDeletableAccounts        = registerFeature("DeletableAccounts", Supported::yes, DefaultVote::yes),
+    // fixQualityUpperBound should be activated before FlowCross
+    fixQualityUpperBound            = registerFeature("fixQualityUpperBound", Supported::yes, DefaultVote::yes),
+    featureRequireFullyCanonicalSig = registerFeature("RequireFullyCanonicalSig", Supported::yes, DefaultVote::yes),
+    // fix1781: XRPEndpointSteps should be included in the circular payment check
+    fix1781                         = registerFeature("fix1781", Supported::yes, DefaultVote::yes),
+    featureHardenedValidations      = registerFeature("HardenedValidations", Supported::yes, DefaultVote::yes),
+    fixAmendmentMajorityCalc        = registerFeature("fixAmendmentMajorityCalc", Supported::yes, DefaultVote::yes),
+    featureNegativeUNL              = registerFeature("NegativeUNL", Supported::no, DefaultVote::no),
+    featureTicketBatch              = registerFeature("TicketBatch", Supported::yes, DefaultVote::yes),
+    featureFlowSortStrands          = registerFeature("FlowSortStrands", Supported::yes, DefaultVote::yes),
+    fixSTAmountCanonicalize         = registerFeature("fixSTAmountCanonicalize", Supported::yes, DefaultVote::yes),
+    fixRmSmallIncreasedQOffers      = registerFeature("fixRmSmallIncreasedQOffers", Supported::yes, DefaultVote::yes);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.
+// All known amendments and amendments that may appear in a validated
+// ledger must be registered either here or above with the "active" amendments
 [[deprecated("The referenced amendment has been retired"), maybe_unused]]
 uint256 const
-    retiredPayChan           = *getRegisteredFeature("PayChan"),
-    retiredCryptoConditions  = *getRegisteredFeature("CryptoConditions"),
-    retiredTickSize          = *getRegisteredFeature("TickSize"),
-    retiredFix1368           = *getRegisteredFeature("fix1368"),
-    retiredEscrow            = *getRegisteredFeature("Escrow"),
-    retiredFix1373           = *getRegisteredFeature("fix1373"),
-    retiredEnforceInvariants = *getRegisteredFeature("EnforceInvariants"),
-    retiredSortedDirectories = *getRegisteredFeature("SortedDirectories"),
-    retiredFix1201           = *getRegisteredFeature("fix1201"),
-    retiredFix1512           = *getRegisteredFeature("fix1512"),
-    retiredFix1523           = *getRegisteredFeature("fix1523"),
-    retiredFix1528           = *getRegisteredFeature("fix1528");
+    retiredMultiSign         = registerFeature("MultiSign", Supported::yes, DefaultVote::no),
+    retiredTrustSetAuth      = registerFeature("TrustSetAuth", Supported::yes, DefaultVote::no),
+    retiredFeeEscalation     = registerFeature("FeeEscalation", Supported::yes, DefaultVote::no),
+    retiredPayChan           = registerFeature("PayChan", Supported::yes, DefaultVote::no),
+    retiredCryptoConditions  = registerFeature("CryptoConditions", Supported::yes, DefaultVote::no),
+    retiredTickSize          = registerFeature("TickSize", Supported::yes, DefaultVote::no),
+    retiredFix1368           = registerFeature("fix1368", Supported::yes, DefaultVote::no),
+    retiredEscrow            = registerFeature("Escrow", Supported::yes, DefaultVote::no),
+    retiredFix1373           = registerFeature("fix1373", Supported::yes, DefaultVote::no),
+    retiredEnforceInvariants = registerFeature("EnforceInvariants", Supported::yes, DefaultVote::no),
+    retiredSortedDirectories = registerFeature("SortedDirectories", Supported::yes, DefaultVote::no),
+    retiredFix1201           = registerFeature("fix1201", Supported::yes, DefaultVote::no),
+    retiredFix1512           = registerFeature("fix1512", Supported::yes, DefaultVote::no),
+    retiredFix1523           = registerFeature("fix1523", Supported::yes, DefaultVote::no),
+    retiredFix1528           = registerFeature("fix1528", Supported::yes, DefaultVote::no);
 
 // clang-format on
 

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -74,14 +74,32 @@ detail::FeatureCollections::bitsetIndexToFeature(size_t i) const
     return features[i];
 }
 
+std::string
+detail::FeatureCollections::featureToName(uint256 const& f) const
+{
+    auto const i = featureToIndex.find(f);
+    assert(featureToIndex.size() == numFeatures());
+    return i == featureToIndex.end() ? to_string(f) : featureNames[i->second];
+}
+
 static detail::FeatureCollections const featureCollections;
 
-/** Amendments that this server supports, but doesn't enable by default */
+/** Amendments that this server supports and will vote for by default.
+   Whether they are enabled depends on the Rules defined in the validated
+   ledger */
 std::vector<std::string> const&
 detail::supportedAmendments()
 {
     // Commented out amendments will be supported in a future release (and
-    // uncommented at that time).
+    // uncommented at that time). Including an amendment here indicates
+    // that development of the feature is complete. Any future behavior
+    // changes will require another amendment.
+    //
+    // In general, any new non-fix amendments added to this list should also be
+    // added to downVotedAmendments for at least one full release cycle to
+    // prevent rippled from automatically voting to enable that amendment by
+    // default for some time. Fix amendments should be carefully considered
+    // based on the risk and severity of the thing they are fixing.
     //
     // There are also unconditionally supported amendments in the list.
     // Those are amendments that were enabled some time ago and the
@@ -140,6 +158,38 @@ detail::supportedAmendments()
     return supported;
 }
 
+/** Amendments that this server won't vote for by default. Overrides the default
+   vote behavior of `supportedAmendments()` */
+std::vector<std::string> const&
+detail::downVotedAmendments()
+{
+    // Amendment names included in this list should also be present and
+    // uncommented in supportedAmendments above. This allows a particular
+    // version of rippled to be able to understand the amendment if it gets
+    // enabled, but not vote for the amendment by default. Additionally, some
+    // tests will fail if an entry in this list is not in supportedAmendments.
+    //
+    // Note that this list can be overridden by the "feature" admin RPC command.
+    //
+    // For example, if amendment FOO is first complete and released in 2.1, but
+    // down voted (included in this list) until 2.3 when it is removed from this
+    // list, then when it is finally enabled by receiving votes from the
+    // majority of UNL validators some time after 2.3 is released, versions 2.1
+    // and later will know how to handle the new behavior and will NOT be
+    // amendment blocked.
+    //
+    // Suggested format for entries in the string vector:
+    //  "AmendmentName",   // Added in 2.1, planned to enable in 2.3
+    //
+    // To enable automatically voting for the amendment, simply remove it from
+    // this list. There should never be a need to comment entries out aside from
+    // testing.
+    static std::vector<std::string> const vetoed{
+        "CryptoConditionsSuite",  // Added in 0.60.0, incomplete, do not enable
+    };
+    return vetoed;
+}
+
 //------------------------------------------------------------------------------
 
 std::optional<uint256>
@@ -158,6 +208,12 @@ uint256
 bitsetIndexToFeature(size_t i)
 {
     return featureCollections.bitsetIndexToFeature(i);
+}
+
+std::string
+featureToName(uint256 const& f)
+{
+    return featureCollections.featureToName(f);
 }
 
 // clang-format off

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -28,8 +28,6 @@ namespace ripple {
 
 enum class Supported : bool { no = false, yes };
 
-enum class DefaultVote : bool { no = false, yes };
-
 namespace detail {
 // *NOTE*
 //
@@ -72,9 +70,9 @@ class FeatureCollections
     std::vector<Feature> features;
     boost::container::flat_map<uint256, std::size_t> featureToIndex;
     boost::container::flat_map<std::string, uint256> nameToFeature;
-    std::vector<std::string> supported;
-    std::vector<std::string> upVote;
-    std::vector<std::string> downVote;
+    std::map<std::string, DefaultVote> supported;
+    std::size_t upVotes = 0;
+    std::size_t downVotes = 0;
     mutable std::atomic<bool> readOnly = false;
 
 public:
@@ -101,24 +99,24 @@ public:
     /** Amendments that this server supports.
     Whether they are enabled depends on the Rules defined in the validated
     ledger */
-    std::vector<std::string> const&
+    std::map<std::string, DefaultVote> const&
     supportedAmendments() const
     {
         return supported;
     }
 
     /** Amendments that this server WON'T vote for by default. */
-    std::vector<std::string> const&
-    downVotedAmendments() const
+    std::size_t
+    numDownVotedAmendments() const
     {
-        return downVote;
+        return downVotes;
     }
 
     /** Amendments that this server WILL vote for by default. */
-    std::vector<std::string> const&
-    upVotedAmendments() const
+    std::size_t
+    numUpVotedAmendments() const
     {
-        return upVote;
+        return upVotes;
     }
 };
 
@@ -131,9 +129,6 @@ detail::FeatureCollections::FeatureCollections()
     features.reserve(ripple::detail::numFeatures);
     featureToIndex.reserve(ripple::detail::numFeatures);
     nameToFeature.reserve(ripple::detail::numFeatures);
-    supported.reserve(ripple::detail::numFeatures);
-    upVote.reserve(ripple::detail::numFeatures);
-    downVote.reserve(ripple::detail::numFeatures);
 }
 
 std::optional<uint256>
@@ -185,14 +180,14 @@ detail::FeatureCollections::registerFeature(
 
         if (support == Supported::yes)
         {
-            supported.emplace_back(name);
+            supported.emplace(name, vote);
 
             if (vote == DefaultVote::yes)
-                upVote.emplace_back(name);
+                ++upVotes;
             else
-                downVote.emplace_back(name);
+                ++downVotes;
         }
-        assert(upVote.size() + downVote.size() == supported.size());
+        assert(upVotes + downVotes == supported.size());
         assert(supported.size() <= features.size());
         return f;
     }
@@ -232,24 +227,24 @@ static detail::FeatureCollections featureCollections;
 /** Amendments that this server supports.
    Whether they are enabled depends on the Rules defined in the validated
    ledger */
-std::vector<std::string> const&
+std::map<std::string, DefaultVote> const&
 detail::supportedAmendments()
 {
     return featureCollections.supportedAmendments();
 }
 
 /** Amendments that this server won't vote for by default. */
-std::vector<std::string> const&
-detail::downVotedAmendments()
+std::size_t
+detail::numDownVotedAmendments()
 {
-    return featureCollections.downVotedAmendments();
+    return featureCollections.numDownVotedAmendments();
 }
 
 /** Amendments that this server will vote for by default. */
-std::vector<std::string> const&
-detail::upVotedAmendments()
+std::size_t
+detail::numUpVotedAmendments()
 {
-    return featureCollections.upVotedAmendments();
+    return featureCollections.numUpVotedAmendments();
 }
 
 //------------------------------------------------------------------------------
@@ -289,11 +284,11 @@ featureToName(uint256 const& f)
 // All known amendments must be registered either here or below with the
 // "retired" amendments
 uint256 const
-    featureOwnerPaysFee             = registerFeature("OwnerPaysFee", Supported::no, DefaultVote::no),
+    featureOwnerPaysFee             = registerFeature("OwnerPaysFee", Supported::no, DefaultVote::abstain),
     featureFlow                     = registerFeature("Flow", Supported::yes, DefaultVote::yes),
-    featureCompareTakerFlowCross    = registerFeature("CompareTakerFlowCross", Supported::no, DefaultVote::no),
+    featureCompareTakerFlowCross    = registerFeature("CompareTakerFlowCross", Supported::no, DefaultVote::abstain),
     featureFlowCross                = registerFeature("FlowCross", Supported::yes, DefaultVote::yes),
-    featureCryptoConditionsSuite    = registerFeature("CryptoConditionsSuite", Supported::yes, DefaultVote::no),
+    featureCryptoConditionsSuite    = registerFeature("CryptoConditionsSuite", Supported::yes, DefaultVote::abstain),
     fix1513                         = registerFeature("fix1513", Supported::yes, DefaultVote::yes),
     featureDepositAuth              = registerFeature("DepositAuth", Supported::yes, DefaultVote::yes),
     featureChecks                   = registerFeature("Checks", Supported::yes, DefaultVote::yes),
@@ -317,7 +312,7 @@ uint256 const
     fix1781                         = registerFeature("fix1781", Supported::yes, DefaultVote::yes),
     featureHardenedValidations      = registerFeature("HardenedValidations", Supported::yes, DefaultVote::yes),
     fixAmendmentMajorityCalc        = registerFeature("fixAmendmentMajorityCalc", Supported::yes, DefaultVote::yes),
-    featureNegativeUNL              = registerFeature("NegativeUNL", Supported::no, DefaultVote::no),
+    featureNegativeUNL              = registerFeature("NegativeUNL", Supported::no, DefaultVote::abstain),
     featureTicketBatch              = registerFeature("TicketBatch", Supported::yes, DefaultVote::yes),
     featureFlowSortStrands          = registerFeature("FlowSortStrands", Supported::yes, DefaultVote::yes),
     fixSTAmountCanonicalize         = registerFeature("fixSTAmountCanonicalize", Supported::yes, DefaultVote::yes),
@@ -329,21 +324,21 @@ uint256 const
 // ledger must be registered either here or above with the "active" amendments
 [[deprecated("The referenced amendment has been retired"), maybe_unused]]
 uint256 const
-    retiredMultiSign         = registerFeature("MultiSign", Supported::yes, DefaultVote::no),
-    retiredTrustSetAuth      = registerFeature("TrustSetAuth", Supported::yes, DefaultVote::no),
-    retiredFeeEscalation     = registerFeature("FeeEscalation", Supported::yes, DefaultVote::no),
-    retiredPayChan           = registerFeature("PayChan", Supported::yes, DefaultVote::no),
-    retiredCryptoConditions  = registerFeature("CryptoConditions", Supported::yes, DefaultVote::no),
-    retiredTickSize          = registerFeature("TickSize", Supported::yes, DefaultVote::no),
-    retiredFix1368           = registerFeature("fix1368", Supported::yes, DefaultVote::no),
-    retiredEscrow            = registerFeature("Escrow", Supported::yes, DefaultVote::no),
-    retiredFix1373           = registerFeature("fix1373", Supported::yes, DefaultVote::no),
-    retiredEnforceInvariants = registerFeature("EnforceInvariants", Supported::yes, DefaultVote::no),
-    retiredSortedDirectories = registerFeature("SortedDirectories", Supported::yes, DefaultVote::no),
-    retiredFix1201           = registerFeature("fix1201", Supported::yes, DefaultVote::no),
-    retiredFix1512           = registerFeature("fix1512", Supported::yes, DefaultVote::no),
-    retiredFix1523           = registerFeature("fix1523", Supported::yes, DefaultVote::no),
-    retiredFix1528           = registerFeature("fix1528", Supported::yes, DefaultVote::no);
+    retiredMultiSign         = registerFeature("MultiSign", Supported::yes, DefaultVote::abstain),
+    retiredTrustSetAuth      = registerFeature("TrustSetAuth", Supported::yes, DefaultVote::abstain),
+    retiredFeeEscalation     = registerFeature("FeeEscalation", Supported::yes, DefaultVote::abstain),
+    retiredPayChan           = registerFeature("PayChan", Supported::yes, DefaultVote::abstain),
+    retiredCryptoConditions  = registerFeature("CryptoConditions", Supported::yes, DefaultVote::abstain),
+    retiredTickSize          = registerFeature("TickSize", Supported::yes, DefaultVote::abstain),
+    retiredFix1368           = registerFeature("fix1368", Supported::yes, DefaultVote::abstain),
+    retiredEscrow            = registerFeature("Escrow", Supported::yes, DefaultVote::abstain),
+    retiredFix1373           = registerFeature("fix1373", Supported::yes, DefaultVote::abstain),
+    retiredEnforceInvariants = registerFeature("EnforceInvariants", Supported::yes, DefaultVote::abstain),
+    retiredSortedDirectories = registerFeature("SortedDirectories", Supported::yes, DefaultVote::abstain),
+    retiredFix1201           = registerFeature("fix1201", Supported::yes, DefaultVote::abstain),
+    retiredFix1512           = registerFeature("fix1512", Supported::yes, DefaultVote::abstain),
+    retiredFix1523           = registerFeature("fix1523", Supported::yes, DefaultVote::abstain),
+    retiredFix1528           = registerFeature("fix1528", Supported::yes, DefaultVote::abstain);
 
 // clang-format on
 

--- a/src/test/app/AmendmentTable_test.cpp
+++ b/src/test/app/AmendmentTable_test.cpp
@@ -86,11 +86,31 @@ private:
         return cfg;
     }
 
+    static std::vector<AmendmentTable::FeatureInfo>
+    makeDefaultYes(std::vector<std::string> const& amendments)
+    {
+        std::vector<AmendmentTable::FeatureInfo> result;
+        result.reserve(amendments.size());
+        for (auto const& a : amendments)
+        {
+            result.emplace_back(a, amendmentId(a), DefaultVote::yes);
+        }
+        return result;
+    }
+
+    static std::vector<AmendmentTable::FeatureInfo>
+    makeDefaultYes(uint256 const amendment)
+    {
+        std::vector<AmendmentTable::FeatureInfo> result{
+            {to_string(amendment), amendment, DefaultVote::yes}};
+        return result;
+    }
+
     // All useful amendments are supported amendments.
     // Enabled amendments are typically a subset of supported amendments.
     // Vetoed amendments should be supported but not enabled.
     // Unsupported amendments may be added to the AmendmentTable.
-    std::vector<std::string> const supported_{
+    std::vector<std::string> const supportedYes_{
         "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k",
         "l", "m", "n", "o", "p", "q", "r", "s", "t", "u"};
     std::vector<std::string> const
@@ -100,6 +120,7 @@ private:
     std::vector<std::string> const unsupportedMajority_{"y", "z"};
 
     Section const emptySection;
+    std::vector<AmendmentTable::FeatureInfo> const emptyYes;
 
     test::SuiteJournal journal;
 
@@ -112,7 +133,7 @@ public:
     makeTable(
         Application& app,
         std::chrono::seconds majorityTime,
-        Section const& supported,
+        std::vector<AmendmentTable::FeatureInfo> const& supported,
         Section const& enabled,
         Section const& vetoed)
     {
@@ -124,7 +145,7 @@ public:
     makeTable(
         test::jtx::Env& env,
         std::chrono::seconds majorityTime,
-        Section const& supported,
+        std::vector<AmendmentTable::FeatureInfo> const& supported,
         Section const& enabled,
         Section const& vetoed)
     {
@@ -137,7 +158,7 @@ public:
         return makeTable(
             env.app(),
             majorityTime,
-            makeSection(supported_),
+            makeDefaultYes(supportedYes_),
             makeSection(enabled_),
             makeSection(vetoed_));
     }
@@ -149,7 +170,7 @@ public:
         test::jtx::Env env{*this, makeConfig()};
         auto table = makeTable(env, weeks(1));
 
-        for (auto const& a : supported_)
+        for (auto const& a : supportedYes_)
         {
             BEAST_EXPECT(table->isSupported(amendmentId(a)));
         }
@@ -174,7 +195,7 @@ public:
         test::jtx::Env env{*this, makeConfig()};
         auto table = makeTable(env, weeks(1));
 
-        for (auto const& a : supported_)
+        for (auto const& a : supportedYes_)
             BEAST_EXPECT(table->find(a) == amendmentId(a));
         for (auto const& a : enabled_)
             BEAST_EXPECT(table->find(a) == amendmentId(a));
@@ -207,7 +228,8 @@ public:
     void
     testBadConfig()
     {
-        auto const section = makeSection(supported_);
+        auto const yesVotes = makeDefaultYes(supportedYes_);
+        auto const section = makeSection(vetoed_);
         auto const id = to_string(amendmentId(enabled_[0]));
 
         testcase("Bad Config");
@@ -219,7 +241,7 @@ public:
             try
             {
                 test::jtx::Env env{*this, makeConfig()};
-                if (makeTable(env, weeks(2), test, emptySection, emptySection))
+                if (makeTable(env, weeks(2), yesVotes, test, emptySection))
                     fail("Accepted only amendment ID");
             }
             catch (...)
@@ -235,7 +257,7 @@ public:
             try
             {
                 test::jtx::Env env{*this, makeConfig()};
-                if (makeTable(env, weeks(2), test, emptySection, emptySection))
+                if (makeTable(env, weeks(2), yesVotes, test, emptySection))
                     fail("Accepted extra arguments");
             }
             catch (...)
@@ -254,7 +276,7 @@ public:
             try
             {
                 test::jtx::Env env{*this, makeConfig()};
-                if (makeTable(env, weeks(2), test, emptySection, emptySection))
+                if (makeTable(env, weeks(2), yesVotes, test, emptySection))
                     fail("Accepted short amendment ID");
             }
             catch (...)
@@ -273,7 +295,7 @@ public:
             try
             {
                 test::jtx::Env env{*this, makeConfig()};
-                if (makeTable(env, weeks(2), test, emptySection, emptySection))
+                if (makeTable(env, weeks(2), yesVotes, test, emptySection))
                     fail("Accepted long amendment ID");
             }
             catch (...)
@@ -293,7 +315,7 @@ public:
             try
             {
                 test::jtx::Env env{*this, makeConfig()};
-                if (makeTable(env, weeks(2), test, emptySection, emptySection))
+                if (makeTable(env, weeks(2), yesVotes, test, emptySection))
                     fail("Accepted non-hex amendment ID");
             }
             catch (...)
@@ -311,30 +333,30 @@ public:
         test::jtx::Env env{*this, makeConfig()};
         std::unique_ptr<AmendmentTable> table = makeTable(env, weeks(2));
 
-        // Note which entries are pre-enabled
+        // Note which entries are enabled
         std::set<uint256> allEnabled;
         for (auto const& a : enabled_)
             allEnabled.insert(amendmentId(a));
 
-        // Subset of amendments to late-enable
-        std::set<uint256> lateEnabled;
-        lateEnabled.insert(amendmentId(supported_[0]));
-        lateEnabled.insert(amendmentId(vetoed_[0]));
-
-        // Do the late enabling.
-        for (uint256 const& a : lateEnabled)
+        for (uint256 const& a : allEnabled)
             BEAST_EXPECT(table->enable(a));
 
         // So far all enabled amendments are supported.
         BEAST_EXPECT(!table->hasUnsupportedEnabled());
 
         // Verify all enables are enabled and nothing else.
-        for (std::string const& a : supported_)
+        for (std::string const& a : supportedYes_)
         {
             uint256 const supportedID = amendmentId(a);
-            BEAST_EXPECT(
+            BEAST_EXPECTS(
                 table->isEnabled(supportedID) ==
-                (allEnabled.find(supportedID) != allEnabled.end()));
+                    (allEnabled.find(supportedID) != allEnabled.end()),
+                a +
+                    (table->isEnabled(supportedID) ? " enabled "
+                                                   : " disabled ") +
+                    (allEnabled.find(supportedID) != allEnabled.end()
+                         ? " found"
+                         : " not found"));
         }
 
         // All supported and unVetoed amendments should be returned as desired.
@@ -350,7 +372,7 @@ public:
             // Unveto an amendment that is already not vetoed.  Shouldn't
             // hurt anything, but the values returned by getDesired()
             // shouldn't change.
-            BEAST_EXPECT(!table->unVeto(amendmentId(supported_[1])));
+            BEAST_EXPECT(!table->unVeto(amendmentId(supportedYes_[1])));
             BEAST_EXPECT(desired == table->getDesired());
         }
 
@@ -366,7 +388,7 @@ public:
         }
 
         // Veto all supported amendments.  Now desired should be empty.
-        for (std::string const& a : supported_)
+        for (std::string const& a : supportedYes_)
         {
             table->veto(amendmentId(a));
         }
@@ -508,7 +530,7 @@ public:
 
         test::jtx::Env env{*this};
         auto table =
-            makeTable(env, weeks(2), emptySection, emptySection, emptySection);
+            makeTable(env, weeks(2), emptyYes, emptySection, emptySection);
 
         std::vector<std::pair<uint256, int>> votes;
         std::vector<uint256> ourVotes;
@@ -569,11 +591,7 @@ public:
 
         test::jtx::Env env{*this};
         auto table = makeTable(
-            env,
-            weeks(2),
-            emptySection,
-            emptySection,
-            makeSection(testAmendment));
+            env, weeks(2), emptyYes, emptySection, makeSection(testAmendment));
 
         auto const validators = makeValidators(10);
 
@@ -632,7 +650,11 @@ public:
 
         test::jtx::Env env{*this};
         auto table = makeTable(
-            env, weeks(2), makeSection(supported_), emptySection, emptySection);
+            env,
+            weeks(2),
+            makeDefaultYes(supportedYes_),
+            emptySection,
+            emptySection);
 
         auto const validators = makeValidators(10);
         std::vector<std::pair<uint256, int>> votes;
@@ -650,13 +672,13 @@ public:
             ourVotes,
             enabled,
             majority);
-        BEAST_EXPECT(ourVotes.size() == supported_.size());
+        BEAST_EXPECT(ourVotes.size() == supportedYes_.size());
         BEAST_EXPECT(enabled.empty());
-        for (auto const& i : supported_)
+        for (auto const& i : supportedYes_)
             BEAST_EXPECT(majority.find(amendmentId(i)) == majority.end());
 
         // Now, everyone votes for this feature
-        for (auto const& i : supported_)
+        for (auto const& i : supportedYes_)
             votes.emplace_back(amendmentId(i), validators.size());
 
         // Week 2: We should recognize a majority
@@ -669,10 +691,10 @@ public:
             ourVotes,
             enabled,
             majority);
-        BEAST_EXPECT(ourVotes.size() == supported_.size());
+        BEAST_EXPECT(ourVotes.size() == supportedYes_.size());
         BEAST_EXPECT(enabled.empty());
 
-        for (auto const& i : supported_)
+        for (auto const& i : supportedYes_)
             BEAST_EXPECT(majority[amendmentId(i)] == weekTime(weeks{2}));
 
         // Week 5: We should enable the amendment
@@ -685,7 +707,7 @@ public:
             ourVotes,
             enabled,
             majority);
-        BEAST_EXPECT(enabled.size() == supported_.size());
+        BEAST_EXPECT(enabled.size() == supportedYes_.size());
 
         // Week 6: We should remove it from our votes and from having a majority
         doRound(
@@ -697,9 +719,9 @@ public:
             ourVotes,
             enabled,
             majority);
-        BEAST_EXPECT(enabled.size() == supported_.size());
+        BEAST_EXPECT(enabled.size() == supportedYes_.size());
         BEAST_EXPECT(ourVotes.empty());
-        for (auto const& i : supported_)
+        for (auto const& i : supportedYes_)
             BEAST_EXPECT(majority.find(amendmentId(i)) == majority.end());
     }
 
@@ -714,7 +736,7 @@ public:
         auto table = makeTable(
             env,
             weeks(2),
-            makeSection(testAmendment),
+            makeDefaultYes(testAmendment),
             emptySection,
             emptySection);
 
@@ -785,7 +807,7 @@ public:
         auto table = makeTable(
             env,
             weeks(8),
-            makeSection(testAmendment),
+            makeDefaultYes(testAmendment),
             emptySection,
             emptySection);
 

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -136,11 +136,10 @@ class TxQ1_test : public beast::unit_test::suite
         for (auto i = env.current()->seq(); i <= 257; ++i)
             env.close();
         // The ledger after the flag ledger creates all the
-        // fee (1) and amendment (upVotedAmendments().size())
+        // fee (1) and amendment (numUpVotedAmendments())
         // pseudotransactions. The queue treats the fees on these
         // transactions as though they are ordinary transactions.
-        auto const flagPerLedger =
-            1 + ripple::detail::upVotedAmendments().size();
+        auto const flagPerLedger = 1 + ripple::detail::numUpVotedAmendments();
         auto const flagMaxQueue = ledgersInQueue * flagPerLedger;
         checkMetrics(env, 0, flagMaxQueue, 0, flagPerLedger, 256);
 
@@ -4157,7 +4156,7 @@ public:
             if (!getMajorityAmendments(*env.closed()).empty())
                 break;
         }
-        auto expectedPerLedger = ripple::detail::upVotedAmendments().size() + 1;
+        auto expectedPerLedger = ripple::detail::numUpVotedAmendments() + 1;
         checkMetrics(env, 0, 5 * expectedPerLedger, 0, expectedPerLedger, 256);
 
         // Now wait 2 weeks modulo 256 ledgers for the amendments to be

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -139,9 +139,12 @@ class TxQ1_test : public beast::unit_test::suite
         // fee (1) and amendment (supportedAmendments().size())
         // pseudotransactions. The queue treats the fees on these
         // transactions as though they are ordinary transactions.
-        auto const flagPerLedger =
-            1 + ripple::detail::supportedAmendments().size();
+        auto const flagPerLedger = 1 +
+            ripple::detail::supportedAmendments().size() -
+            ripple::detail::downVotedAmendments().size();
         auto const flagMaxQueue = ledgersInQueue * flagPerLedger;
+        // If this check fails, check that all the entries in
+        // downVotedAmendments are also in supportedAmendments.
         checkMetrics(env, 0, flagMaxQueue, 0, flagPerLedger, 256);
 
         // Pad a couple of txs with normal fees so the median comes
@@ -4157,8 +4160,8 @@ public:
             if (!getMajorityAmendments(*env.closed()).empty())
                 break;
         }
-        auto expectedPerLedger =
-            ripple::detail::supportedAmendments().size() + 1;
+        auto expectedPerLedger = ripple::detail::supportedAmendments().size() -
+            ripple::detail::downVotedAmendments().size() + 1;
         checkMetrics(env, 0, 5 * expectedPerLedger, 0, expectedPerLedger, 256);
 
         // Now wait 2 weeks modulo 256 ledgers for the amendments to be

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -136,15 +136,12 @@ class TxQ1_test : public beast::unit_test::suite
         for (auto i = env.current()->seq(); i <= 257; ++i)
             env.close();
         // The ledger after the flag ledger creates all the
-        // fee (1) and amendment (supportedAmendments().size())
+        // fee (1) and amendment (upVotedAmendments().size())
         // pseudotransactions. The queue treats the fees on these
         // transactions as though they are ordinary transactions.
-        auto const flagPerLedger = 1 +
-            ripple::detail::supportedAmendments().size() -
-            ripple::detail::downVotedAmendments().size();
+        auto const flagPerLedger =
+            1 + ripple::detail::upVotedAmendments().size();
         auto const flagMaxQueue = ledgersInQueue * flagPerLedger;
-        // If this check fails, check that all the entries in
-        // downVotedAmendments are also in supportedAmendments.
         checkMetrics(env, 0, flagMaxQueue, 0, flagPerLedger, 256);
 
         // Pad a couple of txs with normal fees so the median comes
@@ -4160,8 +4157,7 @@ public:
             if (!getMajorityAmendments(*env.closed()).empty())
                 break;
         }
-        auto expectedPerLedger = ripple::detail::supportedAmendments().size() -
-            ripple::detail::downVotedAmendments().size() + 1;
+        auto expectedPerLedger = ripple::detail::upVotedAmendments().size() + 1;
         checkMetrics(env, 0, 5 * expectedPerLedger, 0, expectedPerLedger, 256);
 
         // Now wait 2 weeks modulo 256 ledgers for the amendments to be
@@ -4216,79 +4212,49 @@ public:
         // These particular amendments don't impact any of the queued
         // transactions, so we won't see any change in the transaction
         // outcomes.  But code coverage is affected.
-        env.close(closeDuration);
-        expectedInQueue -= expectedPerLedger + 2;
-        ++expectedPerLedger;
-        checkMetrics(
-            env,
-            expectedInQueue,
-            5 * expectedPerLedger,
-            expectedPerLedger + 1,
-            expectedPerLedger,
-            256);
+        do
         {
-            auto const expectedPerAccount = expectedInQueue / 6;
-            auto const expectedRemainder = expectedInQueue % 6;
-            BEAST_EXPECT(env.seq(alice) == seqAlice - expectedPerAccount);
-            BEAST_EXPECT(
-                env.seq(bob) ==
-                seqBob - expectedPerAccount - (expectedRemainder > 4 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(carol) ==
-                seqCarol - expectedPerAccount -
-                    (expectedRemainder > 3 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(daria) ==
-                seqDaria - expectedPerAccount -
-                    (expectedRemainder > 2 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(ellie) ==
-                seqEllie - expectedPerAccount -
-                    (expectedRemainder > 1 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(fiona) ==
-                seqFiona - expectedPerAccount -
-                    (expectedRemainder > 0 ? 1 : 0));
-        }
-
-        env.close(closeDuration);
-        auto expectedInLedger = expectedInQueue;
-        expectedInQueue =
-            (expectedInQueue > expectedPerLedger + 2
-                 ? expectedInQueue - (expectedPerLedger + 2)
-                 : 0);
-        ++expectedPerLedger;
-        checkMetrics(
-            env,
-            0,
-            5 * expectedPerLedger,
-            expectedInLedger,
-            expectedPerLedger,
-            256);
-        {
-            auto const expectedPerAccount = expectedInQueue / 6;
-            auto const expectedRemainder = expectedInQueue % 6;
-            BEAST_EXPECT(env.seq(alice) == seqAlice - expectedPerAccount);
-            BEAST_EXPECT(
-                env.seq(bob) ==
-                seqBob - expectedPerAccount - (expectedRemainder > 4 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(carol) ==
-                seqCarol - expectedPerAccount -
-                    (expectedRemainder > 3 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(daria) ==
-                seqDaria - expectedPerAccount -
-                    (expectedRemainder > 2 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(ellie) ==
-                seqEllie - expectedPerAccount -
-                    (expectedRemainder > 1 ? 1 : 0));
-            BEAST_EXPECT(
-                env.seq(fiona) ==
-                seqFiona - expectedPerAccount -
-                    (expectedRemainder > 0 ? 1 : 0));
-        }
+            env.close(closeDuration);
+            auto expectedInLedger = expectedInQueue;
+            expectedInQueue =
+                (expectedInQueue > expectedPerLedger + 2
+                     ? expectedInQueue - (expectedPerLedger + 2)
+                     : 0);
+            expectedInLedger -= expectedInQueue;
+            ++expectedPerLedger;
+            checkMetrics(
+                env,
+                expectedInQueue,
+                5 * expectedPerLedger,
+                expectedInLedger,
+                expectedPerLedger,
+                256);
+            {
+                auto const expectedPerAccount = expectedInQueue / 6;
+                auto const expectedRemainder = expectedInQueue % 6;
+                BEAST_EXPECT(env.seq(alice) == seqAlice - expectedPerAccount);
+                BEAST_EXPECT(
+                    env.seq(bob) ==
+                    seqBob - expectedPerAccount -
+                        (expectedRemainder > 4 ? 1 : 0));
+                BEAST_EXPECT(
+                    env.seq(carol) ==
+                    seqCarol - expectedPerAccount -
+                        (expectedRemainder > 3 ? 1 : 0));
+                BEAST_EXPECT(
+                    env.seq(daria) ==
+                    seqDaria - expectedPerAccount -
+                        (expectedRemainder > 2 ? 1 : 0));
+                BEAST_EXPECT(
+                    env.seq(ellie) ==
+                    seqEllie - expectedPerAccount -
+                        (expectedRemainder > 1 ? 1 : 0));
+                BEAST_EXPECT(
+                    env.seq(fiona) ==
+                    seqFiona - expectedPerAccount -
+                        (expectedRemainder > 0 ? 1 : 0));
+            }
+        } while (expectedInQueue > 0);
     }
 
     void

--- a/src/test/jtx/Env.h
+++ b/src/test/jtx/Env.h
@@ -73,8 +73,9 @@ supported_amendments()
         auto const& sa = ripple::detail::supportedAmendments();
         std::vector<uint256> feats;
         feats.reserve(sa.size());
-        for (auto const& s : sa)
+        for (auto const& [s, vote] : sa)
         {
+            (void)vote;
             if (auto const f = getRegisteredFeature(s))
                 feats.push_back(*f);
             else

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -812,6 +812,7 @@ public:
 
         auto const missingSomeFeatures =
             supported_amendments() - featureMultiSignReserve - featureFlow;
+        BEAST_EXPECT(missingSomeFeatures.count() == (supported.count() - 2));
         {
             // a Env supported_features_except is missing *only* those features
             Env env{*this, missingSomeFeatures};

--- a/src/test/rpc/Feature_test.cpp
+++ b/src/test/rpc/Feature_test.cpp
@@ -27,12 +27,56 @@ namespace ripple {
 class Feature_test : public beast::unit_test::suite
 {
     void
+    testDownVotesSupported()
+    {
+        testcase("internal vetoes are all supported");
+
+        auto const supported = ripple::detail::supportedAmendments();
+        auto const vetoed = ripple::detail::downVotedAmendments();
+
+        for (auto const& veto : vetoed)
+        {
+            BEAST_EXPECTS(
+                std::count(supported.begin(), supported.end(), veto) == 1,
+                veto);
+        }
+    }
+
+    void
+    testFeatureToName()
+    {
+        testcase("featureToName");
+
+        // Test all the supported features. In a perfect world, this would test
+        // FeatureCollections::featureNames, but that's private. Leave it that
+        // way.
+        auto const supported = ripple::detail::supportedAmendments();
+
+        for (auto const& feature : supported)
+        {
+            auto const registered = getRegisteredFeature(feature);
+            if (BEAST_EXPECT(registered))
+                BEAST_EXPECT(featureToName(*registered) == feature);
+        }
+
+        // Test an arbitrary unknown feature
+        uint256 zero{0};
+        BEAST_EXPECT(featureToName(zero) == to_string(zero));
+        BEAST_EXPECT(
+            featureToName(zero) ==
+            "0000000000000000000000000000000000000000000000000000000000000000");
+    }
+
+    void
     testNoParams()
     {
         testcase("No Params, None Enabled");
 
         using namespace test::jtx;
         Env env{*this};
+
+        std::vector<std::string> const& vetoed =
+            ripple::detail::downVotedAmendments();
 
         auto jrr = env.rpc("feature")[jss::result];
         if (!BEAST_EXPECT(jrr.isMember(jss::features)))
@@ -41,13 +85,16 @@ class Feature_test : public beast::unit_test::suite
         {
             if (!BEAST_EXPECT(feature.isMember(jss::name)))
                 return;
-            // default config - so all should be disabled, not vetoed, and
-            // supported
+            // default config - so all should be disabled, and
+            // supported. Some may be vetoed.
+            bool expectVeto =
+                std::count(vetoed.begin(), vetoed.end(), feature[jss::name]) >
+                0;
             BEAST_EXPECTS(
                 !feature[jss::enabled].asBool(),
                 feature[jss::name].asString() + " enabled");
             BEAST_EXPECTS(
-                !feature[jss::vetoed].asBool(),
+                feature[jss::vetoed].asBool() == expectVeto,
                 feature[jss::name].asString() + " vetoed");
             BEAST_EXPECTS(
                 feature[jss::supported].asBool(),
@@ -121,6 +168,9 @@ class Feature_test : public beast::unit_test::suite
         Env env{
             *this, FeatureBitset(featureDepositAuth, featureDepositPreauth)};
 
+        std::vector<std::string> const& vetoed =
+            ripple::detail::downVotedAmendments();
+
         auto jrr = env.rpc("feature")[jss::result];
         if (!BEAST_EXPECT(jrr.isMember(jss::features)))
             return;
@@ -135,11 +185,13 @@ class Feature_test : public beast::unit_test::suite
             bool expectEnabled = env.app().getAmendmentTable().isEnabled(id);
             bool expectSupported =
                 env.app().getAmendmentTable().isSupported(id);
+            bool expectVeto =
+                std::count(vetoed.begin(), vetoed.end(), (*it)[jss::name]) > 0;
             BEAST_EXPECTS(
                 (*it)[jss::enabled].asBool() == expectEnabled,
                 (*it)[jss::name].asString() + " enabled");
             BEAST_EXPECTS(
-                !(*it)[jss::vetoed].asBool(),
+                (*it)[jss::vetoed].asBool() == expectVeto,
                 (*it)[jss::name].asString() + " vetoed");
             BEAST_EXPECTS(
                 (*it)[jss::supported].asBool() == expectSupported,
@@ -198,6 +250,8 @@ class Feature_test : public beast::unit_test::suite
         // There should be at least 5 amendments.  Don't do exact comparison
         // to avoid maintenance as more amendments are added in the future.
         BEAST_EXPECT(majorities.size() >= 5);
+        std::vector<std::string> const& vetoed =
+            ripple::detail::downVotedAmendments();
 
         jrr = env.rpc("feature")[jss::result];
         if (!BEAST_EXPECT(jrr.isMember(jss::features)))
@@ -206,9 +260,16 @@ class Feature_test : public beast::unit_test::suite
         {
             if (!BEAST_EXPECT(feature.isMember(jss::name)))
                 return;
+            bool expectVeto =
+                std::count(vetoed.begin(), vetoed.end(), feature[jss::name]) >
+                0;
             BEAST_EXPECTS(
-                feature.isMember(jss::majority),
+                expectVeto ^ feature.isMember(jss::majority),
                 feature[jss::name].asString() + " majority");
+            BEAST_EXPECTS(
+                feature.isMember(jss::vetoed) &&
+                    feature[jss::vetoed].asBool() == expectVeto,
+                feature[jss::name].asString() + " vetoed");
             BEAST_EXPECTS(
                 feature.isMember(jss::count),
                 feature[jss::name].asString() + " count");
@@ -218,10 +279,10 @@ class Feature_test : public beast::unit_test::suite
             BEAST_EXPECTS(
                 feature.isMember(jss::validations),
                 feature[jss::name].asString() + " validations");
-            BEAST_EXPECT(feature[jss::count] == 1);
+            BEAST_EXPECT(feature[jss::count] == (expectVeto ? 0 : 1));
             BEAST_EXPECT(feature[jss::threshold] == 1);
             BEAST_EXPECT(feature[jss::validations] == 1);
-            BEAST_EXPECT(feature[jss::majority] == 2540);
+            BEAST_EXPECT(expectVeto || feature[jss::majority] == 2740);
         }
     }
 
@@ -273,6 +334,8 @@ public:
     void
     run() override
     {
+        testDownVotesSupported();
+        testFeatureToName();
         testNoParams();
         testSingleFeature();
         testInvalidFeature();

--- a/src/test/rpc/Feature_test.cpp
+++ b/src/test/rpc/Feature_test.cpp
@@ -56,7 +56,12 @@ class Feature_test : public beast::unit_test::suite
         {
             auto const registered = getRegisteredFeature(feature);
             if (BEAST_EXPECT(registered))
+            {
                 BEAST_EXPECT(featureToName(*registered) == feature);
+                BEAST_EXPECT(
+                    bitsetIndexToFeature(featureToBitsetIndex(*registered)) ==
+                    *registered);
+            }
         }
 
         // Test an arbitrary unknown feature
@@ -65,6 +70,16 @@ class Feature_test : public beast::unit_test::suite
         BEAST_EXPECT(
             featureToName(zero) ==
             "0000000000000000000000000000000000000000000000000000000000000000");
+
+        // Test a random sampling of the variables. If any of these get retired
+        // or removed, swap out for any other feature.
+        BEAST_EXPECT(featureToName(featureOwnerPaysFee) == "OwnerPaysFee");
+        BEAST_EXPECT(featureToName(featureFlow) == "Flow");
+        BEAST_EXPECT(featureToName(featureNegativeUNL) == "NegativeUNL");
+        BEAST_EXPECT(featureToName(fix1578) == "fix1578");
+        BEAST_EXPECT(
+            featureToName(fixTakerDryOfferRemoval) ==
+            "fixTakerDryOfferRemoval");
     }
 
     void
@@ -114,6 +129,9 @@ class Feature_test : public beast::unit_test::suite
         BEAST_EXPECTS(jrr[jss::status] == jss::success, "status");
         jrr.removeMember(jss::status);
         BEAST_EXPECT(jrr.size() == 1);
+        BEAST_EXPECT(
+            jrr.isMember("586480873651E106F1D6339B0C4A8945BA705A777F3F4524626FF"
+                         "1FC07EFE41D"));
         auto feature = *(jrr.begin());
 
         BEAST_EXPECTS(feature[jss::name] == "MultiSignReserve", "name");
@@ -282,7 +300,9 @@ class Feature_test : public beast::unit_test::suite
             BEAST_EXPECT(feature[jss::count] == (expectVeto ? 0 : 1));
             BEAST_EXPECT(feature[jss::threshold] == 1);
             BEAST_EXPECT(feature[jss::validations] == 1);
-            BEAST_EXPECT(expectVeto || feature[jss::majority] == 2740);
+            BEAST_EXPECTS(
+                expectVeto || feature[jss::majority] == 2540,
+                "Majority: " + feature[jss::majority].asString());
         }
     }
 

--- a/src/test/rpc/Feature_test.cpp
+++ b/src/test/rpc/Feature_test.cpp
@@ -27,22 +27,6 @@ namespace ripple {
 class Feature_test : public beast::unit_test::suite
 {
     void
-    testDownVotesSupported()
-    {
-        testcase("internal vetoes are all supported");
-
-        auto const supported = ripple::detail::supportedAmendments();
-        auto const vetoed = ripple::detail::downVotedAmendments();
-
-        for (auto const& veto : vetoed)
-        {
-            BEAST_EXPECTS(
-                std::count(supported.begin(), supported.end(), veto) == 1,
-                veto);
-        }
-    }
-
-    void
     testFeatureToName()
     {
         testcase("featureToName");
@@ -52,8 +36,9 @@ class Feature_test : public beast::unit_test::suite
         // way.
         auto const supported = ripple::detail::supportedAmendments();
 
-        for (auto const& feature : supported)
+        for (auto const& [feature, vote] : supported)
         {
+            (void)vote;
             auto const registered = getRegisteredFeature(feature);
             if (BEAST_EXPECT(registered))
             {
@@ -90,8 +75,8 @@ class Feature_test : public beast::unit_test::suite
         using namespace test::jtx;
         Env env{*this};
 
-        std::vector<std::string> const& vetoed =
-            ripple::detail::downVotedAmendments();
+        std::map<std::string, DefaultVote> const& votes =
+            ripple::detail::supportedAmendments();
 
         auto jrr = env.rpc("feature")[jss::result];
         if (!BEAST_EXPECT(jrr.isMember(jss::features)))
@@ -103,8 +88,7 @@ class Feature_test : public beast::unit_test::suite
             // default config - so all should be disabled, and
             // supported. Some may be vetoed.
             bool expectVeto =
-                std::count(vetoed.begin(), vetoed.end(), feature[jss::name]) >
-                0;
+                !(votes.at(feature[jss::name].asString()) == DefaultVote::yes);
             BEAST_EXPECTS(
                 !feature[jss::enabled].asBool(),
                 feature[jss::name].asString() + " enabled");
@@ -186,8 +170,8 @@ class Feature_test : public beast::unit_test::suite
         Env env{
             *this, FeatureBitset(featureDepositAuth, featureDepositPreauth)};
 
-        std::vector<std::string> const& vetoed =
-            ripple::detail::downVotedAmendments();
+        std::map<std::string, DefaultVote> const& votes =
+            ripple::detail::supportedAmendments();
 
         auto jrr = env.rpc("feature")[jss::result];
         if (!BEAST_EXPECT(jrr.isMember(jss::features)))
@@ -204,7 +188,7 @@ class Feature_test : public beast::unit_test::suite
             bool expectSupported =
                 env.app().getAmendmentTable().isSupported(id);
             bool expectVeto =
-                std::count(vetoed.begin(), vetoed.end(), (*it)[jss::name]) > 0;
+                !(votes.at((*it)[jss::name].asString()) == DefaultVote::yes);
             BEAST_EXPECTS(
                 (*it)[jss::enabled].asBool() == expectEnabled,
                 (*it)[jss::name].asString() + " enabled");
@@ -268,8 +252,8 @@ class Feature_test : public beast::unit_test::suite
         // There should be at least 5 amendments.  Don't do exact comparison
         // to avoid maintenance as more amendments are added in the future.
         BEAST_EXPECT(majorities.size() >= 5);
-        std::vector<std::string> const& vetoed =
-            ripple::detail::downVotedAmendments();
+        std::map<std::string, DefaultVote> const& votes =
+            ripple::detail::supportedAmendments();
 
         jrr = env.rpc("feature")[jss::result];
         if (!BEAST_EXPECT(jrr.isMember(jss::features)))
@@ -279,8 +263,7 @@ class Feature_test : public beast::unit_test::suite
             if (!BEAST_EXPECT(feature.isMember(jss::name)))
                 return;
             bool expectVeto =
-                std::count(vetoed.begin(), vetoed.end(), feature[jss::name]) >
-                0;
+                !(votes.at(feature[jss::name].asString()) == DefaultVote::yes);
             BEAST_EXPECTS(
                 expectVeto ^ feature.isMember(jss::majority),
                 feature[jss::name].asString() + " majority");
@@ -354,7 +337,6 @@ public:
     void
     run() override
     {
-        testDownVotesSupported();
         testFeatureToName();
         testNoParams();
         testSingleFeature();


### PR DESCRIPTION
## High Level Overview of Change

This is a follow-up / second attempt to https://github.com/ripple/rippled/pull/3458 at changing default voting amendment behavior. It's more comprehensive, and simplifies the process quite a bit, but it is *not* intended to be the definitive answer to the question of how to manage amendment voting on the network.

It is organized into three commits. Each of the commits should build, but I don't guarantee that they'll pass unit tests. I think it makes more sense to review the changes as a single unit, but they're split up in case there are questions of how something evolved, or if the reviewers absolutely *hate* some subset of the changes.
* The first contains the changes from the older PR (accounting for code drift). Adds yet another list of amendments that should not be voted for by default.
* The second refactors "feature" creation code to centralize the naming, specifying whether it's supported, and providing the default voting behavior in one place.
* The third reorganizes the feature access functions so that supported amendments are always provided with their default votes.

As stated above, the scope of this change is intentionally relatively small. It does not address some of the advanced and controversial questions of amendment voting behavior including, but not limited to:
* Vote proxies
* Abstaining from all voting
* Requiring all amendments to be voted on before starting
* Reducing the voting period
* Adding a "no" voting option. (Current options are "yes" and "abstain".)

### Context of Change

There are two significant problems related to amendment management.
1. All validators will vote for any amendment that is supported (added to the `supportedAmendments` list) by default. This makes it impossible to have multiple versions of the software support a feature without voting for it, without manual intervention from validator operators.
2. It's annoying and error-prone to create a new amendment. The name currently has to be copied in at least three different places.

These changes resolve those issues (and only those issues) by
1. Moving the creation of amendments to one place which specifies the name, whether it's supported, and whether rippled will vote for it by default.
2. Improving instructions and adding runtime validity checks. Developers not familiar with the process should have a much easier time creating and managing the settings for amendments.
3. Allowing an amendment to be supported without being voted for by default by all upgraded validators. This will allow completed features to be released and supported for one or more release cycles before they are voted on by default. Operators will still have full control over voting for or against amendments on their own nodes. If UNL validators wait for more than one release before voting for an amendment (either explicitly or by default), then the "amendment blocked" gating can be significantly reduced.

### Type of Change

- [X ] New feature (non-breaking change which adds functionality)
- [X ] Refactor (non-breaking change that only restructures code)
- [X ] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

### Before

To create an amendment, the name has to be specified (as a string) in two places:
* In Feature.h, the `featureNames` list
* In Feature.cpp a call to `getRegisteredFeature` to define and initialize a `unit256` variable.

Additionally, a variable need to be declared (at least if you want to use it anywhere else in the code):
* In Feature.h an `extern uint256 const` variable declaration

Later, when a feature is development complete, and ready to support, the name also needs to be added (as a string) to
* In Feature.cpp, the `supportedAmendments()` list

There is no way to add an amendment to `supportedAmendments()` and not vote for it without operator intervention.

### After

To create an amendment, the name has to be specified in one place:
* In Feature.cpp a call to `registeredFeature` to define and initialize a `unit256` variable.

Additionally, the `numFeatures` counter must be incremented. However, if this step is skipped, an assert on startup will catch it and remind the developer (reducing potential errors).

The variable still needs to be declared:
* In Feature.h an `extern uint256 const` variable declaration

Later, when a feature is development complete, and ready to support, the existing call to `registerFeature` only needs to have one of it's parameters modified. Another parameter to `registerFeature` specifies the default voting behavior for supported amendments: yes or abstain.

## Test Plan

The "CryptoConditionsSuite" is listed as supported, and has not yet been enabled on the Mainnet, but is "not ready for prime time". However, it cannot be removed, because it could be enabled at any time, and removing it would cause all future versions to be amendment blocked, and cause other problems. Any current node that has not explicitly vetoed it will vote for it. These votes can be captured and verified on any network (main or test) that hasn't enabled it yet.

The updated registration for this amendment specifies it as `Supported::yes, DefaultVote::abstain`, which means it's still supported, but will not be voted for without explicit operator action. Votes captured from updated nodes on any network where it's not enabled will show that amendment _not_ being voted for.
