### PR TITLE
rippled doesn't build with gcc-7 or clang-7

### DIFF
--- a/Builds/CMake/RippledSanity.cmake
+++ b/Builds/CMake/RippledSanity.cmake
@@ -39,14 +39,14 @@ endif ()
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang") # both Clang and AppleClang
   set (is_clang TRUE)
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
-         CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-    message (FATAL_ERROR "This project requires clang 7 or later")
+         CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+    message (FATAL_ERROR "This project requires clang 8 or later")
   endif ()
   # TODO min AppleClang version check ?
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set (is_gcc TRUE)
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-    message (FATAL_ERROR "This project requires GCC 7 or later")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
+    message (FATAL_ERROR "This project requires GCC 8 or later")
   endif ()
 endif ()
 if (CMAKE_GENERATOR STREQUAL "Xcode")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.9.0)
+cmake_minimum_required (VERSION 3.16.3)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.16.3)
+cmake_minimum_required (VERSION 3.16)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
rippled has moved along and cannot be built with gcc-7 anymore.
RocksDB has been updated and cannot be built with CMake 3.9 anymore.
Ubuntu 20.04 provides CMake 3.16.3

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!--
## Future Tasks
For future tasks related to PR.
-->
