### PR TITLE
docs: Update LICENSE.md year to present

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 ISC License
 
 Copyright (c) 2011, Arthur Britto, David Schwartz, Jed McCaleb, Vinnie Falco, Bob Way, Eric Lombrozo, Nikolaos D. Bougalis, Howard Hinnant.
-Copyright (c) 2012-2025, the XRP Ledger developers.
+Copyright (c) 2012-present, the XRP Ledger developers.
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
## High Level Overview of Change

This change updates the end year of the XRPL developer contributions to `present`.

### Context of Change

Rather than updating the file each year, just using `present` is a lot easier.
