### PR TITLE
Comment out Intel specific instruction `_mm_pause` on Apple arm platforms, which may cause a slight performance hit.

### DIFF
--- a/src/ripple/shamap/impl/SHAMapInnerNode.cpp
+++ b/src/ripple/shamap/impl/SHAMapInnerNode.cpp
@@ -34,8 +34,10 @@
 #include <iterator>
 #include <utility>
 
+#ifndef __aarch64__
 // This is used for the _mm_pause instruction:
 #include <immintrin.h>
+#endif
 
 namespace ripple {
 
@@ -100,7 +102,9 @@ public:
                 if (try_lock())
                     return;
 
+#ifndef __aarch64__
                 _mm_pause();
+#endif
             }
 
             std::this_thread::yield();


### PR DESCRIPTION
## Comment out Intel specific instruction _mm_pause on Apple arm platforms, which may cause a slight performance hit

### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)

Add #ifdef in order to use x86 intrinsics only when not on arm platform. 

The use of intrinsic instruction (`_mm_pause()`) is an optimization for yielding the processor and its absence on arm builds should not be an issue. 
