### PR TITLE
ci: Run PR title and description checks on staging and release branches

### DIFF
--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -13,6 +13,8 @@ on:
       - ready_for_review
     branches:
       - develop
+      - "release-*"
+      - "release/*"
       - "staging/*"
 
 jobs:

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -5,8 +5,15 @@ on:
     types:
       - checks_requested
   pull_request:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
-    branches: [develop]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - develop
+      - "staging/*"
 
 jobs:
   check_description:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -13,6 +13,8 @@ on:
       - ready_for_review
     branches:
       - develop
+      - "release-*"
+      - "release/*"
       - "staging/*"
 
 jobs:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -5,8 +5,15 @@ on:
     types:
       - checks_requested
   pull_request:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
-    branches: [develop]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - develop
+      - "staging/*"
 
 jobs:
   check_title:


### PR DESCRIPTION
## High Level Overview of Change

This change enables the `check-pr-title` and `check-pr-description` CI checks for staging and release branches.

### Context of Change

When we create PRs targeting the staging and release branches, which we use for preparing release candidates and releases, their titles and descriptions should also be validated.