### PR TITLE
ci: Support many libc versions in nix images

### DIFF
--- a/docker/nix.Dockerfile
+++ b/docker/nix.Dockerfile
@@ -16,10 +16,23 @@ WORKDIR /tmp/build
 
 FROM builder-source AS builder
 
-# Build our Nix CI environment (all build tools in a single store path)
-RUN nix \
-    --option filter-syscalls false \
-    build
+ARG BASE_IMAGE=nixos/nix:latest
+
+# Build the CI environment variant that matches the target OS's native glibc.
+# The flake exposes per-distro packages (ubuntu/rhel/debian/nixos) that are
+# each compiled against the glibc version shipped by the corresponding base
+# image, so produced binaries don't require symbols newer than what the OS
+# provides at runtime.
+RUN case "$BASE_IMAGE" in \
+        nixos/*) DISTRO="nixos" ;; \
+        ubuntu:*) DISTRO="ubuntu" ;; \
+        *ubi*|*rhel*) DISTRO="rhel" ;; \
+        debian:*) DISTRO="debian" ;; \
+        *) echo "Unknown base image: $BASE_IMAGE, defaulting to ubuntu" >&2; DISTRO="ubuntu" ;; \
+    esac && \
+    nix \
+        --option filter-syscalls false \
+        build ".#${DISTRO}"
 
 # Copy the Nix store closure into a directory. The Nix store closure is the
 # entire set of Nix store values that we need for our build.
@@ -28,8 +41,6 @@ RUN mkdir /tmp/nix-store-closure && \
 
 # Final image
 FROM ${BASE_IMAGE} AS final
-
-ARG BASE_IMAGE
 
 # bash is not located at /bin/bash in nixos/nix, so we need to create a symlink to it.
 RUN if [ -d /nix ]; then \
@@ -97,6 +108,4 @@ RUN /tmp/compile-cpp-sources.sh /tmp/cpp_sources /tmp/bins
 #
 # When build and test images will be separate, we will be to run on vanilla images.
 COPY docker/test_files/run-test-binaries.sh /tmp/run-test-binaries.sh
-RUN if echo "${BASE_IMAGE}" | grep -qiE '(ubuntu|nixos)'; then \
-        /tmp/run-test-binaries.sh /tmp/bins; \
-    fi
+RUN /tmp/run-test-binaries.sh /tmp/bins

--- a/flake.lock
+++ b/flake.lock
@@ -15,7 +15,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-custom-glibc": {
+    "nixpkgs-glibc-2-31": {
       "flake": false,
       "locked": {
         "lastModified": 1593520194,
@@ -32,10 +32,46 @@
         "type": "github"
       }
     },
+    "nixpkgs-glibc-2-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1658843810,
+        "narHash": "sha256-J5iJLliax/TI6vPEtc4yU2jPI0UcQU3ftXwCZcFjezg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd935b2d96037d2eee31529d27340c12098d9b07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd935b2d96037d2eee31529d27340c12098d9b07",
+        "type": "github"
+      }
+    },
+    "nixpkgs-glibc-2-35": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681128000,
+        "narHash": "sha256-S1xCHg38L6l1JwGgQ42/KgHTKzgebZCKWHVixI96xQ8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f9c5b550c2ff7116bb39783f34820754a11c016b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f9c5b550c2ff7116bb39783f34820754a11c016b",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-custom-glibc": "nixpkgs-custom-glibc"
+        "nixpkgs-glibc-2-31": "nixpkgs-glibc-2-31",
+        "nixpkgs-glibc-2-34": "nixpkgs-glibc-2-34",
+        "nixpkgs-glibc-2-35": "nixpkgs-glibc-2-35"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,45 @@
   description = "Nix related things for xrpld";
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
-    # nixpkgs snapshot (2020-06-30) that shipped glibc 2.31 as the primary
-    # version — matches the system libc on Ubuntu 20.04 LTS. Imported
-    # manually (flake = false) because this revision predates nixpkgs'
-    # own flake.nix.
-    nixpkgs-custom-glibc = {
+
+    # Last nixpkgs commit with glibc 2.31 (2020-06-30) — matches Ubuntu 20.04 LTS.
+    # Imported as flake = false because this revision predates nixpkgs' own flake.nix.
+    nixpkgs-glibc-2-31 = {
       url = "github:NixOS/nixpkgs/9cd98386a38891d1074fc18036b842dc4416f562";
+      flake = false;
+    };
+
+    # Last nixpkgs commit with glibc 2.34 (2022-07-26) — matches RHEL 9 / UBI 9.
+    nixpkgs-glibc-2-34 = {
+      url = "github:NixOS/nixpkgs/cd935b2d96037d2eee31529d27340c12098d9b07";
+      flake = false;
+    };
+
+    # Last nixpkgs commit with glibc 2.35 (2023-04-10) — highest available in nixpkgs
+    # below Debian Bookworm's native glibc 2.36 (nixpkgs skipped 2.36, going 2.35→2.37).
+    nixpkgs-glibc-2-35 = {
+      url = "github:NixOS/nixpkgs/f9c5b550c2ff7116bb39783f34820754a11c016b";
       flake = false;
     };
   };
 
   outputs =
-    { nixpkgs, nixpkgs-custom-glibc, ... }:
+    {
+      nixpkgs,
+      nixpkgs-glibc-2-31,
+      nixpkgs-glibc-2-34,
+      nixpkgs-glibc-2-35,
+      ...
+    }:
     let
-      forEachSystem = import ./nix/utils.nix { inherit nixpkgs nixpkgs-custom-glibc; };
+      forEachSystem = import ./nix/utils.nix {
+        inherit
+          nixpkgs
+          nixpkgs-glibc-2-31
+          nixpkgs-glibc-2-34
+          nixpkgs-glibc-2-35
+          ;
+      };
     in
     {
       devShells = forEachSystem (import ./nix/devshell.nix);

--- a/nix/ci-env.nix
+++ b/nix/ci-env.nix
@@ -1,118 +1,143 @@
 {
   pkgs,
-  customGlibc,
+  glibc-2-31,
+  glibc-2-34,
+  glibc-2-35,
   ...
 }:
 let
   inherit (import ./packages.nix { inherit pkgs; }) commonPackages;
   inherit (pkgs) lib;
 
-  # Underlying compiler toolchains to wrap. Bump these in one place to
-  # roll the whole environment forward.
-  customGccPackage = pkgs.gcc15;
-  customLlvmPackages = pkgs.llvmPackages_22;
-  customClangMajor = lib.versions.major (lib.getVersion customLlvmPackages.clang-unwrapped);
+  # Build a complete CI environment that links against the given glibc.
+  # All compiler toolchains (gcc, clang, binutils) are rebuilt to reference
+  # exactly `customGlibc` so that produced binaries stay within the symbol
+  # set available on the target OS.
+  mkCiEnv =
+    customGlibc:
+    let
+      # Underlying compiler toolchains to wrap. Bump these in one place to
+      # roll the whole environment forward.
+      customGccPackage = pkgs.gcc15;
+      customLlvmPackages = pkgs.llvmPackages_22;
+      customClangMajor = lib.versions.major (lib.getVersion customLlvmPackages.clang-unwrapped);
 
-  # binutils wrapped to emit binaries that reference the custom glibc
-  # (dynamic linker path, library search path, RPATH).
-  customBinutils = pkgs.wrapBintoolsWith {
-    bintools = pkgs.binutils-unwrapped;
-    libc = customGlibc;
-  };
+      # binutils wrapped to emit binaries that reference the custom glibc
+      # (dynamic linker path, library search path, RPATH).
+      customBinutils = pkgs.wrapBintoolsWith {
+        bintools = pkgs.binutils-unwrapped;
+        libc = customGlibc;
+      };
 
-  # Rebuild gcc (specifically libstdc++ / libgcc_s) against the custom
-  # glibc. The override swaps gcc.cc's bootstrap stdenv for one that uses
-  # the existing gcc binary but links against the custom glibc, so the
-  # resulting compiler ships runtime libraries that only reference symbols
-  # available in that glibc.
-  customGccCc = customGccPackage.cc.override {
-    stdenv = pkgs.stdenvAdapters.overrideCC pkgs.stdenv (
-      pkgs.wrapCCWith {
-        cc = customGccPackage.cc;
+      # Rebuild gcc (specifically libstdc++ / libgcc_s) against the custom
+      # glibc. The override swaps gcc.cc's bootstrap stdenv for one that uses
+      # the existing gcc binary but links against the custom glibc, so the
+      # resulting compiler ships runtime libraries that only reference symbols
+      # available in that glibc.
+      customGccCc = customGccPackage.cc.override {
+        stdenv = pkgs.stdenvAdapters.overrideCC pkgs.stdenv (
+          pkgs.wrapCCWith {
+            cc = customGccPackage.cc;
+            libc = customGlibc;
+            bintools = customBinutils;
+          }
+        );
+      };
+
+      # cc-wrapper around the rebuilt compiler, pointing at the custom glibc
+      # headers and libraries. This is what we actually expose to users.
+      customGcc = pkgs.wrapCCWith {
+        cc = customGccCc;
         libc = customGlibc;
         bintools = customBinutils;
-      }
-    );
-  };
+      };
 
-  # cc-wrapper around the rebuilt compiler, pointing at the custom glibc
-  # headers and libraries. This is what we actually expose to users.
-  customGcc = pkgs.wrapCCWith {
-    cc = customGccCc;
-    libc = customGlibc;
-    bintools = customBinutils;
-  };
+      # stdenv built around the rebuilt gcc / custom glibc. Used to rebuild
+      # compiler-rt below so its sanitizer runtimes see the custom glibc
+      # headers.
+      customStdenv = pkgs.stdenvAdapters.overrideCC pkgs.stdenv customGcc;
 
-  # stdenv built around the rebuilt gcc / custom glibc. Used to rebuild
-  # compiler-rt below so its sanitizer runtimes see the custom glibc
-  # headers.
-  customStdenv = pkgs.stdenvAdapters.overrideCC pkgs.stdenv customGcc;
+      # Rebuild compiler-rt against the custom glibc so the sanitizer runtimes
+      # don't use glibc symbols (or sysconf constants like _SC_SIGSTKSZ) that
+      # only exist in newer glibc versions. scudo is dropped because its CMake
+      # includes CheckAtomic with -nostdinc++ in CMAKE_REQUIRED_FLAGS, which
+      # makes std::atomic unfindable in our stdenv; we don't use scudo (only
+      # asan/ubsan/tsan etc.).
+      customCompilerRt =
+        (customLlvmPackages.compiler-rt.override {
+          stdenv = customStdenv;
+        }).overrideAttrs
+          (old: {
+            postPatch = (old.postPatch or "") + ''
+              substituteInPlace lib/CMakeLists.txt \
+                --replace-quiet 'add_subdirectory(scudo/standalone)' \
+                                '# scudo/standalone disabled in xrpld ci-env'
+            '';
+          });
 
-  # Rebuild compiler-rt against the custom glibc so the sanitizer runtimes
-  # don't use glibc symbols (or sysconf constants like _SC_SIGSTKSZ) that
-  # only exist in newer glibc versions. scudo is dropped because its CMake
-  # includes CheckAtomic with -nostdinc++ in CMAKE_REQUIRED_FLAGS, which
-  # makes std::atomic unfindable in our stdenv; we don't use scudo (only
-  # asan/ubsan/tsan etc.).
-  customCompilerRt =
-    (customLlvmPackages.compiler-rt.override {
-      stdenv = customStdenv;
-    }).overrideAttrs
-      (old: {
-        postPatch = (old.postPatch or "") + ''
-          substituteInPlace lib/CMakeLists.txt \
-            --replace-quiet 'add_subdirectory(scudo/standalone)' \
-                            '# scudo/standalone disabled in xrpld ci-env'
+      # cc-wrapper around clang, pointing at the custom glibc headers and
+      # libraries. Reuses the rebuilt gcc for libstdc++ / libgcc_s so that
+      # C++ binaries produced by clang also only reference symbols available
+      # in the custom glibc. compiler-rt is wired into a resource-root so
+      # sanitizer runtimes (libclang_rt.*.a) are found at link time; this
+      # mirrors what nixpkgs does internally when building llvmPackages.clang.
+      customClang = pkgs.wrapCCWith {
+        cc = customLlvmPackages.clang-unwrapped;
+        libc = customGlibc;
+        bintools = customBinutils;
+        gccForLibs = customGccCc;
+        extraPackages = [ customCompilerRt ];
+        extraBuildCommands = ''
+          rsrc="$out/resource-root"
+          mkdir "$rsrc"
+          ln -s "${customLlvmPackages.clang-unwrapped.lib}/lib/clang/${customClangMajor}/include" "$rsrc/include"
+          ln -s "${customCompilerRt.out}/lib" "$rsrc/lib"
+          ln -s "${customCompilerRt.out}/share" "$rsrc/share" || true
+          echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
         '';
-      });
+      };
 
-  # cc-wrapper around clang, pointing at the custom glibc headers and
-  # libraries. Reuses the rebuilt gcc for libstdc++ / libgcc_s so that
-  # C++ binaries produced by clang also only reference symbols available
-  # in the custom glibc. compiler-rt is wired into a resource-root so
-  # sanitizer runtimes (libclang_rt.*.a) are found at link time; this
-  # mirrors what nixpkgs does internally when building llvmPackages.clang.
-  customClang = pkgs.wrapCCWith {
-    cc = customLlvmPackages.clang-unwrapped;
-    libc = customGlibc;
-    bintools = customBinutils;
-    gccForLibs = customGccCc;
-    extraPackages = [ customCompilerRt ];
-    extraBuildCommands = ''
-      rsrc="$out/resource-root"
-      mkdir "$rsrc"
-      ln -s "${customLlvmPackages.clang-unwrapped.lib}/lib/clang/${customClangMajor}/include" "$rsrc/include"
-      ln -s "${customCompilerRt.out}/lib" "$rsrc/lib"
-      ln -s "${customCompilerRt.out}/share" "$rsrc/share" || true
-      echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
-    '';
-  };
-
-  # Strip the generic cc/c++/cpp symlinks from the clang wrapper so it can
-  # coexist with the gcc wrapper in buildEnv. gcc remains the default
-  # compiler (cc/c++/cpp); clang is invoked explicitly as clang/clang++.
-  customClangForCiEnv = pkgs.symlinkJoin {
-    name = "clang-wrapper-custom-for-ci-env";
-    paths = [ customClang ];
-    postBuild = ''
-      rm -f $out/bin/cc $out/bin/c++ $out/bin/cpp
-    '';
-  };
+      # Strip the generic cc/c++/cpp symlinks from the clang wrapper so it can
+      # coexist with the gcc wrapper in buildEnv. gcc remains the default
+      # compiler (cc/c++/cpp); clang is invoked explicitly as clang/clang++.
+      customClangForCiEnv = pkgs.symlinkJoin {
+        name = "clang-wrapper-custom-for-ci-env";
+        paths = [ customClang ];
+        postBuild = ''
+          rm -f $out/bin/cc $out/bin/c++ $out/bin/cpp
+        '';
+      };
+    in
+    pkgs.buildEnv {
+      name = "xrpld-ci-env";
+      paths = commonPackages ++ [
+        customGcc
+        customClangForCiEnv
+        customBinutils
+      ];
+      pathsToLink = [
+        "/bin"
+        "/lib"
+        "/include"
+        "/share"
+      ];
+    };
 
 in
 {
-  default = pkgs.buildEnv {
-    name = "xrpld-ci-env";
-    paths = commonPackages ++ [
-      customGcc
-      customClangForCiEnv
-      customBinutils
-    ];
-    pathsToLink = [
-      "/bin"
-      "/lib"
-      "/include"
-      "/share"
-    ];
-  };
+  # Per-distro CI environments — each is built against the native glibc of
+  # the corresponding base OS so that produced binaries stay within the
+  # symbol set available at runtime.
+  #
+  # ubuntu:20.04  → glibc 2.31
+  # ubi9/rhel9    → glibc 2.34
+  # debian:bookworm → glibc 2.35 (nixpkgs skipped 2.36, went 2.35→2.37)
+  # nixos/nix     → latest nixpkgs glibc
+  ubuntu = mkCiEnv glibc-2-31;
+  rhel = mkCiEnv glibc-2-34;
+  debian = mkCiEnv glibc-2-35;
+  nixos = mkCiEnv pkgs.glibc;
+
+  # Backward-compatible default — same as ubuntu.
+  default = mkCiEnv glibc-2-31;
 }

--- a/nix/utils.nix
+++ b/nix/utils.nix
@@ -1,4 +1,9 @@
-{ nixpkgs, nixpkgs-custom-glibc }:
+{
+  nixpkgs,
+  nixpkgs-glibc-2-31,
+  nixpkgs-glibc-2-34,
+  nixpkgs-glibc-2-35,
+}:
 function:
 nixpkgs.lib.genAttrs
   [
@@ -11,11 +16,13 @@ nixpkgs.lib.genAttrs
     system:
     function {
       pkgs = import nixpkgs { inherit system; };
-      # glibc 2.31 — matches the system libc on Ubuntu 20.04 LTS. Sourced
-      # from the nixpkgs snapshot pinned via the `nixpkgs-custom-glibc`
-      # flake input, so the build uses the compiler from that snapshot
-      # (gcc 9.3.0) along with the matching patches, configure flags, and
-      # hardening defaults.
-      customGlibc = (import nixpkgs-custom-glibc { inherit system; }).glibc;
+      # glibc 2.31 — matches Ubuntu 20.04 LTS. Sourced from a nixpkgs snapshot
+      # that predates nixpkgs' own flake.nix (hence flake = false above).
+      glibc-2-31 = (import nixpkgs-glibc-2-31 { inherit system; }).glibc;
+      # glibc 2.34 — matches RHEL 9 / UBI 9.
+      glibc-2-34 = (import nixpkgs-glibc-2-34 { inherit system; }).glibc;
+      # glibc 2.35 — highest version available in nixpkgs that is below Debian
+      # Bookworm's native glibc 2.36 (nixpkgs skipped 2.36 entirely).
+      glibc-2-35 = (import nixpkgs-glibc-2-35 { inherit system; }).glibc;
     }
   )


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

It seems that we'll have to use multiple versions, because libc 2.34 removed pthread, and it seems that it wasn't done in a fully backward-compatible manner.
https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread#

This PR also:
- decouples building binaries from testing them
- adds separate `loader-path.sh` reusable script
- tests non-sanitizer binary
- tests sanitizer binaries under all configurations

In the future, when we drop ubuntu:20.04 support (which we should've almost exactly a year ago, since May 31, 2025 was EOL), we'll be able to use a single libc version (the oldest it would be at the time).

The benefit of current approach is that we build a binary closer to the one which would've built natively.

This PR builds on top of https://github.com/XRPLF/rippled/pull/7355, but the base branch is still develop, to make it test'able in CI in all configurations.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
