### PR TITLE
refactor: Assorted small DID fixes

### DIFF
--- a/include/xrpl/protocol/Protocol.h
+++ b/include/xrpl/protocol/Protocol.h
@@ -209,7 +209,7 @@ std::size_t constexpr maxDIDDocumentLength = 256;
 std::size_t constexpr maxDIDURILength = 256;
 
 /** The maximum length of an Attestation inside a DID */
-std::size_t constexpr maxDIDAttestationLength = 256;
+std::size_t constexpr maxDIDDataLength = 256;
 
 /** The maximum length of a domain */
 std::size_t constexpr maxDomainLength = 256;

--- a/src/libxrpl/tx/transactors/did/DIDDelete.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDDelete.cpp
@@ -33,7 +33,7 @@ DIDDelete::deleteSLE(
     if (!view.dirRemove(keylet::ownerDir(owner), (*sle)[sfOwnerNode], sle->key(), true))
     {
         // LCOV_EXCL_START
-        JLOG(j.fatal()) << "Unable to delete DID Token from owner.";
+        JLOG(j.fatal()) << "Unable to delete DID from owner.";
         return tefBAD_LEDGER;
         // LCOV_EXCL_STOP
     }

--- a/src/libxrpl/tx/transactors/did/DIDSet.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDSet.cpp
@@ -41,7 +41,7 @@ DIDSet::preflight(PreflightContext const& ctx)
     };
 
     if (isTooLong(sfURI, maxDIDURILength) || isTooLong(sfDIDDocument, maxDIDDocumentLength) ||
-        isTooLong(sfData, maxDIDAttestationLength))
+        isTooLong(sfData, maxDIDDataLength))
         return temMALFORMED;
 
     return tesSUCCESS;

--- a/src/libxrpl/tx/transactors/did/DIDSet.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDSet.cpp
@@ -47,7 +47,7 @@ DIDSet::preflight(PreflightContext const& ctx)
     return tesSUCCESS;
 }
 
-TER
+static TER
 addSLE(ApplyContext& ctx, std::shared_ptr<SLE> const& sle, AccountID const& owner)
 {
     auto const sleAccount = ctx.view().peek(keylet::account(owner));

--- a/src/test/app/DID_test.cpp
+++ b/src/test/app/DID_test.cpp
@@ -189,7 +189,7 @@ struct DID_test : public beast::unit_test::suite
         Account const edna{"edna"};
         Account const francis{"francis"};
         Account const george{"george"};
-        env.fund(XRP(5000), alice, bob, charlie, dave, edna, francis);
+        env.fund(XRP(5000), alice, bob, charlie, dave, edna, francis, george);
         env.close();
         BEAST_EXPECT(ownerCount(env, alice) == 0);
         BEAST_EXPECT(ownerCount(env, bob) == 0);
@@ -355,12 +355,14 @@ struct DID_test : public beast::unit_test::suite
         testAccountReserve(all);
         testSetInvalid(all);
         testDeleteInvalid(all);
+        testSetValidInitial(all);
         testSetModify(all);
 
         testEnabled(all - emptyDID);
         testAccountReserve(all - emptyDID);
         testSetInvalid(all - emptyDID);
         testDeleteInvalid(all - emptyDID);
+        testSetValidInitial(all - emptyDID);
         testSetModify(all - emptyDID);
     }
 };

--- a/src/test/jtx/did.h
+++ b/src/test/jtx/did.h
@@ -53,7 +53,7 @@ public:
     }
 };
 
-/** Sets the optional Attestation on a DIDSet. */
+/** Sets the optional Data on a DIDSet. */
 class data
 {
 private:


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Makes `addSLE` in `DIDSet` a static function, instead of a free function.
* Renames `Attestation` to `Data` everywhere (an artifact of a previous name for the field).
* Actually runs a set of tests that were not included in the `run` function of `DID_test`.

### Context of Change

AI code review

> **Description:**
> The helper function `addSLE` is a free function defined in the `xrpl` namespace with external linkage, no declaration in any header, and no `static` keyword:
> 
> ```cpp
> TER
> addSLE(ApplyContext& ctx, std::shared_ptr<SLE> const& sle, AccountID const& owner)
> ```
> 
> This function is logically private to `DIDSet.cpp`. As written:
> 1. It pollutes the `xrpl` namespace and could conflict with similarly named functions in other TUs.
> 2. It creates a potential ODR (One Definition Rule) violation risk.
> 3. It can be accidentally called from other translation units that include the right headers.
> 
> The fix is to declare it `static` or move it into an anonymous namespace (as is done consistently throughout the rest of the codebase — see `DeleteAccount.cpp` which uses `namespace { ... }` for all its helpers).

### API Impact

N/A
