### PR TITLE
Set version to 2.5.0

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.5.0-rc2"
+char const* const versionString = "2.5.0"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
The base branch is `master`. This PR branch will be pushed directly to `release` and `master` (not squashed or rebased, and not using the GitHub UI).

# Release Notes

![XRP](docs/images/xrp-text-mark-black-small@2x.png)
This document contains the notes for the release `2.5.0` of `rippled` , the reference server implementation of the XRP Ledger protocol. To learn more about how to build, run or update a `rippled` server, visit https://xrpl.org/install-rippled.html

This release adds new features and bug fixes.

## `2.5.0` - 2025-06-17

### 📝 Amendments 

- [XLS-56d Batch](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0056d-batch) (#5060)
- [XLS-85d Token Escrow](https://github.com/XRPLF/XRPL-Standards/pull/272/) (#5185)
- [XLS-65d Single Asset Vault](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0065d-single-asset-vault) (#5224)

### 🦟📝 Fix Amendments

- [`fixPayChanV1`](https://xrpl.org/resources/known-amendments#fixpaychancancelafter) `fixPayChanV1`(#4717)
- [`fixAMMv1_3`](https://xrpl.org/resources/known-amendments#fixammv1_3) (#5203)
- [`fixEnforceNFTokenTrustlineV2`](https://xrpl.org/resources/known-amendments#fixenforcenftokentrustlinev2) (#5297) 

### 🚀 Features

- Improve squelching configuration (#5438)

### 🐛 Bug Fixes

- Adds CTID to RPC tx and updates error (#4738)
- Admin RPC webhook queue limit removal and timeout reduction (#5163)
- Address NFT interactions with trustlines (#5297)
- Handle invalid marker parameter in grpc call (#5317)
- Remove null pointer deref, just do abort (#5338)
- Error message for ledger_entry rpc (#5344)
- Trust line RPC no ripple flag (#5345)
- Replaces random endpoint resolution with sequential (#5365)
- Update validators-example.txt fix xrplf example URL (#5384)
- Disable `channel_authorize` when `signing_support` is disabled (#5385)
- Uint128 ambiguousness breaking macos unity build (#5386)
- Use the build image from ghcr.io (#5390)
- Resolve slow test on macOS pipeline (#5392)
- CTID to use correct ledger_index (#5408)
- Ensure that coverage file generation is atomic. (#5426)
- Enable LedgerStateFix for delegation (#5427)
- Update path in `CODEOWNERS` (#5440)
- Fix pseudo-account ID calculation (#5447)
- Improve handling of expired credentials in `VaultDeposit` (#5452)
- Specify transitive_headers when building with Conan 2 (#5462)
- Add tecNO_DELEGATE_PERMISSION and fix flags (#5465)
- Amendment-guard `TokenEscrow` preclaim and expand tests (#5473)
- Ensure delegate tests do not silently fail with batch (#5476)
- Improve multi-sign usage of `simulate` (#5479)

### 🚜 Refactor

- Remove unused and add missing includes (#5293)
- Calculate numFeatures automatically (#5324)
- Updates Conan dependencies: RocksDB (#5335)
- Improve ordering of headers with clang-format (#5343)
- Collapse some split log messages into one (#5347)
- Move integration tests from 'examples/' into 'tests/' (#5367)
- Reorganize ledger entry tests and helper functions (#5376)
- Clean up test logging to make it easier to search (#5396)
- Use east const convention (#5409)

### 📚 Documentation

- Add `-j $(nproc)` to `BUILD.md` (#5288)
- Update build instructions for Ubuntu 22.04+ (#5292)

### 🧪 Testing

- Enable TxQ unit tests work with variable reference fee (#5118)
- Enable unit tests to work with variable reference fee (#5145)
- Enable compile time param to change reference fee value (#5159)

### ⚙️ Miscellaneous Tasks

- Add PR number to payload (#5310)
- Update link to ripple-binary-codec (#5355)
- Rename docs job (#5398)
- Run CI on PRs that are Ready or have the "DraftRunCI" label (#5400)
- Small clarification to lsfDefaultRipple comment (#5410)
- Update CPP ref source (#5453)
- Improve env.meta usage (#5457)
- Remove external project build cores division (#5475)
