### PR TITLE
ci: Fix filtering out of Clang 20+ on ARM

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -131,7 +131,7 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
             continue
 
         # We skip all clang 20+ on arm64 due to Boost build error.
-        if f'{os['compiler_name']}' in ['clang-20', 'clang-21'] and architecture['platform'] == 'linux/arm64':
+        if f'{os['compiler_name']}-{os['compiler_version']}' in ['clang-20', 'clang-21'] and architecture['platform'] == 'linux/arm64':
             continue
 
         # Enable code coverage for Debian Bookworm using GCC 15 in Debug and no


### PR DESCRIPTION
## High Level Overview of Change

This change fixes the strategy matrix check to filter out the Clang 20+ on ARM.

### Context of Change

Clang 20+ builds on ARM still fail due to problems with Boost.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
