### PR TITLE
release: Bump version to 3.2.0-b6

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -23,7 +23,7 @@ namespace {
 //------------------------------------------------------------------------------
 // clang-format off
 // NOLINTNEXTLINE(readability-identifier-naming)
-char const* const versionString = "3.3.0-b0"
+char const* const versionString = "3.2.0-b6"
     // clang-format on
     ;
 


### PR DESCRIPTION
## High Level Overview of Change

This change updates the version number to 3.2.0-b6.

### Context of Change

We will be releasing beta versions from the develop branch going forward, so this change sets the version number to the next beta we will be releasing.