### PR TITLE
lower_bound for clio ETL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ if (POLICY CMP0074)
 endif ()
 
 project (rippled)
+set (CMAKE_CXX_STANDARD 17)
 
 # make GIT_COMMIT_HASH define available to all sources
 find_package(Git)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ if (POLICY CMP0074)
 endif ()
 
 project (rippled)
-set (CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # make GIT_COMMIT_HASH define available to all sources
 find_package(Git)

--- a/src/ripple/proto/org/xrpl/rpc/v1/get_ledger.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/get_ledger.proto
@@ -70,6 +70,9 @@ message GetLedgerResponse
     // map diff
     bool object_neighbors_included = 9;
 
+
+    // Successor information for book directories modified as part of this
+    // ledger
     repeated BookSuccessor book_successors = 10;
 }
 

--- a/src/ripple/proto/org/xrpl/rpc/v1/get_ledger.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/get_ledger.proto
@@ -32,6 +32,10 @@ message GetLedgerRequest
     // coming from a secure_gateway host, then the client is not subject to
     // resource controls
     string user = 6;
+
+    // For every object in the diff, get the object's predecessor and successor
+    // in the state map. Only used if get_objects is also true.
+    bool get_object_neighbors = 7;
 }
 
 message GetLedgerResponse
@@ -58,6 +62,15 @@ message GetLedgerResponse
 
     // True if request was exempt from resource controls
     bool is_unlimited = 7;
+
+    // True if the response contains the state map diff
+    bool objects_included = 8;
+
+    // True if the response contains key of objects adjacent to objects in state
+    // map diff
+    bool object_neighbors_included = 9;
+
+    repeated BookSuccessor book_successors = 10;
 }
 
 message TransactionHashList

--- a/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
@@ -59,12 +59,6 @@ message RawLedgerObject
     bytes predecessor = 4;
 
     bytes successor = 5;
-
-    bool is_first_book_dir = 6;
-
-    bool was_first_book_dir = 7;
-
-    bytes new_first_book_dir = 8;
 }
 
 message RawLedgerObjects

--- a/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
@@ -54,10 +54,13 @@ message RawLedgerObject
         DELETED = 3;
     }
 
+    // Whether the object was created, modified or deleted
     ModificationType mod_type = 3;
 
+    // Key of the object preceding this object in the desired ledger
     bytes predecessor = 4;
 
+    // Key of the object succeeding this object in the desired ledger
     bytes successor = 5;
 }
 
@@ -66,11 +69,16 @@ message RawLedgerObjects
     repeated RawLedgerObject objects = 1;
 }
 
+// Successor information for book directories. The book base is (usually) not
+// an actual object, yet we need to be able to ask for the successor to the
+// book base.
 message BookSuccessor {
 
+    // Base of the book in question
     bytes book_base = 1;
 
-    // empty value here means the entire book is deleted
+    // First book directory in the book. An empty value here means the entire
+    // book is deleted
     bytes first_book = 2;
 
 };

--- a/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/ledger.proto
@@ -55,10 +55,29 @@ message RawLedgerObject
     }
 
     ModificationType mod_type = 3;
+
+    bytes predecessor = 4;
+
+    bytes successor = 5;
+
+    bool is_first_book_dir = 6;
+
+    bool was_first_book_dir = 7;
+
+    bytes new_first_book_dir = 8;
 }
 
 message RawLedgerObjects
 {
     repeated RawLedgerObject objects = 1;
 }
+
+message BookSuccessor {
+
+    bytes book_base = 1;
+
+    // empty value here means the entire book is deleted
+    bytes first_book = 2;
+
+};
 

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -105,6 +105,7 @@ LedgerHandler::check()
 std::pair<org::xrpl::rpc::v1::GetLedgerResponse, grpc::Status>
 doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
 {
+    auto begin = std::chrono::system_clock::now();
     org::xrpl::rpc::v1::GetLedgerRequest& request = context.params;
     org::xrpl::rpc::v1::GetLedgerResponse response;
     grpc::Status status = grpc::Status::OK;
@@ -212,12 +213,104 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
                 obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::DELETED);
             else
                 obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::CREATED);
+            auto blob = inDesired ? inDesired->slice() : inBase->slice();
+            LedgerEntryType objectType =
+                LedgerEntryType{(uint16_t)(blob[1] << 8 | blob[2])};
+
+            if (request.get_object_neighbors())
+            {
+                if (!(inBase && inDesired))
+                {
+                    auto lb = desired->stateMap().lower_bound(k);
+                    auto ub = desired->stateMap().upper_bound(k);
+                    if (lb != desired->stateMap().end())
+                        obj->set_predecessor(
+                            lb->key().data(), lb->key().size());
+                    if (ub != desired->stateMap().end())
+                        obj->set_successor(ub->key().data(), ub->key().size());
+                    if (objectType == ltDIR_NODE)
+                    {
+                        auto sle = std::make_shared<SLE>(SerialIter{blob}, k);
+                        if (!sle->isFieldPresent(sfOwner))
+                        {
+                            auto bookBase = keylet::quality({ltDIR_NODE, k}, 0);
+                            if (!inBase && inDesired)
+                            {
+                                auto firstBook =
+                                    desired->stateMap().upper_bound(
+                                        bookBase.key);
+                                if (firstBook != desired->stateMap().end() &&
+                                    firstBook->key() <
+                                        getQualityNext(bookBase.key) &&
+                                    firstBook->key() == k)
+                                {
+                                    auto succ = response.add_book_successors();
+                                    succ->set_book_base(
+                                        bookBase.key.data(),
+                                        bookBase.key.size());
+                                    succ->set_first_book(
+                                        firstBook->key().data(),
+                                        firstBook->key().size());
+                                }
+                            }
+                            if (inBase && !inDesired)
+                            {
+                                auto oldFirstBook =
+                                    base->stateMap().upper_bound(bookBase.key);
+                                if (oldFirstBook != base->stateMap().end() &&
+                                    oldFirstBook->key() <
+                                        getQualityNext(bookBase.key) &&
+                                    oldFirstBook->key() == k)
+                                {
+                                    obj->set_was_first_book_dir(true);
+                                    auto succ = response.add_book_successors();
+                                    succ->set_book_base(
+                                        bookBase.key.data(),
+                                        bookBase.key.size());
+                                    auto newFirstBook =
+                                        desired->stateMap().upper_bound(
+                                            bookBase.key);
+
+                                    if (newFirstBook !=
+                                            desired->stateMap().end() &&
+                                        newFirstBook->key() <
+                                            getQualityNext(bookBase.key))
+                                    {
+                                        succ->set_first_book(
+                                            newFirstBook->key().data(),
+                                            newFirstBook->key().size());
+                                        obj->set_new_first_book_dir(
+                                            newFirstBook->key().data(),
+                                            newFirstBook->key().size());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
+        response.set_objects_included(true);
+        response.set_object_neighbors_included(request.get_object_neighbors());
         response.set_skiplist_included(true);
     }
 
     response.set_validated(
         RPC::isValidated(context.ledgerMaster, *ledger, context.app));
+
+    auto end = std::chrono::system_clock::now();
+    auto duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - begin)
+            .count() *
+        1.0;
+    JLOG(context.j.warn())
+        << __func__ << " - Extract time = " << duration
+        << " - num objects = " << response.ledger_objects().objects_size()
+        << " - num txns = " << response.transactions_list().transactions_size()
+        << " - ms per obj "
+        << duration / response.ledger_objects().objects_size()
+        << " - ms per txn "
+        << duration / response.transactions_list().transactions_size();
 
     return {response, status};
 }

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -262,7 +262,6 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
                                         getQualityNext(bookBase.key) &&
                                     oldFirstBook->key() == k)
                                 {
-                                    obj->set_was_first_book_dir(true);
                                     auto succ = response.add_book_successors();
                                     succ->set_book_base(
                                         bookBase.key.data(),
@@ -277,9 +276,6 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
                                             getQualityNext(bookBase.key))
                                     {
                                         succ->set_first_book(
-                                            newFirstBook->key().data(),
-                                            newFirstBook->key().size());
-                                        obj->set_new_first_book_dir(
                                             newFirstBook->key().data(),
                                             newFirstBook->key().size());
                                     }

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -213,7 +213,7 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
                 obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::DELETED);
             else
                 obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::CREATED);
-            auto blob = inDesired ? inDesired->slice() : inBase->slice();
+            auto const blob = inDesired ? inDesired->slice() : inBase->slice();
             auto const objectType =
                 static_cast<LedgerEntryType>(blob[1] << 8 | blob[2]);
 

--- a/src/ripple/rpc/handlers/LedgerHandler.cpp
+++ b/src/ripple/rpc/handlers/LedgerHandler.cpp
@@ -214,8 +214,8 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
             else
                 obj->set_mod_type(org::xrpl::rpc::v1::RawLedgerObject::CREATED);
             auto blob = inDesired ? inDesired->slice() : inBase->slice();
-            LedgerEntryType objectType =
-                LedgerEntryType{(uint16_t)(blob[1] << 8 | blob[2])};
+            auto const objectType =
+                static_cast<LedgerEntryType>(blob[1] << 8 | blob[2]);
 
             if (request.get_object_neighbors())
             {

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -213,6 +213,10 @@ public:
     const_iterator
     upper_bound(uint256 const& id) const;
 
+    // traverse functions
+    const_iterator
+    lower_bound(uint256 const& id) const;
+
     /**  Visit every node in this SHAMap
 
          @param function called with every node visited.
@@ -405,6 +409,11 @@ private:
         std::shared_ptr<SHAMapTreeNode>,
         SharedPtrNodeStack& stack,
         int branch = 0) const;
+    SHAMapLeafNode*
+    lastBelow(
+        std::shared_ptr<SHAMapTreeNode> node,
+        SharedPtrNodeStack& stack,
+        int branch = branchFactor) const;
 
     // Simple descent
     // Get a child of the specified node

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -404,16 +404,30 @@ private:
     std::shared_ptr<SHAMapTreeNode>
     writeNode(NodeObjectType t, std::shared_ptr<SHAMapTreeNode> node) const;
 
+    // returns the first item at or below this node
     SHAMapLeafNode*
     firstBelow(
         std::shared_ptr<SHAMapTreeNode>,
         SharedPtrNodeStack& stack,
         int branch = 0) const;
+
+    // returns the last item at or below this node
     SHAMapLeafNode*
     lastBelow(
         std::shared_ptr<SHAMapTreeNode> node,
         SharedPtrNodeStack& stack,
         int branch = branchFactor) const;
+
+    // helper function for the above
+    SHAMapLeafNode*
+    below(
+        std::shared_ptr<SHAMapTreeNode> node,
+        SharedPtrNodeStack& stack,
+        int branch,
+        std::tuple<
+            int,
+            std::function<bool(int)>,
+            std::function<void(int&)>> const& loopParams) const;
 
     // Simple descent
     // Get a child of the specified node

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -210,10 +210,14 @@ public:
     peekItem(uint256 const& id, SHAMapHash& hash) const;
 
     // traverse functions
+
+    // finds the object in the tree with the smallest object id greater than the
+    // input id
     const_iterator
     upper_bound(uint256 const& id) const;
 
-    // traverse functions
+    // finds the object in the tree with the greatest object id smaller than the
+    // input id
     const_iterator
     lower_bound(uint256 const& id) const;
 

--- a/src/ripple/shamap/SHAMap.h
+++ b/src/ripple/shamap/SHAMap.h
@@ -422,9 +422,9 @@ private:
         SharedPtrNodeStack& stack,
         int branch = branchFactor) const;
 
-    // helper function for the above
+    // helper function for firstBelow and lastBelow
     SHAMapLeafNode*
-    below(
+    belowHelper(
         std::shared_ptr<SHAMapTreeNode> node,
         SharedPtrNodeStack& stack,
         int branch,

--- a/src/ripple/shamap/impl/SHAMap.cpp
+++ b/src/ripple/shamap/impl/SHAMap.cpp
@@ -437,7 +437,7 @@ SHAMap::unshareNode(std::shared_ptr<Node> node, SHAMapNodeID const& nodeID)
 }
 
 SHAMapLeafNode*
-SHAMap::below(
+SHAMap::belowHelper(
     std::shared_ptr<SHAMapTreeNode> node,
     SharedPtrNodeStack& stack,
     int branch,
@@ -483,11 +483,11 @@ SHAMap::lastBelow(
     SharedPtrNodeStack& stack,
     int branch) const
 {
-    return below(
-        node,
-        stack,
-        branch,
-        {branchFactor - 1, [](int i) { return i >= 0; }, [](int& i) { --i; }});
+    auto init = branchFactor - 1;
+    auto cmp = [](int i) { return i >= 0; };
+    auto incr = [](int& i) { --i; };
+
+    return belowHelper(node, stack, branch, {init, cmp, incr});
 }
 SHAMapLeafNode*
 SHAMap::firstBelow(
@@ -495,11 +495,11 @@ SHAMap::firstBelow(
     SharedPtrNodeStack& stack,
     int branch) const
 {
-    return below(
-        node,
-        stack,
-        branch,
-        {0, [](int i) { return i <= branchFactor; }, [](int& i) { ++i; }});
+    auto init = 0;
+    auto cmp = [](int i) { return i <= branchFactor; };
+    auto incr = [](int& i) { ++i; };
+
+    return belowHelper(node, stack, branch, {init, cmp, incr});
 }
 static const std::shared_ptr<SHAMapItem const> no_item;
 

--- a/src/test/ledger/View_test.cpp
+++ b/src/test/ledger/View_test.cpp
@@ -385,6 +385,279 @@ class View_test : public beast::unit_test::suite
     }
 
     void
+    testUpperAndLowerBound()
+    {
+        using namespace jtx;
+        Env env(*this);
+        Config config;
+        std::shared_ptr<Ledger const> const genesis = std::make_shared<Ledger>(
+            create_genesis,
+            config,
+            std::vector<uint256>{},
+            env.app().getNodeFamily());
+        auto const ledger = std::make_shared<Ledger>(
+            *genesis, env.app().timeKeeper().closeTime());
+
+        auto setup = [&ledger](std::vector<int> const& vec) {
+            wipe(*ledger);
+            for (auto x : vec)
+            {
+                ledger->rawInsert(sle(x));
+            }
+        };
+        {
+            setup({1, 2, 3});
+            BEAST_EXPECT(sles(*ledger) == list(1, 2, 3));
+            auto e = ledger->stateMap().end();
+            auto b1 = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(1)) == e);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(2)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(3)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(4)) == b1);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(5)) == b1);
+            auto b2 = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(0)) == b2);
+            ++b2;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(1)) == b2);
+            ++b2;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(2)) == b2);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(3)) == e);
+        }
+
+        {
+            setup({2, 4, 6});
+            BEAST_EXPECT(sles(*ledger) == list(2, 4, 6));
+            auto e = ledger->stateMap().end();
+            auto b1 = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(1)) == e);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(2)) == e);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(3)) == b1);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(4)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(5)) == b1);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(6)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(7)) == b1);
+            b1 = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(1)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(2)) == b1);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(3)) == b1);
+            ++b1;
+
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(4)) == b1);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(5)) == b1);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(6)) == e);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(7)) == e);
+        }
+        {
+            setup({2, 3, 5, 6, 10, 15});
+            BEAST_EXPECT(sles(*ledger) == list(2, 3, 5, 6, 10, 15));
+            auto e = ledger->stateMap().end();
+            auto b = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(1)) == e);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(2)) == e);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(3)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(4)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(5)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(6)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(7)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(8)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(9)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(10)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(11)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(12)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(13)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(14)) == b);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(15)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(16)) == b);
+            b = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(0)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(1)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(2)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(3)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(4)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(5)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(6)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(7)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(8)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(9)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(10)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(11)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(12)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(13)) == b);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(14)) == b);
+            ++b;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(15)) == e);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(16)) == e);
+        }
+        {
+            // some full trees, some empty trees, etc
+            setup({0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                   13, 14, 15, 16, 20, 25, 30, 32, 33, 34, 35, 36, 37,
+                   38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 66, 100});
+            BEAST_EXPECT(
+                sles(*ledger) ==
+                list(
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    20,
+                    25,
+                    30,
+                    32,
+                    33,
+                    34,
+                    35,
+                    36,
+                    37,
+                    38,
+                    39,
+                    40,
+                    41,
+                    42,
+                    43,
+                    44,
+                    45,
+                    46,
+                    47,
+                    48,
+                    66,
+                    100));
+            auto b = ledger->stateMap().begin();
+            auto e = ledger->stateMap().end();
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(0)) == e);
+            BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(1)) == b);
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(5))->key() ==
+                uint256(4));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(5))->key() ==
+                uint256(4));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(15))->key() ==
+                uint256(14));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(16))->key() ==
+                uint256(15));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(19))->key() ==
+                uint256(16));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(20))->key() ==
+                uint256(16));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(24))->key() ==
+                uint256(20));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(31))->key() ==
+                uint256(30));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(31))->key() ==
+                uint256(30));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(32))->key() ==
+                uint256(30));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(40))->key() ==
+                uint256(39));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(47))->key() ==
+                uint256(46));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(48))->key() ==
+                uint256(47));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(64))->key() ==
+                uint256(48));
+
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(90))->key() ==
+                uint256(66));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(96))->key() ==
+                uint256(66));
+            BEAST_EXPECT(
+                ledger->stateMap().lower_bound(uint256(100))->key() ==
+                uint256(66));
+
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(0))->key() ==
+                uint256(1));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(5))->key() ==
+                uint256(6));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(15))->key() ==
+                uint256(16));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(16))->key() ==
+                uint256(20));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(18))->key() ==
+                uint256(20));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(20))->key() ==
+                uint256(25));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(31))->key() ==
+                uint256(32));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(32))->key() ==
+                uint256(33));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(47))->key() ==
+                uint256(48));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(48))->key() ==
+                uint256(66));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(53))->key() ==
+                uint256(66));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(66))->key() ==
+                uint256(100));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(70))->key() ==
+                uint256(100));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(85))->key() ==
+                uint256(100));
+            BEAST_EXPECT(
+                ledger->stateMap().upper_bound(uint256(98))->key() ==
+                uint256(100));
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(100)) == e);
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(155)) == e);
+        }
+    }
+
+    void
     testSles()
     {
         using namespace jtx;
@@ -811,6 +1084,7 @@ class View_test : public beast::unit_test::suite
         testStacked();
         testContext();
         testSles();
+        testUpperAndLowerBound();
         testFlags();
         testTransferRate();
         testAreCompatible();

--- a/src/test/ledger/View_test.cpp
+++ b/src/test/ledger/View_test.cpp
@@ -417,12 +417,12 @@ class View_test : public beast::unit_test::suite
             ++b1;
             BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(4)) == b1);
             BEAST_EXPECT(ledger->stateMap().lower_bound(uint256(5)) == b1);
-            auto b2 = ledger->stateMap().begin();
-            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(0)) == b2);
-            ++b2;
-            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(1)) == b2);
-            ++b2;
-            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(2)) == b2);
+            b1 = ledger->stateMap().begin();
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(0)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(1)) == b1);
+            ++b1;
+            BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(2)) == b1);
             BEAST_EXPECT(ledger->stateMap().upper_bound(uint256(3)) == e);
         }
 
@@ -558,9 +558,6 @@ class View_test : public beast::unit_test::suite
                 ledger->stateMap().lower_bound(uint256(5))->key() ==
                 uint256(4));
             BEAST_EXPECT(
-                ledger->stateMap().lower_bound(uint256(5))->key() ==
-                uint256(4));
-            BEAST_EXPECT(
                 ledger->stateMap().lower_bound(uint256(15))->key() ==
                 uint256(14));
             BEAST_EXPECT(
@@ -575,9 +572,6 @@ class View_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 ledger->stateMap().lower_bound(uint256(24))->key() ==
                 uint256(20));
-            BEAST_EXPECT(
-                ledger->stateMap().lower_bound(uint256(31))->key() ==
-                uint256(30));
             BEAST_EXPECT(
                 ledger->stateMap().lower_bound(uint256(31))->key() ==
                 uint256(30));


### PR DESCRIPTION
## High Level Overview of Change

 clio keeps a table of object successors, which given an object, allows one to look up the next object in a given ledger. clio computes this using an in memory cache, but on startup, the cache is empty. So on startup, clio needs to ask rippled for this information, until clio is able to fill its cache and use the cache. To achieve this, a new function was added to `SHAMap`, called `lower_bound`, which returns the first object prior to a given object ID. To implement this function, a new function was added to `SHAMap` called `lastBelow`, which returns the last item at or below a given node.

