### PR TITLE
Memory transfer limit

### DIFF
--- a/include/xrpl/protocol/Protocol.h
+++ b/include/xrpl/protocol/Protocol.h
@@ -254,6 +254,9 @@ constexpr std::uint8_t kMaxAssetCheckDepth = 5;
 /** Maximum length of a Data field in Escrow object that can be updated by WASM code. */
 constexpr std::size_t kMaxWasmDataLength = 1 * 1024;  // 1KB
 
+/** Maximum amount of data transfer across hostfunction<->wasm border. */
+constexpr std::size_t kWasmTransferLimit = 1 << 20;  // 1MB
+
 /** A ledger index. */
 using LedgerIndex = std::uint32_t;
 

--- a/include/xrpl/tx/wasm/WasmCommon.h
+++ b/include/xrpl/tx/wasm/WasmCommon.h
@@ -124,6 +124,12 @@ public:
 
     virtual std::int64_t
     setGas(std::int64_t gas) = 0;
+
+    virtual std::int64_t
+    getTransferLimit() = 0;
+
+    virtual std::int64_t
+    setTransferLimit(std::int64_t transferLimit) = 0;
 };
 using RTOptRef = std::optional<std::reference_wrapper<WasmRuntimeWrapper>>;
 

--- a/include/xrpl/tx/wasm/WasmiVM.h
+++ b/include/xrpl/tx/wasm/WasmiVM.h
@@ -147,6 +147,7 @@ class InstanceWrapper
     mutable int memIdx_ = -1;
     InstancePtr instance_;
     beast::Journal j_ = beast::Journal(beast::Journal::getNullSink());
+    std::int64_t transferLimit_ = kWasmTransferLimit;
 
 private:
     static InstancePtr
@@ -194,6 +195,12 @@ public:
 
     std::int64_t
     setGas(std::int64_t) const;
+
+    std::int64_t
+    getTransferLimit() const;
+
+    std::int64_t
+    setTransferLimit(std::int64_t);
 };
 
 class ModuleWrapper

--- a/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
+++ b/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
@@ -41,6 +41,8 @@ namespace xrpl {
 
 using SFieldCRef = std::reference_wrapper<SField const>;
 
+constexpr int64_t unalignedGas = 1000;
+
 static inline Expected<std::int64_t, HostFunctionError>
 checkGas(WasmRuntimeWrapper& rt, int64_t delta)
 {
@@ -81,6 +83,21 @@ checkGas(WasmRuntimeWrapper& rt, WasmImportFunc const& impFunc)
     return *g;
 }
 
+static inline Expected<std::int64_t, HostFunctionError>
+checkTransfer(WasmRuntimeWrapper& rt, int64_t delta)
+{
+    auto const transLimit = rt.getTransferLimit();
+    int64_t const x = transLimit >= delta ? transLimit - delta : 0;
+
+    if (rt.setTransferLimit(x) < 0)
+        return Unexpected(HostFunctionError::Internal);  // LCOV_EXCL_LINE
+
+    if (transLimit < delta)
+        return Unexpected(HostFunctionError::OutOfTransferLimit);
+
+    return x;
+}
+
 static Expected<std::tuple<HostFunctions&, WasmImportFunc const&>, wasm_trap_t*>
 mainCheck(void* env, wasm_val_vec_t const* params, wasm_val_vec_t* results)
 {
@@ -112,6 +129,14 @@ mainCheck(void* env, wasm_val_vec_t const* params, wasm_val_vec_t* results)
 
     if (auto g = checkGas(rt, impFunc); !g)
         return Unexpected(g.error());  // LCOV_EXCL_LINE
+
+    auto const transLimit = rt.getTransferLimit();
+    if (transLimit <= 0)
+    {
+        wasm_trap_t* trap = reinterpret_cast<wasm_trap_t*>(        // NOLINT
+            WasmEngine::instance().newTrap("no transfer limit"));  // LCOV_EXCL_LINE
+        return Unexpected(trap);                                   // LCOV_EXCL_LINE
+    }
 
     return std::tie(hf, impFunc);
 }
@@ -145,6 +170,9 @@ setData(
         return hfErrorToInt(HostFunctionError::PointerOutOfBounds);
     if (srcSize > dstSize)
         return hfErrorToInt(HostFunctionError::BufferTooSmall);
+
+    if (auto t = checkTransfer(runtime, srcSize); !t)
+        return hfErrorToInt(t.error());
 
     memcpy(memory.p + dst, src, srcSize);
 
@@ -255,6 +283,9 @@ getDataUInt256(WasmRuntimeWrapper& runtime, wasm_val_vec_t const* params, int32_
     if (slice->size() != uint256::size())
         return Unexpected(HostFunctionError::InvalidParams);
 
+    if (auto t = checkTransfer(runtime, uint256::size()); !t)
+        return Unexpected(t.error());
+
     return uint256::fromVoid(slice->data());
 }
 
@@ -267,6 +298,9 @@ getDataAccountID(WasmRuntimeWrapper& runtime, wasm_val_vec_t const* params, int3
 
     if (slice->size() != AccountID::size())
         return Unexpected(HostFunctionError::InvalidParams);
+
+    if (auto t = checkTransfer(runtime, AccountID::size()); !t)
+        return Unexpected(t.error());
 
     return AccountID::fromVoid(slice->data());
 }
@@ -281,6 +315,9 @@ getDataCurrency(WasmRuntimeWrapper& runtime, wasm_val_vec_t const* params, int32
     if (slice->size() != Currency::size())
         return Unexpected(HostFunctionError::InvalidParams);
 
+    if (auto t = checkTransfer(runtime, Currency::size()); !t)
+        return Unexpected(t.error());
+
     return Currency::fromVoid(slice->data());
 }
 
@@ -293,12 +330,18 @@ getDataAsset(WasmRuntimeWrapper& runtime, wasm_val_vec_t const* params, int32_t&
 
     if (slice->size() == MPTID::size())
     {
+        if (auto t = checkTransfer(runtime, slice->size()); !t)
+            return Unexpected(t.error());
+
         auto const mptid = MPTID::fromVoid(slice->data());
         return Asset{mptid};
     }
 
     if (slice->size() == Currency::size())
     {
+        if (auto t = checkTransfer(runtime, slice->size()); !t)
+            return Unexpected(t.error());
+
         auto const currency = Currency::fromVoid(slice->data());
         auto const issue = Issue{currency, xrpAccount()};
         if (!issue.native())
@@ -309,6 +352,9 @@ getDataAsset(WasmRuntimeWrapper& runtime, wasm_val_vec_t const* params, int32_t&
 
     if (slice->size() == (Currency::size() + AccountID::size()))
     {
+        if (auto t = checkTransfer(runtime, slice->size()); !t)
+            return Unexpected(t.error());
+
         auto const issue = Issue(
             Currency::fromVoid(slice->data()),
             AccountID::fromVoid(slice->data() + Currency::size()));
@@ -348,6 +394,12 @@ getDataLocator(WasmRuntimeWrapper& runtime, wasm_val_vec_t const* params, int32_
 
     if ((p & (alignof(int32_t) - 1)) != 0u)
     {  // unaligned
+
+        // Use gas and transfer limit for copying
+        if (auto g = checkGas(runtime, unalignedGas); !g)
+            return Unexpected(g.error());
+        if (auto t = checkTransfer(runtime, slice->size()); !t)
+            return Unexpected(t.error());
 
         std::vector<int32_t> locBuf(locSize);
         memcpy(&locBuf[0], slice->data(), slice->size());
@@ -481,6 +533,7 @@ returnResult(
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+
 wasm_trap_t*
 HostFuncMain_wrap(WASM_CB_PARAMS_LIST)
 {
@@ -1677,6 +1730,7 @@ class MockWasmRuntimeWrapper : public WasmRuntimeWrapper
     Wmem mem_;
 
     std::int64_t gas_ = 1'000'000;
+    std::int64_t transferLimit_ = kWasmTransferLimit;
 
 public:
     MockWasmRuntimeWrapper(Wmem memory) : mem_(memory)
@@ -1701,6 +1755,19 @@ public:
     {
         gas_ = gas;
         return gas_;
+    }
+
+    std::int64_t
+    getTransferLimit() override
+    {
+        return transferLimit_;
+    }
+
+    std::int64_t
+    setTransferLimit(std::int64_t x) override
+    {
+        transferLimit_ = x;
+        return transferLimit_;
     }
 };
 

--- a/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
+++ b/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
@@ -130,15 +130,6 @@ mainCheck(void* env, wasm_val_vec_t const* params, wasm_val_vec_t* results)
     if (auto g = checkGas(rt, impFunc); !g)
         return Unexpected(g.error());  // LCOV_EXCL_LINE
 
-    auto const transLimit = rt.getTransferLimit();
-    if (transLimit <= 0)
-    {
-        // Don't change "no transfer limit" message, it is used in HosFuncMainWrap
-        wasm_trap_t* trap = reinterpret_cast<wasm_trap_t*>(        // NOLINT
-            WasmEngine::instance().newTrap("no transfer limit"));  // LCOV_EXCL_LINE
-        return Unexpected(trap);                                   // LCOV_EXCL_LINE
-    }
-
     return std::tie(hf, impFunc);
 }
 
@@ -544,22 +535,9 @@ HostFuncMain_wrap(WASM_CB_PARAMS_LIST)
     {
         auto const mc = mainCheck(env, params, results);
         if (!mc)
-        {
-            wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
-            wasm_trap_message(mc.error(), &errorMessage);
-            if (errorMessage.size != 0u)
-            {
-                bool const outOfTransfer =
-                    static_cast<bool>(!strcmp("no transfer limit", errorMessage.data));
-                wasm_byte_vec_delete(&errorMessage);
-                if (outOfTransfer)
-                    return hfResult(results, HostFunctionError::OutOfTransferLimit);
-            }
+            return mc.error();
 
-            return mc.error();  // LCOV_EXCL_LINE
-        }
         auto& [hf, impFunc] = *mc;
-
         hfName = impFunc.name;
         auto* fWrap = reinterpret_cast<wasmSecondaryCbFuncType*>(impFunc.wrap);
         return fWrap(hf, params, results);

--- a/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
+++ b/src/libxrpl/tx/wasm/HostFuncWrapper.cpp
@@ -41,7 +41,7 @@ namespace xrpl {
 
 using SFieldCRef = std::reference_wrapper<SField const>;
 
-constexpr int64_t unalignedGas = 1000;
+constexpr int64_t unalignedGas = 50;
 
 static inline Expected<std::int64_t, HostFunctionError>
 checkGas(WasmRuntimeWrapper& rt, int64_t delta)
@@ -133,6 +133,7 @@ mainCheck(void* env, wasm_val_vec_t const* params, wasm_val_vec_t* results)
     auto const transLimit = rt.getTransferLimit();
     if (transLimit <= 0)
     {
+        // Don't change "no transfer limit" message, it is used in HosFuncMainWrap
         wasm_trap_t* trap = reinterpret_cast<wasm_trap_t*>(        // NOLINT
             WasmEngine::instance().newTrap("no transfer limit"));  // LCOV_EXCL_LINE
         return Unexpected(trap);                                   // LCOV_EXCL_LINE
@@ -543,7 +544,20 @@ HostFuncMain_wrap(WASM_CB_PARAMS_LIST)
     {
         auto const mc = mainCheck(env, params, results);
         if (!mc)
+        {
+            wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
+            wasm_trap_message(mc.error(), &errorMessage);
+            if (errorMessage.size != 0u)
+            {
+                bool const outOfTransfer =
+                    static_cast<bool>(!strcmp("no transfer limit", errorMessage.data));
+                wasm_byte_vec_delete(&errorMessage);
+                if (outOfTransfer)
+                    return hfResult(results, HostFunctionError::OutOfTransferLimit);
+            }
+
             return mc.error();  // LCOV_EXCL_LINE
+        }
         auto& [hf, impFunc] = *mc;
 
         hfName = impFunc.name;

--- a/src/libxrpl/tx/wasm/WasmiVM.cpp
+++ b/src/libxrpl/tx/wasm/WasmiVM.cpp
@@ -106,6 +106,18 @@ public:
     {
         return iw_.setGas(gas);
     }
+
+    std::int64_t
+    getTransferLimit() override
+    {
+        return iw_.getTransferLimit();
+    }
+
+    std::int64_t
+    setTransferLimit(std::int64_t x) override
+    {
+        return iw_.setTransferLimit(x);
+    }
 };
 
 InstancePtr
@@ -245,6 +257,32 @@ InstanceWrapper::setGas(std::int64_t gas) const
     }
 
     return gas;
+}
+
+std::int64_t
+InstanceWrapper::getTransferLimit() const
+{
+    if (store_ == nullptr)
+        return -1;  // LCOV_EXCL_LINE
+
+    return transferLimit_;
+}
+
+std::int64_t
+InstanceWrapper::setTransferLimit(std::int64_t x)
+{
+    if (store_ == nullptr)
+        return -1;  // LCOV_EXCL_LINE
+    if (x < 0)
+    {
+        transferLimit_ = std::numeric_limits<decltype(transferLimit_)>::max();
+    }
+    else
+    {
+        transferLimit_ = x;
+    }
+
+    return transferLimit_;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/app/HostFuncImpl_test.cpp
+++ b/src/test/app/HostFuncImpl_test.cpp
@@ -166,8 +166,11 @@ class VirtualRuntime : public WasmRuntimeWrapper
 {
     Bytes buffer_;
     std::int64_t gas_ = 1'000'000;
+    std::int64_t transferLimit_ = kWasmTransferLimit;
 
 public:
+    static constexpr std::int64_t transferDiff = 1024;
+
     VirtualRuntime() : buffer_(1024 * 1024)
     {
     }
@@ -201,6 +204,31 @@ public:
         }
 
         return gas_;
+    }
+
+    std::int64_t
+    getTransferLimit() override
+    {
+        transferLimit_ -= transferDiff;
+        return transferLimit_;
+    }
+
+    std::int64_t
+    setTransferLimit(std::int64_t x) override
+    {
+        if (x == -2)
+            return -1;
+
+        if (x < 0)
+        {
+            transferLimit_ = std::numeric_limits<decltype(transferLimit_)>::max();
+        }
+        else
+        {
+            transferLimit_ = x;
+        }
+
+        return transferLimit_;
     }
 
     void
@@ -6062,6 +6090,117 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
     }
 
     void
+    testTransferLimit()
+    {
+        testcase("transferLimit");
+        using namespace test::jtx;
+
+        Env env{*this};
+        OpenView ov{*env.current()};
+        ApplyContext ac = createApplyContext(env, ov);
+        auto const dummyEscrow = keylet::escrow(env.master, env.seq(env.master));
+        VirtualRuntime vrt;
+        WasmHostFunctionsImpl hfs(ac, dummyEscrow);
+
+        auto import = xrpl::createWasmImport(hfs);
+        hfs.setRT(vrt);
+
+        // Test 1: Test setData() - copying FROM host TO wasm
+        // Multiple calls to getLedgerSqn() which uses setData() to write result to WASM memory
+        vrt.setTransferLimit(kWasmTransferLimit + 1024);
+
+        // hfs.getLedgerSqn();
+        for (int i = 0; i < (kWasmTransferLimit / vrt.transferDiff / 2) - 1; ++i)
+        {
+            WasmValVec params(2), result(1);
+
+            auto* trap = ww(&import.at("get_ledger_sqn"), params, result, 0, sizeof(std::uint32_t));
+
+            BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
+                BEAST_EXPECT(result[0].of.i32 == sizeof(std::uint32_t)) &&
+                BEAST_EXPECT(vrt.getUint32(params, 0) == env.current()->header().seq);
+        }
+
+        // Next call should hit OutOfTransferLimit
+        {
+            WasmValVec params(2), result(1);
+            auto* trap = ww(&import.at("get_ledger_sqn"), params, result, 0, sizeof(std::uint32_t));
+
+            BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
+                BEAST_EXPECT(
+                    result[0].of.i32 == hfErrorToInt(HostFunctionError::OutOfTransferLimit));
+        }
+
+        // After limit exhausted, next call should trap with "no transfer limit"
+        {
+            WasmValVec params(2), result(1);
+            wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
+
+            auto* trap = ww(&import.at("get_ledger_sqn"), params, result, 0, sizeof(std::uint32_t));
+
+            if (BEAST_EXPECT(trap))
+            {
+                wasm_trap_message(trap, &errorMessage);
+                auto const s = std::string_view(errorMessage.data, errorMessage.size - 1);
+                BEAST_EXPECTS(s == "Error { kind: Message(\"no transfer limit\") }", s);
+            }
+        }
+
+        // Reset transfer limit to a small value that can accommodate overhead but not AccountID
+        // copy
+        vrt.setTransferLimit(vrt.transferDiff + 10);
+
+        Account const alice("alice");
+        auto const aliceID = env.master.id();
+        vrt.setBytes(0, aliceID.data(), AccountID::size());
+
+        // This should fail because getDataAccountID() needs to copy AccountID (20 bytes)
+        // After getTransferLimit() overhead (1024), we only have 10 bytes left, not enough for 20
+        {
+            WasmValVec params(4), result(1);
+            auto* trap =
+                ww(&import.at("account_keylet"), params, result, 0, AccountID::size(), 100, 32);
+            BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
+                BEAST_EXPECT(
+                    result[0].of.i32 == hfErrorToInt(HostFunctionError::OutOfTransferLimit));
+        }
+
+        // Verify that reading slices (without copying) does NOT consume transfer limit
+        vrt.setTransferLimit(vrt.transferDiff + 10);
+
+        // trace() uses getDataString() -> getDataSlice() which does NOT check transfer limit
+        std::string testMsg = "This message is longer than 10 bytes to prove slices don't count";
+        vrt.setBytes(0, testMsg.data(), testMsg.size());
+        vrt.setBytes(100, (uint8_t const*)"dummy", 5);  // Empty data slice for trace
+        {
+            WasmValVec params(5), result(1);
+            // trace(msg_ptr, msg_len, data_ptr, data_len, asHex)
+            auto* trap = ww(&import.at("trace"), params, result, 0, testMsg.size(), 100, 5, 0);
+
+            // Should succeed even though message is >10 bytes, because trace only uses slices
+            // (no transfer limit check in getDataSlice)
+            BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
+                BEAST_EXPECT(result[0].of.i32 == 0);
+        }
+
+        // However, setData should trap when transfer limit is exhausted
+        // After trace consumed overhead (1024 bytes), we have 10 - 1024 = negative limit left
+        {
+            WasmValVec params(2), result(1);
+            wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
+            auto* trap = ww(&import.at("get_parent_ledger_hash"), params, result, 500, 32);
+
+            // This should trap because the transfer limit went negative
+            if (BEAST_EXPECT(trap))
+            {
+                wasm_trap_message(trap, &errorMessage);
+                auto const s = std::string_view(errorMessage.data, errorMessage.size - 1);
+                BEAST_EXPECTS(s == "Error { kind: Message(\"no transfer limit\") }", s);
+            }
+        }
+    }
+
+    void
     run() override
     {
         testGetLedgerSqn();
@@ -6099,6 +6238,8 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
         testFloats();
 
         testVectorIndexes();
+
+        testTransferLimit();
     }
 };
 

--- a/src/test/app/HostFuncImpl_test.cpp
+++ b/src/test/app/HostFuncImpl_test.cpp
@@ -213,6 +213,12 @@ public:
         return transferLimit_;
     }
 
+    [[nodiscard]] std::int64_t
+    getTestTransferLimit() const
+    {
+        return transferLimit_;
+    }
+
     std::int64_t
     setTransferLimit(std::int64_t x) override
     {
@@ -6110,7 +6116,7 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
         vrt.setTransferLimit(kWasmTransferLimit + 1024);
 
         // hfs.getLedgerSqn();
-        for (int i = 0; i < (kWasmTransferLimit / vrt.transferDiff / 2) - 1; ++i)
+        for (int i = 0; i < (kWasmTransferLimit / vrt.transferDiff) - 3; ++i)
         {
             WasmValVec params(2), result(1);
 
@@ -6120,6 +6126,8 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
                 BEAST_EXPECT(result[0].of.i32 == sizeof(std::uint32_t)) &&
                 BEAST_EXPECT(vrt.getUint32(params, 0) == env.current()->header().seq);
         }
+
+        BEAST_EXPECT((vrt.getTestTransferLimit() >= 0) && (vrt.getTestTransferLimit() < 1024));
 
         // Next call should hit OutOfTransferLimit
         {
@@ -6131,19 +6139,14 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
                     result[0].of.i32 == hfErrorToInt(HostFunctionError::OutOfTransferLimit));
         }
 
-        // After limit exhausted, next call should trap with "no transfer limit"
+        // After limit exhausted, all next call return OutOfTransferLimit
         {
             WasmValVec params(2), result(1);
-            wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
-
             auto* trap = ww(&import.at("ldgr_index"), params, result, 0, sizeof(std::uint32_t));
 
-            if (BEAST_EXPECT(trap))
-            {
-                wasm_trap_message(trap, &errorMessage);
-                auto const s = std::string_view(errorMessage.data, errorMessage.size - 1);
-                BEAST_EXPECTS(s == "Error { kind: Message(\"no transfer limit\") }", s);
-            }
+            BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
+                BEAST_EXPECT(
+                    result[0].of.i32 == hfErrorToInt(HostFunctionError::OutOfTransferLimit));
         }
 
         // Reset transfer limit to a small value that can accommodate overhead but not AccountID
@@ -6183,20 +6186,16 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
                 BEAST_EXPECT(result[0].of.i32 == 0);
         }
 
-        // However, setData should trap when transfer limit is exhausted
+        // setData should return  when transfer limit is exhausted
         // After trace consumed overhead (1024 bytes), we have 10 - 1024 = negative limit left
         {
             WasmValVec params(2), result(1);
-            wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
             auto* trap = ww(&import.at("parent_ldgr_hash"), params, result, 500, 32);
 
-            // This should trap because the transfer limit went negative
-            if (BEAST_EXPECT(trap))
-            {
-                wasm_trap_message(trap, &errorMessage);
-                auto const s = std::string_view(errorMessage.data, errorMessage.size - 1);
-                BEAST_EXPECTS(s == "Error { kind: Message(\"no transfer limit\") }", s);
-            }
+            //  the transfer limit went negative
+            BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
+                BEAST_EXPECT(
+                    result[0].of.i32 == hfErrorToInt(HostFunctionError::OutOfTransferLimit));
         }
     }
 

--- a/src/test/app/HostFuncImpl_test.cpp
+++ b/src/test/app/HostFuncImpl_test.cpp
@@ -6114,7 +6114,7 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
         {
             WasmValVec params(2), result(1);
 
-            auto* trap = ww(&import.at("get_ledger_sqn"), params, result, 0, sizeof(std::uint32_t));
+            auto* trap = ww(&import.at("ldgr_index"), params, result, 0, sizeof(std::uint32_t));
 
             BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
                 BEAST_EXPECT(result[0].of.i32 == sizeof(std::uint32_t)) &&
@@ -6124,7 +6124,7 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
         // Next call should hit OutOfTransferLimit
         {
             WasmValVec params(2), result(1);
-            auto* trap = ww(&import.at("get_ledger_sqn"), params, result, 0, sizeof(std::uint32_t));
+            auto* trap = ww(&import.at("ldgr_index"), params, result, 0, sizeof(std::uint32_t));
 
             BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
                 BEAST_EXPECT(
@@ -6136,7 +6136,7 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
             WasmValVec params(2), result(1);
             wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
 
-            auto* trap = ww(&import.at("get_ledger_sqn"), params, result, 0, sizeof(std::uint32_t));
+            auto* trap = ww(&import.at("ldgr_index"), params, result, 0, sizeof(std::uint32_t));
 
             if (BEAST_EXPECT(trap))
             {
@@ -6159,7 +6159,7 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
         {
             WasmValVec params(4), result(1);
             auto* trap =
-                ww(&import.at("account_keylet"), params, result, 0, AccountID::size(), 100, 32);
+                ww(&import.at("accountroot_id"), params, result, 0, AccountID::size(), 100, 32);
             BEAST_EXPECT(!trap) && BEAST_EXPECT(result[0].kind == WASM_I32) &&
                 BEAST_EXPECT(
                     result[0].of.i32 == hfErrorToInt(HostFunctionError::OutOfTransferLimit));
@@ -6188,7 +6188,7 @@ struct HostFuncImpl_test : public beast::unit_test::Suite
         {
             WasmValVec params(2), result(1);
             wasm_byte_vec_t errorMessage WASM_EMPTY_VEC;
-            auto* trap = ww(&import.at("get_parent_ledger_hash"), params, result, 500, 32);
+            auto* trap = ww(&import.at("parent_ldgr_hash"), params, result, 500, 32);
 
             // This should trap because the transfer limit went negative
             if (BEAST_EXPECT(trap))


### PR DESCRIPTION
## High Level Overview of Change
Add calculation for data being copied cross boundary wasm<->hostfunctions (both ways). Limit set to 1 Mb


