### PR TITLE
Issue 6470 fix

### DIFF
--- a/src/xrpld/overlay/detail/Message.cpp
+++ b/src/xrpld/overlay/detail/Message.cpp
@@ -83,6 +83,10 @@ Message::compress()
             case protocol::mtPROOF_PATH_RESPONSE:
             case protocol::mtREPLAY_DELTA_REQ:
             case protocol::mtHAVE_TRANSACTIONS:
+            case protocol::mtSQUELCH:
+                break;
+            default:
+                XRPL_ASSERT(false, "Message::compress : unknown message type");
                 break;
         }
         return false;

--- a/src/xrpld/overlay/detail/Message.cpp
+++ b/src/xrpld/overlay/detail/Message.cpp
@@ -86,7 +86,7 @@ Message::compress()
             case protocol::mtSQUELCH:
                 break;
             default:
-                XRPL_ASSERT(false, "Message::compress : unknown message type");
+                UNREACHABLE("Message::compress : unknown message type");
                 break;
         }
         return false;


### PR DESCRIPTION
## High Level Overview of Change

Fix for https://github.com/XRPLF/rippled/issues/6740 where there was no case for mtSQUELCH message types in src/xrpld/overlay/detail/Message.cpp. I have also added a default case to catch future unknown message types.

### Context of Change
INFORMATIONAL — No security impact. This is a code hygiene and maintenance issue.

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
