### PR TITLE
refactor(test): remove memondata, memonformat, memontype

### DIFF
--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -599,9 +599,6 @@ public:
         env(noop("alice"), memodata("data"));
         env(noop("alice"), memoformat("format"));
         env(noop("alice"), memotype("type"));
-        env(noop("alice"), memondata("format", "type"));
-        env(noop("alice"), memonformat("data", "type"));
-        env(noop("alice"), memontype("data", "format"));
         env(noop("alice"), memo("data", "format", "type"));
         env(noop("alice"),
             memo("data1", "format1", "type1"),

--- a/src/test/jtx/impl/memo.cpp
+++ b/src/test/jtx/impl/memo.cpp
@@ -46,39 +46,6 @@ memotype::operator()(Env&, JTx& jt) const
     m["MemoType"] = strHex(s_);
 }
 
-void
-memondata::operator()(Env&, JTx& jt) const
-{
-    auto& jv = jt.jv;
-    auto& ma = jv["Memos"];
-    auto& mi = ma[ma.size()];
-    auto& m = mi["Memo"];
-    m["MemoFormat"] = strHex(format_);
-    m["MemoType"] = strHex(type_);
-}
-
-void
-memonformat::operator()(Env&, JTx& jt) const
-{
-    auto& jv = jt.jv;
-    auto& ma = jv["Memos"];
-    auto& mi = ma[ma.size()];
-    auto& m = mi["Memo"];
-    m["MemoData"] = strHex(data_);
-    m["MemoType"] = strHex(type_);
-}
-
-void
-memontype::operator()(Env&, JTx& jt) const
-{
-    auto& jv = jt.jv;
-    auto& ma = jv["Memos"];
-    auto& mi = ma[ma.size()];
-    auto& m = mi["Memo"];
-    m["MemoData"] = strHex(data_);
-    m["MemoFormat"] = strHex(format_);
-}
-
 }  // namespace jtx
 }  // namespace test
 }  // namespace xrpl

--- a/src/test/jtx/memo.h
+++ b/src/test/jtx/memo.h
@@ -74,54 +74,6 @@ public:
     operator()(Env&, JTx& jt) const;
 };
 
-class memondata
-{
-private:
-    std::string format_;
-    std::string type_;
-
-public:
-    memondata(std::string const& format, std::string const& type)
-        : format_(format), type_(type)
-    {
-    }
-
-    void
-    operator()(Env&, JTx& jt) const;
-};
-
-class memonformat
-{
-private:
-    std::string data_;
-    std::string type_;
-
-public:
-    memonformat(std::string const& data, std::string const& type)
-        : data_(data), type_(type)
-    {
-    }
-
-    void
-    operator()(Env&, JTx& jt) const;
-};
-
-class memontype
-{
-private:
-    std::string data_;
-    std::string format_;
-
-public:
-    memontype(std::string const& data, std::string const& format)
-        : data_(data), format_(format)
-    {
-    }
-
-    void
-    operator()(Env&, JTx& jt) const;
-};
-
 }  // namespace jtx
 }  // namespace test
 }  // namespace xrpl


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the `memondata`, `memonformat`, and `memontype` classes in `jtx`, since they were only ever used in `Env_test.cpp`.

### Context of Change

Pulled out of #5719 

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

### API Impact
N/A
<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
