### PR TITLE
chore: remove unnecessary LCOV_EXCL_LINE

### DIFF
--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -1205,7 +1205,7 @@ EscrowFinish::doApply()
             {
                 // LCOV_EXCL_START
                 JLOG(j_.fatal()) << "Unable to delete Escrow from recipient.";
-                return tefBAD_LEDGER;  // LCOV_EXCL_LINE
+                return tefBAD_LEDGER;
                 // LCOV_EXCL_STOP
             }
         }


### PR DESCRIPTION
## High Level Overview of Change

This PR removes an unnecessary `LCOV_EXCL_LINE` in `Escrow.cpp`.

### Context of Change

This PR fixes this warning:
```
(WARNING) LCOV_EXCL_LINE found on line 1208 in excluded region started on line 1206, when processing /__w/rippled/rippled/src/xrpld/app/tx/detail/Escrow.cpp.
```

#5847 added the `LCOV_EXCL_START` and `LCOV_EXCL_STOP` block, but missed removing the `LCOV_EXCL_LINE` in the middle.

### Type of Change

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

### API Impact

N/A

## Test Plan

The warning goes away in CI.