### PR TITLE
Reduce lock concontion in ManifestCache

### DIFF
--- a/src/ripple/app/misc/Manifest.h
+++ b/src/ripple/app/misc/Manifest.h
@@ -24,7 +24,9 @@
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/protocol/PublicKey.h>
 #include <ripple/protocol/SecretKey.h>
+
 #include <optional>
+#include <shared_mutex>
 #include <string>
 
 namespace ripple {
@@ -223,9 +225,8 @@ class DatabaseCon;
 class ManifestCache
 {
 private:
-    beast::Journal mutable j_;
-    std::mutex apply_mutex_;
-    std::mutex mutable read_mutex_;
+    beast::Journal j_;
+    std::shared_mutex mutable mutex_;
 
     /** Active manifests stored by master public key. */
     hash_map<PublicKey, Manifest> map_;
@@ -378,8 +379,10 @@ public:
 
     /** Invokes the callback once for every populated manifest.
 
-        @note Undefined behavior results when calling ManifestCache members from
-        within the callback
+        @note Do not call ManifestCache member functions from within the
+        callback. This can re-lock the mutex from the same thread, which is UB.
+        @note Do not write ManifestCache member variables from within the
+        callback. This can lead to data races.
 
         @param f Function called for each manifest
 
@@ -391,7 +394,7 @@ public:
     void
     for_each_manifest(Function&& f) const
     {
-        std::lock_guard lock{read_mutex_};
+        std::shared_lock lock{mutex_};
         for (auto const& [_, manifest] : map_)
         {
             (void)_;
@@ -401,8 +404,10 @@ public:
 
     /** Invokes the callback once for every populated manifest.
 
-        @note Undefined behavior results when calling ManifestCache members from
-        within the callback
+        @note Do not call ManifestCache member functions from within the
+        callback. This can re-lock the mutex from the same thread, which is UB.
+        @note Do not write ManifestCache member variables from
+        within the callback. This can lead to data races.
 
         @param pf Pre-function called with the maximum number of times f will be
             called (useful for memory allocations)
@@ -417,7 +422,7 @@ public:
     void
     for_each_manifest(PreFun&& pf, EachFun&& f) const
     {
-        std::lock_guard lock{read_mutex_};
+        std::shared_lock lock{mutex_};
         pf(map_.size());
         for (auto const& [_, manifest] : map_)
         {

--- a/src/ripple/core/Job.h
+++ b/src/ripple/core/Job.h
@@ -52,6 +52,7 @@ enum JobType {
     jtRPC,                // A websocket command from the client
     jtSWEEP,              // Sweep for stale structures
     jtVALIDATION_ut,      // A validation from an untrusted source
+    jtMANIFEST,           // A validator's manifest
     jtUPDATE_PF,          // Update pathfinding requests
     jtTRANSACTION_l,      // A local transaction
     jtREPLAY_REQ,         // Peer request a ledger delta or a skip list

--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -72,6 +72,7 @@ private:
         add(jtPACK,              "makeFetchPack",               1,     0ms,     0ms);
         add(jtPUBOLDLEDGER,      "publishAcqLedger",            2, 10000ms, 15000ms);
         add(jtVALIDATION_ut,     "untrustedValidation",  maxLimit,  2000ms,  5000ms);
+        add(jtMANIFEST,          "manifest",             maxLimit,  2000ms,  5000ms);
         add(jtTRANSACTION_l,     "localTransaction",     maxLimit,   100ms,   500ms);
         add(jtREPLAY_REQ,        "ledgerReplayRequest",        10,   250ms,  1000ms);
         add(jtLEDGER_REQ,        "ledgerRequest",               4,     0ms,     0ms);

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -1070,7 +1070,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMManifests> const& m)
     // VFALCO What's the right job type?
     auto that = shared_from_this();
     app_.getJobQueue().addJob(
-        jtVALIDATION_ut, "receiveManifests", [this, that, m](Job&) {
+        jtMANIFEST, "receiveManifests", [this, that, m](Job&) {
             overlay_.onManifests(m, that);
         });
 }


### PR DESCRIPTION
## High Level Overview of Change

This commit combines the `apply_mutex` and `read_mutex` into a single `mutex_` var. This new `mutex_` var is a `shared_mutex`, and most operations only need to lock it with a `shared_lock`. The only exception is `applyMutex`, which may need a `unique_lock`.

One consequence of removing the `apply_mutex` is more than one `applyMutex` function can run at the same time. To help reduce lock contention that a `unique_lock` would cause, checks that only require reading data are run a `shared_lock` (call these the "prewriteChecks"), then the lock is released, then a `unique_lock` is acquired. Since a currently running `applyManifest` may write data between the time a `shared_lock` is released and the `write_lock` is acquired, the "prewriteChecks" need to be rerun. Duplicating this work isn't ideal, but the "prewirteChecks" are relatively inexpensive.

A couple of other designs were considered. We could restrict more than one `applyMutex` function from running concurrently - either with a `applyMutex` or my setting the max number of manifest jobs on the job queue to one. The biggest issue with this is if any other function ever adds a write lock for any reason, `applyManifest` would not be broken - data could be written between the release of the `shared_lock` and the acquisition of the `unique_lock`. Note: it is tempting to solve this problem by not releasing the `shared_mutex` and simply upgrading the lock. In the presence of concurrently running `applyManifest` functions, this will deadlock (both function need to wait for the other to release their read locks before they can acquire a write lock).

### Context of Change

The `read_mutex_` in the manifest cache was identified as a major source of lock contention. This commit attempts to reduce that lock contention.

### Type of Change

Optimization
