### PR TITLE
Update tools image shas

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,4 @@ jobs:
     uses: XRPLF/actions/.github/workflows/pre-commit.yml@af1b0f0d764cda2e5435f5ac97b240d4bd4d95d3
     with:
       runs_on: ubuntu-latest
-      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit:sha-d1496b8" }'
+      container: '{ "image": "ghcr.io/xrplf/ci/tools-rippled-pre-commit:sha-a8c7be1" }'

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container: ghcr.io/xrplf/ci/tools-rippled-documentation:sha-d1496b8
+    container: ghcr.io/xrplf/ci/tools-rippled-documentation:sha-a8c7be1
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## High Level Overview of Change

Updates the Docker image hashes of the `tools-rippled` images.

### Context of Change

The pre-commit hooks failed with:

```
An unexpected error has occurred: CalledProcessError: command: ('/github/home/.cache/pre-commit/repo721f6h3n/node_env-default/bin/node', '/github/home/.cache/pre-commit/repo721f6h3n/node_env-default/bin/npm', 'install', '--include=dev', '--include=prod', '--ignore-prepublish', '--no-progress', '--no-save')
return code: 127
stdout: (none)
stderr:
    /github/home/.cache/pre-commit/repo721f6h3n/node_env-default/bin/node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

The `tools-rippled` image for pre-commit has been updated with the `libatomic1` package in https://github.com/XRPLF/ci/pull/75, which should fix this issue, and this PR updates the hash of the image. Since the documentation image got updated as well, its hash is also updated.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release