### PR TITLE
ci: remove 'master' branch as a trigger

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -20,8 +20,8 @@ class Config:
 Generate a strategy matrix for GitHub Actions CI.
 
 On each PR commit we will build a selection of Debian, RHEL, Ubuntu, MacOS, and
-Windows configurations, while upon merge into the develop, release, or master
-branches, we will build all configurations, and test most of them.
+Windows configurations, while upon merge into the develop or release branches,
+we will build all configurations, and test most of them.
 
 We will further set additional CMake arguments as follows:
 - All builds will have the `tests`, `werr`, and `xrpld` options.

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - should-run
       - build-test
-    if: ${{ needs.should-run.outputs.go == 'true' && startsWith(github.base_ref, 'release') }}
+    if: ${{ needs.should-run.outputs.go == 'true' && startsWith(github.ref, 'refs/heads/release') }}
     uses: ./.github/workflows/reusable-notify-clio.yml
     secrets:
       clio_notify_token: ${{ secrets.CLIO_NOTIFY_TOKEN }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - should-run
       - build-test
-    if: ${{ needs.should-run.outputs.go == 'true' && (startsWith(github.base_ref, 'release') || github.base_ref == 'master') }}
+    if: ${{ needs.should-run.outputs.go == 'true' && startsWith(github.base_ref, 'release') }}
     uses: ./.github/workflows/reusable-notify-clio.yml
     secrets:
       clio_notify_token: ${{ secrets.CLIO_NOTIFY_TOKEN }}

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -71,7 +71,7 @@ jobs:
       # However, we do not enable ccache for events targeting a release branch,
       # to protect against the rare case that the output produced by ccache is
       # not identical to a regular compilation.
-      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !startsWith(github.base_ref, 'release') }}
+      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !startsWith(github.ref, 'refs/heads/release') }}
       os: ${{ matrix.os }}
       strategy_matrix: ${{ github.event_name == 'schedule' && 'all' || 'minimal' }}
     secrets:

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -1,9 +1,8 @@
-# This workflow runs all workflows to build the dependencies required for the
-# project on various Linux flavors, as well as on MacOS and Windows, on a
-# scheduled basis, on merge into the 'develop', 'release', or 'master' branches,
-# or manually. The missing commits check is only run when the code is merged
-# into the 'develop' or 'release' branches, and the documentation is built when
-# the code is merged into the 'develop' branch.
+# This workflow runs all workflows to build and test the code on various Linux
+# flavors, as well as on MacOS and Windows, on a scheduled basis, on merge into
+# the 'develop' or 'release*' branches, or when requested manually. Upon
+# successful completion, it also uploads the built libxrpl package to the Conan
+# remote.
 name: Trigger
 
 on:
@@ -11,7 +10,6 @@ on:
     branches:
       - "develop"
       - "release*"
-      - "master"
     paths:
       # These paths are unique to `on-trigger.yml`.
       - ".github/workflows/on-trigger.yml"
@@ -70,10 +68,10 @@ jobs:
     with:
       # Enable ccache only for events targeting the XRPLF repository, since
       # other accounts will not have access to our remote cache storage.
-      # However, we do not enable ccache for events targeting the master or a
-      # release branch, to protect against the rare case that the output
-      # produced by ccache is not identical to a regular compilation.
-      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !(github.base_ref == 'master' || startsWith(github.base_ref, 'release')) }}
+      # However, we do not enable ccache for events targeting a release branch,
+      # to protect against the rare case that the output produced by ccache is
+      # not identical to a regular compilation.
+      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !startsWith(github.base_ref, 'release') }}
       os: ${{ matrix.os }}
       strategy_matrix: ${{ github.event_name == 'schedule' && 'all' || 'minimal' }}
     secrets:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,9 @@ name: Run pre-commit hooks
 on:
   pull_request:
   push:
-    branches: [develop, release, master]
+    branches:
+      - "develop"
+      - "release*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## High Level Overview of Change

This change removes the `master` branch as a trigger for the CI pipelines, and updates comments accordingly. It also fixes the pre-commit workflow, so it will run on all release branches.

### Context of Change

We are no longer using the `master` branch, and thus no longer need to include it as a trigger. This simplifies some of the logic as well.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release