### PR TITLE
ci: Add missing commit hash to Conan recipe version

### DIFF
--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -31,7 +31,8 @@ runs:
         fi
 
         echo 'Appending shortened commit hash to version.'
-        VERSION="${VERSION}-${COMMIT_HASH:0:7}"
+        SHA='${{ github.sha }}'
+        VERSION="${VERSION}-${SHA:0:7}"
 
         echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
 


### PR DESCRIPTION
## High Level Overview of Change

This change adds the commit hash as suffix to the Conan recipe version.

### Context of Change

During several iterations of development the commit hash was supposed to be moved into the `run:` statement, but it slipped through the cracks and did not get added.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release