### PR TITLE
Further incremental improvements to path finding memory usage

### DIFF
--- a/src/ripple/app/paths/AccountCurrencies.cpp
+++ b/src/ripple/app/paths/AccountCurrencies.cpp
@@ -33,7 +33,7 @@ accountSourceCurrencies(
     if (includeXRP)
         currencies.insert(xrpCurrency());
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account))
+    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
     {
         auto& saBalance = rspEntry.getBalance();
 
@@ -64,7 +64,7 @@ accountDestCurrencies(
         currencies.insert(xrpCurrency());
     // Even if account doesn't exist
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account))
+    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
     {
         auto& saBalance = rspEntry.getBalance();
 

--- a/src/ripple/app/paths/AccountCurrencies.cpp
+++ b/src/ripple/app/paths/AccountCurrencies.cpp
@@ -33,18 +33,22 @@ accountSourceCurrencies(
     if (includeXRP)
         currencies.insert(xrpCurrency());
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
+    if (auto const lines = lrCache->getRippleLines(account, true))
     {
-        auto& saBalance = rspEntry.getBalance();
-
-        // Filter out non
-        if (saBalance > beast::zero
-            // Have IOUs to send.
-            || (rspEntry.getLimitPeer()
-                // Peer extends credit.
-                && ((-saBalance) < rspEntry.getLimitPeer())))  // Credit left.
+        for (auto const& rspEntry : *lines)
         {
-            currencies.insert(saBalance.getCurrency());
+            auto& saBalance = rspEntry.getBalance();
+
+            // Filter out non
+            if (saBalance > beast::zero
+                // Have IOUs to send.
+                ||
+                (rspEntry.getLimitPeer()
+                 // Peer extends credit.
+                 && ((-saBalance) < rspEntry.getLimitPeer())))  // Credit left.
+            {
+                currencies.insert(saBalance.getCurrency());
+            }
         }
     }
 
@@ -64,12 +68,15 @@ accountDestCurrencies(
         currencies.insert(xrpCurrency());
     // Even if account doesn't exist
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
+    if (auto const lines = lrCache->getRippleLines(account, true))
     {
-        auto& saBalance = rspEntry.getBalance();
+        for (auto const& rspEntry : *lines)
+        {
+            auto& saBalance = rspEntry.getBalance();
 
-        if (saBalance < rspEntry.getLimit())  // Can take more
-            currencies.insert(saBalance.getCurrency());
+            if (saBalance < rspEntry.getLimit())  // Can take more
+                currencies.insert(saBalance.getCurrency());
+        }
     }
 
     currencies.erase(badCurrency());

--- a/src/ripple/app/paths/AccountCurrencies.cpp
+++ b/src/ripple/app/paths/AccountCurrencies.cpp
@@ -33,7 +33,8 @@ accountSourceCurrencies(
     if (includeXRP)
         currencies.insert(xrpCurrency());
 
-    if (auto const lines = lrCache->getRippleLines(account, true))
+    if (auto const lines =
+            lrCache->getRippleLines(account, LineDirection::outgoing))
     {
         for (auto const& rspEntry : *lines)
         {
@@ -68,7 +69,8 @@ accountDestCurrencies(
         currencies.insert(xrpCurrency());
     // Even if account doesn't exist
 
-    if (auto const lines = lrCache->getRippleLines(account, true))
+    if (auto const lines =
+            lrCache->getRippleLines(account, LineDirection::outgoing))
     {
         for (auto const& rspEntry : *lines)
         {

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -748,6 +748,8 @@ PathRequest::doUpdate(
         jvStatus = newStatus;
     }
 
+    JLOG(m_journal.debug())
+        << iIdentifier << " update finished " << (fast ? "fast" : "normal");
     return newStatus;
 }
 

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -736,33 +736,37 @@ Pathfinder::getPathsOut(
     {
         count = app_.getOrderBookDB().getBookSize(issue);
 
-        for (auto const& rspEntry : mRLCache->getRippleLines(account, outgoing))
+        if (auto const lines = mRLCache->getRippleLines(account, outgoing))
         {
-            if (currency != rspEntry.getLimit().getCurrency())
+            for (auto const& rspEntry : *lines)
             {
-            }
-            else if (
-                rspEntry.getBalance() <= beast::zero &&
-                (!rspEntry.getLimitPeer() ||
-                 -rspEntry.getBalance() >= rspEntry.getLimitPeer() ||
-                 (bAuthRequired && !rspEntry.getAuth())))
-            {
-            }
-            else if (isDstCurrency && dstAccount == rspEntry.getAccountIDPeer())
-            {
-                count += 10000;  // count a path to the destination extra
-            }
-            else if (rspEntry.getNoRipplePeer())
-            {
-                // This probably isn't a useful path out
-            }
-            else if (rspEntry.getFreezePeer())
-            {
-                // Not a useful path out
-            }
-            else
-            {
-                ++count;
+                if (currency != rspEntry.getLimit().getCurrency())
+                {
+                }
+                else if (
+                    rspEntry.getBalance() <= beast::zero &&
+                    (!rspEntry.getLimitPeer() ||
+                     -rspEntry.getBalance() >= rspEntry.getLimitPeer() ||
+                     (bAuthRequired && !rspEntry.getAuth())))
+                {
+                }
+                else if (
+                    isDstCurrency && dstAccount == rspEntry.getAccountIDPeer())
+                {
+                    count += 10000;  // count a path to the destination extra
+                }
+                else if (rspEntry.getNoRipplePeer())
+                {
+                    // This probably isn't a useful path out
+                }
+                else if (rspEntry.getFreezePeer())
+                {
+                    // Not a useful path out
+                }
+                else
+                {
+                    ++count;
+                }
             }
         }
     }
@@ -977,120 +981,126 @@ Pathfinder::addLink(
                 bool const bIsNoRippleOut(isNoRippleOut(currentPath));
                 bool const bDestOnly(addFlags & afAC_LAST);
 
-                auto& rippleLines(
-                    mRLCache->getRippleLines(uEndAccount, !bIsNoRippleOut));
-
-                AccountCandidates candidates;
-                candidates.reserve(rippleLines.size());
-
-                for (auto const& rs : rippleLines)
+                if (auto const lines =
+                        mRLCache->getRippleLines(uEndAccount, !bIsNoRippleOut))
                 {
-                    if (continueCallback && !continueCallback())
-                        return;
-                    auto const& acct = rs.getAccountIDPeer();
-                    bool const outgoing = !rs.getNoRipplePeer();
+                    auto& rippleLines = *lines;
 
-                    if (hasEffectiveDestination && (acct == mDstAccount))
-                    {
-                        // We skipped the gateway
-                        continue;
-                    }
+                    AccountCandidates candidates;
+                    candidates.reserve(rippleLines.size());
 
-                    bool bToDestination = acct == mEffectiveDst;
-
-                    if (bDestOnly && !bToDestination)
-                    {
-                        continue;
-                    }
-
-                    if ((uEndCurrency == rs.getLimit().getCurrency()) &&
-                        !currentPath.hasSeen(acct, uEndCurrency, acct))
-                    {
-                        // path is for correct currency and has not been seen
-                        if (rs.getBalance() <= beast::zero &&
-                            (!rs.getLimitPeer() ||
-                             -rs.getBalance() >= rs.getLimitPeer() ||
-                             (bRequireAuth && !rs.getAuth())))
-                        {
-                            // path has no credit
-                        }
-                        else if (bIsNoRippleOut && rs.getNoRipple())
-                        {
-                            // Can't leave on this path
-                        }
-                        else if (bToDestination)
-                        {
-                            // destination is always worth trying
-                            if (uEndCurrency == mDstAmount.getCurrency())
-                            {
-                                // this is a complete path
-                                if (!currentPath.empty())
-                                {
-                                    JLOG(j_.trace())
-                                        << "complete path found ae: "
-                                        << currentPath.getJson(
-                                               JsonOptions::none);
-                                    addUniquePath(mCompletePaths, currentPath);
-                                }
-                            }
-                            else if (!bDestOnly)
-                            {
-                                // this is a high-priority candidate
-                                candidates.push_back(
-                                    {AccountCandidate::highPriority, acct});
-                            }
-                        }
-                        else if (acct == mSrcAccount)
-                        {
-                            // going back to the source is bad
-                        }
-                        else
-                        {
-                            // save this candidate
-                            int out = getPathsOut(
-                                uEndCurrency,
-                                acct,
-                                outgoing,
-                                bIsEndCurrency,
-                                mEffectiveDst,
-                                continueCallback);
-                            if (out)
-                                candidates.push_back({out, acct});
-                        }
-                    }
-                }
-
-                if (!candidates.empty())
-                {
-                    std::sort(
-                        candidates.begin(),
-                        candidates.end(),
-                        std::bind(
-                            compareAccountCandidate,
-                            mLedger->seq(),
-                            std::placeholders::_1,
-                            std::placeholders::_2));
-
-                    int count = candidates.size();
-                    // allow more paths from source
-                    if ((count > 10) && (uEndAccount != mSrcAccount))
-                        count = 10;
-                    else if (count > 50)
-                        count = 50;
-
-                    auto it = candidates.begin();
-                    while (count-- != 0)
+                    for (auto const& rs : rippleLines)
                     {
                         if (continueCallback && !continueCallback())
                             return;
-                        // Add accounts to incompletePaths
-                        STPathElement pathElement(
-                            STPathElement::typeAccount,
-                            it->account,
-                            uEndCurrency,
-                            it->account);
-                        incompletePaths.assembleAdd(currentPath, pathElement);
-                        ++it;
+                        auto const& acct = rs.getAccountIDPeer();
+                        bool const outgoing = !rs.getNoRipplePeer();
+
+                        if (hasEffectiveDestination && (acct == mDstAccount))
+                        {
+                            // We skipped the gateway
+                            continue;
+                        }
+
+                        bool bToDestination = acct == mEffectiveDst;
+
+                        if (bDestOnly && !bToDestination)
+                        {
+                            continue;
+                        }
+
+                        if ((uEndCurrency == rs.getLimit().getCurrency()) &&
+                            !currentPath.hasSeen(acct, uEndCurrency, acct))
+                        {
+                            // path is for correct currency and has not been
+                            // seen
+                            if (rs.getBalance() <= beast::zero &&
+                                (!rs.getLimitPeer() ||
+                                 -rs.getBalance() >= rs.getLimitPeer() ||
+                                 (bRequireAuth && !rs.getAuth())))
+                            {
+                                // path has no credit
+                            }
+                            else if (bIsNoRippleOut && rs.getNoRipple())
+                            {
+                                // Can't leave on this path
+                            }
+                            else if (bToDestination)
+                            {
+                                // destination is always worth trying
+                                if (uEndCurrency == mDstAmount.getCurrency())
+                                {
+                                    // this is a complete path
+                                    if (!currentPath.empty())
+                                    {
+                                        JLOG(j_.trace())
+                                            << "complete path found ae: "
+                                            << currentPath.getJson(
+                                                   JsonOptions::none);
+                                        addUniquePath(
+                                            mCompletePaths, currentPath);
+                                    }
+                                }
+                                else if (!bDestOnly)
+                                {
+                                    // this is a high-priority candidate
+                                    candidates.push_back(
+                                        {AccountCandidate::highPriority, acct});
+                                }
+                            }
+                            else if (acct == mSrcAccount)
+                            {
+                                // going back to the source is bad
+                            }
+                            else
+                            {
+                                // save this candidate
+                                int out = getPathsOut(
+                                    uEndCurrency,
+                                    acct,
+                                    outgoing,
+                                    bIsEndCurrency,
+                                    mEffectiveDst,
+                                    continueCallback);
+                                if (out)
+                                    candidates.push_back({out, acct});
+                            }
+                        }
+                    }
+
+                    if (!candidates.empty())
+                    {
+                        std::sort(
+                            candidates.begin(),
+                            candidates.end(),
+                            std::bind(
+                                compareAccountCandidate,
+                                mLedger->seq(),
+                                std::placeholders::_1,
+                                std::placeholders::_2));
+
+                        int count = candidates.size();
+                        // allow more paths from source
+                        if ((count > 10) && (uEndAccount != mSrcAccount))
+                            count = 10;
+                        else if (count > 50)
+                            count = 50;
+
+                        auto it = candidates.begin();
+                        while (count-- != 0)
+                        {
+                            if (continueCallback && !continueCallback())
+                                return;
+                            // Add accounts to incompletePaths
+                            STPathElement pathElement(
+                                STPathElement::typeAccount,
+                                it->account,
+                                uEndCurrency,
+                                it->account);
+                            incompletePaths.assembleAdd(
+                                currentPath, pathElement);
+                            ++it;
+                        }
                     }
                 }
             }

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -708,6 +708,7 @@ int
 Pathfinder::getPathsOut(
     Currency const& currency,
     AccountID const& account,
+    bool outgoing,
     bool isDstCurrency,
     AccountID const& dstAccount,
     std::function<bool(void)> const& continueCallback)
@@ -735,7 +736,7 @@ Pathfinder::getPathsOut(
     {
         count = app_.getOrderBookDB().getBookSize(issue);
 
-        for (auto const& rspEntry : mRLCache->getRippleLines(account))
+        for (auto const& rspEntry : mRLCache->getRippleLines(account, outgoing))
         {
             if (currency != rspEntry.getLimit().getCurrency())
             {
@@ -976,7 +977,8 @@ Pathfinder::addLink(
                 bool const bIsNoRippleOut(isNoRippleOut(currentPath));
                 bool const bDestOnly(addFlags & afAC_LAST);
 
-                auto& rippleLines(mRLCache->getRippleLines(uEndAccount));
+                auto& rippleLines(
+                    mRLCache->getRippleLines(uEndAccount, !bIsNoRippleOut));
 
                 AccountCandidates candidates;
                 candidates.reserve(rippleLines.size());
@@ -986,6 +988,7 @@ Pathfinder::addLink(
                     if (continueCallback && !continueCallback())
                         return;
                     auto const& acct = rs.getAccountIDPeer();
+                    bool const outgoing = !rs.getNoRipplePeer();
 
                     if (hasEffectiveDestination && (acct == mDstAccount))
                     {
@@ -1047,6 +1050,7 @@ Pathfinder::addLink(
                             int out = getPathsOut(
                                 uEndCurrency,
                                 acct,
+                                outgoing,
                                 bIsEndCurrency,
                                 mEffectiveDst,
                                 continueCallback);

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -144,7 +144,7 @@ private:
     getPathsOut(
         Currency const& currency,
         AccountID const& account,
-        bool outgoing,
+        LineDirection direction,
         bool isDestCurrency,
         AccountID const& dest,
         std::function<bool(void)> const& continueCallback);

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -144,6 +144,7 @@ private:
     getPathsOut(
         Currency const& currency,
         AccountID const& account,
+        bool outgoing,
         bool isDestCurrency,
         AccountID const& dest,
         std::function<bool(void)> const& continueCallback);

--- a/src/ripple/app/paths/RippleLineCache.cpp
+++ b/src/ripple/app/paths/RippleLineCache.cpp
@@ -42,16 +42,17 @@ RippleLineCache::~RippleLineCache()
 }
 
 std::vector<PathFindTrustLine> const&
-RippleLineCache::getRippleLines(AccountID const& accountID)
+RippleLineCache::getRippleLines(AccountID const& accountID, bool outgoing)
 {
-    AccountKey key(accountID, hasher_(accountID));
+    AccountKey key(
+        accountID, outgoing, hasher_(std::pair{accountID, outgoing}));
 
     std::lock_guard sl(mLock);
 
     auto [it, inserted] = lines_.emplace(key, std::vector<PathFindTrustLine>());
 
     if (inserted)
-        it->second = PathFindTrustLine::getItems(accountID, *mLedger);
+        it->second = PathFindTrustLine::getItems(accountID, *mLedger, outgoing);
 
     JLOG(journal_.debug()) << "RippleLineCache getRippleLines for ledger "
                            << mLedger->info().seq << " found "

--- a/src/ripple/app/paths/RippleLineCache.cpp
+++ b/src/ripple/app/paths/RippleLineCache.cpp
@@ -26,40 +26,87 @@ namespace ripple {
 RippleLineCache::RippleLineCache(
     std::shared_ptr<ReadView const> const& ledger,
     beast::Journal j)
-    : journal_(j)
+    : ledger_(ledger), journal_(j)
 {
-    mLedger = ledger;
-
-    JLOG(journal_.debug()) << "RippleLineCache created for ledger "
-                           << mLedger->info().seq;
+    JLOG(journal_.debug()) << "created for ledger " << ledger_->info().seq;
 }
 
 RippleLineCache::~RippleLineCache()
 {
-    JLOG(journal_.debug()) << "~RippleLineCache destroyed for ledger "
-                           << mLedger->info().seq << " with " << lines_.size()
-                           << " accounts";
+    JLOG(journal_.debug()) << "destroyed for ledger " << ledger_->info().seq
+                           << " with " << lines_.size() << " accounts and "
+                           << totalLineCount_ << " distinct trust lines.";
 }
 
-std::vector<PathFindTrustLine> const&
+std::shared_ptr<std::vector<PathFindTrustLine>>
 RippleLineCache::getRippleLines(AccountID const& accountID, bool outgoing)
 {
-    AccountKey key(
-        accountID, outgoing, hasher_(std::pair{accountID, outgoing}));
+    auto const hash = hasher_(accountID);
+    AccountKey key(accountID, outgoing, hash);
+    AccountKey otherkey(accountID, !outgoing, hash);
 
     std::lock_guard sl(mLock);
 
-    auto [it, inserted] = lines_.emplace(key, std::vector<PathFindTrustLine>());
+    auto [it, inserted] = [&]() {
+        if (auto otheriter = lines_.find(otherkey); otheriter != lines_.end())
+        {
+            // The whole point of using the outgoing flag is to reduce the
+            // number of trust line objects held in memory. Ensure that there is
+            // only a single set of trustlines in the cache per account.
+            auto const size = otheriter->second ? otheriter->second->size() : 0;
+            JLOG(journal_.info())
+                << "Request for " << (outgoing ? "outgoing" : "incoming")
+                << " trust lines for account " << accountID << " found " << size
+                << (outgoing ? " incoming" : " outgoing") << " trust lines. "
+                << (outgoing ? "Deleting the subset of incoming"
+                             : "Returning the superset of outgoing")
+                << " trust lines. ";
+            if (outgoing)
+            {
+                // This request is for the outgoing set, but there is already a
+                // subset of incoming lines in the cache. Erase that subset
+                // to be replaced by the full set. The full set will be built
+                // below, and will be returned, if needed, on subsequent calls
+                // for either value of outgoing.
+                assert(size <= totalLineCount_);
+                totalLineCount_ -= size;
+                lines_.erase(otheriter);
+            }
+            else
+            {
+                // This request is for the incoming set, but there is
+                // already a superset of the outgoing trust lines in the cache.
+                // The path finding engine will disregard the non-rippling trust
+                // lines, so to prevent them from being stored twice, return the
+                // outgoing set.
+                key = otherkey;
+                return std::pair{otheriter, false};
+            }
+        }
+        return lines_.emplace(key, nullptr);
+    }();
 
     if (inserted)
-        it->second = PathFindTrustLine::getItems(accountID, *mLedger, outgoing);
+    {
+        assert(it->second == nullptr);
+        auto lines = PathFindTrustLine::getItems(accountID, *ledger_, outgoing);
+        if (lines.size())
+        {
+            it->second = std::make_shared<std::vector<PathFindTrustLine>>(
+                std::move(lines));
+            totalLineCount_ += it->second->size();
+        }
+    }
 
-    JLOG(journal_.debug()) << "RippleLineCache getRippleLines for ledger "
-                           << mLedger->info().seq << " found "
-                           << it->second.size() << " lines for "
-                           << (inserted ? "new " : "existing ") << accountID
-                           << " out of a total of " << lines_.size()
-                           << " accounts";
+    assert(!it->second || (it->second->size() > 0));
+    auto const size = it->second ? it->second->size() : 0;
+    JLOG(journal_.trace()) << "getRippleLines for ledger "
+                           << ledger_->info().seq << " found " << size
+                           << (key.outgoing_ ? " outgoing" : " incoming")
+                           << " lines for " << (inserted ? "new " : "existing ")
+                           << accountID << " out of a total of "
+                           << lines_.size() << " accounts and "
+                           << totalLineCount_ << " trust lines";
 
     return it->second;
 }

--- a/src/ripple/app/paths/RippleLineCache.h
+++ b/src/ripple/app/paths/RippleLineCache.h
@@ -47,8 +47,20 @@ public:
         return mLedger;
     }
 
+    /** Find the trust lines associated with an account.
+
+       @param accountID The account
+       @param outgoing Whether the account is an "outgoing" link on the path.
+       "Outgoing" is defined as the source account, or an account found via a
+       trustline that has rippling enabled on the @accountID's side. If an
+       account is "outgoing", all trust lines will be returned. If an account is
+       not "outgoing", then any trust lines that don't have rippling enabled are
+       not usable, so only return trust lines that have rippling enabled on
+       @accountID's side.
+       @return Returns a vector of the usable trust lines.
+    */
     std::vector<PathFindTrustLine> const&
-    getRippleLines(AccountID const& accountID);
+    getRippleLines(AccountID const& accountID, bool outgoing);
 
 private:
     std::mutex mLock;
@@ -61,10 +73,11 @@ private:
     struct AccountKey final : public CountedObject<AccountKey>
     {
         AccountID account_;
+        bool outgoing_;
         std::size_t hash_value_;
 
-        AccountKey(AccountID const& account, std::size_t hash)
-            : account_(account), hash_value_(hash)
+        AccountKey(AccountID const& account, bool outgoing, std::size_t hash)
+            : account_(account), outgoing_(outgoing), hash_value_(hash)
         {
         }
 
@@ -76,7 +89,8 @@ private:
         bool
         operator==(AccountKey const& lhs) const
         {
-            return hash_value_ == lhs.hash_value_ && account_ == lhs.account_;
+            return hash_value_ == lhs.hash_value_ && account_ == lhs.account_ &&
+                outgoing_ == lhs.outgoing_;
         }
 
         std::size_t

--- a/src/ripple/app/paths/RippleLineCache.h
+++ b/src/ripple/app/paths/RippleLineCache.h
@@ -50,7 +50,7 @@ public:
     /** Find the trust lines associated with an account.
 
        @param accountID The account
-       @param outgoing Whether the account is an "outgoing" link on the path.
+       @param direction Whether the account is an "outgoing" link on the path.
        "Outgoing" is defined as the source account, or an account found via a
        trustline that has rippling enabled on the @accountID's side. If an
        account is "outgoing", all trust lines will be returned. If an account is
@@ -60,7 +60,7 @@ public:
        @return Returns a vector of the usable trust lines.
     */
     std::shared_ptr<std::vector<PathFindTrustLine>>
-    getRippleLines(AccountID const& accountID, bool outgoing);
+    getRippleLines(AccountID const& accountID, LineDirection direction);
 
 private:
     std::mutex mLock;
@@ -73,11 +73,14 @@ private:
     struct AccountKey final : public CountedObject<AccountKey>
     {
         AccountID account_;
-        bool outgoing_;
+        LineDirection direction_;
         std::size_t hash_value_;
 
-        AccountKey(AccountID const& account, bool outgoing, std::size_t hash)
-            : account_(account), outgoing_(outgoing), hash_value_(hash)
+        AccountKey(
+            AccountID const& account,
+            LineDirection direction,
+            std::size_t hash)
+            : account_(account), direction_(direction), hash_value_(hash)
         {
         }
 
@@ -90,7 +93,7 @@ private:
         operator==(AccountKey const& lhs) const
         {
             return hash_value_ == lhs.hash_value_ && account_ == lhs.account_ &&
-                outgoing_ == lhs.outgoing_;
+                direction_ == lhs.direction_;
         }
 
         std::size_t

--- a/src/ripple/app/paths/TrustLine.cpp
+++ b/src/ripple/app/paths/TrustLine.cpp
@@ -61,15 +61,19 @@ PathFindTrustLine::makeItem(
 namespace detail {
 template <class T>
 std::vector<T>
-getTrustLineItems(AccountID const& accountID, ReadView const& view)
+getTrustLineItems(
+    AccountID const& accountID,
+    ReadView const& view,
+    bool outgoing = true)
 {
     std::vector<T> items;
     forEachItem(
         view,
         accountID,
-        [&items, &accountID](std::shared_ptr<SLE const> const& sleCur) {
+        [&items, &accountID, &outgoing](
+            std::shared_ptr<SLE const> const& sleCur) {
             auto ret = T::makeItem(accountID, sleCur);
-            if (ret)
+            if (ret && (outgoing || !ret->getNoRipple()))
                 items.push_back(std::move(*ret));
         });
 
@@ -78,9 +82,13 @@ getTrustLineItems(AccountID const& accountID, ReadView const& view)
 }  // namespace detail
 
 std::vector<PathFindTrustLine>
-PathFindTrustLine::getItems(AccountID const& accountID, ReadView const& view)
+PathFindTrustLine::getItems(
+    AccountID const& accountID,
+    ReadView const& view,
+    bool outgoing)
 {
-    return detail::getTrustLineItems<PathFindTrustLine>(accountID, view);
+    return detail::getTrustLineItems<PathFindTrustLine>(
+        accountID, view, outgoing);
 }
 
 RPCTrustLine::RPCTrustLine(

--- a/src/ripple/app/paths/TrustLine.cpp
+++ b/src/ripple/app/paths/TrustLine.cpp
@@ -64,16 +64,17 @@ std::vector<T>
 getTrustLineItems(
     AccountID const& accountID,
     ReadView const& view,
-    bool outgoing = true)
+    LineDirection direction = LineDirection::outgoing)
 {
     std::vector<T> items;
     forEachItem(
         view,
         accountID,
-        [&items, &accountID, &outgoing](
+        [&items, &accountID, &direction](
             std::shared_ptr<SLE const> const& sleCur) {
             auto ret = T::makeItem(accountID, sleCur);
-            if (ret && (outgoing || !ret->getNoRipple()))
+            if (ret &&
+                (direction == LineDirection::outgoing || !ret->getNoRipple()))
                 items.push_back(std::move(*ret));
         });
     // This list may be around for a while, so free up any unneeded
@@ -88,10 +89,10 @@ std::vector<PathFindTrustLine>
 PathFindTrustLine::getItems(
     AccountID const& accountID,
     ReadView const& view,
-    bool outgoing)
+    LineDirection direction)
 {
     return detail::getTrustLineItems<PathFindTrustLine>(
-        accountID, view, outgoing);
+        accountID, view, direction);
 }
 
 RPCTrustLine::RPCTrustLine(

--- a/src/ripple/app/paths/TrustLine.cpp
+++ b/src/ripple/app/paths/TrustLine.cpp
@@ -76,6 +76,9 @@ getTrustLineItems(
             if (ret && (outgoing || !ret->getNoRipple()))
                 items.push_back(std::move(*ret));
         });
+    // This list may be around for a while, so free up any unneeded
+    // capacity
+    items.shrink_to_fit();
 
     return items;
 }

--- a/src/ripple/app/paths/TrustLine.h
+++ b/src/ripple/app/paths/TrustLine.h
@@ -31,6 +31,15 @@
 
 namespace ripple {
 
+/** Describes how an account was found in a path, and how to find the next set
+of paths. "Outgoing" is defined as the source account, or an account found via a
+trustline that has rippling enabled on the account's side.
+"Incoming" is defined as an account found via a trustline that has rippling
+disabled on the account's side. Any trust lines for an incoming account that
+have rippling disabled are unusable in paths.
+*/
+enum class LineDirection : bool { incoming = false, outgoing = true };
+
 /** Wraps a trust line SLE for convenience.
     The complication of trust lines is that there is a
     "low" account and a "high" account. This wraps the
@@ -109,6 +118,20 @@ public:
         return mFlags & (!mViewLowest ? lsfLowNoRipple : lsfHighNoRipple);
     }
 
+    LineDirection
+    getDirection() const
+    {
+        return getNoRipple() ? LineDirection::incoming
+                             : LineDirection::outgoing;
+    }
+
+    LineDirection
+    getDirectionPeer() const
+    {
+        return getNoRipplePeer() ? LineDirection::incoming
+                                 : LineDirection::outgoing;
+    }
+
     /** Have we set the freeze flag on our peer */
     bool
     getFreeze() const
@@ -170,7 +193,10 @@ public:
     makeItem(AccountID const& accountID, std::shared_ptr<SLE const> const& sle);
 
     static std::vector<PathFindTrustLine>
-    getItems(AccountID const& accountID, ReadView const& view, bool outgoing);
+    getItems(
+        AccountID const& accountID,
+        ReadView const& view,
+        LineDirection direction);
 };
 
 // This wrapper is used for the `AccountLines` command and includes the quality

--- a/src/ripple/app/paths/TrustLine.h
+++ b/src/ripple/app/paths/TrustLine.h
@@ -170,7 +170,7 @@ public:
     makeItem(AccountID const& accountID, std::shared_ptr<SLE const> const& sle);
 
     static std::vector<PathFindTrustLine>
-    getItems(AccountID const& accountID, ReadView const& view);
+    getItems(AccountID const& accountID, ReadView const& view, bool outgoing);
 };
 
 // This wrapper is used for the `AccountLines` command and includes the quality

--- a/src/test/rpc/AmendmentBlocked_test.cpp
+++ b/src/test/rpc/AmendmentBlocked_test.cpp
@@ -43,6 +43,12 @@ class AmendmentBlocked_test : public beast::unit_test::suite
         Account const ali{"ali", KeyType::secp256k1};
         env.fund(XRP(10000), alice, bob, gw);
         env.memoize(ali);
+        // This close() ensures that all the accounts get created and their
+        // default ripple flag gets set before the trust lines are created.
+        // Without it, the ordering manages to create alice's trust line with
+        // noRipple set on gw's end. The existing tests pass either way, but
+        // better to do it right.
+        env.close();
         env.trust(USD(600), alice);
         env.trust(USD(700), bob);
         env(pay(gw, alice, USD(70)));


### PR DESCRIPTION
## High Level Overview of Change

These changes continue building on top of PR #4099, which in turn builds on the changes from PR #4080. Both of those PRs are approved to merge. Thus, reviewers can skip straight to the commit labelled, "Don't load trust lines that can't participate in path finding".

* #4080 reduces the memory requirements per trust line in memory
* #4099 speeds up the removal of trust lines and path finding requests from memory
* This PR significantly reduces the number of trust lines that will be loaded and held in memory in the first place.

### Context of Change

As described in the other two PRs, the number of trustlines on the network has grown significantly over the last few months. That in-turn has led to a significant increase in the amount of memory used to load and cache those trustlines.

### Type of Change

- [X ] New feature (non-breaking change which adds functionality)
- [X ] Refactor (non-breaking change that only restructures code)

## Before / After

These changes take advantage of two facts:
1. "A path is considered invalid if and only if it enters and exits an address node through trust lines where No Ripple has been enabled for that address." (https://xrpl.org/rippling.html#specifics)
2. Most "end-user" accounts / wallets do not have the "default ripple" flag set, and thus have the `NoRipple` flag set on all of their trustlines.

#### Before
Currently, during path finding, all trust lines which might link the source account to the destination account are examined and cached. The path finding engine checks for invalid paths ("enters and exits an address node through trust lines where No Ripple has been enabled"), and does not use any of the cached trust lines to look for more paths, but the trust lines remain cached, potentially for a rather long time.

#### After
After these changes, during path finding, the trust line lookups for a given account consider the state of the no ripple flag on that account's side of the trust line used to find that account. If not set (rippling is allowed), the account is considered "outgoing", and all trust lines are loaded and cached. However, if the no ripple flag is set (rippling is not allowed), the account is considered "incoming", and only trust lines which do not have the no ripple flag set (thus allowing rippling) are loaded and cached.

#### Example
Consider the case where 1000 wallets all have trustlines to the same 100 issued tokens. Alice and Bob are among those 1000. If Alice tries to find a path to Bob, with the current behavior: Alice's 100 trust lines will be loaded and cached. The first token line will be considered, leading to the token issuer. The token issuer's 1000 trust lines will be loaded and cached. Then for each of those 999 other wallet accounts, the 100 trust lines to each issuer will be loaded and cached. Unfortunately, none of those trust lines will be usable in a path. This effectively leads to 99,900 unusable cached trust lines. In this example, the second token issuer will lead to the same set of 1000 accounts, but on the mainnet, there are more accounts trusting more tokens without necessarily overlapping, leading to even bigger data sets.

With these changes, each time a wallet account is considered, no trust lines will be loaded or cached, preventing those 99,900 unusable trustlines from taking up memory. (Under the hood, the `SLE` will be loaded regardless, but no `PathFindTrustLines` will be created. In the case where there are 0 usable trust lines found, the `std::vector` will not even be cached.)

Additionally, the changes handle the case where an account has some trust lines with the no ripple flag and without, and avoids duplication.

## Test Plan

This test plan is similar to the one for #4099 

Run an expensive `path_find` request. Observe that less memory is used by the rippled process overall. Using the `get_counts` command, observe that fewer instances of `PathFindTrustLine` are being created than were created for #4099 and older. (Note that the counter for `PathFindTrustLine` was only added in #4080.) 
