### PR TITLE
Improve the MITM detection during session establishment:

### DIFF
--- a/src/ripple/basics/base_uint.h
+++ b/src/ripple/basics/base_uint.h
@@ -524,6 +524,7 @@ public:
 using uint128 = base_uint<128>;
 using uint160 = base_uint<160>;
 using uint256 = base_uint<256>;
+using uint512 = base_uint<512>;
 
 template <std::size_t Bits, class Tag>
 inline int

--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -20,8 +20,6 @@
 #include <ripple/basics/chrono.h>
 #include <ripple/basics/contract.h>
 #include <ripple/basics/make_SSLContext.h>
-#include <ripple/beast/container/aged_unordered_set.h>
-#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 
@@ -106,7 +104,6 @@ using rsa_ptr = custom_delete_unique_ptr<RSA>;
 static rsa_ptr
 rsa_generate_key(int n_bits)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x00908000L
     BIGNUM* bn = BN_new();
     BN_set_word(bn, RSA_F4);
 
@@ -118,9 +115,6 @@ rsa_generate_key(int n_bits)
     }
 
     BN_free(bn);
-#else
-    RSA* rsa = RSA_generate_key(n_bits, RSA_F4, nullptr, nullptr);
-#endif
 
     if (rsa == nullptr)
         LogicError("RSA_generate_key failed");

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -245,11 +245,26 @@ OverlayImpl::onHandoff(
         return handoff;
     }
 
+    auto const ekm = getSessionEKM(*stream_ptr);
+    if (!ekm)
+    {
+        m_peerFinder->on_closed(slot);
+        handoff.moved = false;
+        handoff.response = makeErrorResponse(
+            slot,
+            request,
+            remote_endpoint.address(),
+            "Session EKM is unavailable");
+        handoff.keep_alive = false;
+        return handoff;
+    }
+
     try
     {
         auto publicKey = verifyHandshake(
             request,
             *sharedValue,
+            *ekm,
             setup_.networkID,
             setup_.public_ip,
             remote_endpoint.address(),

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -728,6 +728,11 @@ PeerImp::doAccept()
     if (!sharedValue)
         return fail("makeSharedValue: Unexpected failure");
 
+    auto const ekm = getSessionEKM(*stream_ptr_);
+
+    if (!ekm)
+        return fail("getSessionEKM: Unexpected failure");
+
     JLOG(journal_.info()) << "Protocol: " << to_string(protocol_);
     JLOG(journal_.info()) << "Public Key: "
                           << toBase58(TokenType::NodePublic, publicKey_);
@@ -755,6 +760,7 @@ PeerImp::doAccept()
         overlay_.setup().public_ip,
         remote_address_.address(),
         *sharedValue,
+        *ekm,
         overlay_.setup().networkID,
         protocol_,
         app_);

--- a/src/ripple/protocol/impl/SecretKey.cpp
+++ b/src/ripple/protocol/impl/SecretKey.cpp
@@ -251,26 +251,7 @@ sign(PublicKey const& pk, SecretKey const& sk, Slice const& m)
         case KeyType::secp256k1: {
             sha512_half_hasher h;
             h(m.data(), m.size());
-            auto const digest = sha512_half_hasher::result_type(h);
-
-            secp256k1_ecdsa_signature sig_imp;
-            if (secp256k1_ecdsa_sign(
-                    secp256k1Context(),
-                    &sig_imp,
-                    reinterpret_cast<unsigned char const*>(digest.data()),
-                    reinterpret_cast<unsigned char const*>(sk.data()),
-                    secp256k1_nonce_function_rfc6979,
-                    nullptr) != 1)
-                LogicError("sign: secp256k1_ecdsa_sign failed");
-
-            unsigned char sig[72];
-            size_t len = sizeof(sig);
-            if (secp256k1_ecdsa_signature_serialize_der(
-                    secp256k1Context(), sig, &len, &sig_imp) != 1)
-                LogicError(
-                    "sign: secp256k1_ecdsa_signature_serialize_der failed");
-
-            return Buffer{sig, len};
+            return signDigest(pk, sk, sha512_half_hasher::result_type(h));
         }
         default:
             LogicError("sign: invalid type");

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -1079,6 +1079,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
                 addr,
                 addr,
                 uint256{1},
+                uint256{1},
                 1,
                 {1, 0},
                 serverEnv.app());

--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -510,6 +510,7 @@ public:
                 addr,
                 addr,
                 uint256{1},
+                uint256{1},
                 1,
                 {1, 0},
                 env->app());

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -1515,6 +1515,7 @@ vp_squelched=1
                     addr,
                     addr,
                     uint256{1},
+                    uint256{1},
                     1,
                     {1, 0},
                     env_.app());


### PR DESCRIPTION
Even for SSL/TLS encrypted connections, it is possible for a determined attacker to mount certain types of relatively inexpensive MITM attacks that might make it possible to intelligently tamper with messages exchanged between endpoints.

This risk can be mitigated if each side has a certificate from CA that the other side trusts. But, in the context of a decentralized and permissionless network, requiring certificates is neither reasonable nor desirable.

Ultimately, the goal is to ensure that two endpoints A and B know that they are talking directly to each other over a single end-to-end TLS session instead of two separate TLS sessions, with the attacker acting as a proxy.

The XRP Ledger protocol prevents this by leveraging the fact that the two servers each have a node identity, in the form of a **`secp256k1`** keypair.

By deriving a secure fingerprint associated with the TLS session and never sent over the wire, which both sides sign with their respective node private key and send to the other, we can strongly bind the TLS session to the node identities of each of the servers at the end of the TLS session.

This commit changes the way the fingerprint is derived, moving away from using `SSL_get_finished` and `SSL_get_peer_finished`, in favor of using `SSL_export_keying_material`.

The change is backwards compatible and servers with this commit will still generate and verify old-style fingerprints, but they also introduce support for new-style fingerprints, generated using `SSL_export_keying_material`.

For a fuller discussion on this topic, please see:
    https://github.com/openssl/openssl/issues/5509

This commit fixes #2413, which was already closed as a 'WONTFIX'.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
