### PR TITLE
ci: Upload Conan recipes for develop, release candidates, and releases

### DIFF
--- a/.github/workflows/reusable-upload-recipe.yml
+++ b/.github/workflows/reusable-upload-recipe.yml
@@ -62,12 +62,28 @@ jobs:
           REMOTE_PASSWORD: ${{ secrets.remote_password }}
         run: conan remote login "${REMOTE_NAME}" "${REMOTE_USERNAME}" --password "${REMOTE_PASSWORD}"
 
-      - name: Upload Conan recipe
+      - name: Upload Conan recipe (version)
         env:
           REMOTE_NAME: ${{ inputs.remote_name }}
         run: |
           conan export . --version=${{ steps.version.outputs.version }}
           conan upload --confirm --check --remote="${REMOTE_NAME}" xrpl/${{ steps.version.outputs.version }}
+
+      - name: Upload Conan recipe (develop)
+        if: ${{ github.ref == 'refs/heads/develop' }}
+        env:
+          REMOTE_NAME: ${{ inputs.remote_name }}
+        run: |
+          conan export . --version=develop
+          conan upload --confirm --check --remote="${REMOTE_NAME}" xrpl/develop
+
+      - name: Upload Conan recipe (release)
+        if: ${{ startsWith(github.ref, 'refs/heads/release') }}
+        env:
+          REMOTE_NAME: ${{ inputs.remote_name }}
+        run: |
+          conan export . --version=release
+          conan upload --confirm --check --remote="${REMOTE_NAME}" xrpl/release
 
     outputs:
       ref: xrpl/${{ steps.version.outputs.version }}

--- a/.github/workflows/reusable-upload-recipe.yml
+++ b/.github/workflows/reusable-upload-recipe.yml
@@ -77,8 +77,16 @@ jobs:
           conan export . --version=develop
           conan upload --confirm --check --remote="${REMOTE_NAME}" xrpl/develop
 
-      - name: Upload Conan recipe (release)
+      - name: Upload Conan recipe (rc)
         if: ${{ startsWith(github.ref, 'refs/heads/release') }}
+        env:
+          REMOTE_NAME: ${{ inputs.remote_name }}
+        run: |
+          conan export . --version=rc
+          conan upload --confirm --check --remote="${REMOTE_NAME}" xrpl/rc
+
+      - name: Upload Conan recipe (release)
+        if: ${{ github.event_name == 'tag' }}
         env:
           REMOTE_NAME: ${{ inputs.remote_name }}
         run: |


### PR DESCRIPTION
## High Level Overview of Change

This change exports and uploads the Conan recipe with the version names `develop`, `rc`, and `release` when applicable.

### Context of Change

To allow developers to consume the latest unstable and (near-)stable versions of our `xrpl` Conan recipe, we should export and upload it whenever a push occurs to the corresponding branch or a release tag has been created. This way, developers do not have to figure out themselves what the most recent shortened commit hash was to determine the latest unstable recipe version (e.g. `3.2.0-b0+a1b2c3d`) or what the most recent release (candidate) was to determine the latest (near-)stable recipe version (e.g. `3.1.0-rc2`).

Now, pushes to the `develop` branch will produce the `develop` recipe version, pushes to the `release` branch will produce the `rc` recipe version, and creation of versioned tags will produce the `release` recipe version.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release