### PR TITLE
ai review nits fixes of host functions

### DIFF
--- a/include/xrpl/tx/wasm/WasmiVM.h
+++ b/include/xrpl/tx/wasm/WasmiVM.h
@@ -293,7 +293,8 @@ private:
         int64_t gas,
         std::string_view funcName,
         std::vector<WasmParam> const& params,
-        ImportVec const& imports);
+        ImportVec const& imports,
+        beast::Journal j);
 
     NotTEC
     checkHlp(
@@ -301,7 +302,8 @@ private:
         HostFunctions& hfs,
         std::string_view funcName,
         std::vector<WasmParam> const& params,
-        ImportVec const& imports);
+        ImportVec const& imports,
+        beast::Journal j);
 
     int
     addModule(Bytes const& wasmCode, bool instantiate, ImportVec const& imports, int64_t gas);

--- a/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
+++ b/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
@@ -491,6 +491,7 @@ isAmendmentEnabled_wrap(void* env, wasm_val_vec_t const* params, wasm_val_vec_t*
         if (auto const ret = hf->isAmendmentEnabled(uint256::fromVoid(slice->data()));
             ret && *ret == 1)
             return returnResult(runtime, params, results, ret, index);
+        // Fall through to string lookup — the 32 bytes may be an amendment name
     }
 
     if (slice->size() > 64)

--- a/src/libxrpl/tx/wasm/WasmiVM.cpp
+++ b/src/libxrpl/tx/wasm/WasmiVM.cpp
@@ -756,24 +756,22 @@ WasmiEngine::run(
     ImportVec const& imports,
     beast::Journal j)
 {
-    j_ = j;
-
     if (gas <= 0)
         return Unexpected<TER>(temBAD_AMOUNT);
 
     try
     {
         checkImports(imports, &hfs);
-        return runHlp(wasmCode, hfs, gas, funcName, params, imports);
+        return runHlp(wasmCode, hfs, gas, funcName, params, imports, j);
     }
     catch (std::exception const& e)
     {
-        print_wasm_error(std::string("exception: ") + e.what(), nullptr, j_);
+        print_wasm_error(std::string("exception: ") + e.what(), nullptr, j);
     }
     // LCOV_EXCL_START
     catch (...)
     {
-        print_wasm_error(std::string("exception: unknown"), nullptr, j_);
+        print_wasm_error(std::string("exception: unknown"), nullptr, j);
     }
     // LCOV_EXCL_STOP
     return Unexpected<TER>(tecFAILED_PROCESSING);
@@ -786,10 +784,12 @@ WasmiEngine::runHlp(
     int64_t gas,
     std::string_view funcName,
     std::vector<WasmParam> const& params,
-    ImportVec const& imports)
+    ImportVec const& imports,
+    beast::Journal j)
 {
     // currently only 1 module support, possible parallel UT run
     std::lock_guard<decltype(m_)> const lg(m_);
+    j_ = j;
 
     if (wasmCode.empty())
         throw std::runtime_error("empty module");
@@ -861,21 +861,19 @@ WasmiEngine::check(
     ImportVec const& imports,
     beast::Journal j)
 {
-    j_ = j;
-
     try
     {
         checkImports(imports, &hfs);
-        return checkHlp(wasmCode, hfs, funcName, params, imports);
+        return checkHlp(wasmCode, hfs, funcName, params, imports, j);
     }
     catch (std::exception const& e)
     {
-        print_wasm_error(std::string("exception: ") + e.what(), nullptr, j_);
+        print_wasm_error(std::string("exception: ") + e.what(), nullptr, j);
     }
     // LCOV_EXCL_START
     catch (...)
     {
-        print_wasm_error(std::string("exception: unknown"), nullptr, j_);
+        print_wasm_error(std::string("exception: unknown"), nullptr, j);
     }
     // LCOV_EXCL_STOP
 
@@ -888,10 +886,12 @@ WasmiEngine::checkHlp(
     HostFunctions& hfs,
     std::string_view funcName,
     std::vector<WasmParam> const& params,
-    ImportVec const& imports)
+    ImportVec const& imports,
+    beast::Journal j)
 {
     // currently only 1 module support, possible parallel UT run
     std::lock_guard<decltype(m_)> const lg(m_);
+    j_ = j;
 
     // Create and instantiate the module.
     if (wasmCode.empty())


### PR DESCRIPTION
(1) Unchecked Expected dereference in isAmendmentEnabled_wrap
Location: src/libxrpl/tx/wasm/HostFuncWrapper.cpp:489

Impact: Low (+1 point)

Confidence: Medium

Category: Code quality / Defensive programming

Description: The code dereferences ret via *ret without checking whether the Expected contains a value. If hf->isAmendmentEnabled(uint256) ever returned an Unexpected (error), *ret would throw bad_expected_access. The current production implementation (WasmHostFunctionsImpl::isAmendmentEnabled) always returns a value (calling rules().enabled() which returns bool), so this cannot trigger today. However, the pattern is inconsistent with the defensive style used elsewhere in the host function wrappers.

Why fix: The current implementation can't return an error, so this is safe today. However, the pattern is genuinely inconsistent with every other host function wrapper in the file, which all check for errors before dereferencing. If someone changes isAmendmentEnabled to return an error in the future, this would crash the node with an uncaught exception. It's a real defensive coding gap worth closing.

Suggested Fix: Add ret && before the *ret == 1 check to guard against future changes that might return an error.

(2) Data race on j_ member before mutex acquisition
Location: src/libxrpl/tx/wasm/WasmiVM.cpp:759 and src/libxrpl/tx/wasm/WasmiVM.cpp:864

Impact: Low (+1 point)

Confidence: High

Category: Code quality / Theoretical UB

Branch: ripple/wasmi-host-functions

Description: Both WasmiEngine::run() and WasmiEngine::check() assign j_ = j BEFORE acquiring the mutex (acquired inside runHlp/checkHlp). Since WasmEngine is a process-wide singleton, concurrent calls create a data race on j_. However, Journal is just a single Sink* pointer — on 64-bit platforms pointer writes are hardware-atomic. Furthermore, j_ is only used for logging and never affects transaction outcomes. The reads of j_ inside the critical section (under mutex) are safe; the only concerning reads are in the catch blocks after the mutex is released, but even there the worst case is logging to a slightly wrong journal. Technically UB per the C++ standard, but practically harmless.

Suggested Fix: Move j_ = j inside runHlp/checkHlp after the mutex is acquired, or pass j as a parameter to eliminate the shared state.

Note — pattern comparison with rest of codebase: This is another area where WasmiEngine diverges from the established rippled pattern. In all normal transactors, beast::Journal is handled as:

PreflightContext, PreclaimContext: beast::Journal const j — a const member, passed as parameter, per-context instance

Transactor: beast::Journal const j_ — a const member, initialized in constructor, per-instance

Every normal transactor gets its own instance with its own journal. There is no shared mutable journal anywhere in the transaction processing pipeline. WasmiEngine is the only place in the tx processing code where j_ is a mutable member on a singleton, overwritten on every call. The fix aligns with the rest of the codebase: pass j as a parameter through the call chain rather than storing it on shared state.