### PR TITLE
chore: Enable clang-tidy use-after-move check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: "-*,
-  bugprone-argument-comment
+  bugprone-argument-comment,
+  bugprone-use-after-move
   "
 # bugprone-assert-side-effect,
 # bugprone-bad-signal-to-kill-thread,
@@ -74,7 +75,6 @@ Checks: "-*,
 # bugprone-unused-local-non-trivial-variable,
 # bugprone-unused-raii,
 # bugprone-unused-return-value,
-# bugprone-use-after-move,
 # bugprone-virtual-near-miss,
 # cppcoreguidelines-init-variables,
 # cppcoreguidelines-misleading-capture-default-by-value,

--- a/src/libxrpl/shamap/SHAMap.cpp
+++ b/src/libxrpl/shamap/SHAMap.cpp
@@ -674,6 +674,7 @@ SHAMap::delItem(uint256 const& id)
 
         node = unshareNode(std::move(node), nodeID);
         node->setChild(selectBranch(nodeID, id), std::move(prevNode));
+        prevNode = intr_ptr::SharedPtr<SHAMapTreeNode>{};
 
         if (!nodeID.isRoot())
         {
@@ -682,6 +683,9 @@ SHAMap::delItem(uint256 const& id)
             int const bc = node->getBranchCount();
             if (bc == 0)
             {
+                // TODO: looks like this branch is not needed anymore because prevNode is already
+                // nullptr
+
                 // no children below this branch
                 prevNode.reset();
             }

--- a/src/test/basics/Buffer_test.cpp
+++ b/src/test/basics/Buffer_test.cpp
@@ -106,18 +106,18 @@ struct Buffer_test : beast::unit_test::suite
             {  // Move-construct from empty buf
                 Buffer x;
                 Buffer y{std::move(x)};
-                BEAST_EXPECT(sane(x));
-                BEAST_EXPECT(x.empty());
+                BEAST_EXPECT(sane(x));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(x.empty());  // NOLINT(bugprone-use-after-move)
                 BEAST_EXPECT(sane(y));
                 BEAST_EXPECT(y.empty());
-                BEAST_EXPECT(x == y);
+                BEAST_EXPECT(x == y);  // NOLINT(bugprone-use-after-move)
             }
 
             {  // Move-construct from non-empty buf
                 Buffer x{b1};
                 Buffer y{std::move(x)};
-                BEAST_EXPECT(sane(x));
-                BEAST_EXPECT(x.empty());
+                BEAST_EXPECT(sane(x));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(x.empty());  // NOLINT(bugprone-use-after-move)
                 BEAST_EXPECT(sane(y));
                 BEAST_EXPECT(y == b1);
             }
@@ -129,8 +129,8 @@ struct Buffer_test : beast::unit_test::suite
                 x = std::move(y);
                 BEAST_EXPECT(sane(x));
                 BEAST_EXPECT(x.empty());
-                BEAST_EXPECT(sane(y));
-                BEAST_EXPECT(y.empty());
+                BEAST_EXPECT(sane(y));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(y.empty());  // NOLINT(bugprone-use-after-move)
             }
 
             {  // Move assign non-empty buf to empty buf
@@ -140,8 +140,8 @@ struct Buffer_test : beast::unit_test::suite
                 x = std::move(y);
                 BEAST_EXPECT(sane(x));
                 BEAST_EXPECT(x == b1);
-                BEAST_EXPECT(sane(y));
-                BEAST_EXPECT(y.empty());
+                BEAST_EXPECT(sane(y));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(y.empty());  // NOLINT(bugprone-use-after-move)
             }
 
             {  // Move assign empty buf to non-empty buf
@@ -151,8 +151,8 @@ struct Buffer_test : beast::unit_test::suite
                 x = std::move(y);
                 BEAST_EXPECT(sane(x));
                 BEAST_EXPECT(x.empty());
-                BEAST_EXPECT(sane(y));
-                BEAST_EXPECT(y.empty());
+                BEAST_EXPECT(sane(y));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(y.empty());  // NOLINT(bugprone-use-after-move)
             }
 
             {  // Move assign non-empty buf to non-empty buf
@@ -163,14 +163,14 @@ struct Buffer_test : beast::unit_test::suite
                 x = std::move(y);
                 BEAST_EXPECT(sane(x));
                 BEAST_EXPECT(!x.empty());
-                BEAST_EXPECT(sane(y));
-                BEAST_EXPECT(y.empty());
+                BEAST_EXPECT(sane(y));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(y.empty());  // NOLINT(bugprone-use-after-move)
 
                 x = std::move(z);
                 BEAST_EXPECT(sane(x));
                 BEAST_EXPECT(!x.empty());
-                BEAST_EXPECT(sane(z));
-                BEAST_EXPECT(z.empty());
+                BEAST_EXPECT(sane(z));    // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(z.empty());  // NOLINT(bugprone-use-after-move)
             }
         }
 

--- a/src/test/core/ClosureCounter_test.cpp
+++ b/src/test/core/ClosureCounter_test.cpp
@@ -217,7 +217,7 @@ class ClosureCounter_test : public beast::unit_test::suite
             BEAST_EXPECT(result.copies == 0);
             BEAST_EXPECT(result.moves == 1);
             BEAST_EXPECT(result.str == "rvalue abcdefghijklmnopqrstuvwxyz!");
-            BEAST_EXPECT(strRValue.str.size() == 0);
+            BEAST_EXPECT(strRValue.str.size() == 0);  // NOLINT(bugprone-use-after-move)
         }
     }
 

--- a/src/test/jtx/Env_test.cpp
+++ b/src/test/jtx/Env_test.cpp
@@ -533,14 +533,14 @@ public:
         BEAST_EXPECT(*jt1.get<int>() == 7);
         BEAST_EXPECT(!jt1.get<UDT>());
         JTx jt2(std::move(jt1));
-        BEAST_EXPECT(!jt1.get<int>());
-        BEAST_EXPECT(!jt1.get<UDT>());
+        BEAST_EXPECT(!jt1.get<int>());  // NOLINT(bugprone-use-after-move)
+        BEAST_EXPECT(!jt1.get<UDT>());  // NOLINT(bugprone-use-after-move)
         BEAST_EXPECT(jt2.get<int>());
         BEAST_EXPECT(*jt2.get<int>() == 7);
         BEAST_EXPECT(!jt2.get<UDT>());
         jt1 = std::move(jt2);
-        BEAST_EXPECT(!jt2.get<int>());
-        BEAST_EXPECT(!jt2.get<UDT>());
+        BEAST_EXPECT(!jt2.get<int>());  // NOLINT(bugprone-use-after-move)
+        BEAST_EXPECT(!jt2.get<UDT>());  // NOLINT(bugprone-use-after-move)
         BEAST_EXPECT(jt1.get<int>());
         BEAST_EXPECT(*jt1.get<int>() == 7);
         BEAST_EXPECT(!jt1.get<UDT>());

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -351,7 +351,7 @@ public:
                 Buffer b(1);
                 BEAST_EXPECT(!b.empty());
                 st[sf4] = std::move(b);
-                BEAST_EXPECT(b.empty()); // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(b.empty());  // NOLINT(bugprone-use-after-move)
                 BEAST_EXPECT(Slice(st[sf4]).size() == 1);
                 st[~sf4] = std::nullopt;
                 BEAST_EXPECT(!~st[~sf4]);
@@ -370,7 +370,7 @@ public:
                 BEAST_EXPECT(!!~st[~sf5]);
                 Buffer b(1);
                 st[sf5] = std::move(b);
-                BEAST_EXPECT(b.empty()); // NOLINT(bugprone-use-after-move)
+                BEAST_EXPECT(b.empty());  // NOLINT(bugprone-use-after-move)
                 BEAST_EXPECT(Slice(st[sf5]).size() == 1);
                 st[~sf4] = std::nullopt;
                 BEAST_EXPECT(!~st[~sf4]);

--- a/src/test/protocol/STObject_test.cpp
+++ b/src/test/protocol/STObject_test.cpp
@@ -351,7 +351,7 @@ public:
                 Buffer b(1);
                 BEAST_EXPECT(!b.empty());
                 st[sf4] = std::move(b);
-                BEAST_EXPECT(b.empty());
+                BEAST_EXPECT(b.empty()); // NOLINT(bugprone-use-after-move)
                 BEAST_EXPECT(Slice(st[sf4]).size() == 1);
                 st[~sf4] = std::nullopt;
                 BEAST_EXPECT(!~st[~sf4]);
@@ -370,7 +370,7 @@ public:
                 BEAST_EXPECT(!!~st[~sf5]);
                 Buffer b(1);
                 st[sf5] = std::move(b);
-                BEAST_EXPECT(b.empty());
+                BEAST_EXPECT(b.empty()); // NOLINT(bugprone-use-after-move)
                 BEAST_EXPECT(Slice(st[sf5]).size() == 1);
                 st[~sf4] = std::nullopt;
                 BEAST_EXPECT(!~st[~sf4]);

--- a/src/tests/libxrpl/json/Value.cpp
+++ b/src/tests/libxrpl/json/Value.cpp
@@ -761,16 +761,16 @@ TEST(json_value, move)
     EXPECT_EQ(v1.asDouble(), 2.5);
 
     Json::Value v2 = std::move(v1);
-    EXPECT_FALSE(v1);
+    EXPECT_FALSE(v1);  // NOLINT(bugprone-use-after-move)
     EXPECT_TRUE(v2.isDouble());
     EXPECT_EQ(v2.asDouble(), 2.5);
-    EXPECT_NE(v1, v2);
+    EXPECT_NE(v1, v2);  // NOLINT(bugprone-use-after-move)
 
     v1 = std::move(v2);
     EXPECT_TRUE(v1.isDouble());
     EXPECT_EQ(v1.asDouble(), 2.5);
-    EXPECT_FALSE(v2);
-    EXPECT_NE(v1, v2);
+    EXPECT_FALSE(v2);   // NOLINT(bugprone-use-after-move)
+    EXPECT_NE(v1, v2);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(json_value, comparisons)
@@ -1348,7 +1348,7 @@ TEST(json_value, memory_leak)
 
         // Note that the type() == nullValue check is implementation
         // specific and not guaranteed to be valid in the future.
-        EXPECT_EQ(temp.type(), Json::nullValue);
+        EXPECT_EQ(temp.type(), Json::nullValue);  // NOLINT(bugprone-use-after-move)
     }
 }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This PR enables use-after-move clang-tidy check. It also fixes all the places where use after move was found.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

Use after move was found only in tests checking the state of object after it was moved.
The fix in SHAmap doesn't change much, because the pointer is already reset after move.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [x] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
