### PR TITLE
Handle commit hashes in the version string that start with "0"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,12 @@ project (rippled)
 find_package(Git)
 if(Git_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=40
-        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE GIT_COMMIT_HASH)
-    message(STATUS gch: ${GIT_COMMIT_HASH})
-    add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+        OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE gch)
+    if(gch)
+        set(GIT_COMMIT_HASH "${gch}")
+        message(STATUS gch: ${GIT_COMMIT_HASH})
+        add_definitions(-DGIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+    endif()
 endif() #git
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Builds/CMake")

--- a/src/ripple/protocol/impl/BuildInfo.cpp
+++ b/src/ripple/protocol/impl/BuildInfo.cpp
@@ -37,10 +37,11 @@ char const* const versionString = "1.8.4"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)
-#ifdef GIT_COMMIT_HASH
-    "-" GIT_COMMIT_HASH
-#endif
     "+"
+#ifdef GIT_COMMIT_HASH
+    GIT_COMMIT_HASH
+    "."
+#endif
 #ifdef DEBUG
     "DEBUG"
 #ifdef SANITIZER


### PR DESCRIPTION
## High Level Overview of Change

Follow-up to #4056, which is already passed. Reviewers can ignore the first commit labelled "Don't set GIT_COMMIT_HASH if no hash found".

This change moves the commit hash, if any to after the "+" sign in the semantic version string, and separates it from any other "metadata" values, such as the "DEBUG" label  and the sanitizer type with a "." delimiter.

### Context of Change

Any items after the "-" separator (AKA pre-release identifiers), will not parse correctly if they have leading zeros. Commit hashes will start with "0" on average 1 out of every 16 commits. The parsing failure prevents rippled from starting.

Additionally, multiple pre-release identifiers are not allowed, so future beta versions (e.g. `1.9.0-b1-HASH`) will not parse correctly without this change.

### Type of Change

- [X ] Bug fix (non-breaking change which fixes an issue)

## Before / After

Before, rippled will fail to start in debug/sanitizer builds if the commit hash starts with "0", and the version string might look something like:
`1.8.4-77ded753be89f99123e79d268926aa95d00d985a+DEBUG`
After, the version string might look something like:
`1.8.4+0b58b1912324bf964f755147eaa0f8f23f7c7359.DEBUG`

## Test Plan

Ensure rippled starts, and that if the version string (`rippled --version`) contains a commit hash, that it is formatted as described above.

Note that I "hash mined" the commit hash on the PR so that it starts with "0", so if tested independently, including in CI, this branch is self-testing.
