### PR TITLE
fix: Minor RPC fixes

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -38,6 +38,8 @@ This section contains changes targeting a future version.
 ### Bugfixes
 
 - Peer Crawler: The `port` field in `overlay.active[]` now consistently returns an integer instead of a string for outbound peers. [#6318](https://github.com/XRPLF/rippled/pull/6318)
+- `ping`: The `ip` field is no longer returned as an empty string for proxied connections without a forwarded-for header. It is now omitted, consistent with the behavior for identified connections.
+- gRPC `GetLedgerDiff`: Fixed error message that incorrectly said "base ledger not validated" when the desired ledger was not validated.
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -38,8 +38,8 @@ This section contains changes targeting a future version.
 ### Bugfixes
 
 - Peer Crawler: The `port` field in `overlay.active[]` now consistently returns an integer instead of a string for outbound peers. [#6318](https://github.com/XRPLF/rippled/pull/6318)
-- `ping`: The `ip` field is no longer returned as an empty string for proxied connections without a forwarded-for header. It is now omitted, consistent with the behavior for identified connections.
-- gRPC `GetLedgerDiff`: Fixed error message that incorrectly said "base ledger not validated" when the desired ledger was not validated.
+- `ping`: The `ip` field is no longer returned as an empty string for proxied connections without a forwarded-for header. It is now omitted, consistent with the behavior for identified connections. [#6730](https://github.com/XRPLF/rippled/pull/6730)
+- gRPC `GetLedgerDiff`: Fixed error message that incorrectly said "base ledger not validated" when the desired ledger was not validated. [#6730](https://github.com/XRPLF/rippled/pull/6730)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/Roles_test.cpp
+++ b/src/test/rpc/Roles_test.cpp
@@ -43,6 +43,7 @@ class Roles_test : public beast::unit_test::suite
             Env env{*this, envconfig(secure_gateway)};
 
             BEAST_EXPECT(env.rpc("ping")["result"]["role"] == "proxied");
+            BEAST_EXPECT(!env.rpc("ping")["result"].isMember("ip"));
             auto wsRes = makeWSClient(env.app().config())->invoke("ping")["result"];
             BEAST_EXPECT(!wsRes.isMember("unlimited") || !wsRes["unlimited"].asBool());
 

--- a/src/xrpld/rpc/handlers/ledger/LedgerDiff.cpp
+++ b/src/xrpld/rpc/handlers/ledger/LedgerDiff.cpp
@@ -36,7 +36,7 @@ doLedgerDiffGrpc(RPC::GRPCContext<org::xrpl::rpc::v1::GetLedgerDiffRequest>& con
         std::dynamic_pointer_cast<Ledger const>(desiredLedgerRv);
     if (!desiredLedger)
     {
-        grpc::Status const errorStatus{grpc::StatusCode::NOT_FOUND, "base ledger not validated"};
+        grpc::Status const errorStatus{grpc::StatusCode::NOT_FOUND, "desired ledger not validated"};
         return {response, errorStatus};
     }
 

--- a/src/xrpld/rpc/handlers/utility/Ping.cpp
+++ b/src/xrpld/rpc/handlers/utility/Ping.cpp
@@ -27,7 +27,9 @@ doPing(RPC::JsonContext& context)
             break;
         case Role::PROXY:
             ret[jss::role] = "proxied";
-            ret[jss::ip] = std::string{context.headers.forwardedFor};
+            if (!context.headers.forwardedFor.empty())
+                ret[jss::ip] = std::string{context.headers.forwardedFor};
+            break;
         default:;
     }
 


### PR DESCRIPTION
## High Level Overview of Change

- `ping`: The `ip` field is no longer returned as an empty string for proxied connections without a forwarded-for header. It is now omitted, consistent with the behavior for identified connections.
  - There was also a missing `break` statement in the proxied connection case block.
- gRPC `GetLedgerDiff`: Fixed error message that incorrectly said "base ledger not validated" when the desired ledger was not validated.

### Context of Change

AI review/triage

> BUG-U002: PROXY case unconditionally emits empty ip field unlike IDENTIFIED case
> 
> **Severity**: LOW  
> 
> In doPing(), the IDENTIFIED case (lines 22-26) conditionally includes the `ip` field only when `context.headers.forwardedFor` is non-empty. The PROXY case (lines 28-30) unconditionally writes `context.headers.forwardedFor` to `ret[jss::ip]`, even when the value is empty. This creates an inconsistency where PROXY connections may return `"ip": ""` in the response, while IDENTIFIED connections would omit the field entirely. A downstream client parsing the response could misinterpret an empty string as a valid IP address or treat the field's presence as meaningful.
> 
> **Root cause**: Lines 28-30 in Ping.cpp set `ret[jss::ip]` without checking `!context.headers.forwardedFor.empty()` first, unlike the analogous check at line 25 for the IDENTIFIED case.


> BUG-U001: Missing break in Ping switch causes PROXY case to fall through to default
> 
> **Severity**: LOW  
> 
> In doPing(), the switch statement on context.role handles Role::PROXY at line 28-30 but is missing a `break` statement. The case falls through directly to `default:;`. Currently the default case is an empty statement, so there is no behavioral change. However, this is a classic C++ switch-fallthrough bug pattern that violates defensive coding practices. If a future maintainer adds any logic to the default case (e.g., error logging, default field values), the PROXY case would silently execute that code as well, leading to unexpected behavior.
> 
> **Root cause**: The `case Role::PROXY:` block at line 28-30 in Ping.cpp does not end with a `break` statement. The `case Role::IDENTIFIED:` block above it correctly has a `break` at line 27, making the omission in the PROXY case clearly unintentional rather than a deliberate fallthrough pattern.


> BUG-U004: Wrong error message for desired ledger in doLedgerDiffGrpc
> 
> **Severity**: LOW  
> 
> When the desired ledger's dynamic_pointer_cast fails in doLedgerDiffGrpc, the error message incorrectly states 'base ledger not validated' instead of 'desired ledger not validated'. This misleads API consumers about which ledger parameter caused the error.
> 
> **Root cause**: LedgerDiff.cpp line 39: the error message string was copy-pasted from the base ledger check (line 31) without updating the text.


### API Impact

Minor bugfixes, no API format change.