### PR TITLE
Release 2.5.0

### DIFF
--- a/.github/workflows/libxrpl.yml
+++ b/.github/workflows/libxrpl.yml
@@ -1,6 +1,6 @@
 name: Check libXRPL compatibility with Clio
 env:
-  CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/conan-non-prod
+  CONAN_URL: http://18.143.149.228:8081/artifactory/api/conan/dev
   CONAN_LOGIN_USERNAME_RIPPLE: ${{ secrets.CONAN_USERNAME }}
   CONAN_PASSWORD_RIPPLE: ${{ secrets.CONAN_TOKEN }}
 on:

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.5.0-rc2"
+char const* const versionString = "2.5.0"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/libxrpl/protocol/STTx.cpp
+++ b/src/libxrpl/protocol/STTx.cpp
@@ -760,6 +760,12 @@ isRawTransactionOkay(STObject const& st, std::string& reason)
         {
             TxType const tt =
                 safe_cast<TxType>(raw.getFieldU16(sfTransactionType));
+            if (tt == ttBATCH)
+            {
+                reason = "Raw Transactions may not contain batch transactions.";
+                return false;
+            }
+
             raw.applyTemplate(getTxFormat(tt)->getSOTemplate());
         }
         catch (std::exception const& e)

--- a/src/test/app/Batch_test.cpp
+++ b/src/test/app/Batch_test.cpp
@@ -24,6 +24,7 @@
 #include <xrpld/app/misc/HashRouter.h>
 #include <xrpld/app/misc/Transaction.h>
 #include <xrpld/app/tx/apply.h>
+#include <xrpld/app/tx/detail/Batch.h>
 
 #include <xrpl/protocol/Batch.h>
 #include <xrpl/protocol/Feature.h>
@@ -317,7 +318,8 @@ class Batch_test : public beast::unit_test::suite
             env.close();
         }
 
-        // temINVALID: Batch: batch cannot have inner batch txn.
+        // DEFENSIVE: temINVALID: Batch: batch cannot have inner batch txn.
+        // ACTUAL: telENV_RPC_FAILED: isRawTransactionOkay()
         {
             auto const seq = env.seq(alice);
             auto const batchFee = batch::calcBatchFee(env, 0, 2);
@@ -325,7 +327,7 @@ class Batch_test : public beast::unit_test::suite
                 batch::inner(
                     batch::outer(alice, seq, batchFee, tfAllOrNothing), seq),
                 batch::inner(pay(alice, bob, XRP(1)), seq + 2),
-                ter(temINVALID));
+                ter(telENV_RPC_FAILED));
             env.close();
         }
 
@@ -3954,6 +3956,176 @@ class Batch_test : public beast::unit_test::suite
     }
 
     void
+    testValidateRPCResponse(FeatureBitset features)
+    {
+        // Verifying that the RPC response from submit includes
+        // the account_sequence_available, account_sequence_next,
+        // open_ledger_cost and validated_ledger_index fields.
+        testcase("Validate RPC response");
+
+        using namespace jtx;
+        Env env(*this);
+        Account const alice("alice");
+        Account const bob("bob");
+        env.fund(XRP(10000), alice, bob);
+        env.close();
+
+        // tes
+        {
+            auto const baseFee = env.current()->fees().base;
+            auto const aliceSeq = env.seq(alice);
+            auto jtx = env.jt(pay(alice, bob, XRP(1)));
+
+            Serializer s;
+            jtx.stx->add(s);
+            auto const jr = env.rpc("submit", strHex(s.slice()))[jss::result];
+            env.close();
+
+            BEAST_EXPECT(jr.isMember(jss::account_sequence_available));
+            BEAST_EXPECT(
+                jr[jss::account_sequence_available].asUInt() == aliceSeq + 1);
+            BEAST_EXPECT(jr.isMember(jss::account_sequence_next));
+            BEAST_EXPECT(
+                jr[jss::account_sequence_next].asUInt() == aliceSeq + 1);
+            BEAST_EXPECT(jr.isMember(jss::open_ledger_cost));
+            BEAST_EXPECT(jr[jss::open_ledger_cost] == to_string(baseFee));
+            BEAST_EXPECT(jr.isMember(jss::validated_ledger_index));
+        }
+
+        // tec failure
+        {
+            auto const baseFee = env.current()->fees().base;
+            auto const aliceSeq = env.seq(alice);
+            env(fset(bob, asfRequireDest));
+            auto jtx = env.jt(pay(alice, bob, XRP(1)), seq(aliceSeq));
+
+            Serializer s;
+            jtx.stx->add(s);
+            auto const jr = env.rpc("submit", strHex(s.slice()))[jss::result];
+            env.close();
+
+            BEAST_EXPECT(jr.isMember(jss::account_sequence_available));
+            BEAST_EXPECT(
+                jr[jss::account_sequence_available].asUInt() == aliceSeq + 1);
+            BEAST_EXPECT(jr.isMember(jss::account_sequence_next));
+            BEAST_EXPECT(
+                jr[jss::account_sequence_next].asUInt() == aliceSeq + 1);
+            BEAST_EXPECT(jr.isMember(jss::open_ledger_cost));
+            BEAST_EXPECT(jr[jss::open_ledger_cost] == to_string(baseFee));
+            BEAST_EXPECT(jr.isMember(jss::validated_ledger_index));
+        }
+
+        // tem failure
+        {
+            auto const baseFee = env.current()->fees().base;
+            auto const aliceSeq = env.seq(alice);
+            auto jtx = env.jt(pay(alice, bob, XRP(1)), seq(aliceSeq + 1));
+
+            Serializer s;
+            jtx.stx->add(s);
+            auto const jr = env.rpc("submit", strHex(s.slice()))[jss::result];
+            env.close();
+
+            BEAST_EXPECT(jr.isMember(jss::account_sequence_available));
+            BEAST_EXPECT(
+                jr[jss::account_sequence_available].asUInt() == aliceSeq);
+            BEAST_EXPECT(jr.isMember(jss::account_sequence_next));
+            BEAST_EXPECT(jr[jss::account_sequence_next].asUInt() == aliceSeq);
+            BEAST_EXPECT(jr.isMember(jss::open_ledger_cost));
+            BEAST_EXPECT(jr[jss::open_ledger_cost] == to_string(baseFee));
+            BEAST_EXPECT(jr.isMember(jss::validated_ledger_index));
+        }
+    }
+
+    void
+    testBatchCalculateBaseFee(FeatureBitset features)
+    {
+        using namespace jtx;
+        Env env(*this);
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const carol("carol");
+        env.fund(XRP(10000), alice, bob, carol);
+        env.close();
+
+        auto getBaseFee = [&](JTx const& jtx) -> XRPAmount {
+            Serializer s;
+            jtx.stx->add(s);
+            return Batch::calculateBaseFee(*env.current(), *jtx.stx);
+        };
+
+        // bad: Inner Batch transaction found
+        {
+            auto const seq = env.seq(alice);
+            XRPAmount const batchFee = batch::calcBatchFee(env, 0, 2);
+            auto jtx = env.jt(
+                batch::outer(alice, seq, batchFee, tfAllOrNothing),
+                batch::inner(
+                    batch::outer(alice, seq, batchFee, tfAllOrNothing), seq),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 2));
+            XRPAmount const txBaseFee = getBaseFee(jtx);
+            BEAST_EXPECT(txBaseFee == XRPAmount(INITIAL_XRP));
+        }
+
+        // bad: Raw Transactions array exceeds max entries.
+        {
+            auto const seq = env.seq(alice);
+            XRPAmount const batchFee = batch::calcBatchFee(env, 0, 2);
+
+            auto jtx = env.jt(
+                batch::outer(alice, seq, batchFee, tfAllOrNothing),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 1),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 2),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 3),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 4),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 5),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 6),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 7),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 8),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 9));
+
+            XRPAmount const txBaseFee = getBaseFee(jtx);
+            BEAST_EXPECT(txBaseFee == XRPAmount(INITIAL_XRP));
+        }
+
+        // bad: Signers array exceeds max entries.
+        {
+            auto const seq = env.seq(alice);
+            XRPAmount const batchFee = batch::calcBatchFee(env, 0, 2);
+
+            auto jtx = env.jt(
+                batch::outer(alice, seq, batchFee, tfAllOrNothing),
+                batch::inner(pay(alice, bob, XRP(10)), seq + 1),
+                batch::inner(pay(alice, bob, XRP(5)), seq + 2),
+                batch::sig(
+                    bob,
+                    carol,
+                    alice,
+                    bob,
+                    carol,
+                    alice,
+                    bob,
+                    carol,
+                    alice,
+                    alice));
+            XRPAmount const txBaseFee = getBaseFee(jtx);
+            BEAST_EXPECT(txBaseFee == XRPAmount(INITIAL_XRP));
+        }
+
+        // good:
+        {
+            auto const seq = env.seq(alice);
+            XRPAmount const batchFee = batch::calcBatchFee(env, 0, 2);
+            auto jtx = env.jt(
+                batch::outer(alice, seq, batchFee, tfAllOrNothing),
+                batch::inner(pay(alice, bob, XRP(1)), seq + 1),
+                batch::inner(pay(bob, alice, XRP(2)), seq + 2));
+            XRPAmount const txBaseFee = getBaseFee(jtx);
+            BEAST_EXPECT(txBaseFee == batchFee);
+        }
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnable(features);
@@ -3983,6 +4155,8 @@ class Batch_test : public beast::unit_test::suite
         testBatchTxQueue(features);
         testBatchNetworkOps(features);
         testBatchDelegate(features);
+        testValidateRPCResponse(features);
+        testBatchCalculateBaseFee(features);
     }
 
 public:

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -96,7 +96,7 @@ Env::AppBundle::~AppBundle()
     if (app)
     {
         app->getJobQueue().rendezvous();
-        app->signalStop();
+        app->signalStop("~AppBundle");
     }
     if (thread.joinable())
         thread.join();

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -285,7 +285,7 @@ public:
                   config_->CONFIG_DIR),
               *this,
               logs_->journal("PerfLog"),
-              [this] { signalStop(); }))
+              [this] { signalStop("PerfLog"); }))
 
         , m_txMaster(*this)
 
@@ -505,7 +505,7 @@ public:
     void
     run() override;
     void
-    signalStop(std::string msg = "") override;
+    signalStop(std::string msg) override;
     bool
     checkSigs() const override;
     void
@@ -977,7 +977,7 @@ public:
         if (!config_->standalone() &&
             !getRelationalDatabase().transactionDbHasSpace(*config_))
         {
-            signalStop();
+            signalStop("Out of transaction DB space");
         }
 
         // VFALCO NOTE Does the order of calls matter?
@@ -1193,7 +1193,7 @@ ApplicationImp::setup(boost::program_options::variables_map const& cmdline)
             JLOG(m_journal.info()) << "Received signal " << signum;
 
             if (signum == SIGTERM || signum == SIGINT)
-                signalStop();
+                signalStop("Signal: " + to_string(signum));
         });
 
     auto debug_log = config_->getDebugLogFile();

--- a/src/xrpld/app/main/Application.h
+++ b/src/xrpld/app/main/Application.h
@@ -141,7 +141,7 @@ public:
     virtual void
     run() = 0;
     virtual void
-    signalStop(std::string msg = "") = 0;
+    signalStop(std::string msg) = 0;
     virtual bool
     checkSigs() const = 0;
     virtual void

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -1701,7 +1701,7 @@ NetworkOPsImp::apply(std::unique_lock<std::mutex>& batchLock)
                 }
             }
 
-            if (!isTemMalformed(e.result) && validatedLedgerIndex)
+            if (validatedLedgerIndex)
             {
                 auto [fee, accountSeq, availableSeq] =
                     app_.getTxQ().getTxRequiredFeeAndSeq(

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -3440,7 +3440,7 @@ PeerImp::processLedgerRequest(std::shared_ptr<protocol::TMGetLedger> const& m)
                 if (!m->has_ledgerhash())
                     info += ", no hash specified";
 
-                JLOG(p_journal_.error())
+                JLOG(p_journal_.warn())
                     << "processLedgerRequest: getNodeFat with nodeId "
                     << *shaMapNodeId << " and ledger info type " << info
                     << " throws exception: " << e.what();

--- a/src/xrpld/rpc/handlers/Stop.cpp
+++ b/src/xrpld/rpc/handlers/Stop.cpp
@@ -31,7 +31,7 @@ struct JsonContext;
 Json::Value
 doStop(RPC::JsonContext& context)
 {
-    context.app.signalStop();
+    context.app.signalStop("RPC");
     return RPC::makeObjectValue(systemName() + " server stopping");
 }
 


### PR DESCRIPTION
# Release Notes

![XRP](docs/images/xrp-text-mark-black-small@2x.png)
This document contains the notes for the release `2.5.0` of `rippled` , the reference server implementation of the XRP Ledger protocol. To learn more about how to build, run or update a `rippled` server, visit https://xrpl.org/install-rippled.html

This release adds new features and bug fixes.

## `2.5.0` - 2025-06-23

### 📝 Amendments 

- [XLS-56d Batch](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0056d-batch) (#5060)
- [XLS-81d Permissioned DEX](https://github.com/XRPLF/XRPL-Standards/pull/281) (#5404)
- [XLS-85d Token Escrow](https://github.com/XRPLF/XRPL-Standards/pull/272/) (#5185)
- [XLS-74d and XLS-75d Permission Delegation](https://github.com/XRPLF/XRPL-Standards/pull/257) (#5354)

### 🦟📝 Fix Amendments

- [`fixPayChanCancelAfter`](https://xrpl.org/resources/known-amendments#fixpaychancancelafter) (#4717)
- [`fixAMMv1_3`](https://xrpl.org/resources/known-amendments#fixammv1_3) (#5203)
- [`fixEnforceNFTokenTrustlineV2`](https://xrpl.org/resources/known-amendments#fixenforcenftokentrustlinev2) (#5297) 

### 🐛 Bug Fixes

- Fix RPC responses for tem codes (#5503)
- Adds CTID to RPC tx and updates error (#4738)
- Admin RPC webhook queue limit removal and timeout reduction (#5163)
- Address NFT interactions with trustlines (#5297)
- Handle invalid marker parameter in grpc call (#5317)
- Remove null pointer deref, just do abort (#5338)
- Error message for ledger_entry rpc (#5344)
- Trust line RPC no ripple flag (#5345)
- Replaces random endpoint resolution with sequential (#5365)
- Update validators-example.txt fix xrplf example URL (#5384)
- Disable `channel_authorize` when `signing_support` is disabled (#5385)
- Uint128 ambiguousness breaking macos unity build (#5386)
- Use the build image from ghcr.io (#5390)
- Resolve slow test on macOS pipeline (#5392)
- CTID to use correct ledger_index (#5408)
- Ensure that coverage file generation is atomic. (#5426)
- Enable LedgerStateFix for delegation (#5427)
- Update path in `CODEOWNERS` (#5440)
- Fix pseudo-account ID calculation (#5447)
- Improve handling of expired credentials in `VaultDeposit` (#5452)
- Specify transitive_headers when building with Conan 2 (#5462)
- Add tecNO_DELEGATE_PERMISSION and fix flags (#5465)
- Amendment-guard `TokenEscrow` preclaim and expand tests (#5473)
- Ensure delegate tests do not silently fail with batch (#5476)
- Improve multi-sign usage of `simulate` (#5479)

### 🚜 Refactor

- Remove unused and add missing includes (#5293)
- Calculate numFeatures automatically (#5324)
- Updates Conan dependencies: RocksDB (#5335)
- Improve ordering of headers with clang-format (#5343)
- Collapse some split log messages into one (#5347)
- Move integration tests from 'examples/' into 'tests/' (#5367)
- Reorganize ledger entry tests and helper functions (#5376)
- Clean up test logging to make it easier to search (#5396)
- Use east const convention (#5409)
- Improve squelching configuration (#5438)
- Change getNodeFat Missing Node State Tree error into warning (#5455)

### 📚 Documentation

- Add `-j $(nproc)` to `BUILD.md` (#5288)
- Update build instructions for Ubuntu 22.04+ (#5292)

### 🧪 Testing

- Enable TxQ unit tests work with variable reference fee (#5118)
- Enable unit tests to work with variable reference fee (#5145)
- Enable compile time param to change reference fee value (#5159)

### ⚙️ Miscellaneous Tasks

- Require a message on "Application::signalStop" (#5255)
- Add PR number to payload (#5310)
- Update link to ripple-binary-codec (#5355)
- Rename docs job (#5398)
- Run CI on PRs that are Ready or have the "DraftRunCI" label (#5400)
- Small clarification to lsfDefaultRipple comment (#5410)
- Update CPP ref source (#5453)
- Improve env.meta usage (#5457)
- Remove external project build cores division (#5475)
- Change libXRPL check conan remote to dev (#5482)
- Amendment work in progress [XLS-65d Single Asset Vault](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0065d-single-asset-vault) (#5224)
