### PR TITLE
fix: Store `Delegate` object in delegating and authorized account directories for proper deletion

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -28,6 +28,8 @@ This section contains changes targeting a future version.
 
 ### Additions
 
+- `ledger_entry`, `account_objects`: The `Delegate` ledger entry now includes an optional `DestinationNode` field, which stores the index into the authorized account's owner directory. This field is present on entries created or modified after bidirectional directory tracking was introduced and may appear in RPC responses for those entries. ([#6681](https://github.com/XRPLF/rippled/pull/6681))
+
 - `server_definitions`: Added the following new sections to the response ([#6321](https://github.com/XRPLF/rippled/pull/6321)):
   - `TRANSACTION_FORMATS`: Describes the fields and their optionality for each transaction type, including common fields shared across all transactions.
   - `LEDGER_ENTRY_FORMATS`: Describes the fields and their optionality for each ledger entry type, including common fields shared across all ledger entries.

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -28,7 +28,7 @@ This section contains changes targeting a future version.
 
 ### Additions
 
-- `ledger_entry`, `account_objects`: The `Delegate` ledger entry now includes an optional `DestinationNode` field, which stores the index into the authorized account's owner directory. This field is present on entries created or modified after bidirectional directory tracking was introduced and may appear in RPC responses for those entries. ([#6681](https://github.com/XRPLF/rippled/pull/6681))
+- `ledger_entry`, `account_objects`: The `Delegate` ledger entry now includes an optional `DestinationNode` field, which stores the index into the authorized account's owner directory. This field is present on entries created after bidirectional directory tracking was introduced and may appear in RPC responses for those entries. ([#6681](https://github.com/XRPLF/rippled/pull/6681))
 
 - `server_definitions`: Added the following new sections to the response ([#6321](https://github.com/XRPLF/rippled/pull/6321)):
   - `TRANSACTION_FORMATS`: Describes the fields and their optionality for each transaction type, including common fields shared across all transactions.

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -466,6 +466,7 @@ LEDGER_ENTRY(ltDELEGATE, 0x0083, Delegate, delegate, ({
     {sfAuthorize,            soeREQUIRED},
     {sfPermissions,          soeREQUIRED},
     {sfOwnerNode,            soeREQUIRED},
+    {sfDestinationNode,      soeOPTIONAL},
     {sfPreviousTxnID,        soeREQUIRED},
     {sfPreviousTxnLgrSeq,    soeREQUIRED},
 }))

--- a/include/xrpl/protocol_autogen/ledger_entries/Delegate.h
+++ b/include/xrpl/protocol_autogen/ledger_entries/Delegate.h
@@ -91,6 +91,30 @@ public:
     }
 
     /**
+     * @brief Get sfDestinationNode (soeOPTIONAL)
+     * @return The field value, or std::nullopt if not present.
+     */
+    [[nodiscard]]
+    protocol_autogen::Optional<SF_UINT64::type::value_type>
+    getDestinationNode() const
+    {
+        if (hasDestinationNode())
+            return this->sle_->at(sfDestinationNode);
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Check if sfDestinationNode is present.
+     * @return True if the field is present, false otherwise.
+     */
+    [[nodiscard]]
+    bool
+    hasDestinationNode() const
+    {
+        return this->sle_->isFieldPresent(sfDestinationNode);
+    }
+
+    /**
      * @brief Get sfPreviousTxnID (soeREQUIRED)
      * @return The field value.
      */
@@ -200,6 +224,17 @@ public:
     setOwnerNode(std::decay_t<typename SF_UINT64::type::value_type> const& value)
     {
         object_[sfOwnerNode] = value;
+        return *this;
+    }
+
+    /**
+     * @brief Set sfDestinationNode (soeOPTIONAL)
+     * @return Reference to this builder for method chaining.
+     */
+    DelegateBuilder&
+    setDestinationNode(std::decay_t<typename SF_UINT64::type::value_type> const& value)
+    {
+        object_[sfDestinationNode] = value;
         return *this;
     }
 

--- a/include/xrpl/tx/transactors/delegate/DelegateSet.h
+++ b/include/xrpl/tx/transactors/delegate/DelegateSet.h
@@ -24,11 +24,7 @@ public:
 
     // Interface used by AccountDelete
     static TER
-    deleteDelegate(
-        ApplyView& view,
-        std::shared_ptr<SLE> const& sle,
-        AccountID const& account,
-        beast::Journal j);
+    deleteDelegate(ApplyView& view, std::shared_ptr<SLE> const& sle, beast::Journal j);
 };
 
 }  // namespace xrpl

--- a/src/libxrpl/tx/transactors/account/AccountDelete.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountDelete.cpp
@@ -177,8 +177,8 @@ TER
 removeDelegateFromLedger(
     ServiceRegistry&,
     ApplyView& view,
-    AccountID const& account,
-    uint256 const& delIndex,
+    AccountID const&,
+    uint256 const&,
     std::shared_ptr<SLE> const& sleDel,
     beast::Journal j)
 {

--- a/src/libxrpl/tx/transactors/account/AccountDelete.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountDelete.cpp
@@ -182,7 +182,7 @@ removeDelegateFromLedger(
     std::shared_ptr<SLE> const& sleDel,
     beast::Journal j)
 {
-    return DelegateSet::deleteDelegate(view, sleDel, account, j);
+    return DelegateSet::deleteDelegate(view, sleDel, j);
 }
 
 // Return nullptr if the LedgerEntryType represents an obligation that can't

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -79,7 +79,7 @@ DelegateSet::doApply()
         if (permissions.empty())
         {
             // if permissions array is empty, delete the ledger object.
-            return deleteDelegate(view(), sle, account_, j_);
+            return deleteDelegate(view(), sle, j_);
         }
 
         sle->setFieldArray(sfPermissions, permissions);
@@ -102,6 +102,8 @@ DelegateSet::doApply()
     sle->setAccountID(sfAuthorize, authAccount);
 
     sle->setFieldArray(sfPermissions, permissions);
+
+    // Add to delegating account's owner directory
     auto const page =
         ctx_.view().dirInsert(keylet::ownerDir(account_), delegateKey, describeOwnerDir(account_));
 
@@ -109,6 +111,17 @@ DelegateSet::doApply()
         return tecDIR_FULL;  // LCOV_EXCL_LINE
 
     (*sle)[sfOwnerNode] = *page;
+
+    // Add to authorized account's owner directory so the object can be found
+    // and cleaned up when the authorized account is deleted.
+    auto const destPage = ctx_.view().dirInsert(
+        keylet::ownerDir(authAccount), delegateKey, describeOwnerDir(authAccount));
+
+    if (!destPage)
+        return tecDIR_FULL;  // LCOV_EXCL_LINE
+
+    (*sle)[sfDestinationNode] = *destPage;
+
     ctx_.view().insert(sle);
     adjustOwnerCount(ctx_.view(), sleOwner, 1, ctx_.journal);
 
@@ -116,16 +129,16 @@ DelegateSet::doApply()
 }
 
 TER
-DelegateSet::deleteDelegate(
-    ApplyView& view,
-    std::shared_ptr<SLE> const& sle,
-    AccountID const& account,
-    beast::Journal j)
+DelegateSet::deleteDelegate(ApplyView& view, std::shared_ptr<SLE> const& sle, beast::Journal j)
 {
     if (!sle)
         return tecINTERNAL;  // LCOV_EXCL_LINE
 
-    if (!view.dirRemove(keylet::ownerDir(account), (*sle)[sfOwnerNode], sle->key(), false))
+    auto const delegator = (*sle)[sfAccount];
+    auto const delegatee = (*sle)[sfAuthorize];
+
+    // Remove from delegating account's owner directory
+    if (!view.dirRemove(keylet::ownerDir(delegator), (*sle)[sfOwnerNode], sle->key(), false))
     {
         // LCOV_EXCL_START
         JLOG(j.fatal()) << "Unable to delete Delegate from owner.";
@@ -133,7 +146,20 @@ DelegateSet::deleteDelegate(
         // LCOV_EXCL_STOP
     }
 
-    auto const sleOwner = view.peek(keylet::account(account));
+    // Remove from authorized account's owner directory, if present
+    if (auto const optPage = (*sle)[~sfDestinationNode])
+    {
+        if (!view.dirRemove(keylet::ownerDir(delegatee), *optPage, sle->key(), false))
+        {
+            // LCOV_EXCL_START
+            JLOG(j.fatal()) << "Unable to delete Delegate from authorized account.";
+            return tefBAD_LEDGER;
+            // LCOV_EXCL_STOP
+        }
+    }
+
+    // Only the delegating account's owner count was incremented on creation
+    auto const sleOwner = view.peek(keylet::account(delegator));
     if (!sleOwner)
         return tecINTERNAL;  // LCOV_EXCL_LINE
 

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -4,7 +4,6 @@
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
-#include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/SField.h>

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -605,9 +605,8 @@ class Delegate_test : public beast::unit_test::suite
             BEAST_EXPECT(env.closed()->exists(delegateKey));
 
             auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
-                return std::find_if(dir.begin(), dir.end(), [&](auto const& sle) {
-                           return sle->key() == key;
-                       }) != dir.end();
+                return std::any_of(
+                    dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
             };
 
             // Delegate object should appear in both alice's and bob's directories
@@ -655,9 +654,8 @@ class Delegate_test : public beast::unit_test::suite
             BEAST_EXPECT(env.closed()->exists(delegateKey));
 
             auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
-                return std::find_if(dir.begin(), dir.end(), [&](auto const& sle) {
-                           return sle->key() == key;
-                       }) != dir.end();
+                return std::any_of(
+                    dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
             };
 
             BEAST_EXPECT(
@@ -725,9 +723,8 @@ class Delegate_test : public beast::unit_test::suite
             auto const carolBobKey = keylet::delegate(carol.id(), bob.id());
 
             auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
-                return std::find_if(dir.begin(), dir.end(), [&](auto const& sle) {
-                           return sle->key() == key;
-                       }) != dir.end();
+                return std::any_of(
+                    dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
             };
 
             // Both Delegate objects exist and are in bob's directory

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -42,6 +42,7 @@
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/jss.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -50,8 +51,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <algorithm>
 
 namespace xrpl {
 namespace test {

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -28,6 +28,7 @@
 #include <xrpl/basics/strHex.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
+#include <xrpl/ledger/Dir.h>
 #include <xrpl/ledger/helpers/DelegateHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
@@ -49,6 +50,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include <algorithm>
 
 namespace xrpl {
 namespace test {
@@ -585,32 +588,182 @@ class Delegate_test : public beast::unit_test::suite
         testcase("test deleting account");
         using namespace jtx;
 
-        Env env(*this);
-        Account const alice{"alice"};
-        Account const bob{"bob"};
-        env.fund(XRP(100000), alice, bob);
-        env.close();
-
-        env(delegate::set(alice, bob, {"Payment"}));
-        env.close();
-        BEAST_EXPECT(env.closed()->exists(keylet::delegate(alice.id(), bob.id())));
-
-        for (std::uint32_t i = 0; i < 256; ++i)
+        // Delegator (alice) deletes account: Delegate object is cleaned up from
+        // both alice's and bob's owner directories.
+        {
+            Env env(*this);
+            Account const alice{"alice"};
+            Account const bob{"bob"};
+            Account const carol{"carol"};
+            env.fund(XRP(100000), alice, bob, carol);
             env.close();
 
-        auto const aliceBalance = env.balance(alice);
-        auto const bobBalance = env.balance(bob);
+            env(delegate::set(alice, bob, {"Payment"}));
+            env.close();
 
-        // alice deletes account, this will remove the Delegate object
-        auto const deleteFee = drops(env.current()->fees().increment);
-        env(acctdelete(alice, bob), fee(deleteFee));
-        env.close();
+            auto const delegateKey = keylet::delegate(alice.id(), bob.id());
+            BEAST_EXPECT(env.closed()->exists(delegateKey));
 
-        BEAST_EXPECT(!env.closed()->exists(keylet::account(alice.id())));
-        BEAST_EXPECT(!env.closed()->exists(keylet::ownerDir(alice.id())));
-        BEAST_EXPECT(env.balance(bob) == bobBalance + aliceBalance - deleteFee);
+            auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
+                return std::find_if(dir.begin(), dir.end(), [&](auto const& sle) {
+                           return sle->key() == key;
+                       }) != dir.end();
+            };
 
-        BEAST_EXPECT(!env.closed()->exists(keylet::delegate(alice.id(), bob.id())));
+            // Delegate object should appear in both alice's and bob's directories
+            BEAST_EXPECT(
+                hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(alice.id())), delegateKey.key));
+            BEAST_EXPECT(
+                hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), delegateKey.key));
+
+            for (std::uint32_t i = 0; i < 256; ++i)
+                env.close();
+
+            auto const aliceBalance = env.balance(alice);
+            auto const carolBalance = env.balance(carol);
+
+            // alice deletes account, this will remove the Delegate object from
+            // both alice's and bob's owner directories
+            auto const deleteFee = drops(env.current()->fees().increment);
+            env(acctdelete(alice, carol), fee(deleteFee));
+            env.close();
+
+            BEAST_EXPECT(!env.closed()->exists(keylet::account(alice.id())));
+            BEAST_EXPECT(!env.closed()->exists(keylet::ownerDir(alice.id())));
+            BEAST_EXPECT(!env.closed()->exists(delegateKey));
+            // bob's directory should no longer reference the Delegate object
+            BEAST_EXPECT(
+                !hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), delegateKey.key));
+            BEAST_EXPECT(env.balance(carol) == carolBalance + aliceBalance - deleteFee);
+        }
+
+        // Delegatee (bob) deletes account: Delegate object is cleaned up from
+        // both alice's and bob's owner directories, freeing alice's reserve so
+        // she can subsequently delete her own account.
+        {
+            Env env(*this);
+            Account const alice{"alice"};
+            Account const bob{"bob"};
+            Account const carol{"carol"};
+            env.fund(XRP(100000), alice, bob, carol);
+            env.close();
+
+            env(delegate::set(alice, bob, {"Payment"}));
+            env.close();
+
+            auto const delegateKey = keylet::delegate(alice.id(), bob.id());
+            BEAST_EXPECT(env.closed()->exists(delegateKey));
+
+            auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
+                return std::find_if(dir.begin(), dir.end(), [&](auto const& sle) {
+                           return sle->key() == key;
+                       }) != dir.end();
+            };
+
+            BEAST_EXPECT(
+                hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(alice.id())), delegateKey.key));
+            BEAST_EXPECT(
+                hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), delegateKey.key));
+
+            // The Delegate entry counts against alice's ownerCount.
+            auto const sleAlice = env.closed()->read(keylet::account(alice.id()));
+            BEAST_EXPECT(sleAlice);
+            BEAST_EXPECT(sleAlice->getFieldU32(sfOwnerCount) == 1);
+
+            for (std::uint32_t i = 0; i < 256; ++i)
+                env.close();
+
+            auto const bobBalance = env.balance(bob);
+            auto const carolBalance = env.balance(carol);
+
+            // bob (the authorized/delegatee account) deletes his account.
+            // This must clean up the Delegate object from both alice's and
+            // bob's owner directories so alice's delegation does not survive
+            // a potential account resurrection.
+            auto const deleteFee = drops(env.current()->fees().increment);
+            env(acctdelete(bob, carol), fee(deleteFee));
+            env.close();
+
+            BEAST_EXPECT(!env.closed()->exists(keylet::account(bob.id())));
+            BEAST_EXPECT(!env.closed()->exists(keylet::ownerDir(bob.id())));
+            BEAST_EXPECT(!env.closed()->exists(delegateKey));
+            // alice's directory should no longer reference the Delegate object
+            BEAST_EXPECT(
+                !hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(alice.id())), delegateKey.key));
+            BEAST_EXPECT(env.balance(carol) == carolBalance + bobBalance - deleteFee);
+
+            // alice's ownerCount is now 0; she can delete her own account.
+            auto const sleAlice2 = env.closed()->read(keylet::account(alice.id()));
+            BEAST_EXPECT(sleAlice2);
+            BEAST_EXPECT(sleAlice2->getFieldU32(sfOwnerCount) == 0);
+
+            auto const aliceDeleteFee = drops(env.current()->fees().increment);
+            env(acctdelete(alice, carol), fee(aliceDeleteFee));
+            env.close();
+
+            BEAST_EXPECT(!env.closed()->exists(keylet::account(alice.id())));
+        }
+
+        // Multiple delegators -> same delegatee: when the delegatee (bob)
+        // deletes his account, ALL Delegate objects (from alice and carol)
+        // must be cleaned up from every delegator's directory.
+        {
+            Env env(*this);
+            Account const alice{"alice"};
+            Account const bob{"bob"};
+            Account const carol{"carol"};
+            Account const dave{"dave"};
+            env.fund(XRP(100000), alice, bob, carol, dave);
+            env.close();
+
+            // Both alice and carol delegate to bob
+            env(delegate::set(alice, bob, {"Payment"}));
+            env(delegate::set(carol, bob, {"EscrowCreate"}));
+            env.close();
+
+            auto const aliceBobKey = keylet::delegate(alice.id(), bob.id());
+            auto const carolBobKey = keylet::delegate(carol.id(), bob.id());
+
+            auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
+                return std::find_if(dir.begin(), dir.end(), [&](auto const& sle) {
+                           return sle->key() == key;
+                       }) != dir.end();
+            };
+
+            // Both Delegate objects exist and are in bob's directory
+            BEAST_EXPECT(env.closed()->exists(aliceBobKey));
+            BEAST_EXPECT(env.closed()->exists(carolBobKey));
+            BEAST_EXPECT(
+                hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), aliceBobKey.key));
+            BEAST_EXPECT(
+                hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(bob.id())), carolBobKey.key));
+
+            for (std::uint32_t i = 0; i < 256; ++i)
+                env.close();
+
+            auto const bobBalance = env.balance(bob);
+            auto const daveBalance = env.balance(dave);
+
+            auto const deleteFee = drops(env.current()->fees().increment);
+            env(acctdelete(bob, dave), fee(deleteFee));
+            env.close();
+
+            // bob's account and directory are gone
+            BEAST_EXPECT(!env.closed()->exists(keylet::account(bob.id())));
+            BEAST_EXPECT(!env.closed()->exists(keylet::ownerDir(bob.id())));
+
+            // Both Delegate objects are erased
+            BEAST_EXPECT(!env.closed()->exists(aliceBobKey));
+            BEAST_EXPECT(!env.closed()->exists(carolBobKey));
+
+            // alice's and carol's directories no longer reference the objects
+            BEAST_EXPECT(
+                !hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(alice.id())), aliceBobKey.key));
+            BEAST_EXPECT(
+                !hasKey(xrpl::Dir(*env.closed(), keylet::ownerDir(carol.id())), carolBobKey.key));
+
+            BEAST_EXPECT(env.balance(dave) == daveBalance + bobBalance - deleteFee);
+        }
     }
 
     void

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -604,7 +604,7 @@ class Delegate_test : public beast::unit_test::suite
             BEAST_EXPECT(env.closed()->exists(delegateKey));
 
             auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
-                return std::any_of(
+                return std::any_of(  // NOLINT(modernize-use-ranges)
                     dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
             };
 
@@ -653,7 +653,7 @@ class Delegate_test : public beast::unit_test::suite
             BEAST_EXPECT(env.closed()->exists(delegateKey));
 
             auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
-                return std::any_of(
+                return std::any_of(  // NOLINT(modernize-use-ranges)
                     dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
             };
 
@@ -722,7 +722,7 @@ class Delegate_test : public beast::unit_test::suite
             auto const carolBobKey = keylet::delegate(carol.id(), bob.id());
 
             auto hasKey = [](xrpl::Dir const& dir, uint256 const& key) {
-                return std::any_of(
+                return std::any_of(  // NOLINT(modernize-use-ranges)
                     dir.begin(), dir.end(), [&](auto const& sle) { return sle->key() == key; });
             };
 

--- a/src/tests/libxrpl/protocol_autogen/ledger_entries/DelegateTests.cpp
+++ b/src/tests/libxrpl/protocol_autogen/ledger_entries/DelegateTests.cpp
@@ -24,6 +24,7 @@ TEST(DelegateTests, BuilderSettersRoundTrip)
     auto const authorizeValue = canonical_ACCOUNT();
     auto const permissionsValue = canonical_ARRAY();
     auto const ownerNodeValue = canonical_UINT64();
+    auto const destinationNodeValue = canonical_UINT64();
     auto const previousTxnIDValue = canonical_UINT256();
     auto const previousTxnLgrSeqValue = canonical_UINT32();
 
@@ -36,6 +37,7 @@ TEST(DelegateTests, BuilderSettersRoundTrip)
         previousTxnLgrSeqValue
     };
 
+    builder.setDestinationNode(destinationNodeValue);
 
     builder.setLedgerIndex(index);
     builder.setFlags(0x1u);
@@ -82,6 +84,14 @@ TEST(DelegateTests, BuilderSettersRoundTrip)
         expectEqualField(expected, actual, "sfPreviousTxnLgrSeq");
     }
 
+    {
+        auto const& expected = destinationNodeValue;
+        auto const actualOpt = entry.getDestinationNode();
+        ASSERT_TRUE(actualOpt.has_value());
+        expectEqualField(expected, *actualOpt, "sfDestinationNode");
+        EXPECT_TRUE(entry.hasDestinationNode());
+    }
+
     EXPECT_TRUE(entry.hasLedgerIndex());
     auto const ledgerIndex = entry.getLedgerIndex();
     ASSERT_TRUE(ledgerIndex.has_value());
@@ -99,6 +109,7 @@ TEST(DelegateTests, BuilderFromSleRoundTrip)
     auto const authorizeValue = canonical_ACCOUNT();
     auto const permissionsValue = canonical_ARRAY();
     auto const ownerNodeValue = canonical_UINT64();
+    auto const destinationNodeValue = canonical_UINT64();
     auto const previousTxnIDValue = canonical_UINT256();
     auto const previousTxnLgrSeqValue = canonical_UINT32();
 
@@ -108,6 +119,7 @@ TEST(DelegateTests, BuilderFromSleRoundTrip)
     sle->at(sfAuthorize) = authorizeValue;
     sle->setFieldArray(sfPermissions, permissionsValue);
     sle->at(sfOwnerNode) = ownerNodeValue;
+    sle->at(sfDestinationNode) = destinationNodeValue;
     sle->at(sfPreviousTxnID) = previousTxnIDValue;
     sle->at(sfPreviousTxnLgrSeq) = previousTxnLgrSeqValue;
 
@@ -180,6 +192,19 @@ TEST(DelegateTests, BuilderFromSleRoundTrip)
         expectEqualField(expected, fromBuilder, "sfPreviousTxnLgrSeq");
     }
 
+    {
+        auto const& expected = destinationNodeValue;
+
+        auto const fromSleOpt = entryFromSle.getDestinationNode();
+        auto const fromBuilderOpt = entryFromBuilder.getDestinationNode();
+
+        ASSERT_TRUE(fromSleOpt.has_value());
+        ASSERT_TRUE(fromBuilderOpt.has_value());
+
+        expectEqualField(expected, *fromSleOpt, "sfDestinationNode");
+        expectEqualField(expected, *fromBuilderOpt, "sfDestinationNode");
+    }
+
     EXPECT_EQ(entryFromSle.getKey(), index);
     EXPECT_EQ(entryFromBuilder.getKey(), index);
 }
@@ -220,4 +245,31 @@ TEST(DelegateTests, BuilderThrowsOnWrongEntryType)
     EXPECT_THROW(DelegateBuilder{wrongEntry.getSle()}, std::runtime_error);
 }
 
+// 5) Build with only required fields and verify optional fields return nullopt.
+TEST(DelegateTests, OptionalFieldsReturnNullopt)
+{
+    uint256 const index{3u};
+
+    auto const accountValue = canonical_ACCOUNT();
+    auto const authorizeValue = canonical_ACCOUNT();
+    auto const permissionsValue = canonical_ARRAY();
+    auto const ownerNodeValue = canonical_UINT64();
+    auto const previousTxnIDValue = canonical_UINT256();
+    auto const previousTxnLgrSeqValue = canonical_UINT32();
+
+    DelegateBuilder builder{
+        accountValue,
+        authorizeValue,
+        permissionsValue,
+        ownerNodeValue,
+        previousTxnIDValue,
+        previousTxnLgrSeqValue
+    };
+
+    auto const entry = builder.build(index);
+
+    // Verify optional fields are not present
+    EXPECT_FALSE(entry.hasDestinationNode());
+    EXPECT_FALSE(entry.getDestinationNode().has_value());
+}
 }


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

When account A (the delegatee) is deleted, any Delegate ledger objects in other accounts' owner directories that reference A via sfAuthorize were not cleaned up, leaving dangling objects on-ledger. 

This PR fixes the issue by storing the Delegate object in both the delegating account's (B) and the authorized account's (A) owner directories, mirroring the pattern used by EscrowCreate. When either party deletes their account, AccountDelete walks their owner directory, finds the ltDELEGATE entry, and deleteDelegate cleans up both sides.

### Context of Change



<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [x] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

I conducted a local test using standalone mode. The core commands I had:
```
% curl -s -X POST http://127.0.0.1:5005 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "account_objects",
    "params": [{"account": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM"}]
  }' | python3 -m json.tool
{
    "result": {
        "account": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM",
        "account_objects": [
            {
                "Account": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM",
                "Authorize": "rK27ECzvntUQPQRnpQfT4ByMKpYdPYktua",
                "DestinationNode": "0",
                "Flags": 0,
                "LedgerEntryType": "Delegate",
                "OwnerNode": "0",
                "Permissions": [
                    {
                        "Permission": {
                            "PermissionValue": "Payment"
                        }
                    }
                ],
                "PreviousTxnID": "ED79B04396CA6D34C74483B8FC5FD14BAFB3F9A8321609A14E2352EB9362FDA6",
                "PreviousTxnLgrSeq": 6,
                "index": "07349519B9ED9599FF6C84C206735741C5C24F4C456AB30EFAAC69C42FC45D77"
            }
        ],
        "ledger_current_index": 7,
        "status": "success",
        "validated": false
    }
}


%curl -s -X POST http://127.0.0.1:5005 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "account_objects",
    "params": [{"account": "rK27ECzvntUQPQRnpQfT4ByMKpYdPYktua"}]
  }' | python3 -m json.tool
{
    "result": {
        "account": "rK27ECzvntUQPQRnpQfT4ByMKpYdPYktua",
        "account_objects": [
            {
                "Account": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM",
                "Authorize": "rK27ECzvntUQPQRnpQfT4ByMKpYdPYktua",
                "DestinationNode": "0",
                "Flags": 0,
                "LedgerEntryType": "Delegate",
                "OwnerNode": "0",
                "Permissions": [
                    {
                        "Permission": {
                            "PermissionValue": "Payment"
                        }
                    }
                ],
                "PreviousTxnID": "ED79B04396CA6D34C74483B8FC5FD14BAFB3F9A8321609A14E2352EB9362FDA6",
                "PreviousTxnLgrSeq": 6,
                "index": "07349519B9ED9599FF6C84C206735741C5C24F4C456AB30EFAAC69C42FC45D77"
            }
        ],
        "ledger_current_index": 7,
        "status": "success",
        "validated": false
    }
}

%for i in $(seq 1 256); do
  curl -s -X POST http://127.0.0.1:5005 \
    -H 'Content-Type: application/json' \
    -d '{"method":"ledger_accept","params":[{}]}' > /dev/null
done
echo "done"
done

%curl -s -X POST http://127.0.0.1:5005 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "submit",
    "params": [{
      "secret": "ssT5qnHJRAFZ6aRK1By3AfkD64Jqn",
      "tx_json": {
        "TransactionType": "AccountDelete",
        "Account": "rK27ECzvntUQPQRnpQfT4ByMKpYdPYktua",
        "Destination": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM",
        "Fee": "2000000",
        "Sequence": 5
      }
    }]
  }' | python3 -m json.tool | grep engine_result
        "engine_result": "tesSUCCESS",
        "engine_result_code": 0,
        "engine_result_message": "The transaction was applied. Only final in a validated ledger.",

% curl -s -X POST http://127.0.0.1:5005 \
  -H 'Content-Type: application/json' \
  -d '{"method":"ledger_accept","params":[{}]}' | python3 -m json.tool | grep ledger_current
        "ledger_current_index": 264,

% curl -s -X POST http://127.0.0.1:5005 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "account_objects",
    "params": [{"account": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM"}]
  }' | python3 -m json.tool
{
    "result": {
        "account": "rGkPsFGDkKprjswvPjtqHVt4VwvRRbz7nM",
        "account_objects": [],
        "ledger_current_index": 264,
        "status": "success",
        "validated": false
    }
}
% curl -s -X POST http://127.0.0.1:5005 \
  -H 'Content-Type: application/json' \
  -d '{
    "method": "account_info",
    "params": [{"account": "rK27ECzvntUQPQRnpQfT4ByMKpYdPYktua"}]
  }' | python3 -m json.tool | grep -E "error|Sequence"
        "error": "actNotFound",
        "error_code": 19,
        "error_message": "Account not found.",
        "status": "error",
```

We can see that now we don't have delegate object for delegator after delegatee's account got deleted.
<!--
## Future Tasks
For future tasks related to PR.
-->
