### PR TITLE
refactor: Clean up comments post-clang-tidy changes

### DIFF
--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -84,7 +84,7 @@ LEDGER_ENTRY(ltNEGATIVE_UNL, 0x004e, NegativeUNL, nunl, ({
 
 /** A ledger object which contains a list of NFTs
 
-    \sa keylet::nftpage_min, keylet::nftpage_max, keylet::nftpage
+    \sa keylet::nftpageMin, keylet::nftpageMax, keylet::nftpage
  */
 LEDGER_ENTRY(ltNFTOKEN_PAGE, 0x0050, NFTokenPage, nft_page, ({
     {sfPreviousPageMin,      SoeOptional},
@@ -112,7 +112,7 @@ LEDGER_ENTRY(ltSIGNER_LIST, 0x0053, SignerList, signer_list, ({
 
 /** A ledger object which describes a ticket.
 
-    \sa keylet::ticket
+    \sa keylet::kTICKET
  */
 LEDGER_ENTRY(ltTICKET, 0x0054, Ticket, ticket, ({
     {sfAccount,              SoeRequired},

--- a/include/xrpl/protocol/detail/ledger_entries.macro
+++ b/include/xrpl/protocol/detail/ledger_entries.macro
@@ -112,7 +112,7 @@ LEDGER_ENTRY(ltSIGNER_LIST, 0x0053, SignerList, signer_list, ({
 
 /** A ledger object which describes a ticket.
 
-    \sa keylet::kTICKET
+    \sa keylet::kTicket
  */
 LEDGER_ENTRY(ltTICKET, 0x0054, Ticket, ticket, ({
     {sfAccount,              SoeRequired},

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -183,15 +183,15 @@ trustCreate(
     bool const bSrcHigh,
     AccountID const& uSrcAccountID,
     AccountID const& uDstAccountID,
-    uint256 const& uIndex,      // --> ripple state entry
-    SLE::ref sleAccount,        // --> the account being set.
-    bool const bAuth,           // --> authorize account.
-    bool const bNoRipple,       // --> others cannot ripple through
-    bool const bFreeze,         // --> funds cannot leave
-    bool bDeepFreeze,           // --> can neither receive nor send funds
-    STAmount const& saBalance,  // --> balance of account being set.
+    uint256 const& uIndex,      // ripple state entry
+    SLE::ref sleAccount,        // the account being set.
+    bool const bAuth,           // authorize account.
+    bool const bNoRipple,       // others cannot ripple through
+    bool const bFreeze,         // funds cannot leave
+    bool bDeepFreeze,           // can neither receive nor send funds
+    STAmount const& saBalance,  // balance of account being set.
                                 // Issuer should be noAccount()
-    STAmount const& saLimit,    // --> limit for account being set.
+    STAmount const& saLimit,    // limit for account being set.
                                 // Issuer should be the account being set.
     std::uint32_t uQualityIn,
     std::uint32_t uQualityOut,

--- a/src/libxrpl/ledger/helpers/TokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/TokenHelpers.cpp
@@ -1191,7 +1191,7 @@ directSendNoLimitMultiMPT(
     // Use uint64_t, not STAmount, to keep MaximumAmount comparisons in exact
     // integer arithmetic. STAmount implicitly converts to Number, whose
     // small-scale mantissa (~16 digits) can lose precision for values near
-    // maxMPTokenAmount (19 digits).
+    // kMaxMpTokenAmount (19 digits).
     std::uint64_t totalSendAmount{0};
     std::uint64_t const maximumAmount = sle->at(~sfMaximumAmount).value_or(kMaxMpTokenAmount);
     std::uint64_t const outstandingAmount = sle->getFieldU64(sfOutstandingAmount);

--- a/src/libxrpl/tx/Transactor.cpp
+++ b/src/libxrpl/tx/Transactor.cpp
@@ -1238,7 +1238,7 @@ Transactor::operator()()
 
     if (isTecClaim(result) && ((view().flags() & TapFailHard) != 0u))
     {
-        // If the tapFAIL_HARD flag is set, a tec result
+        // If the TapFailHard flag is set, a tec result
         // must not do anything
         ctx_.discard();
         applied = false;

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -115,8 +115,8 @@ DelegateSet::doApply()
 
     (*sle)[sfOwnerNode] = *page;
 
-    // Add to authorized account's owner directory so the object can be found
-    // and cleaned up when the authorized account is deleted.
+    // Add to authorized account's owner directory so AccountDelete can find
+    // and clean up inbound delegations when the authorized account is deleted.
     auto const destPage = ctx_.view().dirInsert(
         keylet::ownerDir(authAccount), delegateKey, describeOwnerDir(authAccount));
 

--- a/src/libxrpl/tx/transactors/dex/AMMVote.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMVote.cpp
@@ -80,14 +80,14 @@ AMMVote::preclaim(PreclaimContext const& ctx)
 }
 
 static std::pair<TER, bool>
-applyVote(ApplyContext& ctx, Sandbox& sb, AccountID const& account, beast::Journal j)
+applyVote(ApplyContext& ctx, Sandbox& sb, AccountID const& accountID, beast::Journal j)
 {
     auto const feeNew = ctx.tx[sfTradingFee];
     auto ammSle = sb.peek(keylet::amm(ctx.tx[sfAsset], ctx.tx[sfAsset2]));
     if (!ammSle)
         return {tecINTERNAL, false};
     STAmount const lptAMMBalance = (*ammSle)[sfLPTokenBalance];
-    auto const lpTokensNew = ammLPHolds(sb, *ammSle, account, ctx.journal);
+    auto const lpTokensNew = ammLPHolds(sb, *ammSle, accountID, ctx.journal);
     std::optional<STAmount> minTokens;
     std::size_t minPos{0};
     AccountID minAccount{0};
@@ -108,13 +108,13 @@ applyVote(ApplyContext& ctx, Sandbox& sb, AccountID const& account, beast::Journ
         auto lpTokens = ammLPHolds(sb, *ammSle, entryAccount, ctx.journal);
         if (lpTokens == beast::kZero)
         {
-            JLOG(j.debug()) << "AMMVote::applyVote, account " << entryAccount << " is not LP";
+            JLOG(j.debug()) << "AMMVote::applyVote, accountID " << entryAccount << " is not LP";
             continue;
         }
         auto feeVal = entry[sfTradingFee];
         STObject newEntry = STObject::makeInnerObject(sfVoteEntry);
         // The account already has the vote entry.
-        if (entryAccount == account)
+        if (entryAccount == accountID)
         {
             lpTokens = lpTokensNew;
             feeVal = feeNew;
@@ -156,7 +156,7 @@ applyVote(ApplyContext& ctx, Sandbox& sb, AccountID const& account, beast::Journ
                 sfVoteWeight,
                 static_cast<std::int64_t>(
                     Number(lpTokensNew) * kVoteWeightScaleFactor / lptAMMBalance));
-            newEntry.setAccountID(sfAccount, account);
+            newEntry.setAccountID(sfAccount, accountID);
             num += feeNew * lpTokensNew;
             den += lpTokensNew;
             if (minPos)

--- a/src/libxrpl/tx/transactors/lending/LoanPay.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanPay.cpp
@@ -99,7 +99,7 @@ LoanPay::calculateBaseFee(ReadView const& view, STTx const& tx)
 
     if (loanSle->at(sfPaymentRemaining) <= kLoanPaymentsPerFeeIncrement)
     {
-        // If there are fewer than loanPaymentsPerFeeIncrement payments left to
+        // If there are fewer than kLoanPaymentsPerFeeIncrement payments left to
         // pay, we can skip the computations.
         return normalCost;
     }

--- a/src/test/app/AMMMPT_test.cpp
+++ b/src/test/app/AMMMPT_test.cpp
@@ -7037,7 +7037,7 @@ private:
         }
 
         // This test validates both invariant changes work together for
-        // the specific case of MPT/MPT pools with > maxDeletableAMMTrustLines.
+        // the specific case of MPT/MPT pools with > kMaxDeletableAmmTrustLines.
         {
             Env env(
                 *this,

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -182,7 +182,7 @@ class Invariants_test : public beast::unit_test::Suite
 
         // Invariants normally run in the Transaction's "apply" (operator()) context, and can always
         // access global Rules.
-        CurrentTransactionRulesGuard const rg(ov.rules());
+        CurrentTransactionRulesGuard const rulesGuard(ov.rules());
 
         BEAST_EXPECT(precheck(a1, a2, ac));
 
@@ -358,10 +358,10 @@ class Invariants_test : public beast::unit_test::Suite
             doInvariantCheck(
                 {{"account deletion left behind a "s + type.cStr() + " object"}},
                 // NOLINTNEXTLINE(readability-identifier-naming)
-                [&](Account const& A1, Account const& A2, ApplyContext& ac) {
-                    // Add an object to the ledger for account A1, then delete
-                    // A1
-                    auto const a1 = A1.id();
+                [&](Account const& a1, Account const& a2, ApplyContext& ac) {
+                    // Add an object to the ledger for account a1, then delete
+                    // a1
+                    auto const a1 = a1.id();
                     auto sleA1 = ac.view().peek(keylet::account(a1));
                     if (!sleA1)
                         return false;

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -302,6 +302,7 @@ class Invariants_test : public beast::unit_test::Suite
 
         doInvariantCheck(
             {{"account deletion left behind a non-zero balance"}},
+            // NOLINTNEXTLINE(readability-identifier-naming)
             [&](Account const& A1, Account const& A2, ApplyContext& ac) {
                 // A1 has a balance. Delete A1
                 auto const a1 = A1.id();
@@ -357,10 +358,10 @@ class Invariants_test : public beast::unit_test::Suite
             doInvariantCheck(
                 {{"account deletion left behind a "s + type.cStr() + " object"}},
                 // NOLINTNEXTLINE(readability-identifier-naming)
-                [&](Account const& a1, Account const& a2, ApplyContext& ac) {
-                    // Add an object to the ledger for account a1, then delete
-                    // a1
-                    auto const a1 = a1.id();
+                [&](Account const& A1, Account const& A2, ApplyContext& ac) {
+                    // Add an object to the ledger for account A1, then delete
+                    // A1
+                    auto const a1 = A1.id();
                     auto sleA1 = ac.view().peek(keylet::account(a1));
                     if (!sleA1)
                         return false;

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -302,7 +302,6 @@ class Invariants_test : public beast::unit_test::Suite
 
         doInvariantCheck(
             {{"account deletion left behind a non-zero balance"}},
-            // NOLINTNEXTLINE(readability-identifier-naming)
             [&](Account const& A1, Account const& A2, ApplyContext& ac) {
                 // A1 has a balance. Delete A1
                 auto const a1 = A1.id();

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -4549,7 +4549,7 @@ NetworkOPsImp::getBookPage(
                         uOfferOwnerID,
                         book.out.currency,
                         book.out.account,
-                        FreezeHandling::fhZERO_IF_FROZEN);
+                        FreezeHandling::ZeroIfFrozen);
 
                     if (saOwnerFunds.isNegative())
                     {

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -395,7 +395,7 @@ TxQ::canBeHeld(
     // PreviousTxnID is deprecated and should never be used.
     // AccountTxnID is not supported by the transaction
     // queue yet, but should be added in the future.
-    // tapFAIL_HARD transactions are never held
+    // TapFailHard transactions are never held
     if (tx.isFieldPresent(sfPreviousTxnID) || tx.isFieldPresent(sfAccountTxnID) ||
         ((flags & TapFailHard) != 0u))
         return telCAN_NOT_QUEUE;


### PR DESCRIPTION
## High Level Overview of Change

This PR mostly fixes old variable names in comments, but also renames some variables to be more descriptive.

No functionality changes, mostly just comment changes but all source code changes are pure refactors.

### Context of Change

General cleanup, pulled out of #6620

### API Impact

N/A