### PR TITLE
fix: Restore clang-tidy change to section name in config

### DIFF
--- a/src/libxrpl/server/Port.cpp
+++ b/src/libxrpl/server/Port.cpp
@@ -287,7 +287,7 @@ parsePort(ParsedPort& port, Section const& section, std::ostream& log)
 
     populate(section, "admin", log, port.admin_nets_v4, port.admin_nets_v6);
     populate(
-        section, "secureGateway", log, port.secure_gateway_nets_v4, port.secure_gateway_nets_v6);
+        section, "secure_gateway", log, port.secure_gateway_nets_v4, port.secure_gateway_nets_v6);
 
     set(port.user, "user", section);
     set(port.password, "password", section);

--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -72,7 +72,7 @@ secureGateway(std::unique_ptr<Config> cfg)
 {
     (*cfg)[PORT_RPC].set("admin", "");
     (*cfg)[PORT_WS].set("admin", "");
-    (*cfg)[PORT_RPC].set("secureGateway", getEnvLocalhostAddr());
+    (*cfg)[PORT_RPC].set("secure_gateway", getEnvLocalhostAddr());
     return cfg;
 }
 
@@ -89,8 +89,8 @@ secureGatewayLocalnet(std::unique_ptr<Config> cfg)
 {
     (*cfg)[PORT_RPC].set("admin", "");
     (*cfg)[PORT_WS].set("admin", "");
-    (*cfg)[PORT_RPC].set("secureGateway", "127.0.0.0/8");
-    (*cfg)[PORT_WS].set("secureGateway", "127.0.0.0/8");
+    (*cfg)[PORT_RPC].set("secure_gateway", "127.0.0.0/8");
+    (*cfg)[PORT_WS].set("secure_gateway", "127.0.0.0/8");
     return cfg;
 }
 std::unique_ptr<Config>
@@ -127,7 +127,7 @@ addGrpcConfigWithSecureGateway(std::unique_ptr<Config> cfg, std::string const& s
     // Check https://man7.org/linux/man-pages/man7/ip.7.html
     // "ip_local_port_range" section for using 0 ports
     (*cfg)[SECTION_PORT_GRPC].set("port", "0");
-    (*cfg)[SECTION_PORT_GRPC].set("secureGateway", secureGateway);
+    (*cfg)[SECTION_PORT_GRPC].set("secure_gateway", secureGateway);
     return cfg;
 }
 

--- a/src/xrpld/app/main/GRPCServer.cpp
+++ b/src/xrpld/app/main/GRPCServer.cpp
@@ -361,7 +361,7 @@ GRPCServerImpl::GRPCServerImpl(Application& app)
             Throw<std::runtime_error>("Error setting grpc server address");
         }
 
-        auto const optSecureGateway = section.get("secureGateway");
+        auto const optSecureGateway = section.get("secure_gateway");
         if (optSecureGateway)
         {
             try


### PR DESCRIPTION
## High Level Overview of Change

This change restores a bad clang-tidy change in a config section.

### Context of Change

In https://github.com/XRPLF/rippled/pull/6571 the config section get call was changed from `secure_gateway` to `secureGateway`. This PR restores the name.