### PR TITLE
Merge 2.6.1 into develop

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -41,7 +41,7 @@ XRPL_FIX    (AMMv1_3,                    Supported::yes, VoteBehavior::DefaultNo
 XRPL_FEATURE(PermissionedDEX,            Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Batch,                      Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(SingleAssetVault,           Supported::no,  VoteBehavior::DefaultNo)
-XRPL_FEATURE(PermissionDelegation,       Supported::yes, VoteBehavior::DefaultNo)
+XRPL_FEATURE(PermissionDelegation,       Supported::no,  VoteBehavior::DefaultNo)
 XRPL_FIX    (PayChanCancelAfter,         Supported::yes, VoteBehavior::DefaultNo)
 // Check flags in Credential transactions
 XRPL_FIX    (InvalidTxFlags,             Supported::yes, VoteBehavior::DefaultNo)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.6.1-rc1"
+char const* const versionString = "2.6.1-rc2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "2.6.1-rc2"
+char const* const versionString = "2.6.1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## High Level Overview of Change

**This PR must be merged manually using a push. Do not use the Github UI.**

*Additionally, if `develop` changes, this PR must be rebased using `--rebase-merges`, instead of merging `develop` into it.*

This PR merges the changes from release 2.6.1 back into `develop` so our code history stays consistent.

### Context of Change

Includes the changes between 2.6.1-rc1 and 2.6.1, which are
* Mark `PermissionDelegation` as unsupported.
* Set the version number.

### Type of Change

- [X] Release
