### PR TITLE
fix: Add defensive check for permission to tx type cast

### DIFF
--- a/include/xrpl/protocol/Permissions.h
+++ b/include/xrpl/protocol/Permissions.h
@@ -72,11 +72,11 @@ public:
     isDelegable(std::uint32_t const& permissionValue, Rules const& rules) const;
 
     // for tx level permission, permission value is equal to tx type plus one
-    static uint32_t
+    [[nodiscard]] static uint32_t
     txToPermissionType(TxType const& type);
 
     // tx type value is permission value minus one
-    static TxType
+    [[nodiscard]] static std::optional<TxType>
     permissionToTxType(uint32_t const& value);
 };
 

--- a/src/libxrpl/protocol/Permissions.cpp
+++ b/src/libxrpl/protocol/Permissions.cpp
@@ -106,8 +106,10 @@ Permission::getPermissionName(std::uint32_t const value) const
 
     // not a granular permission, check if it maps to a transaction type
     if (auto const txType = permissionToTxType(value))
+    {
         if (auto const* item = TxFormats::getInstance().findByType(*txType); item != nullptr)
             return item->getName();
+    }
 
     return std::nullopt;
 }

--- a/src/libxrpl/protocol/Permissions.cpp
+++ b/src/libxrpl/protocol/Permissions.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <string>
 
@@ -104,9 +105,9 @@ Permission::getPermissionName(std::uint32_t const value) const
         return granular;
 
     // not a granular permission, check if it maps to a transaction type
-    auto const txType = permissionToTxType(value);
-    if (auto const* item = TxFormats::getInstance().findByType(txType); item != nullptr)
-        return item->getName();
+    if (auto const txType = permissionToTxType(value))
+        if (auto const* item = TxFormats::getInstance().findByType(*txType); item != nullptr)
+            return item->getName();
 
     return std::nullopt;
 }
@@ -166,12 +167,15 @@ Permission::isDelegable(std::uint32_t const& permissionValue, Rules const& rules
     }
 
     auto const txType = permissionToTxType(permissionValue);
-    auto const it = delegableTx_.find(txType);
+    if (!txType)
+        return false;
+
+    auto const it = delegableTx_.find(*txType);
 
     if (it == delegableTx_.end())
         return false;
 
-    auto const txFeaturesIt = txFeatureMap_.find(txType);
+    auto const txFeaturesIt = txFeatureMap_.find(*txType);
     XRPL_ASSERT(
         txFeaturesIt != txFeatureMap_.end(),
         "xrpl::Permissions::isDelegable : tx exists in txFeatureMap_");
@@ -194,9 +198,14 @@ Permission::txToPermissionType(TxType const& type)
     return static_cast<uint32_t>(type) + 1;
 }
 
-TxType
+std::optional<TxType>
 Permission::permissionToTxType(uint32_t const& value)
 {
+    // Defensive check: values outside this range would silently truncate when cast to
+    // uint16_t, for example, 65537 would become 1, mapping to the Payment transaction.
+    if (value == 0 || value > std::numeric_limits<std::uint16_t>::max() + 1u)
+        return std::nullopt;
+
     return static_cast<TxType>(value - 1);
 }
 

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -43,6 +43,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -1916,6 +1916,38 @@ class Delegate_test : public beast::unit_test::suite
     }
 
     void
+    testPermissionToTxType()
+    {
+        testcase("test Permission to Tx type");
+
+        // 0 is not a valid permission value
+        BEAST_EXPECT(!Permission::permissionToTxType(0));
+
+        // 1 maps to Payment transaction
+        BEAST_EXPECT(Permission::permissionToTxType(1) == ttPAYMENT);
+
+        // UINT16_MAX+1 is the maximum possible tx-level permission value
+        constexpr uint32_t maxTxPermission = std::numeric_limits<uint16_t>::max() + 1u;
+        BEAST_EXPECT(Permission::permissionToTxType(maxTxPermission).has_value());
+
+        // exceeding maximum value should return nullopt
+        BEAST_EXPECT(!Permission::permissionToTxType(maxTxPermission + 1));
+
+        // All granular permission values should return nullopt since they do not map to a TxType.
+        for (auto const gp : {
+#pragma push_macro("PERMISSION")
+#undef PERMISSION
+#define PERMISSION(type, txType, value) GranularPermissionType::type,
+#include <xrpl/protocol/detail/permissions.macro>
+#undef PERMISSION
+#pragma pop_macro("PERMISSION")
+             })
+        {
+            BEAST_EXPECT(!Permission::permissionToTxType(static_cast<uint32_t>(gp)));
+        }
+    }
+
+    void
     run() override
     {
         FeatureBitset const all = jtx::testable_amendments();
@@ -1941,6 +1973,7 @@ class Delegate_test : public beast::unit_test::suite
         testTxRequireFeatures(all);
         testTxDelegableCount();
         testDelegateUtilsNullptrCheck();
+        testPermissionToTxType();
     }
 };
 BEAST_DEFINE_TESTSUITE(Delegate, app, xrpl);


### PR DESCRIPTION
In `permissionToTxType`, 
values outside this range would silently truncate when cast to
uint16_t, for example, 65537 would become 1, mapping to the Payment transaction.

(Might have some overlap with https://github.com/XRPLF/rippled/pull/6613. but keeping it as a separate PR for clearer scope, review and tracking.)

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
