### PR TITLE
Revert "Asynchronously write batches to NuDB. (#4503)"

### DIFF
--- a/src/ripple/nodestore/Types.h
+++ b/src/ripple/nodestore/Types.h
@@ -36,9 +36,8 @@ enum {
     // This sets a limit on the maximum number of writes
     // in a batch. Actual usage can be twice this since
     // we have a new batch growing as we write the old.
-    // The main goal is to avoid delays while persisting the ledger.
     //
-    batchWriteLimitSize = 262144
+    batchWriteLimitSize = 65536
 };
 
 /** Return codes from Backend operations. */

--- a/src/ripple/nodestore/backend/NuDBFactory.cpp
+++ b/src/ripple/nodestore/backend/NuDBFactory.cpp
@@ -20,7 +20,6 @@
 #include <ripple/basics/contract.h>
 #include <ripple/nodestore/Factory.h>
 #include <ripple/nodestore/Manager.h>
-#include <ripple/nodestore/impl/BatchWriter.h>
 #include <ripple/nodestore/impl/DecodedBlob.h>
 #include <ripple/nodestore/impl/EncodedBlob.h>
 #include <ripple/nodestore/impl/codec.h>
@@ -36,7 +35,7 @@
 namespace ripple {
 namespace NodeStore {
 
-class NuDBBackend : public Backend, public BatchWriter::Callback
+class NuDBBackend : public Backend
 {
 public:
     static constexpr std::uint64_t currentType = 1;
@@ -47,7 +46,6 @@ public:
 
     beast::Journal const j_;
     size_t const keyBytes_;
-    BatchWriter batch_;
     std::size_t const burstSize_;
     std::string const name_;
     nudb::store db_;
@@ -62,7 +60,6 @@ public:
         beast::Journal journal)
         : j_(journal)
         , keyBytes_(keyBytes)
-        , batch_(*this, scheduler)
         , burstSize_(burstSize)
         , name_(get(keyValues, "path"))
         , deletePath_(false)
@@ -82,7 +79,6 @@ public:
         beast::Journal journal)
         : j_(journal)
         , keyBytes_(keyBytes)
-        , batch_(*this, scheduler)
         , burstSize_(burstSize)
         , name_(get(keyValues, "path"))
         , db_(context)
@@ -266,7 +262,13 @@ public:
     void
     store(std::shared_ptr<NodeObject> const& no) override
     {
-        batch_.store(no);
+        BatchWriteReport report;
+        report.writeCount = 1;
+        auto const start = std::chrono::steady_clock::now();
+        do_insert(no);
+        report.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        scheduler_.onBatchWrite(report);
     }
 
     void
@@ -327,7 +329,7 @@ public:
     int
     getWriteLoad() override
     {
-        return batch_.getWriteLoad();
+        return 0;
     }
 
     void
@@ -353,12 +355,6 @@ public:
         db_.open(dp, kp, lp, ec);
         if (ec)
             Throw<nudb::system_error>(ec);
-    }
-
-    void
-    writeBatch(Batch const& batch) override
-    {
-        storeBatch(batch);
     }
 
     int


### PR DESCRIPTION
This reverts commit 1d9db1bfdd84e980e44e2f521990eaca42633d5e.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.
-->

## High Level Overview of Change
Revert code that introduces problems associated with online deletion.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change
The bug was introduced in PR #4503, which causes writes to block during online deletion. In turn, this delays persisting records to disk during consensus, which causes node desyncs.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->
Run online deletion as normal. It should stay stable, and revert to behavior from 1.12 and previous.

## Future Tasks

If we proceed with this revert, there will there be no reason to consider #4762.

Closes #4762