### PR TITLE
fix: Make assorted NFT fixes

### DIFF
--- a/include/xrpl/tx/transactors/nft/NFTokenUtils.h
+++ b/include/xrpl/tx/transactors/nft/NFTokenUtils.h
@@ -95,7 +95,7 @@ tokenOfferCreatePreflight(
     std::uint16_t nftFlags,
     Rules const& rules,
     std::optional<AccountID> const& owner = std::nullopt,
-    std::uint32_t txFlags = lsfSellNFToken);
+    std::uint32_t txFlags = tfSellNFToken);
 
 /** Preclaim checks shared by NFTokenCreateOffer and NFTokenMint */
 TER

--- a/include/xrpl/tx/transactors/nft/NFTokenUtils.h
+++ b/include/xrpl/tx/transactors/nft/NFTokenUtils.h
@@ -4,6 +4,7 @@
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/nft.h>
 #include <xrpl/tx/Transactor.h>
 
@@ -109,7 +110,7 @@ tokenOfferCreatePreclaim(
     std::uint16_t xferFee,
     beast::Journal j,
     std::optional<AccountID> const& owner = std::nullopt,
-    std::uint32_t txFlags = lsfSellNFToken);
+    std::uint32_t txFlags = tfSellNFToken);
 
 /** doApply implementation shared by NFTokenCreateOffer and NFTokenMint */
 TER
@@ -123,7 +124,7 @@ tokenOfferCreateApply(
     uint256 const& nftokenID,
     XRPAmount const& priorBalance,
     beast::Journal j,
-    std::uint32_t txFlags = lsfSellNFToken);
+    std::uint32_t txFlags = tfSellNFToken);
 
 TER
 checkTrustlineAuthorized(

--- a/src/libxrpl/tx/transactors/nft/NFTokenCreateOffer.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenCreateOffer.cpp
@@ -42,7 +42,7 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
         return tecEXPIRED;
 
     uint256 const nftokenID = ctx.tx[sfNFTokenID];
-    std::uint32_t const txFlags = {ctx.tx.getFlags()};
+    std::uint32_t const txFlags = ctx.tx.getFlags();
 
     if (!nft::findToken(
             ctx.view, ctx.tx[(txFlags & tfSellNFToken) ? sfAccount : sfOwner], nftokenID))

--- a/src/libxrpl/tx/transactors/nft/NFTokenUtils.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenUtils.cpp
@@ -620,7 +620,7 @@ deleteTokenOffer(ApplyView& view, std::shared_ptr<SLE> const& offer)
 
     if (!view.dirRemove(
             ((*offer)[sfFlags] & lsfSellNFToken) ? keylet::nft_sells(nftokenID)
-                                                : keylet::nft_buys(nftokenID),
+                                                 : keylet::nft_buys(nftokenID),
             (*offer)[sfNFTokenOfferNode],
             offer->key(),
             false))

--- a/src/libxrpl/tx/transactors/nft/NFTokenUtils.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenUtils.cpp
@@ -619,7 +619,7 @@ deleteTokenOffer(ApplyView& view, std::shared_ptr<SLE> const& offer)
     auto const nftokenID = (*offer)[sfNFTokenID];
 
     if (!view.dirRemove(
-            ((*offer)[sfFlags] & tfSellNFToken) ? keylet::nft_sells(nftokenID)
+            ((*offer)[sfFlags] & lsfSellNFToken) ? keylet::nft_sells(nftokenID)
                                                 : keylet::nft_buys(nftokenID),
             (*offer)[sfNFTokenOfferNode],
             offer->key(),


### PR DESCRIPTION
## High Level Overview of Change

This PR:
* Removes a set of unnecessary brackets in the initialization of an std::uint32_t
* Fixes a couple of incorrect flags (same value, just wrong variables - so no amendment needed)

### Context of Change

AI review of xrpld

### API Impact

N/A