### PR TITLE
fix: Remove nonexistent `boost::coroutine2` library

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -207,7 +207,6 @@ class Xrpl(ConanFile):
             "boost::chrono",
             "boost::container",
             "boost::context",
-            "boost::coroutine2",
             "boost::date_time",
             "boost::filesystem",
             "boost::json",


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Removes coroutine2 library that Conan doesn't know about.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

Apparently `coroutine` is provided by `context` and if you try to use `libxrpl` it will error out because the `coroutine2` lib is not being exposed. 

[There's no `coroutine2` in the Boost Conan package](https://github.com/conan-io/conan-center-index/blob/master/recipes/boost/all/conanfile.py)

