### PR TITLE
Moved fix1513 to retire state

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -117,7 +117,6 @@ XRPL_FIX    (1543,                       Supported::yes, VoteBehavior::DefaultYe
 XRPL_FIX    (1571,                       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(Checks,                     Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(DepositAuth,                Supported::yes, VoteBehavior::DefaultYes)
-XRPL_FIX    (1513,                       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(Flow,                       Supported::yes, VoteBehavior::DefaultYes)
 
 // The following amendments are obsolete, but must remain supported
@@ -156,3 +155,4 @@ XRPL_RETIRE(fix1512)
 XRPL_RETIRE(fix1523)
 XRPL_RETIRE(fix1528)
 XRPL_RETIRE(FlowCross)
+XRPL_RETIRE(fix1513)

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -1346,14 +1346,11 @@ struct Flow_manual_test : public Flow_test
     {
         using namespace jtx;
         auto const all = testable_amendments();
-        FeatureBitset const f1513{fix1513};
         FeatureBitset const permDex{featurePermissionedDEX};
 
-        testWithFeats(all - f1513 - permDex);
         testWithFeats(all - permDex);
         testWithFeats(all);
 
-        testEmptyStrand(all - f1513 - permDex);
         testEmptyStrand(all - permDex);
         testEmptyStrand(all);
     }

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -5450,13 +5450,12 @@ class Offer_manual_test : public OfferBaseUtil_test
     {
         using namespace jtx;
         FeatureBitset const all{testable_amendments()};
-        FeatureBitset const f1513{fix1513};
         FeatureBitset const immediateOfferKilled{featureImmediateOfferKilled};
         FeatureBitset const takerDryOffer{fixTakerDryOfferRemoval};
         FeatureBitset const fillOrKill{fixFillOrKill};
         FeatureBitset const permDEX{featurePermissionedDEX};
 
-        testAll(all - f1513 - immediateOfferKilled - permDEX);
+        testAll(all - immediateOfferKilled - permDEX);
         testAll(all - immediateOfferKilled - fillOrKill - permDEX);
         testAll(all - fillOrKill - permDEX);
         testAll(all - permDEX);


### PR DESCRIPTION
## High Level Overview of Change
This change retires the `fix1513` amendment.

### Context of Change
Amendments activated for more than 2 years can be retired.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
