### PR TITLE
Eliminate SHAMapInnerNode lock contention:

### DIFF
--- a/src/ripple/shamap/impl/TaggedPointer.ipp
+++ b/src/ripple/shamap/impl/TaggedPointer.ipp
@@ -17,8 +17,8 @@
 */
 //==============================================================================
 
+#include <ripple/basics/ByteUtilities.h>
 #include <ripple/shamap/impl/TaggedPointer.h>
-
 #include <ripple/shamap/SHAMapInnerNode.h>
 
 #include <array>


### PR DESCRIPTION
The `SHAMapInnerNode` class had a global mutex to protect the array of node children. Profiling the old `std::mutex`-based mutex solution, out of 360,000,000 `lock` operations, 11,349,853 blocked because the `mutex` was already locked: that is over 4% of the time.

This commit removes that global mutex, and replaces it with a new per-node 16-way spinlock. Profiling with the new per-node 16-way spinlock suggests that the contention was effectively eliminated. Out of 360,000,000 `lock` operations, only 1,057 failed to acquire the lock on the first 'spin', with 50% of those managing to acquire their requested spinlock on the next spin and in no instance requiring more than 3 spins.

While this patch is unlikely to directly and measurably increase performance, it is a meaningful improvement and does so with no increase in memory usage or additional CPU.

Kudos to @RichardAH who suggested profiling locks and collected the original data that led down this path.