### PR TITLE
Restrict access to the virtual functions move and copy for the STBase-derived types

### DIFF
--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -40,78 +40,61 @@ public:
     using value_type = AccountID;
 
     STAccount();
+
     STAccount(SField const& n);
     STAccount(SField const& n, Buffer&& v);
     STAccount(SerialIter& sit, SField const& name);
     STAccount(SField const& n, AccountID const& v);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
-
+    copy(std::size_t n, void* buf) const override;
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     SerializedTypeID
-    getSType() const override
-    {
-        return STI_ACCOUNT;
-    }
+    getSType() const override;
 
     std::string
     getText() const override;
 
     void
-    add(Serializer& s) const override
-    {
-        assert(fName->isBinary());
-        assert(fName->fieldType == STI_ACCOUNT);
-
-        // Preserve the serialization behavior of an STBlob:
-        //  o If we are default (all zeros) serialize as an empty blob.
-        //  o Otherwise serialize 160 bits.
-        int const size = isDefault() ? 0 : uint160::bytes;
-        s.addVL(value_.data(), size);
-    }
+    add(Serializer& s) const override;
 
     bool
-    isEquivalent(const STBase& t) const override
-    {
-        auto const* const tPtr = dynamic_cast<STAccount const*>(&t);
-        return tPtr && (default_ == tPtr->default_) && (value_ == tPtr->value_);
-    }
+    isEquivalent(const STBase& t) const override;
 
     bool
-    isDefault() const override
-    {
-        return default_;
-    }
+    isDefault() const override;
 
     STAccount&
-    operator=(AccountID const& value)
-    {
-        setValue(value);
-        return *this;
-    }
+    operator=(AccountID const& value);
 
     AccountID
-    value() const noexcept
-    {
-        return value_;
-    }
+    value() const noexcept;
 
     void
-    setValue(AccountID const& v)
-    {
-        value_ = v;
-        default_ = false;
-    }
+    setValue(AccountID const& v);
 };
+
+inline STAccount&
+STAccount::operator=(AccountID const& value)
+{
+    setValue(value);
+    return *this;
+}
+
+inline AccountID
+STAccount::value() const noexcept
+{
+    return value_;
+}
+
+inline void
+STAccount::setValue(AccountID const& v)
+{
+    value_ = v;
+    default_ = false;
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STAccount.h
+++ b/src/ripple/protocol/STAccount.h
@@ -46,11 +46,6 @@ public:
     STAccount(SerialIter& sit, SField const& name);
     STAccount(SField const& n, AccountID const& v);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     SerializedTypeID
     getSType() const override;
 
@@ -74,6 +69,14 @@ public:
 
     void
     setValue(AccountID const& v);
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 inline STAccount&

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -145,29 +145,10 @@ public:
     STAmount(XRPAmount const& amount);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
-
+    copy(std::size_t n, void* buf) const override;
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
-    //--------------------------------------------------------------------------
-
-private:
-    static std::unique_ptr<STAmount>
-    construct(SerialIter&, SField const& name);
-
-    void
-    set(std::int64_t v);
-    void
-    canonicalize();
-
-public:
     //--------------------------------------------------------------------------
     //
     // Observers
@@ -175,64 +156,39 @@ public:
     //--------------------------------------------------------------------------
 
     int
-    exponent() const noexcept
-    {
-        return mOffset;
-    }
+    exponent() const noexcept;
+
     bool
-    native() const noexcept
-    {
-        return mIsNative;
-    }
+    native() const noexcept;
+
     bool
-    negative() const noexcept
-    {
-        return mIsNegative;
-    }
+    negative() const noexcept;
+
     std::uint64_t
-    mantissa() const noexcept
-    {
-        return mValue;
-    }
+    mantissa() const noexcept;
+
     Issue const&
-    issue() const
-    {
-        return mIssue;
-    }
+    issue() const;
 
     // These three are deprecated
     Currency const&
-    getCurrency() const
-    {
-        return mIssue.currency;
-    }
+    getCurrency() const;
+
     AccountID const&
-    getIssuer() const
-    {
-        return mIssue.account;
-    }
+    getIssuer() const;
 
     int
-    signum() const noexcept
-    {
-        return mValue ? (mIsNegative ? -1 : 1) : 0;
-    }
+    signum() const noexcept;
 
     /** Returns a zero value with the same issuer and currency. */
     STAmount
-    zeroed() const
-    {
-        return STAmount(mIssue);
-    }
+    zeroed() const;
 
     void
     setJson(Json::Value&) const;
 
     STAmount const&
-    value() const noexcept
-    {
-        return *this;
-    }
+    value() const noexcept;
 
     //--------------------------------------------------------------------------
     //
@@ -240,28 +196,17 @@ public:
     //
     //--------------------------------------------------------------------------
 
-    explicit operator bool() const noexcept
-    {
-        return *this != beast::zero;
-    }
+    explicit operator bool() const noexcept;
 
     STAmount&
     operator+=(STAmount const&);
     STAmount&
     operator-=(STAmount const&);
 
-    STAmount& operator=(beast::Zero)
-    {
-        clear();
-        return *this;
-    }
+    STAmount& operator=(beast::Zero);
 
     STAmount&
-    operator=(XRPAmount const& amount)
-    {
-        *this = STAmount(amount);
-        return *this;
-    }
+    operator=(XRPAmount const& amount);
 
     //--------------------------------------------------------------------------
     //
@@ -270,42 +215,20 @@ public:
     //--------------------------------------------------------------------------
 
     void
-    negate()
-    {
-        if (*this != beast::zero)
-            mIsNegative = !mIsNegative;
-    }
+    negate();
 
     void
-    clear()
-    {
-        // The -100 is used to allow 0 to sort less than a small positive values
-        // which have a negative exponent.
-        mOffset = mIsNative ? 0 : -100;
-        mValue = 0;
-        mIsNegative = false;
-    }
+    clear();
 
     // Zero while copying currency and issuer.
     void
-    clear(STAmount const& saTmpl)
-    {
-        clear(saTmpl.mIssue);
-    }
+    clear(STAmount const& saTmpl);
 
     void
-    clear(Issue const& issue)
-    {
-        setIssue(issue);
-        clear();
-    }
+    clear(Issue const& issue);
 
     void
-    setIssuer(AccountID const& uIssuer)
-    {
-        mIssue.account = uIssuer;
-        setIssue(mIssue);
-    }
+    setIssuer(AccountID const& uIssuer);
 
     /** Set the Issue for this amount and update mIsNative. */
     void
@@ -318,10 +241,7 @@ public:
     //--------------------------------------------------------------------------
 
     SerializedTypeID
-    getSType() const override
-    {
-        return STI_AMOUNT;
-    }
+    getSType() const override;
 
     std::string
     getFullText() const override;
@@ -338,15 +258,21 @@ public:
     isEquivalent(const STBase& t) const override;
 
     bool
-    isDefault() const override
-    {
-        return (mValue == 0) && mIsNative;
-    }
+    isDefault() const override;
 
     XRPAmount
     xrp() const;
     IOUAmount
     iou() const;
+
+private:
+    static std::unique_ptr<STAmount>
+    construct(SerialIter&, SField const& name);
+
+    void
+    set(std::int64_t v);
+    void
+    canonicalize();
 };
 
 //------------------------------------------------------------------------------
@@ -381,6 +307,122 @@ toSTAmount(STAmount const& a)
 // Observers
 //
 //------------------------------------------------------------------------------
+
+inline int
+STAmount::exponent() const noexcept
+{
+    return mOffset;
+}
+
+inline bool
+STAmount::native() const noexcept
+{
+    return mIsNative;
+}
+
+inline bool
+STAmount::negative() const noexcept
+{
+    return mIsNegative;
+}
+
+inline std::uint64_t
+STAmount::mantissa() const noexcept
+{
+    return mValue;
+}
+
+inline Issue const&
+STAmount::issue() const
+{
+    return mIssue;
+}
+
+inline Currency const&
+STAmount::getCurrency() const
+{
+    return mIssue.currency;
+}
+
+inline AccountID const&
+STAmount::getIssuer() const
+{
+    return mIssue.account;
+}
+
+inline int
+STAmount::signum() const noexcept
+{
+    return mValue ? (mIsNegative ? -1 : 1) : 0;
+}
+
+inline STAmount
+STAmount::zeroed() const
+{
+    return STAmount(mIssue);
+}
+
+inline STAmount::operator bool() const noexcept
+{
+    return *this != beast::zero;
+}
+
+inline STAmount& STAmount::operator=(beast::Zero)
+{
+    clear();
+    return *this;
+}
+
+inline STAmount&
+STAmount::operator=(XRPAmount const& amount)
+{
+    *this = STAmount(amount);
+    return *this;
+}
+
+inline void
+STAmount::negate()
+{
+    if (*this != beast::zero)
+        mIsNegative = !mIsNegative;
+}
+
+inline void
+STAmount::clear()
+{
+    // The -100 is used to allow 0 to sort less than a small positive values
+    // which have a negative exponent.
+    mOffset = mIsNative ? 0 : -100;
+    mValue = 0;
+    mIsNegative = false;
+}
+
+// Zero while copying currency and issuer.
+inline void
+STAmount::clear(STAmount const& saTmpl)
+{
+    clear(saTmpl.mIssue);
+}
+
+inline void
+STAmount::clear(Issue const& issue)
+{
+    setIssue(issue);
+    clear();
+}
+
+inline void
+STAmount::setIssuer(AccountID const& uIssuer)
+{
+    mIssue.account = uIssuer;
+    setIssue(mIssue);
+}
+
+inline STAmount const&
+STAmount::value() const noexcept
+{
+    return *this;
+}
 
 inline bool
 isLegalNet(STAmount const& value)

--- a/src/ripple/protocol/STAmount.h
+++ b/src/ripple/protocol/STAmount.h
@@ -144,11 +144,6 @@ public:
     STAmount(IOUAmount const& amount, Issue const& issue);
     STAmount(XRPAmount const& amount);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     //--------------------------------------------------------------------------
     //
     // Observers
@@ -273,6 +268,13 @@ private:
     set(std::int64_t v);
     void
     canonicalize();
+
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -50,12 +50,6 @@ public:
     explicit STArray(int n);
     explicit STArray(SField const& f);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     STObject&
     operator[](std::size_t j);
 
@@ -134,6 +128,14 @@ public:
 
     bool
     isDefault() const override;
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 inline STObject&

--- a/src/ripple/protocol/STArray.h
+++ b/src/ripple/protocol/STArray.h
@@ -38,160 +38,212 @@ public:
     using const_iterator = list_type::const_iterator;
 
     STArray() = default;
-    STArray(STArray&&);
     STArray(STArray const&) = default;
+    STArray&
+    operator=(STArray const&) = default;
+    STArray(STArray&&);
+    STArray&
+    operator=(STArray&&);
+
     STArray(SField const& f, int n);
     STArray(SerialIter& sit, SField const& f, int depth = 0);
     explicit STArray(int n);
     explicit STArray(SField const& f);
-    STArray&
-    operator=(STArray const&) = default;
-    STArray&
-    operator=(STArray&&);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     STObject&
-    operator[](std::size_t j)
-    {
-        return v_[j];
-    }
+    operator[](std::size_t j);
 
     STObject const&
-    operator[](std::size_t j) const
-    {
-        return v_[j];
-    }
+    operator[](std::size_t j) const;
 
     STObject&
-    back()
-    {
-        return v_.back();
-    }
+    back();
 
     STObject const&
-    back() const
-    {
-        return v_.back();
-    }
+    back() const;
 
     template <class... Args>
     void
-    emplace_back(Args&&... args)
-    {
-        v_.emplace_back(std::forward<Args>(args)...);
-    }
+    emplace_back(Args&&... args);
 
     void
-    push_back(STObject const& object)
-    {
-        v_.push_back(object);
-    }
+    push_back(STObject const& object);
 
     void
-    push_back(STObject&& object)
-    {
-        v_.push_back(std::move(object));
-    }
+    push_back(STObject&& object);
 
     iterator
-    begin()
-    {
-        return v_.begin();
-    }
+    begin();
 
     iterator
-    end()
-    {
-        return v_.end();
-    }
+    end();
 
     const_iterator
-    begin() const
-    {
-        return v_.begin();
-    }
+    begin() const;
 
     const_iterator
-    end() const
-    {
-        return v_.end();
-    }
+    end() const;
 
     size_type
-    size() const
-    {
-        return v_.size();
-    }
+    size() const;
 
     bool
-    empty() const
-    {
-        return v_.empty();
-    }
-    void
-    clear()
-    {
-        v_.clear();
-    }
-    void
-    reserve(std::size_t n)
-    {
-        v_.reserve(n);
-    }
-    void
-    swap(STArray& a) noexcept
-    {
-        v_.swap(a.v_);
-    }
+    empty() const;
 
-    virtual std::string
+    void
+    clear();
+
+    void
+    reserve(std::size_t n);
+
+    void
+    swap(STArray& a) noexcept;
+
+    std::string
     getFullText() const override;
-    virtual std::string
+
+    std::string
     getText() const override;
 
-    virtual Json::Value
+    Json::Value
     getJson(JsonOptions index) const override;
-    virtual void
+
+    void
     add(Serializer& s) const override;
 
     void
     sort(bool (*compare)(const STObject& o1, const STObject& o2));
 
     bool
-    operator==(const STArray& s) const
-    {
-        return v_ == s.v_;
-    }
-    bool
-    operator!=(const STArray& s) const
-    {
-        return v_ != s.v_;
-    }
+    operator==(const STArray& s) const;
 
-    virtual SerializedTypeID
-    getSType() const override
-    {
-        return STI_ARRAY;
-    }
-    virtual bool
+    bool
+    operator!=(const STArray& s) const;
+
+    SerializedTypeID
+    getSType() const override;
+
+    bool
     isEquivalent(const STBase& t) const override;
-    virtual bool
-    isDefault() const override
-    {
-        return v_.empty();
-    }
+
+    bool
+    isDefault() const override;
 };
+
+inline STObject&
+STArray::operator[](std::size_t j)
+{
+    return v_[j];
+}
+
+inline STObject const&
+STArray::operator[](std::size_t j) const
+{
+    return v_[j];
+}
+
+inline STObject&
+STArray::back()
+{
+    return v_.back();
+}
+
+inline STObject const&
+STArray::back() const
+{
+    return v_.back();
+}
+
+template <class... Args>
+inline void
+STArray::emplace_back(Args&&... args)
+{
+    v_.emplace_back(std::forward<Args>(args)...);
+}
+
+inline void
+STArray::push_back(STObject const& object)
+{
+    v_.push_back(object);
+}
+
+inline void
+STArray::push_back(STObject&& object)
+{
+    v_.push_back(std::move(object));
+}
+
+inline STArray::iterator
+STArray::begin()
+{
+    return v_.begin();
+}
+
+inline STArray::iterator
+STArray::end()
+{
+    return v_.end();
+}
+
+inline STArray::const_iterator
+STArray::begin() const
+{
+    return v_.begin();
+}
+
+inline STArray::const_iterator
+STArray::end() const
+{
+    return v_.end();
+}
+
+inline STArray::size_type
+STArray::size() const
+{
+    return v_.size();
+}
+
+inline bool
+STArray::empty() const
+{
+    return v_.empty();
+}
+
+inline void
+STArray::clear()
+{
+    v_.clear();
+}
+
+inline void
+STArray::reserve(std::size_t n)
+{
+    v_.reserve(n);
+}
+
+inline void
+STArray::swap(STArray& a) noexcept
+{
+    v_.swap(a.v_);
+}
+
+inline bool
+STArray::operator==(const STArray& s) const
+{
+    return v_ == s.v_;
+}
+
+inline bool
+STArray::operator!=(const STArray& s) const
+{
+    return v_ != s.v_;
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -61,16 +61,16 @@ enum class JsonOptions { none = 0, include_date = 1 };
 */
 class STBase
 {
+    SField const* fName;
+
 public:
-    STBase();
-
-    explicit STBase(SField const& n);
-
     virtual ~STBase() = default;
-
-    STBase(const STBase& t) = default;
+    STBase();
+    STBase(const STBase&) = default;
     STBase&
     operator=(const STBase& t);
+
+    explicit STBase(SField const& n);
 
     bool
     operator==(const STBase& t) const;
@@ -78,36 +78,17 @@ public:
     operator!=(const STBase& t) const;
 
     virtual STBase*
-    copy(std::size_t n, void* buf) const
-    {
-        return emplace(n, buf, *this);
-    }
-
+    copy(std::size_t n, void* buf) const;
     virtual STBase*
-    move(std::size_t n, void* buf)
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf);
 
     template <class D>
     D&
-    downcast()
-    {
-        D* ptr = dynamic_cast<D*>(this);
-        if (ptr == nullptr)
-            Throw<std::bad_cast>();
-        return *ptr;
-    }
+    downcast();
 
     template <class D>
     D const&
-    downcast() const
-    {
-        D const* ptr = dynamic_cast<D const*>(this);
-        if (ptr == nullptr)
-            Throw<std::bad_cast>();
-        return *ptr;
-    }
+    downcast() const;
 
     virtual SerializedTypeID
     getSType() const;
@@ -142,23 +123,45 @@ public:
     addFieldID(Serializer& s) const;
 
 protected:
-    SField const* fName;
-
     template <class T>
     static STBase*
-    emplace(std::size_t n, void* buf, T&& val)
-    {
-        using U = std::decay_t<T>;
-        if (sizeof(U) > n)
-            return new U(std::forward<T>(val));
-        return new (buf) U(std::forward<T>(val));
-    }
+    emplace(std::size_t n, void* buf, T&& val);
 };
 
 //------------------------------------------------------------------------------
 
 std::ostream&
 operator<<(std::ostream& out, const STBase& t);
+
+template <class D>
+D&
+STBase::downcast()
+{
+    D* ptr = dynamic_cast<D*>(this);
+    if (ptr == nullptr)
+        Throw<std::bad_cast>();
+    return *ptr;
+}
+
+template <class D>
+D const&
+STBase::downcast() const
+{
+    D const* ptr = dynamic_cast<D const*>(this);
+    if (ptr == nullptr)
+        Throw<std::bad_cast>();
+    return *ptr;
+}
+
+template <class T>
+STBase*
+STBase::emplace(std::size_t n, void* buf, T&& val)
+{
+    using U = std::decay_t<T>;
+    if (sizeof(U) > n)
+        return new U(std::forward<T>(val));
+    return new (buf) U(std::forward<T>(val));
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STBase.h
+++ b/src/ripple/protocol/STBase.h
@@ -33,6 +33,10 @@ namespace ripple {
 
 enum class JsonOptions { none = 0, include_date = 1 };
 
+namespace detail {
+class STVar;
+}
+
 // VFALCO TODO fix this restriction on copy assignment.
 //
 // CAUTION: Do not create a vector (or similar container) of any object derived
@@ -76,11 +80,6 @@ public:
     operator==(const STBase& t) const;
     bool
     operator!=(const STBase& t) const;
-
-    virtual STBase*
-    copy(std::size_t n, void* buf) const;
-    virtual STBase*
-    move(std::size_t n, void* buf);
 
     template <class D>
     D&
@@ -126,6 +125,14 @@ protected:
     template <class T>
     static STBase*
     emplace(std::size_t n, void* buf, T&& val);
+
+private:
+    virtual STBase*
+    copy(std::size_t n, void* buf) const;
+    virtual STBase*
+    move(std::size_t n, void* buf);
+
+    friend class detail::STVar;
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -31,92 +31,87 @@ class STBitString final : public STBase
 public:
     using value_type = base_uint<Bits>;
 
+private:
+    value_type value_;
+
+public:
     STBitString() = default;
 
-    STBitString(SField const& n) : STBase(n)
-    {
-    }
-
-    STBitString(const value_type& v) : value_(v)
-    {
-    }
-
-    STBitString(SField const& n, const value_type& v) : STBase(n), value_(v)
-    {
-    }
-
-    STBitString(SerialIter& sit, SField const& name)
-        : STBitString(name, sit.getBitString<Bits>())
-    {
-    }
+    STBitString(SField const& n);
+    STBitString(const value_type& v);
+    STBitString(SField const& n, const value_type& v);
+    STBitString(SerialIter& sit, SField const& name);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     SerializedTypeID
     getSType() const override;
 
     std::string
-    getText() const override
-    {
-        return to_string(value_);
-    }
+    getText() const override;
 
     bool
-    isEquivalent(const STBase& t) const override
-    {
-        const STBitString* v = dynamic_cast<const STBitString*>(&t);
-        return v && (value_ == v->value_);
-    }
+    isEquivalent(const STBase& t) const override;
 
     void
-    add(Serializer& s) const override
-    {
-        assert(fName->isBinary());
-        assert(fName->fieldType == getSType());
-        s.addBitString<Bits>(value_);
-    }
+    add(Serializer& s) const override;
+
+    bool
+    isDefault() const override;
 
     template <typename Tag>
     void
-    setValue(base_uint<Bits, Tag> const& v)
-    {
-        value_ = v;
-    }
+    setValue(base_uint<Bits, Tag> const& v);
 
     value_type const&
-    value() const
-    {
-        return value_;
-    }
+    value() const;
 
-    operator value_type() const
-    {
-        return value_;
-    }
-
-    bool
-    isDefault() const override
-    {
-        return value_ == beast::zero;
-    }
-
-private:
-    value_type value_;
+    operator value_type() const;
 };
 
 using STHash128 = STBitString<128>;
 using STHash160 = STBitString<160>;
 using STHash256 = STBitString<256>;
+
+template <std::size_t Bits>
+inline STBitString<Bits>::STBitString(SField const& n) : STBase(n)
+{
+}
+
+template <std::size_t Bits>
+inline STBitString<Bits>::STBitString(const value_type& v) : value_(v)
+{
+}
+
+template <std::size_t Bits>
+inline STBitString<Bits>::STBitString(SField const& n, const value_type& v)
+    : STBase(n), value_(v)
+{
+}
+
+template <std::size_t Bits>
+inline STBitString<Bits>::STBitString(SerialIter& sit, SField const& name)
+    : STBitString(name, sit.getBitString<Bits>())
+{
+}
+
+template <std::size_t Bits>
+STBase*
+STBitString<Bits>::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+template <std::size_t Bits>
+STBase*
+STBitString<Bits>::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
 
 template <>
 inline SerializedTypeID
@@ -137,6 +132,58 @@ inline SerializedTypeID
 STHash256::getSType() const
 {
     return STI_HASH256;
+}
+
+template <std::size_t Bits>
+std::string
+STBitString<Bits>::getText() const
+{
+    return to_string(value_);
+}
+
+template <std::size_t Bits>
+bool
+STBitString<Bits>::isEquivalent(const STBase& t) const
+{
+    const STBitString* v = dynamic_cast<const STBitString*>(&t);
+    return v && (value_ == v->value_);
+}
+
+template <std::size_t Bits>
+void
+STBitString<Bits>::add(Serializer& s) const
+{
+    assert(getFName().isBinary());
+    assert(getFName().fieldType == getSType());
+    s.addBitString<Bits>(value_);
+}
+
+template <std::size_t Bits>
+template <typename Tag>
+void
+STBitString<Bits>::setValue(base_uint<Bits, Tag> const& v)
+{
+    value_ = v;
+}
+
+template <std::size_t Bits>
+typename STBitString<Bits>::value_type const&
+STBitString<Bits>::value() const
+{
+    return value_;
+}
+
+template <std::size_t Bits>
+STBitString<Bits>::operator value_type() const
+{
+    return value_;
+}
+
+template <std::size_t Bits>
+bool
+STBitString<Bits>::isDefault() const
+{
+    return value_ == beast::zero;
 }
 
 }  // namespace ripple

--- a/src/ripple/protocol/STBitString.h
+++ b/src/ripple/protocol/STBitString.h
@@ -42,12 +42,6 @@ public:
     STBitString(SField const& n, const value_type& v);
     STBitString(SerialIter& sit, SField const& name);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     SerializedTypeID
     getSType() const override;
 
@@ -71,6 +65,14 @@ public:
     value() const;
 
     operator value_type() const;
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 using STHash128 = STBitString<128>;

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -32,109 +32,115 @@ namespace ripple {
 // variable length byte string
 class STBlob : public STBase
 {
+    Buffer value_;
+
 public:
     using value_type = Slice;
 
     STBlob() = default;
-    STBlob(STBlob const& rhs) : STBase(rhs), value_(rhs.data(), rhs.size())
-    {
-    }
+    STBlob(STBlob const& rhs);
 
-    STBlob(SField const& f, void const* data, std::size_t size)
-        : STBase(f), value_(data, size)
-    {
-    }
-
-    STBlob(SField const& f, Buffer&& b) : STBase(f), value_(std::move(b))
-    {
-    }
-
-    STBlob(SField const& n) : STBase(n)
-    {
-    }
-
+    STBlob(SField const& f, void const* data, std::size_t size);
+    STBlob(SField const& f, Buffer&& b);
+    STBlob(SField const& n);
     STBlob(SerialIter&, SField const& name = sfGeneric);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     std::size_t
-    size() const
-    {
-        return value_.size();
-    }
+    size() const;
 
     std::uint8_t const*
-    data() const
-    {
-        return reinterpret_cast<std::uint8_t const*>(value_.data());
-    }
+    data() const;
 
     SerializedTypeID
-    getSType() const override
-    {
-        return STI_VL;
-    }
+    getSType() const override;
 
     std::string
     getText() const override;
 
     void
-    add(Serializer& s) const override
-    {
-        assert(fName->isBinary());
-        assert(
-            (fName->fieldType == STI_VL) || (fName->fieldType == STI_ACCOUNT));
-        s.addVL(value_.data(), value_.size());
-    }
-
-    STBlob&
-    operator=(Slice const& slice)
-    {
-        value_ = Buffer(slice.data(), slice.size());
-        return *this;
-    }
-
-    value_type
-    value() const noexcept
-    {
-        return value_;
-    }
-
-    STBlob&
-    operator=(Buffer&& buffer)
-    {
-        value_ = std::move(buffer);
-        return *this;
-    }
-
-    void
-    setValue(Buffer&& b)
-    {
-        value_ = std::move(b);
-    }
+    add(Serializer& s) const override;
 
     bool
     isEquivalent(const STBase& t) const override;
 
     bool
-    isDefault() const override
-    {
-        return value_.empty();
-    }
+    isDefault() const override;
 
-private:
-    Buffer value_;
+    STBlob&
+    operator=(Slice const& slice);
+
+    value_type
+    value() const noexcept;
+
+    STBlob&
+    operator=(Buffer&& buffer);
+
+    void
+    setValue(Buffer&& b);
 };
+
+inline STBlob::STBlob(STBlob const& rhs)
+    : STBase(rhs), value_(rhs.data(), rhs.size())
+{
+}
+
+inline STBlob::STBlob(SField const& f, void const* data, std::size_t size)
+    : STBase(f), value_(data, size)
+{
+}
+
+inline STBlob::STBlob(SField const& f, Buffer&& b)
+    : STBase(f), value_(std::move(b))
+{
+}
+
+inline STBlob::STBlob(SField const& n) : STBase(n)
+{
+}
+
+inline std::size_t
+STBlob::size() const
+{
+    return value_.size();
+}
+
+inline std::uint8_t const*
+STBlob::data() const
+{
+    return reinterpret_cast<std::uint8_t const*>(value_.data());
+}
+
+inline STBlob&
+STBlob::operator=(Slice const& slice)
+{
+    value_ = Buffer(slice.data(), slice.size());
+    return *this;
+}
+
+inline STBlob::value_type
+STBlob::value() const noexcept
+{
+    return value_;
+}
+
+inline STBlob&
+STBlob::operator=(Buffer&& buffer)
+{
+    value_ = std::move(buffer);
+    return *this;
+}
+
+inline void
+STBlob::setValue(Buffer&& b)
+{
+    value_ = std::move(b);
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STBlob.h
+++ b/src/ripple/protocol/STBlob.h
@@ -45,12 +45,6 @@ public:
     STBlob(SField const& n);
     STBlob(SerialIter&, SField const& name = sfGeneric);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     std::size_t
     size() const;
 
@@ -83,6 +77,14 @@ public:
 
     void
     setValue(Buffer&& b);
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 inline STBlob::STBlob(STBlob const& rhs)

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -38,12 +38,6 @@ public:
     STInteger(SField const& n, Integer v = 0);
     STInteger(SerialIter& sit, SField const& name);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     SerializedTypeID
     getSType() const override;
 
@@ -71,6 +65,14 @@ public:
     setValue(Integer v);
 
     operator Integer() const;
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 using STUInt8 = STInteger<unsigned char>;

--- a/src/ripple/protocol/STInteger.h
+++ b/src/ripple/protocol/STInteger.h
@@ -30,27 +30,19 @@ class STInteger : public STBase
 public:
     using value_type = Integer;
 
-    explicit STInteger(Integer v) : value_(v)
-    {
-    }
+private:
+    Integer value_;
 
-    STInteger(SField const& n, Integer v = 0) : STBase(n), value_(v)
-    {
-    }
-
+public:
+    explicit STInteger(Integer v);
+    STInteger(SField const& n, Integer v = 0);
     STInteger(SerialIter& sit, SField const& name);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     SerializedTypeID
     getSType() const override;
@@ -61,58 +53,107 @@ public:
     getText() const override;
 
     void
-    add(Serializer& s) const override
-    {
-        assert(fName->isBinary());
-        assert(fName->fieldType == getSType());
-        s.addInteger(value_);
-    }
-
-    STInteger&
-    operator=(value_type const& v)
-    {
-        value_ = v;
-        return *this;
-    }
-
-    value_type
-    value() const noexcept
-    {
-        return value_;
-    }
-
-    void
-    setValue(Integer v)
-    {
-        value_ = v;
-    }
-
-    operator Integer() const
-    {
-        return value_;
-    }
-
-    virtual bool
-    isDefault() const override
-    {
-        return value_ == 0;
-    }
+    add(Serializer& s) const override;
 
     bool
-    isEquivalent(const STBase& t) const override
-    {
-        const STInteger* v = dynamic_cast<const STInteger*>(&t);
-        return v && (value_ == v->value_);
-    }
+    isDefault() const override;
 
-private:
-    Integer value_;
+    bool
+    isEquivalent(const STBase& t) const override;
+
+    STInteger&
+    operator=(value_type const& v);
+
+    value_type
+    value() const noexcept;
+
+    void
+    setValue(Integer v);
+
+    operator Integer() const;
 };
 
 using STUInt8 = STInteger<unsigned char>;
 using STUInt16 = STInteger<std::uint16_t>;
 using STUInt32 = STInteger<std::uint32_t>;
 using STUInt64 = STInteger<std::uint64_t>;
+
+template <typename Integer>
+inline STInteger<Integer>::STInteger(Integer v) : value_(v)
+{
+}
+
+template <typename Integer>
+inline STInteger<Integer>::STInteger(SField const& n, Integer v)
+    : STBase(n), value_(v)
+{
+}
+
+template <typename Integer>
+inline STBase*
+STInteger<Integer>::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+template <typename Integer>
+inline STBase*
+STInteger<Integer>::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+template <typename Integer>
+inline void
+STInteger<Integer>::add(Serializer& s) const
+{
+    assert(getFName().isBinary());
+    assert(getFName().fieldType == getSType());
+    s.addInteger(value_);
+}
+
+template <typename Integer>
+inline bool
+STInteger<Integer>::isDefault() const
+{
+    return value_ == 0;
+}
+
+template <typename Integer>
+inline bool
+STInteger<Integer>::isEquivalent(const STBase& t) const
+{
+    const STInteger* v = dynamic_cast<const STInteger*>(&t);
+    return v && (value_ == v->value_);
+}
+
+template <typename Integer>
+inline STInteger<Integer>&
+STInteger<Integer>::operator=(value_type const& v)
+{
+    value_ = v;
+    return *this;
+}
+
+template <typename Integer>
+inline typename STInteger<Integer>::value_type
+STInteger<Integer>::value() const noexcept
+{
+    return value_;
+}
+
+template <typename Integer>
+inline void
+STInteger<Integer>::setValue(Integer v)
+{
+    value_ = v;
+}
+
+template <typename Integer>
+inline STInteger<Integer>::operator Integer() const
+{
+    return value_;
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -29,7 +29,8 @@ class Invariants_test;
 
 class STLedgerEntry final : public STObject, public CountedObject<STLedgerEntry>
 {
-    friend Invariants_test;  // this test wants access to the private type_
+    uint256 key_;
+    LedgerEntryType type_;
 
 public:
     using pointer = std::shared_ptr<STLedgerEntry>;
@@ -37,37 +38,19 @@ public:
 
     /** Create an empty object with the given key and type. */
     explicit STLedgerEntry(Keylet const& k);
-
-    STLedgerEntry(LedgerEntryType type, uint256 const& key)
-        : STLedgerEntry(Keylet(type, key))
-    {
-    }
-
+    STLedgerEntry(LedgerEntryType type, uint256 const& key);
     STLedgerEntry(SerialIter& sit, uint256 const& index);
-    STLedgerEntry(SerialIter&& sit, uint256 const& index)
-        : STLedgerEntry(sit, index)
-    {
-    }
-
+    STLedgerEntry(SerialIter&& sit, uint256 const& index);
     STLedgerEntry(STObject const& object, uint256 const& index);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     SerializedTypeID
-    getSType() const override
-    {
-        return STI_LEDGERENTRY;
-    }
+    getSType() const override;
 
     std::string
     getFullText() const override;
@@ -83,16 +66,10 @@ public:
         the SHAMap associative container.
     */
     uint256 const&
-    key() const
-    {
-        return key_;
-    }
+    key() const;
 
     LedgerEntryType
-    getType() const
-    {
-        return type_;
-    }
+    getType() const;
 
     // is this a ledger entry that can be threaded
     bool
@@ -112,12 +89,36 @@ private:
     void
     setSLEType();
 
-private:
-    uint256 key_;
-    LedgerEntryType type_;
+    friend Invariants_test;  // this test wants access to the private type_
 };
 
 using SLE = STLedgerEntry;
+
+inline STLedgerEntry::STLedgerEntry(LedgerEntryType type, uint256 const& key)
+    : STLedgerEntry(Keylet(type, key))
+{
+}
+
+inline STLedgerEntry::STLedgerEntry(SerialIter&& sit, uint256 const& index)
+    : STLedgerEntry(sit, index)
+{
+}
+
+/** Returns the 'key' (or 'index') of this item.
+    The key identifies this entry's position in
+    the SHAMap associative container.
+*/
+inline uint256 const&
+STLedgerEntry::key() const
+{
+    return key_;
+}
+
+inline LedgerEntryType
+STLedgerEntry::getType() const
+{
+    return type_;
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STLedgerEntry.h
+++ b/src/ripple/protocol/STLedgerEntry.h
@@ -43,12 +43,6 @@ public:
     STLedgerEntry(SerialIter&& sit, uint256 const& index);
     STLedgerEntry(STObject const& object, uint256 const& index);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     SerializedTypeID
     getSType() const override;
 
@@ -90,6 +84,13 @@ private:
     setSLEType();
 
     friend Invariants_test;  // this test wants access to the private type_
+
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 using SLE = STLedgerEntry;

--- a/src/ripple/protocol/STObject.h
+++ b/src/ripple/protocol/STObject.h
@@ -92,12 +92,6 @@ public:
     STObject(SerialIter&& sit, SField const& name);
     explicit STObject(SField const& name);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     iterator
     begin() const;
 
@@ -448,6 +442,13 @@ private:
     template <typename T>
     T&
     peekField(SField const& field);
+
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/STPathSet.h
+++ b/src/ripple/protocol/STPathSet.h
@@ -182,12 +182,6 @@ public:
     STPathSet(SField const& n);
     STPathSet(SerialIter& sit, SField const& name);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     void
     add(Serializer& s) const override;
 
@@ -230,6 +224,14 @@ public:
     template <typename... Args>
     void
     emplace_back(Args&&... args);
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 // ------------ STPathElement ------------

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -42,23 +42,21 @@ enum TxnSql : char {
 
 class STTx final : public STObject, public CountedObject<STTx>
 {
+    uint256 tid_;
+    TxType tx_type_;
+
 public:
     static std::size_t const minMultiSigners = 1;
     static std::size_t const maxMultiSigners = 8;
 
-public:
     STTx() = delete;
+    STTx(STTx const& other) = default;
     STTx&
     operator=(STTx const& other) = delete;
 
-    STTx(STTx const& other) = default;
-
-    explicit STTx(SerialIter& sit) noexcept(false);
-    explicit STTx(SerialIter&& sit) noexcept(false) : STTx(sit)
-    {
-    }
-
-    explicit STTx(STObject&& object) noexcept(false);
+    explicit STTx(SerialIter& sit);
+    explicit STTx(SerialIter&& sit);
+    explicit STTx(STObject&& object);
 
     /** Constructs a transaction.
 
@@ -69,23 +67,15 @@ public:
     STTx(TxType type, std::function<void(STObject&)> assembler);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     // STObject functions.
     SerializedTypeID
-    getSType() const override
-    {
-        return STI_TRANSACTION;
-    }
+    getSType() const override;
+
     std::string
     getFullText() const override;
 
@@ -97,16 +87,10 @@ public:
     getSigningHash() const;
 
     TxType
-    getTxnType() const
-    {
-        return tx_type_;
-    }
+    getTxnType() const;
 
     Blob
-    getSigningPubKey() const
-    {
-        return getFieldVL(sfSigningPubKey);
-    }
+    getSigningPubKey() const;
 
     SeqProxy
     getSeqProxy() const;
@@ -115,10 +99,7 @@ public:
     getMentionedAccounts() const;
 
     uint256
-    getTransactionID() const
-    {
-        return tid_;
-    }
+    getTransactionID() const;
 
     Json::Value
     getJson(JsonOptions options) const override;
@@ -156,9 +137,6 @@ private:
 
     Expected<void, std::string>
     checkMultiSign(RequireFullyCanonicalSig requireCanonicalSig) const;
-
-    uint256 tid_;
-    TxType tx_type_;
 };
 
 bool
@@ -177,6 +155,28 @@ sterilize(STTx const& stx);
 /** Check whether a transaction is a pseudo-transaction */
 bool
 isPseudoTx(STObject const& tx);
+
+inline STTx::STTx(SerialIter&& sit) : STTx(sit)
+{
+}
+
+inline TxType
+STTx::getTxnType() const
+{
+    return tx_type_;
+}
+
+inline Blob
+STTx::getSigningPubKey() const
+{
+    return getFieldVL(sfSigningPubKey);
+}
+
+inline uint256
+STTx::getTransactionID() const
+{
+    return tid_;
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STTx.h
+++ b/src/ripple/protocol/STTx.h
@@ -66,12 +66,6 @@ public:
     */
     STTx(TxType type, std::function<void(STObject&)> assembler);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     // STObject functions.
     SerializedTypeID
     getSType() const override;
@@ -137,6 +131,13 @@ private:
 
     Expected<void, std::string>
     checkMultiSign(RequireFullyCanonicalSig requireCanonicalSig) const;
+
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 bool

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -43,6 +43,21 @@ constexpr std::uint32_t vfFullyCanonicalSig = 0x80000000;
 
 class STValidation final : public STObject, public CountedObject<STValidation>
 {
+    bool mTrusted = false;
+
+    // Determines the validity of the signature in this validation; unseated
+    // optional if we haven't yet checked it, a boolean otherwise.
+    mutable std::optional<bool> valid_;
+
+    // The public key associated with the key used to sign this validation
+    PublicKey const signingPubKey_;
+
+    // The ID of the validator that issued this validation. For validators
+    // that use manifests this will be derived from the master public key.
+    NodeID const nodeID_;
+
+    NetClock::time_point seenTime_ = {};
+
 public:
     /** Construct a STValidation from a peer from serialized data.
 
@@ -61,27 +76,7 @@ public:
     STValidation(
         SerialIter& sit,
         LookupNodeID&& lookupNodeID,
-        bool checkSignature)
-        : STObject(validationFormat(), sit, sfValidation)
-        , signingPubKey_([this]() {
-            auto const spk = getFieldVL(sfSigningPubKey);
-
-            if (publicKeyType(makeSlice(spk)) != KeyType::secp256k1)
-                Throw<std::runtime_error>("Invalid public key in validation");
-
-            return PublicKey{makeSlice(spk)};
-        }())
-        , nodeID_(lookupNodeID(signingPubKey_))
-    {
-        if (checkSignature && !isValid())
-        {
-            JLOG(debugLog().error()) << "Invalid signature in validation: "
-                                     << getJson(JsonOptions::none);
-            Throw<std::runtime_error>("Invalid signature in validation");
-        }
-
-        assert(nodeID_.isNonZero());
-    }
+        bool checkSignature);
 
     /** Construct, sign and trust a new STValidation issued by this node.
 
@@ -97,54 +92,13 @@ public:
         PublicKey const& pk,
         SecretKey const& sk,
         NodeID const& nodeID,
-        F&& f)
-        : STObject(validationFormat(), sfValidation)
-        , signingPubKey_(pk)
-        , nodeID_(nodeID)
-        , seenTime_(signTime)
-    {
-        assert(nodeID_.isNonZero());
-
-        // First, set our own public key:
-        if (publicKeyType(pk) != KeyType::secp256k1)
-            LogicError(
-                "We can only use secp256k1 keys for signing validations");
-
-        setFieldVL(sfSigningPubKey, pk.slice());
-        setFieldU32(sfSigningTime, signTime.time_since_epoch().count());
-
-        // Perform additional initialization
-        f(*this);
-
-        // Finally, sign the validation and mark it as trusted:
-        setFlag(vfFullyCanonicalSig);
-        setFieldVL(sfSignature, signDigest(pk, sk, getSigningHash()));
-        setTrusted();
-
-        // Check to ensure that all required fields are present.
-        for (auto const& e : validationFormat())
-        {
-            if (e.style() == soeREQUIRED && !isFieldPresent(e.sField()))
-                LogicError(
-                    "Required field '" + e.sField().getName() +
-                    "' missing from validation.");
-        }
-
-        // We just signed this, so it should be valid.
-        valid_ = true;
-    }
+        F&& f);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     // Hash of the validated ledger
     uint256
@@ -161,16 +115,10 @@ public:
     getSeenTime() const noexcept;
 
     PublicKey const&
-    getSignerPublic() const noexcept
-    {
-        return signingPubKey_;
-    }
+    getSignerPublic() const noexcept;
 
     NodeID const&
-    getNodeID() const noexcept
-    {
-        return nodeID_;
-    }
+    getNodeID() const noexcept;
 
     bool
     isValid() const noexcept;
@@ -179,31 +127,19 @@ public:
     isFull() const noexcept;
 
     bool
-    isTrusted() const noexcept
-    {
-        return mTrusted;
-    }
+    isTrusted() const noexcept;
 
     uint256
     getSigningHash() const;
 
     void
-    setTrusted()
-    {
-        mTrusted = true;
-    }
+    setTrusted();
 
     void
-    setUntrusted()
-    {
-        mTrusted = false;
-    }
+    setUntrusted();
 
     void
-    setSeen(NetClock::time_point s)
-    {
-        seenTime_ = s;
-    }
+    setSeen(NetClock::time_point s);
 
     Blob
     getSerialized() const;
@@ -214,22 +150,119 @@ public:
 private:
     static SOTemplate const&
     validationFormat();
-
-    bool mTrusted = false;
-
-    // Determines the validity of the signature in this validation; unseated
-    // optional if we haven't yet checked it, a boolean otherwise.
-    mutable std::optional<bool> valid_;
-
-    // The public key associated with the key used to sign this validation
-    PublicKey const signingPubKey_;
-
-    // The ID of the validator that issued this validation. For validators
-    // that use manifests this will be derived from the master public key.
-    NodeID const nodeID_;
-
-    NetClock::time_point seenTime_ = {};
 };
+
+template <class LookupNodeID>
+STValidation::STValidation(
+    SerialIter& sit,
+    LookupNodeID&& lookupNodeID,
+    bool checkSignature)
+    : STObject(validationFormat(), sit, sfValidation)
+    , signingPubKey_([this]() {
+        auto const spk = getFieldVL(sfSigningPubKey);
+
+        if (publicKeyType(makeSlice(spk)) != KeyType::secp256k1)
+            Throw<std::runtime_error>("Invalid public key in validation");
+
+        return PublicKey{makeSlice(spk)};
+    }())
+    , nodeID_(lookupNodeID(signingPubKey_))
+{
+    if (checkSignature && !isValid())
+    {
+        JLOG(debugLog().error()) << "Invalid signature in validation: "
+                                 << getJson(JsonOptions::none);
+        Throw<std::runtime_error>("Invalid signature in validation");
+    }
+
+    assert(nodeID_.isNonZero());
+}
+
+/** Construct, sign and trust a new STValidation issued by this node.
+
+    @param signTime When the validation is signed
+    @param publicKey The current signing public key
+    @param secretKey The current signing secret key
+    @param nodeID ID corresponding to node's public master key
+    @param f callback function to "fill" the validation with necessary data
+*/
+template <typename F>
+STValidation::STValidation(
+    NetClock::time_point signTime,
+    PublicKey const& pk,
+    SecretKey const& sk,
+    NodeID const& nodeID,
+    F&& f)
+    : STObject(validationFormat(), sfValidation)
+    , signingPubKey_(pk)
+    , nodeID_(nodeID)
+    , seenTime_(signTime)
+{
+    assert(nodeID_.isNonZero());
+
+    // First, set our own public key:
+    if (publicKeyType(pk) != KeyType::secp256k1)
+        LogicError("We can only use secp256k1 keys for signing validations");
+
+    setFieldVL(sfSigningPubKey, pk.slice());
+    setFieldU32(sfSigningTime, signTime.time_since_epoch().count());
+
+    // Perform additional initialization
+    f(*this);
+
+    // Finally, sign the validation and mark it as trusted:
+    setFlag(vfFullyCanonicalSig);
+    setFieldVL(sfSignature, signDigest(pk, sk, getSigningHash()));
+    setTrusted();
+
+    // Check to ensure that all required fields are present.
+    for (auto const& e : validationFormat())
+    {
+        if (e.style() == soeREQUIRED && !isFieldPresent(e.sField()))
+            LogicError(
+                "Required field '" + e.sField().getName() +
+                "' missing from validation.");
+    }
+
+    // We just signed this, so it should be valid.
+    valid_ = true;
+}
+
+inline PublicKey const&
+STValidation::getSignerPublic() const noexcept
+{
+    return signingPubKey_;
+}
+
+inline NodeID const&
+STValidation::getNodeID() const noexcept
+{
+    return nodeID_;
+}
+
+inline bool
+STValidation::isTrusted() const noexcept
+{
+    return mTrusted;
+}
+
+inline void
+STValidation::setTrusted()
+{
+    mTrusted = true;
+}
+
+inline void
+STValidation::setUntrusted()
+{
+    mTrusted = false;
+}
+
+inline void
+STValidation::setSeen(NetClock::time_point s)
+{
+    seenTime_ = s;
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STValidation.h
+++ b/src/ripple/protocol/STValidation.h
@@ -94,12 +94,6 @@ public:
         NodeID const& nodeID,
         F&& f);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     // Hash of the validated ledger
     uint256
     getLedgerHash() const;
@@ -150,6 +144,13 @@ public:
 private:
     static SOTemplate const&
     validationFormat();
+
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 template <class LookupNodeID>

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -28,43 +28,26 @@ namespace ripple {
 
 class STVector256 : public STBase
 {
+    std::vector<uint256> mValue;
+
 public:
     using value_type = std::vector<uint256> const&;
 
     STVector256() = default;
 
-    explicit STVector256(SField const& n) : STBase(n)
-    {
-    }
-
-    explicit STVector256(std::vector<uint256> const& vector) : mValue(vector)
-    {
-    }
-
-    STVector256(SField const& n, std::vector<uint256> const& vector)
-        : STBase(n), mValue(vector)
-    {
-    }
-
+    explicit STVector256(SField const& n);
+    explicit STVector256(std::vector<uint256> const& vector);
+    STVector256(SField const& n, std::vector<uint256> const& vector);
     STVector256(SerialIter& sit, SField const& name);
 
     STBase*
-    copy(std::size_t n, void* buf) const override
-    {
-        return emplace(n, buf, *this);
-    }
+    copy(std::size_t n, void* buf) const override;
 
     STBase*
-    move(std::size_t n, void* buf) override
-    {
-        return emplace(n, buf, std::move(*this));
-    }
+    move(std::size_t n, void* buf) override;
 
     SerializedTypeID
-    getSType() const override
-    {
-        return STI_VECTOR256;
-    }
+    getSType() const override;
 
     void
     add(Serializer& s) const override;
@@ -75,130 +58,199 @@ public:
     isEquivalent(const STBase& t) const override;
 
     bool
-    isDefault() const override
-    {
-        return mValue.empty();
-    }
+    isDefault() const override;
 
     STVector256&
-    operator=(std::vector<uint256> const& v)
-    {
-        mValue = v;
-        return *this;
-    }
+    operator=(std::vector<uint256> const& v);
 
     STVector256&
-    operator=(std::vector<uint256>&& v)
-    {
-        mValue = std::move(v);
-        return *this;
-    }
+    operator=(std::vector<uint256>&& v);
 
     void
-    setValue(const STVector256& v)
-    {
-        mValue = v.mValue;
-    }
+    setValue(const STVector256& v);
 
     /** Retrieve a copy of the vector we contain */
-    explicit operator std::vector<uint256>() const
-    {
-        return mValue;
-    }
+    explicit operator std::vector<uint256>() const;
 
     std::size_t
-    size() const
-    {
-        return mValue.size();
-    }
+    size() const;
 
     void
-    resize(std::size_t n)
-    {
-        return mValue.resize(n);
-    }
+    resize(std::size_t n);
 
     bool
-    empty() const
-    {
-        return mValue.empty();
-    }
+    empty() const;
 
     std::vector<uint256>::reference
-    operator[](std::vector<uint256>::size_type n)
-    {
-        return mValue[n];
-    }
+    operator[](std::vector<uint256>::size_type n);
 
     std::vector<uint256>::const_reference
-    operator[](std::vector<uint256>::size_type n) const
-    {
-        return mValue[n];
-    }
+    operator[](std::vector<uint256>::size_type n) const;
 
     std::vector<uint256> const&
-    value() const
-    {
-        return mValue;
-    }
+    value() const;
 
     std::vector<uint256>::iterator
-    insert(std::vector<uint256>::const_iterator pos, uint256 const& value)
-    {
-        return mValue.insert(pos, value);
-    }
+    insert(std::vector<uint256>::const_iterator pos, uint256 const& value);
 
     std::vector<uint256>::iterator
-    insert(std::vector<uint256>::const_iterator pos, uint256&& value)
-    {
-        return mValue.insert(pos, std::move(value));
-    }
+    insert(std::vector<uint256>::const_iterator pos, uint256&& value);
 
     void
-    push_back(uint256 const& v)
-    {
-        mValue.push_back(v);
-    }
+    push_back(uint256 const& v);
 
     std::vector<uint256>::iterator
-    begin()
-    {
-        return mValue.begin();
-    }
+    begin();
 
     std::vector<uint256>::const_iterator
-    begin() const
-    {
-        return mValue.begin();
-    }
+    begin() const;
 
     std::vector<uint256>::iterator
-    end()
-    {
-        return mValue.end();
-    }
+    end();
 
     std::vector<uint256>::const_iterator
-    end() const
-    {
-        return mValue.end();
-    }
+    end() const;
 
     std::vector<uint256>::iterator
-    erase(std::vector<uint256>::iterator position)
-    {
-        return mValue.erase(position);
-    }
+    erase(std::vector<uint256>::iterator position);
 
     void
-    clear() noexcept
-    {
-        return mValue.clear();
-    }
-
-private:
-    std::vector<uint256> mValue;
+    clear() noexcept;
 };
+
+inline STVector256::STVector256(SField const& n) : STBase(n)
+{
+}
+
+inline STVector256::STVector256(std::vector<uint256> const& vector)
+    : mValue(vector)
+{
+}
+
+inline STVector256::STVector256(
+    SField const& n,
+    std::vector<uint256> const& vector)
+    : STBase(n), mValue(vector)
+{
+}
+
+inline STVector256&
+STVector256::operator=(std::vector<uint256> const& v)
+{
+    mValue = v;
+    return *this;
+}
+
+inline STVector256&
+STVector256::operator=(std::vector<uint256>&& v)
+{
+    mValue = std::move(v);
+    return *this;
+}
+
+inline void
+STVector256::setValue(const STVector256& v)
+{
+    mValue = v.mValue;
+}
+
+/** Retrieve a copy of the vector we contain */
+inline STVector256::operator std::vector<uint256>() const
+{
+    return mValue;
+}
+
+inline std::size_t
+STVector256::size() const
+{
+    return mValue.size();
+}
+
+inline void
+STVector256::resize(std::size_t n)
+{
+    return mValue.resize(n);
+}
+
+inline bool
+STVector256::empty() const
+{
+    return mValue.empty();
+}
+
+inline std::vector<uint256>::reference
+STVector256::operator[](std::vector<uint256>::size_type n)
+{
+    return mValue[n];
+}
+
+inline std::vector<uint256>::const_reference
+STVector256::operator[](std::vector<uint256>::size_type n) const
+{
+    return mValue[n];
+}
+
+inline std::vector<uint256> const&
+STVector256::value() const
+{
+    return mValue;
+}
+
+inline std::vector<uint256>::iterator
+STVector256::insert(
+    std::vector<uint256>::const_iterator pos,
+    uint256 const& value)
+{
+    return mValue.insert(pos, value);
+}
+
+inline std::vector<uint256>::iterator
+STVector256::insert(std::vector<uint256>::const_iterator pos, uint256&& value)
+{
+    return mValue.insert(pos, std::move(value));
+}
+
+inline void
+STVector256::push_back(uint256 const& v)
+{
+    mValue.push_back(v);
+}
+
+inline std::vector<uint256>::iterator
+STVector256::begin()
+{
+    return mValue.begin();
+}
+
+inline std::vector<uint256>::const_iterator
+STVector256::begin() const
+{
+    return mValue.begin();
+}
+
+inline std::vector<uint256>::iterator
+STVector256::end()
+{
+    return mValue.end();
+}
+
+inline std::vector<uint256>::const_iterator
+STVector256::end() const
+{
+    return mValue.end();
+}
+
+inline std::vector<uint256>::iterator
+STVector256::erase(std::vector<uint256>::iterator position)
+{
+    return mValue.erase(position);
+}
+
+inline void
+STVector256::clear() noexcept
+{
+    return mValue.clear();
+}
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/STVector256.h
+++ b/src/ripple/protocol/STVector256.h
@@ -40,12 +40,6 @@ public:
     STVector256(SField const& n, std::vector<uint256> const& vector);
     STVector256(SerialIter& sit, SField const& name);
 
-    STBase*
-    copy(std::size_t n, void* buf) const override;
-
-    STBase*
-    move(std::size_t n, void* buf) override;
-
     SerializedTypeID
     getSType() const override;
 
@@ -116,6 +110,14 @@ public:
 
     void
     clear() noexcept;
+
+private:
+    STBase*
+    copy(std::size_t n, void* buf) const override;
+    STBase*
+    move(std::size_t n, void* buf) override;
+
+    friend class detail::STVar;
 };
 
 inline STVector256::STVector256(SField const& n) : STBase(n)

--- a/src/ripple/protocol/impl/STAccount.cpp
+++ b/src/ripple/protocol/impl/STAccount.cpp
@@ -59,6 +59,50 @@ STAccount::STAccount(SField const& n, AccountID const& v)
 {
 }
 
+STBase*
+STAccount::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STAccount::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+SerializedTypeID
+STAccount::getSType() const
+{
+    return STI_ACCOUNT;
+}
+
+void
+STAccount::add(Serializer& s) const
+{
+    assert(getFName().isBinary());
+    assert(getFName().fieldType == STI_ACCOUNT);
+
+    // Preserve the serialization behavior of an STBlob:
+    //  o If we are default (all zeros) serialize as an empty blob.
+    //  o Otherwise serialize 160 bits.
+    int const size = isDefault() ? 0 : uint160::bytes;
+    s.addVL(value_.data(), size);
+}
+
+bool
+STAccount::isEquivalent(const STBase& t) const
+{
+    auto const* const tPtr = dynamic_cast<STAccount const*>(&t);
+    return tPtr && (default_ == tPtr->default_) && (value_ == tPtr->value_);
+}
+
+bool
+STAccount::isDefault() const
+{
+    return default_;
+}
+
 std::string
 STAccount::getText() const
 {

--- a/src/ripple/protocol/impl/STAmount.cpp
+++ b/src/ripple/protocol/impl/STAmount.cpp
@@ -292,6 +292,18 @@ STAmount::construct(SerialIter& sit, SField const& name)
     return std::make_unique<STAmount>(sit, name);
 }
 
+STBase*
+STAmount::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STAmount::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
 //------------------------------------------------------------------------------
 //
 // Conversion
@@ -485,6 +497,12 @@ STAmount::setJson(Json::Value& elem) const
 //
 //------------------------------------------------------------------------------
 
+SerializedTypeID
+STAmount::getSType() const
+{
+    return STI_AMOUNT;
+}
+
 std::string
 STAmount::getFullText() const
 {
@@ -636,6 +654,12 @@ STAmount::isEquivalent(const STBase& t) const
 {
     const STAmount* v = dynamic_cast<const STAmount*>(&t);
     return v && (*v == *this);
+}
+
+bool
+STAmount::isDefault() const
+{
+    return (mValue == 0) && mIsNative;
 }
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/impl/STArray.cpp
+++ b/src/ripple/protocol/impl/STArray.cpp
@@ -89,6 +89,18 @@ STArray::STArray(SerialIter& sit, SField const& f, int depth) : STBase(f)
     }
 }
 
+STBase*
+STArray::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STArray::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
 std::string
 STArray::getFullText() const
 {
@@ -153,11 +165,23 @@ STArray::add(Serializer& s) const
     }
 }
 
+SerializedTypeID
+STArray::getSType() const
+{
+    return STI_ARRAY;
+}
+
 bool
 STArray::isEquivalent(const STBase& t) const
 {
     auto v = dynamic_cast<const STArray*>(&t);
     return v != nullptr && v_ == v->v_;
+}
+
+bool
+STArray::isDefault() const
+{
+    return v_.empty();
 }
 
 void

--- a/src/ripple/protocol/impl/STBase.cpp
+++ b/src/ripple/protocol/impl/STBase.cpp
@@ -53,6 +53,18 @@ STBase::operator!=(const STBase& t) const
     return (getSType() != t.getSType()) || !isEquivalent(t);
 }
 
+STBase*
+STBase::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STBase::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
 SerializedTypeID
 STBase::getSType() const
 {

--- a/src/ripple/protocol/impl/STBlob.cpp
+++ b/src/ripple/protocol/impl/STBlob.cpp
@@ -27,10 +27,38 @@ STBlob::STBlob(SerialIter& st, SField const& name)
 {
 }
 
+STBase*
+STBlob::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STBlob::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+SerializedTypeID
+STBlob::getSType() const
+{
+    return STI_VL;
+}
+
 std::string
 STBlob::getText() const
 {
     return strHex(value_);
+}
+
+void
+STBlob::add(Serializer& s) const
+{
+    assert(getFName().isBinary());
+    assert(
+        (getFName().fieldType == STI_VL) ||
+        (getFName().fieldType == STI_ACCOUNT));
+    s.addVL(value_.data(), value_.size());
 }
 
 bool
@@ -38,6 +66,12 @@ STBlob::isEquivalent(const STBase& t) const
 {
     const STBlob* v = dynamic_cast<const STBlob*>(&t);
     return v && (value_ == v->value_);
+}
+
+bool
+STBlob::isDefault() const
+{
+    return value_.empty();
 }
 
 }  // namespace ripple

--- a/src/ripple/protocol/impl/STLedgerEntry.cpp
+++ b/src/ripple/protocol/impl/STLedgerEntry.cpp
@@ -88,6 +88,24 @@ STLedgerEntry::getFullText() const
     return ret;
 }
 
+STBase*
+STLedgerEntry::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STLedgerEntry::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+SerializedTypeID
+STLedgerEntry::getSType() const
+{
+    return STI_LEDGERENTRY;
+}
+
 std::string
 STLedgerEntry::getText() const
 {

--- a/src/ripple/protocol/impl/STPathSet.cpp
+++ b/src/ripple/protocol/impl/STPathSet.cpp
@@ -101,6 +101,18 @@ STPathSet::STPathSet(SerialIter& sit, SField const& name) : STBase(name)
     }
 }
 
+STBase*
+STPathSet::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STPathSet::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
 bool
 STPathSet::assembleAdd(STPath const& base, STPathElement const& tail)
 {  // assemble base+tail and add it to the set if it's not a duplicate
@@ -127,6 +139,12 @@ STPathSet::isEquivalent(const STBase& t) const
 {
     const STPathSet* v = dynamic_cast<const STPathSet*>(&t);
     return v && (value == v->value);
+}
+
+bool
+STPathSet::isDefault() const
+{
+    return value.empty();
 }
 
 bool
@@ -181,11 +199,17 @@ STPathSet::getJson(JsonOptions options) const
     return ret;
 }
 
+SerializedTypeID
+STPathSet::getSType() const
+{
+    return STI_PATHSET;
+}
+
 void
 STPathSet::add(Serializer& s) const
 {
-    assert(fName->isBinary());
-    assert(fName->fieldType == STI_PATHSET);
+    assert(getFName().isBinary());
+    assert(getFName().fieldType == STI_PATHSET);
     bool first = true;
 
     for (auto const& spPath : value)

--- a/src/ripple/protocol/impl/STTx.cpp
+++ b/src/ripple/protocol/impl/STTx.cpp
@@ -56,14 +56,14 @@ getTxFormat(TxType type)
     return format;
 }
 
-STTx::STTx(STObject&& object) noexcept(false) : STObject(std::move(object))
+STTx::STTx(STObject&& object) : STObject(std::move(object))
 {
     tx_type_ = safe_cast<TxType>(getFieldU16(sfTransactionType));
     applyTemplate(getTxFormat(tx_type_)->getSOTemplate());  //  may throw
     tid_ = getHash(HashPrefix::transactionID);
 }
 
-STTx::STTx(SerialIter& sit) noexcept(false) : STObject(sfTransaction)
+STTx::STTx(SerialIter& sit) : STObject(sfTransaction)
 {
     int length = sit.getBytesLeft();
 
@@ -95,6 +95,25 @@ STTx::STTx(TxType type, std::function<void(STObject&)> assembler)
         LogicError("Transaction type was mutated during assembly");
 
     tid_ = getHash(HashPrefix::transactionID);
+}
+
+STBase*
+STTx::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STTx::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+// STObject functions.
+SerializedTypeID
+STTx::getSType() const
+{
+    return STI_TRANSACTION;
 }
 
 std::string

--- a/src/ripple/protocol/impl/STValidation.cpp
+++ b/src/ripple/protocol/impl/STValidation.cpp
@@ -25,6 +25,18 @@
 
 namespace ripple {
 
+STBase*
+STValidation::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STValidation::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
 SOTemplate const&
 STValidation::validationFormat()
 {

--- a/src/ripple/protocol/impl/STVector256.cpp
+++ b/src/ripple/protocol/impl/STVector256.cpp
@@ -41,11 +41,35 @@ STVector256::STVector256(SerialIter& sit, SField const& name) : STBase(name)
     }
 }
 
+STBase*
+STVector256::copy(std::size_t n, void* buf) const
+{
+    return emplace(n, buf, *this);
+}
+
+STBase*
+STVector256::move(std::size_t n, void* buf)
+{
+    return emplace(n, buf, std::move(*this));
+}
+
+SerializedTypeID
+STVector256::getSType() const
+{
+    return STI_VECTOR256;
+}
+
+bool
+STVector256::isDefault() const
+{
+    return mValue.empty();
+}
+
 void
 STVector256::add(Serializer& s) const
 {
-    assert(fName->isBinary());
-    assert(fName->fieldType == STI_VECTOR256);
+    assert(getFName().isBinary());
+    assert(getFName().fieldType == STI_VECTOR256);
     s.addVL(mValue.begin(), mValue.end(), mValue.size() * (256 / 8));
 }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

Restrict access to the virtual functions move and copy for the STBase-derived types.
These are meant to be used by detail::STVar only and are otherwise error-prone to call.

There is no functionality or behavioral change.

Only the second commit needs to be reviewed.  The first commit belongs to PR #3950.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
