### PR TITLE
Fix SHAMap crashing bug

### DIFF
--- a/src/xrpld/consensus/Validations.h
+++ b/src/xrpld/consensus/Validations.h
@@ -29,6 +29,8 @@
 #include <xrpl/beast/container/aged_unordered_map.h>
 #include <xrpl/protocol/PublicKey.h>
 
+#include "xrpld/shamap/SHAMapMissingNode.h"
+
 #include <mutex>
 #include <optional>
 #include <type_traits>
@@ -386,8 +388,16 @@ private:
     {
         for (auto it = acquiring_.begin(); it != acquiring_.end();)
         {
-            if (std::optional<Ledger> ledger =
-                    adaptor_.acquire(it->first.second))
+            std::optional<Ledger> ledger;
+            try
+            {
+                // Skip if we haven't finished acquiring this ledger,
+                // or the ledger we acquired isn't complete, which can happen
+                // because we're still trying to catch up.
+                ledger = adaptor_.acquire(it->first.second);
+            }
+            catch (SHAMapMissingNode const&) {}
+            if (ledger)
             {
                 for (NodeID const& nodeID : it->second)
                     updateTrie(lock, nodeID, *ledger);

--- a/src/xrpld/consensus/Validations.h
+++ b/src/xrpld/consensus/Validations.h
@@ -396,7 +396,9 @@ private:
                 // because we're still trying to catch up.
                 ledger = adaptor_.acquire(it->first.second);
             }
-            catch (SHAMapMissingNode const&) {}
+            catch (SHAMapMissingNode const&)
+            {
+            }
             if (ledger)
             {
                 for (NodeID const& nodeID : it->second)


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This PR ensures `SHAMap::peekItem` doesn't throw when the item we're looking for isn't available locally and needs to be fetched from other nodes.

Related Antithesis report: https://ripple.antithesis.com/report/s4aMXDdK-Yk2d9b3TzNEinPH/KbrcIV9HXUqml5-eXiP6J1J_nqxy8SAeeys6oBHRuiI.html?auth=v2.public.eyJuYmYiOiIyMDI1LTA5LTI2VDA0OjUwOjU1LjY3NTc1NTMyNloiLCJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0IjoiS2JyY0lWOUhYVXFtbDUtZVhpUDZKMUpfbnF4eThTQWVleXM2b0JIUnVpSS5odG1sIiwicmVwb3J0X2lkIjoiczRhTVhEZEstWWsyZDliM1R6TkVpblBIIn19fZblCvWYAVGyuzs5D-_7sn8-WZZ2LR6dPnZgTv4EvWmhTS_pQmiT6ZO1r0qkbumvjyKVLswltCpvtm3cOtogbQU#/run/b706d583c0a1f57cd8339d36bf83f88c-37-10/finding/b2731663f39a0d5290a4f19f30186b56e239548c

### Context of Change

`SHAMap::walkTowardsKey` currently throws if the parent item says it has the item we're looking for (`inner->isEmptyBranch(branch)` returns `false`) but the item isn't actually available locally (`SHAMap::descend` returns nullptr). Given that the case is absolutely valid, I don't think we should throw an exception here because we'll fetch the item later and the caller doesn't know how to handle the exception.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [x] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
