### PR TITLE
Use ed25519_sign_open_batch() to verify multisignatures:

### DIFF
--- a/src/ripple/protocol/PublicKey.h
+++ b/src/ripple/protocol/PublicKey.h
@@ -259,6 +259,33 @@ verify(
     Slice const& sig,
     bool mustBeFullyCanonical = true) noexcept;
 
+/** Data passed to verifyBatch */
+struct VerifyBatchData
+{
+    PublicKey pubKey;
+    Serializer message;
+    Blob signature;
+
+    explicit VerifyBatchData(PublicKey const& publicKey) : pubKey(publicKey)
+    {
+    }
+};
+
+/** Result returned from verifyBatch */
+enum class VerifyResult { sigUnexamined = 0, sigValid, sigInvalid };
+
+/** Verify a batch of signatures.
+    There are substantial speedups from doing batch verification of
+    Ed25519 signatures.  There is no speedup with secp256k1 signatures,
+    but also no penalty.
+
+    The returned vector has the same size() as the passed in data.
+*/
+[[nodiscard]] std::vector<VerifyResult>
+verifyBatch(
+    std::vector<VerifyBatchData> const& data,
+    bool mustBeFullyCanonical = true);
+
 /** Calculate the 160-bit node ID from a node public key. */
 NodeID
 calcNodeID(PublicKey const&);

--- a/src/ripple/protocol/impl/PublicKey.cpp
+++ b/src/ripple/protocol/impl/PublicKey.cpp
@@ -356,6 +356,14 @@ verifyBatch(std::vector<VerifyBatchData> const& data, bool mustBeFullyCanonical)
         }
         else if (*type == KeyType::ed25519)
         {
+            // rippled unconditionally requires all ed25519 signatures to be
+            // canonical, and batch verification won't do that work for us.
+            if (!ed25519Canonical(makeSlice(data[i].signature)))
+            {
+                result[i] = sigInvalid;
+                return result;
+            }
+
             // If the type is ed25519, then include it in the vectors
             // that will be sent to the batch function later.
             messagesEd.push_back(data[i].message.peekData().data());


### PR DESCRIPTION


## High Level Overview of Change


Measurements show that batch verification of ed25519 signatures can reduce execution time by nearly 50% compared to sequential verification.  secp256k1 signatures are unaffected.


### Context of Change


Batch verification for Ed25519 signatures is added.


### Type of Change


- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] Tests (You added tests for code that already exists, or your new feature included in this PR)

