### PR TITLE
refactor: Move sig verification outside of lock

### DIFF
--- a/src/xrpld/app/misc/detail/Manifest.cpp
+++ b/src/xrpld/app/misc/detail/Manifest.cpp
@@ -343,17 +343,33 @@ ManifestCache::revoked(PublicKey const& pk) const
 ManifestDisposition
 ManifestCache::applyManifest(Manifest m)
 {
+    if (!m.verify())
+    {
+        if (auto stream = j_.warn())
+            logMftAct(stream, "Invalid", m.masterKey, m.sequence);
+        return ManifestDisposition::invalid;
+    }
+
+    bool const revoked = m.revoked();
+    if (auto stream = j_.warn(); stream && revoked)
+        logMftAct(stream, "Revoked", m.masterKey, m.sequence);
+
+    if (!revoked && !m.signingKey)
+    {
+        JLOG(j_.warn()) << to_string(m)
+                        << ": is not revoked and the manifest has no "
+                           "signing key. Hence, the manifest is "
+                           "invalid";
+        return ManifestDisposition::invalid;
+    }
+
     // Check the manifest against the conditions that do not require a
-    // `unique_lock` (write lock) on the `mutex_`. Since the signature can be
-    // relatively expensive, the `checkSignature` parameter determines if the
-    // signature should be checked. Since `prewriteCheck` is run twice (see
-    // comment below), `checkSignature` only needs to be set to true on the
-    // first run.
-    auto prewriteCheck =
-        [this, &m](auto const& iter, bool checkSignature, auto const& lock) -> std::optional<ManifestDisposition> {
-        XRPL_ASSERT(lock.owns_lock(), "xrpl::ManifestCache::applyManifest::prewriteCheck : locked");
+    // `unique_lock` (write lock) on the `mutex_`.
+    auto prewriteCheck = [&](auto const& iter, auto const& lock) -> std::optional<ManifestDisposition> {
+        XRPL_ASSERT(lock.owns_lock(), "xrpl::ManifestCache::applyManifest : locked");
         (void)lock;  // not used. parameter is present to ensure the mutex is
                      // locked when the lambda is called.
+
         if (iter != map_.end() && m.sequence <= iter->second.sequence)
         {
             // We received a manifest whose sequence number is not strictly
@@ -365,13 +381,6 @@ ManifestCache::applyManifest(Manifest m)
             return ManifestDisposition::stale;
         }
 
-        if (checkSignature && !m.verify())
-        {
-            if (auto stream = j_.warn())
-                logMftAct(stream, "Invalid", m.masterKey, m.sequence);
-            return ManifestDisposition::invalid;
-        }
-
         // If the master key associated with a manifest is or might be
         // compromised and is, therefore, no longer trustworthy.
         //
@@ -379,10 +388,6 @@ ManifestCache::applyManifest(Manifest m)
         // setting the sequence number to the highest value possible, the
         // manifest is effectively neutered and cannot be superseded by a forged
         // one.
-        bool const revoked = m.revoked();
-
-        if (auto stream = j_.warn(); stream && revoked)
-            logMftAct(stream, "Revoked", m.masterKey, m.sequence);
 
         // Sanity check: the master key of this manifest should not be used as
         // the ephemeral key of another manifest:
@@ -396,15 +401,6 @@ ManifestCache::applyManifest(Manifest m)
 
         if (!revoked)
         {
-            if (!m.signingKey)
-            {
-                JLOG(j_.warn()) << to_string(m)
-                                << ": is not revoked and the manifest has no "
-                                   "signing key. Hence, the manifest is "
-                                   "invalid";
-                return ManifestDisposition::invalid;
-            }
-
             // Sanity check: the ephemeral key of this manifest should not be
             // used as the master or ephemeral key of another manifest:
             if (auto const x = signingToMasterKeys_.find(*m.signingKey); x != signingToMasterKeys_.end())
@@ -428,25 +424,23 @@ ManifestCache::applyManifest(Manifest m)
 
     {
         std::shared_lock sl{mutex_};
-        if (auto d = prewriteCheck(map_.find(m.masterKey), /*checkSig*/ true, sl))
+        if (auto d = prewriteCheck(map_.find(m.masterKey), sl))
             return *d;
     }
 
-    std::unique_lock sl{mutex_};
+    std::unique_lock ul{mutex_};
     auto const iter = map_.find(m.masterKey);
+
     // Since we released the previously held read lock, it's possible that the
     // collections have been written to. This means we need to run
     // `prewriteCheck` again. This re-does work, but `prewriteCheck` is
     // relatively inexpensive to run, and doing it this way allows us to run
     // `prewriteCheck` under a `shared_lock` above.
-    // Note, the signature has already been checked above, so it
-    // doesn't need to happen again (signature checks are somewhat expensive).
     // Note: It's a mistake to use an upgradable lock. This is a recipe for
     // deadlock.
-    if (auto d = prewriteCheck(iter, /*checkSig*/ false, sl))
+    if (auto d = prewriteCheck(iter, ul))
         return *d;
 
-    bool const revoked = m.revoked();
     // This is the first manifest we are seeing for a master key. This should
     // only ever happen once per validator run.
     if (iter == map_.end())


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change 
Moving sig verification and checks outside of lock since they don't really need to be inside. I initially planned to remove double locking mechanism, but unfortunately that would be really hard to justify without proper performance testing. Thus only doing an easy picking.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
