### PR TITLE
ci: Use commit hash so workflows are not canceled when merging multiple PRs

### DIFF
--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -50,7 +50,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # When a PR is merged into the develop branch it will be assigned a unique
+  # group identifier, so execution will continue even if another PR is merged
+  # while it is still running. In all other cases the group identifier is shared
+  # per branch, so that any in-progress runs are cancelled when a new commit is
+  # pushed.
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && github.sha || github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
## High Level Overview of Change

This change changes the CI concurrency group for pushes to the `develop` branch to use the commit hash instead of the target branch.

### Context of Change

When multiple PRs are merged in close succession, where each triggers a CI pipeline upon merge, GitHub will cancel the earlier pipelines due to the concurrency group being the same for each. However, there is value in letting them run independently, since if a failure occurs we will know which PR is to blame. Note that for manually triggered or the nightly scheduled, we can use the existing ref (i.e. `develop`), as we don't expect to ever run more than one such pipeline at the same time.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
