### PR TITLE
Revert errant commit

### DIFF
--- a/include/xrpl/basics/Number.h
+++ b/include/xrpl/basics/Number.h
@@ -23,7 +23,6 @@
 #include <xrpl/beast/utility/instrumentation.h>
 
 #include <cstdint>
-#include <functional>
 #include <limits>
 #include <optional>
 #include <ostream>


### PR DESCRIPTION
## High Level Overview of Change

The commit / PR is fine, but it should not have been merged until 3.1.0-rc2 is ready and has a version changing commit. This PR should be merged with a push to preserve the commit ID. Do not squash or use the Github UI! (Though it won't be the end of the world if you do.)

This reverts commit ecfe43ece77e24c5d236efe2a16bfce69deb98af.

### Context of Change

See also #6262 
