### PR TITLE
chore: remove dead code in doLogLevel partition branch

### DIFF
--- a/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
+++ b/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
@@ -49,25 +49,24 @@ doLogLevel(RPC::JsonContext& context)
         return Json::objectValue;
     }
 
-    // log_level partition severity base?
-    if (context.params.isMember(jss::partition))
+    // log_level partition severity
+    // At this point jss::partition is guaranteed to be present: the branch
+    // above already returned for the no-partition case. The previous
+    // `if (context.params.isMember(jss::partition))` guard was redundant
+    // and the trailing `return rpcError(rpcINVALID_PARAMS)` was unreachable
+    // (see #6752).
+    std::string const partition(context.params[jss::partition].asString());
+
+    if (boost::iequals(partition, "base"))
     {
-        // set partition threshold
-        std::string const partition(context.params[jss::partition].asString());
-
-        if (boost::iequals(partition, "base"))
-        {
-            context.app.getLogs().threshold(severity);
-        }
-        else
-        {
-            context.app.getLogs().get(partition).threshold(severity);
-        }
-
-        return Json::objectValue;
+        context.app.getLogs().threshold(severity);
+    }
+    else
+    {
+        context.app.getLogs().get(partition).threshold(severity);
     }
 
-    return rpcError(rpcINVALID_PARAMS);
+    return Json::objectValue;
 }
 
 }  // namespace xrpl


### PR DESCRIPTION
### Problem

`doLogLevel` in `src/xrpld/rpc/handlers/admin/log/LogLevel.cpp` already
returns early when `partition` is absent:

```cpp
if (!context.params.isMember(jss::partition))
{
    context.app.getLogs().threshold(severity);
    return Json::objectValue;
}
```

and then wraps the partition-handling code in a redundant check:

```cpp
if (context.params.isMember(jss::partition))  // guaranteed true here
{
    ...
    return Json::objectValue;
}

return rpcError(rpcINVALID_PARAMS);            // unreachable
```

Control flow cannot reach either the inverted-guard-fail path or the
trailing `rpcError(rpcINVALID_PARAMS)`, so the error return is dead code
and the `if` adds nothing. #6752.

### Fix

Drop the redundant guard and the unreachable return. Every reachable
input still hits the same branch as before, so there is no behaviour
change.

```diff
-    // log_level partition severity base?
-    if (context.params.isMember(jss::partition))
-    {
-        // set partition threshold
-        std::string const partition(context.params[jss::partition].asString());
-
-        if (boost::iequals(partition, "base"))
-        ...
-        return Json::objectValue;
-    }
-
-    return rpcError(rpcINVALID_PARAMS);
+    // log_level partition severity
+    std::string const partition(context.params[jss::partition].asString());
+
+    if (boost::iequals(partition, "base"))
+    ...
+    return Json::objectValue;
```

Fixes #6752
