### PR TITLE
bump get_nft host function cost from 1000 to 5000

### DIFF
--- a/src/libxrpl/tx/wasm/WasmVM.cpp
+++ b/src/libxrpl/tx/wasm/WasmVM.cpp
@@ -61,7 +61,7 @@ setCommonHostFunctions(HostFunctions* hfs, ImportVec& i)
     WASM_IMPORT_FUNC2(i, ticketKeylet, "ticket_keylet", hfs,                                                   350);
     WASM_IMPORT_FUNC2(i, vaultKeylet, "vault_keylet", hfs,                                                     350);
 
-    WASM_IMPORT_FUNC2(i, getNFT, "get_nft", hfs,                                                              1000);
+    WASM_IMPORT_FUNC2(i, getNFT, "get_nft", hfs,                                                             5'000);
     WASM_IMPORT_FUNC2(i, getNFTIssuer, "get_nft_issuer", hfs,                                                   70);
     WASM_IMPORT_FUNC2(i, getNFTTaxon, "get_nft_taxon", hfs,                                                     60);
     WASM_IMPORT_FUNC2(i, getNFTFlags, "get_nft_flags", hfs,                                                     60);

--- a/src/test/app/Wasm_test.cpp
+++ b/src/test/app/Wasm_test.cpp
@@ -396,7 +396,7 @@ struct Wasm_test : public beast::unit_test::suite
             auto re = engine.run(
                 allHostFuncWasm, hfs, 1'000'000, ESCROW_FUNCTION_NAME, {}, imp, env.journal);
 
-            checkResult(re, 1, 66'340);
+            checkResult(re, 1, 70'340);
 
             env.close();
         }
@@ -435,7 +435,7 @@ struct Wasm_test : public beast::unit_test::suite
         {
             TestHostFunctions hfs(env, 0);
             auto re = runEscrowWasm(allHFWasm, hfs, 100'000, ESCROW_FUNCTION_NAME, {});
-            checkResult(re, 1, 66'340);
+            checkResult(re, 1, 70'340);
         }
 
         {
@@ -459,7 +459,7 @@ struct Wasm_test : public beast::unit_test::suite
             TestHostFunctions hfs(env, 0);
             auto re = runEscrowWasm(
                 allHFWasm, hfs, std::numeric_limits<int64_t>::max(), ESCROW_FUNCTION_NAME, {});
-            checkResult(re, 1, 66'340);
+            checkResult(re, 1, 70'340);
         }
 
         {  // fail because trying to access nonexistent field
@@ -628,7 +628,7 @@ struct Wasm_test : public beast::unit_test::suite
         auto const codecovWasm = hexToBytes(codecovTestsWasmHex);
         TestHostFunctions hfs(env, 0);
 
-        auto const allowance = 208'169;
+        auto const allowance = 220'169;
         auto re = runEscrowWasm(codecovWasm, hfs, allowance, ESCROW_FUNCTION_NAME, {});
 
         checkResult(re, 1, allowance);


### PR DESCRIPTION
## `cacheLedgerObj` (cost 5000)

  `src/libxrpl/tx/wasm/HostFuncImplGetter.cpp:219`

  1. Cheap input validation + linear scan of small `cache_` array for a free slot.
  2. **`ctx_.view().read(keylet)`** — one SHAMap lookup of an arbitrary ledger object 
  plus full SLE deserialization. This is the cost driver.
  3. Stash `shared_ptr<SLE const>` in `cache_[idx]`.

  Pricing logic: pay 5000 once, then subsequent `get_ledger_obj_field` calls cost only 70
   because they're pointer-chases on the cached SLE.

  ## `getNFT` (cost 1000)
  
  `src/libxrpl/tx/wasm/HostFuncImplNFT.cpp:13` → `nft::findToken` → `nft::locatePage` at 
  `src/libxrpl/ledger/helpers/NFTokenHelpers.cpp:22`.

  1. Two cheap null checks.
  2. `nft::findToken`:
     - `locatePage` does **`view.succ(...)`** (SHAMap successor walk between 
  `nftpage_min` and `nftpage_max`) **plus a `view.read(...)`** of the resulting 
  `NFTokenPage` SLE.
     - Linear scan over `sfNFTokens` (up to 32 entries, comparing 32-byte uint256s).
  3. Read optional `sfURI`, copy bytes (≤ 256 bytes — trivial).

  ## Comparison

  | Op | SHAMap ops | Deserialize | Extra in-mem work |
  |---|---|---|---|
  | `cacheLedgerObj` | 1× `read` | 1 SLE (arbitrary type) | array slot scan |
  | `getNFT` | 1× `succ` + 1× `read` | 1 NFTokenPage SLE (up to 32 tokens, with URIs) | 
  scan up to 32 entries |

  `getNFT` does **strictly more ledger work**: an extra `succ` walk on top of the same 
  `read`, plus an O(32) in-memory scan. The NFTokenPage SLE is also non-trivial — 
  populated pages can run several KB. None of the work `cacheLedgerObj` does is missing 
  here.
  
  ## Verdict

  `getNFT` is under-priced at 1000. Bump to **5000** to match `cacheLedgerObj`'s tier — 
  it's the floor (getNFT does strictly more work), and snapping to an existing tier beats
   inventing a bespoke number given that the current costs aren't precisely calibrated.