### PR TITLE
Improve full & compressed inner node deserialization

### DIFF
--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -182,7 +182,7 @@ SHAMapInnerNode::makeCompressedInner(Slice data)
         auto const hash = si.getBitString<256>();
         auto const pos = si.get8();
 
-        if ((pos < 0) || (pos >= branchFactor))
+        if (pos >= branchFactor)
             Throw<std::runtime_error>("invalid CI node");
 
         hashes[pos].as_uint256() = hash;

--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -132,19 +132,21 @@ SHAMapInnerNode::makeFullInner(
     SHAMapHash const& hash,
     bool hashValid)
 {
-    if (data.size() != 512)
+    // A full inner node is serialized as 16 256-bit hashes, back to back:
+    if (data.size() != branchFactor * uint256::bytes)
         Throw<std::runtime_error>("Invalid FI node");
 
     auto ret = std::make_shared<SHAMapInnerNode>(0, branchFactor);
 
-    Serializer s(data.data(), data.size());
+    SerialIter si(data);
 
-    auto retHashes = ret->hashesAndChildren_.getHashes();
+    auto hashes = ret->hashesAndChildren_.getHashes();
+
     for (int i = 0; i < branchFactor; ++i)
     {
-        s.getBitString(retHashes[i].as_uint256(), i * 32);
+        hashes[i].as_uint256() = si.getBitString<256>();
 
-        if (retHashes[i].isNonZero())
+        if (hashes[i].isNonZero())
             ret->isBranch_ |= (1 << i);
     }
 
@@ -154,39 +156,43 @@ SHAMapInnerNode::makeFullInner(
         ret->hash_ = hash;
     else
         ret->updateHash();
+
     return ret;
 }
 
 std::shared_ptr<SHAMapTreeNode>
 SHAMapInnerNode::makeCompressedInner(Slice data)
 {
-    Serializer s(data.data(), data.size());
+    // A compressed inner node is serialized as a series of 33 byte chunks,
+    // representing a one byte "position" and a 256-bit hash:
+    constexpr std::size_t chunkSize = uint256::bytes + 1;
 
-    int len = s.getLength();
+    if (auto const s = data.size();
+        (s % chunkSize != 0) || (s > chunkSize * branchFactor))
+        Throw<std::runtime_error>("Invalid CI node");
+
+    SerialIter si(data);
 
     auto ret = std::make_shared<SHAMapInnerNode>(0, branchFactor);
 
-    auto retHashes = ret->hashesAndChildren_.getHashes();
-    for (int i = 0; i < (len / 33); ++i)
-    {
-        int pos;
+    auto hashes = ret->hashesAndChildren_.getHashes();
 
-        if (!s.get8(pos, 32 + (i * 33)))
-            Throw<std::runtime_error>("short CI node");
+    while (!si.empty())
+    {
+        auto const hash = si.getBitString<256>();
+        auto const pos = si.get8();
 
         if ((pos < 0) || (pos >= branchFactor))
             Throw<std::runtime_error>("invalid CI node");
 
-        s.getBitString(retHashes[pos].as_uint256(), i * 33);
+        hashes[pos].as_uint256() = hash;
 
-        if (retHashes[pos].isNonZero())
+        if (hashes[pos].isNonZero())
             ret->isBranch_ |= (1 << pos);
     }
 
     ret->resizeChildArrays(ret->getBranchCount());
-
     ret->updateHash();
-
     return ret;
 }
 


### PR DESCRIPTION
### Details

There are two serialization formats for inner nodes: "full" and "compressed". A full node is serialized as 16 32-byte hashes, for a total of 512 bytes. An inner node is serialized as a number of {position, hash} pairs, between 1 and 16, where position is stored as 1 byte and a hash is stored as 32 bytes.

This change removes a redundant copy by using `SerialIter` instead of `Serializer` and makes the buffer size checks more stringent.

No change in functionality is expected.

@HowardHinnant is there any reason to keep `SHAMapHash` as a `class` instead of converting it to something like: `using SHAMapHash = base_uint<256, SHAMap>`, other than then fact that we need to pass such hashes to functions which accept a raw `uint256` and we have no easy easy to "bend" the type system enough to cast a `base_uint<N, X>` to `base_uint<N, Y>` without copying?

### Type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release