### PR TITLE
ci: Run pipelines on all macOS runners

### DIFF
--- a/.github/scripts/strategy-matrix/macos.json
+++ b/.github/scripts/strategy-matrix/macos.json
@@ -2,7 +2,7 @@
   "architecture": [
     {
       "platform": "macos/arm64",
-      "runner": ["self-hosted", "macOS", "ARM64", "mac-runner-m1"]
+      "runner": ["self-hosted", "macOS", "ARM64"]
     }
   ],
   "os": [


### PR DESCRIPTION
## High Level Overview of Change

This change removes a label that unnecessarily restricts the macOS runners to a subset of those available.

### Context of Change

There are idle macOS runners that we can leverage to increase performance of CI builds.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release