### PR TITLE
chore: exclude all `UNREACHABLE` blocks from codecov

### DIFF
--- a/include/xrpl/basics/IntrusivePointer.ipp
+++ b/include/xrpl/basics/IntrusivePointer.ipp
@@ -654,12 +654,14 @@ SharedWeakUnion<T>::convertToWeak()
             break;
         case destroy:
             // We just added a weak ref. How could we destroy?
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::SharedWeakUnion::convertToWeak : destroying freshly "
                 "added ref");
             delete p;
             unsafeSetRawPtr(nullptr);
             return true;  // Should never happen
+            // LCOV_EXCL_STOP
         case partialDestroy:
             // This is a weird case. We just converted the last strong
             // pointer to a weak pointer.

--- a/include/xrpl/beast/net/IPAddress.h
+++ b/include/xrpl/beast/net/IPAddress.h
@@ -94,7 +94,8 @@ hash_append(Hasher& h, beast::IP::Address const& addr) noexcept
     else if (addr.is_v6())
         hash_append(h, addr.to_v6().to_bytes());
     else
-        UNREACHABLE("beast::hash_append : invalid address type");
+        UNREACHABLE(
+            "beast::hash_append : invalid address type");  // LCOV_EXCL_LINE
 }
 }  // namespace beast
 

--- a/include/xrpl/beast/net/IPAddress.h
+++ b/include/xrpl/beast/net/IPAddress.h
@@ -94,8 +94,11 @@ hash_append(Hasher& h, beast::IP::Address const& addr) noexcept
     else if (addr.is_v6())
         hash_append(h, addr.to_v6().to_bytes());
     else
-        UNREACHABLE(
-            "beast::hash_append : invalid address type");  // LCOV_EXCL_LINE
+    {
+        // LCOV_EXCL_START
+        UNREACHABLE("beast::hash_append : invalid address type");
+        // LCOV_EXCL_STOP
+    }
 }
 }  // namespace beast
 

--- a/include/xrpl/ledger/ApplyView.h
+++ b/include/xrpl/ledger/ApplyView.h
@@ -284,12 +284,14 @@ public:
     {
         if (key.type != ltOFFER)
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::ApplyView::dirAppend : only Offers are appended to "
                 "book directories");
             // Only Offers are appended to book directories. Call dirInsert()
             // instead
             return std::nullopt;
+            // LCOV_EXCL_STOP
         }
         return dirAdd(true, directory, key.key, describe);
     }

--- a/include/xrpl/protocol/detail/b58_utils.h
+++ b/include/xrpl/protocol/detail/b58_utils.h
@@ -129,10 +129,12 @@ inplace_bigint_div_rem(std::span<uint64_t> numerator, std::uint64_t divisor)
     {
         // should never happen, but if it does then it seems natural to define
         // the a null set of numbers to be zero, so the remainder is also zero.
+        // LCOV_EXCL_START
         UNREACHABLE(
             "ripple::b58_fast::detail::inplace_bigint_div_rem : empty "
             "numerator");
         return 0;
+        // LCOV_EXCL_STOP
     }
 
     auto to_u128 = [](std::uint64_t high,

--- a/include/xrpl/resource/detail/Logic.h
+++ b/include/xrpl/resource/detail/Logic.h
@@ -436,10 +436,12 @@ public:
                     admin_.erase(admin_.iterator_to(entry));
                     break;
                 default:
+                    // LCOV_EXCL_START
                     UNREACHABLE(
                         "ripple::Resource::Logic::release : invalid entry "
                         "kind");
                     break;
+                    // LCOV_EXCL_STOP
             }
             inactive_.push_back(entry);
             entry.whenExpires = m_clock.now() + secondsUntilExpiration;

--- a/src/libxrpl/basics/Log.cpp
+++ b/src/libxrpl/basics/Log.cpp
@@ -239,9 +239,11 @@ Logs::fromSeverity(beast::severities::Severity level)
         case kError:
             return lsERROR;
 
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("ripple::Logs::fromSeverity : invalid severity");
             [[fallthrough]];
+        // LCOV_EXCL_STOP
         case kFatal:
             break;
     }
@@ -265,9 +267,11 @@ Logs::toSeverity(LogSeverity level)
             return kWarning;
         case lsERROR:
             return kError;
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("ripple::Logs::toSeverity : invalid severity");
             [[fallthrough]];
+        // LCOV_EXCL_STOP
         case lsFATAL:
             break;
     }
@@ -292,9 +296,11 @@ Logs::toString(LogSeverity s)
             return "Error";
         case lsFATAL:
             return "Fatal";
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("ripple::Logs::toString : invalid severity");
             return "Unknown";
+            // LCOV_EXCL_STOP
     }
 }
 
@@ -356,9 +362,11 @@ Logs::format(
         case kError:
             output += "ERR ";
             break;
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("ripple::Logs::format : invalid severity");
             [[fallthrough]];
+        // LCOV_EXCL_STOP
         case kFatal:
             output += "FTL ";
             break;

--- a/src/libxrpl/basics/contract.cpp
+++ b/src/libxrpl/basics/contract.cpp
@@ -36,6 +36,7 @@ LogThrow(std::string const& title)
 [[noreturn]] void
 LogicError(std::string const& s) noexcept
 {
+    // LCOV_EXCL_START
     JLOG(debugLog().fatal()) << s;
     std::cerr << "Logic error: " << s << std::endl;
     // Use a non-standard contract naming here (without namespace) because
@@ -45,6 +46,7 @@ LogicError(std::string const& s) noexcept
     // For the above reasons, we want this contract to stand out.
     UNREACHABLE("LogicError", {{"message", s}});
     std::abort();
+    // LCOV_EXCL_STOP
 }
 
 }  // namespace ripple

--- a/src/libxrpl/json/Object.cpp
+++ b/src/libxrpl/json/Object.cpp
@@ -174,7 +174,7 @@ Array::append(Json::Value const& v)
             return;
         }
     }
-    UNREACHABLE("Json::Array::append : invalid type");
+    UNREACHABLE("Json::Array::append : invalid type");  // LCOV_EXCL_LINE
 }
 
 void
@@ -209,7 +209,7 @@ Object::set(std::string const& k, Json::Value const& v)
             return;
         }
     }
-    UNREACHABLE("Json::Object::set : invalid type");
+    UNREACHABLE("Json::Object::set : invalid type");  // LCOV_EXCL_LINE
 }
 
 //------------------------------------------------------------------------------

--- a/src/libxrpl/json/json_value.cpp
+++ b/src/libxrpl/json/json_value.cpp
@@ -213,8 +213,10 @@ Value::Value(ValueType type) : type_(type), allocated_(0)
             value_.bool_ = false;
             break;
 
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::Value(ValueType) : invalid type");
+            // LCOV_EXCL_STOP
     }
 }
 
@@ -290,8 +292,10 @@ Value::Value(Value const& other) : type_(other.type_)
             value_.map_ = new ObjectValues(*other.value_.map_);
             break;
 
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::Value(Value const&) : invalid type");
+            // LCOV_EXCL_STOP
     }
 }
 
@@ -318,8 +322,10 @@ Value::~Value()
                 delete value_.map_;
             break;
 
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::~Value : invalid type");
+            // LCOV_EXCL_STOP
     }
 }
 
@@ -419,8 +425,10 @@ operator<(Value const& x, Value const& y)
             return *x.value_.map_ < *y.value_.map_;
         }
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::operator<(Value, Value) : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return 0;  // unreachable
@@ -465,8 +473,10 @@ operator==(Value const& x, Value const& y)
             return x.value_.map_->size() == y.value_.map_->size() &&
                 *x.value_.map_ == *y.value_.map_;
 
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::operator==(Value, Value) : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return 0;  // unreachable
@@ -506,8 +516,10 @@ Value::asString() const
         case objectValue:
             JSON_ASSERT_MESSAGE(false, "Type is not convertible to string");
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::asString : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return "";  // unreachable
@@ -548,8 +560,10 @@ Value::asInt() const
         case objectValue:
             JSON_ASSERT_MESSAGE(false, "Type is not convertible to int");
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::asInt : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return 0;  // unreachable;
@@ -590,8 +604,10 @@ Value::asUInt() const
         case objectValue:
             JSON_ASSERT_MESSAGE(false, "Type is not convertible to uint");
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::asUInt : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return 0;  // unreachable;
@@ -622,8 +638,10 @@ Value::asDouble() const
         case objectValue:
             JSON_ASSERT_MESSAGE(false, "Type is not convertible to double");
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::asDouble : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return 0;  // unreachable;
@@ -654,8 +672,10 @@ Value::asBool() const
         case objectValue:
             return value_.map_->size() != 0;
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::asBool : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return false;  // unreachable;
@@ -710,8 +730,10 @@ Value::isConvertibleTo(ValueType other) const
             return other == objectValue ||
                 (other == nullValue && value_.map_->size() == 0);
 
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::isConvertible : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return false;  // unreachable;
@@ -744,8 +766,10 @@ Value::size() const
         case objectValue:
             return Int(value_.map_->size());
 
+            // LCOV_EXCL_START
         default:
             UNREACHABLE("Json::Value::size : invalid type");
+            // LCOV_EXCL_STOP
     }
 
     return 0;  // unreachable;

--- a/src/libxrpl/ledger/ApplyStateTable.cpp
+++ b/src/libxrpl/ledger/ApplyStateTable.cpp
@@ -261,7 +261,7 @@ ApplyStateTable::apply(
             {
                 UNREACHABLE(
                     "ripple::detail::ApplyStateTable::apply : unsupported "
-                    "operation type");
+                    "operation type");  // LCOV_EXCL_LINE
             }
         }
 

--- a/src/libxrpl/ledger/ApplyStateTable.cpp
+++ b/src/libxrpl/ledger/ApplyStateTable.cpp
@@ -259,9 +259,11 @@ ApplyStateTable::apply(
             }
             else
             {
+                // LCOV_EXCL_START
                 UNREACHABLE(
                     "ripple::detail::ApplyStateTable::apply : unsupported "
-                    "operation type");  // LCOV_EXCL_LINE
+                    "operation type");
+                // LCOV_EXCL_STOP
             }
         }
 

--- a/src/libxrpl/ledger/ApplyView.cpp
+++ b/src/libxrpl/ledger/ApplyView.cpp
@@ -133,8 +133,10 @@ ApplyView::emptyDirDelete(Keylet const& directory)
     if (directory.type != ltDIR_NODE ||
         node->getFieldH256(sfRootIndex) != directory.key)
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::ApplyView::emptyDirDelete : invalid node type");
         return false;
+        // LCOV_EXCL_STOP
     }
 
     // The directory still contains entries and so it cannot be removed

--- a/src/libxrpl/ledger/BookDirs.cpp
+++ b/src/libxrpl/ledger/BookDirs.cpp
@@ -36,7 +36,9 @@ BookDirs::BookDirs(ReadView const& view, Book const& book)
     {
         if (!cdirFirst(*view_, key_, sle_, entry_, index_))
         {
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::BookDirs::BookDirs : directory is empty");
+            // LCOV_EXCL_STOP
         }
     }
 }
@@ -110,9 +112,11 @@ BookDirs::const_iterator::operator++()
         }
         else if (!cdirFirst(*view_, cur_key_, sle_, entry_, index_))
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::BookDirs::const_iterator::operator++ : directory is "
                 "empty");
+            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -324,10 +324,12 @@ isVaultPseudoAccountFrozen(
     auto const issuer = mptIssuance->getAccountID(sfIssuer);
     auto const mptIssuer = view.read(keylet::account(issuer));
     if (mptIssuer == nullptr)
-    {  // LCOV_EXCL_START
+    {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::isVaultPseudoAccountFrozen : null MPToken issuer");
         return false;
-    }  // LCOV_EXCL_STOP
+        // LCOV_EXCL_STOP
+    }
 
     if (!mptIssuer->isFieldPresent(sfVaultID))
         return false;  // not a Vault pseudo-account, common case
@@ -338,7 +340,8 @@ isVaultPseudoAccountFrozen(
     {  // LCOV_EXCL_START
         UNREACHABLE("ripple::isVaultPseudoAccountFrozen : null vault");
         return false;
-    }  // LCOV_EXCL_STOP
+        // LCOV_EXCL_STOP
+    }
 
     return isAnyFrozen(view, {issuer, account}, vault->at(sfAsset), depth + 1);
 }
@@ -2676,7 +2679,8 @@ enforceMPTokenAuthorization(
     UNREACHABLE(
         "ripple::enforceMPTokenAuthorization : condition list is incomplete");
     return tefINTERNAL;
-}  // LCOV_EXCL_STOP
+    // LCOV_EXCL_STOP
+}
 
 TER
 canTransfer(

--- a/src/libxrpl/protocol/STBase.cpp
+++ b/src/libxrpl/protocol/STBase.cpp
@@ -112,7 +112,9 @@ void
 STBase::add(Serializer& s) const
 {
     // Should never be called
+    // LCOV_EXCL_START
     UNREACHABLE("ripple::STBase::add : not implemented");
+    // LCOV_EXCL_STOP
 }
 
 bool

--- a/src/libxrpl/protocol/TxMeta.cpp
+++ b/src/libxrpl/protocol/TxMeta.cpp
@@ -238,9 +238,11 @@ TxMeta::getAffectedNode(uint256 const& node)
         if (n.getFieldH256(sfLedgerIndex) == node)
             return n;
     }
+    // LCOV_EXCL_START
     UNREACHABLE("ripple::TxMeta::getAffectedNode(uint256) : node not found");
     Throw<std::runtime_error>("Affected node not found");
     return *(mNodes.begin());  // Silence compiler warning.
+    // LCOV_EXCL_STOP
 }
 
 STObject

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -433,8 +433,10 @@ Ledger::read(Keylet const& k) const
 {
     if (k.key == beast::zero)
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::Ledger::read : zero key");
         return nullptr;
+        // LCOV_EXCL_STOP
     }
     auto const& item = stateMap_.peekItem(k.key);
     if (!item)
@@ -860,6 +862,7 @@ Ledger::assertSensible(beast::Journal ledgerJ) const
         return true;
     }
 
+    // LCOV_EXCL_START
     Json::Value j = getJson({*this, {}});
 
     j[jss::accountTreeHash] = to_string(info_.accountHash);
@@ -870,6 +873,7 @@ Ledger::assertSensible(beast::Journal ledgerJ) const
     UNREACHABLE("ripple::Ledger::assertSensible : ledger is not sensible");
 
     return false;
+    // LCOV_EXCL_STOP
 }
 
 // update the skip list with the information from our previous ledger

--- a/src/xrpld/app/ledger/detail/InboundLedger.cpp
+++ b/src/xrpld/app/ledger/detail/InboundLedger.cpp
@@ -963,8 +963,10 @@ InboundLedger::takeAsRootNode(Slice const& data, SHAMapAddNode& san)
 
     if (!mHaveHeader)
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::InboundLedger::takeAsRootNode : no ledger header");
         return false;
+        // LCOV_EXCL_STOP
     }
 
     AccountStateSF filter(
@@ -988,8 +990,10 @@ InboundLedger::takeTxRootNode(Slice const& data, SHAMapAddNode& san)
 
     if (!mHaveHeader)
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::InboundLedger::takeTxRootNode : no ledger header");
         return false;
+        // LCOV_EXCL_STOP
     }
 
     TransactionStateSF filter(

--- a/src/xrpld/app/ledger/detail/LedgerMaster.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerMaster.cpp
@@ -1273,11 +1273,13 @@ LedgerMaster::findNewLedgersToPublish(
             }
             else if (hash->isZero())
             {
+                // LCOV_EXCL_START
                 JLOG(m_journal.fatal()) << "Ledger: " << valSeq
                                         << " does not have hash for " << seq;
                 UNREACHABLE(
                     "ripple::LedgerMaster::findNewLedgersToPublish : ledger "
                     "not found");
+                // LCOV_EXCL_STOP
             }
             else
             {

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -2045,79 +2045,81 @@ ApplicationImp::loadOldLedger(
             return false;
             // LCOV_EXCL_STOP
         }
-    }
 
-    if (!loadLedger->assertSensible(journal("Ledger")))
-    {
-        // LCOV_EXCL_START
-        JLOG(m_journal.fatal()) << "Ledger is not sensible.";
-        UNREACHABLE(
-            "ripple::ApplicationImp::loadOldLedger : ledger is not "
-            "sensible");
-        return false;
-        // LCOV_EXCL_STOP
-    }
-
-    m_ledgerMaster->setLedgerRangePresent(
-        loadLedger->info().seq, loadLedger->info().seq);
-
-    m_ledgerMaster->switchLCL(loadLedger);
-    loadLedger->setValidated();
-    m_ledgerMaster->setFullLedger(loadLedger, true, false);
-    openLedger_.emplace(loadLedger, cachedSLEs_, logs_->journal("OpenLedger"));
-
-    if (replay)
-    {
-        // inject transaction(s) from the replayLedger into our open ledger
-        // and build replay structure
-        auto replayData =
-            std::make_unique<LedgerReplay>(loadLedger, replayLedger);
-
-        for (auto const& [_, tx] : replayData->orderedTxns())
+        if (!loadLedger->assertSensible(journal("Ledger")))
         {
-            (void)_;
-            auto txID = tx->getTransactionID();
-            if (trapTxID == txID)
+            // LCOV_EXCL_START
+            JLOG(m_journal.fatal()) << "Ledger is not sensible.";
+            UNREACHABLE(
+                "ripple::ApplicationImp::loadOldLedger : ledger is not "
+                "sensible");
+            return false;
+            // LCOV_EXCL_STOP
+        }
+
+        m_ledgerMaster->setLedgerRangePresent(
+            loadLedger->info().seq, loadLedger->info().seq);
+
+        m_ledgerMaster->switchLCL(loadLedger);
+        loadLedger->setValidated();
+        m_ledgerMaster->setFullLedger(loadLedger, true, false);
+        openLedger_.emplace(
+            loadLedger, cachedSLEs_, logs_->journal("OpenLedger"));
+
+        if (replay)
+        {
+            // inject transaction(s) from the replayLedger into our open ledger
+            // and build replay structure
+            auto replayData =
+                std::make_unique<LedgerReplay>(loadLedger, replayLedger);
+
+            for (auto const& [_, tx] : replayData->orderedTxns())
             {
-                trapTxID_ = txID;
-                JLOG(m_journal.debug()) << "Trap transaction set: " << txID;
+                (void)_;
+                auto txID = tx->getTransactionID();
+                if (trapTxID == txID)
+                {
+                    trapTxID_ = txID;
+                    JLOG(m_journal.debug()) << "Trap transaction set: " << txID;
+                }
+
+                auto s = std::make_shared<Serializer>();
+                tx->add(*s);
+
+                forceValidity(getHashRouter(), txID, Validity::SigGoodOnly);
+
+                openLedger_->modify(
+                    [&txID, &s](OpenView& view, beast::Journal j) {
+                        view.rawTxInsert(txID, std::move(s), nullptr);
+                        return true;
+                    });
             }
 
-            auto s = std::make_shared<Serializer>();
-            tx->add(*s);
+            m_ledgerMaster->takeReplay(std::move(replayData));
 
-            forceValidity(getHashRouter(), txID, Validity::SigGoodOnly);
-
-            openLedger_->modify([&txID, &s](OpenView& view, beast::Journal j) {
-                view.rawTxInsert(txID, std::move(s), nullptr);
-                return true;
-            });
-        }
-
-        m_ledgerMaster->takeReplay(std::move(replayData));
-
-        if (trapTxID && !trapTxID_)
-        {
-            JLOG(m_journal.fatal())
-                << "Ledger " << replayLedger->info().seq
-                << " does not contain the transaction hash " << *trapTxID;
-            return false;
+            if (trapTxID && !trapTxID_)
+            {
+                JLOG(m_journal.fatal())
+                    << "Ledger " << replayLedger->info().seq
+                    << " does not contain the transaction hash " << *trapTxID;
+                return false;
+            }
         }
     }
-}
-catch (SHAMapMissingNode const& mn)
-{
-    JLOG(m_journal.fatal()) << "While loading specified ledger: " << mn.what();
-    return false;
-}
-catch (boost::bad_lexical_cast&)
-{
-    JLOG(m_journal.fatal())
-        << "Ledger specified '" << ledgerID << "' is not valid";
-    return false;
-}
+    catch (SHAMapMissingNode const& mn)
+    {
+        JLOG(m_journal.fatal())
+            << "While loading specified ledger: " << mn.what();
+        return false;
+    }
+    catch (boost::bad_lexical_cast&)
+    {
+        JLOG(m_journal.fatal())
+            << "Ledger specified '" << ledgerID << "' is not valid";
+        return false;
+    }
 
-return true;
+    return true;
 }
 
 bool

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -4146,8 +4146,11 @@ NetworkOPsImp::subBook(InfoSub::ref isrListener, Book const& book)
     if (auto listeners = app_.getOrderBookDB().makeBookListeners(book))
         listeners->addSubscriber(isrListener);
     else
-        UNREACHABLE(
-            "ripple::NetworkOPsImp::subBook : null book listeners");  // LCOV_EXCL_LINE
+    {
+        // LCOV_EXCL_START
+        UNREACHABLE("ripple::NetworkOPsImp::subBook : null book listeners");
+        // LCOV_EXCL_STOP
+    }
     return true;
 }
 

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -1798,11 +1798,13 @@ NetworkOPsImp::getOwnerInfo(
 
                     case ltACCOUNT_ROOT:
                     case ltDIR_NODE:
+                    // LCOV_EXCL_START
                     default:
                         UNREACHABLE(
                             "ripple::NetworkOPsImp::getOwnerInfo : invalid "
                             "type");
                         break;
+                        // LCOV_EXCL_STOP
                 }
             }
 
@@ -3831,12 +3833,14 @@ NetworkOPsImp::addAccountHistoryJob(SubAccountHistoryInfoWeak subInfo)
                             accountId, minLedger, maxLedger, marker, 0, true};
                         return db->newestAccountTxPage(options);
                     }
+                    // LCOV_EXCL_START
                     default: {
                         UNREACHABLE(
                             "ripple::NetworkOPsImp::addAccountHistoryJob::"
                             "getMoreTxns : invalid database type");
                         return {};
                     }
+                        // LCOV_EXCL_STOP
                 }
             };
 
@@ -4030,10 +4034,12 @@ NetworkOPsImp::subAccountHistoryStart(
         }
         else
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::NetworkOPsImp::subAccountHistoryStart : failed to "
                 "access genesis account");
             return;
+            // LCOV_EXCL_STOP
         }
     }
     subInfo.index_->historyLastLedgerSeq_ = ledger->seq();
@@ -4140,7 +4146,8 @@ NetworkOPsImp::subBook(InfoSub::ref isrListener, Book const& book)
     if (auto listeners = app_.getOrderBookDB().makeBookListeners(book))
         listeners->addSubscriber(isrListener);
     else
-        UNREACHABLE("ripple::NetworkOPsImp::subBook : null book listeners");
+        UNREACHABLE(
+            "ripple::NetworkOPsImp::subBook : null book listeners");  // LCOV_EXCL_LINE
     return true;
 }
 

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1168,11 +1168,11 @@ ValidatorList::applyList(
 
     if (!publicKeyType(*pubKeyOpt))
     {
-        // LCOV_EXCL_START
         // This is an impossible situation because we will never load an
         // invalid public key type (see checks in `ValidatorList::load`) however
         // we can only arrive here if the key used by the manifest matched one
         // of the loaded keys
+        // LCOV_EXCL_START
         UNREACHABLE(
             "ripple::ValidatorList::applyList : invalid public key type");
         return PublisherListStats{result};

--- a/src/xrpld/app/misc/detail/ValidatorList.cpp
+++ b/src/xrpld/app/misc/detail/ValidatorList.cpp
@@ -1167,15 +1167,17 @@ ValidatorList::applyList(
     }
 
     if (!publicKeyType(*pubKeyOpt))
-    {  // LCOV_EXCL_START
-       // This is an impossible situation because we will never load an
-       // invalid public key type (see checks in `ValidatorList::load`) however
-       // we can only arrive here if the key used by the manifest matched one of
-       // the loaded keys
+    {
+        // LCOV_EXCL_START
+        // This is an impossible situation because we will never load an
+        // invalid public key type (see checks in `ValidatorList::load`) however
+        // we can only arrive here if the key used by the manifest matched one
+        // of the loaded keys
         UNREACHABLE(
             "ripple::ValidatorList::applyList : invalid public key type");
         return PublisherListStats{result};
-    }  // LCOV_EXCL_STOP
+        // LCOV_EXCL_STOP
+    }
 
     PublicKey pubKey = *pubKeyOpt;
     if (result > ListDisposition::pending)

--- a/src/xrpld/app/paths/Pathfinder.cpp
+++ b/src/xrpld/app/paths/Pathfinder.cpp
@@ -648,8 +648,10 @@ Pathfinder::getBestPaths(
 
         if (path.empty())
         {
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::Pathfinder::getBestPaths : path not found");
             continue;
+            // LCOV_EXCL_STOP
         }
 
         bool startsWithIssuer = false;

--- a/src/xrpld/app/paths/detail/BookStep.cpp
+++ b/src/xrpld/app/paths/detail/BookStep.cpp
@@ -1113,11 +1113,13 @@ BookStep<TIn, TOut, TDerived>::revImp(
     {
         case -1: {
             // something went very wrong
+            // LCOV_EXCL_START
             JLOG(j_.error())
                 << "BookStep remainingOut < 0 " << to_string(remainingOut);
             UNREACHABLE("ripple::BookStep::revImp : remaining less than zero");
             cache_.emplace(beast::zero, beast::zero);
             return {beast::zero, beast::zero};
+            // LCOV_EXCL_STOP
         }
         case 0: {
             // due to normalization, remainingOut can be zero without
@@ -1283,12 +1285,14 @@ BookStep<TIn, TOut, TDerived>::fwdImp(
     switch (remainingIn.signum())
     {
         case -1: {
+            // LCOV_EXCL_START
             // something went very wrong
             JLOG(j_.error())
                 << "BookStep remainingIn < 0 " << to_string(remainingIn);
             UNREACHABLE("ripple::BookStep::fwdImp : remaining less than zero");
             cache_.emplace(beast::zero, beast::zero);
             return {beast::zero, beast::zero};
+            // LCOV_EXCL_STOP
         }
         case 0: {
             // due to normalization, remainingIn can be zero without
@@ -1421,8 +1425,10 @@ bookStepEqual(Step const& step, ripple::Book const& book)
     bool const outXRP = isXRP(book.out.currency);
     if (inXRP && outXRP)
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::test::bookStepEqual : no XRP to XRP book step");
         return false;  // no such thing as xrp/xrp book step
+        // LCOV_EXCL_STOP
     }
     if (inXRP && !outXRP)
         return equalHelper<

--- a/src/xrpld/app/paths/detail/DirectStep.cpp
+++ b/src/xrpld/app/paths/detail/DirectStep.cpp
@@ -931,10 +931,12 @@ DirectStepI<TDerived>::check(StrandContext const& ctx) const
         {
             if (!ctx.prevStep)
             {
+                // LCOV_EXCL_START
                 UNREACHABLE(
                     "ripple::DirectStepI::check : prev seen book without a "
                     "prev step");
                 return temBAD_PATH_LOOP;
+                // LCOV_EXCL_STOP
             }
 
             // This is OK if the previous step is a book step that outputs this

--- a/src/xrpld/app/paths/detail/FlowDebugInfo.h
+++ b/src/xrpld/app/paths/detail/FlowDebugInfo.h
@@ -126,10 +126,12 @@ struct FlowDebugInfo
         auto i = timePoints.find(tag);
         if (i == timePoints.end())
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::path::detail::FlowDebugInfo::duration : timepoint not "
                 "found");
             return std::chrono::duration<double>(0);
+            // LCOV_EXCL_STOP
         }
         auto const& t = i->second;
         return std::chrono::duration_cast<std::chrono::duration<double>>(

--- a/src/xrpld/app/paths/detail/PaySteps.cpp
+++ b/src/xrpld/app/paths/detail/PaySteps.cpp
@@ -95,11 +95,13 @@ toStep(
 
     if (e1->isOffer() && e2->isAccount())
     {
+        // LCOV_EXCL_START
         // should already be taken care of
         JLOG(j.error())
             << "Found offer/account payment step. Aborting payment strand.";
         UNREACHABLE("ripple::toStep : offer/account payment payment strand");
         return {temBAD_PATH, std::unique_ptr<Step>{}};
+        // LCOV_EXCL_STOP
     }
 
     XRPL_ASSERT(
@@ -392,8 +394,10 @@ toStrand(
             next->getCurrency() != curIssue.currency)
         {
             // Should never happen
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::toStrand : offer currency mismatch");
             return {temBAD_PATH, Strand{}};
+            // LCOV_EXCL_STOP
         }
 
         auto s = toStep(
@@ -457,9 +461,11 @@ toStrand(
 
     if (!checkStrand())
     {
+        // LCOV_EXCL_START
         JLOG(j.warn()) << "Flow check strand failed";
         UNREACHABLE("ripple::toStrand : invalid strand");
         return {temBAD_PATH, Strand{}};
+        // LCOV_EXCL_STOP
     }
 
     return {tesSUCCESS, std::move(result)};

--- a/src/xrpld/app/paths/detail/StrandFlow.h
+++ b/src/xrpld/app/paths/detail/StrandFlow.h
@@ -167,6 +167,7 @@ flow(
                         // Something is very wrong
                         // throwing out the sandbox can only increase liquidity
                         // yet the limiting is still limiting
+                        // LCOV_EXCL_START
                         JLOG(j.fatal())
                             << "Re-executed limiting step failed. r.first: "
                             << to_string(get<TInAmt>(r.first))
@@ -175,6 +176,7 @@ flow(
                             "ripple::flow : first step re-executing the "
                             "limiting step failed");
                         return Result{strand, std::move(ofrsToRm)};
+                        // LCOV_EXCL_STOP
                     }
                 }
                 else if (!strand[i]->equalOut(r.second, stepOut))
@@ -202,6 +204,7 @@ flow(
                         // Something is very wrong
                         // throwing out the sandbox can only increase liquidity
                         // yet the limiting is still limiting
+                        // LCOV_EXCL_START
 #ifndef NDEBUG
                         JLOG(j.fatal())
                             << "Re-executed limiting step failed. r.second: "
@@ -213,6 +216,7 @@ flow(
                             "ripple::flow : limiting step re-executing the "
                             "limiting step failed");
                         return Result{strand, std::move(ofrsToRm)};
+                        // LCOV_EXCL_STOP
                     }
                 }
 
@@ -238,6 +242,7 @@ flow(
                     // The limits should already have been found, so executing a
                     // strand forward from the limiting step should not find a
                     // new limit
+                    // LCOV_EXCL_START
 #ifndef NDEBUG
                     JLOG(j.fatal())
                         << "Re-executed forward pass failed. r.first: "
@@ -249,6 +254,7 @@ flow(
                         "ripple::flow : non-limiting step re-executing the "
                         "forward pass failed");
                     return Result{strand, std::move(ofrsToRm)};
+                    // LCOV_EXCL_STOP
                 }
                 stepIn = r.second;
             }
@@ -499,8 +505,10 @@ public:
     {
         if (i >= cur_.size())
         {
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::ActiveStrands::get : input out of range");
             return nullptr;
+            // LCOV_EXCL_STOP
         }
         return cur_[i];
     }

--- a/src/xrpld/app/rdb/RelationalDatabase.h
+++ b/src/xrpld/app/rdb/RelationalDatabase.h
@@ -235,12 +235,14 @@ rangeCheckedCast(C c)
          std::numeric_limits<C>::is_signed &&
          c < std::numeric_limits<T>::lowest()))
     {
-        /* This should never happen */
+        // This should never happen
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::rangeCheckedCast : domain error");
         JLOG(debugLog().error())
             << "rangeCheckedCast domain error:"
             << " value = " << c << " min = " << std::numeric_limits<T>::lowest()
             << " max: " << std::numeric_limits<T>::max();
+        // LCOV_EXCL_STOP
     }
 
     return static_cast<T>(c);

--- a/src/xrpld/app/rdb/backend/detail/Node.cpp
+++ b/src/xrpld/app/rdb/backend/detail/Node.cpp
@@ -58,9 +58,11 @@ to_string(TableType type)
             return "Transactions";
         case TableType::AccountTransactions:
             return "AccountTransactions";
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("ripple::detail::to_string : invalid TableType");
             return "Unknown";
+            // LCOV_EXCL_STOP
     }
 }
 
@@ -202,18 +204,22 @@ saveValidatedLedger(
 
     if (!ledger->info().accountHash.isNonZero())
     {
+        // LCOV_EXCL_START
         JLOG(j.fatal()) << "AH is zero: " << getJson({*ledger, {}});
         UNREACHABLE("ripple::detail::saveValidatedLedger : zero account hash");
+        // LCOV_EXCL_STOP
     }
 
     if (ledger->info().accountHash != ledger->stateMap().getHash().as_uint256())
     {
+        // LCOV_EXCL_START
         JLOG(j.fatal()) << "sAL: " << ledger->info().accountHash
                         << " != " << ledger->stateMap().getHash();
         JLOG(j.fatal()) << "saveAcceptedLedger: seq=" << seq
                         << ", current=" << current;
         UNREACHABLE(
             "ripple::detail::saveValidatedLedger : mismatched account hash");
+        // LCOV_EXCL_STOP
     }
 
     XRPL_ASSERT(

--- a/src/xrpld/app/tx/detail/Change.cpp
+++ b/src/xrpld/app/tx/detail/Change.cpp
@@ -151,9 +151,11 @@ Change::doApply()
             return applyFee();
         case ttUNL_MODIFY:
             return applyUNLModify();
+        // LCOV_EXCL_START
         default:
             UNREACHABLE("ripple::Change::doApply : invalid transaction type");
             return tefFAILURE;
+            // LCOV_EXCL_STOP
     }
 }
 

--- a/src/xrpld/app/tx/detail/DeleteAccount.cpp
+++ b/src/xrpld/app/tx/detail/DeleteAccount.cpp
@@ -399,12 +399,14 @@ DeleteAccount::doApply()
                 return {result, SkipEntry::No};
             }
 
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::DeleteAccount::doApply : undeletable item not found "
                 "in preclaim");
             JLOG(j_.error()) << "DeleteAccount undeletable item not "
                                 "found in preclaim.";
             return {tecHAS_OBLIGATIONS, SkipEntry::No};
+            // LCOV_EXCL_STOP
         },
         ctx_.journal);
     if (ter != tesSUCCESS)

--- a/src/xrpld/app/tx/detail/Offer.h
+++ b/src/xrpld/app/tx/detail/Offer.h
@@ -225,11 +225,13 @@ template <class TIn, class TOut>
 void
 TOffer<TIn, TOut>::setFieldAmounts()
 {
+    // LCOV_EXCL_START
 #ifdef _MSC_VER
     UNREACHABLE("ripple::TOffer::setFieldAmounts : must be specialized");
 #else
     static_assert(sizeof(TOut) == -1, "Must be specialized");
 #endif
+    // LCOV_EXCL_STOP
 }
 
 template <class TIn, class TOut>

--- a/src/xrpld/app/tx/detail/OfferStream.cpp
+++ b/src/xrpld/app/tx/detail/OfferStream.cpp
@@ -369,10 +369,12 @@ TOfferStreamBase<TIn, TOut>::step()
                                 std::is_same_v<TOut, XRPAmount>))
                     return shouldRmSmallIncreasedQOffer<IOUAmount, IOUAmount>();
             }
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "rippls::TOfferStreamBase::step::rmSmallIncreasedQOffer : XRP "
                 "vs XRP offer");
             return false;
+            // LCOV_EXCL_STOP
         }();
 
         if (rmSmallIncreasedQOffer)

--- a/src/xrpld/app/tx/detail/SetSignerList.cpp
+++ b/src/xrpld/app/tx/detail/SetSignerList.cpp
@@ -134,8 +134,10 @@ SetSignerList::doApply()
         default:
             break;
     }
+    // LCOV_EXCL_START
     UNREACHABLE("ripple::SetSignerList::doApply : invalid operation");
     return temMALFORMED;
+    // LCOV_EXCL_STOP
 }
 
 void

--- a/src/xrpld/app/tx/detail/Transactor.cpp
+++ b/src/xrpld/app/tx/detail/Transactor.cpp
@@ -1170,11 +1170,13 @@ Transactor::operator()()
 
         if (!s2.isEquivalent(ctx_.tx))
         {
+            // LCOV_EXCL_START
             JLOG(j_.fatal()) << "Transaction serdes mismatch";
             JLOG(j_.info()) << to_string(ctx_.tx.getJson(JsonOptions::none));
             JLOG(j_.fatal()) << s2.getJson(JsonOptions::none);
             UNREACHABLE(
                 "ripple::Transactor::operator() : transaction serdes mismatch");
+            // LCOV_EXCL_STOP
         }
     }
 #endif

--- a/src/xrpld/app/tx/detail/XChainBridge.cpp
+++ b/src/xrpld/app/tx/detail/XChainBridge.cpp
@@ -223,10 +223,12 @@ claimHelper(
         auto i = signersList.find(a.keyAccount);
         if (i == signersList.end())
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::claimHelper : invalid inputs");  // should have already
                                                           // been checked
             continue;
+            // LCOV_EXCL_STOP
         }
         weight += i->second;
         rewardAccounts.push_back(a.rewardAccount);

--- a/src/xrpld/app/tx/detail/applySteps.cpp
+++ b/src/xrpld/app/tx/detail/applySteps.cpp
@@ -129,10 +129,12 @@ invoke_preflight(PreflightContext const& ctx)
     catch (UnknownTxnType const& e)
     {
         // Should never happen
+        // LCOV_EXCL_START
         JLOG(ctx.j.fatal())
             << "Unknown transaction type in preflight: " << e.txnType;
         UNREACHABLE("ripple::invoke_preflight : unknown transaction type");
         return {temUNKNOWN, TxConsequences{temUNKNOWN}};
+        // LCOV_EXCL_STOP
     }
 }
 
@@ -183,10 +185,12 @@ invoke_preclaim(PreclaimContext const& ctx)
     catch (UnknownTxnType const& e)
     {
         // Should never happen
+        // LCOV_EXCL_START
         JLOG(ctx.j.fatal())
             << "Unknown transaction type in preclaim: " << e.txnType;
         UNREACHABLE("ripple::invoke_preclaim : unknown transaction type");
         return temUNKNOWN;
+        // LCOV_EXCL_STOP
     }
 }
 
@@ -217,9 +221,11 @@ invoke_calculateBaseFee(ReadView const& view, STTx const& tx)
     }
     catch (UnknownTxnType const& e)
     {
+        // LCOV_EXCL_START
         UNREACHABLE(
             "ripple::invoke_calculateBaseFee : unknown transaction type");
         return XRPAmount{0};
+        // LCOV_EXCL_STOP
     }
 }
 
@@ -277,10 +283,12 @@ invoke_apply(ApplyContext& ctx)
     catch (UnknownTxnType const& e)
     {
         // Should never happen
+        // LCOV_EXCL_START
         JLOG(ctx.journal.fatal())
             << "Unknown transaction type in apply: " << e.txnType;
         UNREACHABLE("ripple::invoke_apply : unknown transaction type");
         return {temUNKNOWN, false};
+        // LCOV_EXCL_STOP
     }
 }
 

--- a/src/xrpld/nodestore/backend/NuDBFactory.cpp
+++ b/src/xrpld/nodestore/backend/NuDBFactory.cpp
@@ -121,11 +121,13 @@ public:
         using namespace boost::filesystem;
         if (db_.is_open())
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::NodeStore::NuDBBackend::open : database is already "
                 "open");
             JLOG(j_.error()) << "database is already open";
             return;
+            // LCOV_EXCL_STOP
         }
         auto const folder = path(name_);
         auto const dp = (folder / "nudb.dat").string();

--- a/src/xrpld/nodestore/backend/RocksDBFactory.cpp
+++ b/src/xrpld/nodestore/backend/RocksDBFactory.cpp
@@ -232,11 +232,13 @@ public:
     {
         if (m_db)
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::NodeStore::RocksDBBackend::open : database is already "
                 "open");
             JLOG(m_journal.error()) << "database is already open";
             return;
+            // LCOV_EXCL_STOP
         }
         rocksdb::DB* db = nullptr;
         m_options.create_if_missing = createIfMissing;

--- a/src/xrpld/overlay/Compression.h
+++ b/src/xrpld/overlay/Compression.h
@@ -60,12 +60,14 @@ decompress(
                 in, inSize, decompressed, decompressedSize);
         else
         {
+            // LCOV_EXCL_START
             JLOG(debugLog().warn())
                 << "decompress: invalid compression algorithm "
                 << static_cast<int>(algorithm);
             UNREACHABLE(
                 "ripple::compression::decompress : invalid compression "
                 "algorithm");
+            // LCOV_EXCL_STOP
         }
     }
     catch (...)
@@ -98,11 +100,13 @@ compress(
                 in, inSize, std::forward<BufferFactory>(bf));
         else
         {
+            // LCOV_EXCL_START
             JLOG(debugLog().warn()) << "compress: invalid compression algorithm"
                                     << static_cast<int>(algorithm);
             UNREACHABLE(
                 "ripple::compression::compress : invalid compression "
                 "algorithm");
+            // LCOV_EXCL_STOP
         }
     }
     catch (...)

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -2234,10 +2234,12 @@ PeerImp::onValidatorListMessage(
         case ListDisposition::invalid:
         case ListDisposition::unsupported_version:
             break;
+        // LCOV_EXCL_START
         default:
             UNREACHABLE(
                 "ripple::PeerImp::onValidatorListMessage : invalid best list "
                 "disposition");
+            // LCOV_EXCL_STOP
     }
 
     // Charge based on the worst result
@@ -2278,10 +2280,12 @@ PeerImp::onValidatorListMessage(
             // If it happens frequently, that's probably bad.
             fee_.update(Resource::feeInvalidData, "version");
             break;
+        // LCOV_EXCL_START
         default:
             UNREACHABLE(
                 "ripple::PeerImp::onValidatorListMessage : invalid worst list "
                 "disposition");
+            // LCOV_EXCL_STOP
     }
 
     // Log based on all the results.
@@ -2338,10 +2342,12 @@ PeerImp::onValidatorListMessage(
                     << "Ignored " << count << "invalid " << messageType
                     << "(s) from peer " << remote_address_;
                 break;
+            // LCOV_EXCL_START
             default:
                 UNREACHABLE(
                     "ripple::PeerImp::onValidatorListMessage : invalid list "
                     "disposition");
+                // LCOV_EXCL_STOP
         }
     }
 }

--- a/src/xrpld/peerfinder/detail/Counts.h
+++ b/src/xrpld/peerfinder/detail/Counts.h
@@ -295,10 +295,12 @@ private:
                 m_closingCount += n;
                 break;
 
+            // LCOV_EXCL_START
             default:
                 UNREACHABLE(
                     "ripple::PeerFinder::Counts::adjust : invalid input state");
                 break;
+                // LCOV_EXCL_STOP
         };
     }
 

--- a/src/xrpld/peerfinder/detail/Logic.h
+++ b/src/xrpld/peerfinder/detail/Logic.h
@@ -976,11 +976,13 @@ public:
                                         << slot->remote_endpoint();
                 break;
 
+            // LCOV_EXCL_START
             default:
                 UNREACHABLE(
                     "ripple::PeerFinder::Logic::on_closed : invalid slot "
                     "state");
                 break;
+                // LCOV_EXCL_STOP
         }
     }
 

--- a/src/xrpld/perflog/detail/PerfLogImp.cpp
+++ b/src/xrpld/perflog/detail/PerfLogImp.cpp
@@ -53,9 +53,11 @@ PerfLogImp::Counters::Counters(
             if (!inserted)
             {
                 // Ensure that no other function populates this entry.
+                // LCOV_EXCL_START
                 UNREACHABLE(
                     "ripple::perf::PerfLogImp::Counters::Counters : failed to "
                     "insert label");
+                // LCOV_EXCL_STOP
             }
         }
     }
@@ -68,9 +70,11 @@ PerfLogImp::Counters::Counters(
             if (!inserted)
             {
                 // Ensure that no other function populates this entry.
+                // LCOV_EXCL_START
                 UNREACHABLE(
                     "ripple::perf::PerfLogImp::Counters::Counters : failed to "
                     "insert job type");
+                // LCOV_EXCL_STOP
             }
         }
     }
@@ -329,8 +333,10 @@ PerfLogImp::rpcStart(std::string const& method, std::uint64_t const requestId)
     auto counter = counters_.rpc_.find(method);
     if (counter == counters_.rpc_.end())
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::perf::PerfLogImp::rpcStart : valid method input");
         return;
+        // LCOV_EXCL_STOP
     }
 
     {
@@ -351,8 +357,10 @@ PerfLogImp::rpcEnd(
     auto counter = counters_.rpc_.find(method);
     if (counter == counters_.rpc_.end())
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::perf::PerfLogImp::rpcEnd : valid method input");
         return;
+        // LCOV_EXCL_STOP
     }
     steady_time_point startTime;
     {
@@ -365,8 +373,10 @@ PerfLogImp::rpcEnd(
         }
         else
         {
+            // LCOV_EXCL_START
             UNREACHABLE(
                 "ripple::perf::PerfLogImp::rpcEnd : valid requestId input");
+            // LCOV_EXCL_STOP
         }
     }
     std::lock_guard lock(counter->second.mutex);
@@ -384,9 +394,11 @@ PerfLogImp::jobQueue(JobType const type)
     auto counter = counters_.jq_.find(type);
     if (counter == counters_.jq_.end())
     {
+        // LCOV_EXCL_START
         UNREACHABLE(
             "ripple::perf::PerfLogImp::jobQueue : valid job type input");
         return;
+        // LCOV_EXCL_STOP
     }
     std::lock_guard lock(counter->second.mutex);
     ++counter->second.value.queued;
@@ -402,10 +414,13 @@ PerfLogImp::jobStart(
     auto counter = counters_.jq_.find(type);
     if (counter == counters_.jq_.end())
     {
+        // LCOV_EXCL_START
         UNREACHABLE(
             "ripple::perf::PerfLogImp::jobStart : valid job type input");
         return;
+        // LCOV_EXCL_STOP
     }
+
     {
         std::lock_guard lock(counter->second.mutex);
         ++counter->second.value.started;
@@ -422,10 +437,13 @@ PerfLogImp::jobFinish(JobType const type, microseconds dur, int instance)
     auto counter = counters_.jq_.find(type);
     if (counter == counters_.jq_.end())
     {
+        // LCOV_EXCL_START
         UNREACHABLE(
             "ripple::perf::PerfLogImp::jobFinish : valid job type input");
         return;
+        // LCOV_EXCL_STOP
     }
+
     {
         std::lock_guard lock(counter->second.mutex);
         ++counter->second.value.finished;

--- a/src/xrpld/rpc/detail/Handler.cpp
+++ b/src/xrpld/rpc/detail/Handler.cpp
@@ -39,8 +39,10 @@ byRef(Function const& f)
         result = f(context);
         if (result.type() != Json::objectValue)
         {
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::RPC::byRef : result is object");
             result = RPC::makeObjectValue(result);
+            // LCOV_EXCL_STOP
         }
 
         return Status();

--- a/src/xrpld/rpc/detail/Status.cpp
+++ b/src/xrpld/rpc/detail/Status.cpp
@@ -51,8 +51,10 @@ Status::codeString() const
         return sStr.str();
     }
 
+    // LCOV_EXCL_START
     UNREACHABLE("ripple::RPC::codeString : invalid type");
     return "";
+    // LCOV_EXCL_STOP
 }
 
 void

--- a/src/xrpld/rpc/handlers/AccountChannels.cpp
+++ b/src/xrpld/rpc/handlers/AccountChannels.cpp
@@ -169,8 +169,10 @@ doAccountChannels(RPC::JsonContext& context)
                 std::shared_ptr<SLE const> const& sleCur) {
                 if (!sleCur)
                 {
+                    // LCOV_EXCL_START
                     UNREACHABLE("ripple::doAccountChannels : null SLE");
                     return false;
+                    // LCOV_EXCL_STOP
                 }
 
                 if (++count == limit)

--- a/src/xrpld/rpc/handlers/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/AccountLines.cpp
@@ -193,8 +193,10 @@ doAccountLines(RPC::JsonContext& context)
                     std::shared_ptr<SLE const> const& sleCur) {
                     if (!sleCur)
                     {
+                        // LCOV_EXCL_START
                         UNREACHABLE("ripple::doAccountLines : null SLE");
                         return false;
+                        // LCOV_EXCL_STOP
                     }
 
                     if (++count == limit)

--- a/src/xrpld/rpc/handlers/AccountOffers.cpp
+++ b/src/xrpld/rpc/handlers/AccountOffers.cpp
@@ -145,8 +145,10 @@ doAccountOffers(RPC::JsonContext& context)
                 std::shared_ptr<SLE const> const& sle) {
                 if (!sle)
                 {
+                    // LCOV_EXCL_START
                     UNREACHABLE("ripple::doAccountOffers : null SLE");
                     return false;
+                    // LCOV_EXCL_STOP
                 }
 
                 if (++count == limit)

--- a/src/xrpld/rpc/handlers/AccountTx.cpp
+++ b/src/xrpld/rpc/handlers/AccountTx.cpp
@@ -355,7 +355,7 @@ populateJsonResponse(
                     else
                         UNREACHABLE(
                             "ripple::populateJsonResponse : missing "
-                            "transaction medatata");
+                            "transaction medatata");  // LCOV_EXCL_LINE
                 }
             }
         }

--- a/src/xrpld/rpc/handlers/AccountTx.cpp
+++ b/src/xrpld/rpc/handlers/AccountTx.cpp
@@ -353,9 +353,13 @@ populateJsonResponse(
                             jvObj[jss::meta], sttx, *txnMeta);
                     }
                     else
+                    {
+                        // LCOV_EXCL_START
                         UNREACHABLE(
                             "ripple::populateJsonResponse : missing "
-                            "transaction medatata");  // LCOV_EXCL_LINE
+                            "transaction medatata");
+                        // LCOV_EXCL_STOP
+                    }
                 }
             }
         }

--- a/src/xrpld/rpc/handlers/Fee1.cpp
+++ b/src/xrpld/rpc/handlers/Fee1.cpp
@@ -32,9 +32,12 @@ doFee(RPC::JsonContext& context)
     auto result = context.app.getTxQ().doRPC(context.app);
     if (result.type() == Json::objectValue)
         return result;
+
+    // LCOV_EXCL_START
     UNREACHABLE("ripple::doFee : invalid result type");
     RPC::inject_error(rpcINTERNAL, context.params);
     return context.params;
+    // LCOV_EXCL_STOP
 }
 
 }  // namespace ripple

--- a/src/xrpld/shamap/detail/SHAMap.cpp
+++ b/src/xrpld/shamap/detail/SHAMap.cpp
@@ -545,8 +545,10 @@ SHAMap::onlyBelow(SHAMapTreeNode* node) const
 
         if (!nextNode)
         {
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::SHAMap::onlyBelow : no next node");
             return no_item;
+            // LCOV_EXCL_STOP
         }
 
         node = nextNode;
@@ -922,8 +924,10 @@ SHAMap::updateGiveItem(
 
     if (!node || (node->peekItem()->key() != tag))
     {
+        // LCOV_EXCL_START
         UNREACHABLE("ripple::SHAMap::updateGiveItem : invalid node");
         return false;
+        // LCOV_EXCL_STOP
     }
 
     if (node->getType() != type)

--- a/src/xrpld/shamap/detail/SHAMapDelta.cpp
+++ b/src/xrpld/shamap/detail/SHAMapDelta.cpp
@@ -232,8 +232,11 @@ SHAMap::compare(SHAMap const& otherMap, Delta& differences, int maxCount) const
                 }
         }
         else
-            UNREACHABLE(
-                "ripple::SHAMap::compare : invalid node");  // LCOV_EXCL_LINE
+        {
+            // LCOV_EXCL_START
+            UNREACHABLE("ripple::SHAMap::compare : invalid node");
+            // LCOV_EXCL_STOP
+        }
     }
 
     return true;

--- a/src/xrpld/shamap/detail/SHAMapDelta.cpp
+++ b/src/xrpld/shamap/detail/SHAMapDelta.cpp
@@ -149,8 +149,10 @@ SHAMap::compare(SHAMap const& otherMap, Delta& differences, int maxCount) const
 
         if (!ourNode || !otherNode)
         {
+            // LCOV_EXCL_START
             UNREACHABLE("ripple::SHAMap::compare : missing a node");
             Throw<SHAMapMissingNode>(type_, uint256());
+            // LCOV_EXCL_STOP
         }
 
         if (ourNode->isLeaf() && otherNode->isLeaf())
@@ -230,7 +232,8 @@ SHAMap::compare(SHAMap const& otherMap, Delta& differences, int maxCount) const
                 }
         }
         else
-            UNREACHABLE("ripple::SHAMap::compare : invalid node");
+            UNREACHABLE(
+                "ripple::SHAMap::compare : invalid node");  // LCOV_EXCL_LINE
     }
 
     return true;


### PR DESCRIPTION
## High Level Overview of Change

This PR goes through all instances of the `UNREACHABLE` macro's usage in this codebase and marks the blocks of code that contain it as excluded from codecov (`LCOV_EXCL_START`/`LCOV_EXCL_STOP`). **This removes about 170 lines of misses and increases the codecov coverage by 0.2% (78.9% to 79.1%)** (a completely independent set of 170 lines from #5847).

There are no code changes in this PR, just codecov disables (and minor formatting changes that may arise from that).

### Context of Change

There are 113 instances of `UNREACHABLE` used in the rippled codebase, and only a handful of those are excluded from codecov, even though the use of `UNREACHABLE` means that we do not think those blocks of code should ever be reached.

### Type of Change

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

### API Impact

N/A

## Test Plan

CI passes. Codecov improves slightly.