### PR TITLE
chore: Fix docs readme and cmake

### DIFF
--- a/cmake/XrplDocs.cmake
+++ b/cmake/XrplDocs.cmake
@@ -2,9 +2,7 @@
    docs target (optional)
 #]===================================================================]
 
-option(with_docs "Include the docs target?" FALSE)
-
-if(NOT (with_docs OR only_docs))
+if(NOT only_docs)
   return()
 endif()
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@ There is a `docs` target in the CMake configuration.
 ```
 mkdir build
 cd build
-cmake ..
-cmake --build . --target docs
+cmake -Donly_docs=ON ..
+cmake --build . --target docs --parallel
 ```
 
 The output will be in `build/docs/html`.


### PR DESCRIPTION
## High Level Overview of Change

This change removes the unused `with_docs` option and fixes the README instructions on how to build the `docs` target. 

### Context of Change

N/A

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release