### PR TITLE
feat: Install validator-keys

### DIFF
--- a/cmake/RippledInstall.cmake
+++ b/cmake/RippledInstall.cmake
@@ -38,7 +38,7 @@ install(CODE "
   set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
   include(create_symbolic_link)
   create_symbolic_link(xrpl \
-    \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/ripple)
+    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/ripple)
 ")
 
 install (EXPORT RippleExports
@@ -72,7 +72,7 @@ if (is_root_project AND TARGET rippled)
     set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
     include(create_symbolic_link)
     create_symbolic_link(rippled${suffix} \
-      \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/xrpld${suffix})
+       \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/xrpld${suffix})
   ")
 endif ()
 

--- a/cmake/RippledValidatorKeys.cmake
+++ b/cmake/RippledValidatorKeys.cmake
@@ -1,4 +1,4 @@
-option (validator_keys "Enables building of validator-keys-tool as a separate target (imported via FetchContent)" OFF)
+option (validator_keys "Enables building of validator-keys tool as a separate target (imported via FetchContent)" OFF)
 
 if (validator_keys)
   git_branch (current_branch)
@@ -6,17 +6,14 @@ if (validator_keys)
   if (NOT (current_branch STREQUAL "release"))
     set (current_branch "master")
   endif ()
-  message (STATUS "tracking ValidatorKeys branch: ${current_branch}")
+  message (STATUS "Tracking ValidatorKeys branch: ${current_branch}")
 
   FetchContent_Declare (
-    validator_keys_src
+    validator_keys
     GIT_REPOSITORY https://github.com/ripple/validator-keys-tool.git
     GIT_TAG        "${current_branch}"
   )
-  FetchContent_GetProperties (validator_keys_src)
-  if (NOT validator_keys_src_POPULATED)
-    message (STATUS "Pausing to download ValidatorKeys...")
-    FetchContent_Populate (validator_keys_src)
-  endif ()
-  add_subdirectory (${validator_keys_src_SOURCE_DIR} ${CMAKE_BINARY_DIR}/validator-keys)
+  FetchContent_MakeAvailable(validator_keys)
+  install(TARGETS validator-keys RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 endif ()

--- a/cmake/RippledValidatorKeys.cmake
+++ b/cmake/RippledValidatorKeys.cmake
@@ -14,6 +14,7 @@ if (validator_keys)
     GIT_TAG        "${current_branch}"
   )
   FetchContent_MakeAvailable(validator_keys)
+  set_target_properties(validator-keys PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
   install(TARGETS validator-keys RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 endif ()


### PR DESCRIPTION

## High Level Overview of Change

Add the [validator-keys](https://github.com/ripple/validator-keys-tool) as a CMake install target when it is requested to be built.

### Context of Change

Sometimes people ask where this is. Maybe this can make it a little easier to locate. The CMake needed to be updated also and this removes the need for manually installing into packages.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] New feature (non-breaking change which adds functionality)



<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

### Warning during CMake configure.

#### Before

```shell
CMake Warning (dev) at /usr/share/cmake/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(validator_keys_src) is deprecated, call
  FetchContent_MakeAvailable(validator_keys_src) instead.  Policy CMP0169 can
  be set to OLD to allow FetchContent_Populate(validator_keys_src) to be
  called directly for now, but the ability to call it with declared details
  will be removed completely in a future version.
Call Stack (most recent call first):
  cmake/RippledValidatorKeys.cmake:19 (FetchContent_Populate)
  CMakeLists.txt:151 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

#### After

No warning.

--- 

### Fix `DESTDIR` not being respected.

#### Before

CMake error on install.

```shell
CMake Error at cmake/create_symbolic_link.cmake:15 (file):
  file failed to create symbolic link '/usr/local/include/ripple': Permission
  denied
Call Stack (most recent call first):
  build/cmake_install.cmake:88 (create_symbolic_link)
...
CMake Error at cmake/create_symbolic_link.cmake:15 (file):
  file failed to create symbolic link '$DESTDIR/usr/local/bin/xrpld': No such
  file or directory
Call Stack (most recent call first):
  build/cmake_install.cmake:153 (create_symbolic_link)
```

#### After

No errors. Links created.

```shell
% find -L . -xtype l -name xrpld
./rippled_install/usr/local/bin/xrpld
% find -L . -xtype l -name ripple
./rippled_install/usr/local/include/ripple
```

--- 

### No `validator-keys` in installation.

#### Before

`validator-keys` not installed.

```shell
# CMake/configure/install

% find . -type f -name validator-keys
./build/validator-keys/validator-keys
```

#### After

The `validator-keys` tool is installed with `rippled`.

```shell
 % find . -type f -name validator-keys
./rippled_install/usr/local/bin/validator-keys
./build/_deps/validator_keys-build/validator-keys
```
