### PR TITLE
refactor: Revert certain `Throw`s by `LogicError`s

### DIFF
--- a/include/xrpl/ledger/Ledger.h
+++ b/include/xrpl/ledger/Ledger.h
@@ -229,19 +229,6 @@ public:
         std::shared_ptr<Serializer const> const& txn,
         std::shared_ptr<Serializer const> const& metaData) override;
 
-    // Insert the transaction, and return the hash of the SHAMap leaf node
-    // holding the transaction. The hash can be used to fetch the transaction
-    // directly, instead of traversing the SHAMap
-    // @param key transaction ID
-    // @param txn transaction
-    // @param metaData transaction metadata
-    // @return hash of SHAMap leaf node that holds the transaction
-    uint256
-    rawTxInsertWithHash(
-        uint256 const& key,
-        std::shared_ptr<Serializer const> const& txn,
-        std::shared_ptr<Serializer const> const& metaData);
-
     //--------------------------------------------------------------------------
 
     void

--- a/src/libxrpl/ledger/Ledger.cpp
+++ b/src/libxrpl/ledger/Ledger.cpp
@@ -14,7 +14,6 @@
 #include <xrpl/nodestore/NodeObject.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Fees.h>
-#include <xrpl/protocol/HashPrefix.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/Keylet.h>
@@ -31,7 +30,6 @@
 #include <xrpl/protocol/Seed.h>
 #include <xrpl/protocol/Serializer.h>
 #include <xrpl/protocol/SystemParameters.h>
-#include <xrpl/protocol/digest.h>
 #include <xrpl/shamap/Family.h>
 #include <xrpl/shamap/SHAMap.h>
 #include <xrpl/shamap/SHAMapItem.h>
@@ -43,7 +41,6 @@
 #include <exception>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/src/libxrpl/ledger/Ledger.cpp
+++ b/src/libxrpl/ledger/Ledger.cpp
@@ -539,26 +539,6 @@ Ledger::rawTxInsert(
         LogicError("duplicate_tx: " + to_string(key));
 }
 
-uint256
-Ledger::rawTxInsertWithHash(
-    uint256 const& key,
-    std::shared_ptr<Serializer const> const& txn,
-    std::shared_ptr<Serializer const> const& metaData)
-{
-    XRPL_ASSERT(metaData, "xrpl::Ledger::rawTxInsertWithHash : non-null metadata input");
-
-    // low-level - just add to table
-    Serializer s(txn->getDataLength() + metaData->getDataLength() + 16);
-    s.addVL(txn->peekData());
-    s.addVL(metaData->peekData());
-    auto item = make_shamapitem(key, s.slice());
-    auto hash = sha512Half(HashPrefix::txNode, item->slice(), item->key());
-    if (!txMap_.addGiveItem(SHAMapNodeType::tnTRANSACTION_MD, std::move(item)))
-        Throw<std::logic_error>("duplicate_tx: " + to_string(key));
-
-    return hash;
-}
-
 bool
 Ledger::setup()
 {

--- a/src/libxrpl/ledger/Ledger.cpp
+++ b/src/libxrpl/ledger/Ledger.cpp
@@ -493,14 +493,14 @@ void
 Ledger::rawErase(std::shared_ptr<SLE> const& sle)
 {
     if (!stateMap_.delItem(sle->key()))
-        Throw<std::logic_error>("Ledger::rawErase: key not found");
+        LogicError("Ledger::rawErase: key not found");
 }
 
 void
 Ledger::rawErase(uint256 const& key)
 {
     if (!stateMap_.delItem(key))
-        Throw<std::logic_error>("Ledger::rawErase: key not found");
+        LogicError("Ledger::rawErase: key not found");
 }
 
 void
@@ -510,7 +510,7 @@ Ledger::rawInsert(std::shared_ptr<SLE> const& sle)
     sle->add(ss);
     if (!stateMap_.addGiveItem(
             SHAMapNodeType::tnACCOUNT_STATE, make_shamapitem(sle->key(), ss.slice())))
-        Throw<std::logic_error>("Ledger::rawInsert: key already exists");
+        LogicError("Ledger::rawInsert: key already exists");
 }
 
 void
@@ -520,7 +520,7 @@ Ledger::rawReplace(std::shared_ptr<SLE> const& sle)
     sle->add(ss);
     if (!stateMap_.updateGiveItem(
             SHAMapNodeType::tnACCOUNT_STATE, make_shamapitem(sle->key(), ss.slice())))
-        Throw<std::logic_error>("Ledger::rawReplace: key not found");
+        LogicError("Ledger::rawReplace: key not found");
 }
 
 void
@@ -536,7 +536,7 @@ Ledger::rawTxInsert(
     s.addVL(txn->peekData());
     s.addVL(metaData->peekData());
     if (!txMap_.addGiveItem(SHAMapNodeType::tnTRANSACTION_MD, make_shamapitem(key, s.slice())))
-        Throw<std::logic_error>("duplicate_tx: " + to_string(key));
+        LogicError("duplicate_tx: " + to_string(key));
 }
 
 uint256


### PR DESCRIPTION
## High Level Overview of Change

This change reverts a few `Throw` instances to `LogicError`.

### Context of Change

In #6540 a number of `LogicError`, which are `[[noreturn]] noexcept` that call `std::abort()`, were replaced with `Throw<std::logic_error>()`. While this works as expected in transactor code paths (protected by try-catch), the same replacement was applied to `Ledger::rawErase`, `Ledger::rawInsert`, `Ledger::rawReplace`, and `Ledger::rawTxInsert`, which are called from unprotected code paths.

The above notwithstanding, this change is purely cosmetic, for the purpose of making the code "better" even though functionally there is no difference. Using `LogicError` guarantees a clean `std::abort()` with no partial state; although using `Throw` would leave a local ledger in a partially modified state, since the local ledger is never written to disk it would not corrupt the ledger state.