### PR TITLE
Properly handle incorrect port numbers in parseURL (fixes #4200)

### DIFF
--- a/src/ripple/basics/impl/StringUtilities.cpp
+++ b/src/ripple/basics/impl/StringUtilities.cpp
@@ -90,6 +90,12 @@ parseUrl(parsedURL& pUrl, std::string const& strUrl)
     if (!port.empty())
     {
         pUrl.port = beast::lexicalCast<std::uint16_t>(port);
+
+        // For inputs larger than 2^32-1 (65535), lexicalCast returns 0. 
+        // parseUrl returns false for such inputs.
+        if (pUrl.port == 0) {
+            return false;
+        }
     }
     pUrl.path = smMatch[6];
 

--- a/src/test/basics/StringUtilities_test.cpp
+++ b/src/test/basics/StringUtilities_test.cpp
@@ -289,6 +289,12 @@ public:
             BEAST_EXPECT(!parseUrl(pUrl, "nonsense"));
             BEAST_EXPECT(!parseUrl(pUrl, "://"));
             BEAST_EXPECT(!parseUrl(pUrl, ":///"));
+            BEAST_EXPECT(!parseUrl(pUrl, "scheme://user:pass@domain:65536/abc:321"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:23498765/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:0/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:+7/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:-7234/"));
+            BEAST_EXPECT(!parseUrl(pUrl, "UPPER://domain:@#$56!/"));
         }
 
         {


### PR DESCRIPTION
This Pull Request fixes issue 4200 (https://github.com/ripple/rippled/issues/4200). 

Previously, inputs for very large port numbers (more than the 16 bit capacity of the field) was handled incorrectly i.e. lexicalCast returns a zero for such inputs.

The code in this PR returns a boolean value of false if the port number is zero.
This code also handles the case of an input of zero (0) to the port number field.