### PR TITLE
ripple/smart-escrow: Clear CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,2 @@
 # Allow anyone to review any change by default.
 *
-
-# Require the rpc-reviewers team to review changes to the rpc code.
-include/xrpl/protocol/ @xrplf/rpc-reviewers
-src/libxrpl/protocol/ @xrplf/rpc-reviewers
-src/xrpld/rpc/ @xrplf/rpc-reviewers
-src/xrpld/app/misc/ @xrplf/rpc-reviewers


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Turn off CODEOWNERS so they aren't requested for PR review on the ripple/smart-escrow branch only.

### Context of Change

Currently, rpc-reviewers is bothered for many PRs, since ripple/smart-escrow is being actively developed and iterated on quickly. Also, the work is not relevant to the rpc-reviewers yet.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

## Future Tasks

It will only take a minute to rebase out or revert this commit when we are ready to bring back the codeowners.


We should also consider that paths like `src/xrpld/app/misc/` are very broad and include files unrelated to RPC logic. We can make the paths more specific, and/or document the reason why the entire directory is covered. 

We can also apply more granular rules for specific high-risk files. Directory-level rules may capture more than necessary.