### PR TITLE
refactor: clean up uses of std::source_location

### DIFF
--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -15,15 +15,8 @@
 #include <xrpl/protocol/Units.h>
 #include <xrpl/protocol/jss.h>
 
-#include <vector>
-
-#if (defined(__clang_major__) && __clang_major__ < 15)
-#include <experimental/source_location>
-using source_location = std::experimental::source_location;
-#else
 #include <source_location>
-using std::source_location;
-#endif
+#include <vector>
 
 namespace xrpl {
 namespace test {
@@ -640,7 +633,7 @@ checkMetrics(
     std::size_t expectedPerLedger,
     std::uint64_t expectedMinFeeLevel = baseFeeLevel.fee(),
     std::uint64_t expectedMedFeeLevel = minEscalationFeeLevel.fee(),
-    source_location const location = source_location::current())
+    std::source_location const location = std::source_location::current())
 {
     int line = location.line();
     char const* file = location.file_name();

--- a/src/test/rpc/LedgerEntry_test.cpp
+++ b/src/test/rpc/LedgerEntry_test.cpp
@@ -14,13 +14,7 @@
 #include <xrpl/protocol/STXChainBridge.h>
 #include <xrpl/protocol/jss.h>
 
-#if (defined(__clang_major__) && __clang_major__ < 15)
-#include <experimental/source_location>
-using source_location = std::experimental::source_location;
-#else
 #include <source_location>
-using std::source_location;
-#endif
 namespace xrpl {
 
 namespace test {
@@ -114,7 +108,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         Json::Value const& jv,
         std::string const& err,
         std::string const& msg,
-        source_location const location = source_location::current())
+        std::source_location const location = std::source_location::current())
     {
         if (BEAST_EXPECT(jv.isMember(jss::status)))
             BEAST_EXPECTS(
@@ -297,7 +291,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         FieldType const typeID,
         std::string const& expectedError,
         bool required = true,
-        source_location const location = source_location::current())
+        std::source_location const location = std::source_location::current())
     {
         forAllApiVersions([&, this](unsigned apiVersion) {
             if (required)
@@ -350,7 +344,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         FieldType typeID,
         std::string const& expectedError,
         bool required = true,
-        source_location const location = source_location::current())
+        std::source_location const location = std::source_location::current())
     {
         forAllApiVersions([&, this](unsigned apiVersion) {
             if (required)
@@ -407,7 +401,7 @@ class LedgerEntry_test : public beast::unit_test::suite
     runLedgerEntryTest(
         test::jtx::Env& env,
         Json::StaticString const& parentField,
-        source_location const location = source_location::current())
+        std::source_location const location = std::source_location::current())
     {
         testMalformedField(
             env,
@@ -431,7 +425,7 @@ class LedgerEntry_test : public beast::unit_test::suite
         test::jtx::Env& env,
         Json::StaticString const& parentField,
         std::vector<Subfield> const& subfields,
-        source_location const location = source_location::current())
+        std::source_location const location = std::source_location::current())
     {
         testMalformedField(
             env,


### PR DESCRIPTION
## High Level Overview of Change

This PR simplifies uses of `std::source_location` remove the macros checking if the clang version is < 15. 

No source code changes.

### Context of Change

The minimum Clang version supported is 16, so the checks for version < 15 are no longer necessary.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

N/A

## Test Plan

CI still compiles and passes on all versions.