### PR TITLE
Fix release build error

### DIFF
--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -1134,7 +1134,7 @@ createPseudoAccount(
     uint256 const& pseudoOwnerKey,
     SField const& ownerField)
 {
-    auto const& fields = getPseudoAccountFields();
+    [[maybe_unused]] auto const& fields = getPseudoAccountFields();
     XRPL_ASSERT(
         std::count_if(
             fields.begin(),


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Fix `Release` build error with gcc 15.2

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

The `fields` variable is only used in `XRPL_ASSERT` which evaluates to nothing in a Release build, leaving the variable unused. This change silences the build warning:

```
../src/libxrpl/ledger/View.cpp: In function 'ripple::Expected<std::shared_ptr<ripple::STLedgerEntry>, ripple::TERSubset<ripple::CanCvtToTER> > ripple::createPseudoAccount(ApplyView&, const uint256&, const SField&)':
../src/libxrpl/ledger/View.cpp:1134:17: error: unused variable 'fields' [-Werror=unused-variable]
 1134 |     auto const& fields = getPseudoAccountFields();
      |                 ^~~~~~
cc1plus: all warnings being treated as errors
```

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
