### PR TITLE
refactor(cspell): fix spelling issues in private/local variables and functions

### DIFF
--- a/cmake/XrplCompiler.cmake
+++ b/cmake/XrplCompiler.cmake
@@ -149,7 +149,7 @@ elseif (use_gold AND is_gcc)
     ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
     #[=========================================================[
        NOTE: THE gold linker inserts -rpath as DT_RUNPATH by
-       default intead of DT_RPATH, so you might have slightly
+       default instead of DT_RPATH, so you might have slightly
        unexpected runtime ld behavior if you were expecting
        DT_RPATH.  Specify --disable-new-dtags to gold if you do
        not want the default DT_RUNPATH behavior. This rpath

--- a/include/xrpl/basics/IntrusivePointer.h
+++ b/include/xrpl/basics/IntrusivePointer.h
@@ -58,7 +58,7 @@ concept CAdoptTag = std::is_same_v<T, SharedIntrusiveAdoptIncrementStrongTag> ||
     When the strong pointer count goes to zero, the "partialDestructor" is
     called. This can be used to destroy as much of the object as possible while
     still retaining the reference counts. For example, for SHAMapInnerNodes the
-    children may be reset in that function. Note that std::shared_poiner WILL
+    children may be reset in that function. Note that std::shared_pointer WILL
     run the destructor when the strong count reaches zero, but may not free the
     memory used by the object until the weak count reaches zero. In rippled, we
     typically allocate shared pointers with the `make_shared` function. When

--- a/include/xrpl/basics/Slice.h
+++ b/include/xrpl/basics/Slice.h
@@ -152,8 +152,8 @@ public:
 
     /** Return a "sub slice" of given length starting at the given position
 
-        Note that the subslice encompasses the range [pos, pos + rcount),
-        where rcount is the smaller of count and size() - pos.
+        Note that the subslice encompasses the range [pos, pos + rCount),
+        where rCount is the smaller of count and size() - pos.
 
         @param pos position of the first character
         @count requested length

--- a/include/xrpl/basics/StringUtilities.h
+++ b/include/xrpl/basics/StringUtilities.h
@@ -31,7 +31,7 @@ template <class Iterator>
 std::optional<Blob>
 strUnHex(std::size_t strSize, Iterator begin, Iterator end)
 {
-    static constexpr std::array<int, 256> const unxtab = []() {
+    static constexpr std::array<int, 256> const digitLookupTable = []() {
         std::array<int, 256> t{};
 
         for (auto& x : t)
@@ -57,7 +57,7 @@ strUnHex(std::size_t strSize, Iterator begin, Iterator end)
 
     if (strSize & 1)
     {
-        int c = unxtab[*iter++];
+        int c = digitLookupTable[*iter++];
 
         if (c < 0)
             return {};
@@ -67,12 +67,12 @@ strUnHex(std::size_t strSize, Iterator begin, Iterator end)
 
     while (iter != end)
     {
-        int cHigh = unxtab[*iter++];
+        int cHigh = digitLookupTable[*iter++];
 
         if (cHigh < 0)
             return {};
 
-        int cLow = unxtab[*iter++];
+        int cLow = digitLookupTable[*iter++];
 
         if (cLow < 0)
             return {};

--- a/include/xrpl/beast/container/detail/aged_unordered_container.h
+++ b/include/xrpl/beast/container/detail/aged_unordered_container.h
@@ -3189,11 +3189,12 @@ operator==(aged_unordered_container<
 {
     if (size() != other.size())
         return false;
-    for (auto iter(cbegin()), last(cend()), olast(other.cend()); iter != last;
+    for (auto iter(cbegin()), last(cend()), otherLast(other.cend());
+         iter != last;
          ++iter)
     {
-        auto oiter(other.find(extract(*iter)));
-        if (oiter == olast)
+        auto otherIter(other.find(extract(*iter)));
+        if (otherIter == otherLast)
             return false;
     }
     return true;

--- a/include/xrpl/beast/hash/hash_append.h
+++ b/include/xrpl/beast/hash/hash_append.h
@@ -203,7 +203,7 @@ struct is_contiguously_hashable<T[N], HashAlgorithm>
         Throws:
             Never
         Effect:
-            Returns the reslting hash of all the input data.
+            Returns the resulting hash of all the input data.
 */
 /** @{ */
 

--- a/include/xrpl/beast/utility/PropertyStream.h
+++ b/include/xrpl/beast/utility/PropertyStream.h
@@ -376,7 +376,7 @@ public:
         print statement examples
         "parent.child" prints child and all of its children
         "parent.child." start at the parent and print down to child
-        "parent.grandchild" prints nothing- grandchild not direct discendent
+        "parent.grandchild" prints nothing- grandchild not direct descendent
         "parent.grandchild." starts at the parent and prints down to grandchild
         "parent.grandchild.*" starts at parent, print through grandchild
        children

--- a/include/xrpl/json/json_value.h
+++ b/include/xrpl/json/json_value.h
@@ -44,7 +44,7 @@ enum ValueType {
 class StaticString
 {
 public:
-    constexpr explicit StaticString(char const* czstring) : str_(czstring)
+    constexpr explicit StaticString(char const* czString) : str_(czString)
     {
     }
 

--- a/include/xrpl/json/json_writer.h
+++ b/include/xrpl/json/json_writer.h
@@ -90,7 +90,7 @@ private:
     void
     writeArrayValue(Value const& value);
     bool
-    isMultineArray(Value const& value);
+    isMultilineArray(Value const& value);
     void
     pushValue(std::string const& value);
     void
@@ -157,7 +157,7 @@ private:
     void
     writeArrayValue(Value const& value);
     bool
-    isMultineArray(Value const& value);
+    isMultilineArray(Value const& value);
     void
     pushValue(std::string const& value);
     void

--- a/include/xrpl/nodestore/Manager.h
+++ b/include/xrpl/nodestore/Manager.h
@@ -55,7 +55,7 @@ public:
             HyperLevelDB, LevelDBFactory, SQLite, MDB
 
         If the fastBackendParameter is omitted or empty, no ephemeral database
-        is used. If the scheduler parameter is omited or unspecified, a
+        is used. If the scheduler parameter is omitted or unspecified, a
         synchronous scheduler is used which performs all tasks immediately on
         the caller's thread.
 

--- a/include/xrpl/protocol/IOUAmount.h
+++ b/include/xrpl/protocol/IOUAmount.h
@@ -20,7 +20,7 @@ namespace xrpl {
 
     Arithmetic operations can throw std::overflow_error during normalization
     if the amount exceeds the largest representable amount, but underflows
-    will silently trunctate to zero.
+    will silently truncate to zero.
 */
 class IOUAmount : private boost::totally_ordered<IOUAmount>,
                   private boost::additive<IOUAmount>

--- a/src/libxrpl/core/detail/LoadMonitor.cpp
+++ b/src/libxrpl/core/detail/LoadMonitor.cpp
@@ -66,7 +66,7 @@ LoadMonitor::update()
 
         "Imagine if you add 10 to something every second. And you
          also reduce it by 1/4 every second. It will "idle" at 40,
-         correponding to 10 counts per second."
+         corresponding to 10 counts per second."
     */
     do
     {

--- a/src/libxrpl/json/json_valueiterator.cpp
+++ b/src/libxrpl/json/json_valueiterator.cpp
@@ -89,26 +89,26 @@ ValueIteratorBase::copy(SelfType const& other)
 Value
 ValueIteratorBase::key() const
 {
-    Value::CZString const czstring = (*current_).first;
+    Value::CZString const czString = (*current_).first;
 
-    if (czstring.c_str())
+    if (czString.c_str())
     {
-        if (czstring.isStaticString())
-            return Value(StaticString(czstring.c_str()));
+        if (czString.isStaticString())
+            return Value(StaticString(czString.c_str()));
 
-        return Value(czstring.c_str());
+        return Value(czString.c_str());
     }
 
-    return Value(czstring.index());
+    return Value(czString.index());
 }
 
 UInt
 ValueIteratorBase::index() const
 {
-    Value::CZString const czstring = (*current_).first;
+    Value::CZString const czString = (*current_).first;
 
-    if (!czstring.c_str())
-        return czstring.index();
+    if (!czString.c_str())
+        return czString.index();
 
     return Value::UInt(-1);
 }

--- a/src/libxrpl/json/json_writer.cpp
+++ b/src/libxrpl/json/json_writer.cpp
@@ -347,7 +347,7 @@ StyledWriter::writeArrayValue(Value const& value)
         pushValue("[]");
     else
     {
-        bool isArrayMultiLine = isMultineArray(value);
+        bool isArrayMultiLine = isMultilineArray(value);
 
         if (isArrayMultiLine)
         {
@@ -398,7 +398,7 @@ StyledWriter::writeArrayValue(Value const& value)
 }
 
 bool
-StyledWriter::isMultineArray(Value const& value)
+StyledWriter::isMultilineArray(Value const& value)
 {
     int size = value.size();
     bool isMultiLine = size * 3 >= rightMargin_;
@@ -573,7 +573,7 @@ StyledStreamWriter::writeArrayValue(Value const& value)
         pushValue("[]");
     else
     {
-        bool isArrayMultiLine = isMultineArray(value);
+        bool isArrayMultiLine = isMultilineArray(value);
 
         if (isArrayMultiLine)
         {
@@ -624,7 +624,7 @@ StyledStreamWriter::writeArrayValue(Value const& value)
 }
 
 bool
-StyledStreamWriter::isMultineArray(Value const& value)
+StyledStreamWriter::isMultilineArray(Value const& value)
 {
     int size = value.size();
     bool isMultiLine = size * 3 >= rightMargin_;

--- a/src/libxrpl/ledger/CredentialHelpers.cpp
+++ b/src/libxrpl/ledger/CredentialHelpers.cpp
@@ -290,7 +290,7 @@ checkArray(STArray const& credentials, unsigned maxSize, beast::Journal j)
         if (!ins)
         {
             JLOG(j.trace()) << "Malformed transaction: "
-                               "duplicates in credenentials.";
+                               "duplicates in credentials.";
             return temMALFORMED;
         }
     }

--- a/src/libxrpl/net/RegisterSSLCerts.cpp
+++ b/src/libxrpl/net/RegisterSSLCerts.cpp
@@ -49,11 +49,11 @@ registerSSLCerts(
         return;
     }
 
-    auto warn = [&](std::string const& mesg) {
+    auto warn = [&](std::string const& msg) {
         // Buffer based on asio recommended size
         char buf[256];
         ::ERR_error_string_n(ec.value(), buf, sizeof(buf));
-        JLOG(j.warn()) << mesg << " " << buf;
+        JLOG(j.warn()) << msg << " " << buf;
         ::ERR_clear_error();
     };
 

--- a/src/libxrpl/nodestore/Database.cpp
+++ b/src/libxrpl/nodestore/Database.cpp
@@ -158,7 +158,7 @@ Database::stop()
                      << duration_cast<std::chrono::milliseconds>(
                             steady_clock::now() - start)
                             .count()
-                     << " millseconds";
+                     << " milliseconds";
 }
 
 void

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -34,7 +34,7 @@ char const* const versionString = "3.2.0-b0"
 #endif
 
 #ifdef SANITIZER
-    BOOST_PP_STRINGIZE(SANITIZER)
+    BOOST_PP_STRINGIZE(SANITIZER)  // cspell: disable-line
 #endif
 #endif
 

--- a/src/libxrpl/protocol/Indexes.cpp
+++ b/src/libxrpl/protocol/Indexes.cpp
@@ -122,9 +122,9 @@ getBookBase(Book const& book)
 uint256
 getQualityNext(uint256 const& uBase)
 {
-    static constexpr uint256 nextq(
+    static constexpr uint256 nextQuality(
         "0000000000000000000000000000000000000000000000010000000000000000");
-    return uBase + nextq;
+    return uBase + nextQuality;
 }
 
 std::uint64_t

--- a/src/xrpld/app/paths/Pathfinder.cpp
+++ b/src/xrpld/app/paths/Pathfinder.cpp
@@ -40,7 +40,7 @@ final paths and the estimated cost are returned.
 The engine permits the search depth to be selected and the paths table
 includes the depth at which each path type is found.  A search depth of zero
 causes no searching to be done.  Extra paths can also be injected, and this
-should be used to preserve previously-found paths across invokations for the
+should be used to preserve previously-found paths across invocations for the
 same path request (particularly if the search depth may change).
 
 */


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes lots of typos in private/local variables and private functions. There is no functionality change.

### Context of Change

Split up #5719 into smaller PRs that are easier to review

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### API Impact

N/A

## Test Plan

CI passes.