### PR TITLE
fix: Add null check for txRead result in GetAggregatePrice

### DIFF
--- a/src/xrpld/rpc/handlers/GetAggregatePrice.cpp
+++ b/src/xrpld/rpc/handlers/GetAggregatePrice.cpp
@@ -70,6 +70,8 @@ iteratePriceData(
             return;  // LCOV_EXCL_LINE
 
         meta = ledger->txRead(prevTx).second;
+        if (!meta)
+            return;
 
         prevChain = chain;
         for (STObject const& node : meta->getFieldArray(sfAffectedNodes))


### PR DESCRIPTION
## High Level Overview of Change

Add a missing null check 