### PR TITLE
refactor: replace `boost::lexical_cast<std::string>` with `to_string`

### DIFF
--- a/src/test/app/NFTokenBurn_test.cpp
+++ b/src/test/app/NFTokenBurn_test.cpp
@@ -88,10 +88,8 @@ class NFTokenBurnBaseUtil_test : public beast::unit_test::suite
         jvParams[jss::ledger_index] = "current";
         jvParams[jss::binary] = false;
         {
-            Json::Value jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams));
+            Json::Value jrr =
+                env.rpc("json", "ledger_data", to_string(jvParams));
 
             // Iterate the state and print all NFTokenPages.
             if (!jrr.isMember(jss::result) ||
@@ -413,10 +411,8 @@ class NFTokenBurnBaseUtil_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = "current";
             jvParams[jss::binary] = false;
             {
-                Json::Value jrr = env.rpc(
-                    "json",
-                    "ledger_data",
-                    boost::lexical_cast<std::string>(jvParams));
+                Json::Value jrr =
+                    env.rpc("json", "ledger_data", to_string(jvParams));
 
                 Json::Value& state = jrr[jss::result][jss::state];
 
@@ -460,10 +456,8 @@ class NFTokenBurnBaseUtil_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = "current";
             jvParams[jss::binary] = false;
             {
-                Json::Value jrr = env.rpc(
-                    "json",
-                    "ledger_data",
-                    boost::lexical_cast<std::string>(jvParams));
+                Json::Value jrr =
+                    env.rpc("json", "ledger_data", to_string(jvParams));
 
                 Json::Value& state = jrr[jss::result][jss::state];
 
@@ -1235,10 +1229,8 @@ class NFTokenBurnBaseUtil_test : public beast::unit_test::suite
             jvParams[jss::ledger_index] = "current";
             jvParams[jss::binary] = false;
             {
-                Json::Value jrr = env.rpc(
-                    "json",
-                    "ledger_data",
-                    boost::lexical_cast<std::string>(jvParams));
+                Json::Value jrr =
+                    env.rpc("json", "ledger_data", to_string(jvParams));
 
                 Json::Value& state = jrr[jss::result][jss::state];
 

--- a/src/test/app/NFTokenDir_test.cpp
+++ b/src/test/app/NFTokenDir_test.cpp
@@ -47,10 +47,8 @@ class NFTokenDir_test : public beast::unit_test::suite
         jvParams[jss::ledger_index] = "current";
         jvParams[jss::binary] = false;
         {
-            Json::Value jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams));
+            Json::Value jrr =
+                env.rpc("json", "ledger_data", to_string(jvParams));
 
             // Iterate the state and print all NFTokenPages.
             if (!jrr.isMember(jss::result) ||

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -592,10 +592,8 @@ private:
                 jvParams[field] = value;
                 jvParams[jss::binary] = false;
                 jvParams[jss::type] = jss::oracle;
-                Json::Value jrr = env.rpc(
-                    "json",
-                    "ledger_data",
-                    boost::lexical_cast<std::string>(jvParams));
+                Json::Value jrr =
+                    env.rpc("json", "ledger_data", to_string(jvParams));
                 BEAST_EXPECT(jrr[jss::result][jss::state].size() == 2);
             };
             verifyLedgerData(jss::ledger_index, index);

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -411,7 +411,7 @@ Env::sign_and_submit(JTx const& jt, Json::Value params)
     if (params.isNull())
     {
         // Use the command line interface
-        auto const jv = boost::lexical_cast<std::string>(jt.jv);
+        auto const jv = to_string(jt.jv);
         jr = rpc("submit", passphrase, jv);
     }
     else

--- a/src/test/rpc/AccountCurrencies_test.cpp
+++ b/src/test/rpc/AccountCurrencies_test.cpp
@@ -43,9 +43,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
             params[jss::account] = Account{"bob"}.human();
             params[jss::ledger_hash] = 1;
             auto const result = env.rpc(
-                "json",
-                "account_currencies",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "account_currencies", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::error_message] == "ledgerHashNotString");
         }
@@ -107,9 +105,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
             params[jss::account] =
                 "llIIOO";  // these are invalid in bitcoin alphabet
             auto const result = env.rpc(
-                "json",
-                "account_currencies",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "account_currencies", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "actMalformed");
             BEAST_EXPECT(result[jss::error_message] == "Account malformed.");
         }
@@ -119,9 +115,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
             Json::Value params;
             params[jss::account] = "Bob";
             auto const result = env.rpc(
-                "json",
-                "account_currencies",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "account_currencies", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "actMalformed");
             BEAST_EXPECT(result[jss::error_message] == "Account malformed.");
         }
@@ -130,9 +124,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
             Json::Value params;
             params[jss::account] = Account{"bob"}.human();
             auto const result = env.rpc(
-                "json",
-                "account_currencies",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "account_currencies", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "actNotFound");
             BEAST_EXPECT(result[jss::error_message] == "Account not found.");
         }
@@ -161,9 +153,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
         Json::Value params;
         params[jss::account] = alice.human();
         auto result = env.rpc(
-            "json",
-            "account_currencies",
-            boost::lexical_cast<std::string>(params))[jss::result];
+            "json", "account_currencies", to_string(params))[jss::result];
 
         auto arrayCheck =
             [&result](
@@ -189,9 +179,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
 
         // send_currencies should be populated now
         result = env.rpc(
-            "json",
-            "account_currencies",
-            boost::lexical_cast<std::string>(params))[jss::result];
+            "json", "account_currencies", to_string(params))[jss::result];
         BEAST_EXPECT(arrayCheck(jss::receive_currencies, gwCurrencies));
         BEAST_EXPECT(arrayCheck(jss::send_currencies, gwCurrencies));
 
@@ -203,9 +191,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 l[jss::freeze].asBool() == (l[jss::currency] == "USD"));
         result = env.rpc(
-            "json",
-            "account_currencies",
-            boost::lexical_cast<std::string>(params))[jss::result];
+            "json", "account_currencies", to_string(params))[jss::result];
         BEAST_EXPECT(arrayCheck(jss::receive_currencies, gwCurrencies));
         BEAST_EXPECT(arrayCheck(jss::send_currencies, gwCurrencies));
         // clear the freeze
@@ -215,9 +201,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
         env(pay(gw, alice, gw["USA"](50)));
         // USA should now be missing from receive_currencies
         result = env.rpc(
-            "json",
-            "account_currencies",
-            boost::lexical_cast<std::string>(params))[jss::result];
+            "json", "account_currencies", to_string(params))[jss::result];
         decltype(gwCurrencies) gwCurrenciesNoUSA(
             gwCurrencies.begin() + 1, gwCurrencies.end());
         BEAST_EXPECT(arrayCheck(jss::receive_currencies, gwCurrenciesNoUSA));
@@ -228,9 +212,7 @@ class AccountCurrencies_test : public beast::unit_test::suite
         env(trust(gw, alice["USA"](100)));
         env(pay(alice, gw, alice["USA"](200)));
         result = env.rpc(
-            "json",
-            "account_currencies",
-            boost::lexical_cast<std::string>(params))[jss::result];
+            "json", "account_currencies", to_string(params))[jss::result];
         BEAST_EXPECT(arrayCheck(jss::receive_currencies, gwCurrencies));
         BEAST_EXPECT(arrayCheck(jss::send_currencies, gwCurrenciesNoUSA));
     }

--- a/src/test/rpc/Feature_test.cpp
+++ b/src/test/rpc/Feature_test.cpp
@@ -309,10 +309,8 @@ class Feature_test : public beast::unit_test::suite
             params[jss::feature] =
                 "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD"
                 "EF";
-            auto const result = env.rpc(
-                "json",
-                "feature",
-                boost::lexical_cast<std::string>(params))[jss::result];
+            auto const result =
+                env.rpc("json", "feature", to_string(params))[jss::result];
             BEAST_EXPECTS(
                 result[jss::error] == "badFeature", result.toStyledString());
             BEAST_EXPECT(
@@ -326,10 +324,8 @@ class Feature_test : public beast::unit_test::suite
                 "A7";
             // invalid param
             params[jss::vetoed] = true;
-            auto const result = env.rpc(
-                "json",
-                "feature",
-                boost::lexical_cast<std::string>(params))[jss::result];
+            auto const result =
+                env.rpc("json", "feature", to_string(params))[jss::result];
             BEAST_EXPECTS(
                 result[jss::error] == "noPermission",
                 result[jss::error].asString());
@@ -344,10 +340,8 @@ class Feature_test : public beast::unit_test::suite
                 "37";
             Json::Value params;
             params[jss::feature] = feature;
-            auto const result = env.rpc(
-                "json",
-                "feature",
-                boost::lexical_cast<std::string>(params))[jss::result];
+            auto const result =
+                env.rpc("json", "feature", to_string(params))[jss::result];
             BEAST_EXPECT(result.isMember(feature));
             auto const amendmentResult = result[feature];
             BEAST_EXPECT(amendmentResult[jss::enabled].asBool() == false);

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -63,9 +63,7 @@ public:
         jvParams[jss::binary] = false;
         {
             auto const jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(
                 jrr[jss::ledger_current_index].isIntegral() &&
                 jrr[jss::ledger_current_index].asInt() > 0);
@@ -78,9 +76,7 @@ public:
         {
             jvParams[jss::limit] = max_limit + delta;
             auto const jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(checkArraySize(
                 jrr[jss::state],
                 (delta > 0 && !asAdmin) ? max_limit : max_limit + delta));
@@ -109,10 +105,8 @@ public:
         Json::Value jvParams;
         jvParams[jss::ledger_index] = "current";
         jvParams[jss::binary] = true;
-        auto const jrr = env.rpc(
-            "json",
-            "ledger_data",
-            boost::lexical_cast<std::string>(jvParams))[jss::result];
+        auto const jrr =
+            env.rpc("json", "ledger_data", to_string(jvParams))[jss::result];
         BEAST_EXPECT(
             jrr[jss::ledger_current_index].isIntegral() &&
             jrr[jss::ledger_current_index].asInt() > 0);
@@ -137,9 +131,7 @@ public:
             Json::Value jvParams;
             jvParams[jss::limit] = "0";  // NOT an integer
             auto const jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::status] == "error");
             BEAST_EXPECT(
@@ -152,9 +144,7 @@ public:
             Json::Value jvParams;
             jvParams[jss::marker] = "NOT_A_MARKER";
             auto const jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::status] == "error");
             BEAST_EXPECT(
@@ -167,9 +157,7 @@ public:
             Json::Value jvParams;
             jvParams[jss::marker] = 1;
             auto const jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::status] == "error");
             BEAST_EXPECT(
@@ -182,9 +170,7 @@ public:
             Json::Value jvParams;
             jvParams[jss::ledger_index] = 10u;
             auto const jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "lgrNotFound");
             BEAST_EXPECT(jrr[jss::status] == "error");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerNotFound");
@@ -213,27 +199,20 @@ public:
         Json::Value jvParams;
         jvParams[jss::ledger_index] = "current";
         jvParams[jss::binary] = false;
-        auto jrr = env.rpc(
-            "json",
-            "ledger_data",
-            boost::lexical_cast<std::string>(jvParams))[jss::result];
+        auto jrr =
+            env.rpc("json", "ledger_data", to_string(jvParams))[jss::result];
         auto const total_count = jrr[jss::state].size();
 
         // now make request with a limit and loop until we get all
         jvParams[jss::limit] = 5;
-        jrr = env.rpc(
-            "json",
-            "ledger_data",
-            boost::lexical_cast<std::string>(jvParams))[jss::result];
+        jrr = env.rpc("json", "ledger_data", to_string(jvParams))[jss::result];
         BEAST_EXPECT(checkMarker(jrr));
         auto running_total = jrr[jss::state].size();
         while (jrr.isMember(jss::marker))
         {
             jvParams[jss::marker] = jrr[jss::marker];
             jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             running_total += jrr[jss::state].size();
         }
         BEAST_EXPECT(running_total == total_count);
@@ -253,9 +232,7 @@ public:
             Json::Value jvParams;
             jvParams[jss::ledger_index] = "closed";
             auto jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             if (BEAST_EXPECT(jrr.isMember(jss::ledger)))
                 BEAST_EXPECT(
                     jrr[jss::ledger][jss::ledger_hash] ==
@@ -267,9 +244,7 @@ public:
             jvParams[jss::ledger_index] = "closed";
             jvParams[jss::binary] = true;
             auto jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             if (BEAST_EXPECT(jrr.isMember(jss::ledger)))
             {
                 auto data =
@@ -288,9 +263,7 @@ public:
             Json::Value jvParams;
             jvParams[jss::binary] = true;
             auto jrr = env.rpc(
-                "json",
-                "ledger_data",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+                "json", "ledger_data", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(!jrr[jss::ledger].isMember(jss::ledger_data));
         }
@@ -319,9 +292,7 @@ public:
                 jvParams[jss::ledger_index] = "current";
                 jvParams[jss::type] = type;
                 return env.rpc(
-                    "json",
-                    "ledger_data",
-                    boost::lexical_cast<std::string>(jvParams))[jss::result];
+                    "json", "ledger_data", to_string(jvParams))[jss::result];
             };
 
             // Assert that state is an empty array.
@@ -500,9 +471,7 @@ public:
                 jvParams[jss::ledger_index] = "current";
                 jvParams[jss::type] = "misspelling";
                 auto const jrr = env.rpc(
-                    "json",
-                    "ledger_data",
-                    boost::lexical_cast<std::string>(jvParams))[jss::result];
+                    "json", "ledger_data", to_string(jvParams))[jss::result];
                 BEAST_EXPECT(jrr.isMember("error"));
                 BEAST_EXPECT(jrr["error"] == "invalidParams");
                 BEAST_EXPECT(jrr["error_message"] == "Invalid field 'type'.");

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -287,56 +287,39 @@ class LedgerRPC_test : public beast::unit_test::suite
             // access via the legacy ledger field, keyword index values
             Json::Value jvParams;
             jvParams[jss::ledger] = "closed";
-            auto jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            auto jrr =
+                env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "5");
 
             jvParams[jss::ledger] = "validated";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "5");
 
             jvParams[jss::ledger] = "current";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "6");
 
             // ask for a bad ledger keyword
             jvParams[jss::ledger] = "invalid";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerIndexMalformed");
 
             // numeric index
             jvParams[jss::ledger] = 4;
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "4");
 
             // numeric index - out of range
             jvParams[jss::ledger] = 20;
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "lgrNotFound");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerNotFound");
         }
@@ -348,29 +331,21 @@ class LedgerRPC_test : public beast::unit_test::suite
             // access via the ledger_hash field
             Json::Value jvParams;
             jvParams[jss::ledger_hash] = hash3;
-            auto jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            auto jrr =
+                env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "3");
 
             // extra leading hex chars in hash are not allowed
             jvParams[jss::ledger_hash] = "DEADBEEF" + hash3;
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerHashMalformed");
 
             // request with non-string ledger_hash
             jvParams[jss::ledger_hash] = 2;
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerHashNotString");
 
@@ -378,10 +353,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_hash] =
                 "2E81FC6EC0DD943197EGC7E3FBE9AE30"
                 "7F2775F2F7485BB37307984C3C0F2340";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerHashMalformed");
 
@@ -389,10 +361,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             jvParams[jss::ledger_hash] =
                 "8C3EEDB3124D92E49E75D81A8826A2E6"
                 "5A75FD71FC3FD6F36FEB803C5F1D812D";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "lgrNotFound");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerNotFound");
         }
@@ -401,39 +370,28 @@ class LedgerRPC_test : public beast::unit_test::suite
             // access via the ledger_index field, keyword index values
             Json::Value jvParams;
             jvParams[jss::ledger_index] = "closed";
-            auto jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            auto jrr =
+                env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "5");
             BEAST_EXPECT(jrr.isMember(jss::ledger_index));
 
             jvParams[jss::ledger_index] = "validated";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "5");
 
             jvParams[jss::ledger_index] = "current";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr.isMember(jss::ledger));
             BEAST_EXPECT(jrr[jss::ledger][jss::ledger_index] == "6");
             BEAST_EXPECT(jrr.isMember(jss::ledger_current_index));
 
             // ask for a bad ledger keyword
             jvParams[jss::ledger_index] = "invalid";
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "invalidParams");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerIndexMalformed");
 
@@ -441,10 +399,8 @@ class LedgerRPC_test : public beast::unit_test::suite
             for (auto i : {1, 2, 3, 4, 5, 6})
             {
                 jvParams[jss::ledger_index] = i;
-                jrr = env.rpc(
-                    "json",
-                    "ledger",
-                    boost::lexical_cast<std::string>(jvParams))[jss::result];
+                jrr =
+                    env.rpc("json", "ledger", to_string(jvParams))[jss::result];
                 BEAST_EXPECT(jrr.isMember(jss::ledger));
                 if (i < 6)
                     BEAST_EXPECT(jrr.isMember(jss::ledger_hash));
@@ -454,10 +410,7 @@ class LedgerRPC_test : public beast::unit_test::suite
 
             // numeric index - out of range
             jvParams[jss::ledger_index] = 7;
-            jrr = env.rpc(
-                "json",
-                "ledger",
-                boost::lexical_cast<std::string>(jvParams))[jss::result];
+            jrr = env.rpc("json", "ledger", to_string(jvParams))[jss::result];
             BEAST_EXPECT(jrr[jss::error] == "lgrNotFound");
             BEAST_EXPECT(jrr[jss::error_message] == "ledgerNotFound");
         }

--- a/src/test/rpc/NoRippleCheck_test.cpp
+++ b/src/test/rpc/NoRippleCheck_test.cpp
@@ -59,9 +59,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             Json::Value params;
             params[jss::account] = alice.human();
             auto const result = env.rpc(
-                "json",
-                "noripple_check",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "noripple_check", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::error_message] == "Missing field 'role'.");
         }
@@ -92,9 +90,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             params[jss::account] = alice.human();
             params[jss::role] = "not_a_role";
             auto const result = env.rpc(
-                "json",
-                "noripple_check",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "noripple_check", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::error_message] == "Invalid field 'role'.");
         }
@@ -105,9 +101,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             params[jss::role] = "user";
             params[jss::limit] = -1;
             auto const result = env.rpc(
-                "json",
-                "noripple_check",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "noripple_check", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(
                 result[jss::error_message] ==
@@ -120,9 +114,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             params[jss::role] = "user";
             params[jss::ledger_hash] = 1;
             auto const result = env.rpc(
-                "json",
-                "noripple_check",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "noripple_check", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::error_message] == "ledgerHashNotString");
         }
@@ -133,9 +125,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             params[jss::role] = "user";
             params[jss::ledger] = "current";
             auto const result = env.rpc(
-                "json",
-                "noripple_check",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "noripple_check", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "actNotFound");
             BEAST_EXPECT(result[jss::error_message] == "Account not found.");
         }
@@ -147,9 +137,7 @@ class NoRippleCheck_test : public beast::unit_test::suite
             params[jss::role] = "user";
             params[jss::ledger] = "current";
             auto const result = env.rpc(
-                "json",
-                "noripple_check",
-                boost::lexical_cast<std::string>(params))[jss::result];
+                "json", "noripple_check", to_string(params))[jss::result];
             BEAST_EXPECT(result[jss::error] == "actMalformed");
             BEAST_EXPECT(result[jss::error_message] == "Account malformed.");
         }
@@ -184,10 +172,8 @@ class NoRippleCheck_test : public beast::unit_test::suite
         params[jss::account] = alice.human();
         params[jss::role] = (user ? "user" : "gateway");
         params[jss::ledger] = "current";
-        auto result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        auto result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
 
         auto const pa = result["problems"];
         if (!BEAST_EXPECT(pa.isArray()))
@@ -221,10 +207,8 @@ class NoRippleCheck_test : public beast::unit_test::suite
         // now make a second request asking for the relevant transactions this
         // time.
         params[jss::transactions] = true;
-        result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
         if (!BEAST_EXPECT(result[jss::transactions].isArray()))
             return;
 
@@ -343,43 +327,33 @@ class NoRippleCheckLimits_test : public beast::unit_test::suite
         params[jss::account] = alice.human();
         params[jss::role] = "user";
         params[jss::ledger] = "current";
-        auto result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        auto result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
 
         BEAST_EXPECT(result["problems"].size() == 301);
 
         // one below minimum
         params[jss::limit] = 9;
-        result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
         BEAST_EXPECT(result["problems"].size() == (admin ? 10 : 11));
 
         // at minimum
         params[jss::limit] = 10;
-        result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
         BEAST_EXPECT(result["problems"].size() == 11);
 
         // at max
         params[jss::limit] = 400;
-        result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
         BEAST_EXPECT(result["problems"].size() == 401);
 
         // at max+1
         params[jss::limit] = 401;
-        result = env.rpc(
-            "json",
-            "noripple_check",
-            boost::lexical_cast<std::string>(params))[jss::result];
+        result =
+            env.rpc("json", "noripple_check", to_string(params))[jss::result];
         BEAST_EXPECT(result["problems"].size() == (admin ? 402 : 401));
     }
 

--- a/src/test/rpc/TransactionEntry_test.cpp
+++ b/src/test/rpc/TransactionEntry_test.cpp
@@ -258,15 +258,13 @@ class TransactionEntry_test : public beast::unit_test::suite
         Account A2{"A2"};
 
         env.fund(XRP(10000), A1);
-        auto fund_1_tx =
-            boost::lexical_cast<std::string>(env.tx()->getTransactionID());
+        auto fund_1_tx = to_string(env.tx()->getTransactionID());
         BEAST_EXPECT(
             fund_1_tx ==
             "F4E9DF90D829A9E8B423FF68C34413E240D8D8BB0EFD080DF08114ED398E2506");
 
         env.fund(XRP(10000), A2);
-        auto fund_2_tx =
-            boost::lexical_cast<std::string>(env.tx()->getTransactionID());
+        auto fund_2_tx = to_string(env.tx()->getTransactionID());
         BEAST_EXPECT(
             fund_2_tx ==
             "6853CD8226A05068C951CB1F54889FF4E40C5B440DC1C5BA38F114C4E0B1E705");
@@ -308,15 +306,13 @@ class TransactionEntry_test : public beast::unit_test::suite
         // the trust tx is actually a payment since the trust method
         // refunds fees with a payment after TrustSet..so just ignore the type
         // in the check below
-        auto trust_tx =
-            boost::lexical_cast<std::string>(env.tx()->getTransactionID());
+        auto trust_tx = to_string(env.tx()->getTransactionID());
         BEAST_EXPECT(
             trust_tx ==
             "C992D97D88FF444A1AB0C06B27557EC54B7F7DA28254778E60238BEA88E0C101");
 
         env(pay(A2, A1, A2["USD"](5)));
-        auto pay_tx =
-            boost::lexical_cast<std::string>(env.tx()->getTransactionID());
+        auto pay_tx = to_string(env.tx()->getTransactionID());
         env.close();
         BEAST_EXPECT(
             pay_tx ==
@@ -362,8 +358,7 @@ class TransactionEntry_test : public beast::unit_test::suite
             "2000-01-01T00:00:20Z");
 
         env(offer(A2, XRP(100), A2["USD"](1)));
-        auto offer_tx =
-            boost::lexical_cast<std::string>(env.tx()->getTransactionID());
+        auto offer_tx = to_string(env.tx()->getTransactionID());
         BEAST_EXPECT(
             offer_tx ==
             "5FCC1A27A7664F82A0CC4BE5766FBBB7C560D52B93AA7B550CD33B27AEC7EFFB");


### PR DESCRIPTION
## High Level Overview of Change

This PR does a bit of cleanup in the tests to replace some uses of `boost::lexical_cast<std::string>` with `to_string`.

### Context of Change

General cleanup/simplification

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### API Impact

N/A

## Test Plan

CI passes.