### PR TITLE
[TRIVIAL] Remove the `ltINVALID` ledger entry type

### DIFF
--- a/src/ripple/app/ledger/LedgerToJson.h
+++ b/src/ripple/app/ledger/LedgerToJson.h
@@ -37,7 +37,7 @@ struct LedgerFill
         RPC::Context* ctx,
         int o = 0,
         std::vector<TxQ::TxDetails> q = {},
-        LedgerEntryType t = ltINVALID)
+        LedgerEntryType t = ltANY)
         : ledger(l), options(o), txQueue(std::move(q)), type(t), context(ctx)
     {
     }

--- a/src/ripple/app/ledger/impl/LedgerToJson.cpp
+++ b/src/ripple/app/ledger/impl/LedgerToJson.cpp
@@ -209,7 +209,7 @@ fillJsonState(Object& json, LedgerFill const& fill)
 
     for (auto const& sle : ledger.sles)
     {
-        if (fill.type == ltINVALID || sle->getType() == fill.type)
+        if (fill.type == ltANY || sle->getType() == fill.type)
         {
             if (binary)
             {

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -213,8 +213,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
     {
         // Make sure any directory node types that we find are the kind
         // we can delete.
-        Keylet const itemKeylet{ltCHILD, dirEntry};
-        auto sleItem = ctx.view.read(itemKeylet);
+        auto sleItem = ctx.view.read(keylet::child(dirEntry));
         if (!sleItem)
         {
             // Directory node has an invalid index.  Bail out.
@@ -267,8 +266,7 @@ DeleteAccount::doApply()
         do
         {
             // Choose the right way to delete each directory node.
-            Keylet const itemKeylet{ltCHILD, dirEntry};
-            auto sleItem = view().peek(itemKeylet);
+            auto sleItem = view().peek(keylet::child(dirEntry));
             if (!sleItem)
             {
                 // Directory node has an invalid index.  Bail out.

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -38,15 +38,13 @@ enum LedgerEntryType {
         This is used when the type in the Keylet is unknown,
         such as when building metadata.
     */
-    ltANY = -3,
+    ltANY = -2,
 
     /** Special type, anything not a directory
         This is used when the type in the Keylet is unknown,
         such as when iterating
     */
-    ltCHILD = -2,
-
-    ltINVALID = -1,
+    ltCHILD = -1,
 
     //---------------------------------------------------------------------------
 

--- a/src/ripple/protocol/impl/Keylet.cpp
+++ b/src/ripple/protocol/impl/Keylet.cpp
@@ -27,8 +27,6 @@ Keylet::check(SLE const& sle) const
 {
     if (type == ltANY)
         return true;
-    if (type == ltINVALID)
-        return false;
     if (type == ltCHILD)
     {
         assert(sle.getType() != ltDIR_NODE);

--- a/src/ripple/rpc/handlers/AccountObjects.cpp
+++ b/src/ripple/rpc/handlers/AccountObjects.cpp
@@ -111,7 +111,7 @@ doAccountObjects(RPC::JsonContext& context)
             rpcStatus.inject(result);
             return result;
         }
-        else if (type != ltINVALID)
+        else if (type != ltANY)
         {
             typeFilter = std::vector<LedgerEntryType>({type});
         }

--- a/src/ripple/rpc/handlers/LedgerData.cpp
+++ b/src/ripple/rpc/handlers/LedgerData.cpp
@@ -108,7 +108,7 @@ doLedgerData(RPC::JsonContext& context)
             break;
         }
 
-        if (type == ltINVALID || sle->getType() == type)
+        if (type == ltANY || sle->getType() == type)
         {
             if (isBinary)
             {

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -836,7 +836,7 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
 std::pair<RPC::Status, LedgerEntryType>
 chooseLedgerEntryType(Json::Value const& params)
 {
-    std::pair<RPC::Status, LedgerEntryType> result{RPC::Status::OK, ltINVALID};
+    std::pair<RPC::Status, LedgerEntryType> result{RPC::Status::OK, ltANY};
     if (params.isMember(jss::type))
     {
         static constexpr std::array<std::pair<char const*, LedgerEntryType>, 13>


### PR DESCRIPTION
The `ltINVALID` ledger type doesn't really have a raison d'être anymore. In the few places where it's used, `ltANY` seems like a better match. So remove it and simplify the codebase by a smidge.