### PR TITLE
Warning suppression in rngfill() incorrectly removes code

### DIFF
--- a/Builds/CMake/RippledCore.cmake
+++ b/Builds/CMake/RippledCore.cmake
@@ -82,6 +82,7 @@ target_sources (xrpl_core PRIVATE
   src/ripple/protocol/impl/PublicKey.cpp
   src/ripple/protocol/impl/Quality.cpp
   src/ripple/protocol/impl/Rate2.cpp
+  src/ripple/protocol/impl/Rules.cpp
   src/ripple/protocol/impl/SField.cpp
   src/ripple/protocol/impl/SOTemplate.cpp
   src/ripple/protocol/impl/STAccount.cpp
@@ -209,6 +210,7 @@ install (
     src/ripple/protocol/PublicKey.h
     src/ripple/protocol/Quality.h
     src/ripple/protocol/Rate.h
+    src/ripple/protocol/Rules.h
     src/ripple/protocol/SField.h
     src/ripple/protocol/SOTemplate.h
     src/ripple/protocol/STAccount.h

--- a/Builds/CMake/RippledSanity.cmake
+++ b/Builds/CMake/RippledSanity.cmake
@@ -72,10 +72,8 @@ if ("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     "directory from ${CMAKE_CURRENT_SOURCE_DIR} and try building in a separate directory.")
 endif ()
 
-if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio" AND
-    NOT ("${CMAKE_GENERATOR}" MATCHES .*Win64.*))
-  message (FATAL_ERROR
-    "Visual Studio 32-bit build is not supported. Use -G\"${CMAKE_GENERATOR} Win64\"")
+if (MSVC AND CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
+  message (FATAL_ERROR "Visual Studio 32-bit build is not supported.")
 endif ()
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/cfg/rippled-example.cfg
+++ b/cfg/rippled-example.cfg
@@ -1140,17 +1140,10 @@
 #                           The online delete process checks periodically
 #                           that rippled is still in sync with the network,
 #                           and that the validated ledger is less than
-#                           'age_threshold_seconds' old. By default, if it
-#                           is not the online delete process aborts and
-#                           tries again later. If 'recovery_wait_seconds'
-#                           is set and rippled is out of sync, but likely to
-#                           recover quickly, then online delete will wait
-#                           this number of seconds for rippled to get back
-#                           into sync before it aborts.
-#                           Set this value if the node is otherwise staying
-#                           in sync, or recovering quickly, but the online
-#                           delete process is unable to finish.
-#                           Default is unset.
+#                           'age_threshold_seconds' old. If not, then continue
+#                           sleeping for this number of seconds and 
+#                           checking until healthy.
+#                           Default is 5.
 #
 #   Optional keys for Cassandra:
 #

--- a/src/ripple/app/consensus/RCLConsensus.cpp
+++ b/src/ripple/app/consensus/RCLConsensus.cpp
@@ -632,7 +632,7 @@ RCLConsensus::Adaptor::doAccept(
         auto const lastVal = ledgerMaster_.getValidatedLedger();
         std::optional<Rules> rules;
         if (lastVal)
-            rules.emplace(*lastVal, app_.config().features);
+            rules = makeRulesGivenLedger(*lastVal, app_.config().features);
         else
             rules.emplace(app_.config().features);
         app_.openLedger().accept(

--- a/src/ripple/app/ledger/Ledger.cpp
+++ b/src/ripple/app/ledger/Ledger.cpp
@@ -626,7 +626,7 @@ Ledger::setup(Config const& config)
 
     try
     {
-        rules_ = Rules(*this, config.features);
+        rules_ = makeRulesGivenLedger(*this, config.features);
     }
     catch (SHAMapMissingNode const&)
     {

--- a/src/ripple/app/ledger/impl/InboundLedger.cpp
+++ b/src/ripple/app/ledger/impl/InboundLedger.cpp
@@ -44,27 +44,27 @@ using namespace std::chrono_literals;
 
 enum {
     // Number of peers to start with
-    peerCountStart = 4
+    peerCountStart = 5
 
     // Number of peers to add on a timeout
     ,
-    peerCountAdd = 2
+    peerCountAdd = 3
 
     // how many timeouts before we give up
     ,
-    ledgerTimeoutRetriesMax = 10
+    ledgerTimeoutRetriesMax = 6
 
     // how many timeouts before we get aggressive
     ,
-    ledgerBecomeAggressiveThreshold = 6
+    ledgerBecomeAggressiveThreshold = 4
 
     // Number of nodes to find initially
     ,
-    missingNodesFind = 512
+    missingNodesFind = 256
 
     // Number of nodes to request for a reply
     ,
-    reqNodesReply = 256
+    reqNodesReply = 128
 
     // Number of nodes to request blindly
     ,
@@ -72,7 +72,7 @@ enum {
 };
 
 // millisecond for each ledger timeout
-auto constexpr ledgerAcquireTimeout = 2500ms;
+auto constexpr ledgerAcquireTimeout = 3000ms;
 
 InboundLedger::InboundLedger(
     Application& app,
@@ -664,15 +664,15 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
     if (reason != TriggerReason::reply)
     {
         // If we're querying blind, don't query deep
-        tmGL.set_querydepth(1);
+        tmGL.set_querydepth(0);
     }
     else if (peer && peer->isHighLatency())
     {
         // If the peer has high latency, query extra deep
-        tmGL.set_querydepth(3);
+        tmGL.set_querydepth(2);
     }
     else
-        tmGL.set_querydepth(2);
+        tmGL.set_querydepth(1);
 
     // Get the state data first because it's the most likely to be useful
     // if we wind up abandoning this fetch.

--- a/src/ripple/app/misc/NetworkOPs.cpp
+++ b/src/ripple/app/misc/NetworkOPs.cpp
@@ -1749,7 +1749,7 @@ NetworkOPsImp::switchLastClosedLedger(
         auto const lastVal = app_.getLedgerMaster().getValidatedLedger();
         std::optional<Rules> rules;
         if (lastVal)
-            rules.emplace(*lastVal, app_.config().features);
+            rules = makeRulesGivenLedger(*lastVal, app_.config().features);
         else
             rules.emplace(app_.config().features);
         app_.openLedger().accept(

--- a/src/ripple/app/misc/SHAMapStore.h
+++ b/src/ripple/app/misc/SHAMapStore.h
@@ -55,7 +55,7 @@ public:
     clampFetchDepth(std::uint32_t fetch_depth) const = 0;
 
     virtual std::unique_ptr<NodeStore::Database>
-    makeNodeStore(std::int32_t readThreads) = 0;
+    makeNodeStore(int readThreads) = 0;
 
     /** Highest ledger that may be deleted. */
     virtual LedgerIndex

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -138,7 +138,7 @@ SHAMapStoreImp::SHAMapStoreImp(
         if (get_if_exists(section, "age_threshold_seconds", temp))
             ageThreshold_ = std::chrono::seconds{temp};
         if (get_if_exists(section, "recovery_wait_seconds", temp))
-            recoveryWaitTime_.emplace(std::chrono::seconds{temp});
+            recoveryWaitTime_ = std::chrono::seconds{temp};
 
         get_if_exists(section, "advisory_delete", advisoryDelete_);
 
@@ -268,7 +268,7 @@ SHAMapStoreImp::copyNode(std::uint64_t& nodeCount, SHAMapTreeNode const& node)
         true);
     if (!(++nodeCount % checkHealthInterval_))
     {
-        if (health())
+        if (stopping())
             return false;
     }
 
@@ -326,7 +326,7 @@ SHAMapStoreImp::run()
 
         bool const readyToRotate =
             validatedSeq >= lastRotated + deleteInterval_ &&
-            canDelete_ >= lastRotated - 1 && !health();
+            canDelete_ >= lastRotated - 1 && !stopping();
 
         // Make sure we don't delete ledgers currently being
         // imported into the ShardStore
@@ -358,15 +358,8 @@ SHAMapStoreImp::run()
                 << ledgerMaster_->getValidatedLedgerAge().count() << 's';
 
             clearPrior(lastRotated);
-            switch (health())
-            {
-                case Health::stopping:
-                    return;
-                case Health::unhealthy:
-                    continue;
-                case Health::ok:
-                default:;
-            }
+            if (stopping())
+                return;
 
             JLOG(journal_.debug()) << "copying ledger " << validatedSeq;
             std::uint64_t nodeCount = 0;
@@ -375,30 +368,16 @@ SHAMapStoreImp::run()
                 this,
                 std::ref(nodeCount),
                 std::placeholders::_1));
-            switch (health())
-            {
-                case Health::stopping:
-                    return;
-                case Health::unhealthy:
-                    continue;
-                case Health::ok:
-                default:;
-            }
+            if (stopping())
+                return;
             // Only log if we completed without a "health" abort
             JLOG(journal_.debug()) << "copied ledger " << validatedSeq
                                    << " nodecount " << nodeCount;
 
             JLOG(journal_.debug()) << "freshening caches";
             freshenCaches();
-            switch (health())
-            {
-                case Health::stopping:
-                    return;
-                case Health::unhealthy:
-                    continue;
-                case Health::ok:
-                default:;
-            }
+            if (stopping())
+                return;
             // Only log if we completed without a "health" abort
             JLOG(journal_.debug()) << validatedSeq << " freshened caches";
 
@@ -408,15 +387,8 @@ SHAMapStoreImp::run()
                 << validatedSeq << " new backend " << newBackend->getName();
 
             clearCaches(validatedSeq);
-            switch (health())
-            {
-                case Health::stopping:
-                    return;
-                case Health::unhealthy:
-                    continue;
-                case Health::ok:
-                default:;
-            }
+            if (stopping())
+                return;
 
             lastRotated = validatedSeq;
 
@@ -580,7 +552,7 @@ SHAMapStoreImp::clearSql(
         min = *m;
     }
 
-    if (min > lastRotated || health() != Health::ok)
+    if (min > lastRotated || stopping())
         return;
     if (min == lastRotated)
     {
@@ -601,11 +573,11 @@ SHAMapStoreImp::clearSql(
         JLOG(journal_.trace())
             << "End: Delete up to " << deleteBatch_ << " rows with LedgerSeq < "
             << min << " from: " << TableName;
-        if (health())
+        if (stopping())
             return;
         if (min < lastRotated)
             std::this_thread::sleep_for(backOff_);
-        if (health())
+        if (stopping())
             return;
     }
     JLOG(journal_.debug()) << "finished deleting from: " << TableName;
@@ -645,7 +617,7 @@ SHAMapStoreImp::clearPrior(LedgerIndex lastRotated)
     ledgerMaster_->clearPriorLedgers(lastRotated);
     JLOG(journal_.trace()) << "End: Clear internal ledgers up to "
                            << lastRotated;
-    if (health())
+    if (stopping())
         return;
 
     RelationalDBInterfaceSqlite* iface =
@@ -661,7 +633,7 @@ SHAMapStoreImp::clearPrior(LedgerIndex lastRotated)
         [&iface](LedgerIndex min) -> void {
             iface->deleteBeforeLedgerSeq(min);
         });
-    if (health())
+    if (stopping())
         return;
 
     if (!app_.config().useTxTables())
@@ -676,7 +648,7 @@ SHAMapStoreImp::clearPrior(LedgerIndex lastRotated)
         [&iface](LedgerIndex min) -> void {
             iface->deleteTransactionsBeforeLedgerSeq(min);
         });
-    if (health())
+    if (stopping())
         return;
 
     clearSql(
@@ -688,52 +660,30 @@ SHAMapStoreImp::clearPrior(LedgerIndex lastRotated)
         [&iface](LedgerIndex min) -> void {
             iface->deleteAccountTransactionsBeforeLedgerSeq(min);
         });
-    if (health())
+    if (stopping())
         return;
 }
 
-SHAMapStoreImp::Health
-SHAMapStoreImp::health()
+bool
+SHAMapStoreImp::stopping()
 {
+    auto age = ledgerMaster_->getValidatedLedgerAge();
+    OperatingMode mode = netOPs_->getOperatingMode();
+    std::unique_lock lock(mutex_);
+    while (!stop_ && (mode != OperatingMode::FULL || age > ageThreshold_))
     {
-        std::lock_guard lock(mutex_);
-        if (stop_)
-            return Health::stopping;
-    }
-    if (!netOPs_)
-        return Health::ok;
-    assert(deleteInterval_);
-
-    if (healthy_)
-    {
-        auto age = ledgerMaster_->getValidatedLedgerAge();
-        OperatingMode mode = netOPs_->getOperatingMode();
-        if (recoveryWaitTime_ && mode == OperatingMode::SYNCING &&
-            age < ageThreshold_)
-        {
-            JLOG(journal_.warn())
-                << "Waiting " << recoveryWaitTime_->count()
-                << "s for node to get back into sync with network. state: "
-                << app_.getOPs().strOperatingMode(mode, false) << ". age "
-                << age.count() << 's';
-            std::this_thread::sleep_for(*recoveryWaitTime_);
-
-            age = ledgerMaster_->getValidatedLedgerAge();
-            mode = netOPs_->getOperatingMode();
-        }
-        if (mode != OperatingMode::FULL || age > ageThreshold_)
-        {
-            JLOG(journal_.warn()) << "Not deleting. state: "
-                                  << app_.getOPs().strOperatingMode(mode, false)
-                                  << ". age " << age.count() << 's';
-            healthy_ = false;
-        }
+        lock.unlock();
+        JLOG(journal_.warn()) << "Waiting " << recoveryWaitTime_.count()
+                              << "s for node to stabilize. state: "
+                              << app_.getOPs().strOperatingMode(mode, false)
+                              << ". age " << age.count() << 's';
+        std::this_thread::sleep_for(recoveryWaitTime_);
+        age = ledgerMaster_->getValidatedLedgerAge();
+        mode = netOPs_->getOperatingMode();
+        lock.lock();
     }
 
-    if (healthy_)
-        return Health::ok;
-    else
-        return Health::unhealthy;
+    return stop_;
 }
 
 void

--- a/src/ripple/app/misc/SHAMapStoreImp.cpp
+++ b/src/ripple/app/misc/SHAMapStoreImp.cpp
@@ -166,7 +166,7 @@ SHAMapStoreImp::SHAMapStoreImp(
 }
 
 std::unique_ptr<NodeStore::Database>
-SHAMapStoreImp::makeNodeStore(std::int32_t readThreads)
+SHAMapStoreImp::makeNodeStore(int readThreads)
 {
     auto nscfg = app_.config().section(ConfigSection::nodeDatabase());
 

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -40,8 +40,6 @@ class NetworkOPs;
 class SHAMapStoreImp : public SHAMapStore
 {
 private:
-    enum Health : std::uint8_t { ok = 0, stopping, unhealthy };
-
     class SavedStateDB
     {
     public:
@@ -106,12 +104,12 @@ private:
     std::uint32_t deleteBatch_ = 100;
     std::chrono::milliseconds backOff_{100};
     std::chrono::seconds ageThreshold_{60};
-    /// If set, and the node is out of sync during an
+    /// If  the node is out of sync during an
     /// online_delete health check, sleep the thread
-    /// for this time and check again so the node can
-    /// recover.
+    /// for this time, and continue checking until
+    /// recovery.
     /// See also: "recovery_wait_seconds" in rippled-example.cfg
-    std::optional<std::chrono::seconds> recoveryWaitTime_;
+    std::chrono::seconds recoveryWaitTime_{5};
 
     // these do not exist upon SHAMapStore creation, but do exist
     // as of run() or before
@@ -201,7 +199,7 @@ private:
         {
             dbRotating_->fetchNodeObject(
                 key, 0, NodeStore::FetchType::synchronous, true);
-            if (!(++check % checkHealthInterval_) && health())
+            if (!(++check % checkHealthInterval_) && stopping())
                 return true;
         }
 
@@ -225,16 +223,15 @@ private:
     void
     clearPrior(LedgerIndex lastRotated);
 
-    // If rippled is not healthy, defer rotate-delete.
-    // If already unhealthy, do not change state on further check.
-    // Assume that, once unhealthy, a necessary step has been
-    // aborted, so the online-delete process needs to restart
-    // at next ledger.
-    // If recoveryWaitTime_ is set, this may sleep to give rippled
-    // time to recover, so never call it from any thread other than
-    // the main "run()".
-    Health
-    health();
+    /**
+     * This is a health check for online deletion that waits until rippled is
+     * stable until returning. If the server is stopping, then it returns
+     * "true" to inform the caller to allow the server to stop.
+     *
+     * @return Whether the server is stopping.
+     */
+    bool
+    stopping();
 
 public:
     void

--- a/src/ripple/app/misc/SHAMapStoreImp.h
+++ b/src/ripple/app/misc/SHAMapStoreImp.h
@@ -136,7 +136,7 @@ public:
     }
 
     std::unique_ptr<NodeStore::Database>
-    makeNodeStore(std::int32_t readThreads) override;
+    makeNodeStore(int readThreads) override;
 
     LedgerIndex
     setCanDelete(LedgerIndex seq) override

--- a/src/ripple/app/paths/AccountCurrencies.cpp
+++ b/src/ripple/app/paths/AccountCurrencies.cpp
@@ -33,7 +33,7 @@ accountSourceCurrencies(
     if (includeXRP)
         currencies.insert(xrpCurrency());
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account))
+    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
     {
         auto& saBalance = rspEntry.getBalance();
 
@@ -64,7 +64,7 @@ accountDestCurrencies(
         currencies.insert(xrpCurrency());
     // Even if account doesn't exist
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account))
+    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
     {
         auto& saBalance = rspEntry.getBalance();
 

--- a/src/ripple/app/paths/AccountCurrencies.cpp
+++ b/src/ripple/app/paths/AccountCurrencies.cpp
@@ -33,18 +33,23 @@ accountSourceCurrencies(
     if (includeXRP)
         currencies.insert(xrpCurrency());
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
+    if (auto const lines =
+            lrCache->getRippleLines(account, LineDirection::outgoing))
     {
-        auto& saBalance = rspEntry.getBalance();
-
-        // Filter out non
-        if (saBalance > beast::zero
-            // Have IOUs to send.
-            || (rspEntry.getLimitPeer()
-                // Peer extends credit.
-                && ((-saBalance) < rspEntry.getLimitPeer())))  // Credit left.
+        for (auto const& rspEntry : *lines)
         {
-            currencies.insert(saBalance.getCurrency());
+            auto& saBalance = rspEntry.getBalance();
+
+            // Filter out non
+            if (saBalance > beast::zero
+                // Have IOUs to send.
+                ||
+                (rspEntry.getLimitPeer()
+                 // Peer extends credit.
+                 && ((-saBalance) < rspEntry.getLimitPeer())))  // Credit left.
+            {
+                currencies.insert(saBalance.getCurrency());
+            }
         }
     }
 
@@ -64,12 +69,16 @@ accountDestCurrencies(
         currencies.insert(xrpCurrency());
     // Even if account doesn't exist
 
-    for (auto const& rspEntry : lrCache->getRippleLines(account, true))
+    if (auto const lines =
+            lrCache->getRippleLines(account, LineDirection::outgoing))
     {
-        auto& saBalance = rspEntry.getBalance();
+        for (auto const& rspEntry : *lines)
+        {
+            auto& saBalance = rspEntry.getBalance();
 
-        if (saBalance < rspEntry.getLimit())  // Can take more
-            currencies.insert(saBalance.getCurrency());
+            if (saBalance < rspEntry.getLimit())  // Can take more
+                currencies.insert(saBalance.getCurrency());
+        }
     }
 
     currencies.erase(badCurrency());

--- a/src/ripple/app/paths/PathRequest.cpp
+++ b/src/ripple/app/paths/PathRequest.cpp
@@ -748,6 +748,8 @@ PathRequest::doUpdate(
         jvStatus = newStatus;
     }
 
+    JLOG(m_journal.debug())
+        << iIdentifier << " update finished " << (fast ? "fast" : "normal");
     return newStatus;
 }
 

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -708,6 +708,7 @@ int
 Pathfinder::getPathsOut(
     Currency const& currency,
     AccountID const& account,
+    bool outgoing,
     bool isDstCurrency,
     AccountID const& dstAccount,
     std::function<bool(void)> const& continueCallback)
@@ -735,7 +736,7 @@ Pathfinder::getPathsOut(
     {
         count = app_.getOrderBookDB().getBookSize(issue);
 
-        for (auto const& rspEntry : mRLCache->getRippleLines(account))
+        for (auto const& rspEntry : mRLCache->getRippleLines(account, outgoing))
         {
             if (currency != rspEntry.getLimit().getCurrency())
             {
@@ -976,7 +977,8 @@ Pathfinder::addLink(
                 bool const bIsNoRippleOut(isNoRippleOut(currentPath));
                 bool const bDestOnly(addFlags & afAC_LAST);
 
-                auto& rippleLines(mRLCache->getRippleLines(uEndAccount));
+                auto& rippleLines(
+                    mRLCache->getRippleLines(uEndAccount, !bIsNoRippleOut));
 
                 AccountCandidates candidates;
                 candidates.reserve(rippleLines.size());
@@ -986,6 +988,7 @@ Pathfinder::addLink(
                     if (continueCallback && !continueCallback())
                         return;
                     auto const& acct = rs.getAccountIDPeer();
+                    bool const outgoing = !rs.getNoRipplePeer();
 
                     if (hasEffectiveDestination && (acct == mDstAccount))
                     {
@@ -1047,6 +1050,7 @@ Pathfinder::addLink(
                             int out = getPathsOut(
                                 uEndCurrency,
                                 acct,
+                                outgoing,
                                 bIsEndCurrency,
                                 mEffectiveDst,
                                 continueCallback);

--- a/src/ripple/app/paths/Pathfinder.cpp
+++ b/src/ripple/app/paths/Pathfinder.cpp
@@ -708,7 +708,7 @@ int
 Pathfinder::getPathsOut(
     Currency const& currency,
     AccountID const& account,
-    bool outgoing,
+    LineDirection direction,
     bool isDstCurrency,
     AccountID const& dstAccount,
     std::function<bool(void)> const& continueCallback)
@@ -736,33 +736,37 @@ Pathfinder::getPathsOut(
     {
         count = app_.getOrderBookDB().getBookSize(issue);
 
-        for (auto const& rspEntry : mRLCache->getRippleLines(account, outgoing))
+        if (auto const lines = mRLCache->getRippleLines(account, direction))
         {
-            if (currency != rspEntry.getLimit().getCurrency())
+            for (auto const& rspEntry : *lines)
             {
-            }
-            else if (
-                rspEntry.getBalance() <= beast::zero &&
-                (!rspEntry.getLimitPeer() ||
-                 -rspEntry.getBalance() >= rspEntry.getLimitPeer() ||
-                 (bAuthRequired && !rspEntry.getAuth())))
-            {
-            }
-            else if (isDstCurrency && dstAccount == rspEntry.getAccountIDPeer())
-            {
-                count += 10000;  // count a path to the destination extra
-            }
-            else if (rspEntry.getNoRipplePeer())
-            {
-                // This probably isn't a useful path out
-            }
-            else if (rspEntry.getFreezePeer())
-            {
-                // Not a useful path out
-            }
-            else
-            {
-                ++count;
+                if (currency != rspEntry.getLimit().getCurrency())
+                {
+                }
+                else if (
+                    rspEntry.getBalance() <= beast::zero &&
+                    (!rspEntry.getLimitPeer() ||
+                     -rspEntry.getBalance() >= rspEntry.getLimitPeer() ||
+                     (bAuthRequired && !rspEntry.getAuth())))
+                {
+                }
+                else if (
+                    isDstCurrency && dstAccount == rspEntry.getAccountIDPeer())
+                {
+                    count += 10000;  // count a path to the destination extra
+                }
+                else if (rspEntry.getNoRipplePeer())
+                {
+                    // This probably isn't a useful path out
+                }
+                else if (rspEntry.getFreezePeer())
+                {
+                    // Not a useful path out
+                }
+                else
+                {
+                    ++count;
+                }
             }
         }
     }
@@ -977,120 +981,128 @@ Pathfinder::addLink(
                 bool const bIsNoRippleOut(isNoRippleOut(currentPath));
                 bool const bDestOnly(addFlags & afAC_LAST);
 
-                auto& rippleLines(
-                    mRLCache->getRippleLines(uEndAccount, !bIsNoRippleOut));
-
-                AccountCandidates candidates;
-                candidates.reserve(rippleLines.size());
-
-                for (auto const& rs : rippleLines)
+                if (auto const lines = mRLCache->getRippleLines(
+                        uEndAccount,
+                        bIsNoRippleOut ? LineDirection::incoming
+                                       : LineDirection::outgoing))
                 {
-                    if (continueCallback && !continueCallback())
-                        return;
-                    auto const& acct = rs.getAccountIDPeer();
-                    bool const outgoing = !rs.getNoRipplePeer();
+                    auto& rippleLines = *lines;
 
-                    if (hasEffectiveDestination && (acct == mDstAccount))
-                    {
-                        // We skipped the gateway
-                        continue;
-                    }
+                    AccountCandidates candidates;
+                    candidates.reserve(rippleLines.size());
 
-                    bool bToDestination = acct == mEffectiveDst;
-
-                    if (bDestOnly && !bToDestination)
-                    {
-                        continue;
-                    }
-
-                    if ((uEndCurrency == rs.getLimit().getCurrency()) &&
-                        !currentPath.hasSeen(acct, uEndCurrency, acct))
-                    {
-                        // path is for correct currency and has not been seen
-                        if (rs.getBalance() <= beast::zero &&
-                            (!rs.getLimitPeer() ||
-                             -rs.getBalance() >= rs.getLimitPeer() ||
-                             (bRequireAuth && !rs.getAuth())))
-                        {
-                            // path has no credit
-                        }
-                        else if (bIsNoRippleOut && rs.getNoRipple())
-                        {
-                            // Can't leave on this path
-                        }
-                        else if (bToDestination)
-                        {
-                            // destination is always worth trying
-                            if (uEndCurrency == mDstAmount.getCurrency())
-                            {
-                                // this is a complete path
-                                if (!currentPath.empty())
-                                {
-                                    JLOG(j_.trace())
-                                        << "complete path found ae: "
-                                        << currentPath.getJson(
-                                               JsonOptions::none);
-                                    addUniquePath(mCompletePaths, currentPath);
-                                }
-                            }
-                            else if (!bDestOnly)
-                            {
-                                // this is a high-priority candidate
-                                candidates.push_back(
-                                    {AccountCandidate::highPriority, acct});
-                            }
-                        }
-                        else if (acct == mSrcAccount)
-                        {
-                            // going back to the source is bad
-                        }
-                        else
-                        {
-                            // save this candidate
-                            int out = getPathsOut(
-                                uEndCurrency,
-                                acct,
-                                outgoing,
-                                bIsEndCurrency,
-                                mEffectiveDst,
-                                continueCallback);
-                            if (out)
-                                candidates.push_back({out, acct});
-                        }
-                    }
-                }
-
-                if (!candidates.empty())
-                {
-                    std::sort(
-                        candidates.begin(),
-                        candidates.end(),
-                        std::bind(
-                            compareAccountCandidate,
-                            mLedger->seq(),
-                            std::placeholders::_1,
-                            std::placeholders::_2));
-
-                    int count = candidates.size();
-                    // allow more paths from source
-                    if ((count > 10) && (uEndAccount != mSrcAccount))
-                        count = 10;
-                    else if (count > 50)
-                        count = 50;
-
-                    auto it = candidates.begin();
-                    while (count-- != 0)
+                    for (auto const& rs : rippleLines)
                     {
                         if (continueCallback && !continueCallback())
                             return;
-                        // Add accounts to incompletePaths
-                        STPathElement pathElement(
-                            STPathElement::typeAccount,
-                            it->account,
-                            uEndCurrency,
-                            it->account);
-                        incompletePaths.assembleAdd(currentPath, pathElement);
-                        ++it;
+                        auto const& acct = rs.getAccountIDPeer();
+                        LineDirection const direction = rs.getDirectionPeer();
+
+                        if (hasEffectiveDestination && (acct == mDstAccount))
+                        {
+                            // We skipped the gateway
+                            continue;
+                        }
+
+                        bool bToDestination = acct == mEffectiveDst;
+
+                        if (bDestOnly && !bToDestination)
+                        {
+                            continue;
+                        }
+
+                        if ((uEndCurrency == rs.getLimit().getCurrency()) &&
+                            !currentPath.hasSeen(acct, uEndCurrency, acct))
+                        {
+                            // path is for correct currency and has not been
+                            // seen
+                            if (rs.getBalance() <= beast::zero &&
+                                (!rs.getLimitPeer() ||
+                                 -rs.getBalance() >= rs.getLimitPeer() ||
+                                 (bRequireAuth && !rs.getAuth())))
+                            {
+                                // path has no credit
+                            }
+                            else if (bIsNoRippleOut && rs.getNoRipple())
+                            {
+                                // Can't leave on this path
+                            }
+                            else if (bToDestination)
+                            {
+                                // destination is always worth trying
+                                if (uEndCurrency == mDstAmount.getCurrency())
+                                {
+                                    // this is a complete path
+                                    if (!currentPath.empty())
+                                    {
+                                        JLOG(j_.trace())
+                                            << "complete path found ae: "
+                                            << currentPath.getJson(
+                                                   JsonOptions::none);
+                                        addUniquePath(
+                                            mCompletePaths, currentPath);
+                                    }
+                                }
+                                else if (!bDestOnly)
+                                {
+                                    // this is a high-priority candidate
+                                    candidates.push_back(
+                                        {AccountCandidate::highPriority, acct});
+                                }
+                            }
+                            else if (acct == mSrcAccount)
+                            {
+                                // going back to the source is bad
+                            }
+                            else
+                            {
+                                // save this candidate
+                                int out = getPathsOut(
+                                    uEndCurrency,
+                                    acct,
+                                    direction,
+                                    bIsEndCurrency,
+                                    mEffectiveDst,
+                                    continueCallback);
+                                if (out)
+                                    candidates.push_back({out, acct});
+                            }
+                        }
+                    }
+
+                    if (!candidates.empty())
+                    {
+                        std::sort(
+                            candidates.begin(),
+                            candidates.end(),
+                            std::bind(
+                                compareAccountCandidate,
+                                mLedger->seq(),
+                                std::placeholders::_1,
+                                std::placeholders::_2));
+
+                        int count = candidates.size();
+                        // allow more paths from source
+                        if ((count > 10) && (uEndAccount != mSrcAccount))
+                            count = 10;
+                        else if (count > 50)
+                            count = 50;
+
+                        auto it = candidates.begin();
+                        while (count-- != 0)
+                        {
+                            if (continueCallback && !continueCallback())
+                                return;
+                            // Add accounts to incompletePaths
+                            STPathElement pathElement(
+                                STPathElement::typeAccount,
+                                it->account,
+                                uEndCurrency,
+                                it->account);
+                            incompletePaths.assembleAdd(
+                                currentPath, pathElement);
+                            ++it;
+                        }
                     }
                 }
             }

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -144,7 +144,7 @@ private:
     getPathsOut(
         Currency const& currency,
         AccountID const& account,
-        bool outgoing,
+        LineDirection direction,
         bool isDestCurrency,
         AccountID const& dest,
         std::function<bool(void)> const& continueCallback);

--- a/src/ripple/app/paths/Pathfinder.h
+++ b/src/ripple/app/paths/Pathfinder.h
@@ -144,6 +144,7 @@ private:
     getPathsOut(
         Currency const& currency,
         AccountID const& account,
+        bool outgoing,
         bool isDestCurrency,
         AccountID const& dest,
         std::function<bool(void)> const& continueCallback);

--- a/src/ripple/app/paths/RippleLineCache.cpp
+++ b/src/ripple/app/paths/RippleLineCache.cpp
@@ -42,16 +42,17 @@ RippleLineCache::~RippleLineCache()
 }
 
 std::vector<PathFindTrustLine> const&
-RippleLineCache::getRippleLines(AccountID const& accountID)
+RippleLineCache::getRippleLines(AccountID const& accountID, bool outgoing)
 {
-    AccountKey key(accountID, hasher_(accountID));
+    AccountKey key(
+        accountID, outgoing, hasher_(std::pair{accountID, outgoing}));
 
     std::lock_guard sl(mLock);
 
     auto [it, inserted] = lines_.emplace(key, std::vector<PathFindTrustLine>());
 
     if (inserted)
-        it->second = PathFindTrustLine::getItems(accountID, *mLedger);
+        it->second = PathFindTrustLine::getItems(accountID, *mLedger, outgoing);
 
     JLOG(journal_.debug()) << "RippleLineCache getRippleLines for ledger "
                            << mLedger->info().seq << " found "

--- a/src/ripple/app/paths/RippleLineCache.cpp
+++ b/src/ripple/app/paths/RippleLineCache.cpp
@@ -26,40 +26,101 @@ namespace ripple {
 RippleLineCache::RippleLineCache(
     std::shared_ptr<ReadView const> const& ledger,
     beast::Journal j)
-    : journal_(j)
+    : ledger_(ledger), journal_(j)
 {
-    mLedger = ledger;
-
-    JLOG(journal_.debug()) << "RippleLineCache created for ledger "
-                           << mLedger->info().seq;
+    JLOG(journal_.debug()) << "created for ledger " << ledger_->info().seq;
 }
 
 RippleLineCache::~RippleLineCache()
 {
-    JLOG(journal_.debug()) << "~RippleLineCache destroyed for ledger "
-                           << mLedger->info().seq << " with " << lines_.size()
-                           << " accounts";
+    JLOG(journal_.debug()) << "destroyed for ledger " << ledger_->info().seq
+                           << " with " << lines_.size() << " accounts and "
+                           << totalLineCount_ << " distinct trust lines.";
 }
 
-std::vector<PathFindTrustLine> const&
-RippleLineCache::getRippleLines(AccountID const& accountID, bool outgoing)
+std::shared_ptr<std::vector<PathFindTrustLine>>
+RippleLineCache::getRippleLines(
+    AccountID const& accountID,
+    LineDirection direction)
 {
-    AccountKey key(
-        accountID, outgoing, hasher_(std::pair{accountID, outgoing}));
+    auto const hash = hasher_(accountID);
+    AccountKey key(accountID, direction, hash);
+    AccountKey otherkey(
+        accountID,
+        direction == LineDirection::outgoing ? LineDirection::incoming
+                                             : LineDirection::outgoing,
+        hash);
 
     std::lock_guard sl(mLock);
 
-    auto [it, inserted] = lines_.emplace(key, std::vector<PathFindTrustLine>());
+    auto [it, inserted] = [&]() {
+        if (auto otheriter = lines_.find(otherkey); otheriter != lines_.end())
+        {
+            // The whole point of using the direction flag is to reduce the
+            // number of trust line objects held in memory. Ensure that there is
+            // only a single set of trustlines in the cache per account.
+            auto const size = otheriter->second ? otheriter->second->size() : 0;
+            JLOG(journal_.info())
+                << "Request for "
+                << (direction == LineDirection::outgoing ? "outgoing"
+                                                         : "incoming")
+                << " trust lines for account " << accountID << " found " << size
+                << (direction == LineDirection::outgoing ? " incoming"
+                                                         : " outgoing")
+                << " trust lines. "
+                << (direction == LineDirection::outgoing
+                        ? "Deleting the subset of incoming"
+                        : "Returning the superset of outgoing")
+                << " trust lines. ";
+            if (direction == LineDirection::outgoing)
+            {
+                // This request is for the outgoing set, but there is already a
+                // subset of incoming lines in the cache. Erase that subset
+                // to be replaced by the full set. The full set will be built
+                // below, and will be returned, if needed, on subsequent calls
+                // for either value of outgoing.
+                assert(size <= totalLineCount_);
+                totalLineCount_ -= size;
+                lines_.erase(otheriter);
+            }
+            else
+            {
+                // This request is for the incoming set, but there is
+                // already a superset of the outgoing trust lines in the cache.
+                // The path finding engine will disregard the non-rippling trust
+                // lines, so to prevent them from being stored twice, return the
+                // outgoing set.
+                key = otherkey;
+                return std::pair{otheriter, false};
+            }
+        }
+        return lines_.emplace(key, nullptr);
+    }();
 
     if (inserted)
-        it->second = PathFindTrustLine::getItems(accountID, *mLedger, outgoing);
+    {
+        assert(it->second == nullptr);
+        auto lines =
+            PathFindTrustLine::getItems(accountID, *ledger_, direction);
+        if (lines.size())
+        {
+            it->second = std::make_shared<std::vector<PathFindTrustLine>>(
+                std::move(lines));
+            totalLineCount_ += it->second->size();
+        }
+    }
 
-    JLOG(journal_.debug()) << "RippleLineCache getRippleLines for ledger "
-                           << mLedger->info().seq << " found "
-                           << it->second.size() << " lines for "
-                           << (inserted ? "new " : "existing ") << accountID
-                           << " out of a total of " << lines_.size()
-                           << " accounts";
+    assert(!it->second || (it->second->size() > 0));
+    auto const size = it->second ? it->second->size() : 0;
+    JLOG(journal_.trace()) << "getRippleLines for ledger "
+                           << ledger_->info().seq << " found " << size
+                           << (key.direction_ == LineDirection::outgoing
+                                   ? " outgoing"
+                                   : " incoming")
+                           << " lines for " << (inserted ? "new " : "existing ")
+                           << accountID << " out of a total of "
+                           << lines_.size() << " accounts and "
+                           << totalLineCount_ << " trust lines";
 
     return it->second;
 }

--- a/src/ripple/app/paths/RippleLineCache.h
+++ b/src/ripple/app/paths/RippleLineCache.h
@@ -44,13 +44,13 @@ public:
     std::shared_ptr<ReadView const> const&
     getLedger() const
     {
-        return mLedger;
+        return ledger_;
     }
 
     /** Find the trust lines associated with an account.
 
        @param accountID The account
-       @param outgoing Whether the account is an "outgoing" link on the path.
+       @param direction Whether the account is an "outgoing" link on the path.
        "Outgoing" is defined as the source account, or an account found via a
        trustline that has rippling enabled on the @accountID's side. If an
        account is "outgoing", all trust lines will be returned. If an account is
@@ -59,25 +59,28 @@ public:
        @accountID's side.
        @return Returns a vector of the usable trust lines.
     */
-    std::vector<PathFindTrustLine> const&
-    getRippleLines(AccountID const& accountID, bool outgoing);
+    std::shared_ptr<std::vector<PathFindTrustLine>>
+    getRippleLines(AccountID const& accountID, LineDirection direction);
 
 private:
     std::mutex mLock;
 
     ripple::hardened_hash<> hasher_;
-    std::shared_ptr<ReadView const> mLedger;
+    std::shared_ptr<ReadView const> ledger_;
 
     beast::Journal journal_;
 
     struct AccountKey final : public CountedObject<AccountKey>
     {
         AccountID account_;
-        bool outgoing_;
+        LineDirection direction_;
         std::size_t hash_value_;
 
-        AccountKey(AccountID const& account, bool outgoing, std::size_t hash)
-            : account_(account), outgoing_(outgoing), hash_value_(hash)
+        AccountKey(
+            AccountID const& account,
+            LineDirection direction,
+            std::size_t hash)
+            : account_(account), direction_(direction), hash_value_(hash)
         {
         }
 
@@ -90,7 +93,7 @@ private:
         operator==(AccountKey const& lhs) const
         {
             return hash_value_ == lhs.hash_value_ && account_ == lhs.account_ &&
-                outgoing_ == lhs.outgoing_;
+                direction_ == lhs.direction_;
         }
 
         std::size_t
@@ -111,8 +114,17 @@ private:
         };
     };
 
-    hash_map<AccountKey, std::vector<PathFindTrustLine>, AccountKey::Hash>
+    // Use a shared_ptr so entries can be removed from the map safely.
+    // Even though a shared_ptr to a vector will take more memory just a vector,
+    // most accounts are not going to have any entries (estimated over 90%), so
+    // vectors will not need to be created for them. This should lead to far
+    // less memory usage overall.
+    hash_map<
+        AccountKey,
+        std::shared_ptr<std::vector<PathFindTrustLine>>,
+        AccountKey::Hash>
         lines_;
+    std::size_t totalLineCount_ = 0;
 };
 
 }  // namespace ripple

--- a/src/ripple/app/paths/RippleLineCache.h
+++ b/src/ripple/app/paths/RippleLineCache.h
@@ -47,8 +47,20 @@ public:
         return mLedger;
     }
 
+    /** Find the trust lines associated with an account.
+
+       @param accountID The account
+       @param outgoing Whether the account is an "outgoing" link on the path.
+       "Outgoing" is defined as the source account, or an account found via a
+       trustline that has rippling enabled on the @accountID's side. If an
+       account is "outgoing", all trust lines will be returned. If an account is
+       not "outgoing", then any trust lines that don't have rippling enabled are
+       not usable, so only return trust lines that have rippling enabled on
+       @accountID's side.
+       @return Returns a vector of the usable trust lines.
+    */
     std::vector<PathFindTrustLine> const&
-    getRippleLines(AccountID const& accountID);
+    getRippleLines(AccountID const& accountID, bool outgoing);
 
 private:
     std::mutex mLock;
@@ -61,10 +73,11 @@ private:
     struct AccountKey final : public CountedObject<AccountKey>
     {
         AccountID account_;
+        bool outgoing_;
         std::size_t hash_value_;
 
-        AccountKey(AccountID const& account, std::size_t hash)
-            : account_(account), hash_value_(hash)
+        AccountKey(AccountID const& account, bool outgoing, std::size_t hash)
+            : account_(account), outgoing_(outgoing), hash_value_(hash)
         {
         }
 
@@ -76,7 +89,8 @@ private:
         bool
         operator==(AccountKey const& lhs) const
         {
-            return hash_value_ == lhs.hash_value_ && account_ == lhs.account_;
+            return hash_value_ == lhs.hash_value_ && account_ == lhs.account_ &&
+                outgoing_ == lhs.outgoing_;
         }
 
         std::size_t

--- a/src/ripple/app/paths/TrustLine.cpp
+++ b/src/ripple/app/paths/TrustLine.cpp
@@ -64,18 +64,22 @@ std::vector<T>
 getTrustLineItems(
     AccountID const& accountID,
     ReadView const& view,
-    bool outgoing = true)
+    LineDirection direction = LineDirection::outgoing)
 {
     std::vector<T> items;
     forEachItem(
         view,
         accountID,
-        [&items, &accountID, &outgoing](
+        [&items, &accountID, &direction](
             std::shared_ptr<SLE const> const& sleCur) {
             auto ret = T::makeItem(accountID, sleCur);
-            if (ret && (outgoing || !ret->getNoRipple()))
+            if (ret &&
+                (direction == LineDirection::outgoing || !ret->getNoRipple()))
                 items.push_back(std::move(*ret));
         });
+    // This list may be around for a while, so free up any unneeded
+    // capacity
+    items.shrink_to_fit();
 
     return items;
 }
@@ -85,10 +89,10 @@ std::vector<PathFindTrustLine>
 PathFindTrustLine::getItems(
     AccountID const& accountID,
     ReadView const& view,
-    bool outgoing)
+    LineDirection direction)
 {
     return detail::getTrustLineItems<PathFindTrustLine>(
-        accountID, view, outgoing);
+        accountID, view, direction);
 }
 
 RPCTrustLine::RPCTrustLine(

--- a/src/ripple/app/paths/TrustLine.cpp
+++ b/src/ripple/app/paths/TrustLine.cpp
@@ -61,15 +61,19 @@ PathFindTrustLine::makeItem(
 namespace detail {
 template <class T>
 std::vector<T>
-getTrustLineItems(AccountID const& accountID, ReadView const& view)
+getTrustLineItems(
+    AccountID const& accountID,
+    ReadView const& view,
+    bool outgoing = true)
 {
     std::vector<T> items;
     forEachItem(
         view,
         accountID,
-        [&items, &accountID](std::shared_ptr<SLE const> const& sleCur) {
+        [&items, &accountID, &outgoing](
+            std::shared_ptr<SLE const> const& sleCur) {
             auto ret = T::makeItem(accountID, sleCur);
-            if (ret)
+            if (ret && (outgoing || !ret->getNoRipple()))
                 items.push_back(std::move(*ret));
         });
 
@@ -78,9 +82,13 @@ getTrustLineItems(AccountID const& accountID, ReadView const& view)
 }  // namespace detail
 
 std::vector<PathFindTrustLine>
-PathFindTrustLine::getItems(AccountID const& accountID, ReadView const& view)
+PathFindTrustLine::getItems(
+    AccountID const& accountID,
+    ReadView const& view,
+    bool outgoing)
 {
-    return detail::getTrustLineItems<PathFindTrustLine>(accountID, view);
+    return detail::getTrustLineItems<PathFindTrustLine>(
+        accountID, view, outgoing);
 }
 
 RPCTrustLine::RPCTrustLine(

--- a/src/ripple/app/paths/TrustLine.h
+++ b/src/ripple/app/paths/TrustLine.h
@@ -31,6 +31,15 @@
 
 namespace ripple {
 
+/** Describes how an account was found in a path, and how to find the next set
+of paths. "Outgoing" is defined as the source account, or an account found via a
+trustline that has rippling enabled on the account's side.
+"Incoming" is defined as an account found via a trustline that has rippling
+disabled on the account's side. Any trust lines for an incoming account that
+have rippling disabled are unusable in paths.
+*/
+enum class LineDirection : bool { incoming = false, outgoing = true };
+
 /** Wraps a trust line SLE for convenience.
     The complication of trust lines is that there is a
     "low" account and a "high" account. This wraps the
@@ -109,6 +118,20 @@ public:
         return mFlags & (!mViewLowest ? lsfLowNoRipple : lsfHighNoRipple);
     }
 
+    LineDirection
+    getDirection() const
+    {
+        return getNoRipple() ? LineDirection::incoming
+                             : LineDirection::outgoing;
+    }
+
+    LineDirection
+    getDirectionPeer() const
+    {
+        return getNoRipplePeer() ? LineDirection::incoming
+                                 : LineDirection::outgoing;
+    }
+
     /** Have we set the freeze flag on our peer */
     bool
     getFreeze() const
@@ -170,7 +193,10 @@ public:
     makeItem(AccountID const& accountID, std::shared_ptr<SLE const> const& sle);
 
     static std::vector<PathFindTrustLine>
-    getItems(AccountID const& accountID, ReadView const& view, bool outgoing);
+    getItems(
+        AccountID const& accountID,
+        ReadView const& view,
+        LineDirection direction);
 };
 
 // This wrapper is used for the `AccountLines` command and includes the quality

--- a/src/ripple/app/paths/TrustLine.h
+++ b/src/ripple/app/paths/TrustLine.h
@@ -170,7 +170,7 @@ public:
     makeItem(AccountID const& accountID, std::shared_ptr<SLE const> const& sle);
 
     static std::vector<PathFindTrustLine>
-    getItems(AccountID const& accountID, ReadView const& view);
+    getItems(AccountID const& accountID, ReadView const& view, bool outgoing);
 };
 
 // This wrapper is used for the `AccountLines` command and includes the quality

--- a/src/ripple/app/tx/impl/SetSignerList.h
+++ b/src/ripple/app/tx/impl/SetSignerList.h
@@ -25,6 +25,7 @@
 #include <ripple/app/tx/impl/Transactor.h>
 #include <ripple/basics/Log.h>
 #include <ripple/protocol/Indexes.h>
+#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STArray.h>
 #include <ripple/protocol/STObject.h>
 #include <ripple/protocol/STTx.h>
@@ -83,7 +84,8 @@ private:
         std::uint32_t quorum,
         std::vector<SignerEntries::SignerEntry> const& signers,
         AccountID const& account,
-        beast::Journal j);
+        beast::Journal j,
+        Rules const&);
 
     TER
     replaceSignerList();

--- a/src/ripple/app/tx/impl/SignerEntries.cpp
+++ b/src/ripple/app/tx/impl/SignerEntries.cpp
@@ -22,6 +22,7 @@
 #include <ripple/protocol/STArray.h>
 #include <ripple/protocol/STObject.h>
 #include <cstdint>
+#include <optional>
 
 namespace ripple {
 
@@ -41,7 +42,7 @@ SignerEntries::deserialize(
     }
 
     std::vector<SignerEntry> accountVec;
-    accountVec.reserve(STTx::maxMultiSigners);
+    accountVec.reserve(STTx::maxMultiSigners());
 
     STArray const& sEntries(obj.getFieldArray(sfSignerEntries));
     for (STObject const& sEntry : sEntries)
@@ -57,7 +58,9 @@ SignerEntries::deserialize(
         // Extract SignerEntry fields.
         AccountID const account = sEntry.getAccountID(sfAccount);
         std::uint16_t const weight = sEntry.getFieldU16(sfSignerWeight);
-        accountVec.emplace_back(account, weight);
+        std::optional<uint256> const tag = sEntry.at(~sfWalletLocator);
+
+        accountVec.emplace_back(account, weight, tag);
     }
     return accountVec;
 }

--- a/src/ripple/app/tx/impl/SignerEntries.h
+++ b/src/ripple/app/tx/impl/SignerEntries.h
@@ -23,9 +23,11 @@
 #include <ripple/app/tx/impl/Transactor.h>  // NotTEC
 #include <ripple/basics/Expected.h>         //
 #include <ripple/beast/utility/Journal.h>   // beast::Journal
+#include <ripple/protocol/Rules.h>          // Rules
 #include <ripple/protocol/STTx.h>           // STTx::maxMultiSigners
 #include <ripple/protocol/TER.h>            // temMALFORMED
 #include <ripple/protocol/UintTypes.h>      // AccountID
+#include <optional>
 
 namespace ripple {
 
@@ -42,9 +44,13 @@ public:
     {
         AccountID account;
         std::uint16_t weight;
+        std::optional<uint256> tag;
 
-        SignerEntry(AccountID const& inAccount, std::uint16_t inWeight)
-            : account(inAccount), weight(inWeight)
+        SignerEntry(
+            AccountID const& inAccount,
+            std::uint16_t inWeight,
+            std::optional<uint256> inTag)
+            : account(inAccount), weight(inWeight), tag(inTag)
         {
         }
 

--- a/src/ripple/app/tx/impl/apply.cpp
+++ b/src/ripple/app/tx/impl/apply.cpp
@@ -54,7 +54,7 @@ checkValidity(
             ? STTx::RequireFullyCanonicalSig::yes
             : STTx::RequireFullyCanonicalSig::no;
 
-        auto const sigVerify = tx.checkSign(requireCanonicalSig);
+        auto const sigVerify = tx.checkSign(requireCanonicalSig, rules);
         if (!sigVerify)
         {
             router.setFlags(id, SF_SIGBAD);

--- a/src/ripple/beast/utility/rngfill.h
+++ b/src/ripple/beast/utility/rngfill.h
@@ -43,11 +43,13 @@ rngfill(void* buffer, std::size_t bytes, Generator& g)
     // gcc 11.1 (falsely) warns about an array-bounds overflow in release mode.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     if (bytes > 0)
     {
         auto const v = g();
         std::memcpy(buffer, &v, bytes);
     }
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 }

--- a/src/ripple/ledger/ReadView.h
+++ b/src/ripple/ledger/ReadView.h
@@ -29,6 +29,7 @@
 #include <ripple/ledger/detail/ReadViewFwdRange.h>
 #include <ripple/protocol/Indexes.h>
 #include <ripple/protocol/Protocol.h>
+#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/STLedgerEntry.h>
 #include <ripple/protocol/STTx.h>
@@ -121,64 +122,6 @@ struct LedgerInfo
     // will close if there's no transactions.
     //
     NetClock::time_point closeTime = {};
-};
-
-//------------------------------------------------------------------------------
-
-class DigestAwareReadView;
-
-/** Rules controlling protocol behavior. */
-class Rules
-{
-private:
-    class Impl;
-
-    std::shared_ptr<Impl const> impl_;
-
-public:
-    Rules(Rules const&) = default;
-    Rules&
-    operator=(Rules const&) = default;
-
-    Rules() = delete;
-
-    /** Construct an empty rule set.
-
-        These are the rules reflected by
-        the genesis ledger.
-    */
-    explicit Rules(std::unordered_set<uint256, beast::uhash<>> const& presets);
-
-    /** Construct rules from a ledger.
-
-        The ledger contents are analyzed for rules
-        and amendments and extracted to the object.
-    */
-    explicit Rules(
-        DigestAwareReadView const& ledger,
-        std::unordered_set<uint256, beast::uhash<>> const& presets);
-
-    /** Returns `true` if a feature is enabled. */
-    bool
-    enabled(uint256 const& id) const;
-
-    /** Returns `true` if these rules don't match the ledger. */
-    bool
-    changed(DigestAwareReadView const& ledger) const;
-
-    /** Returns `true` if two rule sets are identical.
-
-        @note This is for diagnostics. To determine if new
-        rules should be constructed, call changed() first instead.
-    */
-    bool
-    operator==(Rules const&) const;
-
-    bool
-    operator!=(Rules const& other) const
-    {
-        return !(*this == other);
-    }
 };
 
 //------------------------------------------------------------------------------
@@ -422,6 +365,11 @@ getCloseAgree(LedgerInfo const& info)
 
 void
 addRaw(LedgerInfo const&, Serializer&, bool includeHash = false);
+
+Rules
+makeRulesGivenLedger(
+    DigestAwareReadView const& ledger,
+    std::unordered_set<uint256, beast::uhash<>> const& presets);
 
 }  // namespace ripple
 

--- a/src/ripple/ledger/impl/ReadView.cpp
+++ b/src/ripple/ledger/impl/ReadView.cpp
@@ -21,108 +21,6 @@
 
 namespace ripple {
 
-class Rules::Impl
-{
-private:
-    std::unordered_set<uint256, hardened_hash<>> set_;
-    std::optional<uint256> digest_;
-    std::unordered_set<uint256, beast::uhash<>> const& presets_;
-
-public:
-    explicit Impl(std::unordered_set<uint256, beast::uhash<>> const& presets)
-        : presets_(presets)
-    {
-    }
-
-    explicit Impl(
-        DigestAwareReadView const& ledger,
-        std::unordered_set<uint256, beast::uhash<>> const& presets)
-        : presets_(presets)
-    {
-        auto const k = keylet::amendments();
-        digest_ = ledger.digest(k.key);
-        if (!digest_)
-            return;
-        auto const sle = ledger.read(k);
-        if (!sle)
-        {
-            // LogicError() ?
-            return;
-        }
-
-        for (auto const& item : sle->getFieldV256(sfAmendments))
-            set_.insert(item);
-    }
-
-    bool
-    enabled(uint256 const& feature) const
-    {
-        if (presets_.count(feature) > 0)
-            return true;
-        return set_.count(feature) > 0;
-    }
-
-    bool
-    changed(DigestAwareReadView const& ledger) const
-    {
-        auto const digest = ledger.digest(keylet::amendments().key);
-        if (!digest && !digest_)
-            return false;
-        if (!digest || !digest_)
-            return true;
-        return *digest != *digest_;
-    }
-
-    bool
-    operator==(Impl const& other) const
-    {
-        if (!digest_ && !other.digest_)
-            return true;
-        if (!digest_ || !other.digest_)
-            return false;
-        return *digest_ == *other.digest_;
-    }
-};
-
-//------------------------------------------------------------------------------
-
-Rules::Rules(
-    DigestAwareReadView const& ledger,
-    std::unordered_set<uint256, beast::uhash<>> const& presets)
-    : impl_(std::make_shared<Impl>(ledger, presets))
-{
-}
-
-Rules::Rules(std::unordered_set<uint256, beast::uhash<>> const& presets)
-    : impl_(std::make_shared<Impl>(presets))
-{
-}
-
-bool
-Rules::enabled(uint256 const& id) const
-{
-    assert(impl_);
-    return impl_->enabled(id);
-}
-
-bool
-Rules::changed(DigestAwareReadView const& ledger) const
-{
-    assert(impl_);
-    return impl_->changed(ledger);
-}
-
-bool
-Rules::operator==(Rules const& other) const
-{
-    assert(impl_ && other.impl_);
-    if (impl_.get() == other.impl_.get())
-        return true;
-    return *impl_ == *other.impl_;
-}
-
-//------------------------------------------------------------------------------
-
 ReadView::sles_type::sles_type(ReadView const& view) : ReadViewFwdRange(view)
 {
 }
@@ -165,6 +63,22 @@ auto
 ReadView::txs_type::end() const -> iterator
 {
     return iterator(view_, view_->txsEnd());
+}
+
+Rules
+makeRulesGivenLedger(
+    DigestAwareReadView const& ledger,
+    std::unordered_set<uint256, beast::uhash<>> const& presets)
+{
+    Keylet const k = keylet::amendments();
+    std::optional digest = ledger.digest(k.key);
+    if (digest)
+    {
+        auto const sle = ledger.read(k);
+        if (sle)
+            return Rules(presets, digest, sle->getFieldV256(sfAmendments));
+    }
+    return Rules(presets);
 }
 
 }  // namespace ripple

--- a/src/ripple/net/HTTPDownloader.h
+++ b/src/ripple/net/HTTPDownloader.h
@@ -61,6 +61,12 @@ public:
 
     virtual ~HTTPDownloader() = default;
 
+    bool
+    sessionIsActive() const;
+
+    bool
+    isStopping() const;
+
 protected:
     // must be accessed through a shared_ptr
     // use make_XXX functions to create
@@ -88,7 +94,7 @@ private:
     std::atomic<bool> stop_;
 
     // Used to protect sessionActive_
-    std::mutex m_;
+    mutable std::mutex m_;
     bool sessionActive_;
     std::condition_variable c_;
 

--- a/src/ripple/net/impl/HTTPDownloader.cpp
+++ b/src/ripple/net/impl/HTTPDownloader.cpp
@@ -293,6 +293,20 @@ HTTPDownloader::stop()
     }
 }
 
+bool
+HTTPDownloader::sessionIsActive() const
+{
+    std::lock_guard lock(m_);
+    return sessionActive_;
+}
+
+bool
+HTTPDownloader::isStopping() const
+{
+    std::lock_guard lock(m_);
+    return stop_;
+}
+
 void
 HTTPDownloader::fail(
     boost::filesystem::path dstPath,

--- a/src/ripple/nodestore/Database.h
+++ b/src/ripple/nodestore/Database.h
@@ -324,6 +324,11 @@ protected:
     // The earliest shard index
     std::uint32_t const earliestShardIndex_;
 
+    // The maximum number of requests a thread extracts from the queue in an
+    // attempt to minimize the overhead of mutex acquisition. This is an
+    // advanced tunable, via the config file. The default value is 4.
+    int const requestBundle_;
+
     void
     storeStats(std::uint64_t count, std::uint64_t sz)
     {
@@ -368,6 +373,7 @@ private:
 
     std::atomic<bool> readStopping_ = false;
     std::atomic<int> readThreads_ = 0;
+    std::atomic<int> runningThreads_ = 0;
 
     virtual std::shared_ptr<NodeObject>
     fetchNodeObject(

--- a/src/ripple/overlay/impl/PeerImp.cpp
+++ b/src/ripple/overlay/impl/PeerImp.cpp
@@ -3404,7 +3404,7 @@ PeerImp::getLedger(std::shared_ptr<protocol::TMGetLedger> const& m)
     }
     else
     {
-        JLOG(p_journal_.warn()) << "getLedger: Unable to find ledger";
+        JLOG(p_journal_.debug()) << "getLedger: Unable to find ledger";
     }
 
     return ledger;

--- a/src/ripple/proto/org/xrpl/rpc/v1/common.proto
+++ b/src/ripple/proto/org/xrpl/rpc/v1/common.proto
@@ -373,6 +373,12 @@ message RootIndex
     bytes value = 1;
 }
 
+message WalletLocator
+{
+    // 32 bytes
+    bytes value = 1;
+}
+
 
 // *** Messages wrapping variable length byte arrays ***
 
@@ -586,6 +592,8 @@ message SignerEntry
     Account account = 1;
 
     SignerWeight signer_weight = 2;
+
+    WalletLocator wallet_locator = 3;
 }
 
 // Next field: 3

--- a/src/ripple/protocol/Feature.h
+++ b/src/ripple/protocol/Feature.h
@@ -334,6 +334,7 @@ extern uint256 const fixSTAmountCanonicalize;
 extern uint256 const fixRmSmallIncreasedQOffers;
 extern uint256 const featureCheckCashMakesTrustLine;
 extern uint256 const featureNonFungibleTokensV1;
+extern uint256 const featureExpandedSignerList;
 
 }  // namespace ripple
 

--- a/src/ripple/protocol/Rules.h
+++ b/src/ripple/protocol/Rules.h
@@ -1,0 +1,86 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#ifndef RIPPLE_LEDGER_RULES_H_INCLUDED
+#define RIPPLE_LEDGER_RULES_H_INCLUDED
+
+#include <ripple/basics/base_uint.h>
+#include <ripple/beast/hash/uhash.h>
+#include <ripple/protocol/STVector256.h>
+#include <unordered_set>
+
+namespace ripple {
+
+class DigestAwareReadView;
+
+/** Rules controlling protocol behavior. */
+class Rules
+{
+private:
+    class Impl;
+
+    // Carrying impl by shared_ptr makes Rules comparatively cheap to pass
+    // by value.
+    std::shared_ptr<Impl const> impl_;
+
+public:
+    Rules(Rules const&) = default;
+
+    Rules&
+    operator=(Rules const&) = default;
+
+    Rules() = delete;
+
+    /** Construct an empty rule set.
+
+        These are the rules reflected by
+        the genesis ledger.
+    */
+    explicit Rules(std::unordered_set<uint256, beast::uhash<>> const& presets);
+
+private:
+    // Allow a friend function to construct Rules.
+    friend Rules
+    makeRulesGivenLedger(
+        DigestAwareReadView const& ledger,
+        std::unordered_set<uint256, beast::uhash<>> const& presets);
+
+    Rules(
+        std::unordered_set<uint256, beast::uhash<>> const& presets,
+        std::optional<uint256> const& digest,
+        STVector256 const& amendments);
+
+public:
+    /** Returns `true` if a feature is enabled. */
+    bool
+    enabled(uint256 const& feature) const;
+
+    /** Returns `true` if two rule sets are identical.
+
+        @note This is for diagnostics.
+    */
+    bool
+    operator==(Rules const&) const;
+
+    bool
+    operator!=(Rules const& other) const;
+};
+
+}  // namespace ripple
+#endif

--- a/src/ripple/protocol/impl/Feature.cpp
+++ b/src/ripple/protocol/impl/Feature.cpp
@@ -438,6 +438,7 @@ REGISTER_FIX    (fixSTAmountCanonicalize,       Supported::yes, DefaultVote::yes
 REGISTER_FIX    (fixRmSmallIncreasedQOffers,    Supported::yes, DefaultVote::yes);
 REGISTER_FEATURE(CheckCashMakesTrustLine,       Supported::yes, DefaultVote::no);
 REGISTER_FEATURE(NonFungibleTokensV1,           Supported::yes, DefaultVote::no);
+REGISTER_FEATURE(ExpandedSignerList,            Supported::yes, DefaultVote::no);
 
 // The following amendments have been active for at least two years. Their
 // pre-amendment code has been removed and the identifiers are deprecated.

--- a/src/ripple/protocol/impl/InnerObjectFormats.cpp
+++ b/src/ripple/protocol/impl/InnerObjectFormats.cpp
@@ -28,6 +28,7 @@ InnerObjectFormats::InnerObjectFormats()
         {
             {sfAccount, soeREQUIRED},
             {sfSignerWeight, soeREQUIRED},
+            {sfWalletLocator, soeOPTIONAL},
         });
 
     add(sfSigner.jsonName.c_str(),

--- a/src/ripple/protocol/impl/Rules.cpp
+++ b/src/ripple/protocol/impl/Rules.cpp
@@ -1,0 +1,103 @@
+//------------------------------------------------------------------------------
+/*
+    This file is part of rippled: https://github.com/ripple/rippled
+    Copyright (c) 2012, 2013 Ripple Labs Inc.
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose  with  or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE  SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH  REGARD  TO  THIS  SOFTWARE  INCLUDING  ALL  IMPLIED  WARRANTIES  OF
+    MERCHANTABILITY  AND  FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY  SPECIAL ,  DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER  RESULTING  FROM  LOSS  OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION  OF  CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+    OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+//==============================================================================
+
+#include <ripple/protocol/Rules.h>
+
+#include <ripple/protocol/Indexes.h>
+
+namespace ripple {
+
+class Rules::Impl
+{
+private:
+    std::unordered_set<uint256, hardened_hash<>> set_;
+    std::optional<uint256> digest_;
+    std::unordered_set<uint256, beast::uhash<>> const& presets_;
+
+public:
+    explicit Impl(std::unordered_set<uint256, beast::uhash<>> const& presets)
+        : presets_(presets)
+    {
+    }
+
+    Impl(
+        std::unordered_set<uint256, beast::uhash<>> const& presets,
+        std::optional<uint256> const& digest,
+        STVector256 const& amendments)
+        : presets_(presets)
+    {
+        digest_ = digest;
+        set_.reserve(amendments.size());
+        set_.insert(amendments.begin(), amendments.end());
+    }
+
+    bool
+    enabled(uint256 const& feature) const
+    {
+        if (presets_.count(feature) > 0)
+            return true;
+        return set_.count(feature) > 0;
+    }
+
+    bool
+    operator==(Impl const& other) const
+    {
+        if (!digest_ && !other.digest_)
+            return true;
+        if (!digest_ || !other.digest_)
+            return false;
+        return *digest_ == *other.digest_;
+    }
+};
+
+Rules::Rules(std::unordered_set<uint256, beast::uhash<>> const& presets)
+    : impl_(std::make_shared<Impl>(presets))
+{
+}
+
+Rules::Rules(
+    std::unordered_set<uint256, beast::uhash<>> const& presets,
+    std::optional<uint256> const& digest,
+    STVector256 const& amendments)
+    : impl_(std::make_shared<Impl>(presets, digest, amendments))
+{
+}
+
+bool
+Rules::enabled(uint256 const& feature) const
+{
+    assert(impl_);
+    return impl_->enabled(feature);
+}
+
+bool
+Rules::operator==(Rules const& other) const
+{
+    assert(impl_ && other.impl_);
+    if (impl_.get() == other.impl_.get())
+        return true;
+    return *impl_ == *other.impl_;
+}
+
+bool
+Rules::operator!=(Rules const& other) const
+{
+    return !(*this == other);
+}
+}  // namespace ripple

--- a/src/ripple/rpc/impl/GRPCHelpers.cpp
+++ b/src/ripple/rpc/impl/GRPCHelpers.cpp
@@ -748,6 +748,14 @@ populateSignerListID(T& to, STObject const& from)
 
 template <class T>
 void
+populateWalletLocator(T& to, STObject const& from)
+{
+    populateProtoPrimitive(
+        [&to]() { return to.mutable_wallet_locator(); }, from, sfWalletLocator);
+}
+
+template <class T>
+void
 populateTicketSequence(T& to, STObject const& from)
 {
     populateProtoPrimitive(
@@ -1012,6 +1020,7 @@ populateSignerEntries(T& to, STObject const& from)
         [](auto& innerObj, auto& innerProto) {
             populateAccount(innerProto, innerObj);
             populateSignerWeight(innerProto, innerObj);
+            populateWalletLocator(innerProto, innerObj);
         },
         from,
         sfSignerEntries,

--- a/src/ripple/rpc/impl/RPCHelpers.cpp
+++ b/src/ripple/rpc/impl/RPCHelpers.cpp
@@ -696,19 +696,31 @@ parseRippleLibSeed(Json::Value const& value)
 std::optional<Seed>
 getSeedFromRPC(Json::Value const& params, Json::Value& error)
 {
-    // The array should be constexpr, but that makes Visual Studio unhappy.
-    static char const* const seedTypes[]{
-        jss::passphrase.c_str(), jss::seed.c_str(), jss::seed_hex.c_str()};
+    using string_to_seed_t =
+        std::function<std::optional<Seed>(std::string const&)>;
+    using seed_match_t = std::pair<char const*, string_to_seed_t>;
+
+    static seed_match_t const seedTypes[]{
+        {jss::passphrase.c_str(),
+         [](std::string const& s) { return parseGenericSeed(s); }},
+        {jss::seed.c_str(),
+         [](std::string const& s) { return parseBase58<Seed>(s); }},
+        {jss::seed_hex.c_str(), [](std::string const& s) {
+             uint128 i;
+             if (i.parseHex(s))
+                 return std::optional<Seed>(Slice(i.data(), i.size()));
+             return std::optional<Seed>{};
+         }}};
 
     // Identify which seed type is in use.
-    char const* seedType = nullptr;
+    seed_match_t const* seedType = nullptr;
     int count = 0;
-    for (auto t : seedTypes)
+    for (auto const& t : seedTypes)
     {
-        if (params.isMember(t))
+        if (params.isMember(t.first))
         {
             ++count;
-            seedType = t;
+            seedType = &t;
         }
     }
 
@@ -722,28 +734,17 @@ getSeedFromRPC(Json::Value const& params, Json::Value& error)
     }
 
     // Make sure a string is present
-    if (!params[seedType].isString())
+    auto const& param = params[seedType->first];
+    if (!param.isString())
     {
-        error = RPC::expected_field_error(seedType, "string");
+        error = RPC::expected_field_error(seedType->first, "string");
         return std::nullopt;
     }
 
-    auto const fieldContents = params[seedType].asString();
+    auto const fieldContents = param.asString();
 
     // Convert string to seed.
-    std::optional<Seed> seed;
-
-    if (seedType == jss::seed.c_str())
-        seed = parseBase58<Seed>(fieldContents);
-    else if (seedType == jss::passphrase.c_str())
-        seed = parseGenericSeed(fieldContents);
-    else if (seedType == jss::seed_hex.c_str())
-    {
-        uint128 s;
-
-        if (s.parseHex(fieldContents))
-            seed.emplace(Slice(s.data(), s.size()));
-    }
+    std::optional<Seed> seed = seedType->second(fieldContents);
 
     if (!seed)
         error = rpcError(rpcBAD_SEED);
@@ -757,7 +758,6 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
     bool const has_key_type = params.isMember(jss::key_type);
 
     // All of the secret types we allow, but only one at a time.
-    // The array should be constexpr, but that makes Visual Studio unhappy.
     static char const* const secretTypes[]{
         jss::passphrase.c_str(),
         jss::secret.c_str(),
@@ -811,7 +811,9 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
             return {};
         }
 
-        if (secretType == jss::secret.c_str())
+        // using strcmp as pointers may not match (see
+        // https://developercommunity.visualstudio.com/t/assigning-constexpr-char--to-static-cha/10021357?entry=problem)
+        if (strcmp(secretType, jss::secret.c_str()) == 0)
         {
             error = RPC::make_param_error(
                 "The secret field is not allowed if " +
@@ -823,7 +825,9 @@ keypairForSignature(Json::Value const& params, Json::Value& error)
     // ripple-lib encodes seed used to generate an Ed25519 wallet in a
     // non-standard way. While we never encode seeds that way, we try
     // to detect such keys to avoid user confusion.
-    if (secretType != jss::seed_hex.c_str())
+    // using strcmp as pointers may not match (see
+    // https://developercommunity.visualstudio.com/t/assigning-constexpr-char--to-static-cha/10021357?entry=problem)
+    if (strcmp(secretType, jss::seed_hex.c_str()) != 0)
     {
         seed = RPC::parseRippleLibSeed(params[secretType]);
 

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -34,6 +34,30 @@ class MultiSign_test : public beast::unit_test::suite
     jtx::Account const phase{"phase", KeyType::ed25519};
     jtx::Account const shade{"shade", KeyType::secp256k1};
     jtx::Account const spook{"spook", KeyType::ed25519};
+    jtx::Account const acc10{"acc10", KeyType::ed25519};
+    jtx::Account const acc11{"acc11", KeyType::ed25519};
+    jtx::Account const acc12{"acc12", KeyType::ed25519};
+    jtx::Account const acc13{"acc13", KeyType::ed25519};
+    jtx::Account const acc14{"acc14", KeyType::ed25519};
+    jtx::Account const acc15{"acc15", KeyType::ed25519};
+    jtx::Account const acc16{"acc16", KeyType::ed25519};
+    jtx::Account const acc17{"acc17", KeyType::ed25519};
+    jtx::Account const acc18{"acc18", KeyType::ed25519};
+    jtx::Account const acc19{"acc19", KeyType::ed25519};
+    jtx::Account const acc20{"acc20", KeyType::ed25519};
+    jtx::Account const acc21{"acc21", KeyType::ed25519};
+    jtx::Account const acc22{"acc22", KeyType::ed25519};
+    jtx::Account const acc23{"acc23", KeyType::ed25519};
+    jtx::Account const acc24{"acc24", KeyType::ed25519};
+    jtx::Account const acc25{"acc25", KeyType::ed25519};
+    jtx::Account const acc26{"acc26", KeyType::ed25519};
+    jtx::Account const acc27{"acc27", KeyType::ed25519};
+    jtx::Account const acc28{"acc28", KeyType::ed25519};
+    jtx::Account const acc29{"acc29", KeyType::ed25519};
+    jtx::Account const acc30{"acc30", KeyType::ed25519};
+    jtx::Account const acc31{"acc31", KeyType::ed25519};
+    jtx::Account const acc32{"acc32", KeyType::ed25519};
+    jtx::Account const acc33{"acc33", KeyType::ed25519};
 
 public:
     void
@@ -159,22 +183,30 @@ public:
                  {spook, 1}}),
             ter(temBAD_QUORUM));
 
-        // Make a signer list that's too big.  Should fail.
+        // clang-format off
+        // Make a signer list that's too big.  Should fail. (Even with
+        // ExpandedSignerList)
         Account const spare("spare", KeyType::secp256k1);
         env(signers(
                 alice,
                 1,
-                {{bogie, 1},
-                 {demon, 1},
-                 {ghost, 1},
-                 {haunt, 1},
-                 {jinni, 1},
-                 {phase, 1},
-                 {shade, 1},
-                 {spook, 1},
-                 {spare, 1}}),
+                features[featureExpandedSignerList]
+                    ? std::vector<signer>{{bogie, 1}, {demon, 1}, {ghost, 1},
+                                          {haunt, 1}, {jinni, 1}, {phase, 1},
+                                          {shade, 1}, {spook, 1}, {spare, 1},
+                                          {acc10, 1}, {acc11, 1}, {acc12, 1},
+                                          {acc13, 1}, {acc14, 1}, {acc15, 1},
+                                          {acc16, 1}, {acc17, 1}, {acc18, 1},
+                                          {acc19, 1}, {acc20, 1}, {acc21, 1},
+                                          {acc22, 1}, {acc23, 1}, {acc24, 1},
+                                          {acc25, 1}, {acc26, 1}, {acc27, 1},
+                                          {acc28, 1}, {acc29, 1}, {acc30, 1},
+                                          {acc31, 1}, {acc32, 1}, {acc33, 1}}
+                    : std::vector<signer>{{bogie, 1}, {demon, 1}, {ghost, 1},
+                                          {haunt, 1}, {jinni, 1}, {phase, 1},
+                                          {shade, 1}, {spook, 1}, {spare, 1}}),
             ter(temMALFORMED));
-
+        // clang-format on
         env.close();
         env.require(owners(alice, 0));
     }
@@ -1149,20 +1181,56 @@ public:
                 "fails local checks: Invalid Signers array size.");
         }
         {
-            // Multisign 9 times should fail.
+            // Multisign 9 (!ExpandedSignerList) | 33 (ExpandedSignerList) times
+            // should fail.
             JTx tx = env.jt(
                 noop(alice),
                 fee(2 * baseFee),
-                msig(
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie,
-                    bogie));
+
+                features[featureExpandedSignerList] ? msig(
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie)
+                                                    : msig(
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie,
+                                                          bogie));
             STTx local = *(tx.stx);
             auto const info = submitSTTx(local);
             BEAST_EXPECT(
@@ -1518,6 +1586,82 @@ public:
     }
 
     void
+    test_signersWithTags(FeatureBitset features)
+    {
+        if (!features[featureExpandedSignerList])
+            return;
+
+        testcase("Signers With Tags");
+
+        using namespace jtx;
+        Env env{*this, features};
+        Account const alice{"alice", KeyType::ed25519};
+        env.fund(XRP(1000), alice);
+        env.close();
+        uint8_t tag1[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                          0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+        uint8_t tag2[] =
+            "hello world some ascii 32b long";  // including 1 byte for NUL
+
+        uint256 bogie_tag = ripple::base_uint<256>::fromVoid(tag1);
+        uint256 demon_tag = ripple::base_uint<256>::fromVoid(tag2);
+
+        // Attach phantom signers to alice and use them for a transaction.
+        env(signers(alice, 1, {{bogie, 1, bogie_tag}, {demon, 1, demon_tag}}));
+        env.close();
+        env.require(owners(alice, features[featureMultiSignReserve] ? 1 : 4));
+
+        // This should work.
+        auto const baseFee = env.current()->fees().base;
+        std::uint32_t aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie, demon), fee(3 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+
+        // Either signer alone should work.
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie), fee(2 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(demon), fee(2 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+
+        // Duplicate signers should fail.
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(demon, demon), fee(3 * baseFee), ter(temINVALID));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq);
+
+        // A non-signer should fail.
+        aliceSeq = env.seq(alice);
+        env(noop(alice),
+            msig(bogie, spook),
+            fee(3 * baseFee),
+            ter(tefBAD_SIGNATURE));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq);
+
+        // Don't meet the quorum.  Should fail.
+        env(signers(alice, 2, {{bogie, 1}, {demon, 1}}));
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie), fee(2 * baseFee), ter(tefBAD_QUORUM));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq);
+
+        // Meet the quorum.  Should succeed.
+        aliceSeq = env.seq(alice);
+        env(noop(alice), msig(bogie, demon), fee(3 * baseFee));
+        env.close();
+        BEAST_EXPECT(env.seq(alice) == aliceSeq + 1);
+    }
+
+    void
     testAll(FeatureBitset features)
     {
         test_noReserve(features);
@@ -1537,6 +1681,7 @@ public:
         test_multisigningMultisigner(features);
         test_signForHash(features);
         test_signersWithTickets(features);
+        test_signersWithTags(features);
     }
 
     void
@@ -1545,10 +1690,13 @@ public:
         using namespace jtx;
         auto const all = supported_amendments();
 
-        // The reserve required on a signer list changes based on.
-        // featureMultiSignReserve.  Test both with and without.
-        testAll(all - featureMultiSignReserve);
-        testAll(all | featureMultiSignReserve);
+        // The reserve required on a signer list changes based on
+        // featureMultiSignReserve.  Limits on the number of signers
+        // changes based on featureExpandedSignerList.  Test both with and
+        // without.
+        testAll(all - featureMultiSignReserve - featureExpandedSignerList);
+        testAll(all - featureExpandedSignerList);
+        testAll(all);
         test_amendmentTransition();
     }
 };

--- a/src/test/jtx/impl/multisign.cpp
+++ b/src/test/jtx/impl/multisign.cpp
@@ -22,6 +22,8 @@
 #include <ripple/protocol/Sign.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/jss.h>
+#include <optional>
+#include <sstream>
 #include <test/jtx/multisign.h>
 #include <test/jtx/utility.h>
 
@@ -46,6 +48,8 @@ signers(
         auto& je = ja[i][sfSignerEntry.getJsonName()];
         je[jss::Account] = e.account.human();
         je[sfSignerWeight.getJsonName()] = e.weight;
+        if (e.tag)
+            je[sfWalletLocator.getJsonName()] = to_string(*e.tag);
     }
     return jv;
 }

--- a/src/test/jtx/multisign.h
+++ b/src/test/jtx/multisign.h
@@ -21,6 +21,7 @@
 #define RIPPLE_TEST_JTX_MULTISIGN_H_INCLUDED
 
 #include <cstdint>
+#include <optional>
 #include <test/jtx/Account.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/owners.h>
@@ -35,9 +36,13 @@ struct signer
 {
     std::uint32_t weight;
     Account account;
+    std::optional<uint256> tag;
 
-    signer(Account account_, std::uint32_t weight_ = 1)
-        : weight(weight_), account(std::move(account_))
+    signer(
+        Account account_,
+        std::uint32_t weight_ = 1,
+        std::optional<uint256> tag_ = std::nullopt)
+        : weight(weight_), account(std::move(account_)), tag(std::move(tag_))
     {
     }
 };

--- a/src/test/protocol/STTx_test.cpp
+++ b/src/test/protocol/STTx_test.cpp
@@ -20,6 +20,7 @@
 #include <ripple/basics/Slice.h>
 #include <ripple/beast/unit_test.h>
 #include <ripple/json/to_string.h>
+#include <ripple/protocol/Rules.h>
 #include <ripple/protocol/STAmount.h>
 #include <ripple/protocol/STParsedJSON.h>
 #include <ripple/protocol/STTx.h>
@@ -27,7 +28,6 @@
 #include <ripple/protocol/TxFormats.h>
 #include <ripple/protocol/UintTypes.h>
 #include <ripple/protocol/messages.h>
-
 #include <memory>
 #include <regex>
 
@@ -1591,8 +1591,10 @@ public:
         });
         j.sign(keypair.first, keypair.second);
 
+        Rules defaultRules{{}};
+
         unexpected(
-            !j.checkSign(STTx::RequireFullyCanonicalSig::yes),
+            !j.checkSign(STTx::RequireFullyCanonicalSig::yes, defaultRules),
             "Transaction fails signature test");
 
         Serializer rawTxn;

--- a/src/test/rpc/AmendmentBlocked_test.cpp
+++ b/src/test/rpc/AmendmentBlocked_test.cpp
@@ -43,6 +43,12 @@ class AmendmentBlocked_test : public beast::unit_test::suite
         Account const ali{"ali", KeyType::secp256k1};
         env.fund(XRP(10000), alice, bob, gw);
         env.memoize(ali);
+        // This close() ensures that all the accounts get created and their
+        // default ripple flag gets set before the trust lines are created.
+        // Without it, the ordering manages to create alice's trust line with
+        // noRipple set on gw's end. The existing tests pass either way, but
+        // better to do it right.
+        env.close();
         env.trust(USD(600), alice);
         env.trust(USD(700), bob);
         env(pay(gw, alice, USD(70)));


### PR DESCRIPTION
## Re-enable code commented out by mistake for warning suppression

Correctly `#if ... #endif` desired code

### Context of Change

This could prevent buffers from being fully initialized with random values (last few bytes are skipped)

### Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release
