### PR TITLE
refactor: Remove erroneous base_uint ctor from container

### DIFF
--- a/include/xrpl/basics/base_uint.h
+++ b/include/xrpl/basics/base_uint.h
@@ -46,6 +46,11 @@ struct IsContiguousContainer<Slice> : std::true_type
 {
 };
 
+template <typename...>
+struct AlwaysFalseT : std::bool_constant<false>
+{
+};
+
 }  // namespace detail
 
 /** Integers of any length that is a multiple of 32-bits
@@ -272,10 +277,28 @@ public:
             std::is_trivially_copyable_v<typename Container::value_type>>>
     explicit BaseUInt(Container const& c)
     {
+        // Use AlwaysFalseT so the static_assert condition is dependent
+        // and only triggers when this constructor template is instantiated.
+        static_assert(
+            detail::AlwaysFalseT<Container>::value,
+            "This constructor is not intended to be used and will be soon removed. "
+            "Use base_uint::fromRaw instead.");
+    }
+
+    template <
+        class Container,
+        class = std::enable_if_t<
+            detail::IsContiguousContainer<Container>::value &&
+            std::is_trivially_copyable_v<typename Container::value_type>>>
+    static BaseUInt
+    fromRaw(Container const& c)
+    {
+        BaseUInt result;
         XRPL_ASSERT(
             c.size() * sizeof(typename Container::value_type) == size(),
-            "xrpl::BaseUInt::BaseUInt(Container auto) : input size match");
-        std::memcpy(data_.data(), c.data(), size());
+            "xrpl::BaseUInt::fromRaw(Container auto) : input size match");
+        std::memcpy(result.data_.data(), c.data(), size());
+        return result;
     }
 
     template <class Container>

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -152,7 +152,7 @@ pseudoAccountAddress(ReadView const& view, uint256 const& pseudoOwnerKey)
         RipeshaHasher rsh;
         auto const hash = sha512Half(i, view.header().parentHash, pseudoOwnerKey);
         rsh(hash.data(), hash.size());
-        AccountID const ret{static_cast<RipeshaHasher::result_type>(rsh)};
+        AccountID const ret = AccountID::fromRaw(static_cast<RipeshaHasher::result_type>(rsh));
         if (!view.read(keylet::account(ret)))
             return ret;
     }

--- a/src/libxrpl/protocol/AccountID.cpp
+++ b/src/libxrpl/protocol/AccountID.cpp
@@ -105,7 +105,7 @@ parseBase58(std::string const& s)
     auto const result = decodeBase58Token(s, TokenType::AccountID);
     if (result.size() != AccountID::kBYTES)
         return std::nullopt;
-    return AccountID{result};
+    return AccountID::fromRaw(result);
 }
 
 //------------------------------------------------------------------------------
@@ -150,7 +150,7 @@ calcAccountID(PublicKey const& pk)
 
     RipeshaHasher rsh;
     rsh(pk.data(), pk.size());
-    return AccountID{static_cast<RipeshaHasher::result_type>(rsh)};
+    return AccountID::fromRaw(static_cast<RipeshaHasher::result_type>(rsh));
 }
 
 AccountID const&

--- a/src/libxrpl/protocol/Indexes.cpp
+++ b/src/libxrpl/protocol/Indexes.cpp
@@ -385,7 +385,7 @@ nftpageMin(AccountID const& owner)
 {
     std::array<std::uint8_t, 32> buf{};
     std::memcpy(buf.data(), owner.data(), owner.size());
-    return {ltNFTOKEN_PAGE, uint256{buf}};
+    return {ltNFTOKEN_PAGE, uint256::fromRaw(buf)};
 }
 
 Keylet

--- a/src/libxrpl/protocol/PublicKey.cpp
+++ b/src/libxrpl/protocol/PublicKey.cpp
@@ -297,7 +297,7 @@ calcNodeID(PublicKey const& pk)
 
     RipeshaHasher h;
     h(pk.data(), pk.size());
-    return NodeID{static_cast<RipeshaHasher::result_type>(h)};
+    return NodeID::fromRaw(static_cast<RipeshaHasher::result_type>(h));
 }
 
 }  // namespace xrpl

--- a/src/libxrpl/protocol/STIssue.cpp
+++ b/src/libxrpl/protocol/STIssue.cpp
@@ -28,7 +28,7 @@ STIssue::STIssue(SerialIter& sit, SField const& name) : STBase{name}
 {
     auto const currencyOrAccount = sit.get160();
 
-    if (isXRP(static_cast<Currency>(currencyOrAccount)))
+    if (isXRP(Currency::fromRaw(currencyOrAccount)))
     {
         asset_ = xrpIssue();
     }
@@ -39,7 +39,7 @@ STIssue::STIssue(SerialIter& sit, SField const& name) : STBase{name}
         // - 160 bits MPT issuer account
         // - 160 bits black hole account
         // - 32 bits sequence
-        AccountID const account = static_cast<AccountID>(sit.get160());
+        AccountID const account = AccountID::fromRaw(sit.get160());
         // MPT
         if (noAccount() == account)
         {

--- a/src/libxrpl/protocol/STPathSet.cpp
+++ b/src/libxrpl/protocol/STPathSet.cpp
@@ -93,7 +93,7 @@ STPathSet::STPathSet(SerialIter& sit, SField const& name) : STBase(name)
             XRPL_ASSERT(
                 !(hasCurrency && hasMPT), "xrpl::STPathSet::STPathSet : not has Currency and MPT");
             if (hasCurrency)
-                asset = static_cast<Currency>(sit.get160());
+                asset = Currency::fromRaw(sit.get160());
 
             if (hasMPT)
                 asset = sit.get192();

--- a/src/libxrpl/protocol/STVector256.cpp
+++ b/src/libxrpl/protocol/STVector256.cpp
@@ -30,7 +30,7 @@ STVector256::STVector256(SerialIter& sit, SField const& name) : STBase(name)
     value_.reserve(cnt);
 
     for (std::size_t i = 0; i != cnt; ++i)
-        value_.emplace_back(slice.substr(i * uint256::size(), uint256::size()));
+        value_.push_back(uint256::fromRaw(slice.substr(i * uint256::size(), uint256::size())));
 }
 
 STBase*

--- a/src/libxrpl/protocol/Seed.cpp
+++ b/src/libxrpl/protocol/Seed.cpp
@@ -105,7 +105,7 @@ parseGenericSeed(std::string const& str, bool rfc1751)
         if (RFC1751::getKeyFromEnglish(key, str) == 1)
         {
             Blob const blob(key.rbegin(), key.rend());
-            return Seed{uint128{blob}};
+            return Seed{uint128::fromRaw(blob)};
         }
     }
 

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -3401,7 +3401,7 @@ class Invariants_test : public beast::unit_test::Suite
 
                 sleShares->at(sfFlags) = 0;
                 // Setting wrong pseudo account ID
-                sleShares->at(sfIssuer) = AccountID(uint160(42));
+                sleShares->at(sfIssuer) = AccountID(42);
                 sleShares->at(sfOutstandingAmount) = 0;
                 sleShares->at(sfSequence) = sequence;
 

--- a/src/test/basics/base_uint_test.cpp
+++ b/src/test/basics/base_uint_test.cpp
@@ -134,7 +134,7 @@ struct base_uint_test : beast::unit_test::Suite
         Blob const raw{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
         BEAST_EXPECT(test96::kBYTES == raw.size());
 
-        test96 u{raw};
+        test96 u = test96::fromRaw(raw);
         uset.insert(u);
         BEAST_EXPECT(raw.size() == u.size());
         BEAST_EXPECT(to_string(u) == "0102030405060708090A0B0C");
@@ -155,7 +155,7 @@ struct base_uint_test : beast::unit_test::Suite
         // back into another base_uint (w) for comparison with the original
         Nonhash<96> h{};
         hash_append(h, u);
-        test96 const w{std::vector<std::uint8_t>(h.data.begin(), h.data.end())};
+        test96 const w = test96::fromRaw(std::vector<std::uint8_t>(h.data.begin(), h.data.end()));
         BEAST_EXPECT(w == u);
 
         test96 v{~u};

--- a/src/test/protocol/STParsedJSON_test.cpp
+++ b/src/test/protocol/STParsedJSON_test.cpp
@@ -393,7 +393,7 @@ class STParsedJSON_test : public beast::unit_test::Suite
                 0xCD,
                 0xEF};
             // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-            BEAST_EXPECT(obj.object->getFieldH128(sfEmailHash) == uint128{expected});
+            BEAST_EXPECT(obj.object->getFieldH128(sfEmailHash) == uint128::fromRaw(expected));
         }
 
         // Valid lowercase hex string for UInt128
@@ -488,8 +488,9 @@ class STParsedJSON_test : public beast::unit_test::Suite
             std::array<uint8_t, 20> const expected = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD,
                                                       0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB,
                                                       0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67};
-            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-            BEAST_EXPECT(obj.object->getFieldH160(sfTakerPaysCurrency) == uint160{expected});
+            BEAST_EXPECT(
+                // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                obj.object->getFieldH160(sfTakerPaysCurrency) == uint160::fromRaw(expected));
         }
         // Valid lowercase hex string for UInt160
         {
@@ -575,8 +576,9 @@ class STParsedJSON_test : public beast::unit_test::Suite
             std::array<uint8_t, 24> const expected = {
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-            BEAST_EXPECT(obj.object->getFieldH192(sfMPTokenIssuanceID) == uint192{expected});
+            BEAST_EXPECT(
+                // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                obj.object->getFieldH192(sfMPTokenIssuanceID) == uint192::fromRaw(expected));
         }
 
         // Valid lowercase hex string for UInt192
@@ -676,7 +678,7 @@ class STParsedJSON_test : public beast::unit_test::Suite
                 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB,
                 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
             // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-            BEAST_EXPECT(obj.object->getFieldH256(sfLedgerHash) == uint256{expected});
+            BEAST_EXPECT(obj.object->getFieldH256(sfLedgerHash) == uint256::fromRaw(expected));
         }
         // Valid lowercase hex string for UInt256
         {

--- a/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerReplayMsgHandler.cpp
@@ -56,8 +56,8 @@ LedgerReplayMsgHandler::processProofPathRequest(
     reply.set_ledgerhash(packet.ledgerhash());
     reply.set_type(packet.type());
 
-    uint256 const key(packet.key());
-    uint256 const ledgerHash(packet.ledgerhash());
+    uint256 const key = uint256::fromRaw(packet.key());
+    uint256 const ledgerHash = uint256::fromRaw(packet.ledgerhash());
     auto ledger = app_.getLedgerMaster().getLedgerByHash(ledgerHash);
     if (!ledger)
     {
@@ -107,7 +107,8 @@ LedgerReplayMsgHandler::processProofPathResponse(
 {
     protocol::TMProofPathResponse const& reply = *msg;
     if (reply.has_error() || !reply.has_key() || !reply.has_ledgerhash() || !reply.has_type() ||
-        !reply.has_ledgerheader() || reply.path_size() == 0)
+        !reply.has_ledgerheader() || reply.path_size() == 0 ||
+        reply.ledgerhash().size() != uint256::size() || reply.key().size() != uint256::size())
     {
         JLOG(journal_.debug()) << "Bad message: Error reply";
         return false;
@@ -121,7 +122,7 @@ LedgerReplayMsgHandler::processProofPathResponse(
 
     // deserialize the header
     auto info = deserializeHeader({reply.ledgerheader().data(), reply.ledgerheader().size()});
-    uint256 const replyHash(reply.ledgerhash());
+    uint256 const replyHash = uint256::fromRaw(reply.ledgerhash());
     if (calculateLedgerHash(info) != replyHash)
     {
         JLOG(journal_.debug()) << "Bad message: Hash mismatch";
@@ -129,7 +130,7 @@ LedgerReplayMsgHandler::processProofPathResponse(
     }
     info.hash = replyHash;
 
-    uint256 const key(reply.key());
+    uint256 const key = uint256::fromRaw(reply.key());
     if (key != keylet::skip().key)
     {
         JLOG(journal_.debug()) << "Bad message: we only support the short skip list for now. "
@@ -185,7 +186,7 @@ LedgerReplayMsgHandler::processReplayDeltaRequest(
     }
     reply.set_ledgerhash(packet.ledgerhash());
 
-    uint256 const ledgerHash{packet.ledgerhash()};
+    uint256 const ledgerHash = uint256::fromRaw(packet.ledgerhash());
     auto ledger = app_.getLedgerMaster().getLedgerByHash(ledgerHash);
     if (!ledger || !ledger->isImmutable())
     {
@@ -214,14 +215,15 @@ LedgerReplayMsgHandler::processReplayDeltaResponse(
     std::shared_ptr<protocol::TMReplayDeltaResponse> const& msg)
 {
     protocol::TMReplayDeltaResponse const& reply = *msg;
-    if (reply.has_error() || !reply.has_ledgerheader())
+    if (reply.has_error() || !reply.has_ledgerheader() || !reply.has_ledgerhash() ||
+        reply.ledgerhash().size() != uint256::size())
     {
         JLOG(journal_.debug()) << "Bad message: Error reply";
         return false;
     }
 
     auto info = deserializeHeader({reply.ledgerheader().data(), reply.ledgerheader().size()});
-    uint256 const replyHash(reply.ledgerhash());
+    uint256 const replyHash = uint256::fromRaw(reply.ledgerhash());
     if (calculateLedgerHash(info) != replyHash)
     {
         JLOG(journal_.debug()) << "Bad message: Hash mismatch";

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -212,7 +212,7 @@ PeerImp::run()
             return ret;
 
         if (auto const s = base64Decode(value); s.size() == uint256::size())
-            return uint256{s};
+            return uint256::fromRaw(s);
 
         return std::nullopt;
     };
@@ -1831,7 +1831,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMLedgerData> const& m)
         return;
     }
 
-    uint256 const ledgerHash{m->ledgerhash()};
+    uint256 const ledgerHash = uint256::fromRaw(m->ledgerhash());
 
     // Otherwise check if received data for a candidate transaction set
     if (m->type() == protocol::liTS_CANDIDATE)
@@ -1893,8 +1893,8 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMProposeSet> const& m)
             return;
     }
 
-    uint256 const proposeHash{set.currenttxhash()};
-    uint256 const prevLedger{set.previousledger()};
+    uint256 const proposeHash = uint256::fromRaw(set.currenttxhash());
+    uint256 const prevLedger = uint256::fromRaw(set.previousledger());
 
     NetClock::time_point const closeTime{NetClock::duration{set.closetime()}};
 
@@ -2177,7 +2177,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMHaveTransactionSet> const& m)
         return;
     }
 
-    uint256 const hash{m->hash()};
+    uint256 const hash = uint256::fromRaw(m->hash());
 
     if (m->status() == protocol::tsHAVE)
     {
@@ -2617,7 +2617,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMGetObjectByHash> const& m)
             auto const& obj = packet.objects(i);
             if (obj.has_hash() && stringIsUInt256Sized(obj.hash()))
             {
-                uint256 const hash{obj.hash()};
+                uint256 const hash = uint256::fromRaw(obj.hash());
                 // VFALCO TODO Move this someplace more sensible so we dont
                 //             need to inject the NodeStore interfaces.
                 std::uint32_t const seq{obj.has_ledgerseq() ? obj.ledgerseq() : 0};
@@ -2687,7 +2687,7 @@ PeerImp::onMessage(std::shared_ptr<protocol::TMGetObjectByHash> const& m)
 
                 if (pLDo)
                 {
-                    uint256 const hash{obj.hash()};
+                    uint256 const hash = uint256::fromRaw(obj.hash());
 
                     app_.getLedgerMaster().addFetchPack(
                         hash, std::make_shared<Blob>(obj.data().begin(), obj.data().end()));
@@ -2739,7 +2739,7 @@ PeerImp::handleHaveTransactions(std::shared_ptr<protocol::TMHaveTransactions> co
             return;
         }
 
-        uint256 hash(m->hashes(i));
+        uint256 hash = uint256::fromRaw(m->hashes(i));
 
         auto txn = app_.getMasterTransaction().fetchFromCache(hash);
 
@@ -2873,7 +2873,7 @@ PeerImp::doFetchPack(std::shared_ptr<protocol::TMGetObjectByHash> const& packet)
 
     fee_.fee = Resource::kFEE_HEAVY_BURDEN_PEER;
 
-    uint256 const hash{packet->ledgerhash()};
+    uint256 const hash = uint256::fromRaw(packet->ledgerhash());
 
     std::weak_ptr<PeerImp> const weak = shared_from_this();
     auto elapsed = UptimeClock::now();
@@ -2908,7 +2908,7 @@ PeerImp::doTransactions(std::shared_ptr<protocol::TMGetObjectByHash> const& pack
             return;
         }
 
-        uint256 hash(obj.hash());
+        uint256 hash = uint256::fromRaw(obj.hash());
 
         auto txn = app_.getMasterTransaction().fetchFromCache(hash);
 
@@ -3254,7 +3254,7 @@ PeerImp::getLedger(std::shared_ptr<protocol::TMGetLedger> const& m)
     if (m->has_ledgerhash())
     {
         // Attempt to find ledger by hash
-        uint256 const ledgerHash{m->ledgerhash()};
+        uint256 const ledgerHash = uint256::fromRaw(m->ledgerhash());
         ledger = app_.getLedgerMaster().getLedgerByHash(ledgerHash);
         if (!ledger)
         {
@@ -3333,7 +3333,7 @@ PeerImp::getTxSet(std::shared_ptr<protocol::TMGetLedger> const& m) const
 {
     JLOG(pJournal_.trace()) << "getTxSet: TX set";
 
-    uint256 const txSetHash{m->ledgerhash()};
+    uint256 const txSetHash = uint256::fromRaw(m->ledgerhash());
     std::shared_ptr<SHAMap> shaMap{app_.getInboundTransactions().getSet(txSetHash, false)};
     if (!shaMap)
     {


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This ctor creates a problem - `base_uint(string)` and `base_uint(string_view)` give completely different behaviour.
To fix that, I used a named `static` ctor and added `static_assert(false)` - this helps to make sure that all places which use the old behaviour will be updated to use a new ctor.
This will also help to update Clio.

When all the old code is removed, we will be able to remove this constructor, and we'll be able to use `base_uint(string[view])` directly all the time, and it will behave the same way.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
