### PR TITLE
fix: MPT/DEX assorted fixes

### DIFF
--- a/include/xrpl/ledger/helpers/MPTokenHelpers.h
+++ b/include/xrpl/ledger/helpers/MPTokenHelpers.h
@@ -121,6 +121,15 @@ canTransfer(
 [[nodiscard]] TER
 canTrade(ReadView const& view, Asset const& asset);
 
+/** Convenience to combine canTrade/Transfer. Returns tesSUCCESS if Asset is Issue.
+ */
+[[nodiscard]] TER
+canMPTTradeAndTransfer(
+    ReadView const& v,
+    Asset const& asset,
+    AccountID const& from,
+    AccountID const& to);
+
 //------------------------------------------------------------------------------
 //
 // Empty holding operations (MPT-specific)
@@ -226,18 +235,5 @@ issuerFundsToSelfIssue(ReadView const& view, MPTIssue const& issue);
  */
 void
 issuerSelfDebitHookMPT(ApplyView& view, MPTIssue const& issue, std::uint64_t amount);
-
-//------------------------------------------------------------------------------
-//
-// MPT DEX
-//
-//------------------------------------------------------------------------------
-
-/* Return true if a transaction is allowed for the specified MPT/account. The
- * function checks MPTokenIssuance and MPToken objects flags to determine if the
- * transaction is allowed.
- */
-TER
-checkMPTTxAllowed(ReadView const& v, TxType tx, Asset const& asset, AccountID const& accountID);
 
 }  // namespace xrpl

--- a/include/xrpl/ledger/helpers/TokenHelpers.h
+++ b/include/xrpl/ledger/helpers/TokenHelpers.h
@@ -54,8 +54,14 @@ enum class AuthType { StrongAuth, WeakAuth, Legacy };
 [[nodiscard]] bool
 isGlobalFrozen(ReadView const& view, Asset const& asset);
 
+[[nodiscard]] TER
+checkGlobalFrozen(ReadView const& view, Asset const& asset);
+
 [[nodiscard]] bool
 isIndividualFrozen(ReadView const& view, AccountID const& account, Asset const& asset);
+
+[[nodiscard]] TER
+checkIndividualFrozen(ReadView const& view, AccountID const& account, Asset const& asset);
 
 /**
  *   isFrozen check is recursive for MPT shares in a vault, descending to

--- a/include/xrpl/tx/invariants/InvariantCheck.h
+++ b/include/xrpl/tx/invariants/InvariantCheck.h
@@ -399,7 +399,8 @@ using InvariantChecks = std::tuple<
     ValidLoanBroker,
     ValidLoan,
     ValidVault,
-    ValidMPTPayment>;
+    ValidMPTPayment,
+    ValidMPTTransfer>;
 
 /**
  * @brief get a tuple of all invariant checks

--- a/include/xrpl/tx/invariants/MPTInvariant.h
+++ b/include/xrpl/tx/invariants/MPTInvariant.h
@@ -56,4 +56,22 @@ public:
     finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
 };
 
+class ValidMPTTransfer
+{
+    struct Value
+    {
+        std::optional<std::uint64_t> amtBefore;
+        std::optional<std::uint64_t> amtAfter;
+    };
+    // MPTID: {holder: Value}
+    hash_map<uint192, hash_map<AccountID, Value>> amount_;
+
+public:
+    void
+    visitEntry(bool, std::shared_ptr<SLE const> const&, std::shared_ptr<SLE const> const&);
+
+    bool
+    finalize(STTx const&, TER const, XRPAmount const, ReadView const&, beast::Journal const&);
+};
+
 }  // namespace xrpl

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -496,6 +496,22 @@ canTrade(ReadView const& view, Asset const& asset)
 }
 
 TER
+canMPTTradeAndTransfer(
+    ReadView const& view,
+    Asset const& asset,
+    AccountID const& from,
+    AccountID const& to)
+{
+    if (!asset.holds<MPTIssue>())
+        return tesSUCCESS;
+
+    if (auto const ter = canTrade(view, asset); !isTesSuccess(ter))
+        return ter;
+
+    return canTransfer(view, asset, from, to);
+}
+
+TER
 lockEscrowMPT(ApplyView& view, AccountID const& sender, STAmount const& amount, beast::Journal j)
 {
     auto const mptIssue = amount.get<MPTIssue>();
@@ -860,67 +876,6 @@ issuerSelfDebitHookMPT(ApplyView& view, MPTIssue const& issue, std::uint64_t amo
 {
     auto const available = availableMPTAmount(view, issue);
     view.issuerSelfDebitHookMPT(issue, amount, available);
-}
-
-static TER
-checkMPTAllowed(ReadView const& view, TxType txType, Asset const& asset, AccountID const& accountID)
-{
-    if (!asset.holds<MPTIssue>())
-        return tesSUCCESS;
-
-    auto const& issuanceID = asset.get<MPTIssue>().getMptID();
-    auto const validTx = txType == ttAMM_CREATE || txType == ttAMM_DEPOSIT ||
-        txType == ttAMM_WITHDRAW || txType == ttOFFER_CREATE || txType == ttCHECK_CREATE ||
-        txType == ttCHECK_CASH || txType == ttPAYMENT;
-    XRPL_ASSERT(validTx, "xrpl::checkMPTAllowed : all MPT tx or DEX");
-    if (!validTx)
-        return tefINTERNAL;  // LCOV_EXCL_LINE
-
-    auto const& issuer = asset.getIssuer();
-    if (!view.exists(keylet::account(issuer)))
-        return tecNO_ISSUER;  // LCOV_EXCL_LINE
-
-    auto const issuanceKey = keylet::mptIssuance(issuanceID);
-    auto const issuanceSle = view.read(issuanceKey);
-    if (!issuanceSle)
-        return tecOBJECT_NOT_FOUND;  // LCOV_EXCL_LINE
-
-    auto const flags = issuanceSle->getFlags();
-
-    if ((flags & lsfMPTLocked) != 0u)
-        return tecLOCKED;  // LCOV_EXCL_LINE
-    // Offer crossing and Payment
-    if ((flags & lsfMPTCanTrade) == 0)
-        return tecNO_PERMISSION;
-
-    if (accountID != issuer)
-    {
-        if ((flags & lsfMPTCanTransfer) == 0)
-            return tecNO_PERMISSION;
-
-        auto const mptSle = view.read(keylet::mptoken(issuanceKey.key, accountID));
-        // Allow to succeed since some tx create MPToken if it doesn't exist.
-        // Tx's have their own check for missing MPToken.
-        if (!mptSle)
-            return tesSUCCESS;
-
-        if (mptSle->isFlag(lsfMPTLocked))
-            return tecLOCKED;
-    }
-
-    return tesSUCCESS;
-}
-
-TER
-checkMPTTxAllowed(
-    ReadView const& view,
-    TxType txType,
-    Asset const& asset,
-    AccountID const& accountID)
-{
-    // use isDEXAllowed for payment/offer crossing
-    XRPL_ASSERT(txType != ttPAYMENT, "xrpl::checkMPTTxAllowed : not payment");
-    return checkMPTAllowed(view, txType, asset, accountID);
 }
 
 }  // namespace xrpl

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -40,11 +40,27 @@ isGlobalFrozen(ReadView const& view, Asset const& asset)
         [&](MPTIssue const& issue) { return isGlobalFrozen(view, issue); });
 }
 
+TER
+checkGlobalFrozen(ReadView const& view, Asset const& asset)
+{
+    if (isGlobalFrozen(view, asset))
+        return asset.holds<MPTIssue>() ? tecLOCKED : tecFROZEN;
+    return tesSUCCESS;
+}
+
 bool
 isIndividualFrozen(ReadView const& view, AccountID const& account, Asset const& asset)
 {
     return std::visit(
         [&](auto const& issue) { return isIndividualFrozen(view, account, issue); }, asset.value());
+}
+
+TER
+checkIndividualFrozen(ReadView const& view, AccountID const& account, Asset const& asset)
+{
+    if (isIndividualFrozen(view, account, asset))
+        return asset.holds<MPTIssue>() ? tecLOCKED : tecFROZEN;
+    return tesSUCCESS;
 }
 
 bool

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -425,7 +425,7 @@ ValidMPTTransfer::finalize(
             auto const amount = tx[sfAmount];
             return tx[~sfSendMax].value_or(amount).asset() != amount.asset();
         }
-        return txnType == ttCHECK_CASH || txnType == ttOFFER_CREATE;
+        return txnType == ttOFFER_CREATE;
     }();
 
     // Only enforce once MPTokensV2 is enabled to preserve consensus with non-V2 nodes.

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -369,4 +369,116 @@ ValidMPTPayment::finalize(
     return true;
 }
 
+void
+ValidMPTTransfer::visitEntry(
+    bool,
+    std::shared_ptr<SLE const> const& before,
+    std::shared_ptr<SLE const> const& after)
+{
+    // Record the before/after MPTAmount for each (issuanceID, account) pair
+    // so finalize() can determine whether a transfer actually occurred.
+    auto update = [&](SLE const& sle, bool isBefore) {
+        if (sle.getType() == ltMPTOKEN)
+        {
+            auto const issuanceID = sle[sfMPTokenIssuanceID];
+            auto const account = sle[sfAccount];
+            auto const amount = sle[sfMPTAmount];
+            if (isBefore)
+            {
+                amount_[issuanceID][account].amtBefore = amount;
+            }
+            else
+            {
+                amount_[issuanceID][account].amtAfter = amount;
+            }
+        }
+    };
+
+    if (before)
+        update(*before, true);
+
+    if (after)
+        update(*after, false);
+}
+
+bool
+ValidMPTTransfer::finalize(
+    STTx const& tx,
+    TER const,
+    XRPAmount const,
+    ReadView const& view,
+    beast::Journal const& j)
+{
+    // AMMClawback is called by the issuer, so freeze restrictions do not apply.
+    auto const txnType = tx.getTxnType();
+    if (txnType == ttAMM_CLAWBACK)
+        return true;
+
+    // DEX transactions (payments, check cash, offer creates) are subject to
+    // the MPTCanTrade flag in addition to the standard transfer rules.
+    // A payment is only DEX if it is a cross-currency payment.
+    auto const isDEX = [&tx, &txnType] {
+        if (txnType == ttPAYMENT)
+        {
+            // A payment is cross-currency (and thus DEX) only if SendMax is present
+            // and its asset differs from the destination asset.
+            auto const amount = tx[sfAmount];
+            return tx[~sfSendMax].value_or(amount).asset() != amount.asset();
+        }
+        return txnType == ttCHECK_CASH || txnType == ttOFFER_CREATE;
+    }();
+
+    // Only enforce once MPTokensV2 is enabled to preserve consensus with non-V2 nodes.
+    auto const enforce = !view.rules().enabled(featureMPTokensV2);
+
+    for (auto const& [mptID, values] : amount_)
+    {
+        std::uint16_t senders = 0;
+        std::uint16_t receivers = 0;
+        bool frozen = false;
+        auto const sleIssuance = view.read(keylet::mptIssuance(mptID));
+        if (!sleIssuance)
+        {
+            continue;
+        }
+
+        auto const canTransfer = sleIssuance->isFlag(lsfMPTCanTransfer);
+        auto const canTrade = sleIssuance->isFlag(lsfMPTCanTrade);
+
+        for (auto const& [account, value] : values)
+        {
+            // Check once: if any involved account is frozen, the whole
+            // issuance transfer is considered frozen.
+            if (!frozen && isFrozen(view, account, MPTIssue{mptID}))
+            {
+                frozen = true;
+            }
+            // Classify each account as a sender or receiver based on whether
+            // their MPTAmount decreased or increased.
+            if (value.amtBefore.has_value() && value.amtAfter.has_value() &&
+                *value.amtBefore != *value.amtAfter)
+            {
+                if (*value.amtAfter > *value.amtBefore)
+                {
+                    ++receivers;
+                }
+                else
+                {
+                    ++senders;
+                }
+            }
+        }
+        // A transfer between holders has occurred (senders > 0 && receivers > 0).
+        // Fail if the issuance is frozen, does not permit transfers, or — for
+        // DEX transactions — does not permit trading.
+        if ((frozen || !canTransfer || (isDEX && !canTrade)) && senders > 0 && receivers > 0)
+        {
+            JLOG(j.fatal()) << "Invariant failed: invalid MPToken transfer between holders";
+            return enforce;
+        }
+    }
+
+    return true;
+}
+
 }  // namespace xrpl

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -414,8 +414,8 @@ ValidMPTTransfer::finalize(
     if (txnType == ttAMM_CLAWBACK)
         return true;
 
-    // DEX transactions (cross-currency payments, offer creates) are subject to
-    // the MPTCanTrade flag in addition to the standard transfer rules.
+    // DEX transactions (AMM[Create,Deposit,Withdraw], cross-currency payments, offer creates) are
+    // subject to the MPTCanTrade flag in addition to the standard transfer rules.
     // A payment is only DEX if it is a cross-currency payment.
     auto const isDEX = [&tx, &txnType] {
         if (txnType == ttPAYMENT)
@@ -425,10 +425,12 @@ ValidMPTTransfer::finalize(
             auto const amount = tx[sfAmount];
             return tx[~sfSendMax].value_or(amount).asset() != amount.asset();
         }
-        return txnType == ttOFFER_CREATE;
+        return txnType == ttAMM_CREATE || txnType == ttAMM_DEPOSIT || txnType == ttAMM_WITHDRAW ||
+            txnType == ttOFFER_CREATE;
     }();
 
     // Only enforce once MPTokensV2 is enabled to preserve consensus with non-V2 nodes.
+    // Log invariant failure error even if MPTokensV2 is disabled.
     auto const enforce = !view.rules().enabled(featureMPTokensV2);
 
     for (auto const& [mptID, values] : amount_)
@@ -447,16 +449,10 @@ ValidMPTTransfer::finalize(
 
         for (auto const& [account, value] : values)
         {
-            // Check once: if any involved account is frozen, the whole
-            // issuance transfer is considered frozen.
-            if (!frozen && isFrozen(view, account, MPTIssue{mptID}))
-            {
-                frozen = true;
-            }
-            // Classify each account as a sender or receiver based on whether
-            // their MPTAmount decreased or increased.
-            if (value.amtBefore.has_value() && value.amtAfter.has_value() &&
-                *value.amtBefore != *value.amtAfter)
+            // Classify each account as a sender or receiver based on whether their MPTAmount
+            // decreased or increased. Count new MPToken holders (no amtBefore) as receivers.
+            if (value.amtAfter.has_value() &&
+                (!value.amtBefore.has_value() || *value.amtBefore != *value.amtAfter))
             {
                 if (*value.amtAfter > *value.amtBefore)
                 {
@@ -466,6 +462,13 @@ ValidMPTTransfer::finalize(
                 {
                     ++senders;
                 }
+            }
+            // Check once: if any involved account is frozen, the whole
+            // issuance transfer is considered frozen. Only need to check for
+            // frozen if there is a transfer of funds.
+            if (!frozen && isFrozen(view, account, MPTIssue{mptID}))
+            {
+                frozen = true;
             }
         }
         // A transfer between holders has occurred (senders > 0 && receivers > 0).

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -414,7 +414,7 @@ ValidMPTTransfer::finalize(
     if (txnType == ttAMM_CLAWBACK)
         return true;
 
-    // DEX transactions (payments, check cash, offer creates) are subject to
+    // DEX transactions (cross-currency payments, offer creates) are subject to
     // the MPTCanTrade flag in addition to the standard transfer rules.
     // A payment is only DEX if it is a cross-currency payment.
     auto const isDEX = [&tx, &txnType] {

--- a/src/libxrpl/tx/invariants/MPTInvariant.cpp
+++ b/src/libxrpl/tx/invariants/MPTInvariant.cpp
@@ -451,10 +451,10 @@ ValidMPTTransfer::finalize(
         {
             // Classify each account as a sender or receiver based on whether their MPTAmount
             // decreased or increased. Count new MPToken holders (no amtBefore) as receivers.
-            if (value.amtAfter.has_value() &&
-                (!value.amtBefore.has_value() || *value.amtBefore != *value.amtAfter))
+            // Skip deleted MPToken holders (amtAfter is nullopt); deletion requires zero balance.
+            if (value.amtAfter.has_value() && value.amtBefore.value_or(0) != *value.amtAfter)
             {
-                if (*value.amtAfter > *value.amtBefore)
+                if (!value.amtBefore.has_value() || *value.amtAfter > *value.amtBefore)
                 {
                     ++receivers;
                 }
@@ -462,13 +462,14 @@ ValidMPTTransfer::finalize(
                 {
                     ++senders;
                 }
-            }
-            // Check once: if any involved account is frozen, the whole
-            // issuance transfer is considered frozen. Only need to check for
-            // frozen if there is a transfer of funds.
-            if (!frozen && isFrozen(view, account, MPTIssue{mptID}))
-            {
-                frozen = true;
+
+                // Check once: if any involved account is frozen, the whole
+                // issuance transfer is considered frozen. Only need to check for
+                // frozen if there is a transfer of funds.
+                if (!frozen && isFrozen(view, account, MPTIssue{mptID}))
+                {
+                    frozen = true;
+                }
             }
         }
         // A transfer between holders has occurred (senders > 0 && receivers > 0).

--- a/src/libxrpl/tx/transactors/check/CheckCash.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCash.cpp
@@ -243,9 +243,10 @@ CheckCash::preclaim(PreclaimContext const& ctx)
                         return tecLOCKED;
                     }
 
-                    if (auto const err = canTrade(ctx.view, value.asset()); !isTesSuccess(err))
+                    if (auto const err = canTransfer(ctx.view, issue, srcId, dstId);
+                        !isTesSuccess(err))
                     {
-                        JLOG(ctx.j.warn()) << "MPT DEX is not allowed.";
+                        JLOG(ctx.j.warn()) << "MPT transfer is disabled.";
                         return err;
                     }
 

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -136,9 +136,21 @@ CheckCreate::preclaim(PreclaimContext const& ctx)
                 },
                 [&](MPTIssue const& issue) -> std::optional<TER> {
                     if (srcId != issuerId && isFrozen(ctx.view, srcId, issue))
+                    {
+                        JLOG(ctx.j.warn()) << "Creating a check for locked MPT.";
                         return tecLOCKED;
+                    }
                     if (dstId != issuerId && isFrozen(ctx.view, dstId, issue))
+                    {
+                        JLOG(ctx.j.warn()) << "Creating a check for locked MPT.";
                         return tecLOCKED;
+                    }
+                    if (auto const ter = canTransfer(ctx.view, issue, srcId, dstId);
+                        !isTesSuccess(ter))
+                    {
+                        JLOG(ctx.j.warn()) << "MPT transfer is disabled.";
+                        return ter;
+                    }
 
                     return std::nullopt;
                 });
@@ -152,7 +164,7 @@ CheckCreate::preclaim(PreclaimContext const& ctx)
         return tecEXPIRED;
     }
 
-    return canTrade(ctx.view, ctx.tx[sfSendMax].asset());
+    return tesSUCCESS;
 }
 
 TER

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -94,10 +94,10 @@ CheckCreate::preclaim(PreclaimContext const& ctx)
         {
             // The currency may not be globally frozen
             AccountID const& issuerId{sendMax.getIssuer()};
-            if (isGlobalFrozen(ctx.view, sendMax.asset()))
+            if (auto const ter = checkGlobalFrozen(ctx.view, sendMax.asset()); !isTesSuccess(ter))
             {
-                JLOG(ctx.j.warn()) << "Creating a check for frozen asset";
-                return sendMax.asset().holds<MPTIssue>() ? tecLOCKED : tecFROZEN;
+                JLOG(ctx.j.warn()) << "Creating a check for frozen or locked asset";
+                return ter;
             }
             auto const err = sendMax.asset().visit(
                 [&](Issue const& issue) -> std::optional<TER> {

--- a/src/libxrpl/tx/transactors/dex/AMMCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMCreate.cpp
@@ -94,11 +94,16 @@ AMMCreate::preclaim(PreclaimContext const& ctx)
     }
 
     // Globally or individually frozen
-    if (isFrozen(ctx.view, accountID, amount.asset()) ||
-        isFrozen(ctx.view, accountID, amount2.asset()))
+    if (auto const ter = checkFrozen(ctx.view, accountID, amount.asset()); !isTesSuccess(ter))
+
     {
-        JLOG(ctx.j.debug()) << "AMM Instance: involves frozen asset.";
-        return tecFROZEN;
+        JLOG(ctx.j.debug()) << "AMM Instance: involves frozen or locked asset.";
+        return ter;
+    }
+    if (auto const ter = checkFrozen(ctx.view, accountID, amount2.asset()); !isTesSuccess(ter))
+    {
+        JLOG(ctx.j.debug()) << "AMM Instance: involves frozen or locked asset.";
+        return ter;
     }
 
     auto noDefaultRipple = [](ReadView const& view, Asset const& asset) {
@@ -165,10 +170,10 @@ AMMCreate::preclaim(PreclaimContext const& ctx)
             return terADDRESS_COLLISION;
     }
 
-    if (auto const ter = checkMPTTxAllowed(ctx.view, ttAMM_CREATE, amount.asset(), accountID);
+    if (auto const ter = canMPTTradeAndTransfer(ctx.view, amount.asset(), accountID, accountID);
         !isTesSuccess(ter))
         return ter;
-    if (auto const ter = checkMPTTxAllowed(ctx.view, ttAMM_CREATE, amount2.asset(), accountID);
+    if (auto const ter = canMPTTradeAndTransfer(ctx.view, amount2.asset(), accountID, accountID);
         !isTesSuccess(ter))
         return ter;
 

--- a/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
@@ -243,12 +243,12 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
                 return ter;
             }
 
-            if (isFrozen(ctx.view, accountID, asset))
+            if (auto const ter = checkFrozen(ctx.view, accountID, asset); !isTesSuccess(ter))
             {
-                JLOG(ctx.j.debug()) << "AMM Deposit: account or currency is frozen, "
+                JLOG(ctx.j.debug()) << "AMM Deposit: account or currency is frozen or locked, "
                                     << to_string(accountID) << " " << to_string(asset);
 
-                return tecFROZEN;
+                return ter;
             }
 
             return tesSUCCESS;
@@ -280,18 +280,20 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
                 // LCOV_EXCL_STOP
             }
             // AMM account or currency frozen
-            if (isFrozen(ctx.view, ammAccountID, amount->asset()))
+            if (auto const ter = checkFrozen(ctx.view, ammAccountID, amount->asset());
+                !isTesSuccess(ter))
             {
-                JLOG(ctx.j.debug())
-                    << "AMM Deposit: AMM account or currency is frozen, " << to_string(accountID);
-                return tecFROZEN;
+                JLOG(ctx.j.debug()) << "AMM Deposit: AMM account or currency is frozen or locked, "
+                                    << to_string(accountID);
+                return ter;
             }
             // Account frozen
-            if (isIndividualFrozen(ctx.view, accountID, amount->asset()))
+            if (auto const ter = checkIndividualFrozen(ctx.view, accountID, amount->asset());
+                !isTesSuccess(ter))
             {
-                JLOG(ctx.j.debug()) << "AMM Deposit: account is frozen, " << to_string(accountID)
-                                    << " " << to_string(amount->asset());
-                return tecFROZEN;
+                JLOG(ctx.j.debug()) << "AMM Deposit: account is frozen or locked, "
+                                    << to_string(accountID) << " " << to_string(amount->asset());
+                return ter;
             }
             if (checkBalance)
             {
@@ -344,10 +346,10 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
         }
     }
 
-    if (auto const ter = checkMPTTxAllowed(ctx.view, ttAMM_DEPOSIT, ctx.tx[sfAsset], accountID);
+    if (auto const ter = canMPTTradeAndTransfer(ctx.view, ctx.tx[sfAsset], accountID, accountID);
         !isTesSuccess(ter))
         return ter;
-    if (auto const ter = checkMPTTxAllowed(ctx.view, ttAMM_DEPOSIT, ctx.tx[sfAsset2], accountID);
+    if (auto const ter = canMPTTradeAndTransfer(ctx.view, ctx.tx[sfAsset2], accountID, accountID);
         !isTesSuccess(ter))
         return ter;
 

--- a/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
@@ -211,22 +211,24 @@ AMMWithdraw::preclaim(PreclaimContext const& ctx)
                 return ter;
             }
             // AMM account or currency frozen
-            if (isFrozen(ctx.view, ammAccountID, amount->asset()))
+            if (auto const ter = checkFrozen(ctx.view, ammAccountID, amount->asset());
+                !isTesSuccess(ter))
             {
-                JLOG(ctx.j.debug())
-                    << "AMM Withdraw: AMM account or currency is frozen, " << to_string(accountID);
-                return tecFROZEN;
+                JLOG(ctx.j.debug()) << "AMM Withdraw: AMM account or currency is frozen or locked, "
+                                    << to_string(accountID);
+                return ter;
             }
             // Account frozen
-            if (isIndividualFrozen(ctx.view, accountID, amount->asset()))
+            if (auto const ter = checkIndividualFrozen(ctx.view, accountID, amount->asset());
+                !isTesSuccess(ter))
             {
-                JLOG(ctx.j.debug()) << "AMM Withdraw: account is frozen, " << to_string(accountID)
-                                    << " " << to_string(amount->asset());
-                return tecFROZEN;
+                JLOG(ctx.j.debug()) << "AMM Withdraw: account is frozen or locked, "
+                                    << to_string(accountID) << " " << to_string(amount->asset());
+                return ter;
             }
 
             if (auto const ter =
-                    checkMPTTxAllowed(ctx.view, ttAMM_WITHDRAW, amount->asset(), accountID);
+                    canMPTTradeAndTransfer(ctx.view, amount->asset(), accountID, accountID);
                 !isTesSuccess(ter))
                 return ter;
         }

--- a/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
@@ -606,10 +606,6 @@ AMMWithdraw::withdraw(
             auto const balance_ = isIssue ? std::max(priorBalance, balance.xrp()) : priorBalance;
             if (balance_ < reserve)
                 return tecINSUFFICIENT_RESERVE;
-
-            // Update owner count.
-            if (!isIssue)
-                adjustOwnerCount(view, sleAccount, 1, journal);
         }
         return tesSUCCESS;
     };

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -146,11 +146,15 @@ OfferCreate::preclaim(PreclaimContext const& ctx)
 
     auto viewJ = ctx.registry.get().getJournal("View");
 
-    if (isGlobalFrozen(ctx.view, saTakerPays.asset()) ||
-        isGlobalFrozen(ctx.view, saTakerGets.asset()))
+    if (auto const ter = checkGlobalFrozen(ctx.view, saTakerPays.asset()); !isTesSuccess(ter))
     {
         JLOG(ctx.j.debug()) << "Offer involves frozen asset";
-        return tecFROZEN;
+        return ter;
+    }
+    if (auto const ter = checkGlobalFrozen(ctx.view, saTakerGets.asset()); !isTesSuccess(ter))
+    {
+        JLOG(ctx.j.debug()) << "Offer involves frozen asset";
+        return ter;
     }
 
     // Allow unfunded MPT for issuer (OutstandingAmount >= MaximumAmount)
@@ -281,7 +285,13 @@ OfferCreate::checkAcceptAsset(
         [&](MPTIssue const& issue) -> TER {
             // WeakAuth - don't check if MPToken exists since it's created
             // if needed.
-            return requireAuth(view, issue, id, AuthType::WeakAuth);
+            if (auto const ter = requireAuth(view, issue, id, AuthType::WeakAuth);
+                !isTesSuccess(ter))
+            {
+                return ter;
+            }
+
+            return checkFrozen(view, id, issue);
         });
 }
 

--- a/src/test/app/AMMExtendedMPT_test.cpp
+++ b/src/test/app/AMMExtendedMPT_test.cpp
@@ -3063,10 +3063,8 @@ private:
         BTC.set({.holder = bob, .flags = tfMPTLock});
 
         {
-            // different from IOU. The offer is created but not crossed.
-            env(offer(bob, BTC(5), XRP(25)));
+            env(offer(bob, BTC(5), XRP(25)), ter(tecLOCKED));
             env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 1, {{{BTC(5), XRP(25)}}}));
             BEAST_EXPECT(ammAlice.expectBalances(XRP(500), BTC(105), ammAlice.tokens()));
         }
 
@@ -3169,7 +3167,7 @@ private:
             BTC.set({.flags = tfMPTLock});
 
             // assets can't be bought on the market
-            AMM const ammA3(env, A3, BTC(1), XRP(1), ter(tecFROZEN));
+            AMM const ammA3(env, A3, BTC(1), XRP(1), ter(tecLOCKED));
 
             // direct issues can be sent
             env(pay(G1, A2, BTC(1)));

--- a/src/test/app/AMMMPT_test.cpp
+++ b/src/test/app/AMMMPT_test.cpp
@@ -99,7 +99,7 @@ private:
                  .pay = 30'000,
                  .flags = tfMPTCanLock | MPTDEXFlags});
             USD.set({.flags = tfMPTLock});
-            AMM const ammAliceFail(env, alice, XRP(10'000), USD(10'000), ter(tecFROZEN));
+            AMM const ammAliceFail(env, alice, XRP(10'000), USD(10'000), ter(tecLOCKED));
             USD.set({.flags = tfMPTUnlock});
             AMM const ammAlice(env, alice, XRP(10'000), USD(10'000));
         }
@@ -303,7 +303,7 @@ private:
                  .pay = 30'000,
                  .flags = tfMPTCanLock | MPTDEXFlags});
             BTC.set({.flags = tfMPTLock});
-            AMM const ammAlice(env, alice, USD(10'000), BTC(10'000), ter(tecFROZEN));
+            AMM const ammAlice(env, alice, USD(10'000), BTC(10'000), ter(tecLOCKED));
             BEAST_EXPECT(!ammAlice.ammExists());
         }
 
@@ -320,7 +320,7 @@ private:
             BTC.set({.holder = alice, .flags = tfMPTLock});
 
             // alice's token is locked
-            AMM const ammAlice(env, alice, USD(10'000), BTC(10'000), ter(tecFROZEN));
+            AMM const ammAlice(env, alice, USD(10'000), BTC(10'000), ter(tecLOCKED));
             BEAST_EXPECT(!ammAlice.ammExists());
 
             // bob can create
@@ -645,14 +645,14 @@ private:
             BTC.set({.flags = tfMPTLock});
 
             ammAlice.deposit(
-                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             ammAlice.deposit(
-                carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
-            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
 
-            ammAlice.deposit(carol, USD(100), BTC(100), std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.deposit(carol, USD(100), BTC(100), std::nullopt, std::nullopt, ter(tecLOCKED));
         }
 
         // Individually lock MPT or freeze IOU (AMM) with IOU/MPT AMM
@@ -673,20 +673,19 @@ private:
 
             // Carol can not deposit locked mpt
             ammAlice.deposit(
-                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
-            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             if (!features[featureAMMClawback])
             {
-                ammAlice.deposit(
-                    carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
+                ammAlice.deposit(carol, USD(100), std::nullopt, std::nullopt, std::nullopt);
             }
             else
             {
-                // Carol can not deposit non-forzen token either
+                // Carol can not deposit non-frozen token either
                 ammAlice.deposit(
-                    carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                    carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
             }
 
             // Alice can deposit because she's not individually locked
@@ -727,9 +726,9 @@ private:
             ammAlice.deposit(carol, USD(100), std::nullopt, std::nullopt, std::nullopt);
 
             // Can not deposit locked token
-            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
             ammAlice.deposit(
-                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // Unlock AMM MPT
             BTC.set({.holder = ammAlice.ammAccount(), .flags = tfMPTUnlock});
@@ -761,10 +760,10 @@ private:
             // Carol's BTC is locked
             BTC.set({.holder = carol, .flags = tfMPTLock});
             ammAlice.deposit(
-                carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             ammAlice.deposit(
-                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // Unlock carol's BTC
             BTC.set({.holder = carol, .flags = tfMPTUnlock});
@@ -780,9 +779,9 @@ private:
             ammAlice.deposit(carol, USD(100), std::nullopt, std::nullopt, std::nullopt);
 
             // Can not deposit locked token BTC
-            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
             ammAlice.deposit(
-                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, BTC(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // Unlock AMM MPT BTC
             BTC.set({.holder = ammAlice.ammAccount(), .flags = tfMPTUnlock});
@@ -797,9 +796,9 @@ private:
             ammAlice.deposit(carol, BTC(100), std::nullopt, std::nullopt, std::nullopt);
 
             // Can not deposit locked token USD
-            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.deposit(carol, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
             ammAlice.deposit(
-                carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecFROZEN));
+                carol, USD(100), std::nullopt, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // Unlock AMM MPT USD
             USD.set({.holder = ammAlice.ammAccount(), .flags = tfMPTUnlock});
@@ -853,7 +852,7 @@ private:
 
             AMM amm(env, gw, XRP(10'000), BTC(10'000));
 
-            amm.deposit({.account = alice, .asset1In = BTC(10), .err = ter(tecNO_PERMISSION)});
+            amm.deposit({.account = alice, .asset1In = BTC(10), .err = ter(tecNO_AUTH)});
         }
 
         // Insufficient XRP balance
@@ -2211,7 +2210,7 @@ private:
                     .account = alice,
                     .asset1Out = BTC(100),
                     .assets = {{XRP, BTC}},
-                    .err = ter(tecNO_PERMISSION)});
+                    .err = ter(tecNO_AUTH)});
         }
 
         // Globally locked MPT
@@ -2232,8 +2231,8 @@ private:
             BTC.set({.flags = tfMPTLock});
 
             ammAlice.withdraw(
-                alice, MPT(ammAlice[1])(100), std::nullopt, std::nullopt, ter(tecFROZEN));
-            ammAlice.withdraw(alice, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+                alice, MPT(ammAlice[1])(100), std::nullopt, std::nullopt, ter(tecLOCKED));
+            ammAlice.withdraw(alice, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // can single withdraw the other asset
             ammAlice.withdraw({.account = alice, .asset1Out = XRP(100)});
@@ -2261,8 +2260,8 @@ private:
 
             // Alice's BTC is locked
             BTC.set({.holder = alice, .flags = tfMPTLock});
-            ammAlice.withdraw(alice, 1000, std::nullopt, std::nullopt, ter(tecFROZEN));
-            ammAlice.withdraw(alice, BTC(100), std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.withdraw(alice, 1000, std::nullopt, std::nullopt, ter(tecLOCKED));
+            ammAlice.withdraw(alice, BTC(100), std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // can withdraw the other asset
             ammAlice.withdraw(alice, USD(100), std::nullopt, std::nullopt);
@@ -2290,8 +2289,8 @@ private:
             // Alice's BTC is locked
             BTC.set({.holder = alice, .flags = tfMPTLock});
 
-            ammAlice.withdraw(alice, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
-            ammAlice.withdraw(alice, BTC(100), std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.withdraw(alice, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
+            ammAlice.withdraw(alice, BTC(100), std::nullopt, std::nullopt, ter(tecLOCKED));
             // can still single withdraw the unlocked other asset
             ammAlice.withdraw(alice, USD(100), std::nullopt, std::nullopt);
 
@@ -2310,8 +2309,8 @@ private:
             ammAlice.withdraw(alice, USD(100), std::nullopt, std::nullopt);
 
             // Can not withdraw locked token BTC
-            ammAlice.withdraw(alice, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
-            ammAlice.withdraw(alice, BTC(100), std::nullopt, std::nullopt, ter(tecFROZEN));
+            ammAlice.withdraw(alice, 1'000, std::nullopt, std::nullopt, ter(tecLOCKED));
+            ammAlice.withdraw(alice, BTC(100), std::nullopt, std::nullopt, ter(tecLOCKED));
 
             // Unlock AMM MPT
             BTC.set({.holder = ammAlice.ammAccount(), .flags = tfMPTUnlock});
@@ -6807,33 +6806,33 @@ private:
             cb(amm, BTC);
         };
 
-        // Deposit two assets, one of which is frozen,
-        // then we should get tecFROZEN error.
+        // Deposit two assets, one of which is locked,
+        // then we should get tecLOCKED error.
         {
             Env env(*this);
             testAMMDeposit(env, [&](AMM& amm, MPTTester& BTC) {
-                amm.deposit(alice, BTC(100), XRP(100), std::nullopt, tfTwoAsset, ter(tecFROZEN));
+                amm.deposit(alice, BTC(100), XRP(100), std::nullopt, tfTwoAsset, ter(tecLOCKED));
             });
         }
 
-        // Deposit one asset, which is the frozen token,
-        // then we should get tecFROZEN error.
+        // Deposit one asset, which is the frozen locked,
+        // then we should get tecLOCKED error.
         {
             Env env(*this);
             testAMMDeposit(env, [&](AMM& amm, MPTTester& BTC) {
                 amm.deposit(
-                    alice, BTC(100), std::nullopt, std::nullopt, tfSingleAsset, ter(tecFROZEN));
+                    alice, BTC(100), std::nullopt, std::nullopt, tfSingleAsset, ter(tecLOCKED));
             });
         }
 
         // Deposit one asset which is not the frozen token,
-        // but the other asset is frozen. We should get tecFROZEN error
+        // but the other asset is frozen. We should get tecLOCKED error
         // when feature AMMClawback is enabled.
         {
             Env env(*this);
             testAMMDeposit(env, [&](AMM& amm, MPTTester& BTC) {
                 amm.deposit(
-                    alice, XRP(100), std::nullopt, std::nullopt, tfSingleAsset, ter(tecFROZEN));
+                    alice, XRP(100), std::nullopt, std::nullopt, tfSingleAsset, ter(tecLOCKED));
             });
         }
     }

--- a/src/test/app/CheckMPT_test.cpp
+++ b/src/test/app/CheckMPT_test.cpp
@@ -1813,10 +1813,10 @@ class CheckMPT_test : public beast::unit_test::suite
             // Use offers to automatically create MPT.
             MPT const OF4 = gw1["OF4"];
             gw1.set(OF4, tfMPTLock);
-            env(offer(gw1, XRP(92), OF4(92)), ter(tecFROZEN));
+            env(offer(gw1, XRP(92), OF4(92)), ter(tecLOCKED));
             env.close();
             BEAST_EXPECT(env.le(keylet::mptoken(OF4, alice)) == nullptr);
-            env(offer(alice, OF4(92), XRP(92)), ter(tecFROZEN));
+            env(offer(alice, OF4(92), XRP(92)), ter(tecLOCKED));
             env.close();
 
             // No one's owner count should have changed.
@@ -1904,10 +1904,10 @@ class CheckMPT_test : public beast::unit_test::suite
             // Use offers to automatically create MPT.
             MPT const OF4 = gw1["OF4"];
             gw1.set(OF4, tfMPTLock);
-            env(offer(alice, XRP(91), OF4(91)), ter(tecFROZEN));
+            env(offer(alice, XRP(91), OF4(91)), ter(tecLOCKED));
             env.close();
             BEAST_EXPECT(env.le(keylet::mptoken(OF4, alice)) == nullptr);
-            env(offer(bob, OF4(91), XRP(91)), ter(tecFROZEN));
+            env(offer(bob, OF4(91), XRP(91)), ter(tecLOCKED));
             env.close();
 
             // No one's owner count should have changed.

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -24,7 +24,6 @@
 
 namespace xrpl {
 namespace test {
-
 class Invariants_test : public beast::unit_test::suite
 {
     // The optional Preclose function is used to process additional transactions
@@ -140,7 +139,11 @@ class Invariants_test : public beast::unit_test::suite
         for (TER const& terExpect : ters)
         {
             terActual = ac.checkInvariants(terActual, fee);
-            BEAST_EXPECTS(terExpect == terActual, std::to_string(TERtoInt(terActual)));
+            if (!BEAST_EXPECTS(terExpect == terActual, std::to_string(TERtoInt(terActual))))
+            {
+                std::cout << terExpect << " " << terActual << " "
+                          << std::to_string(TERtoInt(terActual)) << std::endl;
+            }
             auto const messages = sink.messages().str();
 
             if (!isTesSuccess(terActual))
@@ -154,7 +157,10 @@ class Invariants_test : public beast::unit_test::suite
             // std::cerr << messages << '\n';
             for (auto const& m : expect_logs)
             {
-                BEAST_EXPECTS(messages.find(m) != std::string::npos, m);
+                if (!BEAST_EXPECTS(messages.find(m) != std::string::npos, m))
+                {
+                    std::cout << messages << " " << m << std::endl;
+                }
             }
         }
     }
@@ -4000,6 +4006,81 @@ class Invariants_test : public beast::unit_test::suite
                     id = mpt.issuanceID();
                     return true;
                 });
+        }
+
+        // Invalid transfer
+        std::array<std::pair<TxType, bool>, 3> const invalidTransferTests = {
+            std::make_pair(ttAMM_WITHDRAW, false),
+            std::make_pair(ttPAYMENT, false),
+            std::make_pair(ttPAYMENT, true)};
+        for (auto const enabled : {true, false})
+        {
+            for (auto const& [tx, crossCurrencyPayment] : invalidTransferTests)
+            {
+                for (auto const flag :
+                     {static_cast<std::uint32_t>(lsfMPTLocked),
+                      ~lsfMPTCanTransfer,
+                      ~lsfMPTCanTrade,
+                      0u})
+                {
+                    MPTID id{};
+                    auto const isSuccess = !enabled || flag == 0 ||
+                        (tx == ttPAYMENT && !crossCurrencyPayment && (flag == ~lsfMPTCanTrade));
+                    std::pair<TER, TER> const error = isSuccess
+                        ? std::make_pair(TER(tesSUCCESS), TER(tesSUCCESS))
+                        : std::make_pair(TER(tecINVARIANT_FAILED), TER(tefINVARIANT_FAILED));
+                    doInvariantCheck(
+                        {{isSuccess ? "" : "invalid MPToken transfer between holders"}},
+                        [&](Account const& A1, Account const& A2, ApplyContext& ac) {
+                            auto update = [&](AccountID const& a, std::uint64_t v) {
+                                auto sle = ac.view().peek(keylet::mptoken(id, a));
+                                if (!sle)
+                                    return false;
+                                sle->at(sfMPTAmount) = v;
+                                ac.view().update(sle);
+                                return true;
+                            };
+                            auto issuanceSle = ac.view().peek(keylet::mptIssuance(id));
+                            if (!issuanceSle)
+                                return false;
+                            auto const flags = issuanceSle->at(sfFlags);
+                            if (flag == lsfMPTLocked)
+                            {
+                                issuanceSle->at(sfFlags) = flags | lsfMPTLocked;
+                            }
+                            else if (flag != 0u)
+                            {
+                                issuanceSle->at(sfFlags) = flags & flag;
+                            }
+                            issuanceSle->at(sfOutstandingAmount) = 200;
+                            ac.view().update(issuanceSle);
+                            return update(A1, 101) && update(A2, 99);
+                        },
+                        XRPAmount{},
+                        STTx{
+                            tx,
+                            [&](STObject& tx) {
+                                if (crossCurrencyPayment)
+                                {
+                                    tx.setFieldAmount(
+                                        sfSendMax, STAmount(MPTAmount{100}, MPTIssue{id}));
+                                }
+                            }},
+                        {error.first, error.second},
+                        [&](Account const& A1, Account const& A2, Env& env) {
+                            Account const gw("gw");
+                            env.fund(XRP(1'000), gw);
+                            MPTTester const USD(
+                                {.env = env, .issuer = gw, .holders = {A1, A2}, .pay = 100});
+                            id = USD.issuanceID();
+                            if (!enabled)
+                            {
+                                env.disableFeature(featureMPTokensV2);
+                            }
+                            return true;
+                        });
+                }
+            }
         }
     }
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -5833,7 +5833,7 @@ class MPToken_test : public beast::unit_test::suite
             env.close();
         }
 
-        // MPTCanTransfer disabled
+        // MPTCanTransfer is disabled
         {
             Env env{*this, features};
             env.fund(XRP(1'000), gw, alice, carol);
@@ -5874,49 +5874,44 @@ class MPToken_test : public beast::unit_test::suite
             BEAST_EXPECT(env.balance(alice, mpt) == mpt(0));
             BEAST_EXPECT(env.balance(gw, mpt) == mpt(0));
 
-            // neither src nor dst is issuer, can still create
+            // neither src nor dst is issuer, can't create
+            checkId = keylet::check(alice, env.seq(alice)).key;
+            env(check::create(alice, carol, mpt(100)), ter(tecNO_AUTH));
+            env.close();
+
+            // can create now
+            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTransfer});
             checkId = keylet::check(alice, env.seq(alice)).key;
             env(check::create(alice, carol, mpt(100)));
             env.close();
-
-            // can't cash
-            env(check::cash(carol, checkId, mpt(10)), ter(tecPATH_PARTIAL));
-            env.close();
-
-            // can cash now
-            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTransfer});
+            // can cash
             env(pay(gw, alice, mpt(10)));
             env.close();
             env(check::cash(carol, checkId, mpt(10)));
             env.close();
         }
 
-        // MPTCanTrade disabled
+        // MPTCanTrade is disabled
         {
             Env env{*this, features};
             env.fund(XRP(1'000), gw, alice, carol);
             env.close();
 
-            MPTTester mpt(
+            MPT const mpt = MPTTester(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol},
-                 .flags = tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .pay = 10,
+                 .flags = tfMPTCanTransfer});
 
-            uint256 checkId{keylet::check(gw, env.seq(gw)).key};
+            uint256 const checkId{keylet::check(alice, env.seq(alice)).key};
 
-            // can't create
-            env(check::create(gw, alice, mpt(100)), ter(tecNO_PERMISSION));
+            // can create
+            env(check::create(alice, carol, mpt(100)));
             env.close();
-            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTrade});
 
-            // can't cash
-            checkId = keylet::check(gw, env.seq(gw)).key;
-            env(check::create(gw, carol, mpt(100)));
-            env.close();
-            mpt.set({.account = gw, .mutableFlags = tmfMPTClearCanTrade});
-            env(check::cash(carol, checkId, mpt(10)), ter(tecNO_PERMISSION));
+            // can cash
+            env(check::cash(carol, checkId, mpt(10)));
             env.close();
         }
 
@@ -5968,33 +5963,6 @@ class MPToken_test : public beast::unit_test::suite
             env.close();
 
             env(check::cash(carol, chkId, BTC(1)), ter(tecPATH_PARTIAL));
-            env.close();
-        }
-
-        // MPTCanTransfer is not set and the account is not the issuer of MPT
-        {
-            Env env{*this, features};
-            env.fund(XRP(1'000), gw, alice, carol);
-
-            auto EUR = MPTTester(
-                {.env = env, .issuer = gw, .holders = {alice, carol}, .flags = tfMPTCanTrade});
-            uint256 const chkId{getCheckIndex(alice, env.seq(alice))};
-            // alice can create
-            env(check::create(alice, carol, EUR(1)));
-            env.close();
-
-            // carol can't cash
-            env(check::cash(carol, chkId, EUR(1)), ter(tecPATH_PARTIAL));
-            env.close();
-
-            // if issuer creates a check then carol can cash since
-            // it's a transfer from the issuer
-            uint256 const chkId1{getCheckIndex(gw, env.seq(gw))};
-            // alice can't create since CanTransfer is not set
-            env(check::create(gw, carol, EUR(1)));
-            env.close();
-
-            env(check::cash(carol, chkId1, EUR(1)));
             env.close();
         }
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -12,6 +12,7 @@
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/ledger/helpers/AMMHelpers.h>
+#include <xrpl/ledger/helpers/MPTokenHelpers.h>
 #include <xrpl/ledger/helpers/TokenHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/TER.h>
@@ -6625,6 +6626,57 @@ class MPToken_test : public beast::unit_test::suite
         BEAST_EXPECT(carolOwnersAfterWithdraw == carolOwnersBeforeWithdraw + 1);
     }
 
+    void
+    testTradeAndTransfer()
+    {
+        using namespace jtx;
+        testcase("Trade and Transfer");
+
+        // Verify canMPTTradeAndTransfer validates the flags when from == to and from != to
+
+        Account const gw{"gw"};
+        Account const alice{"alice"};
+        Account const carol{"carol"};
+        Env env(*this);
+        env.fund(XRP(1'000), gw, alice, carol);
+
+        MPTTester mpt(
+            {.env = env,
+             .issuer = gw,
+             .holders = {alice, carol},
+             .pay = 100,
+             .flags = MPTDEXFlags,
+             .mutableFlags = tmfMPTCanMutateCanTransfer | tmfMPTCanMutateCanTrade});
+
+        // Both flags are enabled
+        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw)));
+        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice)));
+        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice)));
+        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol)));
+
+        // MPTCanTrade is disabled
+        mpt.set({.mutableFlags = tmfMPTClearCanTrade});
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw) == tecNO_PERMISSION);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice) == tecNO_PERMISSION);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == tecNO_PERMISSION);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == tecNO_PERMISSION);
+
+        // MPTCanTransfer is disabled
+        mpt.set({.mutableFlags = tmfMPTSetCanTrade});
+        mpt.set({.mutableFlags = tmfMPTClearCanTransfer});
+        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw)));
+        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice)));
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == tecNO_AUTH);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == tecNO_AUTH);
+
+        // Both flags are disabled
+        mpt.set({.mutableFlags = tmfMPTClearCanTrade});
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw) == tecNO_PERMISSION);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice) == tecNO_PERMISSION);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == tecNO_PERMISSION);
+        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == tecNO_PERMISSION);
+    }
+
 public:
     void
     run() override
@@ -6731,6 +6783,9 @@ public:
 
         // Test AMM
         testBasicAMM(all);
+
+        // Test Trade/Transfer
+        testTradeAndTransfer();
 
         // Fixes
         testFixDoubleOwnerCount(all);

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -6583,6 +6583,48 @@ class MPToken_test : public beast::unit_test::suite
         }
     }
 
+    void
+    testFixDoubleOwnerCount(FeatureBitset all)
+    {
+        testcase("Fix Double adjustOwnerCount in AMMWithdraw");
+
+        using namespace jtx;
+
+        // Carol deposits XRP into an XRP/MPT pool, then withdraws MPT.
+        // Carol has no MPToken before the withdrawal. If the bug exists,
+        // her ownerCount will be inflated by +1 extra.
+        Account const gw{"gw"};
+        Account const alice{"alice"};
+        Account const carol{"carol"};
+        Env env(*this, all);
+        env.fund(XRP(30'000), gw, alice, carol);
+        env.close();
+
+        // Create MPT with DEX flags. Only alice is a holder initially.
+        MPT const BTC = MPTTester(
+            {.env = env, .issuer = gw, .holders = {alice}, .pay = 20'000, .flags = MPTDEXFlags});
+
+        // Alice creates XRP/MPT AMM pool
+        AMM amm(env, alice, XRP(10'000), BTC(10'000));
+
+        // Carol deposits XRP (single asset) into the pool.
+        // Carol gets LP tokens but does NOT have an MPToken yet.
+        auto const carolOwnersBefore = ownerCount(env, carol);
+        amm.deposit(carol, XRP(1'000), std::nullopt, std::nullopt, tfSingleAsset);
+        auto const carolOwnersAfterDeposit = ownerCount(env, carol);
+        // Carol should have +1 for LP token trustline
+        BEAST_EXPECT(carolOwnersAfterDeposit == carolOwnersBefore + 1);
+
+        auto const carolOwnersBeforeWithdraw = ownerCount(env, carol);
+        // Carol withdraws single MPT asset. She doesn't have an MPToken,
+        // so one must be created. Bug: ownerCount incremented twice.
+        amm.withdraw({.account = carol, .asset1Out = BTC(100), .flags = tfSingleAsset});
+        auto const carolOwnersAfterWithdraw = ownerCount(env, carol);
+
+        // Expected: +1 for the new MPToken (so total increase = 1)
+        BEAST_EXPECT(carolOwnersAfterWithdraw == carolOwnersBeforeWithdraw + 1);
+    }
+
 public:
     void
     run() override
@@ -6689,6 +6731,9 @@ public:
 
         // Test AMM
         testBasicAMM(all);
+
+        // Fixes
+        testFixDoubleOwnerCount(all);
     }
 };
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -5884,9 +5884,15 @@ class MPToken_test : public beast::unit_test::suite
             checkId = keylet::check(alice, env.seq(alice)).key;
             env(check::create(alice, carol, mpt(100)));
             env.close();
-            // can cash
             env(pay(gw, alice, mpt(10)));
             env.close();
+            // can't cash
+            mpt.set({.account = gw, .mutableFlags = tmfMPTClearCanTransfer});
+            env.close();
+            env(check::cash(carol, checkId, mpt(10)), ter(tecNO_AUTH));
+            env.close();
+            // can cash
+            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTransfer});
             env(check::cash(carol, checkId, mpt(10)));
             env.close();
         }

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3395,10 +3395,10 @@ class MPToken_test : public beast::unit_test::suite
                     auto const [errBuy, errSell] = [&]() -> std::pair<TER, TER> {
                         // Global lock
                         if (lockMPTIssue)
-                            return std::make_pair(tecFROZEN, tecFROZEN);
+                            return std::make_pair(tecLOCKED, tecLOCKED);
                         // Local lock
                         if (lockMPToken)
-                            return std::make_pair(tesSUCCESS, error(tecUNFUNDED_OFFER));
+                            return std::make_pair(error(tecLOCKED), error(tecUNFUNDED_OFFER));
                         // MPToken doesn't exist
                         if (requireAuth)
                             return std::make_pair(error(tecNO_AUTH), error(tecUNFUNDED_OFFER));
@@ -3496,10 +3496,9 @@ class MPToken_test : public beast::unit_test::suite
                 else
                 {
                     auto const err = flag == tfMPTLock ? ter(tecUNFUNDED_OFFER) : ter(tesSUCCESS);
+                    auto const err1 = flag == tfMPTLock ? ter(tecLOCKED) : ter(tesSUCCESS);
                     env(offer(alice, ETH(1), BTC(1)), err);
-                    // Offer created by not crossed
-                    env(offer(carol, BTC(1), ETH(1)));
-                    BEAST_EXPECT(expectOffers(env, carol, 1, {{BTC(1), ETH(1)}}));
+                    env(offer(carol, BTC(1), ETH(1)), err1);
                 }
             };
 
@@ -6126,8 +6125,7 @@ class MPToken_test : public beast::unit_test::suite
             AMM amm(env, gw, BTC(100), USD(100));
             env.close();
             // alice can't deposit since MPTCanTransfer is not set
-            amm.deposit(
-                DepositArg{.account = alice, .tokens = 1'000, .err = ter(tecNO_PERMISSION)});
+            amm.deposit(DepositArg{.account = alice, .tokens = 1'000, .err = ter(tecNO_AUTH)});
             env.close();
 
             // can't clawback since alice is not an LP
@@ -6360,8 +6358,8 @@ class MPToken_test : public beast::unit_test::suite
 
             // alice and issuer can't create
             USD.set({.flags = tfMPTLock});
-            createFail(alice, tecFROZEN);
-            createFail(gw, tecFROZEN);
+            createFail(alice, tecLOCKED);
+            createFail(gw, tecLOCKED);
 
             // MPTRequireAuth is set
 
@@ -6381,7 +6379,7 @@ class MPToken_test : public beast::unit_test::suite
             USD.set({.mutableFlags = tmfMPTClearRequireAuth});
             USD.set({.mutableFlags = tmfMPTClearCanTransfer});
             // alice can't create
-            createFail(alice, tecNO_PERMISSION);
+            createFail(alice, tecNO_AUTH);
             // issuer can create
             createDeleteAMM(gw);
             USD.set({.mutableFlags = tmfMPTSetCanTransfer});
@@ -6427,12 +6425,12 @@ class MPToken_test : public beast::unit_test::suite
                     {.account = account,
                      .asset1In = USD(1),
                      .asset2In = EUR(1),
-                     .err = ter(tecFROZEN)});
+                     .err = ter(tecLOCKED)});
                 amm.deposit(
                     {.account = account,
                      .asset1In = EUR(1),
                      .assets = std::make_pair(EUR, USD),
-                     .err = ter(tecFROZEN)});
+                     .err = ter(tecLOCKED)});
             }
             USD.set({.flags = tfMPTUnlock});
 
@@ -6467,15 +6465,12 @@ class MPToken_test : public beast::unit_test::suite
             USD.set({.mutableFlags = tmfMPTClearCanTransfer});
             // carol can't deposit
             amm.deposit(
-                {.account = carol,
-                 .asset1In = USD(1),
-                 .asset2In = EUR(1),
-                 .err = ter(tecNO_PERMISSION)});
+                {.account = carol, .asset1In = USD(1), .asset2In = EUR(1), .err = ter(tecNO_AUTH)});
             amm.deposit(
                 {.account = carol,
                  .asset1In = EUR(1),
                  .assets = std::make_pair(EUR, USD),
-                 .err = ter(tecNO_PERMISSION)});
+                 .err = ter(tecNO_AUTH)});
             // issuer can deposit
             amm.deposit({.account = gw, .tokens = 1'000});
             // carol can deposit
@@ -6517,8 +6512,8 @@ class MPToken_test : public beast::unit_test::suite
                     {.account = account,
                      .asset1Out = USD(1),
                      .asset2Out = EUR(1),
-                     .err = ter(tecFROZEN)});
-                amm.withdraw({.account = account, .tokens = 1'000, .err = ter(tecFROZEN)});
+                     .err = ter(tecLOCKED)});
+                amm.withdraw({.account = account, .tokens = 1'000, .err = ter(tecLOCKED)});
                 // can single withdraw another asset
                 amm.withdraw(
                     {.account = account, .asset1Out = EUR(1), .assets = std::make_pair(EUR, USD)});
@@ -6544,7 +6539,7 @@ class MPToken_test : public beast::unit_test::suite
             USD.authorize({.account = gw, .holder = carol});
             amm.withdraw({.account = carol, .asset1Out = USD(1), .asset2Out = EUR(1)});
 
-            // MPTCanTransfer is set
+            // MPTCanTransfer is not set
 
             USD.set({.mutableFlags = tmfMPTClearRequireAuth});
             USD.set({.mutableFlags = tmfMPTClearCanTransfer});
@@ -6553,7 +6548,7 @@ class MPToken_test : public beast::unit_test::suite
                 {.account = carol,
                  .asset1Out = USD(1),
                  .asset2Out = EUR(1),
-                 .err = ter(tecNO_PERMISSION)});
+                 .err = ter(tecNO_AUTH)});
             // can withdraw another asset
             amm.withdraw(
                 {.account = carol, .asset1Out = EUR(1), .assets = std::make_pair(EUR, USD)});
@@ -6564,6 +6559,9 @@ class MPToken_test : public beast::unit_test::suite
             amm.withdraw({.account = carol, .asset1Out = USD(1), .asset2Out = EUR(1)});
 
             USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+
+            // MPTCanTrade is not set
+
             USD.set({.mutableFlags = tmfMPTClearCanTrade});
             amm.withdraw({.account = gw, .tokens = 1'000, .err = ter(tecNO_PERMISSION)});
             amm.withdraw({.account = carol, .tokens = 1'000, .err = ter(tecNO_PERMISSION)});


### PR DESCRIPTION
## High Level Overview of Change

- ValidMPTTransfer, check for valid MPTLocked, MPTCanTrade, MPTCanTransfer.
- Replace canTrade with canTransfer in CheckCreate/Cash (Check is not DEX tx).
- Change tecFROZEN to tecLOCKED for locked MPT.
- Replace checkMPTTxAllowed() with canMPTTradeAndTransfer().
- Fix double adjustOwnerCount() in AMMWithdraw.


