### PR TITLE
Fix typo in JSON writer documentation

### DIFF
--- a/include/xrpl/json/json_writer.h
+++ b/include/xrpl/json/json_writer.h
@@ -46,7 +46,7 @@ public:
  * without formatting (not human friendly).
  *
  * The JSON document is written in a single line. It is not intended for 'human'
- * consumption, but may be useful to support feature such as RPC where bandwith
+ * consumption, but may be useful to support feature such as RPC where bandwidth
  * is limited. \sa Reader, Value
  */
 


### PR DESCRIPTION
### Type of Change

- [x] Documentation update
