### PR TITLE
Return correct error code for node_to_shard command errors

### DIFF
--- a/src/ripple/net/RPCErr.h
+++ b/src/ripple/net/RPCErr.h
@@ -28,7 +28,7 @@ namespace ripple {
 bool
 isRpcError(Json::Value jvResult);
 Json::Value
-rpcError(int iError, Json::Value jvResult = Json::Value(Json::objectValue));
+rpcError(int iError);
 
 }  // namespace ripple
 

--- a/src/ripple/net/impl/RPCErr.cpp
+++ b/src/ripple/net/impl/RPCErr.cpp
@@ -26,8 +26,9 @@ struct RPCErr;
 
 // VFALCO NOTE Deprecated function
 Json::Value
-rpcError(int iError, Json::Value jvResult)
+rpcError(int iError)
 {
+    Json::Value jvResult(Json::objectValue);
     RPC::inject_error(iError, jvResult);
     return jvResult;
 }

--- a/src/ripple/rpc/handlers/NodeToShard.cpp
+++ b/src/ripple/rpc/handlers/NodeToShard.cpp
@@ -38,7 +38,7 @@ doNodeToShard(RPC::JsonContext& context)
     // Shard store must be enabled
     auto const shardStore = context.app.getShardStore();
     if (!shardStore)
-        return rpcError(rpcINTERNAL, "No shard store");
+        return RPC::make_error(rpcNOT_ENABLED);
 
     if (!context.params.isMember(jss::action))
         return RPC::missing_field_error(jss::action);


### PR DESCRIPTION
## High Level Overview of Change

If the shard store is not enabled in the configuration, the RPC commands should return "Not enabled in configuration".

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
