### PR TITLE
Fix Clio build

### DIFF
--- a/Builds/CMake/deps/Nudb.cmake
+++ b/Builds/CMake/deps/Nudb.cmake
@@ -18,14 +18,14 @@ if (is_root_project) # NuDB not needed in the case of xrpl_core inclusion build
     message (STATUS "Pausing to download NuDB...")
     FetchContent_Populate(nudb_src)
   endif()
-endif ()
 
-file(TO_CMAKE_PATH "${nudb_src_SOURCE_DIR}" nudb_src_SOURCE_DIR)
-# specify as system includes so as to avoid warnings
-target_include_directories (nudb SYSTEM INTERFACE ${nudb_src_SOURCE_DIR}/include)
-target_link_libraries (nudb
-  INTERFACE
-    Boost::thread
-    Boost::system)
-add_library (NIH::nudb ALIAS nudb)
-target_link_libraries (ripple_libs INTERFACE NIH::nudb)
+  file(TO_CMAKE_PATH "${nudb_src_SOURCE_DIR}" nudb_src_SOURCE_DIR)
+  # specify as system includes so as to avoid warnings
+  target_include_directories (nudb SYSTEM INTERFACE ${nudb_src_SOURCE_DIR}/include)
+  target_link_libraries (nudb
+    INTERFACE
+      Boost::thread
+      Boost::system)
+  add_library (NIH::nudb ALIAS nudb)
+  target_link_libraries (ripple_libs INTERFACE NIH::nudb)
+endif ()


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

Fix `endif()` position so nudb library builds for projects that include rippled.
### Context of Change
Other projects which depend on rippled would fail because the wrong `endif()` was left in place. Rippled built fine despite the incorrect placement since this guard is for _other_ projects using rippled.

The wrong `endif()` statement was removed leaving nudb unbuilt in projects outside rippled (Clio)
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)


<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
