### PR TITLE
Fix delegate test silently fail with batch

### DIFF
--- a/src/test/app/Batch_test.cpp
+++ b/src/test/app/Batch_test.cpp
@@ -3810,6 +3810,100 @@ class Batch_test : public beast::unit_test::suite
             BEAST_EXPECT(env.balance(alice) == preAlice - XRP(2) - batchFee);
             BEAST_EXPECT(env.balance(bob) == preBob + XRP(2));
         }
+
+        // delegated non atomic inner (MPTokenIssuance)
+        {
+            test::jtx::Env env{*this, envconfig()};
+            Account alice{"alice"};
+            Account bob{"bob"};
+            env.fund(XRP(100000), alice, bob);
+            env.close();
+
+            auto const mptID = makeMptID(env.seq(alice), alice);
+            MPTTester mpt(env, alice, {.fund = false});
+            env.close();
+            mpt.create({.flags = tfMPTCanLock});
+            env.close();
+
+            // alice gives granular permission to bob of MPTokenIssuanceLock
+            env(delegate::set(
+                alice, bob, {"MPTokenIssuanceLock", "MPTokenIssuanceUnlock"}));
+            env.close();
+
+            auto const seq = env.seq(alice);
+            auto const batchFee = batch::calcBatchFee(env, 0, 2);
+
+            Json::Value jv1;
+            jv1[sfTransactionType] = jss::MPTokenIssuanceSet;
+            jv1[sfAccount] = alice.human();
+            jv1[sfDelegate] = bob.human();
+            jv1[sfSequence] = seq + 1;
+            jv1[sfMPTokenIssuanceID] = to_string(mptID);
+            jv1[sfFlags] = tfMPTLock;
+
+            Json::Value jv2;
+            jv2[sfTransactionType] = jss::MPTokenIssuanceSet;
+            jv2[sfAccount] = alice.human();
+            jv2[sfDelegate] = bob.human();
+            jv2[sfSequence] = seq + 2;
+            jv2[sfMPTokenIssuanceID] = to_string(mptID);
+            jv2[sfFlags] = tfMPTUnlock;
+
+            auto const [txIDs, batchID] = submitBatch(
+                env,
+                tesSUCCESS,
+                batch::outer(alice, seq, batchFee, tfAllOrNothing),
+                batch::inner(jv1, seq + 1),
+                batch::inner(jv2, seq + 2));
+            env.close();
+
+            std::vector<TestLedgerData> testCases = {
+                {0, "Batch", "tesSUCCESS", batchID, std::nullopt},
+                {1, "MPTokenIssuanceSet", "tesSUCCESS", txIDs[0], batchID},
+                {2, "MPTokenIssuanceSet", "tesSUCCESS", txIDs[1], batchID},
+            };
+            validateClosedLedger(env, testCases);
+        }
+
+        // delegated non atomic inner (TrustSet)
+        {
+            test::jtx::Env env{*this, envconfig()};
+            Account gw{"gw"};
+            Account alice{"alice"};
+            Account bob{"bob"};
+            env.fund(XRP(10000), gw, alice, bob);
+            env(fset(gw, asfRequireAuth));
+            env.close();
+            env(trust(alice, gw["USD"](50)));
+            env.close();
+
+            env(delegate::set(
+                gw, bob, {"TrustlineAuthorize", "TrustlineFreeze"}));
+            env.close();
+
+            auto const seq = env.seq(gw);
+            auto const batchFee = batch::calcBatchFee(env, 0, 2);
+
+            auto jv1 = trust(gw, gw["USD"](0), alice, tfSetfAuth);
+            jv1[sfDelegate] = bob.human();
+            auto jv2 = trust(gw, gw["USD"](0), alice, tfSetFreeze);
+            jv2[sfDelegate] = bob.human();
+
+            auto const [txIDs, batchID] = submitBatch(
+                env,
+                tesSUCCESS,
+                batch::outer(gw, seq, batchFee, tfAllOrNothing),
+                batch::inner(jv1, seq + 1),
+                batch::inner(jv2, seq + 2));
+            env.close();
+
+            std::vector<TestLedgerData> testCases = {
+                {0, "Batch", "tesSUCCESS", batchID, std::nullopt},
+                {1, "TrustSet", "tesSUCCESS", txIDs[0], batchID},
+                {2, "TrustSet", "tesSUCCESS", txIDs[1], batchID},
+            };
+            validateClosedLedger(env, testCases);
+        }
     }
 
     void

--- a/src/test/app/Batch_test.cpp
+++ b/src/test/app/Batch_test.cpp
@@ -3938,15 +3938,16 @@ class Batch_test : public beast::unit_test::suite
             auto const [txIDs, batchID] = submitBatch(
                 env,
                 tesSUCCESS,
-                batch::outer(gw, seq, batchFee, tfAllOrNothing),
+                batch::outer(gw, seq, batchFee, tfIndependent),
                 batch::inner(jv1, seq + 1),
-                // tecNO_DELEGATE_PERMISSION: not authorized by the delegating
-                // account.
+                // tecNO_DELEGATE_PERMISSION: not authorized to clear freeze
                 batch::inner(jv2, seq + 2));
             env.close();
 
             std::vector<TestLedgerData> testCases = {
                 {0, "Batch", "tesSUCCESS", batchID, std::nullopt},
+                {1, "TrustSet", "tesSUCCESS", txIDs[0], batchID},
+                {2, "TrustSet", "tecNO_DELEGATE_PERMISSION", txIDs[1], batchID},
             };
             validateClosedLedger(env, testCases);
         }

--- a/src/test/app/Batch_test.cpp
+++ b/src/test/app/Batch_test.cpp
@@ -3765,6 +3765,8 @@ class Batch_test : public beast::unit_test::suite
         }
 
         // delegated non atomic inner (AccountSet)
+        // this also makes sure tfInnerBatchTxn won't block delegated AccountSet
+        // with granular permission
         {
             test::jtx::Env env{*this, envconfig()};
 
@@ -3811,7 +3813,9 @@ class Batch_test : public beast::unit_test::suite
             BEAST_EXPECT(env.balance(bob) == preBob + XRP(2));
         }
 
-        // delegated non atomic inner (MPTokenIssuance)
+        // delegated non atomic inner (MPTokenIssuanceSet)
+        // this also makes sure tfInnerBatchTxn won't block delegated
+        // MPTokenIssuanceSet with granular permission
         {
             test::jtx::Env env{*this, envconfig()};
             Account alice{"alice"};
@@ -3866,6 +3870,8 @@ class Batch_test : public beast::unit_test::suite
         }
 
         // delegated non atomic inner (TrustSet)
+        // this also makes sure tfInnerBatchTxn won't block delegated TrustSet
+        // with granular permission
         {
             test::jtx::Env env{*this, envconfig()};
             Account gw{"gw"};

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -913,37 +913,6 @@ class Delegate_test : public beast::unit_test::suite
                     gw, gw["USD"](0), alice, tfSetfAuth | tfFullyCanonicalSig),
                 delegate::as(bob));
         }
-
-        // tfInnerBatchTxn won't block delegated transaction
-        {
-            Env env(*this);
-            Account gw{"gw"};
-            Account alice{"alice"};
-            Account bob{"bob"};
-            env.fund(XRP(10000), gw, alice, bob);
-            env(fset(gw, asfRequireAuth));
-            env.close();
-            env(trust(alice, gw["USD"](50)));
-            env.close();
-
-            env(delegate::set(
-                gw, bob, {"TrustlineAuthorize", "TrustlineFreeze"}));
-            env.close();
-
-            auto const seq = env.seq(gw);
-            auto const batchFee = batch::calcBatchFee(env, 0, 2);
-            auto jv1 = trust(gw, gw["USD"](0), alice, tfSetfAuth);
-            jv1[sfDelegate] = bob.human();
-            auto jv2 = trust(gw, gw["USD"](0), alice, tfSetFreeze);
-            jv2[sfDelegate] = bob.human();
-
-            // batch::inner will set tfInnerBatchTxn, this should not
-            // block delegated transaction
-            env(batch::outer(gw, seq, batchFee, tfAllOrNothing),
-                batch::inner(jv1, seq + 1),
-                batch::inner(jv2, seq + 2));
-            env.close();
-        }
     }
 
     void
@@ -1234,53 +1203,6 @@ class Delegate_test : public beast::unit_test::suite
             env(jt);
             BEAST_EXPECT((*env.le(alice))[sfDomain] == makeSlice(domain));
         }
-
-        // tfInnerBatchTxn won't block delegated transaction
-        {
-            Env env(*this);
-            Account alice{"alice"};
-            Account bob{"bob"};
-            env.fund(XRP(10000), alice, bob);
-            env.close();
-
-            env(delegate::set(
-                alice, bob, {"AccountDomainSet", "AccountEmailHashSet"}));
-            env.close();
-
-            auto const seq = env.seq(alice);
-            auto const batchFee = batch::calcBatchFee(env, 0, 3);
-
-            auto jv1 = noop(alice);
-            std::string const domain1 = "example1.com";
-            jv1[sfDomain] = strHex(domain1);
-            jv1[sfDelegate] = bob.human();
-            jv1[sfSequence] = seq + 1;
-
-            auto jv2 = noop(alice);
-            std::string const domain2 = "example2.com";
-            jv2[sfDomain] = strHex(domain2);
-            jv2[sfDelegate] = bob.human();
-            jv2[sfSequence] = seq + 2;
-
-            // bob set domain back and add email hash for alice
-            auto jv3 = noop(alice);
-            std::string const mh("5F31A79367DC3137FADA860C05742EE6");
-            jv3[sfDomain] = strHex(domain1);
-            jv3[sfEmailHash] = mh;
-            jv3[sfDelegate] = bob.human();
-            jv3[sfSequence] = seq + 3;
-
-            // batch::inner will set tfInnerBatchTxn, this should not
-            // block delegated transaction
-            env(batch::outer(alice, seq, batchFee, tfAllOrNothing),
-                batch::inner(jv1, seq + 1),
-                batch::inner(jv2, seq + 2),
-                batch::inner(jv3, seq + 3));
-            env.close();
-
-            BEAST_EXPECT((*env.le(alice))[sfDomain] == makeSlice(domain1));
-            BEAST_EXPECT(to_string((*env.le(alice))[sfEmailHash]) == mh);
-        }
     }
 
     void
@@ -1410,52 +1332,6 @@ class Delegate_test : public beast::unit_test::suite
                 {.account = alice,
                  .flags = tfMPTLock | tfFullyCanonicalSig,
                  .delegate = bob});
-        }
-
-        // tfInnerBatchTxn won't block delegated transaction
-        {
-            Env env(*this);
-            Account alice{"alice"};
-            Account bob{"bob"};
-            env.fund(XRP(100000), alice, bob);
-            env.close();
-
-            auto const mptID = makeMptID(env.seq(alice), alice);
-            MPTTester mpt(env, alice, {.fund = false});
-            env.close();
-            mpt.create({.flags = tfMPTCanLock});
-            env.close();
-
-            // alice gives granular permission to bob of MPTokenIssuanceLock
-            env(delegate::set(
-                alice, bob, {"MPTokenIssuanceLock", "MPTokenIssuanceUnlock"}));
-            env.close();
-
-            auto const seq = env.seq(alice);
-            auto const batchFee = batch::calcBatchFee(env, 0, 2);
-
-            Json::Value jv1;
-            jv1[sfTransactionType] = jss::MPTokenIssuanceSet;
-            jv1[sfAccount] = alice.human();
-            jv1[sfDelegate] = bob.human();
-            jv1[sfSequence] = seq + 1;
-            jv1[sfMPTokenIssuanceID] = to_string(mptID);
-            jv1[sfFlags] = tfMPTLock;
-
-            Json::Value jv2;
-            jv2[sfTransactionType] = jss::MPTokenIssuanceSet;
-            jv2[sfAccount] = alice.human();
-            jv2[sfDelegate] = bob.human();
-            jv2[sfSequence] = seq + 2;
-            jv2[sfMPTokenIssuanceID] = to_string(mptID);
-            jv2[sfFlags] = tfMPTUnlock;
-
-            // batch::inner will set tfInnerBatchTxn, this should not
-            // block delegated transaction
-            env(batch::outer(alice, seq, batchFee, tfAllOrNothing),
-                batch::inner(jv1, seq + 1),
-                batch::inner(jv2, seq + 2));
-            env.close();
         }
     }
 


### PR DESCRIPTION
The test to make sure `tfInnerBatchTxn` won't block delegated transactions would silently fail in `Delegate_test.cpp`.
This commit removes these cases from `Delegate_test.cpp`.  and adds them to `Batch_test.cpp`.
This will not silently fail because we will explicitly check batch delegate result.
Moving to `Batch_test.cpp` to avoid refactoring too many helper functions.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
