### PR TITLE
release: Bump version to 3.2.0-b7

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -23,7 +23,7 @@ namespace {
 //------------------------------------------------------------------------------
 // clang-format off
 // NOLINTNEXTLINE(readability-identifier-naming)
-char const* const versionString = "3.2.0-b6"
+char const* const versionString = "3.2.0-b7"
     // clang-format on
     ;
 


### PR DESCRIPTION
This change bumps the version to 3.2.0-b7 so we can test out the new packaging workflow.