### PR TITLE
fix: Change `Tuning::bookOffers` minimum limit to 1

### DIFF
--- a/src/xrpld/rpc/detail/Tuning.h
+++ b/src/xrpld/rpc/detail/Tuning.h
@@ -29,7 +29,7 @@ static LimitRange constexpr accountOffers = {10, 200, 400};
 static LimitRange constexpr accountTx = {10, 200, 400};
 
 /** Limits for the book_offers command. */
-static LimitRange constexpr bookOffers = {0, 60, 100};
+static LimitRange constexpr bookOffers = {1, 60, 100};
 
 /** Limits for the no_ripple_check command. */
 static LimitRange constexpr noRippleCheck = {10, 300, 400};


### PR DESCRIPTION
## High Level Overview of Change

This change updates the `rmin` of `Tuning::bookOffers` from 0 to 1.

### Context of Change

Although `readLimitField` now rejects `limit == 0` for all callers, `Tuning::bookOffers` still has `rmin = 0`. This is inconsistent and makes the tuning misleading. 

In particular, the limit value for `bookOffers` is passed to `getBookOffers`, and if the limit is 0 the work loop is skipped entirely:

```
    while (!bDone && iLimit-- > 0)
```

From both `getBookOffers` and `doBookOffers`, there is no other information added to the return, so you'd get an empty JSON result. The correct solution is therefore to change `bookOffers` minimum to 1, since the value of 0 is rejected anyway as mentioned earlier.
