### PR TITLE
fix: Remove a newline from logging statement in `changeSpotPrice` calculation

### DIFF
--- a/include/xrpl/tx/transactors/dex/AMMHelpers.h
+++ b/include/xrpl/tx/transactors/dex/AMMHelpers.h
@@ -370,7 +370,7 @@ changeSpotPriceQuality(
     if (!amounts)
     {
         JLOG(j.trace()) << "changeSpotPrice calc failed: " << to_string(pool.in) << " "
-                        << to_string(pool.out) << " " << quality << " " << tfee << std::endl;
+                        << to_string(pool.out) << " " << quality << " " << tfee;
         return std::nullopt;
     }
 

--- a/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
@@ -17,7 +17,6 @@ AMMDeposit::checkExtraFeatures(PreflightContext const& ctx)
 
 std::uint32_t
 AMMDeposit::getFlagsMask(PreflightContext const& ctx)
-
 {
     return tfAMMDepositMask;
 }


### PR DESCRIPTION
## High Level Overview of Change

Removed unnecessary newline in logging statement.

std::endl is unneeded in JLOG, since it automatically places a newline at the end of the string. So it's an unnecessary flush.

### Context of Change

AI review triage
