### PR TITLE
fix: Resolve MSVC Debug build failure in JobQueue.h; re-enable _CRTDBG_MAP_ALLOC in CI

### DIFF
--- a/cmake/XrplCompiler.cmake
+++ b/cmake/XrplCompiler.cmake
@@ -118,7 +118,7 @@ if(MSVC)
             NOMINMAX
             # TODO: Resolve these warnings, don't just silence them
             _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS
-            $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>,$<NOT:$<BOOL:${is_ci}>>>:_CRTDBG_MAP_ALLOC>
+            $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:_CRTDBG_MAP_ALLOC>
     )
     target_link_libraries(common INTERFACE -errorreport:none -machine:X64)
 else()

--- a/include/xrpl/core/JobQueue.h
+++ b/include/xrpl/core/JobQueue.h
@@ -14,7 +14,6 @@
 // in Debug builds (see cmake/XrplCompiler.cmake).
 #include <boost/context/protected_fixedsize_stack.hpp>
 #include <boost/coroutine2/coroutine.hpp>
-#include <boost/coroutine2/protected_fixedsize_stack.hpp>
 
 #include <set>
 

--- a/include/xrpl/core/JobQueue.h
+++ b/include/xrpl/core/JobQueue.h
@@ -7,8 +7,14 @@
 #include <xrpl/core/detail/Workers.h>
 #include <xrpl/json/json_value.h>
 
+// Include only the specific Boost.Coroutine2 headers actually used here.
+// Avoid `boost/coroutine2/all.hpp` because it transitively pulls in
+// `boost/context/pooled_fixedsize_stack.hpp`, whose `.malloc()` / `.free()`
+// member calls on `boost::pool` collide with MSVC's `_CRTDBG_MAP_ALLOC` macros
+// in non-CI Debug builds (see cmake/XrplCompiler.cmake).
 #include <boost/context/protected_fixedsize_stack.hpp>
-#include <boost/coroutine2/all.hpp>
+#include <boost/coroutine2/coroutine.hpp>
+#include <boost/coroutine2/protected_fixedsize_stack.hpp>
 
 #include <set>
 

--- a/include/xrpl/core/JobQueue.h
+++ b/include/xrpl/core/JobQueue.h
@@ -11,7 +11,7 @@
 // Avoid `boost/coroutine2/all.hpp` because it transitively pulls in
 // `boost/context/pooled_fixedsize_stack.hpp`, whose `.malloc()` / `.free()`
 // member calls on `boost::pool` collide with MSVC's `_CRTDBG_MAP_ALLOC` macros
-// in non-CI Debug builds (see cmake/XrplCompiler.cmake).
+// in Debug builds (see cmake/XrplCompiler.cmake).
 #include <boost/context/protected_fixedsize_stack.hpp>
 #include <boost/coroutine2/coroutine.hpp>
 #include <boost/coroutine2/protected_fixedsize_stack.hpp>


### PR DESCRIPTION
## High Level Overview of Change

MSVC Debug builds fail to compile `JobQueue.cpp` due to a preprocessor collision between the CRT debug allocator macros and Boost.Context's pool-backed stack allocator. This PR:

1. **Fixes the root cause** by narrowing the `boost/coroutine2` include in `include/xrpl/core/JobQueue.h` to only the sub-headers the project actually uses, avoiding the broken `boost/context/pooled_fixedsize_stack.hpp` entirely.
2. **Reverts the CI workaround** from PR #6562, which disabled `_CRTDBG_MAP_ALLOC` in CI to paper over this same collision. With the root cause fixed, the gate is no longer needed.

### Context of Change

Reported build failure (local MSVC Debug build):

```
boost/context/pooled_fixedsize_stack.hpp(89,34): error C2760: syntax error: ',' was unexpected here; expected ')'
  while compiling class template 'boost::context::basic_pooled_fixedsize_stack'
  (compiling source file 'src/libxrpl/core/detail/JobQueue.cpp')
```

**Root cause:**

- `cmake/XrplCompiler.cmake` defines `_CRTDBG_MAP_ALLOC` for Debug MSVC builds.
- `_CRTDBG_MAP_ALLOC` makes `<crtdbg.h>` redefine `malloc` / `free` as function-like preprocessor macros that expand to `_malloc_dbg` / `_free_dbg`.
- `boost/context/pooled_fixedsize_stack.hpp` (Boost 1.90) calls `.malloc()` / `.free()` as member functions on `boost::pool`, without the `BOOST_PREVENT_MACRO_SUBSTITUTION` guard or defensive `(p.malloc)()` parenthesization that protects other Boost pool headers.
- The preprocessor expands these member calls textually into a syntax error.

PR #6562 previously disabled `_CRTDBG_MAP_ALLOC` in CI as a symptomatic workaround (reasoning: CI doesn't consume Debug artifacts). That left the bug reproducible on any developer doing a local Windows Debug build — which is exactly the failure mode reported here.

**Why this fix:**

- The project never references `pooled_fixedsize_stack` — only `coroutine`, `pull_type`, `push_type`, `asymmetric_coroutine`, and `protected_fixedsize_stack`. The umbrella `boost/coroutine2/all.hpp` was dragging in three unused stack allocators, one of which is broken under `_CRTDBG_MAP_ALLOC`.
- Switching to the narrower `boost/coroutine2/coroutine.hpp` + `boost/coroutine2/protected_fixedsize_stack.hpp` avoids the broken header entirely. No preprocessor fences or `_MSC_VER` gymnastics needed.
- The broken `boost/context/pooled_fixedsize_stack.hpp` has only four transitive entry points in Boost (`coroutine2/all.hpp`, `coroutine2/pooled_fixedsize_stack.hpp`, `fiber/all.hpp`, `fiber/pooled_fixedsize_stack.hpp`) — none of which the project now uses.
- Once the root cause is fixed, the CI gate from PR #6562 is redundant. Removing it restores parity between CI and local Debug builds.
- Side benefit: slightly faster header-parse time across 34 translation units that transitively include `JobQueue.h`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- [x] `clang` Linux builds unaffected (symbols still resolve via the narrower headers)
- [x] Pre-commit hooks pass
- [x] Levelization check clean
- [ ] Windows MSVC Release CI build passes (exercised by the PR's `windows-amd64-release` matrix leg)
- [ ] **Windows MSVC Debug build** — ⚠️ *not* exercised by PR CI. Per `.github/scripts/strategy-matrix/generate.py`, Windows Debug only runs in the scheduled `all` matrix (on merges to `develop`/release), not in PR `minimal` mode. This PR should be validated locally on Windows Debug before merge, or expect Debug coverage to land only post-merge via the nightly matrix.

## Future Tasks

Consider adding a Windows Debug leg to the PR matrix for faster validation of this class of bug — or at minimum, document in `CONTRIBUTING.md` that Windows Debug regressions will only surface on nightly runs.
