### PR TITLE
Update CI strategy matrix to use new RHEL 9 and RHEL 10 images

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -74,14 +74,14 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
                     continue
 
             # RHEL:
-            # - 9.4 using GCC 12: Debug and Unity on linux/amd64.
-            # - 9.6 using Clang: Release and no Unity on linux/amd64.
+            # - 9 using GCC 12: Debug and Unity on linux/amd64.
+            # - 10 using Clang: Release and no Unity on linux/amd64.
             if os['distro_name'] == 'rhel':
                 skip = True
-                if os['distro_version'] == '9.4':
+                if os['distro_version'] == '9':
                     if f'{os['compiler_name']}-{os['compiler_version']}' == 'gcc-12' and build_type == 'Debug' and '-Dunity=ON' in cmake_args and architecture['platform'] == 'linux/amd64':
                         skip = False
-                elif os['distro_version'] == '9.6':
+                elif os['distro_version'] == '10':
                     if f'{os['compiler_name']}-{os['compiler_version']}' == 'clang-any' and build_type == 'Release' and '-Dunity=OFF' in cmake_args and architecture['platform'] == 'linux/amd64':
                         skip = False
                 if skip:

--- a/.github/scripts/strategy-matrix/linux.json
+++ b/.github/scripts/strategy-matrix/linux.json
@@ -14,139 +14,155 @@
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
-      "compiler_version": "12"
+      "compiler_version": "12",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
-      "compiler_version": "13"
+      "compiler_version": "13",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
-      "compiler_version": "14"
+      "compiler_version": "14",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
-      "compiler_version": "15"
-    },
-    {
-      "distro_name": "debian",
-      "distro_version": "bookworm",
-      "compiler_name": "clang",
-      "compiler_version": "16"
-    },
-    {
-      "distro_name": "debian",
-      "distro_version": "bookworm",
-      "compiler_name": "clang",
-      "compiler_version": "17"
+      "compiler_version": "15",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
-      "compiler_version": "18"
+      "compiler_version": "16",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
-      "compiler_version": "19"
+      "compiler_version": "17",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
-      "compiler_version": "20"
+      "compiler_version": "18",
+      "image_sha": "6f723eb"
     },
     {
-      "distro_name": "rhel",
-      "distro_version": "9.4",
-      "compiler_name": "gcc",
-      "compiler_version": "12"
-    },
-    {
-      "distro_name": "rhel",
-      "distro_version": "9.4",
-      "compiler_name": "gcc",
-      "compiler_version": "13"
-    },
-    {
-      "distro_name": "rhel",
-      "distro_version": "9.4",
-      "compiler_name": "gcc",
-      "compiler_version": "14"
-    },
-    {
-      "distro_name": "rhel",
-      "distro_version": "9.6",
-      "compiler_name": "gcc",
-      "compiler_version": "13"
-    },
-    {
-      "distro_name": "rhel",
-      "distro_version": "9.6",
-      "compiler_name": "gcc",
-      "compiler_version": "14"
-    },
-    {
-      "distro_name": "rhel",
-      "distro_version": "9.4",
+      "distro_name": "debian",
+      "distro_version": "bookworm",
       "compiler_name": "clang",
-      "compiler_version": "any"
+      "compiler_version": "19",
+      "image_sha": "6f723eb"
+    },
+    {
+      "distro_name": "debian",
+      "distro_version": "bookworm",
+      "compiler_name": "clang",
+      "compiler_version": "20",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "rhel",
-      "distro_version": "9.6",
+      "distro_version": "9",
+      "compiler_name": "gcc",
+      "compiler_version": "12",
+      "image_sha": "0ab1e4c"
+    },
+    {
+      "distro_name": "rhel",
+      "distro_version": "9",
+      "compiler_name": "gcc",
+      "compiler_version": "13",
+      "image_sha": "0ab1e4c"
+    },
+    {
+      "distro_name": "rhel",
+      "distro_version": "9",
+      "compiler_name": "gcc",
+      "compiler_version": "14",
+      "image_sha": "0ab1e4c"
+    },
+    {
+      "distro_name": "rhel",
+      "distro_version": "9",
       "compiler_name": "clang",
-      "compiler_version": "any"
+      "compiler_version": "any",
+      "image_sha": "0ab1e4c"
+    },
+    {
+      "distro_name": "rhel",
+      "distro_version": "10",
+      "compiler_name": "gcc",
+      "compiler_version": "14",
+      "image_sha": "0ab1e4c"
+    },
+    {
+      "distro_name": "rhel",
+      "distro_version": "10",
+      "compiler_name": "clang",
+      "compiler_version": "any",
+      "image_sha": "0ab1e4c"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "jammy",
       "compiler_name": "gcc",
-      "compiler_version": "12"
+      "compiler_version": "12",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "gcc",
-      "compiler_version": "13"
+      "compiler_version": "13",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "gcc",
-      "compiler_version": "14"
+      "compiler_version": "14",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
-      "compiler_version": "16"
+      "compiler_version": "16",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
-      "compiler_version": "17"
+      "compiler_version": "17",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
-      "compiler_version": "18"
+      "compiler_version": "18",
+      "image_sha": "6f723eb"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
-      "compiler_version": "19"
+      "compiler_version": "19",
+      "image_sha": "6f723eb"
     }
   ],
   "build_type": ["Debug", "Release"],

--- a/.github/scripts/strategy-matrix/macos.json
+++ b/.github/scripts/strategy-matrix/macos.json
@@ -10,7 +10,8 @@
       "distro_name": "macos",
       "distro_version": "",
       "compiler_name": "",
-      "compiler_version": ""
+      "compiler_version": "",
+      "image_sha": ""
     }
   ],
   "build_type": ["Debug", "Release"],

--- a/.github/scripts/strategy-matrix/windows.json
+++ b/.github/scripts/strategy-matrix/windows.json
@@ -10,7 +10,8 @@
       "distro_name": "windows",
       "distro_version": "",
       "compiler_name": "",
-      "compiler_version": ""
+      "compiler_version": "",
+      "image_sha": ""
     }
   ],
   "build_type": ["Debug", "Release"],

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -52,7 +52,7 @@ jobs:
       cmake_args: ${{ matrix.cmake_args }}
       cmake_target: ${{ matrix.cmake_target }}
       runs_on: ${{ toJSON(matrix.architecture.runner) }}
-      image: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-sha-5dd7158', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || '' }}
+      image: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-sha-{4}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version, matrix.os.image_sha) || '' }}
       config_name: ${{ matrix.config_name }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -40,11 +40,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Generate the strategy matrix to be used by the following job.
   generate-matrix:
     uses: ./.github/workflows/reusable-strategy-matrix.yml
     with:
       strategy_matrix: ${{ github.event_name == 'pull_request' && 'minimal' || 'all' }}
 
+  # Build and upload the dependencies for each configuration.
   run-upload-conan-deps:
     needs:
       - generate-matrix
@@ -53,8 +55,7 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     runs-on: ${{ matrix.architecture.runner }}
-    container: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-sha-5dd7158', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version) || null }}
-
+    container: ${{ contains(matrix.architecture.platform, 'linux') && format('ghcr.io/xrplf/ci/{0}-{1}:{2}-{3}-sha-{4}', matrix.os.distro_name, matrix.os.distro_version, matrix.os.compiler_name, matrix.os.compiler_version, matrix.os.image_sha) || null }}
     steps:
       - name: Cleanup workspace
         if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
## High Level Overview of Change

This change uses the new RHEL 9 and 10 images to build and test the binary, and adds support for having different Docker image SHAs per distro-compiler combination.

### Context of Change

Instead of supporting RHEL each minor version, we are simplifying our pipelines by only supporting RHEL major versions. Our CI Docker images have already been updated accordingly, and we recently added support for RHEL 10 as well.

Up until now, the CI Docker images had all been rebuilt at the same time, but that is not necessarily true as the most recent push to the CI repo has shown where the RHEL images now have a different SHA than the Debian and Ubuntu ones.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

