### PR TITLE
refactor: Replace `featureInvariantsV1_1` with `fixCleanup3_2_0`

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -46,9 +46,6 @@ XRPL_FEATURE(Credentials,                Supported::Yes, VoteBehavior::DefaultNo
 XRPL_FEATURE(AMMClawback,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (AMMv1_2,                    Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(MPTokensV1,                 Supported::Yes, VoteBehavior::DefaultNo)
-// InvariantsV1_1 will be changes to Supported::yes when all the
-// invariants expected to be included under it are complete.
-XRPL_FEATURE(InvariantsV1_1,             Supported::No,  VoteBehavior::DefaultNo)
 XRPL_FIX    (NFTokenPageLinks,           Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (InnerObjTemplate2,          Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (EnforceNFTokenTrustline,    Supported::Yes, VoteBehavior::DefaultNo)

--- a/src/libxrpl/tx/invariants/InvariantCheck.cpp
+++ b/src/libxrpl/tx/invariants/InvariantCheck.cpp
@@ -467,7 +467,7 @@ AccountRootsDeletedClean::finalize(
     // transaction processing results, however unlikely, only fail if the
     // feature is enabled. Enabled, or not, though, a fatal-level message will
     // be logged
-    [[maybe_unused]] bool const enforce = view.rules().enabled(Cleanup3_2_0) ||
+    [[maybe_unused]] bool const enforce = view.rules().enabled(fixCleanup3_2_0) ||
         view.rules().enabled(featureSingleAssetVault) ||
         view.rules().enabled(featureLendingProtocol);
 

--- a/src/libxrpl/tx/invariants/InvariantCheck.cpp
+++ b/src/libxrpl/tx/invariants/InvariantCheck.cpp
@@ -467,7 +467,7 @@ AccountRootsDeletedClean::finalize(
     // transaction processing results, however unlikely, only fail if the
     // feature is enabled. Enabled, or not, though, a fatal-level message will
     // be logged
-    [[maybe_unused]] bool const enforce = view.rules().enabled(featureInvariantsV1_1) ||
+    [[maybe_unused]] bool const enforce = view.rules().enabled(Cleanup3_2_0) ||
         view.rules().enabled(featureSingleAssetVault) ||
         view.rules().enabled(featureLendingProtocol);
 

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -94,7 +94,7 @@ class Invariants_test : public beast::unit_test::Suite
     static FeatureBitset
     defaultAmendments()
     {
-        return xrpl::test::jtx::testableAmendments() | featureInvariantsV1_1 | fixSecurity3_1_3;
+        return xrpl::test::jtx::testableAmendments() | Cleanup3_2_0 | fixSecurity3_1_3;
     }
 
     /** Run a specific test case to put the ledger into a state that will be

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -94,7 +94,7 @@ class Invariants_test : public beast::unit_test::Suite
     static FeatureBitset
     defaultAmendments()
     {
-        return xrpl::test::jtx::testableAmendments() | Cleanup3_2_0 | fixSecurity3_1_3;
+        return xrpl::test::jtx::testableAmendments() | fixSecurity3_1_3 | fixCleanup3_2_0;
     }
 
     /** Run a specific test case to put the ledger into a state that will be


### PR DESCRIPTION
## High Level Overview of Change

This PR removes the `featureInvariantsV1_1` amendment and replaces its checks with `fixCleanup3_2_0`.

### Context of Change

This invariant check was added in #4663.

### API Impact

N/A