### PR TITLE
refactor: Enable support for `fixCleanup3_2_0` amendment

### DIFF
--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -15,7 +15,7 @@
 // Add new amendments to the top of this list.
 // Keep it sorted in reverse chronological order.
 
-XRPL_FIX    (Cleanup3_2_0,                Supported::No,  VoteBehavior::DefaultNo)
+XRPL_FIX    (Cleanup3_2_0,                Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FEATURE(MPTokensV2,                  Supported::No,  VoteBehavior::DefaultNo)
 XRPL_FIX    (Cleanup3_1_3,                Supported::Yes, VoteBehavior::DefaultYes)
 XRPL_FIX    (BatchInnerSigs,              Supported::No,  VoteBehavior::DefaultNo)


### PR DESCRIPTION
## High Level Overview of Change

This change enables support for the `fixCleanup3_2_0` amendment.

### Context of Change

In anticipation of the 3.2.0 release, the fix amendment needs to be supported so it can be voted on.
