### PR TITLE
Eliminate code duplication and improve documentation:

### DIFF
--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -3410,13 +3410,7 @@ NetworkOPsImp::getBookPage(
                 uTipIndex = sleOfferDir->key();
                 saDirRate = amountFromQuality(getQuality(uTipIndex));
 
-                cdirFirst(
-                    view,
-                    uTipIndex,
-                    sleOfferDir,
-                    uBookEntry,
-                    offerIndex,
-                    viewJ);
+                cdirFirst(view, uTipIndex, sleOfferDir, uBookEntry, offerIndex);
 
                 JLOG(m_journal.trace())
                     << "getBookPage:   uTipIndex=" << uTipIndex;
@@ -3536,13 +3530,7 @@ NetworkOPsImp::getBookPage(
                 JLOG(m_journal.warn()) << "Missing offer";
             }
 
-            if (!cdirNext(
-                    view,
-                    uTipIndex,
-                    sleOfferDir,
-                    uBookEntry,
-                    offerIndex,
-                    viewJ))
+            if (!cdirNext(view, uTipIndex, sleOfferDir, uBookEntry, offerIndex))
             {
                 bDirectAdvance = true;
             }

--- a/src/ripple/app/tx/impl/BookTip.cpp
+++ b/src/ripple/app/tx/impl/BookTip.cpp
@@ -55,7 +55,7 @@ BookTip::step(beast::Journal j)
         unsigned int di = 0;
         std::shared_ptr<SLE> dir;
 
-        if (dirFirst(view_, *first_page, dir, di, m_index, j))
+        if (dirFirst(view_, *first_page, dir, di, m_index))
         {
             m_dir = dir->key();
             m_entry = view_.peek(keylet::offer(m_index));

--- a/src/ripple/app/tx/impl/DeleteAccount.cpp
+++ b/src/ripple/app/tx/impl/DeleteAccount.cpp
@@ -198,12 +198,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
     uint256 dirEntry{beast::zero};
 
     if (!cdirFirst(
-            ctx.view,
-            ownerDirKeylet.key,
-            sleDirNode,
-            uDirEntry,
-            dirEntry,
-            ctx.j))
+            ctx.view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry))
         // Account has no directory at all.  This _should_ have been caught
         // by the dirIsEmpty() check earlier, but it's okay to catch it here.
         return tesSUCCESS;
@@ -237,7 +232,7 @@ DeleteAccount::preclaim(PreclaimContext const& ctx)
             return tefTOO_BIG;
 
     } while (cdirNext(
-        ctx.view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry, ctx.j));
+        ctx.view, ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));
 
     return tesSUCCESS;
 }
@@ -261,8 +256,7 @@ DeleteAccount::doApply()
     uint256 dirEntry{beast::zero};
 
     if (view().exists(ownerDirKeylet) &&
-        dirFirst(
-            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry, j_))
+        dirFirst(view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry))
     {
         do
         {
@@ -324,7 +318,7 @@ DeleteAccount::doApply()
             uDirEntry = 0;
 
         } while (dirNext(
-            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry, j_));
+            view(), ownerDirKeylet.key, sleDirNode, uDirEntry, dirEntry));
     }
 
     // Transfer any XRP remaining after the fee is paid to the destination:

--- a/src/ripple/ledger/View.h
+++ b/src/ripple/ledger/View.h
@@ -125,30 +125,6 @@ transferRate(ReadView const& view, AccountID const& issuer);
 [[nodiscard]] bool
 dirIsEmpty(ReadView const& view, Keylet const& k);
 
-// Return the first entry and advance uDirEntry.
-// <-- true, if had a next entry.
-// VFALCO Fix these clumsy routines with an iterator
-bool
-cdirFirst(
-    ReadView const& view,
-    uint256 const& uRootIndex,            // --> Root of directory.
-    std::shared_ptr<SLE const>& sleNode,  // <-> current node
-    unsigned int& uDirEntry,              // <-- next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
-
-// Return the current entry and advance uDirEntry.
-// <-- true, if had a next entry.
-// VFALCO Fix these clumsy routines with an iterator
-bool
-cdirNext(
-    ReadView const& view,
-    uint256 const& uRootIndex,            // --> Root of directory
-    std::shared_ptr<SLE const>& sleNode,  // <-> current node
-    unsigned int& uDirEntry,              // <-> next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
-
 // Return the list of enabled amendments
 [[nodiscard]] std::set<uint256>
 getEnabledAmendments(ReadView const& view);
@@ -222,29 +198,69 @@ adjustOwnerCount(
     std::int32_t amount,
     beast::Journal j);
 
-// Return the first entry and advance uDirEntry.
-// <-- true, if had a next entry.
-// VFALCO Fix these clumsy routines with an iterator
+/** @{ */
+/** Returns the first entry in the directory, advancing the index
+
+    @deprecated These are legacy function that are considered deprecated
+                and will soon be replaced with an iterator-based model
+                that is easier to use. You should not use them in new code.
+
+    @param view The view against which to operate
+    @param root The root (i.e. first page) of the directory to iterate
+    @param page The current page
+    @param index The index inside the current page
+    @param entry The entry at the current index
+
+    @return true if the directory isn't empty; false otherwise
+ */
+bool
+cdirFirst(
+    ReadView const& view,
+    uint256 const& root,
+    std::shared_ptr<SLE const>& page,
+    unsigned int& index,
+    uint256& entry);
+
 bool
 dirFirst(
     ApplyView& view,
-    uint256 const& uRootIndex,      // --> Root of directory.
-    std::shared_ptr<SLE>& sleNode,  // <-> current node
-    unsigned int& uDirEntry,        // <-- next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
+    uint256 const& root,
+    std::shared_ptr<SLE>& page,
+    unsigned int& index,
+    uint256& entry);
+/** @} */
 
-// Return the current entry and advance uDirEntry.
-// <-- true, if had a next entry.
-// VFALCO Fix these clumsy routines with an iterator
+/** @{ */
+/** Returns the next entry in the directory, advancing the index
+
+    @deprecated These are legacy function that are considered deprecated
+                and will soon be replaced with an iterator-based model
+                that is easier to use. You should not use them in new code.
+
+    @param view The view against which to operate
+    @param root The root (i.e. first page) of the directory to iterate
+    @param page The current page
+    @param index The index inside the current page
+    @param entry The entry at the current index
+
+    @return true if the directory isn't empty; false otherwise
+ */
+bool
+cdirNext(
+    ReadView const& view,
+    uint256 const& root,
+    std::shared_ptr<SLE const>& page,
+    unsigned int& index,
+    uint256& entry);
+
 bool
 dirNext(
     ApplyView& view,
-    uint256 const& uRootIndex,      // --> Root of directory
-    std::shared_ptr<SLE>& sleNode,  // <-> current node
-    unsigned int& uDirEntry,        // <-> next entry
-    uint256& uEntryIndex,  // <-- The entry, if available. Otherwise, zero.
-    beast::Journal j);
+    uint256 const& root,
+    std::shared_ptr<SLE>& page,
+    unsigned int& index,
+    uint256& entry);
+/** @} */
 
 [[nodiscard]] std::function<void(SLE::ref)>
 describeOwnerDir(AccountID const& account);

--- a/src/ripple/ledger/impl/BookDirs.cpp
+++ b/src/ripple/ledger/impl/BookDirs.cpp
@@ -33,13 +33,7 @@ BookDirs::BookDirs(ReadView const& view, Book const& book)
     assert(root_ != beast::zero);
     if (key_ != beast::zero)
     {
-        if (!cdirFirst(
-                *view_,
-                key_,
-                sle_,
-                entry_,
-                index_,
-                beast::Journal{beast::Journal::getNullSink()}))
+        if (!cdirFirst(*view_, key_, sle_, entry_, index_))
         {
             assert(false);
         }
@@ -96,7 +90,7 @@ BookDirs::const_iterator::operator++()
     using beast::zero;
 
     assert(index_ != zero);
-    if (!cdirNext(*view_, cur_key_, sle_, entry_, index_, j_))
+    if (!cdirNext(*view_, cur_key_, sle_, entry_, index_))
     {
         if (index_ != 0 ||
             (cur_key_ =
@@ -106,7 +100,7 @@ BookDirs::const_iterator::operator++()
             entry_ = 0;
             index_ = zero;
         }
-        else if (!cdirFirst(*view_, cur_key_, sle_, entry_, index_, j_))
+        else if (!cdirFirst(*view_, cur_key_, sle_, entry_, index_))
         {
             assert(false);
         }

--- a/src/test/rpc/Book_test.cpp
+++ b/src/test/rpc/Book_test.cpp
@@ -45,8 +45,7 @@ class Book_test : public beast::unit_test::suite
                 sleOfferDir->key(),
                 sleOfferDir,
                 bookEntry,
-                offerIndex,
-                env.journal);
+                offerIndex);
             auto sleOffer = view->read(keylet::offer(offerIndex));
             dir = to_string(sleOffer->getFieldH256(sfBookDirectory));
         }


### PR DESCRIPTION
The legacy functions `cdirFirst` and `dirFirst` were mostly identical; the differences were only type-related. The same situation existed with `cdirNext` and `dirNext`.

This commit removes the duplicated code by introducing new template functions that abstract away the differences that are present between each pair of functions.

This commit also improves the naming of function arguments, helping to elucidate their purpose & use and to make the code self-documenting.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release