### PR TITLE
Address elevated transaction fees.

### DIFF
--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1080,6 +1080,16 @@ LedgerMaster::checkAccept(std::shared_ptr<Ledger const> const& ledger)
     if (!fees.empty())
     {
         std::sort(fees.begin(), fees.end());
+        if (auto stream = m_journal.debug())
+        {
+            std::stringstream s;
+            s << "Received fees from validations: (" << fees.size() << ") ";
+            for (auto const fee1 : fees)
+            {
+                s << " " << fee1;
+            }
+            stream << s.str();
+        }
         fee = fees[fees.size() / 2];  // median
     }
     else

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -443,8 +443,7 @@ public:
 
         , hashRouter_(std::make_unique<HashRouter>(
               stopwatch(),
-              HashRouter::getDefaultHoldTime(),
-              HashRouter::getDefaultRecoverLimit()))
+              HashRouter::getDefaultHoldTime()))
 
         , mValidations(
               ValidationParms(),

--- a/src/ripple/app/misc/HashRouter.cpp
+++ b/src/ripple/app/misc/HashRouter.cpp
@@ -128,14 +128,4 @@ HashRouter::shouldRelay(uint256 const& key)
     return s.releasePeerSet();
 }
 
-bool
-HashRouter::shouldRecover(uint256 const& key)
-{
-    std::lock_guard lock(mutex_);
-
-    auto& s = emplace(key).first;
-
-    return s.shouldRecover(recoverLimit_);
-}
-
 }  // namespace ripple

--- a/src/ripple/app/misc/HashRouter.h
+++ b/src/ripple/app/misc/HashRouter.h
@@ -116,20 +116,6 @@ private:
             return true;
         }
 
-        /** Determines if this item should be recovered from the open ledger.
-
-            Counts the number of times the item has been recovered.
-            Every `limit` times the function is called, return false.
-            Else return true.
-
-            @note The limit must be > 0
-        */
-        bool
-        shouldRecover(std::uint32_t limit)
-        {
-            return ++recoveries_ % limit != 0;
-        }
-
         bool
         shouldProcess(Stopwatch::time_point now, std::chrono::seconds interval)
         {
@@ -146,7 +132,6 @@ private:
         // than one flag needs to expire independently.
         std::optional<Stopwatch::time_point> relayed_;
         std::optional<Stopwatch::time_point> processed_;
-        std::uint32_t recoveries_ = 0;
     };
 
 public:
@@ -158,19 +143,8 @@ public:
         return 300s;
     }
 
-    static inline std::uint32_t
-    getDefaultRecoverLimit()
-    {
-        return 1;
-    }
-
-    HashRouter(
-        Stopwatch& clock,
-        std::chrono::seconds entryHoldTimeInSeconds,
-        std::uint32_t recoverLimit)
-        : suppressionMap_(clock)
-        , holdTime_(entryHoldTimeInSeconds)
-        , recoverLimit_(recoverLimit + 1u)
+    HashRouter(Stopwatch& clock, std::chrono::seconds entryHoldTimeInSeconds)
+        : suppressionMap_(clock), holdTime_(entryHoldTimeInSeconds)
     {
     }
 
@@ -231,15 +205,6 @@ public:
     std::optional<std::set<PeerShortID>>
     shouldRelay(uint256 const& key);
 
-    /** Determines whether the hashed item should be recovered
-        from the open ledger into the next open ledger or the transaction
-        queue.
-
-        @return `bool` indicates whether the item should be recovered
-    */
-    bool
-    shouldRecover(uint256 const& key);
-
 private:
     // pair.second indicates whether the entry was created
     std::pair<Entry&, bool>
@@ -256,8 +221,6 @@ private:
         suppressionMap_;
 
     std::chrono::seconds const holdTime_;
-
-    std::uint32_t const recoverLimit_;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/misc/LoadFeeTrack.h
+++ b/src/ripple/app/misc/LoadFeeTrack.h
@@ -21,6 +21,7 @@
 #define RIPPLE_CORE_LOADFEETRACK_H_INCLUDED
 
 #include <ripple/basics/FeeUnits.h>
+#include <ripple/basics/Log.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/json/json_value.h>
 #include <algorithm>
@@ -58,6 +59,7 @@ public:
     void
     setRemoteFee(std::uint32_t f)
     {
+        JLOG(j_.trace()) << "setRemoteFee: " << f;
         std::lock_guard sl(lock_);
         remoteTxnLoadFee_ = f;
     }
@@ -110,6 +112,7 @@ public:
     void
     setClusterFee(std::uint32_t fee)
     {
+        JLOG(j_.trace()) << "setClusterFee: " << fee;
         std::lock_guard sl(lock_);
         clusterTxnLoadFee_ = fee;
     }

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -96,13 +96,13 @@ public:
         FeeLevel64 minimumEscalationMultiplier = baseLevel * 500;
         /// Minimum number of transactions to allow into the ledger
         /// before escalation, regardless of the prior ledger's size.
-        std::uint32_t minimumTxnInLedger = 5;
+        std::uint32_t minimumTxnInLedger = 32;
         /// Like @ref minimumTxnInLedger for standalone mode.
         /// Primarily so that tests don't need to worry about queuing.
         std::uint32_t minimumTxnInLedgerSA = 1000;
         /// Number of transactions per ledger that fee escalation "works
         /// towards".
-        std::uint32_t targetTxnInLedger = 50;
+        std::uint32_t targetTxnInLedger = 256;
         /** Optional maximum allowed value of transactions per ledger before
             fee escalation kicks in. By default, the maximum is an emergent
             property of network, validator, and consensus performance. This

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -98,12 +98,11 @@ TxQ::FeeMetrics::update(
     std::sort(feeLevels.begin(), feeLevels.end());
     assert(size == feeLevels.size());
 
-    JLOG(j_.debug()) << "Ledger " << view.info().seq << " has " << size
-                     << " transactions. "
-                     << "Ledgers are processing "
-                     << (timeLeap ? "slowly" : "as expected")
-                     << ". Expected transactions is currently " << txnsExpected_
-                     << " and multiplier is " << escalationMultiplier_;
+    JLOG((timeLeap ? j_.warn() : j_.debug()))
+        << "Ledger " << view.info().seq << " has " << size << " transactions. "
+        << "Ledgers are processing " << (timeLeap ? "slowly" : "as expected")
+        << ". Expected transactions is currently " << txnsExpected_
+        << " and multiplier is " << escalationMultiplier_;
 
     if (timeLeap)
     {
@@ -1262,7 +1261,7 @@ TxQ::apply(
             // valuable, so kick out the cheapest transaction.
             auto dropRIter = endAccount.transactions.rbegin();
             assert(dropRIter->second.account == lastRIter->account);
-            JLOG(j_.warn())
+            JLOG(j_.info())
                 << "Removing last item of account " << lastRIter->account
                 << " from queue with average fee of " << endEffectiveFeeLevel
                 << " in favor of " << transactionID << " with fee of "
@@ -1271,7 +1270,7 @@ TxQ::apply(
         }
         else
         {
-            JLOG(j_.warn())
+            JLOG(j_.info())
                 << "Queue is full, and transaction " << transactionID
                 << " fee is lower than end item's account average fee";
             return {telCAN_NOT_QUEUE_FULL, false};
@@ -1489,7 +1488,7 @@ TxQ::accept(Application& app, OpenView& view)
                     {
                         // Since the failed transaction has a ticket, order
                         // doesn't matter.  Drop this one.
-                        JLOG(j_.warn())
+                        JLOG(j_.info())
                             << "Queue is nearly full, and transaction "
                             << candidateIter->txID << " failed with "
                             << transToken(txnResult)
@@ -1508,7 +1507,7 @@ TxQ::accept(Application& app, OpenView& view)
                             dropRIter->second.account ==
                             candidateIter->account);
 
-                        JLOG(j_.warn())
+                        JLOG(j_.info())
                             << "Queue is nearly full, and transaction "
                             << candidateIter->txID << " failed with "
                             << transToken(txnResult)

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -174,15 +174,19 @@ Transactor::checkFee(PreclaimContext const& ctx, FeeUnit64 baseFee)
     if (!isLegalAmount(feePaid) || feePaid < beast::zero)
         return temBAD_FEE;
 
-    auto const feeDue =
-        minimumFee(ctx.app, baseFee, ctx.view.fees(), ctx.flags);
-
     // Only check fee is sufficient when the ledger is open.
-    if (ctx.view.open() && feePaid < feeDue)
+    if (ctx.view.open())
     {
-        JLOG(ctx.j.trace()) << "Insufficient fee paid: " << to_string(feePaid)
-                            << "/" << to_string(feeDue);
-        return telINSUF_FEE_P;
+        auto const feeDue =
+            minimumFee(ctx.app, baseFee, ctx.view.fees(), ctx.flags);
+
+        if (feePaid < feeDue)
+        {
+            JLOG(ctx.j.trace())
+                << "Insufficient fee paid: " << to_string(feePaid) << "/"
+                << to_string(feeDue);
+            return telINSUF_FEE_P;
+        }
     }
 
     if (feePaid == beast::zero)

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -168,15 +168,13 @@ JobQueue::addLoadEvents(JobType t, int count, std::chrono::milliseconds elapsed)
 bool
 JobQueue::isOverloaded()
 {
-    int count = 0;
-
     for (auto& x : m_jobData)
     {
         if (x.second.load().isOver())
-            ++count;
+            return true;
     }
 
-    return count > 0;
+    return false;
 }
 
 Json::Value

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -168,13 +168,9 @@ JobQueue::addLoadEvents(JobType t, int count, std::chrono::milliseconds elapsed)
 bool
 JobQueue::isOverloaded()
 {
-    for (auto& x : m_jobData)
-    {
-        if (x.second.load().isOver())
-            return true;
-    }
-
-    return false;
+    return std::any_of(m_jobData.begin(), m_jobData.end(), [](auto& entry) {
+        return entry.second.load().isOver();
+    });
 }
 
 Json::Value

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -37,11 +37,6 @@ enum ApplyFlags : std::uint32_t {
     // Transaction can be retried, soft failures allowed
     tapRETRY = 0x20,
 
-    // Transaction must pay more than both the open ledger
-    // fee and all transactions in the queue to get into the
-    // open ledger
-    tapPREFER_QUEUE = 0x40,
-
     // Transaction came from a privileged source
     tapUNLIMITED = 0x400,
 };
@@ -55,10 +50,10 @@ operator|(ApplyFlags const& lhs, ApplyFlags const& rhs)
 }
 
 static_assert(
-    (tapPREFER_QUEUE | tapRETRY) == safe_cast<ApplyFlags>(0x60u),
+    (tapFAIL_HARD | tapRETRY) == safe_cast<ApplyFlags>(0x30u),
     "ApplyFlags operator |");
 static_assert(
-    (tapRETRY | tapPREFER_QUEUE) == safe_cast<ApplyFlags>(0x60u),
+    (tapRETRY | tapFAIL_HARD) == safe_cast<ApplyFlags>(0x30u),
     "ApplyFlags operator |");
 
 constexpr ApplyFlags
@@ -69,8 +64,8 @@ operator&(ApplyFlags const& lhs, ApplyFlags const& rhs)
         safe_cast<std::underlying_type_t<ApplyFlags>>(rhs));
 }
 
-static_assert((tapPREFER_QUEUE & tapRETRY) == tapNONE, "ApplyFlags operator &");
-static_assert((tapRETRY & tapPREFER_QUEUE) == tapNONE, "ApplyFlags operator &");
+static_assert((tapFAIL_HARD & tapRETRY) == tapNONE, "ApplyFlags operator &");
+static_assert((tapRETRY & tapFAIL_HARD) == tapNONE, "ApplyFlags operator &");
 
 constexpr ApplyFlags
 operator~(ApplyFlags const& flags)

--- a/src/test/app/HashRouter_test.cpp
+++ b/src/test/app/HashRouter_test.cpp
@@ -31,7 +31,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -68,7 +68,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -146,7 +146,7 @@ class HashRouter_test : public beast::unit_test::suite
         // Normal HashRouter
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -174,7 +174,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         BEAST_EXPECT(router.setFlags(key1, 10));
@@ -187,7 +187,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 1s, 2);
+        HashRouter router(stopwatch, 1s);
 
         uint256 const key1(1);
 
@@ -226,46 +226,11 @@ class HashRouter_test : public beast::unit_test::suite
     }
 
     void
-    testRecover()
-    {
-        using namespace std::chrono_literals;
-        TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 1s, 5);
-
-        uint256 const key1(1);
-
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(!router.shouldRecover(key1));
-        // Expire, but since the next search will
-        // be for this entry, it will get refreshed
-        // instead.
-        ++stopwatch;
-        BEAST_EXPECT(router.shouldRecover(key1));
-        // Expire, but since the next search will
-        // be for this entry, it will get refreshed
-        // instead.
-        ++stopwatch;
-        // Recover again. Recovery is independent of
-        // time as long as the entry doesn't expire.
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        // Expire again
-        ++stopwatch;
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(!router.shouldRecover(key1));
-    }
-
-    void
     testProcess()
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 5s, 5);
+        HashRouter router(stopwatch, 5s);
         uint256 const key(1);
         HashRouter::PeerShortID peer = 1;
         int flags;
@@ -286,7 +251,6 @@ public:
         testSuppression();
         testSetFlags();
         testRelay();
-        testRecover();
         testProcess();
     }
 };

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -1469,6 +1469,7 @@ public:
                 *this,
                 makeConfig(
                     {{"minimum_txn_in_ledger_standalone", "2"},
+                     {"minimum_txn_in_ledger", "5"},
                      {"target_txn_in_ledger", "4"},
                      {"maximum_txn_in_ledger", "5"}}));
 

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -802,7 +802,7 @@ public:
         env(noop(charlie), fee(7000), queued);
         env(noop(daria), fee(7000), queued);
         env(noop(edgar), fee(7000), queued);
-        env(noop(felicia), fee(7000), queued);
+        env(noop(felicia), fee(6999), queued);
         checkMetrics(env, 6, 6, 4, 3, 257);
 
         env.close();
@@ -816,8 +816,8 @@ public:
         env(noop(daria), fee(8000), queued);
         env(noop(daria), fee(8000), seq(env.seq(daria) + 1), queued);
         env(noop(edgar), fee(8000), queued);
-        env(noop(felicia), fee(8000), queued);
-        env(noop(felicia), fee(8000), seq(env.seq(felicia) + 1), queued);
+        env(noop(felicia), fee(7999), queued);
+        env(noop(felicia), fee(7999), seq(env.seq(felicia) + 1), queued);
         checkMetrics(env, 8, 8, 5, 4, 257, 700 * 256);
 
         env.close();
@@ -1039,7 +1039,7 @@ public:
         checkMetrics(env, 0, initQueueMax, 4, 3, 256);
 
         // Alice - price starts exploding: held
-        env(noop(alice), queued);
+        env(noop(alice), fee(11), queued);
         checkMetrics(env, 1, initQueueMax, 4, 3, 256);
 
         auto aliceSeq = env.seq(alice);
@@ -1088,7 +1088,7 @@ public:
         BEAST_EXPECT(env.seq(charlie) == charlieSeq + 1);
 
         // Alice - fill up the queue
-        std::int64_t aliceFee = 20;
+        std::int64_t aliceFee = 27;
         aliceSeq = env.seq(alice);
         auto lastLedgerSeq = env.current()->info().seq + 2;
         for (auto i = 0; i < 7; i++)
@@ -1096,7 +1096,7 @@ public:
             env(noop(alice),
                 seq(aliceSeq),
                 json(jss::LastLedgerSequence, lastLedgerSeq + i),
-                fee(aliceFee),
+                fee(--aliceFee),
                 queued);
             ++aliceSeq;
         }
@@ -1104,17 +1104,18 @@ public:
         {
             auto& txQ = env.app().getTxQ();
             auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
-            constexpr XRPAmount fee{20};
+            aliceFee = 27;
             auto const& baseFee = env.current()->fees().base;
             auto seq = env.seq(alice);
             BEAST_EXPECT(aliceStat.size() == 7);
             for (auto const& tx : aliceStat)
             {
                 BEAST_EXPECT(tx.seqProxy.isSeq() && tx.seqProxy.value() == seq);
-                BEAST_EXPECT(tx.feeLevel == toFeeLevel(fee, baseFee));
+                BEAST_EXPECT(
+                    tx.feeLevel == toFeeLevel(XRPAmount(--aliceFee), baseFee));
                 BEAST_EXPECT(tx.lastValid);
                 BEAST_EXPECT(
-                    (tx.consequences.fee() == drops(fee) &&
+                    (tx.consequences.fee() == drops(aliceFee) &&
                      tx.consequences.potentialSpend() == drops(0) &&
                      !tx.consequences.isBlocker()) ||
                     tx.seqProxy.value() == env.seq(alice) + 6);
@@ -1141,13 +1142,13 @@ public:
         // Charlie - add another item to the queue, which
         // causes Alice's last txn to drop
         env(noop(charlie), fee(30), queued);
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Alice - now attempt to add one more to the queue,
         // which fails because the last tx was dropped, so
         // there is no complete chain.
         env(noop(alice), seq(aliceSeq), fee(aliceFee), ter(telCAN_NOT_QUEUE));
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Alice wants this tx more than the dropped tx,
         // so resubmits with higher fee, but the queue
@@ -1156,22 +1157,22 @@ public:
             seq(aliceSeq - 1),
             fee(aliceFee),
             ter(telCAN_NOT_QUEUE_FULL));
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Try to replace a middle item in the queue
         // without enough fee.
         aliceSeq = env.seq(alice) + 2;
-        aliceFee = 25;
+        aliceFee = 29;
         env(noop(alice),
             seq(aliceSeq),
             fee(aliceFee),
             ter(telCAN_NOT_QUEUE_FEE));
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Replace a middle item from the queue successfully
         ++aliceFee;
         env(noop(alice), seq(aliceSeq), fee(aliceFee), queued);
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         env.close();
         // Alice's transactions processed, along with
@@ -1186,7 +1187,7 @@ public:
         // more than the minimum reserve in flight before the
         // last queued transaction
         aliceFee =
-            env.le(alice)->getFieldAmount(sfBalance).xrp().drops() - (59);
+            env.le(alice)->getFieldAmount(sfBalance).xrp().drops() - (62);
         env(noop(alice),
             seq(aliceSeq),
             fee(aliceFee),
@@ -1334,6 +1335,9 @@ public:
         auto hankSeq = env.seq(hank);
 
         // This time, use identical fees.
+
+        // This one gets into the queue, but gets dropped when the
+        // higher fee one is added later.
         env(noop(alice), fee(15), queued);
         env(noop(bob), fee(15), queued);
         env(noop(charlie), fee(15), queued);
@@ -1341,8 +1345,6 @@ public:
         env(noop(elmo), fee(15), queued);
         env(noop(fred), fee(15), queued);
         env(noop(gwen), fee(15), queued);
-        // This one gets into the queue, but gets dropped when the
-        // higher fee one is added later.
         env(noop(hank), fee(15), queued);
 
         // Queue is full now. Minimum fee now reflects the
@@ -1362,9 +1364,9 @@ public:
         // Queue is still full.
         checkMetrics(env, 8, 8, 5, 4, 385);
 
-        // alice, bob, charlie, daria, and elmo's txs
+        // bob, charlie, daria, elmo, and fred's txs
         // are processed out of the queue into the ledger,
-        // leaving fred and gwen's txs. hank's tx is
+        // leaving fred and hank's txs. alice's tx is
         // retried from localTxs, and put back into the
         // queue.
         env.close();
@@ -1372,45 +1374,46 @@ public:
 
         BEAST_EXPECT(aliceSeq + 1 == env.seq(alice));
         BEAST_EXPECT(bobSeq + 1 == env.seq(bob));
-        BEAST_EXPECT(charlieSeq + 2 == env.seq(charlie));
+        BEAST_EXPECT(charlieSeq == env.seq(charlie));
         BEAST_EXPECT(dariaSeq + 1 == env.seq(daria));
-        BEAST_EXPECT(elmoSeq + 1 == env.seq(elmo));
-        BEAST_EXPECT(fredSeq == env.seq(fred));
-        BEAST_EXPECT(gwenSeq == env.seq(gwen));
-        BEAST_EXPECT(hankSeq == env.seq(hank));
+        BEAST_EXPECT(elmoSeq == env.seq(elmo));
+        BEAST_EXPECT(fredSeq + 1 == env.seq(fred));
+        BEAST_EXPECT(gwenSeq + 1 == env.seq(gwen));
+        BEAST_EXPECT(hankSeq + 1 == env.seq(hank));
 
         aliceSeq = env.seq(alice);
         bobSeq = env.seq(bob);
         charlieSeq = env.seq(charlie);
         dariaSeq = env.seq(daria);
         elmoSeq = env.seq(elmo);
+        fredSeq = env.seq(fred);
 
         // Fill up the queue again
-        env(noop(alice), fee(15), queued);
-        env(noop(alice), seq(aliceSeq + 1), fee(15), queued);
-        env(noop(alice), seq(aliceSeq + 2), fee(15), queued);
+        env(noop(fred), fee(15), queued);
+        env(noop(fred), seq(fredSeq + 1), fee(15), queued);
+        env(noop(fred), seq(fredSeq + 2), fee(15), queued);
         env(noop(bob), fee(15), queued);
-        env(noop(charlie), fee(15), queued);
+        env(noop(charlie), seq(charlieSeq + 2), fee(15), queued);
         env(noop(daria), fee(15), queued);
         // This one gets into the queue, but gets dropped when the
         // higher fee one is added later.
-        env(noop(elmo), fee(15), queued);
+        env(noop(elmo), seq(elmoSeq + 1), fee(15), queued);
         checkMetrics(env, 10, 10, 6, 5, 385);
 
         // Add another transaction, with a higher fee,
         // Not high enough to get into the ledger, but high
         // enough to get into the queue (and kick somebody out)
-        env(noop(alice), fee(100), seq(aliceSeq + 3), queued);
+        env(noop(fred), fee(100), seq(fredSeq + 3), queued);
 
         env.close();
         checkMetrics(env, 4, 12, 7, 6, 256);
 
-        BEAST_EXPECT(fredSeq + 1 == env.seq(fred));
+        BEAST_EXPECT(fredSeq + 4 == env.seq(fred));
         BEAST_EXPECT(gwenSeq + 1 == env.seq(gwen));
         BEAST_EXPECT(hankSeq + 1 == env.seq(hank));
-        BEAST_EXPECT(aliceSeq + 4 == env.seq(alice));
-        BEAST_EXPECT(bobSeq == env.seq(bob));
-        BEAST_EXPECT(charlieSeq == env.seq(charlie));
+        BEAST_EXPECT(aliceSeq == env.seq(alice));
+        BEAST_EXPECT(bobSeq + 1 == env.seq(bob));
+        BEAST_EXPECT(charlieSeq + 2 == env.seq(charlie));
         BEAST_EXPECT(dariaSeq == env.seq(daria));
         BEAST_EXPECT(elmoSeq == env.seq(elmo));
     }
@@ -2767,7 +2770,7 @@ public:
         // we only see a reduction by 5.
         env.close();
         checkMetrics(env, 9, 50, 6, 5, 256);
-        BEAST_EXPECT(env.seq(alice) == aliceSeq + 16);
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 15);
 
         // Close ledger 7.  That should remove 7 more of alice's transactions.
         env.close();
@@ -2775,7 +2778,7 @@ public:
         BEAST_EXPECT(env.seq(alice) == aliceSeq + 19);
 
         // Close one last ledger to see all of alice's transactions moved
-        // into the ledger.
+        // into the ledger, including the tickets
         env.close();
         checkMetrics(env, 0, 70, 2, 7, 256);
         BEAST_EXPECT(env.seq(alice) == aliceSeq + 21);
@@ -4130,7 +4133,7 @@ public:
             {{"minimum_txn_in_ledger_standalone", "1"},
              {"ledgers_in_queue", "5"},
              {"maximum_txn_per_account", "10"}},
-            {{"account_reserve", "200"}, {"owner_reserve", "50"}});
+            {{"account_reserve", "1000"}, {"owner_reserve", "50"}});
 
         Env env(*this, std::move(cfg));
 
@@ -4184,14 +4187,16 @@ public:
         auto seqDaria = env.seq(daria);
         auto seqEllie = env.seq(ellie);
         auto seqFiona = env.seq(fiona);
+        // Use fees to guarantee order
+        int txFee{90};
         for (int i = 0; i < 10; ++i)
         {
-            env(noop(alice), seq(seqAlice++), ter(terQUEUED));
-            env(noop(bob), seq(seqBob++), ter(terQUEUED));
-            env(noop(carol), seq(seqCarol++), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), ter(terQUEUED));
+            env(noop(alice), seq(seqAlice++), fee(--txFee), ter(terQUEUED));
+            env(noop(bob), seq(seqBob++), fee(--txFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--txFee), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--txFee), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--txFee), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--txFee), ter(terQUEUED));
         }
         std::size_t expectedInQueue = 60;
         checkMetrics(
@@ -4283,8 +4288,8 @@ public:
         // We'll be using fees to control which entries leave the queue in
         // which order.  There's no "lowFee" -- that's the default fee from
         // the unit test.
-        auto const medFee = drops(15);
-        auto const hiFee = drops(1000);
+        int const medFee = 100;
+        int const hiFee = 1000;
 
         auto cfg = makeConfig(
             {{"minimum_txn_in_ledger_standalone", "5"},
@@ -4314,12 +4319,14 @@ public:
         // will expire out soon.
         auto seqAlice = env.seq(alice);
         auto const seqSaveAlice = seqAlice;
+        int feeDrops = 40;
         env(noop(alice),
             seq(seqAlice++),
+            fee(--feeDrops),
             json(R"({"LastLedgerSequence": 7})"),
             ter(terQUEUED));
-        env(noop(alice), seq(seqAlice++), ter(terQUEUED));
-        env(noop(alice), seq(seqAlice++), ter(terQUEUED));
+        env(noop(alice), seq(seqAlice++), fee(--feeDrops), ter(terQUEUED));
+        env(noop(alice), seq(seqAlice++), fee(--feeDrops), ter(terQUEUED));
         BEAST_EXPECT(env.seq(alice) == seqSaveAlice);
 
         // Similarly for bob, but bob uses tickets in his transactions.
@@ -4328,8 +4335,14 @@ public:
             ticket::use(bobTicketSeq + 0),
             json(R"({"LastLedgerSequence": 7})"),
             ter(terQUEUED));
-        env(noop(bob), ticket::use(bobTicketSeq + 1), ter(terQUEUED));
-        env(noop(bob), ticket::use(bobTicketSeq + 2), ter(terQUEUED));
+        env(noop(bob),
+            ticket::use(bobTicketSeq + 1),
+            fee(--feeDrops),
+            ter(terQUEUED));
+        env(noop(bob),
+            ticket::use(bobTicketSeq + 2),
+            fee(--feeDrops),
+            ter(terQUEUED));
 
         // Fill the queue with higher fee transactions so alice's and
         // bob's transactions are stuck in the queue.
@@ -4337,12 +4350,13 @@ public:
         auto seqDaria = env.seq(daria);
         auto seqEllie = env.seq(ellie);
         auto seqFiona = env.seq(fiona);
+        feeDrops = medFee;
         for (int i = 0; i < 7; ++i)
         {
-            env(noop(carol), seq(seqCarol++), fee(medFee), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), fee(medFee), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), fee(medFee), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), fee(medFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
 
         checkMetrics(env, 34, 50, 7, 6, 256);
@@ -4350,24 +4364,26 @@ public:
         checkMetrics(env, 26, 50, 8, 7, 256);
 
         // Re-fill the queue so alice and bob stay stuck.
+        feeDrops = medFee;
         for (int i = 0; i < 3; ++i)
         {
-            env(noop(carol), seq(seqCarol++), fee(medFee), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), fee(medFee), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), fee(medFee), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), fee(medFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
         checkMetrics(env, 38, 50, 8, 7, 256);
         env.close();
         checkMetrics(env, 29, 50, 9, 8, 256);
 
         // One more time...
+        feeDrops = medFee;
         for (int i = 0; i < 3; ++i)
         {
-            env(noop(carol), seq(seqCarol++), fee(medFee), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), fee(medFee), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), fee(medFee), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), fee(medFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
         checkMetrics(env, 41, 50, 9, 8, 256);
         env.close();
@@ -4382,16 +4398,17 @@ public:
         env(noop(alice), seq(seqAlice), fee(hiFee), ter(telCAN_NOT_QUEUE));
 
         // Once again, fill the queue almost to the brim.
+        feeDrops = medFee;
         for (int i = 0; i < 4; ++i)
         {
-            env(noop(carol), seq(seqCarol++), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
-        env(noop(carol), seq(seqCarol++), ter(terQUEUED));
-        env(noop(daria), seq(seqDaria++), ter(terQUEUED));
-        env(noop(ellie), seq(seqEllie++), ter(terQUEUED));
+        env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+        env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+        env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
         checkMetrics(env, 48, 50, 10, 9, 256);
 
         // Now induce a fee jump which should cause all the transactions
@@ -4401,7 +4418,7 @@ public:
         // asynchronously lowered by LoadManager.  Here we're just
         // pushing the local fee up really high and then hoping that we
         // outrace LoadManager undoing our work.
-        for (int i = 0; i < 10; ++i)
+        for (int i = 0; i < 30; ++i)
             env.app().getFeeTrack().raiseLocalFee();
 
         // Now close the ledger, which will attempt to process alice's
@@ -4442,7 +4459,7 @@ public:
 
         // Verify that there's a gap at the front of alice's queue by
         // queuing another low fee transaction into that spot.
-        env(noop(alice), seq(seqAlice++), ter(terQUEUED));
+        env(noop(alice), seq(seqAlice++), fee(11), ter(terQUEUED));
 
         // Verify that the first entry in alice's queue is still there
         // by trying to replace it and having that fail.
@@ -4468,11 +4485,11 @@ public:
 
         // Verify that bob's first transaction was removed from the queue
         // by queueing another low fee transaction into that spot.
-        env(noop(bob), ticket::use(bobTicketSeq + 0), ter(terQUEUED));
+        env(noop(bob), ticket::use(bobTicketSeq + 0), fee(12), ter(terQUEUED));
 
         // Verify that bob's second transaction was removed from the queue
         // by queueing another low fee transaction into that spot.
-        env(noop(bob), ticket::use(bobTicketSeq + 1), ter(terQUEUED));
+        env(noop(bob), ticket::use(bobTicketSeq + 1), fee(11), ter(terQUEUED));
 
         // Verify that the last entry in bob's queue is still there
         // by trying to replace it and having that fail.


### PR DESCRIPTION
## High Level Overview of Change

Two main changes:
* Revert a subset of the changes from https://github.com/ximinez/rippled/commit/62127d725d801641bfaa61dee7d88c95e48820c5 which would defer transactions from one ledger to the next into the transaction queue (TxQ). A transaction that is in the open ledger but doesn't get validated should stay in the open ledger so that it can be proposed in the next transaction set.
* Order the transaction queue deterministically, first be fee level descending, then by transaction ID / hash ascending. This will improve the overlap of initial proposals from different ledgers because they will be more likely to be pulling the same set of transactions out of their queues into their open ledgers.

Also added and changed some logging and made some minor optimizations.

### Context of Change

Between about 14:00 and 17:00 UTC on December 1st, transaction submission rates went up 10-fold. This caused some unexpected side effects. The most observable effect was that transaction queues were full on most nodes in the network, but that was just a symptom. Most of those transactions had a 12 drop fee, but very few of them were getting validated. Transactions paying more would typically land in the open ledger or towards the front of the queues, and were thus being validated. This caused much consternation. The root cause of the problem was that transactions in the proposals for one ledger were being deferred to the next ledger, but the deferral process dropped them entirely because they could not be put back into the now-full queue. tl;dr they should never have attempted to be put back into the queue, but this flaw was not apparent until the current conditions presented themselves.

The problem was further exacerbated by the TxQ policy of ordering transactions with the same fee level by arrival time - basically first come, first served. Because the rate at which transactions are being submitted is so high, most nodes saw most transactions in a drastically different order. Validators would proposed some of these transactions, but very few nodes proposed the _same set_ of transactions. Using a definitive ordering will help increase the overlap between those initial proposals between validators, and the deferral fix will ensure that any differences will be resolved in the next ledger.

Once a majority of UNL validators have this fix, the number of transactions validated should increase dramatically until either they catch up to the backlog, or the new load level becomes the "new normal". Once either of those things happens, the fee escalation logic should have a more accurate view of what the network is capable of and lower baseline fees accordingly.

Note to operators: until a majority of UNL validators are updated, node operators running this change can expect to see 500-1500 transactions in the open ledger, and the transaction queue near or at capacity. This will show a correspondingly large open ledger fee. 

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Refactor (non-breaking change that only restructures code)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
