### PR TITLE
Add extension fee fields to FeeVote log message

### DIFF
--- a/src/xrpld/app/misc/FeeVoteImpl.cpp
+++ b/src/xrpld/app/misc/FeeVoteImpl.cpp
@@ -304,7 +304,10 @@ FeeVoteImpl::doVoting(
         extensionSize.second || gasPrice.second)
     {
         JLOG(journal_.warn()) << "We are voting for a fee change: " << baseFee.first << "/"
-                              << baseReserve.first << "/" << incReserve.first;
+                              << baseReserve.first << "/" << incReserve.first
+                              << " extensionCompute=" << extensionCompute.first
+                              << " extensionSize=" << extensionSize.first
+                              << " gasPrice=" << gasPrice.first;
 
         STTx const feeTx(ttFEE, [=, &rules](auto& obj) {
             obj[sfAccount] = AccountID();


### PR DESCRIPTION
Extension fee fields not in FeeVote log message
Location: src/xrpld/app/misc/FeeVoteImpl.cpp:306-307

Impact: Low (+1 point)

Confidence: High

Category: Observability

Description: The fee change log message only includes base fee, base reserve, and reserve increment. When the fee change is triggered by smart escrow parameters (extensionCompute, extensionSize, gasPrice), the actual changing values are not logged.