### PR TITLE
Amendment: ExpandedSignerList

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -82,6 +82,7 @@ target_sources (xrpl_core PRIVATE
   src/ripple/protocol/impl/PublicKey.cpp
   src/ripple/protocol/impl/Quality.cpp
   src/ripple/protocol/impl/Rate2.cpp
+  src/ripple/protocol/impl/Rules.cpp
   src/ripple/protocol/impl/SField.cpp
   src/ripple/protocol/impl/SOTemplate.cpp
   src/ripple/protocol/impl/STAccount.cpp
@@ -209,6 +210,7 @@ install (
     src/ripple/protocol/PublicKey.h
     src/ripple/protocol/Quality.h
     src/ripple/protocol/Rate.h
+    src/ripple/protocol/Rules.h
     src/ripple/protocol/SField.h
     src/ripple/protocol/SOTemplate.h
     src/ripple/protocol/STAccount.h

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -632,7 +632,7 @@ RCLConsensus::Adaptor::doAccept(
         auto const lastVal = ledgerMaster_.getValidatedLedger();
         std::optional<Rules> rules;
         if (lastVal)
-            rules.emplace(*lastVal, app_.config().features);
+            rules = makeRulesGivenLedger(*lastVal, app_.config().features);
         else
             rules.emplace(app_.config().features);
         app_.openLedger().accept(

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -626,7 +626,7 @@ Ledger::setup(Config const& config)
 
     try
     {
-        rules_ = Rules(*this, config.features);
+        rules_ = makeRulesGivenLedger(*this, config.features);
     }
     catch (SHAMapMissingNode const&)
     {

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1749,7 +1749,7 @@ NetworkOPsImp::switchLastClosedLedger(
         auto const lastVal = app_.getLedgerMaster().getValidatedLedger();
         std::optional<Rules> rules;
         if (lastVal)
-            rules.emplace(*lastVal, app_.config().features);
+            rules = makeRulesGivenLedger(*lastVal, app_.config().features);
         else
             rules.emplace(app_.config().features);
         app_.openLedger().accept(

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -25,6 +25,7 @@
 #include <ripple/app/tx/impl/Transactor.h>
 #include <ripple/basics/Log.h>
 #include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STArray.h>
 #include <ripple/protocol/STObject.h>
 #include <ripple/protocol/STTx.h>
@@ -83,7 +84,8 @@ private:
         std::uint32_t quorum,
         std::vector<SignerEntries::SignerEntry> const& signers,
         AccountID const& account,
-        beast::Journal j);
+        beast::Journal j,
+        Rules const&);
 
     TER
     replaceSignerList();

--- a/src/ripple/app/tx/impl/SignerEntries.cpp
+++ b/src/ripple/app/tx/impl/SignerEntries.cpp
@@ -22,6 +22,7 @@
 #include <ripple/protocol/STArray.h>
 #include <ripple/protocol/STObject.h>
 #include <cstdint>
+#include <optional>
 
 namespace ripple {
 
@@ -41,7 +42,7 @@ SignerEntries::deserialize(
     }
 
     std::vector<SignerEntry> accountVec;
-    accountVec.reserve(STTx::maxMultiSigners);
+    accountVec.reserve(STTx::maxMultiSigners());
 
     STArray const& sEntries(obj.getFieldArray(sfSignerEntries));
     for (STObject const& sEntry : sEntries)
@@ -57,7 +58,9 @@ SignerEntries::deserialize(
         // Extract SignerEntry fields.
         AccountID const account = sEntry.getAccountID(sfAccount);
         std::uint16_t const weight = sEntry.getFieldU16(sfSignerWeight);
-        accountVec.emplace_back(account, weight);
+        std::optional<uint256> const tag = sEntry.at(~sfWalletLocator);
+
+        accountVec.emplace_back(account, weight, tag);
     }
     return accountVec;
 }

--- a/src/ripple/app/tx/impl/SignerEntries.h
+++ b/src/ripple/app/tx/impl/SignerEntries.h
@@ -23,9 +23,11 @@
 #include <ripple/app/tx/impl/Transactor.h>  // NotTEC
 #include <ripple/basics/Expected.h>         //
 #include <ripple/beast/utility/Journal.h>   // beast::Journal
+#include <ripple/protocol/Rules.h>          // Rules
 #include <ripple/protocol/STTx.h>           // STTx::maxMultiSigners
 #include <ripple/protocol/TER.h>            // temMALFORMED
 #include <ripple/protocol/UintTypes.h>      // AccountID
+#include <optional>
 
 namespace ripple {
 
@@ -42,9 +44,13 @@ public:
     {
         AccountID account;
         std::uint16_t weight;
+        std::optional<uint256> tag;
 
-        SignerEntry(AccountID const& inAccount, std::uint16_t inWeight)
-            : account(inAccount), weight(inWeight)
+        SignerEntry(
+            AccountID const& inAccount,
+            std::uint16_t inWeight,
+            std::optional<uint256> inTag)
+            : account(inAccount), weight(inWeight), tag(inTag)
         {
         }
 

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -54,7 +54,7 @@ checkValidity(
             ? STTx::RequireFullyCanonicalSig::yes
             : STTx::RequireFullyCanonicalSig::no;
 
-        auto const sigVerify = tx.checkSign(requireCanonicalSig);
+        auto const sigVerify = tx.checkSign(requireCanonicalSig, rules);
         if (!sigVerify)
         {
             router.setFlags(id, SF_SIGBAD);

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -29,6 +29,7 @@
 #include <ripple/ledger/detail/ReadViewFwdRange.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/Protocol.h>
+#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/STTx.h>
@@ -121,64 +122,6 @@ struct LedgerInfo
     // will close if there's no transactions.
     //
     NetClock::time_point closeTime = {};
-};
-
-//------------------------------------------------------------------------------
-
-class DigestAwareReadView;
-
-/** Rules controlling protocol behavior. */
-class Rules
-{
-private:
-    class Impl;
-
-    std::shared_ptr<Impl const> impl_;
-
-public:
-    Rules(Rules const&) = default;
-    Rules&
-    operator=(Rules const&) = default;
-
-    Rules() = delete;
-
-    /** Construct an empty rule set.
-
-        These are the rules reflected by
-        the genesis ledger.
-    */
-    explicit Rules(std::unordered_set<uint256, beast::uhash<>> const& presets);
-
-    /** Construct rules from a ledger.
-
-        The ledger contents are analyzed for rules
-        and amendments and extracted to the object.
-    */
-    explicit Rules(
-        DigestAwareReadView const& ledger,
-        std::unordered_set<uint256, beast::uhash<>> const& presets);
-
-    /** Returns `true` if a feature is enabled. */
-    bool
-    enabled(uint256 const& id) const;
-
-    /** Returns `true` if these rules don't match the ledger. */
-    bool
-    changed(DigestAwareReadView const& ledger) const;
-
-    /** Returns `true` if two rule sets are identical.
-
-        @note This is for diagnostics. To determine if new
-        rules should be constructed, call changed() first instead.
-    */
-    bool
-    operator==(Rules const&) const;
-
-    bool
-    operator!=(Rules const& other) const
-    {
-        return !(*this == other);
-    }
 };
 
 //------------------------------------------------------------------------------
@@ -422,6 +365,11 @@ getCloseAgree(LedgerInfo const& info)
 
 void
 addRaw(LedgerInfo const&, Serializer&, bool includeHash = false);
+
+Rules
+makeRulesGivenLedger(
+    DigestAwareReadView const& ledger,
+    std::unordered_set<uint256, beast::uhash<>> const& presets);
 
 }  // namespace ripple
 

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -21,108 +21,6 @@
 
 namespace ripple {
 
-class Rules::Impl
-{
-private:
-    std::unordered_set<uint256, hardened_hash<>> set_;
-    std::optional<uint256> digest_;
-    std::unordered_set<uint256, beast::uhash<>> const& presets_;
-
-public:
-    explicit Impl(std::unordered_set<uint256, beast::uhash<>> const& presets)
-        : presets_(presets)
-    {
-    }
-
-    explicit Impl(
-        DigestAwareReadView const& ledger,
-        std::unordered_set<uint256, beast::uhash<>> const& presets)
-        : presets_(presets)
-    {
-        auto const k = keylet::amendments();
-        digest_ = ledger.digest(k.key);
-        if (!digest_)
-            return;
-        auto const sle = ledger.read(k);
-        if (!sle)
-        {
-            // LogicError() ?
-            return;
-        }
-
-        for (auto const& item : sle->getFieldV256(sfAmendments))
-            set_.insert(item);
-    }
-
-    bool
-    enabled(uint256 const& feature) const
-    {
-        if (presets_.count(feature) > 0)
-            return true;
-        return set_.count(feature) > 0;
-    }
-
-    bool
-    changed(DigestAwareReadView const& ledger) const
-    {
-        auto const digest = ledger.digest(keylet::amendments().key);
-        if (!digest && !digest_)
-            return false;
-        if (!digest || !digest_)
-            return true;
-        return *digest != *digest_;
-    }
-
-    bool
-    operator==(Impl const& other) const
-    {
-        if (!digest_ && !other.digest_)
-            return true;
-        if (!digest_ || !other.digest_)
-            return false;
-        return *digest_ == *other.digest_;
-    }
-};
-
-//------------------------------------------------------------------------------
-
-Rules::Rules(
-    DigestAwareReadView const& ledger,
-    std::unordered_set<uint256, beast::uhash<>> const& presets)
-    : impl_(std::make_shared<Impl>(ledger, presets))
-{
-}
-
-Rules::Rules(std::unordered_set<uint256, beast::uhash<>> const& presets)
-    : impl_(std::make_shared<Impl>(presets))
-{
-}
-
-bool
-Rules::enabled(uint256 const& id) const
-{
-    assert(impl_);
-    return impl_->enabled(id);
-}
-
-bool
-Rules::changed(DigestAwareReadView const& ledger) const
-{
-    assert(impl_);
-    return impl_->changed(ledger);
-}
-
-bool
-Rules::operator==(Rules const& other) const
-{
-    assert(impl_ && other.impl_);
-    if (impl_.get() == other.impl_.get())
-        return true;
-    return *impl_ == *other.impl_;
-}
-
-//------------------------------------------------------------------------------
-
 ReadView::sles_type::sles_type(ReadView const& view) : ReadViewFwdRange(view)
 {
 }
@@ -165,6 +63,22 @@ auto
 ReadView::txs_type::end() const -> iterator
 {
     return iterator(view_, view_->txsEnd());
+}
+
+Rules
+makeRulesGivenLedger(
+    DigestAwareReadView const& ledger,
+    std::unordered_set<uint256, beast::uhash<>> const& presets)
+{
+    Keylet const k = keylet::amendments();
+    std::optional digest = ledger.digest(k.key);
+    if (digest)
+    {
+        auto const sle = ledger.read(k);
+        if (sle)
+            return Rules(presets, digest, sle->getFieldV256(sfAmendments));
+    }
+    return Rules(presets);
 }
 
 }  // namespace ripple

--- a/src/ripple/proto/org/xrpl/rpc/v1/common.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/common.proto
@@ -373,6 +373,12 @@ message RootIndex
     bytes value = 1;
 }
 
+message WalletLocator
+{
+    // 32 bytes
+    bytes value = 1;
+}
+
 
 // *** Messages wrapping variable length byte arrays ***
 
@@ -586,6 +592,8 @@ message SignerEntry
     Account account = 1;
 
     SignerWeight signer_weight = 2;
+
+    WalletLocator wallet_locator = 3;
 }
 
 // Next field: 3

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -334,6 +334,7 @@ extern uint256 const fixSTAmountCanonicalize;
 extern uint256 const fixRmSmallIncreasedQOffers;
 extern uint256 const featureCheckCashMakesTrustLine;
 extern uint256 const featureNonFungibleTokensV1;
+extern uint256 const featureExpandedSignerList;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Rules.h
+++ b/src/ripple/protocol/Rules.h
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_LEDGER_RULES_H_INCLUDED
+#define RIPPLE_LEDGER_RULES_H_INCLUDED
+
+#include <ripple/basics/base_uint.h>
+#include <ripple/beast/hash/uhash.h>
+#include <ripple/protocol/STVector256.h>
+#include <unordered_set>
+
+namespace ripple {
+
+class DigestAwareReadView;
+
+/** Rules controlling protocol behavior. */
+class Rules
+{
+private:
+    class Impl;
+
+    // Carrying impl by shared_ptr makes Rules comparatively cheap to pass
+    // by value.
+    std::shared_ptr<Impl const> impl_;
+
+public:
+    Rules(Rules const&) = default;
+
+    Rules&
+    operator=(Rules const&) = default;
+
+    Rules() = delete;
+
+    /** Construct an empty rule set.
+
+        These are the rules reflected by
+        the genesis ledger.
+    */
+    explicit Rules(std::unordered_set<uint256, beast::uhash<>> const& presets);
+
+private:
+    // Allow a friend function to construct Rules.
+    friend Rules
+    makeRulesGivenLedger(
+        DigestAwareReadView const& ledger,
+        std::unordered_set<uint256, beast::uhash<>> const& presets);
+
+    Rules(
+        std::unordered_set<uint256, beast::uhash<>> const& presets,
+        std::optional<uint256> const& digest,
+        STVector256 const& amendments);
+
+public:
+    /** Returns `true` if a feature is enabled. */
+    bool
+    enabled(uint256 const& feature) const;
+
+    /** Returns `true` if two rule sets are identical.
+
+        @note This is for diagnostics.
+    */
+    bool
+    operator==(Rules const&) const;
+
+    bool
+    operator!=(Rules const& other) const;
+};
+
+}  // namespace ripple
+#endif

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -438,6 +438,7 @@ REGISTER_FIX    (fixSTAmountCanonicalize,       Supported::yes, DefaultVote::yes
 REGISTER_FIX    (fixRmSmallIncreasedQOffers,    Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(CheckCashMakesTrustLine,       Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(NonFungibleTokensV1,           Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/ripple/protocol/impl/InnerObjectFormats.cpp
+++ b/src/ripple/protocol/impl/InnerObjectFormats.cpp
@@ -28,6 +28,7 @@ InnerObjectFormats::InnerObjectFormats()
         {
             {sfAccount, soeREQUIRED},
             {sfSignerWeight, soeREQUIRED},
+            {sfWalletLocator, soeOPTIONAL},
         });
 
     add(sfSigner.jsonName.c_str(),

--- a/src/ripple/protocol/impl/Rules.cpp
+++ b/src/ripple/protocol/impl/Rules.cpp
@@ -1,0 +1,103 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/Rules.h>
+
+#include <ripple/protocol/Indexes.h>
+
+namespace ripple {
+
+class Rules::Impl
+{
+private:
+    std::unordered_set<uint256, hardened_hash<>> set_;
+    std::optional<uint256> digest_;
+    std::unordered_set<uint256, beast::uhash<>> const& presets_;
+
+public:
+    explicit Impl(std::unordered_set<uint256, beast::uhash<>> const& presets)
+        : presets_(presets)
+    {
+    }
+
+    Impl(
+        std::unordered_set<uint256, beast::uhash<>> const& presets,
+        std::optional<uint256> const& digest,
+        STVector256 const& amendments)
+        : presets_(presets)
+    {
+        digest_ = digest;
+        set_.reserve(amendments.size());
+        set_.insert(amendments.begin(), amendments.end());
+    }
+
+    bool
+    enabled(uint256 const& feature) const
+    {
+        if (presets_.count(feature) > 0)
+            return true;
+        return set_.count(feature) > 0;
+    }
+
+    bool
+    operator==(Impl const& other) const
+    {
+        if (!digest_ && !other.digest_)
+            return true;
+        if (!digest_ || !other.digest_)
+            return false;
+        return *digest_ == *other.digest_;
+    }
+};
+
+Rules::Rules(std::unordered_set<uint256, beast::uhash<>> const& presets)
+    : impl_(std::make_shared<Impl>(presets))
+{
+}
+
+Rules::Rules(
+    std::unordered_set<uint256, beast::uhash<>> const& presets,
+    std::optional<uint256> const& digest,
+    STVector256 const& amendments)
+    : impl_(std::make_shared<Impl>(presets, digest, amendments))
+{
+}
+
+bool
+Rules::enabled(uint256 const& feature) const
+{
+    assert(impl_);
+    return impl_->enabled(feature);
+}
+
+bool
+Rules::operator==(Rules const& other) const
+{
+    assert(impl_ && other.impl_);
+    if (impl_.get() == other.impl_.get())
+        return true;
+    return *impl_ == *other.impl_;
+}
+
+bool
+Rules::operator!=(Rules const& other) const
+{
+    return !(*this == other);
+}
+}  // namespace ripple

--- a/src/ripple/rpc/impl/GRPCHelpers.cpp
+++ b/src/ripple/rpc/impl/GRPCHelpers.cpp
@@ -748,6 +748,14 @@ populateSignerListID(T& to, STObject const& from)
 
 template <class T>
 void
+populateWalletLocator(T& to, STObject const& from)
+{
+    populateProtoPrimitive(
+        [&to]() { return to.mutable_wallet_locator(); }, from, sfWalletLocator);
+}
+
+template <class T>
+void
 populateTicketSequence(T& to, STObject const& from)
 {
     populateProtoPrimitive(
@@ -1012,6 +1020,7 @@ populateSignerEntries(T& to, STObject const& from)
         [](auto& innerObj, auto& innerProto) {
             populateAccount(innerProto, innerObj);
             populateSignerWeight(innerProto, innerObj);
+            populateWalletLocator(innerProto, innerObj);
         },
         from,
         sfSignerEntries,

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -34,6 +34,30 @@ class MultiSign_test : public beast::unit_test::suite
     jtx::Account const phase{"phase", KeyType::ed25519};
     jtx::Account const shade{"shade", KeyType::secp256k1};
     jtx::Account const spook{"spook", KeyType::ed25519};
+    jtx::Account const acc10{"acc10", KeyType::ed25519};
+    jtx::Account const acc11{"acc11", KeyType::ed25519};
+    jtx::Account const acc12{"acc12", KeyType::ed25519};
+    jtx::Account const acc13{"acc13", KeyType::ed25519};
+    jtx::Account const acc14{"acc14", KeyType::ed25519};
+    jtx::Account const acc15{"acc15", KeyType::ed25519};
+    jtx::Account const acc16{"acc16", KeyType::ed25519};
+    jtx::Account const acc17{"acc17", KeyType::ed25519};
+    jtx::Account const acc18{"acc18", KeyType::ed25519};
+    jtx::Account const acc19{"acc19", KeyType::ed25519};
+    jtx::Account const acc20{"acc20", KeyType::ed25519};
+    jtx::Account const acc21{"acc21", KeyType::ed25519};
+    jtx::Account const acc22{"acc22", KeyType::ed25519};
+    jtx::Account const acc23{"acc23", KeyType::ed25519};
+    jtx::Account const acc24{"acc24", KeyType::ed25519};
+    jtx::Account const acc25{"acc25", KeyType::ed25519};
+    jtx::Account const acc26{"acc26", KeyType::ed25519};
+    jtx::Account const acc27{"acc27", KeyType::ed25519};
+    jtx::Account const acc28{"acc28", KeyType::ed25519};
+    jtx::Account const acc29{"acc29", KeyType::ed25519};
+    jtx::Account const acc30{"acc30", KeyType::ed25519};
+    jtx::Account const acc31{"acc31", KeyType::ed25519};
+    jtx::Account const acc32{"acc32", KeyType::ed25519};
+    jtx::Account const acc33{"acc33", KeyType::ed25519};
 
 public:
     void
@@ -159,22 +183,30 @@ public:
                  {spook, 1}}),
             ter(temBAD_QUORUM));
 
-        // Make a signer list that's too big.  Should fail.
+        // clang-format off
+        // Make a signer list that's too big.  Should fail. (Even with
+        // ExpandedSignerList)
         Account const spare("spare", KeyType::secp256k1);
         env(signers(
                 alice,
                 1,
-                {{bogie, 1},
-                 {demon, 1},
-                 {ghost, 1},
-                 {haunt, 1},
-                 {jinni, 1},
-                 {phase, 1},
-                 {shade, 1},
-                 {spook, 1},
-                 {spare, 1}}),
+                features[featureExpandedSignerList]
+                    ? std::vector<signer>{{bogie, 1}, {demon, 1}, {ghost, 1},
+                                          {haunt, 1}, {jinni, 1}, {phase, 1},
+                                          {shade, 1}, {spook, 1}, {spare, 1},
+                                          {acc10, 1}, {acc11, 1}, {acc12, 1},
+                                          {acc13, 1}, {acc14, 1}, {acc15, 1},
+                                          {acc16, 1}, {acc17, 1}, {acc18, 1},
+                                          {acc19, 1}, {acc20, 1}, {acc21, 1},
+                                          {acc22, 1}, {acc23, 1}, {acc24, 1},
+                                          {acc25, 1}, {acc26, 1}, {acc27, 1},
+                                          {acc28, 1}, {acc29, 1}, {acc30, 1},
+                                          {acc31, 1}, {acc32, 1}, {acc33, 1}}
+                    : std::vector<signer>{{bogie, 1}, {demon, 1}, {ghost, 1},
+                                          {haunt, 1}, {jinni, 1}, {phase, 1},
+                                          {shade, 1}, {spook, 1}, {spare, 1}}),
             ter(temMALFORMED));
-
+        // clang-format on
         env.close();
         env.require(owners(alice, 0));
     }
@@ -1149,20 +1181,56 @@ public:
                 "fails local checks: Invalid Signers array size.");
         }
         {
-            // Multisign 9 times should fail.
+            // Multisign 9 (!ExpandedSignerList) | 33 (ExpandedSignerList) times
+            // should fail.
             JTx tx = env.jt(
                 noop(alice),
                 fee(2 * baseFee),
-                msig(
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie));
+
+                features[featureExpandedSignerList] ? msig(
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie)
+                                                    : msig(
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie));
             STTx local = *(tx.stx);
             auto const info = submitSTTx(local);
             BEAST_EXPECT(
@@ -1518,6 +1586,82 @@ public:
     }
 
     void
+    test_signersWithTags(FeatureBitset features)
+    {
+        if (!features[featureExpandedSignerList])
+            return;
+
+        testcase("Signers With Tags");
+
+        using namespace jtx;
+        Env env{*this, features};
+        Account const alice{"alice", KeyType::ed25519};
+        env.fund(XRP(1000), alice);
+        env.close();
+        uint8_t tag1[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+        uint8_t tag2[] =
+            "hello world some ascii 32b long";  // including 1 byte for NUL
+
+        uint256 bogie_tag = ripple::base_uint<256>::fromVoid(tag1);
+        uint256 demon_tag = ripple::base_uint<256>::fromVoid(tag2);
+
+        // Attach phantom signers to alice and use them for a transaction.
+        env(signers(alice, 1, {{bogie, 1, bogie_tag}, {demon, 1, demon_tag}}));
+        env.close();
+        env.require(owners(alice, features[featureMultiSignReserve] ? 1 : 4));
+
+        // This should work.
+        auto const baseFee = env.current()->fees().base;
+        std::uint32_t aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie, demon), fee(3 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+
+        // Either signer alone should work.
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie), fee(2 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(demon), fee(2 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+
+        // Duplicate signers should fail.
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(demon, demon), fee(3 * baseFee), ter(temINVALID));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq);
+
+        // A non-signer should fail.
+        aliceSeq = env.seq(alice);
+        env(noop(alice),
+            msig(bogie, spook),
+            fee(3 * baseFee),
+            ter(tefBAD_SIGNATURE));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq);
+
+        // Don't meet the quorum.  Should fail.
+        env(signers(alice, 2, {{bogie, 1}, {demon, 1}}));
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie), fee(2 * baseFee), ter(tefBAD_QUORUM));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq);
+
+        // Meet the quorum.  Should succeed.
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie, demon), fee(3 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+    }
+
+    void
     testAll(FeatureBitset features)
     {
         test_noReserve(features);
@@ -1537,6 +1681,7 @@ public:
         test_multisigningMultisigner(features);
         test_signForHash(features);
         test_signersWithTickets(features);
+        test_signersWithTags(features);
     }
 
     void
@@ -1545,10 +1690,13 @@ public:
         using namespace jtx;
         auto const all = supported_amendments();
 
-        // The reserve required on a signer list changes based on.
-        // featureMultiSignReserve.  Test both with and without.
-        testAll(all - featureMultiSignReserve);
-        testAll(all | featureMultiSignReserve);
+        // The reserve required on a signer list changes based on
+        // featureMultiSignReserve.  Limits on the number of signers
+        // changes based on featureExpandedSignerList.  Test both with and
+        // without.
+        testAll(all - featureMultiSignReserve - featureExpandedSignerList);
+        testAll(all - featureExpandedSignerList);
+        testAll(all);
         test_amendmentTransition();
     }
 };

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -22,6 +22,8 @@
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/jss.h>
+#include <optional>
+#include <sstream>
 #include <test/jtx/multisign.h>
 #include <test/jtx/utility.h>
 
@@ -46,6 +48,8 @@ signers(
         auto& je = ja[i][sfSignerEntry.getJsonName()];
         je[jss::Account] = e.account.human();
         je[sfSignerWeight.getJsonName()] = e.weight;
+        if (e.tag)
+            je[sfWalletLocator.getJsonName()] = to_string(*e.tag);
     }
     return jv;
 }

--- a/src/test/jtx/multisign.h
+++ b/src/test/jtx/multisign.h
@@ -21,6 +21,7 @@
 #define RIPPLE_TEST_JTX_MULTISIGN_H_INCLUDED
 
 #include <cstdint>
+#include <optional>
 #include <test/jtx/Account.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/owners.h>
@@ -35,9 +36,13 @@ struct signer
 {
     std::uint32_t weight;
     Account account;
+    std::optional<uint256> tag;
 
-    signer(Account account_, std::uint32_t weight_ = 1)
-        : weight(weight_), account(std::move(account_))
+    signer(
+        Account account_,
+        std::uint32_t weight_ = 1,
+        std::optional<uint256> tag_ = std::nullopt)
+        : weight(weight_), account(std::move(account_)), tag(std::move(tag_))
     {
     }
 };

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/Slice.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/json/to_string.h>
+#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/STParsedJSON.h>
 #include <ripple/protocol/STTx.h>
@@ -27,7 +28,6 @@
 #include <ripple/protocol/TxFormats.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/messages.h>
-
 #include <memory>
 #include <regex>
 
@@ -1591,8 +1591,10 @@ public:
         });
         j.sign(keypair.first, keypair.second);
 
+        Rules defaultRules{{}};
+
         unexpected(
-            !j.checkSign(STTx::RequireFullyCanonicalSig::yes),
+            !j.checkSign(STTx::RequireFullyCanonicalSig::yes, defaultRules),
             "Transaction fails signature test");
 
         Serializer rawTxn;


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
An amendment __ExpandedSignerList__, which if accepted, would:
1. Expand the maximum signer list to 32 entries
2. Allow the optional specification of 32 byte tags with each signer list entry

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
The motivation for this amendment is two fold:
1. Large organisations may have extensive signer lists which require more than 8 keys and may benefit from tags (for example to identify who is in possession of each key.)
2. Layer two smart contract solutions such as Evernode-hotpocket, codius and others gain a security benefit for a common use-case: 
- Often it is useful for layer 2 contracts to control layer 1 accounts, from which they send and receive tokens and currency. To do this, the servers that collectively run the layer 2 contract must hold private keys. The more keys required to sign a layer 1 transaction the harder it is for a third party to compromise the layer 1 account. 

# Remarks
This amendment PR includes a small but important refactor:
The _Rules_ class has been extracted from ReadView.h/cpp and placed in its own files (Rules.h/cpp). A Rules reference may now be more easily passed in the codebase, including for example to signature verification routines (which makes sense because signature verification can be altered by amendments).

At @nbougalis's suggestion serialised field `sfWalletLocator` was reused as the uint256 for the optional tag in each SignerListEntry.

The ability to add tags to SignerListEntries required a change to the InnerObjectFormats definition. This object definition is used both in *ltSIGNER_LIST* and in *ttSIGNER_LIST_SET*. Thus care must be taken at the SetSignerList transactor to ensure tags cannot be set before amendment activation.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [X] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->


## Test Plan

MultSign_test.cpp has been updated with a new test for the tags and additional signers (up to 32).

In addition I have tested using xrpl.js to sign transactions that:
* Set signer list with and without tags
* Set signer list of 8 (success) and 9 (fail) entries when amendment is not active
* Set signer list of 8 (success), 9 (success), 32 (success) and 33 (fail) entries when amendment is active.

I have not included these tests anywhere, I encourage code reviewer to write own tests to avoid reliance on one set of tests.

For reference here is the JSON format for Signer Entries with tags:
```json
{                                                                                                      
    "SignerEntry": {                                                                                   
        "Account": "rsA2LpzuawewSBQXkiju3YQTMzW13pAAdW",                                               
        "SignerWeight": 2,                                                                             
        "WalletLocator": "CAFECAFECAFECAFECAFECAFECAFECAFECAFECAFECAFECAFECAFECAFECAFECAFE"            
    }                                                                                                  
}, 
```

<!--If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
