### PR TITLE
ci: Use plus instead of hyphen for Conan recipe version suffix

### DIFF
--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -17,8 +17,10 @@ runs:
         VERSION: ${{ github.ref_name }}
       run: echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
 
-    # When a tag is not pushed, then the version is extracted from the
-    # BuildInfo.cpp file and the shortened commit hash appended to it.
+    # When a tag is not pushed, then the version (e.g. 1.2.3-b0) is extracted
+    # from the BuildInfo.cpp file and the shortened commit hash appended to it.
+    # We use a plus sign instead of a hyphen because Conan recipe versions do
+    # not support two hyphens.
     - name: Generate version for non-tag event
       if: ${{ github.event_name != 'tag' }}
       shell: bash
@@ -32,7 +34,7 @@ runs:
 
         echo 'Appending shortened commit hash to version.'
         SHA='${{ github.sha }}'
-        VERSION="${VERSION}-${SHA:0:7}"
+        VERSION="${VERSION}+${SHA:0:7}"
 
         echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
 


### PR DESCRIPTION
## High Level Overview of Change

This change uses a `+` to separate a version suffix (commit hash) instead of a `-`.

### Context of Change

Conan recipes use semantic versioning, and since our version already creates a hyphen the second hyphen causes Conan to ignore it. The plus sign is a valid separator we can use instead.

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release
