### PR TITLE
fix: Fix RPM prerelease ordering and start xrpld on DEB install

### DIFF
--- a/package/build_pkg.sh
+++ b/package/build_pkg.sh
@@ -135,8 +135,12 @@ build_rpm() {
 
     # RPM Version can't contain '-'. A pre-release goes in Release with a
     # leading "0." so 3.2.0-b1 sorts before the final 3.2.0-<pkg_release>.
+    # The order is "0.<pkg_release>.<suffix>" (e.g. 0.1.b6) — the Fedora/EPEL
+    # convention. Reversing to "0.<suffix>.<pkg_release>" (e.g. 0.b6.1) breaks
+    # rpmvercmp against the former because numeric segments outrank alphabetic
+    # ones, so "0.1.b5" would sort newer than "0.b6.1".
     local rpm_release="${PKG_RELEASE}"
-    [[ -n "${VER_SUFFIX}" ]] && rpm_release="0.${VER_SUFFIX}.${PKG_RELEASE}"
+    [[ -n "${VER_SUFFIX}" ]] && rpm_release="0.${PKG_RELEASE}.${VER_SUFFIX}"
 
     set -x
     rpmbuild -bb \

--- a/package/debian/rules
+++ b/package/debian/rules
@@ -9,7 +9,7 @@ override_dh_auto_configure override_dh_auto_build override_dh_auto_test:
 	@:
 
 override_dh_installsystemd:
-	dh_installsystemd --no-start xrpld.service
+	dh_installsystemd --no-stop-on-upgrade xrpld.service
 	dh_installsystemd --name=update-xrpld --no-start update-xrpld.service update-xrpld.timer
 
 execute_before_dh_installtmpfiles:


### PR DESCRIPTION
## Summary

1. Fix RPM prerelease version ordering so newer beta builds sort correctly, e.g. `b6` upgrades from `b5`.
1. Start `xrpld.service` on fresh DEB installs while avoiding an immediate restart during DEB upgrades.

## Details

1. The RPM packaging version logic now preserves the expected prerelease ordering for beta builds. This prevents package managers from treating an older beta build as newer or refusing the expected `b5` → `b6` upgrade path.

1. For DEB packaging, `xrpld.service` now uses `dh_installsystemd --no-stop-on-upgrade`. This starts the service after a fresh install, but avoids stopping/restarting an already-running daemon during package upgrades.

The `update-xrpld` timer remains configured with `--no-start`.

## Testing

- [x] Verified RPM package ordering for the affected beta versions.
- [x] Verified fresh DEB install starts `xrpld.service`.
- [x] Verified DEB upgrade does not immediately restart `xrpld.service`.
- [x] Verified `update-xrpld.timer` is not started.