### PR TITLE
Don't suspend writes based on batch size. Instead, log if it seems to be too big

### DIFF
--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -266,7 +266,7 @@ public:
     void
     store(std::shared_ptr<NodeObject> const& no) override
     {
-        batch_.store(no);
+        batch_.store(no, j_);
     }
 
     void

--- a/src/ripple/nodestore/backend/RocksDBFactory.cpp
+++ b/src/ripple/nodestore/backend/RocksDBFactory.cpp
@@ -343,7 +343,7 @@ public:
     void
     store(std::shared_ptr<NodeObject> const& object) override
     {
-        m_batch.store(object);
+        m_batch.store(object, m_journal);
     }
 
     void

--- a/src/ripple/nodestore/impl/BatchWriter.cpp
+++ b/src/ripple/nodestore/impl/BatchWriter.cpp
@@ -37,14 +37,11 @@ BatchWriter::~BatchWriter()
 }
 
 void
-BatchWriter::store(std::shared_ptr<NodeObject> const& object)
+BatchWriter::store(
+    std::shared_ptr<NodeObject> const& object,
+    beast::Journal const& j)
 {
     std::unique_lock<decltype(mWriteMutex)> sl(mWriteMutex);
-
-    // If the batch has reached its limit, we wait
-    // until the batch writer is finished
-    while (mWriteSet.size() >= batchWriteLimitSize)
-        mWriteCondition.wait(sl);
 
     mWriteSet.push_back(object);
 
@@ -52,6 +49,19 @@ BatchWriter::store(std::shared_ptr<NodeObject> const& object)
     {
         mWritePending = true;
 
+        // Log if the write batch size is too big. The trade-off here
+        // is that new ledgers can't be persisted if a limit is enforced,
+        // which causes desync. Versus eventual memory exhaustion if
+        // there are no limits. But we at least stay in sync longer in the
+        // latter case.
+        if (mWriteSet.size() >= batchWriteLimitSize)
+        {
+            JLOG(j.warn())
+                << "Pending write batch size " << mWriteSet.size()
+                << " exceeds threshold of " << batchWriteLimitSize
+                << ". This may be caused by slow i/o. More memory is consumed "
+                   " as pending write count increases.";
+        }
         m_scheduler.scheduleTask(*this);
     }
 }

--- a/src/ripple/nodestore/impl/BatchWriter.h
+++ b/src/ripple/nodestore/impl/BatchWriter.h
@@ -20,6 +20,7 @@
 #ifndef RIPPLE_NODESTORE_BATCHWRITER_H_INCLUDED
 #define RIPPLE_NODESTORE_BATCHWRITER_H_INCLUDED
 
+#include <ripple/basics/Log.h>
 #include <ripple/nodestore/Scheduler.h>
 #include <ripple/nodestore/Task.h>
 #include <ripple/nodestore/Types.h>
@@ -68,7 +69,7 @@ public:
         write the batch out.
     */
     void
-    store(std::shared_ptr<NodeObject> const& object);
+    store(std::shared_ptr<NodeObject> const& object, beast::Journal const& j);
 
     /** Get an estimate of the amount of writing I/O pending. */
     int


### PR DESCRIPTION
## High Level Overview of Change
Removes a limit that blocks nodestore writes. This delays consensus because each new ledger is persisted during consensus processing.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
This removes the check that limits write batch size and blocks when the limit is reached. It also adds logging to indicate when the limit is exceeded. The trade-off is that the pending writes consume memory until they are persisted, so memory can increase without the limit. But since blocking writes result in consensus instability, the existing behavior is a proactive pessimization. Ultimately, pending writes either increase due to increased input (transaction volume), or because of I/O slowdown. If the IO and memory subsystem can't handle the throughput then the process will be unstable regardless.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Performance
- [ ] Release

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
