### PR TITLE
Minor cleanups in offer processing code

### DIFF
--- a/src/ripple/app/ledger/OpenLedger.h
+++ b/src/ripple/app/ledger/OpenLedger.h
@@ -222,8 +222,7 @@ OpenLedger::apply(
     {
         try
         {
-            // Dereferencing the iterator can
-            // throw since it may be transformed.
+            // Dereferencing the iterator can throw since it may be transformed.
             auto const tx = *iter;
             auto const txId = tx->getTransactionID();
             if (check.txExists(txId))
@@ -233,9 +232,10 @@ OpenLedger::apply(
             if (result == Result::retry)
                 retries.insert(tx);
         }
-        catch (std::exception const&)
+        catch (std::exception const& e)
         {
-            JLOG(j.error()) << "Caught exception";
+            JLOG(j.error())
+                << "OpenLedger::apply: Caught exception: " << e.what();
         }
     }
     bool retry = true;

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -638,11 +638,11 @@ LedgerMaster::getValidatedRange(std::uint32_t& minVal, std::uint32_t& maxVal)
             }
             return true;
         }
-        catch (std::exception&)
+        catch (std::exception const& e)
         {
-            JLOG(m_journal.error())
-                << __func__ << " : "
-                << "Error parsing result of getCompleteLedgers()";
+            JLOG(m_journal.error()) << "LedgerMaster::getValidatedRange: "
+                                       "exception parsing complete ledgers: "
+                                    << e.what();
             return false;
         }
     }

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -351,7 +351,6 @@ foreachFeature(FeatureBitset bs, F&& f)
 
 extern uint256 const featureOwnerPaysFee;
 extern uint256 const featureFlow;
-extern uint256 const featureCompareTakerFlowCross;
 extern uint256 const featureFlowCross;
 extern uint256 const featureCryptoConditionsSuite;
 extern uint256 const fix1513;

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -166,7 +166,6 @@ bitsetIndexToFeature(size_t i)
 uint256 const
     featureOwnerPaysFee             = *getRegisteredFeature("OwnerPaysFee"),
     featureFlow                     = *getRegisteredFeature("Flow"),
-    featureCompareTakerFlowCross    = *getRegisteredFeature("CompareTakerFlowCross"),
     featureFlowCross                = *getRegisteredFeature("FlowCross"),
     featureCryptoConditionsSuite    = *getRegisteredFeature("CryptoConditionsSuite"),
     fix1513                         = *getRegisteredFeature("fix1513"),


### PR DESCRIPTION
Remove the comparison code between the newer `Flow` and older `Taker` code, as well as the feature that can be used to enable or disable the comparison at runtime.

Also, adjust some log levels to reduce the possibility of confusion when examining logs.