### PR TITLE
ci: Only upload artifacts in the XRPLF/rippled repository

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -132,7 +132,7 @@ jobs:
     with:
       # Enable ccache only for events targeting the XRPLF repository, since
       # other accounts will not have access to our remote cache storage.
-      ccache_enabled: ${{ github.repository_owner == 'XRPLF' }}
+      ccache_enabled: ${{ github.repository == 'XRPLF/rippled' }}
       os: ${{ matrix.os }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -143,7 +143,7 @@ jobs:
       - build-test
     # Only run when committing to a PR that targets a release branch in the
     # XRPLF repository.
-    if: ${{ github.repository_owner == 'XRPLF' && needs.should-run.outputs.go == 'true' && startsWith(github.ref, 'refs/heads/release') }}
+    if: ${{ github.repository == 'XRPLF/rippled' && needs.should-run.outputs.go == 'true' && startsWith(github.ref, 'refs/heads/release') }}
     uses: ./.github/workflows/reusable-upload-recipe.yml
     secrets:
       remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -132,7 +132,7 @@ jobs:
     with:
       # Enable ccache only for events targeting the XRPLF repository, since
       # other accounts will not have access to our remote cache storage.
-      ccache_enabled: ${{ github.repository == 'XRPLF/rippled' }}
+      ccache_enabled: ${{ github.repository_owner == 'XRPLF' }}
       os: ${{ matrix.os }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -141,8 +141,7 @@ jobs:
     needs:
       - should-run
       - build-test
-    # Only run when committing to a PR that targets a release branch in the
-    # XRPLF repository.
+    # Only run when committing to a PR that targets a release branch.
     if: ${{ github.repository == 'XRPLF/rippled' && needs.should-run.outputs.go == 'true' && startsWith(github.ref, 'refs/heads/release') }}
     uses: ./.github/workflows/reusable-upload-recipe.yml
     secrets:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   upload-recipe:
     # Only run when a tag is pushed to the XRPLF repository.
-    if: ${{ github.repository_owner == 'XRPLF' }}
+    if: ${{ github.repository == 'XRPLF/rippled' }}
     uses: ./.github/workflows/reusable-upload-recipe.yml
     secrets:
       remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -17,7 +17,6 @@ defaults:
 
 jobs:
   upload-recipe:
-    # Only run when a tag is pushed to the XRPLF repository.
     if: ${{ github.repository == 'XRPLF/rippled' }}
     uses: ./.github/workflows/reusable-upload-recipe.yml
     secrets:

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -84,7 +84,7 @@ jobs:
       # However, we do not enable ccache for events targeting a release branch,
       # to protect against the rare case that the output produced by ccache is
       # not identical to a regular compilation.
-      ccache_enabled: ${{ github.repository == 'XRPLF/rippled' && !startsWith(github.ref, 'refs/heads/release') }}
+      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !startsWith(github.ref, 'refs/heads/release') }}
       os: ${{ matrix.os }}
       strategy_matrix: ${{ github.event_name == 'schedule' && 'all' || 'minimal' }}
     secrets:

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -92,7 +92,7 @@ jobs:
 
   upload-recipe:
     needs: build-test
-    # Only run when pushing to the develop branch in the XRPLF repository.
+    # Only run when pushing to the develop branch.
     if: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     uses: ./.github/workflows/reusable-upload-recipe.yml
     secrets:

--- a/.github/workflows/on-trigger.yml
+++ b/.github/workflows/on-trigger.yml
@@ -84,7 +84,7 @@ jobs:
       # However, we do not enable ccache for events targeting a release branch,
       # to protect against the rare case that the output produced by ccache is
       # not identical to a regular compilation.
-      ccache_enabled: ${{ github.repository_owner == 'XRPLF' && !startsWith(github.ref, 'refs/heads/release') }}
+      ccache_enabled: ${{ github.repository == 'XRPLF/rippled' && !startsWith(github.ref, 'refs/heads/release') }}
       os: ${{ matrix.os }}
       strategy_matrix: ${{ github.event_name == 'schedule' && 'all' || 'minimal' }}
     secrets:
@@ -93,7 +93,7 @@ jobs:
   upload-recipe:
     needs: build-test
     # Only run when pushing to the develop branch in the XRPLF repository.
-    if: ${{ github.repository_owner == 'XRPLF' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+    if: ${{ github.repository == 'XRPLF/rippled' && github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     uses: ./.github/workflows/reusable-upload-recipe.yml
     secrets:
       remote_username: ${{ secrets.CONAN_REMOTE_USERNAME }}

--- a/.github/workflows/reusable-build-test-config.yml
+++ b/.github/workflows/reusable-build-test-config.yml
@@ -176,7 +176,7 @@ jobs:
           fi
 
       - name: Upload the binary (Linux)
-        if: ${{ github.repository_owner == 'XRPLF' && runner.os == 'Linux' }}
+        if: ${{ github.repository == 'XRPLF/rippled' && runner.os == 'Linux' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: xrpld-${{ inputs.config_name }}
@@ -266,7 +266,7 @@ jobs:
             --target coverage
 
       - name: Upload coverage report
-        if: ${{ github.repository_owner == 'XRPLF' && !inputs.build_only && env.COVERAGE_ENABLED == 'true' }}
+        if: ${{ github.repository == 'XRPLF/rippled' && !inputs.build_only && env.COVERAGE_ENABLED == 'true' }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           disable_search: true

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -103,11 +103,11 @@ jobs:
           sanitizers: ${{ matrix.sanitizers }}
 
       - name: Log into Conan remote
-        if: ${{ github.repository_owner == 'XRPLF' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ github.repository == 'XRPLF/rippled' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         run: conan remote login "${CONAN_REMOTE_NAME}" "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
 
       - name: Upload Conan packages
-        if: ${{ github.repository_owner == 'XRPLF' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ github.repository == 'XRPLF/rippled' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         env:
           FORCE_OPTION: ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}
         run: conan upload "*" --remote="${CONAN_REMOTE_NAME}" --confirm ${FORCE_OPTION}


### PR DESCRIPTION
## High Level Overview of Change

This change will only attempt to upload artifacts for CI runs performed in the XRPLF/rippled repository.

### Context of Change

When we want to try out something new in a separate repository based on the rippled repository, the CI pipelines will fail when they try to upload the artifacts. We should only attempt to upload artifacts in the rippled repository.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [X] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release