### PR TITLE
ci: Re-enable linux and macos matrix

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows]
+        os: [linux, macos, windows]
     with:
       os: ${{ matrix.os }}
     secrets:


### PR DESCRIPTION
## High Level Overview of Change

This change re-enables the Linux and macOS builds.

### Context of Change

The builds were accidentally disabled in https://github.com/XRPLF/rippled/pull/6089 during testing.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release