### PR TITLE
refactor: Consolidate delegate permission checks into base Transactor

### DIFF
--- a/include/xrpl/tx/Transactor.h
+++ b/include/xrpl/tx/Transactor.h
@@ -2,10 +2,12 @@
 
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/beast/utility/WrappedSink.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Permissions.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/ApplyContext.h>
 #include <xrpl/tx/applySteps.h>
+#include <xrpl/tx/transactors/Delegate/DelegateUtils.h>
 
 namespace xrpl {
 
@@ -206,8 +208,16 @@ public:
         return tesSUCCESS;
     }
 
+    template <typename T>
     static NotTEC
     checkPermission(ReadView const& view, STTx const& tx);
+
+    static NotTEC
+    checkDelegatePermission(
+        ReadView const& view,
+        STTx const& tx,
+        std::shared_ptr<SLE const> const& sle,
+        std::unordered_set<GranularPermissionType> const& granularPermissions);
     /////////////////////////////////////////////////////
 
     // Interface used by DeleteAccount
@@ -393,6 +403,29 @@ Transactor::invokePreflight(PreflightContext const& ctx)
         return ret;
 
     return T::preflightSigValidated(ctx);
+}
+
+template <typename T>
+NotTEC
+Transactor::checkPermission(ReadView const& view, STTx const& tx)
+{
+    auto const delegate = tx[~sfDelegate];
+    if (!delegate)
+        return tesSUCCESS;
+
+    auto const delegateKey = keylet::delegate(tx[sfAccount], *delegate);
+    auto const sle = view.read(delegateKey);
+
+    if (!sle)
+        return terNO_DELEGATE_PERMISSION;
+
+    if (checkTxPermission(sle, tx) == tesSUCCESS)
+        return tesSUCCESS;
+
+    std::unordered_set<GranularPermissionType> granularPermissions;
+    loadGranularPermission(sle, tx.getTxnType(), granularPermissions);
+
+    return T::checkDelegatePermission(view, tx, sle, granularPermissions);
 }
 
 template <class T>

--- a/include/xrpl/tx/Transactor.h
+++ b/include/xrpl/tx/Transactor.h
@@ -207,7 +207,17 @@ public:
         // after checkSeq/Fee/Sign.
         return tesSUCCESS;
     }
+    /**
+       Do NOT define an checkPermission function in a derived class.
+       Instead, use
 
+       static NotTEC
+       checkDelegatePermission(
+           ReadView const& view,
+           STTx const& tx,
+           std::shared_ptr<SLE const> const& sle,
+           std::unordered_set<GranularPermissionType> const& granularPermissions);
+    */
     template <typename T>
     static NotTEC
     checkPermission(ReadView const& view, STTx const& tx);

--- a/include/xrpl/tx/transactors/MPT/MPTokenIssuanceSet.h
+++ b/include/xrpl/tx/transactors/MPT/MPTokenIssuanceSet.h
@@ -23,7 +23,11 @@ public:
     preflight(PreflightContext const& ctx);
 
     static NotTEC
-    checkPermission(ReadView const& view, STTx const& tx);
+    checkDelegatePermission(
+        ReadView const& view,
+        STTx const& tx,
+        std::shared_ptr<SLE const> const& sle,
+        std::unordered_set<GranularPermissionType> const& granularPermissions);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/include/xrpl/tx/transactors/Payment.h
+++ b/include/xrpl/tx/transactors/Payment.h
@@ -32,7 +32,11 @@ public:
     preflight(PreflightContext const& ctx);
 
     static NotTEC
-    checkPermission(ReadView const& view, STTx const& tx);
+    checkDelegatePermission(
+        ReadView const& view,
+        STTx const& tx,
+        std::shared_ptr<SLE const> const& sle,
+        std::unordered_set<GranularPermissionType> const& granularPermissions);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/include/xrpl/tx/transactors/SetAccount.h
+++ b/include/xrpl/tx/transactors/SetAccount.h
@@ -24,7 +24,11 @@ public:
     preflight(PreflightContext const& ctx);
 
     static NotTEC
-    checkPermission(ReadView const& view, STTx const& tx);
+    checkDelegatePermission(
+        ReadView const& view,
+        STTx const& tx,
+        std::shared_ptr<SLE const> const& sle,
+        std::unordered_set<GranularPermissionType> const& granularPermissions);
 
     static TER
     preclaim(PreclaimContext const& ctx);

--- a/include/xrpl/tx/transactors/SetTrust.h
+++ b/include/xrpl/tx/transactors/SetTrust.h
@@ -21,8 +21,11 @@ public:
     preflight(PreflightContext const& ctx);
 
     static NotTEC
-    checkPermission(ReadView const& view, STTx const& tx);
-
+    checkDelegatePermission(
+        ReadView const& view,
+        STTx const& tx,
+        std::shared_ptr<SLE const> const& sle,
+        std::unordered_set<GranularPermissionType> const& granularPermissions);
     static TER
     preclaim(PreclaimContext const& ctx);
 

--- a/src/libxrpl/tx/Transactor.cpp
+++ b/src/libxrpl/tx/Transactor.cpp
@@ -252,19 +252,13 @@ Transactor::preflightSigValidated(PreflightContext const& ctx)
 }
 
 NotTEC
-Transactor::checkPermission(ReadView const& view, STTx const& tx)
+Transactor::checkDelegatePermission(
+    ReadView const& view,
+    STTx const& tx,
+    std::shared_ptr<SLE const> const& sle,
+    std::unordered_set<GranularPermissionType> const& granularPermissions)
 {
-    auto const delegate = tx[~sfDelegate];
-    if (!delegate)
-        return tesSUCCESS;
-
-    auto const delegateKey = keylet::delegate(tx[sfAccount], *delegate);
-    auto const sle = view.read(delegateKey);
-
-    if (!sle)
-        return terNO_DELEGATE_PERMISSION;
-
-    return checkTxPermission(sle, tx);
+    return terNO_DELEGATE_PERMISSION;
 }
 
 XRPAmount

--- a/src/libxrpl/tx/applySteps.cpp
+++ b/src/libxrpl/tx/applySteps.cpp
@@ -177,7 +177,7 @@ invoke_preclaim(PreclaimContext const& ctx)
                         if (NotTEC const result = T::checkPriorTxAndLastLedger(ctx))
                             return result;
 
-                        if (NotTEC const result = T::checkPermission(ctx.view, ctx.tx))
+                        if (NotTEC const result = Transactor::checkPermission<T>(ctx.view, ctx.tx))
                             return result;
 
                         if (NotTEC const result = T::checkSign(ctx))

--- a/src/libxrpl/tx/transactors/MPT/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/MPT/MPTokenIssuanceSet.cpp
@@ -111,30 +111,18 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
 }
 
 NotTEC
-MPTokenIssuanceSet::checkPermission(ReadView const& view, STTx const& tx)
+MPTokenIssuanceSet::checkDelegatePermission(
+    ReadView const& view,
+    STTx const& tx,
+    std::shared_ptr<SLE const> const& sle,
+    std::unordered_set<GranularPermissionType> const& granularPermissions)
 {
-    auto const delegate = tx[~sfDelegate];
-    if (!delegate)
-        return tesSUCCESS;
-
-    auto const delegateKey = keylet::delegate(tx[sfAccount], *delegate);
-    auto const sle = view.read(delegateKey);
-
-    if (!sle)
-        return terNO_DELEGATE_PERMISSION;
-
-    if (checkTxPermission(sle, tx) == tesSUCCESS)
-        return tesSUCCESS;
-
     auto const txFlags = tx.getFlags();
 
     // this is added in case more flags will be added for MPTokenIssuanceSet
     // in the future. Currently unreachable.
     if (txFlags & tfMPTokenIssuanceSetPermissionMask)
         return terNO_DELEGATE_PERMISSION;  // LCOV_EXCL_LINE
-
-    std::unordered_set<GranularPermissionType> granularPermissions;
-    loadGranularPermission(sle, ttMPTOKEN_ISSUANCE_SET, granularPermissions);
 
     if (txFlags & tfMPTLock && !granularPermissions.contains(MPTokenIssuanceLock))
         return terNO_DELEGATE_PERMISSION;

--- a/src/libxrpl/tx/transactors/Payment.cpp
+++ b/src/libxrpl/tx/transactors/Payment.cpp
@@ -219,24 +219,12 @@ Payment::preflight(PreflightContext const& ctx)
 }
 
 NotTEC
-Payment::checkPermission(ReadView const& view, STTx const& tx)
+Payment::checkDelegatePermission(
+    ReadView const& view,
+    STTx const& tx,
+    std::shared_ptr<SLE const> const& sle,
+    std::unordered_set<GranularPermissionType> const& granularPermissions)
 {
-    auto const delegate = tx[~sfDelegate];
-    if (!delegate)
-        return tesSUCCESS;
-
-    auto const delegateKey = keylet::delegate(tx[sfAccount], *delegate);
-    auto const sle = view.read(delegateKey);
-
-    if (!sle)
-        return terNO_DELEGATE_PERMISSION;
-
-    if (checkTxPermission(sle, tx) == tesSUCCESS)
-        return tesSUCCESS;
-
-    std::unordered_set<GranularPermissionType> granularPermissions;
-    loadGranularPermission(sle, ttPAYMENT, granularPermissions);
-
     auto const& dstAmount = tx.getFieldAmount(sfAmount);
     auto const& amountAsset = dstAmount.asset();
 

--- a/src/libxrpl/tx/transactors/SetAccount.cpp
+++ b/src/libxrpl/tx/transactors/SetAccount.cpp
@@ -150,22 +150,14 @@ SetAccount::preflight(PreflightContext const& ctx)
 }
 
 NotTEC
-SetAccount::checkPermission(ReadView const& view, STTx const& tx)
+SetAccount::checkDelegatePermission(
+    ReadView const& view,
+    STTx const& tx,
+    std::shared_ptr<SLE const> const& sle,
+    std::unordered_set<GranularPermissionType> const& granularPermissions)
 {
     // SetAccount is prohibited to be granted on a transaction level,
     // but some granular permissions are allowed.
-    auto const delegate = tx[~sfDelegate];
-    if (!delegate)
-        return tesSUCCESS;
-
-    auto const delegateKey = keylet::delegate(tx[sfAccount], *delegate);
-    auto const sle = view.read(delegateKey);
-
-    if (!sle)
-        return terNO_DELEGATE_PERMISSION;
-
-    std::unordered_set<GranularPermissionType> granularPermissions;
-    loadGranularPermission(sle, ttACCOUNT_SET, granularPermissions);
 
     auto const uSetFlag = tx.getFieldU32(sfSetFlag);
     auto const uClearFlag = tx.getFieldU32(sfClearFlag);

--- a/src/libxrpl/tx/transactors/SetTrust.cpp
+++ b/src/libxrpl/tx/transactors/SetTrust.cpp
@@ -106,21 +106,12 @@ SetTrust::preflight(PreflightContext const& ctx)
 }
 
 NotTEC
-SetTrust::checkPermission(ReadView const& view, STTx const& tx)
+SetTrust::checkDelegatePermission(
+    ReadView const& view,
+    STTx const& tx,
+    std::shared_ptr<SLE const> const& sle,
+    std::unordered_set<GranularPermissionType> const& granularPermissions)
 {
-    auto const delegate = tx[~sfDelegate];
-    if (!delegate)
-        return tesSUCCESS;
-
-    auto const delegateKey = keylet::delegate(tx[sfAccount], *delegate);
-    auto const sle = view.read(delegateKey);
-
-    if (!sle)
-        return terNO_DELEGATE_PERMISSION;
-
-    if (checkTxPermission(sle, tx) == tesSUCCESS)
-        return tesSUCCESS;
-
     std::uint32_t const txFlags = tx.getFlags();
 
     // Currently we only support TrustlineAuthorize, TrustlineFreeze and
@@ -140,9 +131,6 @@ SetTrust::checkPermission(ReadView const& view, STTx const& tx)
     // not allowed to create trustline
     if (!sleRippleState)
         return terNO_DELEGATE_PERMISSION;
-
-    std::unordered_set<GranularPermissionType> granularPermissions;
-    loadGranularPermission(sle, ttTRUST_SET, granularPermissions);
 
     if (txFlags & tfSetfAuth && !granularPermissions.contains(TrustlineAuthorize))
         return terNO_DELEGATE_PERMISSION;


### PR DESCRIPTION


## High Level Overview of Change

Extract the common delegate permission lookup logic (sfDelegate check, SLE read, checkTxPermission, and loadGranularPermission) from each transactor's checkPermission into a single template method Transactor::checkPermission<T>. Each derived class now only implements checkDelegatePermission with its transaction-specific granular permission logic, eliminating duplicated boilerplate across Payment, SetAccount, SetTrust, and MPTokenIssuanceSet.


### Context of Change

In the current implementation, all checks related to Delegates relied on the `checkPermission()` method within each transactor (if exists).

Since this posed a risk when implementing `checkPermission()` for new transactors, I'm changing the structure. I've extracted the common check logic into a template method, so that new `checkDelegatePermission()` in each transactor only needs to handle the Delegate checks specific to that transactor.

After this PR is merged, we should stop using `checkPermission()` and use `checkDelegatePermission()` instead.

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)
