### PR TITLE
ci: Re-enable full nproc for Linux

### DIFF
--- a/.github/workflows/reusable-build-test-config.yml
+++ b/.github/workflows/reusable-build-test-config.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Build the binary
         working-directory: ${{ env.BUILD_DIR }}
         env:
-          BUILD_NPROC: ${{ runner.os == 'Linux' && '16' || steps.nproc.outputs.nproc }}
+          BUILD_NPROC: ${{ steps.nproc.outputs.nproc }}
           BUILD_TYPE: ${{ inputs.build_type }}
           CMAKE_TARGET: ${{ inputs.cmake_target }}
         run: |


### PR DESCRIPTION
Reverts the temporary reduction of nproc #7132 allowing Linux builds full utilization of runners again.
