### PR TITLE
Advance DatabaseDownloder unittest

### DIFF
--- a/src/ripple/net/HTTPDownloader.h
+++ b/src/ripple/net/HTTPDownloader.h
@@ -61,6 +61,12 @@ public:
 
     virtual ~HTTPDownloader() = default;
 
+    bool
+    sessionIsActive() const;
+
+    bool
+    isStopping() const;
+
 protected:
     // must be accessed through a shared_ptr
     // use make_XXX functions to create
@@ -88,7 +94,7 @@ private:
     std::atomic<bool> stop_;
 
     // Used to protect sessionActive_
-    std::mutex m_;
+    mutable std::mutex m_;
     bool sessionActive_;
     std::condition_variable c_;
 

--- a/src/ripple/net/impl/HTTPDownloader.cpp
+++ b/src/ripple/net/impl/HTTPDownloader.cpp
@@ -293,6 +293,20 @@ HTTPDownloader::stop()
     }
 }
 
+bool
+HTTPDownloader::sessionIsActive() const
+{
+    std::lock_guard lock(m_);
+    return sessionActive_;
+}
+
+bool
+HTTPDownloader::isStopping() const
+{
+    std::lock_guard lock(m_);
+    return stop_;
+}
+
 void
 HTTPDownloader::fail(
     boost::filesystem::path dstPath,


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

This pull request aims to fix spurious failures in the `DatabaseDownloader` unit test by increasing a timeout value that purports to be the source of the false positives.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

A timeout value that determines how long the test waits before indicating failure was increased. The error is not reproducible so, lest the issue recur, this PR introduces additional logging information that would hopefully shed some light on the cause.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->

## Future Tasks

Should the failure persist, consult the log output to assist in diagnosing the issue.
