### PR TITLE
chore: Add -fix to clang-tidy invocation

### DIFF
--- a/.github/workflows/reusable-clang-tidy-files.yml
+++ b/.github/workflows/reusable-clang-tidy-files.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           TARGETS: ${{ inputs.files != '' && inputs.files || 'src tests' }}
         run: |
-          run-clang-tidy -j ${{ steps.nproc.outputs.nproc }} -p "${BUILD_DIR}" -quiet -allow-no-checks ${TARGETS} 2>&1 | tee clang-tidy-output.txt
+          run-clang-tidy -j ${{ steps.nproc.outputs.nproc }} -p "${BUILD_DIR}" -quiet -fix -allow-no-checks ${TARGETS} 2>&1 | tee clang-tidy-output.txt
 
       - name: Upload clang-tidy output
         if: ${{ github.event.repository.visibility == 'public' && steps.run_clang_tidy.outcome != 'success' }}


### PR DESCRIPTION
## High Level Overview of Change

Starts running clang-tidy with `-fix` so that the produced diff has a chance to contain anything.

### API Impact

No impact.