### PR TITLE
(Reverted by #4882) Asynchronously write batches to NuDB.

### DIFF
--- a/src/ripple/nodestore/Types.h
+++ b/src/ripple/nodestore/Types.h
@@ -36,8 +36,9 @@ enum {
     // This sets a limit on the maximum number of writes
     // in a batch. Actual usage can be twice this since
     // we have a new batch growing as we write the old.
+    // The main goal is to avoid delays while persisting the ledger.
     //
-    batchWriteLimitSize = 65536
+    batchWriteLimitSize = 262144
 };
 
 /** Return codes from Backend operations. */


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
For NuDB, use BatchWriter for all writes. This is identical behavior to that of RocksDB.
Increase batch size.

This PR is related to 2 others that, when combined, increase throughput significantly:
https://github.com/XRPLF/rippled/pull/4504
https://github.com/XRPLF/rippled/pull/4505

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
This improves transaction throughput. The bulk of writes to the nodestore happen during the "accept" phase of consensus as a new ledger is built. The number of objects increases directly with transaction volume, and write latency directly affects consensus interval duration. Batching writes and performing them in the background minimizes this impact. The new behavior is identical to that of RocksDB, which has used BatchWriter in production for several years already. Increasing the batch size should allow all ledgers for the forseeable future to be persisted this way without blocking consensus.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [X ] New feature (non-breaking change which adds functionality)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->
This change is part of a suite of throughput-enhancing pull requests. They have been tested in conjunction with one another.

<!--
## Future Tasks
For future tasks related to PR.
-->
