### PR TITLE
fix: Make TxQ test resilient to new DefaultYes amendments

### DIFF
--- a/src/test/app/TxQ_test.cpp
+++ b/src/test/app/TxQ_test.cpp
@@ -1036,16 +1036,21 @@ public:
         checkMetrics(*this, env, 0, std::nullopt, 0, 3);
 
         // ledgers in queue is 2 because of makeConfig
-        auto const initQueueMax = initFee(env, 3, 2, 10, 200, 50);
+        initFee(env, 3, 2, 10, 200, 50);
+        // Close an empty ledger to shrink queue from the flag-ledger
+        // size to 2*3=6, independent of amendment count.
+        env.close();
+        constexpr std::size_t normalMaxQueue = 6;
+        checkMetrics(*this, env, 0, normalMaxQueue, 0, 3);
 
         // Create several accounts while the fee is cheap so they all apply.
         env.fund(drops(2000), noripple(alice));
         env.fund(XRP(500000), noripple(bob, charlie, daria));
-        checkMetrics(*this, env, 0, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 0, normalMaxQueue, 4, 3);
 
         // Alice - price starts exploding: held
         env(noop(alice), fee(11), queued);
-        checkMetrics(*this, env, 1, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 1, normalMaxQueue, 4, 3);
 
         auto aliceSeq = env.seq(alice);
         auto bobSeq = env.seq(bob);
@@ -1053,28 +1058,28 @@ public:
 
         // Alice - try to queue a second transaction, but leave a gap
         env(noop(alice), seq(aliceSeq + 2), fee(100), ter(telCAN_NOT_QUEUE));
-        checkMetrics(*this, env, 1, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 1, normalMaxQueue, 4, 3);
 
         // Alice - queue a second transaction. Yay!
         env(noop(alice), seq(aliceSeq + 1), fee(13), queued);
-        checkMetrics(*this, env, 2, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 2, normalMaxQueue, 4, 3);
 
         // Alice - queue a third transaction. Yay.
         env(noop(alice), seq(aliceSeq + 2), fee(17), queued);
-        checkMetrics(*this, env, 3, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 3, normalMaxQueue, 4, 3);
 
         // Bob - queue a transaction
         env(noop(bob), queued);
-        checkMetrics(*this, env, 4, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 4, normalMaxQueue, 4, 3);
 
         // Bob - queue a second transaction
         env(noop(bob), seq(bobSeq + 1), fee(50), queued);
-        checkMetrics(*this, env, 5, initQueueMax, 4, 3);
+        checkMetrics(*this, env, 5, normalMaxQueue, 4, 3);
 
         // Charlie - queue a transaction, with a higher fee
         // than default
         env(noop(charlie), fee(15), queued);
-        checkMetrics(*this, env, 6, initQueueMax, 4, 3, 257);
+        checkMetrics(*this, env, 6, normalMaxQueue, 4, 3, 257);
 
         BEAST_EXPECT(env.seq(alice) == aliceSeq);
         BEAST_EXPECT(env.seq(bob) == bobSeq);


### PR DESCRIPTION
Close an empty ledger after initFee() in testMultiTxnPerAccount to shrink queue from the flag-ledger size (which depends on amendment count) to the deterministic 2*3=6. This makes the queue-full fee pressure assertion independent of how many DefaultYes amendments exist.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
