### PR TITLE
cherry-pick commits from `release-3.1` into `develop`

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -15,9 +15,10 @@
 
 // Add new amendments to the top of this list.
 // Keep it sorted in reverse chronological order.
+
 XRPL_FIX   (PermissionedDomainInvariant, Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (ExpiredNFTokenOfferRemoval, Supported::yes, VoteBehavior::DefaultNo)
-XRPL_FIX    (BatchInnerSigs,             Supported::yes, VoteBehavior::DefaultNo)
+XRPL_FIX    (BatchInnerSigs,             Supported::no, VoteBehavior::DefaultNo)
 XRPL_FEATURE(LendingProtocol,            Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionDelegationV1_1,   Supported::no,  VoteBehavior::DefaultNo)
 XRPL_FIX    (DirectoryLimit,             Supported::yes, VoteBehavior::DefaultNo)
@@ -31,7 +32,7 @@ XRPL_FEATURE(TokenEscrow,                Supported::yes, VoteBehavior::DefaultNo
 XRPL_FIX    (EnforceNFTokenTrustlineV2,  Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (AMMv1_3,                    Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionedDEX,            Supported::yes, VoteBehavior::DefaultNo)
-XRPL_FEATURE(Batch,                      Supported::yes, VoteBehavior::DefaultNo)
+XRPL_FEATURE(Batch,                      Supported::no,  VoteBehavior::DefaultNo)
 XRPL_FEATURE(SingleAssetVault,           Supported::yes,  VoteBehavior::DefaultNo)
 XRPL_FIX    (PayChanCancelAfter,         Supported::yes, VoteBehavior::DefaultNo)
 // Check flags in Credential transactions


### PR DESCRIPTION
## High Level Overview of Change

This PR synchronizes the changes released in hotfix release 3.1.1 into `develop` so they are also included in the next release.

There are two commits, which must remain separate, so do not squash or merge using the Github UI. Instead do a `merge --ff-only` (or an equivalent) locally into `develop` and push once the PR is mergeable.

Note: the second commit (24cbaf76a5cdd2ad95d1eeee7e4382d3a63bb8ea) is empty, and only included so we don't think that something was from the release branch. I can remove it if the consensus is that it's not necessary, but I do think it will prevent confusion in the future.

### Context of Change

* #6402 
* #6410 

### Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

