### PR TITLE
chore: Add comment explaining why `ammLPHolds` is called twice

### DIFF
--- a/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
@@ -128,8 +128,7 @@ AMMClawback::applyGuts(Sandbox& sb)
 
     if (sb.rules().enabled(fixAMMClawbackRounding))
     {
-        // retrieve LP token balance inside the amendment gate to avoid
-        // inconsistent error behavior
+        // retrieve LP token balance inside the amendment gate to avoid inconsistent error behavior
         auto const lpTokenBalance = ammLPHolds(sb, *ammSle, holder, j_);
         if (lpTokenBalance == beast::zero)
             return tecAMM_BALANCE;
@@ -139,6 +138,8 @@ AMMClawback::applyGuts(Sandbox& sb)
             return res.error();  // LCOV_EXCL_LINE
     }
 
+    // calling a second time on purpose since `verifyAndAdjustLPTokenBalance` rounds and may adjust
+    // the balance
     auto const expected =
         ammHolds(sb, *ammSle, asset, asset2, FreezeHandling::fhIGNORE_FREEZE, ctx_.journal);
 

--- a/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
@@ -137,9 +137,6 @@ AMMClawback::applyGuts(Sandbox& sb)
             !res)
             return res.error();  // LCOV_EXCL_LINE
     }
-
-    // calling a second time on purpose since `verifyAndAdjustLPTokenBalance` rounds and may adjust
-    // the balance
     auto const expected =
         ammHolds(sb, *ammSle, asset, asset2, FreezeHandling::fhIGNORE_FREEZE, ctx_.journal);
 
@@ -152,6 +149,8 @@ AMMClawback::applyGuts(Sandbox& sb)
     STAmount amountWithdraw;
     std::optional<STAmount> amount2Withdraw;
 
+    // calling a second time on purpose since `verifyAndAdjustLPTokenBalance` rounds and may adjust
+    // the balance
     auto const holdLPtokens = ammLPHolds(sb, *ammSle, holder, j_);
     if (holdLPtokens == beast::zero)
         return tecAMM_BALANCE;


### PR DESCRIPTION
## High Level Overview of Change

This PR notes that in `AMMClawback`, `ammLPHolds` was called twice on purpose

### Context of Change
AI review triage
