### PR TITLE
chore: Make pre-commit line ending conversions work on Windows (#6832)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
         args: [--maxkb=400, --enforce-all]
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: mixed-line-ending
       - id: check-merge-conflict
         args: [--assume-in-merge]
 
@@ -38,6 +37,7 @@ repos:
     rev: c2bc67fe8f8f549cc489e00ba8b45aa18ee713b1 # frozen: v3.8.1
     hooks:
       - id: prettier
+        args: [--end-of-line=auto]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: ea488cebbfd88a5f50b8bd95d5c829d0bb76feb8 # frozen: 26.1.0


### PR DESCRIPTION
## High Level Overview of Change

Update pre-commit config to keep line endings correct across OSes.

* Remove the "mixed-line-ending" check, because prettier replaces it.
* Pass "--end-of-line=auto" to prettier so that it will respect git's
  core.autocrlf setting, and do the right thing on each OS.

### Context of Change

Using the old settings, formatting a branch on Windows particularly using `pre-commit run -a` would convert _many_ files to have unix-style (LF) line endings. This undid the changes done by git's `core.autocrlf=true` setting, and resulted in a large, bogus change set, plus _many_ warnings along the lines of `warning: in the working copy of 'README.md', LF will be replaced by CRLF the next time Git touches it` in the output of most git commands.