### PR TITLE
ci: Move variable into right place

### DIFF
--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -66,14 +66,14 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
-        # Enable ccache only for events targeting the XRPLF repository, since
-        # other accounts will not have access to our remote cache storage.
-        # However, we do not enable ccache for events targeting the master or a
-        # release branch, to protect against the rare case that the output
-        # produced by ccache is not identical to a regular compilation.
-        ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !(github.base_ref == 'master' || startsWith(github.base_ref, 'release')) }}
         os: [linux, macos, windows]
     with:
+      # Enable ccache only for events targeting the XRPLF repository, since
+      # other accounts will not have access to our remote cache storage.
+      # However, we do not enable ccache for events targeting the master or a
+      # release branch, to protect against the rare case that the output
+      # produced by ccache is not identical to a regular compilation.
+      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !(github.base_ref == 'master' || startsWith(github.base_ref, 'release')) }}
       os: ${{ matrix.os }}
       strategy_matrix: ${{ github.event_name == 'schedule' && 'all' || 'minimal' }}
     secrets:


### PR DESCRIPTION
## High Level Overview of Change

This change moves the `enable_ccache` variable in the `on-trigger.yml` file to the correct location.

### Context of Change

The variable shouldn't be part of the `strategy:` stanza, but the `with:` stanza.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
