### PR TITLE
[Trivial] Use 3.16 for minimum CMake supported that Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -282,7 +282,7 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
         - BUILD_TYPE=Debug
-        - CMAKE_EXE=/opt/local/cmake-3.9/bin/cmake
+        - CMAKE_EXE=/opt/local/cmake/bin/cmake
         - SKIP_TESTS=true
     # validator keys project as subproj of rippled
     - <<: *linux


### PR DESCRIPTION
### Context of Change

Travis tests the minimum CMake version supported. 
It is currently 3.9 and rocksdb cannot be built with this version which necessitates https://github.com/ripple/rippled/pull/4109 increasing that to CMake 3.16.


- [x] Bug fix (non-breaking change which fixes an issue)


<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
