### PR TITLE
chore: Make pre-commit line ending conversions work on Windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: mixed-line-ending
       - id: check-merge-conflict
         args: [--assume-in-merge]
 
@@ -30,6 +29,7 @@ repos:
     rev: 5ba47274f9b181bce26a5150a725577f3c336011 # frozen: v3.6.2
     hooks:
       - id: prettier
+        args: [--end-of-line=auto]
 
 exclude: |
   (?x)^(


### PR DESCRIPTION
## High Level Overview of Change

Update pre-commit config to keep line endings correct across OSes.

* Remove the "mixed-line-ending" check, because prettier replaces it.
* Pass "--end-of-line=auto" to prettier so that it will respect git's
  core.autocrlf setting, and do the right thing on each OS.

### Context of Change

Using the old settings, formatting a branch on Windows particularly using `pre-commit run -a` would convert _many_ files to have unix-style (LF) line endings. This undid the changes done by git's `core.autocrlf=true` setting, and resulted in a large, bogus change set, plus _many_ warnings along the lines of `warning: in the working copy of 'README.md', LF will be replaced by CRLF the next time Git touches it` in the output of most git commands.