### PR TITLE
refactor: Apply various minor improvements and corrections

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -19,7 +19,6 @@ XRPL_FIX    (Cleanup3_2_0,                Supported::no, VoteBehavior::DefaultNo
 XRPL_FEATURE(MPTokensV2,                  Supported::no, VoteBehavior::DefaultNo)
 XRPL_FIX    (Security3_1_3,               Supported::no, VoteBehavior::DefaultNo)
 XRPL_FIX    (PermissionedDomainInvariant, Supported::yes, VoteBehavior::DefaultNo)
-XRPL_FIX    (ExpiredNFTokenOfferRemoval,  Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (BatchInnerSigs,              Supported::no, VoteBehavior::DefaultNo)
 XRPL_FEATURE(LendingProtocol,             Supported::yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(PermissionDelegationV1_1,    Supported::no,  VoteBehavior::DefaultNo)

--- a/src/libxrpl/beast/core/CurrentThreadName.cpp
+++ b/src/libxrpl/beast/core/CurrentThreadName.cpp
@@ -81,12 +81,9 @@ setCurrentThreadNameImpl(std::string_view name)
 {
     // truncate and set the thread name.
     char boundedName[maxThreadNameLength + 1];
-    std::snprintf(
-        boundedName,
-        sizeof(boundedName),
-        "%.*s",
-        static_cast<int>(maxThreadNameLength),
-        name.data());  // NOLINT(bugprone-suspicious-stringview-data-usage)
+    auto const boundedSize = name.size() < maxThreadNameLength ? name.size() : maxThreadNameLength;
+    name.copy(boundedName, boundedSize);
+    boundedName[boundedSize] = '\0';
 
     pthread_setname_np(pthread_self(), boundedName);
 

--- a/src/libxrpl/tx/transactors/nft/NFTokenAcceptOffer.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenAcceptOffer.cpp
@@ -68,15 +68,12 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
 
             if (hasExpired(ctx.view, (*offerSLE)[~sfExpiration]))
             {
-                // Before fixExpiredNFTokenOfferRemoval amendment, expired
-                // offers caused tecEXPIRED in preclaim, leaving them on ledger
-                // forever. After the amendment, we allow expired offers to
-                // reach doApply() where they get deleted and tecEXPIRED is
-                // returned.
-                if (!ctx.view.rules().enabled(fixExpiredNFTokenOfferRemoval))
+                // Before fixSecurity3_1_3 amendment, expired offers caused tecEXPIRED in preclaim,
+                // leaving them on ledger forever. After the amendment, we allow expired offers to
+                // reach doApply() where they get deleted and tecEXPIRED is returned.
+                if (!ctx.view.rules().enabled(fixSecurity3_1_3))
                     return {nullptr, tecEXPIRED};
-                // Amendment enabled: return the expired offer to be handled in
-                // doApply
+                // Amendment enabled: return the expired offer to be handled in doApply.
             }
 
             if ((*offerSLE)[sfAmount].negative())
@@ -450,10 +447,9 @@ NFTokenAcceptOffer::doApply()
     auto bo = loadToken(ctx_.tx[~sfNFTokenBuyOffer]);
     auto so = loadToken(ctx_.tx[~sfNFTokenSellOffer]);
 
-    // With fixExpiredNFTokenOfferRemoval amendment, check for expired offers
-    // and delete them, returning tecEXPIRED. This ensures expired offers
-    // are properly cleaned up from the ledger.
-    if (view().rules().enabled(fixExpiredNFTokenOfferRemoval))
+    // With fixSecurity3_1_3 amendment, check for expired offers and delete them, returning
+    // tecEXPIRED. This ensures expired offers are properly cleaned up from the ledger.
+    if (view().rules().enabled(fixSecurity3_1_3))
     {
         bool foundExpired = false;
 

--- a/src/test/app/NFToken_test.cpp
+++ b/src/test/app/NFToken_test.cpp
@@ -1096,10 +1096,10 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 
         // The buy offer must not have expired.
         // NOTE: this is only a preclaim check with the
-        // fixExpiredNFTokenOfferRemoval amendment disabled.
+        // fixSecurity3_1_3 amendment disabled.
         env(token::acceptBuyOffer(alice, buyerExpOfferIndex), ter(tecEXPIRED));
         env.close();
-        if (features[fixExpiredNFTokenOfferRemoval])
+        if (features[fixSecurity3_1_3])
         {
             buyerCount--;
         }
@@ -1117,12 +1117,12 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 
         // The sell offer must not have expired.
         // NOTE: this is only a preclaim check with the
-        // fixExpiredNFTokenOfferRemoval amendment disabled.
+        // fixSecurity3_1_3 amendment disabled.
         env(token::acceptSellOffer(buyer, aliceExpOfferIndex), ter(tecEXPIRED));
         env.close();
         // Alice's count is decremented by one when the expired offer is
         // removed.
-        if (features[fixExpiredNFTokenOfferRemoval])
+        if (features[fixSecurity3_1_3])
         {
             aliceCount--;
         }
@@ -3101,10 +3101,10 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             // No one can accept an expired sell offer.
             env(token::acceptSellOffer(buyer, offer1), ter(tecEXPIRED));
 
-            // With fixExpiredNFTokenOfferRemoval amendment, the first accept
+            // With fixSecurity3_1_3 amendment, the first accept
             // attempt deletes the expired offer. Without the amendment,
             // the offer remains and we can try to accept it again.
-            if (features[fixExpiredNFTokenOfferRemoval])
+            if (features[fixSecurity3_1_3])
             {
                 // After amendment: offer was deleted by first accept attempt
                 minterCount--;
@@ -3123,7 +3123,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             BEAST_EXPECT(ownerCount(env, minter) == minterCount);
             BEAST_EXPECT(ownerCount(env, buyer) == buyerCount);
 
-            if (!features[fixExpiredNFTokenOfferRemoval])
+            if (!features[fixSecurity3_1_3])
             {
                 // Before amendment: expired offer still exists and needs to be
                 // cancelled
@@ -3189,10 +3189,10 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             // An expired buy offer cannot be accepted.
             env(token::acceptBuyOffer(minter, offer1), ter(tecEXPIRED));
 
-            // With fixExpiredNFTokenOfferRemoval amendment, the first accept
+            // With fixSecurity3_1_3 amendment, the first accept
             // attempt deletes the expired offer. Without the amendment,
             // the offer remains and we can try to accept it again.
-            if (features[fixExpiredNFTokenOfferRemoval])
+            if (features[fixSecurity3_1_3])
             {
                 // After amendment: offer was deleted by first accept attempt
                 buyerCount--;
@@ -3211,7 +3211,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             BEAST_EXPECT(ownerCount(env, minter) == minterCount);
             BEAST_EXPECT(ownerCount(env, buyer) == buyerCount);
 
-            if (!features[fixExpiredNFTokenOfferRemoval])
+            if (!features[fixSecurity3_1_3])
             {
                 // Before amendment: expired offer still exists and can be
                 // cancelled
@@ -3288,7 +3288,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             env(token::brokerOffers(issuer, buyOffer1, sellOffer1), ter(tecEXPIRED));
             env.close();
 
-            if (features[fixExpiredNFTokenOfferRemoval])
+            if (features[fixSecurity3_1_3])
             {
                 // With amendment: expired offers are deleted
                 minterCount--;
@@ -3298,7 +3298,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             BEAST_EXPECT(ownerCount(env, minter) == minterCount);
             BEAST_EXPECT(ownerCount(env, buyer) == buyerCount);
 
-            if (features[fixExpiredNFTokenOfferRemoval])
+            if (features[fixSecurity3_1_3])
             {
                 // The buy offer was deleted, so no need to cancel it
                 // The sell offer still exists, so we can cancel it
@@ -3377,7 +3377,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
             env.close();
 
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
-            if (features[fixExpiredNFTokenOfferRemoval])
+            if (features[fixSecurity3_1_3])
             {
                 // After amendment: expired offers were deleted during broker
                 // attempt
@@ -3463,7 +3463,7 @@ class NFTokenBaseUtil_test : public beast::unit_test::suite
 
             // The expired offers are still in the ledger.
             BEAST_EXPECT(ownerCount(env, issuer) == 0);
-            if (!features[fixExpiredNFTokenOfferRemoval])
+            if (!features[fixSecurity3_1_3])
             {
                 // Before amendment: expired offers still exist in ledger
                 BEAST_EXPECT(ownerCount(env, minter) == 2);
@@ -7190,7 +7190,7 @@ public:
     {
         testWithFeats(
             allFeatures - fixNFTokenReserve - featureNFTokenMintOffer - featureDynamicNFT -
-            fixExpiredNFTokenOfferRemoval);
+            fixSecurity3_1_3);
     }
 };
 
@@ -7227,7 +7227,7 @@ class NFTokenWOExpiredOfferRemoval_test : public NFTokenBaseUtil_test
     void
     run() override
     {
-        testWithFeats(allFeatures - fixExpiredNFTokenOfferRemoval);
+        testWithFeats(allFeatures - fixSecurity3_1_3);
     }
 };
 

--- a/src/test/rpc/LedgerEntry_test.cpp
+++ b/src/test/rpc/LedgerEntry_test.cpp
@@ -1201,7 +1201,7 @@ class LedgerEntry_test : public beast::unit_test::suite
             checkErrorValue(
                 jrr[jss::result],
                 "malformedAuthorizedCredentials",
-                "Invalid field 'authorized_credentials', not array.");
+                "Invalid field 'authorized_credentials', not array of objects.");
         }
 
         {
@@ -1219,7 +1219,7 @@ class LedgerEntry_test : public beast::unit_test::suite
             checkErrorValue(
                 jrr[jss::result],
                 "malformedAuthorizedCredentials",
-                "Invalid field 'authorized_credentials', not array.");
+                "Invalid field 'authorized_credentials', not array of objects.");
         }
 
         {

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -2639,7 +2639,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMGetObjectByHash> const& m)
                     {
                         fee_.update(
                             Resource::feeModerateBurdenPeer,
-                            " Reply limit reached. Truncating reply.");
+                            "Reply limit reached. Truncating reply.");
                         break;
                     }
                 }

--- a/src/xrpld/rpc/handlers/ledger/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/ledger/LedgerEntry.cpp
@@ -267,7 +267,7 @@ parseAuthorizeCredentials(Json::Value const& jv)
         if (!jo.isObject())
         {
             return LedgerEntryHelpers::invalidFieldError(
-                "malformedAuthorizedCredentials", jss::authorized_credentials, "array");
+                "malformedAuthorizedCredentials", jss::authorized_credentials, "array of objects");
         }
 
         if (auto const value = LedgerEntryHelpers::hasRequired(


### PR DESCRIPTION
## High Level Overview of Change

This change backports the changes that targeted the 3.1.3 staging branch.

### Context of Change

As we are preparing for the 3.1.3 release, the changes in https://github.com/XRPLF/rippled/pull/6739/commits/345fc08a07c9dc8cbb30cea1e2b4c3776393f13d still need to be included in the develop branch. As 3.1.3 has not been released yet, the API change log modifications have not been included here.

In short: The `ExpiredNFTokenOfferRemoval` fix amendment is renamed to `fixSecurity_3_1_3` (which will be renamed to `fixCleanup_3_1_3` before the release), a few error messages are improved, and the thread names are properly truncated.