### PR TITLE
Check triggers cmake error unnecessarily

### DIFF
--- a/Builds/CMake/RippledSanity.cmake
+++ b/Builds/CMake/RippledSanity.cmake
@@ -72,10 +72,8 @@ if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     "directory from ${CMAKE_CURRENT_SOURCE_DIR} and try building in a separate directory.")
 endif ()
 
-if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio" AND
-   ("${CMAKE_GENERATOR_PLATFORM}" MATCHES .*Win32.*))
-  message (FATAL_ERROR
-    "Visual Studio 32-bit build is not supported. Use -G\"${CMAKE_GENERATOR} Win64\"")
+if (MSVC AND CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
+  message (FATAL_ERROR "Visual Studio 32-bit build is not supported.")
 endif ()
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/Builds/CMake/RippledSanity.cmake
+++ b/Builds/CMake/RippledSanity.cmake
@@ -73,7 +73,7 @@ if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif ()
 
 if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio" AND
-    NOT ("${CMAKE_GENERATOR}" MATCHES .*Win64.*))
+   ("${CMAKE_GENERATOR_PLATFORM}" MATCHES .*Win32.*))
   message (FATAL_ERROR
     "Visual Studio 32-bit build is not supported. Use -G\"${CMAKE_GENERATOR} Win64\"")
 endif ()


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## Incorrect error for cmake execution on windows when platform unspecified or x64

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

When using cmake-gui to generate solution files on windows, the default platform is stated to be x64, so it is natural to leave the field unfilled, but even among the proposed choices, Win64 is nowhere to be found, we see only x64.

So whether we leave the field blank, or select x64 in the dropdown, cmake generation fails because it checks for the presence of `Win64`.

This change makes the generation of solution files more user friendly on windows, by not causing an error unless we find `Win32`. 

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
