### PR TITLE
Fix Travis CI MacOS builds:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ env:
     - NIH_CACHE_ROOT=${CACHE_DIR}/nih_c
     - PARALLEL_TESTS=true
     # this is NOT used by linux container based builds (which already have boost installed)
-    - BOOST_URL='https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.gz'
+    - BOOST_URL='https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz'
     # Alternate dowload location
-    - BOOST_URL2='https://downloads.sourceforge.net/project/boost/boost/1.70.0/boost_1_70_0.tar.bz2?r=&amp;ts=1594393912&amp;use_mirror=newcontinuum'
+    - BOOST_URL2='https://downloads.sourceforge.net/project/boost/boost/1.76.0/boost_1_76_0.tar.bz2?r=&amp;ts=1594393912&amp;use_mirror=newcontinuum'
     # Travis downloader doesn't seem to have updated certs. Using this option
     # introduces obvious security risks, but they're Travis's risks.
     # Note that this option is only used if the "normal" build fails.
@@ -299,15 +299,15 @@ matrix:
       if: commit_message !~ /travis_run_/ OR commit_message =~ /travis_run_mac/
       stage: build
       os: osx
-      osx_image: xcode11.2
-      name: xcode11.2, debug
+      osx_image: xcode13.1
+      name: xcode13.1, debug
       env:
         # put NIH in non-cache location since it seems to
         # cause failures when homebrew updates
         - NIH_CACHE_ROOT=${TRAVIS_BUILD_DIR}/nih_c
         - BLD_CONFIG=Debug
         - TEST_EXTRA_ARGS=""
-        - BOOST_ROOT=${CACHE_DIR}/boost_1_70_0
+        - BOOST_ROOT=${CACHE_DIR}/boost_1_76_0
         - >-
           CMAKE_ADD="
           -DBOOST_ROOT=${BOOST_ROOT}/_INSTALLED_
@@ -347,8 +347,8 @@ matrix:
       before_script:
         - export TEST_EXTRA_ARGS="--unittest-ipv6"
     - <<: *macos
-      osx_image: xcode11.2
-      name: xcode11.2, debug
+      osx_image: xcode13.1
+      name: xcode13.1, debug
     # windows
     - &windows
       if: commit_message !~ /travis_run_/ OR commit_message =~ /travis_run_win/
@@ -361,13 +361,13 @@ matrix:
         - NIH_CACHE_ROOT=${TRAVIS_BUILD_DIR}/nih_c
         - VCPKG_DEFAULT_TRIPLET="x64-windows-static"
         - MATRIX_EVAL="CC=cl.exe && CXX=cl.exe"
-        - BOOST_ROOT=${CACHE_DIR}/boost_1_70
+        - BOOST_ROOT=${CACHE_DIR}/boost_1_76
         - >-
           CMAKE_ADD="
           -DCMAKE_PREFIX_PATH=${BOOST_ROOT}/_INSTALLED_
           -DBOOST_ROOT=${BOOST_ROOT}/_INSTALLED_
           -DBoost_ROOT=${BOOST_ROOT}/_INSTALLED_
-          -DBoost_DIR=${BOOST_ROOT}/_INSTALLED_/lib/cmake/Boost-1.70.0
+          -DBoost_DIR=${BOOST_ROOT}/_INSTALLED_/lib/cmake/Boost-1.76.0
           -DBoost_COMPILER=vc141
           -DCMAKE_VERBOSE_MAKEFILE=ON
           -DCMAKE_TOOLCHAIN_FILE=${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -338,7 +338,7 @@ matrix:
         - travis_wait ${MAX_TIME_MIN} cmake --build . --parallel --verbose
         - ./rippled --unittest --quiet --unittest-log --unittest-jobs ${NUM_PROCESSORS} ${TEST_EXTRA_ARGS}
     - <<: *macos
-      name: xcode11.2, release
+      name: xcode13.1, release
       before_script:
         - export BLD_CONFIG=Release
         - export CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -Dassert=ON"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ env:
     - NIH_CACHE_ROOT=${CACHE_DIR}/nih_c
     - PARALLEL_TESTS=true
     # this is NOT used by linux container based builds (which already have boost installed)
-    - BOOST_URL='https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz'
+    - BOOST_URL='https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.gz'
     # Alternate dowload location
-    - BOOST_URL2='https://downloads.sourceforge.net/project/boost/boost/1.76.0/boost_1_76_0.tar.bz2?r=&amp;ts=1594393912&amp;use_mirror=newcontinuum'
+    - BOOST_URL2='https://downloads.sourceforge.net/project/boost/boost/1.75.0/boost_1_75_0.tar.bz2?r=&amp;ts=1594393912&amp;use_mirror=newcontinuum'
     # Travis downloader doesn't seem to have updated certs. Using this option
     # introduces obvious security risks, but they're Travis's risks.
     # Note that this option is only used if the "normal" build fails.
@@ -307,7 +307,7 @@ matrix:
         - NIH_CACHE_ROOT=${TRAVIS_BUILD_DIR}/nih_c
         - BLD_CONFIG=Debug
         - TEST_EXTRA_ARGS=""
-        - BOOST_ROOT=${CACHE_DIR}/boost_1_76_0
+        - BOOST_ROOT=${CACHE_DIR}/boost_1_75_0
         - >-
           CMAKE_ADD="
           -DBOOST_ROOT=${BOOST_ROOT}/_INSTALLED_
@@ -361,13 +361,13 @@ matrix:
         - NIH_CACHE_ROOT=${TRAVIS_BUILD_DIR}/nih_c
         - VCPKG_DEFAULT_TRIPLET="x64-windows-static"
         - MATRIX_EVAL="CC=cl.exe && CXX=cl.exe"
-        - BOOST_ROOT=${CACHE_DIR}/boost_1_76
+        - BOOST_ROOT=${CACHE_DIR}/boost_1_75
         - >-
           CMAKE_ADD="
           -DCMAKE_PREFIX_PATH=${BOOST_ROOT}/_INSTALLED_
           -DBOOST_ROOT=${BOOST_ROOT}/_INSTALLED_
           -DBoost_ROOT=${BOOST_ROOT}/_INSTALLED_
-          -DBoost_DIR=${BOOST_ROOT}/_INSTALLED_/lib/cmake/Boost-1.76.0
+          -DBoost_DIR=${BOOST_ROOT}/_INSTALLED_/lib/cmake/Boost-1.75.0
           -DBoost_COMPILER=vc141
           -DCMAKE_VERBOSE_MAKEFILE=ON
           -DCMAKE_TOOLCHAIN_FILE=${VCPKG_DIR}/scripts/buildsystems/vcpkg.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,12 @@ project (rippled)
 find_package(Git)
 if(Git_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=40
-        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE GIT_COMMIT_HASH)
-    message(STATUS gch: ${GIT_COMMIT_HASH})
-    add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE gch)
+    if(gch)
+        set(GIT_COMMIT_HASH "${gch}")
+        message(STATUS gch: ${GIT_COMMIT_HASH})
+        add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+    endif()
 endif() #git
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake")


### PR DESCRIPTION
## High Level Overview of Change

* Update boost version.
* Use latest macOS image.
* Credit to @donovanhide in #4025 for starting this ball rolling, and
  inspiring a boost update.

### Context of Change

MacOS builds using Travis have been consistently failing building dependencies for quite a while.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Test Plan

If Travis CI passes, then we're golden.