### PR TITLE
fix: increment sequence when accepting new manifests

### DIFF
--- a/src/test/app/Manifest_test.cpp
+++ b/src/test/app/Manifest_test.cpp
@@ -827,8 +827,13 @@ public:
 
             // applyManifest should accept new manifests with
             // higher sequence numbers
+            auto const seq0 = cache.sequence();
             BEAST_EXPECT(cache.applyManifest(clone(s_a0)) == ManifestDisposition::accepted);
+            BEAST_EXPECT(cache.sequence() > seq0);
+
+            auto const seq1 = cache.sequence();
             BEAST_EXPECT(cache.applyManifest(clone(s_a0)) == ManifestDisposition::stale);
+            BEAST_EXPECT(cache.sequence() == seq1);
 
             BEAST_EXPECT(cache.applyManifest(clone(s_a1)) == ManifestDisposition::accepted);
             BEAST_EXPECT(cache.applyManifest(clone(s_a1)) == ManifestDisposition::stale);

--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -459,6 +459,10 @@ ManifestCache::applyManifest(Manifest m)
 
         auto masterKey = m.masterKey;
         map_.emplace(std::move(masterKey), std::move(m));
+
+        // Something has changed. Keep track of it.
+        seq_++;
+
         return ManifestDisposition::accepted;
     }
 


### PR DESCRIPTION
The function was returning early without incrementing seq_++. OverlayImpl uses this sequence to identify/invalidate a cached TMManifests message which is exchanged with peers on connection. Depending on network size, startup sequencing, and topology, this could cause syncing issues.