### PR TITLE
check protobuf field size before calling uint256::fromVoid

### DIFF
--- a/src/ripple/app/reporting/ETLSource.cpp
+++ b/src/ripple/app/reporting/ETLSource.cpp
@@ -495,6 +495,9 @@ public:
 
         for (auto& obj : cur_->ledger_objects().objects())
         {
+            if (obj.key().size() != uint256::size())
+                throw std::runtime_error("Received malformed object ID");
+
             auto key = uint256::fromVoid(obj.key().data());
             auto& data = obj.data();
 

--- a/src/ripple/app/reporting/ETLSource.cpp
+++ b/src/ripple/app/reporting/ETLSource.cpp
@@ -495,14 +495,14 @@ public:
 
         for (auto& obj : cur_->ledger_objects().objects())
         {
-            if (obj.key().size() != uint256::size())
+            auto key = uint256::fromVoidChecked(obj.key());
+            if (!key)
                 throw std::runtime_error("Received malformed object ID");
 
-            auto key = uint256::fromVoid(obj.key().data());
             auto& data = obj.data();
 
             SerialIter it{data.data(), data.size()};
-            std::shared_ptr<SLE> sle = std::make_shared<SLE>(it, key);
+            std::shared_ptr<SLE> sle = std::make_shared<SLE>(it, *key);
 
             queue.push(sle);
         }

--- a/src/ripple/app/reporting/ReportingETL.cpp
+++ b/src/ripple/app/reporting/ReportingETL.cpp
@@ -405,6 +405,9 @@ ReportingETL::buildNextLedger(
 
     for (auto& obj : rawData.ledger_objects().objects())
     {
+        if (obj.key().size() != uint256::size())
+            throw std::runtime_error("Recevied malformed object ID");
+
         auto key = uint256::fromVoid(obj.key().data());
         auto& data = obj.data();
 

--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -313,6 +313,15 @@ public:
         return base_uint(data, VoidHelper());
     }
 
+    template <class T>
+    static std::optional<base_uint>
+    fromVoidChecked(T const& from)
+    {
+        if (from.size() != size())
+            return {};
+        return fromVoid(from.data());
+    }
+
     constexpr int
     signum() const
     {

--- a/src/ripple/rpc/handlers/AccountTx.cpp
+++ b/src/ripple/rpc/handlers/AccountTx.cpp
@@ -97,14 +97,17 @@ parseLedgerArgs(
         }
         else if (ledgerCase == LedgerCase::kHash)
         {
-            if (uint256::size() != specifier.hash().size())
+            if (auto hash = uint256::fromVoidChecked(specifier.hash()))
+            {
+                ledger = *hash;
+            }
+            else
             {
                 grpc::Status errorStatus{
                     grpc::StatusCode::INVALID_ARGUMENT,
                     "ledger hash malformed"};
                 return errorStatus;
             }
-            ledger = uint256::fromVoid(specifier.hash().data());
         }
         return ledger;
     }

--- a/src/ripple/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/rpc/handlers/LedgerEntry.cpp
@@ -377,21 +377,30 @@ doLedgerEntryGrpc(
     grpc::Status status = grpc::Status::OK;
 
     std::shared_ptr<ReadView const> ledger;
-    if (RPC::ledgerFromRequest(ledger, context))
+    if (auto status = RPC::ledgerFromRequest(ledger, context))
     {
-        grpc::Status errorStatus{
-            grpc::StatusCode::NOT_FOUND, "ledger not found"};
+        grpc::Status errorStatus;
+        if (status.toErrorCode() == rpcINVALID_PARAMS)
+        {
+            errorStatus = grpc::Status(
+                grpc::StatusCode::INVALID_ARGUMENT, status.message());
+        }
+        else
+        {
+            errorStatus =
+                grpc::Status(grpc::StatusCode::NOT_FOUND, status.message());
+        }
         return {response, errorStatus};
     }
 
     std::string const& keyBytes = request.key();
-    auto key = uint256::fromVoid(keyBytes.data());
-    if (keyBytes.size() != key.size())
+    if (keyBytes.size() != uint256::size())
     {
         grpc::Status errorStatus{
             grpc::StatusCode::INVALID_ARGUMENT, "index malformed"};
         return {response, errorStatus};
     }
+    auto key = uint256::fromVoid(keyBytes.data());
 
     auto const sleNode = ledger->read(keylet::unchecked(key));
     if (!sleNode)

--- a/src/ripple/rpc/handlers/LedgerEntry.cpp
+++ b/src/ripple/rpc/handlers/LedgerEntry.cpp
@@ -393,16 +393,15 @@ doLedgerEntryGrpc(
         return {response, errorStatus};
     }
 
-    std::string const& keyBytes = request.key();
-    if (keyBytes.size() != uint256::size())
+    auto key = uint256::fromVoidChecked(request.key());
+    if (!key)
     {
         grpc::Status errorStatus{
             grpc::StatusCode::INVALID_ARGUMENT, "index malformed"};
         return {response, errorStatus};
     }
-    auto key = uint256::fromVoid(keyBytes.data());
 
-    auto const sleNode = ledger->read(keylet::unchecked(key));
+    auto const sleNode = ledger->read(keylet::unchecked(*key));
     if (!sleNode)
     {
         grpc::Status errorStatus{

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -457,13 +457,13 @@ doTxGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetTransactionRequest>& context)
     TxArgs args;
 
     std::string const& hashBytes = request.hash();
-    args.hash = uint256::fromVoid(hashBytes.data());
-    if (args.hash.size() != hashBytes.size())
+    if (hashBytes.size() != uint256::size())
     {
         grpc::Status errorStatus{
-            grpc::StatusCode::INVALID_ARGUMENT, "ledger hash malformed"};
+            grpc::StatusCode::INVALID_ARGUMENT, "tx hash malformed"};
         return {response, errorStatus};
     }
+    args.hash = uint256::fromVoid(hashBytes.data());
 
     args.binary = request.binary();
 

--- a/src/ripple/rpc/handlers/Tx.cpp
+++ b/src/ripple/rpc/handlers/Tx.cpp
@@ -456,14 +456,16 @@ doTxGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetTransactionRequest>& context)
 
     TxArgs args;
 
-    std::string const& hashBytes = request.hash();
-    if (hashBytes.size() != uint256::size())
+    if (auto hash = uint256::fromVoidChecked(request.hash()))
+    {
+        args.hash = *hash;
+    }
+    else
     {
         grpc::Status errorStatus{
             grpc::StatusCode::INVALID_ARGUMENT, "tx hash malformed"};
         return {response, errorStatus};
     }
-    args.hash = uint256::fromVoid(hashBytes.data());
 
     args.binary = request.binary();
 

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -294,12 +294,11 @@ ledgerFromSpecifier(
     switch (ledgerCase)
     {
         case LedgerCase::kHash: {
-            if (specifier.hash().size() != uint256::size())
+            if (auto hash = uint256::fromVoidChecked(specifier.hash()))
             {
-                return {rpcINVALID_PARAMS, "ledgerHashMalformed"};
+                return getLedger(ledger, *hash, context);
             }
-            uint256 ledgerHash = uint256::fromVoid(specifier.hash().data());
-            return getLedger(ledger, ledgerHash, context);
+            return {rpcINVALID_PARAMS, "ledgerHashMalformed"};
         }
         case LedgerCase::kSequence:
             return getLedger(ledger, specifier.sequence(), context);

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -294,6 +294,10 @@ ledgerFromSpecifier(
     switch (ledgerCase)
     {
         case LedgerCase::kHash: {
+            if (specifier.hash().size() != uint256::size())
+            {
+                return {rpcINVALID_PARAMS, "ledgerHashMalformed"};
+            }
             uint256 ledgerHash = uint256::fromVoid(specifier.hash().data());
             return getLedger(ledger, ledgerHash, context);
         }

--- a/src/test/rpc/ReportingETL_test.cpp
+++ b/src/test/rpc/ReportingETL_test.cpp
@@ -419,6 +419,14 @@ class ReportingETL_test : public beast::unit_test::suite
             }
         }
 
+        {
+            auto [status, reply] =
+                grpcLedgerData(env.closed()->seq(), "bad marker");
+            BEAST_EXPECT(!status.ok());
+            BEAST_EXPECT(
+                status.error_code() == grpc::StatusCode::INVALID_ARGUMENT);
+        }
+
         num_accounts = 3000;
 
         for (auto i = 0; i < num_accounts; i++)


### PR DESCRIPTION
## High Level Overview of Change

There were numerous places in the code where we were calling `uint256::fromVoid()` to convert a protobuf byte array to a `uint256` without first checking the size of the byte array. If the byte array is less than 32 bytes, `fromVoid()` will read past the end of the array, which is undefined behavior. This PR changes the code to check the size of the byte array before calling `fromVoid()`, and returns an appropriate error if the byte array is malformed.

### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

