### PR TITLE
fix: Clamp VaultClawback to assetsAvailable for zero-amount clawback (#6646)

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -115,7 +115,8 @@ jobs:
     needs:
       - should-run
       - build-test
-    if: ${{ needs.should-run.outputs.go == 'true' && (startsWith(github.base_ref, 'release') || github.base_ref == 'master') }}
+    # Only run when committing to a PR that targets a release branch or master.
+    if: ${{ github.repository == 'XRPLF/rippled' && needs.should-run.outputs.go == 'true' && (startsWith(github.base_ref, 'release') || github.base_ref == 'master') }}
     uses: ./.github/workflows/reusable-notify-clio.yml
     secrets:
       clio_notify_token: ${{ secrets.CLIO_NOTIFY_TOKEN }}

--- a/.github/workflows/reusable-build-test-config.yml
+++ b/.github/workflows/reusable-build-test-config.yml
@@ -130,7 +130,7 @@ jobs:
             --target "${CMAKE_TARGET}"
 
       - name: Upload rippled artifact (Linux)
-        if: ${{ github.repository_owner == 'XRPLF' && runner.os == 'Linux' }}
+        if: ${{ github.repository == 'XRPLF/rippled' && runner.os == 'Linux' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         env:
           BUILD_DIR: ${{ inputs.build_dir }}
@@ -201,7 +201,7 @@ jobs:
             --target coverage
 
       - name: Upload coverage report
-        if: ${{ github.repository_owner == 'XRPLF' && !inputs.build_only && env.ENABLED_COVERAGE == 'true' }}
+        if: ${{ github.repository == 'XRPLF/rippled' && !inputs.build_only && env.ENABLED_COVERAGE == 'true' }}
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           disable_search: true

--- a/.github/workflows/upload-conan-deps.yml
+++ b/.github/workflows/upload-conan-deps.yml
@@ -101,11 +101,11 @@ jobs:
           log_verbosity: ${{ runner.os == 'Windows' && 'quiet' || 'verbose' }}
 
       - name: Log into Conan remote
-        if: ${{ github.repository_owner == 'XRPLF' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ github.repository == 'XRPLF/rippled' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         run: conan remote login "${CONAN_REMOTE_NAME}" "${{ secrets.CONAN_REMOTE_USERNAME }}" --password "${{ secrets.CONAN_REMOTE_PASSWORD }}"
 
       - name: Upload Conan packages
-        if: ${{ github.repository_owner == 'XRPLF' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ github.repository == 'XRPLF/rippled' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         env:
           FORCE_OPTION: ${{ github.event.inputs.force_upload == 'true' && '--force' || '' }}
         run: conan upload "*" --remote="${CONAN_REMOTE_NAME}" --confirm ${FORCE_OPTION}

--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -2669,51 +2669,82 @@ rippleSendMultiMPT(
     beast::Journal j,
     WaiveTransferFee waiveFee)
 {
-    // Safe to get MPT since rippleSendMultiMPT is only called by
-    // accountSendMultiMPT
     auto const& issuer = mptIssue.getIssuer();
 
     auto const sle = view.read(keylet::mptIssuance(mptIssue.getMptID()));
     if (!sle)
         return tecOBJECT_NOT_FOUND;
 
-    // These may diverge
+    // For the issuer-as-sender case, track the running total to validate
+    // against MaximumAmount. The read-only SLE (view.read) is not updated
+    // by rippleCreditMPT, so a per-iteration SLE read would be stale.
+    // Use uint64_t, not STAmount, to keep MaximumAmount comparisons in exact
+    // integer arithmetic. STAmount implicitly converts to Number, whose
+    // small-scale mantissa (~16 digits) can lose precision for values near
+    // maxMPTokenAmount (19 digits).
+    std::uint64_t totalSendAmount{0};
+    std::uint64_t const maximumAmount =
+        sle->at(~sfMaximumAmount).value_or(maxMPTokenAmount);
+    std::uint64_t const outstandingAmount =
+        sle->getFieldU64(sfOutstandingAmount);
+
+    // actual accumulates the total cost to the sender (includes transfer
+    // fees for third-party transit sends). takeFromSender accumulates only
+    // the transit portion that is debited to the issuer in bulk after the
+    // loop. They diverge when there are transfer fees.
     STAmount takeFromSender{mptIssue};
     actual = takeFromSender;
 
-    for (auto const& r : receivers)
+    for (auto const& [receiverID, amt] : receivers)
     {
-        auto const& receiverID = r.first;
-        STAmount amount{mptIssue, r.second};
+        STAmount amount{mptIssue, amt};
 
         if (amount < beast::zero)
-        {
             return tecINTERNAL;  // LCOV_EXCL_LINE
-        }
 
-        /* If we aren't sending anything or if the sender is the same as the
-         * receiver then we don't need to do anything.
-         */
-        if (!amount || (senderID == receiverID))
+        if (!amount || senderID == receiverID)
             continue;
 
         if (senderID == issuer || receiverID == issuer)
         {
-            // if sender is issuer, check that the new OutstandingAmount will
-            // not exceed MaximumAmount
             if (senderID == issuer)
             {
                 XRPL_ASSERT_PARTS(
                     takeFromSender == beast::zero,
                     "rippler::rippleSendMultiMPT",
                     "sender == issuer, takeFromSender == zero");
-                auto const sendAmount = amount.mpt().value();
-                auto const maximumAmount =
-                    sle->at(~sfMaximumAmount).value_or(maxMPTokenAmount);
-                if (sendAmount > maximumAmount ||
-                    sle->getFieldU64(sfOutstandingAmount) >
-                        maximumAmount - sendAmount)
-                    return tecPATH_DRY;
+
+                std::uint64_t const sendAmount = amount.mpt().value();
+
+                if (view.rules().enabled(fixSecurity3_1_3))
+                {
+                    // Post-fixSecurity3_1_3: aggregate MaximumAmount
+                    // check. WARNING: the order of conditions is
+                    // critical — each guards the subtraction in the
+                    // next against unsigned underflow. Do not reorder.
+                    bool const exceedsMaximumAmount =
+                        // This send alone exceeds the max cap
+                        sendAmount > maximumAmount ||
+                        // The aggregate of all sends exceeds the max cap
+                        totalSendAmount > maximumAmount - sendAmount ||
+                        // Outstanding + aggregate exceeds the max cap
+                        outstandingAmount >
+                            maximumAmount - sendAmount - totalSendAmount;
+
+                    if (exceedsMaximumAmount)
+                        return tecPATH_DRY;
+                    totalSendAmount += sendAmount;
+                }
+                else
+                {
+                    // Pre-fixSecurity3_1_3: per-iteration MaximumAmount
+                    // check. Reads sfOutstandingAmount from a stale
+                    // view.read() snapshot — incorrect for multi-destination
+                    // sends but retained for ledger replay compatibility.
+                    if (sendAmount > maximumAmount ||
+                        outstandingAmount > maximumAmount - sendAmount)
+                        return tecPATH_DRY;
+                }
             }
 
             // Direct send: redeeming MPTs and/or sending own MPTs.
@@ -2721,8 +2752,8 @@ rippleSendMultiMPT(
                     rippleCreditMPT(view, senderID, receiverID, amount, j))
                 return ter;
             actual += amount;
-            // Do not add amount to takeFromSender, because rippleCreditMPT took
-            // it
+            // Do not add amount to takeFromSender, because rippleCreditMPT
+            // took it.
 
             continue;
         }

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3653,34 +3653,30 @@ class MPToken_test : public beast::unit_test::suite
 
         // Each test case creates a fresh ApplyView and calls
         // accountSendMulti from the issuer to the given receivers.
-        auto const runTest =
-            [&](MultiplePaymentDestinations const& receivers,
-                TER expectedTer,
-                std::optional<std::uint64_t> expectedOutstanding,
-                std::string const& label) {
-                ApplyViewImpl av(&*env.current(), tapNONE);
-                auto const ter = accountSendMulti(
-                    av,
-                    issuer.id(),
-                    asset,
-                    receivers,
-                    env.app().getJournal("View"));
-                BEAST_EXPECTS(ter == expectedTer, label);
+        auto const runTest = [&](MultiplePaymentDestinations const& receivers,
+                                 TER expectedTer,
+                                 std::optional<std::uint64_t>
+                                     expectedOutstanding,
+                                 std::string const& label) {
+            ApplyViewImpl av(&*env.current(), tapNONE);
+            auto const ter = accountSendMulti(
+                av, issuer.id(), asset, receivers, env.app().journal("View"));
+            BEAST_EXPECTS(ter == expectedTer, label);
 
-                // Only verify OutstandingAmount on success — on error the
-                // view may contain partial state and must be discarded.
-                if (expectedOutstanding)
-                {
-                    auto const sle =
-                        av.peek(keylet::mptIssuance(mptt.issuanceID()));
-                    if (!BEAST_EXPECT(sle))
-                        return;
-                    BEAST_EXPECTS(
-                        sle->getFieldU64(sfOutstandingAmount) ==
-                            *expectedOutstanding,
-                        label);
-                }
-            };
+            // Only verify OutstandingAmount on success — on error the
+            // view may contain partial state and must be discarded.
+            if (expectedOutstanding)
+            {
+                auto const sle =
+                    av.peek(keylet::mptIssuance(mptt.issuanceID()));
+                if (!BEAST_EXPECT(sle))
+                    return;
+                BEAST_EXPECTS(
+                    sle->getFieldU64(sfOutstandingAmount) ==
+                        *expectedOutstanding,
+                    label);
+            }
+        };
 
         using R = MultiplePaymentDestinations;
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3625,6 +3625,143 @@ class MPToken_test : public beast::unit_test::suite
         mptAlice.claw(alice, bob, 1, tecNO_PERMISSION);
     }
 
+    void
+    testMultiSendMaximumAmount(FeatureBitset features)
+    {
+        // Verify that rippleSendMultiMPT correctly enforces MaximumAmount
+        // when the issuer sends to multiple receivers. Pre-fixSecurity3_1_3,
+        // a stale view.read() snapshot caused per-iteration checks to miss
+        // aggregate overflows. Post-fix, a running total is used instead.
+        testcase("Multi-send MaximumAmount enforcement");
+
+        using namespace test::jtx;
+
+        Account const issuer("issuer");
+        Account const alice("alice");
+        Account const bob("bob");
+
+        std::uint64_t constexpr maxAmt = 150;
+        Env env{*this, features};
+
+        MPTTester mptt(env, issuer, {.holders = {alice, bob}});
+        mptt.create(
+            {.maxAmt = maxAmt, .ownerCount = 1, .flags = tfMPTCanTransfer});
+        mptt.authorize({.account = alice});
+        mptt.authorize({.account = bob});
+
+        Asset const asset{MPTIssue{mptt.issuanceID()}};
+
+        // Each test case creates a fresh ApplyView and calls
+        // accountSendMulti from the issuer to the given receivers.
+        auto const runTest =
+            [&](MultiplePaymentDestinations const& receivers,
+                TER expectedTer,
+                std::optional<std::uint64_t> expectedOutstanding,
+                std::string const& label) {
+                ApplyViewImpl av(&*env.current(), tapNONE);
+                auto const ter = accountSendMulti(
+                    av,
+                    issuer.id(),
+                    asset,
+                    receivers,
+                    env.app().getJournal("View"));
+                BEAST_EXPECTS(ter == expectedTer, label);
+
+                // Only verify OutstandingAmount on success — on error the
+                // view may contain partial state and must be discarded.
+                if (expectedOutstanding)
+                {
+                    auto const sle =
+                        av.peek(keylet::mptIssuance(mptt.issuanceID()));
+                    if (!BEAST_EXPECT(sle))
+                        return;
+                    BEAST_EXPECTS(
+                        sle->getFieldU64(sfOutstandingAmount) ==
+                            *expectedOutstanding,
+                        label);
+                }
+            };
+
+        using R = MultiplePaymentDestinations;
+
+        // Post-amendment: aggregate check with running total
+        runTest(
+            R{{alice.id(), 100}, {bob.id(), 100}},
+            tecPATH_DRY,
+            std::nullopt,
+            "aggregate exceeds max");
+
+        runTest(
+            R{{alice.id(), 75}, {bob.id(), 75}},
+            tesSUCCESS,
+            maxAmt,
+            "aggregate at boundary");
+
+        runTest(
+            R{{alice.id(), 50}, {bob.id(), 50}},
+            tesSUCCESS,
+            100,
+            "aggregate within limit");
+
+        runTest(
+            R{{alice.id(), 150}, {bob.id(), 0}},
+            tesSUCCESS,
+            maxAmt,
+            "one receiver at max, other zero");
+
+        runTest(
+            R{{alice.id(), 151}, {bob.id(), 0}},
+            tecPATH_DRY,
+            std::nullopt,
+            "one receiver exceeds max, other zero");
+
+        // Issue 50 tokens so outstandingAmount is nonzero, then verify
+        // the third condition: outstandingAmount > maximumAmount - sendAmount -
+        // totalSendAmount
+        mptt.pay(issuer, alice, 50);
+        env.close();
+
+        // maxAmt=150, outstanding=50, so 100 more available
+        runTest(
+            R{{alice.id(), 50}, {bob.id(), 50}},
+            tesSUCCESS,
+            maxAmt,
+            "nonzero outstanding, aggregate at boundary");
+
+        runTest(
+            R{{alice.id(), 50}, {bob.id(), 51}},
+            tecPATH_DRY,
+            std::nullopt,
+            "nonzero outstanding, aggregate exceeds max");
+
+        runTest(
+            R{{alice.id(), 100}, {bob.id(), 0}},
+            tesSUCCESS,
+            maxAmt,
+            "nonzero outstanding, single send at remaining capacity");
+
+        runTest(
+            R{{alice.id(), 101}, {bob.id(), 0}},
+            tecPATH_DRY,
+            std::nullopt,
+            "nonzero outstanding, single send exceeds remaining capacity");
+
+        // Pre-amendment: the stale per-iteration check allows each
+        // individual send (100 <= 150) even though the aggregate (200)
+        // exceeds MaximumAmount. Preserved for ledger replay.
+        {
+            // KNOWN BUG (pre-fixSecurity3_1_3): preserved for ledger replay
+            // only
+            env.disableFeature(fixSecurity3_1_3);
+            runTest(
+                R{{alice.id(), 100}, {bob.id(), 100}},
+                tesSUCCESS,
+                250,
+                "pre-amendment allows over-send");
+            env.enableFeature(fixSecurity3_1_3);
+        }
+    }
+
 public:
     void
     run() override
@@ -3632,6 +3769,7 @@ public:
         using namespace test::jtx;
         FeatureBitset const all{testable_amendments()};
 
+        testMultiSendMaximumAmount(all);
         // MPTokenIssuanceCreate
         testCreateValidation(all - featureSingleAssetVault);
         testCreateValidation(all - featurePermissionedDomains);

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -5561,6 +5561,7 @@ class Vault_test : public beast::unit_test::suite
         using namespace loanBroker;
         using namespace loan;
         Env env(*this);
+        env.enableFeature(fixSecurity3_1_3);
 
         auto const setupVault =
             [&](PrettyAsset const& asset,
@@ -5576,6 +5577,8 @@ class Vault_test : public beast::unit_test::suite
 
             auto const& vaultSle = env.le(vaultKeylet);
             BEAST_EXPECT(vaultSle != nullptr);
+            if (vaultSle)
+                env.memoize(Account("vault", vaultSle->at(sfAccount)));
             env(vault.deposit(
                     {.depositor = depositor,
                      .id = vaultKeylet.key,
@@ -5765,6 +5768,306 @@ class Vault_test : public beast::unit_test::suite
                     ter(tesSUCCESS),
                     THISLINE);
             }
+
+            {
+                testcase(
+                    "VaultClawback (asset) - " + prefix +
+                    " zero-amount clawback clamped with outstanding loan");
+                auto [vault, vaultKeylet] =
+                    setupVault(asset, owner, depositor, issuer);
+
+                auto const vaultSle = env.le(vaultKeylet);
+                BEAST_EXPECT(vaultSle != nullptr);
+                if (!vaultSle)
+                    return;
+
+                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+                // Create a loan broker backed by this vault
+                auto const brokerKeylet =
+                    keylet::loanbroker(owner.id(), env.seq(owner));
+                env(set(owner, vaultKeylet.key));
+                env.close();
+
+                // Depositor borrows 40 units, reducing assetsAvailable to 60
+                // while assetsTotal stays at 100
+                env(set(depositor, brokerKeylet.key, asset(40).value()),
+                    loan::interestRate(TenthBips32(0)),
+                    gracePeriod(60),
+                    paymentInterval(120),
+                    paymentTotal(10),
+                    sig(sfCounterpartySignature, owner),
+                    fee(env.current()->fees().base * 2),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(60).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
+                }
+
+                auto const sharesBefore =
+                    env.balance(depositor, shares.raw().get<MPTIssue>());
+
+                // Zero-amount clawback (= "clawback all") should succeed,
+                // clamped to assetsAvailable (60) rather than the full
+                // share value (100).
+                env(vault.clawback({
+                        .issuer = issuer,
+                        .id = vaultKeylet.key,
+                        .holder = depositor,
+                    }),
+                    ter(tesSUCCESS));
+                env.close();
+
+                // Only 60 assets clawed back; loan's 40 still outstanding
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle != nullptr);
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(40).value());
+
+                    // 60 of 100 shares destroyed (1:1 ratio), 40 remain
+                    auto const sharesAfter =
+                        env.balance(depositor, shares.raw().get<MPTIssue>());
+                    BEAST_EXPECT(sharesAfter < sharesBefore);
+                    BEAST_EXPECT(sharesAfter > shares(0));
+                }
+            }
+
+            {
+                testcase(
+                    "VaultClawback (asset) - " + prefix +
+                    " non-zero clawback clamped with outstanding loan");
+                auto [vault, vaultKeylet] =
+                    setupVault(asset, owner, depositor, issuer);
+
+                auto const vaultSle = env.le(vaultKeylet);
+                BEAST_EXPECT(vaultSle != nullptr);
+                if (!vaultSle)
+                    return;
+                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+                // Create a loan broker backed by this vault
+                auto const brokerKeylet =
+                    keylet::loanbroker(owner.id(), env.seq(owner));
+                env(set(owner, vaultKeylet.key));
+                env.close();
+
+                // Depositor borrows 40 units
+                env(set(depositor, brokerKeylet.key, asset(40).value()),
+                    loan::interestRate(TenthBips32(0)),
+                    gracePeriod(60),
+                    paymentInterval(120),
+                    paymentTotal(10),
+                    sig(sfCounterpartySignature, owner),
+                    fee(env.current()->fees().base * 2),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(60).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
+                }
+
+                auto const sharesBefore = env.balance(depositor, shares);
+
+                // Request 100 but only 60 available — clamped to 60
+                env(vault.clawback({
+                        .issuer = issuer,
+                        .id = vaultKeylet.key,
+                        .holder = depositor,
+                        .amount = asset(100).value(),
+                    }),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle != nullptr);
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(40).value());
+                }
+
+                auto const sharesAfter = env.balance(depositor, shares);
+                BEAST_EXPECT(sharesAfter < sharesBefore);
+                BEAST_EXPECT(sharesAfter > shares(0));
+            }
+
+            {
+                testcase(
+                    "VaultClawback (asset) - " + prefix +
+                    " partial clawback below available with outstanding loan");
+                auto [vault, vaultKeylet] =
+                    setupVault(asset, owner, depositor, issuer);
+
+                auto const vaultSle = env.le(vaultKeylet);
+                BEAST_EXPECT(vaultSle != nullptr);
+                if (!vaultSle)
+                    return;
+                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+                // Create a loan broker backed by this vault
+                auto const brokerKeylet =
+                    keylet::loanbroker(owner.id(), env.seq(owner));
+                env(set(owner, vaultKeylet.key));
+                env.close();
+
+                // Depositor borrows 40 units: assetsAvailable=60, assetsTotal=100
+                env(set(depositor, brokerKeylet.key, asset(40).value()),
+                    loan::interestRate(TenthBips32(0)),
+                    gracePeriod(60),
+                    paymentInterval(120),
+                    paymentTotal(10),
+                    sig(sfCounterpartySignature, owner),
+                    fee(env.current()->fees().base * 2),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(60).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
+                }
+
+                // Clawback 30 — well under available (60), no clamping needed
+                env(vault.clawback({
+                        .issuer = issuer,
+                        .id = vaultKeylet.key,
+                        .holder = depositor,
+                        .amount = asset(30).value(),
+                    }),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle != nullptr);
+                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(30).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(70).value());
+                }
+            }
+
+            {
+                testcase(
+                    "VaultClawback (asset) - " + prefix +
+                    " clawback exactly equal to available with outstanding loan");
+                auto [vault, vaultKeylet] =
+                    setupVault(asset, owner, depositor, issuer);
+
+                auto const vaultSle = env.le(vaultKeylet);
+                BEAST_EXPECT(vaultSle != nullptr);
+                if (!vaultSle)
+                    return;
+                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+                auto const brokerKeylet =
+                    keylet::loanbroker(owner.id(), env.seq(owner));
+                env(set(owner, vaultKeylet.key));
+                env.close();
+
+                // Depositor borrows 40 units: assetsAvailable=60, assetsTotal=100
+                env(set(depositor, brokerKeylet.key, asset(40).value()),
+                    loan::interestRate(TenthBips32(0)),
+                    gracePeriod(60),
+                    paymentInterval(120),
+                    paymentTotal(10),
+                    sig(sfCounterpartySignature, owner),
+                    fee(env.current()->fees().base * 2),
+                    ter(tesSUCCESS));
+                env.close();
+
+                // Clawback exactly 60 — at the boundary, no clamping needed
+                env(vault.clawback({
+                        .issuer = issuer,
+                        .id = vaultKeylet.key,
+                        .holder = depositor,
+                        .amount = asset(60).value(),
+                    }),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle != nullptr);
+                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(40).value());
+                }
+            }
+
+            {
+                testcase(
+                    "VaultClawback (asset) - " + prefix +
+                    " clawback with zero available (fully borrowed)");
+                auto [vault, vaultKeylet] =
+                    setupVault(asset, owner, depositor, issuer);
+
+                auto const vaultSle = env.le(vaultKeylet);
+                BEAST_EXPECT(vaultSle != nullptr);
+                if (!vaultSle)
+                    return;
+                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+                auto const brokerKeylet =
+                    keylet::loanbroker(owner.id(), env.seq(owner));
+                env(set(owner, vaultKeylet.key));
+                env.close();
+
+                // Depositor borrows all 100 units: assetsAvailable=0, assetsTotal=100
+                env(set(depositor, brokerKeylet.key, asset(100).value()),
+                    loan::interestRate(TenthBips32(0)),
+                    gracePeriod(60),
+                    paymentInterval(120),
+                    paymentTotal(10),
+                    sig(sfCounterpartySignature, owner),
+                    fee(env.current()->fees().base * 2),
+                    ter(tesSUCCESS));
+                env.close();
+
+                {
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
+                }
+
+                auto const sharesBefore = env.balance(depositor, shares);
+
+                // Zero-amount clawback — nothing available, clamped to 0,
+                // resulting in zero shares destroyed → tecPRECISION_LOSS
+                env(vault.clawback({
+                        .issuer = issuer,
+                        .id = vaultKeylet.key,
+                        .holder = depositor,
+                    }),
+                    ter(tecPRECISION_LOSS));
+                env.close();
+
+                // Explicit amount clawback — also nothing available
+                env(vault.clawback({
+                        .issuer = issuer,
+                        .id = vaultKeylet.key,
+                        .holder = depositor,
+                        .amount = asset(50).value(),
+                    }),
+                    ter(tecPRECISION_LOSS));
+                env.close();
+
+                {
+                    // Nothing changed — vault and shares unchanged
+                    auto const sle = env.le(vaultKeylet);
+                    BEAST_EXPECT(sle != nullptr);
+                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
+                    auto const sharesAfter = env.balance(depositor, shares);
+                    BEAST_EXPECT(sharesAfter == sharesBefore);
+                }
+            }
         };
 
         Account owner{"alice"};
@@ -5782,10 +6085,10 @@ class Vault_test : public beast::unit_test::suite
         PrettyAsset IOU = issuer["IOU"];
         env(fset(issuer, asfAllowTrustLineClawback));
         env.close();
-        env.trust(IOU(1000), owner);
-        env.trust(IOU(1000), depositor);
-        env(pay(issuer, owner, IOU(1000)));
-        env(pay(issuer, depositor, IOU(1000)));
+        env.trust(IOU(2000), owner);
+        env.trust(IOU(2000), depositor);
+        env(pay(issuer, owner, IOU(2000)));
+        env(pay(issuer, depositor, IOU(2000)));
         env.close();
         testCase(IOU, "IOU", owner, depositor, issuer);
 
@@ -5796,9 +6099,338 @@ class Vault_test : public beast::unit_test::suite
         PrettyAsset MPT = mptt.issuanceID();
         mptt.authorize({.account = owner});
         mptt.authorize({.account = depositor});
-        env(pay(issuer, depositor, MPT(1000)));
+        env(pay(issuer, depositor, MPT(2000)));
         env.close();
         testCase(MPT, "MPT", owner, depositor, issuer);
+
+        // Test pre-fixSecurity3_1_3 legacy path: zero-amount clawback
+        // returns early without clamping to assetsAvailable.
+        {
+            testcase(
+                "VaultClawback (asset) - IOU pre-fixSecurity3_1_3"
+                " zero-amount clawback unclamped with outstanding loan");
+
+            env.disableFeature(fixSecurity3_1_3);
+
+            auto [vault, vaultKeylet] =
+                setupVault(IOU, owner, depositor, issuer);
+
+            auto const vaultSle = env.le(vaultKeylet);
+            BEAST_EXPECT(vaultSle != nullptr);
+            if (!vaultSle)
+                return;
+
+            PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+            // Create a loan broker backed by this vault
+            auto const brokerKeylet =
+                keylet::loanbroker(owner.id(), env.seq(owner));
+            env(set(owner, vaultKeylet.key));
+            env.close();
+
+            // Depositor borrows 40 units, reducing assetsAvailable to 60
+            // while assetsTotal stays at 100
+            env(set(depositor, brokerKeylet.key, IOU(40).value()),
+                loan::interestRate(TenthBips32(0)),
+                gracePeriod(60),
+                paymentInterval(120),
+                paymentTotal(10),
+                sig(sfCounterpartySignature, owner),
+                fee(env.current()->fees().base * 2),
+                ter(tesSUCCESS));
+            env.close();
+
+            {
+                auto const sle = env.le(vaultKeylet);
+                BEAST_EXPECT(sle->at(sfAssetsAvailable) == IOU(60).value());
+                BEAST_EXPECT(sle->at(sfAssetsTotal) == IOU(100).value());
+            }
+
+            auto const sharesBefore = env.balance(depositor, shares);
+
+            // Legacy: zero-amount clawback tries to recover the full
+            // share value (100) without clamping to assetsAvailable (60).
+            // This causes the vault balance to go negative, triggering
+            // the sanity check in doApply → tefINTERNAL.
+            env(vault.clawback({
+                    .issuer = issuer,
+                    .id = vaultKeylet.key,
+                    .holder = depositor,
+                }),
+                ter(tefINTERNAL));
+            env.close();
+
+            {
+                // Transaction rolled back — vault and shares unchanged
+                auto const sle = env.le(vaultKeylet);
+                BEAST_EXPECT(sle != nullptr);
+                BEAST_EXPECT(sle->at(sfAssetsAvailable) == IOU(60).value());
+                BEAST_EXPECT(sle->at(sfAssetsTotal) == IOU(100).value());
+                auto const sharesAfter = env.balance(depositor, shares);
+                BEAST_EXPECT(sharesAfter == sharesBefore);
+            }
+
+            env.enableFeature(fixSecurity3_1_3);
+        }
+    }
+
+    void
+    testVaultEscrowedMPT()
+    {
+        using namespace test::jtx;
+        using namespace std::literals;
+
+        // Verify vault deposit/withdraw/clawback respect sfLockedAmount.
+        // When MPT tokens are escrowed, sfMPTAmount is reduced and
+        // sfLockedAmount is increased. Vault operations go through
+        // accountSend/accountHolds which read sfMPTAmount, so escrowed
+        // tokens are naturally excluded.
+
+        {
+            testcase("Vault deposit fails when MPT asset is escrowed");
+
+            Env env{*this, testable_amendments()};
+            auto const baseFee = env.current()->fees().base;
+            Account const owner{"owner"};
+            Account const depositor{"depositor"};
+            Account const issuer{"issuer"};
+            Account const bob{"bob"};
+
+            env.fund(XRP(10000), issuer, owner, depositor, bob);
+            env.close();
+
+            MPTTester mptt{env, issuer, mptInitNoFund};
+            mptt.create(
+                {.flags = tfMPTCanClawback | tfMPTCanTransfer | tfMPTCanLock |
+                     tfMPTCanEscrow});
+            mptt.authorize({.account = owner});
+            mptt.authorize({.account = depositor});
+            mptt.authorize({.account = bob});
+            PrettyAsset const asset = mptt.issuanceID();
+            env(pay(issuer, depositor, asset(100)));
+            env.close();
+
+            // Escrow 60 of 100 MPT tokens: sfMPTAmount drops to 40
+            auto const escrowSeq = env.seq(depositor);
+            env(escrow::create(depositor, bob, asset(60)),
+                escrow::condition(escrow::cb1),
+                escrow::finish_time(env.now() + 1s),
+                fee(baseFee * 150),
+                ter(tesSUCCESS));
+            env.close();
+
+            Vault vault{env};
+            auto [tx, vaultKeylet] =
+                vault.create({.owner = owner, .asset = asset});
+            env(tx, ter(tesSUCCESS));
+            env.close();
+
+            // Deposit 100 should fail — only 40 spendable
+            env(vault.deposit(
+                    {.depositor = depositor,
+                     .id = vaultKeylet.key,
+                     .amount = asset(100)}),
+                ter(tecINSUFFICIENT_FUNDS));
+            env.close();
+
+            // Deposit 40 (the unlocked balance) should succeed
+            env(vault.deposit(
+                    {.depositor = depositor,
+                     .id = vaultKeylet.key,
+                     .amount = asset(40)}),
+                ter(tesSUCCESS));
+            env.close();
+
+            {
+                auto const sle = env.le(vaultKeylet);
+                BEAST_EXPECT(
+                    sle->at(sfAssetsTotal) == asset(40).value());
+            }
+
+            // Clean up escrow
+            env(escrow::finish(bob, depositor, escrowSeq),
+                escrow::condition(escrow::cb1),
+                escrow::fulfillment(escrow::fb1),
+                fee(baseFee * 150),
+                ter(tesSUCCESS));
+            env.close();
+        }
+
+        {
+            testcase("Vault withdraw respects escrowed shares");
+
+            Env env{*this, testable_amendments()};
+            auto const baseFee = env.current()->fees().base;
+            Account const owner{"owner"};
+            Account const depositor{"depositor"};
+            Account const issuer{"issuer"};
+            Account const bob{"bob"};
+
+            env.fund(XRP(10000), issuer, owner, depositor, bob);
+            env.close();
+
+            MPTTester mptt{env, issuer, mptInitNoFund};
+            mptt.create(
+                {.flags = tfMPTCanClawback | tfMPTCanTransfer | tfMPTCanLock |
+                     tfMPTCanEscrow});
+            mptt.authorize({.account = owner});
+            mptt.authorize({.account = depositor});
+            PrettyAsset const asset = mptt.issuanceID();
+            env(pay(issuer, depositor, asset(100)));
+            env.close();
+
+            Vault vault{env};
+            auto [tx, vaultKeylet] =
+                vault.create({.owner = owner, .asset = asset});
+            env(tx, ter(tesSUCCESS));
+            env.close();
+
+            // Deposit 100 → get shares
+            env(vault.deposit(
+                    {.depositor = depositor,
+                     .id = vaultKeylet.key,
+                     .amount = asset(100)}),
+                ter(tesSUCCESS));
+            env.close();
+
+            auto const vaultSle = env.le(vaultKeylet);
+            if (!BEAST_EXPECT(vaultSle))
+                return;
+            PrettyAsset const shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+            // Authorize bob for share MPT so he can receive escrowed
+            // shares
+            auto const shareMPTID = vaultSle->at(sfShareMPTID);
+            {
+                Json::Value jv;
+                jv[jss::Account] = bob.human();
+                jv[sfMPTokenIssuanceID] = to_string(shareMPTID);
+                jv[jss::TransactionType] = jss::MPTokenAuthorize;
+                env(jv, ter(tesSUCCESS));
+                env.close();
+            }
+
+            // Escrow 60% of shares
+            auto const escrowAmount =
+                shares(Number{6, vaultSle->at(sfScale) + 1});
+            env(escrow::create(depositor, bob, escrowAmount),
+                escrow::condition(escrow::cb1),
+                escrow::finish_time(env.now() + 1s),
+                fee(baseFee * 150),
+                ter(tesSUCCESS));
+            env.close();
+
+            // Withdraw all 100 should fail — only 40% of shares are
+            // unlocked
+            env(vault.withdraw(
+                    {.depositor = depositor,
+                     .id = vaultKeylet.key,
+                     .amount = asset(100)}),
+                ter(tecINSUFFICIENT_FUNDS));
+            env.close();
+
+            // Withdraw 40 (matching unlocked shares) should succeed
+            env(vault.withdraw(
+                    {.depositor = depositor,
+                     .id = vaultKeylet.key,
+                     .amount = asset(40)}),
+                ter(tesSUCCESS));
+            env.close();
+
+            {
+                auto const sle = env.le(vaultKeylet);
+                BEAST_EXPECT(
+                    sle->at(sfAssetsTotal) == asset(60).value());
+            }
+        }
+
+        {
+            testcase("Vault clawback only recovers unlocked shares");
+
+            Env env{*this, testable_amendments() | fixSecurity3_1_3};
+            auto const baseFee = env.current()->fees().base;
+            Account const owner{"owner"};
+            Account const depositor{"depositor"};
+            Account const issuer{"issuer"};
+            Account const bob{"bob"};
+
+            env.fund(XRP(10000), issuer, owner, depositor, bob);
+            env.close();
+
+            MPTTester mptt{env, issuer, mptInitNoFund};
+            mptt.create(
+                {.flags = tfMPTCanClawback | tfMPTCanTransfer | tfMPTCanLock |
+                     tfMPTCanEscrow});
+            mptt.authorize({.account = owner});
+            mptt.authorize({.account = depositor});
+            PrettyAsset const asset = mptt.issuanceID();
+            env(pay(issuer, depositor, asset(100)));
+            env.close();
+
+            Vault vault{env};
+            auto [tx, vaultKeylet] =
+                vault.create({.owner = owner, .asset = asset});
+            env(tx, ter(tesSUCCESS));
+            env.close();
+
+            // Deposit 100 → get shares
+            env(vault.deposit(
+                    {.depositor = depositor,
+                     .id = vaultKeylet.key,
+                     .amount = asset(100)}),
+                ter(tesSUCCESS));
+            env.close();
+
+            auto const vaultSle = env.le(vaultKeylet);
+            if (!BEAST_EXPECT(vaultSle))
+                return;
+            PrettyAsset const shares = MPTIssue(vaultSle->at(sfShareMPTID));
+
+            // Authorize bob for share MPT so he can receive escrowed
+            // shares
+            auto const shareMPTID = vaultSle->at(sfShareMPTID);
+            {
+                Json::Value jv;
+                jv[jss::Account] = bob.human();
+                jv[sfMPTokenIssuanceID] = to_string(shareMPTID);
+                jv[jss::TransactionType] = jss::MPTokenAuthorize;
+                env(jv, ter(tesSUCCESS));
+                env.close();
+            }
+
+            // Escrow 60% of shares
+            auto const escrowAmount =
+                shares(Number{6, vaultSle->at(sfScale) + 1});
+            env(escrow::create(depositor, bob, escrowAmount),
+                escrow::condition(escrow::cb1),
+                escrow::finish_time(env.now() + 1s),
+                fee(baseFee * 150),
+                ter(tesSUCCESS));
+            env.close();
+
+            // Zero-amount clawback ("all") — should only recover assets
+            // corresponding to unlocked shares (40%)
+            env(vault.clawback({
+                    .issuer = issuer,
+                    .id = vaultKeylet.key,
+                    .holder = depositor,
+                }),
+                ter(tesSUCCESS));
+            env.close();
+
+            {
+                auto const sle = env.le(vaultKeylet);
+                BEAST_EXPECT(sle != nullptr);
+                // Only 40 of 100 assets recovered (matching 40%
+                // unlocked shares)
+                BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(60).value());
+                BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(60).value());
+
+                // Depositor's unlocked shares are now 0
+                auto const sharesAfter = env.balance(depositor, shares);
+                BEAST_EXPECT(sharesAfter == shares(0));
+            }
+        }
     }
 
     void
@@ -6078,6 +6710,7 @@ public:
         testDelegate();
         testVaultClawbackBurnShares();
         testVaultClawbackAssets();
+        testVaultEscrowedMPT();
         testAssetsMaximum();
     }
 };

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -5919,7 +5919,8 @@ class Vault_test : public beast::unit_test::suite
                 env(set(owner, vaultKeylet.key));
                 env.close();
 
-                // Depositor borrows 40 units: assetsAvailable=60, assetsTotal=100
+                // Depositor borrows 40 units: assetsAvailable=60,
+                // assetsTotal=100
                 env(set(depositor, brokerKeylet.key, asset(40).value()),
                     loan::interestRate(TenthBips32(0)),
                     gracePeriod(60),
@@ -5932,7 +5933,8 @@ class Vault_test : public beast::unit_test::suite
 
                 {
                     auto const sle = env.le(vaultKeylet);
-                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(60).value());
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(60).value());
                     BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
                 }
 
@@ -5949,7 +5951,8 @@ class Vault_test : public beast::unit_test::suite
                 {
                     auto const sle = env.le(vaultKeylet);
                     BEAST_EXPECT(sle != nullptr);
-                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(30).value());
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(30).value());
                     BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(70).value());
                 }
             }
@@ -5957,7 +5960,8 @@ class Vault_test : public beast::unit_test::suite
             {
                 testcase(
                     "VaultClawback (asset) - " + prefix +
-                    " clawback exactly equal to available with outstanding loan");
+                    " clawback exactly equal to available with outstanding "
+                    "loan");
                 auto [vault, vaultKeylet] =
                     setupVault(asset, owner, depositor, issuer);
 
@@ -5972,7 +5976,8 @@ class Vault_test : public beast::unit_test::suite
                 env(set(owner, vaultKeylet.key));
                 env.close();
 
-                // Depositor borrows 40 units: assetsAvailable=60, assetsTotal=100
+                // Depositor borrows 40 units: assetsAvailable=60,
+                // assetsTotal=100
                 env(set(depositor, brokerKeylet.key, asset(40).value()),
                     loan::interestRate(TenthBips32(0)),
                     gracePeriod(60),
@@ -5996,7 +6001,8 @@ class Vault_test : public beast::unit_test::suite
                 {
                     auto const sle = env.le(vaultKeylet);
                     BEAST_EXPECT(sle != nullptr);
-                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(0).value());
                     BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(40).value());
                 }
             }
@@ -6019,7 +6025,8 @@ class Vault_test : public beast::unit_test::suite
                 env(set(owner, vaultKeylet.key));
                 env.close();
 
-                // Depositor borrows all 100 units: assetsAvailable=0, assetsTotal=100
+                // Depositor borrows all 100 units: assetsAvailable=0,
+                // assetsTotal=100
                 env(set(depositor, brokerKeylet.key, asset(100).value()),
                     loan::interestRate(TenthBips32(0)),
                     gracePeriod(60),
@@ -6032,7 +6039,8 @@ class Vault_test : public beast::unit_test::suite
 
                 {
                     auto const sle = env.le(vaultKeylet);
-                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(0).value());
                     BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
                 }
 
@@ -6062,7 +6070,8 @@ class Vault_test : public beast::unit_test::suite
                     // Nothing changed — vault and shares unchanged
                     auto const sle = env.le(vaultKeylet);
                     BEAST_EXPECT(sle != nullptr);
-                    BEAST_EXPECT(sle->at(sfAssetsAvailable) == asset(0).value());
+                    BEAST_EXPECT(
+                        sle->at(sfAssetsAvailable) == asset(0).value());
                     BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(100).value());
                     auto const sharesAfter = env.balance(depositor, shares);
                     BEAST_EXPECT(sharesAfter == sharesBefore);
@@ -6243,8 +6252,7 @@ class Vault_test : public beast::unit_test::suite
 
             {
                 auto const sle = env.le(vaultKeylet);
-                BEAST_EXPECT(
-                    sle->at(sfAssetsTotal) == asset(40).value());
+                BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(40).value());
             }
 
             // Clean up escrow
@@ -6339,8 +6347,7 @@ class Vault_test : public beast::unit_test::suite
 
             {
                 auto const sle = env.le(vaultKeylet);
-                BEAST_EXPECT(
-                    sle->at(sfAssetsTotal) == asset(60).value());
+                BEAST_EXPECT(sle->at(sfAssetsTotal) == asset(60).value());
             }
         }
 

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -5911,7 +5911,6 @@ class Vault_test : public beast::unit_test::suite
                 BEAST_EXPECT(vaultSle != nullptr);
                 if (!vaultSle)
                     return;
-                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
 
                 // Create a loan broker backed by this vault
                 auto const brokerKeylet =
@@ -5969,7 +5968,6 @@ class Vault_test : public beast::unit_test::suite
                 BEAST_EXPECT(vaultSle != nullptr);
                 if (!vaultSle)
                     return;
-                PrettyAsset shares = MPTIssue(vaultSle->at(sfShareMPTID));
 
                 auto const brokerKeylet =
                     keylet::loanbroker(owner.id(), env.seq(owner));

--- a/src/xrpld/app/tx/detail/VaultClawback.cpp
+++ b/src/xrpld/app/tx/detail/VaultClawback.cpp
@@ -22,6 +22,7 @@
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/ledger/View.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/MPTIssue.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STAmount.h>
@@ -257,7 +258,12 @@ VaultClawback::assetsToClawback(
     auto const mptIssuanceID = *vault->at(sfShareMPTID);
     MPTIssue const share{mptIssuanceID};
 
-    if (clawbackAmount == beast::zero)
+    // Pre-fixSecurity3_1_3: zero-amount clawback returned early without
+    // clamping to assetsAvailable, allowing more assets to be recovered
+    // than available when there was an outstanding loan. Retained for
+    // ledger replay compatibility.
+    if (!ctx_.view().rules().enabled(fixSecurity3_1_3) &&
+        clawbackAmount == beast::zero)
     {
         auto const sharesDestroyed = accountHolds(
             view(),
@@ -275,23 +281,42 @@ VaultClawback::assetsToClawback(
     }
 
     STAmount sharesDestroyed;
-    STAmount assetsRecovered = clawbackAmount;
+    STAmount assetsRecovered;
+
     try
     {
+        if (clawbackAmount == beast::zero)
         {
-            auto const maybeShares = assetsToSharesWithdraw(
-                vault, sleShareIssuance, assetsRecovered);
-            if (!maybeShares)
+            sharesDestroyed = accountHolds(
+                view(),
+                holder,
+                share,
+                FreezeHandling::fhIGNORE_FREEZE,
+                AuthHandling::ahIGNORE_AUTH,
+                j_);
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault, sleShareIssuance, sharesDestroyed);
+            if (!maybeAssets)
                 return Unexpected(tecINTERNAL);  // LCOV_EXCL_LINE
-            sharesDestroyed = *maybeShares;
+
+            assetsRecovered = *maybeAssets;
         }
+        else
+        {
+            {
+                auto const maybeShares = assetsToSharesWithdraw(
+                    vault, sleShareIssuance, clawbackAmount);
+                if (!maybeShares)
+                    return Unexpected(tecINTERNAL);  // LCOV_EXCL_LINE
+                sharesDestroyed = *maybeShares;
+            }
 
-        auto const maybeAssets =
-            sharesToAssetsWithdraw(vault, sleShareIssuance, sharesDestroyed);
-        if (!maybeAssets)
-            return Unexpected(tecINTERNAL);  // LCOV_EXCL_LINE
-        assetsRecovered = *maybeAssets;
-
+            auto const maybeAssets = sharesToAssetsWithdraw(
+                vault, sleShareIssuance, sharesDestroyed);
+            if (!maybeAssets)
+                return Unexpected(tecINTERNAL);  // LCOV_EXCL_LINE
+            assetsRecovered = *maybeAssets;
+        }
         // Clamp to maximum.
         if (assetsRecovered > *assetsAvailable)
         {
@@ -371,7 +396,7 @@ VaultClawback::doApply()
         lossUnrealized <= (assetsTotal - assetsAvailable),
         "ripple::VaultClawback::doApply : loss and assets do balance");
 
-    AccountID holder = tx[sfHolder];
+    AccountID const holder = tx[sfHolder];
     STAmount sharesDestroyed = {share};
     STAmount assetsRecovered = {vault->at(sfAsset)};
 


### PR DESCRIPTION
This is a port of https://github.com/XRPLF/rippled/pull/6646 for the older version of the `rippled` codebase.

## Summary

- **Fix**: Zero-amount `VaultClawback` (meaning "clawback all") now clamps recovered assets to `assetsAvailable` when there is an outstanding loan, preventing recovery of more assets than are actually available. The old unclamped behavior is preserved behind the `fixSecurity3_1_3` amendment gate for ledger replay compatibility.
- **Fix**: Non-zero clawback path now passes the original `clawbackAmount` (rather than `assetsRecovered`) to `assetsToSharesWithdraw`, ensuring correct share-to-asset conversion before clamping.
- **Test**: Added boundary condition tests for clawback with outstanding loans (zero-amount clamped, non-zero clamped, partial, exact boundary, fully borrowed).
- **Test**: Added pre-`fixSecurity3_1_3` legacy path coverage verifying the old behavior triggers `tefINTERNAL`.
- **Test**: Added `testVaultEscrowedMPT` verifying vault deposit/withdraw/clawback correctly respect escrowed (locked) MPT tokens.
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
