### PR TITLE
Fix cmake soci patch (duplicate)

### DIFF
--- a/Builds/CMake/deps/Rocksdb.cmake
+++ b/Builds/CMake/deps/Rocksdb.cmake
@@ -63,7 +63,7 @@ if (local_rocksdb)
     GIT_TAG v6.7.3
     PATCH_COMMAND
       # only used by windows build
-      ${CMAKE_COMMAND} -E copy
+      ${CMAKE_COMMAND} -E copy_if_different
       ${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake/rocks_thirdparty.inc
       <SOURCE_DIR>/thirdparty.inc
     COMMAND

--- a/Builds/CMake/soci_patch.cmake
+++ b/Builds/CMake/soci_patch.cmake
@@ -1,13 +1,30 @@
 # This patches unsigned-types.h in the soci official sources
 # so as to remove type range check exceptions that cause
 # us trouble when using boost::optional to select int values
+
+# Some versions of CMake erroneously patch external projects on every build.
+# If the patch makes no changes, skip it. This workaround can be
+# removed once we stop supporting vulnerable versions of CMake.
+# https://gitlab.kitware.com/cmake/cmake/-/issues/21086
 file (STRINGS include/soci/unsigned-types.h sourcecode)
+# Delete the .patched file if it exists, so it doesn't end up duplicated.
+# Trying to remove a file that does not exist is not a problem.
+file (REMOVE include/soci/unsigned-types.h.patched)
 foreach (line_ ${sourcecode})
   if (line_ MATCHES "^[ \\t]+throw[ ]+soci_error[ ]*\\([ ]*\"Value outside of allowed.+$")
     set (line_ "//${CMAKE_MATCH_0}")
   endif ()
   file (APPEND include/soci/unsigned-types.h.patched "${line_}\n")
 endforeach ()
+execute_process( COMMAND ${CMAKE_COMMAND} -E compare_files
+                 include/soci/unsigned-types.h include/soci/unsigned-types.h.patched
+                 RESULT_VARIABLE compare_result
+)
+if( compare_result EQUAL 0)
+  message(DEBUG "The soci source and patch files are identical. Make no changes.")
+  file (REMOVE include/soci/unsigned-types.h.patched)
+  return()
+endif()
 file (RENAME include/soci/unsigned-types.h include/soci/unsigned-types.h.orig)
 file (RENAME include/soci/unsigned-types.h.patched include/soci/unsigned-types.h)
 # also fix Boost.cmake so that it just returns when we override the Boost_FOUND var


### PR DESCRIPTION
## High Level Overview of Change

This is a copy of https://github.com/ripple/rippled/pull/3886 with some changes suggested in review, but that @guidovranken has not yet addressed. When merging *do not* squash their commit so that their work can be acknowledged.

*Original from #3886*
This prevents `soci` getting patched more than once over the course of multiple builds within the same CMake build environment.

### Context of Change

*Original from #3886*
The various `unity_*_cxx.cxx.o` kept getting built anew after they've been built already.
The reason for this is that each time the `make` command is issued, `soci` is patched anew. Because `soci` is a dependency of the `unity_*_cxx.cxx.o` files, the build system then reasons that the `unity_*_cxx.cxx.o` files must be built anew because `soci` has a more recent timestamp.

Patching `soci` only needs to be done once; from that point on it can be reused any number of times.

This PR makes a change to the script responsible for patching, and only proceeds to patch if it finds that there is no back-up of original (unpatched) `soci`. If a back-up already exists, this indicates that `soci` has already been patched, and the patch procedure is skipped.

*Update:*
This PR makes a change to the script responsible for patching. It patches the file, then compares the patched file to the original. If they are identical, it deletes the patched file and exits. If not, it backs up the original, then replaces it with the patch.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before: Repeated builds in the same CMake environment with no changes will unnecessarily build many of the files. In unity builds, they will be `unity_*_.cxx`. In non-unity builds, they will be individual source files.

After: Repeated builds in the same CMake environment does not build any source, allowing the build to take far less time. On my workstation, time for various build configs was reduced from a range of 11s - 42s to a range of 2s - 7s. Unfortunately, CMake still has some overhead dealing with external projects and such, which accounts for some of the remaining time.

## Future Tasks

Find any other unnecessary file replacements and fix those.