### PR TITLE
ci: Add Conan retry

### DIFF
--- a/conan/global.conf
+++ b/conan/global.conf
@@ -3,3 +3,5 @@
 core:non_interactive=True
 core.download:parallel={{ os.cpu_count() }}
 core.upload:parallel={{ os.cpu_count() }}
+tools.files.download:retry=5
+tools.files.download:retry_wait=10


### PR DESCRIPTION
## High Level Overview of Change

Bumps Conan's download retry settings so that transient upstream failures ([occasionally 502s from GitHub](https://github.com/XRPLF/rippled/actions/runs/25591406423/job/75129649449#step:10:1522) when a recipe's `source()` step fetches an archive) no longer fail the "Build dependencies" step on the first hiccup.

Adds to `global.conf`
- `tools.files.download:retry=5` (default: 2)
- `tools.files.download:retry_wait=10` (default: 1 second)

## Context of Change

The `xrplf` Conan remote at `conan.ripplex.io` mirrors recipes and prebuilt binaries but does **not** mirror upstream source archives. Whenever `conan install --build=missing` encounters a `package_id` that has no prebuilt (new compiler, new sanitizer profile, new option combination), Conan falls back to building from source, which fetches the tarball directly from the recipe's upstream URL. GitHub's archive host has been returning intermittent 502s, which currently fail the job immediately on the second attempt.


## Future Tasks

It is possible to mirror the source to Artifactory also if we want and configure `core.sources:download_urls` to point there.