### PR TITLE
Periodically reshare federator sigs

### DIFF
--- a/src/ripple/app/sidechain/Federator.cpp
+++ b/src/ripple/app/sidechain/Federator.cpp
@@ -45,7 +45,6 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/error.hpp>
 #include <boost/system/detail/errc.hpp>
 

--- a/src/ripple/app/sidechain/Federator.cpp
+++ b/src/ripple/app/sidechain/Federator.cpp
@@ -41,14 +41,18 @@
 #include <ripple/rpc/Role.h>
 #include <ripple/rpc/impl/RPCHelpers.h>
 #include <ripple/rpc/impl/TransactionSign.h>
-#include <mutex>
 #include <ripple.pb.h>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/system/detail/errc.hpp>
 
 #include <chrono>
 #include <cmath>
+#include <memory>
+#include <mutex>
 #include <sstream>
 
 namespace ripple {
@@ -815,6 +819,13 @@ Federator::init(
     ticketRunner_.setRpcChannel(false, sidechainListener_);
     mainDoorKeeper_.setRpcChannel(mainchainListener_);
     sideDoorKeeper_.setRpcChannel(sidechainListener_);
+
+    heartbeatTimer =
+        std::make_unique<boost::asio::deadline_timer>(ios, heartbeatInterval);
+    heartbeatTimer->async_wait(
+        [self = shared_from_this()](boost::system::error_code const& ec) {
+            self->heartbeatTimerHandler(ec);
+        });
 }
 
 Federator::~Federator()
@@ -851,6 +862,25 @@ Federator::stop()
         running_ = false;
     }
     mainchainListener_->shutdown();
+}
+
+void
+Federator::heartbeatTimerHandler(const boost::system::error_code& ec)
+{
+    if (ec == boost::asio::error::operation_aborted)
+        return;
+
+    if (ec == boost::system::errc::success)
+    {
+        onEvent(event::HeartbeatTimer{});
+    }
+
+    heartbeatTimer->expires_at(
+        heartbeatTimer->expires_at() + heartbeatInterval);
+    heartbeatTimer->async_wait(
+        [self = shared_from_this()](boost::system::error_code const& ec) {
+            self->heartbeatTimerHandler(ec);
+        });
 }
 
 void
@@ -1354,6 +1384,13 @@ Federator::onEvent(event::HeartbeatTimer const& e)
         "Federator::onEvent",
         jv("eventtype", "HeartbeatTimer"),
         jv("event", e.toJson()));
+
+    static bool shareMain = false;
+    shareMain = !shareMain;
+    if (shareMain)
+        mainSigCollector_.reshareSigs();
+    else
+        sideSigCollector_.reshareSigs();
 }
 
 void

--- a/src/ripple/app/sidechain/Federator.h
+++ b/src/ripple/app/sidechain/Federator.h
@@ -40,6 +40,7 @@
 #include <ripple/protocol/SecretKey.h>
 
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/container/flat_map.hpp>
 
 #include <atomic>

--- a/src/ripple/app/sidechain/Federator.h
+++ b/src/ripple/app/sidechain/Federator.h
@@ -39,6 +39,7 @@
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/SecretKey.h>
 
+#include <boost/asio.hpp>
 #include <boost/container/flat_map.hpp>
 
 #include <atomic>
@@ -139,6 +140,9 @@ private:
     TicketRunner ticketRunner_;
     DoorKeeper mainDoorKeeper_;
     DoorKeeper sideDoorKeeper_;
+
+    boost::posix_time::seconds const heartbeatInterval{5};
+    std::unique_ptr<boost::asio::deadline_timer> heartbeatTimer;
 
     struct PeerTxnSignature
     {
@@ -307,6 +311,9 @@ private:
         std::uint16_t port,
         std::shared_ptr<MainchainListener>&& mainchainListener,
         std::shared_ptr<SidechainListener>&& sidechainListener);
+
+    void
+    heartbeatTimerHandler(const boost::system::error_code& ec);
 
     // Convert between the asset on the src chain to the asset on the other
     // chain. The `assetProps_` array controls how this conversion is done.

--- a/src/ripple/app/sidechain/impl/SignatureCollector.h
+++ b/src/ripple/app/sidechain/impl/SignatureCollector.h
@@ -122,6 +122,9 @@ public:
     void
     setRpcChannel(std::shared_ptr<ChainListener> channel);
 
+    void
+    reshareSigs() EXCLUDES(mtx_);
+
 private:
     // verify a signature (if it is from a peer) and add to a collection
     bool


### PR DESCRIPTION
## High Level Overview of Change

This PR will periodically reshare federator signatures and clean out old signatures.  It will only remove signatures for txns the federator is unaware of. It will reshare mainchain and sidechain signatures on a heartbeat timer. It will wwitch between sharing sidechain and mainchain signatures on each timeout, in an attempt to reduce network traffic.

