### PR TITLE
Fix test failures with newer msvc compilers (related to string aliasing)

### DIFF
--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -696,19 +696,31 @@ parseRippleLibSeed(Json::Value const& value)
 std::optional<Seed>
 getSeedFromRPC(Json::Value const& params, Json::Value& error)
 {
-    // The array should be constexpr, but that makes Visual Studio unhappy.
-    static char const* const seedTypes[]{
-        jss::passphrase.c_str(), jss::seed.c_str(), jss::seed_hex.c_str()};
+    using string_to_seed_t =
+        std::function<std::optional<Seed>(const std::string&)>;
+    using seed_match_t = std::pair<const char*, string_to_seed_t>;
+
+    static seed_match_t const seedTypes[]{
+        {jss::passphrase.c_str(),
+         [](const std::string& s) { return parseGenericSeed(s); }},
+        {jss::seed.c_str(),
+         [](const std::string& s) { return parseBase58<Seed>(s); }},
+        {jss::seed_hex.c_str(), [](const std::string& s) {
+             uint128 i;
+             if (i.parseHex(s))
+                 return std::optional<Seed>(Slice(i.data(), i.size()));
+             return std::optional<Seed>{};
+         }}};
 
     // Identify which seed type is in use.
-    char const* seedType = nullptr;
+    const seed_match_t* seedType = nullptr;
     int count = 0;
-    for (auto t : seedTypes)
+    for (const auto& t : seedTypes)
     {
-        if (params.isMember(t))
+        if (params.isMember(t.first))
         {
             ++count;
-            seedType = t;
+            seedType = &t;
         }
     }
 
@@ -722,28 +734,17 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
     }
 
     // Make sure a string is present
-    if (!params[seedType].isString())
+    const auto& param = params[seedType->first];
+    if (!param.isString())
     {
-        error = RPC::expected_field_error(seedType, "string");
+        error = RPC::expected_field_error(seedType->first, "string");
         return std::nullopt;
     }
 
-    auto const fieldContents = params[seedType].asString();
+    auto const fieldContents = param.asString();
 
     // Convert string to seed.
-    std::optional<Seed> seed;
-
-    if (seedType == jss::seed.c_str())
-        seed = parseBase58<Seed>(fieldContents);
-    else if (seedType == jss::passphrase.c_str())
-        seed = parseGenericSeed(fieldContents);
-    else if (seedType == jss::seed_hex.c_str())
-    {
-        uint128 s;
-
-        if (s.parseHex(fieldContents))
-            seed.emplace(Slice(s.data(), s.size()));
-    }
+    std::optional<Seed> seed = seedType->second(fieldContents);
 
     if (!seed)
         error = rpcError(rpcBAD_SEED);
@@ -757,7 +758,6 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
     bool const has_key_type = params.isMember(jss::key_type);
 
     // All of the secret types we allow, but only one at a time.
-    // The array should be constexpr, but that makes Visual Studio unhappy.
     static char const* const secretTypes[]{
         jss::passphrase.c_str(),
         jss::secret.c_str(),
@@ -811,7 +811,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
             return {};
         }
 
-        if (secretType == jss::secret.c_str())
+        if (strcmp(secretType, jss::secret.c_str()) ==
+            0)  // don't assume that pointers are the same
         {
             error = RPC::make_param_error(
                 "The secret field is not allowed if " +
@@ -823,7 +824,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
     // ripple-lib encodes seed used to generate an Ed25519 wallet in a
     // non-standard way. While we never encode seeds that way, we try
     // to detect such keys to avoid user confusion.
-    if (secretType != jss::seed_hex.c_str())
+    if (strcmp(secretType, jss::seed_hex.c_str()) !=
+        0)  // don't assume that pointers are the same
     {
         seed = RPC::parseRippleLibSeed(params[secretType]);
 

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -811,8 +811,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
             return {};
         }
 
-        if (strcmp(secretType, jss::secret.c_str()) ==
-            0)  // don't assume that pointers are the same
+        // using strcmp as pointers may not match (see  https://bit.ly/3OGvf0E)
+        if (strcmp(secretType, jss::secret.c_str()) == 0)
         {
             error = RPC::make_param_error(
                 "The secret field is not allowed if " +
@@ -824,8 +824,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
     // ripple-lib encodes seed used to generate an Ed25519 wallet in a
     // non-standard way. While we never encode seeds that way, we try
     // to detect such keys to avoid user confusion.
-    if (strcmp(secretType, jss::seed_hex.c_str()) !=
-        0)  // don't assume that pointers are the same
+    // using strcmp as pointers may not match (see  https://bit.ly/3OGvf0E)
+    if (strcmp(secretType, jss::seed_hex.c_str()) != 0)
     {
         seed = RPC::parseRippleLibSeed(params[secretType]);
 

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -697,15 +697,15 @@ std::optional<Seed>
 getSeedFromRPC(Json::Value const& params, Json::Value& error)
 {
     using string_to_seed_t =
-        std::function<std::optional<Seed>(const std::string&)>;
-    using seed_match_t = std::pair<const char*, string_to_seed_t>;
+        std::function<std::optional<Seed>(std::string const&)>;
+    using seed_match_t = std::pair<char const*, string_to_seed_t>;
 
     static seed_match_t const seedTypes[]{
         {jss::passphrase.c_str(),
-         [](const std::string& s) { return parseGenericSeed(s); }},
+         [](std::string const& s) { return parseGenericSeed(s); }},
         {jss::seed.c_str(),
-         [](const std::string& s) { return parseBase58<Seed>(s); }},
-        {jss::seed_hex.c_str(), [](const std::string& s) {
+         [](std::string const& s) { return parseBase58<Seed>(s); }},
+        {jss::seed_hex.c_str(), [](std::string const& s) {
              uint128 i;
              if (i.parseHex(s))
                  return std::optional<Seed>(Slice(i.data(), i.size()));
@@ -713,7 +713,7 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
          }}};
 
     // Identify which seed type is in use.
-    const seed_match_t* seedType = nullptr;
+    seed_match_t const* seedType = nullptr;
     int count = 0;
     for (auto const& t : seedTypes)
     {
@@ -734,7 +734,7 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
     }
 
     // Make sure a string is present
-    const auto& param = params[seedType->first];
+    auto const& param = params[seedType->first];
     if (!param.isString())
     {
         error = RPC::expected_field_error(seedType->first, "string");
@@ -811,7 +811,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
             return {};
         }
 
-        // using strcmp as pointers may not match (see  https://bit.ly/3OGvf0E)
+        // using strcmp as pointers may not match (see
+        // https://developercommunity.visualstudio.com/t/assigning-constexpr-char--to-static-cha/10021357?entry=problem)
         if (strcmp(secretType, jss::secret.c_str()) == 0)
         {
             error = RPC::make_param_error(
@@ -824,7 +825,8 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
     // ripple-lib encodes seed used to generate an Ed25519 wallet in a
     // non-standard way. While we never encode seeds that way, we try
     // to detect such keys to avoid user confusion.
-    // using strcmp as pointers may not match (see  https://bit.ly/3OGvf0E)
+    // using strcmp as pointers may not match (see
+    // https://developercommunity.visualstudio.com/t/assigning-constexpr-char--to-static-cha/10021357?entry=problem)
     if (strcmp(secretType, jss::seed_hex.c_str()) != 0)
     {
         seed = RPC::parseRippleLibSeed(params[secretType]);

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -715,7 +715,7 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
     // Identify which seed type is in use.
     const seed_match_t* seedType = nullptr;
     int count = 0;
-    for (const auto& t : seedTypes)
+    for (auto const& t : seedTypes)
     {
         if (params.isMember(t.first))
         {


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## Fix test failures with newer mscv compilers (related to string aliasing)

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

When building rippled on Windows with the latest msvc compilers & toolset (newer that Visual Studio 2017), there are string aliasing issues (demonstrated by this [repo](https://github.com/ximinez/staticstring)), where assigning a `constexpr` `const char *` to a `static const char *` actually stores a pointer to a new string, so the two pointers don't compare equal (strcmp still works of course).

This issue is seen only with specific flag combinations. I have seen it with the [`/ZI`](https://docs.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170) flag and the [`/Gy-`](https://docs.microsoft.com/en-us/cpp/build/reference/gy-enable-function-level-linking?view=msvc-170) flag which [disables Function-Level Linking](https://docs.microsoft.com/en-us/cpp/build/reference/gy-enable-function-level-linking?view=msvc-170).

In order to avoid the issue altogether regardless if the compiler aliases strings, this change updates the code we don't do string pointer comparisons, but consistently use strcmp.

My suspicion is that the pointer comparisons should work, but we'd have to see where it is specified in the standard, otherwise we are just relying on UB. Anyways I have file a [bug report](https://developercommunity.visualstudio.com/t/assigning-constexpr-char--to-static-cha/10021357?port=1025&fsid=d8283102-25c7-4356-b049-032b8433fba9&entry=problem) with Microsoft, we'll see what they say. I also asked the [question](https://stackoverflow.com/questions/71960681/c-assigning-constexpr-char-to-static-char-copies-the-string-is-it-a) on stack overflow.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
