### PR TITLE
Retire amendment fix1515 

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -109,8 +109,6 @@ XRPL_FIX    (MasterKeyAsRegularKey,      Supported::yes, VoteBehavior::DefaultYe
 XRPL_FIX    (TakerDryOfferRemoval,       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(MultiSignReserve,           Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (1578,                       Supported::yes, VoteBehavior::DefaultYes)
-// fix1515: Use liquidity from strands that consume max offers, but mark as dry
-XRPL_FIX    (1515,                       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FEATURE(DepositPreauth,             Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (1623,                       Supported::yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (1543,                       Supported::yes, VoteBehavior::DefaultYes)
@@ -156,3 +154,4 @@ XRPL_RETIRE(fix1523)
 XRPL_RETIRE(fix1528)
 XRPL_RETIRE(FlowCross)
 XRPL_RETIRE(fix1513)
+XRPL_RETIRE(fix1515)


### PR DESCRIPTION
## High Level Overview of Change
This change retires the `fix1515` amendment.

### Context of Change
Amendments activated for more than 2 years can be retired.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release