### PR TITLE
fix: Fix Workers::stop() race between m_allPaused and m_runningTaskCount

### DIFF
--- a/src/libxrpl/core/detail/Workers.cpp
+++ b/src/libxrpl/core/detail/Workers.cpp
@@ -1,5 +1,4 @@
 #include <xrpl/beast/core/CurrentThreadName.h>
-#include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/core/PerfLog.h>
 #include <xrpl/core/detail/Workers.h>
 
@@ -96,11 +95,12 @@ Workers::stop()
 {
     setNumberOfThreads(0);
 
+    // Wait until all workers have paused AND no tasks are actively running.
+    // Both conditions are needed because m_allPaused (mutex-protected) and
+    // m_runningTaskCount (atomic) are not synchronized under the same lock,
+    // so m_allPaused can momentarily be true while a task is still finishing.
     std::unique_lock<std::mutex> lk{m_mut};
-    m_cv.wait(lk, [this] { return m_allPaused; });
-    lk.unlock();
-
-    XRPL_ASSERT(numberOfCurrentlyRunningTasks() == 0, "xrpl::Workers::stop : zero running tasks");
+    m_cv.wait(lk, [this] { return m_allPaused && numberOfCurrentlyRunningTasks() == 0; });
 }
 
 void
@@ -217,7 +217,18 @@ Workers::Worker::run()
             //
             ++m_workers.m_runningTaskCount;
             m_workers.m_callback.processTask(instance_);
-            --m_workers.m_runningTaskCount;
+
+            // When the running task count drops to zero, wake stop() which
+            // may be waiting for both m_allPaused and zero running tasks.
+            // Locking m_mut before notify_all() prevents a lost wakeup:
+            // it serializes against the predicate check inside stop()'s
+            // cv.wait(), ensuring the notification is not missed between
+            // the predicate evaluation and the actual sleep.
+            if (--m_workers.m_runningTaskCount == 0)
+            {
+                std::lock_guard lk{m_workers.m_mut};
+                m_workers.m_cv.notify_all();
+            }
         }
 
         // Any worker that goes into the paused list must

--- a/src/libxrpl/core/detail/Workers.cpp
+++ b/src/libxrpl/core/detail/Workers.cpp
@@ -101,6 +101,7 @@ Workers::stop()
     // so m_allPaused can momentarily be true while a task is still finishing.
     std::unique_lock<std::mutex> lk{m_mut};
     m_cv.wait(lk, [this] { return m_allPaused && numberOfCurrentlyRunningTasks() == 0; });
+    lk.unlock();
 }
 
 void


### PR DESCRIPTION
## High Level Overview of Change

Fix an intermittent assertion failure in `Workers::stop()` caused by a race condition between `m_allPaused` (mutex-protected bool) and `m_runningTaskCount` (atomic int). These two states use independent synchronization, so `m_allPaused` can be `true` while a task is still finishing.

Triggered by [this CI failure](https://github.com/XRPLF/rippled/actions/runs/23232660547/job/67529409278) on `debian-bookworm-gcc-12-amd64-debug`.

### Context of Change

`Workers::stop()` previously asserted `numberOfCurrentlyRunningTasks() == 0` **after** confirming `m_allPaused` was true, but outside any lock. Since `m_allPaused` and `m_runningTaskCount` are synchronized independently (mutex vs. atomic), there is a window where `m_allPaused` is true while a worker still has `m_runningTaskCount > 0`.

This fix:
1. **Replaces the assertion** with a compound condition variable predicate: `m_allPaused && numberOfCurrentlyRunningTasks() == 0`
2. **Notifies `m_cv`** when `m_runningTaskCount` drops to zero (locking `m_mut` first to prevent lost wakeups)

This is an alternative approach to PR #6302, which used memory fences. The compound predicate is more robust — it handles the logical race (not just memory ordering) and works correctly on all architectures.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### API Impact

_None_ — internal threading change only.

### Before / After

**Before:** `stop()` waits for `m_allPaused`, then asserts `m_runningTaskCount == 0`. Assertion can fail if the two states are transiently inconsistent.

**After:** `stop()` waits for both conditions in a single predicate. No assertion can fail; `stop()` simply waits until both are satisfied.

### Test Plan

Existing `xrpl.core.Workers` test suite covers this. The fix eliminates the intermittent crash rather than adding new test cases — the race is timing-dependent and not reliably reproducible in a unit test.

Jira: [RIPD-5329](https://ripplelabs.atlassian.net/browse/RIPD-5329)
Related: #6302 (RIPD-4759), #5774