### PR TITLE
Don't dereference empty optional in ReportingETL constructor

### DIFF
--- a/src/ripple/app/reporting/ReportingETL.cpp
+++ b/src/ripple/app/reporting/ReportingETL.cpp
@@ -929,10 +929,14 @@ ReportingETL::ReportingETL(Application& app)
         {
             auto const optStartSeq = section.get("start_sequence");
             if (optStartSeq)
+            {
+                // set a value so we can dereference
+                startSequence_ = 0;
                 asciiToIntThrows(
                     *startSequence_,
                     *optStartSeq,
                     "Expected integral start_sequence config entry. Got: ");
+            }
         }
 
         auto const optFlushInterval = section.get("flush_interval");


### PR DESCRIPTION
An empty optional was being dereferenced in the ReportingETL constructor in certain configurations. Assign a value to it first so we can then dereference and assign a different value.