### PR TITLE
ci: Update CI image hashes to use netstat

### DIFF
--- a/.github/scripts/strategy-matrix/linux.json
+++ b/.github/scripts/strategy-matrix/linux.json
@@ -15,168 +15,168 @@
       "distro_version": "bookworm",
       "compiler_name": "gcc",
       "compiler_version": "12",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
       "compiler_version": "13",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "gcc",
       "compiler_version": "15",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
       "compiler_version": "16",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
       "compiler_version": "17",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
       "compiler_version": "18",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
       "compiler_version": "19",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "debian",
       "distro_version": "bookworm",
       "compiler_name": "clang",
       "compiler_version": "20",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "8",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "8",
       "compiler_name": "clang",
       "compiler_version": "any",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "gcc",
       "compiler_version": "12",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "gcc",
       "compiler_version": "13",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "9",
       "compiler_name": "clang",
       "compiler_version": "any",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "10",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "rhel",
       "distro_version": "10",
       "compiler_name": "clang",
       "compiler_version": "any",
-      "image_sha": "10e69b4"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "jammy",
       "compiler_name": "gcc",
       "compiler_version": "12",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "gcc",
       "compiler_version": "13",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "gcc",
       "compiler_version": "14",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
       "compiler_version": "16",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
       "compiler_version": "17",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
       "compiler_version": "18",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     },
     {
       "distro_name": "ubuntu",
       "distro_version": "noble",
       "compiler_name": "clang",
       "compiler_version": "19",
-      "image_sha": "6948666"
+      "image_sha": "97ba375"
     }
   ],
   "build_type": ["Debug", "Release"],


### PR DESCRIPTION
## High Level Overview of Change

This change uses the new CI images created by https://github.com/XRPLF/ci/pull/79.

### Context of Change

To debug test failures we would like to use `netstat`, but that package wasn't installed yet in the CI images.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release