### PR TITLE
Don't set GIT_COMMIT_HASH if no hash found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,12 @@ project (rippled)
 find_package(Git)
 if(Git_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=40
-        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE GIT_COMMIT_HASH)
-    message(STATUS gch: ${GIT_COMMIT_HASH})
-    add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE gch)
+    if(gch)
+        set(GIT_COMMIT_HASH "${gch}")
+        message(STATUS gch: ${GIT_COMMIT_HASH})
+        add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+    endif()
 endif() #git
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake")


### PR DESCRIPTION
## High Level Overview of Change

If the git executable is found, but the code is not currently in a git folder (e.g. in some CI configurations), the `git describe` call will set `GIT_COMMIT_HASH` to an empty string, leading to a version string that looks like `1.8.2-+DEBUG`, which is malformed. This change checks the result of the call to `git describe`, and does not set `GIT_COMMIT_HASH` if it is empty.

### Context of Change

#4024 (https://github.com/ripple/rippled/commit/bf013c02ad8e49b9242d73afae245e48fa0ad5b3) introduced functionality to include the current git commit hash in the version string. It works perfectly fine in the overwhelming majority of circumstances, but missed this edge case.

One example failure is from the Github Actions CI still in review:
* [Empty `gch` string after git error](https://github.com/ximinez/rippled/runs/4720291029?check_suite_focus=true#step:11:452)
* ["Logic error: 1.8.2-+DEBUG: Bad server version string"](https://github.com/ximinez/rippled/runs/4720291029?check_suite_focus=true#step:11:1169)
* (note that these links may expire).

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Test Plan

1. As long as the version string continues to include the commit hash as it does in 1.8.2, everything is fine.
2. I have included this commit in the Github Actions CI branch mentioned above and have confirmed that the version string is now building correctly.
    * [git error with no `gch` message](https://github.com/ximinez/rippled/runs/4728904104?check_suite_focus=true#step:11:1307)
    * [zero test failures](https://github.com/ximinez/rippled/runs/4728904104?check_suite_focus=true#step:11:1381)
    * (note that these links may expire)
