### PR TITLE
refactor(tests): replace JSON LastLedgerSequence with `last_ledger_seq`

### DIFF
--- a/src/test/app/Transaction_ordering_test.cpp
+++ b/src/test/app/Transaction_ordering_test.cpp
@@ -37,10 +37,8 @@ struct Transaction_ordering_test : public beast::unit_test::suite
         auto const aliceSequence = env.seq(alice);
 
         auto const tx1 = env.jt(noop(alice), seq(aliceSequence));
-        auto const tx2 = env.jt(
-            noop(alice),
-            seq(aliceSequence + 1),
-            json(R"({"LastLedgerSequence":7})"));
+        auto const tx2 =
+            env.jt(noop(alice), seq(aliceSequence + 1), last_ledger_seq(7));
 
         env(tx1);
         env.close();
@@ -83,10 +81,8 @@ struct Transaction_ordering_test : public beast::unit_test::suite
         auto const aliceSequence = env.seq(alice);
 
         auto const tx1 = env.jt(noop(alice), seq(aliceSequence));
-        auto const tx2 = env.jt(
-            noop(alice),
-            seq(aliceSequence + 1),
-            json(R"({"LastLedgerSequence":7})"));
+        auto const tx2 =
+            env.jt(noop(alice), seq(aliceSequence + 1), last_ledger_seq(7));
 
         env(tx2, ter(terPRE_SEQ));
         BEAST_EXPECT(env.seq(alice) == aliceSequence);
@@ -131,9 +127,7 @@ struct Transaction_ordering_test : public beast::unit_test::suite
         for (auto i = 0; i < 5; ++i)
         {
             tx.emplace_back(env.jt(
-                noop(alice),
-                seq(aliceSequence + i),
-                json(R"({"LastLedgerSequence":7})")));
+                noop(alice), seq(aliceSequence + i), last_ledger_seq(7)));
         }
 
         for (auto i = 1; i < 5; ++i)

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -747,11 +747,9 @@ public:
 
         BEAST_EXPECT(env.current()->info().seq == 6);
         // Fail to queue an item with a low LastLedgerSeq
-        env(noop(alice),
-            json(R"({"LastLedgerSequence":7})"),
-            ter(telCAN_NOT_QUEUE));
+        env(noop(alice), last_ledger_seq(7), ter(telCAN_NOT_QUEUE));
         // Queue an item with a sufficient LastLedgerSeq.
-        env(noop(alice), json(R"({"LastLedgerSequence":8})"), queued);
+        env(noop(alice), last_ledger_seq(8), queued);
 
         constexpr auto largeFeeMultiplier = 700;
         auto const largeFee = baseFee * largeFeeMultiplier;
@@ -2705,21 +2703,15 @@ public:
 
         auto const aliceSeq = env.seq(alice);
         BEAST_EXPECT(env.current()->info().seq == 3);
-        env(noop(alice),
-            seq(aliceSeq),
-            json(R"({"LastLedgerSequence":5})"),
-            ter(terQUEUED));
-        env(noop(alice),
-            seq(aliceSeq + 1),
-            json(R"({"LastLedgerSequence":5})"),
-            ter(terQUEUED));
+        env(noop(alice), seq(aliceSeq), last_ledger_seq(5), ter(terQUEUED));
+        env(noop(alice), seq(aliceSeq + 1), last_ledger_seq(5), ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 2),
-            json(R"({"LastLedgerSequence":10})"),
+            last_ledger_seq(10),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 3),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         checkMetrics(*this, env, 4, std::nullopt, 2, 1);
         auto const bobSeq = env.seq(bob);
@@ -2816,39 +2808,39 @@ public:
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 11),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 12),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 13),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 14),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 15),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 16),
-            json(R"({"LastLedgerSequence": 5})"),
+            last_ledger_seq(5),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 17),
-            json(R"({"LastLedgerSequence": 5})"),
+            last_ledger_seq(5),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 18),
-            json(R"({"LastLedgerSequence": 5})"),
+            last_ledger_seq(5),
             ter(terQUEUED));
         env(noop(alice),
             seq(aliceSeq + 19),
-            json(R"({"LastLedgerSequence":11})"),
+            last_ledger_seq(11),
             ter(terQUEUED));
         checkMetrics(*this, env, 10, std::nullopt, 2, 1);
 
@@ -4575,7 +4567,7 @@ public:
         env(noop(alice),
             seq(seqAlice++),
             fee(--feeDrops),
-            json(R"({"LastLedgerSequence": 7})"),
+            last_ledger_seq(7),
             ter(terQUEUED));
         env(noop(alice), seq(seqAlice++), fee(--feeDrops), ter(terQUEUED));
         env(noop(alice), seq(seqAlice++), fee(--feeDrops), ter(terQUEUED));
@@ -4585,7 +4577,7 @@ public:
         // The drop penalty works a little differently with tickets.
         env(noop(bob),
             ticket::use(bobTicketSeq + 0),
-            json(R"({"LastLedgerSequence": 7})"),
+            last_ledger_seq(7),
             ter(terQUEUED));
         env(noop(bob),
             ticket::use(bobTicketSeq + 1),

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -527,7 +527,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         // Alice
         auto aliceSeq = env.seq(alice);
         env(pay(alice, "george", XRP(1000)),
-            json(R"({"LastLedgerSequence":7})"),
+            last_ledger_seq(7),
             ter(terQUEUED));
         env(offer(alice, XRP(50000), alice["USD"](5000)),
             seq(aliceSeq + 1),


### PR DESCRIPTION
## High Level Overview of Change

This PR replaces instances of `json(R"({"LastLedgerSequence":n})")` with `last_ledger_seq(7)`. This makes the tests a bit simpler and easier to read.

### Context of Change

General cleanup

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### API Impact

N/A

## Test Plan

CI passes