### PR TITLE
refactor: Improve exception handling

### DIFF
--- a/include/xrpl/net/AutoSocket.h
+++ b/include/xrpl/net/AutoSocket.h
@@ -156,7 +156,7 @@ public:
             {
                 lowest_layer().shutdown(plain_socket::shutdown_both);
             }
-            catch (boost::system::system_error& e)
+            catch (boost::system::system_error const& e)
             {
                 ec = e.code();
             }

--- a/src/libxrpl/ledger/ApplyStateTable.cpp
+++ b/src/libxrpl/ledger/ApplyStateTable.cpp
@@ -412,14 +412,14 @@ ApplyStateTable::erase(ReadView const& base, std::shared_ptr<SLE> const& sle)
 {
     auto const iter = items_.find(sle->key());
     if (iter == items_.end())
-        LogicError("ApplyStateTable::erase: missing key");
+        Throw<std::logic_error>("ApplyStateTable::erase: missing key");
     auto& item = iter->second;
     if (item.second != sle)
-        LogicError("ApplyStateTable::erase: unknown SLE");
+        Throw<std::logic_error>("ApplyStateTable::erase: unknown SLE");
     switch (item.first)
     {
         case Action::erase:
-            LogicError("ApplyStateTable::erase: double erase");
+            Throw<std::logic_error>("ApplyStateTable::erase: double erase");
             break;
         case Action::insert:
             items_.erase(iter);
@@ -445,7 +445,7 @@ ApplyStateTable::rawErase(ReadView const& base, std::shared_ptr<SLE> const& sle)
     switch (item.first)
     {
         case Action::erase:
-            LogicError("ApplyStateTable::rawErase: double erase");
+            Throw<std::logic_error>("ApplyStateTable::rawErase: double erase");
             break;
         case Action::insert:
             items_.erase(result.first);
@@ -476,11 +476,13 @@ ApplyStateTable::insert(ReadView const& base, std::shared_ptr<SLE> const& sle)
     switch (item.first)
     {
         case Action::cache:
-            LogicError("ApplyStateTable::insert: already cached");
+            Throw<std::logic_error>("ApplyStateTable::insert: already cached");
         case Action::insert:
-            LogicError("ApplyStateTable::insert: already inserted");
+            Throw<std::logic_error>(
+                "ApplyStateTable::insert: already inserted");
         case Action::modify:
-            LogicError("ApplyStateTable::insert: already modified");
+            Throw<std::logic_error>(
+                "ApplyStateTable::insert: already modified");
         case Action::erase:
             break;
     }
@@ -506,7 +508,7 @@ ApplyStateTable::replace(ReadView const& base, std::shared_ptr<SLE> const& sle)
     switch (item.first)
     {
         case Action::erase:
-            LogicError("ApplyStateTable::replace: already erased");
+            Throw<std::logic_error>("ApplyStateTable::replace: already erased");
         case Action::cache:
             item.first = Action::modify;
             break;
@@ -522,14 +524,14 @@ ApplyStateTable::update(ReadView const& base, std::shared_ptr<SLE> const& sle)
 {
     auto const iter = items_.find(sle->key());
     if (iter == items_.end())
-        LogicError("ApplyStateTable::update: missing key");
+        Throw<std::logic_error>("ApplyStateTable::update: missing key");
     auto& item = iter->second;
     if (item.second != sle)
-        LogicError("ApplyStateTable::update: unknown SLE");
+        Throw<std::logic_error>("ApplyStateTable::update: unknown SLE");
     switch (item.first)
     {
         case Action::erase:
-            LogicError("ApplyStateTable::update: erased");
+            Throw<std::logic_error>("ApplyStateTable::update: erased");
             break;
         case Action::cache:
             item.first = Action::modify;

--- a/src/libxrpl/ledger/ApplyView.cpp
+++ b/src/libxrpl/ledger/ApplyView.cpp
@@ -59,10 +59,8 @@ findPreviousPage(ApplyView& view, Keylet const& directory, SLE::ref start)
     {
         node = view.peek(keylet::page(directory, page));
         if (!node)
-        {  // LCOV_EXCL_START
-            LogicError("Directory chain: root back-pointer broken.");
-            // LCOV_EXCL_STOP
-        }
+            Throw<std::logic_error>(
+                "Directory chain: root back-pointer broken.");  // LCOV_EXCL_LINE
     }
 
     auto indexes = node->getFieldV256(sfIndexes);
@@ -81,21 +79,22 @@ insertKey(
     if (preserveOrder)
     {
         if (std::find(indexes.begin(), indexes.end(), key) != indexes.end())
-            LogicError("dirInsert: double insertion");  // LCOV_EXCL_LINE
+            Throw<std::logic_error>(
+                "dirInsert: double insertion");  // LCOV_EXCL_LINE
 
         indexes.push_back(key);
     }
     else
     {
-        // We can't be sure if this page is already sorted because
-        // it may be a legacy page we haven't yet touched. Take
-        // the time to sort it.
+        // We can't be sure if this page is already sorted because it may be a
+        // legacy page we haven't yet touched. Take the time to sort it.
         std::sort(indexes.begin(), indexes.end());
 
         auto pos = std::lower_bound(indexes.begin(), indexes.end(), key);
 
         if (pos != indexes.end() && key == *pos)
-            LogicError("dirInsert: double insertion");  // LCOV_EXCL_LINE
+            Throw<std::logic_error>(
+                "dirInsert: double insertion");  // LCOV_EXCL_LINE
 
         indexes.insert(pos, key);
     }
@@ -149,8 +148,7 @@ insertPage(
     node->setFieldH256(sfRootIndex, directory.key);
     node->setFieldV256(sfIndexes, indexes);
 
-    // Save some space by not specifying the value 0 since
-    // it's the default.
+    // Save some space by not specifying the value 0 since it's the default.
     if (page != 1)
         node->setFieldU64(sfIndexPrevious, page - 1);
     XRPL_ASSERT_PARTS(
@@ -226,28 +224,27 @@ ApplyView::emptyDirDelete(Keylet const& directory)
     auto nextPage = node->getFieldU64(sfIndexNext);
 
     if (nextPage == rootPage && prevPage != rootPage)
-        LogicError("Directory chain: fwd link broken");  // LCOV_EXCL_LINE
+        Throw<std::logic_error>(
+            "Directory chain: fwd link broken");  // LCOV_EXCL_LINE
 
     if (prevPage == rootPage && nextPage != rootPage)
-        LogicError("Directory chain: rev link broken");  // LCOV_EXCL_LINE
+        Throw<std::logic_error>(
+            "Directory chain: rev link broken");  // LCOV_EXCL_LINE
 
-    // Older versions of the code would, in some cases, allow the last
-    // page to be empty. Remove such pages:
+    // Older versions of the code would, in some cases, allow the last page to
+    // be empty. Remove such pages:
     if (nextPage == prevPage && nextPage != rootPage)
     {
         auto last = peek(keylet::page(directory, nextPage));
 
         if (!last)
-        {  // LCOV_EXCL_START
-            LogicError("Directory chain: fwd link broken.");
-            // LCOV_EXCL_STOP
-        }
+            Throw<std::logic_error>(
+                "Directory chain: fwd link broken.");  // LCOV_EXCL_LINE
 
         if (!last->getFieldV256(sfIndexes).empty())
             return false;
 
-        // Update the first page's linked list and
-        // mark it as updated.
+        // Update the first page's linked list and mark it as updated.
         node->setFieldU64(sfIndexNext, rootPage);
         node->setFieldU64(sfIndexPrevious, rootPage);
         update(node);
@@ -255,8 +252,7 @@ ApplyView::emptyDirDelete(Keylet const& directory)
         // And erase the empty last page:
         erase(last);
 
-        // Make sure our local values reflect the
-        // updated information:
+        // Make sure our local values reflect the updated information:
         nextPage = rootPage;
         prevPage = rootPage;
     }
@@ -300,46 +296,36 @@ ApplyView::dirRemove(
             return true;
     }
 
-    // The current page is now empty; check if it can be
-    // deleted, and, if so, whether the entire directory
-    // can now be removed.
+    // The current page is now empty; check if it can be deleted, and, if so,
+    // whether the entire directory can now be removed.
     auto prevPage = node->getFieldU64(sfIndexPrevious);
     auto nextPage = node->getFieldU64(sfIndexNext);
 
-    // The first page is the directory's root node and is
-    // treated specially: it can never be deleted even if
-    // it is empty, unless we plan on removing the entire
-    // directory.
+    // The first page is the directory's root node and is treated specially: it
+    // can never be deleted even if it is empty, unless we plan on removing the
+    // entire directory.
     if (page == rootPage)
     {
         if (nextPage == page && prevPage != page)
-        {  // LCOV_EXCL_START
-            LogicError("Directory chain: fwd link broken");
-            // LCOV_EXCL_STOP
-        }
+            Throw<std::logic_error>(
+                "Directory chain: fwd link broken");  // LCOV_EXCL_LINE
 
         if (prevPage == page && nextPage != page)
-        {  // LCOV_EXCL_START
-            LogicError("Directory chain: rev link broken");
-            // LCOV_EXCL_STOP
-        }
+            Throw<std::logic_error>(
+                "Directory chain: rev link broken");  // LCOV_EXCL_LINE
 
-        // Older versions of the code would, in some cases,
-        // allow the last page to be empty. Remove such
-        // pages if we stumble on them:
+        // Older versions of the code would, in some cases, allow the last page
+        // to be empty. Remove such pages if we stumble on them:
         if (nextPage == prevPage && nextPage != page)
         {
             auto last = peek(keylet::page(directory, nextPage));
             if (!last)
-            {  // LCOV_EXCL_START
-                LogicError("Directory chain: fwd link broken.");
-                // LCOV_EXCL_STOP
-            }
+                Throw<std::logic_error>(
+                    "Directory chain: fwd link broken.");  // LCOV_EXCL_LINE
 
             if (last->getFieldV256(sfIndexes).empty())
             {
-                // Update the first page's linked list and
-                // mark it as updated.
+                // Update the first page's linked list and mark it as updated.
                 node->setFieldU64(sfIndexNext, page);
                 node->setFieldU64(sfIndexPrevious, page);
                 update(node);
@@ -347,8 +333,7 @@ ApplyView::dirRemove(
                 // And erase the empty last page:
                 erase(last);
 
-                // Make sure our local values reflect the
-                // updated information:
+                // Make sure our local values reflect the updated information:
                 nextPage = page;
                 prevPage = page;
             }
@@ -366,25 +351,28 @@ ApplyView::dirRemove(
 
     // This can never happen for nodes other than the root:
     if (nextPage == page)
-        LogicError("Directory chain: fwd link broken");  // LCOV_EXCL_LINE
+        Throw<std::logic_error>(
+            "Directory chain: fwd link broken");  // LCOV_EXCL_LINE
 
     if (prevPage == page)
-        LogicError("Directory chain: rev link broken");  // LCOV_EXCL_LINE
+        Throw<std::logic_error>(
+            "Directory chain: rev link broken");  // LCOV_EXCL_LINE
 
-    // This node isn't the root, so it can either be in the
-    // middle of the list, or at the end. Unlink it first
-    // and then check if that leaves the list with only a
-    // root:
+    // This node isn't the root, so it can either be in the middle of the list,
+    // or at the end. Unlink it first and then check if that leaves the list
+    // with only a root:
     auto prev = peek(keylet::page(directory, prevPage));
     if (!prev)
-        LogicError("Directory chain: fwd link broken.");  // LCOV_EXCL_LINE
+        Throw<std::logic_error>(
+            "Directory chain: fwd link broken.");  // LCOV_EXCL_LINE
     // Fix previous to point to its new next.
     prev->setFieldU64(sfIndexNext, nextPage);
     update(prev);
 
     auto next = peek(keylet::page(directory, nextPage));
     if (!next)
-        LogicError("Directory chain: rev link broken.");  // LCOV_EXCL_LINE
+        Throw<std::logic_error>(
+            "Directory chain: rev link broken.");  // LCOV_EXCL_LINE
     // Fix next to point to its new previous.
     next->setFieldU64(sfIndexPrevious, prevPage);
     update(next);
@@ -392,13 +380,12 @@ ApplyView::dirRemove(
     // The page is no longer linked. Delete it.
     erase(node);
 
-    // Check whether the next page is the last page and, if
-    // so, whether it's empty. If it is, delete it.
+    // Check whether the next page is the last page and, if so, whether it's
+    // empty. If it is, delete it.
     if (nextPage != rootPage && next->getFieldU64(sfIndexNext) == rootPage &&
         next->getFieldV256(sfIndexes).empty())
     {
-        // Since next doesn't point to the root, it
-        // can't be pointing to prev.
+        // Since next doesn't point to the root, it can't be pointing to prev.
         erase(next);
 
         // The previous page is now the last page:
@@ -408,18 +395,17 @@ ApplyView::dirRemove(
         // And the root points to the last page:
         auto root = peek(keylet::page(directory, rootPage));
         if (!root)
-        {  // LCOV_EXCL_START
-            LogicError("Directory chain: root link broken.");
-            // LCOV_EXCL_STOP
-        }
+            Throw<std::logic_error>(
+                "Directory chain: root link broken.");  // LCOV_EXCL_LINE
+
         root->setFieldU64(sfIndexPrevious, prevPage);
         update(root);
 
         nextPage = rootPage;
     }
 
-    // If we're not keeping the root, then check to see if
-    // it's left empty. If so, delete it as well.
+    // If we're not keeping the root, then check to see if it's left empty.
+    // If so, delete it as well.
     if (!keepRoot && nextPage == rootPage && prevPage == rootPage)
     {
         if (prev->getFieldV256(sfIndexes).empty())

--- a/src/libxrpl/ledger/OpenView.cpp
+++ b/src/libxrpl/ledger/OpenView.cpp
@@ -266,7 +266,8 @@ OpenView::rawTxInsert(
         std::forward_as_tuple(key),
         std::forward_as_tuple(txn, metaData));
     if (!result.second)
-        LogicError("rawTxInsert: duplicate TX id: " + to_string(key));
+        Throw<std::logic_error>(
+            "rawTxInsert: duplicate TX id: " + to_string(key));
 }
 
 }  // namespace ripple

--- a/src/libxrpl/ledger/RawStateTable.cpp
+++ b/src/libxrpl/ledger/RawStateTable.cpp
@@ -252,7 +252,7 @@ RawStateTable::erase(std::shared_ptr<SLE> const& sle)
     switch (item.action)
     {
         case Action::erase:
-            LogicError("RawStateTable::erase: already erased");
+            Throw<std::logic_error>("RawStateTable::erase: already erased");
             break;
         case Action::insert:
             items_.erase(result.first);
@@ -281,10 +281,10 @@ RawStateTable::insert(std::shared_ptr<SLE> const& sle)
             item.sle = sle;
             break;
         case Action::insert:
-            LogicError("RawStateTable::insert: already inserted");
+            Throw<std::logic_error>("RawStateTable::insert: already inserted");
             break;
         case Action::replace:
-            LogicError("RawStateTable::insert: already exists");
+            Throw<std::logic_error>("RawStateTable::insert: already exists");
             break;
     }
 }
@@ -302,7 +302,7 @@ RawStateTable::replace(std::shared_ptr<SLE> const& sle)
     switch (item.action)
     {
         case Action::erase:
-            LogicError("RawStateTable::replace: was erased");
+            Throw<std::logic_error>("RawStateTable::replace: was erased");
             break;
         case Action::insert:
         case Action::replace:

--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -1178,10 +1178,9 @@ getPseudoAccountFields()
         if (!ar)
         {
             // LCOV_EXCL_START
-            LogicError(
+            Throw<std::logic_error>(
                 "ripple::getPseudoAccountFields : unable to find account root "
-                "ledger "
-                "format");
+                "ledger format");
             // LCOV_EXCL_STOP
         }
         auto const& soTemplate = ar->getSOTemplate();

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "3.1.2-rc1"
+char const* const versionString = "3.1.2"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -36,7 +36,7 @@ namespace BuildInfo {
 //  and follow the format described at http://semver.org/
 //------------------------------------------------------------------------------
 // clang-format off
-char const* const versionString = "3.1.1"
+char const* const versionString = "3.1.2-rc1"
 // clang-format on
 
 #if defined(DEBUG) || defined(SANITIZER)

--- a/src/test/core/Config_test.cpp
+++ b/src/test/core/Config_test.cpp
@@ -413,7 +413,7 @@ port_wss_admin
                 c.loadFromString(
                     boost::str(configTemplate % validationSeed % token));
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -434,7 +434,7 @@ port_wss_admin
 main
 )rippleConfig");
         }
-        catch (std::runtime_error& e)
+        catch (std::runtime_error const& e)
         {
             error = e.what();
         }
@@ -447,7 +447,7 @@ main
             c.loadFromString(R"rippleConfig(
 )rippleConfig");
         }
-        catch (std::runtime_error& e)
+        catch (std::runtime_error const& e)
         {
             error = e.what();
         }
@@ -462,7 +462,7 @@ main
 255
 )rippleConfig");
         }
-        catch (std::runtime_error& e)
+        catch (std::runtime_error const& e)
         {
             error = e.what();
         }
@@ -477,7 +477,7 @@ main
 10000
 )rippleConfig");
         }
-        catch (std::runtime_error& e)
+        catch (std::runtime_error const& e)
         {
             error = e.what();
         }
@@ -505,7 +505,7 @@ main
                 Config c;
                 c.loadFromString(boost::str(cc % missingPath));
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -526,7 +526,7 @@ main
                 Config c;
                 c.loadFromString(boost::str(cc % invalidFile.string()));
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -646,7 +646,7 @@ trustthesevalidators.gov
                 c.loadFromString(toLoad);
                 fail();
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -675,7 +675,7 @@ value = 2
                 c.loadFromString(toLoad);
                 fail();
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -724,7 +724,7 @@ trustthesevalidators.gov
                 c.loadFromString(toLoad);
                 fail();
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -901,7 +901,7 @@ trustthesevalidators.gov
                 c.loadFromString(boost::str(cc % vtg.validatorsFile()));
                 fail();
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -928,7 +928,7 @@ trustthesevalidators.gov
                 Config c2;
                 c2.loadFromString(boost::str(cc % vtg.validatorsFile()));
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -1411,7 +1411,7 @@ r.ripple.com:51235
                 else
                     fail();
             }
-            catch (std::runtime_error&)
+            catch (std::runtime_error const&)
             {
                 if (!shouldPass)
                     pass();
@@ -1434,7 +1434,7 @@ r.ripple.com:51235
                 c.loadFromString("[overlay]\nmax_unknown_time=" + value);
                 return c.MAX_UNKNOWN_TIME;
             }
-            catch (std::runtime_error&)
+            catch (std::runtime_error const&)
             {
                 return {};
             }
@@ -1469,7 +1469,7 @@ r.ripple.com:51235
                 c.loadFromString("[overlay]\nmax_diverged_time=" + value);
                 return c.MAX_DIVERGED_TIME;
             }
-            catch (std::runtime_error&)
+            catch (std::runtime_error const&)
             {
                 return {};
             }

--- a/src/test/overlay/reduce_relay_test.cpp
+++ b/src/test/overlay/reduce_relay_test.cpp
@@ -1412,7 +1412,7 @@ vp_enable=0
             {
                 c.loadFromString(toLoad);
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }
@@ -1456,7 +1456,7 @@ vp_base_squelch_max_selected_peers=2
             {
                 c2.loadFromString(toLoad);
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 error = e.what();
             }

--- a/src/test/protocol/STParsedJSON_test.cpp
+++ b/src/test/protocol/STParsedJSON_test.cpp
@@ -2079,7 +2079,7 @@ class STParsedJSON_test : public beast::unit_test::suite
                 STParsedJSONObject parsed("test", faultyJson);
                 BEAST_EXPECT(!parsed.object);
             }
-            catch (std::runtime_error& e)
+            catch (std::runtime_error const& e)
             {
                 std::string what(e.what());
                 unexpected(

--- a/src/xrpld/app/ledger/Ledger.cpp
+++ b/src/xrpld/app/ledger/Ledger.cpp
@@ -517,14 +517,14 @@ void
 Ledger::rawErase(std::shared_ptr<SLE> const& sle)
 {
     if (!stateMap_.delItem(sle->key()))
-        LogicError("Ledger::rawErase: key not found");
+        Throw<std::logic_error>("Ledger::rawErase: key not found");
 }
 
 void
 Ledger::rawErase(uint256 const& key)
 {
     if (!stateMap_.delItem(key))
-        LogicError("Ledger::rawErase: key not found");
+        Throw<std::logic_error>("Ledger::rawErase: key not found");
 }
 
 void
@@ -535,7 +535,7 @@ Ledger::rawInsert(std::shared_ptr<SLE> const& sle)
     if (!stateMap_.addGiveItem(
             SHAMapNodeType::tnACCOUNT_STATE,
             make_shamapitem(sle->key(), ss.slice())))
-        LogicError("Ledger::rawInsert: key already exists");
+        Throw<std::logic_error>("Ledger::rawInsert: key already exists");
 }
 
 void
@@ -546,7 +546,7 @@ Ledger::rawReplace(std::shared_ptr<SLE> const& sle)
     if (!stateMap_.updateGiveItem(
             SHAMapNodeType::tnACCOUNT_STATE,
             make_shamapitem(sle->key(), ss.slice())))
-        LogicError("Ledger::rawReplace: key not found");
+        Throw<std::logic_error>("Ledger::rawReplace: key not found");
 }
 
 void
@@ -564,7 +564,7 @@ Ledger::rawTxInsert(
     s.addVL(metaData->peekData());
     if (!txMap_.addGiveItem(
             SHAMapNodeType::tnTRANSACTION_MD, make_shamapitem(key, s.slice())))
-        LogicError("duplicate_tx: " + to_string(key));
+        Throw<std::logic_error>("duplicate_tx: " + to_string(key));
 }
 
 uint256
@@ -584,7 +584,7 @@ Ledger::rawTxInsertWithHash(
     auto item = make_shamapitem(key, s.slice());
     auto hash = sha512Half(HashPrefix::txNode, item->slice(), item->key());
     if (!txMap_.addGiveItem(SHAMapNodeType::tnTRANSACTION_MD, std::move(item)))
-        LogicError("duplicate_tx: " + to_string(key));
+        Throw<std::logic_error>("duplicate_tx: " + to_string(key));
 
     return hash;
 }

--- a/src/xrpld/rpc/detail/RPCCall.cpp
+++ b/src/xrpld/rpc/detail/RPCCall.cpp
@@ -1621,7 +1621,7 @@ rpcClient(
         // YYY We could have a command line flag for single line output for
         // scripts. YYY We would intercept output here and simplify it.
     }
-    catch (RequestNotParseable& e)
+    catch (RequestNotParseable const& e)
     {
         jvOutput = rpcError(rpcINVALID_PARAMS);
         jvOutput["error_what"] = e.what();

--- a/src/xrpld/rpc/detail/TransactionSign.cpp
+++ b/src/xrpld/rpc/detail/TransactionSign.cpp
@@ -653,7 +653,7 @@ transactionPreProcessImpl(
 
         stTx = std::make_shared<STTx>(std::move(parsed.object.value()));
     }
-    catch (STObject::FieldErr& err)
+    catch (STObject::FieldErr const& err)
     {
         return RPC::make_error(rpcINVALID_PARAMS, err.what());
     }
@@ -1364,7 +1364,7 @@ transactionSubmitMultiSigned(
             stTx =
                 std::make_shared<STTx>(std::move(parsedTx_json.object.value()));
         }
-        catch (STObject::FieldErr& err)
+        catch (STObject::FieldErr const& err)
         {
             return RPC::make_error(rpcINVALID_PARAMS, err.what());
         }

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -821,7 +821,7 @@ doLedgerEntry(RPC::JsonContext& context)
             return RPC::make_param_error("No ledger_entry params provided.");
         }
     }
-    catch (Json::error& e)
+    catch (Json::error const& e)
     {
         if (context.apiVersion > 1u)
         {

--- a/src/xrpld/rpc/handlers/Subscribe.cpp
+++ b/src/xrpld/rpc/handlers/Subscribe.cpp
@@ -85,7 +85,7 @@ doSubscribe(RPC::JsonContext& context)
                 ispSub = context.netOps.addRpcSub(
                     strUrl, std::dynamic_pointer_cast<InfoSub>(rspSub));
             }
-            catch (std::runtime_error& ex)
+            catch (std::runtime_error const& ex)
             {
                 return RPC::make_param_error(ex.what());
             }


### PR DESCRIPTION
## High Level Overview of Change

This change replaces `LogicError` by `Throw<std::logic_error>` in transactors, and adds `const` to exception handlers.

### Context of Change

Transactor executions are already being performed within a try-catch statement, so we may as well use throw to gracefully return in case of an edge case occurring. Clang-tidy further indicated that the exceptions can be made constant in the catch statements.