### PR TITLE
refactor: Rename `rippled` binary to `xrpld` and add symlink

### DIFF
--- a/.github/scripts/rename/README.md
+++ b/.github/scripts/rename/README.md
@@ -26,6 +26,9 @@ run from the repository root.
    references to `ripple` and `rippled` (with or without capital letters) to
    `xrpl` and `xrpld`, respectively. The name of the binary will remain as-is,
    and will only be renamed to `xrpld` by a later script.
+4. `.github/scripts/rename/binary.sh`: This script will rename the binary from
+   `rippled` to `xrpld`, and create a symlink named `rippled` that points to the
+   `xrpld` binary.
 
 You can run all these scripts from the repository root as follows:
 
@@ -33,4 +36,5 @@ You can run all these scripts from the repository root as follows:
 ./.github/scripts/rename/definitions.sh .
 ./.github/scripts/rename/copyright.sh .
 ./.github/scripts/rename/cmake.sh .
+./.github/scripts/rename/binary.sh .
 ```

--- a/.github/scripts/rename/binary.sh
+++ b/.github/scripts/rename/binary.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Exit the script as soon as an error occurs.
+set -e
+
+# On MacOS, ensure that GNU sed is installed and available as `gsed`.
+SED_COMMAND=sed
+if [[ "${OSTYPE}" == 'darwin'* ]]; then
+  if ! command -v gsed &> /dev/null; then
+      echo "Error: gsed is not installed. Please install it using 'brew install gnu-sed'."
+      exit 1
+  fi
+  SED_COMMAND=gsed
+fi
+
+# This script changes the binary name from `rippled` to `xrpld`, and creates a
+# symlink named `rippled` that points to the `xrpld` binary.
+# Usage: .github/scripts/rename/binary.sh <repository directory>
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <repository directory>"
+    exit 1
+fi
+
+DIRECTORY=$1
+echo "Processing directory: ${DIRECTORY}"
+if [ ! -d "${DIRECTORY}" ]; then
+    echo "Error: Directory '${DIRECTORY}' does not exist."
+    exit 1
+fi
+
+FILE="${DIRECTORY}/cmake/XrplCore.cmake"
+echo "Processing file: ${FILE}"
+${SED_COMMAND} -i -E 's/For the time being.+/Create a symlink named "rippled" for backward compatibility./g' "${FILE}"
+${SED_COMMAND} -i -E 's/set_target_properties\(xrpld.+/add_custom_command(TARGET xrpld POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink "xrpld" "rippled")/g' "${FILE}"
+
+echo "Processing complete."

--- a/.github/workflows/reusable-check-rename.yml
+++ b/.github/workflows/reusable-check-rename.yml
@@ -25,6 +25,8 @@ jobs:
         run: .github/scripts/rename/copyright.sh .
       - name: Check CMake configs
         run: .github/scripts/rename/cmake.sh .
+      - name: Check binary name
+        run: .github/scripts/rename/binary.sh .
       - name: Check for differences
         env:
           MESSAGE: |

--- a/cmake/XrplCore.cmake
+++ b/cmake/XrplCore.cmake
@@ -226,6 +226,6 @@ if(xrpld)
       src/test/ledger/Invariants_test.cpp
       PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
   endif()
-  # For the time being, we will keep the name of the binary as it was.
-  set_target_properties(xrpld PROPERTIES OUTPUT_NAME "rippled")
+  # Create a symlink named "rippled" for backward compatibility.
+  add_custom_command(TARGET xrpld POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink "xrpld" "rippled")
 endif()


### PR DESCRIPTION
## High Level Overview of Change

This change modifies the binary name from `rippled` to `xrpld`, and creates a symlink named `rippled` that points to the `xrpld` binary.

### Context of Change

Per [XLS-0095](https://xls.xrpl.org/xls/XLS-0095-rename-rippled-to-xrpld.html), we are taking steps to rename ripple(d) to xrpl(d).

This change essentially ensures that the binary will now be named `xrpld`. At the same time, everyone who has automations and other scripts that expect the binary to be named `rippled` should not be affected, as this change also creates a symlink so `rippled` redirects to `xrpld`. The plan is to remove this symlink in about 6 months to give everyone plenty of time to update these automations and scripts to reference `xrpld` instead.

Note that the [previous](https://github.com/XRPLF/rippled/pull/5975) PR renamed any references to `rippled` in the CMake files and their contents, but explicitly maintained the `rippled` binary name by adding an exception. This change now undoes this exception and adds an explicit symlink instead.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release