### PR TITLE
refactor: Remove dead `fetchBatch` code

### DIFF
--- a/include/xrpl/nodestore/Backend.h
+++ b/include/xrpl/nodestore/Backend.h
@@ -83,10 +83,6 @@ public:
     virtual Status
     fetch(uint256 const& hash, std::shared_ptr<NodeObject>* pObject) = 0;
 
-    /** Fetch a batch synchronously. */
-    virtual std::pair<std::vector<std::shared_ptr<NodeObject>>, Status>
-    fetchBatch(std::vector<uint256> const& hashes) = 0;
-
     /** Store a single object.
         Depending on the implementation this may happen immediately
         or deferred using a scheduled task.

--- a/include/xrpl/nodestore/detail/DatabaseNodeImp.h
+++ b/include/xrpl/nodestore/detail/DatabaseNodeImp.h
@@ -67,9 +67,6 @@ public:
         backend_->sync();
     }
 
-    std::vector<std::shared_ptr<NodeObject>>
-    fetchBatch(std::vector<uint256> const& hashes);
-
     void
     asyncFetch(
         uint256 const& hash,

--- a/src/libxrpl/nodestore/DatabaseNodeImp.cpp
+++ b/src/libxrpl/nodestore/DatabaseNodeImp.cpp
@@ -81,33 +81,4 @@ DatabaseNodeImp::fetchNodeObject(
     return nodeObject;
 }
 
-std::vector<std::shared_ptr<NodeObject>>
-DatabaseNodeImp::fetchBatch(std::vector<uint256> const& hashes)
-{
-    using namespace std::chrono;
-    auto const before = steady_clock::now();
-
-    // Get the node objects that match the hashes from the backend. To protect
-    // against the backends returning fewer or more results than expected, the
-    // container is resized to the number of hashes.
-    auto results = backend_->fetchBatch(hashes).first;
-    XRPL_ASSERT(
-        results.size() == hashes.size() || results.empty(),
-        "number of output objects either matches number of input hashes or is empty");
-    results.resize(hashes.size());
-    for (size_t i = 0; i < results.size(); ++i)
-    {
-        if (!results[i])
-        {
-            JLOG(j_.error()) << "fetchBatch - "
-                             << "record not found in db. hash = " << strHex(hashes[i]);
-        }
-    }
-
-    auto fetchDurationUs =
-        std::chrono::duration_cast<std::chrono::microseconds>(steady_clock::now() - before).count();
-    updateFetchMetrics(hashes.size(), 0, fetchDurationUs);
-    return results;
-}
-
 }  // namespace xrpl::NodeStore

--- a/src/libxrpl/nodestore/DatabaseNodeImp.cpp
+++ b/src/libxrpl/nodestore/DatabaseNodeImp.cpp
@@ -4,21 +4,16 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/basics/contract.h>
-#include <xrpl/basics/strHex.h>
-#include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/nodestore/Database.h>
 #include <xrpl/nodestore/NodeObject.h>
 #include <xrpl/nodestore/Scheduler.h>
 #include <xrpl/nodestore/Types.h>
 
-#include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
 #include <memory>
 #include <utility>
-#include <vector>
 
 namespace xrpl::NodeStore {
 

--- a/src/libxrpl/nodestore/backend/MemoryFactory.cpp
+++ b/src/libxrpl/nodestore/backend/MemoryFactory.cpp
@@ -22,7 +22,6 @@
 #include <string>
 #include <tuple>
 #include <utility>
-#include <vector>
 
 namespace xrpl::NodeStore {
 

--- a/src/libxrpl/nodestore/backend/MemoryFactory.cpp
+++ b/src/libxrpl/nodestore/backend/MemoryFactory.cpp
@@ -146,28 +146,6 @@ public:
         return Status::Ok;
     }
 
-    std::pair<std::vector<std::shared_ptr<NodeObject>>, Status>
-    fetchBatch(std::vector<uint256> const& hashes) override
-    {
-        std::vector<std::shared_ptr<NodeObject>> results;
-        results.reserve(hashes.size());
-        for (auto const& h : hashes)
-        {
-            std::shared_ptr<NodeObject> nObj;
-            Status const status = fetch(h, &nObj);
-            if (status != Status::Ok)
-            {
-                results.push_back({});
-            }
-            else
-            {
-                results.push_back(nObj);
-            }
-        }
-
-        return {results, Status::Ok};
-    }
-
     void
     store(std::shared_ptr<NodeObject> const& object) override
     {

--- a/src/libxrpl/nodestore/backend/NuDBFactory.cpp
+++ b/src/libxrpl/nodestore/backend/NuDBFactory.cpp
@@ -42,7 +42,6 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace xrpl::NodeStore {
 

--- a/src/libxrpl/nodestore/backend/NuDBFactory.cpp
+++ b/src/libxrpl/nodestore/backend/NuDBFactory.cpp
@@ -232,28 +232,6 @@ public:
         return status;
     }
 
-    std::pair<std::vector<std::shared_ptr<NodeObject>>, Status>
-    fetchBatch(std::vector<uint256> const& hashes) override
-    {
-        std::vector<std::shared_ptr<NodeObject>> results;
-        results.reserve(hashes.size());
-        for (auto const& h : hashes)
-        {
-            std::shared_ptr<NodeObject> nObj;
-            Status const status = fetch(h, &nObj);
-            if (status != Status::Ok)
-            {
-                results.push_back({});
-            }
-            else
-            {
-                results.push_back(nObj);
-            }
-        }
-
-        return {results, Status::Ok};
-    }
-
     void
     doInsert(std::shared_ptr<NodeObject> const& no)
     {

--- a/src/libxrpl/nodestore/backend/NullFactory.cpp
+++ b/src/libxrpl/nodestore/backend/NullFactory.cpp
@@ -52,12 +52,6 @@ public:
         return Status::NotFound;
     }
 
-    std::pair<std::vector<std::shared_ptr<NodeObject>>, Status>
-    fetchBatch(std::vector<uint256> const& hashes) override
-    {
-        return {};
-    }
-
     void
     store(std::shared_ptr<NodeObject> const& object) override
     {

--- a/src/libxrpl/nodestore/backend/NullFactory.cpp
+++ b/src/libxrpl/nodestore/backend/NullFactory.cpp
@@ -12,8 +12,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <utility>
-#include <vector>
 
 namespace xrpl::NodeStore {
 

--- a/src/libxrpl/nodestore/backend/RocksDBFactory.cpp
+++ b/src/libxrpl/nodestore/backend/RocksDBFactory.cpp
@@ -330,28 +330,6 @@ public:
         return status;
     }
 
-    std::pair<std::vector<std::shared_ptr<NodeObject>>, Status>
-    fetchBatch(std::vector<uint256> const& hashes) override
-    {
-        std::vector<std::shared_ptr<NodeObject>> results;
-        results.reserve(hashes.size());
-        for (auto const& h : hashes)
-        {
-            std::shared_ptr<NodeObject> nObj;
-            Status const status = fetch(h, &nObj);
-            if (status != Status::Ok)
-            {
-                results.push_back({});
-            }
-            else
-            {
-                results.push_back(nObj);
-            }
-        }
-
-        return {results, Status::Ok};
-    }
-
     void
     store(std::shared_ptr<NodeObject> const& object) override
     {

--- a/src/libxrpl/nodestore/backend/RocksDBFactory.cpp
+++ b/src/libxrpl/nodestore/backend/RocksDBFactory.cpp
@@ -29,8 +29,6 @@
 #include <functional>
 #include <stdexcept>
 #include <string>
-#include <utility>
-#include <vector>
 
 #if XRPL_ROCKSDB_AVAILABLE
 #include <xrpl/basics/ByteUtilities.h>


### PR DESCRIPTION
## High Level Overview of Change

This change removes the `fetchBatch` functionality, as it was unused.

### Context of Change

The `fetchBatch` functionality was introduced in https://github.com/XRPLF/rippled/commit/1b497768190c69c4d8177d4778cb265a120cab15, but the code was actually never used.