### PR TITLE
`drop_untrusted` validations and proposals config option

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -622,18 +622,28 @@
 #
 # [relay_proposals]
 #
-#   Controls the relaying behavior for proposals received by this server that
-#   are issued by validators that are not on the server's UNL.
+#   Controls the relay and processing behavior for proposals received by this
+#   server that are issued by validators that are not on the server's UNL.
 #
-#   Legal values are: "trusted" and "all". The default is "trusted".
+#   Legal values are:
+#     "all"            - Relay and process all incoming proposals
+#     "trusted"        - Relay only trusted proposals, but locally process all
+#     "drop_untrusted" - Relay only trusted proposals, do not process untrusted
+#
+#   The default is "trusted".
 #
 #
 # [relay_validations]
 #
-#   Controls the relaying behavior for validations received by this server that
-#   are issued by validators that are not on the server's UNL.
+#   Controls the relay and processing behavior for validations received by this
+#   server that are issued by validators that are not on the server's UNL.
 #
-#   Legal values are: "trusted" and "all". The default is "all".
+#   Legal values are:
+#     "all"            - Relay and process all incoming validations
+#     "trusted"        - Relay only trusted validations, but locally process all
+#     "drop_untrusted" - Relay only trusted validations, do not process untrusted
+#
+#   The default is "all".
 #
 #
 #

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2249,7 +2249,7 @@ NetworkOPsImp::recvValidation(
 
     // We will always relay trusted validations; if configured, we will
     // also relay all untrusted validations.
-    return app_.config().RELAY_UNTRUSTED_VALIDATIONS || val->isTrusted();
+    return app_.config().RELAY_UNTRUSTED_VALIDATIONS == 1 || val->isTrusted();
 }
 
 Json::Value

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -146,8 +146,10 @@ public:
     std::size_t NETWORK_QUORUM = 1;
 
     // Peer networking parameters
-    bool RELAY_UNTRUSTED_VALIDATIONS = true;
-    bool RELAY_UNTRUSTED_PROPOSALS = false;
+    // 1 = relay, 0 = do not relay (but process), -1 = drop completely (do NOT
+    // process)
+    int RELAY_UNTRUSTED_VALIDATIONS = 1;
+    int RELAY_UNTRUSTED_PROPOSALS = 0;
 
     // True to ask peers not to relay current IP.
     bool PEER_PRIVATE = false;

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -553,9 +553,11 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_RELAY_VALIDATIONS, strTemp, j_))
     {
         if (boost::iequals(strTemp, "all"))
-            RELAY_UNTRUSTED_VALIDATIONS = true;
+            RELAY_UNTRUSTED_VALIDATIONS = 1;
         else if (boost::iequals(strTemp, "trusted"))
-            RELAY_UNTRUSTED_VALIDATIONS = false;
+            RELAY_UNTRUSTED_VALIDATIONS = 0;
+        else if (boost::iequals(strTemp, "drop_untrusted"))
+            RELAY_UNTRUSTED_VALIDATIONS = -1;
         else
             Throw<std::runtime_error>(
                 "Invalid value specified in [" SECTION_RELAY_VALIDATIONS
@@ -565,9 +567,11 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_RELAY_PROPOSALS, strTemp, j_))
     {
         if (boost::iequals(strTemp, "all"))
-            RELAY_UNTRUSTED_PROPOSALS = true;
+            RELAY_UNTRUSTED_PROPOSALS = 1;
         else if (boost::iequals(strTemp, "trusted"))
-            RELAY_UNTRUSTED_PROPOSALS = false;
+            RELAY_UNTRUSTED_PROPOSALS = 0;
+        else if (boost::iequals(strTemp, "drop_untrusted"))
+            RELAY_UNTRUSTED_PROPOSALS = -1;
         else
             Throw<std::runtime_error>(
                 "Invalid value specified in [" SECTION_RELAY_PROPOSALS

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1929,10 +1929,21 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
         return;
     }
 
+    // RH TODO: when isTrusted = false we should probably also cache a key
+    // suppression for 30 seconds to avoid doing a relatively expensive lookup
+    // every time a spam packet is received
+    PublicKey const publicKey{makeSlice(set.nodepubkey())};
+    auto const isTrusted = app_.validators().trusted(publicKey);
+
+    // If the operator has specified that untrusted proposals be dropped then
+    // this happens here I.e. before further wasting CPU verifying the signature
+    // of an untrusted key
+    if (!isTrusted && app_.config().RELAY_UNTRUSTED_PROPOSALS == -1)
+        return;
+
     uint256 const proposeHash{set.currenttxhash()};
     uint256 const prevLedger{set.previousledger()};
 
-    PublicKey const publicKey{makeSlice(set.nodepubkey())};
     NetClock::time_point const closeTime{NetClock::duration{set.closetime()}};
 
     uint256 const suppression = proposalUniqueId(
@@ -1956,8 +1967,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
         JLOG(p_journal_.trace()) << "Proposal: duplicate";
         return;
     }
-
-    auto const isTrusted = app_.validators().trusted(publicKey);
 
     if (!isTrusted)
     {
@@ -2543,6 +2552,18 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
             return;
         }
 
+        // RH TODO: when isTrusted = false we should probably also cache a key
+        // suppression for 30 seconds to avoid doing a relatively expensive
+        // lookup every time a spam packet is received
+        auto const isTrusted =
+            app_.validators().trusted(val->getSignerPublic());
+
+        // If the operator has specified that untrusted validations be dropped
+        // then this happens here I.e. before further wasting CPU verifying the
+        // signature of an untrusted key
+        if (!isTrusted && app_.config().RELAY_UNTRUSTED_VALIDATIONS == -1)
+            return;
+
         auto key = sha512Half(makeSlice(m->validation()));
         if (auto [added, relayed] =
                 app_.getHashRouter().addSuppressionPeerWithStatus(key, id_);
@@ -2559,9 +2580,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
             JLOG(p_journal_.trace()) << "Validation: duplicate";
             return;
         }
-
-        auto const isTrusted =
-            app_.validators().trusted(val->getSignerPublic());
 
         if (!isTrusted && (tracking_.load() == Tracking::diverged))
         {
@@ -3106,7 +3124,7 @@ PeerImp::checkPropose(
     if (isTrusted)
         relay = app_.getOPs().processTrustedProposal(peerPos);
     else
-        relay = app_.config().RELAY_UNTRUSTED_PROPOSALS || cluster();
+        relay = app_.config().RELAY_UNTRUSTED_PROPOSALS == 1 || cluster();
 
     if (relay)
     {


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Prevent untrusted validations and proposals from consuming local resources.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
Recently the network is filled with massive numbers of untrusted validations. Currently the ratio is around 4 untrusted validations to every 1 trusted validation. These are relayed without billing the peer who sends them. This packet type can be used in an amplification attack against the network. 

Although an option already exists to not relay untrusted validations, this still incurs the penalty of local processing. Local processing includes SHA512Half and jobqueue insertion (which requires jobqueue mutex to be held). 

`drop_untrusted` is here presented as a third option to not relay nor locally process untrusted validations.


<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
