### PR TITLE
Set fail fast to false, except for when the merge group is used

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -103,6 +103,7 @@ jobs:
     if: ${{ needs.should-run.outputs.go == 'true' }}
     uses: ./.github/workflows/reusable-build-test.yml
     strategy:
+      fail-fast: false
       matrix:
         os: [linux, macos, windows]
     with:

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -65,6 +65,7 @@ jobs:
   build-test:
     uses: ./.github/workflows/reusable-build-test.yml
     strategy:
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         os: [linux, macos, windows]
     with:

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -42,7 +42,7 @@ jobs:
       - generate-matrix
     uses: ./.github/workflows/reusable-build-test-config.yml
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     with:


### PR DESCRIPTION
## High Level Overview of Change

This PR sets the fail-fast strategy option to false (it defaults to true), unless it is run by a merge group.

### Context of Change

For regular builds in PRs, when a flaky GitHub runner causes a job to be canceled, all other jobs get canceled too. This PR sets `fail-fast: false` for those builds. For builds that are run when using a merge group, since a single failure causes the PR to be taken out of the queue, we should set `fail-fast: true` only for those cases.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
