### PR TITLE
ci: Fix build errors on windows

### DIFF
--- a/cmake/XrplCompiler.cmake
+++ b/cmake/XrplCompiler.cmake
@@ -118,7 +118,7 @@ if(MSVC)
             NOMINMAX
             # TODO: Resolve these warnings, don't just silence them
             _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-            $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_CRTDBG_MAP_ALLOC>
+            $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>,$<NOT:$<BOOL:${is_ci}>>>:_CRTDBG_MAP_ALLOC>
     )
     target_link_libraries(common INTERFACE -errorreport:none -machine:X64)
 else()


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This PR stops defining the macro `_CRTDBG_MAP_ALLOC` on windows when building in ci.

### Context of Change

We're getting some build errors on Windows after we redeployed the windows build runners. https://github.com/XRPLF/rippled/actions/runs/23182100319/job/67376175628

An MSVC update seems to have added `crtdbg.h` include dependency to `<string>`. As the result, `pooled_fixedsize_stack` in `boost` (https://www.boost.org/doc/libs/1_89_0/boost/context/pooled_fixedsize_stack.hpp) has stopped working on windows because it calls a member function `malloc` which conflicts with the macro name `malloc` introduced by `crtdbg.h`.

The purpose of  `_CRTDBG_MAP_ALLOC` is to use debug `malloc` and `realloc` to help debug memory leaks. However, it makes no sense to use it in CI because we don't run the debug builds produced by CI, also, never have we directly included `crtdbg.h` and used its functionalities. 

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
