### PR TITLE
fix: Fix the edge case in NegativeUNLVote::buildScoreTable

### DIFF
--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -956,9 +956,12 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::Suite
             //    (strict > check). With the amendment, it returns the
             //    score table (>= check).
 
-            auto const minVals = NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE;
-
             // Without fixCleanup3_2_0 (default testableAmendments)
+            //
+            for (auto const& minVals :
+                 {NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE - 1,
+                  NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE,
+                  NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE + 1})
             {
                 NetworkHistory history = {
                     *this,
@@ -991,12 +994,19 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::Suite
                     NegativeUNLVote vote(myId, history.env.journal);
                     // Without the amendment, exactly minVals should
                     // fail the strict > check.
-                    BEAST_EXPECT(!vote.buildScoreTable(
-                        history.lastLedger(), history.UNLNodeIDSet, history.validations));
+                    auto const scoreTable = vote.buildScoreTable(
+                        history.lastLedger(), history.UNLNodeIDSet, history.validations);
+                    auto const expected =
+                        minVals > NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE;
+                    BEAST_EXPECT(scoreTable.has_value() == expected);
                 }
             }
 
             // With fixCleanup3_2_0 enabled
+            for (auto const& minVals :
+                 {NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE - 1,
+                  NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE,
+                  NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE + 1})
             {
                 NetworkHistory history = {
                     *this,
@@ -1029,7 +1039,9 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::Suite
                     // pass the >= check.
                     auto scoreTable = vote.buildScoreTable(
                         history.lastLedger(), history.UNLNodeIDSet, history.validations);
-                    BEAST_EXPECT(scoreTable);
+                    auto const expected =
+                        minVals >= NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE;
+                    BEAST_EXPECT(scoreTable.has_value() == expected);
                     if (scoreTable)
                     {
                         auto const it = scoreTable->find(myId);

--- a/src/test/consensus/NegativeUNL_test.cpp
+++ b/src/test/consensus/NegativeUNL_test.cpp
@@ -12,6 +12,7 @@
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/Ledger.h>
 #include <xrpl/ledger/OpenView.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/KeyType.h>
 #include <xrpl/protocol/Protocol.h>
@@ -541,8 +542,13 @@ struct NetworkHistory
         std::optional<int> numLedgers;
     };
 
-    NetworkHistory(beast::unit_test::Suite& suite, Parameter const& p)
-        : env(suite, jtx::testableAmendments()), param(p), validations(env.app().getValidations())
+    NetworkHistory(
+        beast::unit_test::Suite& suite,
+        Parameter const& p,
+        std::optional<FeatureBitset> amendments = std::nullopt)
+        : env(suite, amendments.value_or(jtx::testableAmendments()))
+        , param(p)
+        , validations(env.app().getValidations())
     {
         createNodes();
         if (!param.numLedgers)
@@ -782,6 +788,7 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::Suite
          * 4. a node double validated some seq
          * 5. local node had enough validations but on a wrong chain
          * 6. a good case, long enough history and perfect scores
+         * 7. fixCleanup3_2_0 boundary: exactly minVals validations
          */
         {
             // 1. no skip list
@@ -937,6 +944,96 @@ class NegativeUNLVoteInternal_test : public beast::unit_test::Suite
                     {
                         (void)_;
                         BEAST_EXPECT(score == 256);
+                    }
+                }
+            }
+        }
+
+        {
+            // 7. fixCleanup3_2_0 boundary: local node has exactly
+            //    kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE validations.
+            //    Without the amendment, buildScoreTable returns empty
+            //    (strict > check). With the amendment, it returns the
+            //    score table (>= check).
+
+            auto const minVals = NegativeUNLVote::kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE;
+
+            // Without fixCleanup3_2_0 (default testableAmendments)
+            {
+                NetworkHistory history = {
+                    *this,
+                    {.numNodes = 10,
+                     .negUNLSize = 0,
+                     .hasToDisable = false,
+                     .hasToReEnable = false,
+                     .numLedgers = 256 + 2},
+                    jtx::testableAmendments() - fixCleanup3_2_0};
+                BEAST_EXPECT(history.goodHistory);
+                if (history.goodHistory)
+                {
+                    NodeID myId = history.UNLNodeIDs[3];
+                    // Add exactly minVals validations for my node,
+                    // and full validations for everyone else.
+                    std::uint32_t myCount = 0;
+                    history.walkHistoryAndAddValidations(
+                        [&](std::shared_ptr<Ledger const> const& l, std::size_t idx) -> bool {
+                            if (history.UNLNodeIDs[idx] == myId)
+                            {
+                                if (myCount < minVals)
+                                {
+                                    ++myCount;
+                                    return true;
+                                }
+                                return false;
+                            }
+                            return true;
+                        });
+                    NegativeUNLVote vote(myId, history.env.journal);
+                    // Without the amendment, exactly minVals should
+                    // fail the strict > check.
+                    BEAST_EXPECT(!vote.buildScoreTable(
+                        history.lastLedger(), history.UNLNodeIDSet, history.validations));
+                }
+            }
+
+            // With fixCleanup3_2_0 enabled
+            {
+                NetworkHistory history = {
+                    *this,
+                    {.numNodes = 10,
+                     .negUNLSize = 0,
+                     .hasToDisable = false,
+                     .hasToReEnable = false,
+                     .numLedgers = 256 + 2},
+                    jtx::testableAmendments() | fixCleanup3_2_0};
+                BEAST_EXPECT(history.goodHistory);
+                if (history.goodHistory)
+                {
+                    NodeID myId = history.UNLNodeIDs[3];
+                    std::uint32_t myCount = 0;
+                    history.walkHistoryAndAddValidations(
+                        [&](std::shared_ptr<Ledger const> const& l, std::size_t idx) -> bool {
+                            if (history.UNLNodeIDs[idx] == myId)
+                            {
+                                if (myCount < minVals)
+                                {
+                                    ++myCount;
+                                    return true;
+                                }
+                                return false;
+                            }
+                            return true;
+                        });
+                    NegativeUNLVote vote(myId, history.env.journal);
+                    // With the amendment, exactly minVals should
+                    // pass the >= check.
+                    auto scoreTable = vote.buildScoreTable(
+                        history.lastLedger(), history.UNLNodeIDSet, history.validations);
+                    BEAST_EXPECT(scoreTable);
+                    if (scoreTable)
+                    {
+                        auto const it = scoreTable->find(myId);
+                        BEAST_EXPECT(it != scoreTable->end() && it->second == minVals);
                     }
                 }
             }

--- a/src/xrpld/app/misc/NegativeUNLVote.cpp
+++ b/src/xrpld/app/misc/NegativeUNLVote.cpp
@@ -8,6 +8,7 @@
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/ledger/Ledger.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Protocol.h>
 #include <xrpl/protocol/PublicKey.h>

--- a/src/xrpld/app/misc/NegativeUNLVote.cpp
+++ b/src/xrpld/app/misc/NegativeUNLVote.cpp
@@ -219,10 +219,22 @@ NegativeUNLVote::buildScoreTable(
                          << " The reliability measurement could be wrong.";
         return {};
     }
-    if (myValidationCount > kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE &&
-        myValidationCount <= kFLAG_LEDGER_INTERVAL)
+
+    if (prevLedger->rules().enabled(fixCleanup3_2_0))
     {
-        return scoreTable;
+        if (myValidationCount >= kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE &&
+            myValidationCount <= kFLAG_LEDGER_INTERVAL)
+        {
+            return scoreTable;
+        }
+    }
+    else
+    {
+        if (myValidationCount > kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE &&
+            myValidationCount <= kFLAG_LEDGER_INTERVAL)
+        {
+            return scoreTable;
+        }
     }
 
     // cannot happen because validations.getTrustedForLedger does not


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This PR changes `myValidationCount > kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE` to `myValidationCount >= kNEGATIVE_UNL_MIN_LOCAL_VALS_TO_VOTE` in `NegativeUNLVote::buildScoreTable`

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

The function requires `myValidationCount` to be strictly above 230 and rejects if it's smaller. There's an edge case where `myValidationCount` is equal to 230, and we'll log that the node has had too many validations and return an empty table in such a case, which is not correct.

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
