### PR TITLE
Patch soci only once

### DIFF
--- a/Builds/CMake/soci_patch.cmake
+++ b/Builds/CMake/soci_patch.cmake
@@ -1,15 +1,17 @@
 # This patches unsigned-types.h in the soci official sources
 # so as to remove type range check exceptions that cause
 # us trouble when using boost::optional to select int values
-file (STRINGS include/soci/unsigned-types.h sourcecode)
-foreach (line_ ${sourcecode})
-  if (line_ MATCHES "^[ \\t]+throw[ ]+soci_error[ ]*\\([ ]*\"Value outside of allowed.+$")
-    set (line_ "//${CMAKE_MATCH_0}")
-  endif ()
-  file (APPEND include/soci/unsigned-types.h.patched "${line_}\n")
-endforeach ()
-file (RENAME include/soci/unsigned-types.h include/soci/unsigned-types.h.orig)
-file (RENAME include/soci/unsigned-types.h.patched include/soci/unsigned-types.h)
+if(NOT EXISTS "include/soci/unsigned-types.h.orig")
+  file (STRINGS include/soci/unsigned-types.h sourcecode)
+  foreach (line_ ${sourcecode})
+    if (line_ MATCHES "^[ \\t]+throw[ ]+soci_error[ ]*\\([ ]*\"Value outside of allowed.+$")
+      set (line_ "//${CMAKE_MATCH_0}")
+    endif ()
+    file (APPEND include/soci/unsigned-types.h.patched "${line_}\n")
+  endforeach ()
+  file (RENAME include/soci/unsigned-types.h include/soci/unsigned-types.h.orig)
+  file (RENAME include/soci/unsigned-types.h.patched include/soci/unsigned-types.h)
+endif()
 # also fix Boost.cmake so that it just returns when we override the Boost_FOUND var
 file (APPEND cmake/dependencies/Boost.cmake.patched "if (Boost_FOUND)\n")
 file (APPEND cmake/dependencies/Boost.cmake.patched "  return ()\n")


### PR DESCRIPTION
Fixes https://github.com/ripple/rippled/issues/3885

## High Level Overview of Change

This prevents `soci` getting patched more than once over the course of multiple builds within the same CMake build environment.

### Context of Change

The various `unity_*_cxx.cxx.o` kept getting built anew after they've been built already.
The reason for this is that each time the `make` command is issued, `soci` is patched anew. Because `soci` is a dependency of the `unity_*_cxx.cxx.o` files, the build system then reasons that the `unity_*_cxx.cxx.o` files must be built anew because `soci` has a more recent timestamp.

Patching `soci` only needs to be done once; from that point on it can be reused any number of times.

This PR makes a change to the script responsible for patching, and only proceeds to patch if it finds that there is no back-up of original (unpatched) `soci`. If a back-up already exists, this indicates that `soci` has already been patched, and the patch procedure is skipped.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)