### PR TITLE
Fix regression in ConnectAttempt

### DIFF
--- a/src/xrpld/overlay/detail/ConnectAttempt.cpp
+++ b/src/xrpld/overlay/detail/ConnectAttempt.cpp
@@ -600,8 +600,8 @@ ConnectAttempt::processResponse()
             JLOG(journal_.info()) << "Cluster name: " << *member;
         }
 
-        auto const result =
-            overlay_.peerFinder().activate(slot_, publicKey, !member->empty());
+        auto const result = overlay_.peerFinder().activate(
+            slot_, publicKey, member.has_value());
         if (result != PeerFinder::Result::success)
         {
             std::stringstream ss;


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Fix a regression bug from #5669 

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

A regression was introduced in #5669 which would cause `rippled` to potentially dereference a disengaged `std::optional` when connecting to a peer. This would cause UB in release build and crash in debug.

The bug does not affect version 3.0.0 since #5669 was not planned for release in this version and got explicitly reverted.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
