### PR TITLE
chore: Fix clang-tidy header filter

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,6 @@
 ---
+# This entire group of checks was applied to all cpp files but not all header files.
+# ---
 Checks: "-*,
   bugprone-argument-comment,
   bugprone-assert-side-effect,
@@ -8,26 +10,26 @@ Checks: "-*,
   bugprone-chained-comparison,
   bugprone-compare-pointer-to-member-virtual-function,
   bugprone-copy-constructor-init,
-  bugprone-crtp-constructor-accessibility,
+  # bugprone-crtp-constructor-accessibility, # has issues
   bugprone-dangling-handle,
   bugprone-dynamic-static-initializers,
-  bugprone-empty-catch,
+  # bugprone-empty-catch, # has issues
   bugprone-fold-init-type,
-  bugprone-forward-declaration-namespace,
-  bugprone-inaccurate-erase,
-  bugprone-inc-dec-in-conditions,
-  bugprone-incorrect-enable-if,
-  bugprone-incorrect-roundings,
-  bugprone-infinite-loop,
-  bugprone-integer-division,
+  # bugprone-forward-declaration-namespace, # has issues
+  # bugprone-inaccurate-erase,
+  # bugprone-inc-dec-in-conditions,
+  # bugprone-incorrect-enable-if,
+  # bugprone-incorrect-roundings,
+  # bugprone-infinite-loop,
+  # bugprone-integer-division,
   bugprone-lambda-function-name,
-  bugprone-macro-parentheses,
+  # bugprone-macro-parentheses, # has issues
   bugprone-macro-repeated-side-effects,
   bugprone-misplaced-operator-in-strlen-in-alloc,
   bugprone-misplaced-pointer-arithmetic-in-alloc,
   bugprone-misplaced-widening-cast,
   bugprone-move-forwarding-reference,
-  bugprone-multi-level-implicit-pointer-conversion,
+  # bugprone-multi-level-implicit-pointer-conversion, # has issues
   bugprone-multiple-new-in-one-expression,
   bugprone-multiple-statement-macro,
   bugprone-no-escape,
@@ -37,13 +39,13 @@ Checks: "-*,
   bugprone-pointer-arithmetic-on-polymorphic-object,
   bugprone-posix-return,
   bugprone-redundant-branch-condition,
-  bugprone-reserved-identifier,
-  bugprone-return-const-ref-from-parameter,
+  # bugprone-reserved-identifier, # has issues
+  # bugprone-return-const-ref-from-parameter, # has issues
   bugprone-shared-ptr-array-mismatch,
   bugprone-signal-handler,
   bugprone-signed-char-misuse,
   bugprone-sizeof-container,
-  bugprone-sizeof-expression,
+  # bugprone-sizeof-expression, # has issues
   bugprone-spuriously-wake-up-functions,
   bugprone-standalone-empty,
   bugprone-string-constructor,
@@ -60,7 +62,7 @@ Checks: "-*,
   bugprone-suspicious-string-compare,
   bugprone-suspicious-stringview-data-usage,
   bugprone-swapped-arguments,
-  bugprone-switch-missing-default-case,
+  # bugprone-switch-missing-default-case, # has issues
   bugprone-terminating-continue,
   bugprone-throw-keyword-missing,
   bugprone-too-small-loop-variable,
@@ -71,25 +73,25 @@ Checks: "-*,
   bugprone-unhandled-self-assignment,
   bugprone-unique-ptr-array-mismatch,
   bugprone-unsafe-functions,
-  bugprone-use-after-move,
+  # bugprone-use-after-move, # has issues
   bugprone-unused-raii,
   bugprone-unused-return-value,
   bugprone-unused-local-non-trivial-variable,
   bugprone-virtual-near-miss,
-  cppcoreguidelines-init-variables,
-  cppcoreguidelines-misleading-capture-default-by-value,
+  # cppcoreguidelines-init-variables, # has issues
+  # cppcoreguidelines-misleading-capture-default-by-value, # has issues
   cppcoreguidelines-no-suspend-with-lock,
-  cppcoreguidelines-pro-type-member-init,
+  # cppcoreguidelines-pro-type-member-init, # has issues
   cppcoreguidelines-pro-type-static-cast-downcast,
-  cppcoreguidelines-rvalue-reference-param-not-moved,
-  cppcoreguidelines-use-default-member-init,
-  cppcoreguidelines-virtual-class-destructor,
+  # cppcoreguidelines-rvalue-reference-param-not-moved, # has issues
+  # cppcoreguidelines-use-default-member-init, # has issues
+  # cppcoreguidelines-virtual-class-destructor, # has issues
   hicpp-ignored-remove-result,
-  misc-definitions-in-headers,
+  # misc-definitions-in-headers, # has issues
   misc-header-include-cycle,
   misc-misplaced-const,
   misc-static-assert,
-  misc-throw-by-value-catch-by-reference,
+  # misc-throw-by-value-catch-by-reference, # has issues
   misc-unused-alias-decls,
   misc-unused-using-decls,
   modernize-deprecated-headers,
@@ -98,34 +100,34 @@ Checks: "-*,
   performance-implicit-conversion-in-loop,
   performance-move-constructor-init,
   performance-trivially-destructible,
-  readability-avoid-nested-conditional-operator,
-  readability-avoid-return-with-void-value,
-  readability-braces-around-statements,
-  readability-const-return-type,
-  readability-container-contains,
-  readability-container-size-empty,
-  readability-convert-member-functions-to-static,
+  # readability-avoid-nested-conditional-operator, # has issues
+  # readability-avoid-return-with-void-value, # has issues
+  # readability-braces-around-statements, # has issues
+  # readability-const-return-type, # has issues
+  # readability-container-contains, # has issues
+  # readability-container-size-empty, # has issues
+  # readability-convert-member-functions-to-static, # has issues
   readability-duplicate-include,
-  readability-else-after-return,
-  readability-enum-initial-value,
-  readability-implicit-bool-conversion,
-  readability-make-member-function-const,
-  readability-math-missing-parentheses,
+  # readability-else-after-return, # has issues
+  # readability-enum-initial-value, # has issues
+  # readability-implicit-bool-conversion, # has issues
+  # readability-make-member-function-const, # has issues
+  # readability-math-missing-parentheses, # has issues
   readability-misleading-indentation,
   readability-non-const-parameter,
-  readability-redundant-casting,
-  readability-redundant-declaration,
-  readability-redundant-inline-specifier,
-  readability-redundant-member-init,
+  # readability-redundant-casting, # has issues
+  # readability-redundant-declaration, # has issues
+  # readability-redundant-inline-specifier, # has issues
+  # readability-redundant-member-init, # has issues
   readability-redundant-string-init,
   readability-reference-to-constructed-temporary,
-  readability-simplify-boolean-expr,
-  readability-static-definition-in-anonymous-namespace,
-  readability-suspicious-call-argument,
+  # readability-simplify-boolean-expr, # has issues
+  # readability-static-definition-in-anonymous-namespace, # has issues
+  # readability-suspicious-call-argument, # has issues
   readability-use-std-min-max
   "
 # ---
-# checks that have some issues that need to be resolved:
+# other checks that have issues that need to be resolved:
 #
 # llvm-namespace-comment,
 # misc-const-correctness,
@@ -134,7 +136,7 @@ Checks: "-*,
 #
 # readability-inconsistent-declaration-parameter-name, # in this codebase this check will break a lot of arg names
 # readability-static-accessed-through-instance,        # this check is probably unnecessary. it makes the code less readable
-# readability-identifier-naming,
+# readability-identifier-naming,                       # https://github.com/XRPLF/rippled/pull/6571
 #
 # modernize-concat-nested-namespaces,
 # modernize-pass-by-value,
@@ -149,6 +151,7 @@ Checks: "-*,
 # modernize-use-std-numbers,
 # modernize-use-using,
 #
+# the following are in https://github.com/XRPLF/rippled/pull/6648 :
 # performance-faster-string-find,
 # performance-for-range-copy,
 # performance-inefficient-vector-operation,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -195,5 +195,6 @@ CheckOptions:
   bugprone-unused-return-value.CheckedReturnTypes: ::std::error_code;::std::error_condition;::std::errc
 #   misc-include-cleaner.IgnoreHeaders: '.*/(detail|impl)/.*;.*(expected|unexpected).*;.*ranges_lower_bound\.h;time.h;stdlib.h;__chrono/.*;fmt/chrono.h;boost/uuid/uuid_hash.hpp'
 #
-# HeaderFilterRegex: '^.*/(src|tests)/.*\.(h|hpp)$'
+HeaderFilterRegex: '^.*/(test|xrpl|xrpld)/.*\.(h|hpp)$'
+ExcludeHeaderFilterRegex: '^.*/protocol_autogen/.*\.(h|hpp)$'
 WarningsAsErrors: "*"


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Turns out the header filter was commented out which leads to clang-tidy processing less code than we want to, skipping many of the headers. This PR fixes the configuration such that clang-tidy runs against more of our code.

In previous PRs we have fixed multiple checks for all .cpp files, now we will have to fix some of them again but for all remaining .h files that were previously ignored. 

### API Impact

No impact.
