### PR TITLE
fix: Disable unnecessary sanity-check in VaultDeposit

### DIFF
--- a/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
@@ -7,6 +7,7 @@
 #include <xrpl/ledger/helpers/MPTokenHelpers.h>
 #include <xrpl/ledger/helpers/TokenHelpers.h>
 #include <xrpl/ledger/helpers/VaultHelpers.h>
+#include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/LedgerFormats.h>

--- a/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
@@ -269,10 +269,8 @@ VaultDeposit::doApply()
                 AuthHandling::IgnoreAuth,
                 j_) < beast::kZero)
         {
-            // LCOV_EXCL_START
             JLOG(j_.error()) << "VaultDeposit: negative balance of account assets.";
             return tefINTERNAL;
-            // LCOV_EXCL_STOP
         }
     }
 

--- a/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDeposit.cpp
@@ -252,19 +252,28 @@ VaultDeposit::doApply()
         !isTesSuccess(ter))
         return ter;
 
-    // Sanity check
-    if (accountHolds(
-            view(),
-            accountID_,
-            assetsDeposited.asset(),
-            FreezeHandling::IgnoreFreeze,
-            AuthHandling::IgnoreAuth,
-            j_) < beast::kZero)
+    // This check is wrong. Disable it with fixCleanup3_2_0.
+    // For XRP and MPT the predicate is structurally unsatisfiable: xrpLiquid clamps at zero, and
+    // MPT balances are unsigned. For IOUs it only fires when the deposit drove the depositor's
+    // trust line into debt the exact case preclaim authorizes via SpendableHandling::FullBalance.
+    // The check thus converts a preclaim- authorized deposit into tefINTERNAL after the asset
+    // transfer.
+    if (!view().rules().enabled(fixCleanup3_2_0))
     {
-        // LCOV_EXCL_START
-        JLOG(j_.error()) << "VaultDeposit: negative balance of account assets.";
-        return tefINTERNAL;
-        // LCOV_EXCL_STOP
+        // Sanity check
+        if (accountHolds(
+                view(),
+                accountID_,
+                assetsDeposited.asset(),
+                FreezeHandling::IgnoreFreeze,
+                AuthHandling::IgnoreAuth,
+                j_) < beast::kZero)
+        {
+            // LCOV_EXCL_START
+            JLOG(j_.error()) << "VaultDeposit: negative balance of account assets.";
+            return tefINTERNAL;
+            // LCOV_EXCL_STOP
+        }
     }
 
     // Transfer shares from vault to depositor.

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -6184,7 +6184,7 @@ class Vault_test : public beast::unit_test::Suite
             env.close();
 
             // Create the IOU vault.
-            Vault vault{env};
+            Vault const vault{env};
             auto [vaultTx, keylet] = vault.create({.owner = owner, .asset = usd});
             env(vaultTx);
             env.close();

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -6140,10 +6140,90 @@ class Vault_test : public beast::unit_test::Suite
         runTest(amendments);
     }
 
+    // VaultDeposit::preclaim uses accountHolds(..., SpendableHandling::
+    // shFULL_BALANCE), which for an IOU asset adds the counterparty's
+    // LowLimit/HighLimit to the depositor's raw balance (TokenHelpers.cpp:
+    // getTrustLineBalance with includeOppositeLimit=true). When the
+    // depositor's raw balance < deposit amount but raw + opposite limit >=
+    // amount, preclaim is satisfied. doApply then calls
+    // directSendNoFeeIOU, which unconditionally subtracts saAmount from
+    // saBalance — driving the trust line negative — and returns tesSUCCESS.
+    // The post-send sanity check uses the default shSIMPLE_BALANCE (no
+    // opposite-limit add), sees a negative balance, and returns tefINTERNAL.
+    void
+    testVaultDepositNegativeBalanceFromOppositeLimit()
+    {
+        auto runTest = [&](FeatureBitset f, TER expected) {
+            using namespace test::jtx;
+            using namespace std::literals;
+
+            Env env{*this, f};
+            Account const gw{"gateway"};
+            Account const owner{"owner"};
+            Account const depositor{"depositor"};
+
+            env.fund(XRP(10000), gw, owner, depositor);
+            env.close();
+
+            // Gateway with DefaultRipple so vault creation on its IOU works.
+            env(fset(gw, asfDefaultRipple));
+            env.close();
+
+            // Depositor opens a trust line to gateway and receives a small
+            // balance.
+            PrettyAsset const usd = gw["USD"];
+            env.trust(usd(1000), depositor);
+            env(pay(gw, depositor, usd(100)));  // raw trust-line balance: 100
+            env.close();
+
+            // Key precondition: gateway sets a non-zero limit on the same
+            // RippleState — the "opposite field" from depositor's perspective.
+            // This is what inflates shFULL_BALANCE in preclaim above the raw
+            // balance.
+            env(trust(gw, depositor["USD"](1000)));
+            env.close();
+
+            // Create the IOU vault.
+            Vault vault{env};
+            auto [vaultTx, keylet] = vault.create({.owner = owner, .asset = usd});
+            env(vaultTx);
+            env.close();
+
+            // Submit a deposit of 500 USD:
+            //   - raw balance:                100 USD
+            //   - opposite limit (gw's side): 1000 USD
+            //   - preclaim sees 100 + 1000 = 1100, passes (>= 500)
+            //   - doApply transfers 500, depositor's trust-line balance
+            //     becomes -400
+            //   - sanity check at VaultDeposit.cpp:256 fires
+            //   - tx returns tefINTERNAL (BUG — should be tesSUCCESS.
+            auto depositTx =
+                vault.deposit({.depositor = depositor, .id = keylet.key, .amount = usd(500)});
+            env(depositTx, Ter(expected));
+            env.close();
+        };
+
+        {
+            testcase(
+                "IOU vault deposit exceeding depositor's balance but "
+                "within counterparty's trust limit, pre-fixCleanup3_2_0 "
+                "(tefINTERNAL)");
+            runTest(test::jtx::testableAmendments() - fixCleanup3_2_0, tefINTERNAL);
+        }
+        {
+            testcase(
+                "IOU vault deposit exceeding depositor's balance but "
+                "within counterparty's trust limit, post-fixCleanup3_2_0 "
+                "(tesSUCCESS)");
+            runTest(test::jtx::testableAmendments(), tesSUCCESS);
+        }
+    }
+
 public:
     void
     run() override
     {
+        testVaultDepositNegativeBalanceFromOppositeLimit();
         testSequences();
         testPreflight();
         testCreateFailXRP();


### PR DESCRIPTION
## Summary

Wraps the post-`accountSend` sanity check in `VaultDeposit::doApply` behind `fixCleanup3_2_0`. The check verifies that the depositor's holdings of the deposited asset are not negative after the transfer to the vault. It is unreachable for XRP and MPT, and for IOUs it only fires in a case that `preclaim` explicitly authorizes converting a valid deposit into `tefINTERNAL`.

## Background

`VaultDeposit::preclaim` admits a deposit when

```cpp
accountHolds(..., SpendableHandling::FullBalance) >= assets
```

For IOUs, `FullBalance` is `(current trust-line balance) + (the issuer's reciprocal trust limit)`. When the asset issuer has set a non-zero limit on its side of the trust line, the depositor can legitimately deposit up to that combined cap, taking on debt with the issuer via the 3rd-party transit path inside `accountSend`.

Post-transfer, `accountHolds(..., SimpleBalance)` returns the now-negative on-trust-line balance, and the sanity check rejects the transaction with `tefINTERNAL` — wrapped in `LCOV_EXCL` as if the case were unreachable.

For XRP the check is unsatisfiable because `xrpLiquid` clamps at zero. For MPT it is unsatisfiable because `sfMPTAmount` is `uint64_t` (and `directSendNoFeeMPT` refuses overdraft).

So in three of four cases the check provides no protection, and in the fourth it contradicts the `preclaim` contract. Removing it behind an amendment restores the intended `preclaim → tesSUCCESS` path for IOU deposits that draw on the issuer's reciprocal limit.

## Test plan

- [x] New `Vault_test.cpp` test
  `testVaultDepositNegativeBalanceFromOppositeLimit` covers both
  amendment branches:
  - Pre-`fixCleanup3_2_0`: deposit returns `tefINTERNAL` (current
    buggy behavior preserved for replay).
  - Post-`fixCleanup3_2_0`: same deposit returns `tesSUCCESS`.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
