### PR TITLE
fix: Fix unity build for book step

### DIFF
--- a/src/libxrpl/tx/paths/BookStep.cpp
+++ b/src/libxrpl/tx/paths/BookStep.cpp
@@ -1438,7 +1438,18 @@ bookStepEqual(Step const& step, xrpl::Book const& book)
         [&]<typename TIn, typename TOut>(TIn const&, TOut const&) {
             using TIn_ = typename TIn::amount_type;
             using TOut_ = typename TOut::amount_type;
-            return equalHelper<TIn_, TOut_, BookPaymentStep<TIn_, TOut_>>(step, book);
+
+            if constexpr (ValidTaker<TIn_, TOut_>)
+            {
+                return equalHelper<TIn_, TOut_, BookPaymentStep<TIn_, TOut_>>(step, book);
+            }
+            else
+            {
+                // LCOV_EXCL_START
+                UNREACHABLE("xrpl::test::bookStepEqual : invalid book step");
+                // LCOV_EXCL_STOP
+                return false;
+            }
         },
         book.in.getAmountType(),
         book.out.getAmountType());

--- a/src/libxrpl/tx/paths/BookStep.cpp
+++ b/src/libxrpl/tx/paths/BookStep.cpp
@@ -1446,7 +1446,7 @@ bookStepEqual(Step const& step, xrpl::Book const& book)
             else
             {
                 // LCOV_EXCL_START
-                UNREACHABLE("xrpl::test::bookStepEqual : invalid book step");
+                UNREACHABLE("xrpl::bookStepEqual : invalid book step");
                 // LCOV_EXCL_STOP
                 return false;
             }

--- a/src/libxrpl/tx/paths/BookStep.cpp
+++ b/src/libxrpl/tx/paths/BookStep.cpp
@@ -1427,13 +1427,6 @@ equalHelper(Step const& step, xrpl::Book const& book)
 bool
 bookStepEqual(Step const& step, xrpl::Book const& book)
 {
-    if (isXRP(book.in) && isXRP(book.out))
-    {
-        // LCOV_EXCL_START
-        UNREACHABLE("xrpl::test::bookStepEqual : no XRP to XRP book step");
-        return false;  // no such thing as xrp/xrp book step
-        // LCOV_EXCL_STOP
-    }
     return std::visit(
         [&]<typename TIn, typename TOut>(TIn const&, TOut const&) {
             using TIn_ = typename TIn::amount_type;
@@ -1447,8 +1440,8 @@ bookStepEqual(Step const& step, xrpl::Book const& book)
             {
                 // LCOV_EXCL_START
                 UNREACHABLE("xrpl::bookStepEqual : invalid book step");
-                // LCOV_EXCL_STOP
                 return false;
+                // LCOV_EXCL_STOP
             }
         },
         book.in.getAmountType(),

--- a/src/libxrpl/tx/paths/OfferStream.cpp
+++ b/src/libxrpl/tx/paths/OfferStream.cpp
@@ -279,7 +279,6 @@ TOfferStreamBase<TIn, TOut>::step()
             continue;
         }
 
-        static_assert(!std::same_as<TIn, XRPAmount> || !std::same_as<TOut, XRPAmount>);
         if (shouldRmSmallIncreasedQOffer<TIn, TOut>())
         {
             auto const original_funds = accountFundsHelper(

--- a/src/libxrpl/tx/paths/OfferStream.cpp
+++ b/src/libxrpl/tx/paths/OfferStream.cpp
@@ -5,8 +5,13 @@
 #include <xrpl/ledger/helpers/PermissionedDEXHelpers.h>
 #include <xrpl/ledger/helpers/RippleStateHelpers.h>
 #include <xrpl/protocol/Feature.h>
+#include <xrpl/protocol/IOUAmount.h>
 #include <xrpl/protocol/LedgerFormats.h>
+#include <xrpl/protocol/MPTAmount.h>
+#include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/paths/OfferStream.h>
+
+#include <type_traits>
 
 namespace xrpl {
 
@@ -274,6 +279,7 @@ TOfferStreamBase<TIn, TOut>::step()
             continue;
         }
 
+        static_assert(!std::same_as<TIn, XRPAmount> || !std::same_as<TOut, XRPAmount>);
         if (shouldRmSmallIncreasedQOffer<TIn, TOut>())
         {
             auto const original_funds = accountFundsHelper(

--- a/src/libxrpl/tx/paths/OfferStream.cpp
+++ b/src/libxrpl/tx/paths/OfferStream.cpp
@@ -5,13 +5,8 @@
 #include <xrpl/ledger/helpers/PermissionedDEXHelpers.h>
 #include <xrpl/ledger/helpers/RippleStateHelpers.h>
 #include <xrpl/protocol/Feature.h>
-#include <xrpl/protocol/IOUAmount.h>
 #include <xrpl/protocol/LedgerFormats.h>
-#include <xrpl/protocol/MPTAmount.h>
-#include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/paths/OfferStream.h>
-
-#include <type_traits>
 
 namespace xrpl {
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This PR adds a static check in `src/libxrpl/tx/paths/BookStep.cpp` to avoid the case where both `TIn` and `TOut` are `XRPAmount`. 

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->


### Context of Change

Because unity build puts OfferStream.cpp and BookStep.cpp in the same translation unit, the compiler sees `TOfferStreamBase<XRPAmount, XRPAmount>` which further triggers the compiler error. 

With this fix, we explicitly disallow this combination so that we get rid of the build error.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
