### PR TITLE
ignore_default option on account_lines

### DIFF
--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -280,6 +280,7 @@ JSS(hotwallet);             // in: GatewayBalances
 JSS(id);                    // websocket.
 JSS(ident);                 // in: AccountCurrencies, AccountInfo,
                             //     OwnerInfo
+JSS(ignore_default);        // in: AccountLines
 JSS(inLedger);              // out: tx/Transaction
 JSS(inbound);               // out: PeerImp
 JSS(index);                 // in: LedgerEntry, DownloadShard


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Add `ignore_default` flag to `account_lines`. This flag suppresses the output of incoming trustlines in default state.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
Users of XUMM often have unwanted incoming trustlines in default state, these are not useful in the vast majority of cases. Ability to suppress these in `account_lines` saves bandwidth and resources.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
