### PR TITLE
fix: Reject zero DomainID at preflight in OfferCreate and Payment

### DIFF
--- a/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
@@ -19,6 +19,14 @@ namespace xrpl::permissioned_dex {
 bool
 accountInDomain(ReadView const& view, AccountID const& account, Domain const& domainID)
 {
+    // A zero domainID is malformed: it would build a keylet with a zero key
+    // and violate Ledger::read's invariant. Defense in depth: callers should
+    // reject this at preflight, but guard here too so any future caller and
+    // the order-book sweep path (offerInDomain -> here) cannot trip the
+    // invariant.
+    if (domainID.isZero())
+        return false;
+
     auto const sleDomain = view.read(keylet::permissionedDomain(domainID));
     if (!sleDomain)
         return false;

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -94,6 +94,16 @@ OfferCreate::preflight(PreflightContext const& ctx)
     if (tx.isFlag(tfHybrid) && !tx.isFieldPresent(sfDomainID))
         return temINVALID_FLAG;
 
+    // A present but zero DomainID is malformed: it would build a keylet with
+    // a zero key and violate Ledger::read's invariant. Reject at preflight
+    // (temMALFORMED) instead of letting it slip to preclaim and be
+    // misclassified as tecNO_PERMISSION.
+    if (tx.isFieldPresent(sfDomainID) && tx.getFieldH256(sfDomainID).isZero())
+    {
+        JLOG(j.debug()) << "Malformed offer: zero DomainID";
+        return temMALFORMED;
+    }
+
     bool const bImmediateOrCancel(tx.isFlag(tfImmediateOrCancel));
     bool const bFillOrKill(tx.isFlag(tfFillOrKill));
 

--- a/src/libxrpl/tx/transactors/payment/Payment.cpp
+++ b/src/libxrpl/tx/transactors/payment/Payment.cpp
@@ -125,6 +125,16 @@ Payment::preflight(PreflightContext const& ctx)
     if (!mpTokensV2 && isDstMPT && ctx.tx.isFieldPresent(sfPaths))
         return temMALFORMED;
 
+    // A present but zero DomainID is malformed: it would build a keylet with
+    // a zero key and violate Ledger::read's invariant. Reject at preflight
+    // (temMALFORMED) instead of letting it slip to preclaim and be
+    // misclassified as tecNO_PERMISSION.
+    if (tx.isFieldPresent(sfDomainID) && tx.getFieldH256(sfDomainID).isZero())
+    {
+        JLOG(j.debug()) << "Malformed payment: zero DomainID";
+        return temMALFORMED;
+    }
+
     bool const partialPaymentAllowed = tx.isFlag(tfPartialPayment);
     bool const limitQuality = tx.isFlag(tfLimitQuality);
     bool const defaultPathsAllowed = !tx.isFlag(tfNoRippleDirect);

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -278,6 +278,17 @@ class PermissionedDEX_test : public beast::unit_test::Suite
             env.close();
         }
 
+        // preflight - a present but zero DomainID is malformed.
+        // Regression test for "Ledger::read : zero key" assertion.
+        {
+            Env env(*this, features);
+            auto const& [gw_, domainOwner, alice_, bob_, carol_, USD, domainID, credType] =
+                PermissionedDEX(env);
+
+            env(offer(bob_, XRP(10), USD(10)), Domain(uint256{}), Ter(temMALFORMED));
+            env.close();
+        }
+
         // apply - offer can be created even if takergets issuer is not in
         // domain
         {
@@ -410,6 +421,21 @@ class PermissionedDEX_test : public beast::unit_test::Suite
                 Sendmax(XRP(10)),
                 Domain(badDomain),
                 Ter(tecNO_PERMISSION));
+            env.close();
+        }
+
+        // preflight - a present but zero DomainID is malformed.
+        // Regression test for "Ledger::read : zero key" assertion.
+        {
+            Env env(*this, features);
+            auto const& [gw_, domainOwner, alice_, bob_, carol_, USD, domainID, credType] =
+                PermissionedDEX(env);
+
+            env(pay(bob_, alice_, USD(10)),
+                Path(~USD),
+                Sendmax(XRP(10)),
+                Domain(uint256{}),
+                Ter(temMALFORMED));
             env.close();
         }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

`OfferCreate` and `Payment` accepted transactions with `sfDomainID` present but set to all zeros. In Debug/ASan builds this triggered the `Ledger::read` : zero key assertion in `permissioned_dex::accountInDomain`.  In Release builds the malformed transaction was misclassified as `tecNO_PERMISSION`, charging a fee, consuming a sequence, and writing the failed tx to he ledger.

The fix rejects zero `sfDomainID` at preflight with `temMALFORMED`, matching the existing convention for `PermissionedDomainSet` (which already rejects uint256(0) as malformed).

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
