### PR TITLE
Set correct version on self-signed certificate

### DIFF
--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -169,7 +169,7 @@ x509_new()
     if (x509 == nullptr)
         LogicError("X509_new failed");
 
-    X509_set_version(x509, X509_VERSION_1);
+    X509_set_version(x509, 0);  // Equivalent of X509_VERSION_1
 
     int const margin = 60 * 60;                     //      3600, one hour
     int const length = 10 * 365.25 * 24 * 60 * 60;  // 315576000, ten years

--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -22,6 +22,11 @@
 #include <ripple/basics/make_SSLContext.h>
 #include <ripple/beast/container/aged_unordered_set.h>
 #include <cstdint>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
 #include <sstream>
 #include <stdexcept>
 

--- a/src/ripple/basics/impl/make_SSLContext.cpp
+++ b/src/ripple/basics/impl/make_SSLContext.cpp
@@ -164,7 +164,7 @@ x509_new()
     if (x509 == nullptr)
         LogicError("X509_new failed");
 
-    X509_set_version(x509, NID_X509);
+    X509_set_version(x509, X509_VERSION_1);
 
     int const margin = 60 * 60;                     //      3600, one hour
     int const length = 10 * 365.25 * 24 * 60 * 60;  // 315576000, ten years


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->
X.509 certificates can have a version number between 1 and 3 inclusive. The constant NID_X509 equals 12. The correct constants are one of X509_VERSION_1,X509_VERSION_2 or X509_VERSION_3. X509_VERSION_1 has been chosen because no extensions are used in the self-signed certificate.

Fixes #4007


### Context of Change

Make it possible for other libraries, such as `crypto\tls` in Go, to parse the self-signed certificate.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
