### PR TITLE
Update broken Boost URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
     - NIH_CACHE_ROOT=${CACHE_DIR}/nih_c
     - PARALLEL_TESTS=true
     # this is NOT used by linux container based builds (which already have boost installed)
-    - BOOST_URL='https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2'
+    - BOOST_URL='https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.gz'
     # Alternate dowload location
     - BOOST_URL2='https://downloads.sourceforge.net/project/boost/boost/1.70.0/boost_1_70_0.tar.bz2?r=&amp;ts=1594393912&amp;use_mirror=newcontinuum'
     # Travis downloader doesn't seem to have updated certs. Using this option
@@ -439,4 +439,3 @@ cache:
 
 notifications:
   email: false
-

--- a/Builds/containers/shared/build_deps.sh
+++ b/Builds/containers/shared/build_deps.sh
@@ -9,7 +9,7 @@ function build_boost()
     mkdir -p /opt/local
     cd /opt/local
     BOOST_ROOT=/opt/local/boost_${boost_path}
-    BOOST_URL="https://dl.bintray.com/boostorg/release/${boost_ver}/source/boost_${boost_path}.tar.bz2"
+    BOOST_URL="https://boostorg.jfrog.io/artifactory/main/release/${boost_ver}/source/boost_${boost_path}.tar.gz"
     BOOST_BUILD_ALL=true
     . /tmp/install_boost.sh
     if [ "$do_link" = true ] ; then
@@ -145,4 +145,3 @@ if [ "${CI_USE}" = true ] ; then
     pip install requests
     pip install https://github.com/codecov/codecov-python/archive/master.zip
 fi
-

--- a/Builds/linux/README.md
+++ b/Builds/linux/README.md
@@ -36,9 +36,8 @@ protobuf will give errors.
 Boost 1.70 or later is required. We recommend downloading and compiling boost
 with the following process: After changing to the directory where
 you wish to download and compile boost, run
-
 ``` 
-$ wget https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.gz
+$ wget https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.gz
 $ tar -xzf boost_1_70_0.tar.gz
 $ cd boost_1_70_0
 $ ./bootstrap.sh
@@ -240,5 +239,3 @@ change the `/opt/local` module path above to match your chosen installation pref
 `rippled` builds a set of unit tests into the server executable. To run these unit
 tests after building, pass the `--unittest` option to the compiled `rippled`
 executable. The executable will exit with summary info after running the unit tests.
-
-

--- a/Builds/macos/README.md
+++ b/Builds/macos/README.md
@@ -64,7 +64,7 @@ Boost 1.70 or later is required.
 
 We want to compile boost with clang/libc++
 
-Download [a release](https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2)
+Download [a release](https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.gz)
 
 Extract it to a folder, making note of where, open a terminal, then:
 
@@ -227,5 +227,3 @@ Several other infrequently used options are available - run `ccmake` or
 `rippled` builds a set of unit tests into the server executable. To run these unit
 tests after building, pass the `--unittest` option to the compiled `rippled`
 executable. The executable will exit with summary info after running the unit tests.
-
-


### PR DESCRIPTION
## High Level Overview of Change

Update broken Boost URLs

### Context of Change

JFrog has sunset bintray. This updates the URLs to where JFrog is now hosting Boost.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release
