### PR TITLE
Set version to 3.1.0

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "3.1.0-rc2"
+char const* const versionString = "3.1.0"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)


### PR DESCRIPTION
## High Level Overview of Change

This change sets the version to 3.1.0.

### Context of Change

3.1.0 is getting close to ready to release. When it is, this PR will be merged to update the version number, starting the release process.