### PR TITLE
refactor: remove unused credential signature hash prefix

### DIFF
--- a/include/xrpl/protocol/HashPrefix.h
+++ b/include/xrpl/protocol/HashPrefix.h
@@ -67,9 +67,6 @@ enum class HashPrefix : std::uint32_t {
     /** Payment Channel Claim */
     paymentChannelClaim = detail::make_hash_prefix('C', 'L', 'M'),
 
-    /** Credentials signature */
-    credential = detail::make_hash_prefix('C', 'R', 'D'),
-
     /** Batch */
     batch = detail::make_hash_prefix('B', 'C', 'H'),
 };


### PR DESCRIPTION
## High Level Overview of Change

This PR removes `HashPrefix::credential`, which is not used anywhere.

### Context of Change

Drive-by fix

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

N/A

## Test Plan

CI passes.