### PR TITLE
test: Improve test coverage for tecDIR_FULL error in xrpld

### DIFF
--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -301,7 +301,7 @@ dirLink(
     auto const page =
         view.dirInsert(keylet::ownerDir(owner), object->key(), describeOwnerDir(owner));
     if (!page)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
     object->setFieldU64(node, *page);
     return tesSUCCESS;
 }

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -765,7 +765,7 @@ createMPToken(
         view.dirInsert(keylet::ownerDir(account), mptokenKey, describeOwnerDir(account));
 
     if (!ownerNode)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     auto mptoken = std::make_shared<SLE>(mptokenKey);
     (*mptoken)[sfAccount] = account;

--- a/src/libxrpl/ledger/helpers/NFTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/NFTokenHelpers.cpp
@@ -959,7 +959,7 @@ tokenOfferCreateApply(
             view.dirInsert(keylet::ownerDir(acctID), offerID, describeOwnerDir(acctID));
 
         if (!ownerNode)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         bool const isSellOffer = (txFlags & tfSellNFToken) != 0u;
 
@@ -974,7 +974,7 @@ tokenOfferCreateApply(
             });
 
         if (!offerNode)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         std::uint32_t sleFlags = 0;
 

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -199,13 +199,13 @@ trustCreate(
         keylet::ownerDir(uLowAccountID), sleRippleState->key(), describeOwnerDir(uLowAccountID));
 
     if (!lowNode)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     auto highNode = view.dirInsert(
         keylet::ownerDir(uHighAccountID), sleRippleState->key(), describeOwnerDir(uHighAccountID));
 
     if (!highNode)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     bool const bSetDst = saLimit.getIssuer() == uDstAccountID;
     bool const bSetHigh = bSrcHigh ^ bSetDst;

--- a/src/libxrpl/tx/transactors/account/SignerListSet.cpp
+++ b/src/libxrpl/tx/transactors/account/SignerListSet.cpp
@@ -323,7 +323,7 @@ SignerListSet::replaceSignerList()
                      << (page ? "success" : "failure");
 
     if (!page)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     signerList->setFieldU64(sfOwnerNode, *page);
 

--- a/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
+++ b/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
@@ -1109,12 +1109,12 @@ applyCreateAccountAttestations(
         auto const page = psb.dirInsert(
             keylet::ownerDir(doorAccount), claimIDKeylet, describeOwnerDir(doorAccount));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*createdSleClaimID)[sfOwnerNode] = *page;
 
         auto const sleDoor = psb.peek(doorK);
         if (!sleDoor)
-            return tecINTERNAL;  // LCOV_EXCL_LINE
+            return tecINTERNAL;
 
         // Reserve was already checked
         adjustOwnerCount(psb, sleDoor, 1, j);
@@ -1456,7 +1456,7 @@ XChainCreateBridge::doApply()
         auto const page = ctx_.view().dirInsert(
             keylet::ownerDir(account), bridgeKeylet, describeOwnerDir(account));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*sleBridge)[sfOwnerNode] = *page;
     }
 
@@ -2016,7 +2016,7 @@ XChainCreateClaimID::doApply()
         auto const page = ctx_.view().dirInsert(
             keylet::ownerDir(account), claimIDKeylet, describeOwnerDir(account));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*sleClaimID)[sfOwnerNode] = *page;
     }
 

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -206,7 +206,7 @@ CheckCreate::doApply()
                          << ": " << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         sleCheck->setFieldU64(sfDestinationNode, *page);
     }
@@ -219,7 +219,7 @@ CheckCreate::doApply()
                          << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         sleCheck->setFieldU64(sfOwnerNode, *page);
     }

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -97,7 +97,7 @@ DelegateSet::doApply()
         ctx_.view().dirInsert(keylet::ownerDir(account_), delegateKey, describeOwnerDir(account_));
 
     if (!page)
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
 
     (*sle)[sfOwnerNode] = *page;
     ctx_.view().insert(sle);

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -522,7 +522,7 @@ OfferCreate::applyHybrid(
     if (!bookNode)
     {
         JLOG(j_.debug()) << "final result: failed to add hybrid offer to open book";
-        return tecDIR_FULL;  // LCOV_EXCL_LINE
+        return tecDIR_FULL;
     }
 
     STArray bookArr(sfAdditionalBooks, 1);
@@ -799,10 +799,8 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
 
     if (!ownerNode)
     {
-        // LCOV_EXCL_START
         JLOG(j_.debug()) << "final result: failed to add offer to owner's directory";
         return {tecDIR_FULL, true};
-        // LCOV_EXCL_STOP
     }
 
     // Update owner count.
@@ -853,10 +851,8 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
 
     if (!bookNode)
     {
-        // LCOV_EXCL_START
         JLOG(j_.debug()) << "final result: failed to add offer to book";
         return {tecDIR_FULL, true};
-        // LCOV_EXCL_STOP
     }
 
     auto sleOffer = std::make_shared<SLE>(offer_index);

--- a/src/libxrpl/tx/transactors/did/DIDSet.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDSet.cpp
@@ -72,7 +72,7 @@ addSLE(ApplyContext& ctx, std::shared_ptr<SLE> const& sle, AccountID const& owne
         auto page =
             ctx.view().dirInsert(keylet::ownerDir(owner), sle->key(), describeOwnerDir(owner));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
         (*sle)[sfOwnerNode] = *page;
     }
     adjustOwnerCount(ctx.view(), sleAccount, 1, ctx.journal);

--- a/src/libxrpl/tx/transactors/oracle/OracleSet.cpp
+++ b/src/libxrpl/tx/transactors/oracle/OracleSet.cpp
@@ -294,7 +294,7 @@ OracleSet::doApply()
         auto page = ctx_.view().dirInsert(
             keylet::ownerDir(account_), sle->key(), describeOwnerDir(account_));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         (*sle)[sfOwnerNode] = *page;
 

--- a/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
+++ b/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
@@ -167,7 +167,7 @@ DepositPreauth::doApply()
                          << to_string(preauthKeylet.key) << ": " << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         slePreauth->setFieldU64(sfOwnerNode, *page);
 
@@ -228,7 +228,7 @@ DepositPreauth::doApply()
                          << ": " << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         slePreauth->setFieldU64(sfOwnerNode, *page);
 

--- a/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainSet.cpp
+++ b/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainSet.cpp
@@ -107,7 +107,7 @@ PermissionedDomainSet::doApply()
         auto const page =
             view().dirInsert(keylet::ownerDir(account_), pdKeylet, describeOwnerDir(account_));
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         slePd->setFieldU64(sfOwnerNode, *page);
         // If we succeeded, the new entry counts against the creator's reserve.

--- a/src/libxrpl/tx/transactors/system/TicketCreate.cpp
+++ b/src/libxrpl/tx/transactors/system/TicketCreate.cpp
@@ -101,7 +101,7 @@ TicketCreate::doApply()
                          << (page ? "success" : "failure");
 
         if (!page)
-            return tecDIR_FULL;  // LCOV_EXCL_LINE
+            return tecDIR_FULL;
 
         sleTicket->setFieldU64(sfOwnerNode, *page);
     }

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
@@ -96,7 +96,7 @@ MPTokenIssuanceCreate::create(ApplyView& view, beast::Journal journal, MPTCreate
             keylet::ownerDir(args.account), mptIssuanceKeylet, describeOwnerDir(args.account));
 
         if (!ownerNode)
-            return Unexpected(tecDIR_FULL);  // LCOV_EXCL_LINE
+            return Unexpected(tecDIR_FULL);
 
         auto mptIssuance = std::make_shared<SLE>(mptIssuanceKeylet);
         (*mptIssuance)[sfFlags] = args.flags & ~tfUniversal;

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -272,7 +272,7 @@ class Check_test : public beast::unit_test::suite
 
         Env env{*this, features};
 
-        STAmount const startBalance{XRP(1000).value()};
+        STAmount const startBalance{XRP(5000).value()};
         env.fund(startBalance, gw1, gwF, alice, bob);
         env.close();
 
@@ -440,6 +440,36 @@ class Check_test : public beast::unit_test::suite
 
         env(check::create(cheri, bob, USD(50)));
         env.close();
+    }
+
+    void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+
+        using namespace test::jtx;
+        using namespace ::xrpl::test::jtx::directory;
+
+        Account const alice{"alice"};
+        Account const bob{"bob"};
+
+        Env env{*this, features};
+        env.fund(XRP(10000), alice, bob);
+        env.close();
+
+        auto const bobDir = keylet::ownerDir(bob.id());
+        auto const n1 = getIndexCountToBump(env, bobDir);
+        env(ticket::create(bob, n1));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+        env(check::create(alice, bob, XRP(1)), ter(tecDIR_FULL));
+
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n2 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n2));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        env(check::create(alice, bob, XRP(1)), ter(tecDIR_FULL));
     }
 
     void
@@ -2435,6 +2465,7 @@ class Check_test : public beast::unit_test::suite
         testCreateValid(features);
         testCreateDisallowIncoming(features);
         testCreateInvalid(features);
+        testDirectoryFull(features);
         testCashXRP(features);
         testCashIOU(features);
         testCashXferFee(features);

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -511,16 +511,12 @@ struct Credentials_test : public beast::unit_test::suite
             {
                 testcase("Credentials fail, directory full");
                 std::uint32_t const issuerSeq{env.seq(issuer) + 1};
-                env(ticket::create(issuer, 63));
-                env.close();
 
+                auto const issuerDir = keylet::ownerDir(issuer.id());
+                auto const n1 = directory::getIndexCountToBump(env, issuerDir);
+                env(ticket::create(issuer, n1)); env.close();
                 // Everything below can only be tested on open ledger.
-                auto const res1 = directory::bumpLastPage(
-                    env,
-                    directory::maximumPageIndex(env),
-                    keylet::ownerDir(issuer.id()),
-                    directory::adjustOwnerNode);
-                BEAST_EXPECT(res1);
+                BEAST_EXPECT(directory::bumpLastPage(env, directory::maximumPageIndex(env), issuerDir, directory::adjustOwnerNode));
 
                 // NOLINTNEXTLINE(readability-suspicious-call-argument)
                 auto const jv = credentials::create(issuer, subject, credType);
@@ -529,13 +525,10 @@ struct Credentials_test : public beast::unit_test::suite
                 env(noop(issuer), ticket::use(issuerSeq + 40));
 
                 // Fill subject directory
-                env(ticket::create(subject, 63));
-                auto const res2 = directory::bumpLastPage(
-                    env,
-                    directory::maximumPageIndex(env),
-                    keylet::ownerDir(subject.id()),
-                    directory::adjustOwnerNode);
-                BEAST_EXPECT(res2);
+                auto const subjectDir = keylet::ownerDir(subject.id());
+                auto const n2 = directory::getIndexCountToBump(env, subjectDir);
+                env(ticket::create(subject, n2));
+                BEAST_EXPECT(directory::bumpLastPage(env, directory::maximumPageIndex(env), subjectDir, directory::adjustOwnerNode));
                 env(jv, ter(tecDIR_FULL));
 
                 // End test

--- a/src/test/app/DID_test.cpp
+++ b/src/test/app/DID_test.cpp
@@ -1,5 +1,6 @@
 #include <test/jtx.h>
 
+#include <xrpl/ledger/Dir.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 
@@ -346,6 +347,30 @@ struct DID_test : public beast::unit_test::suite
     }
 
     void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+
+        using namespace jtx;
+        using namespace ::xrpl::test::jtx::directory;
+
+        Account const alice{"alice"};
+
+        Env env{*this, features};
+        env.fund(XRP(10000), alice);
+        env.close();
+
+
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        env(did::setValid(alice), ter(tecDIR_FULL));
+        env.close();
+    }
+
+    void
     run() override
     {
         using namespace test::jtx;
@@ -357,6 +382,7 @@ struct DID_test : public beast::unit_test::suite
         testDeleteInvalid(all);
         testSetValidInitial(all);
         testSetModify(all);
+        testDirectoryFull(all);
 
         testEnabled(all - emptyDID);
         testAccountReserve(all - emptyDID);

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -193,6 +193,15 @@ class Delegate_test : public beast::unit_test::suite
             env(delegate::set(gw, alice, {"SetFee"}), ter(temMALFORMED));
             env(delegate::set(gw, alice, {"Batch"}), ter(temMALFORMED));
         }
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const aliceDir = keylet::ownerDir(alice.id());
+            auto const n = getIndexCountToBump(env, aliceDir);
+            env(ticket::create(alice, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+            env(delegate::set(alice, bob, {"Payment"}), ter(tecDIR_FULL));
+        }
     }
 
     void

--- a/src/test/app/EscrowToken_test.cpp
+++ b/src/test/app/EscrowToken_test.cpp
@@ -2656,6 +2656,46 @@ struct EscrowToken_test : public beast::unit_test::suite
             env.close();
         }
 
+        // tecDir_FULL: bob submits; directory full
+        {
+            Env env{*this, features};
+            auto const baseFee = env.current()->fees().base;
+            auto const alice = Account("alice");
+            auto const bob = Account("bob");
+            auto const gw = Account("gw");
+            env.fund(XRP(10'000), bob);
+            env.close();
+
+            MPTTester mptGw(env, gw, {.holders = {alice}});
+            mptGw.create(
+                {.ownerCount = 1, .holderCount = 0, .flags = tfMPTCanEscrow | tfMPTCanTransfer});
+            mptGw.authorize({.account = alice});
+            auto const MPT = mptGw["MPT"];
+            env(pay(gw, alice, MPT(10'000)));
+            env.close();
+
+            auto const seq1 = env.seq(alice);
+            env(escrow::create(alice, bob, MPT(10)),
+                escrow::condition(escrow::cb1),
+                escrow::finish_time(env.now() + 1s),
+                fee(baseFee * 150),
+                ter(tesSUCCESS));
+            env.close();
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const bobDir = keylet::ownerDir(bob.id());
+            auto const n = getIndexCountToBump(env, bobDir);
+            env(ticket::create(bob, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(escrow::finish(bob, alice, seq1),
+                escrow::condition(escrow::cb1),
+                escrow::fulfillment(escrow::fb1),
+                fee(baseFee * 150),
+                ter(tecDIR_FULL));
+            env.close();
+        }
+
         // tecNO_PERMISSION: carol submits; finish MPT not created
         {
             Env env{*this, features};

--- a/src/test/app/Escrow_test.cpp
+++ b/src/test/app/Escrow_test.cpp
@@ -1561,6 +1561,72 @@ struct Escrow_test : public beast::unit_test::suite
     }
 
     void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+        using namespace jtx;
+        using namespace std::chrono;
+
+        Env env(*this, features);
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const USD = gw["USD"];
+        auto const EUR = gw["EUR"];
+        auto const GBP = gw["GBP"];
+
+        env.fund(XRP(10000), gw, alice, bob);
+        env(fset(gw, asfAllowTrustLineLocking));
+        env.close();
+
+        env.trust(USD(10000), alice);
+        env.close();
+
+        env(pay(gw, alice, USD(10000)));
+
+        std::uint32_t const noopSeq{env.seq(alice) + 1};
+        env.close();
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1));
+        env.close();
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+        env(escrow::create(alice, bob, USD(1000)),
+            escrow::finish_time(env.now() + 1h),
+            ter(tecDIR_FULL));
+
+        env(trust(alice, EUR(10000)), ter(tecDIR_FULL));
+        env.close();
+
+        env(noop(alice), ticket::use(noopSeq));
+
+        auto const bobDir = keylet::ownerDir(bob.id());
+        auto const n2 = getIndexCountToBump(env, bobDir);
+        env(ticket::create(bob, n2));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+        env(escrow::create(alice, bob, USD(1000)),
+            escrow::finish_time(env.now() + 1h),
+            ter(tecDIR_FULL));
+        env.close();
+
+        // add issuer somehow
+        env(noop(alice), ticket::use(noopSeq + 1));
+        auto const gwDir = keylet::ownerDir(gw.id());
+        auto const n3 = getIndexCountToBump(env, gwDir);
+        env(ticket::create(gw, n3));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), gwDir, adjustOwnerNode));
+
+        env(escrow::create(alice, bob, USD(1000)),
+            escrow::finish_time(env.now() + 1h),
+            ter(tecDIR_FULL));
+        env(trust(alice, GBP(10000)), ter(tecDIR_FULL));
+        env.close();
+    }
+
+    void
     testWithFeats(FeatureBitset features)
     {
         testEnablement(features);
@@ -1583,6 +1649,7 @@ public:
     {
         using namespace test::jtx;
         FeatureBitset const all{testable_amendments()};
+        testDirectoryFull(all);
         testWithFeats(all);
         testWithFeats(all - featureTokenEscrow);
         testTags(all - fixIncludeKeyletFields);

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -329,6 +329,19 @@ class MPToken_test : public beast::unit_test::suite
             mptAlice.authorize({.account = bob, .id = id, .err = tecOBJECT_NOT_FOUND});
         }
 
+        {
+            Env env{*this, features};
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const aliceDir = keylet::ownerDir(alice.id());
+            auto const n = getIndexCountToBump(env, aliceDir);
+            env(ticket::create(alice, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+            env(mptAlice.createJV({.issuer = alice, .ownerCount = 1}), ter(tecDIR_FULL));
+        }
+
         // Test bad scenarios without allowlisting in MPTokenAuthorize
         // (preclaim)
         {

--- a/src/test/app/MultiSign_test.cpp
+++ b/src/test/app/MultiSign_test.cpp
@@ -117,7 +117,7 @@ public:
         using namespace jtx;
         Env env{*this, features};
         Account const alice{"alice", KeyType::ed25519};
-        env.fund(XRP(1000), alice);
+        env.fund(XRP(10000), alice);
         env.close();
 
         // Add alice as a multisigner for herself.  Should fail.
@@ -179,6 +179,13 @@ public:
             ter(temMALFORMED));
         env.close();
         env.require(owners(alice, 0));
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n2 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n2));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+        env(signers(alice, 1, {{bogie, 1}, {demon, 1}}), ter(tecDIR_FULL));
     }
 
     void

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -786,11 +786,36 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 
         // We don't care whether the offer is fully funded until the offer is
         // accepted.  Success at last!
-        env(token::createOffer(buyer, nftAlice0ID, gwAUD(1000)),
+        env(token::createOffer(buyer, nftAlice0ID, gwAUD(10)),
             token::owner(alice),
             ter(tesSUCCESS));
         env.close();
         BEAST_EXPECT(ownerCount(env, buyer) == 2);
+
+        {
+            env(pay(env.master, buyer, XRP(10000)));
+            env.close();
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const nftDir = keylet::nft_buys(nftAlice0ID);
+            auto const n1 = getIndexCountToBump(env, nftDir);
+            for (auto i=1; i<=n1; ++i)
+                env(token::createOffer(buyer, nftAlice0ID, gwAUD(i)), token::owner(alice));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), nftDir, adjustOwnerNode));
+
+            env(token::createOffer(buyer, nftAlice0ID, gwAUD(1)),
+                token::owner(alice),
+                ter(tecDIR_FULL));
+
+            auto const buyerDir = keylet::ownerDir(buyer.id());
+            auto const n = getIndexCountToBump(env, buyerDir);
+            env(ticket::create(buyer, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), buyerDir, adjustOwnerNode));
+
+            env(token::createOffer(buyer, nftAlice0ID, gwAUD(1)),
+                token::owner(alice),
+                ter(tecDIR_FULL));
+        }
     }
 
     void

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -707,6 +707,61 @@ public:
         }
     }
 
+    void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+
+        using namespace jtx;
+
+        Env env{*this, features};
+
+        auto const gw = Account{"gateway"};
+        auto const alice = Account{"alice"};
+        auto const bob = Account{"bob"};
+        auto const USD = gw["USD"];
+        auto const EUR = gw["EUR"];
+        auto const GBP = gw["GBP"];
+
+        env.fund(XRP(10000), gw, alice, bob);
+        env.close();
+
+        env(rate(gw, 1.005));
+
+        env.trust(USD(10000), alice);
+        env.trust(EUR(10000), alice);
+        env.close();
+        env(pay(gw, alice, USD(10000)));
+        env(pay(gw, alice, EUR(10000)));
+
+        std::uint32_t const noopSeq{env.seq(alice) + 1};
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1 + 32));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        auto rate = getRate(EUR(50), USD(50));
+        env(offer(alice, USD(50), EUR(50)), ter(tecDIR_FULL));
+
+        env.close();
+
+        Book const book{USD.issue(), EUR.issue(), {}};
+        auto dir = keylet::quality(keylet::book(book), rate);
+        auto const n2 = getIndexCountToBump(env, dir);
+        for (auto i = 0; i < static_cast<int>(n2); ++i)
+        {
+            env(offer(alice, USD(50), EUR(50)), ticket::use(noopSeq + i + 1));
+            env.close();
+        }
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), dir, adjustOwnerNode));
+
+        env(offer(alice, USD(50), EUR(50)), ticket::use(noopSeq), ter(tecDIR_FULL));
+
+        // test for hybrid as well
+    }
+
     // Helper function that returns the Offers on an account.
     static std::vector<std::shared_ptr<SLE const>>
     offersOnAccount(jtx::Env& env, jtx::Account const& account)
@@ -5066,6 +5121,7 @@ public:
     void
     testAll(FeatureBitset features)
     {
+        testDirectoryFull(features);
         testCanceledOffer(features);
         testRmFundedOffer(features);
         testTinyPayment(features);

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -49,18 +49,17 @@ private:
             Oracle oracle(
                 env, {.owner = owner, .fee = static_cast<int>(env.current()->fees().base.drops())});
             BEAST_EXPECT(oracle.exists());
-            oracle.set(
-                UpdateArg{
-                    .series =
-                        {
-                            {"XRP", "EUR", 740, 1},
-                            {"XRP", "GBP", 740, 1},
-                            {"XRP", "CNY", 740, 1},
-                            {"XRP", "CAD", 740, 1},
-                            {"XRP", "AUD", 740, 1},
-                        },
-                    .fee = static_cast<int>(env.current()->fees().base.drops()),
-                    .err = ter(tecINSUFFICIENT_RESERVE)});
+            oracle.set(UpdateArg{
+                .series =
+                    {
+                        {"XRP", "EUR", 740, 1},
+                        {"XRP", "GBP", 740, 1},
+                        {"XRP", "CNY", 740, 1},
+                        {"XRP", "CAD", 740, 1},
+                        {"XRP", "AUD", 740, 1},
+                    },
+                .fee = static_cast<int>(env.current()->fees().base.drops()),
+                .err = ter(tecINSUFFICIENT_RESERVE)});
         }
 
         {
@@ -74,49 +73,44 @@ private:
                 CreateArg{.flags = tfSellNFToken, .fee = baseFee, .err = ter(temINVALID_FLAG)});
 
             // Duplicate token pair
-            oracle.set(
-                CreateArg{
-                    .series = {{"XRP", "USD", 740, 1}, {"XRP", "USD", 750, 1}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(CreateArg{
+                .series = {{"XRP", "USD", 740, 1}, {"XRP", "USD", 750, 1}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
 
             // Price is not included
-            oracle.set(
-                CreateArg{
-                    .series = {{"XRP", "USD", 740, 1}, {"XRP", "EUR", std::nullopt, 1}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(CreateArg{
+                .series = {{"XRP", "USD", 740, 1}, {"XRP", "EUR", std::nullopt, 1}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
 
             // Token pair is in update and delete
-            oracle.set(
-                CreateArg{
-                    .series = {{"XRP", "USD", 740, 1}, {"XRP", "USD", std::nullopt, 1}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(CreateArg{
+                .series = {{"XRP", "USD", 740, 1}, {"XRP", "USD", std::nullopt, 1}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
             // Token pair is in add and delete
-            oracle.set(
-                CreateArg{
-                    .series = {{"XRP", "EUR", 740, 1}, {"XRP", "EUR", std::nullopt, 1}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(CreateArg{
+                .series = {{"XRP", "EUR", 740, 1}, {"XRP", "EUR", std::nullopt, 1}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
 
             // Array of token pair is 0 or exceeds 10
-            oracle.set(
-                CreateArg{
-                    .series =
-                        {{"XRP", "US1", 740, 1},
-                         {"XRP", "US2", 750, 1},
-                         {"XRP", "US3", 740, 1},
-                         {"XRP", "US4", 750, 1},
-                         {"XRP", "US5", 740, 1},
-                         {"XRP", "US6", 750, 1},
-                         {"XRP", "US7", 740, 1},
-                         {"XRP", "US8", 750, 1},
-                         {"XRP", "US9", 740, 1},
-                         {"XRP", "U10", 750, 1},
-                         {"XRP", "U11", 740, 1}},
-                    .fee = baseFee,
-                    .err = ter(temARRAY_TOO_LARGE)});
+            oracle.set(CreateArg{
+                .series =
+                    {{"XRP", "US1", 740, 1},
+                     {"XRP", "US2", 750, 1},
+                     {"XRP", "US3", 740, 1},
+                     {"XRP", "US4", 750, 1},
+                     {"XRP", "US5", 740, 1},
+                     {"XRP", "US6", 750, 1},
+                     {"XRP", "US7", 740, 1},
+                     {"XRP", "US8", 750, 1},
+                     {"XRP", "US9", 740, 1},
+                     {"XRP", "U10", 750, 1},
+                     {"XRP", "U11", 740, 1}},
+                .fee = baseFee,
+                .err = ter(temARRAY_TOO_LARGE)});
             oracle.set(CreateArg{.series = {}, .fee = baseFee, .err = ter(temARRAY_EMPTY)});
         }
 
@@ -129,23 +123,22 @@ private:
             Oracle oracle(
                 env,
                 CreateArg{.owner = owner, .series = {{{"XRP", "USD", 740, 1}}}, .fee = baseFee});
-            oracle.set(
-                UpdateArg{
-                    .series =
-                        {
-                            {"XRP", "US1", 740, 1},
-                            {"XRP", "US2", 750, 1},
-                            {"XRP", "US3", 740, 1},
-                            {"XRP", "US4", 750, 1},
-                            {"XRP", "US5", 740, 1},
-                            {"XRP", "US6", 750, 1},
-                            {"XRP", "US7", 740, 1},
-                            {"XRP", "US8", 750, 1},
-                            {"XRP", "US9", 740, 1},
-                            {"XRP", "U10", 750, 1},
-                        },
-                    .fee = baseFee,
-                    .err = ter(tecARRAY_TOO_LARGE)});
+            oracle.set(UpdateArg{
+                .series =
+                    {
+                        {"XRP", "US1", 740, 1},
+                        {"XRP", "US2", 750, 1},
+                        {"XRP", "US3", 740, 1},
+                        {"XRP", "US4", 750, 1},
+                        {"XRP", "US5", 740, 1},
+                        {"XRP", "US6", 750, 1},
+                        {"XRP", "US7", 740, 1},
+                        {"XRP", "US8", 750, 1},
+                        {"XRP", "US9", 740, 1},
+                        {"XRP", "U10", 750, 1},
+                    },
+                .fee = baseFee,
+                .err = ter(tecARRAY_TOO_LARGE)});
         }
 
         {
@@ -155,36 +148,32 @@ private:
             Oracle oracle(env, {.owner = owner, .fee = baseFee}, false);
 
             // Asset class or provider not included on create
-            oracle.set(
-                CreateArg{
-                    .assetClass = std::nullopt,
-                    .provider = "provider",
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
-            oracle.set(
-                CreateArg{
-                    .assetClass = "currency",
-                    .provider = std::nullopt,
-                    .uri = "URI",
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(CreateArg{
+                .assetClass = std::nullopt,
+                .provider = "provider",
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
+            oracle.set(CreateArg{
+                .assetClass = "currency",
+                .provider = std::nullopt,
+                .uri = "URI",
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
 
             // Asset class or provider are included on update
             // and don't match the current values
             oracle.set(CreateArg{.fee = static_cast<int>(env.current()->fees().base.drops())});
             BEAST_EXPECT(oracle.exists());
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .provider = "provider1",
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .assetClass = "currency1",
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 740, 1}},
+                .provider = "provider1",
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 740, 1}},
+                .assetClass = "currency1",
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
         }
 
         {
@@ -222,12 +211,11 @@ private:
             env.fund(XRP(1'000), some);
             Oracle oracle(env, {.owner = owner, .fee = baseFee});
             BEAST_EXPECT(oracle.exists());
-            oracle.set(
-                UpdateArg{
-                    .owner = some,
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(UpdateArg{
+                .owner = some,
+                .series = {{"XRP", "USD", 740, 1}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
         }
 
         {
@@ -245,36 +233,32 @@ private:
             BEAST_EXPECT(oracle.exists());
             env.close(seconds(400));
             // Less than the last close time - 300s
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .lastUpdateTime = static_cast<std::uint32_t>(closeTime() - 301),
-                    .fee = baseFee,
-                    .err = ter(tecINVALID_UPDATE_TIME)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 740, 1}},
+                .lastUpdateTime = static_cast<std::uint32_t>(closeTime() - 301),
+                .fee = baseFee,
+                .err = ter(tecINVALID_UPDATE_TIME)});
             // Greater than last close time + 300s
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .lastUpdateTime = static_cast<std::uint32_t>(closeTime() + 311),
-                    .fee = baseFee,
-                    .err = ter(tecINVALID_UPDATE_TIME)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 740, 1}},
+                .lastUpdateTime = static_cast<std::uint32_t>(closeTime() + 311),
+                .fee = baseFee,
+                .err = ter(tecINVALID_UPDATE_TIME)});
             oracle.set(UpdateArg{.series = {{"XRP", "USD", 740, 1}}, .fee = baseFee});
             BEAST_EXPECT(oracle.expectLastUpdateTime(
                 static_cast<std::uint32_t>(testStartTime.count() + 450)));
             // Less than the previous lastUpdateTime
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .lastUpdateTime = static_cast<std::uint32_t>(449),
-                    .fee = baseFee,
-                    .err = ter(tecINVALID_UPDATE_TIME)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 740, 1}},
+                .lastUpdateTime = static_cast<std::uint32_t>(449),
+                .fee = baseFee,
+                .err = ter(tecINVALID_UPDATE_TIME)});
             // Less than the epoch time
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 740, 1}},
-                    .lastUpdateTime = static_cast<int>(epoch_offset.count() - 1),
-                    .fee = baseFee,
-                    .err = ter(tecINVALID_UPDATE_TIME)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 740, 1}},
+                .lastUpdateTime = static_cast<int>(epoch_offset.count() - 1),
+                .fee = baseFee,
+                .err = ter(tecINVALID_UPDATE_TIME)});
         }
 
         {
@@ -284,17 +268,15 @@ private:
             env.fund(XRP(1'000), owner);
             Oracle oracle(env, {.owner = owner, .fee = baseFee});
             BEAST_EXPECT(oracle.exists());
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "EUR", std::nullopt, std::nullopt}},
-                    .fee = baseFee,
-                    .err = ter(tecTOKEN_PAIR_NOT_FOUND)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "EUR", std::nullopt, std::nullopt}},
+                .fee = baseFee,
+                .err = ter(tecTOKEN_PAIR_NOT_FOUND)});
             // delete all token pairs
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", std::nullopt, std::nullopt}},
-                    .fee = baseFee,
-                    .err = ter(tecARRAY_EMPTY)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", std::nullopt, std::nullopt}},
+                .fee = baseFee,
+                .err = ter(tecARRAY_EMPTY)});
         }
 
         {
@@ -329,24 +311,21 @@ private:
             auto const baseFee = static_cast<int>(env.current()->fees().base.drops());
             env.fund(XRP(1'000), owner);
             Oracle oracle(env, {.owner = owner, .fee = baseFee});
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "EUR", std::nullopt, std::nullopt}, {"XRP", "EUR", 740, 1}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "EUR", std::nullopt, std::nullopt}, {"XRP", "EUR", 740, 1}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
             // Delete token pair that doesn't exist in this oracle
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "EUR", std::nullopt, std::nullopt}},
-                    .fee = baseFee,
-                    .err = ter(tecTOKEN_PAIR_NOT_FOUND)});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "EUR", std::nullopt, std::nullopt}},
+                .fee = baseFee,
+                .err = ter(tecTOKEN_PAIR_NOT_FOUND)});
             // Delete token pair in oracle, which is not in the ledger
-            oracle.set(
-                UpdateArg{
-                    .documentID = 10,
-                    .series = {{"XRP", "EUR", std::nullopt, std::nullopt}},
-                    .fee = baseFee,
-                    .err = ter(temMALFORMED)});
+            oracle.set(UpdateArg{
+                .documentID = 10,
+                .series = {{"XRP", "EUR", std::nullopt, std::nullopt}},
+                .fee = baseFee,
+                .err = ter(temMALFORMED)});
         }
 
         {
@@ -357,6 +336,25 @@ private:
             Oracle const oracle1(
                 env, {.owner = owner, .fee = static_cast<int>(env.current()->fees().base.drops())});
             oracle.set(UpdateArg{.owner = owner, .fee = -1, .err = ter(temBAD_FEE)});
+        }
+        {
+            Env env(*this);
+            env.fund(XRP(10000), owner);
+
+            CreateArg arg{
+                .owner = owner,
+                .fee = static_cast<int>(env.current()->fees().base.drops()),
+                .err = ter(tecDIR_FULL)};
+            // Oracle closes env, which reverts changes made in bumpLastPage
+            Oracle oracle1(env, arg, false);
+
+            using namespace ::xrpl::test::jtx::directory;
+            auto const ownerDir = keylet::ownerDir(owner.id());
+            auto const n = getIndexCountToBump(env, ownerDir);
+            env(ticket::create(owner, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), ownerDir, adjustOwnerNode));
+
+            oracle1.set(arg);
         }
     }
 
@@ -570,39 +568,36 @@ private:
             BEAST_EXPECT(ownerCount(env, owner) == count);
 
             // update both pairs
-            oracle.set(
-                UpdateArg{
-                    .series = {{"XRP", "USD", 741, 2}, {"XRP", "EUR", 710, 2}}, .fee = baseFee});
+            oracle.set(UpdateArg{
+                .series = {{"XRP", "USD", 741, 2}, {"XRP", "EUR", 710, 2}}, .fee = baseFee});
             BEAST_EXPECT(oracle.expectPrice({{"XRP", "USD", 741, 2}, {"XRP", "EUR", 710, 2}}));
             // owner count is not changed since the number of pairs is 2
             BEAST_EXPECT(ownerCount(env, owner) == count);
 
             // owner count is increased by 1 since the number of pairs is 6
-            oracle.set(
-                UpdateArg{
-                    .series =
-                        {
-                            {"BTC", "USD", 741, 2},
-                            {"ETH", "EUR", 710, 2},
-                            {"YAN", "EUR", 710, 2},
-                            {"CAN", "EUR", 710, 2},
-                        },
-                    .fee = baseFee});
+            oracle.set(UpdateArg{
+                .series =
+                    {
+                        {"BTC", "USD", 741, 2},
+                        {"ETH", "EUR", 710, 2},
+                        {"YAN", "EUR", 710, 2},
+                        {"CAN", "EUR", 710, 2},
+                    },
+                .fee = baseFee});
             count += 1;
             BEAST_EXPECT(ownerCount(env, owner) == count);
 
             // update two pairs and delete four
             oracle.set(
                 UpdateArg{.series = {{"BTC", "USD", std::nullopt, std::nullopt}}, .fee = baseFee});
-            oracle.set(
-                UpdateArg{
-                    .series =
-                        {{"XRP", "USD", 742, 2},
-                         {"XRP", "EUR", 711, 2},
-                         {"ETH", "EUR", std::nullopt, std::nullopt},
-                         {"YAN", "EUR", std::nullopt, std::nullopt},
-                         {"CAN", "EUR", std::nullopt, std::nullopt}},
-                    .fee = baseFee});
+            oracle.set(UpdateArg{
+                .series =
+                    {{"XRP", "USD", 742, 2},
+                     {"XRP", "EUR", 711, 2},
+                     {"ETH", "EUR", std::nullopt, std::nullopt},
+                     {"YAN", "EUR", std::nullopt, std::nullopt},
+                     {"CAN", "EUR", std::nullopt, std::nullopt}},
+                .fee = baseFee});
             BEAST_EXPECT(oracle.expectPrice({{"XRP", "USD", 742, 2}, {"XRP", "EUR", 711, 2}}));
             // owner count is decreased by 1 since the number of pairs is 2
             count -= 1;
@@ -705,21 +700,18 @@ private:
         BEAST_EXPECT(oracle.exists());
 
         // Update
-        oracle.set(
-            UpdateArg{
-                .series = {{"XRP", "USD", 740, 1}},
-                .msig = msig(becky),
-                .fee = baseFee,
-                .err = ter(tefBAD_QUORUM)});
-        oracle.set(
-            UpdateArg{
-                .series = {{"XRP", "USD", 740, 1}},
-                .msig = msig(zelda),
-                .fee = baseFee,
-                .err = ter(tefBAD_SIGNATURE)});
-        oracle.set(
-            UpdateArg{
-                .series = {{"XRP", "USD", 741, 1}}, .msig = msig(becky, bogie), .fee = baseFee});
+        oracle.set(UpdateArg{
+            .series = {{"XRP", "USD", 740, 1}},
+            .msig = msig(becky),
+            .fee = baseFee,
+            .err = ter(tefBAD_QUORUM)});
+        oracle.set(UpdateArg{
+            .series = {{"XRP", "USD", 740, 1}},
+            .msig = msig(zelda),
+            .fee = baseFee,
+            .err = ter(tefBAD_SIGNATURE)});
+        oracle.set(UpdateArg{
+            .series = {{"XRP", "USD", 741, 1}}, .msig = msig(becky, bogie), .fee = baseFee});
         BEAST_EXPECT(oracle.expectPrice({{"XRP", "USD", 741, 1}}));
         // remove the signer list
         env(signers(alice, jtx::none), sig(alie));
@@ -729,16 +721,14 @@ private:
         env(signers(alice, 2, {{zelda, 1}, {bob, 1}, {ed, 2}}), sig(alie));
         env.close();
         // old list fails
-        oracle.set(
-            UpdateArg{
-                .series = {{"XRP", "USD", 740, 1}},
-                .msig = msig(becky, bogie),
-                .fee = baseFee,
-                .err = ter(tefBAD_SIGNATURE)});
+        oracle.set(UpdateArg{
+            .series = {{"XRP", "USD", 740, 1}},
+            .msig = msig(becky, bogie),
+            .fee = baseFee,
+            .err = ter(tefBAD_SIGNATURE)});
         // updated list succeeds
-        oracle.set(
-            UpdateArg{
-                .series = {{"XRP", "USD", 7412, 2}}, .msig = msig(zelda, bob), .fee = baseFee});
+        oracle.set(UpdateArg{
+            .series = {{"XRP", "USD", 7412, 2}}, .msig = msig(zelda, bob), .fee = baseFee});
         BEAST_EXPECT(oracle.expectPrice({{"XRP", "USD", 7412, 2}}));
         oracle.set(
             UpdateArg{.series = {{"XRP", "USD", 74245, 3}}, .msig = msig(ed), .fee = baseFee});

--- a/src/test/app/PayChan_test.cpp
+++ b/src/test/app/PayChan_test.cpp
@@ -274,6 +274,17 @@ struct PayChan_test : public beast::unit_test::suite
             env(create(cho, alice, XRP(1000), settleDelay, pk), ter(tesSUCCESS));
             BEAST_EXPECT(channelExists(*env.current(), chan));
         }
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const choDir = keylet::ownerDir(cho.id());
+            auto const n = getIndexCountToBump(env, choDir);
+            env(ticket::create(cho, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), choDir, adjustOwnerNode));
+
+            env(create(cho, alice, XRP(1000), settleDelay, pk), ter(tecDIR_FULL));
+            env(create(bob, cho, XRP(1000), settleDelay, pk), ter(tecDIR_FULL));
+        }
     }
 
     void

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -971,6 +971,17 @@ class PermissionedDEX_test : public beast::unit_test::suite
             env(offer(bob, XRP(10), USD(10)), txflags(tfHybrid), domain(domainID));
             env.close();
             BEAST_EXPECT(checkOffer(env, bob, offerSeq, XRP(10), USD(10), lsfHybrid, true));
+
+            // hybrid offer not created if book directory is full
+            using namespace ::xrpl::test::jtx::directory;
+            Book book{Issue(XRP), Issue(USD), std::nullopt};
+            auto const bobDir = keylet::quality(keylet::book(book), getRate(USD(10), XRP(10)));
+            auto const n = getIndexCountToBump(env, bobDir);
+            for (auto i = 0; i < n; ++i)
+                env(offer(bob, XRP(10), USD(10)), txflags(tfHybrid), domain(domainID));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(offer(bob, XRP(10), USD(10)), txflags(tfHybrid), domain(domainID), ter(tecDIR_FULL));
         }
 
         // apply - domain offer can cross with hybrid

--- a/src/test/app/PermissionedDomains_test.cpp
+++ b/src/test/app/PermissionedDomains_test.cpp
@@ -512,6 +512,25 @@ class PermissionedDomains_test : public beast::unit_test::suite
         BEAST_EXPECT(env.ownerCount(alice) == 1);
     }
 
+    void
+    testDirectoryFull(FeatureBitset features)
+    {
+        testcase("Directory full");
+        Account const alice("alice");
+        Env env(*this, features);
+        env.fund(XRP(10000), alice);
+
+        using namespace ::xrpl::test::jtx::directory;
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n));
+        env.close();
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        pdomain::Credentials credentials{{alice, "first credential"}};
+        env(pdomain::setTx(alice, credentials), ter(tecDIR_FULL));
+    }
+
 public:
     void
     run() override
@@ -526,6 +545,8 @@ public:
         testDelete(withFix_);
         testAccountReserve(withFeature_);
         testAccountReserve(withFix_);
+        testDirectoryFull(withFeature_);
+        testDirectoryFull(withFix_);
     }
 };
 

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -803,6 +803,29 @@ class Ticket_test : public beast::unit_test::suite
     }
 
     void
+    testDirectoryFull()
+    {
+        testcase("Directory full");
+
+        using namespace test::jtx;
+        using namespace ::xrpl::test::jtx::directory;
+
+        Env env{*this, testable_amendments()};
+        Account const alice{"alice"};
+
+        env.fund(XRP(10000), alice);
+        env.close();
+
+        auto const aliceDir = keylet::ownerDir(alice.id());
+        auto const n1 = getIndexCountToBump(env, aliceDir);
+        env(ticket::create(alice, n1));
+        BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), aliceDir, adjustOwnerNode));
+
+        env(ticket::create(alice, 1), ter(tecDIR_FULL));
+        env.close();
+    }
+
+    void
     testFixBothSeqAndTicket()
     {
         using namespace test::jtx;
@@ -839,6 +862,7 @@ public:
     void
     run() override
     {
+        testDirectoryFull();
         testTicketCreatePreflightFail();
         testTicketCreatePreclaimFail();
         testTicketInsufficientReserve();

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -487,6 +487,17 @@ struct XChain_test : public beast::unit_test::suite, public jtx::XChainBridgeObj
         XEnv(*this)
             .disableFeature(featureXChainBridge)
             .tx(create_bridge(mcAlice, jvb), ter(temDISABLED));
+
+        {
+            XEnv xenv(*this, true);
+            using namespace ::xrpl::test::jtx::directory;
+            auto const masterDir = keylet::ownerDir(Account::master.id());
+            auto const n = getIndexCountToBump(xenv.env_, masterDir);
+            xenv.tx(ticket::create(Account::master, n));
+            BEAST_EXPECT(bumpLastPage(xenv.env_, maximumPageIndex(xenv.env_), masterDir, adjustOwnerNode));
+
+            xenv.tx(create_bridge(Account::master, jvb), ter(tecDIR_FULL));
+        }
     }
 
     void
@@ -1234,6 +1245,20 @@ struct XChain_test : public beast::unit_test::suite, public jtx::XChainBridgeObj
             .close()
             .tx(xchain_create_claim_id(scAlice, jvb, reward, mcAlice), ter(temDISABLED))
             .close();
+
+        {
+            XEnv xenv(*this, true);
+            using namespace ::xrpl::test::jtx::directory;
+            auto const aliceDir = keylet::ownerDir(scAlice.id());
+            auto const n = getIndexCountToBump(xenv.env_, aliceDir);
+            xenv.tx(ticket::create(scAlice, n));
+            BEAST_EXPECT(bumpLastPage(xenv.env_, maximumPageIndex(xenv.env_), aliceDir, adjustOwnerNode));
+
+            xenv
+                .tx(create_bridge(Account::master, jvb))
+                .tx(xchain_create_claim_id(scAlice, jvb, reward, mcAlice), ter(tecDIR_FULL))
+                .close();
+        }
     }
 
     void
@@ -1835,6 +1860,56 @@ struct XChain_test : public beast::unit_test::suite, public jtx::XChainBridgeObj
 
                 BEAST_EXPECT(!scEnv.caClaimID(jvb, 3));    // claim id 3 deleted
                 BEAST_EXPECT(scEnv.claimCount(jvb) == 3);  // claim count now 3
+            }
+
+            // {
+            //     Balance door(scEnv, Account::master);
+
+            //     using namespace ::xrpl::test::jtx::directory;
+            //     auto const masterDir = keylet::ownerDir(Account::master.id());
+            //     auto const n = getIndexCountToBump(scEnv.env_, masterDir);
+            //     scEnv.tx(ticket::create(Account::master, n));
+            //     BEAST_EXPECT(bumpLastPage(scEnv.env_, maximumPageIndex(scEnv.env_), masterDir, adjustOwnerNode));
+
+            //     scEnv.multiTx(att_create_acct_vec(2, amt, scuBob, 1)).close();
+
+            // }
+        }
+
+        {
+            XEnv mcEnv(*this);
+            XEnv scEnv(*this, true);
+            auto const amt = XRP(1000);
+            auto const amt_plus_reward = amt + reward;
+
+            {
+                Balance door(mcEnv, mcDoor);
+                Balance carol(mcEnv, mcCarol);
+
+                mcEnv.tx(create_bridge(mcDoor, jvb, reward, XRP(20)))
+                    .close()
+                    .tx(sidechain_xchain_account_create(mcAlice, jvb, scuAlice, amt, reward))
+                    .tx(sidechain_xchain_account_create(mcBob, jvb, scuBob, amt, reward))
+                    .tx(sidechain_xchain_account_create(mcCarol, jvb, scuCarol, amt, reward))
+                    .close();
+
+                BEAST_EXPECT(
+                    door.diff() == (multiply(amt_plus_reward, STAmount(3), xrpIssue()) - tx_fee));
+                BEAST_EXPECT(carol.diff() == -(amt + reward + tx_fee));
+            }
+
+            scEnv.tx(create_bridge(Account::master, jvb, reward, XRP(20)))
+                .tx(jtx::signers(Account::master, quorum, signers))
+                .close();
+
+            {
+                using namespace ::xrpl::test::jtx::directory;
+                auto const masterDir = keylet::ownerDir(Account::master.id());
+                auto const n = getIndexCountToBump(scEnv.env_, masterDir);
+                scEnv.tx(ticket::create(Account::master, n));
+                BEAST_EXPECT(bumpLastPage(scEnv.env_, maximumPageIndex(scEnv.env_), masterDir, adjustOwnerNode));
+
+                scEnv.multiTx(att_create_acct_vec(1, amt, scuAlice, 2), ter(tecDIR_FULL)).close();
             }
         }
 

--- a/src/test/jtx/directory.h
+++ b/src/test/jtx/directory.h
@@ -23,6 +23,13 @@ enum Error {
     AdjustmentError
 };
 
+/// Returns the number of directory entries that must be created so that the
+/// last page of the given directory is full and the directory has at least two
+/// pages. Call this before bumpLastPage to determine how many objects (e.g.
+/// tickets) to create.
+std::size_t
+getIndexCountToBump(Env& env, Keylet directory);
+
 /// Move the position of the last page in the user's directory on open ledger to
 /// newLastPage. Requirements:
 /// - directory must have at least two pages (root and one more)

--- a/src/test/jtx/impl/directory.cpp
+++ b/src/test/jtx/impl/directory.cpp
@@ -7,6 +7,37 @@ namespace xrpl::test::jtx {
 /** Directory operations. */
 namespace directory {
 
+std::size_t
+getIndexCountToBump(Env& env, Keylet directory)
+{
+    std::size_t toAdd = 0;
+    env.app().getOpenLedger().modify([&](OpenView& view, beast::Journal j) -> bool {
+        Sandbox sb(&view, tapNONE);
+
+        // Find the root page
+        auto sleRoot = sb.peek(directory);
+        if (!sleRoot)
+        {
+            toAdd += 64;
+            return false;
+        }
+
+        auto const lastIndex0 = sleRoot->getFieldU64(sfIndexPrevious);
+        auto slePage0 = sb.peek(keylet::page(directory, lastIndex0));
+        if (!slePage0)
+        {
+            return false;
+        }
+        auto indexes0 = slePage0->getFieldV256(sfIndexes);
+        if (lastIndex0 == 0)
+            toAdd += 32;
+        if (indexes0.size() < 32)
+            toAdd += 32 - indexes0.size();
+        return false;
+    });
+    return toAdd;
+}
+
 auto
 bumpLastPage(
     Env& env,

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -299,7 +299,7 @@ MPTTester::authorize(MPTAuthorize const& arg)
                 return env_.le(keylet::mptoken(*id_, arg.account->id())) != nullptr;
             }));
         }
-        else
+        else if (result != tecDIR_FULL)
         {
             // Verify MPToken doesn't exist if holder failed authorizing(unless
             // it already exists)

--- a/src/test/ledger/Directory_test.cpp
+++ b/src/test/ledger/Directory_test.cpp
@@ -486,8 +486,9 @@ struct Directory_test : public beast::unit_test::suite
 
             auto const [lastPage, full] = setup(env);
 
-            // Populate root page and last page
-            for (int i = 0; i < 63; ++i)
+            auto const aliceDir = keylet::ownerDir(alice.id());
+            auto const n = directory::getIndexCountToBump(env, aliceDir);
+            for (int i = 0; i < n; ++i)
                 env(credentials::create(alice, alice, std::to_string(i)));
             env.close();
 
@@ -495,12 +496,12 @@ struct Directory_test : public beast::unit_test::suite
             // there is no transaction type to express what bumpLastPage does.
 
             // Bump position of last page from 1 to highest possible
-            auto const res = directory::bumpLastPage(
+            BEAST_EXPECT(directory::bumpLastPage(
                 env,
                 lastPage,
-                keylet::ownerDir(alice.id()),
-                [lastPage, this](ApplyView& view, uint256 key, std::uint64_t page) {
-                    auto sle = view.peek({ltCREDENTIAL, key});
+                aliceDir,
+                [lastPage, this](ApplyView& view, uint256 const& key, std::uint64_t page) {
+                    auto const sle = view.peek({ltCREDENTIAL, key});
                     if (!BEAST_EXPECT(sle))
                         return false;
 
@@ -509,18 +510,14 @@ struct Directory_test : public beast::unit_test::suite
                     // sfSubjectNode is not set in self-issued credentials
                     view.update(sle);
                     return true;
-                });
-            BEAST_EXPECT(res);
-
-            // Create one more credential
-            env(credentials::create(alice, alice, std::to_string(63)));
+                }));
 
             // Not enough space for another object if full
             auto const expected = full ? ter{tecDIR_FULL} : ter{tesSUCCESS};
             env(credentials::create(alice, alice, "foo"), expected);
 
             // Destroy all objects in directory
-            for (int i = 0; i < 64; ++i)
+            for (int i = 0; i < n; ++i)
                 env(credentials::deleteCred(alice, alice, alice, std::to_string(i)));
 
             if (!full)

--- a/src/test/rpc/DepositAuthorized_test.cpp
+++ b/src/test/rpc/DepositAuthorized_test.cpp
@@ -51,9 +51,11 @@ public:
         Account const alice{"alice"};
         Account const becky{"becky"};
         Account const carol{"carol"};
+        Account const bob("bob");
 
         Env env(*this);
         env.fund(XRP(1000), alice, becky, carol);
+        env.fund(XRP(10000), bob);
         env.close();
 
         // becky is authorized to deposit to herself.
@@ -97,9 +99,20 @@ public:
                 depositAuthArgs(becky, alice, "current").toStyledString()),
             true);
 
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const bobDir = keylet::ownerDir(bob.id());
+            auto const n = getIndexCountToBump(env, bobDir);
+            env(ticket::create(bob, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(deposit::auth(bob, alice), ter(tecDIR_FULL));
+        }
+
         // becky creates a deposit authorization for alice.
         env(deposit::auth(becky, alice));
         env.close();
+
 
         // alice is now authorized to deposit to becky.
         validateDepositAuthResult(
@@ -291,9 +304,11 @@ public:
         Account const becky{"becky"};
         Account const diana{"diana"};
         Account const carol{"carol"};
+        Account const bob("bob");
 
         Env env(*this);
         env.fund(XRP(1000), alice, becky, carol, diana);
+        env.fund(XRP(10000), bob);
         env.close();
 
         // carol recognize alice
@@ -306,6 +321,16 @@ public:
         // becky sets the DepositAuth flag in the current ledger.
         env(fset(becky, asfDepositAuth));
         env.close();
+
+        {
+            using namespace ::xrpl::test::jtx::directory;
+            auto const bobDir = keylet::ownerDir(bob.id());
+            auto const n = getIndexCountToBump(env, bobDir);
+            env(ticket::create(bob, n));
+            BEAST_EXPECT(bumpLastPage(env, maximumPageIndex(env), bobDir, adjustOwnerNode));
+
+            env(deposit::authCredentials(bob, {{carol, credType}}), ter(tecDIR_FULL));
+        }
 
         // becky authorize any account recognized by carol to make a payment
         env(deposit::authCredentials(becky, {{carol, credType}}));


### PR DESCRIPTION
## High Level Overview of Change

The main goal of this PR is to improve test coverage for the `xrpld` application. 

With the recent ability to simulate the `tecDIR_FULL` error, we can now comprehensively cover all cases where this error is returned. Consequently, this PR modifies production code solely to remove the now-obsolete `LCOV_EXCL_LINE` comments.

### Context of Change

This PR is enabled by the implementation of #5935. 
Once completed, it will resolve issue #5969.

### Type of Change

- [x] `test:` - The changes *only* affect unit tests.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

## Test Plan

Verification is done by running the automated unit test suite. 
Code coverage metrics will reflect the newly covered `tecDIR_FULL` error branches.

## WIP Status & Future Tasks

**Note: This PR is currently a Draft.**
Pending tasks before marking as "Ready to merge":
- [ ] Cover remaining edge cases.
- [ ] Resolve existing merge conflicts.
- [ ] Code and PR polishing.
- [ ] Ensure all commits are squashed logically, follow the 50/72 formatting rule, and are **signed** via GPG.