### PR TITLE
refactor: Rename `account_` to `accountID_`

### DIFF
--- a/include/xrpl/tx/Transactor.h
+++ b/include/xrpl/tx/Transactor.h
@@ -115,7 +115,7 @@ protected:
     beast::WrappedSink sink_;
     beast::Journal const j_;
 
-    AccountID const account_;
+    AccountID const accountID_;
     XRPAmount preFeeBalance_{};  // Balance before fees.
 
 public:

--- a/include/xrpl/tx/paths/Offer.h
+++ b/include/xrpl/tx/paths/Offer.h
@@ -21,7 +21,7 @@ class TOffer
 private:
     SLE::pointer entry_;
     Quality quality_{};
-    AccountID account_;
+    AccountID accountID_;
     Asset assetIn_;
     Asset assetOut_;
 
@@ -53,7 +53,7 @@ public:
     [[nodiscard]] AccountID const&
     owner() const
     {
-        return account_;
+        return accountID_;
     }
 
     /** Returns the in and out amounts.
@@ -122,7 +122,7 @@ public:
     isFunded() const
     {
         // Offer owner is issuer; they have unlimited funds if IOU
-        return account_ == assetOut_.getIssuer() && assetOut_.holds<Issue>();
+        return accountID_ == assetOut_.getIssuer() && assetOut_.holds<Issue>();
     }
 
     static std::pair<std::uint32_t, std::uint32_t>
@@ -159,7 +159,7 @@ public:
 
 template <StepAmount TIn, StepAmount TOut>
 TOffer<TIn, TOut>::TOffer(SLE::pointer entry, Quality quality)
-    : entry_(std::move(entry)), quality_(quality), account_(entry_->getAccountID(sfAccount))
+    : entry_(std::move(entry)), quality_(quality), accountID_(entry_->getAccountID(sfAccount))
 {
     auto const tp = entry_->getFieldAmount(sfTakerPays);
     auto const tg = entry_->getFieldAmount(sfTakerGets);

--- a/include/xrpl/tx/transactors/dex/AMMContext.h
+++ b/include/xrpl/tx/transactors/dex/AMMContext.h
@@ -22,7 +22,7 @@ public:
 
 private:
     // Tx account owner is required to get the AMM trading fee in BookStep
-    AccountID account_;
+    AccountID accountID_;
     // true if payment has multiple paths
     bool multiPath_{false};
     // Is true if AMM offer is consumed during a payment engine iteration.
@@ -31,7 +31,8 @@ private:
     std::uint16_t ammIters_{0};
 
 public:
-    AMMContext(AccountID const& account, bool multiPath) : account_(account), multiPath_(multiPath)
+    AMMContext(AccountID const& account, bool multiPath)
+        : accountID_(account), multiPath_(multiPath)
     {
     }
     ~AMMContext() = default;
@@ -80,7 +81,7 @@ public:
     [[nodiscard]] AccountID
     account() const
     {
-        return account_;
+        return accountID_;
     }
 
     /** Strand execution may fail. Reset the flag at the start

--- a/src/libxrpl/tx/Transactor.cpp
+++ b/src/libxrpl/tx/Transactor.cpp
@@ -262,7 +262,7 @@ Transactor::Transactor(ApplyContext& ctx)
     : ctx_(ctx)
     , sink_(ctx.journal, toShortString(ctx.tx.getTransactionID()) + " ")
     , j_(sink_)
-    , account_(ctx.tx.getAccountID(sfAccount))
+    , accountID_(ctx.tx.getAccountID(sfAccount))
 {
 }
 
@@ -431,7 +431,7 @@ Transactor::payFee()
     // Deduct the fee, so it's not available during the transaction.
     // Will only write the account back if the transaction succeeds.
     sle->setFieldAmount(sfBalance, sle->getFieldAmount(sfBalance) - feePaid);
-    if (feePayer != account_)
+    if (feePayer != accountID_)
         view().update(sle);  // done in `apply()` for the account
 
     // VFALCO Should we call view().rawDestroyXRP() here as well?
@@ -544,7 +544,7 @@ Transactor::consumeSeqProxy(SLE::pointer const& sleAccount)
         sleAccount->setFieldU32(sfSequence, seqProx.value() + 1);
         return tesSUCCESS;
     }
-    return ticketDelete(view(), account_, getTicketIndex(account_, seqProx), j_);
+    return ticketDelete(view(), accountID_, getTicketIndex(accountID_, seqProx), j_);
 }
 
 // Remove a single Ticket from the ledger.
@@ -617,7 +617,7 @@ Transactor::ticketDelete(
 void
 Transactor::preCompute()
 {
-    XRPL_ASSERT(account_ != beast::kZero, "xrpl::Transactor::preCompute : nonzero account");
+    XRPL_ASSERT(accountID_ != beast::kZero, "xrpl::Transactor::preCompute : nonzero account");
 }
 
 TER
@@ -627,12 +627,12 @@ Transactor::apply()
 
     // If the transactor requires a valid account and the transaction doesn't
     // list one, preflight will have already a flagged a failure.
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peek(keylet::account(accountID_));
 
     // sle must exist except for transactions
     // that allow zero account.
     XRPL_ASSERT(
-        sle != nullptr || account_ == beast::kZero,
+        sle != nullptr || accountID_ == beast::kZero,
         "xrpl::Transactor::apply : non-null SLE or zero account");
 
     if (sle)

--- a/src/libxrpl/tx/transactors/account/AccountDelete.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountDelete.cpp
@@ -344,7 +344,7 @@ AccountDelete::preclaim(PreclaimContext const& ctx)
 TER
 AccountDelete::doApply()
 {
-    auto src = view().peek(keylet::account(account_));
+    auto src = view().peek(keylet::account(accountID_));
     XRPL_ASSERT(src, "xrpl::AccountDelete::doApply : non-null source account");
 
     auto const dstID = ctx_.tx[sfDestination];
@@ -357,12 +357,12 @@ AccountDelete::doApply()
     if (ctx_.tx.isFieldPresent(sfCredentialIDs))
     {
         if (auto err =
-                verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, dstID, dst, ctx_.journal);
+                verifyDepositPreauth(ctx_.tx, ctx_.view(), accountID_, dstID, dst, ctx_.journal);
             !isTesSuccess(err))
             return err;
     }
 
-    Keylet const ownerDirKeylet{keylet::ownerDir(account_)};
+    Keylet const ownerDirKeylet{keylet::ownerDir(accountID_)};
     auto const ter = cleanupOnAccountDelete(
         view(),
         ownerDirKeylet,
@@ -371,7 +371,7 @@ AccountDelete::doApply()
             std::shared_ptr<SLE>& sleItem) -> std::pair<TER, SkipEntry> {
             if (auto deleter = nonObligationDeleter(nodeType))
             {
-                TER const result{deleter(ctx_.registry, view(), account_, dirEntry, sleItem, j_)};
+                TER const result{deleter(ctx_.registry, view(), accountID_, dirEntry, sleItem, j_)};
 
                 return {result, SkipEntry::No};
             }
@@ -402,7 +402,7 @@ AccountDelete::doApply()
     // delete it.
     if (view().exists(ownerDirKeylet) && !view().emptyDirDelete(ownerDirKeylet))
     {
-        JLOG(j_.error()) << "AccountDelete cannot delete root dir node of " << toBase58(account_);
+        JLOG(j_.error()) << "AccountDelete cannot delete root dir node of " << toBase58(accountID_);
         return tecHAS_OBLIGATIONS;
     }
 

--- a/src/libxrpl/tx/transactors/account/AccountSet.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountSet.cpp
@@ -279,7 +279,7 @@ AccountSet::preclaim(PreclaimContext const& ctx)
 TER
 AccountSet::doApply()
 {
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peek(keylet::account(accountID_));
     if (!sle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -298,7 +298,7 @@ AccountSet::doApply()
     bool const bSetDisallowXRP{tx.isFlag(tfDisallowXRP) || (uSetFlag == asfDisallowXRP)};
     bool const bClearDisallowXRP{tx.isFlag(tfAllowXRP) || (uClearFlag == asfDisallowXRP)};
 
-    bool const sigWithMaster{[&tx, &acct = account_]() {
+    bool const sigWithMaster{[&tx, &acct = accountID_]() {
         auto const spk = tx.getSigningPubKey();
 
         if (publicKeyType(makeSlice(spk)))
@@ -367,7 +367,7 @@ AccountSet::doApply()
             return tecNEED_MASTER_KEY;
         }
 
-        if ((!sle->isFieldPresent(sfRegularKey)) && (!view().peek(keylet::signers(account_))))
+        if ((!sle->isFieldPresent(sfRegularKey)) && (!view().peek(keylet::signers(accountID_))))
         {
             // Account has no regular key or multi-signer signer list.
             return tecNO_ALTERNATIVE_KEY;

--- a/src/libxrpl/tx/transactors/account/SetRegularKey.cpp
+++ b/src/libxrpl/tx/transactors/account/SetRegularKey.cpp
@@ -55,7 +55,7 @@ SetRegularKey::preflight(PreflightContext const& ctx)
 TER
 SetRegularKey::doApply()
 {
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peek(keylet::account(accountID_));
     if (!sle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -69,7 +69,7 @@ SetRegularKey::doApply()
     else
     {
         // Account has disabled master key and no multi-signer signer list.
-        if (sle->isFlag(lsfDisableMaster) && !view().peek(keylet::signers(account_)))
+        if (sle->isFlag(lsfDisableMaster) && !view().peek(keylet::signers(accountID_)))
             return tecNO_ALTERNATIVE_KEY;
 
         sle->makeFieldAbsent(sfRegularKey);

--- a/src/libxrpl/tx/transactors/account/SignerListSet.cpp
+++ b/src/libxrpl/tx/transactors/account/SignerListSet.cpp
@@ -300,9 +300,9 @@ SignerListSet::validateQuorumAndSignerEntries(
 TER
 SignerListSet::replaceSignerList()
 {
-    auto const accountKeylet = keylet::account(account_);
-    auto const ownerDirKeylet = keylet::ownerDir(account_);
-    auto const signerListKeylet = keylet::signers(account_);
+    auto const accountKeylet = keylet::account(accountID_);
+    auto const ownerDirKeylet = keylet::ownerDir(accountID_);
+    auto const signerListKeylet = keylet::signers(accountID_);
 
     // This may be either a create or a replace.  Preemptively remove any
     // old signer list.  May reduce the reserve, so this is done before
@@ -337,9 +337,9 @@ SignerListSet::replaceSignerList()
     auto viewJ = ctx_.registry.get().getJournal("View");
     // Add the signer list to the account's directory.
     auto const page =
-        ctx_.view().dirInsert(ownerDirKeylet, signerListKeylet, describeOwnerDir(account_));
+        ctx_.view().dirInsert(ownerDirKeylet, signerListKeylet, describeOwnerDir(accountID_));
 
-    JLOG(j_.trace()) << "Create signer list for account " << toBase58(account_) << ": "
+    JLOG(j_.trace()) << "Create signer list for account " << toBase58(accountID_) << ": "
                      << (page ? "success" : "failure");
 
     if (!page)
@@ -356,7 +356,7 @@ SignerListSet::replaceSignerList()
 TER
 SignerListSet::destroySignerList()
 {
-    auto const accountKeylet = keylet::account(account_);
+    auto const accountKeylet = keylet::account(accountID_);
     // Destroying the signer list is only allowed if either the master key
     // is enabled or there is a regular key.
     SLE::pointer const ledgerEntry = view().peek(accountKeylet);
@@ -366,8 +366,8 @@ SignerListSet::destroySignerList()
     if ((ledgerEntry->isFlag(lsfDisableMaster)) && (!ledgerEntry->isFieldPresent(sfRegularKey)))
         return tecNO_ALTERNATIVE_KEY;
 
-    auto const ownerDirKeylet = keylet::ownerDir(account_);
-    auto const signerListKeylet = keylet::signers(account_);
+    auto const ownerDirKeylet = keylet::ownerDir(accountID_);
+    auto const signerListKeylet = keylet::signers(accountID_);
     return removeSignersFromLedger(
         ctx_.registry, view(), accountKeylet, ownerDirKeylet, signerListKeylet, j_);
 }
@@ -378,7 +378,7 @@ SignerListSet::writeSignersToSLE(SLE::pointer const& ledgerEntry, std::uint32_t 
     // Assign the quorum, default SignerListID, and flags.
     if (ctx_.view().rules().enabled(fixIncludeKeyletFields))
     {
-        ledgerEntry->setAccountID(sfOwner, account_);
+        ledgerEntry->setAccountID(sfOwner, accountID_);
     }
     ledgerEntry->setFieldU32(sfSignerQuorum, quorum_);
     ledgerEntry->setFieldU32(sfSignerListID, kDefaultSignerListId);

--- a/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
+++ b/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
@@ -1920,7 +1920,7 @@ XChainCommit::doApply()
 
     // Support dipping into reserves to pay the fee
     TransferHelperSubmittingAccountInfo submittingAccountInfo{
-        .account = account_,
+        .account = accountID_,
         .preFeeBalance = preFeeBalance_,
         .postFeeBalance = (*sleAccount)[sfBalance]};
 
@@ -2197,7 +2197,9 @@ XChainCreateAccountCommit::doApply()
 
     // Support dipping into reserves to pay the fee
     TransferHelperSubmittingAccountInfo submittingAccountInfo{
-        .account = account_, .preFeeBalance = preFeeBalance_, .postFeeBalance = (*sle)[sfBalance]};
+        .account = accountID_,
+        .preFeeBalance = preFeeBalance_,
+        .postFeeBalance = (*sle)[sfBalance]};
     STAmount const toTransfer = amount + reward;
     auto const thTer = transferHelper(
         psb,

--- a/src/libxrpl/tx/transactors/check/CheckCash.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCash.cpp
@@ -294,7 +294,7 @@ CheckCash::doApply()
     }
 
     AccountID const srcId{sleCheck->getAccountID(sfAccount)};
-    if (!psb.exists(keylet::account(srcId)) || !psb.exists(keylet::account(account_)))
+    if (!psb.exists(keylet::account(srcId)) || !psb.exists(keylet::account(accountID_)))
     {
         // LCOV_EXCL_START
         JLOG(ctx_.journal.fatal()) << "Precheck did not verify source or destination's existence.";
@@ -315,7 +315,7 @@ CheckCash::doApply()
     auto viewJ = ctx_.registry.get().getJournal("View");
     auto const optDeliverMin = ctx_.tx[~sfDeliverMin];
 
-    if (srcId != account_)
+    if (srcId != accountID_)
     {
         STAmount const sendMax = sleCheck->at(sfSendMax);
 
@@ -353,7 +353,7 @@ CheckCash::doApply()
             }
 
             // The source account has enough XRP so make the ledger change.
-            if (TER const ter{transferXRP(psb, srcId, account_, xrpDeliver, viewJ)};
+            if (TER const ter{transferXRP(psb, srcId, accountID_, xrpDeliver, viewJ)};
                 !isTesSuccess(ter))
             {
                 // The transfer failed.  Return the error code.
@@ -383,7 +383,7 @@ CheckCash::doApply()
             // Check reserve. Return destination account SLE if enough reserve,
             // otherwise return nullptr.
             auto checkReserve = [&]() -> std::shared_ptr<SLE> {
-                auto sleDst = psb.peek(keylet::account(account_));
+                auto sleDst = psb.peek(keylet::account(accountID_));
 
                 // Can the account cover the trust line's or MPT reserve?
                 if (std::uint32_t const ownerCount = {sleDst->at(sfOwnerCount)};
@@ -405,9 +405,9 @@ CheckCash::doApply()
                 [&](Issue const& issue) -> std::optional<TER> {
                     // If a trust line does not exist yet create one.
                     Issue const& trustLineIssue = issue;
-                    AccountID const truster = deliverIssuer == account_ ? srcId : account_;
+                    AccountID const truster = deliverIssuer == accountID_ ? srcId : accountID_;
                     trustLineKey = keylet::line(truster, trustLineIssue);
-                    destLow = deliverIssuer > account_;
+                    destLow = deliverIssuer > accountID_;
 
                     if (!psb.exists(*trustLineKey))
                     {
@@ -433,7 +433,7 @@ CheckCash::doApply()
                                 psb,                                // payment sandbox
                                 destLow,                            // is dest low?
                                 deliverIssuer,                      // source
-                                account_,                           // destination
+                                accountID_,                         // destination
                                 trustLineKey->key,                  // ledger index
                                 sleDst,                             // Account to add to
                                 false,                              // authorize account
@@ -441,7 +441,7 @@ CheckCash::doApply()
                                 false,                              // freeze trust line
                                 false,                              // deep freeze trust line
                                 initialBalance,                     // zero initial balance
-                                Issue(currency, account_),          // limit of zero
+                                Issue(currency, accountID_),        // limit of zero
                                 0,                                  // quality in
                                 0,                                  // quality out
                                 viewJ);                             // journal
@@ -479,18 +479,18 @@ CheckCash::doApply()
                     return std::nullopt;
                 },
                 [&](MPTIssue const& issue) -> std::optional<TER> {
-                    if (account_ != deliverIssuer)
+                    if (accountID_ != deliverIssuer)
                     {
                         auto const& mptID = issue.getMptID();
                         // Create MPT if it doesn't exist
-                        auto const mptokenKey = keylet::mptoken(mptID, account_);
+                        auto const mptokenKey = keylet::mptoken(mptID, accountID_);
                         if (!psb.exists(mptokenKey))
                         {
                             auto sleDst = checkReserve();
                             if (sleDst == nullptr)
                                 return tecINSUFFICIENT_RESERVE;
 
-                            if (auto const err = checkCreateMPT(psb, mptID, account_, j_);
+                            if (auto const err = checkCreateMPT(psb, mptID, accountID_, j_);
                                 !isTesSuccess(err))
                             {
                                 return err;
@@ -518,7 +518,7 @@ CheckCash::doApply()
                 psb,
                 flowDeliver,
                 srcId,
-                account_,
+                accountID_,
                 STPathSet{},
                 true,                              // default path
                 static_cast<bool>(optDeliverMin),  // partial payment
@@ -556,9 +556,9 @@ CheckCash::doApply()
 
     // Check was cashed.  If not a self send (and it shouldn't be), remove
     // check link from destination directory.
-    if (srcId != account_ &&
+    if (srcId != accountID_ &&
         !psb.dirRemove(
-            keylet::ownerDir(account_), sleCheck->at(sfDestinationNode), sleCheck->key(), true))
+            keylet::ownerDir(accountID_), sleCheck->at(sfDestinationNode), sleCheck->key(), true))
     {
         // LCOV_EXCL_START
         JLOG(j_.fatal()) << "Unable to delete check from destination.";

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -175,7 +175,7 @@ CheckCreate::preclaim(PreclaimContext const& ctx)
 TER
 CheckCreate::doApply()
 {
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peek(keylet::account(accountID_));
     if (!sle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -192,10 +192,10 @@ CheckCreate::doApply()
     // Note that we use the value from the sequence or ticket as the
     // Check sequence.  For more explanation see comments in SeqProxy.h.
     std::uint32_t const seq = ctx_.tx.getSeqValue();
-    Keylet const checkKeylet = keylet::check(account_, seq);
+    Keylet const checkKeylet = keylet::check(accountID_, seq);
     auto sleCheck = std::make_shared<SLE>(checkKeylet);
 
-    sleCheck->setAccountID(sfAccount, account_);
+    sleCheck->setAccountID(sfAccount, accountID_);
     AccountID const dstAccountId = ctx_.tx[sfDestination];
     sleCheck->setAccountID(sfDestination, dstAccountId);
     sleCheck->setFieldU32(sfSequence, seq);
@@ -214,7 +214,7 @@ CheckCreate::doApply()
     auto viewJ = ctx_.registry.get().getJournal("View");
     // If it's not a self-send (and it shouldn't be), add Check to the
     // destination's owner directory.
-    if (dstAccountId != account_)
+    if (dstAccountId != accountID_)
     {
         auto const page = view().dirInsert(
             keylet::ownerDir(dstAccountId), checkKeylet, describeOwnerDir(dstAccountId));
@@ -229,8 +229,8 @@ CheckCreate::doApply()
     }
 
     {
-        auto const page =
-            view().dirInsert(keylet::ownerDir(account_), checkKeylet, describeOwnerDir(account_));
+        auto const page = view().dirInsert(
+            keylet::ownerDir(accountID_), checkKeylet, describeOwnerDir(accountID_));
 
         JLOG(j_.trace()) << "Adding Check to owner directory " << to_string(checkKeylet.key) << ": "
                          << (page ? "success" : "failure");

--- a/src/libxrpl/tx/transactors/credentials/CredentialAccept.cpp
+++ b/src/libxrpl/tx/transactors/credentials/CredentialAccept.cpp
@@ -89,7 +89,7 @@ CredentialAccept::doApply()
     AccountID const issuer{ctx_.tx[sfIssuer]};
 
     // Both exist as credential object exist itself (checked in preclaim)
-    auto const sleSubject = view().peek(keylet::account(account_));
+    auto const sleSubject = view().peek(keylet::account(accountID_));
     auto const sleIssuer = view().peek(keylet::account(issuer));
 
     if (!sleSubject || !sleIssuer)
@@ -103,7 +103,7 @@ CredentialAccept::doApply()
     }
 
     auto const credType(ctx_.tx[sfCredentialType]);
-    Keylet const credentialKey = keylet::credential(account_, issuer, credType);
+    Keylet const credentialKey = keylet::credential(accountID_, issuer, credType);
     auto const sleCred = view().peek(credentialKey);  // Checked in preclaim()
     if (!sleCred)
         return tefINTERNAL;  // LCOV_EXCL_LINE

--- a/src/libxrpl/tx/transactors/credentials/CredentialCreate.cpp
+++ b/src/libxrpl/tx/transactors/credentials/CredentialCreate.cpp
@@ -104,7 +104,7 @@ CredentialCreate::doApply()
 {
     auto const subject = ctx_.tx[sfSubject];
     auto const credType(ctx_.tx[sfCredentialType]);
-    Keylet const credentialKey = keylet::credential(subject, account_, credType);
+    Keylet const credentialKey = keylet::credential(subject, accountID_, credType);
 
     auto const sleCred = std::make_shared<SLE>(credentialKey);
     if (!sleCred)
@@ -126,7 +126,7 @@ CredentialCreate::doApply()
         sleCred->setFieldU32(sfExpiration, *optExp);
     }
 
-    auto const sleIssuer = view().peek(keylet::account(account_));
+    auto const sleIssuer = view().peek(keylet::account(accountID_));
     if (!sleIssuer)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -138,15 +138,15 @@ CredentialCreate::doApply()
     }
 
     sleCred->setAccountID(sfSubject, subject);
-    sleCred->setAccountID(sfIssuer, account_);
+    sleCred->setAccountID(sfIssuer, accountID_);
     sleCred->setFieldVL(sfCredentialType, credType);
 
     if (ctx_.tx.isFieldPresent(sfURI))
         sleCred->setFieldVL(sfURI, ctx_.tx.getFieldVL(sfURI));
 
     {
-        auto const page =
-            view().dirInsert(keylet::ownerDir(account_), credentialKey, describeOwnerDir(account_));
+        auto const page = view().dirInsert(
+            keylet::ownerDir(accountID_), credentialKey, describeOwnerDir(accountID_));
         JLOG(j_.trace()) << "Adding Credential to owner directory " << to_string(credentialKey.key)
                          << ": " << (page ? "success" : "failure");
         if (!page)
@@ -156,7 +156,7 @@ CredentialCreate::doApply()
         adjustOwnerCount(view(), sleIssuer, 1, j_);
     }
 
-    if (subject == account_)
+    if (subject == accountID_)
     {
         sleCred->setFieldU32(sfFlags, lsfAccepted);
     }

--- a/src/libxrpl/tx/transactors/credentials/CredentialDelete.cpp
+++ b/src/libxrpl/tx/transactors/credentials/CredentialDelete.cpp
@@ -78,15 +78,15 @@ CredentialDelete::preclaim(PreclaimContext const& ctx)
 TER
 CredentialDelete::doApply()
 {
-    auto const subject = ctx_.tx[~sfSubject].value_or(account_);
-    auto const issuer = ctx_.tx[~sfIssuer].value_or(account_);
+    auto const subject = ctx_.tx[~sfSubject].value_or(accountID_);
+    auto const issuer = ctx_.tx[~sfIssuer].value_or(accountID_);
 
     auto const credType(ctx_.tx[sfCredentialType]);
     auto const sleCred = view().peek(keylet::credential(subject, issuer, credType));
     if (!sleCred)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    if ((subject != account_) && (issuer != account_) &&
+    if ((subject != accountID_) && (issuer != accountID_) &&
         !checkExpired(*sleCred, ctx_.view().header().parentCloseTime))
     {
         JLOG(j_.trace()) << "Can't delete non-expired credential.";

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -68,12 +68,12 @@ DelegateSet::preclaim(PreclaimContext const& ctx)
 TER
 DelegateSet::doApply()
 {
-    auto const sleOwner = ctx_.view().peek(keylet::account(account_));
+    auto const sleOwner = ctx_.view().peek(keylet::account(accountID_));
     if (!sleOwner)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
     auto const& authAccount = ctx_.tx[sfAuthorize];
-    auto const delegateKey = keylet::delegate(account_, authAccount);
+    auto const delegateKey = keylet::delegate(accountID_, authAccount);
 
     auto sle = ctx_.view().peek(delegateKey);
     if (sle)
@@ -101,14 +101,14 @@ DelegateSet::doApply()
         return tecINSUFFICIENT_RESERVE;
 
     sle = std::make_shared<SLE>(delegateKey);
-    sle->setAccountID(sfAccount, account_);
+    sle->setAccountID(sfAccount, accountID_);
     sle->setAccountID(sfAuthorize, authAccount);
 
     sle->setFieldArray(sfPermissions, permissions);
 
     // Add to delegating account's owner directory
-    auto const page =
-        ctx_.view().dirInsert(keylet::ownerDir(account_), delegateKey, describeOwnerDir(account_));
+    auto const page = ctx_.view().dirInsert(
+        keylet::ownerDir(accountID_), delegateKey, describeOwnerDir(accountID_));
 
     if (!page)
         return tecDIR_FULL;  // LCOV_EXCL_LINE

--- a/src/libxrpl/tx/transactors/dex/AMMBid.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMBid.cpp
@@ -371,7 +371,7 @@ AMMBid::doApply()
     // as we go on processing transactions.
     Sandbox sb(&ctx_.view());
 
-    auto const result = applyBid(ctx_, sb, account_, j_);
+    auto const result = applyBid(ctx_, sb, accountID_, j_);
     if (result.second)
         sb.apply(ctx_.rawView());
 

--- a/src/libxrpl/tx/transactors/dex/AMMCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMCreate.cpp
@@ -385,7 +385,7 @@ AMMCreate::doApply()
     // as we go on processing transactions.
     Sandbox sb(&ctx_.view());
 
-    auto const result = applyCreate(ctx_, sb, account_, j_);
+    auto const result = applyCreate(ctx_, sb, accountID_, j_);
     if (result.second)
         sb.apply(ctx_.rawView());
 

--- a/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMDeposit.cpp
@@ -403,7 +403,7 @@ AMMDeposit::applyGuts(Sandbox& sb)
     auto const [amountBalance, amount2Balance, lptAMMBalance] = *expected;
     auto const tfee = (lptAMMBalance == beast::kZero)
         ? ctx_.tx[~sfTradingFee].value_or(0)
-        : getTradingFee(ctx_.view(), *ammSle, account_);
+        : getTradingFee(ctx_.view(), *ammSle, accountID_);
 
     auto const subTxType = ctx_.tx.getFlags() & tfDepositSubTx;
 
@@ -474,7 +474,7 @@ AMMDeposit::applyGuts(Sandbox& sb)
         // LP depositing into AMM empty state gets the auction slot
         // and the voting
         if (lptAMMBalance == beast::kZero)
-            initializeFeeAuctionVote(sb, ammSle, account_, lptAMMBalance.asset(), tfee);
+            initializeFeeAuctionVote(sb, ammSle, accountID_, lptAMMBalance.asset(), tfee);
 
         sb.update(ammSle);
     }
@@ -519,14 +519,14 @@ AMMDeposit::deposit(
         {
             auto const& lpIssue = lpTokensDeposit.get<Issue>();
             // Adjust the reserve if LP doesn't have LPToken trustline
-            auto const sle = view.read(keylet::line(account_, lpIssue.account, lpIssue.currency));
-            if (xrpLiquid(view, account_, !sle, j_) >= depositAmount)
+            auto const sle = view.read(keylet::line(accountID_, lpIssue.account, lpIssue.currency));
+            if (xrpLiquid(view, accountID_, !sle, j_) >= depositAmount)
                 return tesSUCCESS;
         }
         else if (
             accountFunds(
                 view,
-                account_,
+                accountID_,
                 depositAmount,
                 FreezeHandling::IgnoreFreeze,
                 AuthHandling::IgnoreAuth,
@@ -574,7 +574,7 @@ AMMDeposit::deposit(
     }
 
     auto res = accountSend(
-        view, account_, ammAccount, amountDepositActual, ctx_.journal, WaiveTransferFee::Yes);
+        view, accountID_, ammAccount, amountDepositActual, ctx_.journal, WaiveTransferFee::Yes);
     if (!isTesSuccess(res))
     {
         JLOG(ctx_.journal.debug()) << "AMM Deposit: failed to deposit " << amountDepositActual;
@@ -593,7 +593,12 @@ AMMDeposit::deposit(
         }
 
         res = accountSend(
-            view, account_, ammAccount, *amount2DepositActual, ctx_.journal, WaiveTransferFee::Yes);
+            view,
+            accountID_,
+            ammAccount,
+            *amount2DepositActual,
+            ctx_.journal,
+            WaiveTransferFee::Yes);
         if (!isTesSuccess(res))
         {
             JLOG(ctx_.journal.debug())
@@ -603,7 +608,7 @@ AMMDeposit::deposit(
     }
 
     // Deposit LP tokens
-    res = accountSend(view, ammAccount, account_, lpTokensDepositActual, ctx_.journal);
+    res = accountSend(view, ammAccount, accountID_, lpTokensDepositActual, ctx_.journal);
     if (!isTesSuccess(res))
     {
         JLOG(ctx_.journal.debug()) << "AMM Deposit: failed to deposit LPTokens";

--- a/src/libxrpl/tx/transactors/dex/AMMVote.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMVote.cpp
@@ -241,7 +241,7 @@ AMMVote::doApply()
     // as we go on processing transactions.
     Sandbox sb(&ctx_.view());
 
-    auto const result = applyVote(ctx_, sb, account_, j_);
+    auto const result = applyVote(ctx_, sb, accountID_, j_);
     if (result.second)
         sb.apply(ctx_.rawView());
 

--- a/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
@@ -329,11 +329,11 @@ AMMWithdraw::applyGuts(Sandbox& sb)
     // might not match the LP's trustline balance
     if (sb.rules().enabled(fixAMMv1_1))
     {
-        if (auto const res = verifyAndAdjustLPTokenBalance(sb, lpTokens, ammSle, account_); !res)
+        if (auto const res = verifyAndAdjustLPTokenBalance(sb, lpTokens, ammSle, accountID_); !res)
             return {res.error(), false};
     }
 
-    auto const tfee = getTradingFee(ctx_.view(), *ammSle, account_);
+    auto const tfee = getTradingFee(ctx_.view(), *ammSle, accountID_);
 
     auto const expected = ammHolds(
         sb,
@@ -458,7 +458,7 @@ AMMWithdraw::withdraw(
         view,
         ammSle,
         ammAccount,
-        account_,
+        accountID_,
         amountBalance,
         amountWithdraw,
         amount2Withdraw,
@@ -748,7 +748,7 @@ AMMWithdraw::equalWithdrawTokens(
     std::tie(ter, newLPTokenBalance, std::ignore, std::ignore) = equalWithdrawTokens(
         view,
         ammSle,
-        account_,
+        accountID_,
         ammAccount,
         amountBalance,
         amount2Balance,

--- a/src/libxrpl/tx/transactors/dex/OfferCancel.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCancel.cpp
@@ -55,11 +55,11 @@ OfferCancel::doApply()
 {
     auto const offerSequence = ctx_.tx[sfOfferSequence];
 
-    auto const sle = view().read(keylet::account(account_));
+    auto const sle = view().read(keylet::account(accountID_));
     if (!sle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    if (auto sleOffer = view().peek(keylet::offer(account_, offerSequence)))
+    if (auto sleOffer = view().peek(keylet::offer(accountID_, offerSequence)))
     {
         JLOG(j_.debug()) << "Trying to cancel offer #" << offerSequence;
         return offerDelete(view(), sleOffer, ctx_.registry.get().getJournal("View"));

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -341,14 +341,14 @@ OfferCreate::flowCross(
         // below the reserve) so we check this case again.
         STAmount const inStartBalance = accountFunds(
             psb,
-            account_,
+            accountID_,
             takerAmount.in,
             FreezeHandling::ZeroIfFrozen,
             AuthHandling::ZeroIfUnauthorized,
             j_);
         // Allow unfunded MPT issuer
         auto const disallowUnfunded =
-            !inStartBalance.holds<MPTIssue>() || inStartBalance.getIssuer() != account_;
+            !inStartBalance.holds<MPTIssue>() || inStartBalance.getIssuer() != accountID_;
         if (disallowUnfunded && inStartBalance <= beast::kZero)
         {
             // The account balance can't cover even part of the offer.
@@ -361,7 +361,7 @@ OfferCreate::flowCross(
         // offer taker.  Set sendMax to allow for the gateway's cut.
         Rate gatewayXferRate{QUALITY_ONE};
         STAmount sendMax = takerAmount.in;
-        if (!sendMax.native() && (account_ != sendMax.getIssuer()))
+        if (!sendMax.native() && (accountID_ != sendMax.getIssuer()))
         {
             gatewayXferRate = transferRate(psb, sendMax);
             if (gatewayXferRate.value != QUALITY_ONE)
@@ -428,8 +428,8 @@ OfferCreate::flowCross(
         auto const result = flow(
             psb,
             deliver,
-            account_,
-            account_,
+            accountID_,
+            accountID_,
             paths,
             true,                           // default path
             !ctx_.tx.isFlag(tfFillOrKill),  // partial payment
@@ -455,7 +455,7 @@ OfferCreate::flowCross(
         {
             STAmount const takerInBalance = accountFunds(
                 psb,
-                account_,
+                accountID_,
                 takerAmount.in,
                 FreezeHandling::ZeroIfFrozen,
                 AuthHandling::ZeroIfUnauthorized,
@@ -619,7 +619,7 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
     // Process a cancellation request that's passed along with an offer.
     if (cancelSequence)
     {
-        auto const sleCancel = sb.peek(keylet::offer(account_, *cancelSequence));
+        auto const sleCancel = sb.peek(keylet::offer(accountID_, *cancelSequence));
 
         // It's not an error to not find the offer to cancel: it might have
         // been consumed or removed. If it is found, however, it's an error
@@ -810,7 +810,7 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
         return {tesSUCCESS, true};
     }
 
-    auto const sleCreator = sb.peek(keylet::account(account_));
+    auto const sleCreator = sb.peek(keylet::account(accountID_));
     if (!sleCreator)
         return {tefINTERNAL, false};
 
@@ -836,11 +836,11 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
     }
 
     // We need to place the remainder of the offer into its order book.
-    auto const offerIndex = keylet::offer(account_, offerSequence);
+    auto const offerIndex = keylet::offer(accountID_, offerSequence);
 
     // Add offer to owner's directory.
     auto const ownerNode =
-        sb.dirInsert(keylet::ownerDir(account_), offerIndex, describeOwnerDir(account_));
+        sb.dirInsert(keylet::ownerDir(accountID_), offerIndex, describeOwnerDir(accountID_));
 
     if (!ownerNode)
     {
@@ -905,7 +905,7 @@ OfferCreate::applyGuts(Sandbox& sb, Sandbox& sbCancel)
     }
 
     auto sleOffer = std::make_shared<SLE>(offerIndex);
-    sleOffer->setAccountID(sfAccount, account_);
+    sleOffer->setAccountID(sfAccount, accountID_);
     sleOffer->setFieldU32(sfSequence, offerSequence);
     sleOffer->setFieldH256(sfBookDirectory, dir.key);
     sleOffer->setFieldAmount(sfTakerPays, saTakerPays);

--- a/src/libxrpl/tx/transactors/did/DIDDelete.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDDelete.cpp
@@ -67,7 +67,7 @@ DIDDelete::deleteSLE(
 TER
 DIDDelete::doApply()
 {
-    return deleteSLE(ctx_, keylet::did(account_), account_);
+    return deleteSLE(ctx_, keylet::did(accountID_), accountID_);
 }
 
 void

--- a/src/libxrpl/tx/transactors/did/DIDSet.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDSet.cpp
@@ -99,7 +99,7 @@ TER
 DIDSet::doApply()
 {
     // Edit ledger object if it already exists
-    Keylet const didKeylet = keylet::did(account_);
+    Keylet const didKeylet = keylet::did(accountID_);
     if (auto const sleDID = ctx_.view().peek(didKeylet))
     {
         auto update = [&](auto const& sField) {
@@ -130,7 +130,7 @@ DIDSet::doApply()
 
     // Create new ledger object otherwise
     auto const sleDID = std::make_shared<SLE>(didKeylet);
-    (*sleDID)[sfAccount] = account_;
+    (*sleDID)[sfAccount] = accountID_;
 
     auto set = [&](auto const& sField) {
         if (auto const field = ctx_.tx[~sField]; field && !field->empty())
@@ -146,7 +146,7 @@ DIDSet::doApply()
         return tecEMPTY_DID;
     }
 
-    return addSLE(ctx_, sleDID, account_);
+    return addSLE(ctx_, sleDID, accountID_);
 }
 
 void

--- a/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCancel.cpp
@@ -178,7 +178,7 @@ EscrowCancel::doApply()
             return temDISABLED;  // LCOV_EXCL_LINE
 
         auto const issuer = amount.getIssuer();
-        bool const createAsset = account == account_;
+        bool const createAsset = account == accountID_;
         if (auto const ret = std::visit(
                 [&]<typename T>(T const&) {
                     return escrowUnlockApplyHelper<T>(

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -417,7 +417,7 @@ EscrowCreate::doApply()
     if (ctx_.tx[~sfFinishAfter] && after(closeTime, ctx_.tx[sfFinishAfter]))
         return tecNO_PERMISSION;
 
-    auto const sle = ctx_.view().peek(keylet::account(account_));
+    auto const sle = ctx_.view().peek(keylet::account(accountID_));
     if (!sle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -448,10 +448,10 @@ EscrowCreate::doApply()
 
     // Create escrow in ledger.  Note that we use the value from the
     // sequence or ticket.  For more explanation see comments in SeqProxy.h.
-    Keylet const escrowKeylet = keylet::escrow(account_, ctx_.tx.getSeqValue());
+    Keylet const escrowKeylet = keylet::escrow(accountID_, ctx_.tx.getSeqValue());
     auto const slep = std::make_shared<SLE>(escrowKeylet);
     (*slep)[sfAmount] = amount;
-    (*slep)[sfAccount] = account_;
+    (*slep)[sfAccount] = accountID_;
     (*slep)[~sfCondition] = ctx_.tx[~sfCondition];
     (*slep)[~sfSourceTag] = ctx_.tx[~sfSourceTag];
     (*slep)[sfDestination] = ctx_.tx[sfDestination];
@@ -476,7 +476,7 @@ EscrowCreate::doApply()
     // Add escrow to sender's owner directory
     {
         auto page = ctx_.view().dirInsert(
-            keylet::ownerDir(account_), escrowKeylet, describeOwnerDir(account_));
+            keylet::ownerDir(accountID_), escrowKeylet, describeOwnerDir(accountID_));
         if (!page)
             return tecDIR_FULL;  // LCOV_EXCL_LINE
         (*slep)[sfOwnerNode] = *page;
@@ -484,7 +484,7 @@ EscrowCreate::doApply()
 
     // If it's not a self-send, add escrow to recipient's owner directory.
     AccountID const dest = ctx_.tx[sfDestination];
-    if (dest != account_)
+    if (dest != accountID_)
     {
         auto page =
             ctx_.view().dirInsert(keylet::ownerDir(dest), escrowKeylet, describeOwnerDir(dest));
@@ -497,7 +497,7 @@ EscrowCreate::doApply()
     // track the total locked balance. For MPT, this isn't necessary because the
     // locked balance is already stored directly in the MPTokenIssuance object.
     AccountID const issuer = amount.getIssuer();
-    if (!isXRP(amount) && issuer != account_ && issuer != dest && !amount.holds<MPTIssue>())
+    if (!isXRP(amount) && issuer != accountID_ && issuer != dest && !amount.holds<MPTIssue>())
     {
         auto page =
             ctx_.view().dirInsert(keylet::ownerDir(issuer), escrowKeylet, describeOwnerDir(issuer));
@@ -515,7 +515,7 @@ EscrowCreate::doApply()
     {
         if (auto const ret = std::visit(
                 [&]<typename T>(T const&) {
-                    return escrowLockApplyHelper<T>(ctx_.view(), issuer, account_, amount, j_);
+                    return escrowLockApplyHelper<T>(ctx_.view(), issuer, accountID_, amount, j_);
                 },
                 amount.asset().value());
             !isTesSuccess(ret))

--- a/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowFinish.cpp
@@ -310,7 +310,8 @@ EscrowFinish::doApply()
     if (!sled)
         return tecNO_DST;
 
-    if (auto err = verifyDepositPreauth(ctx_.tx, ctx_.view(), account_, destID, sled, ctx_.journal);
+    if (auto err =
+            verifyDepositPreauth(ctx_.tx, ctx_.view(), accountID_, destID, sled, ctx_.journal);
         !isTesSuccess(err))
         return err;
 
@@ -355,7 +356,7 @@ EscrowFinish::doApply()
             ? xrpl::Rate(slep->getFieldU32(sfTransferRate))
             : kParityRate;
         auto const issuer = amount.getIssuer();
-        bool const createAsset = destID == account_;
+        bool const createAsset = destID == accountID_;
         if (auto const ret = std::visit(
                 [&]<typename T>(T const&) {
                     return escrowUnlockApplyHelper<T>(

--- a/src/libxrpl/tx/transactors/lending/LoanBrokerCoverDeposit.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerCoverDeposit.cpp
@@ -121,7 +121,8 @@ LoanBrokerCoverDeposit::doApply()
     auto const brokerPseudoID = broker->at(sfAccount);
 
     // Transfer assets from depositor to pseudo-account.
-    if (auto ter = accountSend(view(), account_, brokerPseudoID, amount, j_, WaiveTransferFee::Yes))
+    if (auto ter =
+            accountSend(view(), accountID_, brokerPseudoID, amount, j_, WaiveTransferFee::Yes))
         return ter;
 
     // Increase the LoanBroker's CoverAvailable by Amount

--- a/src/libxrpl/tx/transactors/lending/LoanBrokerCoverWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerCoverWithdraw.cpp
@@ -163,7 +163,7 @@ LoanBrokerCoverWithdraw::doApply()
 
     auto const brokerID = tx[sfLoanBrokerID];
     auto const amount = tx[sfAmount];
-    auto const dstAcct = tx[~sfDestination].value_or(account_);
+    auto const dstAcct = tx[~sfDestination].value_or(accountID_);
 
     auto broker = view().peek(keylet::loanbroker(brokerID));
     if (!broker)
@@ -183,7 +183,7 @@ LoanBrokerCoverWithdraw::doApply()
 
     associateAsset(*broker, vaultAsset);
 
-    return doWithdraw(view(), tx, account_, dstAcct, brokerPseudoID, preFeeBalance_, amount, j_);
+    return doWithdraw(view(), tx, accountID_, dstAcct, brokerPseudoID, preFeeBalance_, amount, j_);
 }
 
 void

--- a/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
@@ -130,7 +130,7 @@ LoanBrokerDelete::doApply()
     auto const brokerPseudoID = broker->at(sfAccount);
 
     if (!view().dirRemove(
-            keylet::ownerDir(account_), broker->at(sfOwnerNode), broker->key(), false))
+            keylet::ownerDir(accountID_), broker->at(sfOwnerNode), broker->key(), false))
     {
         return tefBAD_LEDGER;  // LCOV_EXCL_LINE
     }
@@ -143,7 +143,7 @@ LoanBrokerDelete::doApply()
     {
         auto const coverAvailable = STAmount{vaultAsset, broker->at(sfCoverAvailable)};
         if (auto const ter = accountSend(
-                view(), brokerPseudoID, account_, coverAvailable, j_, WaiveTransferFee::Yes))
+                view(), brokerPseudoID, accountID_, coverAvailable, j_, WaiveTransferFee::Yes))
             return ter;
     }
 
@@ -177,7 +177,7 @@ LoanBrokerDelete::doApply()
     view().erase(broker);
 
     {
-        auto owner = view().peek(keylet::account(account_));
+        auto owner = view().peek(keylet::account(accountID_));
         if (!owner)
             return tefBAD_LEDGER;  // LCOV_EXCL_LINE
 

--- a/src/libxrpl/tx/transactors/lending/LoanBrokerSet.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerSet.cpp
@@ -220,7 +220,7 @@ LoanBrokerSet::doApply()
         auto const vaultAsset = sleVault->at(sfAsset);
         auto const sequence = tx.getSeqValue();
 
-        auto owner = view.peek(keylet::account(account_));
+        auto owner = view.peek(keylet::account(accountID_));
         if (!owner)
         {
             // This should be impossible
@@ -229,9 +229,9 @@ LoanBrokerSet::doApply()
             return tefBAD_LEDGER;
             // LCOV_EXCL_STOP
         }
-        auto broker = std::make_shared<SLE>(keylet::loanbroker(account_, sequence));
+        auto broker = std::make_shared<SLE>(keylet::loanbroker(accountID_, sequence));
 
-        if (auto const ter = dirLink(view, account_, broker))
+        if (auto const ter = dirLink(view, accountID_, broker))
             return ter;  // LCOV_EXCL_LINE
         if (auto const ter = dirLink(view, vaultPseudoID, broker, sfVaultNode))
             return ter;  // LCOV_EXCL_LINE
@@ -255,7 +255,7 @@ LoanBrokerSet::doApply()
         // Initialize data fields:
         broker->at(sfSequence) = sequence;
         broker->at(sfVaultID) = vaultID;
-        broker->at(sfOwner) = account_;
+        broker->at(sfOwner) = accountID_;
         broker->at(sfAccount) = pseudoId;
         // The LoanSequence indexes loans created by this broker, starting at 1
         broker->at(sfLoanSequence) = 1;

--- a/src/libxrpl/tx/transactors/lending/LoanPay.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanPay.cpp
@@ -581,13 +581,13 @@ LoanPay::doApply()
     // These three values are used to check that funds are conserved after the transfers
     auto const accountBalanceBefore = accountHolds(
         view,
-        account_,
+        accountID_,
         asset,
         FreezeHandling::IgnoreFreeze,
         AuthHandling::IgnoreAuth,
         j_,
         SpendableHandling::FullBalance);
-    auto const vaultBalanceBefore = account_ == vaultPseudoAccount
+    auto const vaultBalanceBefore = accountID_ == vaultPseudoAccount
         ? STAmount{asset, 0}
         : accountHolds(
               view,
@@ -597,15 +597,16 @@ LoanPay::doApply()
               AuthHandling::IgnoreAuth,
               j_,
               SpendableHandling::FullBalance);
-    auto const brokerBalanceBefore = account_ == brokerPayee ? STAmount{asset, 0}
-                                                             : accountHolds(
-                                                                   view,
-                                                                   brokerPayee,
-                                                                   asset,
-                                                                   FreezeHandling::IgnoreFreeze,
-                                                                   AuthHandling::IgnoreAuth,
-                                                                   j_,
-                                                                   SpendableHandling::FullBalance);
+    auto const brokerBalanceBefore = accountID_ == brokerPayee
+        ? STAmount{asset, 0}
+        : accountHolds(
+              view,
+              brokerPayee,
+              asset,
+              FreezeHandling::IgnoreFreeze,
+              AuthHandling::IgnoreAuth,
+              j_,
+              SpendableHandling::FullBalance);
 
     if (totalPaidToVaultRounded != beast::kZero)
     {
@@ -615,7 +616,7 @@ LoanPay::doApply()
 
     if (totalPaidToBroker != beast::kZero)
     {
-        if (brokerPayee == account_)
+        if (brokerPayee == accountID_)
         {
             // The broker may have deleted their holding. Recreate it if needed
             if (auto const ter = addEmptyHolding(
@@ -633,7 +634,7 @@ LoanPay::doApply()
 
     if (auto const ter = accountSendMulti(
             view,
-            account_,
+            accountID_,
             asset,
             {{vaultPseudoAccount, totalPaidToVaultRounded}, {brokerPayee, totalPaidToBroker}},
             j_,
@@ -659,13 +660,13 @@ LoanPay::doApply()
     // Check that funds are conserved
     auto const accountBalanceAfter = accountHolds(
         view,
-        account_,
+        accountID_,
         asset,
         FreezeHandling::IgnoreFreeze,
         AuthHandling::IgnoreAuth,
         j_,
         SpendableHandling::FullBalance);
-    auto const vaultBalanceAfter = account_ == vaultPseudoAccount
+    auto const vaultBalanceAfter = accountID_ == vaultPseudoAccount
         ? STAmount{asset, 0}
         : accountHolds(
               view,
@@ -675,15 +676,15 @@ LoanPay::doApply()
               AuthHandling::IgnoreAuth,
               j_,
               SpendableHandling::FullBalance);
-    auto const brokerBalanceAfter = account_ == brokerPayee ? STAmount{asset, 0}
-                                                            : accountHolds(
-                                                                  view,
-                                                                  brokerPayee,
-                                                                  asset,
-                                                                  FreezeHandling::IgnoreFreeze,
-                                                                  AuthHandling::IgnoreAuth,
-                                                                  j_,
-                                                                  SpendableHandling::FullBalance);
+    auto const brokerBalanceAfter = accountID_ == brokerPayee ? STAmount{asset, 0}
+                                                              : accountHolds(
+                                                                    view,
+                                                                    brokerPayee,
+                                                                    asset,
+                                                                    FreezeHandling::IgnoreFreeze,
+                                                                    AuthHandling::IgnoreAuth,
+                                                                    j_,
+                                                                    SpendableHandling::FullBalance);
     auto const balanceScale = [&]() {
         // Find a reasonable scale to use for the balance comparisons.
         //
@@ -800,7 +801,7 @@ LoanPay::doApply()
         goodRounding, "xrpl::LoanPay::doApply", "funds are conserved (with rounding)");
 
     XRPL_ASSERT_PARTS(
-        accountBalanceAfter < accountBalanceBefore || account_ == asset.getIssuer(),
+        accountBalanceAfter < accountBalanceBefore || accountID_ == asset.getIssuer(),
         "xrpl::LoanPay::doApply",
         "account balance decreased");
     XRPL_ASSERT_PARTS(

--- a/src/libxrpl/tx/transactors/lending/LoanSet.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanSet.cpp
@@ -388,7 +388,7 @@ LoanSet::doApply()
     Asset const vaultAsset = vaultSle->at(sfAsset);
 
     auto const counterparty = tx[~sfCounterparty].value_or(brokerOwner);
-    auto const borrower = counterparty == brokerOwner ? account_ : counterparty;
+    auto const borrower = counterparty == brokerOwner ? accountID_ : counterparty;
     auto const borrowerSle = view.peek(keylet::account(borrower));
     if (!borrowerSle)
     {
@@ -508,7 +508,7 @@ LoanSet::doApply()
     {
         auto const ownerCount = borrowerSle->at(sfOwnerCount);
         auto const balance =
-            account_ == borrower ? preFeeBalance_ : borrowerSle->at(sfBalance).value().xrp();
+            accountID_ == borrower ? preFeeBalance_ : borrowerSle->at(sfBalance).value().xrp();
         if (balance < view.fees().accountReserve(ownerCount))
             return tecINSUFFICIENT_RESERVE;
     }
@@ -520,7 +520,7 @@ LoanSet::doApply()
     // Create a holding for the borrower if one does not already exist.
 
     XRPL_ASSERT_PARTS(
-        borrower == account_ || borrower == counterparty,
+        borrower == accountID_ || borrower == counterparty,
         "xrpl::LoanSet::doApply",
         "borrower signed transaction");
     if (auto const ter = addEmptyHolding(
@@ -542,7 +542,7 @@ LoanSet::doApply()
         // Create the holding if it doesn't already exist (necessary for MPTs).
         // The owner may have deleted their MPT / line at some point.
         XRPL_ASSERT_PARTS(
-            brokerOwner == account_ || brokerOwner == counterparty,
+            brokerOwner == accountID_ || brokerOwner == counterparty,
             "xrpl::LoanSet::doApply",
             "broker owner signed transaction");
 

--- a/src/libxrpl/tx/transactors/nft/NFTokenAcceptOffer.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenAcceptOffer.cpp
@@ -407,8 +407,8 @@ NFTokenAcceptOffer::acceptOffer(std::shared_ptr<SLE> const& offer)
 {
     bool const isSell = offer->isFlag(lsfSellNFToken);
     AccountID const owner = (*offer)[sfOwner];
-    AccountID const& seller = isSell ? owner : account_;
-    AccountID const& buyer = isSell ? account_ : owner;
+    AccountID const& seller = isSell ? owner : accountID_;
+    AccountID const& buyer = isSell ? accountID_ : owner;
 
     auto const nftokenID = (*offer)[sfNFTokenID];
 
@@ -528,7 +528,7 @@ NFTokenAcceptOffer::doApply()
         // Send the broker the amount they requested.
         if (auto const cut = ctx_.tx[~sfNFTokenBrokerFee]; cut && cut.value() != beast::kZero)
         {
-            if (auto const r = pay(buyer, account_, cut.value()); !isTesSuccess(r))
+            if (auto const r = pay(buyer, accountID_, cut.value()); !isTesSuccess(r))
                 return r;
 
             amount -= cut.value();

--- a/src/libxrpl/tx/transactors/nft/NFTokenMint.cpp
+++ b/src/libxrpl/tx/transactors/nft/NFTokenMint.cpp
@@ -222,7 +222,7 @@ NFTokenMint::preclaim(PreclaimContext const& ctx)
 TER
 NFTokenMint::doApply()
 {
-    auto const issuer = ctx_.tx[~sfIssuer].value_or(account_);
+    auto const issuer = ctx_.tx[~sfIssuer].value_or(accountID_);
 
     auto const tokenSeq = [this, &issuer]() -> Expected<std::uint32_t, TER> {
         auto const root = view().peek(keylet::account(issuer));
@@ -279,7 +279,7 @@ NFTokenMint::doApply()
         return (tokenSeq.error());
 
     std::uint32_t const ownerCountBefore =
-        view().read(keylet::account(account_))->getFieldU32(sfOwnerCount);
+        view().read(keylet::account(accountID_))->getFieldU32(sfOwnerCount);
 
     // Assemble the new NFToken.
     SOTemplate const* nfTokenTemplate =
@@ -305,7 +305,7 @@ NFTokenMint::doApply()
             object.setFieldVL(sfURI, *uri);
     });
 
-    if (TER const ret = nft::insertToken(ctx_.view(), account_, std::move(newToken));
+    if (TER const ret = nft::insertToken(ctx_.view(), accountID_, std::move(newToken));
         !isTesSuccess(ret))
         return ret;
 
@@ -333,7 +333,7 @@ NFTokenMint::doApply()
     // requiring the reserve to be met each time.  The reserve is
     // only managed when a new NFT page or sell offer is added.
     if (auto const ownerCountAfter =
-            view().read(keylet::account(account_))->getFieldU32(sfOwnerCount);
+            view().read(keylet::account(accountID_))->getFieldU32(sfOwnerCount);
         ownerCountAfter > ownerCountBefore)
     {
         if (auto const reserve = view().fees().accountReserve(ownerCountAfter);

--- a/src/libxrpl/tx/transactors/oracle/OracleDelete.cpp
+++ b/src/libxrpl/tx/transactors/oracle/OracleDelete.cpp
@@ -82,8 +82,8 @@ OracleDelete::deleteOracle(
 TER
 OracleDelete::doApply()
 {
-    if (auto sle = ctx_.view().peek(keylet::oracle(account_, ctx_.tx[sfOracleDocumentID])))
-        return deleteOracle(ctx_.view(), sle, account_, j_);
+    if (auto sle = ctx_.view().peek(keylet::oracle(accountID_, ctx_.tx[sfOracleDocumentID])))
+        return deleteOracle(ctx_.view(), sle, accountID_, j_);
 
     return tecINTERNAL;  // LCOV_EXCL_LINE
 }

--- a/src/libxrpl/tx/transactors/oracle/OracleSet.cpp
+++ b/src/libxrpl/tx/transactors/oracle/OracleSet.cpp
@@ -201,7 +201,7 @@ setPriceDataInnerObjTemplate(STObject& obj)
 TER
 OracleSet::doApply()
 {
-    auto const oracleID = keylet::oracle(account_, ctx_.tx[sfOracleDocumentID]);
+    auto const oracleID = keylet::oracle(accountID_, ctx_.tx[sfOracleDocumentID]);
 
     auto populatePriceData = [](STObject& priceData, STObject const& entry) {
         setPriceDataInnerObjTemplate(priceData);
@@ -311,7 +311,7 @@ OracleSet::doApply()
         sle->setFieldU32(sfLastUpdateTime, ctx_.tx[sfLastUpdateTime]);
 
         auto page = ctx_.view().dirInsert(
-            keylet::ownerDir(account_), sle->key(), describeOwnerDir(account_));
+            keylet::ownerDir(accountID_), sle->key(), describeOwnerDir(accountID_));
         if (!page)
             return tecDIR_FULL;  // LCOV_EXCL_LINE
 

--- a/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
+++ b/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
@@ -153,7 +153,7 @@ DepositPreauth::doApply()
 {
     if (ctx_.tx.isFieldPresent(sfAuthorize))
     {
-        auto const sleOwner = view().peek(keylet::account(account_));
+        auto const sleOwner = view().peek(keylet::account(accountID_));
         if (!sleOwner)
             return {tefINTERNAL};
 
@@ -171,15 +171,15 @@ DepositPreauth::doApply()
         // Preclaim already verified that the Preauth entry does not yet exist.
         // Create and populate the Preauth entry.
         AccountID const auth{ctx_.tx[sfAuthorize]};
-        Keylet const preauthKeylet = keylet::depositPreauth(account_, auth);
+        Keylet const preauthKeylet = keylet::depositPreauth(accountID_, auth);
         auto slePreauth = std::make_shared<SLE>(preauthKeylet);
 
-        slePreauth->setAccountID(sfAccount, account_);
+        slePreauth->setAccountID(sfAccount, accountID_);
         slePreauth->setAccountID(sfAuthorize, auth);
         view().insert(slePreauth);
 
-        auto const page =
-            view().dirInsert(keylet::ownerDir(account_), preauthKeylet, describeOwnerDir(account_));
+        auto const page = view().dirInsert(
+            keylet::ownerDir(accountID_), preauthKeylet, describeOwnerDir(accountID_));
 
         JLOG(j_.trace()) << "Adding DepositPreauth to owner directory "
                          << to_string(preauthKeylet.key) << ": " << (page ? "success" : "failure");
@@ -194,13 +194,13 @@ DepositPreauth::doApply()
     }
     else if (ctx_.tx.isFieldPresent(sfUnauthorize))
     {
-        auto const preauth = keylet::depositPreauth(account_, ctx_.tx[sfUnauthorize]);
+        auto const preauth = keylet::depositPreauth(accountID_, ctx_.tx[sfUnauthorize]);
 
         return DepositPreauth::removeFromLedger(view(), preauth.key, j_);
     }
     else if (ctx_.tx.isFieldPresent(sfAuthorizeCredentials))
     {
-        auto const sleOwner = view().peek(keylet::account(account_));
+        auto const sleOwner = view().peek(keylet::account(accountID_));
         if (!sleOwner)
             return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -229,18 +229,18 @@ DepositPreauth::doApply()
             sortedLE.pushBack(std::move(cred));
         }
 
-        Keylet const preauthKey = keylet::depositPreauth(account_, sortedTX);
+        Keylet const preauthKey = keylet::depositPreauth(accountID_, sortedTX);
         auto slePreauth = std::make_shared<SLE>(preauthKey);
         if (!slePreauth)
             return tefINTERNAL;  // LCOV_EXCL_LINE
 
-        slePreauth->setAccountID(sfAccount, account_);
+        slePreauth->setAccountID(sfAccount, accountID_);
         slePreauth->peekFieldArray(sfAuthorizeCredentials) = std::move(sortedLE);
 
         view().insert(slePreauth);
 
-        auto const page =
-            view().dirInsert(keylet::ownerDir(account_), preauthKey, describeOwnerDir(account_));
+        auto const page = view().dirInsert(
+            keylet::ownerDir(accountID_), preauthKey, describeOwnerDir(accountID_));
 
         JLOG(j_.trace()) << "Adding DepositPreauth to owner directory " << to_string(preauthKey.key)
                          << ": " << (page ? "success" : "failure");
@@ -256,7 +256,7 @@ DepositPreauth::doApply()
     else if (ctx_.tx.isFieldPresent(sfUnauthorizeCredentials))
     {
         auto const preauthKey = keylet::depositPreauth(
-            account_, credentials::makeSorted(ctx_.tx.getFieldArray(sfUnauthorizeCredentials)));
+            accountID_, credentials::makeSorted(ctx_.tx.getFieldArray(sfUnauthorizeCredentials)));
         return DepositPreauth::removeFromLedger(view(), preauthKey.key, j_);
     }
 

--- a/src/libxrpl/tx/transactors/payment/Payment.cpp
+++ b/src/libxrpl/tx/transactors/payment/Payment.cpp
@@ -410,7 +410,7 @@ Payment::doApply()
     AccountID const dstAccountID(ctx_.tx.getAccountID(sfDestination));
     STAmount const dstAmount(ctx_.tx.getFieldAmount(sfAmount));
     bool const isDstMPT = dstAmount.holds<MPTIssue>();
-    STAmount const maxSourceAmount = getMaxSourceAmount(account_, dstAmount, sendMax);
+    STAmount const maxSourceAmount = getMaxSourceAmount(accountID_, dstAmount, sendMax);
 
     JLOG(j_.trace()) << "maxSourceAmount=" << maxSourceAmount.getFullText()
                      << " dstAmount=" << dstAmount.getFullText();
@@ -453,7 +453,7 @@ Payment::doApply()
         //  2. If Account is deposit preauthorized by destination.
 
         if (auto err = verifyDepositPreauth(
-                ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
+                ctx_.tx, ctx_.view(), accountID_, dstAccountID, sleDst, ctx_.journal);
             !isTesSuccess(err))
             return err;
 
@@ -472,7 +472,7 @@ Payment::doApply()
                 maxSourceAmount,
                 dstAmount,
                 dstAccountID,
-                account_,
+                accountID_,
                 ctx_.tx.getFieldPathSet(sfPaths),
                 ctx_.tx[~sfDomainID],
                 ctx_.registry,
@@ -512,18 +512,18 @@ Payment::doApply()
         JLOG(j_.trace()) << " dstAmount=" << dstAmount.getFullText();
         auto const& mptIssue = dstAmount.get<MPTIssue>();
 
-        if (auto const ter = requireAuth(view(), mptIssue, account_); !isTesSuccess(ter))
+        if (auto const ter = requireAuth(view(), mptIssue, accountID_); !isTesSuccess(ter))
             return ter;
 
         if (auto const ter = requireAuth(view(), mptIssue, dstAccountID); !isTesSuccess(ter))
             return ter;
 
-        if (auto const ter = canTransfer(view(), mptIssue, account_, dstAccountID);
+        if (auto const ter = canTransfer(view(), mptIssue, accountID_, dstAccountID);
             !isTesSuccess(ter))
             return ter;
 
         if (auto err = verifyDepositPreauth(
-                ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
+                ctx_.tx, ctx_.view(), accountID_, dstAccountID, sleDst, ctx_.journal);
             !isTesSuccess(err))
             return err;
 
@@ -532,13 +532,13 @@ Payment::doApply()
         // Transfer rate
         Rate rate{QUALITY_ONE};
         // Payment between the holders
-        if (account_ != issuer && dstAccountID != issuer)
+        if (accountID_ != issuer && dstAccountID != issuer)
         {
             // If globally/individually locked then
             //   - can't send between holders
             //   - holder can send back to issuer
             //   - issuer can send to holder
-            if (isAnyFrozen(view(), {account_, dstAccountID}, mptIssue))
+            if (isAnyFrozen(view(), {accountID_, dstAccountID}, mptIssue))
                 return tecLOCKED;
 
             // Get the rate for a payment between the holders.
@@ -566,7 +566,7 @@ Payment::doApply()
             return tecPATH_PARTIAL;
 
         PaymentSandbox pv(&view());
-        auto res = accountSend(pv, account_, dstAccountID, amountDeliver, ctx_.journal);
+        auto res = accountSend(pv, accountID_, dstAccountID, amountDeliver, ctx_.journal);
         if (isTesSuccess(res))
         {
             pv.apply(ctx_.rawView());
@@ -589,7 +589,7 @@ Payment::doApply()
 
     // Direct XRP payment.
 
-    auto const sleSrc = view().peek(keylet::account(account_));
+    auto const sleSrc = view().peek(keylet::account(accountID_));
     if (!sleSrc)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -601,10 +601,10 @@ Payment::doApply()
     auto const reserve = view().fees().accountReserve(ownerCount);
 
     // In a delegated payment, the fee payer is the delegated account,
-    // not the source account (account_).
-    bool const accountIsPayer = (ctx_.tx.getFeePayer() == account_);
+    // not the source account (accountID_).
+    bool const accountIsPayer = (ctx_.tx.getFeePayer() == accountID_);
 
-    // preFeeBalance_ is the balance on the source account (account_) BEFORE the fees
+    // preFeeBalance_ is the balance on the source account (accountID_) BEFORE the fees
     // were charged. If source account is the fee payer, it must also cover the fee.
     // The final spend may use the reserve to cover fees.
     auto const minRequiredFunds =
@@ -656,7 +656,7 @@ Payment::doApply()
     if (dstAmount > dstReserve || sleDst->getFieldAmount(sfBalance) > dstReserve)
     {
         if (auto err = verifyDepositPreauth(
-                ctx_.tx, ctx_.view(), account_, dstAccountID, sleDst, ctx_.journal);
+                ctx_.tx, ctx_.view(), accountID_, dstAccountID, sleDst, ctx_.journal);
             !isTesSuccess(err))
             return err;
     }

--- a/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainDelete.cpp
+++ b/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainDelete.cpp
@@ -55,7 +55,7 @@ PermissionedDomainDelete::doApply()
     auto const slePd = view().peek(keylet::permissionedDomain(ctx_.tx.at(sfDomainID)));
     auto const page = (*slePd)[sfOwnerNode];
 
-    if (!view().dirRemove(keylet::ownerDir(account_), page, slePd->key(), true))
+    if (!view().dirRemove(keylet::ownerDir(accountID_), page, slePd->key(), true))
     {
         // LCOV_EXCL_START
         JLOG(j_.fatal()) << "Unable to delete permissioned domain directory entry.";
@@ -63,7 +63,7 @@ PermissionedDomainDelete::doApply()
         // LCOV_EXCL_STOP
     }
 
-    auto const ownerSle = view().peek(keylet::account(account_));
+    auto const ownerSle = view().peek(keylet::account(accountID_));
     XRPL_ASSERT(
         ownerSle && ownerSle->getFieldU32(sfOwnerCount) > 0,
         "xrpl::PermissionedDomainDelete::doApply : nonzero owner count");

--- a/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainSet.cpp
+++ b/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainSet.cpp
@@ -77,7 +77,7 @@ PermissionedDomainSet::preclaim(PreclaimContext const& ctx)
 TER
 PermissionedDomainSet::doApply()
 {
-    auto const ownerSle = view().peek(keylet::account(account_));
+    auto const ownerSle = view().peek(keylet::account(accountID_));
     if (!ownerSle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -112,14 +112,14 @@ PermissionedDomainSet::doApply()
 
         bool const fixEnabled = view().rules().enabled(fixCleanup3_1_3);
         auto const seq = fixEnabled ? ctx_.tx.getSeqValue() : ctx_.tx.getFieldU32(sfSequence);
-        Keylet const pdKeylet = keylet::permissionedDomain(account_, seq);
+        Keylet const pdKeylet = keylet::permissionedDomain(accountID_, seq);
         auto slePd = std::make_shared<SLE>(pdKeylet);
 
-        slePd->setAccountID(sfOwner, account_);
+        slePd->setAccountID(sfOwner, accountID_);
         slePd->setFieldU32(sfSequence, seq);
         slePd->peekFieldArray(sfAcceptedCredentials) = std::move(sortedLE);
         auto const page =
-            view().dirInsert(keylet::ownerDir(account_), pdKeylet, describeOwnerDir(account_));
+            view().dirInsert(keylet::ownerDir(accountID_), pdKeylet, describeOwnerDir(accountID_));
         if (!page)
             return tecDIR_FULL;  // LCOV_EXCL_LINE
 

--- a/src/libxrpl/tx/transactors/system/Change.cpp
+++ b/src/libxrpl/tx/transactors/system/Change.cpp
@@ -154,7 +154,7 @@ Change::doApply()
 void
 Change::preCompute()
 {
-    XRPL_ASSERT(account_ == beast::kZero, "xrpl::Change::preCompute : zero account");
+    XRPL_ASSERT(accountID_ == beast::kZero, "xrpl::Change::preCompute : zero account");
 }
 
 TER

--- a/src/libxrpl/tx/transactors/system/TicketCreate.cpp
+++ b/src/libxrpl/tx/transactors/system/TicketCreate.cpp
@@ -67,7 +67,7 @@ TicketCreate::preclaim(PreclaimContext const& ctx)
 TER
 TicketCreate::doApply()
 {
-    SLE::pointer const sleAccountRoot = view().peek(keylet::account(account_));
+    SLE::pointer const sleAccountRoot = view().peek(keylet::account(accountID_));
     if (!sleAccountRoot)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -100,15 +100,15 @@ TicketCreate::doApply()
     for (std::uint32_t i = 0; i < ticketCount; ++i)
     {
         std::uint32_t const curTicketSeq = firstTicketSeq + i;
-        Keylet const ticketKeylet = keylet::kTicket(account_, curTicketSeq);
+        Keylet const ticketKeylet = keylet::kTicket(accountID_, curTicketSeq);
         SLE::pointer const sleTicket = std::make_shared<SLE>(ticketKeylet);
 
-        sleTicket->setAccountID(sfAccount, account_);
+        sleTicket->setAccountID(sfAccount, accountID_);
         sleTicket->setFieldU32(sfTicketSequence, curTicketSeq);
         view().insert(sleTicket);
 
-        auto const page =
-            view().dirInsert(keylet::ownerDir(account_), ticketKeylet, describeOwnerDir(account_));
+        auto const page = view().dirInsert(
+            keylet::ownerDir(accountID_), ticketKeylet, describeOwnerDir(accountID_));
 
         JLOG(j_.trace()) << "Creating ticket " << to_string(ticketKeylet.key) << ": "
                          << (page ? "success" : "failure");

--- a/src/libxrpl/tx/transactors/token/MPTokenAuthorize.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenAuthorize.cpp
@@ -148,7 +148,7 @@ MPTokenAuthorize::doApply()
         ctx_.view(),
         preFeeBalance_,
         tx[sfMPTokenIssuanceID],
-        account_,
+        accountID_,
         ctx_.journal,
         tx.getFlags(),
         tx[~sfHolder]);

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
@@ -159,7 +159,7 @@ MPTokenIssuanceCreate::doApply()
         j_,
         {
             .priorBalance = preFeeBalance_,
-            .account = account_,
+            .account = accountID_,
             .sequence = tx.getSeqValue(),
             .flags = tx.getFlags(),
             .maxAmount = tx[~sfMaximumAmount],

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceDestroy.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceDestroy.cpp
@@ -45,15 +45,15 @@ TER
 MPTokenIssuanceDestroy::doApply()
 {
     auto const mpt = view().peek(keylet::mptIssuance(ctx_.tx[sfMPTokenIssuanceID]));
-    if (account_ != mpt->getAccountID(sfIssuer))
+    if (accountID_ != mpt->getAccountID(sfIssuer))
         return tecINTERNAL;  // LCOV_EXCL_LINE
 
-    if (!view().dirRemove(keylet::ownerDir(account_), (*mpt)[sfOwnerNode], mpt->key(), false))
+    if (!view().dirRemove(keylet::ownerDir(accountID_), (*mpt)[sfOwnerNode], mpt->key(), false))
         return tefBAD_LEDGER;  // LCOV_EXCL_LINE
 
     view().erase(mpt);
 
-    adjustOwnerCount(view(), view().peek(keylet::account(account_)), -1, j_);
+    adjustOwnerCount(view(), view().peek(keylet::account(accountID_)), -1, j_);
 
     return tesSUCCESS;
 }

--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -336,9 +336,9 @@ TrustSet::doApply()
     AccountID const uDstAccountID(saLimitAmount.getIssuer());
 
     // true, if current is high account.
-    bool const bHigh = account_ > uDstAccountID;
+    bool const bHigh = accountID_ > uDstAccountID;
 
-    auto const sle = view().peek(keylet::account(account_));
+    auto const sle = view().peek(keylet::account(accountID_));
     if (!sle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
@@ -391,10 +391,10 @@ TrustSet::doApply()
     }
 
     STAmount saLimitAllow = saLimitAmount;
-    saLimitAllow.get<Issue>().account = account_;
+    saLimitAllow.get<Issue>().account = accountID_;
 
     SLE::pointer const sleRippleState =
-        view().peek(keylet::line(account_, uDstAccountID, currency));
+        view().peek(keylet::line(accountID_, uDstAccountID, currency));
 
     if (sleRippleState)
     {
@@ -406,8 +406,8 @@ TrustSet::doApply()
         std::uint32_t uLowQualityOut = 0;
         std::uint32_t uHighQualityIn = 0;
         std::uint32_t uHighQualityOut = 0;
-        auto const& uLowAccountID = !bHigh ? account_ : uDstAccountID;
-        auto const& uHighAccountID = bHigh ? account_ : uDstAccountID;
+        auto const& uLowAccountID = !bHigh ? accountID_ : uDstAccountID;
+        auto const& uHighAccountID = bHigh ? accountID_ : uDstAccountID;
         SLE::ref sleLowAccount = !bHigh ? sle : sleDst;
         SLE::ref sleHighAccount = bHigh ? sle : sleDst;
 
@@ -642,7 +642,7 @@ TrustSet::doApply()
         // Zero balance in currency.
         STAmount const saBalance(Issue{currency, noAccount()});
 
-        auto const k = keylet::line(account_, uDstAccountID, currency);
+        auto const k = keylet::line(accountID_, uDstAccountID, currency);
 
         JLOG(j_.trace()) << "doTrustSet: Creating ripple line: " << to_string(k.key);
 
@@ -650,7 +650,7 @@ TrustSet::doApply()
         terResult = trustCreate(
             view(),
             bHigh,
-            account_,
+            accountID_,
             uDstAccountID,
             k.key,
             sle,

--- a/src/libxrpl/tx/transactors/vault/VaultClawback.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultClawback.cpp
@@ -349,7 +349,7 @@ VaultClawback::doApply()
     MPTIssue const share{mptIssuanceID};
 
     Asset const vaultAsset = vault->at(sfAsset);
-    STAmount const amount = clawbackAmount(vault, tx[~sfAmount], account_);
+    STAmount const amount = clawbackAmount(vault, tx[~sfAmount], accountID_);
 
     auto assetsAvailable = vault->at(sfAssetsAvailable);
     auto assetsTotal = vault->at(sfAssetsTotal);
@@ -364,7 +364,7 @@ VaultClawback::doApply()
     STAmount assetsRecovered = {vault->at(sfAsset)};
 
     // The Owner is burning shares
-    if (account_ == vault->at(sfOwner) && amount.asset() == share)
+    if (accountID_ == vault->at(sfOwner) && amount.asset() == share)
     {
         sharesDestroyed = accountHolds(
             view(), holder, share, FreezeHandling::IgnoreFreeze, AuthHandling::IgnoreAuth, j_);
@@ -426,7 +426,7 @@ VaultClawback::doApply()
     {
         // Transfer assets from vault to issuer.
         if (auto const ter = accountSend(
-                view(), vaultAccount, account_, assetsRecovered, j_, WaiveTransferFee::Yes);
+                view(), vaultAccount, accountID_, assetsRecovered, j_, WaiveTransferFee::Yes);
             !isTesSuccess(ter))
             return ter;
 

--- a/src/libxrpl/tx/transactors/vault/VaultCreate.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultCreate.cpp
@@ -145,13 +145,13 @@ VaultCreate::doApply()
 
     auto const& tx = ctx_.tx;
     auto const sequence = tx.getSeqValue();
-    auto const owner = view().peek(keylet::account(account_));
+    auto const owner = view().peek(keylet::account(accountID_));
     if (owner == nullptr)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    auto vault = std::make_shared<SLE>(keylet::vault(account_, sequence));
+    auto vault = std::make_shared<SLE>(keylet::vault(accountID_, sequence));
 
-    if (auto ter = dirLink(view(), account_, vault))
+    if (auto ter = dirLink(view(), accountID_, vault))
         return ter;
     // We will create Vault and PseudoAccount, hence increase OwnerCount by 2
     adjustOwnerCount(view(), owner, 2, j_);
@@ -204,7 +204,7 @@ VaultCreate::doApply()
     vault->setFieldIssue(sfAsset, STIssue{sfAsset, asset});
     vault->at(sfFlags) = tx.getFlags() & tfVaultPrivate;
     vault->at(sfSequence) = sequence;
-    vault->at(sfOwner) = account_;
+    vault->at(sfOwner) = accountID_;
     vault->at(sfAccount) = pseudoId;
     vault->at(sfAssetsTotal) = Number(0);
     vault->at(sfAssetsAvailable) = Number(0);
@@ -230,7 +230,7 @@ VaultCreate::doApply()
 
     // Explicitly create MPToken for the vault owner
     if (auto const err =
-            authorizeMPToken(view(), preFeeBalance_, mptIssuanceID, account_, ctx_.journal);
+            authorizeMPToken(view(), preFeeBalance_, mptIssuanceID, accountID_, ctx_.journal);
         !isTesSuccess(err))
         return err;
 
@@ -238,7 +238,7 @@ VaultCreate::doApply()
     if (tx.isFlag(tfVaultPrivate))
     {
         if (auto const err = authorizeMPToken(
-                view(), preFeeBalance_, mptIssuanceID, pseudoId, ctx_.journal, {}, account_);
+                view(), preFeeBalance_, mptIssuanceID, pseudoId, ctx_.journal, {}, accountID_);
             !isTesSuccess(err))
             return err;
     }

--- a/src/libxrpl/tx/transactors/vault/VaultDelete.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDelete.cpp
@@ -122,16 +122,16 @@ VaultDelete::doApply()
     }
 
     // Try to remove MPToken for vault shares for the vault owner if it exists.
-    if (auto const mptoken = view().peek(keylet::mptoken(shareMPTID, account_)))
+    if (auto const mptoken = view().peek(keylet::mptoken(shareMPTID, accountID_)))
     {
-        if (auto const ter = removeEmptyHolding(view(), account_, MPTIssue(shareMPTID), j_);
+        if (auto const ter = removeEmptyHolding(view(), accountID_, MPTIssue(shareMPTID), j_);
             !isTesSuccess(ter))
         {
             // LCOV_EXCL_START
             JLOG(j_.error())  //
                 << "VaultDelete: failed to remove vault owner's MPToken"
-                << " MPTID=" << to_string(shareMPTID)  //
-                << " account=" << toBase58(account_)   //
+                << " MPTID=" << to_string(shareMPTID)   //
+                << " account=" << toBase58(accountID_)  //
                 << " with result: " << transToken(ter);
             return ter;
             // LCOV_EXCL_STOP

--- a/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
@@ -156,20 +156,20 @@ VaultDeposit::doApply()
 
     auto const& vaultAccount = vault->at(sfAccount);
     // Note, vault owner is always authorized
-    if (vault->isFlag(lsfVaultPrivate) && account_ != vault->at(sfOwner))
+    if (vault->isFlag(lsfVaultPrivate) && accountID_ != vault->at(sfOwner))
     {
         if (auto const err = enforceMPTokenAuthorization(
-                ctx_.view(), mptIssuanceID, account_, preFeeBalance_, j_);
+                ctx_.view(), mptIssuanceID, accountID_, preFeeBalance_, j_);
             !isTesSuccess(err))
             return err;
     }
-    else  // !vault->isFlag(lsfVaultPrivate) || account_ == vault->at(sfOwner)
+    else  // !vault->isFlag(lsfVaultPrivate) || accountID_ == vault->at(sfOwner)
     {
         // No authorization needed, but must ensure there is MPToken
-        if (!view().exists(keylet::mptoken(mptIssuanceID, account_)))
+        if (!view().exists(keylet::mptoken(mptIssuanceID, accountID_)))
         {
             if (auto const err = authorizeMPToken(
-                    view(), preFeeBalance_, mptIssuanceID->value(), account_, ctx_.journal);
+                    view(), preFeeBalance_, mptIssuanceID->value(), accountID_, ctx_.journal);
                 !isTesSuccess(err))
                 return err;
         }
@@ -179,15 +179,15 @@ VaultDeposit::doApply()
         {
             // This follows from the reverse of the outer enclosing if condition
             XRPL_ASSERT(
-                account_ == vault->at(sfOwner), "xrpl::VaultDeposit::doApply : account is owner");
+                accountID_ == vault->at(sfOwner), "xrpl::VaultDeposit::doApply : account is owner");
             if (auto const err = authorizeMPToken(
                     view(),
                     preFeeBalance_,             // priorBalance
                     mptIssuanceID->value(),     // mptIssuanceID
                     sleIssuance->at(sfIssuer),  // account
                     ctx_.journal,
-                    {},       // flags
-                    account_  // holderID
+                    {},         // flags
+                    accountID_  // holderID
                 );
                 !isTesSuccess(err))
                 return err;
@@ -247,15 +247,15 @@ VaultDeposit::doApply()
         return tecLIMIT_EXCEEDED;
 
     // Transfer assets from depositor to vault.
-    if (auto const ter =
-            accountSend(view(), account_, vaultAccount, assetsDeposited, j_, WaiveTransferFee::Yes);
+    if (auto const ter = accountSend(
+            view(), accountID_, vaultAccount, assetsDeposited, j_, WaiveTransferFee::Yes);
         !isTesSuccess(ter))
         return ter;
 
     // Sanity check
     if (accountHolds(
             view(),
-            account_,
+            accountID_,
             assetsDeposited.asset(),
             FreezeHandling::IgnoreFreeze,
             AuthHandling::IgnoreAuth,
@@ -269,7 +269,7 @@ VaultDeposit::doApply()
 
     // Transfer shares from vault to depositor.
     if (auto const ter =
-            accountSend(view(), vaultAccount, account_, sharesCreated, j_, WaiveTransferFee::Yes);
+            accountSend(view(), vaultAccount, accountID_, sharesCreated, j_, WaiveTransferFee::Yes);
         !isTesSuccess(ter))
         return ter;
 

--- a/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultWithdraw.cpp
@@ -222,7 +222,7 @@ VaultWithdraw::doApply()
     }
 
     if (accountHolds(
-            view(), account_, share, FreezeHandling::ZeroIfFrozen, AuthHandling::IgnoreAuth, j_) <
+            view(), accountID_, share, FreezeHandling::ZeroIfFrozen, AuthHandling::IgnoreAuth, j_) <
         sharesRedeemed)
     {
         JLOG(j_.debug()) << "VaultWithdraw: account doesn't hold enough shares";
@@ -251,23 +251,23 @@ VaultWithdraw::doApply()
 
     auto const& vaultAccount = vault->at(sfAccount);
     // Transfer shares from depositor to vault.
-    if (auto const ter =
-            accountSend(view(), account_, vaultAccount, sharesRedeemed, j_, WaiveTransferFee::Yes);
+    if (auto const ter = accountSend(
+            view(), accountID_, vaultAccount, sharesRedeemed, j_, WaiveTransferFee::Yes);
         !isTesSuccess(ter))
         return ter;
 
     // Try to remove MPToken for shares, if the account balance is zero. Vault
     // pseudo-account will never set lsfMPTAuthorized, so we ignore flags.
     // Keep MPToken if holder is the vault owner.
-    if (account_ != vault->at(sfOwner))
+    if (accountID_ != vault->at(sfOwner))
     {
-        if (auto const ter = removeEmptyHolding(view(), account_, sharesRedeemed.asset(), j_);
+        if (auto const ter = removeEmptyHolding(view(), accountID_, sharesRedeemed.asset(), j_);
             isTesSuccess(ter))
         {
             JLOG(j_.debug())  //
                 << "VaultWithdraw: removed empty MPToken for vault shares"
                 << " MPTID=" << to_string(mptIssuanceID)  //
-                << " account=" << toBase58(account_);
+                << " account=" << toBase58(accountID_);
         }
         else if (ter != tecHAS_OBLIGATIONS)
         {
@@ -275,7 +275,7 @@ VaultWithdraw::doApply()
             JLOG(j_.error())  //
                 << "VaultWithdraw: failed to remove MPToken for vault shares"
                 << " MPTID=" << to_string(mptIssuanceID)  //
-                << " account=" << toBase58(account_)      //
+                << " account=" << toBase58(accountID_)    //
                 << " with result: " << transToken(ter);
             return ter;
             // LCOV_EXCL_STOP
@@ -283,12 +283,12 @@ VaultWithdraw::doApply()
         // else quietly ignore, account balance is not zero
     }
 
-    auto const dstAcct = ctx_.tx[~sfDestination].value_or(account_);
+    auto const dstAcct = ctx_.tx[~sfDestination].value_or(accountID_);
 
     associateAsset(*vault, vaultAsset);
 
     return doWithdraw(
-        view(), ctx_.tx, account_, dstAcct, vaultAccount, preFeeBalance_, assetsWithdrawn, j_);
+        view(), ctx_.tx, accountID_, dstAcct, vaultAccount, preFeeBalance_, assetsWithdrawn, j_);
 }
 
 void


### PR DESCRIPTION
## High Level Overview of Change

This PR renames the `account_` field in `Transactor` to `accountID_` (as well as in a couple of other classes that are used by transactors).

### Context of Change

In preparation for #6620 - will simplify that PR

### API Impact

N/A
