### PR TITLE
fix: Reject ClearCanTransfer if TransferFee is non-zero and immutable

### DIFF
--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
@@ -248,6 +248,14 @@ MPTokenIssuanceSet::preclaim(PreclaimContext const& ctx)
         if ((*mutableFlags & tmfMPTClearRequireAuth) != 0u &&
             sleMptIssuance->isFieldPresent(sfDomainID))
             return tecNO_PERMISSION;
+
+        // Clearing CanTransfer implicitly clears TransferFee. Reject if the
+        // fee is non-zero but TransferFee is not mutable, to prevent bypassing
+        // an immutable fee by toggling CanTransfer.
+        if ((*mutableFlags & tmfMPTClearCanTransfer) != 0u &&
+            sleMptIssuance->isFieldPresent(sfTransferFee) &&
+            !isMutableFlag(lsmfMPTCanMutateTransferFee))
+            return tecNO_PERMISSION;
     }
 
     if (!isMutableFlag(lsmfMPTCanMutateMetadata) && ctx.tx.isFieldPresent(sfMPTokenMetadata))

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3257,7 +3257,8 @@ class MPToken_test : public beast::unit_test::Suite
 
             BEAST_EXPECT(mptAlice.checkTransferFee(100));
 
-            // Clear MPTCanTransfer and transfer fee is removed
+            // Clearing MPTCanTransfer is allowed when lsmfMPTCanMutateTransferFee is set, even if
+            // the transfer fee is currently non-zero. This will implicitly clear the transfer fee.
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTransfer});
             BEAST_EXPECT(!mptAlice.isTransferFeePresent());
 
@@ -3265,6 +3266,46 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.set({.account = alice, .transferFee = 0});
 
             // TransferFee field is still not present
+            BEAST_EXPECT(!mptAlice.isTransferFeePresent());
+        }
+
+        // Clearing CanTransfer is rejected when TransferFee is non-zero
+        // and lsmfMPTCanMutateTransferFee not set.
+        // This prevents bypassing an immutable fee by toggling CanTransfer.
+        {
+            Env env{*this, features};
+
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+            mptAlice.create(
+                {.transferFee = 100,
+                 .ownerCount = 1,
+                 .flags = tfMPTCanTransfer,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+
+            BEAST_EXPECT(mptAlice.checkTransferFee(100));
+
+            mptAlice.set(
+                {.account = alice,
+                 .mutableFlags = tmfMPTClearCanTransfer,
+                 .err = tecNO_PERMISSION});
+
+            BEAST_EXPECT(mptAlice.checkTransferFee(100));
+        }
+
+        // Clearing CanTransfer succeeds when TransferFee is zero, even if
+        // lsmfMPTCanMutateTransferFee is not set.
+        {
+            Env env{*this, features};
+
+            MPTTester mptAlice(env, alice, {.holders = {bob}});
+            mptAlice.create(
+                {.ownerCount = 1,
+                 .flags = tfMPTCanTransfer,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+
+            BEAST_EXPECT(!mptAlice.isTransferFeePresent());
+
+            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTransfer});
             BEAST_EXPECT(!mptAlice.isTransferFeePresent());
         }
     }


### PR DESCRIPTION
### **Problem:**

MPTokenIssuanceSet::doApply unconditionally clears sfTransferFee as a side effect of clearing lsfMPTCanTransfer. This created a bypass: an issuer who set a non-zero TransferFee without lsmfMPTCanMutateTransferFee (intending the fee to be permanent) could still remove it by:

1. Submitting MPTokenIssuanceSet with tmfMPTClearCanTransfer
2. Submitting another MPTokenIssuanceSet with tmfMPTSetCanTransfer


### **Fix**:
Add a preclaim check that returns `tecNO_PERMISSION` when `tmfMPTClearCanTransfer` is requested, `sfTransferFee` is present on the issuance (non-zero because it is `soeDefault`), and lsmfMPTCanMutateTransferFee is not set. 


<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
4. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
5. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
