### PR TITLE
fix: Skip deleted book directories and non-root modifications in `ValidBookDirectory` invariant

### DIFF
--- a/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
+++ b/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
@@ -45,9 +45,12 @@ ValidBookDirectory::visitEntry(
     std::shared_ptr<SLE const> const& after)
 {
     // New root directories must have matching exchange-rate metadata. New
-    // child directories must point to an existing root. Skip once a bad
-    // directory was found, for deletions, defensively when after is missing,
-    // and for non-directory entries.
+    // child directories, and modified directories that change sfRootIndex, must
+    // point to an existing root.
+
+    // Only validate newly-created directories and sfRootIndex changes;
+    // LedgerStateFix handles legacy bad exchange-rate metadata. Skip deletions
+    // because `after` is not guaranteed to be null.
     if (badBookDirectory_ || isDelete || !after || after->getType() != ltDIR_NODE)
         return;
 

--- a/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
+++ b/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
@@ -45,14 +45,19 @@ ValidBookDirectory::visitEntry(
     std::shared_ptr<SLE const> const& after)
 {
     // New root directories must have matching exchange-rate metadata. New
-    // child directories must point to an existing root.
-
-    // Only validate newly-created directories; LedgerStateFix handles legacy
-    // bad exchange-rate metadata.
-    if (badBookDirectory_ || isDelete || before || !after || after->getType() != ltDIR_NODE)
+    // child directories must point to an existing root. Skip once a bad
+    // directory was found, for deletions, defensively when after is missing,
+    // and for non-directory entries.
+    if (badBookDirectory_ || isDelete || !after || after->getType() != ltDIR_NODE)
         return;
 
     auto const rootIndex = after->getFieldH256(sfRootIndex);
+    // Ignore ordinary modifications that do not change which root this
+    // directory belongs to. That tolerates legacy bad exchange-rate metadata
+    // during normal operation while still checking sfRootIndex changes.
+    if (before && before->getFieldH256(sfRootIndex) == rootIndex)
+        return;
+
     if (after->key() == rootIndex && !badBookDirectory_)
     {
         badBookDirectory_ = badBookDirectory_ || badExchangeRate(*after);

--- a/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
+++ b/src/libxrpl/tx/invariants/DirectoryInvariant.cpp
@@ -40,7 +40,7 @@ badExchangeRate(SLE const& dir)
 
 void
 ValidBookDirectory::visitEntry(
-    bool,
+    bool isDelete,
     std::shared_ptr<SLE const> const& before,
     std::shared_ptr<SLE const> const& after)
 {
@@ -49,7 +49,7 @@ ValidBookDirectory::visitEntry(
 
     // Only validate newly-created directories; LedgerStateFix handles legacy
     // bad exchange-rate metadata.
-    if (badBookDirectory_ || before || !after || after->getType() != ltDIR_NODE)
+    if (badBookDirectory_ || isDelete || before || !after || after->getType() != ltDIR_NODE)
         return;
 
     auto const rootIndex = after->getFieldH256(sfRootIndex);

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -2138,8 +2138,9 @@ class Invariants_test : public beast::unit_test::Suite
                 invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
         }
 
-        // A bad root is rejected when added, but ignored when a legacy bad
-        // root is modified without changing sfRootIndex or deleted.
+        // A bad root is rejected when added, ignored when a legacy bad root is
+        // modified without changing sfRootIndex or deleted, and checked when a
+        // modified directory changes sfRootIndex.
         {
             Env env{*this, defaultAmendments()};
             Account const a1{"A1"};
@@ -2149,6 +2150,7 @@ class Invariants_test : public beast::unit_test::Suite
             OpenView view{*env.current()};
             auto const directoryQuality = STAmount::kURateOne;
             auto const rootDir = getBookRootKey(a1, directoryQuality);
+            auto const missingRootDir = getBookRootKey(a1, directoryQuality + 1);
             auto const badRoot = makeRootPage(rootDir, directoryQuality + 1);
             view.rawInsert(badRoot);
 
@@ -2170,6 +2172,23 @@ class Invariants_test : public beast::unit_test::Suite
 
                 BEAST_EXPECT(
                     invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
+            }
+            {
+                // modify (changing sfRootIndex to a missing root)
+                auto const childBefore = makeChildPage(rootDir);
+                auto const childAfter = std::make_shared<SLE>(*childBefore, childBefore->key());
+                childAfter->setFieldH256(sfRootIndex, missingRootDir.key);
+
+                ValidBookDirectory invariant;
+                invariant.visitEntry(false, childBefore, childAfter);
+
+                test::StreamSink missingRootSink{beast::Severity::Warning};
+                beast::Journal const missingRootJlog{missingRootSink};
+                BEAST_EXPECT(!invariant.finalize(
+                    makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, missingRootJlog));
+                BEAST_EXPECT(
+                    missingRootSink.messages().str().find("book directory root missing") !=
+                    std::string::npos);
             }
             {
                 view.rawErase(badRoot);

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -2191,10 +2191,10 @@ class Invariants_test : public beast::unit_test::Suite
                     std::string::npos);
             }
             {
+                // delete
                 view.rawErase(badRoot);
                 BEAST_EXPECT(!view.exists(rootDir));
 
-                // delete
                 ValidBookDirectory invariant;
                 invariant.visitEntry(true, badRoot, badRoot);
                 BEAST_EXPECT(

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -2138,9 +2138,8 @@ class Invariants_test : public beast::unit_test::Suite
                 invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
         }
 
-        // Deleting a bad legacy root must not be reported as creating a bad
-        // root. The invariant receives an explicit isDelete marker, and the
-        // deleted SLE image may still be present in the callback.
+        // A bad root is rejected when added, but ignored when a legacy bad
+        // root is modified without changing sfRootIndex or deleted.
         {
             Env env{*this, defaultAmendments()};
             Account const a1{"A1"};
@@ -2152,16 +2151,36 @@ class Invariants_test : public beast::unit_test::Suite
             auto const rootDir = getBookRootKey(a1, directoryQuality);
             auto const badRoot = makeRootPage(rootDir, directoryQuality + 1);
             view.rawInsert(badRoot);
-            view.rawErase(badRoot);
-            BEAST_EXPECT(!view.exists(rootDir));
-
-            ValidBookDirectory invariant;
-            invariant.visitEntry(true, nullptr, badRoot);
 
             test::StreamSink sink{beast::Severity::Warning};
             beast::Journal const jlog{sink};
-            BEAST_EXPECT(
-                invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
+
+            {
+                // add
+                ValidBookDirectory invariant;
+                invariant.visitEntry(false, nullptr, badRoot);
+
+                BEAST_EXPECT(
+                    !invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
+            }
+            {
+                // modify (without changing the sfRootIndex)
+                ValidBookDirectory invariant;
+                invariant.visitEntry(false, badRoot, badRoot);
+
+                BEAST_EXPECT(
+                    invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
+            }
+            {
+                view.rawErase(badRoot);
+                BEAST_EXPECT(!view.exists(rootDir));
+
+                // delete
+                ValidBookDirectory invariant;
+                invariant.visitEntry(true, badRoot, badRoot);
+                BEAST_EXPECT(
+                    invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
+            }
         }
     }
 

--- a/src/test/app/Invariants_test.cpp
+++ b/src/test/app/Invariants_test.cpp
@@ -2137,6 +2137,32 @@ class Invariants_test : public beast::unit_test::Suite
             BEAST_EXPECT(
                 invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
         }
+
+        // Deleting a bad legacy root must not be reported as creating a bad
+        // root. The invariant receives an explicit isDelete marker, and the
+        // deleted SLE image may still be present in the callback.
+        {
+            Env env{*this, defaultAmendments()};
+            Account const a1{"A1"};
+            env.fund(XRP(1000), a1);
+            env.close();
+
+            OpenView view{*env.current()};
+            auto const directoryQuality = STAmount::kURateOne;
+            auto const rootDir = getBookRootKey(a1, directoryQuality);
+            auto const badRoot = makeRootPage(rootDir, directoryQuality + 1);
+            view.rawInsert(badRoot);
+            view.rawErase(badRoot);
+            BEAST_EXPECT(!view.exists(rootDir));
+
+            ValidBookDirectory invariant;
+            invariant.visitEntry(true, nullptr, badRoot);
+
+            test::StreamSink sink{beast::Severity::Warning};
+            beast::Journal const jlog{sink};
+            BEAST_EXPECT(
+                invariant.finalize(makeOfferCreateTx(), tesSUCCESS, XRPAmount{}, view, jlog));
+        }
     }
 
     Keylet


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
Update ValidBookDirectory to validate newly-created directory nodes and modified
directory nodes only when `sfRootIndex` changes. This keeps legacy bad
exchange-rate metadata from causing false positives during ordinary
modifications, while still checking root-link changes.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
