### PR TITLE
Add `book_changes` subscription type

### DIFF
--- a/src/ripple/net/InfoSub.h
+++ b/src/ripple/net/InfoSub.h
@@ -129,6 +129,11 @@ public:
         unsubLedger(std::uint64_t uListener) = 0;
 
         virtual bool
+        subBookChanges(ref ispListener) = 0;
+        virtual bool
+        unsubBookChanges(std::uint64_t uListener) = 0;
+
+        virtual bool
         subManifests(ref ispListener) = 0;
         virtual bool
         unsubManifests(std::uint64_t uListener) = 0;

--- a/src/ripple/protocol/jss.h
+++ b/src/ripple/protocol/jss.h
@@ -166,11 +166,13 @@ JSS(build_path);             // in: TransactionSign
 JSS(build_version);          // out: NetworkOPs
 JSS(cancel_after);           // out: AccountChannels
 JSS(can_delete);             // out: CanDelete
+JSS(changes);                // out: BookChanges
 JSS(channel_id);             // out: AccountChannels
 JSS(channels);               // out: AccountChannels
 JSS(check);                  // in: AccountObjects
 JSS(check_nodes);            // in: LedgerCleaner
 JSS(clear);                  // in/out: FetchInfo
+JSS(close);                  // out: BookChanges
 JSS(close_flags);            // out: LedgerToJson
 JSS(close_time);             // in: Application, out: NetworkOPs,
                              //      RCLCxPeerPos, LedgerToJson
@@ -193,6 +195,8 @@ JSS(converge_time_s);        // out: NetworkOPs
 JSS(cookie);                 // out: NetworkOPs
 JSS(count);                  // in: AccountTx*, ValidatorList
 JSS(counters);               // in/out: retrieve counters
+JSS(cur_a);                  // out: BookChanges
+JSS(cur_b);                  // out: BookChanges
 JSS(currentShard);           // out: NodeToShardStatus
 JSS(currentShardIndex);      // out: NodeToShardStatus
 JSS(currency);               // in: paths/PathRequest, STAmount
@@ -282,6 +286,7 @@ JSS(hashes);                // in: AccountObjects
 JSS(have_header);           // out: InboundLedger
 JSS(have_state);            // out: InboundLedger
 JSS(have_transactions);     // out: InboundLedger
+JSS(high);                  // out: BookChanges
 JSS(highest_sequence);      // out: AccountInfo
 JSS(highest_ticket);        // out: AccountInfo
 JSS(historical_perminute);  // historical_perminute.
@@ -363,6 +368,7 @@ JSS(load_fee);                    // out: LoadFeeTrackImp, NetworkOPs
 JSS(local);                       // out: resource/Logic.h
 JSS(local_txs);                   // out: GetCounts
 JSS(local_static_keys);           // out: ValidatorList
+JSS(low);                         // out: BookChanges
 JSS(lowest_sequence);             // out: AccountInfo
 JSS(lowest_ticket);               // out: AccountInfo
 JSS(majority);                    // out: RPC feature
@@ -639,6 +645,8 @@ JSS(validator_sites);         // out: ValidatorSites
 JSS(value);                   // out: STAmount
 JSS(version);                 // out: RPCVersion
 JSS(vetoed);                  // out: AmendmentTableImpl
+JSS(vol_a);                   // out: BookChanges
+JSS(vol_b);                   // out: BookChanges
 JSS(vote);                    // in: Feature
 JSS(warning);                 // rpc:
 JSS(warnings);                // out: server_info, server_state

--- a/src/ripple/rpc/handlers/Subscribe.cpp
+++ b/src/ripple/rpc/handlers/Subscribe.cpp
@@ -136,6 +136,10 @@ doSubscribe(RPC::JsonContext& context)
             {
                 context.netOps.subLedger(ispSub, jvResult);
             }
+            else if (streamName == "book_changes")
+            {
+                context.netOps.subBookChanges(ispSub);
+            }
             else if (streamName == "manifests")
             {
                 context.netOps.subManifests(ispSub);


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

With Ripple's data API becoming unreliable and/or going offline, reliable DEX trading data is now in demand.

This new subscription type produces candle stick data per altered book per closed ledger, meaning anyone can be their own source for this data.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
<!--

If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->
A new stream type is added:
`{"command":"subscribe","streams":["book_changes"]}`


## Test Plan
I tested this manually. Unit tests are possible but presently I don't have time to write them.

Since this is an RPC call and is completely opt-in, any bug is unlikely to affect anyone except those using it. 
<!--
## Future Tasks
For future tasks related to PR.
-->