### PR TITLE
Set version to 3.2.0-b0

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -17,7 +17,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "3.1.0-b0"
+char const* const versionString = "3.2.0-b0"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## High Level Overview of Change

This change sets the version to 3.2.0-b0.

### Context of Change

In anticipation of the release following 3.1, for which now a release branch has been created, we update the version number to the zero beta.
