### PR TITLE
change log to debug level for AMM offer retrieval and IOU payment check

### DIFF
--- a/src/xrpld/app/paths/detail/AMMLiquidity.cpp
+++ b/src/xrpld/app/paths/detail/AMMLiquidity.cpp
@@ -248,7 +248,7 @@ AMMLiquidity<TIn, TOut>::getOffer(
             return offer;
         }
 
-        JLOG(j_.error()) << "AMMLiquidity::getOffer, failed "
+        JLOG(j_.debug()) << "AMMLiquidity::getOffer, no valid offer "
                          << ammContext_.multiPath() << " "
                          << ammContext_.curIters() << " "
                          << (clobQuality ? clobQuality->rate() : STAmount{})

--- a/src/xrpld/app/paths/detail/DirectStep.cpp
+++ b/src/xrpld/app/paths/detail/DirectStep.cpp
@@ -423,7 +423,7 @@ DirectIPaymentStep::check(
             !((*sleLine)[sfFlags] & authField) &&
             (*sleLine)[sfBalance] == beast::zero)
         {
-            JLOG(j_.warn())
+            JLOG(j_.debug())
                 << "DirectStepI: can't receive IOUs from issuer without auth."
                 << " src: " << src_;
             return terNO_AUTH;


### PR DESCRIPTION
## High Level Overview of Change

Reduce log noise by changing two log statements from error/warn level to debug level. These logs occur during normal operation when AMM offers are not available or when IOU authorization checks fail, which are expected scenarios that don't require an elevated log level.

### Context of Change

During normal path-finding operations, the following scenarios frequently occur and generate unnecessary error/warning logs:
1. AMM liquidity checks may not find offers with competitive liquidity - normal
2. DirectStep IOU payment checks may fail due to missing authorization - this is an expected validation while exploring payment paths that require authorization

These situations are not errors but expected behaviors during path-finding. The excessive logging at error/warn levels creates noise in production logs, making it harder to identify actual issues.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

- No API impact - this change only affects internal logging levels