### PR TITLE
only forward to p2p nodes that are in sync

### DIFF
--- a/src/ripple/app/reporting/ETLHelpers.h
+++ b/src/ripple/app/reporting/ETLHelpers.h
@@ -71,6 +71,15 @@ public:
         return max_;
     }
 
+    /// Get most recently validated sequence.
+    /// @return sequence of most recently validated ledger, or empty optional
+    /// if no ledgers are known to have been validated.
+    std::optional<uint32_t>
+    tryGetMostRecent()
+    {
+        return max_;
+    }
+
     /// Waits for the sequence to be validated by the network
     /// @param sequence to wait for
     /// @return true if sequence was validated, false otherwise

--- a/src/ripple/app/reporting/ETLHelpers.h
+++ b/src/ripple/app/reporting/ETLHelpers.h
@@ -43,7 +43,7 @@ class NetworkValidatedLedgers
 
     mutable std::mutex m_;
 
-    std::condition_variable cv_;
+    mutable std::condition_variable cv_;
 
     bool stopping_ = false;
 
@@ -64,7 +64,7 @@ public:
     /// @return sequence of most recently validated ledger. empty optional if
     /// the datastructure has been stopped
     std::optional<uint32_t>
-    getMostRecent()
+    getMostRecent() const
     {
         std::unique_lock lck(m_);
         cv_.wait(lck, [this]() { return max_ || stopping_; });
@@ -75,8 +75,9 @@ public:
     /// @return sequence of most recently validated ledger, or empty optional
     /// if no ledgers are known to have been validated.
     std::optional<uint32_t>
-    tryGetMostRecent()
+    tryGetMostRecent() const
     {
+        std::unique_lock lk(m_);
         return max_;
     }
 

--- a/src/ripple/app/reporting/ETLSource.cpp
+++ b/src/ripple/app/reporting/ETLSource.cpp
@@ -774,7 +774,7 @@ ETLLoadBalancer::forwardToP2p(RPC::JsonContext& context) const
             increment();
             continue;
         }
-        res = sources_[sourceIdx]->forwardToP2p(context);
+        res = src->forwardToP2p(context);
         if (!res.isMember("forwarded") || res["forwarded"] != true)
         {
             increment();

--- a/src/ripple/app/reporting/ETLSource.cpp
+++ b/src/ripple/app/reporting/ETLSource.cpp
@@ -760,13 +760,24 @@ ETLLoadBalancer::forwardToP2p(RPC::JsonContext& context) const
     srand((unsigned)time(0));
     auto sourceIdx = rand() % sources_.size();
     auto numAttempts = 0;
+
+    auto mostRecent = etl_.getNetworkValidatedLedgers().tryGetMostRecent();
     while (numAttempts < sources_.size())
     {
+        auto increment = [&]() {
+            sourceIdx = (sourceIdx + 1) % sources_.size();
+            ++numAttempts;
+        };
+        auto& src = sources_[sourceIdx];
+        if (mostRecent && !src->hasLedger(*mostRecent))
+        {
+            increment();
+            continue;
+        }
         res = sources_[sourceIdx]->forwardToP2p(context);
         if (!res.isMember("forwarded") || res["forwarded"] != true)
         {
-            sourceIdx = (sourceIdx + 1) % sources_.size();
-            ++numAttempts;
+            increment();
             continue;
         }
         return res;


### PR DESCRIPTION
This commit was made by @cjcobb23 and has been running on our reporting servers.

## High Level Overview of Change

Previously, reporting mode servers blindly forwarded a request to one of the p2p nodes at random. If the p2p node is totally down, reporting mode would try a different server. But if the p2p node was up but not synced, the reporting mode server considered the response valid, and returned `noNetwork`. This affected requests such as `submit` and `fee`. 

With this change, the reporting mode server only forwards requests to p2p mode servers that have the latest ledger. This would cover the situation where servers are not synced, as well as amendment blocked servers.

### Context of Change

In s2, one of the p2p mode servers lost sync, and reporting mode was returning errors for `submit`.


## Test Plan
I brought up a reporting mode server with two ETL sources. I restarted one of the ETL sources, and then sent `fee` requests to the reporting mode server. Before this change, roughly half of the requests would return `noNetwork`, since the restarted ETL source was not yet synced. After this change, every request succeeded, since at least one ETL source was in sync.
