### PR TITLE
ci: Only upload codecov reports in the original repo, not in forks

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -126,7 +126,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload coverage report
-        if: ${{ inputs.cmake_target == 'coverage' }}
+        if: ${{ github.repository_owner == 'XRPLF' && inputs.cmake_target == 'coverage' }}
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           disable_search: true


### PR DESCRIPTION
## High Level Overview of Change

This change only uploads the Codecov report in the original repository.

### Context of Change

Forks will not have access to the token necessary to authenticate with Codecov, so that job will fail. Although it would be simplest if we could just check whether the token secret is empty, GitHub doesn't permit using secrets in `if:` statements. Instead, we can check whether the owner of the repository matches `XRPLF` to check if a fork is used.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release