### PR TITLE
docs: Add --parallel flag to cmake build commands in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -427,15 +427,18 @@ install ccache --version 4.11.3 --allow-downgrade`.
    Single-config generators:
 
    ```
-   cmake --build .
+   cmake --build . --parallel N
    ```
 
    Multi-config generators:
 
    ```
-   cmake --build . --config Release
-   cmake --build . --config Debug
+   cmake --build . --config Release --parallel N
+   cmake --build . --config Debug --parallel N
    ```
+
+   Replace the `--parallel` parameter N with the desired number of parallel jobs. A common starting point is half of the number of available CPU
+   cores.
 
 5. Test xrpld.
 


### PR DESCRIPTION


## High Level Overview of Change

Added the `--parallel N` flag to the `cmake --build` commands in BUILD.md to document how to speed up builds using parallel jobs.

### Context of Change

The build documentation didn't mention the `--parallel` flag, which is a common way to significantly reduce build times. This is a documentation-only change with no code impact.

### API Impact

No impact. Only a documentation change.

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)