### PR TITLE
chore: fix lcov warning

### DIFF
--- a/src/xrpld/app/tx/detail/LoanBrokerDelete.cpp
+++ b/src/xrpld/app/tx/detail/LoanBrokerDelete.cpp
@@ -67,7 +67,7 @@ LoanBrokerDelete::preclaim(PreclaimContext const& ctx)
             JLOG(ctx.j.warn()) << "LoanBrokerDelete: Debt total is "
                                << debtTotal << ", which rounds to " << rounded;
             return tecHAS_OBLIGATIONS;
-            // LCOV_EXCL_START
+            // LCOV_EXCL_STOP
         }
     }
 


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes a typo in LCOV flags. No source code change.

### Context of Change

In Actions:
<img width="1325" height="653" alt="image" src="https://github.com/user-attachments/assets/2e1765c6-933a-4173-b7dd-4df378fbb1b9" />

### Type of Change

- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

The warning no longer shows up in CI.