### PR TITLE
fix: xrpld symlink renamed incorrectly

### DIFF
--- a/.github/scripts/rename/cmake.sh
+++ b/.github/scripts/rename/cmake.sh
@@ -74,7 +74,7 @@ if grep -q '"xrpld"' cmake/XrplCore.cmake; then
   # The script has been rerun, so just restore the name of the binary.
   ${SED_COMMAND} -i 's/"xrpld"/"rippled"/' cmake/XrplCore.cmake
 elif ! grep -q '"rippled"' cmake/XrplCore.cmake; then
-  ghead -n -1 cmake/XrplCore.cmake > cmake.tmp
+  ${HEAD_COMMAND} -n -1 cmake/XrplCore.cmake > cmake.tmp
   echo '  # For the time being, we will keep the name of the binary as it was.' >> cmake.tmp
   echo '  set_target_properties(xrpld PROPERTIES OUTPUT_NAME "rippled")' >> cmake.tmp
   tail -1 cmake/XrplCore.cmake >> cmake.tmp

--- a/.github/scripts/rename/cmake.sh
+++ b/.github/scripts/rename/cmake.sh
@@ -82,11 +82,11 @@ elif ! grep -q '"rippled"' cmake/XrplCore.cmake; then
 fi
 
 # Restore the symlink from 'xrpld' to 'rippled'.
-${SED_COMMAND} -z -i -E 's/create_symbolic_link\(xrpld/create_symbolic_link(rippled/' cmake/XrplInstall.cmake
+${SED_COMMAND} -i -E 's@create_symbolic_link\(xrpld@create_symbolic_link(rippled@' cmake/XrplInstall.cmake
 
 # Remove the symlink that previously pointed from 'ripple' to 'xrpl' but now is
 # no longer needed.
-${SED_COMMAND} -z -i -E 's@install\(CODE.+CMAKE_INSTALL_INCLUDEDIR}/xrpl\)\n"\)@@' cmake/XrplInstall.cmake
+${SED_COMMAND} -z -i -E 's@install\(CODE.+CMAKE_INSTALL_INCLUDEDIR}/xrpl\)\n"\)\n+@@' cmake/XrplInstall.cmake
 
 popd
 echo "Renaming complete."

--- a/.github/scripts/rename/cmake.sh
+++ b/.github/scripts/rename/cmake.sh
@@ -81,9 +81,12 @@ elif ! grep -q '"rippled"' cmake/XrplCore.cmake; then
   mv cmake.tmp cmake/XrplCore.cmake
 fi
 
+# Restore the symlink from 'xrpld' to 'rippled'.
+${SED_COMMAND} -z -i -E 's/create_symbolic_link\(xrpld/create_symbolic_link(rippled/' cmake/XrplInstall.cmake
+
 # Remove the symlink that previously pointed from 'ripple' to 'xrpl' but now is
 # no longer needed.
-${SED_COMMAND} -z -i -E 's@install\(CODE.+CMAKE_INSTALL_INCLUDEDIR}/xrpl\)\n"\)@install(CODE "set(CMAKE_MODULE_PATH \\"${CMAKE_MODULE_PATH}\\")")@' cmake/XrplInstall.cmake
+${SED_COMMAND} -z -i -E 's@install\(CODE.+CMAKE_INSTALL_INCLUDEDIR}/xrpl\)\n"\)@@' cmake/XrplInstall.cmake
 
 popd
 echo "Renaming complete."

--- a/cmake/XrplInstall.cmake
+++ b/cmake/XrplInstall.cmake
@@ -37,7 +37,7 @@ install(
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
-install(CODE "set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")")
+
 
 install (EXPORT XrplExports
   FILE XrplTargets.cmake
@@ -69,8 +69,8 @@ if (is_root_project AND TARGET xrpld)
   install(CODE "
     set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
     include(create_symbolic_link)
-    create_symbolic_link(xrpld${suffix} \
-       \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/rippled${suffix})
+    create_symbolic_link(rippled${suffix} \
+       \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/xrpld${suffix})
   ")
 endif ()
 

--- a/cmake/XrplInstall.cmake
+++ b/cmake/XrplInstall.cmake
@@ -70,7 +70,7 @@ if (is_root_project AND TARGET xrpld)
     set(CMAKE_MODULE_PATH \"${CMAKE_MODULE_PATH}\")
     include(create_symbolic_link)
     create_symbolic_link(xrpld${suffix} \
-       \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/xrpld${suffix})
+       \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/rippled${suffix})
   ")
 endif ()
 

--- a/cmake/XrplInstall.cmake
+++ b/cmake/XrplInstall.cmake
@@ -37,8 +37,6 @@ install(
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
-
-
 install (EXPORT XrplExports
   FILE XrplTargets.cmake
   NAMESPACE Xrpl::


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
#5975 Changed the target of the `xrpld` symlink to `xrpld` [and now points to itself](https://github.com/XRPLF/rippled/blob/173f9f7bb0f3939e756c3afea8caf3338c97e51c/cmake/XrplInstall.cmake#L72-L73). 

We renamed the `rippled` target to `xrpld` but set the output binary to still be `rippled` so this symlink should not have been updated.

To be clear, this PR recreates the previous configuration:

```shell
bin
├── rippled
└── xrpld -> rippled
```

or we can just rip the band-aid off now and have `rippled` be a symlink to `xrpld`.



<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
