### PR TITLE
fix: Revert PR pipeline trigger rules

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -31,9 +31,9 @@ on:
       - "conanfile.py"
     types:
       - opened
+      - reopened
       - synchronize
-      - labeled
-      - unlabeled
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,24 +48,10 @@ env:
   CONAN_REMOTE_URL: https://conan.ripplex.io
 
 jobs:
-  # This job determines whether the workflow should run. It runs when:
-  # * Opened as a non-draft PR.
-  # * A commit is added to a non-draft PR or the PR has the 'DraftRunCI' label.
-  # * A draft PR has the 'DraftRunCI' label added.
-  # * A non-draft PR has the 'DraftRunCI' label removed.
-  # These checks are in part to ensure the workflow won't run needlessly while
-  # also allowing it to be triggered without having to add a no-op commit. A new
-  # workflow execution can be triggered by adding and then removing the label on
-  # a non-draft PR, or conversely by removing it and then adding it back on a
-  # draft PR; this can be useful in certain cases.
+  # This job determines whether the workflow should run. It runs when the PR is
+  # not a draft or has the 'DraftRunCI' label.
   should-run:
-    if: >-
-      ${{
-        (github.event.action == 'opened' && !github.event.pull_request.draft) ||
-        (github.event.action == 'synchronize' && (!github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI'))) ||
-        (github.event.action == 'labeled' && github.event.pull_request.draft && github.event.label.name == 'DraftRunCI') ||
-        (github.event.action == 'unlabeled' && !github.event.pull_request.draft && github.event.label.name == 'DraftRunCI')
-      }}
+    if: ${{ !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'DraftRunCI') }}
     runs-on: ubuntu-latest
     steps:
       - name: No-op


### PR DESCRIPTION
## High Level Overview of Change

This change removes `labeled` and `unlabeled` as pipeline trigger actions, and instead adds `reopened` and `ready_for_review`. The logic whether to run the pipeline jobs is then simplified, although to get a draft PR with the `DraftCIRun` label to run it can be necessary to close and reopen a PR.

### Context of Change

The intention was to allow the CI pipeline to be triggered when the `DraftCIRun` label was applied, but it had as unintended consequence that when another label was applied the pipeline would trigger but skip all jobs - making it impossible to merge because skipped jobs don't count towards meeting the status check requirements. This change reverts to what it used to be.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release