### PR TITLE
Prevent CI scripts from echoing all commands

### DIFF
--- a/Builds/containers/gitlab-ci/docker_alpine_setup.sh
+++ b/Builds/containers/gitlab-ci/docker_alpine_setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -ex
+set -e
 # used as a before/setup script for docker steps in gitlab-ci
 # expects to be run in standard alpine/dind image
 echo $(nproc)
@@ -13,4 +13,3 @@ apk add \
 pip3 install awscli
 # list curdir contents to build log:
 ls -la
-

--- a/Builds/containers/gitlab-ci/push_to_artifactory.sh
+++ b/Builds/containers/gitlab-ci/push_to_artifactory.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -ex
+set -e
 action=$1
 filter=$2
 

--- a/Builds/containers/gitlab-ci/smoketest.sh
+++ b/Builds/containers/gitlab-ci/smoketest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -ex
+set -e
 install_from=$1
 use_private=${2:-0} # this option not currently needed by any CI scripts,
                     # reserved for possible future use

--- a/Builds/containers/gitlab-ci/tag_docker_image.sh
+++ b/Builds/containers/gitlab-ci/tag_docker_image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -ex
+set -e
 docker login -u rippled \
     -p ${ARTIFACTORY_DEPLOY_KEY_RIPPLED} "${ARTIFACTORY_HUB}"
 # this gives us rippled_version :
@@ -19,4 +19,3 @@ for label in ${rippled_version} latest ; do
     docker push \
         "${ARTIFACTORY_HUB}/${DPKG_CONTAINER_NAME}:${label}_${CI_COMMIT_REF_SLUG}"
 done
-


### PR DESCRIPTION

Removes 'set -x' from the scripts to prevent echoing all commands executed

- [x] Refactor (non-breaking change that only restructures code)

<!--
## Future Tasks
For future tasks related to PR.
-->
