### PR TITLE
fix: Add null check

### DIFF
--- a/src/xrpld/rpc/handlers/orderbook/GetAggregatePrice.cpp
+++ b/src/xrpld/rpc/handlers/orderbook/GetAggregatePrice.cpp
@@ -51,7 +51,6 @@ iteratePriceData(
     std::shared_ptr<SLE const> const& sle,
     std::function<bool(STObject const&)> const& f)
 {
-    using Meta = std::shared_ptr<STObject const>;
     static constexpr std::uint8_t kMaxHistory = 3;
     bool isNew = false;
     std::uint8_t history = 0;
@@ -73,7 +72,7 @@ iteratePriceData(
     // for the Oracle is not found in the inner loop
     STObject const* prevChain = nullptr;
 
-    Meta meta = nullptr;
+    std::shared_ptr<STObject const> meta = nullptr;
     while (true)
     {
         if (prevChain == chain)

--- a/src/xrpld/rpc/handlers/orderbook/GetAggregatePrice.cpp
+++ b/src/xrpld/rpc/handlers/orderbook/GetAggregatePrice.cpp
@@ -93,6 +93,8 @@ iteratePriceData(
             return;  // LCOV_EXCL_LINE
 
         meta = ledger->txRead(prevTx).second;
+        if (!meta)
+            return;
 
         prevChain = chain;
         for (STObject const& node : meta->getFieldArray(sfAffectedNodes))


### PR DESCRIPTION
## High Level Overview of Change
Add a missing null check after `txRead()` in `iteratePriceData()` (GetAggregatePrice.cpp), preventing a potential nullptr dereference.

## Context of Change
`iteratePriceData()` walks the chain of previous transactions that modified a PriceOracle ledger object. At line 72, it calls `ledger->txRead(prevTx).second` to get the transaction metadata, then immediately dereferences it on the next line `(meta->getFieldArray(sfAffectedNodes))` without checking for null.

This is inconsistent with every other txRead call site in the codebase, which all check for null before dereferencing. If txRead returns a null metadata pointer, this would be a nullptr dereference / crash.

Triggering conditions: The bug cannot be triggered remotely on a node with consistent data. The `sfPreviousTxnID` field is maintained by the transaction engine and always points to a real transaction. For `txRead` to return `null`, the ledger would need to exist but not contain the referenced transaction — which requires pre-existing local data corruption (SHAMap structural corruption, transaction engine bug, or incomplete ledger reconstruction).

The fix adds a null guard that returns early, matching the existing defensive pattern used throughout the function.

## API Impact
No API impact. This is a defensive null check — behavior is unchanged for nodes with consistent data.

## Test Plan
Existing `GetAggregatePrice_test` passes (no behavioral change for valid data paths)
Code inspection confirms the fix matches the defensive pattern used at other `txRead` call sites in the codebase