### PR TITLE
fix: Check for empty `sfAdditionalBooks` array in hybrid offer invariant (#6716)

### DIFF
--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -1724,47 +1724,31 @@ class Invariants_test : public beast::unit_test::suite
             STTx{ttOFFER_CREATE, [&](STObject& tx) {}},
             {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
 
-        // empty sfAdditionalBooks (size 0)
-        {
-            Env env1(*this, features);
+        // empty sfAdditionalBooks (size 0) - caught by fixSecurity3_1_3
+        // (testable_amendments() always enables fixSecurity3_1_3)
+        doInvariantCheck(
+            {{"hybrid offer is malformed"}},
+            [&](Account const& A1, Account const& A2, ApplyContext& ac) {
+                Keylet const pdKeylet = keylet::permissionedDomain(A1.id(), 10);
+                auto slePd = std::make_shared<SLE>(pdKeylet);
+                createPermissionedDomain(ac, slePd, A1, A2);
 
-            Account const A1{"A1"};
-            Account const A2{"A2"};
-            env1.fund(XRP(1000), A1, A2);
-            env1.close();
+                Keylet const offerKey = keylet::offer(A2.id(), 10);
+                auto sleOffer = std::make_shared<SLE>(offerKey);
+                sleOffer->setAccountID(sfAccount, A2);
+                sleOffer->setFieldAmount(sfTakerPays, A1["USD"](10));
+                sleOffer->setFieldAmount(sfTakerGets, XRP(1));
+                sleOffer->setFlag(lsfHybrid);
+                sleOffer->setFieldH256(sfDomainID, pdKeylet.key);
 
-            [[maybe_unused]] auto [seq1, pd1] =
-                createPermissionedDomainEnv(env1, A1, A2);
-            env1.close();
-
-            doInvariantCheck(
-                std::move(env1),
-                A1,
-                A2,
-                fixS313Enabled
-                    ? std::vector<std::string>{{"hybrid offer is malformed"}}
-                    : std::vector<std::string>{},
-                [&pd1](Account const& A1, Account const& A2, ApplyContext& ac) {
-                    Keylet const offerKey = keylet::offer(A2.id(), 10);
-                    auto sleOffer = std::make_shared<SLE>(offerKey);
-                    sleOffer->setAccountID(sfAccount, A2);
-                    sleOffer->setFieldAmount(sfTakerPays, A1["USD"](10));
-                    sleOffer->setFieldAmount(sfTakerGets, XRP(1));
-                    sleOffer->setFlag(lsfHybrid);
-                    sleOffer->setFieldH256(sfDomainID, pd1);
-
-                    STArray const bookArr;  // empty array, size 0
-                    sleOffer->setFieldArray(sfAdditionalBooks, bookArr);
-                    ac.view().insert(sleOffer);
-                    return true;
-                },
-                XRPAmount{},
-                STTx{ttOFFER_CREATE, [&](STObject&) {}},
-                fixS313Enabled
-                    ? std::initializer_list<
-                          TER>{tecINVARIANT_FAILED, tecINVARIANT_FAILED}
-                    : std::initializer_list<TER>{tesSUCCESS, tesSUCCESS});
-        }
+                STArray const bookArr;  // empty array, size 0
+                sleOffer->setFieldArray(sfAdditionalBooks, bookArr);
+                ac.view().insert(sleOffer);
+                return true;
+            },
+            XRPAmount{},
+            STTx{ttOFFER_CREATE, [&](STObject&) {}},
+            {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
 
         // hybrid offer missing sfAdditionalBooks
         doInvariantCheck(

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -1966,8 +1966,7 @@ class Invariants_test : public beast::unit_test::suite
             {{"hybrid offer is malformed"}},
             [&](Account const& A1, Account const& A2, ApplyContext& ac) {
                 Keylet const pdKeylet = keylet::permissionedDomain(A1.id(), 10);
-                auto slePd = std::make_shared<SLE>(pdKeylet);
-                createPermissionedDomain(ac, slePd, A1, A2);
+                createPermissionedDomain(ac, A1, A2);
 
                 Keylet const offerKey = keylet::offer(A2.id(), 10);
                 auto sleOffer = std::make_shared<SLE>(offerKey);

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -1753,7 +1753,7 @@ class Invariants_test : public beast::unit_test::suite
                     sleOffer->setFlag(lsfHybrid);
                     sleOffer->setFieldH256(sfDomainID, pd1);
 
-                    STArray bookArr;  // empty array, size 0
+                    STArray const bookArr;  // empty array, size 0
                     sleOffer->setFieldArray(sfAdditionalBooks, bookArr);
                     ac.view().insert(sleOffer);
                     return true;

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -1961,29 +1961,41 @@ class Invariants_test : public beast::unit_test::suite
         }
 
         // empty sfAdditionalBooks (size 0) - caught by fixSecurity3_1_3
-        // (testable_amendments() always enables fixSecurity3_1_3)
-        doInvariantCheck(
-            {{"hybrid offer is malformed"}},
-            [&](Account const& A1, Account const& A2, ApplyContext& ac) {
-                Keylet const pdKeylet = keylet::permissionedDomain(A1.id(), 10);
-                createPermissionedDomain(ac, A1, A2);
+        {
+            Env env1(*this, defaultAmendments() | fixSecurity3_1_3);
 
-                Keylet const offerKey = keylet::offer(A2.id(), 10);
-                auto sleOffer = std::make_shared<SLE>(offerKey);
-                sleOffer->setAccountID(sfAccount, A2);
-                sleOffer->setFieldAmount(sfTakerPays, A1["USD"](10));
-                sleOffer->setFieldAmount(sfTakerGets, XRP(1));
-                sleOffer->setFlag(lsfHybrid);
-                sleOffer->setFieldH256(sfDomainID, pdKeylet.key);
+            Account const A1{"A1"};
+            Account const A2{"A2"};
+            env1.fund(XRP(1000), A1, A2);
+            env1.close();
 
-                STArray const bookArr;  // empty array, size 0
-                sleOffer->setFieldArray(sfAdditionalBooks, bookArr);
-                ac.view().insert(sleOffer);
-                return true;
-            },
-            XRPAmount{},
-            STTx{ttOFFER_CREATE, [&](STObject&) {}},
-            {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
+            [[maybe_unused]] auto [seq1, pd1] =
+                createPermissionedDomainEnv(env1, A1, A2);
+            env1.close();
+
+            doInvariantCheck(
+                std::move(env1),
+                A1,
+                A2,
+                {{"hybrid offer is malformed"}},
+                [&pd1](Account const& A1, Account const& A2, ApplyContext& ac) {
+                    Keylet const offerKey = keylet::offer(A2.id(), 10);
+                    auto sleOffer = std::make_shared<SLE>(offerKey);
+                    sleOffer->setAccountID(sfAccount, A2);
+                    sleOffer->setFieldAmount(sfTakerPays, A1["USD"](10));
+                    sleOffer->setFieldAmount(sfTakerGets, XRP(1));
+                    sleOffer->setFlag(lsfHybrid);
+                    sleOffer->setFieldH256(sfDomainID, pd1);
+
+                    STArray const bookArr;  // empty array, size 0
+                    sleOffer->setFieldArray(sfAdditionalBooks, bookArr);
+                    ac.view().insert(sleOffer);
+                    return true;
+                },
+                XRPAmount{},
+                STTx{ttOFFER_CREATE, [&](STObject&) {}},
+                {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
+        }
 
         // hybrid offer missing sfAdditionalBooks
         {

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -1724,6 +1724,43 @@ class Invariants_test : public beast::unit_test::suite
             STTx{ttOFFER_CREATE, [&](STObject& tx) {}},
             {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
 
+        // empty sfAdditionalBooks (size 0)
+        {
+            Env env1(*this, features);
+
+            Account const A1{"A1"};
+            Account const A2{"A2"};
+            env1.fund(XRP(1000), A1, A2);
+            env1.close();
+
+            [[maybe_unused]] auto [seq1, pd1] =
+                createPermissionedDomainEnv(env1, A1, A2);
+            env1.close();
+
+            doInvariantCheck(
+                std::move(env1),
+                A1,
+                A2,
+                {{"hybrid offer is malformed"}},
+                [&pd1](Account const& A1, Account const& A2, ApplyContext& ac) {
+                    Keylet const offerKey = keylet::offer(A2.id(), 10);
+                    auto sleOffer = std::make_shared<SLE>(offerKey);
+                    sleOffer->setAccountID(sfAccount, A2);
+                    sleOffer->setFieldAmount(sfTakerPays, A1["USD"](10));
+                    sleOffer->setFieldAmount(sfTakerGets, XRP(1));
+                    sleOffer->setFlag(lsfHybrid);
+                    sleOffer->setFieldH256(sfDomainID, pd1);
+
+                    STArray bookArr;  // empty array, size 0
+                    sleOffer->setFieldArray(sfAdditionalBooks, bookArr);
+                    ac.view().insert(sleOffer);
+                    return true;
+                },
+                XRPAmount{},
+                STTx{ttOFFER_CREATE, [&](STObject&) {}},
+                {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
+        }
+
         // hybrid offer missing sfAdditionalBooks
         doInvariantCheck(
             {{"hybrid offer is malformed"}},

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -1741,7 +1741,9 @@ class Invariants_test : public beast::unit_test::suite
                 std::move(env1),
                 A1,
                 A2,
-                {{"hybrid offer is malformed"}},
+                fixS313Enabled
+                    ? std::vector<std::string>{{"hybrid offer is malformed"}}
+                    : std::vector<std::string>{},
                 [&pd1](Account const& A1, Account const& A2, ApplyContext& ac) {
                     Keylet const offerKey = keylet::offer(A2.id(), 10);
                     auto sleOffer = std::make_shared<SLE>(offerKey);
@@ -1758,7 +1760,10 @@ class Invariants_test : public beast::unit_test::suite
                 },
                 XRPAmount{},
                 STTx{ttOFFER_CREATE, [&](STObject&) {}},
-                {tecINVARIANT_FAILED, tecINVARIANT_FAILED});
+                fixS313Enabled
+                    ? std::initializer_list<
+                          TER>{tecINVARIANT_FAILED, tecINVARIANT_FAILED}
+                    : std::initializer_list<TER>{tesSUCCESS, tesSUCCESS});
         }
 
         // hybrid offer missing sfAdditionalBooks

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -1587,7 +1587,7 @@ class PermissionedDEX_test : public beast::unit_test::suite
         // sfAdditionalBooks is present but empty (size 0). This is the
         // malformed state that fixSecurity3_1_3 is designed to catch.
         auto const offerKey = keylet::offer(bob.id(), bobOfferSeq);
-        env.app().getOpenLedger().modify(
+        env.app().openLedger().modify(
             [&offerKey](OpenView& view, beast::Journal) {
                 auto const sle = view.read(offerKey);
                 if (!sle)

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -27,6 +27,7 @@
 #include <xrpl/basics/Slice.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/ledger/ApplyViewImpl.h>
+#include <xrpl/ledger/OpenView.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/IOUAmount.h>
 #include <xrpl/protocol/Indexes.h>
@@ -34,6 +35,7 @@
 #include <xrpl/protocol/Keylet.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/STAmount.h>
+#include <xrpl/protocol/STArray.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/jss.h>
@@ -1547,6 +1549,73 @@ class PermissionedDEX_test : public beast::unit_test::suite
         BEAST_EXPECT(!offerExists(env, bob, carolOfferSeq));
     }
 
+    void
+    testHybridMalformedOffer(FeatureBitset features)
+    {
+        bool const fixS313Enabled = features[fixSecurity3_1_3];
+
+        testcase << "Hybrid offer with empty AdditionalBooks"
+                 << (fixS313Enabled ? " (fixSecurity3_1_3 enabled)"
+                                    : " (fixSecurity3_1_3 disabled)");
+
+        // offerInDomain has two code paths gated by fixSecurity3_1_3:
+        //
+        // pre-fix:  only rejects a hybrid offer when sfAdditionalBooks is
+        //           entirely absent — an empty array (size 0) passes through.
+        // post-fix: also rejects a hybrid offer whose sfAdditionalBooks array
+        //           has size != 1 (i.e. 0 or >1 entries).
+        //
+        // We create a valid hybrid offer, then directly manipulate its SLE to
+        // produce the size==0 case that cannot occur via normal transactions,
+        // and verify that the two code paths produce the expected outcomes.
+        //
+        // Note: the PermissionedDEX invariant checker (ValidPermissionedDEX)
+        // does not flag this malformation for ttPAYMENT — only for
+        // ttOFFER_CREATE — so the without-fix payment completes as tesSUCCESS.
+
+        Env env(*this, features);
+        auto const& [gw, domainOwner, alice, bob, carol, USD, domainID, credType] =
+            PermissionedDEX(env);
+
+        // Create a valid hybrid offer (sfAdditionalBooks has exactly 1 entry)
+        auto const bobOfferSeq{env.seq(bob)};
+        env(offer(bob, XRP(10), USD(10)), txflags(tfHybrid), domain(domainID));
+        env.close();
+        BEAST_EXPECT(offerExists(env, bob, bobOfferSeq));
+
+        // Directly manipulate the offer SLE in the open ledger so that
+        // sfAdditionalBooks is present but empty (size 0). This is the
+        // malformed state that fixSecurity3_1_3 is designed to catch.
+        auto const offerKey = keylet::offer(bob.id(), bobOfferSeq);
+        env.app().getOpenLedger().modify([&offerKey](OpenView& view, beast::Journal) {
+            auto const sle = view.read(offerKey);
+            if (!sle)
+                return false;
+            auto replacement = std::make_shared<SLE>(*sle, sle->key());
+            replacement->setFieldArray(sfAdditionalBooks, STArray{});
+            view.rawReplace(replacement);
+            return true;
+        });
+
+        if (fixS313Enabled)
+        {
+            // post-fixSecurity3_1_3: offerInDomain rejects the malformed
+            // offer (size == 0), so no valid domain offer is found.
+            env(pay(alice, carol, USD(10)),
+                path(~USD),
+                sendmax(XRP(10)),
+                domain(domainID),
+                ter(tecPATH_PARTIAL));
+        }
+        else
+        {
+            // pre-fixSecurity3_1_3: offerInDomain only checks for a missing
+            // sfAdditionalBooks field; size == 0 passes through, so the
+            // malformed offer is crossed and the payment succeeds.
+            env(pay(alice, carol, USD(10)), path(~USD), sendmax(XRP(10)), domain(domainID));
+        }
+    }
+
 public:
     void
     run() override
@@ -1568,6 +1637,8 @@ public:
         testHybridBookStep(all);
         testHybridInvalidOffer(all);
         testHybridOfferDirectories(all);
+        testHybridMalformedOffer(all);
+        testHybridMalformedOffer(all - fixSecurity3_1_3);
     }
 };
 

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -1587,15 +1587,16 @@ class PermissionedDEX_test : public beast::unit_test::suite
         // sfAdditionalBooks is present but empty (size 0). This is the
         // malformed state that fixSecurity3_1_3 is designed to catch.
         auto const offerKey = keylet::offer(bob.id(), bobOfferSeq);
-        env.app().getOpenLedger().modify([&offerKey](OpenView& view, beast::Journal) {
-            auto const sle = view.read(offerKey);
-            if (!sle)
-                return false;
-            auto replacement = std::make_shared<SLE>(*sle, sle->key());
-            replacement->setFieldArray(sfAdditionalBooks, STArray{});
-            view.rawReplace(replacement);
-            return true;
-        });
+        env.app().getOpenLedger().modify(
+            [&offerKey](OpenView& view, beast::Journal) {
+                auto const sle = view.read(offerKey);
+                if (!sle)
+                    return false;
+                auto replacement = std::make_shared<SLE>(*sle, sle->key());
+                replacement->setFieldArray(sfAdditionalBooks, STArray{});
+                view.rawReplace(replacement);
+                return true;
+            });
 
         if (fixS313Enabled)
         {
@@ -1612,7 +1613,10 @@ class PermissionedDEX_test : public beast::unit_test::suite
             // pre-fixSecurity3_1_3: offerInDomain only checks for a missing
             // sfAdditionalBooks field; size == 0 passes through, so the
             // malformed offer is crossed and the payment succeeds.
-            env(pay(alice, carol, USD(10)), path(~USD), sendmax(XRP(10)), domain(domainID));
+            env(pay(alice, carol, USD(10)),
+                path(~USD),
+                sendmax(XRP(10)),
+                domain(domainID));
         }
     }
 

--- a/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
+++ b/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
@@ -73,13 +73,29 @@ offerInDomain(
     if (sleOffer->getFieldH256(sfDomainID) != domainID)
         return false;  // LCOV_EXCL_LINE
 
-    if (sleOffer->isFlag(lsfHybrid) &&
-        (!sleOffer->isFieldPresent(sfAdditionalBooks) ||
-         sleOffer->getFieldArray(sfAdditionalBooks).size() != 1))
+    if (view.rules().enabled(fixSecurity3_1_3))
     {
-        JLOG(j.error()) << "Hybrid offer " << offerID
-                        << " missing or malformed AdditionalBooks field";
-        return false;  // LCOV_EXCL_LINE
+        // post-fixSecurity3_1_3: also catches empty sfAdditionalBooks (size ==
+        // 0)
+        if (sleOffer->isFlag(lsfHybrid) &&
+            (!sleOffer->isFieldPresent(sfAdditionalBooks) ||
+             sleOffer->getFieldArray(sfAdditionalBooks).size() != 1))
+        {
+            JLOG(j.error()) << "Hybrid offer " << offerID
+                            << " missing or malformed AdditionalBooks field";
+            return false;  // LCOV_EXCL_LINE
+        }
+    }
+    else
+    {
+        // pre-fixSecurity3_1_3: only check for missing sfAdditionalBooks
+        if (sleOffer->isFlag(lsfHybrid) &&
+            !sleOffer->isFieldPresent(sfAdditionalBooks))
+        {
+            JLOG(j.error()) << "Hybrid offer " << offerID
+                            << " missing AdditionalBooks field";
+            return false;  // LCOV_EXCL_LINE
+        }
     }
 
     return accountInDomain(view, sleOffer->getAccountID(sfAccount), domainID);

--- a/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
+++ b/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
@@ -75,8 +75,8 @@ offerInDomain(
 
     if (view.rules().enabled(fixSecurity3_1_3))
     {
-        // post-fixSecurity3_1_3: also catches empty sfAdditionalBooks (size ==
-        // 0)
+        // post-fixSecurity3_1_3: a valid hybrid offer must have sfAdditionalBooks
+        // present with exactly 1 entry
         if (sleOffer->isFlag(lsfHybrid) &&
             (!sleOffer->isFieldPresent(sfAdditionalBooks) ||
              sleOffer->getFieldArray(sfAdditionalBooks).size() != 1))
@@ -88,7 +88,8 @@ offerInDomain(
     }
     else
     {
-        // pre-fixSecurity3_1_3: only check for missing sfAdditionalBooks
+        // pre-fixSecurity3_1_3: a valid hybrid offer must have sfAdditionalBooks
+        // present (size is not checked)
         if (sleOffer->isFlag(lsfHybrid) &&
             !sleOffer->isFieldPresent(sfAdditionalBooks))
         {

--- a/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
+++ b/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
@@ -75,8 +75,8 @@ offerInDomain(
 
     if (view.rules().enabled(fixSecurity3_1_3))
     {
-        // post-fixSecurity3_1_3: a valid hybrid offer must have sfAdditionalBooks
-        // present with exactly 1 entry
+        // post-fixSecurity3_1_3: a valid hybrid offer must have
+        // sfAdditionalBooks present with exactly 1 entry
         if (sleOffer->isFlag(lsfHybrid) &&
             (!sleOffer->isFieldPresent(sfAdditionalBooks) ||
              sleOffer->getFieldArray(sfAdditionalBooks).size() != 1))
@@ -88,8 +88,8 @@ offerInDomain(
     }
     else
     {
-        // pre-fixSecurity3_1_3: a valid hybrid offer must have sfAdditionalBooks
-        // present (size is not checked)
+        // pre-fixSecurity3_1_3: a valid hybrid offer must have
+        // sfAdditionalBooks present (size is not checked)
         if (sleOffer->isFlag(lsfHybrid) &&
             !sleOffer->isFieldPresent(sfAdditionalBooks))
         {

--- a/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
+++ b/src/xrpld/app/misc/PermissionedDEXHelpers.cpp
@@ -74,10 +74,11 @@ offerInDomain(
         return false;  // LCOV_EXCL_LINE
 
     if (sleOffer->isFlag(lsfHybrid) &&
-        !sleOffer->isFieldPresent(sfAdditionalBooks))
+        (!sleOffer->isFieldPresent(sfAdditionalBooks) ||
+         sleOffer->getFieldArray(sfAdditionalBooks).size() != 1))
     {
         JLOG(j.error()) << "Hybrid offer " << offerID
-                        << " missing AdditionalBooks field";
+                        << " missing or malformed AdditionalBooks field";
         return false;  // LCOV_EXCL_LINE
     }
 

--- a/src/xrpld/app/tx/detail/InvariantCheck.cpp
+++ b/src/xrpld/app/tx/detail/InvariantCheck.cpp
@@ -1871,20 +1871,17 @@ ValidPermissionedDEX::visitEntry(
         else
             regularOffers_ = true;
 
-        // pre-fixSecurity3_1_3: hybrid offer missing domain, missing
-        // sfAdditionalBooks, or sfAdditionalBooks has more than one entry
-        if (after->isFlag(lsfHybrid) &&
-            (!after->isFieldPresent(sfDomainID) ||
-             !after->isFieldPresent(sfAdditionalBooks) ||
-             after->getFieldArray(sfAdditionalBooks).size() > 1))
-            badHybridsOld_ = true;
-
-        // post-fixSecurity3_1_3: same as above but also catches size == 0
-        if (after->isFlag(lsfHybrid) &&
-            (!after->isFieldPresent(sfDomainID) ||
-             !after->isFieldPresent(sfAdditionalBooks) ||
-             after->getFieldArray(sfAdditionalBooks).size() != 1))
-            badHybrids_ = true;
+        if (after->isFlag(lsfHybrid))
+        {
+            if (!after->isFieldPresent(sfDomainID) ||
+                !after->isFieldPresent(sfAdditionalBooks) ||
+                after->getFieldArray(sfAdditionalBooks).size() > 1)
+                badHybridsOld_ = true;
+            if (!after->isFieldPresent(sfDomainID) ||
+                !after->isFieldPresent(sfAdditionalBooks) ||
+                after->getFieldArray(sfAdditionalBooks).size() != 1)
+                badHybrids_ = true;
+        }
     }
 }
 

--- a/src/xrpld/app/tx/detail/InvariantCheck.cpp
+++ b/src/xrpld/app/tx/detail/InvariantCheck.cpp
@@ -1876,7 +1876,7 @@ ValidPermissionedDEX::visitEntry(
         if (after->isFlag(lsfHybrid) &&
             (!after->isFieldPresent(sfDomainID) ||
              !after->isFieldPresent(sfAdditionalBooks) ||
-             after->getFieldArray(sfAdditionalBooks).size() > 1))
+             after->getFieldArray(sfAdditionalBooks).size() != 1))
             badHybrids_ = true;
     }
 }

--- a/src/xrpld/app/tx/detail/InvariantCheck.cpp
+++ b/src/xrpld/app/tx/detail/InvariantCheck.cpp
@@ -1877,14 +1877,14 @@ ValidPermissionedDEX::visitEntry(
             (!after->isFieldPresent(sfDomainID) ||
              !after->isFieldPresent(sfAdditionalBooks) ||
              after->getFieldArray(sfAdditionalBooks).size() > 1))
-            badHybridPre_ = true;
+            badHybridsOld_ = true;
 
         // post-fixSecurity3_1_3: same as above but also catches size == 0
         if (after->isFlag(lsfHybrid) &&
             (!after->isFieldPresent(sfDomainID) ||
              !after->isFieldPresent(sfAdditionalBooks) ||
              after->getFieldArray(sfAdditionalBooks).size() != 1))
-            badHybridPost_ = true;
+            badHybrids_ = true;
     }
 }
 
@@ -1904,7 +1904,7 @@ ValidPermissionedDEX::finalize(
     // For each offercreate transaction, check if
     // permissioned offers are valid
     bool const isMalformed =
-        view.rules().enabled(fixSecurity3_1_3) ? badHybridPost_ : badHybridPre_;
+        view.rules().enabled(fixSecurity3_1_3) ? badHybrids_ : badHybridsOld_;
     if (txType == ttOFFER_CREATE && isMalformed)
     {
         JLOG(j.fatal()) << "Invariant failed: hybrid offer is malformed";

--- a/src/xrpld/app/tx/detail/InvariantCheck.cpp
+++ b/src/xrpld/app/tx/detail/InvariantCheck.cpp
@@ -1873,13 +1873,16 @@ ValidPermissionedDEX::visitEntry(
 
         if (after->isFlag(lsfHybrid))
         {
-            if (!after->isFieldPresent(sfDomainID) ||
-                !after->isFieldPresent(sfAdditionalBooks) ||
-                after->getFieldArray(sfAdditionalBooks).size() > 1)
+            bool const hasDomainID = after->isFieldPresent(sfDomainID);
+            std::optional<std::size_t> additionalBooksSize;
+            if (after->isFieldPresent(sfAdditionalBooks))
+                additionalBooksSize =
+                    after->getFieldArray(sfAdditionalBooks).size();
+            if (!hasDomainID || !additionalBooksSize ||
+                *additionalBooksSize > 1)
                 badHybridsOld_ = true;
-            if (!after->isFieldPresent(sfDomainID) ||
-                !after->isFieldPresent(sfAdditionalBooks) ||
-                after->getFieldArray(sfAdditionalBooks).size() != 1)
+            if (!hasDomainID || !additionalBooksSize ||
+                *additionalBooksSize != 1)
                 badHybrids_ = true;
         }
     }

--- a/src/xrpld/app/tx/detail/InvariantCheck.cpp
+++ b/src/xrpld/app/tx/detail/InvariantCheck.cpp
@@ -1871,13 +1871,20 @@ ValidPermissionedDEX::visitEntry(
         else
             regularOffers_ = true;
 
-        // if a hybrid offer is missing domain or additional book, there's
-        // something wrong
+        // pre-fixSecurity3_1_3: hybrid offer missing domain, missing
+        // sfAdditionalBooks, or sfAdditionalBooks has more than one entry
+        if (after->isFlag(lsfHybrid) &&
+            (!after->isFieldPresent(sfDomainID) ||
+             !after->isFieldPresent(sfAdditionalBooks) ||
+             after->getFieldArray(sfAdditionalBooks).size() > 1))
+            badHybridPre_ = true;
+
+        // post-fixSecurity3_1_3: same as above but also catches size == 0
         if (after->isFlag(lsfHybrid) &&
             (!after->isFieldPresent(sfDomainID) ||
              !after->isFieldPresent(sfAdditionalBooks) ||
              after->getFieldArray(sfAdditionalBooks).size() != 1))
-            badHybrids_ = true;
+            badHybridPost_ = true;
     }
 }
 
@@ -1896,7 +1903,9 @@ ValidPermissionedDEX::finalize(
 
     // For each offercreate transaction, check if
     // permissioned offers are valid
-    if (txType == ttOFFER_CREATE && badHybrids_)
+    bool const isMalformed =
+        view.rules().enabled(fixSecurity3_1_3) ? badHybridPost_ : badHybridPre_;
+    if (txType == ttOFFER_CREATE && isMalformed)
     {
         JLOG(j.fatal()) << "Invariant failed: hybrid offer is malformed";
         return false;

--- a/src/xrpld/app/tx/detail/InvariantCheck.h
+++ b/src/xrpld/app/tx/detail/InvariantCheck.h
@@ -662,7 +662,10 @@ public:
 class ValidPermissionedDEX
 {
     bool regularOffers_ = false;
-    bool badHybrids_ = false;
+    bool badHybridPre_ =
+        false;  // pre-fixSecurity3_1_3: missing field/domain or size > 1
+    bool badHybridPost_ =
+        false;  // post-fixSecurity3_1_3: also catches size == 0 (size != 1)
     hash_set<uint256> domains_;
 
 public:

--- a/src/xrpld/app/tx/detail/InvariantCheck.h
+++ b/src/xrpld/app/tx/detail/InvariantCheck.h
@@ -662,9 +662,9 @@ public:
 class ValidPermissionedDEX
 {
     bool regularOffers_ = false;
-    bool badHybridPre_ =
+    bool badHybridsOld_ =
         false;  // pre-fixSecurity3_1_3: missing field/domain or size > 1
-    bool badHybridPost_ =
+    bool badHybrids_ =
         false;  // post-fixSecurity3_1_3: also catches size == 0 (size != 1)
     hash_set<uint256> domains_;
 


### PR DESCRIPTION
This change adds the commits from the following PR into the 3.1.3 staging branch：
* [fix: Hybrid offer invariant sfAdditionalBooks empty check](https://github.com/XRPLF/rippled/pull/6716)
