### PR TITLE
fix bug in TaggedPointer move constructor

### DIFF
--- a/src/ripple/shamap/impl/TaggedPointer.ipp
+++ b/src/ripple/shamap/impl/TaggedPointer.ipp
@@ -372,7 +372,7 @@ inline TaggedPointer::TaggedPointer(
                     ++srcDstIndex;
                 }
             }
-            else if (!inDst && !inDst)
+            else if (!inSrc && !inDst)
             {
                 // in neither
                 if (srcDstIsDense)
@@ -433,7 +433,7 @@ inline TaggedPointer::TaggedPointer(
                     ++srcIndex;
                 }
             }
-            else if (!inDst && !inDst)
+            else if (!inSrc && !inDst)
             {
                 // in neither
                 if (dstIsDense)


### PR DESCRIPTION
The !inSrc, !inDst case was not handled correctly. This case is when a caller
explicitly removes a child that's not part of the node. Fortunately, existing
callers of this code never used this case.

- [ x] Bug fix (non-breaking change which fixes an issue)
