### PR TITLE
fix: Modify jobs to use '>>' instead of 'tee' for GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Generate strategy matrix
         working-directory: .github/scripts/strategy-matrix
         id: generate
-        run: python generate.py ${{ inputs.strategy_matrix_all && '--all' || '' }} --config=${{ inputs.os }}.json | tee "${GITHUB_OUTPUT}"
+        run: python generate.py ${{ inputs.strategy_matrix_all && '--all' || '' }} --config=${{ inputs.os }}.json >> "${GITHUB_OUTPUT}"
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
 

--- a/.github/workflows/notify-clio.yml
+++ b/.github/workflows/notify-clio.yml
@@ -45,9 +45,9 @@ jobs:
         id: generate
         run: |
           echo 'Generating channel.'
-          echo channel="clio/pr_${{ github.event.pull_request.number }}" | tee "${GITHUB_OUTPUT}"
+          echo channel="clio/pr_${{ github.event.pull_request.number }}" >> "${GITHUB_OUTPUT}"
           echo 'Extracting version.'
-          echo version="$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" | awk -F '"' '{print $2}')" | tee -a "${GITHUB_OUTPUT}"
+          echo version="$(cat src/libxrpl/protocol/BuildInfo.cpp | grep "versionString =" | awk -F '"' '{print $2}')" >> "${GITHUB_OUTPUT}"
       - name: Add Conan remote
         run: |
           echo "Adding Conan remote '${{ inputs.conan_remote_name }}' at ${{ inputs.conan_remote_url }}."

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -82,14 +82,14 @@ jobs:
         id: generate
         run: |
           if [[ "${{ github.event_name }}" == 'push' ]]; then
-            echo 'dependencies_force_build=false' | tee "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=false' | tee -a "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=false' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
           elif [[ "${{ github.event_name }}" == 'schedule' ]]; then
-            echo 'dependencies_force_build=true' | tee "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=false' | tee -a "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=true' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=false' >> "${GITHUB_OUTPUT}"
           else
-            echo 'dependencies_force_build=${{ inputs.dependencies_force_build }}' | tee "${GITHUB_OUTPUT}"
-            echo 'dependencies_force_upload=${{ inputs.dependencies_force_upload }}' | tee -a "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_build=${{ inputs.dependencies_force_build }}' >> "${GITHUB_OUTPUT}"
+            echo 'dependencies_force_upload=${{ inputs.dependencies_force_upload }}' >> "${GITHUB_OUTPUT}"
           fi
     outputs:
       conan_remote_name: ${{ env.CONAN_REMOTE_NAME }}


### PR DESCRIPTION
## High Level Overview of Change

This change replaces the use of the `tee` command to `>>` instead.

### Context of Change

Some of the workflows write more than one output to `${GITHUB_OUTPUT}`, whereby currently the last output overwrites all previous outputs. Using `>>` is less error-prone than `tee` in that situation.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
