### PR TITLE
Remove Xpring forum link from issue configs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@ contact_links:
   - name: XRP Ledger Documentation
     url: https://xrpl.org/
     about: All things about XRPL
-  - name: General question for the community
-    url: https://forum.xpring.io/c/community/
-    about: Please ask and answer questions here.
   - name: Security bug bounty program
     url: https://ripple.com/bug-bounty/
     about: Please report security-relevant bugs in our software here.


### PR DESCRIPTION
## High Level Overview of Change
- Change GitHub issue template to remove Xpring forum link

### Context of Change
The Xpring Forum shut down a while back, so it's no longer a relevant link for community discussions.

### Type of Change

- [x] Documentation Updates
