### PR TITLE
Add support for RHEL 8

### DIFF
--- a/.github/scripts/strategy-matrix/linux.json
+++ b/.github/scripts/strategy-matrix/linux.json
@@ -75,45 +75,59 @@
     },
     {
       "distro_name": "rhel",
+      "distro_version": "8",
+      "compiler_name": "gcc",
+      "compiler_version": "14",
+      "image_sha": "10e69b4"
+    },
+    {
+      "distro_name": "rhel",
+      "distro_version": "8",
+      "compiler_name": "clang",
+      "compiler_version": "any",
+      "image_sha": "10e69b4"
+    },
+    {
+      "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "gcc",
       "compiler_version": "12",
-      "image_sha": "6948666"
+      "image_sha": "10e69b4"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "gcc",
       "compiler_version": "13",
-      "image_sha": "6948666"
+      "image_sha": "10e69b4"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "6948666"
+      "image_sha": "10e69b4"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "clang",
       "compiler_version": "any",
-      "image_sha": "6948666"
+      "image_sha": "10e69b4"
     },
     {
       "distro_name": "rhel",
       "distro_version": "10",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "6948666"
+      "image_sha": "10e69b4"
     },
     {
       "distro_name": "rhel",
       "distro_version": "10",
       "compiler_name": "clang",
       "compiler_version": "any",
-      "image_sha": "6948666"
+      "image_sha": "10e69b4"
     },
     {
       "distro_name": "ubuntu",


### PR DESCRIPTION
## High Level Overview of Change

This PR adds support for RHEL 8.

### Context of Change

Some node operators are still running RHEL 8 and have paid for long-term support. We would like to ensure they can keep running rippled.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
