### PR TITLE
Add wildcard to support triggering for release pipelines

### DIFF
--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -9,9 +9,9 @@ name: Trigger
 on:
   push:
     branches:
-      - develop
-      - release*
-      - master
+      - "develop"
+      - "release*"
+      - "master"
     paths:
       # These paths are unique to `on-trigger.yml`.
       - ".github/workflows/reusable-check-missing-commits.yml"

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - develop
-      - release
+      - release*
       - master
     paths:
       # These paths are unique to `on-trigger.yml`.


### PR DESCRIPTION
## High Level Overview of Change

This change adds a wildcard to the release branch in the CI pipeline spec.

### Context of Change

After adopting an improved release process, with release branches that now look like `release-X.Y`, the trigger pipeline was no longer running as it only searched for an exact match to `release`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
