### PR TITLE
make cassandra io threads configurable

### DIFF
--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1132,6 +1132,9 @@
 #                           cluster. Setting this option can help eliminate
 #                           write timeouts and other write errors due to the
 #                           cluster being overloaded.
+#       io_threads
+#                           Set the number of IO threads used by the
+#                           Cassandra driver. Defaults to 4.
 #
 #   Notes:
 #       The 'node_db' entry configures the primary, persistent storage.


### PR DESCRIPTION
This commit was authored by @cjcobb23 and has been running in our reporting environments.

## High Level Overview of Change

The cassandra driver uses worker threads to process requests. The number of worker threads is configurable, though previously we just set it to `std::thread::hardware_concurrency`. For large machines with many cores, this is probably too much. We noticed on the large machines that under high CPU load, a large majority of the CPU time was spent in system calls. Reducing the number of io threads used by the driver brought the amount of time spent in system calls down. This commit introduces a config option to set the number of io threads, and also changes the default to 4.