### PR TITLE
ci: Remove superfluous build directory creation

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -4,9 +4,6 @@ description: "Install Conan dependencies, optionally forcing a rebuild of all de
 # Note that actions do not support 'type' and all inputs are strings, see
 # https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#inputs.
 inputs:
-  build_dir:
-    description: "The directory where to build."
-    required: true
   build_type:
     description: 'The build type to use ("Debug", "Release").'
     required: true
@@ -28,17 +25,13 @@ runs:
     - name: Install Conan dependencies
       shell: bash
       env:
-        BUILD_DIR: ${{ inputs.build_dir }}
         BUILD_NPROC: ${{ inputs.build_nproc }}
         BUILD_OPTION: ${{ inputs.force_build == 'true' && '*' || 'missing' }}
         BUILD_TYPE: ${{ inputs.build_type }}
         LOG_VERBOSITY: ${{ inputs.log_verbosity }}
       run: |
         echo 'Installing dependencies.'
-        mkdir -p "${BUILD_DIR}"
-        cd "${BUILD_DIR}"
         conan install \
-          --output-folder . \
           --build="${BUILD_OPTION}" \
           --options:host='&:tests=True' \
           --options:host='&:xrpld=True' \
@@ -46,4 +39,4 @@ runs:
           --conf:all tools.build:jobs=${BUILD_NPROC} \
           --conf:all tools.build:verbosity="${LOG_VERBOSITY}" \
           --conf:all tools.compilation:verbosity="${LOG_VERBOSITY}" \
-          ..
+          .

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  BUILD_DIR: .build
+  BUILD_DIR: build
   NPROC_SUBTRACT: 2
 
 jobs:

--- a/.github/workflows/reusable-build-test-config.yml
+++ b/.github/workflows/reusable-build-test-config.yml
@@ -3,11 +3,6 @@ name: Build and test configuration
 on:
   workflow_call:
     inputs:
-      build_dir:
-        description: "The directory where to build."
-        required: true
-        type: string
-
       build_only:
         description: 'Whether to only build or to build and test the code ("true", "false").'
         required: true
@@ -59,6 +54,11 @@ defaults:
   run:
     shell: bash
 
+env:
+  # Conan installs the generators in the build/generators directory, see the
+  # layout() method in conanfile.py. We then run CMake from the build directory.
+  BUILD_DIR: build
+
 jobs:
   build-and-test:
     name: ${{ inputs.config_name }}
@@ -96,7 +96,6 @@ jobs:
       - name: Build dependencies
         uses: ./.github/actions/build-deps
         with:
-          build_dir: ${{ inputs.build_dir }}
           build_nproc: ${{ steps.nproc.outputs.nproc }}
           build_type: ${{ inputs.build_type }}
           # Set the verbosity to "quiet" for Windows to avoid an excessive
@@ -104,7 +103,7 @@ jobs:
           log_verbosity: ${{ runner.os == 'Windows' && 'quiet' || 'verbose' }}
 
       - name: Configure CMake
-        working-directory: ${{ inputs.build_dir }}
+        working-directory: ${{ env.BUILD_DIR }}
         env:
           BUILD_TYPE: ${{ inputs.build_type }}
           CMAKE_ARGS: ${{ inputs.cmake_args }}
@@ -117,7 +116,7 @@ jobs:
             ..
 
       - name: Build the binary
-        working-directory: ${{ inputs.build_dir }}
+        working-directory: ${{ env.BUILD_DIR }}
         env:
           BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
           BUILD_TYPE: ${{ inputs.build_type }}
@@ -132,8 +131,6 @@ jobs:
       - name: Upload the binary (Linux)
         if: ${{ github.repository_owner == 'XRPLF' && runner.os == 'Linux' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        env:
-          BUILD_DIR: ${{ inputs.build_dir }}
         with:
           name: xrpld-${{ inputs.config_name }}
           path: ${{ env.BUILD_DIR }}/xrpld
@@ -142,7 +139,7 @@ jobs:
 
       - name: Check linking (Linux)
         if: ${{ runner.os == 'Linux' }}
-        working-directory: ${{ inputs.build_dir }}
+        working-directory: ${{ env.BUILD_DIR }}
         run: |
           ldd ./xrpld
           if [ "$(ldd ./xrpld | grep -E '(libstdc\+\+|libgcc)' | wc -l)" -eq 0 ]; then
@@ -154,13 +151,13 @@ jobs:
 
       - name: Verify presence of instrumentation (Linux)
         if: ${{ runner.os == 'Linux' && env.ENABLED_VOIDSTAR == 'true' }}
-        working-directory: ${{ inputs.build_dir }}
+        working-directory: ${{ env.BUILD_DIR }}
         run: |
           ./xrpld --version | grep libvoidstar
 
       - name: Run the separate tests
         if: ${{ !inputs.build_only }}
-        working-directory: ${{ inputs.build_dir }}
+        working-directory: ${{ env.BUILD_DIR }}
         # Windows locks some of the build files while running tests, and parallel jobs can collide
         env:
           BUILD_TYPE: ${{ inputs.build_type }}
@@ -173,7 +170,7 @@ jobs:
 
       - name: Run the embedded tests
         if: ${{ !inputs.build_only }}
-        working-directory: ${{ runner.os == 'Windows' && format('{0}/{1}', inputs.build_dir, inputs.build_type) || inputs.build_dir }}
+        working-directory: ${{ runner.os == 'Windows' && format('{0}/{1}', env.BUILD_DIR, inputs.build_type) || env.BUILD_DIR }}
         env:
           BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
         run: |
@@ -189,7 +186,7 @@ jobs:
 
       - name: Prepare coverage report
         if: ${{ !inputs.build_only && env.ENABLED_COVERAGE == 'true' }}
-        working-directory: ${{ inputs.build_dir }}
+        working-directory: ${{ env.BUILD_DIR }}
         env:
           BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
           BUILD_TYPE: ${{ inputs.build_type }}
@@ -207,7 +204,7 @@ jobs:
           disable_search: true
           disable_telem: true
           fail_ci_if_error: true
-          files: ${{ inputs.build_dir }}/coverage.xml
+          files: ${{ env.BUILD_DIR }}/coverage.xml
           plugins: noop
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -8,11 +8,6 @@ name: Build and test
 on:
   workflow_call:
     inputs:
-      build_dir:
-        description: "The directory where to build."
-        required: false
-        type: string
-        default: ".build"
       os:
         description: 'The operating system to use for the build ("linux", "macos", "windows").'
         required: true
@@ -46,7 +41,6 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 10
     with:
-      build_dir: ${{ inputs.build_dir }}
       build_only: ${{ matrix.build_only }}
       build_type: ${{ matrix.build_type }}
       cmake_args: ${{ matrix.cmake_args }}

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -92,7 +92,6 @@ jobs:
       - name: Build dependencies
         uses: ./.github/actions/build-deps
         with:
-          build_dir: .build
           build_nproc: ${{ steps.nproc.outputs.nproc }}
           build_type: ${{ matrix.build_type }}
           force_build: ${{ github.event_name == 'schedule' || github.event.inputs.force_source_build == 'true' }}


### PR DESCRIPTION
## High Level Overview of Change

This changes the build directory structure from `build/build/xxx` or `.build/build/xxx` to just `build/xxx`.

### Context of Change

The `conanfile.py` has the CMake generators build directory hardcoded to `build/generators`. We may as well leverage the top-level build directory without introducing another layer of directory nesting.

A follow-up PR in the next month or two will refactor the readmes, which will clean up the instructions to avoid the nested build directory structure for developers on their own machines.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
