### PR TITLE
refactor: paychan namespace and update related tests

### DIFF
--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -3666,7 +3666,7 @@ private:
             auto const settleDelay = 100s;
             NetClock::time_point const cancelAfter =
                 env.current()->info().parentCloseTime + 200s;
-            env(create(
+            env(paychan::create(
                     carol,
                     ammAlice.ammAccount(),
                     XRP(1'000),

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -31,6 +31,8 @@
 
 namespace ripple {
 namespace test {
+using namespace jtx::paychan;
+
 struct PayChan_test : public beast::unit_test::suite
 {
     FeatureBitset const disallowIncoming{featureDisallowIncoming};

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -502,6 +502,7 @@ expectLedgerEntryRoot(
 
 /* Payment Channel */
 /******************************************************************************/
+namespace paychan {
 
 Json::Value
 create(
@@ -560,6 +561,8 @@ channelBalance(ReadView const& view, uint256 const& chan);
 
 bool
 channelExists(ReadView const& view, uint256 const& chan);
+
+}  // namespace paychan
 
 /* Crossing Limits */
 /******************************************************************************/

--- a/src/test/jtx/impl/TestHelpers.cpp
+++ b/src/test/jtx/impl/TestHelpers.cpp
@@ -237,6 +237,8 @@ expectLedgerEntryRoot(
 
 /* Payment Channel */
 /******************************************************************************/
+namespace paychan {
+
 Json::Value
 create(
     AccountID const& account,
@@ -327,6 +329,8 @@ channelExists(ReadView const& view, uint256 const& chan)
     auto const slep = view.read({ltPAYCHAN, chan});
     return bool(slep);
 }
+
+}  // namespace paychan
 
 /* Crossing Limits */
 /******************************************************************************/


### PR DESCRIPTION
## High Level Overview of Change

<!--
### Context of Change
-->

Adds a `paychan` namespace to the TestHelpers and implementation files, improving organization and clarity. Additionally, it updates the AMM test to use the new `paychan::create` function for payment channel creation.


### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
