### PR TITLE
chore: Clean up Conan variables in CI

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -28,6 +28,7 @@ runs:
         BUILD_DIR: ${{ inputs.build_dir }}
         BUILD_OPTION: ${{ inputs.force_build == 'true' && '*' || 'missing' }}
         BUILD_TYPE: ${{ inputs.build_type }}
+        VERBOSITY: ${{ inputs.verbosity }}
       run: |
         echo 'Installing dependencies.'
         mkdir -p '${{ env.BUILD_DIR }}'
@@ -38,7 +39,6 @@ runs:
           --options:host='&:tests=True' \
           --options:host='&:xrpld=True' \
           --settings:all build_type='${{ env.BUILD_TYPE }}' \
-          --conf:all tools.build:verbosity='${{ inputs.verbosity }}' \
-          --conf:all tools.compilation:verbosity='${{ inputs.verbosity }}' \
-          --conf:all tools.build:jobs=$(nproc) \
+          --conf:all tools.build:verbosity='${{ env.VERBOSITY }}' \
+          --conf:all tools.compilation:verbosity='${{ env.VERBOSITY }}' \
           ..

--- a/.github/workflows/reusable-notify-clio.yml
+++ b/.github/workflows/reusable-notify-clio.yml
@@ -64,7 +64,9 @@ jobs:
           conan_remote_name: ${{ inputs.conan_remote_name }}
           conan_remote_url: ${{ inputs.conan_remote_url }}
       - name: Log into Conan remote
-        run: conan remote login ${{ inputs.conan_remote_name }} "${{ secrets.conan_remote_username }}" --password "${{ secrets.conan_remote_password }}"
+        env:
+          CONAN_REMOTE_NAME: ${{ inputs.conan_remote_name }}
+        run: conan remote login ${{ env.CONAN_REMOTE_NAME }} "${{ secrets.conan_remote_username }}" --password "${{ secrets.conan_remote_password }}"
       - name: Upload package
         env:
           CONAN_REMOTE_NAME: ${{ inputs.conan_remote_name }}

--- a/conan/global.conf
+++ b/conan/global.conf
@@ -3,4 +3,4 @@
 core:non_interactive=True
 core.download:parallel={{ os.cpu_count() }}
 core.upload:parallel={{ os.cpu_count() }}
-tools.build:jobs={{ (os.cpu_count() * 4/5) | int }}
+tools.build:jobs={{ os.cpu_count() - 1 }}


### PR DESCRIPTION
## High Level Overview of Change

This change sanitizes inputs by setting them as environment variables, and adjusts the number of CPUs used for building.

### Context of Change

GitHub inputs should be sanitized, per recommendation by Semgrep, as using them directly poses a security risk. A recent change further overrode the global configuration by having builds use all cores, but as we have noticed an increased number of job cancelation this change updates it to use all cores less one.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release