### PR TITLE
Adjust default number of threads for JobQueue:

### DIFF
--- a/src/ripple/app/consensus/RCLValidations.cpp
+++ b/src/ripple/app/consensus/RCLValidations.cpp
@@ -87,7 +87,8 @@ RCLValidatedLedger::operator[](Seq const& s) const -> ID
 
     JLOG(j_.warn()) << "Unable to determine hash of ancestor seq=" << s
                     << " from ledger hash=" << ledgerID_
-                    << " seq=" << ledgerSeq_;
+                    << " seq=" << ledgerSeq_ << " (available: " << minSeq()
+                    << "-" << seq() << ")";
     // Default ID that is less than all others
     return ID{0};
 }

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -283,6 +283,30 @@ public:
               logs_->journal("Collector")))
 
         , m_jobQueue(std::make_unique<JobQueue>(
+              [this]() {
+                  if (config_->standalone() && !config_->reporting())
+                      return 1;
+
+                  if (config_->WORKERS)
+                      return config_->WORKERS;
+
+                  auto count =
+                      static_cast<int>(std::thread::hardware_concurrency());
+
+                  // Be more aggressive about the number of threads to use
+                  // for the job queue if the server is configured as "large"
+                  // or "huge".
+                  if (config_->NODE_SIZE >= 3)
+                      count = 4 + std::min(count, 8);
+                  else
+                      count = 2 + std::min(count, 4);
+
+                  JLOG(m_journal.info())
+                      << "Auto-tuning to " << count
+                      << " validation/transaction/proposal threads.";
+
+                  return count;
+              }(),
               m_collectorManager->group("jobq"),
               logs_->journal("JobQueue"),
               *logs_,
@@ -1220,9 +1244,6 @@ ApplicationImp::setup()
 
     // Optionally turn off logging to console.
     logs_->silent(config_->silent());
-
-    m_jobQueue->setThreadCount(
-        config_->WORKERS, config_->standalone() && !config_->reporting());
 
     if (!config_->standalone())
         timeKeeper_->run(config_->SNTP_SERVERS);

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -202,7 +202,7 @@ public:
     std::chrono::seconds AMENDMENT_MAJORITY_TIME = defaultAmendmentMajorityTime;
 
     // Thread pool configuration
-    std::size_t WORKERS = 0;
+    int WORKERS = 0;
 
     // Reduce-relay - these parameters are experimental.
     // Enable reduce-relay features

--- a/src/ripple/core/JobQueue.h
+++ b/src/ripple/core/JobQueue.h
@@ -141,6 +141,7 @@ public:
     using JobFunction = std::function<void(Job&)>;
 
     JobQueue(
+        int threadCount,
         beast::insight::Collector::ptr const& collector,
         beast::Journal journal,
         Logs& logs,
@@ -199,11 +200,6 @@ public:
      */
     int
     getJobCountGE(JobType t) const;
-
-    /** Set the number of thread serving the job queue to precisely this number.
-     */
-    void
-    setThreadCount(int c, bool const standaloneMode);
 
     /** Return a scoped LoadEvent.
      */

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -628,7 +628,13 @@ Config::loadFromString(std::string const& fileContents)
         DEBUG_LOGFILE = strTemp;
 
     if (getSingleSection(secConfig, SECTION_WORKERS, strTemp, j_))
-        WORKERS = beast::lexicalCastThrow<std::size_t>(strTemp);
+    {
+        WORKERS = beast::lexicalCastThrow<int>(strTemp);
+
+        if (WORKERS < 1 || WORKERS > 128)
+            Throw<std::runtime_error>("Invalid " SECTION_WORKERS
+                                      ": must be between 1 and 128 inclusive.");
+    }
 
     if (getSingleSection(secConfig, SECTION_COMPRESSION, strTemp, j_))
         COMPRESSION = beast::lexicalCastThrow<bool>(strTemp);

--- a/src/test/app/Transaction_ordering_test.cpp
+++ b/src/test/app/Transaction_ordering_test.cpp
@@ -69,8 +69,11 @@ struct Transaction_ordering_test : public beast::unit_test::suite
     {
         using namespace jtx;
 
-        Env env(*this);
-        env.app().getJobQueue().setThreadCount(0, false);
+        Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
+            cfg->section("workers").legacy("5");
+            return cfg;
+        }));
+
         auto const alice = Account("alice");
         env.fund(XRP(1000), noripple(alice));
 
@@ -109,8 +112,11 @@ struct Transaction_ordering_test : public beast::unit_test::suite
     {
         using namespace jtx;
 
-        Env env(*this);
-        env.app().getJobQueue().setThreadCount(0, false);
+        Env env(*this, envconfig([](std::unique_ptr<Config> cfg) {
+            cfg->section("workers").legacy("6");
+            return cfg;
+        }));
+
         auto const alice = Account("alice");
         env.fund(XRP(1000), noripple(alice));
 


### PR DESCRIPTION
The existing calculation would limit the maximum number of threads that would be created by default to at most 6; this may have been reasonable a few years ago, but given both the load on the network as of today and the increase in the number of CPU cores, the value
should be revisited.

This commit, if merged, changes the default calculation for nodes that are configured as `large` or `huge` to allow for up to twelve threads.
