### PR TITLE
Enforce reserve when creating trust line or MPToken in `VaultWithdraw`

### DIFF
--- a/include/xrpl/protocol/detail/transactions.macro
+++ b/include/xrpl/protocol/detail/transactions.macro
@@ -909,7 +909,7 @@ TRANSACTION(ttVAULT_DEPOSIT, 68, VaultDeposit,
 TRANSACTION(ttVAULT_WITHDRAW, 69, VaultWithdraw,
     Delegation::delegatable,
     featureSingleAssetVault,
-    mayDeleteMPT | mustModifyVault,
+    mayDeleteMPT | mayAuthorizeMPT | mustModifyVault,
     ({
     {sfVaultID, soeREQUIRED},
     {sfAmount, soeREQUIRED, soeMPTSupported},

--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -1242,6 +1242,12 @@ addEmptyHolding(
     // If the line already exists, don't create it again.
     if (view.read(index))
         return tecDUPLICATE;
+
+    // Can the account cover the trust line reserve ?
+    std::uint32_t const ownerCount = sleDst->at(sfOwnerCount);
+    if (priorBalance < view.fees().accountReserve(ownerCount + 1))
+        return tecNO_LINE_INSUF_RESERVE;
+
     return trustCreate(
         view,
         high,

--- a/src/xrpld/app/tx/detail/VaultDeposit.cpp
+++ b/src/xrpld/app/tx/detail/VaultDeposit.cpp
@@ -202,8 +202,7 @@ VaultDeposit::doApply()
     else  // !vault->isFlag(lsfVaultPrivate) || account_ == vault->at(sfOwner)
     {
         // No authorization needed, but must ensure there is MPToken
-        auto sleMpt = view().read(keylet::mptoken(mptIssuanceID, account_));
-        if (!sleMpt)
+        if (!view().exists(keylet::mptoken(mptIssuanceID, account_)))
         {
             if (auto const err = authorizeMPToken(
                     view(),


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Similarly to other transaction typed which can create a trust line or MPToken for the transaction submitter (e.g. `CashCheck` #5285 , `EscrowFinish` #5185 ), `VaultWithdraw` should enforce reserve before creating a new object.

Additionally, enforce `lsfRequireDestTag` account flag for the transaction submitter.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

This fixes #5837 and improves consistency with other transaction types.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
