### PR TITLE
chore: Remove unnecessary commands in install cmake file

### DIFF
--- a/cmake/XrplInstall.cmake
+++ b/cmake/XrplInstall.cmake
@@ -2,8 +2,6 @@
    install stuff
 #]===================================================================]
 
-include(create_symbolic_link)
-
 install (
   TARGETS
     common

--- a/cmake/XrplInstall.cmake
+++ b/cmake/XrplInstall.cmake
@@ -37,13 +37,6 @@ install(
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
-install(CODE "
-  set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
-  include(create_symbolic_link)
-  create_symbolic_link(xrpl \
-    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/xrpl)
-")
-
 install (EXPORT XrplExports
   FILE XrplTargets.cmake
   NAMESPACE Xrpl::
@@ -70,12 +63,6 @@ if (is_root_project AND TARGET xrpld)
     endmacro()
     copy_if_not_exists(\"${CMAKE_CURRENT_SOURCE_DIR}/cfg/rippled-example.cfg\" etc rippled.cfg)
     copy_if_not_exists(\"${CMAKE_CURRENT_SOURCE_DIR}/cfg/validators-example.txt\" etc validators.txt)
-  ")
-  install(CODE "
-    set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
-    include(create_symbolic_link)
-    create_symbolic_link(xrpld${suffix} \
-       \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/xrpld${suffix})
   ")
 endif ()
 


### PR DESCRIPTION
## High Level Overview of Change

This change removes two stanzas in the `XrplInstall.cmake` file that are unnecessary.

### Context of Change

Our packaging pipeline currently patches the install CMake file to remove these stanzas. We may as well remove them directly from the file itself.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release