### PR TITLE
Use nproc-2 to set parallelism for builds and tests

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -4,20 +4,23 @@ description: "Install Conan dependencies, optionally forcing a rebuild of all de
 # Note that actions do not support 'type' and all inputs are strings, see
 # https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputs.
 inputs:
-  verbosity:
-    description: "The build verbosity."
-    required: false
-    default: "verbose"
   build_dir:
     description: "The directory where to build."
     required: true
   build_type:
     description: 'The build type to use ("Debug", "Release").'
     required: true
+  build_nproc:
+    description: "The number of processors to use for building."
+    required: true
   force_build:
     description: 'Force building of all dependencies ("true", "false").'
     required: false
     default: "false"
+  log_verbosity:
+    description: "The logging verbosity."
+    required: false
+    default: "verbose"
 
 runs:
   using: composite
@@ -26,9 +29,10 @@ runs:
       shell: bash
       env:
         BUILD_DIR: ${{ inputs.build_dir }}
+        BUILD_NPROC: ${{ inputs.build_nproc }}
         BUILD_OPTION: ${{ inputs.force_build == 'true' && '*' || 'missing' }}
         BUILD_TYPE: ${{ inputs.build_type }}
-        VERBOSITY: ${{ inputs.verbosity }}
+        LOG_VERBOSITY: ${{ inputs.log_verbosity }}
       run: |
         echo 'Installing dependencies.'
         mkdir -p "${BUILD_DIR}"
@@ -39,6 +43,7 @@ runs:
           --options:host='&:tests=True' \
           --options:host='&:xrpld=True' \
           --settings:all build_type="${BUILD_TYPE}" \
-          --conf:all tools.build:verbosity="${VERBOSITY}" \
-          --conf:all tools.compilation:verbosity="${VERBOSITY}" \
+          --conf:all tools.build:jobs=${BUILD_NPROC} \
+          --conf:all tools.build:verbosity="${LOG_VERBOSITY}" \
+          --conf:all tools.compilation:verbosity="${LOG_VERBOSITY}" \
           ..

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,6 +23,7 @@ defaults:
 
 env:
   BUILD_DIR: .build
+  NPROC_SUBTRACT: 2
 
 jobs:
   publish:
@@ -33,6 +34,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Get number of processors
+        uses: XRPLF/actions/.github/actions/get-nproc@046b1620f6bfd6cd0985dc82c3df02786801fe0a
+        id: nproc
+        with:
+          subtract: ${{ env.NPROC_SUBTRACT }}
+
       - name: Check configuration
         run: |
           echo 'Checking path.'
@@ -46,12 +54,16 @@ jobs:
 
           echo 'Checking Doxygen version.'
           doxygen --version
+
       - name: Build documentation
+        env:
+          BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
         run: |
           mkdir -p "${BUILD_DIR}"
           cd "${BUILD_DIR}"
           cmake -Donly_docs=ON ..
-          cmake --build . --target docs --parallel $(nproc)
+          cmake --build . --target docs --parallel ${BUILD_NPROC}
+
       - name: Publish documentation
         if: ${{ github.ref_type == 'branch' && github.ref_name == github.event.repository.default_branch }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/.github/workflows/reusable-build-test-config.yml
+++ b/.github/workflows/reusable-build-test-config.yml
@@ -39,6 +39,12 @@ on:
         required: true
         type: string
 
+      nproc_subtract:
+        description: "The number of processors to subtract when calculating parallelism."
+        required: false
+        type: number
+        default: 2
+
     secrets:
       CODECOV_TOKEN:
         description: "The Codecov token to use for uploading coverage reports."
@@ -55,6 +61,7 @@ jobs:
       runs_on: ${{ inputs.runs_on }}
       image: ${{ inputs.image }}
       config_name: ${{ inputs.config_name }}
+      nproc_subtract: ${{ inputs.nproc_subtract }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -67,3 +74,4 @@ jobs:
       runs_on: ${{ inputs.runs_on }}
       image: ${{ inputs.image }}
       config_name: ${{ inputs.config_name }}
+      nproc_subtract: ${{ inputs.nproc_subtract }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -34,6 +34,11 @@ on:
         required: true
         type: string
 
+      nproc_subtract:
+        description: "The number of processors to subtract when calculating parallelism."
+        required: true
+        type: number
+
     secrets:
       CODECOV_TOKEN:
         description: "The Codecov token to use for uploading coverage reports."
@@ -65,6 +70,12 @@ jobs:
       - name: Print build environment
         uses: ./.github/actions/print-env
 
+      - name: Get number of processors
+        uses: XRPLF/actions/.github/actions/get-nproc@046b1620f6bfd6cd0985dc82c3df02786801fe0a
+        id: nproc
+        with:
+          subtract: ${{ inputs.nproc_subtract }}
+
       - name: Setup Conan
         uses: ./.github/actions/setup-conan
 
@@ -72,7 +83,11 @@ jobs:
         uses: ./.github/actions/build-deps
         with:
           build_dir: ${{ inputs.build_dir }}
+          build_nproc: ${{ steps.nproc.outputs.nproc }}
           build_type: ${{ inputs.build_type }}
+          # Set the verbosity to "quiet" for Windows to avoid an excessive
+          # amount of logs. For other OSes, the "verbose" logs are more useful.
+          log_verbosity: ${{ runner.os == 'Windows' && 'quiet' || 'verbose' }}
 
       - name: Configure CMake
         shell: bash
@@ -92,13 +107,14 @@ jobs:
         shell: bash
         working-directory: ${{ inputs.build_dir }}
         env:
+          BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
           BUILD_TYPE: ${{ inputs.build_type }}
           CMAKE_TARGET: ${{ inputs.cmake_target }}
         run: |
           cmake \
             --build . \
             --config "${BUILD_TYPE}" \
-            --parallel $(nproc) \
+            --parallel ${BUILD_NPROC} \
             --target "${CMAKE_TARGET}"
 
       - name: Put built binaries in one location

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -26,6 +26,11 @@ on:
         required: true
         type: string
 
+      nproc_subtract:
+        description: "The number of processors to subtract when calculating parallelism."
+        required: true
+        type: number
+
 jobs:
   test:
     name: Test ${{ inputs.config_name }}
@@ -36,6 +41,12 @@ jobs:
       - name: Cleanup workspace
         if: ${{ runner.os == 'macOS' }}
         uses: XRPLF/actions/.github/actions/cleanup-workspace@3f044c7478548e3c32ff68980eeb36ece02b364e
+
+      - name: Get number of processors
+        uses: XRPLF/actions/.github/actions/get-nproc@046b1620f6bfd6cd0985dc82c3df02786801fe0a
+        id: nproc
+        with:
+          subtract: ${{ inputs.nproc_subtract }}
 
       - name: Download rippled artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -69,8 +80,10 @@ jobs:
       - name: Run the embedded tests
         if: ${{ inputs.run_tests }}
         shell: bash
+        env:
+          BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
         run: |
-          ./rippled --unittest --unittest-jobs $(nproc)
+          ./rippled --unittest --unittest-jobs ${BUILD_NPROC}
 
       - name: Run the separate tests
         if: ${{ inputs.run_tests }}

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -34,6 +34,7 @@ on:
 env:
   CONAN_REMOTE_NAME: xrplf
   CONAN_REMOTE_URL: https://conan.ripplex.io
+  NPROC_SUBTRACT: 2
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -61,11 +62,22 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         uses: XRPLF/actions/.github/actions/cleanup-workspace@3f044c7478548e3c32ff68980eeb36ece02b364e
 
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
       - name: Prepare runner
         uses: XRPLF/actions/.github/actions/prepare-runner@638e0dc11ea230f91bd26622fb542116bb5254d5
         with:
           disable_ccache: false
+
+      - name: Print build environment
+        uses: ./.github/actions/print-env
+
+      - name: Get number of processors
+        uses: XRPLF/actions/.github/actions/get-nproc@046b1620f6bfd6cd0985dc82c3df02786801fe0a
+        id: nproc
+        with:
+          subtract: ${{ env.NPROC_SUBTRACT }}
 
       - name: Setup Conan
         uses: ./.github/actions/setup-conan
@@ -77,11 +89,12 @@ jobs:
         uses: ./.github/actions/build-deps
         with:
           build_dir: .build
+          build_nproc: ${{ steps.nproc.outputs.nproc }}
           build_type: ${{ matrix.build_type }}
           force_build: ${{ github.event_name == 'schedule' || github.event.inputs.force_source_build == 'true' }}
-          # The verbosity is set to "quiet" for Windows to avoid an excessive amount of logs, while it
-          # is set to "verbose" otherwise to provide more information during the build process.
-          verbosity: ${{ runner.os == 'Windows' && 'quiet' || 'verbose' }}
+          # Set the verbosity to "quiet" for Windows to avoid an excessive
+          # amount of logs. For other OSes, the "verbose" logs are more useful.
+          log_verbosity: ${{ runner.os == 'Windows' && 'quiet' || 'verbose' }}
 
       - name: Log into Conan remote
         if: ${{ github.repository_owner == 'XRPLF' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}

--- a/conan/global.conf
+++ b/conan/global.conf
@@ -1,6 +1,5 @@
 # Global configuration for Conan. This is used to set the number of parallel
-# downloads, uploads, and build jobs.
+# downloads and uploads.
 core:non_interactive=True
 core.download:parallel={{ os.cpu_count() }}
 core.upload:parallel={{ os.cpu_count() }}
-tools.build:jobs={{ os.cpu_count() - 1 }}


### PR DESCRIPTION
## High Level Overview of Change

This change reduces the number of cores used to build and test by two in CI.

### Context of Change

Using all cores may be contributing to occasional build and test failures. Only the Conan profile currently specifies that the number of cores minus one should be used for the level of parallelism, but that does not affect the building and testing as those are currently set to `$(nproc)`.

A new action was created in https://github.com/XRPLF/actions/pull/17, which this PR leverages to determine the number of processors supported by the OS on which the job is being executed, while subtracting 2 processors to reserve those for infrastructure-related tasks (e.g. some runners run on K8s). We also apply this to the Conan profile for consistency.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

