### PR TITLE
fix: Gate -mcmodel flags to x86_64 in sanitizer builds

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -73,7 +73,7 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
                     if (
                         f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-15"
                         and build_type == "Debug"
-                        and architecture["platform"] == "linux/amd64"
+                        and architecture["platform"] in ["linux/amd64", "linux/arm64"]
                     ):
                         skip = False
                     if (

--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -64,58 +64,9 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
                 skip = True
                 if os["distro_version"] == "bookworm":
                     if (
-                        f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-13"
-                        and build_type == "Debug"
-                        and architecture["platform"] == "linux/amd64"
-                    ):
-                        cmake_args = f"-DUNIT_TEST_REFERENCE_FEE=500 {cmake_args}"
-                        skip = False
-                    if (
                         f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-15"
                         and build_type == "Debug"
-                        and architecture["platform"] == "linux/amd64"
-                    ):
-                        skip = False
-                    if (
-                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-16"
-                        and build_type == "Debug"
-                        and architecture["platform"] == "linux/amd64"
-                    ):
-                        cmake_args = f"-Dvoidstar=ON {cmake_args}"
-                        skip = False
-                    if (
-                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-17"
-                        and build_type == "Release"
-                        and architecture["platform"] == "linux/amd64"
-                    ):
-                        cmake_args = f"-DUNIT_TEST_REFERENCE_FEE=1000 {cmake_args}"
-                        skip = False
-                    if (
-                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-20"
-                        and build_type == "Debug"
-                        and architecture["platform"] == "linux/amd64"
-                    ):
-                        skip = False
-                if skip:
-                    continue
-
-            # RHEL:
-            # - 9 using GCC 12: Debug on linux/amd64.
-            # - 10 using Clang: Release on linux/amd64.
-            if os["distro_name"] == "rhel":
-                skip = True
-                if os["distro_version"] == "9":
-                    if (
-                        f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-12"
-                        and build_type == "Debug"
-                        and architecture["platform"] == "linux/amd64"
-                    ):
-                        skip = False
-                elif os["distro_version"] == "10":
-                    if (
-                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-any"
-                        and build_type == "Release"
-                        and architecture["platform"] == "linux/amd64"
+                        and architecture["platform"] == "linux/arm64"
                     ):
                         skip = False
                 if skip:

--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -64,9 +64,58 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
                 skip = True
                 if os["distro_version"] == "bookworm":
                     if (
+                        f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-13"
+                        and build_type == "Debug"
+                        and architecture["platform"] == "linux/amd64"
+                    ):
+                        cmake_args = f"-DUNIT_TEST_REFERENCE_FEE=500 {cmake_args}"
+                        skip = False
+                    if (
                         f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-15"
                         and build_type == "Debug"
-                        and architecture["platform"] == "linux/arm64"
+                        and architecture["platform"] == "linux/amd64"
+                    ):
+                        skip = False
+                    if (
+                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-16"
+                        and build_type == "Debug"
+                        and architecture["platform"] == "linux/amd64"
+                    ):
+                        cmake_args = f"-Dvoidstar=ON {cmake_args}"
+                        skip = False
+                    if (
+                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-17"
+                        and build_type == "Release"
+                        and architecture["platform"] == "linux/amd64"
+                    ):
+                        cmake_args = f"-DUNIT_TEST_REFERENCE_FEE=1000 {cmake_args}"
+                        skip = False
+                    if (
+                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-20"
+                        and build_type == "Debug"
+                        and architecture["platform"] == "linux/amd64"
+                    ):
+                        skip = False
+                if skip:
+                    continue
+
+            # RHEL:
+            # - 9 using GCC 12: Debug on linux/amd64.
+            # - 10 using Clang: Release on linux/amd64.
+            if os["distro_name"] == "rhel":
+                skip = True
+                if os["distro_version"] == "9":
+                    if (
+                        f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-12"
+                        and build_type == "Debug"
+                        and architecture["platform"] == "linux/amd64"
+                    ):
+                        skip = False
+                elif os["distro_version"] == "10":
+                    if (
+                        f"{os['compiler_name']}-{os['compiler_version']}" == "clang-any"
+                        and build_type == "Release"
+                        and architecture["platform"] == "linux/amd64"
                     ):
                         skip = False
                 if skip:
@@ -182,6 +231,10 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
             config_name += "-coverage"
         if "-Dunity=ON" in cmake_args:
             config_name += "-unity"
+
+        # TEMP: Only run ARM64 sanitizer configs for build fix validation.
+        if config_name != "debian-bookworm-gcc-15-arm64-debug":
+            continue
 
         # Add the configuration to the list, with the most unique fields first,
         # so that they are easier to identify in the GitHub Actions UI, as long

--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -73,7 +73,7 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
                     if (
                         f"{os['compiler_name']}-{os['compiler_version']}" == "gcc-15"
                         and build_type == "Debug"
-                        and architecture["platform"] in ["linux/amd64", "linux/arm64"]
+                        and architecture["platform"] == "linux/amd64"
                     ):
                         skip = False
                     if (
@@ -231,10 +231,6 @@ def generate_strategy_matrix(all: bool, config: Config) -> list:
             config_name += "-coverage"
         if "-Dunity=ON" in cmake_args:
             config_name += "-unity"
-
-        # TEMP: Only run ARM64 sanitizer configs for build fix validation.
-        if config_name != "debian-bookworm-gcc-15-arm64-debug":
-            continue
 
         # Add the configuration to the list, with the most unique fields first,
         # so that they are easier to identify in the GitHub Actions UI, as long

--- a/cmake/XrplSanitizers.cmake
+++ b/cmake/XrplSanitizers.cmake
@@ -34,10 +34,12 @@
      * -fsanitize=<types>: Links sanitizer runtime libraries
      * -mcmodel=large/medium: (GCC only) Matches compile-time code model
 
-   - SANITIZERS_RELOCATION_FLAGS: (GCC only) Code model flags for linking.
+   - SANITIZERS_RELOCATION_FLAGS: (GCC only, x86_64 only) Code model flags for linking.
      Used to handle large instrumented binaries on x86_64:
      * -mcmodel=large: For AddressSanitizer (prevents relocation errors)
      * -mcmodel=medium: For ThreadSanitizer (large model is incompatible)
+     On ARM64, these flags are omitted since GCC does not support
+     -mcmodel=large with -fPIC, and -mcmodel=medium does not exist.
 #]===================================================================]
 
 include(CompilationEnv)
@@ -151,9 +153,11 @@ if(is_gcc)
     elseif(enable_tsan)
         # GCC doesn't support atomic_thread_fence with tsan. Suppress warnings.
         list(APPEND SANITIZERS_COMPILE_FLAGS "-Wno-tsan")
-        message(STATUS "  Using medium code model (-mcmodel=medium)")
-        list(APPEND SANITIZERS_COMPILE_FLAGS "-mcmodel=medium")
-        list(APPEND SANITIZERS_RELOCATION_FLAGS "-mcmodel=medium")
+        if(is_amd64)
+            message(STATUS "  Using medium code model (-mcmodel=medium)")
+            list(APPEND SANITIZERS_COMPILE_FLAGS "-mcmodel=medium")
+            list(APPEND SANITIZERS_RELOCATION_FLAGS "-mcmodel=medium")
+        endif()
     endif()
 
     # Join sanitizer flags with commas for -fsanitize option

--- a/conan/profiles/sanitizers
+++ b/conan/profiles/sanitizers
@@ -1,5 +1,6 @@
 include(default)
 {% set compiler, version, compiler_exe = detect_api.detect_default_compiler() %}
+{% set arch = detect_api.detect_arch() %}
 {% set sanitizers = os.getenv("SANITIZERS") %}
 
 [conf]
@@ -13,12 +14,16 @@ include(default)
 
             {% if "address" in sanitizers %}
                 {% set _ = sanitizer_list.append("address") %}
-                {% set model_code = "-mcmodel=large" %}
+                {% if arch == "x86_64" %}
+                    {% set model_code = "-mcmodel=large" %}
+                {% endif %}
                 {% set _ = defines.append("BOOST_USE_ASAN")%}
                 {% set _ = defines.append("BOOST_USE_UCONTEXT")%}
             {% elif "thread" in sanitizers %}
                 {% set _ = sanitizer_list.append("thread") %}
-                {% set model_code = "-mcmodel=medium" %}
+                {% if arch == "x86_64" %}
+                    {% set model_code = "-mcmodel=medium" %}
+                {% endif %}
                 {% set _ = extra_cxxflags.append("-Wno-tsan") %}
                 {% set _ = defines.append("BOOST_USE_TSAN")%}
                 {% set _ = defines.append("BOOST_USE_UCONTEXT")%}


### PR DESCRIPTION
## High Level Overview of Change

Gate `-mcmodel=large` (ASAN) and `-mcmodel=medium` (TSAN) behind x86_64 architecture checks in both the Conan sanitizer profile and CMake sanitizer module, fixing ARM64 ASAN/TSAN CI builds.

### Context of Change

The `debian-bookworm-gcc-15-arm64-debug-asan` CI job fails during the Conan dependency build phase (snappy) with:
```
cc1plus: sorry, unimplemented: code model 'large' with '-fPIC'
```
https://github.com/XRPLF/rippled/actions/runs/25019997726/job/73277846482

The CMake module (`XrplSanitizers.cmake`) already had an `is_amd64` guard on the ASAN path but not on the TSAN path. The Conan profile (`conan/profiles/sanitizers`) had no architecture check at all, causing the flags to propagate to all dependency builds on all architectures.

### Testing
Testing on CI by running build with config: `debian-bookworm-gcc-15-arm64-debug-asan`
Working build: https://github.com/XRPLF/rippled/actions/runs/25121180695/job/73622146413?pr=7049