### PR TITLE
Enforce account RPC limits by account objects traversed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,15 @@ endif ()
 
 project (rippled)
 
+# make GIT_COMMIT_HASH define available to all sources
+find_package(Git)
+if(Git_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=40
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE GIT_COMMIT_HASH)
+    message(STATUS gch: ${GIT_COMMIT_HASH})
+    add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+endif() #git
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake/deps")
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # The XRP Ledger
 
-The [XRP Ledger](https://xrpl.org/) is a decentralized cryptographic ledger powered by a network of peer-to-peer servers. The XRP Ledger uses a novel Byzantine Fault Tolerant consensus algorithm to settle and record transactions in a secure distributed database without a central operator.
+The [XRP Ledger](https://xrpl.org/) is a decentralized cryptographic ledger powered by a network of peer-to-peer nodes. The XRP Ledger uses a novel Byzantine Fault Tolerant consensus algorithm to settle and record transactions in a secure distributed database without a central operator.
 
 ## XRP
 [XRP](https://xrpl.org/xrp.html) is a public, counterparty-free asset native to the XRP Ledger, and is designed to bridge the many different currencies in use worldwide. XRP is traded on the open-market and is available for anyone to access. The XRP Ledger was created in 2012 with a finite supply of 100 billion units of XRP. Its creators gifted 80 billion XRP to a company, now called [Ripple](https://ripple.com/), to develop the XRP Ledger and its ecosystem. Ripple uses XRP to help build the Internet of Value, ushering in a world in which money moves as fast and efficiently as information does today.
 
 ## rippled
-The server software that powers the XRP Ledger is called `rippled` and is available in this repository under the permissive [ISC open-source license](LICENSE). The `rippled` server is written primarily in C++ and runs on a variety of platforms.
+The server software that powers the XRP Ledger is called `rippled` and is available in this repository under the permissive [ISC open-source license](LICENSE.md). The `rippled` server software is written primarily in C++ and runs on a variety of platforms. The `rippled` server software can run in several modes depending on its [configuration](https://xrpl.org/rippled-server-modes.html).  
 
 ### Build from Source
 
 * [Linux](Builds/linux/README.md)
-* [Mac](Builds/macos/README.md)
-* [Windows](Builds/VisualStudio2017/README.md)
+* [Mac](Builds/macos/README.md) (Not recommended for production)
+* [Windows](Builds/VisualStudio2017/README.md) (Not recommended for production)
 
 ## Key Features of the XRP Ledger
 

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -622,18 +622,28 @@
 #
 # [relay_proposals]
 #
-#   Controls the relaying behavior for proposals received by this server that
-#   are issued by validators that are not on the server's UNL.
+#   Controls the relay and processing behavior for proposals received by this
+#   server that are issued by validators that are not on the server's UNL.
 #
-#   Legal values are: "trusted" and "all". The default is "trusted".
+#   Legal values are:
+#     "all"            - Relay and process all incoming proposals
+#     "trusted"        - Relay only trusted proposals, but locally process all
+#     "drop_untrusted" - Relay only trusted proposals, do not process untrusted
+#
+#   The default is "trusted".
 #
 #
 # [relay_validations]
 #
-#   Controls the relaying behavior for validations received by this server that
-#   are issued by validators that are not on the server's UNL.
+#   Controls the relay and processing behavior for validations received by this
+#   server that are issued by validators that are not on the server's UNL.
 #
-#   Legal values are: "trusted" and "all". The default is "all".
+#   Legal values are:
+#     "all"            - Relay and process all incoming validations
+#     "trusted"        - Relay only trusted validations, but locally process all
+#     "drop_untrusted" - Relay only trusted validations, do not process untrusted
+#
+#   The default is "all".
 #
 #
 #

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -779,6 +779,14 @@
 #   number of processor threads plus 2 for networked nodes. Nodes running in
 #   stand alone mode default to 1 worker.
 #
+# [io_workers]
+#
+#   Configures the number of threads for processing raw inbound and outbound IO.
+#
+# [prefetch_workers]
+#
+#   Configures the number of threads for performing nodestore prefetching.
+#
 #
 #
 # [network_id]

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1150,6 +1150,9 @@
 #                           cluster. Setting this option can help eliminate
 #                           write timeouts and other write errors due to the
 #                           cluster being overloaded.
+#       io_threads
+#                           Set the number of IO threads used by the
+#                           Cassandra driver. Defaults to 4.
 #
 #   Notes:
 #       The 'node_db' entry configures the primary, persistent storage.

--- a/docs/consensus.md
+++ b/docs/consensus.md
@@ -469,7 +469,7 @@ struct Ledger
   // Whether the ledger's close time was a non-trivial consensus result
   bool closeAgree() const;
 
-  // The close time resolution used in determing the close time
+  // The close time resolution used in determining the close time
   NetClock::duration closeTimeResolution() const;
 
   // The (effective) close time, based on the closeTimeResolution

--- a/src/ripple/app/ledger/impl/LedgerMaster.cpp
+++ b/src/ripple/app/ledger/impl/LedgerMaster.cpp
@@ -1080,6 +1080,16 @@ LedgerMaster::checkAccept(std::shared_ptr<Ledger const> const& ledger)
     if (!fees.empty())
     {
         std::sort(fees.begin(), fees.end());
+        if (auto stream = m_journal.debug())
+        {
+            std::stringstream s;
+            s << "Received fees from validations: (" << fees.size() << ") ";
+            for (auto const fee1 : fees)
+            {
+                s << " " << fee1;
+            }
+            stream << s.str();
+        }
         fee = fees[fees.size() / 2];  // median
     }
     else

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -246,6 +246,10 @@ public:
 #if RIPPLE_SINGLE_IO_SERVICE_THREAD
         return 1;
 #else
+
+        if (config.IO_WORKERS > 0)
+            return config.IO_WORKERS;
+
         auto const cores = std::thread::hardware_concurrency();
 
         // Use a single thread when running on under-provisioned systems
@@ -342,7 +346,8 @@ public:
               m_collectorManager->collector(),
               logs_->journal("Resource")))
 
-        , m_nodeStore(m_shaMapStore->makeNodeStore(4))
+        , m_nodeStore(m_shaMapStore->makeNodeStore(
+              config_->PREFETCH_WORKERS > 0 ? config_->PREFETCH_WORKERS : 4))
 
         , nodeFamily_(*this, *m_collectorManager)
 

--- a/src/ripple/app/main/Application.cpp
+++ b/src/ripple/app/main/Application.cpp
@@ -448,8 +448,7 @@ public:
 
         , hashRouter_(std::make_unique<HashRouter>(
               stopwatch(),
-              HashRouter::getDefaultHoldTime(),
-              HashRouter::getDefaultRecoverLimit()))
+              HashRouter::getDefaultHoldTime()))
 
         , mValidations(
               ValidationParms(),

--- a/src/ripple/app/main/GRPCServer.cpp
+++ b/src/ripple/app/main/GRPCServer.cpp
@@ -144,11 +144,11 @@ GRPCServerImpl::CallData<Request, Response>::process(
     {
         auto usage = getUsage();
         bool isUnlimited = clientIsUnlimited();
-        if (!isUnlimited && usage.disconnect())
+        if (!isUnlimited && usage.disconnect(app_.journal("gRPCServer")))
         {
             grpc::Status status{
                 grpc::StatusCode::RESOURCE_EXHAUSTED,
-                "usage balance exceeds threshhold"};
+                "usage balance exceeds threshold"};
             responder_.FinishWithError(status, this);
         }
         else

--- a/src/ripple/app/misc/FeeEscalation.md
+++ b/src/ripple/app/misc/FeeEscalation.md
@@ -92,7 +92,7 @@ traffic periods, and give those transactions a much better chance to
 succeed.
 
 1. If an incoming transaction meets both the base [fee
-level](#fee-level) and the load fee minimum, but does not have a high
+level](#fee-level) and the [load fee](#load-fee) minimum, but does not have a high
 enough [fee level](#fee-level) to immediately go into the open ledger,
 it is instead put into the queue and broadcast to peers. Each peer will
 then make an independent decision about whether to put the transaction
@@ -172,6 +172,10 @@ fee level`.
 This demonstrates that a simpler transaction paying less XRP can be more
 likely to get into the open ledger, or be sorted earlier in the queue
 than a more complex transaction paying more XRP.
+
+### Load Fee
+
+Each rippled server maintains a minimum cost threshold based on its current load. If you submit a transaction with a fee that is lower than the current load-based transaction cost of the rippled server, the server neither applies nor relays the transaction to its peers. A transaction is very unlikely to survive the consensus process unless its transaction fee value meets the requirements of a majority of servers.
 
 ### Reference Transaction
 

--- a/src/ripple/app/misc/HashRouter.cpp
+++ b/src/ripple/app/misc/HashRouter.cpp
@@ -128,14 +128,4 @@ HashRouter::shouldRelay(uint256 const& key)
     return s.releasePeerSet();
 }
 
-bool
-HashRouter::shouldRecover(uint256 const& key)
-{
-    std::lock_guard lock(mutex_);
-
-    auto& s = emplace(key).first;
-
-    return s.shouldRecover(recoverLimit_);
-}
-
 }  // namespace ripple

--- a/src/ripple/app/misc/HashRouter.h
+++ b/src/ripple/app/misc/HashRouter.h
@@ -116,20 +116,6 @@ private:
             return true;
         }
 
-        /** Determines if this item should be recovered from the open ledger.
-
-            Counts the number of times the item has been recovered.
-            Every `limit` times the function is called, return false.
-            Else return true.
-
-            @note The limit must be > 0
-        */
-        bool
-        shouldRecover(std::uint32_t limit)
-        {
-            return ++recoveries_ % limit != 0;
-        }
-
         bool
         shouldProcess(Stopwatch::time_point now, std::chrono::seconds interval)
         {
@@ -146,7 +132,6 @@ private:
         // than one flag needs to expire independently.
         std::optional<Stopwatch::time_point> relayed_;
         std::optional<Stopwatch::time_point> processed_;
-        std::uint32_t recoveries_ = 0;
     };
 
 public:
@@ -158,19 +143,8 @@ public:
         return 300s;
     }
 
-    static inline std::uint32_t
-    getDefaultRecoverLimit()
-    {
-        return 1;
-    }
-
-    HashRouter(
-        Stopwatch& clock,
-        std::chrono::seconds entryHoldTimeInSeconds,
-        std::uint32_t recoverLimit)
-        : suppressionMap_(clock)
-        , holdTime_(entryHoldTimeInSeconds)
-        , recoverLimit_(recoverLimit + 1u)
+    HashRouter(Stopwatch& clock, std::chrono::seconds entryHoldTimeInSeconds)
+        : suppressionMap_(clock), holdTime_(entryHoldTimeInSeconds)
     {
     }
 
@@ -231,15 +205,6 @@ public:
     std::optional<std::set<PeerShortID>>
     shouldRelay(uint256 const& key);
 
-    /** Determines whether the hashed item should be recovered
-        from the open ledger into the next open ledger or the transaction
-        queue.
-
-        @return `bool` indicates whether the item should be recovered
-    */
-    bool
-    shouldRecover(uint256 const& key);
-
 private:
     // pair.second indicates whether the entry was created
     std::pair<Entry&, bool>
@@ -256,8 +221,6 @@ private:
         suppressionMap_;
 
     std::chrono::seconds const holdTime_;
-
-    std::uint32_t const recoverLimit_;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/misc/LoadFeeTrack.h
+++ b/src/ripple/app/misc/LoadFeeTrack.h
@@ -21,6 +21,7 @@
 #define RIPPLE_CORE_LOADFEETRACK_H_INCLUDED
 
 #include <ripple/basics/FeeUnits.h>
+#include <ripple/basics/Log.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/json/json_value.h>
 #include <algorithm>
@@ -58,6 +59,7 @@ public:
     void
     setRemoteFee(std::uint32_t f)
     {
+        JLOG(j_.trace()) << "setRemoteFee: " << f;
         std::lock_guard sl(lock_);
         remoteTxnLoadFee_ = f;
     }
@@ -110,6 +112,7 @@ public:
     void
     setClusterFee(std::uint32_t fee)
     {
+        JLOG(j_.trace()) << "setClusterFee: " << fee;
         std::lock_guard sl(lock_);
         clusterTxnLoadFee_ = fee;
     }

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2943,7 +2943,7 @@ NetworkOPsImp::reportFeeChange()
     if (f != mLastFeeSummary)
     {
         m_job_queue.addJob(
-            jtCLIENT, "reportFeeChange->pubServer", [this](Job&) {
+            jtCLIENT_FEE_CHANGE, "reportFeeChange->pubServer", [this](Job&) {
                 pubServer();
             });
     }
@@ -2953,7 +2953,7 @@ void
 NetworkOPsImp::reportConsensusStateChange(ConsensusPhase phase)
 {
     m_job_queue.addJob(
-        jtCLIENT,
+        jtCLIENT_CONSENSUS,
         "reportConsensusStateChange->pubConsensus",
         [this, phase](Job&) { pubConsensus(phase); });
 }
@@ -3346,7 +3346,7 @@ NetworkOPsImp::addAccountHistoryJob(SubAccountHistoryInfoWeak subInfo)
     }
 
     app_.getJobQueue().addJob(
-        jtCLIENT,
+        jtCLIENT_ACCT_HIST,
         "AccountHistoryTxStream",
         [this, dbType = databaseType, subInfo](Job&) {
             auto const& accountId = subInfo.index_->accountId_;

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2250,7 +2250,7 @@ NetworkOPsImp::recvValidation(
 
     // We will always relay trusted validations; if configured, we will
     // also relay all untrusted validations.
-    return app_.config().RELAY_UNTRUSTED_VALIDATIONS || val->isTrusted();
+    return app_.config().RELAY_UNTRUSTED_VALIDATIONS == 1 || val->isTrusted();
 }
 
 Json::Value

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -2574,6 +2574,11 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             if (std::abs(closeOffset.count()) >= 60)
                 l[jss::close_time_offset] = closeOffset.count();
 
+#if RIPPLED_REPORTING
+            std::int64_t const dbAge =
+                std::max(m_ledgerMaster.getValidatedLedgerAge().count(), 0L);
+            l[jss::age] = Json::UInt(dbAge);
+#else
             constexpr std::chrono::seconds highAgeThreshold{1000000};
             if (m_ledgerMaster.haveValidated())
             {
@@ -2593,6 +2598,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
                         Json::UInt(age < highAgeThreshold ? age.count() : 0);
                 }
             }
+#endif
         }
 
         if (valid)

--- a/src/ripple/app/misc/TxQ.h
+++ b/src/ripple/app/misc/TxQ.h
@@ -96,13 +96,13 @@ public:
         FeeLevel64 minimumEscalationMultiplier = baseLevel * 500;
         /// Minimum number of transactions to allow into the ledger
         /// before escalation, regardless of the prior ledger's size.
-        std::uint32_t minimumTxnInLedger = 5;
+        std::uint32_t minimumTxnInLedger = 32;
         /// Like @ref minimumTxnInLedger for standalone mode.
         /// Primarily so that tests don't need to worry about queuing.
         std::uint32_t minimumTxnInLedgerSA = 1000;
         /// Number of transactions per ledger that fee escalation "works
         /// towards".
-        std::uint32_t targetTxnInLedger = 50;
+        std::uint32_t targetTxnInLedger = 256;
         /** Optional maximum allowed value of transactions per ledger before
             fee escalation kicks in. By default, the maximum is an emergent
             property of network, validator, and consensus performance. This

--- a/src/ripple/app/misc/impl/TxQ.cpp
+++ b/src/ripple/app/misc/impl/TxQ.cpp
@@ -98,12 +98,11 @@ TxQ::FeeMetrics::update(
     std::sort(feeLevels.begin(), feeLevels.end());
     assert(size == feeLevels.size());
 
-    JLOG(j_.debug()) << "Ledger " << view.info().seq << " has " << size
-                     << " transactions. "
-                     << "Ledgers are processing "
-                     << (timeLeap ? "slowly" : "as expected")
-                     << ". Expected transactions is currently " << txnsExpected_
-                     << " and multiplier is " << escalationMultiplier_;
+    JLOG((timeLeap ? j_.warn() : j_.debug()))
+        << "Ledger " << view.info().seq << " has " << size << " transactions. "
+        << "Ledgers are processing " << (timeLeap ? "slowly" : "as expected")
+        << ". Expected transactions is currently " << txnsExpected_
+        << " and multiplier is " << escalationMultiplier_;
 
     if (timeLeap)
     {
@@ -1262,7 +1261,7 @@ TxQ::apply(
             // valuable, so kick out the cheapest transaction.
             auto dropRIter = endAccount.transactions.rbegin();
             assert(dropRIter->second.account == lastRIter->account);
-            JLOG(j_.warn())
+            JLOG(j_.info())
                 << "Removing last item of account " << lastRIter->account
                 << " from queue with average fee of " << endEffectiveFeeLevel
                 << " in favor of " << transactionID << " with fee of "
@@ -1271,7 +1270,7 @@ TxQ::apply(
         }
         else
         {
-            JLOG(j_.warn())
+            JLOG(j_.info())
                 << "Queue is full, and transaction " << transactionID
                 << " fee is lower than end item's account average fee";
             return {telCAN_NOT_QUEUE_FULL, false};
@@ -1489,7 +1488,7 @@ TxQ::accept(Application& app, OpenView& view)
                     {
                         // Since the failed transaction has a ticket, order
                         // doesn't matter.  Drop this one.
-                        JLOG(j_.warn())
+                        JLOG(j_.info())
                             << "Queue is nearly full, and transaction "
                             << candidateIter->txID << " failed with "
                             << transToken(txnResult)
@@ -1508,7 +1507,7 @@ TxQ::accept(Application& app, OpenView& view)
                             dropRIter->second.account ==
                             candidateIter->account);
 
-                        JLOG(j_.warn())
+                        JLOG(j_.info())
                             << "Queue is nearly full, and transaction "
                             << candidateIter->txID << " failed with "
                             << transToken(txnResult)

--- a/src/ripple/app/reporting/ETLHelpers.h
+++ b/src/ripple/app/reporting/ETLHelpers.h
@@ -43,7 +43,7 @@ class NetworkValidatedLedgers
 
     mutable std::mutex m_;
 
-    std::condition_variable cv_;
+    mutable std::condition_variable cv_;
 
     bool stopping_ = false;
 
@@ -64,10 +64,20 @@ public:
     /// @return sequence of most recently validated ledger. empty optional if
     /// the datastructure has been stopped
     std::optional<uint32_t>
-    getMostRecent()
+    getMostRecent() const
     {
         std::unique_lock lck(m_);
         cv_.wait(lck, [this]() { return max_ || stopping_; });
+        return max_;
+    }
+
+    /// Get most recently validated sequence.
+    /// @return sequence of most recently validated ledger, or empty optional
+    /// if no ledgers are known to have been validated.
+    std::optional<uint32_t>
+    tryGetMostRecent() const
+    {
+        std::unique_lock lk(m_);
         return max_;
     }
 

--- a/src/ripple/app/reporting/ETLSource.cpp
+++ b/src/ripple/app/reporting/ETLSource.cpp
@@ -760,13 +760,24 @@ ETLLoadBalancer::forwardToP2p(RPC::JsonContext& context) const
     srand((unsigned)time(0));
     auto sourceIdx = rand() % sources_.size();
     auto numAttempts = 0;
+
+    auto mostRecent = etl_.getNetworkValidatedLedgers().tryGetMostRecent();
     while (numAttempts < sources_.size())
     {
-        res = sources_[sourceIdx]->forwardToP2p(context);
-        if (!res.isMember("forwarded") || res["forwarded"] != true)
-        {
+        auto increment = [&]() {
             sourceIdx = (sourceIdx + 1) % sources_.size();
             ++numAttempts;
+        };
+        auto& src = sources_[sourceIdx];
+        if (mostRecent && !src->hasLedger(*mostRecent))
+        {
+            increment();
+            continue;
+        }
+        res = src->forwardToP2p(context);
+        if (!res.isMember("forwarded") || res["forwarded"] != true)
+        {
+            increment();
             continue;
         }
         return res;

--- a/src/ripple/app/tx/impl/Transactor.cpp
+++ b/src/ripple/app/tx/impl/Transactor.cpp
@@ -174,15 +174,19 @@ Transactor::checkFee(PreclaimContext const& ctx, FeeUnit64 baseFee)
     if (!isLegalAmount(feePaid) || feePaid < beast::zero)
         return temBAD_FEE;
 
-    auto const feeDue =
-        minimumFee(ctx.app, baseFee, ctx.view.fees(), ctx.flags);
-
     // Only check fee is sufficient when the ledger is open.
-    if (ctx.view.open() && feePaid < feeDue)
+    if (ctx.view.open())
     {
-        JLOG(ctx.j.trace()) << "Insufficient fee paid: " << to_string(feePaid)
-                            << "/" << to_string(feeDue);
-        return telINSUF_FEE_P;
+        auto const feeDue =
+            minimumFee(ctx.app, baseFee, ctx.view.fees(), ctx.flags);
+
+        if (feePaid < feeDue)
+        {
+            JLOG(ctx.j.trace())
+                << "Insufficient fee paid: " << to_string(feePaid) << "/"
+                << to_string(feeDue);
+            return telINSUF_FEE_P;
+        }
     }
 
     if (feePaid == beast::zero)

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -214,8 +214,11 @@ public:
     // Amendment majority time
     std::chrono::seconds AMENDMENT_MAJORITY_TIME = defaultAmendmentMajorityTime;
 
-    // Thread pool configuration
-    int WORKERS = 0;
+    // Thread pool configuration (0 = choose for me)
+    int WORKERS = 0;           // jobqueue thread count. default: upto 6
+    int IO_WORKERS = 0;        // io svc thread count. default: 2
+    int PREFETCH_WORKERS = 0;  // prefetch thread count. default: 4
+
     // Can only be set in code, specifically unit tests
     bool FORCE_MULTI_THREAD = false;
 

--- a/src/ripple/core/Config.h
+++ b/src/ripple/core/Config.h
@@ -146,8 +146,10 @@ public:
     std::size_t NETWORK_QUORUM = 1;
 
     // Peer networking parameters
-    bool RELAY_UNTRUSTED_VALIDATIONS = true;
-    bool RELAY_UNTRUSTED_PROPOSALS = false;
+    // 1 = relay, 0 = do not relay (but process), -1 = drop completely (do NOT
+    // process)
+    int RELAY_UNTRUSTED_VALIDATIONS = 1;
+    int RELAY_UNTRUSTED_PROPOSALS = 0;
 
     // True to ask peers not to relay current IP.
     bool PEER_PRIVATE = false;

--- a/src/ripple/core/ConfigSections.h
+++ b/src/ripple/core/ConfigSections.h
@@ -96,6 +96,8 @@ struct ConfigSection
 #define SECTION_VALIDATOR_TOKEN "validator_token"
 #define SECTION_VETO_AMENDMENTS "veto_amendments"
 #define SECTION_WORKERS "workers"
+#define SECTION_IO_WORKERS "io_workers"
+#define SECTION_PREFETCH_WORKERS "prefetch_workers"
 #define SECTION_LEDGER_REPLAY "ledger_replay"
 #define SECTION_BETA_RPC_API "beta_rpc_api"
 #define SECTION_SWEEP_INTERVAL "sweep_interval"

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -39,34 +39,41 @@ enum JobType {
     // earlier jobs having lower priority than later jobs. If you wish to
     // insert a job at a specific priority, simply add it at the right location.
 
-    jtPACK,           // Make a fetch pack for a peer
-    jtPUBOLDLEDGER,   // An old ledger has been accepted
-    jtCLIENT,         // A websocket command from the client
-    jtRPC,            // A websocket command from the client
-    jtVALIDATION_ut,  // A validation from an untrusted source
-    jtUPDATE_PF,      // Update pathfinding requests
-    jtTRANSACTION_l,  // A local transaction
-    jtREPLAY_REQ,     // Peer request a ledger delta or a skip list
-    jtLEDGER_REQ,     // Peer request ledger/txnset data
-    jtPROPOSAL_ut,    // A proposal from an untrusted source
-    jtREPLAY_TASK,    // A Ledger replay task/subtask
-    jtLEDGER_DATA,    // Received data for a ledger we're acquiring
-    jtSWEEP,          // Sweep for stale structures
-    jtTRANSACTION,    // A transaction received from the network
-    jtMISSING_TXN,    // Request missing transactions
-    jtREQUESTED_TXN,  // Reply with requested transactions
-    jtBATCH,          // Apply batched transactions
-    jtADVANCE,        // Advance validated/acquired ledgers
-    jtPUBLEDGER,      // Publish a fully-accepted ledger
-    jtTXN_DATA,       // Fetch a proposed set
-    jtWAL,            // Write-ahead logging
-    jtVALIDATION_t,   // A validation from a trusted source
-    jtWRITE,          // Write out hashed objects
-    jtACCEPT,         // Accept a consensus ledger
-    jtPROPOSAL_t,     // A proposal from a trusted source
-    jtNETOP_CLUSTER,  // NetworkOPs cluster peer report
-    jtNETOP_TIMER,    // NetworkOPs net timer processing
-    jtADMIN,          // An administrative operation
+    jtPACK,               // Make a fetch pack for a peer
+    jtPUBOLDLEDGER,       // An old ledger has been accepted
+    jtCLIENT,             // A placeholder for the priority of all jtCLIENT jobs
+    jtCLIENT_SUBSCRIBE,   // A websocket subscription by a client
+    jtCLIENT_FEE_CHANGE,  // Subscription for fee change by a client
+    jtCLIENT_CONSENSUS,   // Subscription for consensus state change by a client
+    jtCLIENT_ACCT_HIST,   // Subscription for account history by a client
+    jtCLIENT_SHARD,       // Client request for shard archiving
+    jtCLIENT_RPC,         // Client RPC request
+    jtCLIENT_WEBSOCKET,   // Client websocket request
+    jtRPC,                // A websocket command from the client
+    jtSWEEP,              // Sweep for stale structures
+    jtVALIDATION_ut,      // A validation from an untrusted source
+    jtUPDATE_PF,          // Update pathfinding requests
+    jtTRANSACTION_l,      // A local transaction
+    jtREPLAY_REQ,         // Peer request a ledger delta or a skip list
+    jtLEDGER_REQ,         // Peer request ledger/txnset data
+    jtPROPOSAL_ut,        // A proposal from an untrusted source
+    jtREPLAY_TASK,        // A Ledger replay task/subtask
+    jtLEDGER_DATA,        // Received data for a ledger we're acquiring
+    jtTRANSACTION,        // A transaction received from the network
+    jtMISSING_TXN,        // Request missing transactions
+    jtREQUESTED_TXN,      // Reply with requested transactions
+    jtBATCH,              // Apply batched transactions
+    jtADVANCE,            // Advance validated/acquired ledgers
+    jtPUBLEDGER,          // Publish a fully-accepted ledger
+    jtTXN_DATA,           // Fetch a proposed set
+    jtWAL,                // Write-ahead logging
+    jtVALIDATION_t,       // A validation from a trusted source
+    jtWRITE,              // Write out hashed objects
+    jtACCEPT,             // Accept a consensus ledger
+    jtPROPOSAL_t,         // A proposal from a trusted source
+    jtNETOP_CLUSTER,      // NetworkOPs cluster peer report
+    jtNETOP_TIMER,        // NetworkOPs net timer processing
+    jtADMIN,              // An administrative operation
 
     // Special job types which are not dispatched by the job pool
     jtPEER,

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -67,46 +67,55 @@ private:
         };
 
         // clang-format off
-        add(jtPACK,          "makeFetchPack",                 1,     0ms,     0ms);
-        add(jtPUBOLDLEDGER,  "publishAcqLedger",              2, 10000ms, 15000ms);
-        add(jtVALIDATION_ut, "untrustedValidation",    maxLimit,  2000ms,  5000ms);
-        add(jtTRANSACTION_l, "localTransaction",       maxLimit,   100ms,   500ms);
-        add(jtREPLAY_REQ,    "ledgerReplayRequest",          10,   250ms,  1000ms);
-        add(jtLEDGER_REQ,    "ledgerRequest",                 4,     0ms,     0ms);
-        add(jtPROPOSAL_ut,   "untrustedProposal",      maxLimit,   500ms,  1250ms);
-        add(jtREPLAY_TASK,   "ledgerReplayTask",       maxLimit,     0ms,     0ms);
-        add(jtLEDGER_DATA,   "ledgerData",                    4,     0ms,     0ms);
-        add(jtCLIENT,        "clientCommand",          maxLimit,  2000ms,  5000ms);
-        add(jtRPC,           "RPC",                    maxLimit,     0ms,     0ms);
-        add(jtUPDATE_PF,     "updatePaths",                   1,     0ms,     0ms);
-        add(jtTRANSACTION,   "transaction",            maxLimit,   250ms,  1000ms);
-        add(jtBATCH,         "batch",                  maxLimit,   250ms,  1000ms);
-        add(jtADVANCE,       "advanceLedger",          maxLimit,     0ms,     0ms);
-        add(jtPUBLEDGER,     "publishNewLedger",       maxLimit,  3000ms,  4500ms);
-        add(jtTXN_DATA,      "fetchTxnData",                  5,     0ms,     0ms);
-        add(jtWAL,           "writeAhead",             maxLimit,  1000ms,  2500ms);
-        add(jtVALIDATION_t,  "trustedValidation",      maxLimit,   500ms,  1500ms);
-        add(jtWRITE,         "writeObjects",           maxLimit,  1750ms,  2500ms);
-        add(jtACCEPT,        "acceptLedger",           maxLimit,     0ms,     0ms);
-        add(jtPROPOSAL_t,    "trustedProposal",        maxLimit,   100ms,   500ms);
-        add(jtSWEEP,         "sweep",                         1,     0ms,     0ms);
-        add(jtNETOP_CLUSTER, "clusterReport",                 1,  9999ms,  9999ms);
-        add(jtNETOP_TIMER,   "heartbeat",                     1,   999ms,   999ms);
-        add(jtADMIN,         "administration",         maxLimit,     0ms,     0ms);
-        add(jtMISSING_TXN,   "handleHaveTransactions",     1200,     0ms,     0ms);
-        add(jtREQUESTED_TXN, "doTransactions",             1200,     0ms,     0ms);
+        //                                                           avg     peak
+        //  JobType               name                    limit    latency  latency
+        add(jtPACK,              "makeFetchPack",               1,     0ms,     0ms);
+        add(jtPUBOLDLEDGER,      "publishAcqLedger",            2, 10000ms, 15000ms);
+        add(jtVALIDATION_ut,     "untrustedValidation",  maxLimit,  2000ms,  5000ms);
+        add(jtTRANSACTION_l,     "localTransaction",     maxLimit,   100ms,   500ms);
+        add(jtREPLAY_REQ,        "ledgerReplayRequest",        10,   250ms,  1000ms);
+        add(jtLEDGER_REQ,        "ledgerRequest",               4,     0ms,     0ms);
+        add(jtPROPOSAL_ut,       "untrustedProposal",    maxLimit,   500ms,  1250ms);
+        add(jtREPLAY_TASK,       "ledgerReplayTask",     maxLimit,     0ms,     0ms);
+        add(jtLEDGER_DATA,       "ledgerData",                  4,     0ms,     0ms);
+        add(jtCLIENT,            "clientCommand",        maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_SUBSCRIBE,  "clientSubscribe",      maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_FEE_CHANGE, "clientFeeChange",      maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_CONSENSUS,  "clientConsensus",      maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_ACCT_HIST,  "clientAccountHistory", maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_SHARD,      "clientShardArchive",   maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_RPC,        "clientRPC",            maxLimit,  2000ms,  5000ms);
+        add(jtCLIENT_WEBSOCKET,  "clientWebsocket",      maxLimit,  2000ms,  5000ms);
+        add(jtRPC,               "RPC",                  maxLimit,     0ms,     0ms);
+        add(jtUPDATE_PF,         "updatePaths",                 1,     0ms,     0ms);
+        add(jtTRANSACTION,       "transaction",          maxLimit,   250ms,  1000ms);
+        add(jtBATCH,             "batch",                maxLimit,   250ms,  1000ms);
+        add(jtADVANCE,           "advanceLedger",        maxLimit,     0ms,     0ms);
+        add(jtPUBLEDGER,         "publishNewLedger",     maxLimit,  3000ms,  4500ms);
+        add(jtTXN_DATA,          "fetchTxnData",                5,     0ms,     0ms);
+        add(jtWAL,               "writeAhead",           maxLimit,  1000ms,  2500ms);
+        add(jtVALIDATION_t,      "trustedValidation",    maxLimit,   500ms,  1500ms);
+        add(jtWRITE,             "writeObjects",         maxLimit,  1750ms,  2500ms);
+        add(jtACCEPT,            "acceptLedger",         maxLimit,     0ms,     0ms);
+        add(jtPROPOSAL_t,        "trustedProposal",      maxLimit,   100ms,   500ms);
+        add(jtSWEEP,             "sweep",                       1,     0ms,     0ms);
+        add(jtNETOP_CLUSTER,     "clusterReport",               1,  9999ms,  9999ms);
+        add(jtNETOP_TIMER,       "heartbeat",                   1,   999ms,   999ms);
+        add(jtADMIN,             "administration",       maxLimit,     0ms,     0ms);
+        add(jtMISSING_TXN,       "handleHaveTransactions",   1200,     0ms,     0ms);
+        add(jtREQUESTED_TXN,     "doTransactions",           1200,     0ms,     0ms);
 
-        add(jtPEER,          "peerCommand",                   0,   200ms,  2500ms);
-        add(jtDISK,          "diskAccess",                    0,   500ms,  1000ms);
-        add(jtTXN_PROC,      "processTransaction",            0,     0ms,     0ms);
-        add(jtOB_SETUP,      "orderBookSetup",                0,     0ms,     0ms);
-        add(jtPATH_FIND,     "pathFind",                      0,     0ms,     0ms);
-        add(jtHO_READ,       "nodeRead",                      0,     0ms,     0ms);
-        add(jtHO_WRITE,      "nodeWrite",                     0,     0ms,     0ms);
-        add(jtGENERIC,       "generic",                       0,     0ms,     0ms);
-        add(jtNS_SYNC_READ,  "SyncReadNode",                  0,     0ms,     0ms);
-        add(jtNS_ASYNC_READ, "AsyncReadNode",                 0,     0ms,     0ms);
-        add(jtNS_WRITE,      "WriteNode",                     0,     0ms,     0ms);
+        add(jtPEER,              "peerCommand",                 0,   200ms,  2500ms);
+        add(jtDISK,              "diskAccess",                  0,   500ms,  1000ms);
+        add(jtTXN_PROC,          "processTransaction",          0,     0ms,     0ms);
+        add(jtOB_SETUP,          "orderBookSetup",              0,     0ms,     0ms);
+        add(jtPATH_FIND,         "pathFind",                    0,     0ms,     0ms);
+        add(jtHO_READ,           "nodeRead",                    0,     0ms,     0ms);
+        add(jtHO_WRITE,          "nodeWrite",                   0,     0ms,     0ms);
+        add(jtGENERIC,           "generic",                     0,     0ms,     0ms);
+        add(jtNS_SYNC_READ,      "SyncReadNode",                0,     0ms,     0ms);
+        add(jtNS_ASYNC_READ,     "AsyncReadNode",               0,     0ms,     0ms);
+        add(jtNS_WRITE,          "WriteNode",                   0,     0ms,     0ms);
         // clang-format on
     }
 

--- a/src/ripple/core/Pg.cpp
+++ b/src/ripple/core/Pg.cpp
@@ -792,11 +792,7 @@ CREATE OR REPLACE FUNCTION tx (
     _in_trans_id bytea
 ) RETURNS jsonb AS $$
 DECLARE
-    _min_ledger        bigint := min_ledger();
-    _min_seq           bigint := (SELECT ledger_seq
-                                    FROM ledgers
-                                   WHERE ledger_seq = _min_ledger
-                                     FOR SHARE);
+    _min_seq           bigint := min_ledger();
     _max_seq           bigint := max_ledger();
     _ledger_seq        bigint;
     _nodestore_hash    bytea;

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -655,6 +655,26 @@ Config::loadFromString(std::string const& fileContents)
                 ": must be between 1 and 1024 inclusive.");
     }
 
+    if (getSingleSection(secConfig, SECTION_IO_WORKERS, strTemp, j_))
+    {
+        IO_WORKERS = beast::lexicalCastThrow<int>(strTemp);
+
+        if (IO_WORKERS < 1 || IO_WORKERS > 1024)
+            Throw<std::runtime_error>(
+                "Invalid " SECTION_IO_WORKERS
+                ": must be between 1 and 1024 inclusive.");
+    }
+
+    if (getSingleSection(secConfig, SECTION_PREFETCH_WORKERS, strTemp, j_))
+    {
+        PREFETCH_WORKERS = beast::lexicalCastThrow<int>(strTemp);
+
+        if (PREFETCH_WORKERS < 1 || PREFETCH_WORKERS > 1024)
+            Throw<std::runtime_error>(
+                "Invalid " SECTION_PREFETCH_WORKERS
+                ": must be between 1 and 1024 inclusive.");
+    }
+
     if (getSingleSection(secConfig, SECTION_COMPRESSION, strTemp, j_))
         COMPRESSION = beast::lexicalCastThrow<bool>(strTemp);
 

--- a/src/ripple/core/impl/Config.cpp
+++ b/src/ripple/core/impl/Config.cpp
@@ -553,9 +553,11 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_RELAY_VALIDATIONS, strTemp, j_))
     {
         if (boost::iequals(strTemp, "all"))
-            RELAY_UNTRUSTED_VALIDATIONS = true;
+            RELAY_UNTRUSTED_VALIDATIONS = 1;
         else if (boost::iequals(strTemp, "trusted"))
-            RELAY_UNTRUSTED_VALIDATIONS = false;
+            RELAY_UNTRUSTED_VALIDATIONS = 0;
+        else if (boost::iequals(strTemp, "drop_untrusted"))
+            RELAY_UNTRUSTED_VALIDATIONS = -1;
         else
             Throw<std::runtime_error>(
                 "Invalid value specified in [" SECTION_RELAY_VALIDATIONS
@@ -565,9 +567,11 @@ Config::loadFromString(std::string const& fileContents)
     if (getSingleSection(secConfig, SECTION_RELAY_PROPOSALS, strTemp, j_))
     {
         if (boost::iequals(strTemp, "all"))
-            RELAY_UNTRUSTED_PROPOSALS = true;
+            RELAY_UNTRUSTED_PROPOSALS = 1;
         else if (boost::iequals(strTemp, "trusted"))
-            RELAY_UNTRUSTED_PROPOSALS = false;
+            RELAY_UNTRUSTED_PROPOSALS = 0;
+        else if (boost::iequals(strTemp, "drop_untrusted"))
+            RELAY_UNTRUSTED_PROPOSALS = -1;
         else
             Throw<std::runtime_error>(
                 "Invalid value specified in [" SECTION_RELAY_PROPOSALS

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -168,15 +168,13 @@ JobQueue::addLoadEvents(JobType t, int count, std::chrono::milliseconds elapsed)
 bool
 JobQueue::isOverloaded()
 {
-    int count = 0;
-
     for (auto& x : m_jobData)
     {
         if (x.second.load().isOver())
-            ++count;
+            return true;
     }
 
-    return count > 0;
+    return false;
 }
 
 Json::Value

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -168,13 +168,9 @@ JobQueue::addLoadEvents(JobType t, int count, std::chrono::milliseconds elapsed)
 bool
 JobQueue::isOverloaded()
 {
-    for (auto& x : m_jobData)
-    {
-        if (x.second.load().isOver())
-            return true;
-    }
-
-    return false;
+    return std::any_of(m_jobData.begin(), m_jobData.end(), [](auto& entry) {
+        return entry.second.load().isOver();
+    });
 }
 
 Json::Value

--- a/src/ripple/core/impl/JobQueue.cpp
+++ b/src/ripple/core/impl/JobQueue.cpp
@@ -94,7 +94,9 @@ JobQueue::addRefCountedJob(
 
     // FIXME: Workaround incorrect client shutdown ordering
     // do not add jobs to a queue with no threads
-    assert(type == jtCLIENT || m_workers.getNumberOfThreads() > 0);
+    assert(
+        (type >= jtCLIENT && type <= jtCLIENT_WEBSOCKET) ||
+        m_workers.getNumberOfThreads() > 0);
 
     {
         std::lock_guard lock(m_mutex);

--- a/src/ripple/crypto/impl/RFC1751.cpp
+++ b/src/ripple/crypto/impl/RFC1751.cpp
@@ -438,7 +438,7 @@ RFC1751::etob(std::string& strData, std::vector<std::string> vsHuman)
     return 1;
 }
 
-/** Convert words seperated by spaces into a 128 bit key in big-endian format.
+/** Convert words separated by spaces into a 128 bit key in big-endian format.
 
     @return
          1 if succeeded

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -37,11 +37,6 @@ enum ApplyFlags : std::uint32_t {
     // Transaction can be retried, soft failures allowed
     tapRETRY = 0x20,
 
-    // Transaction must pay more than both the open ledger
-    // fee and all transactions in the queue to get into the
-    // open ledger
-    tapPREFER_QUEUE = 0x40,
-
     // Transaction came from a privileged source
     tapUNLIMITED = 0x400,
 };
@@ -55,10 +50,10 @@ operator|(ApplyFlags const& lhs, ApplyFlags const& rhs)
 }
 
 static_assert(
-    (tapPREFER_QUEUE | tapRETRY) == safe_cast<ApplyFlags>(0x60u),
+    (tapFAIL_HARD | tapRETRY) == safe_cast<ApplyFlags>(0x30u),
     "ApplyFlags operator |");
 static_assert(
-    (tapRETRY | tapPREFER_QUEUE) == safe_cast<ApplyFlags>(0x60u),
+    (tapRETRY | tapFAIL_HARD) == safe_cast<ApplyFlags>(0x30u),
     "ApplyFlags operator |");
 
 constexpr ApplyFlags
@@ -69,8 +64,8 @@ operator&(ApplyFlags const& lhs, ApplyFlags const& rhs)
         safe_cast<std::underlying_type_t<ApplyFlags>>(rhs));
 }
 
-static_assert((tapPREFER_QUEUE & tapRETRY) == tapNONE, "ApplyFlags operator &");
-static_assert((tapRETRY & tapPREFER_QUEUE) == tapNONE, "ApplyFlags operator &");
+static_assert((tapFAIL_HARD & tapRETRY) == tapNONE, "ApplyFlags operator &");
+static_assert((tapRETRY & tapFAIL_HARD) == tapNONE, "ApplyFlags operator &");
 
 constexpr ApplyFlags
 operator~(ApplyFlags const& flags)

--- a/src/ripple/net/impl/RPCSub.cpp
+++ b/src/ripple/net/impl/RPCSub.cpp
@@ -96,7 +96,9 @@ public:
             JLOG(j_.info()) << "RPCCall::fromNetwork start";
 
             mSending = m_jobQueue.addJob(
-                jtCLIENT, "RPCSub::sendThread", [this](Job&) { sendThread(); });
+                jtCLIENT_SUBSCRIBE, "RPCSub::sendThread", [this](Job&) {
+                    sendThread();
+                });
         }
     }
 

--- a/src/ripple/overlay/impl/OverlayImpl.cpp
+++ b/src/ripple/overlay/impl/OverlayImpl.cpp
@@ -190,7 +190,7 @@ OverlayImpl::onHandoff(
 
     auto consumer = m_resourceManager.newInboundEndpoint(
         beast::IPAddressConversion::from_asio(remote_endpoint));
-    if (consumer.disconnect())
+    if (consumer.disconnect(journal))
         return handoff;
 
     auto const slot = m_peerFinder->new_inbound_slot(
@@ -392,7 +392,7 @@ OverlayImpl::connect(beast::IP::Endpoint const& remote_endpoint)
     assert(work_);
 
     auto usage = resourceManager().newOutboundEndpoint(remote_endpoint);
-    if (usage.disconnect())
+    if (usage.disconnect(journal_))
     {
         JLOG(journal_.info()) << "Over resource limit: " << remote_endpoint;
         return;

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -342,8 +342,8 @@ PeerImp::removeTxQueue(uint256 const& hash)
 void
 PeerImp::charge(Resource::Charge const& fee)
 {
-    if ((usage_.charge(fee) == Resource::drop) && usage_.disconnect() &&
-        strand_.running_in_this_thread())
+    if ((usage_.charge(fee) == Resource::drop) &&
+        usage_.disconnect(p_journal_) && strand_.running_in_this_thread())
     {
         // Sever the connection
         overlay_.incPeerDisconnectCharges();

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1929,10 +1929,21 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
         return;
     }
 
+    // RH TODO: when isTrusted = false we should probably also cache a key
+    // suppression for 30 seconds to avoid doing a relatively expensive lookup
+    // every time a spam packet is received
+    PublicKey const publicKey{makeSlice(set.nodepubkey())};
+    auto const isTrusted = app_.validators().trusted(publicKey);
+
+    // If the operator has specified that untrusted proposals be dropped then
+    // this happens here I.e. before further wasting CPU verifying the signature
+    // of an untrusted key
+    if (!isTrusted && app_.config().RELAY_UNTRUSTED_PROPOSALS == -1)
+        return;
+
     uint256 const proposeHash{set.currenttxhash()};
     uint256 const prevLedger{set.previousledger()};
 
-    PublicKey const publicKey{makeSlice(set.nodepubkey())};
     NetClock::time_point const closeTime{NetClock::duration{set.closetime()}};
 
     uint256 const suppression = proposalUniqueId(
@@ -1956,8 +1967,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
         JLOG(p_journal_.trace()) << "Proposal: duplicate";
         return;
     }
-
-    auto const isTrusted = app_.validators().trusted(publicKey);
 
     if (!isTrusted)
     {
@@ -2543,6 +2552,18 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
             return;
         }
 
+        // RH TODO: when isTrusted = false we should probably also cache a key
+        // suppression for 30 seconds to avoid doing a relatively expensive
+        // lookup every time a spam packet is received
+        auto const isTrusted =
+            app_.validators().trusted(val->getSignerPublic());
+
+        // If the operator has specified that untrusted validations be dropped
+        // then this happens here I.e. before further wasting CPU verifying the
+        // signature of an untrusted key
+        if (!isTrusted && app_.config().RELAY_UNTRUSTED_VALIDATIONS == -1)
+            return;
+
         auto key = sha512Half(makeSlice(m->validation()));
         if (auto [added, relayed] =
                 app_.getHashRouter().addSuppressionPeerWithStatus(key, id_);
@@ -2559,9 +2580,6 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMValidation> const& m)
             JLOG(p_journal_.trace()) << "Validation: duplicate";
             return;
         }
-
-        auto const isTrusted =
-            app_.validators().trusted(val->getSignerPublic());
 
         if (!isTrusted && (tracking_.load() == Tracking::diverged))
         {
@@ -3106,7 +3124,7 @@ PeerImp::checkPropose(
     if (isTrusted)
         relay = app_.getOPs().processTrustedProposal(peerPos);
     else
-        relay = app_.config().RELAY_UNTRUSTED_PROPOSALS || cluster();
+        relay = app_.config().RELAY_UNTRUSTED_PROPOSALS == 1 || cluster();
 
     if (relay)
     {

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -37,6 +37,9 @@ char const* const versionString = "1.8.1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)
+#ifdef GIT_COMMIT_HASH
+    "-" GIT_COMMIT_HASH
+#endif
     "+"
 #ifdef DEBUG
     "DEBUG"

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -280,6 +280,7 @@ JSS(hotwallet);             // in: GatewayBalances
 JSS(id);                    // websocket.
 JSS(ident);                 // in: AccountCurrencies, AccountInfo,
                             //     OwnerInfo
+JSS(ignore_default);        // in: AccountLines
 JSS(inLedger);              // out: tx/Transaction
 JSS(inbound);               // out: PeerImp
 JSS(index);                 // in: LedgerEntry, DownloadShard

--- a/src/ripple/resource/Consumer.h
+++ b/src/ripple/resource/Consumer.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_RESOURCE_CONSUMER_H_INCLUDED
 #define RIPPLE_RESOURCE_CONSUMER_H_INCLUDED
 
+#include <ripple/basics/Log.h>
 #include <ripple/resource/Charge.h>
 #include <ripple/resource/Disposition.h>
 
@@ -76,7 +77,7 @@ public:
 
     /** Returns `true` if the consumer should be disconnected. */
     bool
-    disconnect();
+    disconnect(beast::Journal const& j);
 
     /** Returns the credit balance representing consumption. */
     int

--- a/src/ripple/resource/impl/Consumer.cpp
+++ b/src/ripple/resource/impl/Consumer.cpp
@@ -114,10 +114,15 @@ Consumer::warn()
 }
 
 bool
-Consumer::disconnect()
+Consumer::disconnect(beast::Journal const& j)
 {
     assert(m_entry != nullptr);
-    return m_logic->disconnect(*m_entry);
+    bool const d = m_logic->disconnect(*m_entry);
+    if (d)
+    {
+        JLOG(j.debug()) << "disconnecting " << m_entry->to_string();
+    }
+    return d;
 }
 
 int

--- a/src/ripple/rpc/handlers/AccountOffers.cpp
+++ b/src/ripple/rpc/handlers/AccountOffers.cpp
@@ -86,68 +86,94 @@ doAccountOffers(RPC::JsonContext& context)
     if (auto err = readLimitField(limit, RPC::Tuning::accountOffers, context))
         return *err;
 
+    if (limit == 0)
+        return rpcError(rpcINVALID_PARAMS);
+
     Json::Value& jsonOffers(result[jss::offers] = Json::arrayValue);
     std::vector<std::shared_ptr<SLE const>> offers;
-    unsigned int reserve(limit);
-    uint256 startAfter;
-    std::uint64_t startHint;
+    uint256 startAfter = beast::zero;
+    std::uint64_t startHint = 0;
 
     if (params.isMember(jss::marker))
     {
-        // We have a start point. Use limit - 1 from the result and use the
-        // very last one for the resume.
-        Json::Value const& marker(params[jss::marker]);
-
-        if (!marker.isString())
+        if (!params[jss::marker].isString())
             return RPC::expected_field_error(jss::marker, "string");
 
-        if (!startAfter.parseHex(marker.asString()))
+        // Marker is composed of a comma separated index and start hint. The
+        // former will be read as hex, and the latter using boost lexical cast.
+        std::stringstream marker(params[jss::marker].asString());
+        std::string value;
+        if (!std::getline(marker, value, ','))
             return rpcError(rpcINVALID_PARAMS);
 
-        auto const sleOffer = ledger->read({ltOFFER, startAfter});
+        if (!startAfter.parseHex(value))
+            return rpcError(rpcINVALID_PARAMS);
 
-        if (!sleOffer || accountID != sleOffer->getAccountID(sfAccount))
+        if (!std::getline(marker, value, ','))
+            return rpcError(rpcINVALID_PARAMS);
+
+        try
+        {
+            startHint = boost::lexical_cast<std::uint64_t>(value);
+        }
+        catch (boost::bad_lexical_cast&)
         {
             return rpcError(rpcINVALID_PARAMS);
         }
 
-        startHint = sleOffer->getFieldU64(sfOwnerNode);
-        // Caller provided the first offer (startAfter), add it as first result
-        appendOfferJson(sleOffer, jsonOffers);
-        offers.reserve(reserve);
-    }
-    else
-    {
-        startHint = 0;
-        // We have no start point, limit should be one higher than requested.
-        offers.reserve(++reserve);
+        // We then must check if the object pointed to by the marker is actually
+        // owned by the account in the request.
+        auto const sle = ledger->read({ltANY, startAfter});
+
+        if (!sle)
+            return rpcError(rpcINVALID_PARAMS);
+
+        if (!RPC::isOwnedByAccount(*ledger, sle, accountID))
+            return rpcError(rpcINVALID_PARAMS);
     }
 
+    auto count = 0;
+    std::optional<uint256> marker = {};
+    std::uint64_t nextHint = 0;
     if (!forEachItemAfter(
             *ledger,
             accountID,
             startAfter,
             startHint,
-            reserve,
-            [&offers](std::shared_ptr<SLE const> const& offer) {
-                if (offer->getType() == ltOFFER)
+            limit + 1,
+            [&offers, &count, &marker, &limit, &nextHint, &accountID](
+                std::shared_ptr<SLE const> const& sle) {
+                if (!sle)
                 {
-                    offers.emplace_back(offer);
-                    return true;
+                    assert(false);
+                    return false;
                 }
 
-                return false;
+                if (++count == limit)
+                {
+                    marker = sle->key();
+                    nextHint = RPC::getStartHint(sle, accountID);
+                }
+
+                if (count <= limit && sle->getType() == ltOFFER)
+                {
+                    offers.emplace_back(sle);
+                }
+
+                return true;
             }))
     {
         return rpcError(rpcINVALID_PARAMS);
     }
 
-    if (offers.size() == reserve)
+    // Both conditions need to be checked because marker is set on the limit-th
+    // item, but if there is no item on the limit + 1 iteration, then there is
+    // no need to return a marker.
+    if (count == limit + 1 && marker)
     {
         result[jss::limit] = limit;
-
-        result[jss::marker] = to_string(offers.back()->key());
-        offers.pop_back();
+        result[jss::marker] =
+            to_string(*marker) + "," + std::to_string(nextHint);
     }
 
     for (auto const& offer : offers)

--- a/src/ripple/rpc/impl/RPCHandler.cpp
+++ b/src/ripple/rpc/impl/RPCHandler.cpp
@@ -129,12 +129,11 @@ fillHandler(JsonContext& context, Handler const*& result)
 {
     if (!isUnlimited(context.role))
     {
-        // VFALCO NOTE Should we also add up the jtRPC jobs?
-        //
-        int jc = context.app.getJobQueue().getJobCountGE(jtCLIENT);
-        if (jc > Tuning::maxJobQueueClients)
+        // Count all jobs at jtCLIENT priority or higher.
+        int const jobCount = context.app.getJobQueue().getJobCountGE(jtCLIENT);
+        if (jobCount > Tuning::maxJobQueueClients)
         {
-            JLOG(context.j.debug()) << "Too busy for command: " << jc;
+            JLOG(context.j.debug()) << "Too busy for command: " << jobCount;
             return rpcTOO_BUSY;
         }
     }

--- a/src/ripple/rpc/impl/RPCHelpers.h
+++ b/src/ripple/rpc/impl/RPCHelpers.h
@@ -71,6 +71,25 @@ accountFromStringWithCode(
     std::string const& strIdent,
     bool bStrict = false);
 
+/** Gets the start hint for traversing account objects
+ * @param sle - Ledger entry defined by the marker passed into the RPC.
+ * @param accountID - The ID of the account whose objects you are traversing.
+ */
+std::uint64_t
+getStartHint(std::shared_ptr<SLE const> const& sle, AccountID const& accountID);
+
+/**
+ * Tests if a SLE is owned by accountID.
+ * @param ledger - The ledger used to search for the sle.
+ * @param sle - The SLE to test for ownership.
+ * @param account - The account being tested for SLE ownership.
+ */
+bool
+isOwnedByAccount(
+    ReadView const& ledger,
+    std::shared_ptr<SLE const> const& sle,
+    AccountID const& accountID);
+
 /** Gathers all objects for an account in a ledger.
     @param ledger Ledger to search account objects.
     @param account AccountID to find objects for.

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -292,7 +292,7 @@ ServerHandlerImp::onRequest(Session& session)
 
     std::shared_ptr<Session> detachedSession = session.detach();
     auto const postResult = m_jobQueue.postCoro(
-        jtCLIENT,
+        jtCLIENT_RPC,
         "RPC-Client",
         [this, detachedSession](std::shared_ptr<JobQueue::Coro> coro) {
             processSession(detachedSession, coro);
@@ -339,7 +339,7 @@ ServerHandlerImp::onWSMessage(
     JLOG(m_journal.trace()) << "Websocket received '" << jv << "'";
 
     auto const postResult = m_jobQueue.postCoro(
-        jtCLIENT,
+        jtCLIENT_WEBSOCKET,
         "WS-Client",
         [this, session, jv = std::move(jv)](
             std::shared_ptr<JobQueue::Coro> const& coro) {

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -384,7 +384,7 @@ ServerHandlerImp::processSession(
     Json::Value const& jv)
 {
     auto is = std::static_pointer_cast<WSInfoSub>(session->appDefined);
-    if (is->getConsumer().disconnect())
+    if (is->getConsumer().disconnect(m_journal))
     {
         session->close(
             {boost::beast::websocket::policy_error, "threshold exceeded"});
@@ -687,7 +687,7 @@ ServerHandlerImp::processRequest(
         {
             usage = m_resourceManager.newInboundEndpoint(
                 remoteIPAddress, role == Role::PROXY, forwardedFor);
-            if (usage.disconnect())
+            if (usage.disconnect(m_journal))
             {
                 if (!batch)
                 {

--- a/src/ripple/rpc/impl/ShardArchiveHandler.cpp
+++ b/src/ripple/rpc/impl/ShardArchiveHandler.cpp
@@ -382,7 +382,7 @@ ShardArchiveHandler::next(std::lock_guard<std::mutex> const& l)
         return onClosureFailed(
             "failed to wrap closure for starting download", l);
 
-    app_.getJobQueue().addJob(jtCLIENT, "ShardArchiveHandler", *wrapper);
+    app_.getJobQueue().addJob(jtCLIENT_SHARD, "ShardArchiveHandler", *wrapper);
 
     return true;
 }
@@ -465,7 +465,7 @@ ShardArchiveHandler::complete(path dstPath)
     }
 
     // Process in another thread to not hold up the IO service
-    app_.getJobQueue().addJob(jtCLIENT, "ShardArchiveHandler", *wrapper);
+    app_.getJobQueue().addJob(jtCLIENT_SHARD, "ShardArchiveHandler", *wrapper);
 }
 
 void

--- a/src/ripple/rpc/impl/Tuning.h
+++ b/src/ripple/rpc/impl/Tuning.h
@@ -46,7 +46,7 @@ static LimitRange constexpr accountObjects = {10, 200, 400};
 static LimitRange constexpr accountOffers = {10, 200, 400};
 
 /** Limits for the book_offers command. */
-static LimitRange constexpr bookOffers = {0, 300, 400};
+static LimitRange constexpr bookOffers = {0, 60, 100};
 
 /** Limits for the no_ripple_check command. */
 static LimitRange constexpr noRippleCheck = {10, 300, 400};

--- a/src/test/app/HashRouter_test.cpp
+++ b/src/test/app/HashRouter_test.cpp
@@ -31,7 +31,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -68,7 +68,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -146,7 +146,7 @@ class HashRouter_test : public beast::unit_test::suite
         // Normal HashRouter
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         uint256 const key2(2);
@@ -174,7 +174,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 2s, 2);
+        HashRouter router(stopwatch, 2s);
 
         uint256 const key1(1);
         BEAST_EXPECT(router.setFlags(key1, 10));
@@ -187,7 +187,7 @@ class HashRouter_test : public beast::unit_test::suite
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 1s, 2);
+        HashRouter router(stopwatch, 1s);
 
         uint256 const key1(1);
 
@@ -226,46 +226,11 @@ class HashRouter_test : public beast::unit_test::suite
     }
 
     void
-    testRecover()
-    {
-        using namespace std::chrono_literals;
-        TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 1s, 5);
-
-        uint256 const key1(1);
-
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(!router.shouldRecover(key1));
-        // Expire, but since the next search will
-        // be for this entry, it will get refreshed
-        // instead.
-        ++stopwatch;
-        BEAST_EXPECT(router.shouldRecover(key1));
-        // Expire, but since the next search will
-        // be for this entry, it will get refreshed
-        // instead.
-        ++stopwatch;
-        // Recover again. Recovery is independent of
-        // time as long as the entry doesn't expire.
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(router.shouldRecover(key1));
-        // Expire again
-        ++stopwatch;
-        BEAST_EXPECT(router.shouldRecover(key1));
-        BEAST_EXPECT(!router.shouldRecover(key1));
-    }
-
-    void
     testProcess()
     {
         using namespace std::chrono_literals;
         TestStopwatch stopwatch;
-        HashRouter router(stopwatch, 5s, 5);
+        HashRouter router(stopwatch, 5s);
         uint256 const key(1);
         HashRouter::PeerShortID peer = 1;
         int flags;
@@ -286,7 +251,6 @@ public:
         testSuppression();
         testSetFlags();
         testRelay();
-        testRecover();
         testProcess();
     }
 };

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -1033,8 +1033,7 @@ struct PayChan_test : public beast::unit_test::suite
         {
             // degenerate case
             auto const r = testLimit(env, alice, 0);
-            BEAST_EXPECT(r.isMember(jss::marker));
-            BEAST_EXPECT(r[jss::channels].size() == 0);
+            BEAST_EXPECT(r.isMember(jss::error_message));
         }
     }
 

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -1469,6 +1469,7 @@ public:
                 *this,
                 makeConfig(
                     {{"minimum_txn_in_ledger_standalone", "2"},
+                     {"minimum_txn_in_ledger", "5"},
                      {"target_txn_in_ledger", "4"},
                      {"maximum_txn_in_ledger", "5"}}));
 

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -802,7 +802,7 @@ public:
         env(noop(charlie), fee(7000), queued);
         env(noop(daria), fee(7000), queued);
         env(noop(edgar), fee(7000), queued);
-        env(noop(felicia), fee(7000), queued);
+        env(noop(felicia), fee(6999), queued);
         checkMetrics(env, 6, 6, 4, 3, 257);
 
         env.close();
@@ -816,8 +816,8 @@ public:
         env(noop(daria), fee(8000), queued);
         env(noop(daria), fee(8000), seq(env.seq(daria) + 1), queued);
         env(noop(edgar), fee(8000), queued);
-        env(noop(felicia), fee(8000), queued);
-        env(noop(felicia), fee(8000), seq(env.seq(felicia) + 1), queued);
+        env(noop(felicia), fee(7999), queued);
+        env(noop(felicia), fee(7999), seq(env.seq(felicia) + 1), queued);
         checkMetrics(env, 8, 8, 5, 4, 257, 700 * 256);
 
         env.close();
@@ -1039,7 +1039,7 @@ public:
         checkMetrics(env, 0, initQueueMax, 4, 3, 256);
 
         // Alice - price starts exploding: held
-        env(noop(alice), queued);
+        env(noop(alice), fee(11), queued);
         checkMetrics(env, 1, initQueueMax, 4, 3, 256);
 
         auto aliceSeq = env.seq(alice);
@@ -1088,7 +1088,7 @@ public:
         BEAST_EXPECT(env.seq(charlie) == charlieSeq + 1);
 
         // Alice - fill up the queue
-        std::int64_t aliceFee = 20;
+        std::int64_t aliceFee = 27;
         aliceSeq = env.seq(alice);
         auto lastLedgerSeq = env.current()->info().seq + 2;
         for (auto i = 0; i < 7; i++)
@@ -1096,7 +1096,7 @@ public:
             env(noop(alice),
                 seq(aliceSeq),
                 json(jss::LastLedgerSequence, lastLedgerSeq + i),
-                fee(aliceFee),
+                fee(--aliceFee),
                 queued);
             ++aliceSeq;
         }
@@ -1104,17 +1104,18 @@ public:
         {
             auto& txQ = env.app().getTxQ();
             auto aliceStat = txQ.getAccountTxs(alice.id(), *env.current());
-            constexpr XRPAmount fee{20};
+            aliceFee = 27;
             auto const& baseFee = env.current()->fees().base;
             auto seq = env.seq(alice);
             BEAST_EXPECT(aliceStat.size() == 7);
             for (auto const& tx : aliceStat)
             {
                 BEAST_EXPECT(tx.seqProxy.isSeq() && tx.seqProxy.value() == seq);
-                BEAST_EXPECT(tx.feeLevel == toFeeLevel(fee, baseFee));
+                BEAST_EXPECT(
+                    tx.feeLevel == toFeeLevel(XRPAmount(--aliceFee), baseFee));
                 BEAST_EXPECT(tx.lastValid);
                 BEAST_EXPECT(
-                    (tx.consequences.fee() == drops(fee) &&
+                    (tx.consequences.fee() == drops(aliceFee) &&
                      tx.consequences.potentialSpend() == drops(0) &&
                      !tx.consequences.isBlocker()) ||
                     tx.seqProxy.value() == env.seq(alice) + 6);
@@ -1141,13 +1142,13 @@ public:
         // Charlie - add another item to the queue, which
         // causes Alice's last txn to drop
         env(noop(charlie), fee(30), queued);
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Alice - now attempt to add one more to the queue,
         // which fails because the last tx was dropped, so
         // there is no complete chain.
         env(noop(alice), seq(aliceSeq), fee(aliceFee), ter(telCAN_NOT_QUEUE));
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Alice wants this tx more than the dropped tx,
         // so resubmits with higher fee, but the queue
@@ -1156,22 +1157,22 @@ public:
             seq(aliceSeq - 1),
             fee(aliceFee),
             ter(telCAN_NOT_QUEUE_FULL));
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Try to replace a middle item in the queue
         // without enough fee.
         aliceSeq = env.seq(alice) + 2;
-        aliceFee = 25;
+        aliceFee = 29;
         env(noop(alice),
             seq(aliceSeq),
             fee(aliceFee),
             ter(telCAN_NOT_QUEUE_FEE));
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         // Replace a middle item from the queue successfully
         ++aliceFee;
         env(noop(alice), seq(aliceSeq), fee(aliceFee), queued);
-        checkMetrics(env, 8, 8, 5, 4, 513);
+        checkMetrics(env, 8, 8, 5, 4, 538);
 
         env.close();
         // Alice's transactions processed, along with
@@ -1186,7 +1187,7 @@ public:
         // more than the minimum reserve in flight before the
         // last queued transaction
         aliceFee =
-            env.le(alice)->getFieldAmount(sfBalance).xrp().drops() - (59);
+            env.le(alice)->getFieldAmount(sfBalance).xrp().drops() - (62);
         env(noop(alice),
             seq(aliceSeq),
             fee(aliceFee),
@@ -1334,6 +1335,9 @@ public:
         auto hankSeq = env.seq(hank);
 
         // This time, use identical fees.
+
+        // This one gets into the queue, but gets dropped when the
+        // higher fee one is added later.
         env(noop(alice), fee(15), queued);
         env(noop(bob), fee(15), queued);
         env(noop(charlie), fee(15), queued);
@@ -1341,8 +1345,6 @@ public:
         env(noop(elmo), fee(15), queued);
         env(noop(fred), fee(15), queued);
         env(noop(gwen), fee(15), queued);
-        // This one gets into the queue, but gets dropped when the
-        // higher fee one is added later.
         env(noop(hank), fee(15), queued);
 
         // Queue is full now. Minimum fee now reflects the
@@ -1362,9 +1364,9 @@ public:
         // Queue is still full.
         checkMetrics(env, 8, 8, 5, 4, 385);
 
-        // alice, bob, charlie, daria, and elmo's txs
+        // bob, charlie, daria, elmo, and fred's txs
         // are processed out of the queue into the ledger,
-        // leaving fred and gwen's txs. hank's tx is
+        // leaving fred and hank's txs. alice's tx is
         // retried from localTxs, and put back into the
         // queue.
         env.close();
@@ -1372,45 +1374,46 @@ public:
 
         BEAST_EXPECT(aliceSeq + 1 == env.seq(alice));
         BEAST_EXPECT(bobSeq + 1 == env.seq(bob));
-        BEAST_EXPECT(charlieSeq + 2 == env.seq(charlie));
+        BEAST_EXPECT(charlieSeq == env.seq(charlie));
         BEAST_EXPECT(dariaSeq + 1 == env.seq(daria));
-        BEAST_EXPECT(elmoSeq + 1 == env.seq(elmo));
-        BEAST_EXPECT(fredSeq == env.seq(fred));
-        BEAST_EXPECT(gwenSeq == env.seq(gwen));
-        BEAST_EXPECT(hankSeq == env.seq(hank));
+        BEAST_EXPECT(elmoSeq == env.seq(elmo));
+        BEAST_EXPECT(fredSeq + 1 == env.seq(fred));
+        BEAST_EXPECT(gwenSeq + 1 == env.seq(gwen));
+        BEAST_EXPECT(hankSeq + 1 == env.seq(hank));
 
         aliceSeq = env.seq(alice);
         bobSeq = env.seq(bob);
         charlieSeq = env.seq(charlie);
         dariaSeq = env.seq(daria);
         elmoSeq = env.seq(elmo);
+        fredSeq = env.seq(fred);
 
         // Fill up the queue again
-        env(noop(alice), fee(15), queued);
-        env(noop(alice), seq(aliceSeq + 1), fee(15), queued);
-        env(noop(alice), seq(aliceSeq + 2), fee(15), queued);
+        env(noop(fred), fee(15), queued);
+        env(noop(fred), seq(fredSeq + 1), fee(15), queued);
+        env(noop(fred), seq(fredSeq + 2), fee(15), queued);
         env(noop(bob), fee(15), queued);
-        env(noop(charlie), fee(15), queued);
+        env(noop(charlie), seq(charlieSeq + 2), fee(15), queued);
         env(noop(daria), fee(15), queued);
         // This one gets into the queue, but gets dropped when the
         // higher fee one is added later.
-        env(noop(elmo), fee(15), queued);
+        env(noop(elmo), seq(elmoSeq + 1), fee(15), queued);
         checkMetrics(env, 10, 10, 6, 5, 385);
 
         // Add another transaction, with a higher fee,
         // Not high enough to get into the ledger, but high
         // enough to get into the queue (and kick somebody out)
-        env(noop(alice), fee(100), seq(aliceSeq + 3), queued);
+        env(noop(fred), fee(100), seq(fredSeq + 3), queued);
 
         env.close();
         checkMetrics(env, 4, 12, 7, 6, 256);
 
-        BEAST_EXPECT(fredSeq + 1 == env.seq(fred));
+        BEAST_EXPECT(fredSeq + 4 == env.seq(fred));
         BEAST_EXPECT(gwenSeq + 1 == env.seq(gwen));
         BEAST_EXPECT(hankSeq + 1 == env.seq(hank));
-        BEAST_EXPECT(aliceSeq + 4 == env.seq(alice));
-        BEAST_EXPECT(bobSeq == env.seq(bob));
-        BEAST_EXPECT(charlieSeq == env.seq(charlie));
+        BEAST_EXPECT(aliceSeq == env.seq(alice));
+        BEAST_EXPECT(bobSeq + 1 == env.seq(bob));
+        BEAST_EXPECT(charlieSeq + 2 == env.seq(charlie));
         BEAST_EXPECT(dariaSeq == env.seq(daria));
         BEAST_EXPECT(elmoSeq == env.seq(elmo));
     }
@@ -2767,7 +2770,7 @@ public:
         // we only see a reduction by 5.
         env.close();
         checkMetrics(env, 9, 50, 6, 5, 256);
-        BEAST_EXPECT(env.seq(alice) == aliceSeq + 16);
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 15);
 
         // Close ledger 7.  That should remove 7 more of alice's transactions.
         env.close();
@@ -2775,7 +2778,7 @@ public:
         BEAST_EXPECT(env.seq(alice) == aliceSeq + 19);
 
         // Close one last ledger to see all of alice's transactions moved
-        // into the ledger.
+        // into the ledger, including the tickets
         env.close();
         checkMetrics(env, 0, 70, 2, 7, 256);
         BEAST_EXPECT(env.seq(alice) == aliceSeq + 21);
@@ -4130,7 +4133,7 @@ public:
             {{"minimum_txn_in_ledger_standalone", "1"},
              {"ledgers_in_queue", "5"},
              {"maximum_txn_per_account", "10"}},
-            {{"account_reserve", "200"}, {"owner_reserve", "50"}});
+            {{"account_reserve", "1000"}, {"owner_reserve", "50"}});
 
         Env env(*this, std::move(cfg));
 
@@ -4184,14 +4187,16 @@ public:
         auto seqDaria = env.seq(daria);
         auto seqEllie = env.seq(ellie);
         auto seqFiona = env.seq(fiona);
+        // Use fees to guarantee order
+        int txFee{90};
         for (int i = 0; i < 10; ++i)
         {
-            env(noop(alice), seq(seqAlice++), ter(terQUEUED));
-            env(noop(bob), seq(seqBob++), ter(terQUEUED));
-            env(noop(carol), seq(seqCarol++), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), ter(terQUEUED));
+            env(noop(alice), seq(seqAlice++), fee(--txFee), ter(terQUEUED));
+            env(noop(bob), seq(seqBob++), fee(--txFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--txFee), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--txFee), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--txFee), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--txFee), ter(terQUEUED));
         }
         std::size_t expectedInQueue = 60;
         checkMetrics(
@@ -4283,8 +4288,8 @@ public:
         // We'll be using fees to control which entries leave the queue in
         // which order.  There's no "lowFee" -- that's the default fee from
         // the unit test.
-        auto const medFee = drops(15);
-        auto const hiFee = drops(1000);
+        int const medFee = 100;
+        int const hiFee = 1000;
 
         auto cfg = makeConfig(
             {{"minimum_txn_in_ledger_standalone", "5"},
@@ -4314,12 +4319,14 @@ public:
         // will expire out soon.
         auto seqAlice = env.seq(alice);
         auto const seqSaveAlice = seqAlice;
+        int feeDrops = 40;
         env(noop(alice),
             seq(seqAlice++),
+            fee(--feeDrops),
             json(R"({"LastLedgerSequence": 7})"),
             ter(terQUEUED));
-        env(noop(alice), seq(seqAlice++), ter(terQUEUED));
-        env(noop(alice), seq(seqAlice++), ter(terQUEUED));
+        env(noop(alice), seq(seqAlice++), fee(--feeDrops), ter(terQUEUED));
+        env(noop(alice), seq(seqAlice++), fee(--feeDrops), ter(terQUEUED));
         BEAST_EXPECT(env.seq(alice) == seqSaveAlice);
 
         // Similarly for bob, but bob uses tickets in his transactions.
@@ -4328,8 +4335,14 @@ public:
             ticket::use(bobTicketSeq + 0),
             json(R"({"LastLedgerSequence": 7})"),
             ter(terQUEUED));
-        env(noop(bob), ticket::use(bobTicketSeq + 1), ter(terQUEUED));
-        env(noop(bob), ticket::use(bobTicketSeq + 2), ter(terQUEUED));
+        env(noop(bob),
+            ticket::use(bobTicketSeq + 1),
+            fee(--feeDrops),
+            ter(terQUEUED));
+        env(noop(bob),
+            ticket::use(bobTicketSeq + 2),
+            fee(--feeDrops),
+            ter(terQUEUED));
 
         // Fill the queue with higher fee transactions so alice's and
         // bob's transactions are stuck in the queue.
@@ -4337,12 +4350,13 @@ public:
         auto seqDaria = env.seq(daria);
         auto seqEllie = env.seq(ellie);
         auto seqFiona = env.seq(fiona);
+        feeDrops = medFee;
         for (int i = 0; i < 7; ++i)
         {
-            env(noop(carol), seq(seqCarol++), fee(medFee), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), fee(medFee), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), fee(medFee), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), fee(medFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
 
         checkMetrics(env, 34, 50, 7, 6, 256);
@@ -4350,24 +4364,26 @@ public:
         checkMetrics(env, 26, 50, 8, 7, 256);
 
         // Re-fill the queue so alice and bob stay stuck.
+        feeDrops = medFee;
         for (int i = 0; i < 3; ++i)
         {
-            env(noop(carol), seq(seqCarol++), fee(medFee), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), fee(medFee), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), fee(medFee), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), fee(medFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
         checkMetrics(env, 38, 50, 8, 7, 256);
         env.close();
         checkMetrics(env, 29, 50, 9, 8, 256);
 
         // One more time...
+        feeDrops = medFee;
         for (int i = 0; i < 3; ++i)
         {
-            env(noop(carol), seq(seqCarol++), fee(medFee), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), fee(medFee), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), fee(medFee), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), fee(medFee), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
         checkMetrics(env, 41, 50, 9, 8, 256);
         env.close();
@@ -4382,16 +4398,17 @@ public:
         env(noop(alice), seq(seqAlice), fee(hiFee), ter(telCAN_NOT_QUEUE));
 
         // Once again, fill the queue almost to the brim.
+        feeDrops = medFee;
         for (int i = 0; i < 4; ++i)
         {
-            env(noop(carol), seq(seqCarol++), ter(terQUEUED));
-            env(noop(daria), seq(seqDaria++), ter(terQUEUED));
-            env(noop(ellie), seq(seqEllie++), ter(terQUEUED));
-            env(noop(fiona), seq(seqFiona++), ter(terQUEUED));
+            env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
+            env(noop(fiona), seq(seqFiona++), fee(--feeDrops), ter(terQUEUED));
         }
-        env(noop(carol), seq(seqCarol++), ter(terQUEUED));
-        env(noop(daria), seq(seqDaria++), ter(terQUEUED));
-        env(noop(ellie), seq(seqEllie++), ter(terQUEUED));
+        env(noop(carol), seq(seqCarol++), fee(--feeDrops), ter(terQUEUED));
+        env(noop(daria), seq(seqDaria++), fee(--feeDrops), ter(terQUEUED));
+        env(noop(ellie), seq(seqEllie++), fee(--feeDrops), ter(terQUEUED));
         checkMetrics(env, 48, 50, 10, 9, 256);
 
         // Now induce a fee jump which should cause all the transactions
@@ -4401,7 +4418,7 @@ public:
         // asynchronously lowered by LoadManager.  Here we're just
         // pushing the local fee up really high and then hoping that we
         // outrace LoadManager undoing our work.
-        for (int i = 0; i < 10; ++i)
+        for (int i = 0; i < 30; ++i)
             env.app().getFeeTrack().raiseLocalFee();
 
         // Now close the ledger, which will attempt to process alice's
@@ -4442,7 +4459,7 @@ public:
 
         // Verify that there's a gap at the front of alice's queue by
         // queuing another low fee transaction into that spot.
-        env(noop(alice), seq(seqAlice++), ter(terQUEUED));
+        env(noop(alice), seq(seqAlice++), fee(11), ter(terQUEUED));
 
         // Verify that the first entry in alice's queue is still there
         // by trying to replace it and having that fail.
@@ -4468,11 +4485,11 @@ public:
 
         // Verify that bob's first transaction was removed from the queue
         // by queueing another low fee transaction into that spot.
-        env(noop(bob), ticket::use(bobTicketSeq + 0), ter(terQUEUED));
+        env(noop(bob), ticket::use(bobTicketSeq + 0), fee(12), ter(terQUEUED));
 
         // Verify that bob's second transaction was removed from the queue
         // by queueing another low fee transaction into that spot.
-        env(noop(bob), ticket::use(bobTicketSeq + 1), ter(terQUEUED));
+        env(noop(bob), ticket::use(bobTicketSeq + 1), fee(11), ter(terQUEUED));
 
         // Verify that the last entry in bob's queue is still there
         // by trying to replace it and having that fail.

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -146,7 +146,7 @@ public:
                 if (c.charge(fee) == drop)
                 {
                     // Disconnect abusive Consumer
-                    BEAST_EXPECT(c.disconnect() == limited);
+                    BEAST_EXPECT(c.disconnect(j) == limited);
                     break;
                 }
                 ++logic.clock();

--- a/src/test/rpc/Roles_test.cpp
+++ b/src/test/rpc/Roles_test.cpp
@@ -20,9 +20,12 @@
 #include <ripple/beast/unit_test.h>
 #include <ripple/protocol/ErrorCodes.h>
 #include <ripple/protocol/jss.h>
-#include <string>
 #include <test/jtx.h>
 #include <test/jtx/WSClient.h>
+
+#include <boost/asio/ip/address_v4.hpp>
+
+#include <string>
 #include <unordered_map>
 
 namespace ripple {
@@ -31,6 +34,14 @@ namespace test {
 
 class Roles_test : public beast::unit_test::suite
 {
+    bool
+    isValidIpAddress(std::string const& addr)
+    {
+        boost::system::error_code ec;
+        boost::asio::ip::make_address(addr, ec);
+        return !ec.failed();
+    }
+
     void
     testRoles()
     {
@@ -63,31 +74,65 @@ class Roles_test : public beast::unit_test::suite
                 !wsRes.isMember("unlimited") || !wsRes["unlimited"].asBool());
 
             std::unordered_map<std::string, std::string> headers;
+            Json::Value rpcRes;
+
+            // IPv4 tests.
             headers["X-Forwarded-For"] = "12.34.56.78";
-            auto rpcRes = env.rpc(headers, "ping")["result"];
+            rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["role"] == "proxied");
             BEAST_EXPECT(rpcRes["ip"] == "12.34.56.78");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             headers["X-Forwarded-For"] = "87.65.43.21, 44.33.22.11";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "87.65.43.21");
-            headers.erase("X-Forwarded-For");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
+            headers["X-Forwarded-For"] = "87.65.43.21:47011, 44.33.22.11";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "87.65.43.21");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers = {};
             headers["Forwarded"] = "for=88.77.66.55";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "88.77.66.55");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             headers["Forwarded"] =
                 "what=where;for=55.66.77.88;for=nobody;"
                 "who=3";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             headers["Forwarded"] =
-                "what=where;for=55.66.77.88, 99.00.11.22;"
+                "what=where; for=55.66.77.88, for=99.00.11.22;"
                 "who=3";
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "what=where; For=99.88.77.66, for=55.66.77.88;"
+                "who=3";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "99.88.77.66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "what=where; for=\"55.66.77.88:47011\";"
+                "who=3";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "what=where; For= \" 99.88.77.66 \" ,for=11.22.33.44;"
+                "who=3";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["ip"] == "99.88.77.66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
 
             wsRes = makeWSClient(env.app().config(), true, 2, headers)
                         ->invoke("ping")["result"];
@@ -99,10 +144,218 @@ class Roles_test : public beast::unit_test::suite
             rpcRes = env.rpc(headers, "ping")["result"];
             BEAST_EXPECT(rpcRes["role"] == "identified");
             BEAST_EXPECT(rpcRes["username"] == name);
-            BEAST_EXPECT(rpcRes["ip"] == "55.66.77.88");
+            BEAST_EXPECT(rpcRes["ip"] == "99.88.77.66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
             wsRes = makeWSClient(env.app().config(), true, 2, headers)
                         ->invoke("ping")["result"];
             BEAST_EXPECT(wsRes["unlimited"].asBool());
+
+            // IPv6 tests.
+            headers = {};
+            headers["X-Forwarded-For"] =
+                "2001:db8:3333:4444:5555:6666:7777:8888";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:8888");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "2001:db8:3333:4444:5555:6666:7777:9999, a:b:c:d:e:f, "
+                "g:h:i:j:k:l";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:9999");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:7777:8888]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:8888");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:7777:9999], [a:b:c:d:e:f], "
+                "[g:h:i:j:k:l]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:9999");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers = {};
+            headers["Forwarded"] =
+                "for=\"[2001:db8:3333:4444:5555:6666:7777:aaaa]\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:7777:aaaa");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "For=\"[2001:db8:bb:cc:dd:ee:ff::]:2345\", for=99.00.11.22";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "2001:db8:bb:cc:dd:ee:ff::");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "proto=http;FOR=\"[2001:db8:11:22:33:44:55:66]\""
+                ";by=203.0.113.43";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "2001:db8:11:22:33:44:55:66");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            // IPv6 (dual) tests.
+            headers = {};
+            headers["X-Forwarded-For"] = "2001:db8:3333:4444:5555:6666:1.2.3.4";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:1.2.3.4");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "2001:db8:3333:4444:5555:6666:5.6.7.8, a:b:c:d:e:f, "
+                "g:h:i:j:k:l";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:5.6.7.8");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:9.10.11.12]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:9.10.11.12");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["X-Forwarded-For"] =
+                "[2001:db8:3333:4444:5555:6666:13.14.15.16], [a:b:c:d:e:f], "
+                "[g:h:i:j:k:l]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:13.14.15.16");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers = {};
+            headers["Forwarded"] =
+                "for=\"[2001:db8:3333:4444:5555:6666:20.19.18.17]\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(
+                rpcRes["ip"] == "2001:db8:3333:4444:5555:6666:20.19.18.17");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "For=\"[2001:db8:bb:cc::24.23.22.21]\", for=99.00.11.22";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "2001:db8:bb:cc::24.23.22.21");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+
+            headers["Forwarded"] =
+                "proto=http;FOR=\"[::11:22:33:44:45.55.65.75]:234\""
+                ";by=203.0.113.43";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "proxied");
+            BEAST_EXPECT(rpcRes["ip"] == "::11:22:33:44:45.55.65.75");
+            BEAST_EXPECT(isValidIpAddress(rpcRes["ip"].asString()));
+        }
+    }
+
+    void
+    testInvalidIpAddresses()
+    {
+        using namespace test::jtx;
+
+        {
+            Env env(*this);
+
+            std::unordered_map<std::string, std::string> headers;
+            Json::Value rpcRes;
+
+            // No "for=" in Forwarded.
+            headers["Forwarded"] = "for 88.77.66.55";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers["Forwarded"] = "by=88.77.66.55";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Empty field.
+            headers = {};
+            headers["Forwarded"] = "for=";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "     ";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Empty quotes.
+            headers = {};
+            headers["Forwarded"] = "for= \"    \" ";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "\"\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Unbalanced outer quotes.
+            headers = {};
+            headers["X-Forwarded-For"] = "\"12.34.56.78   ";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers["X-Forwarded-For"] = "12.34.56.78\"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Unbalanced square brackets for IPv6.
+            headers = {};
+            headers["Forwarded"] = "FOR=[2001:db8:bb:cc::";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "2001:db8:bb:cc::24.23.22.21]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            // Empty square brackets.
+            headers = {};
+            headers["Forwarded"] = "FOR=[]";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
+
+            headers = {};
+            headers["X-Forwarded-For"] = "\"  [      ]  \"";
+            rpcRes = env.rpc(headers, "ping")["result"];
+            BEAST_EXPECT(rpcRes["role"] == "admin");
+            BEAST_EXPECT(!rpcRes.isMember("ip"));
         }
     }
 
@@ -111,6 +364,7 @@ public:
     run() override
     {
         testRoles();
+        testInvalidIpAddresses();
     }
 };
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Modifies account RPCs to enforce limits by number of account objects traversed.

### Context of Change
Previously, we limited account RPCs by the number of objects returned, not the number of objects traversed. This can get expensive when traversing accounts with a lot of owned objects. This PR modifies this behavior to enforce limits based on number of objects traversed. It also slightly changes how we do markers, including the marker `startHint` in the marker, similar to how `account_objects` works.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.

Some tests had to be modified, including increasing limits and changing markers.

<!--
## Future Tasks
For future tasks related to PR.
-->
