### PR TITLE
Refactor: replace `fee().accountReserve(0)` with `fee().reserve`

### DIFF
--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -747,7 +747,7 @@ public:
         // Note that the fee structure for unit tests does not match the fees
         // on the production network (October 2019).  Unit tests have a base
         // reserve of 200 XRP.
-        env.fund(env.current()->fees().accountReserve(0), noripple(alice));
+        env.fund(env.current()->fees().reserve, noripple(alice));
         env.close();
 
         // Burn a chunk of alice's funds so she only has 1 XRP remaining in

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -619,7 +619,7 @@ class Check_test : public beast::unit_test::suite
         }
         {
             // Write a check that chews into alice's reserve.
-            STAmount const reserve{env.current()->fees().accountReserve(0)};
+            STAmount const reserve{env.current()->fees().reserve};
             STAmount const checkAmount{
                 startBalance - reserve - drops(baseFeeDrops)};
             uint256 const chkId{getCheckIndex(alice, env.seq(alice))};
@@ -657,7 +657,7 @@ class Check_test : public beast::unit_test::suite
         }
         {
             // Write a check that goes one drop past what alice can pay.
-            STAmount const reserve{env.current()->fees().accountReserve(0)};
+            STAmount const reserve{env.current()->fees().reserve};
             STAmount const checkAmount{
                 startBalance - reserve - drops(baseFeeDrops - 1)};
             uint256 const chkId{getCheckIndex(alice, env.seq(alice))};

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -578,7 +578,7 @@ struct Credentials_test : public beast::unit_test::suite
             using namespace jtx;
             Env env{*this, features};
 
-            auto const reserve = drops(env.current()->fees().accountReserve(0));
+            auto const reserve = drops(env.current()->fees().reserve);
             env.fund(reserve, subject, issuer);
             env.close();
 

--- a/src/test/app/DID_test.cpp
+++ b/src/test/app/DID_test.cpp
@@ -64,7 +64,7 @@ struct DID_test : public beast::unit_test::suite
 
         // Fund alice enough to exist, but not enough to meet
         // the reserve for creating a DID.
-        auto const acctReserve = env.current()->fees().accountReserve(0);
+        auto const acctReserve = env.current()->fees().reserve;
         auto const incReserve = env.current()->fees().increment;
         auto const baseFee = env.current()->fees().base;
         env.fund(acctReserve, alice);

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -691,7 +691,7 @@ struct EscrowToken_test : public beast::unit_test::suite
         {
             Env env{*this, features};
             auto const baseFee = env.current()->fees().base;
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
             auto const alice = Account("alice");
             auto const bob = Account("bob");
@@ -2691,7 +2691,7 @@ struct EscrowToken_test : public beast::unit_test::suite
         {
             Env env{*this, features};
             auto const baseFee = env.current()->fees().base;
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
 
             auto const alice = Account("alice");

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -447,7 +447,7 @@ class MPToken_test : public beast::unit_test::suite
         // Test mptoken reserve requirement - first two mpts free (doApply)
         {
             Env env{*this, features};
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
 
             // 1 drop

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -208,7 +208,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 
         // Fund alice and minter enough to exist, but not enough to meet
         // the reserve for creating their first NFT.
-        auto const acctReserve = env.current()->fees().accountReserve(0);
+        auto const acctReserve = env.current()->fees().reserve;
         auto const incReserve = env.current()->fees().increment;
         auto const baseFee = env.current()->fees().base;
 
@@ -6744,8 +6744,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 
             {
                 // check reserve
-                auto const acctReserve =
-                    env.current()->fees().accountReserve(0);
+                auto const acctReserve = env.current()->fees().reserve;
                 auto const incReserve = env.current()->fees().increment;
 
                 env.fund(acctReserve + incReserve, bob);
@@ -7134,7 +7133,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             Account const bob{"bob"};
 
             Env env{*this, features};
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
             auto const baseFee = env.current()->fees().base;
 
@@ -7217,7 +7216,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             Account const bob{"bob"};
 
             Env env{*this, features};
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
 
             env.fund(XRP(10000), alice);
@@ -7314,7 +7313,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             Account const bob{"bob"};
 
             Env env{*this, features};
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
             auto const baseFee = env.current()->fees().base;
 
@@ -7365,7 +7364,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             Account const broker{"broker"};
 
             Env env{*this, features};
-            auto const acctReserve = env.current()->fees().accountReserve(0);
+            auto const acctReserve = env.current()->fees().reserve;
             auto const incReserve = env.current()->fees().increment;
             auto const baseFee = env.current()->fees().base;
 

--- a/src/test/app/PermissionedDomains_test.cpp
+++ b/src/test/app/PermissionedDomains_test.cpp
@@ -528,7 +528,7 @@ class PermissionedDomains_test : public beast::unit_test::suite
 
         // Fund alice enough to exist, but not enough to meet
         // the reserve.
-        auto const acctReserve = env.current()->fees().accountReserve(0);
+        auto const acctReserve = env.current()->fees().reserve;
         auto const incReserve = env.current()->fees().increment;
         env.fund(acctReserve, alice);
         env.close();

--- a/src/test/app/SetTrust_test.cpp
+++ b/src/test/app/SetTrust_test.cpp
@@ -192,7 +192,7 @@ public:
         auto const& assistor = createOnHighAcct ? acctC : acctD;
 
         auto const txFee = env.current()->fees().base;
-        auto const baseReserve = env.current()->fees().accountReserve(0);
+        auto const baseReserve = env.current()->fees().reserve;
         auto const threelineReserve = env.current()->fees().accountReserve(3);
 
         env.fund(XRP(10000), gwA, gwB, assistor);

--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -142,7 +142,7 @@ FeeVoteImpl::doValidation(
         };
         vote(lastFees.base, target_.reference_fee, "base fee", sfBaseFeeDrops);
         vote(
-            lastFees.accountReserve(0),
+            lastFees.reserve,
             target_.account_reserve,
             "base reserve",
             sfReserveBaseDrops);
@@ -178,7 +178,7 @@ FeeVoteImpl::doValidation(
 
         vote(lastFees.base, target_.reference_fee, to64, "base fee", sfBaseFee);
         vote(
-            lastFees.accountReserve(0),
+            lastFees.reserve,
             target_.account_reserve,
             to32,
             "base reserve",
@@ -207,7 +207,7 @@ FeeVoteImpl::doVoting(
         lastClosedLedger->fees().base, target_.reference_fee);
 
     detail::VotableValue baseReserveVote(
-        lastClosedLedger->fees().accountReserve(0), target_.account_reserve);
+        lastClosedLedger->fees().reserve, target_.account_reserve);
 
     detail::VotableValue incReserveVote(
         lastClosedLedger->fees().increment, target_.owner_reserve);

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -2936,8 +2936,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
         if (!human)
         {
             l[jss::base_fee] = baseFee.jsonClipped();
-            l[jss::reserve_base] =
-                lpClosed->fees().accountReserve(0).jsonClipped();
+            l[jss::reserve_base] = lpClosed->fees().reserve.jsonClipped();
             l[jss::reserve_inc] = lpClosed->fees().increment.jsonClipped();
             l[jss::close_time] = Json::Value::UInt(
                 lpClosed->info().closeTime.time_since_epoch().count());
@@ -2945,8 +2944,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
         else
         {
             l[jss::base_fee_xrp] = baseFee.decimalXRP();
-            l[jss::reserve_base_xrp] =
-                lpClosed->fees().accountReserve(0).decimalXRP();
+            l[jss::reserve_base_xrp] = lpClosed->fees().reserve.decimalXRP();
             l[jss::reserve_inc_xrp] = lpClosed->fees().increment.decimalXRP();
 
             if (auto const closeOffset = app_.timeKeeper().closeOffset();
@@ -3136,8 +3134,7 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
             if (!lpAccepted->rules().enabled(featureXRPFees))
                 jvObj[jss::fee_ref] = Config::FEE_UNITS_DEPRECATED;
             jvObj[jss::fee_base] = lpAccepted->fees().base.jsonClipped();
-            jvObj[jss::reserve_base] =
-                lpAccepted->fees().accountReserve(0).jsonClipped();
+            jvObj[jss::reserve_base] = lpAccepted->fees().reserve.jsonClipped();
             jvObj[jss::reserve_inc] =
                 lpAccepted->fees().increment.jsonClipped();
 
@@ -4215,8 +4212,7 @@ NetworkOPsImp::subLedger(InfoSub::ref isrListener, Json::Value& jvResult)
         if (!lpClosed->rules().enabled(featureXRPFees))
             jvResult[jss::fee_ref] = Config::FEE_UNITS_DEPRECATED;
         jvResult[jss::fee_base] = lpClosed->fees().base.jsonClipped();
-        jvResult[jss::reserve_base] =
-            lpClosed->fees().accountReserve(0).jsonClipped();
+        jvResult[jss::reserve_base] = lpClosed->fees().reserve.jsonClipped();
         jvResult[jss::reserve_inc] = lpClosed->fees().increment.jsonClipped();
         jvResult[jss::network_id] = app_.config().NETWORK_ID;
     }

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -1113,7 +1113,7 @@ TxQ::apply(
                comparable scale to the base fee, ignore the
                reserve. Only check the account balance.
             */
-            auto const reserve = view.fees().accountReserve(0);
+            auto const reserve = view.fees().reserve;
             auto const base = view.fees().base;
             if (totalFee >= balance ||
                 (reserve > 10 * base && totalFee >= reserve))

--- a/src/xrpld/app/paths/PathRequest.cpp
+++ b/src/xrpld/app/paths/PathRequest.cpp
@@ -206,8 +206,7 @@ PathRequest::isValid(std::shared_ptr<RippleLineCache> const& crCache)
             return false;
         }
 
-        if (!convert_all_ &&
-            saDstAmount < STAmount(lrLedger->fees().accountReserve(0)))
+        if (!convert_all_ && saDstAmount < STAmount(lrLedger->fees().reserve))
         {
             // Payment must meet reserve.
             jvStatus = rpcError(rpcDST_AMT_MALFORMED);

--- a/src/xrpld/app/paths/Pathfinder.cpp
+++ b/src/xrpld/app/paths/Pathfinder.cpp
@@ -278,7 +278,7 @@ Pathfinder::findPaths(
             return false;
         }
 
-        auto const reserve = STAmount(mLedger->fees().accountReserve(0));
+        auto const reserve = STAmount(mLedger->fees().reserve);
         if (mDstAmount < reserve)
         {
             JLOG(j_.debug())

--- a/src/xrpld/app/tx/detail/Payment.cpp
+++ b/src/xrpld/app/tx/detail/Payment.cpp
@@ -346,7 +346,7 @@ Payment::preclaim(PreclaimContext const& ctx)
             // transaction would succeed.
             return telNO_DST_PARTIAL;
         }
-        else if (dstAmount < STAmount(ctx.view.fees().accountReserve(0)))
+        else if (dstAmount < STAmount(ctx.view.fees().reserve))
         {
             // accountReserve is the minimum amount that an account can have.
             // Reserve is not scaled by load.
@@ -690,7 +690,7 @@ Payment::doApply()
         // to get the account un-wedged.
 
         // Get the base reserve.
-        XRPAmount const dstReserve{view().fees().accountReserve(0)};
+        XRPAmount const dstReserve{view().fees().reserve};
 
         if (dstAmount > dstReserve ||
             sleDst->getFieldAmount(sfBalance) > dstReserve)

--- a/src/xrpld/app/tx/detail/XChainBridge.cpp
+++ b/src/xrpld/app/tx/detail/XChainBridge.cpp
@@ -476,7 +476,7 @@ transferHelper(
                 // Already checked, but OK to check again
                 return tecNO_DST;
             }
-            if (amt < psb.fees().accountReserve(0))
+            if (amt < psb.fees().reserve)
             {
                 JLOG(j.trace()) << "Insufficient payment to create account.";
                 return tecNO_DST_INSUF_XRP;


### PR DESCRIPTION

## High Level Overview of Change

Fixed `fee().accountReserve(0)` to use `fee().reserve` for getting the **current network** reserve amount that not for acquiring **account’s** reserve.

<!--
### Context of Change
-->


### Type of Change

- [x] Refactor (non-breaking change that only restructures code)



<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
