### PR TITLE
Proxy validation_quorum when in reporting mode

### DIFF
--- a/src/ripple/rpc/handlers/ServerInfo.cpp
+++ b/src/ripple/rpc/handlers/ServerInfo.cpp
@@ -44,6 +44,8 @@ doServerInfo(RPC::JsonContext& context)
     {
         Json::Value const proxied = forwardToP2p(context);
         auto const lf = proxied[jss::result][jss::info][jss::load_factor];
+        auto const vq = proxied[jss::result][jss::info][jss::validation_quorum];
+        ret[jss::info][jss::validation_quorum] = vq.isNull() ? 1 : vq;
         ret[jss::info][jss::load_factor] = lf.isNull() ? 1 : lf;
     }
     return ret;


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Forward `validation_quorum` when in reporting mode.

### Context of Change
Reporting mode servers don't know what the validation quorum is, and as such, must request that information from a p2p node. 

We were already requesting that info from p2p nodes, so this PR only has to parse the `validation_quorum` from the p2p node `server_info`, and add it to the response.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

## Test Plan
Tested w/ reporting mode locally, and `server_info` now shows a `validation_quorum: 28`

<!--
## Future Tasks
For future tasks related to PR.
-->
