### PR TITLE
chore: Removes unnecessary creation of symlink in CMake install file

### DIFF
--- a/.github/scripts/rename/cmake.sh
+++ b/.github/scripts/rename/cmake.sh
@@ -81,5 +81,9 @@ elif ! grep -q '"rippled"' cmake/XrplCore.cmake; then
   mv cmake.tmp cmake/XrplCore.cmake
 fi
 
+# Remove the symlink that previously pointed from 'ripple' to 'xrpl' but now is
+# no longer needed.
+${SED_COMMAND} -z -i -E 's@install\(CODE.+CMAKE_INSTALL_INCLUDEDIR}/xrpl\)\n"\)@install(CODE "set(CMAKE_MODULE_PATH \\"${CMAKE_MODULE_PATH}\\")")@' cmake/XrplInstall.cmake
+
 popd
 echo "Renaming complete."

--- a/cmake/XrplInstall.cmake
+++ b/cmake/XrplInstall.cmake
@@ -37,12 +37,7 @@ install(
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
-install(CODE "
-  set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
-  include(create_symbolic_link)
-  create_symbolic_link(xrpl \
-    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/xrpl)
-")
+install(CODE "set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")")
 
 install (EXPORT XrplExports
   FILE XrplTargets.cmake


### PR DESCRIPTION
## High Level Overview of Change

This change removes the creation of a symlink that after https://github.com/XRPLF/rippled/pull/5975 results in errors, by updating the renaming script.

### Context of Change

The changes in https://github.com/XRPLF/rippled/pull/5975 renamed ripple(d) to xrpl(d) in CMake files. Previously, changes had already been made in anticipation of this renaming, whereby a symlink "ripple" was made to point to "xrpl". Now after renaming, "ripple" has become "xrpl" and a symlink is attempted to be made from "xrpl" to "xrpl", which therefore fails. This symlink is thus now no longer needed, and can be removed.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
