### PR TITLE
Fix potential deadlock in Validator sites:

### DIFF
--- a/src/ripple/app/misc/ValidatorSite.h
+++ b/src/ripple/app/misc/ValidatorSite.h
@@ -117,7 +117,7 @@ private:
     Application& app_;
     beast::Journal const j_;
 
-    // If both mutex are to be locked at the same time, `sites_mutes_` must be
+    // If both mutex are to be locked at the same time, `sites_mutex_` must be
     // locked before `state_mutex_` or we may deadlock.
     std::mutex mutable sites_mutex_;
     std::mutex mutable state_mutex_;

--- a/src/ripple/app/misc/ValidatorSite.h
+++ b/src/ripple/app/misc/ValidatorSite.h
@@ -117,6 +117,8 @@ private:
     Application& app_;
     beast::Journal const j_;
 
+    // If both mutex are to be locked at the same time, `sites_mutes_` must be
+    // locked before `state_mutex_` or we may deadlock.
     std::mutex mutable sites_mutex_;
     std::mutex mutable state_mutex_;
 
@@ -201,9 +203,11 @@ private:
         std::lock_guard<std::mutex> const&);
 
     /// Queue next site to be fetched
-    /// lock over state_mutex_ required
+    /// lock over site_mutex_ and state_mutex_ required
     void
-    setTimer(std::lock_guard<std::mutex> const&);
+    setTimer(
+        std::lock_guard<std::mutex> const&,
+        std::lock_guard<std::mutex> const&);
 
     /// request took too long
     void


### PR DESCRIPTION
## High Level Overview of Change

There are two mutexes in ValidatorSite: `site_mutex_` and `state_mutex_`. Some
function end up locking both mutexes. However, depending on the call, the
mutexes could be locked in different orders, resulting in deadlocks.

If both mutexes are locked, this patch always locks the `sites_mutex_` first.

### Type of Change

- [x ] Bug fix (non-breaking change which fixes an issue)
