### PR TITLE
Improved handling for HTTP X-Forwarded-For and Forwarded

### DIFF
--- a/src/test/rpc/Roles_test.cpp
+++ b/src/test/rpc/Roles_test.cpp
@@ -20,9 +20,12 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/jss.h>
-#include <string>
 #include <test/jtx.h>
 #include <test/jtx/WSClient.h>
+
+#include <boost/asio/ip/address_v4.hpp>
+
+#include <string>
 #include <unordered_map>
 
 namespace ripple {
@@ -31,6 +34,14 @@ namespace test {
 
 class Roles_test : public beast::unit_test::suite
 {
+    bool
+    isValidIpAddress(std::string const& addr)
+    {
+        boost::system::error_code ec;
+        boost::asio::ip::make_address(addr, ec);
+        return !ec.failed();
+    }
+
     void
     testRoles()
     {
@@ -63,31 +74,65 @@ class Roles_test : public beast::unit_test::suite
                 !wsRes.isMember("unlimited") || !wsRes["unlimited"].asBool());
 
             std::unordered_map<std::string, std::string> headers;
+            Json::Value rpcRes;
+
+            // IPv4 tests.
             headers["X-Forwarded-For"] = "12.34.56.78";
-            auto rpcRes = env.rpc(headers, "ping")["result"];
+            rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["role"] == "proxied");
             BEAST_EXPECT(rpcRes["ip"] == "12.34.56.78");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             headers["X-Forwarded-For"] = "87.65.43.21, 44.33.22.11";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "87.65.43.21");
-            headers.erase("X-Forwarded-For");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
+            headers["X-Forwarded-For"] = "87.65.43.21:47011, 44.33.22.11";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "87.65.43.21");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers = {};
             headers["Forwarded"] = "for=88.77.66.55";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "88.77.66.55");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             headers["Forwarded"] =
                 "what=where;for=55.66.77.88;for=nobody;"
                 "who=3";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             headers["Forwarded"] =
-                "what=where;for=55.66.77.88, 99.00.11.22;"
+                "what=where; for=55.66.77.88, for=99.00.11.22;"
                 "who=3";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "what=where; For=99.88.77.66, for=55.66.77.88;"
+                "who=3";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "99.88.77.66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "what=where; for=\"55.66.77.88:47011\";"
+                "who=3";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "what=where; For= \" 99.88.77.66 \" ,for=11.22.33.44;"
+                "who=3";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "99.88.77.66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             wsRes = makeWSClient(env.app().config(), true, 2, headers)
                         ->invoke("ping")["result"];
@@ -99,10 +144,218 @@ class Roles_test : public beast::unit_test::suite
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["role"] == "identified");
             BEAST_EXPECT(rpcRes["username"] == name);
-            BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(rpcRes["ip"] == "99.88.77.66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
             wsRes = makeWSClient(env.app().config(), true, 2, headers)
                         ->invoke("ping")["result"];
             BEAST_EXPECT(wsRes["unlimited"].asBool());
+
+            // IPv6 tests.
+            headers = {};
+            headers["X-Forwarded-For"] =
+                "2001:db8:3333:4444:5555:6666:7777:8888";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:8888");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "2001:db8:3333:4444:5555:6666:7777:9999, a:b:c:d:e:f, "
+                "g:h:i:j:k:l";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:9999");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:7777:8888]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:8888");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:7777:9999], [a:b:c:d:e:f], "
+                "[g:h:i:j:k:l]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:9999");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers = {};
+            headers["Forwarded"] =
+                "for=\"[2001:db8:3333:4444:5555:6666:7777:aaaa]\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:aaaa");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "For=\"[2001:db8:bb:cc:dd:ee:ff::]:2345\", for=99.00.11.22";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "2001:db8:bb:cc:dd:ee:ff::");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "proto=http;FOR=\"[2001:db8:11:22:33:44:55:66]\""
+                ";by=203.0.113.43";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "2001:db8:11:22:33:44:55:66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            // IPv6 (dual) tests.
+            headers = {};
+            headers["X-Forwarded-For"] = "2001:db8:3333:4444:5555:6666:1.2.3.4";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:1.2.3.4");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "2001:db8:3333:4444:5555:6666:5.6.7.8, a:b:c:d:e:f, "
+                "g:h:i:j:k:l";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:5.6.7.8");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:9.10.11.12]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:9.10.11.12");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:13.14.15.16], [a:b:c:d:e:f], "
+                "[g:h:i:j:k:l]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:13.14.15.16");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers = {};
+            headers["Forwarded"] =
+                "for=\"[2001:db8:3333:4444:5555:6666:20.19.18.17]\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:20.19.18.17");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "For=\"[2001:db8:bb:cc::24.23.22.21]\", for=99.00.11.22";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "2001:db8:bb:cc::24.23.22.21");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "proto=http;FOR=\"[::11:22:33:44:45.55.65.75]:234\""
+                ";by=203.0.113.43";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "::11:22:33:44:45.55.65.75");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+        }
+    }
+
+    void
+    testInvalidIpAddresses()
+    {
+        using namespace test::jtx;
+
+        {
+            Env env(*this);
+
+            std::unordered_map<std::string, std::string> headers;
+            Json::Value rpcRes;
+
+            // No "for=" in Forwarded.
+            headers["Forwarded"] = "for 88.77.66.55";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers["Forwarded"] = "by=88.77.66.55";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Empty field.
+            headers = {};
+            headers["Forwarded"] = "for=";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "     ";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Empty quotes.
+            headers = {};
+            headers["Forwarded"] = "for= \"    \" ";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "\"\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Unbalanced outer quotes.
+            headers = {};
+            headers["X-Forwarded-For"] = "\"12.34.56.78   ";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers["X-Forwarded-For"] = "12.34.56.78\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Unbalanced square brackets for IPv6.
+            headers = {};
+            headers["Forwarded"] = "FOR=[2001:db8:bb:cc::";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "2001:db8:bb:cc::24.23.22.21]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Empty square brackets.
+            headers = {};
+            headers["Forwarded"] = "FOR=[]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "\"  [      ]  \"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
         }
     }
 
@@ -111,6 +364,7 @@ public:
     run() override
     {
         testRoles();
+        testInvalidIpAddresses();
     }
 };
 


### PR DESCRIPTION
## Improve handling of HTTP `X-Forwarded-For` and `Forwarded` fields

It was discovered that rippled was not handling IPv6 and IPv6 (dual) formatted IP addresses in `X-Forwarded-For` and `Forwarded` fields.  This commit improves the situation and adds tests to verify.

### Context of Change

The problem was discovered when services were forwarding requests to reporting mode servers.  IPV6 formatted addresses were not being handled correctly.  The upshot of the change should simply be that addresses which failed before should now be handled correctly.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Test Plan

The unit tests simply confirm that the `X-Forwarded-For` and `Forwarded` fields are isolated correctly and forms a valid IP address.

It may be smart to add integration tests that use `X-Forwarded-For` and `Forwarded` fields so the changes can be exercised in an actual running environment.