### PR TITLE
Merge 2.6.1-rc1

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.6.0"
+char const* const versionString = "2.6.1-rc1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## High Level Overview of Change

**This PR must be merged manually using a push. Do not use the Github UI.**

*Additionally, if `develop` changes, this PR must be rebased using `--rebase-merges`, instead of merging `develop` into it.*

This PR merges the changes from release candidate 2.6.1-rc1 back into `develop` so our code history stays consistent.

### Context of Change

No code changes, since the changes are already in `develop`.

### Type of Change

- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
