### PR TITLE
Prefer using a local Sandbox over using the Context's view

### DIFF
--- a/src/ripple/app/tx/impl/CreateOffer.cpp
+++ b/src/ripple/app/tx/impl/CreateOffer.cpp
@@ -637,7 +637,7 @@ CreateOffer::takerCross(
     Sandbox& sbCancel,
     Amounts const& takerAmount)
 {
-    NetClock::time_point const when = ctx_.view().parentCloseTime();
+    NetClock::time_point const when = sb.parentCloseTime();
 
     beast::WrappedSink takerSink(j_, "Taker ");
 
@@ -957,7 +957,7 @@ CreateOffer::applyGuts(Sandbox& sb, Sandbox& sbCancel)
     // Expiration is defined in terms of the close time of the parent ledger,
     // because we definitively know the time that it closed but we do not
     // know the closing time of the ledger that is under construction.
-    if (expiration && (ctx_.view().parentCloseTime() >= tp{d{*expiration}}))
+    if (expiration && (sb.parentCloseTime() >= tp{d{*expiration}}))
     {
         // If the offer has expired, the transaction has successfully
         // done nothing, so short circuit from here.
@@ -965,13 +965,12 @@ CreateOffer::applyGuts(Sandbox& sb, Sandbox& sbCancel)
         // The return code change is attached to featureDepositPreauth as a
         // convenience.  The change is not big enough to deserve a fix code.
         TER const ter{
-            ctx_.view().rules().enabled(featureDepositPreauth)
-                ? TER{tecEXPIRED}
-                : TER{tesSUCCESS}};
+            sb.rules().enabled(featureDepositPreauth) ? TER{tecEXPIRED}
+                                                      : TER{tesSUCCESS}};
         return {ter, true};
     }
 
-    bool const bOpenLedger = ctx_.view().open();
+    bool const bOpenLedger = sb.open();
     bool crossed = false;
 
     if (result == tesSUCCESS)
@@ -1129,8 +1128,8 @@ CreateOffer::applyGuts(Sandbox& sb, Sandbox& sbCancel)
         return {tefINTERNAL, false};
 
     {
-        XRPAmount reserve = ctx_.view().fees().accountReserve(
-            sleCreator->getFieldU32(sfOwnerCount) + 1);
+        XRPAmount reserve =
+            sb.fees().accountReserve(sleCreator->getFieldU32(sfOwnerCount) + 1);
 
         if (mPriorBalance < reserve)
         {


### PR DESCRIPTION
## High Level Overview of Change

If a transactor has access to a `Sandbox`, using that `Sandbox` is preferable to directly using the `View` underlying the `Sandbox`.  This branch fixes some places in the `CreateOffer` transactor that were not following this guideline.

### Context of Change

These are errors that have crept in over time.  There have been a couple of recent bugs that brought attention to this kind of error, which is how they came to my attention.  The changed uses of `View` should not have caused any bugs, but were counter to current guidance.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

This change should not be user-visible.  The commit does not need to be mentioned in the release notes.  Standard unit tests and integration tests should be sufficient for test coverage.

I consider the change to be trivial, so I'm only requesting one reviewer.  I'm open to being persuaded that it needs a more serious review.