### PR TITLE
Fix nullptr resolving, no db config

### DIFF
--- a/src/xrpld/app/rdb/backend/detail/Node.cpp
+++ b/src/xrpld/app/rdb/backend/detail/Node.cpp
@@ -254,6 +254,14 @@ saveValidatedLedger(
 
         if (app.config().useTxTables())
         {
+            if (!txnDB)
+            {
+                // LCOV_EXCL_START
+                JLOG(j.fatal()) << "TxTables db isn't available";
+                Throw<std::runtime_error>("TxTables db isn't available");
+                // LCOV_EXCL_STOP
+            }
+
             auto db = txnDB->checkoutDb();
 
             soci::transaction tr(*db);

--- a/src/xrpld/app/rdb/backend/detail/Node.cpp
+++ b/src/xrpld/app/rdb/backend/detail/Node.cpp
@@ -171,7 +171,7 @@ getRowsMinMax(soci::session& session, TableType type)
 bool
 saveValidatedLedger(
     DatabaseCon& ldgDB,
-    DatabaseCon& txnDB,
+    std::unique_ptr<DatabaseCon> const& txnDB,
     Application& app,
     std::shared_ptr<Ledger const> const& ledger,
     bool current)
@@ -254,7 +254,7 @@ saveValidatedLedger(
 
         if (app.config().useTxTables())
         {
-            auto db = txnDB.checkoutDb();
+            auto db = txnDB->checkoutDb();
 
             soci::transaction tr(*db);
 

--- a/src/xrpld/app/rdb/backend/detail/Node.h
+++ b/src/xrpld/app/rdb/backend/detail/Node.h
@@ -111,7 +111,7 @@ getRowsMinMax(soci::session& session, TableType type);
 bool
 saveValidatedLedger(
     DatabaseCon& ldgDB,
-    DatabaseCon& txnDB,
+    std::unique_ptr<DatabaseCon> const& txnDB,
     Application& app,
     std::shared_ptr<Ledger const> const& ledger,
     bool current);

--- a/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
+++ b/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
@@ -392,8 +392,7 @@ SQLiteDatabaseImp::saveValidatedLedger(
 {
     if (existsLedger())
     {
-        if (!detail::saveValidatedLedger(
-                *lgrdb_, *txdb_, app_, ledger, current))
+        if (!detail::saveValidatedLedger(*lgrdb_, txdb_, app_, ledger, current))
             return false;
     }
 


### PR DESCRIPTION
## High Level Overview of Change
Fix resolving nullptr


### Context of Change
If config disable sql db usage (like validator)
```
[ledger_tx_tables]
use_tx_tables = 0
```
then pointer to DB engine is null, but still resolved during startup. I suppose that there is no crash for now because of c++ optimizer which drop the code with resolving pointer. Reproduced 100% in debug mode.


### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release



