### PR TITLE
Add modification type to GetLedger gRPC method

### DIFF
--- a/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
@@ -45,6 +45,16 @@ message RawLedgerObject
 
     // Key of the ledger object
     bytes key = 2;
+
+    enum ModificationType
+    {
+        UNSPECIFIED = 0;
+        CREATED = 1;
+        MODIFIED = 2;
+        DELETED = 3;
+    }
+
+    ModificationType mod_type = 3;
 }
 
 message RawLedgerObjects

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -205,6 +205,13 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
                 assert(inDesired->size() > 0);
                 obj->set_data(inDesired->data(), inDesired->size());
             }
+            if (inBase && inDesired)
+                obj->set_mod_type(
+                    org::xrpl::rpc::v1::RawLedgerObject::MODIFIED);
+            else if (inBase && !inDesired)
+                obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::DELETED);
+            else
+                obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::CREATED);
         }
         response.set_skiplist_included(true);
     }


### PR DESCRIPTION
* Specify whether a ledger object was created, modified or deleted.


## High Level Overview of Change

Add a field to the protobuf message used for ETL by reporting mode and project clio. This eliminates some expensive processing that would have to be done client side, processing that is nearly free server side.


### Context of Change

Needed for Project Clio

### Type of Change



- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release


