### PR TITLE
fix: Use correct format and event for workflows for release tags

### DIFF
--- a/.github/actions/generate-version/action.yml
+++ b/.github/actions/generate-version/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     # When a tag is pushed, the version is used as-is.
     - name: Generate version for tag event
-      if: ${{ github.event_name == 'tag' }}
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       shell: bash
       env:
         VERSION: ${{ github.ref_name }}
@@ -22,7 +22,7 @@ runs:
     # We use a plus sign instead of a hyphen because Conan recipe versions do
     # not support two hyphens.
     - name: Generate version for non-tag event
-      if: ${{ github.event_name != 'tag' }}
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
       shell: bash
       run: |
         echo 'Extracting version from BuildInfo.cpp.'

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -5,7 +5,7 @@ name: Tag
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]*.[0-9]*.[0-9]*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -5,7 +5,7 @@ name: Tag
 on:
   push:
     tags:
-      - "[0-9]*.[0-9]*.[0-9]*"
+      - "[0-9]+.[0-9]+.[0-9]*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/reusable-upload-recipe.yml
+++ b/.github/workflows/reusable-upload-recipe.yml
@@ -92,7 +92,7 @@ jobs:
       # When this workflow is triggered by a push event, it will always be when tagging a final
       # release, see on-tag.yml.
       - name: Upload Conan recipe (release)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         env:
           REMOTE_NAME: ${{ inputs.remote_name }}
         run: |

--- a/.github/workflows/reusable-upload-recipe.yml
+++ b/.github/workflows/reusable-upload-recipe.yml
@@ -89,10 +89,10 @@ jobs:
           conan export . --version=rc
           conan upload --confirm --check --remote="${REMOTE_NAME}" xrpl/rc
 
-      # When this workflow is triggered by a tag event, it will always be when tagging a final
+      # When this workflow is triggered by a push event, it will always be when tagging a final
       # release, see on-tag.yml.
       - name: Upload Conan recipe (release)
-        if: ${{ github.event_name == 'tag' }}
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           REMOTE_NAME: ${{ inputs.remote_name }}
         run: |


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Trying to fix 2 issues:
  1. Conan recipes for release would never be uploaded since there's no `tag` event in GitHub.
  2. `on-tag.yml` would never trigger unless we start tagging releases prefixed with `v`.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->


