### PR TITLE
refactor: Use named constant for leaf item size (#39)

### DIFF
--- a/include/xrpl/shamap/SHAMapTreeNode.h
+++ b/include/xrpl/shamap/SHAMapTreeNode.h
@@ -7,6 +7,7 @@
 #include <xrpl/shamap/SHAMapItem.h>
 #include <xrpl/shamap/SHAMapNodeID.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -19,6 +20,9 @@ static constexpr unsigned char const kWIRE_TYPE_ACCOUNT_STATE = 1;
 static constexpr unsigned char const kWIRE_TYPE_INNER = 2;
 static constexpr unsigned char const kWIRE_TYPE_COMPRESSED_INNER = 3;
 static constexpr unsigned char const kWIRE_TYPE_TRANSACTION_WITH_META = 4;
+
+// Lower bound on SHAMap leaf item payload size, in bytes.
+inline constexpr std::size_t kMIN_SHA_MAP_ITEM_BYTES = 12;
 
 enum class SHAMapNodeType {
     TnInner = 1,

--- a/src/libxrpl/shamap/SHAMapLeafNode.cpp
+++ b/src/libxrpl/shamap/SHAMapLeafNode.cpp
@@ -19,7 +19,7 @@ SHAMapLeafNode::SHAMapLeafNode(boost::intrusive_ptr<SHAMapItem const> item, std:
     : SHAMapTreeNode(cowid), item_(std::move(item))
 {
     XRPL_ASSERT(
-        item_->size() >= 12,
+        item_->size() >= kMIN_SHA_MAP_ITEM_BYTES,
         "xrpl::SHAMapLeafNode::SHAMapLeafNode(boost::intrusive_ptr<"
         "SHAMapItem const>, std::uint32_t) : minimum input size");
 }
@@ -31,7 +31,7 @@ SHAMapLeafNode::SHAMapLeafNode(
     : SHAMapTreeNode(cowid, hash), item_(std::move(item))
 {
     XRPL_ASSERT(
-        item_->size() >= 12,
+        item_->size() >= kMIN_SHA_MAP_ITEM_BYTES,
         "xrpl::SHAMapLeafNode::SHAMapLeafNode(boost::intrusive_ptr<"
         "SHAMapItem const>, std::uint32_t, SHAMapHash const&) : minimum input "
         "size");

--- a/src/libxrpl/shamap/SHAMapTreeNode.cpp
+++ b/src/libxrpl/shamap/SHAMapTreeNode.cpp
@@ -28,6 +28,13 @@ namespace xrpl {
 intr_ptr::SharedPtr<SHAMapTreeNode>
 SHAMapTreeNode::makeTransaction(Slice data, SHAMapHash const& hash, bool hashValid)
 {
+    if (data.size() < kMIN_SHA_MAP_ITEM_BYTES)
+    {
+        Throw<std::runtime_error>(
+            "Short TXN node: " + std::to_string(data.size()) + " bytes (minimum " +
+            std::to_string(kMIN_SHA_MAP_ITEM_BYTES) + " required)");
+    }
+
     auto item = makeShamapitem(sha512Half(HashPrefix::TransactionId, data), data);
 
     if (hashValid)
@@ -44,13 +51,29 @@ SHAMapTreeNode::makeTransactionWithMeta(Slice data, SHAMapHash const& hash, bool
     uint256 tag;
 
     if (s.size() < tag.kBYTES)
-        Throw<std::runtime_error>("Short TXN+MD node");
+    {
+        Throw<std::runtime_error>(
+            "Short TXN+MD node: " + std::to_string(s.size()) + " bytes (minimum " +
+            std::to_string(tag.kBYTES) + " required for tag)");
+    }
 
     // FIXME: improve this interface so that the above check isn't needed
     if (!s.getBitString(tag, s.size() - tag.kBYTES))
-        Throw<std::out_of_range>("Short TXN+MD node (" + std::to_string(s.size()) + ")");
+    {
+        Throw<std::out_of_range>(
+            "Short TXN+MD node: failed to read tag at offset " +
+            std::to_string(s.size() - tag.kBYTES));
+    }
 
     s.chop(tag.kBYTES);
+
+    if (s.size() < kMIN_SHA_MAP_ITEM_BYTES)
+    {
+        Throw<std::runtime_error>(
+            "Short TXN+MD node: " + std::to_string(s.size()) +
+            " bytes after tag removal (minimum " + std::to_string(kMIN_SHA_MAP_ITEM_BYTES) +
+            " required)");
+    }
 
     auto item = makeShamapitem(tag, s.slice());
 
@@ -68,16 +91,30 @@ SHAMapTreeNode::makeAccountState(Slice data, SHAMapHash const& hash, bool hashVa
     uint256 tag;
 
     if (s.size() < tag.kBYTES)
-        Throw<std::runtime_error>("short AS node");
+    {
+        Throw<std::runtime_error>(
+            "Short AS node: " + std::to_string(s.size()) + " bytes (minimum " +
+            std::to_string(tag.kBYTES) + " required for tag)");
+    }
 
     // FIXME: improve this interface so that the above check isn't needed
     if (!s.getBitString(tag, s.size() - tag.kBYTES))
-        Throw<std::out_of_range>("Short AS node (" + std::to_string(s.size()) + ")");
+    {
+        Throw<std::out_of_range>(
+            "Short AS node: failed to read tag at offset " + std::to_string(s.size() - tag.kBYTES));
+    }
 
     s.chop(tag.kBYTES);
 
     if (tag.isZero())
         Throw<std::runtime_error>("Invalid AS node");
+
+    if (s.size() < kMIN_SHA_MAP_ITEM_BYTES)
+    {
+        Throw<std::runtime_error>(
+            "Short AS node: " + std::to_string(s.size()) + " bytes after tag removal (minimum " +
+            std::to_string(kMIN_SHA_MAP_ITEM_BYTES) + " required)");
+    }
 
     auto item = makeShamapitem(tag, s.slice());
 


### PR DESCRIPTION
## High Level Overview of Change

Tightens input validation in SHAMap leaf-node construction and unifies short-node error messages across makeTransaction, makeTransactionWithMeta, and makeAccountState.

## Context of Change

The SHAMapLeafNode constructor assumed a minimum payload size via XRPL_ASSERT, which is a no-op in release builds and leaves no guard against undersized input at the wire-parsing boundary. This PR:

- Adds an explicit size check at each wire-parsing factory (makeTransaction, makeTransactionWithMeta, makeAccountState) so undersized payloads are rejected before leaf-node construction, in both debug and release builds.
- Replaces the hardcoded 12 with a named constant (minSHAMapItemBytes) so the threshold is visible and consistent across the three entry points.
- Normalizes the existing short-node error messages to include actual and expected sizes, so logs and debugging are uniform.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior? If a new feature, why was this architecture chosen? What were the alternatives? If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here. -->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html -->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level. If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing? -->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce. This section may not be needed if your change includes thoroughly commented unit tests. -->

<!--
## Future Tasks
For future tasks related to PR.
-->

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->


