### PR TITLE
refactor: rename `LedgerInfo` to `LedgerHeader`

### DIFF
--- a/include/xrpl/ledger/CachedView.h
+++ b/include/xrpl/ledger/CachedView.h
@@ -47,7 +47,7 @@ public:
         return base_.open();
     }
 
-    LedgerInfo const&
+    LedgerHeader const&
     info() const override
     {
         return base_.info();

--- a/include/xrpl/ledger/OpenView.h
+++ b/include/xrpl/ledger/OpenView.h
@@ -82,7 +82,7 @@ private:
         monotonic_resource_;
     txs_map txs_;
     Rules rules_;
-    LedgerInfo info_;
+    LedgerHeader info_;
     ReadView const* base_;
     detail::RawStateTable items_;
     std::shared_ptr<void const> hold_;
@@ -158,7 +158,7 @@ public:
 
         Effects:
 
-            The LedgerInfo is copied from the base.
+            The LedgerHeader is copied from the base.
 
             The rules are inherited from the base.
 
@@ -188,7 +188,7 @@ public:
 
     // ReadView
 
-    LedgerInfo const&
+    LedgerHeader const&
     info() const override;
 
     Fees const&

--- a/include/xrpl/ledger/ReadView.h
+++ b/include/xrpl/ledger/ReadView.h
@@ -80,7 +80,7 @@ public:
     }
 
     /** Returns information about the ledger. */
-    virtual LedgerInfo const&
+    virtual LedgerHeader const&
     info() const = 0;
 
     /** Returns true if this reflects an open ledger. */

--- a/include/xrpl/ledger/detail/ApplyViewBase.h
+++ b/include/xrpl/ledger/detail/ApplyViewBase.h
@@ -27,7 +27,7 @@ public:
     bool
     open() const override;
 
-    LedgerInfo const&
+    LedgerHeader const&
     info() const override;
 
     Fees const&

--- a/include/xrpl/protocol/LedgerHeader.h
+++ b/include/xrpl/protocol/LedgerHeader.h
@@ -53,12 +53,6 @@ struct LedgerHeader
     NetClock::time_point closeTime = {};
 };
 
-// We call them "headers" in conversation
-// but "info" in code. Unintuitive.
-// This alias lets us give the "correct" name to the class
-// without yet disturbing existing uses.
-using LedgerInfo = LedgerHeader;
-
 // ledger close flags
 static std::uint32_t const sLCF_NoConsensusTime = 0x01;
 

--- a/src/libxrpl/ledger/ApplyViewBase.cpp
+++ b/src/libxrpl/ledger/ApplyViewBase.cpp
@@ -16,7 +16,7 @@ ApplyViewBase::open() const
     return base_->open();
 }
 
-LedgerInfo const&
+LedgerHeader const&
 ApplyViewBase::info() const
 {
     return base_->info();

--- a/src/libxrpl/ledger/OpenView.cpp
+++ b/src/libxrpl/ledger/OpenView.cpp
@@ -115,7 +115,7 @@ OpenView::apply(TxsRawView& to) const
 
 //---
 
-LedgerInfo const&
+LedgerHeader const&
 OpenView::info() const
 {
     return info_;

--- a/src/test/app/SHAMapStore_test.cpp
+++ b/src/test/app/SHAMapStore_test.cpp
@@ -49,11 +49,11 @@ class SHAMapStore_test : public beast::unit_test::suite
 
         auto const seq = json[jss::result][jss::ledger_index].asUInt();
 
-        std::optional<LedgerInfo> oinfo =
+        std::optional<LedgerHeader> oinfo =
             env.app().getRelationalDatabase().getLedgerInfoByIndex(seq);
         if (!oinfo)
             return false;
-        LedgerInfo const& info = oinfo.value();
+        LedgerHeader const& info = oinfo.value();
 
         std::string const outHash = to_string(info.hash);
         LedgerIndex const outSeq = info.seq;

--- a/src/test/overlay/compression_test.cpp
+++ b/src/test/overlay/compression_test.cpp
@@ -38,7 +38,7 @@ using namespace ripple::test;
 using namespace ripple::test::jtx;
 
 static uint256
-ledgerHash(LedgerInfo const& info)
+ledgerHash(LedgerHeader const& info)
 {
     return ripple::sha512Half(
         HashPrefix::ledgerMaster,
@@ -252,7 +252,7 @@ public:
 
         for (int i = 0; i < n; i++)
         {
-            LedgerInfo info;
+            LedgerHeader info;
             info.seq = i;
             info.parentCloseTime = ct;
             info.hash = ripple::sha512Half(i);

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -68,7 +68,7 @@ public:
         }
         env.fund(XRP(10000), alice);
         env.close();
-        LedgerInfo const ledger3Info = env.closed()->info();
+        LedgerHeader const ledger3Info = env.closed()->info();
         BEAST_EXPECT(ledger3Info.seq == 3);
 
         {
@@ -118,7 +118,7 @@ public:
             env(pay(gw1, alice, gw1Currency(50 + c)));
         }
         env.close();
-        LedgerInfo const ledger4Info = env.closed()->info();
+        LedgerHeader const ledger4Info = env.closed()->info();
         BEAST_EXPECT(ledger4Info.seq == 4);
 
         // Add another set of trust lines in another ledger so we can see
@@ -153,13 +153,13 @@ public:
                 tfSetNoRipple | tfSetFreeze | tfSetDeepFreeze));
         }
         env.close();
-        LedgerInfo const ledger58Info = env.closed()->info();
+        LedgerHeader const ledger58Info = env.closed()->info();
         BEAST_EXPECT(ledger58Info.seq == 58);
 
         // A re-usable test for historic ledgers.
         auto testAccountLinesHistory = [this, &env](
                                            Account const& account,
-                                           LedgerInfo const& info,
+                                           LedgerHeader const& info,
                                            int count) {
             // Get account_lines by ledger index.
             Json::Value paramsSeq;
@@ -803,7 +803,7 @@ public:
         }
         env.fund(XRP(10000), alice);
         env.close();
-        LedgerInfo const ledger3Info = env.closed()->info();
+        LedgerHeader const ledger3Info = env.closed()->info();
         BEAST_EXPECT(ledger3Info.seq == 3);
 
         {
@@ -884,7 +884,7 @@ public:
             env(pay(gw1, alice, gw1Currency(50 + c)));
         }
         env.close();
-        LedgerInfo const ledger4Info = env.closed()->info();
+        LedgerHeader const ledger4Info = env.closed()->info();
         BEAST_EXPECT(ledger4Info.seq == 4);
 
         // Add another set of trust lines in another ledger so we can see
@@ -919,13 +919,13 @@ public:
                 tfSetNoRipple | tfSetFreeze | tfSetDeepFreeze));
         }
         env.close();
-        LedgerInfo const ledger58Info = env.closed()->info();
+        LedgerHeader const ledger58Info = env.closed()->info();
         BEAST_EXPECT(ledger58Info.seq == 58);
 
         // A re-usable test for historic ledgers.
         auto testAccountLinesHistory = [this, &env](
                                            Account const& account,
-                                           LedgerInfo const& info,
+                                           LedgerHeader const& info,
                                            int count) {
             // Get account_lines by ledger index.
             Json::Value paramsSeq;

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -32,7 +32,7 @@ namespace ripple {
 create_genesis_t const create_genesis{};
 
 uint256
-calculateLedgerHash(LedgerInfo const& info)
+calculateLedgerHash(LedgerHeader const& info)
 {
     // VFALCO This has to match addRaw in View.h.
     return sha512Half(
@@ -210,7 +210,7 @@ Ledger::Ledger(
 }
 
 Ledger::Ledger(
-    LedgerInfo const& info,
+    LedgerHeader const& info,
     bool& loaded,
     bool acquire,
     Config const& config,
@@ -285,7 +285,7 @@ Ledger::Ledger(Ledger const& prevLedger, NetClock::time_point closeTime)
     }
 }
 
-Ledger::Ledger(LedgerInfo const& info, Config const& config, Family& family)
+Ledger::Ledger(LedgerHeader const& info, Config const& config, Family& family)
     : mImmutable(true)
     , txMap_(SHAMapType::TRANSACTION, info.txHash, family)
     , stateMap_(SHAMapType::STATE, info.accountHash, family)
@@ -1042,13 +1042,13 @@ Ledger::invariants() const
 /*
  * Make ledger using info loaded from database.
  *
- * @param LedgerInfo: Ledger information.
+ * @param LedgerHeader: Ledger information.
  * @param app: Link to the Application.
  * @param acquire: Acquire the ledger if not found locally.
  * @return Shared pointer to the ledger.
  */
 std::shared_ptr<Ledger>
-loadLedgerHelper(LedgerInfo const& info, Application& app, bool acquire)
+loadLedgerHelper(LedgerHeader const& info, Application& app, bool acquire)
 {
     bool loaded;
     auto ledger = std::make_shared<Ledger>(
@@ -1088,7 +1088,7 @@ finishLoadByIndexOrHash(
 std::tuple<std::shared_ptr<Ledger>, std::uint32_t, uint256>
 getLatestLedger(Application& app)
 {
-    std::optional<LedgerInfo> const info =
+    std::optional<LedgerHeader> const info =
         app.getRelationalDatabase().getNewestLedgerInfo();
     if (!info)
         return {std::shared_ptr<Ledger>(), {}, {}};
@@ -1098,7 +1098,7 @@ getLatestLedger(Application& app)
 std::shared_ptr<Ledger>
 loadByIndex(std::uint32_t ledgerIndex, Application& app, bool acquire)
 {
-    if (std::optional<LedgerInfo> info =
+    if (std::optional<LedgerHeader> info =
             app.getRelationalDatabase().getLedgerInfoByIndex(ledgerIndex))
     {
         std::shared_ptr<Ledger> ledger = loadLedgerHelper(*info, app, acquire);
@@ -1111,7 +1111,7 @@ loadByIndex(std::uint32_t ledgerIndex, Application& app, bool acquire)
 std::shared_ptr<Ledger>
 loadByHash(uint256 const& ledgerHash, Application& app, bool acquire)
 {
-    if (std::optional<LedgerInfo> info =
+    if (std::optional<LedgerHeader> info =
             app.getRelationalDatabase().getLedgerInfoByHash(ledgerHash))
     {
         std::shared_ptr<Ledger> ledger = loadLedgerHelper(*info, app, acquire);

--- a/src/xrpld/app/ledger/Ledger.h
+++ b/src/xrpld/app/ledger/Ledger.h
@@ -88,14 +88,14 @@ public:
         std::vector<uint256> const& amendments,
         Family& family);
 
-    Ledger(LedgerInfo const& info, Config const& config, Family& family);
+    Ledger(LedgerHeader const& info, Config const& config, Family& family);
 
     /** Used for ledgers loaded from JSON files
 
         @param acquire If true, acquires the ledger if not found locally
     */
     Ledger(
-        LedgerInfo const& info,
+        LedgerHeader const& info,
         bool& loaded,
         bool acquire,
         Config const& config,
@@ -129,14 +129,14 @@ public:
         return false;
     }
 
-    LedgerInfo const&
+    LedgerHeader const&
     info() const override
     {
         return info_;
     }
 
     void
-    setLedgerInfo(LedgerInfo const& info)
+    setLedgerInfo(LedgerHeader const& info)
     {
         info_ = info;
     }
@@ -397,7 +397,7 @@ private:
 
     Fees fees_;
     Rules rules_;
-    LedgerInfo info_;
+    LedgerHeader info_;
     beast::Journal j_;
 };
 
@@ -423,7 +423,7 @@ pendSaveValidated(
     bool isCurrent);
 
 std::shared_ptr<Ledger>
-loadLedgerHelper(LedgerInfo const& sinfo, Application& app, bool acquire);
+loadLedgerHelper(LedgerHeader const& sinfo, Application& app, bool acquire);
 
 std::shared_ptr<Ledger>
 loadByIndex(std::uint32_t ledgerIndex, Application& app, bool acquire = true);
@@ -457,7 +457,7 @@ std::pair<std::shared_ptr<STTx const>, std::shared_ptr<STObject const>>
 deserializeTxPlusMeta(SHAMapItem const& item);
 
 uint256
-calculateLedgerHash(LedgerInfo const& info);
+calculateLedgerHash(LedgerHeader const& info);
 
 }  // namespace ripple
 

--- a/src/xrpld/app/ledger/LedgerReplayer.h
+++ b/src/xrpld/app/ledger/LedgerReplayer.h
@@ -85,7 +85,7 @@ public:
      */
     void
     gotSkipList(
-        LedgerInfo const& info,
+        LedgerHeader const& info,
         boost::intrusive_ptr<SHAMapItem const> const& data);
 
     /**
@@ -96,7 +96,7 @@ public:
      */
     void
     gotReplayDelta(
-        LedgerInfo const& info,
+        LedgerHeader const& info,
         std::map<std::uint32_t, std::shared_ptr<STTx const>>&& txns);
 
     /** Remove completed tasks */

--- a/src/xrpld/app/ledger/detail/LedgerDeltaAcquire.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerDeltaAcquire.cpp
@@ -118,7 +118,7 @@ LedgerDeltaAcquire::pmDowncast()
 
 void
 LedgerDeltaAcquire::processData(
-    LedgerInfo const& info,
+    LedgerHeader const& info,
     std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns)
 {
     ScopedLockType sl(mtx_);

--- a/src/xrpld/app/ledger/detail/LedgerDeltaAcquire.h
+++ b/src/xrpld/app/ledger/detail/LedgerDeltaAcquire.h
@@ -69,7 +69,7 @@ public:
      */
     void
     processData(
-        LedgerInfo const& info,
+        LedgerHeader const& info,
         std::map<std::uint32_t, std::shared_ptr<STTx const>>&& orderedTxns);
 
     /**

--- a/src/xrpld/app/ledger/detail/LedgerReplayer.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerReplayer.cpp
@@ -152,7 +152,7 @@ LedgerReplayer::createDeltas(std::shared_ptr<LedgerReplayTask> task)
 
 void
 LedgerReplayer::gotSkipList(
-    LedgerInfo const& info,
+    LedgerHeader const& info,
     boost::intrusive_ptr<SHAMapItem const> const& item)
 {
     std::shared_ptr<SkipListAcquire> skipList = {};
@@ -175,7 +175,7 @@ LedgerReplayer::gotSkipList(
 
 void
 LedgerReplayer::gotReplayDelta(
-    LedgerInfo const& info,
+    LedgerHeader const& info,
     std::map<std::uint32_t, std::shared_ptr<STTx const>>&& txns)
 {
     std::shared_ptr<LedgerDeltaAcquire> delta = {};

--- a/src/xrpld/app/ledger/detail/LedgerToJson.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerToJson.cpp
@@ -37,7 +37,7 @@ void
 fillJson(
     Object& json,
     bool closed,
-    LedgerInfo const& info,
+    LedgerHeader const& info,
     bool bFull,
     unsigned apiVersion)
 {
@@ -80,7 +80,7 @@ fillJson(
 
 template <class Object>
 void
-fillJsonBinary(Object& json, bool closed, LedgerInfo const& info)
+fillJsonBinary(Object& json, bool closed, LedgerHeader const& info)
 {
     if (!closed)
         json[jss::closed] = false;

--- a/src/xrpld/app/rdb/RelationalDatabase.h
+++ b/src/xrpld/app/rdb/RelationalDatabase.h
@@ -127,14 +127,14 @@ public:
      * @param ledgerSeq Ledger sequence.
      * @return The ledger if found, otherwise no value.
      */
-    virtual std::optional<LedgerInfo>
+    virtual std::optional<LedgerHeader>
     getLedgerInfoByIndex(LedgerIndex ledgerSeq) = 0;
 
     /**
      * @brief getNewestLedgerInfo Returns the info of the newest saved ledger.
      * @return Ledger info if found, otherwise no value.
      */
-    virtual std::optional<LedgerInfo>
+    virtual std::optional<LedgerHeader>
     getNewestLedgerInfo() = 0;
 
     /**
@@ -143,7 +143,7 @@ public:
      * @param ledgerHash Hash of the ledger.
      * @return Ledger if found, otherwise no value.
      */
-    virtual std::optional<LedgerInfo>
+    virtual std::optional<LedgerHeader>
     getLedgerInfoByHash(uint256 const& ledgerHash) = 0;
 
     /**

--- a/src/xrpld/app/rdb/backend/SQLiteDatabase.h
+++ b/src/xrpld/app/rdb/backend/SQLiteDatabase.h
@@ -100,7 +100,7 @@ public:
      * @param ledgerFirstIndex Minimum ledger sequence.
      * @return Ledger info if found, otherwise no value.
      */
-    virtual std::optional<LedgerInfo>
+    virtual std::optional<LedgerHeader>
     getLimitedOldestLedgerInfo(LedgerIndex ledgerFirstIndex) = 0;
 
     /**
@@ -110,7 +110,7 @@ public:
      * @param ledgerFirstIndex Minimum ledger sequence.
      * @return Ledger info if found, otherwise no value.
      */
-    virtual std::optional<LedgerInfo>
+    virtual std::optional<LedgerHeader>
     getLimitedNewestLedgerInfo(LedgerIndex ledgerFirstIndex) = 0;
 
     /**

--- a/src/xrpld/app/rdb/backend/detail/Node.cpp
+++ b/src/xrpld/app/rdb/backend/detail/Node.cpp
@@ -391,7 +391,7 @@ saveValidatedLedger(
  * @param j Journal.
  * @return Ledger info or no value if the ledger was not found.
  */
-static std::optional<LedgerInfo>
+static std::optional<LedgerHeader>
 getLedgerInfo(
     soci::session& session,
     std::string const& sqlSuffix,
@@ -425,7 +425,7 @@ getLedgerInfo(
     using time_point = NetClock::time_point;
     using duration = NetClock::duration;
 
-    LedgerInfo info;
+    LedgerHeader info;
 
     if (hash && !info.hash.parseHex(*hash))
     {
@@ -461,7 +461,7 @@ getLedgerInfo(
     return info;
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLedgerInfoByIndex(
     soci::session& session,
     LedgerIndex ledgerSeq,
@@ -472,7 +472,7 @@ getLedgerInfoByIndex(
     return getLedgerInfo(session, s.str(), j);
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getNewestLedgerInfo(soci::session& session, beast::Journal j)
 {
     std::ostringstream s;
@@ -480,7 +480,7 @@ getNewestLedgerInfo(soci::session& session, beast::Journal j)
     return getLedgerInfo(session, s.str(), j);
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLimitedOldestLedgerInfo(
     soci::session& session,
     LedgerIndex ledgerFirstIndex,
@@ -492,7 +492,7 @@ getLimitedOldestLedgerInfo(
     return getLedgerInfo(session, s.str(), j);
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLimitedNewestLedgerInfo(
     soci::session& session,
     LedgerIndex ledgerFirstIndex,
@@ -504,7 +504,7 @@ getLimitedNewestLedgerInfo(
     return getLedgerInfo(session, s.str(), j);
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLedgerInfoByHash(
     soci::session& session,
     uint256 const& ledgerHash,

--- a/src/xrpld/app/rdb/backend/detail/Node.h
+++ b/src/xrpld/app/rdb/backend/detail/Node.h
@@ -123,7 +123,7 @@ saveValidatedLedger(
  * @param j Journal.
  * @return Ledger or none if ledger not found.
  */
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLedgerInfoByIndex(
     soci::session& session,
     LedgerIndex ledgerSeq,
@@ -135,7 +135,7 @@ getLedgerInfoByIndex(
  * @param j Journal.
  * @return Ledger info or none if ledger not found.
  */
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getNewestLedgerInfo(soci::session& session, beast::Journal j);
 
 /**
@@ -146,7 +146,7 @@ getNewestLedgerInfo(soci::session& session, beast::Journal j);
  * @param j Journal.
  * @return Ledger info or none if ledger not found.
  */
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLimitedOldestLedgerInfo(
     soci::session& session,
     LedgerIndex ledgerFirstIndex,
@@ -160,7 +160,7 @@ getLimitedOldestLedgerInfo(
  * @param j Journal.
  * @return Ledger info or none if ledger not found.
  */
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLimitedNewestLedgerInfo(
     soci::session& session,
     LedgerIndex ledgerFirstIndex,
@@ -173,7 +173,7 @@ getLimitedNewestLedgerInfo(
  * @param j Journal.
  * @return Ledger or none if ledger not found.
  */
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 getLedgerInfoByHash(
     soci::session& session,
     uint256 const& ledgerHash,

--- a/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
+++ b/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
@@ -73,19 +73,19 @@ public:
         std::shared_ptr<Ledger const> const& ledger,
         bool current) override;
 
-    std::optional<LedgerInfo>
+    std::optional<LedgerHeader>
     getLedgerInfoByIndex(LedgerIndex ledgerSeq) override;
 
-    std::optional<LedgerInfo>
+    std::optional<LedgerHeader>
     getNewestLedgerInfo() override;
 
-    std::optional<LedgerInfo>
+    std::optional<LedgerHeader>
     getLimitedOldestLedgerInfo(LedgerIndex ledgerFirstIndex) override;
 
-    std::optional<LedgerInfo>
+    std::optional<LedgerHeader>
     getLimitedNewestLedgerInfo(LedgerIndex ledgerFirstIndex) override;
 
-    std::optional<LedgerInfo>
+    std::optional<LedgerHeader>
     getLedgerInfoByHash(uint256 const& ledgerHash) override;
 
     uint256
@@ -399,7 +399,7 @@ SQLiteDatabaseImp::saveValidatedLedger(
     return true;
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 SQLiteDatabaseImp::getLedgerInfoByIndex(LedgerIndex ledgerSeq)
 {
     if (existsLedger())
@@ -414,7 +414,7 @@ SQLiteDatabaseImp::getLedgerInfoByIndex(LedgerIndex ledgerSeq)
     return {};
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 SQLiteDatabaseImp::getNewestLedgerInfo()
 {
     if (existsLedger())
@@ -429,7 +429,7 @@ SQLiteDatabaseImp::getNewestLedgerInfo()
     return {};
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 SQLiteDatabaseImp::getLimitedOldestLedgerInfo(LedgerIndex ledgerFirstIndex)
 {
     if (existsLedger())
@@ -445,7 +445,7 @@ SQLiteDatabaseImp::getLimitedOldestLedgerInfo(LedgerIndex ledgerFirstIndex)
     return {};
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 SQLiteDatabaseImp::getLimitedNewestLedgerInfo(LedgerIndex ledgerFirstIndex)
 {
     if (existsLedger())
@@ -461,7 +461,7 @@ SQLiteDatabaseImp::getLimitedNewestLedgerInfo(LedgerIndex ledgerFirstIndex)
     return {};
 }
 
-std::optional<LedgerInfo>
+std::optional<LedgerHeader>
 SQLiteDatabaseImp::getLedgerInfoByHash(uint256 const& ledgerHash)
 {
     if (existsLedger())

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -3227,7 +3227,7 @@ PeerImp::sendLedgerBase(
 {
     JLOG(p_journal_.trace()) << "sendLedgerBase: Base data";
 
-    Serializer s(sizeof(LedgerInfo));
+    Serializer s(sizeof(LedgerHeader));
     addRaw(ledger->info(), s);
     ledgerData.add_nodes()->set_nodedata(s.getDataPtr(), s.getLength());
 


### PR DESCRIPTION
## High Level Overview of Change

This PR renames `LedgerInfo` to `LedgerHeader`.

### Context of Change

`LedgerInfo` was already an alias for `LedgerHeader`, and the comments next to the alias suggested that it would make sense to rename it, since that makes it clearer what it is.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### API Impact

N/A

## Test Plan

It builds and CI passes. 