### PR TITLE
refactor: rename info() to header()

### DIFF
--- a/include/xrpl/ledger/CachedView.h
+++ b/include/xrpl/ledger/CachedView.h
@@ -48,9 +48,9 @@ public:
     }
 
     LedgerHeader const&
-    info() const override
+    header() const override
     {
-        return base_.info();
+        return base_.header();
     }
 
     Fees const&

--- a/include/xrpl/ledger/OpenView.h
+++ b/include/xrpl/ledger/OpenView.h
@@ -82,7 +82,7 @@ private:
         monotonic_resource_;
     txs_map txs_;
     Rules rules_;
-    LedgerHeader info_;
+    LedgerHeader header_;
     ReadView const* base_;
     detail::RawStateTable items_;
     std::shared_ptr<void const> hold_;

--- a/include/xrpl/ledger/OpenView.h
+++ b/include/xrpl/ledger/OpenView.h
@@ -189,7 +189,7 @@ public:
     // ReadView
 
     LedgerHeader const&
-    info() const override;
+    header() const override;
 
     Fees const&
     fees() const override;

--- a/include/xrpl/ledger/ReadView.h
+++ b/include/xrpl/ledger/ReadView.h
@@ -81,7 +81,7 @@ public:
 
     /** Returns information about the ledger. */
     virtual LedgerHeader const&
-    info() const = 0;
+    header() const = 0;
 
     /** Returns true if this reflects an open ledger. */
     virtual bool
@@ -91,14 +91,14 @@ public:
     NetClock::time_point
     parentCloseTime() const
     {
-        return info().parentCloseTime;
+        return header().parentCloseTime;
     }
 
     /** Returns the sequence number of the base ledger. */
     LedgerIndex
     seq() const
     {
-        return info().seq;
+        return header().seq;
     }
 
     /** Returns the fees for the base ledger. */

--- a/include/xrpl/ledger/detail/ApplyViewBase.h
+++ b/include/xrpl/ledger/detail/ApplyViewBase.h
@@ -28,7 +28,7 @@ public:
     open() const override;
 
     LedgerHeader const&
-    info() const override;
+    header() const override;
 
     Fees const&
     fees() const override;

--- a/src/libxrpl/ledger/ApplyViewBase.cpp
+++ b/src/libxrpl/ledger/ApplyViewBase.cpp
@@ -17,9 +17,9 @@ ApplyViewBase::open() const
 }
 
 LedgerHeader const&
-ApplyViewBase::info() const
+ApplyViewBase::header() const
 {
-    return base_->info();
+    return base_->header();
 }
 
 Fees const&

--- a/src/libxrpl/ledger/CredentialHelpers.cpp
+++ b/src/libxrpl/ledger/CredentialHelpers.cpp
@@ -22,7 +22,7 @@ checkExpired(
 bool
 removeExpired(ApplyView& view, STVector256 const& arr, beast::Journal const j)
 {
-    auto const closeTime = view.info().parentCloseTime;
+    auto const closeTime = view.header().parentCloseTime;
     bool foundExpired = false;
 
     for (auto const& h : arr)
@@ -181,7 +181,7 @@ validDomain(ReadView const& view, uint256 domainID, AccountID const& subject)
     if (!slePD)
         return tecOBJECT_NOT_FOUND;
 
-    auto const closeTime = view.info().parentCloseTime;
+    auto const closeTime = view.header().parentCloseTime;
     bool foundExpired = false;
     for (auto const& h : slePD->getFieldArray(sfAcceptedCredentials))
     {

--- a/src/libxrpl/ledger/OpenView.cpp
+++ b/src/libxrpl/ledger/OpenView.cpp
@@ -76,15 +76,15 @@ OpenView::OpenView(
           boost::container::pmr::monotonic_buffer_resource>(initialBufferSize)}
     , txs_{monotonic_resource_.get()}
     , rules_(rules)
-    , info_(base->info())
+    , info_(base->header())
     , base_(base)
     , hold_(std::move(hold))
 {
     info_.validated = false;
     info_.accepted = false;
-    info_.seq = base_->info().seq + 1;
-    info_.parentCloseTime = base_->info().closeTime;
-    info_.parentHash = base_->info().hash;
+    info_.seq = base_->header().seq + 1;
+    info_.parentCloseTime = base_->header().closeTime;
+    info_.parentHash = base_->header().hash;
 }
 
 OpenView::OpenView(ReadView const* base, std::shared_ptr<void const> hold)
@@ -92,7 +92,7 @@ OpenView::OpenView(ReadView const* base, std::shared_ptr<void const> hold)
           boost::container::pmr::monotonic_buffer_resource>(initialBufferSize)}
     , txs_{monotonic_resource_.get()}
     , rules_(base->rules())
-    , info_(base->info())
+    , info_(base->header())
     , base_(base)
     , hold_(std::move(hold))
     , open_(base->open())
@@ -116,7 +116,7 @@ OpenView::apply(TxsRawView& to) const
 //---
 
 LedgerHeader const&
-OpenView::info() const
+OpenView::header() const
 {
     return info_;
 }

--- a/src/libxrpl/ledger/OpenView.cpp
+++ b/src/libxrpl/ledger/OpenView.cpp
@@ -61,7 +61,7 @@ OpenView::OpenView(OpenView const& rhs)
           boost::container::pmr::monotonic_buffer_resource>(initialBufferSize)}
     , txs_{rhs.txs_, monotonic_resource_.get()}
     , rules_{rhs.rules_}
-    , info_{rhs.info_}
+    , header_{rhs.header_}
     , base_{rhs.base_}
     , items_{rhs.items_}
     , hold_{rhs.hold_}
@@ -76,15 +76,15 @@ OpenView::OpenView(
           boost::container::pmr::monotonic_buffer_resource>(initialBufferSize)}
     , txs_{monotonic_resource_.get()}
     , rules_(rules)
-    , info_(base->header())
+    , header_(base->header())
     , base_(base)
     , hold_(std::move(hold))
 {
-    info_.validated = false;
-    info_.accepted = false;
-    info_.seq = base_->header().seq + 1;
-    info_.parentCloseTime = base_->header().closeTime;
-    info_.parentHash = base_->header().hash;
+    header_.validated = false;
+    header_.accepted = false;
+    header_.seq = base_->header().seq + 1;
+    header_.parentCloseTime = base_->header().closeTime;
+    header_.parentHash = base_->header().hash;
 }
 
 OpenView::OpenView(ReadView const* base, std::shared_ptr<void const> hold)
@@ -92,7 +92,7 @@ OpenView::OpenView(ReadView const* base, std::shared_ptr<void const> hold)
           boost::container::pmr::monotonic_buffer_resource>(initialBufferSize)}
     , txs_{monotonic_resource_.get()}
     , rules_(base->rules())
-    , info_(base->header())
+    , header_(base->header())
     , base_(base)
     , hold_(std::move(hold))
     , open_(base->open())
@@ -118,7 +118,7 @@ OpenView::apply(TxsRawView& to) const
 LedgerHeader const&
 OpenView::header() const
 {
-    return info_;
+    return header_;
 }
 
 Fees const&
@@ -230,7 +230,7 @@ void
 OpenView::rawDestroyXRP(XRPAmount const& fee)
 {
     items_.destroyXRP(fee);
-    // VFALCO Deduct from info_.totalDrops ?
+    // VFALCO Deduct from header_.totalDrops ?
     //        What about child views?
 }
 

--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -907,14 +907,14 @@ areCompatible(
 {
     bool ret = true;
 
-    if (validLedger.info().seq < testLedger.info().seq)
+    if (validLedger.header().seq < testLedger.header().seq)
     {
         // valid -> ... -> test
         auto hash = hashOfSeq(
             testLedger,
-            validLedger.info().seq,
+            validLedger.header().seq,
             beast::Journal{beast::Journal::getNullSink()});
-        if (hash && (*hash != validLedger.info().hash))
+        if (hash && (*hash != validLedger.header().hash))
         {
             JLOG(s) << reason << " incompatible with valid ledger";
 
@@ -923,14 +923,14 @@ areCompatible(
             ret = false;
         }
     }
-    else if (validLedger.info().seq > testLedger.info().seq)
+    else if (validLedger.header().seq > testLedger.header().seq)
     {
         // test -> ... -> valid
         auto hash = hashOfSeq(
             validLedger,
-            testLedger.info().seq,
+            testLedger.header().seq,
             beast::Journal{beast::Journal::getNullSink()});
-        if (hash && (*hash != testLedger.info().hash))
+        if (hash && (*hash != testLedger.header().hash))
         {
             JLOG(s) << reason << " incompatible preceding ledger";
 
@@ -940,8 +940,8 @@ areCompatible(
         }
     }
     else if (
-        (validLedger.info().seq == testLedger.info().seq) &&
-        (validLedger.info().hash != testLedger.info().hash))
+        (validLedger.header().seq == testLedger.header().seq) &&
+        (validLedger.header().hash != testLedger.header().hash))
     {
         // Same sequence number, different hash
         JLOG(s) << reason << " incompatible ledger";
@@ -951,11 +951,11 @@ areCompatible(
 
     if (!ret)
     {
-        JLOG(s) << "Val: " << validLedger.info().seq << " "
-                << to_string(validLedger.info().hash);
+        JLOG(s) << "Val: " << validLedger.header().seq << " "
+                << to_string(validLedger.header().hash);
 
-        JLOG(s) << "New: " << testLedger.info().seq << " "
-                << to_string(testLedger.info().hash);
+        JLOG(s) << "New: " << testLedger.header().seq << " "
+                << to_string(testLedger.header().hash);
     }
 
     return ret;
@@ -971,7 +971,7 @@ areCompatible(
 {
     bool ret = true;
 
-    if (testLedger.info().seq > validIndex)
+    if (testLedger.header().seq > validIndex)
     {
         // Ledger we are testing follows last valid ledger
         auto hash = hashOfSeq(
@@ -987,8 +987,8 @@ areCompatible(
         }
     }
     else if (
-        (validIndex == testLedger.info().seq) &&
-        (testLedger.info().hash != validHash))
+        (validIndex == testLedger.header().seq) &&
+        (testLedger.header().hash != validHash))
     {
         JLOG(s) << reason << " incompatible ledger";
 
@@ -999,8 +999,8 @@ areCompatible(
     {
         JLOG(s) << "Val: " << validIndex << " " << to_string(validHash);
 
-        JLOG(s) << "New: " << testLedger.info().seq << " "
-                << to_string(testLedger.info().hash);
+        JLOG(s) << "New: " << testLedger.header().seq << " "
+                << to_string(testLedger.header().hash);
     }
 
     return ret;
@@ -1071,9 +1071,9 @@ hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal)
         return std::nullopt;
     }
     if (seq == ledger.seq())
-        return ledger.info().hash;
+        return ledger.header().hash;
     if (seq == (ledger.seq() - 1))
-        return ledger.info().parentHash;
+        return ledger.header().parentHash;
 
     if (int diff = ledger.seq() - seq; diff <= 256)
     {
@@ -1095,7 +1095,7 @@ hashOfSeq(ReadView const& ledger, LedgerIndex seq, beast::Journal journal)
         else
         {
             JLOG(journal.warn())
-                << "Ledger " << ledger.seq() << ":" << ledger.info().hash
+                << "Ledger " << ledger.seq() << ":" << ledger.header().hash
                 << " missing normal list";
         }
     }
@@ -1180,7 +1180,8 @@ pseudoAccountAddress(ReadView const& view, uint256 const& pseudoOwnerKey)
     for (std::uint16_t i = 0; i < maxAccountAttempts; ++i)
     {
         ripesha_hasher rsh;
-        auto const hash = sha512Half(i, view.info().parentHash, pseudoOwnerKey);
+        auto const hash =
+            sha512Half(i, view.header().parentHash, pseudoOwnerKey);
         rsh(hash.data(), hash.size());
         AccountID const ret{static_cast<ripesha_hasher::result_type>(rsh)};
         if (!view.read(keylet::account(ret)))

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -3646,7 +3646,7 @@ private:
             auto const pk = carol.pk();
             auto const settleDelay = 100s;
             NetClock::time_point const cancelAfter =
-                env.current()->info().parentCloseTime + 200s;
+                env.current()->header().parentCloseTime + 200s;
             env(paychan::create(
                     carol,
                     ammAlice.ammAccount(),

--- a/src/test/app/AccountDelete_test.cpp
+++ b/src/test/app/AccountDelete_test.cpp
@@ -922,7 +922,7 @@ public:
 
                 auto jv = credentials::create(john, carol, credType);
                 uint32_t const t = env.current()
-                                       ->info()
+                                       ->header()
                                        .parentCloseTime.time_since_epoch()
                                        .count() +
                     20;

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -336,7 +336,7 @@ struct Credentials_test : public beast::unit_test::suite
             auto const credKey = credentials::keylet(subject, issuer, credType);
             auto jv = credentials::create(subject, issuer, credType);
             uint32_t const t = env.current()
-                                   ->info()
+                                   ->header()
                                    .parentCloseTime.time_since_epoch()
                                    .count();
             jv[sfExpiration.jsonName] = t + 20;
@@ -498,7 +498,7 @@ struct Credentials_test : public beast::unit_test::suite
                 auto jv = credentials::create(subject, issuer, credType);
                 // current time in ripple epoch - 1s
                 uint32_t const t = env.current()
-                                       ->info()
+                                       ->header()
                                        .parentCloseTime.time_since_epoch()
                                        .count() -
                     1;
@@ -725,7 +725,7 @@ struct Credentials_test : public beast::unit_test::suite
                 testcase("CredentialsAccept fail, expired credentials.");
                 auto jv = credentials::create(subject, issuer, credType2);
                 uint32_t const t = env.current()
-                                       ->info()
+                                       ->header()
                                        .parentCloseTime.time_since_epoch()
                                        .count();
                 jv[sfExpiration.jsonName] = t;
@@ -870,7 +870,7 @@ struct Credentials_test : public beast::unit_test::suite
                 auto jv = credentials::create(subject, issuer, credType);
                 // current time in ripple epoch + 1000s
                 uint32_t const t = env.current()
-                                       ->info()
+                                       ->header()
                                        .parentCloseTime.time_since_epoch()
                                        .count() +
                     1000;

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -1107,7 +1107,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
             // Current time in ripple epoch.
             // Every time ledger close, unittest timer increase by 10s
             uint32_t const t = env.current()
-                                   ->info()
+                                   ->header()
                                    .parentCloseTime.time_since_epoch()
                                    .count() +
                 60;
@@ -1122,7 +1122,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
             // Create credential which not expired
             jv = credentials::create(alice, issuer, credType2);
             uint32_t const t2 = env.current()
-                                    ->info()
+                                    ->header()
                                     .parentCloseTime.time_since_epoch()
                                     .count() +
                 1000;
@@ -1199,7 +1199,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
             {
                 auto jv = credentials::create(gw, issuer, credType);
                 uint32_t const t = env.current()
-                                       ->info()
+                                       ->header()
                                        .parentCloseTime.time_since_epoch()
                                        .count() +
                     40;
@@ -1252,7 +1252,7 @@ struct DepositPreauth_test : public beast::unit_test::suite
             // Create credentials
             auto jv = credentials::create(zelda, issuer, credType);
             uint32_t const t = env.current()
-                                   ->info()
+                                   ->header()
                                    .parentCloseTime.time_since_epoch()
                                    .count() +
                 50;

--- a/src/test/app/LedgerHistory_test.cpp
+++ b/src/test/app/LedgerHistory_test.cpp
@@ -43,7 +43,7 @@ public:
                 env.app().getNodeFamily());
         }
         auto res = std::make_shared<Ledger>(
-            *prev, prev->info().closeTime + closeOffset);
+            *prev, prev->header().closeTime + closeOffset);
 
         if (stx)
         {
@@ -62,8 +62,8 @@ public:
 
         // Accept ledger
         res->setAccepted(
-            res->info().closeTime,
-            res->info().closeTimeResolution,
+            res->header().closeTime,
+            res->header().closeTimeResolution,
             true /* close time correct*/);
         lh.insert(res, false);
         return res;

--- a/src/test/app/LedgerMaster_test.cpp
+++ b/src/test/app/LedgerMaster_test.cpp
@@ -37,7 +37,7 @@ class LedgerMaster_test : public beast::unit_test::suite
         // build ledgers
         std::vector<std::shared_ptr<STTx const>> txns;
         std::vector<std::shared_ptr<STObject const>> metas;
-        auto const startLegSeq = env.current()->info().seq;
+        auto const startLegSeq = env.current()->header().seq;
         for (int i = 0; i < 2; ++i)
         {
             env(noop(alice));
@@ -48,7 +48,7 @@ class LedgerMaster_test : public beast::unit_test::suite
         }
         // add last (empty) ledger
         env.close();
-        auto const endLegSeq = env.closed()->info().seq;
+        auto const endLegSeq = env.closed()->header().seq;
 
         // test invalid range
         {

--- a/src/test/app/LedgerReplay_test.cpp
+++ b/src/test/app/LedgerReplay_test.cpp
@@ -40,7 +40,7 @@ struct LedgerReplay_test : public beast::unit_test::suite
         LedgerMaster& ledgerMaster = env.app().getLedgerMaster();
         auto const lastClosed = ledgerMaster.getClosedLedger();
         auto const lastClosedParent =
-            ledgerMaster.getLedgerByHash(lastClosed->info().parentHash);
+            ledgerMaster.getLedgerByHash(lastClosed->header().parentHash);
 
         auto const replayed = buildLedger(
             LedgerReplay(lastClosedParent, lastClosed),
@@ -48,7 +48,7 @@ struct LedgerReplay_test : public beast::unit_test::suite
             env.app(),
             env.journal);
 
-        BEAST_EXPECT(replayed->info().hash == lastClosed->info().hash);
+        BEAST_EXPECT(replayed->header().hash == lastClosed->header().hash);
     }
 };
 
@@ -610,7 +610,7 @@ public:
             auto const l = ledgerMaster.getLedgerByHash(hash);
             if (!l)
                 return false;
-            hash = l->info().parentHash;
+            hash = l->header().parentHash;
         }
         return true;
     }
@@ -890,7 +890,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             // request, missing key
             auto request = std::make_shared<protocol::TMProofPathRequest>();
             request->set_ledgerhash(
-                l->info().hash.data(), l->info().hash.size());
+                l->header().hash.data(), l->header().hash.size());
             request->set_type(protocol::TMLedgerMapType::lmACCOUNT_STATE);
             auto reply = std::make_shared<protocol::TMProofPathResponse>(
                 server.msgHandler.processProofPathRequest(request));
@@ -914,7 +914,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             // good request
             auto request = std::make_shared<protocol::TMProofPathRequest>();
             request->set_ledgerhash(
-                l->info().hash.data(), l->info().hash.size());
+                l->header().hash.data(), l->header().hash.size());
             request->set_type(protocol::TMLedgerMapType::lmACCOUNT_STATE);
             request->set_key(
                 keylet::skip().key.data(), keylet::skip().key.size());
@@ -970,7 +970,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             // good request
             auto request = std::make_shared<protocol::TMReplayDeltaRequest>();
             request->set_ledgerhash(
-                l->info().hash.data(), l->info().hash.size());
+                l->header().hash.data(), l->header().hash.size());
             auto reply = std::make_shared<protocol::TMReplayDeltaResponse>(
                 server.msgHandler.processReplayDeltaRequest(request));
             BEAST_EXPECT(!reply->has_error());
@@ -1132,7 +1132,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
         NetworkOfTwo net(*this, {totalReplay + 1}, psBhvr, ilBhvr, peerFeature);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         for (int i = 0; i < totalReplay; ++i)
         {
             BEAST_EXPECT(l);
@@ -1140,7 +1140,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             {
                 net.client.ledgerMaster.storeLedger(l);
                 l = net.server.ledgerMaster.getLedgerByHash(
-                    l->info().parentHash);
+                    l->header().parentHash);
             }
             else
                 break;
@@ -1175,7 +1175,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             PeerFeature::None);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
 
@@ -1220,10 +1220,10 @@ struct LedgerReplayer_test : public beast::unit_test::suite
 
         // feed client with start ledger since InboundLedgers drops all
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         for (int i = 0; i < totalReplay - 1; ++i)
         {
-            l = net.server.ledgerMaster.getLedgerByHash(l->info().parentHash);
+            l = net.server.ledgerMaster.getLedgerByHash(l->header().parentHash);
         }
         net.client.ledgerMaster.storeLedger(l);
 
@@ -1258,7 +1258,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             PeerFeature::LedgerReplayEnabled);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
 
@@ -1288,7 +1288,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             PeerFeature::LedgerReplayEnabled);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
 
@@ -1333,14 +1333,14 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             PeerFeature::LedgerReplayEnabled);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.ledgerMaster.storeLedger(l);
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
 
-        auto delta = net.client.findLedgerDeltaAcquire(l->info().parentHash);
+        auto delta = net.client.findLedgerDeltaAcquire(l->header().parentHash);
         delta->processData(
-            l->info(),  // wrong ledger info
+            l->header(),  // wrong ledger info
             std::map<std::uint32_t, std::shared_ptr<STTx const>>());
         BEAST_EXPECT(net.client.taskStatus(delta) == TaskStatus::Failed);
         BEAST_EXPECT(
@@ -1367,7 +1367,7 @@ struct LedgerReplayer_test : public beast::unit_test::suite
             InboundLedgersBehavior::Good,
             PeerFeature::LedgerReplayEnabled);
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
         std::vector<TaskStatus> deltaStatuses(
@@ -1392,9 +1392,9 @@ struct LedgerReplayer_test : public beast::unit_test::suite
         // no overlap
         for (int i = 0; i < totalReplay + 2; ++i)
         {
-            l = net.server.ledgerMaster.getLedgerByHash(l->info().parentHash);
+            l = net.server.ledgerMaster.getLedgerByHash(l->header().parentHash);
         }
-        auto finalHash_early = l->info().hash;
+        auto finalHash_early = l->header().hash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash_early, totalReplay);
         BEAST_EXPECT(net.client.waitAndCheckStatus(
@@ -1407,8 +1407,8 @@ struct LedgerReplayer_test : public beast::unit_test::suite
         BEAST_EXPECT(net.client.countsAsExpected(3, 2, 2 * (totalReplay - 1)));
 
         // partial overlap
-        l = net.server.ledgerMaster.getLedgerByHash(l->info().parentHash);
-        auto finalHash_moreEarly = l->info().parentHash;
+        l = net.server.ledgerMaster.getLedgerByHash(l->header().parentHash);
+        auto finalHash_moreEarly = l->header().parentHash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash_moreEarly, totalReplay);
         BEAST_EXPECT(net.client.waitAndCheckStatus(
@@ -1479,7 +1479,7 @@ struct LedgerReplayerTimeout_test : public beast::unit_test::suite
             PeerFeature::LedgerReplayEnabled);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
 
@@ -1510,7 +1510,7 @@ struct LedgerReplayerTimeout_test : public beast::unit_test::suite
             PeerFeature::LedgerReplayEnabled);
 
         auto l = net.server.ledgerMaster.getClosedLedger();
-        uint256 finalHash = l->info().hash;
+        uint256 finalHash = l->header().hash;
         net.client.ledgerMaster.storeLedger(l);
         net.client.replayer.replay(
             InboundLedger::Reason::GENERIC, finalHash, totalReplay);
@@ -1558,11 +1558,11 @@ struct LedgerReplayerLong_test : public beast::unit_test::suite
         auto l = net.server.ledgerMaster.getClosedLedger();
         for (int i = 0; i < rounds; ++i)
         {
-            finishHashes.push_back(l->info().hash);
+            finishHashes.push_back(l->header().hash);
             for (int j = 0; j < totalReplay; ++j)
             {
                 l = net.server.ledgerMaster.getLedgerByHash(
-                    l->info().parentHash);
+                    l->header().parentHash);
             }
         }
         BEAST_EXPECT(finishHashes.size() == rounds);

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -1398,7 +1398,7 @@ protected:
         env.close();
 
         auto const startDate =
-            env.current()->info().parentCloseTime.time_since_epoch().count();
+            env.current()->header().parentCloseTime.time_since_epoch().count();
 
         if (auto const brokerSle = env.le(keylet::loanbroker(broker.brokerID));
             BEAST_EXPECT(brokerSle))
@@ -3761,7 +3761,7 @@ protected:
 
         env.close();
 
-        auto const startDate = env.current()->info().parentCloseTime;
+        auto const startDate = env.current()->header().parentCloseTime;
 
         // Loan is successfully created
         {

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -57,7 +57,10 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
     std::uint32_t
     lastClose(test::jtx::Env& env)
     {
-        return env.current()->info().parentCloseTime.time_since_epoch().count();
+        return env.current()
+            ->header()
+            .parentCloseTime.time_since_epoch()
+            .count();
     }
 
     void

--- a/src/test/app/NetworkID_test.cpp
+++ b/src/test/app/NetworkID_test.cpp
@@ -112,7 +112,7 @@ public:
                 jvn[jss::TransactionType] = jss::AccountSet;
                 jvn[jss::Fee] = to_string(env.current()->fees().base);
                 jvn[jss::Sequence] = env.seq(alice);
-                jvn[jss::LastLedgerSequence] = env.current()->info().seq + 2;
+                jvn[jss::LastLedgerSequence] = env.current()->header().seq + 2;
                 auto jt = env.jtnofill(jvn);
                 Serializer s;
                 jt.stx->add(s);

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -20,7 +20,10 @@ class OfferBaseUtil_test : public beast::unit_test::suite
     std::uint32_t
     lastClose(jtx::Env& env)
     {
-        return env.current()->info().parentCloseTime.time_since_epoch().count();
+        return env.current()
+            ->header()
+            .parentCloseTime.time_since_epoch()
+            .count();
     }
 
     static auto

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -252,7 +252,9 @@ private:
                 static_cast<int>(env.current()->fees().base.drops());
             auto closeTime = [&]() {
                 return duration_cast<seconds>(
-                           env.current()->info().closeTime.time_since_epoch() -
+                           env.current()
+                               ->header()
+                               .closeTime.time_since_epoch() -
                            10'000s)
                     .count();
             };
@@ -559,7 +561,7 @@ private:
             BEAST_EXPECT(oracle.exists());
             BEAST_EXPECT(oracle1.exists());
             auto const index = env.closed()->seq();
-            auto const hash = env.closed()->info().hash;
+            auto const hash = env.closed()->header().hash;
             for (int i = 0; i < 256; ++i)
                 env.close();
             env(acctdelete(owner, alice), fee(acctDelFee));

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -322,7 +322,7 @@ struct PayChan_test : public beast::unit_test::suite
             auto const pk = alice.pk();
             auto const settleDelay = 100s;
             NetClock::time_point const cancelAfter =
-                env.current()->info().parentCloseTime + 3600s;
+                env.current()->header().parentCloseTime + 3600s;
             auto const channelFunds = XRP(1000);
             auto const chan = channel(alice, bob, env.seq(alice));
             env(create(alice, bob, channelFunds, settleDelay, pk, cancelAfter));
@@ -354,7 +354,7 @@ struct PayChan_test : public beast::unit_test::suite
             auto const pk = alice.pk();
             auto const settleDelay = 100s;
             NetClock::time_point const cancelAfter =
-                env.current()->info().parentCloseTime + 3600s;
+                env.current()->header().parentCloseTime + 3600s;
             auto const channelFunds = XRP(1000);
             auto const chan = channel(alice, bob, env.seq(alice));
             env(create(alice, bob, channelFunds, settleDelay, pk, cancelAfter));
@@ -385,7 +385,7 @@ struct PayChan_test : public beast::unit_test::suite
                 auto const settleDelay = 100s;
                 auto const channelFunds = XRP(1000);
                 NetClock::time_point const cancelAfter =
-                    env.current()->info().parentCloseTime - 1s;
+                    env.current()->header().parentCloseTime - 1s;
                 auto const txResult =
                     withFixPayChan ? ter(tecEXPIRED) : ter(tesSUCCESS);
                 env(create(
@@ -409,7 +409,7 @@ struct PayChan_test : public beast::unit_test::suite
                 auto const settleDelay = 100s;
                 auto const channelFunds = XRP(1000);
                 NetClock::time_point const cancelAfter =
-                    env.current()->info().parentCloseTime;
+                    env.current()->header().parentCloseTime;
                 env(create(
                         alice, bob, channelFunds, settleDelay, pk, cancelAfter),
                     ter(tesSUCCESS));
@@ -430,7 +430,7 @@ struct PayChan_test : public beast::unit_test::suite
         env.fund(XRP(10000), alice, bob, carol);
         auto const pk = alice.pk();
         auto const settleDelay = 3600s;
-        auto const closeTime = env.current()->info().parentCloseTime;
+        auto const closeTime = env.current()->header().parentCloseTime;
         auto const minExpiration = closeTime + settleDelay;
         NetClock::time_point const cancelAfter = closeTime + 7200s;
         auto const channelFunds = XRP(1000);
@@ -496,7 +496,7 @@ struct PayChan_test : public beast::unit_test::suite
         auto const pk = alice.pk();
         auto const settleDelay = 3600s;
         NetClock::time_point const settleTimepoint =
-            env.current()->info().parentCloseTime + settleDelay;
+            env.current()->header().parentCloseTime + settleDelay;
         auto const channelFunds = XRP(1000);
         auto const chan = channel(alice, bob, env.seq(alice));
         env(create(alice, bob, channelFunds, settleDelay, pk));
@@ -861,7 +861,7 @@ struct PayChan_test : public beast::unit_test::suite
             {  // create credentials
                 auto jv = credentials::create(alice, carol, credType);
                 uint32_t const t = env.current()
-                                       ->info()
+                                       ->header()
                                        .parentCloseTime.time_since_epoch()
                                        .count() +
                     100;
@@ -1910,7 +1910,7 @@ struct PayChan_test : public beast::unit_test::suite
                 env.close();
                 // settle delay hasn't elapsed. Channels should exist.
                 BEAST_EXPECT(channelExists(*env.current(), chan));
-                auto const closeTime = env.current()->info().parentCloseTime;
+                auto const closeTime = env.current()->header().parentCloseTime;
                 auto const minExpiration = closeTime + settleDelay;
                 env.close(minExpiration);
                 env(claim(alice, chan), txflags(tfClose));

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -242,7 +242,7 @@ class PermissionedDEX_test : public beast::unit_test::suite
 
             auto jv = credentials::create(devin, domainOwner, credType);
             uint32_t const t = env.current()
-                                   ->info()
+                                   ->header()
                                    .parentCloseTime.time_since_epoch()
                                    .count();
             jv[sfExpiration.jsonName] = t + 20;
@@ -797,7 +797,7 @@ class PermissionedDEX_test : public beast::unit_test::suite
 
             auto jv = credentials::create(devin, domainOwner, credType);
             uint32_t const t = env.current()
-                                   ->info()
+                                   ->header()
                                    .parentCloseTime.time_since_epoch()
                                    .count();
             jv[sfExpiration.jsonName] = t + 20;

--- a/src/test/app/RCLValidations_test.cpp
+++ b/src/test/app/RCLValidations_test.cpp
@@ -111,13 +111,13 @@ class RCLValidations_test : public beast::unit_test::suite
         {
             std::shared_ptr<Ledger const> ledger = history.back();
             RCLValidatedLedger a{ledger, env.journal};
-            BEAST_EXPECT(a.seq() == ledger->info().seq);
+            BEAST_EXPECT(a.seq() == ledger->header().seq);
             BEAST_EXPECT(a.minSeq() == a.seq() - maxAncestors);
             // Ensure the ancestral 256 ledgers have proper ID
             for (Seq s = a.seq(); s > 0; s--)
             {
                 if (s >= a.minSeq())
-                    BEAST_EXPECT(a[s] == history[s - 1]->info().hash);
+                    BEAST_EXPECT(a[s] == history[s - 1]->header().hash);
                 else
                     BEAST_EXPECT(a[s] == ID{0});
             }

--- a/src/test/app/Regression_test.cpp
+++ b/src/test/app/Regression_test.cpp
@@ -50,7 +50,7 @@ struct Regression_test : public beast::unit_test::suite
             std::vector<uint256>{},
             env.app().getNodeFamily());
         auto expectedDrops = INITIAL_XRP;
-        BEAST_EXPECT(closed->info().drops == expectedDrops);
+        BEAST_EXPECT(closed->header().drops == expectedDrops);
 
         auto const aliceXRP = 400;
         auto const aliceAmount = XRP(aliceXRP);
@@ -70,7 +70,7 @@ struct Regression_test : public beast::unit_test::suite
             accum.apply(*next);
         }
         expectedDrops -= next->fees().base;
-        BEAST_EXPECT(next->info().drops == expectedDrops);
+        BEAST_EXPECT(next->header().drops == expectedDrops);
         {
             auto const sle = next->read(keylet::account(Account("alice").id()));
             BEAST_EXPECT(sle);
@@ -101,7 +101,7 @@ struct Regression_test : public beast::unit_test::suite
             BEAST_EXPECT(balance == XRP(0));
         }
         expectedDrops -= aliceXRP * dropsPerXRP;
-        BEAST_EXPECT(next->info().drops == expectedDrops);
+        BEAST_EXPECT(next->header().drops == expectedDrops);
     }
 
     void

--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -726,7 +726,7 @@ public:
         env(noop(daria));
         checkMetrics(*this, env, 0, std::nullopt, 3, 2);
 
-        BEAST_EXPECT(env.current()->info().seq == 6);
+        BEAST_EXPECT(env.current()->header().seq == 6);
         // Fail to queue an item with a low LastLedgerSeq
         env(noop(alice), last_ledger_seq(7), ter(telCAN_NOT_QUEUE));
         // Queue an item with a sufficient LastLedgerSeq.
@@ -1075,7 +1075,7 @@ public:
         // Alice - fill up the queue
         std::int64_t aliceFee = 27;
         aliceSeq = env.seq(alice);
-        auto lastLedgerSeq = env.current()->info().seq + 2;
+        auto lastLedgerSeq = env.current()->header().seq + 2;
         for (auto i = 0; i < 7; i++)
         {
             env(noop(alice),
@@ -2683,7 +2683,7 @@ public:
         checkMetrics(*this, env, 0, std::nullopt, 2, 1);
 
         auto const aliceSeq = env.seq(alice);
-        BEAST_EXPECT(env.current()->info().seq == 3);
+        BEAST_EXPECT(env.current()->header().seq == 3);
         env(noop(alice), seq(aliceSeq), last_ledger_seq(5), ter(terQUEUED));
         env(noop(alice), seq(aliceSeq + 1), last_ledger_seq(5), ter(terQUEUED));
         env(noop(alice),
@@ -2779,7 +2779,7 @@ public:
         checkMetrics(*this, env, 0, std::nullopt, 2, 1);
 
         auto const aliceSeq = env.seq(alice);
-        BEAST_EXPECT(env.current()->info().seq == 3);
+        BEAST_EXPECT(env.current()->header().seq == 3);
 
         // Start by procuring tickets for alice to use to keep her queue full
         // without affecting the sequence gap that will appear later.
@@ -2932,7 +2932,7 @@ public:
 
         // Queue up several transactions for alice sign-and-submit
         auto const aliceSeq = env.seq(alice);
-        auto const lastLedgerSeq = env.current()->info().seq + 2;
+        auto const lastLedgerSeq = env.current()->header().seq + 2;
 
         auto submitParams = Json::Value(Json::objectValue);
         for (int i = 0; i < 5; ++i)
@@ -3073,7 +3073,7 @@ public:
         prevLedgerWithQueue[jss::account] = alice.human();
         prevLedgerWithQueue[jss::queue] = true;
         prevLedgerWithQueue[jss::ledger_index] = 3;
-        BEAST_EXPECT(env.current()->info().seq > 3);
+        BEAST_EXPECT(env.current()->header().seq > 3);
 
         {
             // account_info without the "queue" argument.

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -3520,7 +3520,7 @@ class Vault_test : public beast::unit_test::suite
         {
             testcase("private vault expired authorization");
             uint32_t const closeTime = env.current()
-                                           ->info()
+                                           ->header()
                                            .parentCloseTime.time_since_epoch()
                                            .count();
             {

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -621,7 +621,7 @@ struct NetworkHistory
             keyPair.second,
             v,
             [&](STValidation& v) {
-                v.setFieldH256(sfLedgerHash, ledger->info().hash);
+                v.setFieldH256(sfLedgerHash, ledger->header().hash);
                 v.setFieldU32(sfLedgerSequence, ledger->seq());
                 v.setFlag(vfFullValidation);
             });
@@ -1773,7 +1773,7 @@ class NegativeUNLVoteFilterValidations_test : public beast::unit_test::suite
                 keys.second,
                 calcNodeID(keys.first),
                 [&](STValidation& v) {
-                    v.setFieldH256(sfLedgerHash, l->info().hash);
+                    v.setFieldH256(sfLedgerHash, l->header().hash);
                     v.setFieldU32(sfLedgerSequence, l->seq());
                     v.setFlag(vfFullValidation);
                 });

--- a/src/test/jtx/impl/Env.cpp
+++ b/src/test/jtx/impl/Env.cpp
@@ -67,7 +67,8 @@ Env::AppBundle::AppBundle(
     app->logs().threshold(thresh);
     if (!app->setup({}))
         Throw<std::runtime_error>("Env::AppBundle: setup failed");
-    timeKeeper->set(app->getLedgerMaster().getClosedLedger()->info().closeTime);
+    timeKeeper->set(
+        app->getLedgerMaster().getClosedLedger()->header().closeTime);
     app->start(false /*don't start timers*/);
     thread = std::thread([&]() { app->run(); });
 
@@ -107,7 +108,7 @@ Env::close(
     // Round up to next distinguishable value
     using namespace std::chrono_literals;
     bool res = true;
-    closeTime += closed()->info().closeTimeResolution - 1s;
+    closeTime += closed()->header().closeTimeResolution - 1s;
     timeKeeper().set(closeTime);
     // Go through the rpc interface unless we need to simulate
     // a specific consensus delay.
@@ -130,7 +131,7 @@ Env::close(
             res = false;
         }
     }
-    timeKeeper().set(closed()->info().closeTime);
+    timeKeeper().set(closed()->header().closeTime);
     return res;
 }
 

--- a/src/test/jtx/impl/Oracle.cpp
+++ b/src/test/jtx/impl/Oracle.cpp
@@ -216,7 +216,7 @@ Oracle::set(UpdateArg const& arg)
     else
         jv[jss::LastUpdateTime] = to_string(
             duration_cast<seconds>(
-                env_.current()->info().closeTime.time_since_epoch())
+                env_.current()->header().closeTime.time_since_epoch())
                 .count() +
             epoch_offset.count());
     Json::Value dataSeries(Json::arrayValue);

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -436,7 +436,7 @@ struct Directory_test : public beast::unit_test::suite
         // exist
         env(offer(alice, XRP(1), USD(1)));
         auto const txID = to_string(env.tx()->getTransactionID());
-        auto const ledgerSeq = env.current()->info().seq;
+        auto const ledgerSeq = env.current()->header().seq;
         env.close();
         // Make sure the fields only exist if the object is touched
         env(noop(gw));

--- a/src/test/ledger/SkipList_test.cpp
+++ b/src/test/ledger/SkipList_test.cpp
@@ -35,32 +35,35 @@ class SkipList_test : public beast::unit_test::suite
 
         {
             auto l = *(std::next(std::begin(history)));
-            BEAST_EXPECT((*std::begin(history))->info().seq < l->info().seq);
             BEAST_EXPECT(
-                !hashOfSeq(*l, l->info().seq + 1, env.journal).has_value());
+                (*std::begin(history))->header().seq < l->header().seq);
             BEAST_EXPECT(
-                hashOfSeq(*l, l->info().seq, env.journal) == l->info().hash);
+                !hashOfSeq(*l, l->header().seq + 1, env.journal).has_value());
             BEAST_EXPECT(
-                hashOfSeq(*l, l->info().seq - 1, env.journal) ==
-                l->info().parentHash);
-            BEAST_EXPECT(!hashOfSeq(*history.back(), l->info().seq, env.journal)
-                              .has_value());
+                hashOfSeq(*l, l->header().seq, env.journal) ==
+                l->header().hash);
+            BEAST_EXPECT(
+                hashOfSeq(*l, l->header().seq - 1, env.journal) ==
+                l->header().parentHash);
+            BEAST_EXPECT(
+                !hashOfSeq(*history.back(), l->header().seq, env.journal)
+                     .has_value());
         }
 
         // ledger skip lists store up to the previous 256 hashes
         for (auto i = history.crbegin(); i != history.crend(); i += 256)
         {
             for (auto n = i;
-                 n != std::next(i, (*i)->info().seq - 256 > 1 ? 257 : 256);
+                 n != std::next(i, (*i)->header().seq - 256 > 1 ? 257 : 256);
                  ++n)
             {
                 BEAST_EXPECT(
-                    hashOfSeq(**i, (*n)->info().seq, env.journal) ==
-                    (*n)->info().hash);
+                    hashOfSeq(**i, (*n)->header().seq, env.journal) ==
+                    (*n)->header().hash);
             }
 
             // edge case accessing beyond 256
-            BEAST_EXPECT(!hashOfSeq(**i, (*i)->info().seq - 258, env.journal)
+            BEAST_EXPECT(!hashOfSeq(**i, (*i)->header().seq - 258, env.journal)
                               .has_value());
         }
 
@@ -71,8 +74,8 @@ class SkipList_test : public beast::unit_test::suite
             for (auto n = std::next(i, 512); n != history.crend(); n += 256)
             {
                 BEAST_EXPECT(
-                    hashOfSeq(**i, (*n)->info().seq, env.journal) ==
-                    (*n)->info().hash);
+                    hashOfSeq(**i, (*n)->header().seq, env.journal) ==
+                    (*n)->header().hash);
             }
         }
     }

--- a/src/test/ledger/View_test.cpp
+++ b/src/test/ledger/View_test.cpp
@@ -1019,8 +1019,8 @@ class View_test : public beast::unit_test::suite
 
         // Try the other interface.
         // Note that the different interface has different outcomes.
-        auto const& iA3 = rdViewA3->info();
-        auto const& iA4 = rdViewA4->info();
+        auto const& iA3 = rdViewA3->header();
+        auto const& iA4 = rdViewA4->header();
 
         BEAST_EXPECT(areCompatible(iA3.hash, iA3.seq, *rdViewA4, jStream, ""));
         BEAST_EXPECT(areCompatible(iA4.hash, iA4.seq, *rdViewA3, jStream, ""));

--- a/src/test/rpc/AccountLines_test.cpp
+++ b/src/test/rpc/AccountLines_test.cpp
@@ -68,7 +68,7 @@ public:
         }
         env.fund(XRP(10000), alice);
         env.close();
-        LedgerHeader const ledger3Info = env.closed()->info();
+        LedgerHeader const ledger3Info = env.closed()->header();
         BEAST_EXPECT(ledger3Info.seq == 3);
 
         {
@@ -118,7 +118,7 @@ public:
             env(pay(gw1, alice, gw1Currency(50 + c)));
         }
         env.close();
-        LedgerHeader const ledger4Info = env.closed()->info();
+        LedgerHeader const ledger4Info = env.closed()->header();
         BEAST_EXPECT(ledger4Info.seq == 4);
 
         // Add another set of trust lines in another ledger so we can see
@@ -153,7 +153,7 @@ public:
                 tfSetNoRipple | tfSetFreeze | tfSetDeepFreeze));
         }
         env.close();
-        LedgerHeader const ledger58Info = env.closed()->info();
+        LedgerHeader const ledger58Info = env.closed()->header();
         BEAST_EXPECT(ledger58Info.seq == 58);
 
         // A re-usable test for historic ledgers.
@@ -817,7 +817,7 @@ public:
         }
         env.fund(XRP(10000), alice);
         env.close();
-        LedgerHeader const ledger3Info = env.closed()->info();
+        LedgerHeader const ledger3Info = env.closed()->header();
         BEAST_EXPECT(ledger3Info.seq == 3);
 
         {
@@ -899,7 +899,7 @@ public:
             env(pay(gw1, alice, gw1Currency(50 + c)));
         }
         env.close();
-        LedgerHeader const ledger4Info = env.closed()->info();
+        LedgerHeader const ledger4Info = env.closed()->header();
         BEAST_EXPECT(ledger4Info.seq == 4);
 
         // Add another set of trust lines in another ledger so we can see
@@ -934,7 +934,7 @@ public:
                 tfSetNoRipple | tfSetFreeze | tfSetDeepFreeze));
         }
         env.close();
-        LedgerHeader const ledger58Info = env.closed()->info();
+        LedgerHeader const ledger58Info = env.closed()->header();
         BEAST_EXPECT(ledger58Info.seq == 58);
 
         // A re-usable test for historic ledgers.

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -242,7 +242,7 @@ class AccountTx_test : public beast::unit_test::suite
                     env.rpc("json", "account_tx", to_string(p)),
                     rpcLGR_IDX_MALFORMED));
 
-            p[jss::ledger_index_min] = env.current()->info().seq;
+            p[jss::ledger_index_min] = env.current()->header().seq;
             BEAST_EXPECT(isErr(
                 env.rpc("json", "account_tx", to_string(p)),
                 (apiVersion == 1 ? rpcLGR_IDXS_INVALID
@@ -256,7 +256,7 @@ class AccountTx_test : public beast::unit_test::suite
             BEAST_EXPECT(hasTxs(
                 env.rpc(apiVersion, "json", "account_tx", to_string(p))));
 
-            p[jss::ledger_index_max] = env.current()->info().seq;
+            p[jss::ledger_index_max] = env.current()->header().seq;
             if (apiVersion < 2u)
                 BEAST_EXPECT(hasTxs(
                     env.rpc(apiVersion, "json", "account_tx", to_string(p))));
@@ -269,11 +269,11 @@ class AccountTx_test : public beast::unit_test::suite
             BEAST_EXPECT(hasTxs(
                 env.rpc(apiVersion, "json", "account_tx", to_string(p))));
 
-            p[jss::ledger_index_max] = env.closed()->info().seq;
+            p[jss::ledger_index_max] = env.closed()->header().seq;
             BEAST_EXPECT(hasTxs(
                 env.rpc(apiVersion, "json", "account_tx", to_string(p))));
 
-            p[jss::ledger_index_max] = env.closed()->info().seq - 1;
+            p[jss::ledger_index_max] = env.closed()->header().seq - 1;
             BEAST_EXPECT(noTxs(env.rpc("json", "account_tx", to_string(p))));
         }
 
@@ -281,19 +281,19 @@ class AccountTx_test : public beast::unit_test::suite
         {
             Json::Value p{jParams};
 
-            p[jss::ledger_index] = env.closed()->info().seq;
+            p[jss::ledger_index] = env.closed()->header().seq;
             BEAST_EXPECT(hasTxs(
                 env.rpc(apiVersion, "json", "account_tx", to_string(p))));
 
-            p[jss::ledger_index] = env.closed()->info().seq - 1;
+            p[jss::ledger_index] = env.closed()->header().seq - 1;
             BEAST_EXPECT(noTxs(env.rpc("json", "account_tx", to_string(p))));
 
-            p[jss::ledger_index] = env.current()->info().seq;
+            p[jss::ledger_index] = env.current()->header().seq;
             BEAST_EXPECT(isErr(
                 env.rpc("json", "account_tx", to_string(p)),
                 rpcLGR_NOT_VALIDATED));
 
-            p[jss::ledger_index] = env.current()->info().seq + 1;
+            p[jss::ledger_index] = env.current()->header().seq + 1;
             BEAST_EXPECT(isErr(
                 env.rpc("json", "account_tx", to_string(p)), rpcLGR_NOT_FOUND));
         }
@@ -302,11 +302,11 @@ class AccountTx_test : public beast::unit_test::suite
         {
             Json::Value p{jParams};
 
-            p[jss::ledger_hash] = to_string(env.closed()->info().hash);
+            p[jss::ledger_hash] = to_string(env.closed()->header().hash);
             BEAST_EXPECT(hasTxs(
                 env.rpc(apiVersion, "json", "account_tx", to_string(p))));
 
-            p[jss::ledger_hash] = to_string(env.closed()->info().parentHash);
+            p[jss::ledger_hash] = to_string(env.closed()->header().parentHash);
             BEAST_EXPECT(noTxs(env.rpc("json", "account_tx", to_string(p))));
         }
 
@@ -333,7 +333,7 @@ class AccountTx_test : public beast::unit_test::suite
         // Ledger index max only
         {
             Json::Value p{jParams};
-            p[jss::ledger_index_max] = env.current()->info().seq;
+            p[jss::ledger_index_max] = env.current()->header().seq;
             if (apiVersion < 2u)
                 BEAST_EXPECT(hasTxs(
                     env.rpc(apiVersion, "json", "account_tx", to_string(p))));
@@ -903,7 +903,7 @@ class AccountTx_test : public beast::unit_test::suite
         //
         // ledger hash should be fixed regardless any change to account history
         // BEAST_EXPECT(
-        //     to_string(env.closed()->info().hash) ==
+        //     to_string(env.closed()->header().hash) ==
         //     "0BD507BB87D3C0E73B462485E6E381798A8C82FC49BF17FE39C60E08A1AF035D");
 
         // alice authorizes bob

--- a/src/test/rpc/DepositAuthorized_test.cpp
+++ b/src/test/rpc/DepositAuthorized_test.cpp
@@ -557,7 +557,7 @@ public:
             // check expired credentials
             char const credType2[] = "fghijk";
             std::uint32_t const x = env.current()
-                                        ->info()
+                                        ->header()
                                         .parentCloseTime.time_since_epoch()
                                         .count() +
                 40;

--- a/src/test/rpc/LedgerData_test.cpp
+++ b/src/test/rpc/LedgerData_test.cpp
@@ -217,7 +217,7 @@ public:
             if (BEAST_EXPECT(jrr.isMember(jss::ledger)))
                 BEAST_EXPECT(
                     jrr[jss::ledger][jss::ledger_hash] ==
-                    to_string(env.closed()->info().hash));
+                    to_string(env.closed()->header().hash));
         }
         {
             // Closed ledger with binary form

--- a/src/test/rpc/LedgerEntry_test.cpp
+++ b/src/test/rpc/LedgerEntry_test.cpp
@@ -539,7 +539,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env.fund(XRP(10000), alice);
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         {
             // Exercise ledger_closed along the way.
             Json::Value const jrr = env.rpc("ledger_closed")[jss::result];
@@ -646,7 +646,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(check::create(env.master, alice, XRP(100)));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         {
             // Request a check.
             Json::Value jvParams;
@@ -765,7 +765,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env.close();
         env(delegate::set(alice, bob, {"Payment", "CheckCreate"}));
         env.close();
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         std::string delegateIndex;
         {
             // Request by account and authorize
@@ -823,7 +823,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(deposit::auth(alice, becky));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         std::string depositPreauthIndex;
         {
             // Request a depositPreauth by owner and authorized.
@@ -1171,7 +1171,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         }
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         {
             // Exercise ledger_closed along the way.
             Json::Value const jrr = env.rpc("ledger_closed")[jss::result];
@@ -1331,7 +1331,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(escrowCreate(alice, alice, XRP(333), env.now() + 2s));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         std::string escrowIndex;
         {
             // Request the escrow using owner and sequence.
@@ -1379,7 +1379,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(offer(alice, USD(321), XRP(322)));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         std::string offerIndex;
         {
             // Request the offer using owner and sequence.
@@ -1443,7 +1443,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(payChanCreate(alice, env.master, XRP(57), 18s, alice.pk()));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
 
         uint256 const payChanIndex{
             keylet::payChan(alice, env.master, env.seq(alice) - 1).key};
@@ -1495,7 +1495,8 @@ class LedgerEntry_test : public beast::unit_test::suite
         // check both aliases
         for (auto const& fieldName : {jss::ripple_state, jss::state})
         {
-            std::string const ledgerHash{to_string(env.closed()->info().hash)};
+            std::string const ledgerHash{
+                to_string(env.closed()->header().hash)};
             {
                 // Request the trust line using the accounts and currency.
                 Json::Value jvParams;
@@ -1637,7 +1638,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(ticket::create(env.master, 2));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         // Request four tickets: one before the first one we created, the
         // two created tickets, and the ticket that would come after the
         // last created ticket.
@@ -1734,7 +1735,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(didCreate(alice));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
 
         {
             // Request the DID using its index.
@@ -1865,7 +1866,7 @@ class LedgerEntry_test : public beast::unit_test::suite
                  tfMPTCanTrade | tfMPTCanTransfer | tfMPTCanClawback});
         mptAlice.authorize({.account = bob, .holderCount = 1});
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
 
         std::string const badMptID =
             "00000193B9DDCAF401B5B3B26875986043F82CD0D13B4315";
@@ -2024,7 +2025,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         env(check::create(env.master, alice, XRP(100)));
         env.close();
 
-        std::string const ledgerHash{to_string(env.closed()->info().hash)};
+        std::string const ledgerHash{to_string(env.closed()->header().hash)};
         {
             // Request a check.
             Json::Value const jrr =
@@ -2095,7 +2096,7 @@ class LedgerEntry_XChain_test : public beast::unit_test::suite,
 
         createBridgeObjects(mcEnv, scEnv);
 
-        std::string const ledgerHash{to_string(mcEnv.closed()->info().hash)};
+        std::string const ledgerHash{to_string(mcEnv.closed()->header().hash)};
         std::string bridge_index;
         Json::Value mcBridge;
         {

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -60,7 +60,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         Env env{*this};
 
         env.close();
-        BEAST_EXPECT(env.current()->info().seq == 4);
+        BEAST_EXPECT(env.current()->header().seq == 4);
 
         {
             Json::Value jvParams;
@@ -87,9 +87,9 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(jrr[jss::ledger][jss::closed] == false);
             BEAST_EXPECT(
                 jrr[jss::ledger][jss::ledger_index] ==
-                std::to_string(env.current()->info().seq));
+                std::to_string(env.current()->header().seq));
             BEAST_EXPECT(
-                jrr[jss::ledger_current_index] == env.current()->info().seq);
+                jrr[jss::ledger_current_index] == env.current()->header().seq);
         }
     }
 
@@ -182,12 +182,12 @@ class LedgerRPC_test : public beast::unit_test::suite
         Env env{*this};
 
         env.close();
-        BEAST_EXPECT(env.current()->info().seq == 4);
+        BEAST_EXPECT(env.current()->header().seq == 4);
 
         {
             auto const jrr = env.rpc("ledger_current")[jss::result];
             BEAST_EXPECT(
-                jrr[jss::ledger_current_index] == env.current()->info().seq);
+                jrr[jss::ledger_current_index] == env.current()->header().seq);
         }
     }
 
@@ -475,7 +475,7 @@ class LedgerRPC_test : public beast::unit_test::suite
             env(noop(alice));
         }
 
-        BEAST_EXPECT(env.current()->info().seq == 5);
+        BEAST_EXPECT(env.current()->header().seq == 5);
         // Put some txs in the queue
         // Alice
         auto aliceSeq = env.seq(alice);
@@ -508,7 +508,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         env.close();
         env.close();
         env.close();
-        BEAST_EXPECT(env.current()->info().seq == 8);
+        BEAST_EXPECT(env.current()->header().seq == 8);
 
         jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
         BEAST_EXPECT(jrr[jss::queue_data].size() == 11);
@@ -517,7 +517,7 @@ class LedgerRPC_test : public beast::unit_test::suite
 
         jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
         std::string const txid0 = [&]() {
-            auto const& parentHash = env.current()->info().parentHash;
+            auto const& parentHash = env.current()->header().parentHash;
             if (BEAST_EXPECT(jrr[jss::queue_data].size() == 2))
             {
                 std::string const txid1 = [&]() {
@@ -559,7 +559,7 @@ class LedgerRPC_test : public beast::unit_test::suite
         jrr = env.rpc("json", "ledger", to_string(jv))[jss::result];
         if (BEAST_EXPECT(jrr[jss::queue_data].size() == 2))
         {
-            auto const& parentHash = env.current()->info().parentHash;
+            auto const& parentHash = env.current()->header().parentHash;
             auto const txid1 = [&]() {
                 auto const& txj = jrr[jss::queue_data][1u];
                 BEAST_EXPECT(txj[jss::account] == alice.human());

--- a/src/test/rpc/LedgerRequest_test.cpp
+++ b/src/test/rpc/LedgerRequest_test.cpp
@@ -32,7 +32,7 @@ public:
 
         env.close();
         env.close();
-        BEAST_EXPECT(env.current()->info().seq == 5);
+        BEAST_EXPECT(env.current()->header().seq == 5);
 
         {
             // arbitrary text is converted to 0.

--- a/src/test/rpc/Simulate_test.cpp
+++ b/src/test/rpc/Simulate_test.cpp
@@ -1027,7 +1027,7 @@ class Simulate_test : public beast::unit_test::suite
 
         auto jv = credentials::create(subject, issuer, credType);
         uint32_t const t =
-            env.current()->info().parentCloseTime.time_since_epoch().count();
+            env.current()->header().parentCloseTime.time_since_epoch().count();
         jv[sfExpiration.jsonName] = t;
         env(jv);
         env.close();

--- a/src/test/rpc/Subscribe_test.cpp
+++ b/src/test/rpc/Subscribe_test.cpp
@@ -469,11 +469,11 @@ public:
                     return false;
 
                 if (jv[jss::ledger_hash] !=
-                    to_string(env.closed()->info().hash))
+                    to_string(env.closed()->header().hash))
                     return false;
 
                 if (jv[jss::ledger_index] !=
-                    std::to_string(env.closed()->info().seq))
+                    std::to_string(env.closed()->header().seq))
                     return false;
 
                 if (jv[jss::flags] != (vfFullyCanonicalSig | vfFullValidation))
@@ -504,7 +504,7 @@ public:
 
                 // Certain fields are only added on a flag ledger.
                 bool const isFlagLedger =
-                    (env.closed()->info().seq + 1) % 256 == 0;
+                    (env.closed()->header().seq + 1) % 256 == 0;
 
                 if (jv.isMember(jss::server_version) != isFlagLedger)
                     return false;
@@ -520,7 +520,7 @@ public:
 
             // Check stream update.  Look at enough stream entries so we see
             // at least one flag ledger.
-            while (env.closed()->info().seq < 300)
+            while (env.closed()->header().seq < 300)
             {
                 env.close();
                 using namespace std::chrono_literals;

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -50,7 +50,7 @@ class Transaction_test : public beast::unit_test::suite
 
         std::vector<std::shared_ptr<STTx const>> txns;
         std::vector<std::shared_ptr<STObject const>> metas;
-        auto const startLegSeq = env.current()->info().seq;
+        auto const startLegSeq = env.current()->header().seq;
         for (int i = 0; i < 750; ++i)
         {
             env(noop(alice));
@@ -59,7 +59,7 @@ class Transaction_test : public beast::unit_test::suite
             metas.emplace_back(
                 env.closed()->txRead(env.tx()->getTransactionID()).second);
         }
-        auto const endLegSeq = env.closed()->info().seq;
+        auto const endLegSeq = env.closed()->header().seq;
 
         // Find the existing transactions
         for (size_t i = 0; i < txns.size(); ++i)
@@ -302,7 +302,7 @@ class Transaction_test : public beast::unit_test::suite
 
         std::vector<std::shared_ptr<STTx const>> txns;
         std::vector<std::shared_ptr<STObject const>> metas;
-        auto const startLegSeq = env.current()->info().seq;
+        auto const startLegSeq = env.current()->header().seq;
         for (int i = 0; i < 750; ++i)
         {
             env(noop(alice));
@@ -311,7 +311,7 @@ class Transaction_test : public beast::unit_test::suite
             metas.emplace_back(
                 env.closed()->txRead(env.tx()->getTransactionID()).second);
         }
-        auto const endLegSeq = env.closed()->info().seq;
+        auto const endLegSeq = env.closed()->header().seq;
 
         // Find the existing transactions
         for (size_t i = 0; i < txns.size(); ++i)
@@ -630,7 +630,7 @@ class Transaction_test : public beast::unit_test::suite
             auto const alice = Account("alice");
             auto const bob = Account("bob");
 
-            auto const startLegSeq = env.current()->info().seq;
+            auto const startLegSeq = env.current()->header().seq;
             env.fund(XRP(10000), alice, bob);
             env(pay(alice, bob, XRP(10)));
             env.close();
@@ -661,7 +661,7 @@ class Transaction_test : public beast::unit_test::suite
             Account const alice = Account("alice");
             Account const bob = Account("bob");
 
-            std::uint32_t const startLegSeq = env.current()->info().seq;
+            std::uint32_t const startLegSeq = env.current()->header().seq;
             env.fund(XRP(10000), alice, bob);
             env(pay(alice, bob, XRP(10)));
             env.close();
@@ -709,7 +709,7 @@ class Transaction_test : public beast::unit_test::suite
             env(pay(alice, bob, XRP(10)));
             env.close();
 
-            auto const ledgerSeq = env.current()->info().seq;
+            auto const ledgerSeq = env.current()->header().seq;
 
             env(noop(alice), ter(tesSUCCESS));
             env.close();
@@ -738,7 +738,7 @@ class Transaction_test : public beast::unit_test::suite
             auto const alice = Account("alice");
             auto const bob = Account("bob");
 
-            auto const startLegSeq = env.current()->info().seq;
+            auto const startLegSeq = env.current()->header().seq;
             env.fund(XRP(10000), alice, bob);
             env(pay(alice, bob, XRP(10)));
             env.close();

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -842,7 +842,7 @@ class ServerStatus_test : public beast::unit_test::suite,
 
         // mark the Network as having an Amendment Warning, but won't fail
         env.app().getOPs().setAmendmentWarned();
-        env.app().getOPs().beginConsensus(env.closed()->info().hash, {});
+        env.app().getOPs().beginConsensus(env.closed()->header().hash, {});
 
         // consensus doesn't change
         BEAST_EXPECT(
@@ -973,7 +973,7 @@ class ServerStatus_test : public beast::unit_test::suite,
         // mark the Network as Amendment Blocked, but still won't fail until
         // ELB is enabled (next step)
         env.app().getOPs().setAmendmentBlocked();
-        env.app().getOPs().beginConsensus(env.closed()->info().hash, {});
+        env.app().getOPs().beginConsensus(env.closed()->header().hash, {});
 
         // consensus now sees validation disabled
         BEAST_EXPECT(

--- a/src/xrpld/app/consensus/RCLConsensus.cpp
+++ b/src/xrpld/app/consensus/RCLConsensus.cpp
@@ -135,11 +135,11 @@ RCLConsensus::Adaptor::acquireLedger(LedgerHash const& hash)
         !built->open() && built->isImmutable(),
         "ripple::RCLConsensus::Adaptor::acquireLedger : valid ledger state");
     XRPL_ASSERT(
-        built->info().hash == hash,
+        built->header().hash == hash,
         "ripple::RCLConsensus::Adaptor::acquireLedger : ledger hash match");
 
     // Notify inbound transactions of the new ledger sequence number
-    inboundTransactions_.newRound(built->info().seq);
+    inboundTransactions_.newRound(built->header().seq);
 
     return RCLCxLedger(built);
 }
@@ -309,7 +309,7 @@ RCLConsensus::Adaptor::onClose(
 
     ledgerMaster_.applyHeldTransactions();
     // Tell the ledger master not to acquire the ledger we're probably building
-    ledgerMaster_.setBuildingLedger(prevLedger->info().seq + 1);
+    ledgerMaster_.setBuildingLedger(prevLedger->header().seq + 1);
 
     auto initialLedger = app_.openLedger().current();
 
@@ -338,7 +338,7 @@ RCLConsensus::Adaptor::onClose(
             // pseudo-transactions
             auto validations = app_.validators().negativeUNLFilter(
                 app_.getValidations().getTrustedForLedger(
-                    prevLedger->info().parentHash, prevLedger->seq() - 1));
+                    prevLedger->header().parentHash, prevLedger->seq() - 1));
             if (validations.size() >= app_.validators().quorum())
             {
                 feeVote_->doVoting(prevLedger, validations, initialSet);
@@ -364,7 +364,7 @@ RCLConsensus::Adaptor::onClose(
 
     if (!wrongLCL)
     {
-        LedgerIndex const seq = prevLedger->info().seq + 1;
+        LedgerIndex const seq = prevLedger->header().seq + 1;
         RCLCensorshipDetector<TxID, LedgerIndex>::TxIDSeqVec proposed;
 
         initialSet->visitLeaves(
@@ -382,7 +382,7 @@ RCLConsensus::Adaptor::onClose(
     return Result{
         std::move(initialSet),
         RCLCxPeerPos::Proposal{
-            initialLedger->info().parentHash,
+            initialLedger->header().parentHash,
             RCLCxPeerPos::Proposal::seqJoin,
             setHash,
             closeTime,
@@ -663,10 +663,10 @@ RCLConsensus::Adaptor::doAccept(
 
         // Do these need to exist?
         XRPL_ASSERT(
-            ledgerMaster_.getClosedLedger()->info().hash == built.id(),
+            ledgerMaster_.getClosedLedger()->header().hash == built.id(),
             "ripple::RCLConsensus::Adaptor::doAccept : ledger hash match");
         XRPL_ASSERT(
-            app_.openLedger().current()->info().parentHash == built.id(),
+            app_.openLedger().current()->header().parentHash == built.id(),
             "ripple::RCLConsensus::Adaptor::doAccept : parent hash match");
     }
 
@@ -764,7 +764,7 @@ RCLConsensus::Adaptor::buildLCL(
         if (auto const replayData = ledgerMaster_.releaseReplay())
         {
             XRPL_ASSERT(
-                replayData->parent()->info().hash == previousLedger.id(),
+                replayData->parent()->header().hash == previousLedger.id(),
                 "ripple::RCLConsensus::Adaptor::buildLCL : parent hash match");
             return buildLedger(*replayData, tapNONE, app_, j_);
         }
@@ -786,7 +786,7 @@ RCLConsensus::Adaptor::buildLCL(
     // And stash the ledger in the ledger master
     if (ledgerMaster_.storeLedger(built))
         JLOG(j_.debug()) << "Consensus built ledger we already had";
-    else if (app_.getInboundLedgers().find(built->info().hash))
+    else if (app_.getInboundLedgers().find(built->header().hash))
         JLOG(j_.debug()) << "Consensus built ledger we were acquiring";
     else
         JLOG(j_.debug()) << "Consensus built new ledger";
@@ -833,7 +833,7 @@ RCLConsensus::Adaptor::validate(
             // validated ledger. This may be the hash of the ledger we are
             // validating here, and that's fine.
             if (auto const vl = ledgerMaster_.getValidatedLedger())
-                v.setFieldH256(sfValidatedHash, vl->info().hash);
+                v.setFieldH256(sfValidatedHash, vl->header().hash);
 
             v.setFieldU64(sfCookie, valCookie_);
 

--- a/src/xrpld/app/consensus/RCLCxLedger.h
+++ b/src/xrpld/app/consensus/RCLCxLedger.h
@@ -41,49 +41,49 @@ public:
     Seq const&
     seq() const
     {
-        return ledger_->info().seq;
+        return ledger_->header().seq;
     }
 
     //! Unique identifier (hash) of this ledger.
     ID const&
     id() const
     {
-        return ledger_->info().hash;
+        return ledger_->header().hash;
     }
 
     //! Unique identifier (hash) of this ledger's parent.
     ID const&
     parentID() const
     {
-        return ledger_->info().parentHash;
+        return ledger_->header().parentHash;
     }
 
     //! Resolution used when calculating this ledger's close time.
     NetClock::duration
     closeTimeResolution() const
     {
-        return ledger_->info().closeTimeResolution;
+        return ledger_->header().closeTimeResolution;
     }
 
     //! Whether consensus process agreed on close time of the ledger.
     bool
     closeAgree() const
     {
-        return ripple::getCloseAgree(ledger_->info());
+        return ripple::getCloseAgree(ledger_->header());
     }
 
     //! The close time of this ledger
     NetClock::time_point
     closeTime() const
     {
-        return ledger_->info().closeTime;
+        return ledger_->header().closeTime;
     }
 
     //! The close time of this ledger's parent.
     NetClock::time_point
     parentCloseTime() const
     {
-        return ledger_->info().parentCloseTime;
+        return ledger_->header().parentCloseTime;
     }
 
     //! JSON representation of this ledger.

--- a/src/xrpld/app/consensus/RCLValidations.cpp
+++ b/src/xrpld/app/consensus/RCLValidations.cpp
@@ -23,7 +23,7 @@ RCLValidatedLedger::RCLValidatedLedger(MakeGenesis)
 RCLValidatedLedger::RCLValidatedLedger(
     std::shared_ptr<Ledger const> const& ledger,
     beast::Journal j)
-    : ledgerID_{ledger->info().hash}, ledgerSeq_{ledger->seq()}, j_{j}
+    : ledgerID_{ledger->header().hash}, ledgerSeq_{ledger->seq()}, j_{j}
 {
     auto const hashIndex = ledger->read(keylet::skip());
     if (hashIndex)
@@ -136,7 +136,7 @@ RCLValidationsAdaptor::acquire(LedgerHash const& hash)
         !ledger->open() && ledger->isImmutable(),
         "ripple::RCLValidationsAdaptor::acquire : valid ledger state");
     XRPL_ASSERT(
-        ledger->info().hash == hash,
+        ledger->header().hash == hash,
         "ripple::RCLValidationsAdaptor::acquire : ledger hash match");
 
     return RCLValidatedLedger(std::move(ledger), j_);

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -265,13 +265,13 @@ Ledger::Ledger(Ledger const& prevLedger, NetClock::time_point closeTime)
 {
     info_.seq = prevLedger.info_.seq + 1;
     info_.parentCloseTime = prevLedger.info_.closeTime;
-    info_.hash = prevLedger.info().hash + uint256(1);
-    info_.drops = prevLedger.info().drops;
+    info_.hash = prevLedger.header().hash + uint256(1);
+    info_.drops = prevLedger.header().drops;
     info_.closeTimeResolution = prevLedger.info_.closeTimeResolution;
-    info_.parentHash = prevLedger.info().hash;
+    info_.parentHash = prevLedger.header().hash;
     info_.closeTimeResolution = getNextLedgerTimeResolution(
         prevLedger.info_.closeTimeResolution,
-        getCloseAgree(prevLedger.info()),
+        getCloseAgree(prevLedger.header()),
         info_.seq);
 
     if (prevLedger.info_.closeTime == NetClock::time_point{})
@@ -951,7 +951,7 @@ saveValidatedLedger(
     bool current)
 {
     auto j = app.journal("Ledger");
-    auto seq = ledger->info().seq;
+    auto seq = ledger->header().seq;
     if (!app.pendingSaves().startWork(seq))
     {
         // The save was completed synchronously
@@ -982,13 +982,13 @@ pendSaveValidated(
     bool isCurrent)
 {
     if (!app.getHashRouter().setFlags(
-            ledger->info().hash, HashRouterFlags::SAVED))
+            ledger->header().hash, HashRouterFlags::SAVED))
     {
         // We have tried to save this ledger recently
         auto stream = app.journal("Ledger").debug();
-        JLOG(stream) << "Double pend save for " << ledger->info().seq;
+        JLOG(stream) << "Double pend save for " << ledger->header().seq;
 
-        if (!isSynchronous || !app.pendingSaves().pending(ledger->info().seq))
+        if (!isSynchronous || !app.pendingSaves().pending(ledger->header().seq))
         {
             // Either we don't need it to be finished
             // or it is finished
@@ -999,11 +999,11 @@ pendSaveValidated(
     XRPL_ASSERT(
         ledger->isImmutable(), "ripple::pendSaveValidated : immutable ledger");
 
-    if (!app.pendingSaves().shouldWork(ledger->info().seq, isSynchronous))
+    if (!app.pendingSaves().shouldWork(ledger->header().seq, isSynchronous))
     {
         auto stream = app.journal("Ledger").debug();
         JLOG(stream) << "Pend save with seq in pending saves "
-                     << ledger->info().seq;
+                     << ledger->header().seq;
 
         return true;
     }
@@ -1075,12 +1075,12 @@ finishLoadByIndexOrHash(
         return;
 
     XRPL_ASSERT(
-        ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+        ledger->header().seq < XRP_LEDGER_EARLIEST_FEES ||
             ledger->read(keylet::fees()),
         "ripple::finishLoadByIndexOrHash : valid ledger fees");
     ledger->setImmutable();
 
-    JLOG(j.trace()) << "Loaded ledger: " << to_string(ledger->info().hash);
+    JLOG(j.trace()) << "Loaded ledger: " << to_string(ledger->header().hash);
 
     ledger->setFull();
 }
@@ -1117,7 +1117,7 @@ loadByHash(uint256 const& ledgerHash, Application& app, bool acquire)
         std::shared_ptr<Ledger> ledger = loadLedgerHelper(*info, app, acquire);
         finishLoadByIndexOrHash(ledger, app.config(), app.journal("Ledger"));
         XRPL_ASSERT(
-            !ledger || ledger->info().hash == ledgerHash,
+            !ledger || ledger->header().hash == ledgerHash,
             "ripple::loadByHash : ledger hash match if loaded");
         return ledger;
     }

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -157,9 +157,9 @@ Ledger::Ledger(
     , rules_{config.features}
     , j_(beast::Journal(beast::Journal::getNullSink()))
 {
-    info_.seq = 1;
-    info_.drops = INITIAL_XRP;
-    info_.closeTimeResolution = ledgerGenesisTimeResolution;
+    header_.seq = 1;
+    header_.drops = INITIAL_XRP;
+    header_.closeTimeResolution = ledgerGenesisTimeResolution;
 
     static auto const id = calcAccountID(
         generateKeyPair(KeyType::secp256k1, generateSeed("masterpassphrase"))
@@ -168,7 +168,7 @@ Ledger::Ledger(
         auto const sle = std::make_shared<SLE>(keylet::account(id));
         sle->setFieldU32(sfSequence, 1);
         sle->setAccountID(sfAccount, id);
-        sle->setFieldAmount(sfBalance, info_.drops);
+        sle->setFieldAmount(sfBalance, header_.drops);
         rawInsert(sle);
     }
 
@@ -220,23 +220,25 @@ Ledger::Ledger(
     , txMap_(SHAMapType::TRANSACTION, info.txHash, family)
     , stateMap_(SHAMapType::STATE, info.accountHash, family)
     , rules_(config.features)
-    , info_(info)
+    , header_(info)
     , j_(j)
 {
     loaded = true;
 
-    if (info_.txHash.isNonZero() &&
-        !txMap_.fetchRoot(SHAMapHash{info_.txHash}, nullptr))
+    if (header_.txHash.isNonZero() &&
+        !txMap_.fetchRoot(SHAMapHash{header_.txHash}, nullptr))
     {
         loaded = false;
-        JLOG(j.warn()) << "Don't have transaction root for ledger" << info_.seq;
+        JLOG(j.warn()) << "Don't have transaction root for ledger"
+                       << header_.seq;
     }
 
-    if (info_.accountHash.isNonZero() &&
-        !stateMap_.fetchRoot(SHAMapHash{info_.accountHash}, nullptr))
+    if (header_.accountHash.isNonZero() &&
+        !stateMap_.fetchRoot(SHAMapHash{header_.accountHash}, nullptr))
     {
         loaded = false;
-        JLOG(j.warn()) << "Don't have state data root for ledger" << info_.seq;
+        JLOG(j.warn()) << "Don't have state data root for ledger"
+                       << header_.seq;
     }
 
     txMap_.setImmutable();
@@ -248,9 +250,9 @@ Ledger::Ledger(
 
     if (!loaded)
     {
-        info_.hash = calculateLedgerHash(info_);
+        header_.hash = calculateLedgerHash(header_);
         if (acquire)
-            family.missingNodeAcquireByHash(info_.hash, info_.seq);
+            family.missingNodeAcquireByHash(header_.hash, header_.seq);
     }
 }
 
@@ -263,25 +265,26 @@ Ledger::Ledger(Ledger const& prevLedger, NetClock::time_point closeTime)
     , rules_(prevLedger.rules_)
     , j_(beast::Journal(beast::Journal::getNullSink()))
 {
-    info_.seq = prevLedger.info_.seq + 1;
-    info_.parentCloseTime = prevLedger.info_.closeTime;
-    info_.hash = prevLedger.header().hash + uint256(1);
-    info_.drops = prevLedger.header().drops;
-    info_.closeTimeResolution = prevLedger.info_.closeTimeResolution;
-    info_.parentHash = prevLedger.header().hash;
-    info_.closeTimeResolution = getNextLedgerTimeResolution(
-        prevLedger.info_.closeTimeResolution,
+    header_.seq = prevLedger.header_.seq + 1;
+    header_.parentCloseTime = prevLedger.header_.closeTime;
+    header_.hash = prevLedger.header().hash + uint256(1);
+    header_.drops = prevLedger.header().drops;
+    header_.closeTimeResolution = prevLedger.header_.closeTimeResolution;
+    header_.parentHash = prevLedger.header().hash;
+    header_.closeTimeResolution = getNextLedgerTimeResolution(
+        prevLedger.header_.closeTimeResolution,
         getCloseAgree(prevLedger.header()),
-        info_.seq);
+        header_.seq);
 
-    if (prevLedger.info_.closeTime == NetClock::time_point{})
+    if (prevLedger.header_.closeTime == NetClock::time_point{})
     {
-        info_.closeTime = roundCloseTime(closeTime, info_.closeTimeResolution);
+        header_.closeTime =
+            roundCloseTime(closeTime, header_.closeTimeResolution);
     }
     else
     {
-        info_.closeTime =
-            prevLedger.info_.closeTime + info_.closeTimeResolution;
+        header_.closeTime =
+            prevLedger.header_.closeTime + header_.closeTimeResolution;
     }
 }
 
@@ -290,10 +293,10 @@ Ledger::Ledger(LedgerHeader const& info, Config const& config, Family& family)
     , txMap_(SHAMapType::TRANSACTION, info.txHash, family)
     , stateMap_(SHAMapType::STATE, info.accountHash, family)
     , rules_{config.features}
-    , info_(info)
+    , header_(info)
     , j_(beast::Journal(beast::Journal::getNullSink()))
 {
-    info_.hash = calculateLedgerHash(info_);
+    header_.hash = calculateLedgerHash(header_);
 }
 
 Ledger::Ledger(
@@ -307,9 +310,9 @@ Ledger::Ledger(
     , rules_{config.features}
     , j_(beast::Journal(beast::Journal::getNullSink()))
 {
-    info_.seq = ledgerSeq;
-    info_.closeTime = closeTime;
-    info_.closeTimeResolution = ledgerDefaultTimeResolution;
+    header_.seq = ledgerSeq;
+    header_.closeTime = closeTime;
+    header_.closeTimeResolution = ledgerDefaultTimeResolution;
     defaultFees(config);
     setup();
 }
@@ -321,12 +324,12 @@ Ledger::setImmutable(bool rehash)
     // place the hash transitions to valid
     if (!mImmutable && rehash)
     {
-        info_.txHash = txMap_.getHash().as_uint256();
-        info_.accountHash = stateMap_.getHash().as_uint256();
+        header_.txHash = txMap_.getHash().as_uint256();
+        header_.accountHash = stateMap_.getHash().as_uint256();
     }
 
     if (rehash)
-        info_.hash = calculateLedgerHash(info_);
+        header_.hash = calculateLedgerHash(header_);
 
     mImmutable = true;
     txMap_.setImmutable();
@@ -343,9 +346,9 @@ Ledger::setAccepted(
     // Used when we witnessed the consensus.
     XRPL_ASSERT(!open(), "ripple::Ledger::setAccepted : valid ledger state");
 
-    info_.closeTime = closeTime;
-    info_.closeTimeResolution = closeResolution;
-    info_.closeFlags = correctCloseTime ? 0 : sLCF_NoConsensusTime;
+    header_.closeTime = closeTime;
+    header_.closeTimeResolution = closeResolution;
+    header_.closeFlags = correctCloseTime ? 0 : sLCF_NoConsensusTime;
     setImmutable();
 }
 
@@ -788,11 +791,11 @@ Ledger::walkLedger(beast::Journal j, bool parallel) const
     std::vector<SHAMapMissingNode> missingNodes1;
     std::vector<SHAMapMissingNode> missingNodes2;
 
-    if (stateMap_.getHash().isZero() && !info_.accountHash.isZero() &&
-        !stateMap_.fetchRoot(SHAMapHash{info_.accountHash}, nullptr))
+    if (stateMap_.getHash().isZero() && !header_.accountHash.isZero() &&
+        !stateMap_.fetchRoot(SHAMapHash{header_.accountHash}, nullptr))
     {
         missingNodes1.emplace_back(
-            SHAMapType::STATE, SHAMapHash{info_.accountHash});
+            SHAMapType::STATE, SHAMapHash{header_.accountHash});
     }
     else
     {
@@ -811,11 +814,11 @@ Ledger::walkLedger(beast::Journal j, bool parallel) const
         }
     }
 
-    if (txMap_.getHash().isZero() && info_.txHash.isNonZero() &&
-        !txMap_.fetchRoot(SHAMapHash{info_.txHash}, nullptr))
+    if (txMap_.getHash().isZero() && header_.txHash.isNonZero() &&
+        !txMap_.fetchRoot(SHAMapHash{header_.txHash}, nullptr))
     {
         missingNodes2.emplace_back(
-            SHAMapType::TRANSACTION, SHAMapHash{info_.txHash});
+            SHAMapType::TRANSACTION, SHAMapHash{header_.txHash});
     }
     else
     {
@@ -836,9 +839,9 @@ Ledger::walkLedger(beast::Journal j, bool parallel) const
 bool
 Ledger::assertSensible(beast::Journal ledgerJ) const
 {
-    if (info_.hash.isNonZero() && info_.accountHash.isNonZero() &&
-        (info_.accountHash == stateMap_.getHash().as_uint256()) &&
-        (info_.txHash == txMap_.getHash().as_uint256()))
+    if (header_.hash.isNonZero() && header_.accountHash.isNonZero() &&
+        (header_.accountHash == stateMap_.getHash().as_uint256()) &&
+        (header_.txHash == txMap_.getHash().as_uint256()))
     {
         return true;
     }
@@ -846,8 +849,8 @@ Ledger::assertSensible(beast::Journal ledgerJ) const
     // LCOV_EXCL_START
     Json::Value j = getJson({*this, {}});
 
-    j[jss::accountTreeHash] = to_string(info_.accountHash);
-    j[jss::transTreeHash] = to_string(info_.txHash);
+    j[jss::accountTreeHash] = to_string(header_.accountHash);
+    j[jss::transTreeHash] = to_string(header_.txHash);
 
     JLOG(ledgerJ.fatal()) << "ledger is not sensible" << j;
 
@@ -862,10 +865,10 @@ Ledger::assertSensible(beast::Journal ledgerJ) const
 void
 Ledger::updateSkipList()
 {
-    if (info_.seq == 0)  // genesis ledger has no previous ledger
+    if (header_.seq == 0)  // genesis ledger has no previous ledger
         return;
 
-    std::uint32_t prevIndex = info_.seq - 1;
+    std::uint32_t prevIndex = header_.seq - 1;
 
     // update record of every 256th ledger
     if ((prevIndex & 0xff) == 0)
@@ -889,7 +892,7 @@ Ledger::updateSkipList()
         XRPL_ASSERT(
             hashes.size() <= 256,
             "ripple::Ledger::updateSkipList : first maximum hashes size");
-        hashes.push_back(info_.parentHash);
+        hashes.push_back(header_.parentHash);
         sle->setFieldV256(sfHashes, STVector256(hashes));
         sle->setFieldU32(sfLastLedgerSequence, prevIndex);
         if (created)
@@ -918,7 +921,7 @@ Ledger::updateSkipList()
         "ripple::Ledger::updateSkipList : second maximum hashes size");
     if (hashes.size() == 256)
         hashes.erase(hashes.begin());
-    hashes.push_back(info_.parentHash);
+    hashes.push_back(header_.parentHash);
     sle->setFieldV256(sfHashes, STVector256(hashes));
     sle->setFieldU32(sfLastLedgerSequence, prevIndex);
     if (created)
@@ -930,12 +933,12 @@ Ledger::updateSkipList()
 bool
 Ledger::isFlagLedger() const
 {
-    return info_.seq % FLAG_LEDGER_INTERVAL == 0;
+    return header_.seq % FLAG_LEDGER_INTERVAL == 0;
 }
 bool
 Ledger::isVotingLedger() const
 {
-    return (info_.seq + 1) % FLAG_LEDGER_INTERVAL == 0;
+    return (header_.seq + 1) % FLAG_LEDGER_INTERVAL == 0;
 }
 
 bool

--- a/src/xrpld/app/ledger/Ledger.h
+++ b/src/xrpld/app/ledger/Ledger.h
@@ -132,13 +132,13 @@ public:
     LedgerHeader const&
     header() const override
     {
-        return info_;
+        return header_;
     }
 
     void
     setLedgerInfo(LedgerHeader const& info)
     {
-        info_ = info;
+        header_ = info;
     }
 
     Fees const&
@@ -213,7 +213,7 @@ public:
     void
     rawDestroyXRP(XRPAmount const& fee) override
     {
-        info_.drops -= fee;
+        header_.drops -= fee;
     }
 
     //
@@ -244,7 +244,7 @@ public:
     void
     setValidated() const
     {
-        info_.validated = true;
+        header_.validated = true;
     }
 
     void
@@ -276,15 +276,15 @@ public:
     setFull() const
     {
         txMap_.setFull();
-        txMap_.setLedgerSeq(info_.seq);
+        txMap_.setLedgerSeq(header_.seq);
         stateMap_.setFull();
-        stateMap_.setLedgerSeq(info_.seq);
+        stateMap_.setLedgerSeq(header_.seq);
     }
 
     void
     setTotalDrops(std::uint64_t totDrops)
     {
-        info_.drops = totDrops;
+        header_.drops = totDrops;
     }
 
     SHAMap const&
@@ -397,7 +397,7 @@ private:
 
     Fees fees_;
     Rules rules_;
-    LedgerHeader info_;
+    LedgerHeader header_;
     beast::Journal j_;
 };
 

--- a/src/xrpld/app/ledger/Ledger.h
+++ b/src/xrpld/app/ledger/Ledger.h
@@ -130,7 +130,7 @@ public:
     }
 
     LedgerHeader const&
-    info() const override
+    header() const override
     {
         return info_;
     }

--- a/src/xrpld/app/ledger/LedgerHistory.cpp
+++ b/src/xrpld/app/ledger/LedgerHistory.cpp
@@ -47,9 +47,9 @@ LedgerHistory::insert(
     std::unique_lock sl(m_ledgers_by_hash.peekMutex());
 
     bool const alreadyHad = m_ledgers_by_hash.canonicalize_replace_cache(
-        ledger->info().hash, ledger);
+        ledger->header().hash, ledger);
     if (validated)
-        mLedgersByIndex[ledger->info().seq] = ledger->info().hash;
+        mLedgersByIndex[ledger->header().seq] = ledger->header().hash;
 
     return alreadyHad;
 }
@@ -84,7 +84,7 @@ LedgerHistory::getLedgerBySeq(LedgerIndex index)
         return ret;
 
     XRPL_ASSERT(
-        ret->info().seq == index,
+        ret->header().seq == index,
         "ripple::LedgerHistory::getLedgerBySeq : result sequence match");
 
     {
@@ -94,9 +94,9 @@ LedgerHistory::getLedgerBySeq(LedgerIndex index)
         XRPL_ASSERT(
             ret->isImmutable(),
             "ripple::LedgerHistory::getLedgerBySeq : immutable result ledger");
-        m_ledgers_by_hash.canonicalize_replace_client(ret->info().hash, ret);
-        mLedgersByIndex[ret->info().seq] = ret->info().hash;
-        return (ret->info().seq == index) ? ret : nullptr;
+        m_ledgers_by_hash.canonicalize_replace_client(ret->header().hash, ret);
+        mLedgersByIndex[ret->header().seq] = ret->header().hash;
+        return (ret->header().seq == index) ? ret : nullptr;
     }
 }
 
@@ -112,7 +112,7 @@ LedgerHistory::getLedgerByHash(LedgerHash const& hash)
             "ripple::LedgerHistory::getLedgerByHash : immutable fetched "
             "ledger");
         XRPL_ASSERT(
-            ret->info().hash == hash,
+            ret->header().hash == hash,
             "ripple::LedgerHistory::getLedgerByHash : fetched ledger hash "
             "match");
         return ret;
@@ -127,11 +127,11 @@ LedgerHistory::getLedgerByHash(LedgerHash const& hash)
         ret->isImmutable(),
         "ripple::LedgerHistory::getLedgerByHash : immutable loaded ledger");
     XRPL_ASSERT(
-        ret->info().hash == hash,
+        ret->header().hash == hash,
         "ripple::LedgerHistory::getLedgerByHash : loaded ledger hash match");
-    m_ledgers_by_hash.canonicalize_replace_client(ret->info().hash, ret);
+    m_ledgers_by_hash.canonicalize_replace_client(ret->header().hash, ret);
     XRPL_ASSERT(
-        ret->info().hash == hash,
+        ret->header().hash == hash,
         "ripple::LedgerHistory::getLedgerByHash : result hash match");
 
     return ret;
@@ -342,7 +342,7 @@ LedgerHistory::handleMismatch(
     }
 
     XRPL_ASSERT(
-        builtLedger->info().seq == validLedger->info().seq,
+        builtLedger->header().seq == validLedger->header().seq,
         "ripple::LedgerHistory::handleMismatch : sequence match");
 
     if (auto stream = j_.debug())
@@ -356,14 +356,14 @@ LedgerHistory::handleMismatch(
     // failure from transaction processing difference
 
     // Disagreement over prior ledger indicates sync issue
-    if (builtLedger->info().parentHash != validLedger->info().parentHash)
+    if (builtLedger->header().parentHash != validLedger->header().parentHash)
     {
         JLOG(j_.error()) << "MISMATCH on prior ledger";
         return;
     }
 
     // Disagreement over close time indicates Byzantine failure
-    if (builtLedger->info().closeTime != validLedger->info().closeTime)
+    if (builtLedger->header().closeTime != validLedger->header().closeTime)
     {
         JLOG(j_.error()) << "MISMATCH on close time";
         return;
@@ -434,8 +434,8 @@ LedgerHistory::builtLedger(
     uint256 const& consensusHash,
     Json::Value consensus)
 {
-    LedgerIndex index = ledger->info().seq;
-    LedgerHash hash = ledger->info().hash;
+    LedgerIndex index = ledger->header().seq;
+    LedgerHash hash = ledger->header().hash;
     XRPL_ASSERT(
         !hash.isZero(), "ripple::LedgerHistory::builtLedger : nonzero hash");
 
@@ -475,8 +475,8 @@ LedgerHistory::validatedLedger(
     std::shared_ptr<Ledger const> const& ledger,
     std::optional<uint256> const& consensusHash)
 {
-    LedgerIndex index = ledger->info().seq;
-    LedgerHash hash = ledger->info().hash;
+    LedgerIndex index = ledger->header().seq;
+    LedgerHash hash = ledger->header().hash;
     XRPL_ASSERT(
         !hash.isZero(),
         "ripple::LedgerHistory::validatedLedger : nonzero hash");
@@ -533,7 +533,7 @@ LedgerHistory::clearLedgerCachePrior(LedgerIndex seq)
     for (LedgerHash it : m_ledgers_by_hash.getKeys())
     {
         auto const ledger = getLedgerByHash(it);
-        if (!ledger || ledger->info().seq < seq)
+        if (!ledger || ledger->header().seq < seq)
             m_ledgers_by_hash.del(it, false);
     }
 }

--- a/src/xrpld/app/ledger/detail/BuildLedger.cpp
+++ b/src/xrpld/app/ledger/detail/BuildLedger.cpp
@@ -58,7 +58,7 @@ buildLedgerImpl(
 
     // Accept ledger
     XRPL_ASSERT(
-        built->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+        built->header().seq < XRP_LEDGER_EARLIEST_FEES ||
             built->read(keylet::fees()),
         "ripple::buildLedgerImpl : valid ledger fees");
     built->setAccepted(closeTime, closeResolution, closeTimeCorrect);
@@ -213,13 +213,13 @@ buildLedger(
 {
     auto const& replayLedger = replayData.replay();
 
-    JLOG(j.debug()) << "Report: Replay Ledger " << replayLedger->info().hash;
+    JLOG(j.debug()) << "Report: Replay Ledger " << replayLedger->header().hash;
 
     return buildLedgerImpl(
         replayData.parent(),
-        replayLedger->info().closeTime,
-        ((replayLedger->info().closeFlags & sLCF_NoConsensusTime) == 0),
-        replayLedger->info().closeTimeResolution,
+        replayLedger->header().closeTime,
+        ((replayLedger->header().closeFlags & sLCF_NoConsensusTime) == 0),
+        replayLedger->header().closeTimeResolution,
         app,
         j,
         [&](OpenView& accum, std::shared_ptr<Ledger> const& built) {

--- a/src/xrpld/app/ledger/detail/InboundLedger.cpp
+++ b/src/xrpld/app/ledger/detail/InboundLedger.cpp
@@ -102,7 +102,7 @@ InboundLedger::init(ScopedLockType& collectionLock)
     JLOG(journal_.debug()) << "Acquiring ledger we already have in "
                            << " local store. " << hash_;
     XRPL_ASSERT(
-        mLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+        mLedger->header().seq < XRP_LEDGER_EARLIEST_FEES ||
             mLedger->read(keylet::fees()),
         "ripple::InboundLedger::init : valid ledger fees");
     mLedger->setImmutable();
@@ -206,14 +206,15 @@ neededHashes(
 std::vector<uint256>
 InboundLedger::neededTxHashes(int max, SHAMapSyncFilter* filter) const
 {
-    return neededHashes(mLedger->info().txHash, mLedger->txMap(), max, filter);
+    return neededHashes(
+        mLedger->header().txHash, mLedger->txMap(), max, filter);
 }
 
 std::vector<uint256>
 InboundLedger::neededStateHashes(int max, SHAMapSyncFilter* filter) const
 {
     return neededHashes(
-        mLedger->info().accountHash, mLedger->stateMap(), max, filter);
+        mLedger->header().accountHash, mLedger->stateMap(), max, filter);
 }
 
 // See how much of the ledger data is stored locally
@@ -229,8 +230,8 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
                 deserializePrefixedHeader(makeSlice(data)),
                 app_.config(),
                 app_.getNodeFamily());
-            if (mLedger->info().hash != hash_ ||
-                (mSeq != 0 && mSeq != mLedger->info().seq))
+            if (mLedger->header().hash != hash_ ||
+                (mSeq != 0 && mSeq != mLedger->header().seq))
             {
                 // We know for a fact the ledger can never be acquired
                 JLOG(journal_.warn())
@@ -256,7 +257,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
             {
                 Blob blob{nodeObject->getData()};
                 dstDB.store(
-                    hotLEDGER, std::move(blob), hash_, mLedger->info().seq);
+                    hotLEDGER, std::move(blob), hash_, mLedger->header().seq);
             }
         }
         else
@@ -274,11 +275,11 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
 
             // Store the ledger header in the ledger's database
             mLedger->stateMap().family().db().store(
-                hotLEDGER, std::move(*data), hash_, mLedger->info().seq);
+                hotLEDGER, std::move(*data), hash_, mLedger->header().seq);
         }
 
         if (mSeq == 0)
-            mSeq = mLedger->info().seq;
+            mSeq = mLedger->header().seq;
         mLedger->stateMap().setLedgerSeq(mSeq);
         mLedger->txMap().setLedgerSeq(mSeq);
         mHaveHeader = true;
@@ -286,7 +287,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
 
     if (!mHaveTransactions)
     {
-        if (mLedger->info().txHash.isZero())
+        if (mLedger->header().txHash.isZero())
         {
             JLOG(journal_.trace()) << "No TXNs to fetch";
             mHaveTransactions = true;
@@ -296,7 +297,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
             TransactionStateSF filter(
                 mLedger->txMap().family().db(), app_.getLedgerMaster());
             if (mLedger->txMap().fetchRoot(
-                    SHAMapHash{mLedger->info().txHash}, &filter))
+                    SHAMapHash{mLedger->header().txHash}, &filter))
             {
                 if (neededTxHashes(1, &filter).empty())
                 {
@@ -309,7 +310,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
 
     if (!mHaveState)
     {
-        if (mLedger->info().accountHash.isZero())
+        if (mLedger->header().accountHash.isZero())
         {
             JLOG(journal_.fatal())
                 << "We are acquiring a ledger with a zero account hash";
@@ -319,7 +320,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
         AccountStateSF filter(
             mLedger->stateMap().family().db(), app_.getLedgerMaster());
         if (mLedger->stateMap().fetchRoot(
-                SHAMapHash{mLedger->info().accountHash}, &filter))
+                SHAMapHash{mLedger->header().accountHash}, &filter))
         {
             if (neededStateHashes(1, &filter).empty())
             {
@@ -334,7 +335,7 @@ InboundLedger::tryDB(NodeStore::Database& srcDB)
         JLOG(journal_.debug()) << "Had everything locally";
         complete_ = true;
         XRPL_ASSERT(
-            mLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+            mLedger->header().seq < XRP_LEDGER_EARLIEST_FEES ||
                 mLedger->read(keylet::fees()),
             "ripple::InboundLedger::tryDB : valid ledger fees");
         mLedger->setImmutable();
@@ -437,7 +438,7 @@ InboundLedger::done()
     if (complete_ && !failed_ && mLedger)
     {
         XRPL_ASSERT(
-            mLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+            mLedger->header().seq < XRP_LEDGER_EARLIEST_FEES ||
                 mLedger->read(keylet::fees()),
             "ripple::InboundLedger::done : valid ledger fees");
         mLedger->setImmutable();
@@ -582,7 +583,7 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
     }
 
     if (mLedger)
-        tmGL.set_ledgerseq(mLedger->info().seq);
+        tmGL.set_ledgerseq(mLedger->header().seq);
 
     if (reason != TriggerReason::reply)
     {
@@ -744,7 +745,7 @@ InboundLedger::trigger(std::shared_ptr<Peer> const& peer, TriggerReason reason)
     {
         JLOG(journal_.debug())
             << "Done:" << (complete_ ? " complete" : "")
-            << (failed_ ? " failed " : " ") << mLedger->info().seq;
+            << (failed_ ? " failed " : " ") << mLedger->header().seq;
         sl.unlock();
         done();
     }
@@ -808,17 +809,17 @@ InboundLedger::takeHeader(std::string const& data)
     auto* f = &app_.getNodeFamily();
     mLedger = std::make_shared<Ledger>(
         deserializeHeader(makeSlice(data)), app_.config(), *f);
-    if (mLedger->info().hash != hash_ ||
-        (mSeq != 0 && mSeq != mLedger->info().seq))
+    if (mLedger->header().hash != hash_ ||
+        (mSeq != 0 && mSeq != mLedger->header().seq))
     {
         JLOG(journal_.warn())
-            << "Acquire hash mismatch: " << mLedger->info().hash
+            << "Acquire hash mismatch: " << mLedger->header().hash
             << "!=" << hash_;
         mLedger.reset();
         return false;
     }
     if (mSeq == 0)
-        mSeq = mLedger->info().seq;
+        mSeq = mLedger->header().seq;
     mLedger->stateMap().setLedgerSeq(mSeq);
     mLedger->txMap().setLedgerSeq(mSeq);
     mHaveHeader = true;
@@ -828,10 +829,10 @@ InboundLedger::takeHeader(std::string const& data)
     s.addRaw(data.data(), data.size());
     f->db().store(hotLEDGER, std::move(s.modData()), hash_, mSeq);
 
-    if (mLedger->info().txHash.isZero())
+    if (mLedger->header().txHash.isZero())
         mHaveTransactions = true;
 
-    if (mLedger->info().accountHash.isZero())
+    if (mLedger->header().accountHash.isZero())
         mHaveState = true;
 
     mLedger->txMap().setSynching();
@@ -871,12 +872,12 @@ InboundLedger::receiveNode(protocol::TMLedgerData& packet, SHAMapAddNode& san)
         if (packet.type() == protocol::liTX_NODE)
             return {
                 mLedger->txMap(),
-                SHAMapHash{mLedger->info().txHash},
+                SHAMapHash{mLedger->header().txHash},
                 std::make_unique<TransactionStateSF>(
                     mLedger->txMap().family().db(), app_.getLedgerMaster())};
         return {
             mLedger->stateMap(),
-            SHAMapHash{mLedger->info().accountHash},
+            SHAMapHash{mLedger->header().accountHash},
             std::make_unique<AccountStateSF>(
                 mLedger->stateMap().family().db(), app_.getLedgerMaster())};
     }();
@@ -953,7 +954,7 @@ InboundLedger::takeAsRootNode(Slice const& data, SHAMapAddNode& san)
     AccountStateSF filter(
         mLedger->stateMap().family().db(), app_.getLedgerMaster());
     san += mLedger->stateMap().addRootNode(
-        SHAMapHash{mLedger->info().accountHash}, data, &filter);
+        SHAMapHash{mLedger->header().accountHash}, data, &filter);
     return san.isGood();
 }
 
@@ -980,7 +981,7 @@ InboundLedger::takeTxRootNode(Slice const& data, SHAMapAddNode& san)
     TransactionStateSF filter(
         mLedger->txMap().family().db(), app_.getLedgerMaster());
     san += mLedger->txMap().addRootNode(
-        SHAMapHash{mLedger->info().txHash}, data, &filter);
+        SHAMapHash{mLedger->header().txHash}, data, &filter);
     return san.isGood();
 }
 

--- a/src/xrpld/app/ledger/detail/LedgerCleaner.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerCleaner.cpp
@@ -233,10 +233,10 @@ private:
         catch (SHAMapMissingNode const& mn)
         {
             JLOG(j_.warn())
-                << "Ledger #" << ledger->info().seq << ": " << mn.what();
+                << "Ledger #" << ledger->header().seq << ": " << mn.what();
             app_.getInboundLedgers().acquire(
-                ledger->info().hash,
-                ledger->info().seq,
+                ledger->header().hash,
+                ledger->header().seq,
                 InboundLedger::Reason::GENERIC);
         }
         return hash ? *hash : beast::zero;  // kludge
@@ -268,8 +268,8 @@ private:
         }
 
         auto dbLedger = loadByIndex(ledgerIndex, app_);
-        if (!dbLedger || (dbLedger->info().hash != ledgerHash) ||
-            (dbLedger->info().parentHash != nodeLedger->info().parentHash))
+        if (!dbLedger || (dbLedger->header().hash != ledgerHash) ||
+            (dbLedger->header().parentHash != nodeLedger->header().parentHash))
         {
             // Ideally we'd also check for more than one ledger with that index
             JLOG(j_.debug())
@@ -314,7 +314,7 @@ private:
     {
         LedgerHash ledgerHash;
 
-        if (!referenceLedger || (referenceLedger->info().seq < ledgerIndex))
+        if (!referenceLedger || (referenceLedger->header().seq < ledgerIndex))
         {
             referenceLedger = app_.getLedgerMaster().getValidatedLedger();
             if (!referenceLedger)
@@ -324,7 +324,7 @@ private:
             }
         }
 
-        if (referenceLedger->info().seq >= ledgerIndex)
+        if (referenceLedger->header().seq >= ledgerIndex)
         {
             // See if the hash for the ledger we need is in the reference ledger
             ledgerHash = getLedgerHash(referenceLedger, ledgerIndex);

--- a/src/xrpld/app/ledger/detail/LedgerDeltaAcquire.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerDeltaAcquire.cpp
@@ -184,12 +184,12 @@ LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)
         parent->seq() + 1 == replayTemp_->seq(),
         "ripple::LedgerDeltaAcquire::tryBuild : parent sequence match");
     XRPL_ASSERT(
-        parent->info().hash == replayTemp_->info().parentHash,
+        parent->header().hash == replayTemp_->header().parentHash,
         "ripple::LedgerDeltaAcquire::tryBuild : parent hash match");
     // build ledger
     LedgerReplay replayData(parent, replayTemp_, std::move(orderedTxns_));
     fullLedger_ = buildLedger(replayData, tapNONE, app_, journal_);
-    if (fullLedger_ && fullLedger_->info().hash == hash_)
+    if (fullLedger_ && fullLedger_->header().hash == hash_)
     {
         JLOG(journal_.info()) << "Built " << hash_;
         onLedgerBuilt(sl);
@@ -200,7 +200,7 @@ LedgerDeltaAcquire::tryBuild(std::shared_ptr<Ledger const> const& parent)
         failed_ = true;
         complete_ = false;
         JLOG(journal_.error()) << "tryBuild failed " << hash_ << " with parent "
-                               << parent->info().hash;
+                               << parent->header().hash;
         Throw<std::runtime_error>("Cannot replay ledger");
     }
 }

--- a/src/xrpld/app/ledger/detail/LedgerMaster.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerMaster.cpp
@@ -103,7 +103,7 @@ LedgerMaster::LedgerMaster(
 LedgerIndex
 LedgerMaster::getCurrentLedgerIndex()
 {
-    return app_.openLedger().current()->info().seq;
+    return app_.openLedger().current()->header().seq;
 }
 
 LedgerIndex
@@ -227,7 +227,7 @@ LedgerMaster::setValidLedger(std::shared_ptr<Ledger const> const& l)
     {
         auto validations = app_.validators().negativeUNLFilter(
             app_.getValidations().getTrustedForLedger(
-                l->info().hash, l->info().seq));
+                l->header().hash, l->header().seq));
         times.reserve(validations.size());
         for (auto const& val : validations)
             times.push_back(val->getSignTime());
@@ -248,18 +248,18 @@ LedgerMaster::setValidLedger(std::shared_ptr<Ledger const> const& l)
     }
     else
     {
-        signTime = l->info().closeTime;
+        signTime = l->header().closeTime;
     }
 
     mValidLedger.set(l);
     mValidLedgerSign = signTime.time_since_epoch().count();
     XRPL_ASSERT(
         mValidLedgerSeq || !app_.getMaxDisallowedLedger() ||
-            l->info().seq + max_ledger_difference_ >
+            l->header().seq + max_ledger_difference_ >
                 app_.getMaxDisallowedLedger(),
         "ripple::LedgerMaster::setValidLedger : valid ledger sequence");
     (void)max_ledger_difference_;
-    mValidLedgerSeq = l->info().seq;
+    mValidLedgerSeq = l->header().seq;
 
     app_.getOPs().updateLocalTx(*l);
     app_.getSHAMapStore().onLedgerClosed(getValidatedLedger());
@@ -304,8 +304,8 @@ void
 LedgerMaster::setPubLedger(std::shared_ptr<Ledger const> const& l)
 {
     mPubLedger = l;
-    mPubLedgerClose = l->info().closeTime.time_since_epoch().count();
-    mPubLedgerSeq = l->info().seq;
+    mPubLedgerClose = l->header().closeTime.time_since_epoch().count();
+    mPubLedgerSeq = l->header().seq;
 }
 
 void
@@ -328,11 +328,11 @@ LedgerMaster::canBeCurrent(std::shared_ptr<Ledger const> const& ledger)
     // last validated ledger
 
     auto validLedger = getValidatedLedger();
-    if (validLedger && (ledger->info().seq < validLedger->info().seq))
+    if (validLedger && (ledger->header().seq < validLedger->header().seq))
     {
         JLOG(m_journal.trace())
-            << "Candidate for current ledger has low seq " << ledger->info().seq
-            << " < " << validLedger->info().seq;
+            << "Candidate for current ledger has low seq "
+            << ledger->header().seq << " < " << validLedger->header().seq;
         return false;
     }
 
@@ -342,17 +342,17 @@ LedgerMaster::canBeCurrent(std::shared_ptr<Ledger const> const& ledger)
     // few ledgers as our clock can be off when we first start up
 
     auto closeTime = app_.timeKeeper().closeTime();
-    auto ledgerClose = ledger->info().parentCloseTime;
+    auto ledgerClose = ledger->header().parentCloseTime;
 
     using namespace std::chrono_literals;
-    if ((validLedger || (ledger->info().seq > 10)) &&
+    if ((validLedger || (ledger->header().seq > 10)) &&
         ((std::max(closeTime, ledgerClose) - std::min(closeTime, ledgerClose)) >
          5min))
     {
         JLOG(m_journal.warn())
             << "Candidate for current ledger has close time "
             << to_string(ledgerClose) << " at network time "
-            << to_string(closeTime) << " seq " << ledger->info().seq;
+            << to_string(closeTime) << " seq " << ledger->header().seq;
         return false;
     }
 
@@ -363,25 +363,25 @@ LedgerMaster::canBeCurrent(std::shared_ptr<Ledger const> const& ledger)
         // every two seconds. The goal is to prevent a malicious ledger
         // from increasing our sequence unreasonably high
 
-        LedgerIndex maxSeq = validLedger->info().seq + 10;
+        LedgerIndex maxSeq = validLedger->header().seq + 10;
 
-        if (closeTime > validLedger->info().parentCloseTime)
+        if (closeTime > validLedger->header().parentCloseTime)
             maxSeq += std::chrono::duration_cast<std::chrono::seconds>(
-                          closeTime - validLedger->info().parentCloseTime)
+                          closeTime - validLedger->header().parentCloseTime)
                           .count() /
                 2;
 
-        if (ledger->info().seq > maxSeq)
+        if (ledger->header().seq > maxSeq)
         {
             JLOG(m_journal.warn())
                 << "Candidate for current ledger has high seq "
-                << ledger->info().seq << " > " << maxSeq;
+                << ledger->header().seq << " > " << maxSeq;
             return false;
         }
 
         JLOG(m_journal.trace())
-            << "Acceptable seq range: " << validLedger->info().seq
-            << " <= " << ledger->info().seq << " <= " << maxSeq;
+            << "Acceptable seq range: " << validLedger->header().seq
+            << " <= " << ledger->header().seq << " <= " << maxSeq;
     }
 
     return true;
@@ -422,7 +422,7 @@ LedgerMaster::fixIndex(LedgerIndex ledgerIndex, LedgerHash const& ledgerHash)
 bool
 LedgerMaster::storeLedger(std::shared_ptr<Ledger const> ledger)
 {
-    bool validated = ledger->info().validated;
+    bool validated = ledger->header().validated;
     // Returns true if we already had the ledger
     return mLedgerHistory.insert(std::move(ledger), validated);
 }
@@ -439,7 +439,7 @@ LedgerMaster::applyHeldTransactions()
         std::lock_guard sl(m_mutex);
         // VFALCO NOTE The hash for an open ledger is undefined so we use
         // something that is a reasonable substitute.
-        CanonicalTXSet set(app_.openLedger().current()->info().parentHash);
+        CanonicalTXSet set(app_.openLedger().current()->header().parentHash);
         std::swap(mHeldTransactions, set);
         return set;
     }();
@@ -482,10 +482,10 @@ LedgerMaster::isValidated(ReadView const& ledger)
     if (ledger.open())
         return false;
 
-    if (ledger.info().validated)
+    if (ledger.header().validated)
         return true;
 
-    auto const seq = ledger.info().seq;
+    auto const seq = ledger.header().seq;
     try
     {
         // Use the skip list in the last validated ledger to see if ledger
@@ -493,7 +493,7 @@ LedgerMaster::isValidated(ReadView const& ledger)
         // validated).
         auto const hash = walkHashBySeq(seq, InboundLedger::Reason::GENERIC);
 
-        if (!hash || ledger.info().hash != *hash)
+        if (!hash || ledger.header().hash != *hash)
         {
             // This ledger's hash is not the hash of the validated ledger
             if (hash)
@@ -503,7 +503,7 @@ LedgerMaster::isValidated(ReadView const& ledger)
                     "ripple::LedgerMaster::isValidated : nonzero hash");
                 uint256 valHash =
                     app_.getRelationalDatabase().getHashByIndex(seq);
-                if (valHash == ledger.info().hash)
+                if (valHash == ledger.header().hash)
                 {
                     // SQL database doesn't match ledger chain
                     clearLedger(seq);
@@ -519,7 +519,7 @@ LedgerMaster::isValidated(ReadView const& ledger)
     }
 
     // Mark ledger as validated to save time if we see it again.
-    ledger.info().validated = true;
+    ledger.header().validated = true;
     return true;
 }
 
@@ -597,7 +597,7 @@ LedgerMaster::getEarliestFetch()
 {
     // The earliest ledger we will let people fetch is ledger zero,
     // unless that creates a larger range than allowed
-    std::uint32_t e = getClosedLedger()->info().seq;
+    std::uint32_t e = getClosedLedger()->header().seq;
 
     if (e > fetch_depth_)
         e -= fetch_depth_;
@@ -609,8 +609,8 @@ LedgerMaster::getEarliestFetch()
 void
 LedgerMaster::tryFill(std::shared_ptr<Ledger const> ledger)
 {
-    std::uint32_t seq = ledger->info().seq;
-    uint256 prevHash = ledger->info().parentHash;
+    std::uint32_t seq = ledger->header().seq;
+    uint256 prevHash = ledger->header().parentHash;
 
     std::map<std::uint32_t, LedgerHashPair> ledgerHashes;
 
@@ -732,7 +732,7 @@ LedgerMaster::fixMismatch(ReadView const& ledger)
     int invalidate = 0;
     std::optional<uint256> hash;
 
-    for (std::uint32_t lSeq = ledger.info().seq - 1; lSeq > 0; --lSeq)
+    for (std::uint32_t lSeq = ledger.header().seq - 1; lSeq > 0; --lSeq)
     {
         if (haveLedger(lSeq))
         {
@@ -754,7 +754,7 @@ LedgerMaster::fixMismatch(ReadView const& ledger)
                 // try to close the seam
                 auto otherLedger = getLedgerBySeq(lSeq);
 
-                if (otherLedger && (otherLedger->info().hash == *hash))
+                if (otherLedger && (otherLedger->header().hash == *hash))
                 {
                     // we closed the seam
                     if (invalidate != 0)
@@ -788,8 +788,8 @@ LedgerMaster::setFullLedger(
     bool isCurrent)
 {
     // A new ledger has been accepted as part of the trusted chain
-    JLOG(m_journal.debug()) << "Ledger " << ledger->info().seq
-                            << " accepted :" << ledger->info().hash;
+    JLOG(m_journal.debug()) << "Ledger " << ledger->header().seq
+                            << " accepted :" << ledger->header().hash;
     XRPL_ASSERT(
         ledger->stateMap().getHash().isNonZero(),
         "ripple::LedgerMaster::setFullLedger : nonzero ledger state hash");
@@ -803,23 +803,23 @@ LedgerMaster::setFullLedger(
     {
         // Check the SQL database's entry for the sequence before this
         // ledger, if it's not this ledger's parent, invalidate it
-        uint256 prevHash =
-            app_.getRelationalDatabase().getHashByIndex(ledger->info().seq - 1);
-        if (prevHash.isNonZero() && prevHash != ledger->info().parentHash)
-            clearLedger(ledger->info().seq - 1);
+        uint256 prevHash = app_.getRelationalDatabase().getHashByIndex(
+            ledger->header().seq - 1);
+        if (prevHash.isNonZero() && prevHash != ledger->header().parentHash)
+            clearLedger(ledger->header().seq - 1);
     }
 
     pendSaveValidated(app_, ledger, isSynchronous, isCurrent);
 
     {
         std::lock_guard ml(mCompleteLock);
-        mCompleteLedgers.insert(ledger->info().seq);
+        mCompleteLedgers.insert(ledger->header().seq);
     }
 
     {
         std::lock_guard ml(m_mutex);
 
-        if (ledger->info().seq > mValidLedgerSeq)
+        if (ledger->header().seq > mValidLedgerSeq)
             setValidLedger(ledger);
         if (!mPubLedger)
         {
@@ -827,13 +827,13 @@ LedgerMaster::setFullLedger(
             app_.getOrderBookDB().setup(ledger);
         }
 
-        if (ledger->info().seq != 0 && haveLedger(ledger->info().seq - 1))
+        if (ledger->header().seq != 0 && haveLedger(ledger->header().seq - 1))
         {
             // we think we have the previous ledger, double check
-            auto prevLedger = getLedgerBySeq(ledger->info().seq - 1);
+            auto prevLedger = getLedgerBySeq(ledger->header().seq - 1);
 
             if (!prevLedger ||
-                (prevLedger->info().hash != ledger->info().parentHash))
+                (prevLedger->header().hash != ledger->header().parentHash))
             {
                 JLOG(m_journal.warn())
                     << "Acquired ledger invalidates previous ledger: "
@@ -926,23 +926,23 @@ LedgerMaster::checkAccept(std::shared_ptr<Ledger const> const& ledger)
     // publish?
     std::lock_guard ml(m_mutex);
 
-    if (ledger->info().seq <= mValidLedgerSeq)
+    if (ledger->header().seq <= mValidLedgerSeq)
         return;
 
     auto const minVal = getNeededValidations();
     auto validations = app_.validators().negativeUNLFilter(
         app_.getValidations().getTrustedForLedger(
-            ledger->info().hash, ledger->info().seq));
+            ledger->header().hash, ledger->header().seq));
     auto const tvc = validations.size();
     if (tvc < minVal)  // nothing we can do
     {
         JLOG(m_journal.trace())
-            << "Only " << tvc << " validations for " << ledger->info().hash;
+            << "Only " << tvc << " validations for " << ledger->header().hash;
         return;
     }
 
     JLOG(m_journal.info()) << "Advancing accepted ledger to "
-                           << ledger->info().seq << " with >= " << minVal
+                           << ledger->header().seq << " with >= " << minVal
                            << " validations";
 
     ledger->setValidated();
@@ -956,10 +956,10 @@ LedgerMaster::checkAccept(std::shared_ptr<Ledger const> const& ledger)
     }
 
     std::uint32_t const base = app_.getFeeTrack().getLoadBase();
-    auto fees = app_.getValidations().fees(ledger->info().hash, base);
+    auto fees = app_.getValidations().fees(ledger->header().hash, base);
     {
         auto fees2 =
-            app_.getValidations().fees(ledger->info().parentHash, base);
+            app_.getValidations().fees(ledger->header().parentHash, base);
         fees.reserve(fees.size() + fees2.size());
         std::copy(fees2.begin(), fees2.end(), std::back_inserter(fees));
     }
@@ -1007,7 +1007,7 @@ LedgerMaster::checkAccept(std::shared_ptr<Ledger const> const& ledger)
         {
             // Have not printed the warning before, check if need to print.
             auto const vals = app_.getValidations().getTrustedForLedger(
-                ledger->info().parentHash, ledger->info().seq - 1);
+                ledger->header().parentHash, ledger->header().seq - 1);
             std::size_t higherVersionCount = 0;
             std::size_t rippledCount = 0;
             for (auto const& v : vals)
@@ -1077,10 +1077,10 @@ LedgerMaster::consensusBuilt(
 
     mLedgerHistory.builtLedger(ledger, consensusHash, std::move(consensus));
 
-    if (ledger->info().seq <= mValidLedgerSeq)
+    if (ledger->header().seq <= mValidLedgerSeq)
     {
         auto stream = app_.journal("LedgerConsensus").info();
-        JLOG(stream) << "Consensus built old ledger: " << ledger->info().seq
+        JLOG(stream) << "Consensus built old ledger: " << ledger->header().seq
                      << " <= " << mValidLedgerSeq;
         return;
     }
@@ -1088,7 +1088,7 @@ LedgerMaster::consensusBuilt(
     // See if this ledger can be the new fully-validated ledger
     checkAccept(ledger);
 
-    if (ledger->info().seq <= mValidLedgerSeq)
+    if (ledger->header().seq <= mValidLedgerSeq)
     {
         auto stream = app_.journal("LedgerConsensus").debug();
         JLOG(stream) << "Consensus ledger fully validated";
@@ -1134,7 +1134,7 @@ LedgerMaster::consensusBuilt(
 
     auto const neededValidations = getNeededValidations();
     auto maxSeq = mValidLedgerSeq.load();
-    auto maxLedger = ledger->info().hash;
+    auto maxLedger = ledger->header().hash;
 
     // Of the ledgers with sufficient validations,
     // find the one with the highest sequence
@@ -1145,7 +1145,7 @@ LedgerMaster::consensusBuilt(
             if (v.second.ledgerSeq_ == 0)
             {
                 if (auto l = getLedgerByHash(v.first))
-                    v.second.ledgerSeq_ = l->info().seq;
+                    v.second.ledgerSeq_ = l->header().seq;
             }
 
             if (v.second.ledgerSeq_ > maxSeq)
@@ -1172,7 +1172,7 @@ LedgerMaster::getLedgerHashForHistory(
     std::optional<LedgerHash> ret;
     auto const& l{mHistLedger};
 
-    if (l && l->info().seq >= index)
+    if (l && l->header().seq >= index)
     {
         ret = hashOfSeq(*l, index, m_journal);
         if (!ret)
@@ -1230,7 +1230,7 @@ LedgerMaster::findNewLedgersToPublish(
 
     auto pubSeq = mPubLedgerSeq + 1;  // Next sequence to publish
     auto valLedger = mValidLedger.get();
-    std::uint32_t valSeq = valLedger->info().seq;
+    std::uint32_t valSeq = valLedger->header().seq;
 
     scope_unlock sul{sl};
     try
@@ -1276,7 +1276,7 @@ LedgerMaster::findNewLedgersToPublish(
             }
 
             // Did we acquire the next ledger we need to publish?
-            if (ledger && (ledger->info().seq == pubSeq))
+            if (ledger && (ledger->header().seq == pubSeq))
             {
                 ledger->setValidated();
                 ret.push_back(ledger);
@@ -1307,7 +1307,7 @@ LedgerMaster::findNewLedgersToPublish(
         while (startLedger->seq() + 1 < finishLedger->seq())
         {
             if (auto const parent = mLedgerHistory.getLedgerByHash(
-                    finishLedger->info().parentHash);
+                    finishLedger->header().parentHash);
                 parent)
             {
                 finishLedger = parent;
@@ -1318,13 +1318,13 @@ LedgerMaster::findNewLedgersToPublish(
                     finishLedger->seq() - startLedger->seq() + 1;
                 JLOG(m_journal.debug())
                     << "Publish LedgerReplays " << numberLedgers
-                    << " ledgers, from seq=" << startLedger->info().seq << ", "
-                    << startLedger->info().hash
-                    << " to seq=" << finishLedger->info().seq << ", "
-                    << finishLedger->info().hash;
+                    << " ledgers, from seq=" << startLedger->header().seq
+                    << ", " << startLedger->header().hash
+                    << " to seq=" << finishLedger->header().seq << ", "
+                    << finishLedger->header().hash;
                 app_.getLedgerReplayer().replay(
                     InboundLedger::Reason::GENERIC,
-                    finishLedger->info().hash,
+                    finishLedger->header().hash,
                     numberLedgers);
                 break;
             }
@@ -1390,7 +1390,8 @@ LedgerMaster::updatePaths()
             std::lock_guard ml(m_mutex);
 
             if (!mValidLedger.empty() &&
-                (!mPathLedger || (mPathLedger->info().seq != mValidLedgerSeq)))
+                (!mPathLedger ||
+                 (mPathLedger->header().seq != mValidLedgerSeq)))
             {  // We have a new valid ledger since the last full pathfinding
                 mPathLedger = mValidLedger.get();
                 lastLedger = mPathLedger;
@@ -1412,7 +1413,7 @@ LedgerMaster::updatePaths()
         {  // don't pathfind with a ledger that's more than 60 seconds old
             using namespace std::chrono;
             auto age = time_point_cast<seconds>(app_.timeKeeper().closeTime()) -
-                lastLedger->info().closeTime;
+                lastLedger->header().closeTime;
             if (age > 1min)
             {
                 JLOG(m_journal.debug())
@@ -1461,16 +1462,16 @@ LedgerMaster::updatePaths()
             {
                 // our parent is the problem
                 app_.getInboundLedgers().acquire(
-                    lastLedger->info().parentHash,
-                    lastLedger->info().seq - 1,
+                    lastLedger->header().parentHash,
+                    lastLedger->header().seq - 1,
                     InboundLedger::Reason::GENERIC);
             }
             else
             {
                 // this ledger is the problem
                 app_.getInboundLedgers().acquire(
-                    lastLedger->info().hash,
-                    lastLedger->info().seq,
+                    lastLedger->header().hash,
+                    lastLedger->header().seq,
                     InboundLedger::Reason::GENERIC);
             }
         }
@@ -1635,7 +1636,7 @@ LedgerMaster::walkHashBySeq(
     std::shared_ptr<ReadView const> const& referenceLedger,
     InboundLedger::Reason reason)
 {
-    if (!referenceLedger || (referenceLedger->info().seq < index))
+    if (!referenceLedger || (referenceLedger->header().seq < index))
     {
         // Nothing we can do. No validated ledger.
         return std::nullopt;
@@ -1693,7 +1694,7 @@ LedgerMaster::getLedgerBySeq(std::uint32_t index)
         // Always prefer a validated ledger
         if (auto valid = mValidLedger.get())
         {
-            if (valid->info().seq == index)
+            if (valid->header().seq == index)
                 return valid;
 
             try
@@ -1714,7 +1715,7 @@ LedgerMaster::getLedgerBySeq(std::uint32_t index)
         return ret;
 
     auto ret = mClosedLedger.get();
-    if (ret && (ret->info().seq == index))
+    if (ret && (ret->header().seq == index))
         return ret;
 
     clearLedger(index);
@@ -1728,7 +1729,7 @@ LedgerMaster::getLedgerByHash(uint256 const& hash)
         return ret;
 
     auto ret = mClosedLedger.get();
-    if (ret && (ret->info().hash == hash))
+    if (ret && (ret->header().hash == hash))
         return ret;
 
     return {};
@@ -1818,7 +1819,7 @@ LedgerMaster::fetchForHistory(
         }
         if (ledger)
         {
-            auto seq = ledger->info().seq;
+            auto seq = ledger->header().seq;
             XRPL_ASSERT(
                 seq == missing,
                 "ripple::LedgerMaster::fetchForHistory : sequence match");
@@ -1832,7 +1833,7 @@ LedgerMaster::fetchForHistory(
             }
             if (fillInProgress == 0 &&
                 app_.getRelationalDatabase().getHashByIndex(seq - 1) ==
-                    ledger->info().parentHash)
+                    ledger->header().parentHash)
             {
                 {
                     // Previous ledger is in DB
@@ -1919,7 +1920,7 @@ LedgerMaster::doAdvance(std::unique_lock<std::recursive_mutex>& sl)
                     std::lock_guard sll(mCompleteLock);
                     missing = prevMissing(
                         mCompleteLedgers,
-                        mPubLedger->info().seq,
+                        mPubLedger->header().seq,
                         app_.getNodeStore().earliestLedgerSeq());
                 }
                 if (missing)
@@ -1966,7 +1967,7 @@ LedgerMaster::doAdvance(std::unique_lock<std::recursive_mutex>& sl)
                 {
                     scope_unlock sul{sl};
                     JLOG(m_journal.debug())
-                        << "tryAdvance publishing seq " << ledger->info().seq;
+                        << "tryAdvance publishing seq " << ledger->header().seq;
                     setFullLedger(ledger, true, true);
                 }
 
@@ -2118,14 +2119,14 @@ LedgerMaster::makeFetchPack(
         return;
     }
 
-    if (have->info().seq < getEarliestFetch())
+    if (have->header().seq < getEarliestFetch())
     {
         JLOG(m_journal.debug()) << "Peer requests fetch pack that is too early";
         peer->charge(Resource::feeMalformedRequest, "get_object ledger early");
         return;
     }
 
-    auto want = getLedgerByHash(have->info().parentHash);
+    auto want = getLedgerByHash(have->header().parentHash);
 
     if (!want)
     {
@@ -2160,19 +2161,19 @@ LedgerMaster::makeFetchPack(
         //     the same process adding the previous ledger to the FetchPack.
         do
         {
-            std::uint32_t lSeq = want->info().seq;
+            std::uint32_t lSeq = want->header().seq;
 
             {
                 // Serialize the ledger header:
                 hdr.erase();
 
                 hdr.add32(HashPrefix::ledgerMaster);
-                addRaw(want->info(), hdr);
+                addRaw(want->header(), hdr);
 
                 // Add the data
                 protocol::TMIndexedObject* obj = reply.add_objects();
                 obj->set_hash(
-                    want->info().hash.data(), want->info().hash.size());
+                    want->header().hash.data(), want->header().hash.size());
                 obj->set_data(hdr.getDataPtr(), hdr.getLength());
                 obj->set_ledgerseq(lSeq);
             }
@@ -2182,14 +2183,14 @@ LedgerMaster::makeFetchPack(
 
             // We use nullptr here because transaction maps are per ledger
             // and so the requestor is unlikely to already have it.
-            if (want->info().txHash.isNonZero())
+            if (want->header().txHash.isNonZero())
                 populateFetchPack(want->txMap(), nullptr, 512, &reply, lSeq);
 
             if (reply.objects().size() >= 512)
                 break;
 
             have = std::move(want);
-            want = getLedgerByHash(have->info().parentHash);
+            want = getLedgerByHash(have->header().parentHash);
         } while (want && UptimeClock::now() <= uptime + 1s);
 
         auto msg = std::make_shared<Message>(reply, protocol::mtGET_OBJECTS);

--- a/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp
@@ -72,7 +72,7 @@ LedgerReplayMsgHandler::processProofPathRequest(
 
     // pack header
     Serializer nData(128);
-    addRaw(ledger->info(), nData);
+    addRaw(ledger->header(), nData);
     reply.set_ledgerheader(nData.getDataPtr(), nData.getLength());
     // pack path
     for (auto const& b : *path)
@@ -185,7 +185,7 @@ LedgerReplayMsgHandler::processReplayDeltaRequest(
 
     // pack header
     Serializer nData(128);
-    addRaw(ledger->info(), nData);
+    addRaw(ledger->header(), nData);
     reply.set_ledgerheader(nData.getDataPtr(), nData.getLength());
     // pack transactions
     auto const& txMap = ledger->txMap();

--- a/src/xrpld/app/ledger/detail/LedgerReplayTask.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerReplayTask.cpp
@@ -173,7 +173,7 @@ LedgerReplayTask::tryAdvance(ScopedLockType& sl)
                                                 : ", waiting to fill parameter")
                            << ", deltaIndex=" << deltaToBuild_
                            << ", totalDeltas=" << deltas_.size() << ", parent "
-                           << (parent_ ? parent_->info().hash : uint256());
+                           << (parent_ ? parent_->header().hash : uint256());
 
     bool shouldTry = parent_ && parameter_.full_ &&
         parameter_.totalLedgers_ - 1 == deltas_.size();
@@ -191,7 +191,7 @@ LedgerReplayTask::tryAdvance(ScopedLockType& sl)
             if (auto l = delta->tryBuild(parent_); l)
             {
                 JLOG(journal_.debug())
-                    << "Task " << hash_ << " got ledger " << l->info().hash
+                    << "Task " << hash_ << " got ledger " << l->header().hash
                     << " deltaIndex=" << deltaToBuild_
                     << " totalDeltas=" << deltas_.size();
                 parent_ = l;

--- a/src/xrpld/app/ledger/detail/LedgerToJson.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerToJson.cpp
@@ -147,7 +147,7 @@ fillJsonTx(
         }
 
         if (!fill.ledger.open())
-            txJson[jss::ledger_hash] = to_string(fill.ledger.info().hash);
+            txJson[jss::ledger_hash] = to_string(fill.ledger.header().hash);
 
         bool const validated =
             fill.context->ledgerMaster.isValidated(fill.ledger);
@@ -305,12 +305,12 @@ fillJson(Object& json, LedgerFill const& fill)
     // Is there a way to report this back?
     auto bFull = isFull(fill);
     if (isBinary(fill))
-        fillJsonBinary(json, !fill.ledger.open(), fill.ledger.info());
+        fillJsonBinary(json, !fill.ledger.open(), fill.ledger.header());
     else
         fillJson(
             json,
             !fill.ledger.open(),
-            fill.ledger.info(),
+            fill.ledger.header(),
             bFull,
             (fill.context ? fill.context->apiVersion
                           : RPC::apiMaximumSupportedVersion));

--- a/src/xrpld/app/ledger/detail/LocalTxs.cpp
+++ b/src/xrpld/app/ledger/detail/LocalTxs.cpp
@@ -126,7 +126,7 @@ public:
         std::lock_guard lock(m_lock);
 
         m_txns.remove_if([&view](auto const& txn) {
-            if (txn.isExpired(view.info().seq))
+            if (txn.isExpired(view.header().seq))
                 return true;
             if (view.txExists(txn.getID()))
                 return true;

--- a/src/xrpld/app/main/Application.cpp
+++ b/src/xrpld/app/main/Application.cpp
@@ -1384,7 +1384,7 @@ ApplicationImp::setup(boost::program_options::variables_map const& cmdline)
 
     // start first consensus round
     if (!m_networkOPs->beginConsensus(
-            m_ledgerMaster->getClosedLedger()->info().hash, {}))
+            m_ledgerMaster->getClosedLedger()->header().hash, {}))
     {
         JLOG(m_journal.fatal()) << "Unable to start consensus";
         return false;
@@ -1699,7 +1699,7 @@ ApplicationImp::startGenesisLedger()
         std::make_shared<Ledger>(*genesis, timeKeeper().closeTime());
     next->updateSkipList();
     XRPL_ASSERT(
-        next->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+        next->header().seq < XRP_LEDGER_EARLIEST_FEES ||
             next->read(keylet::fees()),
         "ripple::ApplicationImp::startGenesisLedger : valid ledger fees");
     next->setImmutable();
@@ -1721,7 +1721,7 @@ ApplicationImp::getLastFullLedger()
             return ledger;
 
         XRPL_ASSERT(
-            ledger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+            ledger->header().seq < XRP_LEDGER_EARLIEST_FEES ||
                 ledger->read(keylet::fees()),
             "ripple::ApplicationImp::getLastFullLedger : valid ledger fees");
         ledger->setImmutable();
@@ -1729,7 +1729,7 @@ ApplicationImp::getLastFullLedger()
         if (getLedgerMaster().haveLedger(seq))
             ledger->setValidated();
 
-        if (ledger->info().hash == hash)
+        if (ledger->header().hash == hash)
         {
             JLOG(j.trace()) << "Loaded ledger: " << hash;
             return ledger;
@@ -1876,7 +1876,7 @@ ApplicationImp::loadLedgerFromFile(std::string const& name)
         loadLedger->stateMap().flushDirty(hotACCOUNT_NODE);
 
         XRPL_ASSERT(
-            loadLedger->info().seq < XRP_LEDGER_EARLIEST_FEES ||
+            loadLedger->header().seq < XRP_LEDGER_EARLIEST_FEES ||
                 loadLedger->read(keylet::fees()),
             "ripple::ApplicationImp::loadLedgerFromFile : valid ledger fees");
         loadLedger->setAccepted(
@@ -1955,7 +1955,7 @@ ApplicationImp::loadOldLedger(
 
             JLOG(m_journal.info()) << "Loading parent ledger";
 
-            loadLedger = loadByHash(replayLedger->info().parentHash, *this);
+            loadLedger = loadByHash(replayLedger->header().parentHash, *this);
             if (!loadLedger)
             {
                 JLOG(m_journal.info())
@@ -1964,7 +1964,7 @@ ApplicationImp::loadOldLedger(
                 // Try to build the ledger from the back end
                 auto il = std::make_shared<InboundLedger>(
                     *this,
-                    replayLedger->info().parentHash,
+                    replayLedger->header().parentHash,
                     0,
                     InboundLedger::Reason::GENERIC,
                     stopwatch(),
@@ -1989,7 +1989,7 @@ ApplicationImp::loadOldLedger(
         using namespace date;
         static constexpr NetClock::time_point ledgerWarnTimePoint{
             sys_days{January / 1 / 2018} - sys_days{January / 1 / 2000}};
-        if (loadLedger->info().closeTime < ledgerWarnTimePoint)
+        if (loadLedger->header().closeTime < ledgerWarnTimePoint)
         {
             JLOG(m_journal.fatal())
                 << "\n\n***  WARNING   ***\n"
@@ -2003,10 +2003,10 @@ ApplicationImp::loadOldLedger(
                    "get the older rules.\n*** CONTINUING ***\n";
         }
 
-        JLOG(m_journal.info()) << "Loading ledger " << loadLedger->info().hash
-                               << " seq:" << loadLedger->info().seq;
+        JLOG(m_journal.info()) << "Loading ledger " << loadLedger->header().hash
+                               << " seq:" << loadLedger->header().seq;
 
-        if (loadLedger->info().accountHash.isZero())
+        if (loadLedger->header().accountHash.isZero())
         {
             // LCOV_EXCL_START
             JLOG(m_journal.fatal()) << "Ledger is empty.";
@@ -2039,7 +2039,7 @@ ApplicationImp::loadOldLedger(
         }
 
         m_ledgerMaster->setLedgerRangePresent(
-            loadLedger->info().seq, loadLedger->info().seq);
+            loadLedger->header().seq, loadLedger->header().seq);
 
         m_ledgerMaster->switchLCL(loadLedger);
         loadLedger->setValidated();
@@ -2081,7 +2081,7 @@ ApplicationImp::loadOldLedger(
             if (trapTxID && !trapTxID_)
             {
                 JLOG(m_journal.fatal())
-                    << "Ledger " << replayLedger->info().seq
+                    << "Ledger " << replayLedger->header().seq
                     << " does not contain the transaction hash " << *trapTxID;
                 return false;
             }

--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -266,7 +266,7 @@ FeeVoteImpl::doVoting(
     auto const baseReserve = baseReserveVote.getVotes();
     auto const incReserve = incReserveVote.getVotes();
 
-    auto const seq = lastClosedLedger->info().seq + 1;
+    auto const seq = lastClosedLedger->header().seq + 1;
 
     // add transactions to our position
     if (baseFee.second || baseReserve.second || incReserve.second)

--- a/src/xrpld/app/misc/NegativeUNLVote.cpp
+++ b/src/xrpld/app/misc/NegativeUNLVote.cpp
@@ -59,7 +59,7 @@ NegativeUNLVote::doVoting(
             }
         }
 
-        auto const seq = prevLedger->info().seq + 1;
+        auto const seq = prevLedger->header().seq + 1;
         purgeNewValidators(seq);
 
         // Process the table and find all candidates to disable or to re-enable
@@ -69,8 +69,8 @@ NegativeUNLVote::doVoting(
         // Pick one to disable and one to re-enable if any, add ttUNL_MODIFY Tx
         if (!candidates.toDisableCandidates.empty())
         {
-            auto n =
-                choose(prevLedger->info().hash, candidates.toDisableCandidates);
+            auto n = choose(
+                prevLedger->header().hash, candidates.toDisableCandidates);
             XRPL_ASSERT(
                 nidToKeyMap.contains(n),
                 "ripple::NegativeUNLVote::doVoting : found node to disable");
@@ -80,7 +80,7 @@ NegativeUNLVote::doVoting(
         if (!candidates.toReEnableCandidates.empty())
         {
             auto n = choose(
-                prevLedger->info().hash, candidates.toReEnableCandidates);
+                prevLedger->header().hash, candidates.toReEnableCandidates);
             XRPL_ASSERT(
                 nidToKeyMap.contains(n),
                 "ripple::NegativeUNLVote::doVoting : found node to enable");
@@ -154,7 +154,7 @@ NegativeUNLVote::buildScoreTable(
 
     // Ask the validation container to keep enough validation message history
     // for next time.
-    auto const seq = prevLedger->info().seq + 1;
+    auto const seq = prevLedger->header().seq + 1;
     validations.setSeqToKeep(seq - 1, seq + FLAG_LEDGER_INTERVAL);
 
     // Find FLAG_LEDGER_INTERVAL (i.e. 256) previous ledger hashes

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -1514,7 +1514,7 @@ NetworkOPsImp::apply(std::unique_lock<std::mutex>& batchLock)
 
         std::optional<LedgerIndex> validatedLedgerIndex;
         if (auto const l = m_ledgerMaster.getValidatedLedger())
-            validatedLedgerIndex = l->info().seq;
+            validatedLedgerIndex = l->header().seq;
 
         auto newOL = app_.openLedger().current();
         for (TransactionStatus& e : transactions)
@@ -1882,8 +1882,8 @@ NetworkOPsImp::checkLastClosedLedger(
     if (!ourClosed)
         return false;
 
-    uint256 closedLedger = ourClosed->info().hash;
-    uint256 prevClosedLedger = ourClosed->info().parentHash;
+    uint256 closedLedger = ourClosed->header().hash;
+    uint256 prevClosedLedger = ourClosed->header().parentHash;
     JLOG(m_journal.trace()) << "OurClosed:  " << closedLedger;
     JLOG(m_journal.trace()) << "PrevClosed: " << prevClosedLedger;
 
@@ -1924,7 +1924,7 @@ NetworkOPsImp::checkLastClosedLedger(
     {
         // don't switch to our own previous ledger
         JLOG(m_journal.info()) << "We won't switch to our own previous ledger";
-        networkClosed = ourClosed->info().hash;
+        networkClosed = ourClosed->header().hash;
         switchLedgers = false;
     }
     else
@@ -1946,12 +1946,12 @@ NetworkOPsImp::checkLastClosedLedger(
     {
         // Don't switch to a ledger not on the validated chain
         // or with an invalid close time or sequence
-        networkClosed = ourClosed->info().hash;
+        networkClosed = ourClosed->header().hash;
         return false;
     }
 
     JLOG(m_journal.warn()) << "We are not running on the consensus ledger";
-    JLOG(m_journal.info()) << "Our LCL: " << ourClosed->info().hash
+    JLOG(m_journal.info()) << "Our LCL: " << ourClosed->header().hash
                            << getJson({*ourClosed, {}});
     JLOG(m_journal.info()) << "Net LCL " << closedLedger;
 
@@ -1977,7 +1977,7 @@ NetworkOPsImp::switchLastClosedLedger(
 {
     // set the newLCL as our last closed ledger -- this is abnormal code
     JLOG(m_journal.error())
-        << "JUMP last closed ledger to " << newLCL->info().hash;
+        << "JUMP last closed ledger to " << newLCL->header().hash;
 
     clearNeedNetworkLedger();
 
@@ -2015,11 +2015,13 @@ NetworkOPsImp::switchLastClosedLedger(
 
     protocol::TMStatusChange s;
     s.set_newevent(protocol::neSWITCHED_LEDGER);
-    s.set_ledgerseq(newLCL->info().seq);
+    s.set_ledgerseq(newLCL->header().seq);
     s.set_networktime(app_.timeKeeper().now().time_since_epoch().count());
     s.set_ledgerhashprevious(
-        newLCL->info().parentHash.begin(), newLCL->info().parentHash.size());
-    s.set_ledgerhash(newLCL->info().hash.begin(), newLCL->info().hash.size());
+        newLCL->header().parentHash.begin(),
+        newLCL->header().parentHash.size());
+    s.set_ledgerhash(
+        newLCL->header().hash.begin(), newLCL->header().hash.size());
 
     app_.overlay().foreach(
         send_always(std::make_shared<Message>(s, protocol::mtSTATUS_CHANGE)));
@@ -2034,7 +2036,7 @@ NetworkOPsImp::beginConsensus(
         networkClosed.isNonZero(),
         "ripple::NetworkOPsImp::beginConsensus : nonzero input");
 
-    auto closingInfo = m_ledgerMaster.getCurrentLedger()->info();
+    auto closingInfo = m_ledgerMaster.getCurrentLedger()->header();
 
     JLOG(m_journal.info()) << "Consensus time for #" << closingInfo.seq
                            << " with LCL " << closingInfo.parentHash;
@@ -2056,11 +2058,12 @@ NetworkOPsImp::beginConsensus(
     }
 
     XRPL_ASSERT(
-        prevLedger->info().hash == closingInfo.parentHash,
+        prevLedger->header().hash == closingInfo.parentHash,
         "ripple::NetworkOPsImp::beginConsensus : prevLedger hash matches "
         "parent");
     XRPL_ASSERT(
-        closingInfo.parentHash == m_ledgerMaster.getClosedLedger()->info().hash,
+        closingInfo.parentHash ==
+            m_ledgerMaster.getClosedLedger()->header().hash,
         "ripple::NetworkOPsImp::beginConsensus : closedLedger parent matches "
         "hash");
 
@@ -2147,7 +2150,7 @@ NetworkOPsImp::mapComplete(std::shared_ptr<SHAMap> const& map, bool fromAcquire)
 void
 NetworkOPsImp::endConsensus(std::unique_ptr<std::stringstream> const& clog)
 {
-    uint256 deadLedger = m_ledgerMaster.getClosedLedger()->info().parentHash;
+    uint256 deadLedger = m_ledgerMaster.getClosedLedger()->header().parentHash;
 
     for (auto const& it : app_.overlay().getActivePeers())
     {
@@ -2193,8 +2196,9 @@ NetworkOPsImp::endConsensus(std::unique_ptr<std::stringstream> const& clog)
         // Note: Do not go to FULL if we don't have the previous ledger
         // check if the ledger is bad enough to go to CONNECTE  D -- TODO
         auto current = m_ledgerMaster.getCurrentLedger();
-        if (app_.timeKeeper().now() < (current->info().parentCloseTime +
-                                       2 * current->info().closeTimeResolution))
+        if (app_.timeKeeper().now() <
+            (current->header().parentCloseTime +
+             2 * current->header().closeTimeResolution))
         {
             setMode(OperatingMode::FULL);
         }
@@ -2911,8 +2915,8 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
     {
         XRPAmount const baseFee = lpClosed->fees().base;
         Json::Value l(Json::objectValue);
-        l[jss::seq] = Json::UInt(lpClosed->info().seq);
-        l[jss::hash] = to_string(lpClosed->info().hash);
+        l[jss::seq] = Json::UInt(lpClosed->header().seq);
+        l[jss::hash] = to_string(lpClosed->header().hash);
 
         if (!human)
         {
@@ -2920,7 +2924,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             l[jss::reserve_base] = lpClosed->fees().reserve.jsonClipped();
             l[jss::reserve_inc] = lpClosed->fees().increment.jsonClipped();
             l[jss::close_time] = Json::Value::UInt(
-                lpClosed->info().closeTime.time_since_epoch().count());
+                lpClosed->header().closeTime.time_since_epoch().count());
         }
         else
         {
@@ -2942,7 +2946,7 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
             }
             else
             {
-                auto lCloseTime = lpClosed->info().closeTime;
+                auto lCloseTime = lpClosed->header().closeTime;
                 auto closeTime = app_.timeKeeper().closeTime();
                 if (lCloseTime <= closeTime)
                 {
@@ -2962,8 +2966,8 @@ NetworkOPsImp::getServerInfo(bool human, bool admin, bool counters)
         auto lpPublished = m_ledgerMaster.getPublishedLedger();
         if (!lpPublished)
             info[jss::published_ledger] = "none";
-        else if (lpPublished->info().seq != lpClosed->info().seq)
-            info[jss::published_ledger] = lpPublished->info().seq;
+        else if (lpPublished->header().seq != lpClosed->header().seq)
+            info[jss::published_ledger] = lpPublished->header().seq;
     }
 
     accounting_.json(info);
@@ -3083,12 +3087,12 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
     // Holes are filled across connection loss or other catastrophe
 
     std::shared_ptr<AcceptedLedger> alpAccepted =
-        app_.getAcceptedLedgerCache().fetch(lpAccepted->info().hash);
+        app_.getAcceptedLedgerCache().fetch(lpAccepted->header().hash);
     if (!alpAccepted)
     {
         alpAccepted = std::make_shared<AcceptedLedger>(lpAccepted, app_);
         app_.getAcceptedLedgerCache().canonicalize_replace_client(
-            lpAccepted->info().hash, alpAccepted);
+            lpAccepted->header().hash, alpAccepted);
     }
 
     XRPL_ASSERT(
@@ -3097,8 +3101,8 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
 
     {
         JLOG(m_journal.debug())
-            << "Publishing ledger " << lpAccepted->info().seq << " "
-            << lpAccepted->info().hash;
+            << "Publishing ledger " << lpAccepted->header().seq << " "
+            << lpAccepted->header().hash;
 
         std::lock_guard sl(mSubLock);
 
@@ -3107,10 +3111,10 @@ NetworkOPsImp::pubLedger(std::shared_ptr<ReadView const> const& lpAccepted)
             Json::Value jvObj(Json::objectValue);
 
             jvObj[jss::type] = "ledgerClosed";
-            jvObj[jss::ledger_index] = lpAccepted->info().seq;
-            jvObj[jss::ledger_hash] = to_string(lpAccepted->info().hash);
+            jvObj[jss::ledger_index] = lpAccepted->header().seq;
+            jvObj[jss::ledger_hash] = to_string(lpAccepted->header().hash);
             jvObj[jss::ledger_time] = Json::Value::UInt(
-                lpAccepted->info().closeTime.time_since_epoch().count());
+                lpAccepted->header().closeTime.time_since_epoch().count());
 
             jvObj[jss::network_id] = app_.config().NETWORK_ID;
 
@@ -3273,27 +3277,27 @@ NetworkOPsImp::transJson(
             netID = transaction->getFieldU32(sfNetworkID);
 
         if (std::optional<std::string> ctid =
-                RPC::encodeCTID(ledger->info().seq, txnSeq, netID);
+                RPC::encodeCTID(ledger->header().seq, txnSeq, netID);
             ctid)
             jvObj[jss::ctid] = *ctid;
     }
     if (!ledger->open())
-        jvObj[jss::ledger_hash] = to_string(ledger->info().hash);
+        jvObj[jss::ledger_hash] = to_string(ledger->header().hash);
 
     if (validated)
     {
-        jvObj[jss::ledger_index] = ledger->info().seq;
+        jvObj[jss::ledger_index] = ledger->header().seq;
         jvObj[jss::transaction][jss::date] =
-            ledger->info().closeTime.time_since_epoch().count();
+            ledger->header().closeTime.time_since_epoch().count();
         jvObj[jss::validated] = true;
-        jvObj[jss::close_time_iso] = to_string_iso(ledger->info().closeTime);
+        jvObj[jss::close_time_iso] = to_string_iso(ledger->header().closeTime);
 
         // WRITEME: Put the account next seq here
     }
     else
     {
         jvObj[jss::validated] = false;
-        jvObj[jss::ledger_current_index] = ledger->info().seq;
+        jvObj[jss::ledger_current_index] = ledger->header().seq;
     }
 
     jvObj[jss::status] = validated ? "closed" : "proposed";
@@ -4177,9 +4181,9 @@ NetworkOPsImp::acceptLedger(
 
     // FIXME Could we improve on this and remove the need for a specialized
     // API in Consensus?
-    beginConsensus(m_ledgerMaster.getClosedLedger()->info().hash, {});
+    beginConsensus(m_ledgerMaster.getClosedLedger()->header().hash, {});
     mConsensus.simulate(app_.timeKeeper().closeTime(), consensusDelay);
-    return m_ledgerMaster.getCurrentLedger()->info().seq;
+    return m_ledgerMaster.getCurrentLedger()->header().seq;
 }
 
 // <-- bool: true=added, false=already there
@@ -4188,10 +4192,10 @@ NetworkOPsImp::subLedger(InfoSub::ref isrListener, Json::Value& jvResult)
 {
     if (auto lpClosed = m_ledgerMaster.getValidatedLedger())
     {
-        jvResult[jss::ledger_index] = lpClosed->info().seq;
-        jvResult[jss::ledger_hash] = to_string(lpClosed->info().hash);
+        jvResult[jss::ledger_index] = lpClosed->header().seq;
+        jvResult[jss::ledger_hash] = to_string(lpClosed->header().hash);
         jvResult[jss::ledger_time] = Json::Value::UInt(
-            lpClosed->info().closeTime.time_since_epoch().count());
+            lpClosed->header().closeTime.time_since_epoch().count());
         if (!lpClosed->rules().enabled(featureXRPFees))
             jvResult[jss::fee_ref] = Config::FEE_UNITS_DEPRECATED;
         jvResult[jss::fee_base] = lpClosed->fees().base.jsonClipped();

--- a/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
+++ b/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
@@ -29,7 +29,7 @@ accountInDomain(
                 return false;
 
             return !credentials::checkExpired(
-                sleCred, view.info().parentCloseTime);
+                sleCred, view.header().parentCloseTime);
         });
 
     return inDomain;

--- a/src/xrpld/app/misc/SHAMapStoreImp.cpp
+++ b/src/xrpld/app/misc/SHAMapStoreImp.cpp
@@ -278,7 +278,7 @@ SHAMapStoreImp::run()
                 continue;
         }
 
-        LedgerIndex const validatedSeq = validatedLedger->info().seq;
+        LedgerIndex const validatedSeq = validatedLedger->header().seq;
         if (!lastRotated)
         {
             lastRotated = validatedSeq;

--- a/src/xrpld/app/misc/detail/AMMUtils.cpp
+++ b/src/xrpld/app/misc/detail/AMMUtils.cpp
@@ -171,7 +171,7 @@ getTradingFee(ReadView const& view, SLE const& ammSle, AccountID const& account)
         // Not expired
         if (auto const expiration = auctionSlot[~sfExpiration];
             duration_cast<seconds>(
-                view.info().parentCloseTime.time_since_epoch())
+                view.header().parentCloseTime.time_since_epoch())
                 .count() < expiration)
         {
             if (auctionSlot[~sfAccount] == account)
@@ -347,9 +347,10 @@ initializeFeeAuctionVote(
     STObject& auctionSlot = ammSle->peekFieldObject(sfAuctionSlot);
     auctionSlot.setAccountID(sfAccount, account);
     // current + sec in 24h
-    auto const expiration = std::chrono::duration_cast<std::chrono::seconds>(
-                                view.info().parentCloseTime.time_since_epoch())
-                                .count() +
+    auto const expiration =
+        std::chrono::duration_cast<std::chrono::seconds>(
+            view.header().parentCloseTime.time_since_epoch())
+            .count() +
         TOTAL_TIME_SLOT_SECS;
     auctionSlot.setFieldU32(sfExpiration, expiration);
     auctionSlot.setFieldAmount(sfPrice, STAmount{lptIssue, 0});

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -82,7 +82,8 @@ TxQ::FeeMetrics::update(
         "ripple::TxQ::FeeMetrics::update : fee levels size");
 
     JLOG((timeLeap ? j_.warn() : j_.debug()))
-        << "Ledger " << view.info().seq << " has " << size << " transactions. "
+        << "Ledger " << view.header().seq << " has " << size
+        << " transactions. "
         << "Ledgers are processing " << (timeLeap ? "slowly" : "as expected")
         << ". Expected transactions is currently " << txnsExpected_
         << " and multiplier is " << escalationMultiplier_;
@@ -384,7 +385,7 @@ TxQ::canBeHeld(
         // a realistic chance of getting into a ledger.
         auto const lastValid = getLastLedgerSequence(tx);
         if (lastValid &&
-            *lastValid < view.info().seq + setup_.minimumLastLedgerBuffer)
+            *lastValid < view.header().seq + setup_.minimumLastLedgerBuffer)
             return telCAN_NOT_QUEUE;
     }
 
@@ -1349,7 +1350,7 @@ TxQ::processClosedLedger(Application& app, ReadView const& view, bool timeLeap)
     feeMetrics_.update(app, view, timeLeap, setup_);
     auto const& snapshot = feeMetrics_.getSnapshot();
 
-    auto ledgerSeq = view.info().seq;
+    auto ledgerSeq = view.header().seq;
 
     if (!timeLeap)
         maxSize_ = std::max(
@@ -1548,7 +1549,7 @@ TxQ::accept(Application& app, OpenView& view)
     // ledger have been. Rebuild the queue using the open ledger's
     // parent hash, so that transactions paying the same fee are
     // reordered.
-    LedgerHash const& parentHash = view.info().parentHash;
+    LedgerHash const& parentHash = view.header().parentHash;
     if (parentHash == parentHash_)
         JLOG(j_.warn()) << "Parent ledger hash unchanged from " << parentHash;
     else
@@ -1851,7 +1852,7 @@ TxQ::doRPC(Application& app) const
 
     auto& levels = ret[jss::levels] = Json::objectValue;
 
-    ret[jss::ledger_current_index] = view->info().seq;
+    ret[jss::ledger_current_index] = view->header().seq;
     ret[jss::expected_ledger_size] = std::to_string(metrics.txPerLedger);
     ret[jss::current_ledger_size] = std::to_string(metrics.txInLedger);
     ret[jss::current_queue_size] = std::to_string(metrics.txCount);

--- a/src/xrpld/app/paths/PathRequest.cpp
+++ b/src/xrpld/app/paths/PathRequest.cpp
@@ -207,7 +207,7 @@ PathRequest::isValid(std::shared_ptr<RippleLineCache> const& crCache)
             (sleDest->getFlags() & lsfRequireDestTag);
     }
 
-    jvStatus[jss::ledger_hash] = to_string(lrLedger->info().hash);
+    jvStatus[jss::ledger_hash] = to_string(lrLedger->header().hash);
     jvStatus[jss::ledger_index] = lrLedger->seq();
     return true;
 }

--- a/src/xrpld/app/paths/RippleLineCache.cpp
+++ b/src/xrpld/app/paths/RippleLineCache.cpp
@@ -8,12 +8,12 @@ RippleLineCache::RippleLineCache(
     beast::Journal j)
     : ledger_(ledger), journal_(j)
 {
-    JLOG(journal_.debug()) << "created for ledger " << ledger_->info().seq;
+    JLOG(journal_.debug()) << "created for ledger " << ledger_->header().seq;
 }
 
 RippleLineCache::~RippleLineCache()
 {
-    JLOG(journal_.debug()) << "destroyed for ledger " << ledger_->info().seq
+    JLOG(journal_.debug()) << "destroyed for ledger " << ledger_->header().seq
                            << " with " << lines_.size() << " accounts and "
                            << totalLineCount_ << " distinct trust lines.";
 }
@@ -99,7 +99,7 @@ RippleLineCache::getRippleLines(
         "ripple::RippleLineCache::getRippleLines : null or nonempty lines");
     auto const size = it->second ? it->second->size() : 0;
     JLOG(journal_.trace()) << "getRippleLines for ledger "
-                           << ledger_->info().seq << " found " << size
+                           << ledger_->header().seq << " found " << size
                            << (key.direction_ == LineDirection::outgoing
                                    ? " outgoing"
                                    : " incoming")

--- a/src/xrpld/app/rdb/backend/detail/Node.cpp
+++ b/src/xrpld/app/rdb/backend/detail/Node.cpp
@@ -177,13 +177,13 @@ saveValidatedLedger(
     bool current)
 {
     auto j = app.journal("Ledger");
-    auto seq = ledger->info().seq;
+    auto seq = ledger->header().seq;
 
     // TODO(tom): Fix this hard-coded SQL!
     JLOG(j.trace()) << "saveValidatedLedger " << (current ? "" : "fromAcquire ")
                     << seq;
 
-    if (!ledger->info().accountHash.isNonZero())
+    if (!ledger->header().accountHash.isNonZero())
     {
         // LCOV_EXCL_START
         JLOG(j.fatal()) << "AH is zero: " << getJson({*ledger, {}});
@@ -191,10 +191,11 @@ saveValidatedLedger(
         // LCOV_EXCL_STOP
     }
 
-    if (ledger->info().accountHash != ledger->stateMap().getHash().as_uint256())
+    if (ledger->header().accountHash !=
+        ledger->stateMap().getHash().as_uint256())
     {
         // LCOV_EXCL_START
-        JLOG(j.fatal()) << "sAL: " << ledger->info().accountHash
+        JLOG(j.fatal()) << "sAL: " << ledger->header().accountHash
                         << " != " << ledger->stateMap().getHash();
         JLOG(j.fatal()) << "saveAcceptedLedger: seq=" << seq
                         << ", current=" << current;
@@ -204,33 +205,33 @@ saveValidatedLedger(
     }
 
     XRPL_ASSERT(
-        ledger->info().txHash == ledger->txMap().getHash().as_uint256(),
+        ledger->header().txHash == ledger->txMap().getHash().as_uint256(),
         "ripple::detail::saveValidatedLedger : transaction hash match");
 
     // Save the ledger header in the hashed object store
     {
         Serializer s(128);
         s.add32(HashPrefix::ledgerMaster);
-        addRaw(ledger->info(), s);
+        addRaw(ledger->header(), s);
         app.getNodeStore().store(
-            hotLEDGER, std::move(s.modData()), ledger->info().hash, seq);
+            hotLEDGER, std::move(s.modData()), ledger->header().hash, seq);
     }
 
     std::shared_ptr<AcceptedLedger> aLedger;
     try
     {
-        aLedger = app.getAcceptedLedgerCache().fetch(ledger->info().hash);
+        aLedger = app.getAcceptedLedgerCache().fetch(ledger->header().hash);
         if (!aLedger)
         {
             aLedger = std::make_shared<AcceptedLedger>(ledger, app);
             app.getAcceptedLedgerCache().canonicalize_replace_client(
-                ledger->info().hash, aLedger);
+                ledger->header().hash, aLedger);
         }
     }
     catch (std::exception const&)
     {
         JLOG(j.warn()) << "An accepted ledger was missing nodes";
-        app.getLedgerMaster().failedSave(seq, ledger->info().hash);
+        app.getLedgerMaster().failedSave(seq, ledger->header().hash);
         // Clients can now trust the database for information about this
         // ledger sequence.
         app.pendingSaves().finishWork(seq);
@@ -357,18 +358,18 @@ saveValidatedLedger(
 
             soci::transaction tr(*db);
 
-            auto const hash = to_string(ledger->info().hash);
-            auto const parentHash = to_string(ledger->info().parentHash);
-            auto const drops = to_string(ledger->info().drops);
+            auto const hash = to_string(ledger->header().hash);
+            auto const parentHash = to_string(ledger->header().parentHash);
+            auto const drops = to_string(ledger->header().drops);
             auto const closeTime =
-                ledger->info().closeTime.time_since_epoch().count();
+                ledger->header().closeTime.time_since_epoch().count();
             auto const parentCloseTime =
-                ledger->info().parentCloseTime.time_since_epoch().count();
+                ledger->header().parentCloseTime.time_since_epoch().count();
             auto const closeTimeResolution =
-                ledger->info().closeTimeResolution.count();
-            auto const closeFlags = ledger->info().closeFlags;
-            auto const accountHash = to_string(ledger->info().accountHash);
-            auto const txHash = to_string(ledger->info().txHash);
+                ledger->header().closeTimeResolution.count();
+            auto const closeFlags = ledger->header().closeFlags;
+            auto const accountHash = to_string(ledger->header().accountHash);
+            auto const txHash = to_string(ledger->header().txHash);
 
             *db << addLedger, soci::use(hash), soci::use(seq),
                 soci::use(parentHash), soci::use(drops), soci::use(closeTime),

--- a/src/xrpld/app/tx/detail/AMMBid.cpp
+++ b/src/xrpld/app/tx/detail/AMMBid.cpp
@@ -180,7 +180,7 @@ applyBid(
     auto& auctionSlot = ammSle->peekFieldObject(sfAuctionSlot);
     auto const current =
         duration_cast<seconds>(
-            ctx_.view().info().parentCloseTime.time_since_epoch())
+            ctx_.view().header().parentCloseTime.time_since_epoch())
             .count();
     // Auction slot discounted fee
     auto const discountedFee =

--- a/src/xrpld/app/tx/detail/Credentials.cpp
+++ b/src/xrpld/app/tx/detail/Credentials.cpp
@@ -104,7 +104,7 @@ CredentialCreate::doApply()
     if (optExp)
     {
         std::uint32_t const closeTime =
-            ctx_.view().info().parentCloseTime.time_since_epoch().count();
+            ctx_.view().header().parentCloseTime.time_since_epoch().count();
 
         if (closeTime > *optExp)
         {
@@ -242,7 +242,7 @@ CredentialDelete::doApply()
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
     if ((subject != account_) && (issuer != account_) &&
-        !checkExpired(sleCred, ctx_.view().info().parentCloseTime))
+        !checkExpired(sleCred, ctx_.view().header().parentCloseTime))
     {
         JLOG(j_.trace()) << "Can't delete non-expired credential.";
         return tecNO_PERMISSION;
@@ -336,7 +336,7 @@ CredentialAccept::doApply()
     Keylet const credentialKey = keylet::credential(account_, issuer, credType);
     auto const sleCred = view().peek(credentialKey);  // Checked in preclaim()
 
-    if (checkExpired(sleCred, view().info().parentCloseTime))
+    if (checkExpired(sleCred, view().header().parentCloseTime))
     {
         JLOG(j_.trace()) << "Credential is expired: " << sleCred->getText();
         // delete expired credentials even if the transaction failed

--- a/src/xrpld/app/tx/detail/Escrow.cpp
+++ b/src/xrpld/app/tx/detail/Escrow.cpp
@@ -416,7 +416,7 @@ escrowLockApplyHelper<MPTIssue>(
 TER
 EscrowCreate::doApply()
 {
-    auto const closeTime = ctx_.view().info().parentCloseTime;
+    auto const closeTime = ctx_.view().header().parentCloseTime;
 
     if (ctx_.tx[~sfCancelAfter] && after(closeTime, ctx_.tx[sfCancelAfter]))
         return tecNO_PERMISSION;
@@ -964,7 +964,7 @@ EscrowFinish::doApply()
 
     // If a cancel time is present, a finish operation should only succeed prior
     // to that time.
-    auto const now = ctx_.view().info().parentCloseTime;
+    auto const now = ctx_.view().header().parentCloseTime;
 
     // Too soon: can't execute before the finish time
     if ((*slep)[~sfFinishAfter] && !after(now, (*slep)[sfFinishAfter]))
@@ -1226,7 +1226,7 @@ EscrowCancel::doApply()
         return tecNO_TARGET;
     }
 
-    auto const now = ctx_.view().info().parentCloseTime;
+    auto const now = ctx_.view().header().parentCloseTime;
 
     // No cancel time specified: can't execute at all.
     if (!(*slep)[~sfCancelAfter])

--- a/src/xrpld/app/tx/detail/LoanSet.cpp
+++ b/src/xrpld/app/tx/detail/LoanSet.cpp
@@ -188,7 +188,7 @@ LoanSet::getValueFields()
 static std::uint32_t
 getStartDate(ReadView const& view)
 {
-    return view.info().closeTime.time_since_epoch().count();
+    return view.header().closeTime.time_since_epoch().count();
 }
 
 TER

--- a/src/xrpld/app/tx/detail/PayChan.cpp
+++ b/src/xrpld/app/tx/detail/PayChan.cpp
@@ -231,7 +231,7 @@ PayChanCreate::doApply()
 
     if (ctx_.view().rules().enabled(fixPayChanCancelAfter))
     {
-        auto const closeTime = ctx_.view().info().parentCloseTime;
+        auto const closeTime = ctx_.view().header().parentCloseTime;
         if (ctx_.tx[~sfCancelAfter] && after(closeTime, ctx_.tx[sfCancelAfter]))
             return tecEXPIRED;
     }
@@ -324,7 +324,7 @@ PayChanFund::doApply()
     {
         auto const cancelAfter = (*slep)[~sfCancelAfter];
         auto const closeTime =
-            ctx_.view().info().parentCloseTime.time_since_epoch().count();
+            ctx_.view().header().parentCloseTime.time_since_epoch().count();
         if ((cancelAfter && closeTime >= *cancelAfter) ||
             (expiration && closeTime >= *expiration))
             return closeChannel(
@@ -338,7 +338,7 @@ PayChanFund::doApply()
     if (auto extend = ctx_.tx[~sfExpiration])
     {
         auto minExpiration =
-            ctx_.view().info().parentCloseTime.time_since_epoch().count() +
+            ctx_.view().header().parentCloseTime.time_since_epoch().count() +
             (*slep)[sfSettleDelay];
         if (expiration && *expiration < minExpiration)
             minExpiration = *expiration;
@@ -481,7 +481,7 @@ PayChanClaim::doApply()
     {
         auto const cancelAfter = (*slep)[~sfCancelAfter];
         auto const closeTime =
-            ctx_.view().info().parentCloseTime.time_since_epoch().count();
+            ctx_.view().header().parentCloseTime.time_since_epoch().count();
         if ((cancelAfter && closeTime >= *cancelAfter) ||
             (curExpiration && closeTime >= *curExpiration))
             return closeChannel(
@@ -549,7 +549,7 @@ PayChanClaim::doApply()
                 slep, ctx_.view(), k.key, ctx_.app.journal("View"));
 
         auto const settleExpiration =
-            ctx_.view().info().parentCloseTime.time_since_epoch().count() +
+            ctx_.view().header().parentCloseTime.time_since_epoch().count() +
             (*slep)[sfSettleDelay];
 
         if (!curExpiration || *curExpiration > settleExpiration)

--- a/src/xrpld/app/tx/detail/SetOracle.cpp
+++ b/src/xrpld/app/tx/detail/SetOracle.cpp
@@ -51,7 +51,7 @@ SetOracle::preclaim(PreclaimContext const& ctx)
     // of the last closed ledger
     using namespace std::chrono;
     std::size_t const closeTime =
-        duration_cast<seconds>(ctx.view.info().closeTime.time_since_epoch())
+        duration_cast<seconds>(ctx.view.header().closeTime.time_since_epoch())
             .count();
     std::size_t const lastUpdateTime = ctx.tx[sfLastUpdateTime];
     if (lastUpdateTime < epoch_offset.count())

--- a/src/xrpld/overlay/detail/Handshake.cpp
+++ b/src/xrpld/overlay/detail/Handshake.cpp
@@ -199,8 +199,8 @@ buildHandshake(
 
     if (auto const cl = app.getLedgerMaster().getClosedLedger())
     {
-        h.insert("Closed-Ledger", strHex(cl->info().hash));
-        h.insert("Previous-Ledger", strHex(cl->info().parentHash));
+        h.insert("Closed-Ledger", strHex(cl->header().hash));
+        h.insert("Previous-Ledger", strHex(cl->header().parentHash));
     }
 }
 

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -3228,7 +3228,7 @@ PeerImp::sendLedgerBase(
     JLOG(p_journal_.trace()) << "sendLedgerBase: Base data";
 
     Serializer s(sizeof(LedgerHeader));
-    addRaw(ledger->info(), s);
+    addRaw(ledger->header(), s);
     ledgerData.add_nodes()->set_nodedata(s.getDataPtr(), s.getLength());
 
     auto const& stateMap{ledger->stateMap()};
@@ -3241,7 +3241,7 @@ PeerImp::sendLedgerBase(
         ledgerData.add_nodes()->set_nodedata(
             root.getDataPtr(), root.getLength());
 
-        if (ledger->info().txHash != beast::zero)
+        if (ledger->header().txHash != beast::zero)
         {
             auto const& txMap{ledger->txMap()};
             if (txMap.getHash() != beast::zero)
@@ -3326,7 +3326,7 @@ PeerImp::getLedger(std::shared_ptr<protocol::TMGetLedger> const& m)
     if (ledger)
     {
         // Validate retrieved ledger sequence
-        auto const ledgerSeq{ledger->info().seq};
+        auto const ledgerSeq{ledger->header().seq};
         if (m->has_ledgerseq())
         {
             if (ledgerSeq != m->ledgerseq())
@@ -3440,9 +3440,9 @@ PeerImp::processLedgerRequest(std::shared_ptr<protocol::TMGetLedger> const& m)
             return;
 
         // Fill out the reply
-        auto const ledgerHash{ledger->info().hash};
+        auto const ledgerHash{ledger->header().hash};
         ledgerData.set_ledgerhash(ledgerHash.begin(), ledgerHash.size());
-        ledgerData.set_ledgerseq(ledger->info().seq);
+        ledgerData.set_ledgerseq(ledger->header().seq);
         ledgerData.set_type(itype);
         if (m->has_requestcookie())
             ledgerData.set_requestcookie(m->requestcookie());

--- a/src/xrpld/rpc/BookChanges.h
+++ b/src/xrpld/rpc/BookChanges.h
@@ -166,11 +166,11 @@ computeBookChanges(std::shared_ptr<L const> const& lpAccepted)
     jvObj[jss::type] = "bookChanges";
 
     // retrieve validated information from LedgerHeader class
-    jvObj[jss::validated] = lpAccepted->info().validated;
-    jvObj[jss::ledger_index] = lpAccepted->info().seq;
-    jvObj[jss::ledger_hash] = to_string(lpAccepted->info().hash);
+    jvObj[jss::validated] = lpAccepted->header().validated;
+    jvObj[jss::ledger_index] = lpAccepted->header().seq;
+    jvObj[jss::ledger_hash] = to_string(lpAccepted->header().hash);
     jvObj[jss::ledger_time] = Json::Value::UInt(
-        lpAccepted->info().closeTime.time_since_epoch().count());
+        lpAccepted->header().closeTime.time_since_epoch().count());
 
     jvObj[jss::changes] = Json::arrayValue;
 

--- a/src/xrpld/rpc/detail/DeliveredAmount.cpp
+++ b/src/xrpld/rpc/detail/DeliveredAmount.cpp
@@ -88,7 +88,7 @@ insertDeliveredAmount(
     std::shared_ptr<STTx const> const& serializedTx,
     TxMeta const& transactionMeta)
 {
-    auto const info = ledger.info();
+    auto const info = ledger.header();
 
     if (canHaveDeliveredAmount(serializedTx, transactionMeta))
     {

--- a/src/xrpld/rpc/detail/RPCLedgerHelpers.cpp
+++ b/src/xrpld/rpc/detail/RPCLedgerHelpers.cpp
@@ -234,7 +234,7 @@ getLedger(T& ledger, uint32_t ledgerIndex, Context const& context)
     if (ledger == nullptr)
     {
         auto cur = context.ledgerMaster.getCurrentLedger();
-        if (cur->info().seq == ledgerIndex)
+        if (cur->header().seq == ledgerIndex)
         {
             ledger = cur;
         }
@@ -243,7 +243,7 @@ getLedger(T& ledger, uint32_t ledgerIndex, Context const& context)
     if (ledger == nullptr)
         return {rpcLGR_NOT_FOUND, "ledgerNotFound"};
 
-    if (ledger->info().seq > context.ledgerMaster.getValidLedgerIndex() &&
+    if (ledger->header().seq > context.ledgerMaster.getValidLedgerIndex() &&
         isValidatedOld(context.ledgerMaster, context.app.config().standalone()))
     {
         ledger.reset();
@@ -307,7 +307,7 @@ getLedger(T& ledger, LedgerShortcut shortcut, Context const& context)
 
         static auto const minSequenceGap = 10;
 
-        if (ledger->info().seq + minSequenceGap <
+        if (ledger->header().seq + minSequenceGap <
             context.ledgerMaster.getValidLedgerIndex())
         {
             ledger.reset();
@@ -360,7 +360,7 @@ lookupLedger(
     if (auto status = ledgerFromRequest(ledger, context))
         return status;
 
-    auto& info = ledger->info();
+    auto& info = ledger->header();
 
     if (!ledger->open())
     {
@@ -433,7 +433,7 @@ getOrAcquireLedger(RPC::JsonContext const& context)
         ledgerIndex = jsonIndex.asInt();
         auto ledger = ledgerMaster.getValidatedLedger();
 
-        if (ledgerIndex >= ledger->info().seq)
+        if (ledgerIndex >= ledger->header().seq)
             return Unexpected(RPC::make_param_error("Ledger index too large"));
         if (ledgerIndex <= 0)
             return Unexpected(RPC::make_param_error("Ledger index too small"));

--- a/src/xrpld/rpc/handlers/AMMInfo.cpp
+++ b/src/xrpld/rpc/handlers/AMMInfo.cpp
@@ -194,7 +194,7 @@ doAMMInfo(RPC::JsonContext& context)
         {
             Json::Value auction;
             auto const timeSlot = ammAuctionTimeSlot(
-                ledger->info().parentCloseTime.time_since_epoch().count(),
+                ledger->header().parentCloseTime.time_since_epoch().count(),
                 auctionSlot);
             auction[jss::time_interval] =
                 timeSlot ? *timeSlot : AUCTION_SLOT_TIME_INTERVALS;
@@ -230,7 +230,7 @@ doAMMInfo(RPC::JsonContext& context)
     result[jss::amm] = std::move(ammResult);
     if (!result.isMember(jss::ledger_index) &&
         !result.isMember(jss::ledger_hash))
-        result[jss::ledger_current_index] = ledger->info().seq;
+        result[jss::ledger_current_index] = ledger->header().seq;
     result[jss::validated] = context.ledgerMaster.isValidated(*ledger);
 
     return result;

--- a/src/xrpld/rpc/handlers/AccountTx.cpp
+++ b/src/xrpld/rpc/handlers/AccountTx.cpp
@@ -176,12 +176,13 @@ getLedgerRange(
                     bool validated =
                         context.ledgerMaster.isValidated(*ledgerView);
 
-                    if (!validated || ledgerView->info().seq > uValidatedMax ||
-                        ledgerView->info().seq < uValidatedMin)
+                    if (!validated ||
+                        ledgerView->header().seq > uValidatedMax ||
+                        ledgerView->header().seq < uValidatedMin)
                     {
                         return rpcLGR_NOT_VALIDATED;
                     }
-                    uLedgerMin = uLedgerMax = ledgerView->info().seq;
+                    uLedgerMin = uLedgerMax = ledgerView->header().seq;
                 }
                 return RPC::Status::OK;
             },

--- a/src/xrpld/rpc/handlers/CanDelete.cpp
+++ b/src/xrpld/rpc/handlers/CanDelete.cpp
@@ -60,7 +60,7 @@ doCanDelete(RPC::JsonContext& context)
                 if (!ledger)
                     return RPC::make_error(rpcLGR_NOT_FOUND, "ledgerNotFound");
 
-                canDeleteSeq = ledger->info().seq;
+                canDeleteSeq = ledger->header().seq;
             }
             else
             {

--- a/src/xrpld/rpc/handlers/DepositAuthorized.cpp
+++ b/src/xrpld/rpc/handlers/DepositAuthorized.cpp
@@ -135,7 +135,7 @@ doDepositAuthorized(RPC::JsonContext& context)
             }
 
             if (credentials::checkExpired(
-                    sleCred, ledger->info().parentCloseTime))
+                    sleCred, ledger->header().parentCloseTime))
             {
                 RPC::inject_error(
                     rpcBAD_CREDENTIALS, "credentials are expired", result);

--- a/src/xrpld/rpc/handlers/LedgerClosed.cpp
+++ b/src/xrpld/rpc/handlers/LedgerClosed.cpp
@@ -14,8 +14,8 @@ doLedgerClosed(RPC::JsonContext& context)
     XRPL_ASSERT(ledger, "ripple::doLedgerClosed : non-null closed ledger");
 
     Json::Value jvResult;
-    jvResult[jss::ledger_index] = ledger->info().seq;
-    jvResult[jss::ledger_hash] = to_string(ledger->info().hash);
+    jvResult[jss::ledger_index] = ledger->header().seq;
+    jvResult[jss::ledger_hash] = to_string(ledger->header().hash);
 
     return jvResult;
 }

--- a/src/xrpld/rpc/handlers/LedgerData.cpp
+++ b/src/xrpld/rpc/handlers/LedgerData.cpp
@@ -59,8 +59,8 @@ doLedgerData(RPC::JsonContext& context)
     if ((limit < 0) || ((limit > maxLimit) && (!isUnlimited(context.role))))
         limit = maxLimit;
 
-    jvResult[jss::ledger_hash] = to_string(lpLedger->info().hash);
-    jvResult[jss::ledger_index] = lpLedger->info().seq;
+    jvResult[jss::ledger_hash] = to_string(lpLedger->header().hash);
+    jvResult[jss::ledger_index] = lpLedger->header().seq;
 
     if (!isMarker)
     {

--- a/src/xrpld/rpc/handlers/LedgerHandler.cpp
+++ b/src/xrpld/rpc/handlers/LedgerHandler.cpp
@@ -103,7 +103,7 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
     }
 
     Serializer s;
-    addRaw(ledger->info(), s, true);
+    addRaw(ledger->header(), s, true);
 
     response.set_ledger_header(s.peekData().data(), s.getLength());
 
@@ -139,7 +139,7 @@ doLedgerGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerRequest>& context)
         {
             JLOG(context.j.error())
                 << __func__ << " - Error deserializing transaction in ledger "
-                << ledger->info().seq
+                << ledger->header().seq
                 << " . skipping transaction and following transactions. You "
                    "should look into this further";
         }

--- a/src/xrpld/rpc/handlers/LedgerHeader.cpp
+++ b/src/xrpld/rpc/handlers/LedgerHeader.cpp
@@ -21,7 +21,7 @@ doLedgerHeader(RPC::JsonContext& context)
         return jvResult;
 
     Serializer s;
-    addRaw(lpLedger->info(), s);
+    addRaw(lpLedger->header(), s);
     jvResult[jss::ledger_data] = strHex(s.peekData());
 
     // This information isn't verified: they should only use it if they trust

--- a/src/xrpld/rpc/handlers/LedgerRequest.cpp
+++ b/src/xrpld/rpc/handlers/LedgerRequest.cpp
@@ -24,7 +24,7 @@ doLedgerRequest(RPC::JsonContext& context)
     auto const& ledger = res.value();
 
     Json::Value jvResult;
-    jvResult[jss::ledger_index] = ledger->info().seq;
+    jvResult[jss::ledger_index] = ledger->header().seq;
     addJson(jvResult, {*ledger, &context, 0});
     return jvResult;
 }

--- a/src/xrpld/rpc/handlers/Tx.cpp
+++ b/src/xrpld/rpc/handlers/Tx.cpp
@@ -26,7 +26,7 @@ isValidated(LedgerMaster& ledgerMaster, std::uint32_t seq, uint256 const& hash)
     if (!ledgerMaster.haveLedger(seq))
         return false;
 
-    if (seq > ledgerMaster.getValidatedLedger()->info().seq)
+    if (seq > ledgerMaster.getValidatedLedger()->header().seq)
         return false;
 
     return ledgerMaster.getHashBySeq(seq) == hash;
@@ -130,7 +130,7 @@ doTxHelp(RPC::Context& context, TxArgs args)
         context.ledgerMaster.getLedgerBySeq(txn->getLedger());
 
     if (ledger && !ledger->open())
-        result.ledgerHash = ledger->info().hash;
+        result.ledgerHash = ledger->header().hash;
 
     if (ledger && meta)
     {
@@ -143,7 +143,7 @@ doTxHelp(RPC::Context& context, TxArgs args)
             result.meta = meta;
         }
         result.validated = isValidated(
-            context.ledgerMaster, ledger->info().seq, ledger->info().hash);
+            context.ledgerMaster, ledger->header().seq, ledger->header().hash);
         if (result.validated)
             result.closeTime =
                 context.ledgerMaster.getCloseTimeBySeq(txn->getLedger());
@@ -151,7 +151,7 @@ doTxHelp(RPC::Context& context, TxArgs args)
         // compute outgoing CTID
         if (meta->getAsObject().isFieldPresent(sfTransactionIndex))
         {
-            uint32_t lgrSeq = ledger->info().seq;
+            uint32_t lgrSeq = ledger->header().seq;
             uint32_t txnIdx =
                 meta->getAsObject().getFieldU32(sfTransactionIndex);
             uint32_t netID = context.app.config().NETWORK_ID;


### PR DESCRIPTION
## High Level Overview of Change

This PR renames all the `info()` functions to `header()`, since they return `LedgerHeader` structs. It also renames the underlying variables from `info_` to `header_`.

### Context of Change

Follow-up from #6136, making it clearer what certain methods are returning

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### API Impact

N/A

## Test Plan

rippled builds and CI passes.