### PR TITLE
fix: Update `clang-tidy` to include `src/tests` directory header check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -199,6 +199,6 @@ CheckOptions:
   readability-identifier-naming.PublicMemberSuffix: ""
   readability-identifier-naming.GlobalFunctionIgnoredRegexp: "^(to_string|hash_append|tuple_hash)$"
 
-HeaderFilterRegex: '^.*/(test|xrpl|xrpld)/.*\.(h|hpp|ipp)$'
+HeaderFilterRegex: '^.*/(tests?|xrpl|xrpld)/.*\.(h|hpp|ipp)$'
 ExcludeHeaderFilterRegex: '^.*/protocol_autogen/.*\.(h|hpp)$'
 WarningsAsErrors: "*"

--- a/src/tests/libxrpl/helpers/Account.cpp
+++ b/src/tests/libxrpl/helpers/Account.cpp
@@ -7,7 +7,7 @@
 
 namespace xrpl::test {
 
-Account const Account::master{"masterpassphrase"};
+Account const Account::kMaster{"masterpassphrase"};
 
 Account::Account(std::string_view name, KeyType type)
     : name_(name)

--- a/src/tests/libxrpl/helpers/Account.h
+++ b/src/tests/libxrpl/helpers/Account.h
@@ -26,7 +26,7 @@ public:
      * This account is created in the genesis ledger with all 100 billion XRP.
      * It uses the well-known seed "masterpassphrase".
      */
-    static Account const master;
+    static Account const kMaster;
 
     /**
      * @brief Create an account from a name.
@@ -39,28 +39,28 @@ public:
     explicit Account(std::string_view name, KeyType type = KeyType::Secp256k1);
 
     /** @brief Return the human-readable name. */
-    std::string const&
+    [[nodiscard]] std::string const&
     name() const noexcept
     {
         return name_;
     }
 
     /** @brief Return the AccountID. */
-    AccountID const&
+    [[nodiscard]] AccountID const&
     id() const noexcept
     {
         return id_;
     }
 
     /** @brief Return the public key. */
-    PublicKey const&
+    [[nodiscard]] PublicKey const&
     pk() const noexcept
     {
         return keyPair_.first;
     }
 
     /** @brief Return the secret key. */
-    SecretKey const&
+    [[nodiscard]] SecretKey const&
     sk() const noexcept
     {
         return keyPair_.second;

--- a/src/tests/libxrpl/helpers/IOU.h
+++ b/src/tests/libxrpl/helpers/IOU.h
@@ -49,8 +49,7 @@ public:
      * @param currency The Currency object.
      * @param issuer The account that issues this currency.
      */
-    IOU(Currency currency, Account const& issuer)
-        : currency_(std::move(currency)), issuer_(issuer.id())
+    IOU(Currency currency, Account const& issuer) : currency_(currency), issuer_(issuer.id())
     {
         XRPL_ASSERT(!isXRP(currency_), "IOU: currency code must not resolve to XRP");
     }

--- a/src/tests/libxrpl/helpers/TestFamily.h
+++ b/src/tests/libxrpl/helpers/TestFamily.h
@@ -7,8 +7,7 @@
 
 #include <memory>
 
-namespace xrpl {
-namespace test {
+namespace xrpl::test {
 
 /** Test implementation of Family for unit tests.
 
@@ -49,7 +48,7 @@ public:
         return *db_;
     }
 
-    NodeStore::Database const&
+    [[nodiscard]] NodeStore::Database const&
     db() const override
     {
         return *db_;
@@ -107,5 +106,4 @@ public:
     }
 };
 
-}  // namespace test
-}  // namespace xrpl
+}  // namespace xrpl::test

--- a/src/tests/libxrpl/helpers/TestFamily.h
+++ b/src/tests/libxrpl/helpers/TestFamily.h
@@ -94,8 +94,8 @@ public:
     void
     reset() override
     {
-        fbCache_->reset();
-        tnCache_->reset();
+        (*fbCache_).reset();
+        (*tnCache_).reset();
     }
 
     /** Access the test clock for time manipulation in tests. */

--- a/src/tests/libxrpl/helpers/TestServiceRegistry.h
+++ b/src/tests/libxrpl/helpers/TestServiceRegistry.h
@@ -16,8 +16,7 @@
 #include <optional>
 #include <stdexcept>
 
-namespace xrpl {
-namespace test {
+namespace xrpl::test {
 
 /** Logs implementation that creates TestSink instances. */
 class TestLogs : public Logs
@@ -63,7 +62,7 @@ private:
 class TestServiceRegistry : public ServiceRegistry
 {
     TestLogs logs_{beast::Severity::Warning};
-    boost::asio::io_context io_context_;
+    boost::asio::io_context ioContext_;
     TestFamily family_{logs_.journal("TestFamily")};
     LoadFeeTrack feeTrack_{logs_.journal("LoadFeeTrack")};
     TestNetworkIDService networkIDService_;
@@ -344,7 +343,7 @@ public:
     boost::asio::io_context&
     getIOContext() override
     {
-        return io_context_;
+        return ioContext_;
     }
 
     Logs&
@@ -374,5 +373,4 @@ public:
     }
 };
 
-}  // namespace test
-}  // namespace xrpl
+}  // namespace xrpl::test

--- a/src/tests/libxrpl/helpers/TxTest.cpp
+++ b/src/tests/libxrpl/helpers/TxTest.cpp
@@ -123,7 +123,7 @@ void
 TxTest::createAccount(Account const& account, XRPAmount xrp, uint32_t accountFlags)
 {
     auto const paymentTer =
-        submit(transactions::PaymentBuilder{Account::master, account, xrp}, Account::master).ter;
+        submit(transactions::PaymentBuilder{Account::kMaster, account, xrp}, Account::kMaster).ter;
 
     if (paymentTer != tesSUCCESS)
     {

--- a/src/tests/libxrpl/helpers/TxTest.h
+++ b/src/tests/libxrpl/helpers/TxTest.h
@@ -44,7 +44,7 @@ namespace xrpl::test {
  */
 template <std::integral T>
 constexpr XRPAmount
-XRP(T xrp)
+XRP(T xrp)  // NOLINT(readability-identifier-naming)
 {
     return XRPAmount{static_cast<std::int64_t>(xrp) * kDropsPerXrp.drops()};
 }

--- a/src/tests/libxrpl/tx/AccountSet.cpp
+++ b/src/tests/libxrpl/tx/AccountSet.cpp
@@ -436,7 +436,7 @@ TEST(AccountSet, TransferRate)
         {.set = 1.1, .code = tesSUCCESS, .get = 1.1},
         {.set = 2.0, .code = tesSUCCESS, .get = 2.0},
         {.set = 2.1, .code = temBAD_TRANSFER_RATE, .get = 2.0},  // > 2.0 is invalid
-        {.set = 0.0, .code = tesSUCCESS, .get = 1.0},  // 0 clears the rate (default = 1.0)
+        {.set = 0.0, .code = tesSUCCESS, .get = 1.0},            // 0 clears; default rate is 1.0
         {.set = 2.0, .code = tesSUCCESS, .get = 2.0},
         {.set = 0.9, .code = temBAD_TRANSFER_RATE, .get = 2.0},  // < 1.0 is invalid
     };

--- a/src/tests/libxrpl/tx/AccountSet.cpp
+++ b/src/tests/libxrpl/tx/AccountSet.cpp
@@ -432,13 +432,13 @@ TEST(AccountSet, TransferRate)
 
     // Test data: {rate to set, expected TER, expected stored rate}
     std::vector<TestCase> const testData = {
-        {1.0, tesSUCCESS, 1.0},
-        {1.1, tesSUCCESS, 1.1},
-        {2.0, tesSUCCESS, 2.0},
-        {2.1, temBAD_TRANSFER_RATE, 2.0},  // > 2.0 is invalid
-        {0.0, tesSUCCESS, 1.0},            // 0 clears the rate (default = 1.0)
-        {2.0, tesSUCCESS, 2.0},
-        {0.9, temBAD_TRANSFER_RATE, 2.0},  // < 1.0 is invalid
+        {.set = 1.0, .code = tesSUCCESS, .get = 1.0},
+        {.set = 1.1, .code = tesSUCCESS, .get = 1.1},
+        {.set = 2.0, .code = tesSUCCESS, .get = 2.0},
+        {.set = 2.1, .code = temBAD_TRANSFER_RATE, .get = 2.0},  // > 2.0 is invalid
+        {.set = 0.0, .code = tesSUCCESS, .get = 1.0},  // 0 clears the rate (default = 1.0)
+        {.set = 2.0, .code = tesSUCCESS, .get = 2.0},
+        {.set = 0.9, .code = temBAD_TRANSFER_RATE, .get = 2.0},  // < 1.0 is invalid
     };
 
     TxTest env;


### PR DESCRIPTION
## High Level Overview of Change

Update configuration of the `clang-tidy` tool to include headers from the `src/tests` and apply the project style to affected files.

### Context of Change

The goal is to improve automated checks for the project.

### API Impact

No API changes

