### PR TITLE
Number: Change LendingProtocol and SAV features to supported

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -17,7 +17,7 @@
 // Keep it sorted in reverse chronological order.
 
 XRPL_FIX    (BatchInnerSigs,             Supported::yes, VoteBehavior::DefaultNo)
-XRPL_FEATURE(LendingProtocol,            Supported::no,  VoteBehavior::DefaultNo)
+XRPL_FEATURE(LendingProtocol,            Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionDelegationV1_1,   Supported::no,  VoteBehavior::DefaultNo)
 XRPL_FIX    (DirectoryLimit,             Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (IncludeKeyletFields,        Supported::yes, VoteBehavior::DefaultNo)
@@ -31,7 +31,7 @@ XRPL_FIX    (EnforceNFTokenTrustlineV2,  Supported::yes, VoteBehavior::DefaultNo
 XRPL_FIX    (AMMv1_3,                    Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionedDEX,            Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(Batch,                      Supported::yes, VoteBehavior::DefaultNo)
-XRPL_FEATURE(SingleAssetVault,           Supported::no,  VoteBehavior::DefaultNo)
+XRPL_FEATURE(SingleAssetVault,           Supported::yes,  VoteBehavior::DefaultNo)
 XRPL_FIX    (PayChanCancelAfter,         Supported::yes, VoteBehavior::DefaultNo)
 // Check flags in Credential transactions
 XRPL_FIX    (InvalidTxFlags,             Supported::yes, VoteBehavior::DefaultNo)


### PR DESCRIPTION
## High Level Overview of Change

Change `LendingProtocol` feature and dependencies to `Supported::yes`. Enables testing.

### Context of Change

Includes the `Number` expansion refactor pending merge in PR #6025 - "Expand Number to support the full integer range"

The original implementation of `LendingProtocol` was merged from #5270 on 12/2/2025.

Updates to `LendingProtocol` are pending in #6102 - "Lending protocol - ongoing work and bug fixes - XLS-66"

See also:
* #6092 
* #6093 
* #5632 

### Type of Change

- [X] New feature (non-breaking change which adds functionality)
