### PR TITLE
refactor: Use `isFlag` where possible instead of bitwise math

### DIFF
--- a/include/xrpl/ledger/helpers/EscrowHelpers.h
+++ b/include/xrpl/ledger/helpers/EscrowHelpers.h
@@ -70,21 +70,21 @@ escrowUnlockApplyHelper<Issue>(
         initialBalance.get<Issue>().account = noAccount();
 
         if (TER const ter = trustCreate(
-                view,                                           // payment sandbox
-                recvLow,                                        // is dest low?
-                issuer,                                         // source
-                receiver,                                       // destination
-                trustLineKey.key,                               // ledger index
-                sleDest,                                        // Account to add to
-                false,                                          // authorize account
-                (sleDest->getFlags() & lsfDefaultRipple) == 0,  //
-                false,                                          // freeze trust line
-                false,                                          // deep freeze trust line
-                initialBalance,                                 // zero initial balance
-                Issue(currency, receiver),                      // limit of zero
-                0,                                              // quality in
-                0,                                              // quality out
-                journal);                                       // journal
+                view,                                // payment sandbox
+                recvLow,                             // is dest low?
+                issuer,                              // source
+                receiver,                            // destination
+                trustLineKey.key,                    // ledger index
+                sleDest,                             // Account to add to
+                false,                               // authorize account
+                !sleDest->isFlag(lsfDefaultRipple),  //
+                false,                               // freeze trust line
+                false,                               // deep freeze trust line
+                initialBalance,                      // zero initial balance
+                Issue(currency, receiver),           // limit of zero
+                0,                                   // quality in
+                0,                                   // quality out
+                journal);                            // journal
             !isTesSuccess(ter))
         {
             return ter;  // LCOV_EXCL_LINE

--- a/include/xrpl/tx/paths/detail/StepChecks.h
+++ b/include/xrpl/tx/paths/detail/StepChecks.h
@@ -77,8 +77,8 @@ checkNoRipple(
     if (!sleIn || !sleOut)
         return terNO_LINE;
 
-    if ((((*sleIn)[sfFlags] & ((cur > prev) ? lsfHighNoRipple : lsfLowNoRipple)) != 0u) &&
-        (((*sleOut)[sfFlags] & ((cur > next) ? lsfHighNoRipple : lsfLowNoRipple)) != 0u))
+    if (sleIn->isFlag((cur > prev) ? lsfHighNoRipple : lsfLowNoRipple) &&
+        sleOut->isFlag((cur > next) ? lsfHighNoRipple : lsfLowNoRipple))
     {
         JLOG(j.info()) << "Path violates noRipple constraint between " << prev << ", " << cur
                        << " and " << next;

--- a/src/libxrpl/ledger/helpers/CredentialHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/CredentialHelpers.cpp
@@ -105,7 +105,7 @@ deleteSLE(ApplyView& view, std::shared_ptr<SLE> const& sleCredential, beast::Jou
 
     auto const issuer = sleCredential->getAccountID(sfIssuer);
     auto const subject = sleCredential->getAccountID(sfSubject);
-    bool const accepted = (sleCredential->getFlags() & lsfAccepted) != 0u;
+    bool const accepted = sleCredential->isFlag(lsfAccepted);
 
     auto err = delSLE(issuer, sfIssuerNode, !accepted || (subject == issuer));
     if (!isTesSuccess(err))
@@ -174,7 +174,7 @@ valid(STTx const& tx, ReadView const& view, AccountID const& src, beast::Journal
             return tecBAD_CREDENTIALS;
         }
 
-        if ((sleCred->getFlags() & lsfAccepted) == 0u)
+        if (!sleCred->isFlag(lsfAccepted))
         {
             JLOG(j.trace()) << "Credential isn't accepted. Cred: " << h;
             return tecBAD_CREDENTIALS;
@@ -215,7 +215,7 @@ validDomain(ReadView const& view, uint256 domainID, AccountID const& subject)
                 foundExpired = true;
                 continue;
             }
-            if ((sleCredential->getFlags() & lsfAccepted) != 0u)
+            if (sleCredential->isFlag(lsfAccepted))
             {
                 return tesSUCCESS;
             }
@@ -339,7 +339,7 @@ verifyValidDomain(ApplyView& view, AccountID const& account, uint256 domainID, b
         if (!sleCredential)
             continue;  // expired, i.e. deleted in credentials::removeExpired
 
-        if ((sleCredential->getFlags() & lsfAccepted) != 0u)
+        if (sleCredential->isFlag(lsfAccepted))
             return tesSUCCESS;
     }
 
@@ -373,7 +373,7 @@ verifyDepositPreauth(
             return tecEXPIRED;
     }
 
-    if (sleDst && ((sleDst->getFlags() & lsfDepositAuth) != 0u))
+    if (sleDst && sleDst->isFlag(lsfDepositAuth))
     {
         if (src != dst)
         {

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -358,7 +358,7 @@ requireAuth(
     if (maybeDomainID)
     {
         XRPL_ASSERT(
-            sleIssuance->getFieldU32(sfFlags) & lsfMPTRequireAuth,
+            sleIssuance->isFlag(lsfMPTRequireAuth),
             "xrpl::requireAuth : issuance requires authorization");
         // ter = tefINTERNAL | tecOBJECT_NOT_FOUND | tecNO_AUTH | tecEXPIRED
         auto const ter = credentials::validDomain(view, *maybeDomainID, account);

--- a/src/libxrpl/ledger/helpers/NFTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/NFTokenHelpers.cpp
@@ -636,8 +636,8 @@ deleteTokenOffer(ApplyView& view, std::shared_ptr<SLE> const& offer)
     auto const nftokenID = (*offer)[sfNFTokenID];
 
     if (!view.dirRemove(
-            (((*offer)[sfFlags] & lsfSellNFToken) != 0u) ? keylet::nftSells(nftokenID)
-                                                         : keylet::nftBuys(nftokenID),
+            offer->isFlag(lsfSellNFToken) ? keylet::nftSells(nftokenID)
+                                          : keylet::nftBuys(nftokenID),
             (*offer)[sfNFTokenOfferNode],
             offer->key(),
             false))
@@ -888,7 +888,7 @@ tokenOfferCreatePreclaim(
             return tecNO_DST;
 
         // check if the destination has disallowed incoming offers
-        if ((sleDst->getFlags() & lsfDisallowIncomingNFTokenOffer) != 0u)
+        if (sleDst->isFlag(lsfDisallowIncomingNFTokenOffer))
             return tecNO_PERMISSION;
     }
 
@@ -901,7 +901,7 @@ tokenOfferCreatePreclaim(
         if (!sleOwner)
             return tecNO_TARGET;
 
-        if ((sleOwner->getFlags() & lsfDisallowIncomingNFTokenOffer) != 0u)
+        if (sleOwner->isFlag(lsfDisallowIncomingNFTokenOffer))
             return tecNO_PERMISSION;
     }
 

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -274,7 +274,7 @@ trustCreate(
         uFlags |= (bSetHigh ? lsfHighDeepFreeze : lsfLowDeepFreeze);
     }
 
-    if ((slePeer->getFlags() & lsfDefaultRipple) == 0)
+    if (!slePeer->isFlag(lsfDefaultRipple))
     {
         // The other side's default is no rippling
         uFlags |= (bSetHigh ? lsfLowNoRipple : lsfHighNoRipple);
@@ -341,22 +341,25 @@ updateTrustLine(
 {
     if (!state)
         return false;
-    std::uint32_t const flags(state->getFieldU32(sfFlags));
 
     auto sle = view.peek(keylet::account(sender));
     if (!sle)
         return false;
+
+    auto const senderReserveFlag = !bSenderHigh ? lsfLowReserve : lsfHighReserve;
+    auto const senderNoRippleFlag = !bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple;
+    auto const senderFreezeFlag = !bSenderHigh ? lsfLowFreeze : lsfHighFreeze;
+    auto const receiverReserveFlag = bSenderHigh ? lsfLowReserve : lsfHighReserve;
 
     // YYY Could skip this if rippling in reverse.
     if (before > beast::kZERO
         // Sender balance was positive.
         && after <= beast::kZERO
         // Sender is zero or negative.
-        && ((flags & (!bSenderHigh ? lsfLowReserve : lsfHighReserve)) != 0u)
+        && state->isFlag(senderReserveFlag)
         // Sender reserve is set.
-        && static_cast<bool>(flags & (!bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple)) !=
-            static_cast<bool>(sle->getFlags() & lsfDefaultRipple) &&
-        ((flags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) == 0u) &&
+        && state->isFlag(senderNoRippleFlag) != sle->isFlag(lsfDefaultRipple) &&
+        !state->isFlag(senderFreezeFlag) &&
         !state->getFieldAmount(!bSenderHigh ? sfLowLimit : sfHighLimit)
         // Sender trust limit is 0.
         && (state->getFieldU32(!bSenderHigh ? sfLowQualityIn : sfHighQualityIn) == 0u)
@@ -369,11 +372,10 @@ updateTrustLine(
         adjustOwnerCount(view, sle, -1, j);
 
         // Clear reserve flag.
-        state->setFieldU32(sfFlags, flags & (!bSenderHigh ? ~lsfLowReserve : ~lsfHighReserve));
+        state->clearFlag(senderReserveFlag);
 
         // Balance is zero, receiver reserve is clear.
-        if (!after  // Balance is zero.
-            && ((flags & (bSenderHigh ? lsfLowReserve : lsfHighReserve)) == 0u))
+        if (!after && !state->isFlag(receiverReserveFlag))
             return true;
     }
     return false;
@@ -453,7 +455,7 @@ issueIOU(
     if (!receiverAccount)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    bool const noRipple = (receiverAccount->getFlags() & lsfDefaultRipple) == 0;
+    bool const noRipple = !receiverAccount->isFlag(lsfDefaultRipple);
 
     return trustCreate(
         view,
@@ -564,12 +566,11 @@ requireAuth(ReadView const& view, Issue const& issue, AccountID const& account, 
     // If this is a weak or legacy check, or if the account has a line, fail if
     // auth is required and not set on the line
     if (auto const issuerAccount = view.read(keylet::account(issue.account));
-        issuerAccount && (((*issuerAccount)[sfFlags] & lsfRequireAuth) != 0u))
+        issuerAccount && issuerAccount->isFlag(lsfRequireAuth))
     {
         if (trustLine)
         {
-            return (((*trustLine)[sfFlags] &
-                     ((account > issue.account) ? lsfLowAuth : lsfHighAuth)) != 0u)
+            return trustLine->isFlag((account > issue.account) ? lsfLowAuth : lsfHighAuth)
                 ? tesSUCCESS
                 : TER{tecNO_AUTH};
         }
@@ -774,7 +775,7 @@ deleteAMMTrustLine(
     }
 
     auto const uFlags = !ammLow ? lsfLowReserve : lsfHighReserve;
-    if ((sleState->getFlags() & uFlags) == 0u)
+    if (!sleState->isFlag(uFlags))
         return tecINTERNAL;  // LCOV_EXCL_LINE
 
     adjustOwnerCount(view, !ammLow ? sleLow : sleHigh, -1, j);

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -346,9 +346,9 @@ updateTrustLine(
     if (!sle)
         return false;
 
-    auto const senderReserveFlag = !bSenderHigh ? lsfLowReserve : lsfHighReserve;
-    auto const senderNoRippleFlag = !bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple;
-    auto const senderFreezeFlag = !bSenderHigh ? lsfLowFreeze : lsfHighFreeze;
+    auto const senderReserveFlag = bSenderHigh ? lsfHighReserve : lsfLowReserve;
+    auto const senderNoRippleFlag = bSenderHigh ? lsfHighNoRipple : lsfLowNoRipple;
+    auto const senderFreezeFlag = bSenderHigh ? lsfHighFreeze : lsfLowFreeze;
     auto const receiverReserveFlag = bSenderHigh ? lsfLowReserve : lsfHighReserve;
 
     // YYY Could skip this if rippling in reverse.

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -581,8 +581,7 @@ directSendNoFeeIOU(
             && ((uFlags & (!bSenderHigh ? lsfLowReserve : lsfHighReserve)) != 0u)
             // Sender reserve is set.
             && static_cast<bool>(uFlags & (!bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple)) !=
-                static_cast<bool>(
-                    view.read(keylet::account(uSenderID))->getFlags() & lsfDefaultRipple) &&
+                view.read(keylet::account(uSenderID))->isFlag(lsfDefaultRipple) &&
             ((uFlags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) == 0u) &&
             !sleRippleState->getFieldAmount(!bSenderHigh ? sfLowLimit : sfHighLimit)
             // Sender trust limit is 0.
@@ -640,7 +639,7 @@ directSendNoFeeIOU(
     if (!sleAccount)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    bool const noRipple = (sleAccount->getFlags() & lsfDefaultRipple) == 0;
+    bool const noRipple = !sleAccount->isFlag(lsfDefaultRipple);
 
     return trustCreate(
         view,

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -587,12 +587,12 @@ directSendNoFeeIOU(
             && sleRippleState->isFlag(senderNoRippleFlag) !=
                 view.read(keylet::account(uSenderID))->isFlag(lsfDefaultRipple) &&
             !sleRippleState->isFlag(senderFreezeFlag) &&
-            !sleRippleState->getFieldAmount(!bSenderHigh ? sfLowLimit : sfHighLimit)
+            !sleRippleState->getFieldAmount(bSenderHigh ? sfHighLimit : sfLowLimit)
             // Sender trust limit is 0.
-            && (sleRippleState->getFieldU32(!bSenderHigh ? sfLowQualityIn : sfHighQualityIn) == 0u)
+            && (sleRippleState->getFieldU32(bSenderHigh ? sfHighQualityIn : sfLowQualityIn) == 0u)
             // Sender quality in is 0.
             &&
-            (sleRippleState->getFieldU32(!bSenderHigh ? sfLowQualityOut : sfHighQualityOut) == 0u))
+            (sleRippleState->getFieldU32(bSenderHigh ? sfHighQualityOut : sfLowQualityOut) == 0u))
         // Sender quality out is 0.
         {
             // Clear the reserve of the sender, possibly delete the line!
@@ -620,7 +620,7 @@ directSendNoFeeIOU(
                 view,
                 sleRippleState,
                 bSenderHigh ? uReceiverID : uSenderID,
-                !bSenderHigh ? uReceiverID : uSenderID,
+                bSenderHigh ? uSenderID : uReceiverID,
                 j);
         }
 

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -569,7 +569,6 @@ directSendNoFeeIOU(
                         << " amount=" << saAmount.getFullText()
                         << " after=" << saBalance.getFullText();
 
-        std::uint32_t const uFlags(sleRippleState->getFieldU32(sfFlags));
         bool bDelete = false;
 
         auto const senderReserveFlag = bSenderHigh ? lsfHighReserve : lsfLowReserve;
@@ -600,7 +599,7 @@ directSendNoFeeIOU(
             adjustOwnerCount(view, view.peek(keylet::account(uSenderID)), -1, j);
 
             // Clear reserve flag.
-            sleRippleState->setFieldU32(sfFlags, uFlags & ~senderReserveFlag);
+            sleRippleState->clearFlag(senderReserveFlag);
 
             // Balance is zero, receiver reserve is clear.
             bDelete = !saBalance  // Balance is zero.

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -572,17 +572,22 @@ directSendNoFeeIOU(
         std::uint32_t const uFlags(sleRippleState->getFieldU32(sfFlags));
         bool bDelete = false;
 
+        auto const senderReserveFlag = bSenderHigh ? lsfHighReserve : lsfLowReserve;
+        auto const senderNoRippleFlag = bSenderHigh ? lsfHighNoRipple : lsfLowNoRipple;
+        auto const senderFreezeFlag = bSenderHigh ? lsfHighFreeze : lsfLowFreeze;
+        auto const receiverReserveFlag = bSenderHigh ? lsfLowReserve : lsfHighReserve;
+
         // FIXME This NEEDS to be cleaned up and simplified. It's impossible
         //       for anyone to understand.
         if (saBefore > beast::kZERO
             // Sender balance was positive.
             && saBalance <= beast::kZERO
             // Sender is zero or negative.
-            && ((uFlags & (!bSenderHigh ? lsfLowReserve : lsfHighReserve)) != 0u)
+            && sleRippleState->isFlag(senderReserveFlag)
             // Sender reserve is set.
-            && static_cast<bool>(uFlags & (!bSenderHigh ? lsfLowNoRipple : lsfHighNoRipple)) !=
+            && sleRippleState->isFlag(senderNoRippleFlag) !=
                 view.read(keylet::account(uSenderID))->isFlag(lsfDefaultRipple) &&
-            ((uFlags & (!bSenderHigh ? lsfLowFreeze : lsfHighFreeze)) == 0u) &&
+            !sleRippleState->isFlag(senderFreezeFlag) &&
             !sleRippleState->getFieldAmount(!bSenderHigh ? sfLowLimit : sfHighLimit)
             // Sender trust limit is 0.
             && (sleRippleState->getFieldU32(!bSenderHigh ? sfLowQualityIn : sfHighQualityIn) == 0u)
@@ -595,12 +600,11 @@ directSendNoFeeIOU(
             adjustOwnerCount(view, view.peek(keylet::account(uSenderID)), -1, j);
 
             // Clear reserve flag.
-            sleRippleState->setFieldU32(
-                sfFlags, uFlags & (!bSenderHigh ? ~lsfLowReserve : ~lsfHighReserve));
+            sleRippleState->setFieldU32(sfFlags, uFlags & ~senderReserveFlag);
 
             // Balance is zero, receiver reserve is clear.
             bDelete = !saBalance  // Balance is zero.
-                && ((uFlags & (bSenderHigh ? lsfLowReserve : lsfHighReserve)) == 0u);
+                && !sleRippleState->isFlag(receiverReserveFlag);
             // Receiver reserve is clear.
         }
 

--- a/src/libxrpl/tx/invariants/AMMInvariant.cpp
+++ b/src/libxrpl/tx/invariants/AMMInvariant.cpp
@@ -44,7 +44,7 @@ ValidAMM::visitEntry(
         }
         // AMM pool changed
         else if (
-            (type == ltRIPPLE_STATE && ((after->getFlags() & lsfAMMNode) != 0u)) ||
+            (type == ltRIPPLE_STATE && after->isFlag(lsfAMMNode)) ||
             (type == ltACCOUNT_ROOT && after->isFieldPresent(sfAMMID)))
         {
             ammPoolChanged_ = true;

--- a/src/libxrpl/tx/invariants/InvariantCheck.cpp
+++ b/src/libxrpl/tx/invariants/InvariantCheck.cpp
@@ -675,12 +675,11 @@ NoDeepFreezeTrustLinesWithoutFreeze::visitEntry(
     {
         bool const overwriteFixEnabled = isFeatureEnabled(fixCleanup3_1_3, true);
 
-        std::uint32_t const uFlags = after->getFieldU32(sfFlags);
-        bool const lowFreeze = (uFlags & lsfLowFreeze) != 0u;
-        bool const lowDeepFreeze = (uFlags & lsfLowDeepFreeze) != 0u;
+        bool const lowFreeze = after->isFlag(lsfLowFreeze);
+        bool const lowDeepFreeze = after->isFlag(lsfLowDeepFreeze);
 
-        bool const highFreeze = (uFlags & lsfHighFreeze) != 0u;
-        bool const highDeepFreeze = (uFlags & lsfHighDeepFreeze) != 0u;
+        bool const highFreeze = after->isFlag(lsfHighFreeze);
+        bool const highDeepFreeze = after->isFlag(lsfHighDeepFreeze);
 
         bool const bad = (lowDeepFreeze && !lowFreeze) || (highDeepFreeze && !highFreeze);
         if (overwriteFixEnabled)

--- a/src/libxrpl/tx/paths/BookStep.cpp
+++ b/src/libxrpl/tx/paths/BookStep.cpp
@@ -1357,8 +1357,7 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
                     auto sle = view.read(keylet::line(*prev, cur, issue.currency));
                     if (!sle)
                         return terNO_LINE;
-                    if (((*sle)[sfFlags] & ((cur > *prev) ? lsfHighNoRipple : lsfLowNoRipple)) !=
-                        0u)
+                    if (sle->isFlag((cur > *prev) ? lsfHighNoRipple : lsfLowNoRipple))
                         return terNO_RIPPLE;
                     return std::nullopt;
                 },

--- a/src/libxrpl/tx/paths/DirectStep.cpp
+++ b/src/libxrpl/tx/paths/DirectStep.cpp
@@ -429,8 +429,8 @@ DirectIPaymentStep::check(StrandContext const& ctx, std::shared_ptr<const SLE> c
 
         auto const authField = (src_ > dst_) ? lsfHighAuth : lsfLowAuth;
 
-        if ((((*sleSrc)[sfFlags] & lsfRequireAuth) != 0u) &&
-            (((*sleLine)[sfFlags] & authField) == 0u) && (*sleLine)[sfBalance] == beast::kZERO)
+        if (sleSrc->isFlag(lsfRequireAuth) && !sleLine->isFlag(authField) &&
+            (*sleLine)[sfBalance] == beast::kZERO)
         {
             JLOG(j_.debug()) << "DirectStepI: can't receive IOUs from issuer without auth."
                              << " src: " << src_;
@@ -441,9 +441,7 @@ DirectIPaymentStep::check(StrandContext const& ctx, std::shared_ptr<const SLE> c
         {
             if (ctx.prevStep->bookStepBook())
             {
-                auto const noRippleSrcToDst =
-                    ((*sleLine)[sfFlags] & ((src_ > dst_) ? lsfHighNoRipple : lsfLowNoRipple));
-                if (noRippleSrcToDst != 0u)
+                if (sleLine->isFlag((src_ > dst_) ? lsfHighNoRipple : lsfLowNoRipple))
                     return terNO_RIPPLE;
             }
         }

--- a/src/libxrpl/tx/transactors/account/AccountDelete.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountDelete.cpp
@@ -231,7 +231,7 @@ AccountDelete::preclaim(PreclaimContext const& ctx)
     if (!sleDst)
         return tecNO_DST;
 
-    if ((((*sleDst)[sfFlags] & lsfRequireDestTag) != 0u) && !ctx.tx[~sfDestinationTag])
+    if (sleDst->isFlag(lsfRequireDestTag) && !ctx.tx[~sfDestinationTag])
         return tecDST_TAG_NEEDED;
 
     // If credentials are provided - check them anyway
@@ -243,7 +243,7 @@ AccountDelete::preclaim(PreclaimContext const& ctx)
     if (!ctx.tx.isFieldPresent(sfCredentialIDs))
     {
         // Check whether the destination account requires deposit authorization.
-        if ((sleDst->getFlags() & lsfDepositAuth) != 0u)
+        if (sleDst->isFlag(lsfDepositAuth))
         {
             if (!ctx.view.exists(keylet::depositPreauth(dst, account)))
                 return tecNO_PERMISSION;

--- a/src/libxrpl/tx/transactors/account/AccountSet.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountSet.cpp
@@ -69,8 +69,6 @@ AccountSet::preflight(PreflightContext const& ctx)
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
-    std::uint32_t const uTxFlags = tx.getFlags();
-
     std::uint32_t const uSetFlag = tx.getFieldU32(sfSetFlag);
     std::uint32_t const uClearFlag = tx.getFieldU32(sfClearFlag);
 
@@ -83,9 +81,8 @@ AccountSet::preflight(PreflightContext const& ctx)
     //
     // RequireAuth
     //
-    bool const bSetRequireAuth = ((uTxFlags & tfRequireAuth) != 0u) || (uSetFlag == asfRequireAuth);
-    bool const bClearRequireAuth =
-        ((uTxFlags & tfOptionalAuth) != 0u) || (uClearFlag == asfRequireAuth);
+    bool const bSetRequireAuth = tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuth);
+    bool const bClearRequireAuth = tx.isFlag(tfOptionalAuth) || (uClearFlag == asfRequireAuth);
 
     if (bSetRequireAuth && bClearRequireAuth)
     {
@@ -96,10 +93,8 @@ AccountSet::preflight(PreflightContext const& ctx)
     //
     // RequireDestTag
     //
-    bool const bSetRequireDest =
-        ((uTxFlags & tfRequireDestTag) != 0u) || (uSetFlag == asfRequireDest);
-    bool const bClearRequireDest =
-        ((uTxFlags & tfOptionalDestTag) != 0u) || (uClearFlag == asfRequireDest);
+    bool const bSetRequireDest = tx.isFlag(tfRequireDestTag) || (uSetFlag == asfRequireDest);
+    bool const bClearRequireDest = tx.isFlag(tfOptionalDestTag) || (uClearFlag == asfRequireDest);
 
     if (bSetRequireDest && bClearRequireDest)
     {
@@ -110,9 +105,8 @@ AccountSet::preflight(PreflightContext const& ctx)
     //
     // DisallowXRP
     //
-    bool const bSetDisallowXRP = ((uTxFlags & tfDisallowXRP) != 0u) || (uSetFlag == asfDisallowXRP);
-    bool const bClearDisallowXRP =
-        ((uTxFlags & tfAllowXRP) != 0u) || (uClearFlag == asfDisallowXRP);
+    bool const bSetDisallowXRP = tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowXRP);
+    bool const bClearDisallowXRP = tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowXRP);
 
     if (bSetDisallowXRP && bClearDisallowXRP)
     {
@@ -195,12 +189,11 @@ AccountSet::checkPermission(ReadView const& view, STTx const& tx)
 
     auto const uSetFlag = tx.getFieldU32(sfSetFlag);
     auto const uClearFlag = tx.getFieldU32(sfClearFlag);
-    auto const uTxFlags = tx.getFlags();
     // We don't support any flag based granular permission under
     // AccountSet transaction. If any delegated account is trying to
     // update the flag on behalf of another account, it is not
     // authorized.
-    if (uSetFlag != 0 || uClearFlag != 0 || ((uTxFlags & tfUniversalMask) != 0u))
+    if (uSetFlag != 0 || uClearFlag != 0 || tx.isFlag(tfUniversalMask))
         return terNO_DELEGATE_PERMISSION;
 
     if (tx.isFieldPresent(sfEmailHash) && !granularPermissions.contains(AccountEmailHashSet))
@@ -229,23 +222,19 @@ AccountSet::preclaim(PreclaimContext const& ctx)
 {
     auto const id = ctx.tx[sfAccount];
 
-    std::uint32_t const uTxFlags = ctx.tx.getFlags();
-
     auto const sle = ctx.view.read(keylet::account(id));
     if (!sle)
         return terNO_ACCOUNT;
 
-    std::uint32_t const uFlagsIn = sle->getFieldU32(sfFlags);
-
     std::uint32_t const uSetFlag = ctx.tx.getFieldU32(sfSetFlag);
 
     // legacy AccountSet flags
-    bool const bSetRequireAuth = ((uTxFlags & tfRequireAuth) != 0u) || (uSetFlag == asfRequireAuth);
+    bool const bSetRequireAuth = ctx.tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuth);
 
     //
     // RequireAuth
     //
-    if (bSetRequireAuth && ((uFlagsIn & lsfRequireAuth) == 0u))
+    if (bSetRequireAuth && !sle->isFlag(lsfRequireAuth))
     {
         if (!dirIsEmpty(ctx.view, keylet::ownerDir(id)))
         {
@@ -261,7 +250,7 @@ AccountSet::preclaim(PreclaimContext const& ctx)
     {
         if (uSetFlag == asfAllowTrustLineClawback)
         {
-            if ((uFlagsIn & lsfNoFreeze) != 0u)
+            if (sle->isFlag(lsfNoFreeze))
             {
                 JLOG(ctx.j.trace()) << "Can't set Clawback if NoFreeze is set";
                 return tecNO_PERMISSION;
@@ -276,7 +265,7 @@ AccountSet::preclaim(PreclaimContext const& ctx)
         else if (uSetFlag == asfNoFreeze)
         {
             // Cannot set NoFreeze if clawback is enabled
-            if ((uFlagsIn & lsfAllowTrustLineClawback) != 0u)
+            if (sle->isFlag(lsfAllowTrustLineClawback))
             {
                 JLOG(ctx.j.trace()) << "Can't set NoFreeze if clawback is enabled";
                 return tecNO_PERMISSION;
@@ -302,16 +291,12 @@ AccountSet::doApply()
     std::uint32_t const uClearFlag{tx.getFieldU32(sfClearFlag)};
 
     // legacy AccountSet flags
-    std::uint32_t const uTxFlags{tx.getFlags()};
-    bool const bSetRequireDest{
-        ((uTxFlags & tfRequireDestTag) != 0u) || (uSetFlag == asfRequireDest)};
-    bool const bClearRequireDest{
-        ((uTxFlags & tfOptionalDestTag) != 0u) || (uClearFlag == asfRequireDest)};
-    bool const bSetRequireAuth{((uTxFlags & tfRequireAuth) != 0u) || (uSetFlag == asfRequireAuth)};
-    bool const bClearRequireAuth{
-        ((uTxFlags & tfOptionalAuth) != 0u) || (uClearFlag == asfRequireAuth)};
-    bool const bSetDisallowXRP{((uTxFlags & tfDisallowXRP) != 0u) || (uSetFlag == asfDisallowXRP)};
-    bool const bClearDisallowXRP{((uTxFlags & tfAllowXRP) != 0u) || (uClearFlag == asfDisallowXRP)};
+    bool const bSetRequireDest{tx.isFlag(tfRequireDestTag) || (uSetFlag == asfRequireDest)};
+    bool const bClearRequireDest{tx.isFlag(tfOptionalDestTag) || (uClearFlag == asfRequireDest)};
+    bool const bSetRequireAuth{tx.isFlag(tfRequireAuth) || (uSetFlag == asfRequireAuth)};
+    bool const bClearRequireAuth{tx.isFlag(tfOptionalAuth) || (uClearFlag == asfRequireAuth)};
+    bool const bSetDisallowXRP{tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowXRP)};
+    bool const bClearDisallowXRP{tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowXRP)};
 
     bool const sigWithMaster{[&tx, &acct = account_]() {
         auto const spk = tx.getSigningPubKey();
@@ -329,13 +314,13 @@ AccountSet::doApply()
     //
     // RequireAuth
     //
-    if (bSetRequireAuth && ((uFlagsIn & lsfRequireAuth) == 0u))
+    if (bSetRequireAuth && !sle->isFlag(lsfRequireAuth))
     {
         JLOG(j_.trace()) << "Set RequireAuth.";
         uFlagsOut |= lsfRequireAuth;
     }
 
-    if (bClearRequireAuth && ((uFlagsIn & lsfRequireAuth) != 0u))
+    if (bClearRequireAuth && sle->isFlag(lsfRequireAuth))
     {
         JLOG(j_.trace()) << "Clear RequireAuth.";
         uFlagsOut &= ~lsfRequireAuth;
@@ -344,13 +329,13 @@ AccountSet::doApply()
     //
     // RequireDestTag
     //
-    if (bSetRequireDest && ((uFlagsIn & lsfRequireDestTag) == 0u))
+    if (bSetRequireDest && !sle->isFlag(lsfRequireDestTag))
     {
         JLOG(j_.trace()) << "Set lsfRequireDestTag.";
         uFlagsOut |= lsfRequireDestTag;
     }
 
-    if (bClearRequireDest && ((uFlagsIn & lsfRequireDestTag) != 0u))
+    if (bClearRequireDest && sle->isFlag(lsfRequireDestTag))
     {
         JLOG(j_.trace()) << "Clear lsfRequireDestTag.";
         uFlagsOut &= ~lsfRequireDestTag;
@@ -359,13 +344,13 @@ AccountSet::doApply()
     //
     // DisallowXRP
     //
-    if (bSetDisallowXRP && ((uFlagsIn & lsfDisallowXRP) == 0u))
+    if (bSetDisallowXRP && !sle->isFlag(lsfDisallowXRP))
     {
         JLOG(j_.trace()) << "Set lsfDisallowXRP.";
         uFlagsOut |= lsfDisallowXRP;
     }
 
-    if (bClearDisallowXRP && ((uFlagsIn & lsfDisallowXRP) != 0u))
+    if (bClearDisallowXRP && sle->isFlag(lsfDisallowXRP))
     {
         JLOG(j_.trace()) << "Clear lsfDisallowXRP.";
         uFlagsOut &= ~lsfDisallowXRP;
@@ -374,7 +359,7 @@ AccountSet::doApply()
     //
     // DisableMaster
     //
-    if ((uSetFlag == asfDisableMaster) && ((uFlagsIn & lsfDisableMaster) == 0u))
+    if ((uSetFlag == asfDisableMaster) && !sle->isFlag(lsfDisableMaster))
     {
         if (!sigWithMaster)
         {
@@ -392,7 +377,7 @@ AccountSet::doApply()
         uFlagsOut |= lsfDisableMaster;
     }
 
-    if ((uClearFlag == asfDisableMaster) && ((uFlagsIn & lsfDisableMaster) != 0u))
+    if ((uClearFlag == asfDisableMaster) && sle->isFlag(lsfDisableMaster))
     {
         JLOG(j_.trace()) << "Clear lsfDisableMaster.";
         uFlagsOut &= ~lsfDisableMaster;
@@ -417,7 +402,7 @@ AccountSet::doApply()
     //
     if (uSetFlag == asfNoFreeze)
     {
-        if (!sigWithMaster && ((uFlagsIn & lsfDisableMaster) == 0u))
+        if (!sigWithMaster && !sle->isFlag(lsfDisableMaster))
         {
             JLOG(j_.trace()) << "Must use master key to set NoFreeze.";
             return tecNEED_MASTER_KEY;

--- a/src/libxrpl/tx/transactors/account/AccountSet.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountSet.cpp
@@ -193,7 +193,7 @@ AccountSet::checkPermission(ReadView const& view, STTx const& tx)
     // AccountSet transaction. If any delegated account is trying to
     // update the flag on behalf of another account, it is not
     // authorized.
-    if (uSetFlag != 0 || uClearFlag != 0 || tx.isFlag(tfUniversalMask))
+    if (uSetFlag != 0 || uClearFlag != 0 || ((tx.getFlags() & tfUniversalMask) != 0u))
         return terNO_DELEGATE_PERMISSION;
 
     if (tx.isFieldPresent(sfEmailHash) && !granularPermissions.contains(AccountEmailHashSet))

--- a/src/libxrpl/tx/transactors/account/SetRegularKey.cpp
+++ b/src/libxrpl/tx/transactors/account/SetRegularKey.cpp
@@ -29,7 +29,7 @@ SetRegularKey::calculateBaseFee(ReadView const& view, STTx const& tx)
         {
             auto const sle = view.read(keylet::account(id));
 
-            if (sle && ((sle->getFlags() & lsfPasswordSpent) == 0u))
+            if (sle && !sle->isFlag(lsfPasswordSpent))
             {
                 // flag is armed and they signed with the right account
                 return XRPAmount{0};

--- a/src/libxrpl/tx/transactors/account/SignerListSet.cpp
+++ b/src/libxrpl/tx/transactors/account/SignerListSet.cpp
@@ -197,7 +197,7 @@ removeSignersFromLedger(
     // If the lsfOneOwnerCount bit is set then remove just one owner count.
     // Otherwise use the pre-MultiSignReserve amendment calculation.
     int removeFromOwnerCount = -1;
-    if ((signers->getFlags() & lsfOneOwnerCount) == 0)
+    if (!signers->isFlag(lsfOneOwnerCount))
     {
         STArray const& actualList = signers->getFieldArray(sfSignerEntries);
         removeFromOwnerCount =

--- a/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
+++ b/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
@@ -130,7 +130,7 @@ checkAttestationPublicKey(
         if (accountFromPK == attestationSignerAccount)
         {
             // master key
-            if ((sleAttestationSigningAccount->getFieldU32(sfFlags) & lsfDisableMaster) != 0u)
+            if (sleAttestationSigningAccount->isFlag(lsfDisableMaster))
             {
                 JLOG(j.trace()) << "Attempt to add an attestation with "
                                    "disabled master key.";
@@ -408,7 +408,7 @@ transferHelper(
     {
         // Check dst tag and deposit auth
 
-        if (((sleDst->getFlags() & lsfRequireDestTag) != 0u) && !dstTag)
+        if (sleDst->isFlag(lsfRequireDestTag) && !dstTag)
             return tecDST_TAG_NEEDED;
 
         // If the destination is the claim owner, and this is a claim
@@ -417,7 +417,7 @@ transferHelper(
         bool const canBypassDepositAuth =
             dst == claimOwner && depositAuthPolicy == DepositAuthPolicy::DstCanBypass;
 
-        if (!canBypassDepositAuth && ((sleDst->getFlags() & lsfDepositAuth) != 0u) &&
+        if (!canBypassDepositAuth && sleDst->isFlag(lsfDepositAuth) &&
             !psb.exists(keylet::depositPreauth(dst, src)))
         {
             return tecNO_PERMISSION;
@@ -1425,7 +1425,7 @@ XChainCreateBridge::preclaim(PreclaimContext const& ctx)
 
         // Allowing clawing back funds would break the bridge's invariant that
         // wrapped funds are always backed by locked funds
-        if ((sleIssuer->getFlags() & lsfAllowTrustLineClawback) != 0u)
+        if (sleIssuer->isFlag(lsfAllowTrustLineClawback))
             return tecNO_PERMISSION;
     }
 
@@ -1504,7 +1504,7 @@ BridgeModify::preflight(PreflightContext const& ctx)
     auto const reward = ctx.tx[~sfSignatureReward];
     auto const minAccountCreate = ctx.tx[~sfMinAccountCreateAmount];
     auto const bridgeSpec = ctx.tx[sfXChainBridge];
-    bool const clearAccountCreate = (ctx.tx.getFlags() & tfClearAccountCreateAmount) != 0u;
+    bool const clearAccountCreate = ctx.tx.isFlag(tfClearAccountCreateAmount);
 
     if (!reward && !minAccountCreate && !clearAccountCreate)
     {
@@ -1562,7 +1562,7 @@ BridgeModify::doApply()
     auto const bridgeSpec = ctx_.tx[sfXChainBridge];
     auto const reward = ctx_.tx[~sfSignatureReward];
     auto const minAccountCreate = ctx_.tx[~sfMinAccountCreateAmount];
-    bool const clearAccountCreate = (ctx_.tx.getFlags() & tfClearAccountCreateAmount) != 0u;
+    bool const clearAccountCreate = ctx_.tx.isFlag(tfClearAccountCreateAmount);
 
     auto const sleAcct = ctx_.view().peek(keylet::account(account));
     if (!sleAcct)

--- a/src/libxrpl/tx/transactors/check/CheckCash.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCash.cpp
@@ -115,8 +115,7 @@ CheckCash::preclaim(PreclaimContext const& ctx)
             return tecNO_ENTRY;
         }
 
-        if (((sleDst->getFlags() & lsfRequireDestTag) != 0u) &&
-            !sleCheck->isFieldPresent(sfDestinationTag))
+        if (sleDst->isFlag(lsfRequireDestTag) && !sleCheck->isFieldPresent(sfDestinationTag))
         {
             // The tag is basically account-specific information we don't
             // understand, but we can require someone to fill it in.
@@ -433,21 +432,21 @@ CheckCash::doApply()
                         initialBalance.get<Issue>().account = noAccount();
 
                         if (TER const ter = trustCreate(
-                                psb,                                           // payment sandbox
-                                destLow,                                       // is dest low?
-                                deliverIssuer,                                 // source
-                                account_,                                      // destination
-                                trustLineKey->key,                             // ledger index
-                                sleDst,                                        // Account to add to
-                                false,                                         // authorize account
-                                (sleDst->getFlags() & lsfDefaultRipple) == 0,  //
-                                false,                                         // freeze trust line
-                                false,                      // deep freeze trust line
-                                initialBalance,             // zero initial balance
-                                Issue(currency, account_),  // limit of zero
-                                0,                          // quality in
-                                0,                          // quality out
-                                viewJ);                     // journal
+                                psb,                                // payment sandbox
+                                destLow,                            // is dest low?
+                                deliverIssuer,                      // source
+                                account_,                           // destination
+                                trustLineKey->key,                  // ledger index
+                                sleDst,                             // Account to add to
+                                false,                              // authorize account
+                                !sleDst->isFlag(lsfDefaultRipple),  //
+                                false,                              // freeze trust line
+                                false,                              // deep freeze trust line
+                                initialBalance,                     // zero initial balance
+                                Issue(currency, account_),          // limit of zero
+                                0,                                  // quality in
+                                0,                                  // quality out
+                                viewJ);                             // journal
                             !isTesSuccess(ter))
                         {
                             return ter;

--- a/src/libxrpl/tx/transactors/check/CheckCash.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCash.cpp
@@ -199,7 +199,7 @@ CheckCash::preclaim(PreclaimContext const& ctx)
                         return tecNO_ISSUER;
                     }
 
-                    if ((sleIssuer->at(sfFlags) & lsfRequireAuth) != 0u)
+                    if (sleIssuer->isFlag(lsfRequireAuth))
                     {
                         if (!sleTrustLine)
                         {

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -86,10 +86,8 @@ CheckCreate::preclaim(PreclaimContext const& ctx)
         return tecNO_DST;
     }
 
-    auto const flags = sleDst->getFlags();
-
     // Check if the destination has disallowed incoming checks
-    if ((flags & lsfDisallowIncomingCheck) != 0u)
+    if (sleDst->isFlag(lsfDisallowIncomingCheck))
         return tecNO_PERMISSION;
 
     // Pseudo-accounts cannot cash checks. Note, this is not amendment-gated
@@ -99,7 +97,7 @@ CheckCreate::preclaim(PreclaimContext const& ctx)
     if (isPseudoAccount(sleDst))
         return tecNO_PERMISSION;
 
-    if (((flags & lsfRequireDestTag) != 0u) && !ctx.tx.isFieldPresent(sfDestinationTag))
+    if (sleDst->isFlag(lsfRequireDestTag) && !ctx.tx.isFieldPresent(sfDestinationTag))
     {
         // The tag is basically account-specific information we don't
         // understand, but we can require someone to fill it in.

--- a/src/libxrpl/tx/transactors/credentials/CredentialAccept.cpp
+++ b/src/libxrpl/tx/transactors/credentials/CredentialAccept.cpp
@@ -73,7 +73,7 @@ CredentialAccept::preclaim(PreclaimContext const& ctx)
         return tecNO_ENTRY;
     }
 
-    if ((sleCred->getFieldU32(sfFlags) & lsfAccepted) != 0u)
+    if (sleCred->isFlag(lsfAccepted))
     {
         JLOG(ctx.j.warn()) << "Credential already accepted: " << to_string(subject) << ", "
                            << to_string(issuer) << ", " << credType;

--- a/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMClawback.cpp
@@ -71,9 +71,7 @@ AMMClawback::preflight(PreflightContext const& ctx)
     if (isXRP(asset))
         return temMALFORMED;
 
-    auto const flags = ctx.tx.getFlags();
-
-    if (((flags & tfClawTwoAssets) != 0u) && asset.getIssuer() != asset2.getIssuer())
+    if (ctx.tx.isFlag(tfClawTwoAssets) && asset.getIssuer() != asset2.getIssuer())
     {
         JLOG(ctx.j.trace()) << "AMMClawback: tfClawTwoAssets can only be enabled when two "
                                "assets in the AMM pool are both issued by the issuer";
@@ -119,13 +117,11 @@ AMMClawback::preclaim(PreclaimContext const& ctx)
         return terNO_AMM;
     }
 
-    std::uint32_t const issuerFlagsIn = sleIssuer->getFieldU32(sfFlags);
     if (!ctx.view.rules().enabled(featureMPTokensV2))
     {
         // If AllowTrustLineClawback is not set or NoFreeze is set, return no
         // permission
-        if (((issuerFlagsIn & lsfAllowTrustLineClawback) == 0u) ||
-            ((issuerFlagsIn & lsfNoFreeze) != 0u))
+        if (!sleIssuer->isFlag(lsfAllowTrustLineClawback) || sleIssuer->isFlag(lsfNoFreeze))
         {
             return tecNO_PERMISSION;
         }
@@ -137,8 +133,8 @@ AMMClawback::preclaim(PreclaimContext const& ctx)
                 if (issue.native())
                     return false;  // LCOV_EXCL_LINE
 
-                return ((issuerFlagsIn & lsfAllowTrustLineClawback) != 0u) &&
-                    ((issuerFlagsIn & lsfNoFreeze) == 0u);
+                return sleIssuer->isFlag(lsfAllowTrustLineClawback) &&
+                    !sleIssuer->isFlag(lsfNoFreeze);
             },
             [&](MPTIssue const& issue) {
                 auto const sleIssuance = ctx.view.read(keylet::mptIssuance(issue.getMptID()));
@@ -288,8 +284,7 @@ AMMClawback::applyGuts(Sandbox& sb)
     if (!amount2Withdraw)
         return tecINTERNAL;  // LCOV_EXCL_LINE
 
-    auto const flags = ctx_.tx.getFlags();
-    if ((flags & tfClawTwoAssets) != 0u)
+    if (ctx_.tx.isFlag(tfClawTwoAssets))
         return sendAmount(*amount2Withdraw);
 
     return tesSUCCESS;

--- a/src/libxrpl/tx/transactors/dex/AMMCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMCreate.cpp
@@ -132,7 +132,7 @@ AMMCreate::preclaim(PreclaimContext const& ctx)
             return false;
 
         if (auto const issuerAccount = view.read(keylet::account(asset.getIssuer())))
-            return (issuerAccount->getFlags() & lsfDefaultRipple) == 0;
+            return !issuerAccount->isFlag(lsfDefaultRipple);
 
         return false;
     };

--- a/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
@@ -75,35 +75,35 @@ AMMDeposit::preflight(PreflightContext const& ctx)
         JLOG(ctx.j.debug()) << "AMM Deposit: invalid flags.";
         return temMALFORMED;
     }
-    if ((flags & tfLPToken) != 0u)
+    if (ctx.tx.isFlag(tfLPToken))
     {
         // if included then both amount and amount2 are deposit min
         if (!lpTokens || ePrice || (amount && !amount2) || (!amount && amount2) || tradingFee)
             return temMALFORMED;
     }
-    else if ((flags & tfSingleAsset) != 0u)
+    else if (ctx.tx.isFlag(tfSingleAsset))
     {
         // if included then lpTokens is deposit min
         if (!amount || amount2 || ePrice || tradingFee)
             return temMALFORMED;
     }
-    else if ((flags & tfTwoAsset) != 0u)
+    else if (ctx.tx.isFlag(tfTwoAsset))
     {
         // if included then lpTokens is deposit min
         if (!amount || !amount2 || ePrice || tradingFee)
             return temMALFORMED;
     }
-    else if ((flags & tfOneAssetLPToken) != 0u)
+    else if (ctx.tx.isFlag(tfOneAssetLPToken))
     {
         if (!amount || !lpTokens || amount2 || ePrice || tradingFee)
             return temMALFORMED;
     }
-    else if ((flags & tfLimitLPToken) != 0u)
+    else if (ctx.tx.isFlag(tfLimitLPToken))
     {
         if (!amount || !ePrice || lpTokens || amount2 || tradingFee)
             return temMALFORMED;
     }
-    else if ((flags & tfTwoAssetIfEmpty) != 0u)
+    else if (ctx.tx.isFlag(tfTwoAssetIfEmpty))
     {
         if (!amount || !amount2 || ePrice || lpTokens)
             return temMALFORMED;

--- a/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
@@ -198,7 +198,7 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
     if (!expected)
         return expected.error();  // LCOV_EXCL_LINE
     auto const [amountBalance, amount2Balance, lptAMMBalance] = *expected;
-    if ((ctx.tx.getFlags() & tfTwoAssetIfEmpty) != 0u)
+    if (ctx.tx.isFlag(tfTwoAssetIfEmpty))
     {
         if (lptAMMBalance != beast::kZERO)
             return tecAMM_NOT_EMPTY;
@@ -331,7 +331,7 @@ AMMDeposit::preclaim(PreclaimContext const& ctx)
     };
 
     // amount and amount2 are deposit min in case of tfLPToken
-    if ((ctx.tx.getFlags() & tfLPToken) == 0u)
+    if (!ctx.tx.isFlag(tfLPToken))
     {
         if (auto const ter = checkAmount(amount, true))
             return ter;

--- a/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
@@ -145,7 +145,7 @@ AMMWithdraw::preflight(PreflightContext const& ctx)
         if (auto const res = invalidAMMAmount(
                 *amount,
                 std::make_optional(std::make_pair(asset, asset2)),
-                ctx.tx.isFlag(tfOneAssetWithdrawAll | tfOneAssetLPToken) || ePrice))
+                ((flags & (tfOneAssetWithdrawAll | tfOneAssetLPToken)) != 0u) || ePrice))
         {
             JLOG(ctx.j.debug()) << "AMM Withdraw: invalid Asset1Out";
             return res;
@@ -297,7 +297,7 @@ AMMWithdraw::preclaim(PreclaimContext const& ctx)
         return temBAD_AMM_TOKENS;
     }
 
-    if (ctx.tx.isFlag(tfLPToken | tfWithdrawAll))
+    if ((ctx.tx.getFlags() & (tfLPToken | tfWithdrawAll)) != 0u)
     {
         if (auto const ter = checkAmount(amountBalance, amountBalance))
             return ter;
@@ -1141,7 +1141,7 @@ AMMWithdraw::singleWithdrawEPrice(
 WithdrawAll
 AMMWithdraw::isWithdrawAll(STTx const& tx)
 {
-    if (tx.isFlag(tfWithdrawAll | tfOneAssetWithdrawAll))
+    if ((tx[sfFlags] & (tfWithdrawAll | tfOneAssetWithdrawAll)) != 0u)
         return WithdrawAll::Yes;
     return WithdrawAll::No;
 }

--- a/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
@@ -83,37 +83,37 @@ AMMWithdraw::preflight(PreflightContext const& ctx)
         JLOG(ctx.j.debug()) << "AMM Withdraw: invalid flags.";
         return temMALFORMED;
     }
-    if ((flags & tfLPToken) != 0u)
+    if (ctx.tx.isFlag(tfLPToken))
     {
         if (!lpTokens || amount || amount2 || ePrice)
             return temMALFORMED;
     }
-    else if ((flags & tfWithdrawAll) != 0u)
+    else if (ctx.tx.isFlag(tfWithdrawAll))
     {
         if (lpTokens || amount || amount2 || ePrice)
             return temMALFORMED;
     }
-    else if ((flags & tfOneAssetWithdrawAll) != 0u)
+    else if (ctx.tx.isFlag(tfOneAssetWithdrawAll))
     {
         if (!amount || lpTokens || amount2 || ePrice)
             return temMALFORMED;
     }
-    else if ((flags & tfSingleAsset) != 0u)
+    else if (ctx.tx.isFlag(tfSingleAsset))
     {
         if (!amount || lpTokens || amount2 || ePrice)
             return temMALFORMED;
     }
-    else if ((flags & tfTwoAsset) != 0u)
+    else if (ctx.tx.isFlag(tfTwoAsset))
     {
         if (!amount || !amount2 || lpTokens || ePrice)
             return temMALFORMED;
     }
-    else if ((flags & tfOneAssetLPToken) != 0u)
+    else if (ctx.tx.isFlag(tfOneAssetLPToken))
     {
         if (!amount || !lpTokens || amount2 || ePrice)
             return temMALFORMED;
     }
-    else if ((flags & tfLimitLPToken) != 0u)
+    else if (ctx.tx.isFlag(tfLimitLPToken))
     {
         if (!amount || !ePrice || lpTokens || amount2)
             return temMALFORMED;
@@ -145,7 +145,7 @@ AMMWithdraw::preflight(PreflightContext const& ctx)
         if (auto const res = invalidAMMAmount(
                 *amount,
                 std::make_optional(std::make_pair(asset, asset2)),
-                ((flags & (tfOneAssetWithdrawAll | tfOneAssetLPToken)) != 0u) || ePrice))
+                ctx.tx.isFlag(tfOneAssetWithdrawAll | tfOneAssetLPToken) || ePrice))
         {
             JLOG(ctx.j.debug()) << "AMM Withdraw: invalid Asset1Out";
             return res;
@@ -297,7 +297,7 @@ AMMWithdraw::preclaim(PreclaimContext const& ctx)
         return temBAD_AMM_TOKENS;
     }
 
-    if ((ctx.tx.getFlags() & (tfLPToken | tfWithdrawAll)) != 0u)
+    if (ctx.tx.isFlag(tfLPToken | tfWithdrawAll))
     {
         if (auto const ter = checkAmount(amountBalance, amountBalance))
             return ter;
@@ -1141,7 +1141,7 @@ AMMWithdraw::singleWithdrawEPrice(
 WithdrawAll
 AMMWithdraw::isWithdrawAll(STTx const& tx)
 {
-    if ((tx[sfFlags] & (tfWithdrawAll | tfOneAssetWithdrawAll)) != 0u)
+    if (tx.isFlag(tfWithdrawAll | tfOneAssetWithdrawAll))
         return WithdrawAll::Yes;
     return WithdrawAll::No;
 }

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -307,7 +307,8 @@ OfferCreate::checkAcceptAsset(
 
             // There's no difference which side enacted deep freeze, accepting
             // tokens shouldn't be possible.
-            bool const deepFrozen = trustLine->isFlag(lsfLowDeepFreeze | lsfHighDeepFreeze);
+            bool const deepFrozen =
+                ((*trustLine)[sfFlags] & (lsfLowDeepFreeze | lsfHighDeepFreeze)) != 0u;
 
             if (deepFrozen)
             {

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -91,13 +91,11 @@ OfferCreate::preflight(PreflightContext const& ctx)
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
-    std::uint32_t const uTxFlags = tx.getFlags();
-
     if (tx.isFlag(tfHybrid) && !tx.isFieldPresent(sfDomainID))
         return temINVALID_FLAG;
 
-    bool const bImmediateOrCancel((uTxFlags & tfImmediateOrCancel) != 0u);
-    bool const bFillOrKill((uTxFlags & tfFillOrKill) != 0u);
+    bool const bImmediateOrCancel(tx.isFlag(tfImmediateOrCancel));
+    bool const bFillOrKill(tx.isFlag(tfFillOrKill));
 
     if (bImmediateOrCancel && bFillOrKill)
     {
@@ -309,8 +307,7 @@ OfferCreate::checkAcceptAsset(
 
             // There's no difference which side enacted deep freeze, accepting
             // tokens shouldn't be possible.
-            bool const deepFrozen =
-                ((*trustLine)[sfFlags] & (lsfLowDeepFreeze | lsfHighDeepFreeze)) != 0u;
+            bool const deepFrozen = trustLine->isFlag(lsfLowDeepFreeze | lsfHighDeepFreeze);
 
             if (deepFrozen)
             {
@@ -379,8 +376,7 @@ OfferCreate::flowCross(
 
         // If we're creating a passive offer adjust the threshold so we only
         // cross offers that have a better quality than this one.
-        std::uint32_t const txFlags = ctx_.tx.getFlags();
-        if ((txFlags & tfPassive) != 0u)
+        if (ctx_.tx.isFlag(tfPassive))
             ++threshold;
 
         // Don't send more than our balance.
@@ -402,7 +398,7 @@ OfferCreate::flowCross(
         STAmount deliver = takerAmount.out;
         auto const& deliverAsset = deliver.asset();
         OfferCrossing offerCrossing = OfferCrossing::Yes;
-        if ((txFlags & tfSell) != 0u)
+        if (ctx_.tx.isFlag(tfSell))
         {
             offerCrossing = OfferCrossing::Sell;
             // We are selling, so we will accept *more* than the offer
@@ -436,9 +432,9 @@ OfferCreate::flowCross(
             account_,
             account_,
             paths,
-            true,                            // default path
-            (txFlags & tfFillOrKill) == 0u,  // partial payment
-            true,                            // owner pays transfer fee
+            true,                           // default path
+            !ctx_.tx.isFlag(tfFillOrKill),  // partial payment
+            true,                           // owner pays transfer fee
             offerCrossing,
             threshold,
             sendMax,
@@ -477,7 +473,7 @@ OfferCreate::flowCross(
             {
                 STAmount const rate{Quality{takerAmount.out, takerAmount.in}.rate()};
 
-                if ((txFlags & tfSell) != 0u)
+                if (ctx_.tx.isFlag(tfSell))
                 {
                     // If selling then scale the new out amount based on how
                     // much we sold during crossing.  This preserves the offer
@@ -596,13 +592,11 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
 {
     using beast::kZERO;
 
-    std::uint32_t const uTxFlags = ctx_.tx.getFlags();
-
-    bool const bPassive((uTxFlags & tfPassive) != 0u);
-    bool const bImmediateOrCancel((uTxFlags & tfImmediateOrCancel) != 0u);
-    bool const bFillOrKill((uTxFlags & tfFillOrKill) != 0u);
-    bool const bSell((uTxFlags & tfSell) != 0u);
-    bool const bHybrid((uTxFlags & tfHybrid) != 0u);
+    bool const bPassive(ctx_.tx.isFlag(tfPassive));
+    bool const bImmediateOrCancel(ctx_.tx.isFlag(tfImmediateOrCancel));
+    bool const bFillOrKill(ctx_.tx.isFlag(tfFillOrKill));
+    bool const bSell(ctx_.tx.isFlag(tfSell));
+    bool const bHybrid(ctx_.tx.isFlag(tfHybrid));
 
     auto saTakerPays = ctx_.tx[sfTakerPays];
     auto saTakerGets = ctx_.tx[sfTakerGets];

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -274,7 +274,7 @@ OfferCreate::checkAcceptAsset(
     return asset.visit(
         [&](Issue const& issue) -> TER {
             auto const& issuer = issue.getIssuer();
-            if (((*issuerAccount)[sfFlags] & lsfRequireAuth) != 0u)
+            if (issuerAccount->isFlag(lsfRequireAuth))
             {
                 auto const trustLine = view.read(keylet::line(id, issuer, issue.currency));
 
@@ -289,8 +289,7 @@ OfferCreate::checkAcceptAsset(
                 // access.
                 bool const canonicalGt(id > issuer);
 
-                bool const isAuthorized(
-                    ((*trustLine)[sfFlags] & (canonicalGt ? lsfLowAuth : lsfHighAuth)) != 0u);
+                bool const isAuthorized(trustLine->isFlag(canonicalGt ? lsfLowAuth : lsfHighAuth));
 
                 if (!isAuthorized)
                 {

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -442,7 +442,7 @@ EscrowCreate::doApply()
         auto const sled = ctx_.view().read(keylet::account(ctx_.tx[sfDestination]));
         if (!sled)
             return tecNO_DST;  // LCOV_EXCL_LINE
-        if ((((*sled)[sfFlags] & lsfRequireDestTag) != 0u) && !ctx_.tx[~sfDestinationTag])
+        if (sled->isFlag(lsfRequireDestTag) && !ctx_.tx[~sfDestinationTag])
             return tecDST_TAG_NEEDED;
     }
 

--- a/src/libxrpl/tx/transactors/nft/NFTokenAcceptOffer.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenAcceptOffer.cpp
@@ -159,7 +159,7 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
 
     if (bo)
     {
-        if (((*bo)[sfFlags] & lsfSellNFToken) == lsfSellNFToken)
+        if (bo->isFlag(lsfSellNFToken))
             return tecNFTOKEN_OFFER_TYPE_MISMATCH;
 
         // An account can't accept an offer it placed:
@@ -218,7 +218,7 @@ NFTokenAcceptOffer::preclaim(PreclaimContext const& ctx)
 
     if (so)
     {
-        if (((*so)[sfFlags] & lsfSellNFToken) != lsfSellNFToken)
+        if (!so->isFlag(lsfSellNFToken))
             return tecNFTOKEN_OFFER_TYPE_MISMATCH;
 
         // An account can't accept an offer it placed:

--- a/src/libxrpl/tx/transactors/nft/NFTokenCreateOffer.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenCreateOffer.cpp
@@ -55,9 +55,8 @@ NFTokenCreateOffer::preclaim(PreclaimContext const& ctx)
 
     uint256 const nftokenID = ctx.tx[sfNFTokenID];
     std::uint32_t const txFlags = ctx.tx.getFlags();
-
     if (!nft::findToken(
-            ctx.view, ctx.tx[((txFlags & tfSellNFToken) != 0u) ? sfAccount : sfOwner], nftokenID))
+            ctx.view, ctx.tx[ctx.tx.isFlag(tfSellNFToken) ? sfAccount : sfOwner], nftokenID))
         return tecNO_ENTRY;
 
     // Use implementation shared with NFTokenMint

--- a/src/libxrpl/tx/transactors/payment/Payment.cpp
+++ b/src/libxrpl/tx/transactors/payment/Payment.cpp
@@ -122,14 +122,12 @@ Payment::preflight(PreflightContext const& ctx)
     if (!ctx.rules.enabled(featureMPTokensV1) && isDstMPT)
         return temDISABLED;
 
-    std::uint32_t const txFlags = tx.getFlags();
-
     if (!mpTokensV2 && isDstMPT && ctx.tx.isFieldPresent(sfPaths))
         return temMALFORMED;
 
-    bool const partialPaymentAllowed = (txFlags & tfPartialPayment) != 0u;
-    bool const limitQuality = (txFlags & tfLimitQuality) != 0u;
-    bool const defaultPathsAllowed = (txFlags & tfNoRippleDirect) == 0u;
+    bool const partialPaymentAllowed = tx.isFlag(tfPartialPayment);
+    bool const limitQuality = tx.isFlag(tfLimitQuality);
+    bool const defaultPathsAllowed = !tx.isFlag(tfNoRippleDirect);
     bool const hasPaths = tx.isFieldPresent(sfPaths);
     bool const hasMax = tx.isFieldPresent(sfSendMax);
 
@@ -311,8 +309,7 @@ TER
 Payment::preclaim(PreclaimContext const& ctx)
 {
     // Ripple if source or destination is non-native or if there are paths.
-    std::uint32_t const txFlags = ctx.tx.getFlags();
-    bool const partialPaymentAllowed = (txFlags & tfPartialPayment) != 0u;
+    bool const partialPaymentAllowed = ctx.tx.isFlag(tfPartialPayment);
     auto const hasPaths = ctx.tx.isFieldPresent(sfPaths);
     auto const sendMax = ctx.tx[~sfSendMax];
 
@@ -404,10 +401,9 @@ Payment::doApply()
     auto const deliverMin = ctx_.tx[~sfDeliverMin];
 
     // Ripple if source or destination is non-native or if there are paths.
-    std::uint32_t const txFlags = ctx_.tx.getFlags();
-    bool const partialPaymentAllowed = (txFlags & tfPartialPayment) != 0u;
-    bool const limitQuality = (txFlags & tfLimitQuality) != 0u;
-    bool const defaultPathsAllowed = (txFlags & tfNoRippleDirect) == 0u;
+    bool const partialPaymentAllowed = ctx_.tx.isFlag(tfPartialPayment);
+    bool const limitQuality = ctx_.tx.isFlag(tfLimitQuality);
+    bool const defaultPathsAllowed = !ctx_.tx.isFlag(tfNoRippleDirect);
     auto const hasPaths = ctx_.tx.isFieldPresent(sfPaths);
     auto const sendMax = ctx_.tx[~sfSendMax];
 

--- a/src/libxrpl/tx/transactors/payment/Payment.cpp
+++ b/src/libxrpl/tx/transactors/payment/Payment.cpp
@@ -357,9 +357,7 @@ Payment::preclaim(PreclaimContext const& ctx)
             return tecNO_DST_INSUF_XRP;
         }
     }
-    else if (
-        ((sleDst->getFlags() & lsfRequireDestTag) != 0u) &&
-        !ctx.tx.isFieldPresent(sfDestinationTag))
+    else if (sleDst->isFlag(lsfRequireDestTag) && !ctx.tx.isFieldPresent(sfDestinationTag))
     {
         // The tag is basically account-specific information we don't
         // understand, but we can require someone to fill it in.
@@ -672,7 +670,7 @@ Payment::doApply()
     sleDst->setFieldAmount(sfBalance, sleDst->getFieldAmount(sfBalance) + dstAmount);
 
     // Re-arm the password change fee if we can and need to.
-    if ((sleDst->getFlags() & lsfPasswordSpent) != 0u)
+    if (sleDst->isFlag(lsfPasswordSpent))
         sleDst->clearFlag(lsfPasswordSpent);
 
     return tesSUCCESS;

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelClaim.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelClaim.cpp
@@ -173,7 +173,7 @@ PaymentChannelClaim::doApply()
         ctx_.view().update(slep);
     }
 
-    if ((ctx_.tx.getFlags() & tfRenew) != 0u)
+    if (ctx_.tx.isFlag(tfRenew))
     {
         if (src != txAccount)
             return tecNO_PERMISSION;
@@ -181,7 +181,7 @@ PaymentChannelClaim::doApply()
         ctx_.view().update(slep);
     }
 
-    if ((ctx_.tx.getFlags() & tfClose) != 0u)
+    if (ctx_.tx.isFlag(tfClose))
     {
         // Channel will close immediately if dry or the receiver closes
         if (dst == txAccount || (*slep)[sfBalance] == (*slep)[sfAmount])

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelClaim.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelClaim.cpp
@@ -55,9 +55,7 @@ PaymentChannelClaim::preflight(PreflightContext const& ctx)
         return temBAD_AMOUNT;
 
     {
-        auto const flags = ctx.tx.getFlags();
-
-        if (((flags & tfClose) != 0u) && ((flags & tfRenew) != 0u))
+        if (ctx.tx.isFlag(tfClose) && ctx.tx.isFlag(tfRenew))
             return temMALFORMED;
     }
 

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
@@ -96,13 +96,11 @@ PaymentChannelCreate::preclaim(PreclaimContext const& ctx)
         if (!sled)
             return tecNO_DST;
 
-        auto const flags = sled->getFlags();
-
         // Check if they have disallowed incoming payment channels
-        if ((flags & lsfDisallowIncomingPayChan) != 0u)
+        if (sled->isFlag(lsfDisallowIncomingPayChan))
             return tecNO_PERMISSION;
 
-        if (((flags & lsfRequireDestTag) != 0u) && !ctx.tx[~sfDestinationTag])
+        if (sled->isFlag(lsfRequireDestTag) && !ctx.tx[~sfDestinationTag])
             return tecDST_TAG_NEEDED;
 
         // Pseudo-accounts cannot receive payment channels, other than native

--- a/src/libxrpl/tx/transactors/system/Batch.cpp
+++ b/src/libxrpl/tx/transactors/system/Batch.cpp
@@ -287,7 +287,7 @@ Batch::preflight(PreflightContext const& ctx)
             return temINVALID_INNER_BATCH;
         }
 
-        if ((stx.getFlags() & tfInnerBatchTxn) == 0u)
+        if (!stx.isFlag(tfInnerBatchTxn))
         {
             JLOG(ctx.j.debug()) << "BatchTrace[" << parentBatchId << "]: "
                                 << "inner txn must have the tfInnerBatchTxn flag. "

--- a/src/libxrpl/tx/transactors/system/Batch.cpp
+++ b/src/libxrpl/tx/transactors/system/Batch.cpp
@@ -352,7 +352,7 @@ Batch::preflight(PreflightContext const& ctx)
         }
 
         // Duplicate sequence and ticket checks
-        if (ctx.tx.isFlag(tfAllOrNothing | tfUntilFailure))
+        if ((flags & (tfAllOrNothing | tfUntilFailure)) != 0u)
         {
             if (auto const seq = stx.getFieldU32(sfSequence); seq != 0)
             {

--- a/src/libxrpl/tx/transactors/system/Batch.cpp
+++ b/src/libxrpl/tx/transactors/system/Batch.cpp
@@ -352,7 +352,7 @@ Batch::preflight(PreflightContext const& ctx)
         }
 
         // Duplicate sequence and ticket checks
-        if ((flags & (tfAllOrNothing | tfUntilFailure)) != 0u)
+        if (ctx.tx.isFlag(tfAllOrNothing | tfUntilFailure))
         {
             if (auto const seq = stx.getFieldU32(sfSequence); seq != 0)
             {

--- a/src/libxrpl/tx/transactors/system/Change.cpp
+++ b/src/libxrpl/tx/transactors/system/Change.cpp
@@ -177,10 +177,8 @@ Change::applyAmendment()
     if (std::ranges::find(amendments, amendment) != amendments.end())
         return tefALREADY;
 
-    auto flags = ctx_.tx.getFlags();
-
-    bool const gotMajority = (flags & tfGotMajority) != 0;
-    bool const lostMajority = (flags & tfLostMajority) != 0;
+    bool const gotMajority = ctx_.tx.isFlag(tfGotMajority);
+    bool const lostMajority = ctx_.tx.isFlag(tfLostMajority);
 
     if (gotMajority && lostMajority)
         return temINVALID_FLAG;

--- a/src/libxrpl/tx/transactors/token/Clawback.cpp
+++ b/src/libxrpl/tx/transactors/token/Clawback.cpp
@@ -105,12 +105,9 @@ preclaimHelper<Issue>(
     AccountID const& holder,
     STAmount const& clawAmount)
 {
-    std::uint32_t const issuerFlagsIn = sleIssuer.getFieldU32(sfFlags);
-
     // If AllowTrustLineClawback is not set or NoFreeze is set, return no
     // permission
-    if (((issuerFlagsIn & lsfAllowTrustLineClawback) == 0u) ||
-        ((issuerFlagsIn & lsfNoFreeze) != 0u))
+    if (!sleIssuer.isFlag(lsfAllowTrustLineClawback) || sleIssuer.isFlag(lsfNoFreeze))
         return tecNO_PERMISSION;
 
     auto const sleRippleState =

--- a/src/libxrpl/tx/transactors/token/Clawback.cpp
+++ b/src/libxrpl/tx/transactors/token/Clawback.cpp
@@ -23,7 +23,6 @@
 #include <xrpl/tx/Transactor.h>
 
 #include <algorithm>
-#include <cstdint>
 #include <memory>
 #include <variant>
 

--- a/src/libxrpl/tx/transactors/token/Clawback.cpp
+++ b/src/libxrpl/tx/transactors/token/Clawback.cpp
@@ -163,7 +163,7 @@ preclaimHelper<MPTIssue>(
     if (!sleIssuance)
         return tecOBJECT_NOT_FOUND;
 
-    if (((*sleIssuance)[sfFlags] & lsfMPTCanClawback) == 0u)
+    if (!sleIssuance->isFlag(lsfMPTCanClawback))
         return tecNO_PERMISSION;
 
     if (sleIssuance->getAccountID(sfIssuer) != issuer)

--- a/src/libxrpl/tx/transactors/token/MPTokenAuthorize.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenAuthorize.cpp
@@ -112,8 +112,6 @@ MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
     if (!sleMptIssuance)
         return tecOBJECT_NOT_FOUND;
 
-    std::uint32_t const mptIssuanceFlags = sleMptIssuance->getFieldU32(sfFlags);
-
     // If tx is submitted by issuer, they would either try to do the following
     // for allowlisting:
     // 1. authorize an account
@@ -126,7 +124,7 @@ MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
 
     // If tx is submitted by issuer, it only applies for MPT with
     // lsfMPTRequireAuth set
-    if ((mptIssuanceFlags & lsfMPTRequireAuth) == 0u)
+    if (!sleMptIssuance->isFlag(lsfMPTRequireAuth))
         return tecNO_AUTH;
 
     // The holder must create the MPT before the issuer can authorize it.

--- a/src/libxrpl/tx/transactors/token/MPTokenAuthorize.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenAuthorize.cpp
@@ -58,7 +58,7 @@ MPTokenAuthorize::preclaim(PreclaimContext const& ctx)
         // before fetching the MPTIssuance object.
 
         // if holder wants to delete/unauthorize a mpt
-        if ((ctx.tx.getFlags() & tfMPTUnauthorize) != 0u)
+        if (ctx.tx.isFlag(tfMPTUnauthorize))
         {
             if (!sleMpt)
                 return tecOBJECT_NOT_FOUND;

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
@@ -72,7 +72,7 @@ MPTokenIssuanceCreate::preflight(PreflightContext const& ctx)
             return temMALFORMED;
 
         // Domain present implies that MPTokenIssuance is not public
-        if ((ctx.tx.getFlags() & tfMPTRequireAuth) == 0)
+        if (!ctx.tx.isFlag(tfMPTRequireAuth))
             return temMALFORMED;
     }
 

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
@@ -86,10 +86,8 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
     if (ctx.tx.isFieldPresent(sfDomainID) && ctx.tx.isFieldPresent(sfHolder))
         return temMALFORMED;
 
-    auto const txFlags = ctx.tx.getFlags();
-
     // fails if both flags are set
-    if (((txFlags & tfMPTLock) != 0u) && ((txFlags & tfMPTUnlock) != 0u))
+    if (ctx.tx.isFlag(tfMPTLock) && ctx.tx.isFlag(tfMPTUnlock))
         return temINVALID_FLAG;
 
     auto const accountID = ctx.tx[sfAccount];
@@ -100,7 +98,7 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
     if (ctx.rules.enabled(featureSingleAssetVault) || ctx.rules.enabled(featureDynamicMPT))
     {
         // Is this transaction actually changing anything ?
-        if (txFlags == 0 && !ctx.tx.isFieldPresent(sfDomainID) && !isMutate)
+        if (ctx.tx.getFlags() == 0 && !ctx.tx.isFieldPresent(sfDomainID) && !isMutate)
             return temMALFORMED;
     }
 
@@ -111,7 +109,7 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
             return temMALFORMED;
 
         // Can not set flags when mutating MPTokenIssuance
-        if (isMutate && ((txFlags & tfUniversalMask) != 0u))
+        if (isMutate && ctx.tx.isFlag(tfUniversalMask))
             return temMALFORMED;
 
         if (transferFee && *transferFee > kMAX_TRANSFER_FEE)
@@ -157,20 +155,18 @@ MPTokenIssuanceSet::checkPermission(ReadView const& view, STTx const& tx)
     if (isTesSuccess(checkTxPermission(sle, tx)))
         return tesSUCCESS;
 
-    auto const txFlags = tx.getFlags();
-
     // this is added in case more flags will be added for MPTokenIssuanceSet
     // in the future. Currently unreachable.
-    if ((txFlags & tfMPTokenIssuanceSetMask) != 0u)
+    if (tx.isFlag(tfMPTokenIssuanceSetMask))
         return terNO_DELEGATE_PERMISSION;  // LCOV_EXCL_LINE
 
     std::unordered_set<GranularPermissionType> granularPermissions;
     loadGranularPermission(sle, ttMPTOKEN_ISSUANCE_SET, granularPermissions);
 
-    if (((txFlags & tfMPTLock) != 0u) && !granularPermissions.contains(MPTokenIssuanceLock))
+    if (tx.isFlag(tfMPTLock) && !granularPermissions.contains(MPTokenIssuanceLock))
         return terNO_DELEGATE_PERMISSION;
 
-    if (((txFlags & tfMPTUnlock) != 0u) && !granularPermissions.contains(MPTokenIssuanceUnlock))
+    if (tx.isFlag(tfMPTUnlock) && !granularPermissions.contains(MPTokenIssuanceUnlock))
         return terNO_DELEGATE_PERMISSION;
 
     return tesSUCCESS;
@@ -273,7 +269,6 @@ TER
 MPTokenIssuanceSet::doApply()
 {
     auto const mptIssuanceID = ctx_.tx[sfMPTokenIssuanceID];
-    auto const txFlags = ctx_.tx.getFlags();
     auto const holderID = ctx_.tx[~sfHolder];
     auto const domainID = ctx_.tx[~sfDomainID];
     std::shared_ptr<SLE> sle;
@@ -293,11 +288,11 @@ MPTokenIssuanceSet::doApply()
     std::uint32_t const flagsIn = sle->getFieldU32(sfFlags);
     std::uint32_t flagsOut = flagsIn;
 
-    if ((txFlags & tfMPTLock) != 0u)
+    if (ctx_.tx.isFlag(tfMPTLock))
     {
         flagsOut |= lsfMPTLocked;
     }
-    else if ((txFlags & tfMPTUnlock) != 0u)
+    else if (ctx_.tx.isFlag(tfMPTUnlock))
     {
         flagsOut &= ~lsfMPTLocked;
     }

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
@@ -109,7 +109,7 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
             return temMALFORMED;
 
         // Can not set flags when mutating MPTokenIssuance
-        if (isMutate && ctx.tx.isFlag(tfUniversalMask))
+        if (isMutate && ((ctx.tx.getFlags() & tfUniversalMask) != 0u))
             return temMALFORMED;
 
         if (transferFee && *transferFee > kMAX_TRANSFER_FEE)
@@ -157,7 +157,7 @@ MPTokenIssuanceSet::checkPermission(ReadView const& view, STTx const& tx)
 
     // this is added in case more flags will be added for MPTokenIssuanceSet
     // in the future. Currently unreachable.
-    if (tx.isFlag(tfMPTokenIssuanceSetMask))
+    if ((tx.getFlags() & tfMPTokenIssuanceSetMask) != 0u)
         return terNO_DELEGATE_PERMISSION;  // LCOV_EXCL_LINE
 
     std::unordered_set<GranularPermissionType> granularPermissions;

--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -82,7 +82,7 @@ TrustSet::preflight(PreflightContext const& ctx)
     {
         // Even though the deep freeze flags are included in the
         // `tfTrustSetMask`, they are not valid if the amendment is not enabled.
-        if (tx.isFlag(tfSetDeepFreeze | tfClearDeepFreeze))
+        if ((tx.getFlags() & (tfSetDeepFreeze | tfClearDeepFreeze)) != 0u)
         {
             return temINVALID_FLAG;
         }
@@ -143,7 +143,7 @@ TrustSet::checkPermission(ReadView const& view, STTx const& tx)
     // Currently we only support TrustlineAuthorize, TrustlineFreeze and
     // TrustlineUnfreeze granular permission. Setting other flags returns
     // error.
-    if (tx.isFlag(tfTrustSetPermissionMask))
+    if ((tx.getFlags() & tfTrustSetPermissionMask) != 0u)
         return terNO_DELEGATE_PERMISSION;
 
     if (tx.isFieldPresent(sfQualityIn) || tx.isFieldPresent(sfQualityOut))

--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -78,13 +78,11 @@ TrustSet::preflight(PreflightContext const& ctx)
     auto& tx = ctx.tx;
     auto& j = ctx.j;
 
-    std::uint32_t const uTxFlags = tx.getFlags();
-
     if (!ctx.rules.enabled(featureDeepFreeze))
     {
         // Even though the deep freeze flags are included in the
         // `tfTrustSetMask`, they are not valid if the amendment is not enabled.
-        if ((uTxFlags & (tfSetDeepFreeze | tfClearDeepFreeze)) != 0u)
+        if (tx.isFlag(tfSetDeepFreeze | tfClearDeepFreeze))
         {
             return temINVALID_FLAG;
         }
@@ -142,12 +140,10 @@ TrustSet::checkPermission(ReadView const& view, STTx const& tx)
     if (isTesSuccess(checkTxPermission(sle, tx)))
         return tesSUCCESS;
 
-    std::uint32_t const txFlags = tx.getFlags();
-
     // Currently we only support TrustlineAuthorize, TrustlineFreeze and
     // TrustlineUnfreeze granular permission. Setting other flags returns
     // error.
-    if ((txFlags & tfTrustSetPermissionMask) != 0u)
+    if (tx.isFlag(tfTrustSetPermissionMask))
         return terNO_DELEGATE_PERMISSION;
 
     if (tx.isFieldPresent(sfQualityIn) || tx.isFieldPresent(sfQualityOut))
@@ -166,11 +162,11 @@ TrustSet::checkPermission(ReadView const& view, STTx const& tx)
     std::unordered_set<GranularPermissionType> granularPermissions;
     loadGranularPermission(sle, ttTRUST_SET, granularPermissions);
 
-    if (((txFlags & tfSetfAuth) != 0u) && !granularPermissions.contains(TrustlineAuthorize))
+    if (tx.isFlag(tfSetfAuth) && !granularPermissions.contains(TrustlineAuthorize))
         return terNO_DELEGATE_PERMISSION;
-    if (((txFlags & tfSetFreeze) != 0u) && !granularPermissions.contains(TrustlineFreeze))
+    if (tx.isFlag(tfSetFreeze) && !granularPermissions.contains(TrustlineFreeze))
         return terNO_DELEGATE_PERMISSION;
-    if (((txFlags & tfClearFreeze) != 0u) && !granularPermissions.contains(TrustlineUnfreeze))
+    if (tx.isFlag(tfClearFreeze) && !granularPermissions.contains(TrustlineUnfreeze))
         return terNO_DELEGATE_PERMISSION;
 
     // updating LimitAmount is not allowed only with granular permissions,
@@ -197,9 +193,7 @@ TrustSet::preclaim(PreclaimContext const& ctx)
     if (!sle)
         return terNO_ACCOUNT;
 
-    std::uint32_t const uTxFlags = ctx.tx.getFlags();
-
-    bool const bSetAuth = (uTxFlags & tfSetfAuth) != 0u;
+    bool const bSetAuth = ctx.tx.isFlag(tfSetfAuth);
 
     if (bSetAuth && !sle->isFlag(lsfRequireAuth))
     {
@@ -288,8 +282,8 @@ TrustSet::preclaim(PreclaimContext const& ctx)
     if (ctx.view.rules().enabled(featureDeepFreeze))
     {
         bool const bNoFreeze = sle->isFlag(lsfNoFreeze);
-        bool const bSetFreeze = (uTxFlags & tfSetFreeze) != 0u;
-        bool const bSetDeepFreeze = (uTxFlags & tfSetDeepFreeze) != 0u;
+        bool const bSetFreeze = ctx.tx.isFlag(tfSetFreeze);
+        bool const bSetDeepFreeze = ctx.tx.isFlag(tfSetDeepFreeze);
 
         if (bNoFreeze && (bSetFreeze || bSetDeepFreeze))
         {
@@ -297,8 +291,8 @@ TrustSet::preclaim(PreclaimContext const& ctx)
             return tecNO_PERMISSION;
         }
 
-        bool const bClearFreeze = (uTxFlags & tfClearFreeze) != 0u;
-        bool const bClearDeepFreeze = (uTxFlags & tfClearDeepFreeze) != 0u;
+        bool const bClearFreeze = ctx.tx.isFlag(tfClearFreeze);
+        bool const bClearDeepFreeze = ctx.tx.isFlag(tfClearDeepFreeze);
         if ((bSetFreeze || bSetDeepFreeze) && (bClearFreeze || bClearDeepFreeze))
         {
             // Freezing and unfreezing in the same transaction should be
@@ -378,15 +372,13 @@ TrustSet::doApply()
     if (bQualityOut && QUALITY_ONE == uQualityOut)
         uQualityOut = 0;
 
-    std::uint32_t const uTxFlags = ctx_.tx.getFlags();
-
-    bool const bSetAuth = (uTxFlags & tfSetfAuth) != 0u;
-    bool const bSetNoRipple = (uTxFlags & tfSetNoRipple) != 0u;
-    bool const bClearNoRipple = (uTxFlags & tfClearNoRipple) != 0u;
-    bool const bSetFreeze = (uTxFlags & tfSetFreeze) != 0u;
-    bool const bClearFreeze = (uTxFlags & tfClearFreeze) != 0u;
-    bool const bSetDeepFreeze = (uTxFlags & tfSetDeepFreeze) != 0u;
-    bool const bClearDeepFreeze = (uTxFlags & tfClearDeepFreeze) != 0u;
+    bool const bSetAuth = ctx_.tx.isFlag(tfSetfAuth);
+    bool const bSetNoRipple = ctx_.tx.isFlag(tfSetNoRipple);
+    bool const bClearNoRipple = ctx_.tx.isFlag(tfClearNoRipple);
+    bool const bSetFreeze = ctx_.tx.isFlag(tfSetFreeze);
+    bool const bClearFreeze = ctx_.tx.isFlag(tfClearFreeze);
+    bool const bSetDeepFreeze = ctx_.tx.isFlag(tfSetDeepFreeze);
+    bool const bClearDeepFreeze = ctx_.tx.isFlag(tfClearDeepFreeze);
 
     auto viewJ = ctx_.registry.get().getJournal("View");
 
@@ -553,8 +545,8 @@ TrustSet::doApply()
 
         bool const bDefault = bLowReserveClear && bHighReserveClear;
 
-        bool const bLowReserved = (uFlagsIn & lsfLowReserve) != 0u;
-        bool const bHighReserved = (uFlagsIn & lsfHighReserve) != 0u;
+        bool const bLowReserved = sleRippleState->isFlag(lsfLowReserve);
+        bool const bHighReserved = sleRippleState->isFlag(lsfHighReserve);
 
         bool bReserveIncrease = false;
 

--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -201,7 +201,7 @@ TrustSet::preclaim(PreclaimContext const& ctx)
 
     bool const bSetAuth = (uTxFlags & tfSetfAuth) != 0u;
 
-    if (bSetAuth && ((sle->getFieldU32(sfFlags) & lsfRequireAuth) == 0u))
+    if (bSetAuth && !sle->isFlag(lsfRequireAuth))
     {
         JLOG(ctx.j.trace()) << "Retry: Auth not required.";
         return tefNO_AUTH_REQUIRED;
@@ -223,7 +223,7 @@ TrustSet::preclaim(PreclaimContext const& ctx)
 
     // If the destination has opted to disallow incoming trustlines
     // then honour that flag
-    if ((sleDst->getFlags() & lsfDisallowIncomingTrustline) != 0u)
+    if (sleDst->isFlag(lsfDisallowIncomingTrustline))
     {
         // The original implementation of featureDisallowIncoming was
         // too restrictive. If
@@ -538,8 +538,8 @@ TrustSet::doApply()
         if (QUALITY_ONE == uHighQualityOut)
             uHighQualityOut = 0;
 
-        bool const bLowDefRipple = (sleLowAccount->getFlags() & lsfDefaultRipple) != 0u;
-        bool const bHighDefRipple = (sleHighAccount->getFlags() & lsfDefaultRipple) != 0u;
+        bool const bLowDefRipple = sleLowAccount->isFlag(lsfDefaultRipple);
+        bool const bHighDefRipple = sleHighAccount->isFlag(lsfDefaultRipple);
 
         bool const bLowReserveSet = (uLowQualityIn != 0u) || (uLowQualityOut != 0u) ||
             ((uFlagsOut & lsfLowNoRipple) == 0) != bLowDefRipple ||

--- a/src/libxrpl/tx/transactors/vault/VaultClawback.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultClawback.cpp
@@ -26,7 +26,6 @@
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/tx/Transactor.h>
 
-#include <cstdint>
 #include <memory>
 #include <optional>
 #include <stdexcept>

--- a/src/libxrpl/tx/transactors/vault/VaultClawback.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultClawback.cpp
@@ -186,8 +186,7 @@ VaultClawback::preclaim(PreclaimContext const& ctx)
                 if (mptIssue == nullptr)
                     return tecOBJECT_NOT_FOUND;
 
-                std::uint32_t const issueFlags = mptIssue->getFieldU32(sfFlags);
-                if ((issueFlags & lsfMPTCanClawback) == 0u)
+                if (!mptIssue->isFlag(lsfMPTCanClawback))
                 {
                     JLOG(ctx.j.debug()) << "VaultClawback: cannot clawback "
                                            "MPT vault asset.";
@@ -206,9 +205,7 @@ VaultClawback::preclaim(PreclaimContext const& ctx)
                     // LCOV_EXCL_STOP
                 }
 
-                std::uint32_t const issuerFlags = issuerSle->getFieldU32(sfFlags);
-                if (((issuerFlags & lsfAllowTrustLineClawback) == 0u) ||
-                    ((issuerFlags & lsfNoFreeze) != 0u))
+                if (!issuerSle->isFlag(lsfAllowTrustLineClawback) || issuerSle->isFlag(lsfNoFreeze))
                 {
                     JLOG(ctx.j.debug()) << "VaultClawback: cannot clawback "
                                            "IOU vault asset.";

--- a/src/libxrpl/tx/transactors/vault/VaultCreate.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultCreate.cpp
@@ -173,11 +173,10 @@ VaultCreate::doApply()
         ? 0
         : ctx_.tx[~sfScale].value_or(kVAULT_DEFAULT_IOU_SCALE);
 
-    auto txFlags = tx.getFlags();
     std::uint32_t mptFlags = 0;
-    if ((txFlags & tfVaultShareNonTransferable) == 0)
+    if (!tx.isFlag(tfVaultShareNonTransferable))
         mptFlags |= (lsfMPTCanEscrow | lsfMPTCanTrade | lsfMPTCanTransfer);
-    if ((txFlags & tfVaultPrivate) != 0u)
+    if (tx.isFlag(tfVaultPrivate))
         mptFlags |= lsfMPTRequireAuth;
 
     // Note, here we are **not** creating an MPToken for the assets held in
@@ -203,7 +202,7 @@ VaultCreate::doApply()
     auto const& mptIssuanceID = *maybeShare;
 
     vault->setFieldIssue(sfAsset, STIssue{sfAsset, asset});
-    vault->at(sfFlags) = txFlags & tfVaultPrivate;
+    vault->at(sfFlags) = tx.getFlags() & tfVaultPrivate;
     vault->at(sfSequence) = sequence;
     vault->at(sfOwner) = account_;
     vault->at(sfAccount) = pseudoId;
@@ -236,7 +235,7 @@ VaultCreate::doApply()
         return err;
 
     // If the vault is private, set the authorized flag for the vault owner
-    if ((txFlags & tfVaultPrivate) != 0u)
+    if (tx.isFlag(tfVaultPrivate))
     {
         if (auto const err = authorizeMPToken(
                 view(), preFeeBalance_, mptIssuanceID, pseudoId, ctx_.journal, {}, account_);

--- a/src/libxrpl/tx/transactors/vault/VaultCreate.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultCreate.cpp
@@ -68,7 +68,7 @@ VaultCreate::preflight(PreflightContext const& ctx)
         {
             return temMALFORMED;
         }
-        if ((ctx.tx.getFlags() & tfVaultPrivate) == 0)
+        if (!ctx.tx.isFlag(tfVaultPrivate))
         {
             return temMALFORMED;  // DomainID only allowed on private vaults
         }

--- a/src/libxrpl/tx/transactors/vault/VaultSet.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultSet.cpp
@@ -103,7 +103,7 @@ VaultSet::preclaim(PreclaimContext const& ctx)
         }
 
         // Sanity check only, this should be enforced by VaultCreate
-        if ((sleIssuance->getFlags() & lsfMPTRequireAuth) == 0)
+        if (!sleIssuance->isFlag(lsfMPTRequireAuth))
         {
             // LCOV_EXCL_START
             JLOG(ctx.j.error()) << "VaultSet: issuance of vault shares is not private.";

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -142,7 +142,7 @@ struct Credentials_test : public beast::unit_test::Suite
 
                 BEAST_EXPECT(sleCred->getAccountID(sfSubject) == issuer.id());
                 BEAST_EXPECT(sleCred->getAccountID(sfIssuer) == issuer.id());
-                BEAST_EXPECT((sleCred->getFieldU32(sfFlags) & lsfAccepted));
+                BEAST_EXPECT(sleCred->isFlag(lsfAccepted));
                 BEAST_EXPECT(
                     sleCred->getFieldU64(sfIssuerNode) == sleCred->getFieldU64(sfSubjectNode));
                 BEAST_EXPECT(ownerCount(env, issuer) == 1);
@@ -1074,7 +1074,7 @@ struct Credentials_test : public beast::unit_test::Suite
         // Verify credential exists and is accepted
         {
             auto const sleCred = env.current()->read(credKeylet);
-            BEAST_EXPECT(sleCred && sleCred->getFlags() & lsfAccepted);
+            BEAST_EXPECT(sleCred && sleCred->isFlag(lsfAccepted));
         }
 
         // Create DepositPreauth
@@ -1127,11 +1127,11 @@ struct Credentials_test : public beast::unit_test::Suite
 
         auto const dpTer = xrpl::verifyDepositPreauth(*stx, av, subject, becky, {}, j);
         auto sleCredAfter = av.read(credKeylet);
-        BEAST_EXPECT(sleCredAfter && (sleCredAfter->getFlags() & lsfAccepted));
+        BEAST_EXPECT(sleCredAfter && sleCredAfter->isFlag(lsfAccepted));
 
         auto const domTer = xrpl::verifyValidDomain(av, subject.id(), domain, j);
         sleCredAfter = av.read(credKeylet);
-        BEAST_EXPECT(sleCredAfter && (sleCredAfter->getFlags() & lsfAccepted));
+        BEAST_EXPECT(sleCredAfter && sleCredAfter->isFlag(lsfAccepted));
 
         if (fixEnabled)
         {

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -58,7 +58,7 @@ reserve(jtx::Env& env, std::uint32_t count)
 static bool
 hasDepositAuth(jtx::Env const& env, jtx::Account const& acct)
 {
-    return ((*env.le(acct))[sfFlags] & lsfDepositAuth) == lsfDepositAuth;
+    return env.le(acct)->isFlag(lsfDepositAuth);
 }
 
 struct DepositAuth_test : public beast::unit_test::Suite

--- a/src/test/app/SetRegularKey_test.cpp
+++ b/src/test/app/SetRegularKey_test.cpp
@@ -84,15 +84,12 @@ public:
         env.fund(XRP(10000), alice, bob);
 
         auto ar = env.le(alice);
-        BEAST_EXPECT(
-            ar->isFieldPresent(sfFlags) && ((ar->getFieldU32(sfFlags) & lsfPasswordSpent) == 0));
+        BEAST_EXPECT(ar->isFieldPresent(sfFlags) && !ar->isFlag(lsfPasswordSpent));
 
         env(regkey(alice, bob), Sig(alice), Fee(0));
 
         ar = env.le(alice);
-        BEAST_EXPECT(
-            ar->isFieldPresent(sfFlags) &&
-            ((ar->getFieldU32(sfFlags) & lsfPasswordSpent) == lsfPasswordSpent));
+        BEAST_EXPECT(ar->isFieldPresent(sfFlags) && ar->isFlag(lsfPasswordSpent));
 
         // The second SetRegularKey transaction with Fee=0 should fail.
         env(regkey(alice, bob), Sig(alice), Fee(0), Ter(telINSUF_FEE_P));
@@ -100,8 +97,7 @@ public:
         env.trust(bob["USD"](1), alice);
         env(pay(bob, alice, bob["USD"](1)));
         ar = env.le(alice);
-        BEAST_EXPECT(
-            ar->isFieldPresent(sfFlags) && ((ar->getFieldU32(sfFlags) & lsfPasswordSpent) == 0));
+        BEAST_EXPECT(ar->isFieldPresent(sfFlags) && !ar->isFlag(lsfPasswordSpent));
     }
 
     void

--- a/src/test/jtx/impl/flags.cpp
+++ b/src/test/jtx/impl/flags.cpp
@@ -34,7 +34,7 @@ Flags::operator()(Env& env) const
     }
     else if (sle->isFieldPresent(sfFlags))
     {
-        env.test.expect((sle->getFieldU32(sfFlags) & mask_) == mask_);
+        env.test.expect(sle->isFlag(mask_));
     }
     else
     {

--- a/src/xrpld/rpc/detail/PathRequest.cpp
+++ b/src/xrpld/rpc/detail/PathRequest.cpp
@@ -219,7 +219,7 @@ PathRequest::isValid(std::shared_ptr<AssetCache> const& crCache)
     }
     else
     {
-        bool const disallowXRP((sleDest->getFlags() & lsfDisallowXRP) != 0u);
+        bool const disallowXRP(sleDest->isFlag(lsfDisallowXRP));
 
         auto const destAssets = accountDestAssets(*raDstAccount_, crCache, !disallowXRP);
 

--- a/src/xrpld/rpc/detail/Pathfinder.cpp
+++ b/src/xrpld/rpc/detail/Pathfinder.cpp
@@ -952,7 +952,7 @@ Pathfinder::isNoRipple(
 
     auto const flag((toAccount > fromAccount) ? lsfHighNoRipple : lsfLowNoRipple);
 
-    return sleRipple && ((sleRipple->getFieldU32(sfFlags) & flag) != 0u);
+    return sleRipple && sleRipple->isFlag(flag);
 }
 
 // Does this path end on an account-to-account link whose last account has
@@ -1032,7 +1032,7 @@ Pathfinder::addLink(
 
             if (sleEnd)
             {
-                bool const bRequireAuth((sleEnd->getFieldU32(sfFlags) & lsfRequireAuth) != 0u);
+                bool const bRequireAuth(sleEnd->isFlag(lsfRequireAuth));
                 bool const bIsEndAsset(uEndPathAsset == dstAmount_.asset());
                 bool const bIsNoRippleOut(isNoRippleOut(currentPath));
                 bool const bDestOnly((addFlags & kAF_AC_LAST) != 0u);

--- a/src/xrpld/rpc/handlers/account/AccountLines.cpp
+++ b/src/xrpld/rpc/handlers/account/AccountLines.cpp
@@ -219,11 +219,11 @@ doAccountLines(RPC::JsonContext& context)
                     {
                         if (sleCur->getFieldAmount(sfLowLimit).getIssuer() == visitData.accountID)
                         {
-                            ignore = !(sleCur->getFieldU32(sfFlags) & lsfLowReserve);
+                            ignore = !sleCur->isFlag(lsfLowReserve);
                         }
                         else
                         {
-                            ignore = !(sleCur->getFieldU32(sfFlags) & lsfHighReserve);
+                            ignore = !sleCur->isFlag(lsfHighReserve);
                         }
                     }
 

--- a/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
+++ b/src/xrpld/rpc/handlers/account/NoRippleCheck.cpp
@@ -116,7 +116,7 @@ doNoRippleCheck(RPC::JsonContext& context)
 
     json::Value& problems = (result["problems"] = json::ValueType::Array);
 
-    bool const bDefaultRipple = (sle->getFieldU32(sfFlags) & lsfDefaultRipple) != 0u;
+    bool const bDefaultRipple = sle->isFlag(lsfDefaultRipple);
 
     if (bDefaultRipple && !roleGateway)
     {
@@ -143,8 +143,7 @@ doNoRippleCheck(RPC::JsonContext& context)
             {
                 bool const bLow = accountID == ownedItem->getFieldAmount(sfLowLimit).getIssuer();
 
-                bool const bNoRipple =
-                    ownedItem->getFieldU32(sfFlags) & (bLow ? lsfLowNoRipple : lsfHighNoRipple);
+                bool const bNoRipple = ownedItem->isFlag(bLow ? lsfLowNoRipple : lsfHighNoRipple);
 
                 std::string problem;
                 bool needFix = false;

--- a/src/xrpld/rpc/handlers/orderbook/DepositAuthorized.cpp
+++ b/src/xrpld/rpc/handlers/orderbook/DepositAuthorized.cpp
@@ -86,7 +86,7 @@ doDepositAuthorized(RPC::JsonContext& context)
         return result;
     }
 
-    bool const reqAuth = ((sleDest->getFlags() & lsfDepositAuth) != 0u) && (srcAcct != dstAcct);
+    bool const reqAuth = sleDest->isFlag(lsfDepositAuth) && (srcAcct != dstAcct);
     bool const credentialsPresent = params.isMember(jss::credentials);
 
     std::set<std::pair<AccountID, Slice>> sorted;
@@ -135,7 +135,7 @@ doDepositAuthorized(RPC::JsonContext& context)
                 return result;
             }
 
-            if ((sleCred->getFlags() & lsfAccepted) == 0u)
+            if (!sleCred->isFlag(lsfAccepted))
             {
                 RPC::injectError(RpcBadCredentials, "credentials aren't accepted", result);
                 return result;


### PR DESCRIPTION
## High Level Overview of Change

Title pretty much says it all. I did some additional refactors to remove `flags` variables where relevant. A few ternaries of the form `!bool ? X : Y` were also flipped (to `bool ? Y : X`).

No functionality changes, this is a pure refactor.

### Context of Change

Bitwise math is harder to read/reason about

### API Impact

N/A