### PR TITLE
[Trivial] Reduce log level of "Unable to find ledger" message: fixes #3996.

### DIFF
--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -3404,7 +3404,7 @@ PeerImp::getLedger(std::shared_ptr<protocol::TMGetLedger> const& m)
     }
     else
     {
-        JLOG(p_journal_.warn()) << "getLedger: Unable to find ledger";
+        JLOG(p_journal_.debug()) << "getLedger: Unable to find ledger";
     }
 
     return ledger;


### PR DESCRIPTION
## High Level Overview of Change

GitHub issue https://github.com/ripple/rippled/issues/3996  notes a lot of unhelpful noise from the `"Unable to find ledger ..."` log message.  The proposed change is to reduce the log level from `warn()` to `debug()`.

### Context of Change

Work to reduce noise in the log noted by GitHub issue https://github.com/ripple/rippled/issues/3996.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
