### PR TITLE
Add AMM Instance Create.

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -375,6 +375,8 @@ target_sources (rippled PRIVATE
   src/ripple/app/reporting/ReportingETL.cpp
   src/ripple/app/reporting/ETLSource.cpp
   src/ripple/app/reporting/P2pProxy.cpp
+  src/ripple/app/misc/impl/AMM.cpp
+  src/ripple/app/misc/impl/AMM_formulae.cpp
   src/ripple/app/misc/CanonicalTXSet.cpp
   src/ripple/app/misc/FeeVoteImpl.cpp
   src/ripple/app/misc/HashRouter.cpp
@@ -411,6 +413,7 @@ target_sources (rippled PRIVATE
   src/ripple/app/rdb/impl/RelationalDBInterface_nodes.cpp
   src/ripple/app/rdb/impl/RelationalDBInterface_postgres.cpp
   src/ripple/app/rdb/impl/RelationalDBInterface_shards.cpp
+  src/ripple/app/tx/impl/AMMCreate.cpp
   src/ripple/app/tx/impl/ApplyContext.cpp
   src/ripple/app/tx/impl/BookTip.cpp
   src/ripple/app/tx/impl/CancelCheck.cpp
@@ -572,6 +575,7 @@ target_sources (rippled PRIVATE
   src/ripple/rpc/handlers/AccountOffers.cpp
   src/ripple/rpc/handlers/AccountTx.cpp
   src/ripple/rpc/handlers/AccountTxOld.cpp
+  src/ripple/rpc/handlers/AMMInfo.cpp
   src/ripple/rpc/handlers/BlackList.cpp
   src/ripple/rpc/handlers/BookOffers.cpp
   src/ripple/rpc/handlers/CanDelete.cpp
@@ -670,6 +674,7 @@ if (tests)
     src/test/app/AccountDelete_test.cpp
     src/test/app/AccountTxPaging_test.cpp
     src/test/app/AmendmentTable_test.cpp
+    src/test/app/AMM_test.cpp
     src/test/app/Check_test.cpp
     src/test/app/CrossingLimits_test.cpp
     src/test/app/DeliverMin_test.cpp
@@ -804,6 +809,7 @@ if (tests)
     src/test/jtx/Env_test.cpp
     src/test/jtx/WSClient_test.cpp
     src/test/jtx/impl/Account.cpp
+    src/test/jtx/impl/AMM.cpp
     src/test/jtx/impl/Env.cpp
     src/test/jtx/impl/JSONRPCClient.cpp
     src/test/jtx/impl/ManualTimeKeeper.cpp

--- a/src/ripple/app/misc/AMM.h
+++ b/src/ripple/app/misc/AMM.h
@@ -1,0 +1,136 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#ifndef RIPPLE_APP_MISC_AMM_H_INLCUDED
+#define RIPPLE_APP_MISC_AMM_H_INLCUDED
+
+#include <ripple/protocol/Quality.h>
+#include <ripple/protocol/STAmount.h>
+#include <ripple/protocol/digest.h>
+
+namespace ripple {
+
+/** Calculate AMM account ID.
+ * @return AMM account id
+ */
+template <typename... Args>
+AccountID
+calcAccountID(Args const&... args)
+{
+    ripesha_hasher rsh;
+    auto hash = sha512Half(args...);
+    rsh(hash.data(), hash.size());
+    return AccountID{static_cast<ripesha_hasher::result_type>(rsh)};
+}
+
+/** Calculate account ID for all AMM's with the same issue combination.
+ * Issues are sorted in canonical order.
+ * @param issue1 issue of one side of the AMM instance
+ * @param issue2 issue of the other side of the AMM instance
+ * @return account id
+ */
+AccountID
+calcAMMGroupAccountID(Issue const& issue1, Issue const& issue2);
+
+/** Calculate AMM instance account ID and return the weight
+ * based on the issues canonical order. I.e. if issue1 > issue2
+ * then returned weight is weight1, otherwise it's 100 - weight1.
+ */
+std::pair<AccountID, std::uint8_t>
+calcAMMAccountIDAndWeight(
+    int weight1,
+    Issue const& issue1,
+    Issue const& issue2);
+
+/** A weight, based on the issues canonical order, is stored in the account
+ * root. Return weights based on this order.
+ */
+std::pair<std::uint8_t, std::uint8_t>
+canonicalWeights(int weight, Issue const& in, Issue const& out);
+
+/** Calculate AMM account ID.
+ * @weight1 weight associated with issue1
+ * @issue1 issue of one side of the pool
+ * @issue2 issue of another side of the pool
+ * @return AMM account id
+ */
+inline AccountID
+calcAMMAccountID(int weight1, Issue const& issue1, Issue const& issue2)
+{
+    auto [id, weight] = calcAMMAccountIDAndWeight(weight1, issue1, issue2);
+    (void)weight;
+    return id;
+}
+
+/** Calculate Liquidity Provider Token (LPT) Currency.
+ * @param ammAccountID AMM's instance account id
+ * @return LPT Currency
+ */
+Currency
+calcLPTCurrency(AccountID const& ammAccountID);
+
+/** Calculate LPT Issue.
+ * @param ammAccountID AMM's instance account id
+ * @return LPT Issue
+ */
+Issue
+calcLPTIssue(AccountID const& ammAccountID);
+
+/** Get AMM reserves in/out. AMM trades in both
+ * directions but given specific BookStep
+ * the direction is set to in/out.
+ */
+std::pair<STAmount, STAmount>
+getAMMReserves(
+    ReadView const& view,
+    AccountID const& ammAccountID,
+    Issue const& in,
+    Issue const& out,
+    beast::Journal const j);
+
+/** Get AMM reserves and AMM LPT balance.
+ * If issue1 is set then return reserves
+ * in the order issue1 first. If in addition
+ * issue2 is set then validate it matches
+ * the issue of the second asset. This
+ * method is needed for AMMTrade functionality
+ * when trade options don't provide any issue,
+ * one issue, or both issues.
+ */
+std::tuple<STAmount, STAmount, STAmount>
+getAMMReserves(
+    ReadView const& view,
+    AccountID const& ammAccountID,
+    std::optional<AccountID> const& lpAccountID,
+    std::optional<Issue> const& issue1,
+    std::optional<Issue> const& issue2,
+    beast::Journal const j);
+
+/** Return the balance of AMM tokens - sum of all LP tokens.
+ * If lpAccount is seated then return tokens for this LP.
+ */
+STAmount
+getAMMLPTokens(
+    ReadView const& view,
+    AccountID const& ammAccountID,
+    std::optional<AccountID> const& lpAccount,
+    beast::Journal const j);
+
+}  // namespace ripple
+
+#endif  // RIPPLE_APP_MISC_AMM_H_INLCUDED

--- a/src/ripple/app/misc/AMM_formulae.h
+++ b/src/ripple/app/misc/AMM_formulae.h
@@ -1,0 +1,93 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_APP_MISC_AMM_FORMULAE_H_INCLUDED
+#define RIPPLE_APP_MISC_AMM_FORMULAE_H_INCLUDED
+
+#include <ripple/basics/IOUAmount.h>
+#include <ripple/protocol/Issue.h>
+#include <ripple/protocol/Quality.h>
+#include <ripple/protocol/STAccount.h>
+#include <ripple/protocol/STAmount.h>
+
+#include <type_traits>
+
+namespace ripple {
+
+namespace detail {
+
+double
+saToDouble(STAmount const& a);
+
+template <typename T>
+inline std::enable_if_t<(std::is_floating_point<T>::value), std::size_t>
+decimal_places(T v)
+{
+    std::size_t count = 0;
+    v = std::abs(v);
+    auto c = v - std::floor(v);
+    T factor = 10;
+    T eps = std::numeric_limits<T>::epsilon() * c;
+
+    while ((c > eps && c < (1 - eps)) &&
+           count < std::numeric_limits<T>::max_digits10)
+    {
+        c = v * factor;
+        c = c - std::floor(c);
+        factor *= 10;
+        eps = std::numeric_limits<T>::epsilon() * v * factor;
+        count++;
+    }
+
+    return count;
+}
+
+STAmount
+toSTAfromDouble(double v, Issue const& issue = noIssue());
+
+template <typename T>
+T
+get(STAmount const& a)
+{
+    if constexpr (std::is_same_v<T, XRPAmount>)
+        return a.xrp();
+    else if constexpr (std::is_same_v<T, IOUAmount>)
+        return a.iou();
+    else
+        return a;
+}
+
+}  // namespace detail
+
+/** Calculate LP Tokens given AMM pool reserves.
+ * @param asset1 AMM one side of the pool reserve
+ * @param asset2 AMM another side of the pool reserve
+ * @param weight1 xrp pool weight
+ * @return LP Tokens as IOU
+ */
+STAmount
+calcAMMLPT(
+    STAmount const& asset1,
+    STAmount const& asset2,
+    Issue const& lptIssue,
+    std::uint8_t weight1);
+
+}  // namespace ripple
+
+#endif  // RIPPLE_APP_MISC_AMM_FORMULAE_H_INCLUDED

--- a/src/ripple/app/misc/impl/AMM.cpp
+++ b/src/ripple/app/misc/impl/AMM.cpp
@@ -1,0 +1,206 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#include <ripple/app/misc/AMM.h>
+
+namespace ripple {
+
+AccountID
+calcAMMGroupAccountID(Issue const& issue1, Issue const& issue2)
+{
+    if (isXRP(issue1.currency))
+        return calcAccountID(issue2);
+    else if (isXRP(issue2.currency))
+        return calcAccountID(issue1);
+    else if (issue1 > issue2)
+        return calcAccountID(
+            issue1.account, issue1.currency, issue2.account, issue2.currency);
+    return calcAccountID(
+        issue2.account, issue2.currency, issue1.account, issue1.currency);
+}
+
+std::pair<AccountID, std::uint8_t>
+calcAMMAccountIDAndWeight(int weight1, Issue const& issue1, Issue const& issue2)
+{
+    auto const weight2 = 100 - weight1;
+    if (isXRP(issue1.currency))
+        return std::make_pair(calcAccountID(weight2, issue2), weight2);
+    else if (isXRP(issue2.currency))
+        return std::make_pair(calcAccountID(weight1, issue1), weight1);
+    else if (issue1 > issue2)
+        return std::make_pair(
+            calcAccountID(
+                weight1,
+                issue1.account,
+                issue1.currency,
+                issue2.account,
+                issue2.currency),
+            weight1);
+    return std::make_pair(
+        calcAccountID(
+            weight2,
+            issue2.account,
+            issue2.currency,
+            issue1.account,
+            issue1.currency),
+        weight2);
+}
+
+std::pair<std::uint8_t, std::uint8_t>
+canonicalWeights(int weight, Issue const& in, Issue const& out)
+{
+    if (isXRP(in.currency))
+        return std::make_pair(100 - weight, weight);
+    else if (isXRP(out.currency))
+        return std::make_pair(weight, 100 - weight);
+    else if (in > out)
+        return std::make_pair(weight, 100 - weight);
+    return std::make_pair(100 - weight, weight);
+}
+
+Currency
+calcLPTCurrency(AccountID const& ammAccountID)
+{
+    return Currency::fromVoid(ammAccountID.data());
+}
+
+Issue
+calcLPTIssue(AccountID const& ammAccountID)
+{
+    return Issue(calcLPTCurrency(ammAccountID), ammAccountID);
+}
+
+std::pair<STAmount, STAmount>
+getAMMReserves(
+    ReadView const& view,
+    AccountID const& ammAccountID,
+    Issue const& in,
+    Issue const& out,
+    beast::Journal const j)
+{
+    auto const assetInBalance = accountHolds(
+        view,
+        ammAccountID,
+        in.currency,
+        in.account,
+        FreezeHandling::fhZERO_IF_FROZEN,
+        j);
+    auto const assetOutBalance = accountHolds(
+        view,
+        ammAccountID,
+        out.currency,
+        out.account,
+        FreezeHandling::fhZERO_IF_FROZEN,
+        j);
+    return std::make_pair(assetInBalance, assetOutBalance);
+}
+
+template <typename F>
+void
+forEeachAMMTrustLine(ReadView const& view, AccountID const& ammAccountID, F&& f)
+{
+    forEachItem(view, ammAccountID, [&](std::shared_ptr<SLE const> const& sle) {
+        if (sle && sle->getType() == ltRIPPLE_STATE)
+        {
+            auto const line = ripple::RippleState::makeItem(ammAccountID, sle);
+            f(*line);
+        }
+    });
+}
+
+std::tuple<STAmount, STAmount, STAmount>
+getAMMReserves(
+    ReadView const& view,
+    AccountID const& ammAccountID,
+    std::optional<AccountID> const& lpAccountID,
+    std::optional<Issue> const& issue1,
+    std::optional<Issue> const& issue2,
+    beast::Journal const j)
+{
+    assert(!issue2 || (issue2 && issue1));
+    std::optional<Issue> issue1Opt{};
+    std::optional<Issue> issue2Opt = xrpIssue();
+    auto const lptIssue = calcLPTIssue(ammAccountID);
+    STAmount lpTokens{lptIssue, 0};
+    forEeachAMMTrustLine(
+        view, ammAccountID, [&](ripple::RippleState const& line) {
+            // TODO Can the tokens be frozen?
+            auto balance = line.getBalance();
+            if (balance.getCurrency() == lptIssue.currency &&
+                (!lpAccountID || *lpAccountID == line.getAccountIDPeer()))
+            {
+                balance.setIssuer(ammAccountID);
+                if (balance.negative())
+                    balance.negate();
+                lpTokens += balance;
+                return true;
+            }
+            if (!issue1Opt)
+            {
+                issue1Opt = balance.issue();
+                issue1Opt->account = line.getAccountIDPeer();
+            }
+            else
+            {
+                issue2Opt = balance.issue();
+                issue2Opt->account = line.getAccountIDPeer();
+            }
+            return true;
+        });
+    if (!issue1Opt)
+        return std::make_tuple(STAmount{0}, STAmount{0}, STAmount{0});
+    // re-order if needed
+    if (issue1 && *issue1Opt != *issue1)
+        issue1Opt.swap(issue2Opt);
+    // validate issues
+    if ((issue1 && *issue1Opt != *issue1) || (issue2 && *issue2Opt != *issue2))
+        return std::make_tuple(STAmount{0}, STAmount{0}, STAmount{0});
+    // Get reserves given the issues.
+    // We want to make sure there is no freeze.
+    auto const [balance1, balance2] =
+        getAMMReserves(view, ammAccountID, *issue1Opt, *issue2Opt, j);
+    return std::make_tuple(balance1, balance2, lpTokens);
+}
+
+STAmount
+getAMMLPTokens(
+    ReadView const& view,
+    AccountID const& ammAccountID,
+    std::optional<AccountID> const& lpAccount,
+    beast::Journal const j)
+{
+    auto const lptIssue = calcLPTIssue(ammAccountID);
+    STAmount lpTokens{lptIssue, 0};
+    forEeachAMMTrustLine(
+        view, ammAccountID, [&](ripple::RippleState const& line) {
+            auto balance = line.getBalance();
+            if (balance.getCurrency() == lptIssue.currency)
+            {
+                balance.setIssuer(ammAccountID);
+                if (balance.negative())
+                    balance.negate();
+                if (lpAccount && *lpAccount == line.getAccountIDPeer())
+                    lpTokens = balance;
+                else
+                    lpTokens += balance;
+            }
+        });
+    return lpTokens;
+}
+
+}  // namespace ripple

--- a/src/ripple/app/misc/impl/AMM_formulae.cpp
+++ b/src/ripple/app/misc/impl/AMM_formulae.cpp
@@ -1,0 +1,65 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/misc/AMM_formulae.h>
+
+#include <cmath>
+
+namespace ripple {
+
+namespace detail {
+#pragma message( \
+    "THIS IS TEMPORARY. PORTABLE POW() AND LIB FOR IOU/XRP OPS MUST BE IMPLEMENTED.")
+
+double
+saToDouble(STAmount const& a)
+{
+    return static_cast<double>(a.mantissa() * std::pow(10, a.exponent()));
+}
+
+STAmount
+toSTAfromDouble(double v, Issue const& issue)
+{
+    auto exponent = decimal_places(v);
+    std::int64_t mantissa = v * pow(10, exponent);
+    exponent = -exponent;
+    return STAmount(issue, mantissa, exponent);
+}
+
+STAmount
+sqrt(STAmount const& a)
+{
+    return toSTAfromDouble(std::sqrt(saToDouble(a)), a.issue());
+}
+
+}  // namespace detail
+
+STAmount
+calcAMMLPT(
+    STAmount const& asset1,
+    STAmount const& asset2,
+    Issue const& lptIssue,
+    std::uint8_t weight1)
+{
+    assert(weight1 == 50);
+
+    return detail::sqrt(multiply(asset1, asset2, lptIssue));
+}
+
+}  // namespace ripple

--- a/src/ripple/app/tx/impl/AMMCreate.cpp
+++ b/src/ripple/app/tx/impl/AMMCreate.cpp
@@ -1,0 +1,248 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/misc/AMM.h>
+#include <ripple/app/misc/AMM_formulae.h>
+#include <ripple/app/tx/impl/AMMCreate.h>
+#include <ripple/ledger/Sandbox.h>
+#include <ripple/ledger/View.h>
+#include <ripple/protocol/Feature.h>
+#include <ripple/protocol/STAccount.h>
+
+namespace ripple {
+
+TxConsequences
+AMMCreate::makeTxConsequences(PreflightContext const& ctx)
+{
+    return TxConsequences{ctx.tx};
+}
+
+NotTEC
+AMMCreate::preflight(PreflightContext const& ctx)
+{
+    auto const ret = preflight1(ctx);
+    if (!isTesSuccess(ret))
+        return ret;
+
+    auto& tx = ctx.tx;
+    auto& j = ctx.j;
+
+    if (tx.getFlags() != 0)
+    {
+        JLOG(j.debug()) << "Malformed AMM Instance: invalid flags.";
+        return temINVALID_FLAG;
+    }
+
+    auto const saAsset1 = tx[sfAsset1Details];
+    auto const saAsset2 = tx[sfAsset2Details];
+    if (saAsset1.issue() == saAsset2.issue())
+    {
+        JLOG(j.debug())
+            << "Malformed AMM Instance: assets can not have the same issue.";
+        return temBAD_AMM;
+    }
+    if (saAsset1 <= beast::zero || saAsset2 <= beast::zero)
+    {
+        JLOG(j.debug()) << "Malformed AMM Instance: bad amount.";
+        return temBAD_AMOUNT;
+    }
+
+    // We don't allow a non-native currency to use the currency code XRP.
+    if (badCurrency() == saAsset1.getCurrency() ||
+        badCurrency() == saAsset2.getCurrency())
+    {
+        JLOG(j.debug()) << "Malformed AMM Instance: bad currency.";
+        return temBAD_CURRENCY;
+    }
+
+    if ((saAsset1.native() && saAsset1.native() != !saAsset1.getIssuer()) ||
+        (saAsset2.native() && saAsset2.native() != !saAsset2.getIssuer()))
+    {
+        JLOG(j.debug()) << "Malformed AMM Instance: bad issuer.";
+        return temBAD_ISSUER;
+    }
+
+    // TODO can the fee be 0?
+    auto const tfee = tx[sfTradingFee];
+    if (tfee > 70000)
+    {
+        JLOG(j.debug()) << "Malformed AMM Instance: invalid trading fee.";
+        return temBAD_FEE;
+    }
+
+    return preflight2(ctx);
+}
+
+TER
+AMMCreate::preclaim(PreclaimContext const& ctx)
+{
+    auto& tx = ctx.tx;
+    auto& j = ctx.j;
+    auto const id = tx[sfAccount];
+
+    auto const saAsset1 = tx[sfAsset1Details];
+    auto const saAsset2 = tx[sfAsset2Details];
+    if ((!saAsset1.native() &&
+         isGlobalFrozen(ctx.view, saAsset1.getIssuer())) ||
+        (!saAsset2.native() && isGlobalFrozen(ctx.view, saAsset2.getIssuer())))
+    {
+        JLOG(j.debug()) << "AMM Instance involves frozen asset";
+        return tecFROZEN;
+    }
+
+    auto const issue1Balance = accountHolds(
+        ctx.view,
+        id,
+        saAsset1.issue().currency,
+        saAsset1.issue().account,
+        FreezeHandling::fhZERO_IF_FROZEN,
+        ctx.j);
+    auto const issue2Balance = accountHolds(
+        ctx.view,
+        id,
+        saAsset2.issue().currency,
+        saAsset2.issue().account,
+        FreezeHandling::fhZERO_IF_FROZEN,
+        ctx.j);
+    if (issue1Balance < saAsset1 || issue2Balance < saAsset2)
+    {
+        JLOG(j.debug()) << "AMM Instance has insufficient funds";
+        return tecUNFUNDED_PAYMENT;
+    }
+
+    return tesSUCCESS;
+}
+
+void
+AMMCreate::preCompute()
+{
+    return Transactor::preCompute();
+}
+
+std::pair<TER, bool>
+AMMCreate::applyGuts(Sandbox& sb)
+{
+    auto const saAsset1 = ctx_.tx[sfAsset1Details];
+    auto const saAsset2 = ctx_.tx[sfAsset2Details];
+    auto const weight1 = ctx_.tx.isFieldPresent(sfAssetWeight)
+        ? ctx_.tx.getFieldU8(sfAssetWeight)
+        : 50;
+
+    // AMM's creator account.
+    auto const sleCreator = sb.peek(keylet::account(account_));
+    if (!sleCreator)
+        return {terNO_ACCOUNT, false};
+
+    // The weight matches issue's canonical order.
+    auto const [ammAccountID, weight] =
+        calcAMMAccountIDAndWeight(weight1, saAsset1.issue(), saAsset2.issue());
+
+    // AMM already exists.
+    if (sb.peek(keylet::account(ammAccountID)))
+    {
+        JLOG(j_.debug()) << "AMM Instance: AMM already exists.";
+        return {tefINTERNAL, false};
+    }
+
+    // LP Token already exists.
+    auto const lptIssue = calcLPTIssue(ammAccountID);
+    if (sb.read(keylet::line(ammAccountID, lptIssue)))
+    {
+        JLOG(j_.debug()) << "AMM Instance: LP Token already exists.";
+        return {tefINTERNAL, false};
+    }
+
+    // Create AMM Root Account.
+    auto sleAMM = std::make_shared<SLE>(keylet::account(ammAccountID));
+    sleAMM->setAccountID(sfAccount, ammAccountID);
+    sleAMM->setFieldAmount(sfBalance, STAmount{});
+    std::uint32_t const seqno{
+        view().rules().enabled(featureDeletableAccounts) ? view().seq() : 1};
+    sleAMM->setFieldU32(sfSequence, seqno);
+    sleAMM->setFieldU8(sfAssetWeight, weight);
+    sleAMM->setFieldU32(sfTradingFee, ctx_.tx[sfTradingFee]);
+    // Internal flag to ignore reserves requirement for AMM.
+    sleAMM->setFieldU32(sfFlags, lsfAMM);
+    sb.insert(sleAMM);
+
+    // Add directory entry so the payment engine
+    // can retrieve all AMM's with different weights.
+    auto amms = calcAMMGroupAccountID(saAsset1.issue(), saAsset2.issue());
+    auto const ammNode = sb.dirAppend(
+        keylet::ownerDir(amms),
+        keylet::amm(ammAccountID),
+        describeOwnerDir(amms));
+    if (!ammNode)
+    {
+        JLOG(j_.debug()) << "AMM Instance: failed to add AMM entry.";
+        return {tecDIR_FULL, true};
+    }
+
+    // Calculate initial LPT balance.
+    auto const lpTokens = calcAMMLPT(saAsset1, saAsset2, lptIssue, weight1);
+    // Send LPT to LP.
+    auto res = accountSend(sb, ammAccountID, account_, lpTokens, ctx_.journal);
+    if (res != tesSUCCESS)
+    {
+        JLOG(j_.debug()) << "AMM Instance: failed to send LPT " << lpTokens;
+        return {res, false};
+    }
+
+    // Send asset1.
+    res = accountSend(sb, account_, ammAccountID, saAsset1, ctx_.journal);
+    if (res != tesSUCCESS)
+    {
+        JLOG(j_.debug()) << "AMM Instance: failed to send " << saAsset1;
+        return {res, false};
+    }
+
+    // Send asset2.
+    res = accountSend(sb, account_, ammAccountID, saAsset2, ctx_.journal);
+    if (res != tesSUCCESS)
+        JLOG(j_.debug()) << "AMM Instance: failed to send " << saAsset2;
+    else
+        JLOG(j_.debug()) << "AMM Instance: success " << ammAccountID << " "
+                         << lptIssue << saAsset1 << " " << saAsset2 << " "
+                         << weight;
+
+    return {res, res == tesSUCCESS};
+}
+
+TER
+AMMCreate::doApply()
+{
+    // This is the ledger view that we work against. Transactions are applied
+    // as we go on processing transactions.
+    Sandbox sb(&ctx_.view());
+
+    // This is a ledger with just the fees paid and any unfunded or expired
+    // offers we encounter removed. It's used when handling Fill-or-Kill offers,
+    // if the order isn't going to be placed, to avoid wasting the work we did.
+    Sandbox sbCancel(&ctx_.view());
+
+    auto const result = applyGuts(sb);
+    if (result.second)
+        sb.apply(ctx_.rawView());
+    else
+        sbCancel.apply(ctx_.rawView());
+
+    return result.first;
+}
+
+}  // namespace ripple

--- a/src/ripple/app/tx/impl/AMMCreate.h
+++ b/src/ripple/app/tx/impl/AMMCreate.h
@@ -1,0 +1,73 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TX_AMMCREATE_H_INCLUDED
+#define RIPPLE_TX_AMMCREATE_H_INCLUDED
+
+#include <ripple/app/tx/impl/Transactor.h>
+
+namespace ripple {
+
+class Sandbox;
+
+/** AMMCreate implements Automatic Market Maker(AMM) creation Transactor.
+ *  It creates a new AMM instance with two tokens.
+ *  AMM instance creates AccountRoot (no private key)
+ *  object for book-keeping of the AMM and XRP balance if one of the tokens
+ *  is XRP, a trustline for each IOU token, a trustline to keep track
+ *  of Liquidity Provider (LP) Tokens (LP share in the AMM instance)
+ *  and a directory entry to keep track of the AMM with different weights
+ *  (50/50 in the first release).
+ */
+class AMMCreate : public Transactor
+{
+public:
+    static constexpr ConsequencesFactoryType ConsequencesFactory{Custom};
+
+    explicit AMMCreate(ApplyContext& ctx) : Transactor(ctx)
+    {
+    }
+
+    static TxConsequences
+    makeTxConsequences(PreflightContext const& ctx);
+
+    /** Enforce constraints beyond those of the Transactor base class. */
+    static NotTEC
+    preflight(PreflightContext const& ctx);
+
+    /** Enforce constraints beyond those of the Transactor base class. */
+    static TER
+    preclaim(PreclaimContext const& ctx);
+
+    /** Gather information beyond what the Transactor base class gathers. */
+    void
+    preCompute() override;
+
+    /** Attempt to create the AMM instance. */
+    TER
+    doApply() override;
+
+private:
+    std::pair<TER, bool>
+    applyGuts(Sandbox& view);
+};
+
+}  // namespace ripple
+
+#endif  // RIPPLE_TX_AMMCREATE_H_INCLUDED

--- a/src/ripple/app/tx/impl/InvariantCheck.cpp
+++ b/src/ripple/app/tx/impl/InvariantCheck.cpp
@@ -131,12 +131,16 @@ XRPNotCreated::visitEntry(
 
 bool
 XRPNotCreated::finalize(
-    STTx const&,
+    STTx const& tx,
     TER const,
     XRPAmount const fee,
     ReadView const&,
     beast::Journal const& j)
 {
+    // AMM is created with AMMInstanceCreate, not payment
+    if (tx.getTxnType() == ttAMM_CREATE)
+        return true;
+
     // The net change should never be positive, as this would mean that the
     // transaction created XRP out of thin air. That's not possible.
     if (drops_ > 0)
@@ -366,6 +370,7 @@ LedgerEntryTypesMatch::visitEntry(
             case ltCHECK:
             case ltDEPOSIT_PREAUTH:
             case ltNEGATIVE_UNL:
+            case ltAMM:
                 break;
             default:
                 invalidTypeAdded_ = true;
@@ -466,7 +471,8 @@ ValidNewAccountRoot::finalize(
     }
 
     // From this point on we know exactly one account was created.
-    if (tx.getTxnType() == ttPAYMENT && result == tesSUCCESS)
+    if ((tx.getTxnType() == ttPAYMENT || tx.getTxnType() == ttAMM_CREATE) &&
+        result == tesSUCCESS)
     {
         std::uint32_t const startingSeq{
             view.rules().enabled(featureDeletableAccounts) ? view.seq() : 1};

--- a/src/ripple/app/tx/impl/applySteps.cpp
+++ b/src/ripple/app/tx/impl/applySteps.cpp
@@ -18,6 +18,7 @@
 //==============================================================================
 
 #include <ripple/app/tx/applySteps.h>
+#include <ripple/app/tx/impl/AMMCreate.h>
 #include <ripple/app/tx/impl/ApplyContext.h>
 #include <ripple/app/tx/impl/CancelCheck.h>
 #include <ripple/app/tx/impl/CancelOffer.h>
@@ -132,6 +133,8 @@ invoke_preflight(PreflightContext const& ctx)
         case ttFEE:
         case ttUNL_MODIFY:
             return invoke_preflight_helper<Change>(ctx);
+        case ttAMM_CREATE:
+            return invoke_preflight_helper<AMMCreate>(ctx);
         default:
             assert(false);
             return {temUNKNOWN, TxConsequences{temUNKNOWN}};
@@ -223,6 +226,8 @@ invoke_preclaim(PreclaimContext const& ctx)
         case ttFEE:
         case ttUNL_MODIFY:
             return invoke_preclaim<Change>(ctx);
+        case ttAMM_CREATE:
+            return invoke_preclaim<AMMCreate>(ctx);
         default:
             assert(false);
             return temUNKNOWN;
@@ -276,6 +281,8 @@ invoke_calculateBaseFee(ReadView const& view, STTx const& tx)
         case ttFEE:
         case ttUNL_MODIFY:
             return Change::calculateBaseFee(view, tx);
+        case ttAMM_CREATE:
+            return AMMCreate::calculateBaseFee(view, tx);
         default:
             assert(false);
             return FeeUnit64{0};
@@ -406,6 +413,10 @@ invoke_apply(ApplyContext& ctx)
         case ttFEE:
         case ttUNL_MODIFY: {
             Change p(ctx);
+            return p();
+        }
+        case ttAMM_CREATE: {
+            AMMCreate p(ctx);
             return p();
         }
         default:

--- a/src/ripple/ledger/ApplyView.h
+++ b/src/ripple/ledger/ApplyView.h
@@ -274,9 +274,9 @@ public:
         Keylet const& key,
         std::function<void(std::shared_ptr<SLE> const&)> const& describe)
     {
-        if (key.type != ltOFFER)
+        if (key.type != ltOFFER && key.type != ltAMM)
         {
-            assert(!"Only Offers are appended to book directories.  "
+            assert(!"Only Offers and AMMs are appended to book directories.  "
                 "Call dirInsert() instead.");
             return std::nullopt;
         }

--- a/src/ripple/ledger/impl/View.cpp
+++ b/src/ripple/ledger/impl/View.cpp
@@ -356,7 +356,9 @@ xrpLiquid(
 
     auto const balance = view.balanceHook(id, xrpAccount(), fullBalance);
 
-    STAmount amount = balance - reserve;
+    // AMM doesn't require the reserves
+    STAmount amount =
+        (sle->getFlags() & lsfAMM) ? balance : (balance - reserve);
     if (balance < reserve)
         amount.clear();
 

--- a/src/ripple/net/impl/RPCCall.cpp
+++ b/src/ripple/net/impl/RPCCall.cpp
@@ -1241,6 +1241,7 @@ public:
             {"account_objects", &RPCParser::parseAccountItems, 1, 5},
             {"account_offers", &RPCParser::parseAccountItems, 1, 4},
             {"account_tx", &RPCParser::parseAccountTransactions, 1, 8},
+            {"amm_info", &RPCParser::parseAsIs, 1, 2},
             {"book_offers", &RPCParser::parseBookOffers, 2, 7},
             {"can_delete", &RPCParser::parseCanDelete, 0, 1},
             {"channel_authorize", &RPCParser::parseChannelAuthorize, 3, 4},

--- a/src/ripple/protocol/Indexes.h
+++ b/src/ripple/protocol/Indexes.h
@@ -225,6 +225,10 @@ escrow(AccountID const& src, std::uint32_t seq) noexcept;
 Keylet
 payChan(AccountID const& src, AccountID const& dst, std::uint32_t seq) noexcept;
 
+/** AMM entry */
+Keylet
+amm(AccountID const& amm) noexcept;
+
 }  // namespace keylet
 
 // Everything below is deprecated and should be removed in favor of keylets:

--- a/src/ripple/protocol/LedgerFormats.h
+++ b/src/ripple/protocol/LedgerFormats.h
@@ -149,6 +149,12 @@ enum LedgerEntryType : std::uint16_t
      */
     ltNEGATIVE_UNL = 0x004e,
 
+    /** The ledger object which tracks the AMM.
+
+       \sa keylet::amm
+    */
+    ltAMM = 0x0079,
+
     //---------------------------------------------------------------------------
     /** A special type, matching any ledger entry type.
 
@@ -237,6 +243,9 @@ enum LedgerSpecificFlags {
 
     // ltSIGNER_LIST
     lsfOneOwnerCount = 0x00010000,  // True, uses only one OwnerCount
+
+    // ltAMM
+    lsfAMM = 0x00010000, // True, AMM account
 };
 
 //------------------------------------------------------------------------------

--- a/src/ripple/protocol/SField.h
+++ b/src/ripple/protocol/SField.h
@@ -341,6 +341,7 @@ extern SF_UINT8 const sfMethod;
 extern SF_UINT8 const sfTransactionResult;
 extern SF_UINT8 const sfTickSize;
 extern SF_UINT8 const sfUNLModifyDisabling;
+extern SF_UINT8 const sfAssetWeight;
 
 // 16-bit integers
 extern SF_UINT16 const sfLedgerEntryType;
@@ -364,6 +365,7 @@ extern SF_UINT32 const sfTransferRate;
 extern SF_UINT32 const sfWalletSize;
 extern SF_UINT32 const sfOwnerCount;
 extern SF_UINT32 const sfDestinationTag;
+extern SF_UINT32 const sfTradingFee;
 
 // 32-bit integers (uncommon)
 extern SF_UINT32 const sfHighQualityIn;
@@ -448,6 +450,8 @@ extern SF_AMOUNT const sfHighLimit;
 extern SF_AMOUNT const sfFee;
 extern SF_AMOUNT const sfSendMax;
 extern SF_AMOUNT const sfDeliverMin;
+extern SF_AMOUNT const sfAsset1Details;
+extern SF_AMOUNT const sfAsset2Details;
 
 // currency amount (uncommon)
 extern SF_AMOUNT const sfMinimumOffer;
@@ -486,6 +490,7 @@ extern SF_ACCOUNT const sfAuthorize;
 extern SF_ACCOUNT const sfUnauthorize;
 extern SF_ACCOUNT const sfTarget;
 extern SF_ACCOUNT const sfRegularKey;
+extern SF_ACCOUNT const sfAMMAccount;
 
 // path set
 extern SField const sfPaths;

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -81,6 +81,7 @@ enum TEMcodes : TERUnderlyingType {
     // - Cannot succeed in any imagined ledger.
     temMALFORMED = -299,
 
+    temBAD_AMM,
     temBAD_AMOUNT,
     temBAD_CURRENCY,
     temBAD_EXPIRATION,

--- a/src/ripple/protocol/TxFormats.h
+++ b/src/ripple/protocol/TxFormats.h
@@ -124,6 +124,8 @@ enum TxType : std::uint16_t
     /** This transaction type installs a hook. */
     ttHOOK_SET [[maybe_unused]] = 22,
 
+    /** This transaction type creates an AMM instance */
+    ttAMM_CREATE = 23,
     /** This system-generated transaction type is used to update the status of the various amendments.
 
         For details, see: https://xrpl.org/amendments.html

--- a/src/ripple/protocol/impl/Indexes.cpp
+++ b/src/ripple/protocol/impl/Indexes.cpp
@@ -325,6 +325,12 @@ payChan(AccountID const& src, AccountID const& dst, std::uint32_t seq) noexcept
         indexHash(LedgerNameSpace::XRP_PAYMENT_CHANNEL, src, dst, seq)};
 }
 
+Keylet
+amm(AccountID const& amm) noexcept
+{
+    return {ltAMM, indexHash(LedgerNameSpace::ACCOUNT, amm)};
+}
+
 }  // namespace keylet
 
 }  // namespace ripple

--- a/src/ripple/protocol/impl/LedgerFormats.cpp
+++ b/src/ripple/protocol/impl/LedgerFormats.cpp
@@ -54,6 +54,8 @@ LedgerFormats::LedgerFormats()
             {sfDomain, soeOPTIONAL},
             {sfTickSize, soeOPTIONAL},
             {sfTicketCount, soeOPTIONAL},
+            {sfAssetWeight, soeOPTIONAL},
+            {sfTradingFee, soeOPTIONAL},
         },
         commonFields);
 

--- a/src/ripple/protocol/impl/SField.cpp
+++ b/src/ripple/protocol/impl/SField.cpp
@@ -84,6 +84,7 @@ CONSTRUCT_UNTYPED_SFIELD(sfMetadata,            "Metadata",             METADATA
 CONSTRUCT_TYPED_SFIELD(sfCloseResolution,       "CloseResolution",      UINT8,      1);
 CONSTRUCT_TYPED_SFIELD(sfMethod,                "Method",               UINT8,      2);
 CONSTRUCT_TYPED_SFIELD(sfTransactionResult,     "TransactionResult",    UINT8,      3);
+CONSTRUCT_TYPED_SFIELD(sfAssetWeight,           "AssetWeight",          UINT8,      5);
 
 // 8-bit integers (uncommon)
 CONSTRUCT_TYPED_SFIELD(sfTickSize,              "TickSize",             UINT8,     16);
@@ -111,6 +112,7 @@ CONSTRUCT_TYPED_SFIELD(sfTransferRate,          "TransferRate",         UINT32, 
 CONSTRUCT_TYPED_SFIELD(sfWalletSize,            "WalletSize",           UINT32,    12);
 CONSTRUCT_TYPED_SFIELD(sfOwnerCount,            "OwnerCount",           UINT32,    13);
 CONSTRUCT_TYPED_SFIELD(sfDestinationTag,        "DestinationTag",       UINT32,    14);
+CONSTRUCT_TYPED_SFIELD(sfTradingFee,            "TradingFee",           UINT32,    15);
 
 // 32-bit integers (uncommon)
 CONSTRUCT_TYPED_SFIELD(sfHighQualityIn,         "HighQualityIn",        UINT32,    16);
@@ -196,6 +198,8 @@ CONSTRUCT_TYPED_SFIELD(sfHighLimit,             "HighLimit",            AMOUNT, 
 CONSTRUCT_TYPED_SFIELD(sfFee,                   "Fee",                  AMOUNT,     8);
 CONSTRUCT_TYPED_SFIELD(sfSendMax,               "SendMax",              AMOUNT,     9);
 CONSTRUCT_TYPED_SFIELD(sfDeliverMin,            "DeliverMin",           AMOUNT,    10);
+CONSTRUCT_TYPED_SFIELD(sfAsset1Details,         "Asset1Details",        AMOUNT,    11);
+CONSTRUCT_TYPED_SFIELD(sfAsset2Details,         "Asset2Details",        AMOUNT,    12);
 
 // currency amount (uncommon)
 CONSTRUCT_TYPED_SFIELD(sfMinimumOffer,          "MinimumOffer",         AMOUNT,    16);
@@ -235,6 +239,7 @@ CONSTRUCT_TYPED_SFIELD(sfAuthorize,             "Authorize",            ACCOUNT,
 CONSTRUCT_TYPED_SFIELD(sfUnauthorize,           "Unauthorize",          ACCOUNT,    6);
 //                                                                                  7 is currently unused
 CONSTRUCT_TYPED_SFIELD(sfRegularKey,            "RegularKey",           ACCOUNT,    8);
+CONSTRUCT_TYPED_SFIELD(sfAMMAccount,            "AMMAccount",           ACCOUNT,    9);
 
 // vector of 256-bit
 CONSTRUCT_TYPED_SFIELD(sfIndexes,               "Indexes",              VECTOR256,  1, SField::sMD_Never);

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -117,6 +117,7 @@ transResults()
         MAKE_ERROR(telCAN_NOT_QUEUE_FULL,     "Can not queue at this time: queue is full."),
 
         MAKE_ERROR(temMALFORMED,              "Malformed transaction."),
+        MAKE_ERROR(temBAD_AMOUNT,             "Malformed: Bad AMM."),
         MAKE_ERROR(temBAD_AMOUNT,             "Can only send positive amounts."),
         MAKE_ERROR(temBAD_CURRENCY,           "Malformed: Bad currency."),
         MAKE_ERROR(temBAD_EXPIRATION,         "Malformed: Bad expiration."),

--- a/src/ripple/protocol/impl/TxFormats.cpp
+++ b/src/ripple/protocol/impl/TxFormats.cpp
@@ -79,6 +79,14 @@ TxFormats::TxFormats()
         },
         commonFields);
 
+    add(jss::AMMInstanceCreate,
+        ttAMM_CREATE,
+        {
+            {sfAsset1Details, soeREQUIRED},
+            {sfAsset2Details, soeREQUIRED},
+            {sfTradingFee, soeREQUIRED},
+        },
+        commonFields);
     add(jss::OfferCancel,
         ttOFFER_CANCEL,
         {

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -46,8 +46,13 @@ JSS(Account);                // in: TransactionSign; field.
 JSS(AccountDelete);          // transaction type.
 JSS(AccountRoot);            // ledger type.
 JSS(AccountSet);             // transaction type.
+JSS(AMMAccount);             // field
+JSS(AMMInstanceCreate);      // transaction type
 JSS(Amendments);             // ledger type.
 JSS(Amount);                 // in: TransactionSign; field.
+JSS(Asset1Details);          // in/out: AMM IOU/XRP pool amount
+JSS(Asset2Details);          // in/out: AMM IOU pool amount
+JSS(AssetWeight);            // in/out: AMM asset1 weight
 JSS(Check);                  // ledger type.
 JSS(CheckCancel);            // transaction type.
 JSS(CheckCash);              // transaction type.
@@ -97,6 +102,7 @@ JSS(TakerPays);              // field.
 JSS(Ticket);                 // ledger type.
 JSS(TicketCreate);           // transaction type.
 JSS(TxnSignature);           // field.
+JSS(TradingFee);             // in/out: AMM trading fee
 JSS(TransactionType);        // in: TransactionSign.
 JSS(TransferRate);           // in: TransferRate.
 JSS(TrustSet);               // transaction type.

--- a/src/ripple/rpc/handlers/AMMInfo.cpp
+++ b/src/ripple/rpc/handlers/AMMInfo.cpp
@@ -1,0 +1,96 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#include <ripple/app/misc/AMM.h>
+#include <ripple/json/json_value.h>
+#include <ripple/ledger/ReadView.h>
+#include <ripple/net/RPCErr.h>
+#include <ripple/protocol/Issue.h>
+#include <ripple/rpc/Context.h>
+#include <ripple/rpc/impl/RPCHelpers.h>
+
+namespace ripple {
+
+std::optional<AccountID>
+getAccount(Json::Value const& v, Json::Value& result)
+{
+    std::string strIdent(v.asString());
+    AccountID accountID;
+
+    if (auto jv = RPC::accountFromString(accountID, strIdent))
+    {
+        for (auto it = jv.begin(); it != jv.end(); ++it)
+            result[it.memberName()] = (*it);
+
+        return std::nullopt;
+    }
+    return std::optional<AccountID>(accountID);
+}
+
+Json::Value
+doAMMInfo(RPC::JsonContext& context)
+{
+    auto const& params(context.params);
+    Json::Value result;
+    std::optional<AccountID> accountID;
+
+    if (!params.isMember(jss::AMMAccount))
+        return RPC::missing_field_error(jss::AMMAccount);
+
+    auto const ammAccountID = getAccount(params[jss::AMMAccount], result);
+    if (!ammAccountID)
+    {
+        RPC::inject_error(rpcACT_MALFORMED, result);
+        return result;
+    }
+
+    std::shared_ptr<ReadView const> ledger;
+    result = RPC::lookupLedger(ledger, context);
+    if (!ledger)
+        return result;
+
+    if (params.isMember(jss::account))
+    {
+        accountID = getAccount(params[jss::account], result);
+        if (!accountID)
+        {
+            RPC::inject_error(rpcACT_MALFORMED, result);
+            return result;
+        }
+    }
+
+    auto const sle = ledger->read(keylet::account(*ammAccountID));
+    if (sle == nullptr)
+        return rpcError(rpcACT_NOT_FOUND);
+
+    auto const [asset1Balance, asset2Balance, lptAMMBalance] = getAMMReserves(
+        *ledger,
+        *ammAccountID,
+        accountID,
+        std::nullopt,
+        std::nullopt,
+        context.j);
+
+    asset1Balance.setJson(result[jss::Asset1Details]);
+    asset2Balance.setJson(result[jss::Asset2Details]);
+    lptAMMBalance.setJson(result[jss::balance]);
+
+    return result;
+}
+
+}  // namespace ripple

--- a/src/ripple/rpc/handlers/Handlers.h
+++ b/src/ripple/rpc/handlers/Handlers.h
@@ -39,6 +39,8 @@ doAccountOffers(RPC::JsonContext&);
 Json::Value
 doAccountTxJson(RPC::JsonContext&);
 Json::Value
+doAMMInfo(RPC::JsonContext&);
+Json::Value
 doBookOffers(RPC::JsonContext&);
 Json::Value
 doBlackList(RPC::JsonContext&);

--- a/src/ripple/rpc/impl/Handler.cpp
+++ b/src/ripple/rpc/impl/Handler.cpp
@@ -70,6 +70,7 @@ Handler const handlerArray[]{
     {"account_objects", byRef(&doAccountObjects), Role::USER, NO_CONDITION},
     {"account_offers", byRef(&doAccountOffers), Role::USER, NO_CONDITION},
     {"account_tx", byRef(&doAccountTxJson), Role::USER, NO_CONDITION},
+    {"amm_info", byRef(&doAMMInfo), Role::USER, NO_CONDITION},
     {"blacklist", byRef(&doBlackList), Role::ADMIN, NO_CONDITION},
     {"book_offers", byRef(&doBookOffers), Role::USER, NO_CONDITION},
     {"can_delete", byRef(&doCanDelete), Role::ADMIN, NO_CONDITION},

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -1,0 +1,286 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+#include <ripple/app/misc/AMM.h>
+#include <boost/regex.hpp>
+#include <test/jtx.h>
+#include <test/jtx/AMM.h>
+#include <test/jtx/PathSet.h>
+
+namespace ripple {
+namespace test {
+
+template <typename E>
+Json::Value
+rpc(E& env, std::string const& command, Json::Value const& v)
+{
+    return env.rpc("json", command, to_string(v));
+}
+
+using idmap_t = std::map<std::string, std::string>;
+
+/** Wrapper class. Maintains a map of account id -> name.
+ * The map is used to output a user-friendly account name
+ * instead of the hash.
+ */
+class AccountX : public jtx::Account
+{
+    static inline idmap_t idmap_;
+
+public:
+    AccountX(std::string const& name) : jtx::Account(name)
+    {
+        idmap_[to_string(id())] = name;
+    }
+    idmap_t const
+    idmap() const
+    {
+        return idmap_;
+    }
+};
+
+/** Map accound id to name.
+ */
+std::string
+domap(std::string const& s, std::optional<idmap_t> const& idmap)
+{
+    if (!idmap)
+        return s;
+    std::string str = s;
+    for (auto [id, name] : *idmap)
+    {
+        boost::regex re(id.c_str());
+        str = boost::regex_replace(str, re, name);
+    }
+    return str;
+}
+
+template <typename E>
+void
+readOffers(
+    E& env,
+    AccountID const& acct,
+    std::optional<idmap_t> const& idmap = {})
+{
+    Json::Value jv;
+    jv[jss::account] = to_string(acct);
+    auto const r = rpc(env, "account_offers", jv);
+    std::cout << "offers " << domap(r.toStyledString(), idmap) << std::endl;
+}
+
+template <typename E>
+void
+readOffers(E& env, AccountX const& acct)
+{
+    readOffers(env, acct.id(), acct.idmap());
+}
+
+template <typename E>
+void
+readLines(
+    E& env,
+    AccountID const& acctId,
+    std::string const& name,
+    std::optional<idmap_t> const& idmap = {})
+{
+    Json::Value jv;
+    jv[jss::account] = to_string(acctId);
+    auto const r = rpc(env, "account_lines", jv);
+    std::cout << name << " account lines " << domap(r.toStyledString(), idmap)
+              << std::endl;
+}
+
+template <typename E>
+void
+readLines(E& env, AccountX const& acct)
+{
+    readLines(env, acct.id(), acct.name(), acct.idmap());
+}
+
+struct AMM_test : public beast::unit_test::suite
+{
+    void
+    testInstanceCreate()
+    {
+        testcase("Instance Create");
+
+        using namespace jtx;
+
+        auto const gw = AccountX{"gateway"};
+        auto const USD = gw["USD"];
+        auto const BTC = gw["BTC"];
+        AccountX const alice{"alice"};
+        AccountX const carol{"carol"};
+
+        auto fund = [&](auto& env) {
+            env.fund(XRP(20000), alice, carol, gw);
+            env.trust(USD(10000), alice);
+            env.trust(USD(25000), carol);
+            env.trust(BTC(0.625), carol);
+
+            env(pay(gw, alice, USD(10000)));
+            env(pay(gw, carol, USD(25000)));
+            env(pay(gw, carol, BTC(0.625)));
+        };
+
+        {
+            Env env{*this};
+            fund(env);
+            // XRP to IOU
+            AMM ammAlice(env, alice, XRP(10000), USD(10000));
+            BEAST_EXPECT(ammAlice.expectBalances(
+                XRP(10000), USD(10000), IOUAmount{10000000, 0}));
+            BEAST_EXPECT(ammAlice.expectAmmInfo(
+                XRP(10000), USD(10000), IOUAmount{10000000, 0}));
+
+            // IOU to IOU
+            AMM ammCarol(env, carol, USD(20000), BTC(0.5));
+            BEAST_EXPECT(ammCarol.expectBalances(
+                USD(20000), BTC(0.5), IOUAmount{100, 0}));
+            BEAST_EXPECT(ammCarol.expectAmmInfo(
+                USD(20000), BTC(0.5), IOUAmount{100, 0}, carol));
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            env(rate(gw, 1.25));
+            // IOU to IOU
+            AMM ammCarol(env, carol, USD(20000), BTC(0.5));
+            BEAST_EXPECT(ammCarol.expectBalances(
+                USD(20000), BTC(0.5), IOUAmount{100, 0}));
+            // Charging the AMM's LP the transfer fee. Should we?!!!
+            env.require(balance(carol, USD(0)));
+            env.require(balance(carol, BTC(0)));
+        }
+    }
+
+    void
+    testInvalidInstance()
+    {
+        testcase("Invalid Instance");
+
+        using namespace jtx;
+
+        auto const gw = Account{"gateway"};
+        auto const USD = gw["USD"];
+        auto const BAD = IOU(gw, badCurrency());
+        Account const alice{"alice"};
+        Account const carol{"carol"};
+
+        auto fund = [&](auto& env) {
+            env.fund(XRP(30000), alice, carol, gw);
+            env.trust(USD(30000), alice);
+            env.trust(USD(30000), carol);
+
+            env(pay(gw, alice, USD(30000)));
+            env(pay(gw, carol, USD(30000)));
+        };
+
+        {
+            Env env{*this};
+            fund(env);
+            // Can't have both XRP
+            AMM ammAlice(env, alice, XRP(10000), XRP(10000), ter(temBAD_AMM));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // Can't have both IOU
+            AMM ammAlice(env, alice, USD(10000), USD(10000), ter(temBAD_AMM));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // Can't have zero amounts
+            AMM ammAlice(env, alice, XRP(0), USD(0), ter(temBAD_AMOUNT));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // Bad currency
+            AMM ammAlice(
+                env, alice, XRP(10000), BAD(10000), ter(temBAD_CURRENCY));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // Insufficient IOU balance
+            AMM ammAlice(
+                env, alice, XRP(10000), USD(40000), ter(tecUNFUNDED_PAYMENT));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // Insufficient XRP balance
+            AMM ammAlice(
+                env, alice, XRP(40000), USD(10000), ter(tecUNFUNDED_PAYMENT));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // Invalid trading fee
+            AMM ammAlice(
+                env, alice, XRP(10000), USD(10001), 50, 70001, ter(temBAD_FEE));
+            BEAST_EXPECT(!ammAlice.accountRootExists());
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // AMM already exists
+            AMM ammAlice(env, alice, XRP(10000), USD(10000));
+            BEAST_EXPECT(ammAlice.expectBalances(
+                USD(10000), USD(10000), IOUAmount{10000000, 0}));
+            AMM ammCarol(env, carol, XRP(10000), USD(10000), ter(tefINTERNAL));
+        }
+
+        {
+            Env env{*this};
+            fund(env);
+            // AMM already exists
+            auto const ammAccount = calcAMMAccountID(50, XRP, USD);
+            env(amm::pay(gw, ammAccount, XRP(10000)));
+            AMM ammCarol(env, carol, XRP(10000), USD(10000), ter(tefINTERNAL));
+        }
+    }
+
+    void
+    run() override
+    {
+        testInvalidInstance();
+        testInstanceCreate();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE_PRIO(AMM, app, ripple, 2);
+
+}  // namespace test
+}  // namespace ripple

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_TEST_JTX_AMM_H_INCLUDED
+#define RIPPLE_TEST_JTX_AMM_H_INCLUDED
+
+#include <ripple/json/json_value.h>
+#include <ripple/protocol/STAmount.h>
+#include <test/jtx/Account.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+/** Convenience class to test AMM functionality.
+ */
+class AMM
+{
+    Env& env_;
+    Account const creatorAccount_;
+    AccountID ammAccountID_;
+    Issue lptIssue_;
+    STAmount asset1_;
+    STAmount asset2_;
+    std::uint8_t weight1_;
+    std::optional<ter> ter_;
+
+    void
+    create(std::uint32_t tfee = 0);
+
+public:
+    AMM(Env& env,
+        Account const& account,
+        STAmount const& asset1,
+        STAmount const& asset2,
+        std::uint8_t weight1 = 50,
+        std::uint32_t tfee = 0,
+        std::optional<ter> const& ter = std::nullopt);
+    AMM(Env& env,
+        Account const& account,
+        STAmount const& asset1,
+        STAmount const& asset2,
+        ter const& ter);
+
+    /** Send amm_info RPC command
+     */
+    std::optional<Json::Value>
+    ammInfo(std::optional<Account> const& account = {}) const;
+
+    /** Get AMM pool and tokens balance.
+     */
+    std::tuple<STAmount, STAmount, STAmount>
+    ammBalances(std::optional<AccountID> const& account = {}) const;
+
+    /** Verify the AMM balances.
+     */
+    bool
+    expectBalances(
+        STAmount const& asset1,
+        std::optional<STAmount> const& asset2 = std::nullopt,
+        std::optional<IOUAmount> const& lpt = std::nullopt) const;
+
+    bool
+    expectAmmInfo(
+        STAmount const& asset1,
+        STAmount const& asset2,
+        IOUAmount const& balance,
+        std::optional<Account> const& account = {});
+
+    bool
+    accountRootExists() const;
+};
+
+namespace amm {
+Json::Value
+trust(
+    AccountID const& account,
+    STAmount const& amount,
+    std::uint32_t flags = 0);
+Json::Value
+pay(Account const& account, AccountID const& to, STAmount const& amount);
+}  // namespace amm
+
+}  // namespace jtx
+}  // namespace test
+}  // namespace ripple
+
+#endif  // RIPPLE_TEST_JTX_AMM_H_INCLUDED

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -1,0 +1,187 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2022 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/app/misc/AMM.h>
+#include <ripple/protocol/jss.h>
+#include <test/jtx/AMM.h>
+#include <test/jtx/Env.h>
+
+namespace ripple {
+namespace test {
+namespace jtx {
+
+AMM::AMM(
+    Env& env,
+    Account const& account,
+    STAmount const& asset1,
+    STAmount const& asset2,
+    std::uint8_t weight1,
+    std::uint32_t tfee,
+    std::optional<ter> const& ter)
+    : env_(env)
+    , creatorAccount_(account)
+    , ammAccountID_(
+          ripple::calcAMMAccountID(weight1, asset1.issue(), asset2.issue()))
+    , lptIssue_(ripple::calcLPTIssue(ammAccountID_))
+    , asset1_(asset1)
+    , asset2_(asset2)
+    , weight1_(weight1)
+    , ter_(ter)
+{
+    create(tfee);
+}
+
+AMM::AMM(
+    Env& env,
+    Account const& account,
+    STAmount const& asset1,
+    STAmount const& asset2,
+    ter const& ter)
+    : AMM(env, account, asset1, asset2, 50, 0, ter)
+{
+}
+
+void
+AMM::create(std::uint32_t tfee)
+{
+    Json::Value jv;
+    jv[jss::Account] = creatorAccount_.human();
+    jv[jss::Asset1Details] = asset1_.getJson(JsonOptions::none);
+    jv[jss::Asset2Details] = asset2_.getJson(JsonOptions::none);
+#if 0
+    jv[jss::AssetWeight] = weight1_;
+#endif
+    jv[jss::TradingFee] = tfee;
+    jv[jss::TransactionType] = jss::AMMInstanceCreate;
+    if (ter_)
+        env_(jv, *ter_);
+    else
+        env_(jv);
+}
+
+std::optional<Json::Value>
+AMM::ammInfo(std::optional<Account> const& account) const
+{
+    Json::Value jv;
+    if (account)
+        jv[jss::account] = account->human();
+    jv[jss::AMMAccount] = to_string(ammAccountID_);
+    auto jr = env_.rpc("json", "amm_info", to_string(jv));
+    if (jr.isObject() && jr.isMember(jss::result) &&
+        jr[jss::result].isMember(jss::status) &&
+        jr[jss::result][jss::status].asString() == "success")
+        return jr[jss::result];
+    return std::nullopt;
+}
+
+std::tuple<STAmount, STAmount, STAmount>
+AMM::ammBalances(std::optional<AccountID> const& account) const
+{
+    return getAMMReserves(
+        *env_.current(),
+        ammAccountID_,
+        account,
+        std::nullopt,
+        std::nullopt,
+        env_.journal);
+}
+
+bool
+AMM::expectBalances(
+    STAmount const& asset1,
+    std::optional<STAmount> const& asset2,
+    std::optional<IOUAmount> const& lpt) const
+{
+    STAmount a1;
+    STAmount a2;
+    STAmount l;
+    std::tie(a1, a2, l) = ammBalances();
+    auto eq = [&](auto const& a) {
+        // issue is different
+        return a == a1 || a == a2;
+    };
+    return eq(asset1) && (!asset2 || eq(*asset2)) && (!lpt || lpt == l.iou());
+}
+
+bool
+AMM::accountRootExists() const
+{
+    return env_.current()->read(keylet::account(ammAccountID_)) != nullptr;
+}
+
+bool
+AMM::expectAmmInfo(
+    STAmount const& asset1,
+    STAmount const& asset2,
+    IOUAmount const& balance,
+    std::optional<Account> const& account)
+{
+    auto const jv = ammInfo(account);
+    if (!jv || !jv->isMember(jss::Asset1Details) ||
+        !jv->isMember(jss::Asset2Details) || !jv->isMember(jss::balance))
+        return false;
+    auto const& v = jv.value();
+    STAmount asset1Details;
+    if (!amountFromJsonNoThrow(asset1Details, v[jss::Asset1Details]))
+        return false;
+    STAmount asset2Details;
+    if (!amountFromJsonNoThrow(asset2Details, v[jss::Asset2Details]))
+        return false;
+    STAmount lptBalance;
+    if (!amountFromJsonNoThrow(lptBalance, v[jss::balance]))
+        return false;
+    // ammInfo returns unordered assets
+    if (asset1Details.issue() != asset1.issue())
+    {
+        auto const tmp = asset1Details;
+        asset1Details = asset2Details;
+        asset2Details = tmp;
+    }
+    return asset1 == asset1Details && asset2 == asset2Details &&
+        lptBalance == STAmount{balance, lptIssue_};
+}
+
+namespace amm {
+Json::Value
+trust(AccountID const& account, STAmount const& amount, std::uint32_t flags)
+{
+    if (isXRP(amount))
+        Throw<std::runtime_error>("trust() requires IOU");
+    Json::Value jv;
+    jv[jss::Account] = to_string(account);
+    jv[jss::LimitAmount] = amount.getJson(JsonOptions::none);
+    jv[jss::TransactionType] = jss::TrustSet;
+    jv[jss::Flags] = flags;
+    return jv;
+}
+Json::Value
+pay(Account const& account, AccountID const& to, STAmount const& amount)
+{
+    Json::Value jv;
+    jv[jss::Account] = account.human();
+    jv[jss::Amount] = amount.getJson(JsonOptions::none);
+    jv[jss::Destination] = to_string(to);
+    jv[jss::TransactionType] = jss::Payment;
+    jv[jss::Flags] = tfUniversal;
+    return jv;
+}
+}  // namespace amm
+}  // namespace jtx
+}  // namespace test
+}  // namespace ripple


### PR DESCRIPTION
## High Level Overview of Change

Adds AMM core functionality Instance Create, which creates AMM pool with two tokens.

### Context of Change

Adds AMM Root Account, trustline for each IOU AMM token, trustline to track Liquidity Provider Tokens (LPT),
and directory entry to track all AMM's with different weights. Note that only equal weights are supported
in the first release. A new RPC method `amm_info` is added to fetch the pool and LPT balances.

### Type of Change

- [ x] New feature (non-breaking change which adds functionality)

## Test Plan

AMM unit test is added to test AMM Creation.

## Future Tasks

Additional core functionality is AMM Deposit, Withdrawl, and Swap.

