### PR TITLE
fix encrypt zero balance and remove improper throw

### DIFF
--- a/include/xrpl/protocol/ConfidentialTransfer.h
+++ b/include/xrpl/protocol/ConfidentialTransfer.h
@@ -82,7 +82,7 @@ encryptAmount(
     Slice const& pubKeySlice,
     Slice const& blindingFactor);
 
-Buffer
+std::optional<Buffer>
 encryptCanonicalZeroAmount(
     Slice const& pubKeySlice,
     AccountID const& account,

--- a/src/libxrpl/protocol/ConfidentialTransfer.cpp
+++ b/src/libxrpl/protocol/ConfidentialTransfer.cpp
@@ -1,6 +1,5 @@
 #include <xrpl/protocol/ConfidentialTransfer.h>
 #include <xrpl/protocol/Protocol.h>
-#include <xrpl/protocol/TER.h>
 
 #include <openssl/rand.h>
 #include <openssl/sha.h>
@@ -219,15 +218,15 @@ encryptAmount(
     return buf;
 }
 
-Buffer
+std::optional<Buffer>
 encryptCanonicalZeroAmount(
     Slice const& pubKeySlice,
     AccountID const& account,
     MPTID const& mptId)
 {
-    Buffer buf(ecGamalEncryptedTotalLength);
+    if (pubKeySlice.size() != ecPubKeyLength)
+        return std::nullopt;  // LCOV_EXCL_LINE
 
-    // Allocate ciphertext placeholders
     secp256k1_pubkey c1, c2;
     secp256k1_pubkey pubKey;
 
@@ -241,12 +240,13 @@ encryptCanonicalZeroAmount(
             &pubKey,
             account.data(),
             mptId.data()))
-        Throw<std::runtime_error>("Failed to encrypt amount");
+        return std::nullopt;
+
+    Buffer buf(ecGamalEncryptedTotalLength);
 
     // Serialize the ciphertext pair into the buffer
     if (!serializeEcPair(c1, c2, buf))
-        Throw<std::runtime_error>(
-            "Failed to serialize into 66 byte compressed format");
+        return std::nullopt;
 
     return buf;
 }

--- a/src/xrpld/app/tx/detail/ConfidentialClawback.cpp
+++ b/src/xrpld/app/tx/detail/ConfidentialClawback.cpp
@@ -1,4 +1,3 @@
-#include <xrpld/app/misc/DelegateUtils.h>
 #include <xrpld/app/tx/detail/ConfidentialClawback.h>
 
 #include <xrpl/ledger/View.h>
@@ -18,20 +17,21 @@ ConfidentialClawback::preflight(PreflightContext const& ctx)
         return temDISABLED;
 
     auto const account = ctx.tx[sfAccount];
-    auto const issuer = MPTIssue(ctx.tx[sfMPTokenIssuanceID]).getIssuer();
 
     // Only issuer can clawback
-    if (account != issuer)
+    if (account != MPTIssue(ctx.tx[sfMPTokenIssuanceID]).getIssuer())
         return temMALFORMED;
 
     // Cannot clawback from self
     if (account == ctx.tx[sfHolder])
         return temMALFORMED;
 
+    // Check invalid claw amount
     auto const clawAmount = ctx.tx[sfMPTAmount];
     if (clawAmount == 0 || clawAmount > maxMPTokenAmount)
         return temBAD_AMOUNT;
 
+    // Verify proof length
     if (ctx.tx[sfZKProof].length() != ecEqualityProofLength)
         return temMALFORMED;
 
@@ -84,13 +84,17 @@ ConfidentialClawback::preclaim(PreclaimContext const& ctx)
     if (amount > (*sleIssuance)[~sfConfidentialOutstandingAmount].value_or(0))
         return tecINSUFFICIENT_FUNDS;
 
-    auto const ciphertext = (*sleHolderMPToken)[sfIssuerEncryptedBalance];
-    auto const pubKeySlice = (*sleIssuance)[sfIssuerElGamalPublicKey];
-
     auto const contextHash = getClawbackContextHash(
         account, ctx.tx[sfSequence], mptIssuanceID, amount, holder);
+
+    // Verify the revealed confidential amount by the issuer matches the exact
+    // confidential balance of the holder.
     return verifyClawbackEqualityProof(
-        amount, ctx.tx[sfZKProof], pubKeySlice, ciphertext, contextHash);
+        amount,
+        ctx.tx[sfZKProof],
+        (*sleIssuance)[sfIssuerElGamalPublicKey],
+        (*sleHolderMPToken)[sfIssuerEncryptedBalance],
+        contextHash);
 }
 
 TER
@@ -110,53 +114,39 @@ ConfidentialClawback::doApply()
     Slice const holderPubKey = (*sleHolderMPToken)[sfHolderElGamalPublicKey];
     Slice const issuerPubKey = (*sleIssuance)[sfIssuerElGamalPublicKey];
 
-    // Encrypt zero amount
-    Buffer encZeroForHolder;
-    Buffer encZeroForIssuer;
-    try
-    {
-        encZeroForHolder =
-            encryptCanonicalZeroAmount(holderPubKey, holder, mptIssuanceID);
-
-        encZeroForIssuer =
-            encryptCanonicalZeroAmount(issuerPubKey, holder, mptIssuanceID);
-    }
-    catch (std::exception const& e)
-    {
-        JLOG(ctx_.journal.error())
-            << "ConfidentialClawback: Failed to generate canonical zero: "
-            << e.what();
+    // After clawback, the balance should be encrypted zero.
+    auto const encZeroForHolder =
+        encryptCanonicalZeroAmount(holderPubKey, holder, mptIssuanceID);
+    if (!encZeroForHolder)
         return tecINTERNAL;  // LCOV_EXCL_LINE
-    }
+
+    auto const encZeroForIssuer =
+        encryptCanonicalZeroAmount(issuerPubKey, holder, mptIssuanceID);
+    if (!encZeroForIssuer)
+        return tecINTERNAL;  // LCOV_EXCL_LINE
 
     // Set holder's confidential balances to encrypted zero
-    (*sleHolderMPToken)[sfConfidentialBalanceInbox] = encZeroForHolder;
-    (*sleHolderMPToken)[sfConfidentialBalanceSpending] = encZeroForHolder;
-    (*sleHolderMPToken)[sfIssuerEncryptedBalance] = encZeroForIssuer;
+    (*sleHolderMPToken)[sfConfidentialBalanceInbox] = *encZeroForHolder;
+    (*sleHolderMPToken)[sfConfidentialBalanceSpending] = *encZeroForHolder;
+    (*sleHolderMPToken)[sfIssuerEncryptedBalance] = *encZeroForIssuer;
     (*sleHolderMPToken)[sfConfidentialBalanceVersion] = 0;
 
     if (sleHolderMPToken->isFieldPresent(sfAuditorEncryptedBalance))
     {
-        // check that issuance has auditor's pubkey before accessing it, if the
-        // field is absent, something has gone bad
+        // Sanity check: the issuance must have an auditor public key if
+        // auditing is enabled.
         if (!sleIssuance->isFieldPresent(sfAuditorElGamalPublicKey))
             return tecINTERNAL;  // LCOV_EXCL_LINE
 
         Slice const auditorPubKey = (*sleIssuance)[sfAuditorElGamalPublicKey];
 
-        try
-        {
-            Buffer const encZeroForAuditor = encryptCanonicalZeroAmount(
-                auditorPubKey, holder, mptIssuanceID);
-            (*sleHolderMPToken)[sfAuditorEncryptedBalance] = encZeroForAuditor;
-        }
-        catch (std::exception const& e)
-        {
-            JLOG(ctx_.journal.error())
-                << "ConfidentialClawback: Failed to generate canonical zero: "
-                << e.what();
+        auto const encZeroForAuditor =
+            encryptCanonicalZeroAmount(auditorPubKey, holder, mptIssuanceID);
+
+        if (!encZeroForAuditor)
             return tecINTERNAL;  // LCOV_EXCL_LINE
-        }
+
+        (*sleHolderMPToken)[sfAuditorEncryptedBalance] = *encZeroForAuditor;
     }
 
     // Decrease Global Confidential Outstanding Amount

--- a/src/xrpld/app/tx/detail/ConfidentialConvert.cpp
+++ b/src/xrpld/app/tx/detail/ConfidentialConvert.cpp
@@ -1,4 +1,3 @@
-#include <xrpld/app/misc/DelegateUtils.h>
 #include <xrpld/app/tx/detail/ConfidentialConvert.h>
 
 #include <xrpl/ledger/View.h>
@@ -85,13 +84,8 @@ ConfidentialConvert::preclaim(PreclaimContext const& ctx)
         sleIssuance->isFieldPresent(sfAuditorElGamalPublicKey);
 
     // tx must include auditor ciphertext if the issuance has enabled
-    // auditing
-    if (requiresAuditor && !hasAuditor)
-        return tecNO_PERMISSION;
-
-    // if auditing is not supported then user should not upload auditor
-    // ciphertext
-    if (!requiresAuditor && hasAuditor)
+    // auditing, and must not include it if auditing is not enabled
+    if (requiresAuditor != hasAuditor)
         return tecNO_PERMISSION;
 
     auto const sleMptoken = ctx.view.read(keylet::mptoken(issuanceID, account));
@@ -112,18 +106,21 @@ ConfidentialConvert::preclaim(PreclaimContext const& ctx)
         return tecINSUFFICIENT_FUNDS;
     }
 
+    auto const hasHolderKeyOnLedger =
+        sleMptoken->isFieldPresent(sfHolderElGamalPublicKey);
+    auto const hasHolderKeyInTx =
+        ctx.tx.isFieldPresent(sfHolderElGamalPublicKey);
+
     // must have pk to convert
-    if (!sleMptoken->isFieldPresent(sfHolderElGamalPublicKey) &&
-        !ctx.tx.isFieldPresent(sfHolderElGamalPublicKey))
+    if (!hasHolderKeyOnLedger && !hasHolderKeyInTx)
         return tecNO_PERMISSION;
 
     // can't update if there's already a pk
-    if (sleMptoken->isFieldPresent(sfHolderElGamalPublicKey) &&
-        ctx.tx.isFieldPresent(sfHolderElGamalPublicKey))
+    if (hasHolderKeyOnLedger && hasHolderKeyInTx)
         return tecDUPLICATE;
 
     Slice holderPubKey;
-    if (ctx.tx.isFieldPresent(sfHolderElGamalPublicKey))
+    if (hasHolderKeyInTx)
     {
         holderPubKey = ctx.tx[sfHolderElGamalPublicKey];
 
@@ -188,7 +185,7 @@ ConfidentialConvert::doApply()
     Slice const holderEc = ctx_.tx[sfHolderEncryptedAmount];
     Slice const issuerEc = ctx_.tx[sfIssuerEncryptedAmount];
 
-    std::optional<Slice> const auditorEc = ctx_.tx[~sfAuditorEncryptedAmount];
+    auto const auditorEc = ctx_.tx[~sfAuditorEncryptedAmount];
 
     // todo: we should check sfConfidentialBalanceSpending depending on
     // if we encrypt zero amount
@@ -243,10 +240,8 @@ ConfidentialConvert::doApply()
             (*sleMptoken)[sfAuditorEncryptedBalance] = *auditorEc;
 
         // encrypt sfConfidentialBalanceSpending with zero balance
-        auto const zeroBalance = encryptAmount(
-            0,
-            (*sleMptoken)[sfHolderElGamalPublicKey],
-            generateBlindingFactor());
+        auto const zeroBalance = encryptCanonicalZeroAmount(
+            (*sleMptoken)[sfHolderElGamalPublicKey], account_, mptIssuanceID);
 
         if (!zeroBalance)
             return tecINTERNAL;  // LCOV_EXCL_LINE

--- a/src/xrpld/app/tx/detail/ConfidentialMergeInbox.cpp
+++ b/src/xrpld/app/tx/detail/ConfidentialMergeInbox.cpp
@@ -44,7 +44,8 @@ ConfidentialMergeInbox::preclaim(PreclaimContext const& ctx)
         return tecOBJECT_NOT_FOUND;
 
     if (!sleMptoken->isFieldPresent(sfConfidentialBalanceInbox) ||
-        !sleMptoken->isFieldPresent(sfConfidentialBalanceSpending))
+        !sleMptoken->isFieldPresent(sfConfidentialBalanceSpending) ||
+        !sleMptoken->isFieldPresent(sfHolderElGamalPublicKey))
         return tecNO_PERMISSION;
 
     return tesSUCCESS;
@@ -58,6 +59,14 @@ ConfidentialMergeInbox::doApply()
     if (!sleMptoken)
         return tecINTERNAL;
 
+    // sanity check
+    if (!sleMptoken->isFieldPresent(sfConfidentialBalanceSpending) ||
+        !sleMptoken->isFieldPresent(sfConfidentialBalanceInbox) ||
+        !sleMptoken->isFieldPresent(sfHolderElGamalPublicKey))
+    {
+        return tecINTERNAL;
+    }
+
     // homomorphically add holder's encrypted balance
     Buffer sum(ecGamalEncryptedTotalLength);
     if (TER const ter = homomorphicAdd(
@@ -69,17 +78,13 @@ ConfidentialMergeInbox::doApply()
 
     (*sleMptoken)[sfConfidentialBalanceSpending] = sum;
 
-    try
-    {
-        Buffer zeroEncyption;
-        zeroEncyption = encryptCanonicalZeroAmount(
-            (*sleMptoken)[sfHolderElGamalPublicKey], account_, mptIssuanceID);
-        (*sleMptoken)[sfConfidentialBalanceInbox] = zeroEncyption;
-    }
-    catch (std::exception const& e)
-    {
-        return tecINTERNAL;
-    }
+    auto const zeroEncryption = encryptCanonicalZeroAmount(
+        (*sleMptoken)[sfHolderElGamalPublicKey], account_, mptIssuanceID);
+
+    if (!zeroEncryption)
+        return tecINTERNAL;  // LCOV_EXCL_LINE
+
+    (*sleMptoken)[sfConfidentialBalanceInbox] = *zeroEncryption;
 
     // it's fine if it reaches max uint32, it just resets to 0
     (*sleMptoken)[sfConfidentialBalanceVersion] =

--- a/src/xrpld/app/tx/detail/ConfidentialSend.cpp
+++ b/src/xrpld/app/tx/detail/ConfidentialSend.cpp
@@ -1,4 +1,3 @@
-#include <xrpld/app/misc/DelegateUtils.h>
 #include <xrpld/app/tx/detail/ConfidentialSend.h>
 
 #include <xrpl/ledger/CredentialHelpers.h>
@@ -30,6 +29,7 @@ ConfidentialSend::preflight(PreflightContext const& ctx)
     if (account == ctx.tx[sfDestination])
         return temMALFORMED;
 
+    // Check the length of the encrypted amounts
     if (ctx.tx[sfSenderEncryptedAmount].length() !=
             ecGamalEncryptedTotalLength ||
         ctx.tx[sfDestinationEncryptedAmount].length() !=
@@ -43,16 +43,18 @@ ConfidentialSend::preflight(PreflightContext const& ctx)
             ecGamalEncryptedTotalLength)
         return temBAD_CIPHERTEXT;
 
-    if (!isValidCiphertext(ctx.tx[sfSenderEncryptedAmount]) ||
-        !isValidCiphertext(ctx.tx[sfDestinationEncryptedAmount]) ||
-        !isValidCiphertext(ctx.tx[sfIssuerEncryptedAmount]))
-        return temBAD_CIPHERTEXT;
-
     if (hasAuditor && !isValidCiphertext(ctx.tx[sfAuditorEncryptedAmount]))
         return temBAD_CIPHERTEXT;
 
     // if (ctx.tx[sfZKProof].length() != ecEqualityProofLength)
     //     return temMALFORMED;
+
+    // Check the encrypted amount formats, this is more expensive so put it at
+    // the end
+    if (!isValidCiphertext(ctx.tx[sfSenderEncryptedAmount]) ||
+        !isValidCiphertext(ctx.tx[sfDestinationEncryptedAmount]) ||
+        !isValidCiphertext(ctx.tx[sfIssuerEncryptedAmount]))
+        return temBAD_CIPHERTEXT;
 
     return tesSUCCESS;
 }
@@ -92,22 +94,16 @@ ConfidentialSend::preclaim(PreclaimContext const& ctx)
     bool const requiresAuditor =
         sleIssuance->isFieldPresent(sfAuditorElGamalPublicKey);
 
-    // tx must include auditor ciphertext if the issuance has enabled
-    // auditing
-    if (requiresAuditor && !hasAuditor)
+    // Tx must include auditor ciphertext if the issuance has enabled
+    // auditing, and must not include it if auditing is not enabled
+    if (requiresAuditor != hasAuditor)
         return tecNO_PERMISSION;
 
-    // if auditing is not supported then user should not upload auditor
-    // ciphertext
-    if (!requiresAuditor && hasAuditor)
-        return tecNO_PERMISSION;
-
-    // already checked in preflight, but should also check that issuer on the
-    // issuance isn't the account either
+    // Sanity check: issuer isn't the sender
     if (sleIssuance->getAccountID(sfIssuer) == ctx.tx[sfAccount])
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    // Check sender's MPToken
+    // Check sender's MPToken existence
     auto const sleSenderMPToken =
         ctx.view.read(keylet::mptoken(mptIssuanceID, account));
     if (!sleSenderMPToken)
@@ -119,7 +115,13 @@ ConfidentialSend::preclaim(PreclaimContext const& ctx)
         !sleSenderMPToken->isFieldPresent(sfIssuerEncryptedBalance))
         return tecNO_PERMISSION;
 
-    // Check destination's MPToken
+    // Sanity check: MPToken's auditor field must be present if auditing is
+    // enabled
+    if (requiresAuditor &&
+        !sleSenderMPToken->isFieldPresent(sfAuditorEncryptedBalance))
+        return tefINTERNAL;
+
+    // Check destination's MPToken existence
     auto const sleDestinationMPToken =
         ctx.view.read(keylet::mptoken(mptIssuanceID, destination));
     if (!sleDestinationMPToken)
@@ -149,23 +151,6 @@ ConfidentialSend::preclaim(PreclaimContext const& ctx)
     if (auto const ter = requireAuth(ctx.view, mptIssue, destination);
         !isTesSuccess(ter))
         return ter;
-
-    // todo: check zkproof. equality proof and range proof, combined or separate
-    // TBD. TER const terProof = verifyConfidentialSendProof(
-    //     ctx.tx[sfZKProof],
-    //     (*sleSender)[sfConfidentialBalanceSpending],
-    //     ctx.tx[sfSenderEncryptedAmount],
-    //     ctx.tx[sfDestinationEncryptedAmount],
-    //     ctx.tx[sfIssuerEncryptedAmount],
-    //     (*sleSender)[sfHolderElGamalPublicKey],
-    //     (*sleDestination)[sfHolderElGamalPublicKey],
-    //     (*sleIssuance)[sfIssuerElGamalPublicKey],
-    //     (*sleSender)[~sfConfidentialBalanceVersion].value_or(0),
-    //     ctx.tx.getTransactionID()
-    // );
-
-    // if (!isTesSuccess(terProof))
-    //     return tecBAD_PROOF;
 
     return tesSUCCESS;
 }
@@ -199,7 +184,7 @@ ConfidentialSend::doApply()
     Slice const destEc = ctx_.tx[sfDestinationEncryptedAmount];
     Slice const issuerEc = ctx_.tx[sfIssuerEncryptedAmount];
 
-    std::optional<Slice> const auditorEc = ctx_.tx[~sfAuditorEncryptedAmount];
+    auto const auditorEc = ctx_.tx[~sfAuditorEncryptedAmount];
 
     // Subtract from sender's spending balance
     {


### PR DESCRIPTION
-  convert zero balance should not involve generate randomness, use `encryptCanonicalZeroAmount` instead;
- `encryptCanonicalZeroAmount` should return std::optional instead of throw;
- move isValidCiphertext to the end of preflight because it is an expensive check

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
