### PR TITLE
chore: Pin pre-commit hooks to commit hashes

### DIFF
--- a/.config/cspell.config.yaml
+++ b/.config/cspell.config.yaml
@@ -69,6 +69,7 @@ words:
   - cryptoconditional
   - cryptoconditions
   - csprng
+  - ctest
   - ctid
   - currenttxhash
   - daria
@@ -104,6 +105,7 @@ words:
   - iou
   - ious
   - isrdc
+  - itype
   - jemalloc
   - jlog
   - keylet
@@ -192,10 +194,12 @@ words:
   - roundings
   - sahyadri
   - Satoshi
+  - scons
   - secp
   - sendq
   - seqit
   - sf
+  - SFIELD
   - shamap
   - shamapitem
   - sidechain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,12 +32,12 @@ repos:
       - id: prettier
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.11.0
+    rev: 831207fd435b47aeffdf6af853097e64322b4d44 # frozen: v25.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v9.2.0
+    rev: 1cfa010f078c354f3ffb8413616280cc28f5ba21 # frozen: v9.4.0
     hooks:
       - id: cspell # Spell check changed files
         exclude: .config/cspell.config.yaml


### PR DESCRIPTION
## High Level Overview of Change

This change updates and pins the Black and CSpell pre-commit hooks.

### Context of Change

To avoid surprises, e.g. in case tags are moved to another commit, pinning of versions using the commit hash is preferred.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release