### PR TITLE
Fix issue #6798 (Created using wrong account)

### DIFF
--- a/src/test/rpc/TransactionEntry_test.cpp
+++ b/src/test/rpc/TransactionEntry_test.cpp
@@ -1,11 +1,7 @@
 #include <test/jtx.h>
 #include <test/jtx/Env.h>
 
-#include <xrpl/json/json_reader.h>
-#include <xrpl/json/json_value.h>
-#include <xrpl/protocol/jss.h>
 
-#include <functional>
 
 namespace xrpl {
 
@@ -24,7 +20,7 @@ class TransactionEntry_test : public beast::unit_test::suite
         {
             // no params
             auto const result = env.client().invoke("transaction_entry", {})[jss::result];
-            BEAST_EXPECT(result[jss::error] == "fieldNotFoundTransaction");
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::status] == "error");
         }
 
@@ -41,7 +37,7 @@ class TransactionEntry_test : public beast::unit_test::suite
             params[jss::ledger] = "current";
             params[jss::tx_hash] = "DEADBEEF";
             auto const result = env.client().invoke("transaction_entry", params)[jss::result];
-            BEAST_EXPECT(result[jss::error] == "notYetImplemented");
+            BEAST_EXPECT(result[jss::error] == "notImpl");
             BEAST_EXPECT(result[jss::status] == "error");
         }
 
@@ -51,7 +47,7 @@ class TransactionEntry_test : public beast::unit_test::suite
             params[jss::tx_hash] = "DEADBEEF";
             auto const result = env.client().invoke("transaction_entry", params)[jss::result];
             BEAST_EXPECT(!result[jss::ledger_hash].asString().empty());
-            BEAST_EXPECT(result[jss::error] == "malformedRequest");
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
             BEAST_EXPECT(result[jss::status] == "error");
         }
 
@@ -113,7 +109,7 @@ class TransactionEntry_test : public beast::unit_test::suite
             // Valid structure, but transaction not found.
             Json::Value const result{env.rpc("transaction_entry", txHash, "closed")};
             BEAST_EXPECT(!result[jss::result][jss::ledger_hash].asString().empty());
-            BEAST_EXPECT(result[jss::result][jss::error] == "transactionNotFound");
+            BEAST_EXPECT(result[jss::result][jss::error] == "txnNotFound");
             BEAST_EXPECT(result[jss::result][jss::status] == "error");
         }
     }

--- a/src/xrpld/rpc/handlers/transaction/TransactionEntry.cpp
+++ b/src/xrpld/rpc/handlers/transaction/TransactionEntry.cpp
@@ -3,10 +3,6 @@
 #include <xrpld/rpc/Context.h>
 #include <xrpld/rpc/detail/RPCLedgerHelpers.h>
 
-#include <xrpl/ledger/ReadView.h>
-#include <xrpl/protocol/jss.h>
-
-namespace xrpl {
 
 // {
 //   ledger_hash : <ledger>,
@@ -26,14 +22,14 @@ doTransactionEntry(RPC::JsonContext& context)
 
     if (!context.params.isMember(jss::tx_hash))
     {
-        jvResult[jss::error] = "fieldNotFoundTransaction";
+        RPC::inject_error(error_code_i::rpcINVALID_PARAMS, jvResult);
     }
     else if (jvResult.get(jss::ledger_hash, Json::nullValue).isNull())
     {
         // We don't work on ledger current.
 
         // XXX We don't support any transaction yet.
-        jvResult[jss::error] = "notYetImplemented";
+        RPC::inject_error(error_code_i::rpcNOT_IMPL, jvResult);
     }
     else
     {
@@ -42,14 +38,14 @@ doTransactionEntry(RPC::JsonContext& context)
         // routine, returning success or failure.
         if (!uTransID.parseHex(context.params[jss::tx_hash].asString()))
         {
-            jvResult[jss::error] = "malformedRequest";
+            RPC::inject_error(error_code_i::rpcINVALID_PARAMS, jvResult);
             return jvResult;
         }
 
         auto [sttx, stobj] = lpLedger->txRead(uTransID);
         if (!sttx)
         {
-            jvResult[jss::error] = "transactionNotFound";
+            RPC::inject_error(error_code_i::rpcTXN_NOT_FOUND, jvResult);
         }
         else
         {


### PR DESCRIPTION
## Summary

- Replaced ad-hoc string error assignments in `doTransactionEntry` with `RPC::inject_error()` calls using typed
 `error_code_i` constants, aligning the handler with the standard RPC error reporting convention used elsewhere in the codebase
- Error mappings: missing `tx_hash` → `rpcINVALID_PARAMS`, current ledger request → `rpcNOT_IMPL`, malformed hash →
    `rpcINVALID_PARAMS`, transaction not found → `rpcTXN_NOT_FOUND`

## Test plan

- [ ] Run `./xrpld --unittest=TransactionEntry` and confirm all cases pass with updated error strings (`invalidParams`, `notImpl`, `txnNotFound`)
- [ ] Confirm no other `transaction_entry` callers depend on the old non-standard error strings (`fieldNotFoundTransaction`, `notYetImplemented`, `malformedRequest`, `transactionNotFound`)