### PR TITLE
fix: Pin overpayment principal reduction to exact on-grid value

### DIFF
--- a/include/xrpl/ledger/helpers/LendingHelpers.h
+++ b/include/xrpl/ledger/helpers/LendingHelpers.h
@@ -461,6 +461,7 @@ loanAccruedInterest(
 
 ExtendedPaymentComponents
 computeOverpaymentComponents(
+    Rules const& rules,
     Asset const& asset,
     int32_t const loanScale,
     Number const& overpayment,

--- a/src/libxrpl/ledger/helpers/LendingHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/LendingHelpers.cpp
@@ -559,32 +559,25 @@ tryOverpayment(
                     << ", new total value: " << newLoanProperties.loanState.valueOutstanding
                     << ", first payment principal: " << newLoanProperties.firstPaymentPrincipal;
 
-    // Calculate what the new loan state should be with the new periodic payment
-    // including rounding errors
-    auto newTheoreticalState = computeTheoreticalLoanState(
-                                   rules,
-                                   newLoanProperties.periodicPayment,
-                                   periodicRate,
-                                   paymentRemaining,
-                                   managementFeeRate) +
-        errors;
-    // The stored principal is known exactly: it is reduced by the overpayment's
-    // principal portion, i.e. roundedOldState.principalOutstanding minus
-    // trackedPrincipalDelta (both already at loan scale, so the subtraction is
-    // exact and on-grid). computeTheoreticalLoanState instead re-derives the
-    // principal from the new periodic payment via loanPrincipalFromPeriodicPayment
-    // -- a (P * factor) / factor round-trip that is not exact in Number
-    // arithmetic. A positive residual, combined with the Upward rounding below,
-    // pushes the stored principal one scale-unit high and breaks the
-    // "principal change agrees" check. Pin the principal to the exact value and
-    // re-derive interest so the V = P + I + M invariant still holds.
-    if (rules.enabled(fixCleanup3_2_0))
-    {
-        newTheoreticalState = constructLoanState(
-            newTheoreticalState.valueOutstanding,
-            roundedOldState.principalOutstanding - overpaymentComponents.trackedPrincipalDelta,
-            newTheoreticalState.managementFeeDue);
-    }
+    // Calculate what the new loan state should be with the new periodic payment,
+    // including the preserved rounding errors.
+
+    auto const newTheoreticalState = [&]() {
+        auto const state = computeTheoreticalLoanState(
+                               rules,
+                               newLoanProperties.periodicPayment,
+                               periodicRate,
+                               paymentRemaining,
+                               managementFeeRate) +
+            errors;
+
+        return rules.enabled(fixCleanup3_2_0) ? constructLoanState(
+                                                    state.valueOutstanding,
+                                                    roundedOldState.principalOutstanding -
+                                                        overpaymentComponents.trackedPrincipalDelta,
+                                                    state.managementFeeDue)
+                                              : state;
+    }();
 
     JLOG(j.debug()) << "new theoretical value: " << newTheoreticalState.valueOutstanding
                     << ", principal: " << newTheoreticalState.principalOutstanding
@@ -779,23 +772,6 @@ doOverpayment(
     // The proxies still hold the original (pre-overpayment) values, which
     // allows us to compute deltas and verify they match what we expect
     // from the overpaymentComponents and loanPaymentParts.
-
-    // The three checks below ("principal change agrees", "interest paid agrees",
-    // "principal payment matches") are invariants that only hold once
-    // fixCleanup3_2_0 pins the new principal to the exact reduction
-    // (oldPrincipal - trackedPrincipalDelta). Before the amendment, the lossy
-    // (P * factor) / factor round-trip can leave the new principal one
-    // scale-unit high, so these equalities do not hold on the pre-amendment
-    // code path and must be gated to match the fix they verify.
-    if (rules.enabled(fixCleanup3_2_0))
-    {
-        XRPL_ASSERT_PARTS(
-            overpaymentComponents.trackedPrincipalDelta ==
-                principalOutstandingProxy - newRoundedLoanState.principalOutstanding,
-            "xrpl::detail::doOverpayment",
-            "principal change agrees");
-    }
-
     JLOG(j.debug()) << "valueChange: " << loanPaymentParts.valueChange
                     << ", totalValue before: " << *totalValueOutstandingProxy
                     << ", totalValue after: " << newRoundedLoanState.valueOutstanding
@@ -807,23 +783,28 @@ doOverpayment(
                     << overpaymentComponents.trackedPrincipalDelta -
             (totalValueOutstandingProxy - newRoundedLoanState.valueOutstanding);
 
-    // The valueChange returned by tryOverpayment satisfies
-    //   valueChange = (newInterestDue - oldInterestDue) + untrackedInterest.
-    // Using the loan-state identity v = p + i + m and the adjacent
-    // `principal change agrees` assertion (dp = oldP - newP), this
-    // rearranges into three independently-computable terms:
-    //
-    //   1. TVO change beyond what principal repayment alone explains:
-    //        newTVO - (oldTVO - dp)
-    //   2. Management fee released by re-amortization (positive when
-    //      mfee decreased; zero when managementFeeRate == 0):
-    //        oldMfee - newMfee
-    //   3. The overpayment's penalty interest part (= untrackedInterest
-    //      for the overpayment path; see computeOverpaymentComponents):
-    //        trackedInterestPart()
-    // Gated together with the principal-change check above (same rationale).
+    // The three assertions below are invariants that only hold once
+    // fixCleanup3_2_0 pins the new principal to the exact reduction
+    // (oldPrincipal - trackedPrincipalDelta). Before the amendment, the lossy
+    // (P * factor) / factor round-trip can leave the new principal one
+    // scale-unit high, so these equalities do not hold on the pre-amendment
+    // code path and must be gated to match the fix they verify.
     if (rules.enabled(fixCleanup3_2_0))
     {
+        // The valueChange returned by tryOverpayment satisfies
+        //   valueChange = (newInterestDue - oldInterestDue) + untrackedInterest.
+        // Using the loan-state identity v = p + i + m and the adjacent
+        // `principal change agrees` assertion (dp = oldP - newP), this
+        // rearranges into three independently-computable terms:
+        //
+        //   1. TVO change beyond what principal repayment alone explains:
+        //        newTVO - (oldTVO - dp)
+        //   2. Management fee released by re-amortization (positive when
+        //      mfee decreased; zero when managementFeeRate == 0):
+        //        oldMfee - newMfee
+        //   3. The overpayment's penalty interest part (= untrackedInterest
+        //      for the overpayment path; see computeOverpaymentComponents):
+        //        trackedInterestPart()
         [[maybe_unused]] Number const tvoChange = newRoundedLoanState.valueOutstanding -
             (totalValueOutstandingProxy - overpaymentComponents.trackedPrincipalDelta);
         [[maybe_unused]] Number const managementFeeReleased =
@@ -831,19 +812,22 @@ doOverpayment(
         [[maybe_unused]] Number const interestPart = overpaymentComponents.trackedInterestPart();
 
         XRPL_ASSERT_PARTS(
+            overpaymentComponents.trackedPrincipalDelta ==
+                principalOutstandingProxy - newRoundedLoanState.principalOutstanding,
+            "xrpl::detail::doOverpayment",
+            "principal change agrees");
+
+        XRPL_ASSERT_PARTS(
             loanPaymentParts.valueChange == tvoChange + managementFeeReleased + interestPart,
             "xrpl::detail::doOverpayment",
             "interest paid agrees");
-    }
 
-    // Gated together with the principal-change check above (same rationale).
-    if (rules.enabled(fixCleanup3_2_0))
-    {
         XRPL_ASSERT_PARTS(
             overpaymentComponents.trackedPrincipalDelta == loanPaymentParts.principalPaid,
             "xrpl::detail::doOverpayment",
             "principal payment matches");
     }
+
     // All validations passed, so update the proxy objects (which will
     // modify the actual Loan ledger object)
     totalValueOutstandingProxy = newRoundedLoanState.valueOutstanding;

--- a/src/libxrpl/ledger/helpers/LendingHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/LendingHelpers.cpp
@@ -561,13 +561,30 @@ tryOverpayment(
 
     // Calculate what the new loan state should be with the new periodic payment
     // including rounding errors
-    auto const newTheoreticalState = computeTheoreticalLoanState(
-                                         rules,
-                                         newLoanProperties.periodicPayment,
-                                         periodicRate,
-                                         paymentRemaining,
-                                         managementFeeRate) +
+    auto newTheoreticalState = computeTheoreticalLoanState(
+                                   rules,
+                                   newLoanProperties.periodicPayment,
+                                   periodicRate,
+                                   paymentRemaining,
+                                   managementFeeRate) +
         errors;
+    // The stored principal is known exactly: it is reduced by the overpayment's
+    // principal portion, i.e. roundedOldState.principalOutstanding minus
+    // trackedPrincipalDelta (both already at loan scale, so the subtraction is
+    // exact and on-grid). computeTheoreticalLoanState instead re-derives the
+    // principal from the new periodic payment via loanPrincipalFromPeriodicPayment
+    // -- a (P * factor) / factor round-trip that is not exact in Number
+    // arithmetic. A positive residual, combined with the Upward rounding below,
+    // pushes the stored principal one scale-unit high and breaks the
+    // "principal change agrees" check. Pin the principal to the exact value and
+    // re-derive interest so the V = P + I + M invariant still holds.
+    if (rules.enabled(fixCleanup3_2_0))
+    {
+        newTheoreticalState = constructLoanState(
+            newTheoreticalState.valueOutstanding,
+            roundedOldState.principalOutstanding - overpaymentComponents.trackedPrincipalDelta,
+            newTheoreticalState.managementFeeDue);
+    }
 
     JLOG(j.debug()) << "new theoretical value: " << newTheoreticalState.valueOutstanding
                     << ", principal: " << newTheoreticalState.principalOutstanding
@@ -763,11 +780,21 @@ doOverpayment(
     // allows us to compute deltas and verify they match what we expect
     // from the overpaymentComponents and loanPaymentParts.
 
-    XRPL_ASSERT_PARTS(
-        overpaymentComponents.trackedPrincipalDelta ==
-            principalOutstandingProxy - newRoundedLoanState.principalOutstanding,
-        "xrpl::detail::doOverpayment",
-        "principal change agrees");
+    // The three checks below ("principal change agrees", "interest paid agrees",
+    // "principal payment matches") are invariants that only hold once
+    // fixCleanup3_2_0 pins the new principal to the exact reduction
+    // (oldPrincipal - trackedPrincipalDelta). Before the amendment, the lossy
+    // (P * factor) / factor round-trip can leave the new principal one
+    // scale-unit high, so these equalities do not hold on the pre-amendment
+    // code path and must be gated to match the fix they verify.
+    if (rules.enabled(fixCleanup3_2_0))
+    {
+        XRPL_ASSERT_PARTS(
+            overpaymentComponents.trackedPrincipalDelta ==
+                principalOutstandingProxy - newRoundedLoanState.principalOutstanding,
+            "xrpl::detail::doOverpayment",
+            "principal change agrees");
+    }
 
     JLOG(j.debug()) << "valueChange: " << loanPaymentParts.valueChange
                     << ", totalValue before: " << *totalValueOutstandingProxy
@@ -794,22 +821,29 @@ doOverpayment(
     //   3. The overpayment's penalty interest part (= untrackedInterest
     //      for the overpayment path; see computeOverpaymentComponents):
     //        trackedInterestPart()
-    [[maybe_unused]] Number const tvoChange = newRoundedLoanState.valueOutstanding -
-        (totalValueOutstandingProxy - overpaymentComponents.trackedPrincipalDelta);
-    [[maybe_unused]] Number const managementFeeReleased =
-        managementFeeOutstandingProxy - newRoundedLoanState.managementFeeDue;
-    [[maybe_unused]] Number const interestPart = overpaymentComponents.trackedInterestPart();
+    // Gated together with the principal-change check above (same rationale).
+    if (rules.enabled(fixCleanup3_2_0))
+    {
+        [[maybe_unused]] Number const tvoChange = newRoundedLoanState.valueOutstanding -
+            (totalValueOutstandingProxy - overpaymentComponents.trackedPrincipalDelta);
+        [[maybe_unused]] Number const managementFeeReleased =
+            managementFeeOutstandingProxy - newRoundedLoanState.managementFeeDue;
+        [[maybe_unused]] Number const interestPart = overpaymentComponents.trackedInterestPart();
 
-    XRPL_ASSERT_PARTS(
-        loanPaymentParts.valueChange == tvoChange + managementFeeReleased + interestPart,
-        "xrpl::detail::doOverpayment",
-        "interest paid agrees");
+        XRPL_ASSERT_PARTS(
+            loanPaymentParts.valueChange == tvoChange + managementFeeReleased + interestPart,
+            "xrpl::detail::doOverpayment",
+            "interest paid agrees");
+    }
 
-    XRPL_ASSERT_PARTS(
-        overpaymentComponents.trackedPrincipalDelta == loanPaymentParts.principalPaid,
-        "xrpl::detail::doOverpayment",
-        "principal payment matches");
-
+    // Gated together with the principal-change check above (same rationale).
+    if (rules.enabled(fixCleanup3_2_0))
+    {
+        XRPL_ASSERT_PARTS(
+            overpaymentComponents.trackedPrincipalDelta == loanPaymentParts.principalPaid,
+            "xrpl::detail::doOverpayment",
+            "principal payment matches");
+    }
     // All validations passed, so update the proxy objects (which will
     // modify the actual Loan ledger object)
     totalValueOutstandingProxy = newRoundedLoanState.valueOutstanding;

--- a/src/libxrpl/ledger/helpers/LendingHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/LendingHelpers.cpp
@@ -1171,11 +1171,13 @@ computePaymentComponents(
     // Cap each component to never exceed what's actually outstanding
     deltas.principal = std::min(deltas.principal, currentLedgerState.principalOutstanding);
 
-    XRPL_ASSERT_PARTS(
-        deltas.interest <= currentLedgerState.interestDue,
-        "xrpl::detail::computePaymentComponents",
-        "interest due delta not greater than outstanding");
-
+    if (fixCleanup320Enabled)
+    {
+        XRPL_ASSERT_PARTS(
+            deltas.interest <= currentLedgerState.interestDue,
+            "xrpl::detail::computePaymentComponents",
+            "interest due delta not greater than outstanding");
+    }
     // Cap interest to both the outstanding amount AND what's left of the
     // periodic payment after principal is paid
     deltas.interest = std::min(
@@ -1316,6 +1318,7 @@ computePaymentComponents(
  */
 ExtendedPaymentComponents
 computeOverpaymentComponents(
+    Rules const& rules,
     Asset const& asset,
     int32_t const loanScale,
     Number const& overpayment,
@@ -1323,10 +1326,13 @@ computeOverpaymentComponents(
     TenthBips32 const overpaymentFeeRate,
     TenthBips16 const managementFeeRate)
 {
-    XRPL_ASSERT(
-        overpayment > 0 && isRounded(asset, overpayment, loanScale),
-        "xrpl::detail::computeOverpaymentComponents : valid overpayment "
-        "amount");
+    if (rules.enabled(fixCleanup3_2_0))
+    {
+        XRPL_ASSERT(
+            overpayment > 0 && isRounded(asset, overpayment, loanScale),
+            "xrpl::detail::computeOverpaymentComponents : valid overpayment "
+            "amount");
+    }
 
     // First, deduct the fixed overpayment fee from the total amount.
     // This reduces the effective payment that will be applied to the loan.
@@ -2082,6 +2088,7 @@ loanMakePayment(
         {
             detail::ExtendedPaymentComponents const overpaymentComponents =
                 detail::computeOverpaymentComponents(
+                    view.rules(),
                     asset,
                     loanScale,
                     overpayment,

--- a/src/libxrpl/ledger/helpers/LendingHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/LendingHelpers.cpp
@@ -571,12 +571,21 @@ tryOverpayment(
                                managementFeeRate) +
             errors;
 
-        return rules.enabled(fixCleanup3_2_0) ? constructLoanState(
-                                                    state.valueOutstanding,
-                                                    roundedOldState.principalOutstanding -
-                                                        overpaymentComponents.trackedPrincipalDelta,
-                                                    state.managementFeeDue)
-                                              : state;
+        if (!rules.enabled(fixCleanup3_2_0))
+            return state;
+
+        // The new principal is known exactly: it is reduced by the overpayment's
+        // principal portion. computeTheoreticalLoanState instead derives the
+        // principal -- and, from it, the management fee and interest -- via a
+        // lossy (P * factor) / factor round-trip. Pin the principal to the exact
+        // value and re-derive the management fee from the exact interest gross
+        // (value - principal), so the intermediate state is fully consistent with
+        // the exact principal rather than the one-scale-unit-high round-trip.
+        Number const principal =
+            roundedOldState.principalOutstanding - overpaymentComponents.trackedPrincipalDelta;
+        Number const managementFee =
+            tenthBipsOfValue(state.valueOutstanding - principal, managementFeeRate);
+        return constructLoanState(state.valueOutstanding, principal, managementFee);
     }();
 
     JLOG(j.debug()) << "new theoretical value: " << newTheoreticalState.valueOutstanding

--- a/src/test/app/LendingHelpers_test.cpp
+++ b/src/test/app/LendingHelpers_test.cpp
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -1406,8 +1407,12 @@ class LendingHelpers_test : public beast::unit_test::Suite
 
         auto const fixedOpt = run(testableAmendments());
         auto const legacyOpt = run(testableAmendments() - fixCleanup3_2_0);
-        if (!BEAST_EXPECT(fixedOpt && legacyOpt))
+        if (!fixedOpt || !legacyOpt)
+        {
+            BEAST_EXPECT(fixedOpt.has_value());
+            BEAST_EXPECT(legacyOpt.has_value());
             return;
+        }
         Outcome const& fixed = *fixedOpt;
         Outcome const& legacy = *legacyOpt;
 

--- a/src/test/app/LendingHelpers_test.cpp
+++ b/src/test/app/LendingHelpers_test.cpp
@@ -514,7 +514,9 @@ class LendingHelpers_test : public beast::unit_test::Suite
         auto const expectedOverpaymentManagementFee = Number{10};   // 10% of 100
         auto const expectedPrincipalPortion = Number{400};          // 1,000 - 100 - 500
 
+        Env const env{*this};
         auto const components = xrpl::detail::computeOverpaymentComponents(
+            env.current()->rules(),
             iou,
             loanScale,
             overpayment,
@@ -855,7 +857,13 @@ class LendingHelpers_test : public beast::unit_test::Suite
         Number const overpaymentAmount{50};
 
         auto const overpaymentComponents = computeOverpaymentComponents(
-            asset, loanScale, overpaymentAmount, TenthBips32(0), TenthBips32(0), managementFeeRate);
+            env.current()->rules(),
+            asset,
+            loanScale,
+            overpaymentAmount,
+            TenthBips32(0),
+            TenthBips32(0),
+            managementFeeRate);
 
         auto const loanProperties = computeLoanProperties(
             env.current()->rules(),
@@ -943,6 +951,7 @@ class LendingHelpers_test : public beast::unit_test::Suite
         auto const periodicRate = loanPeriodicRate(loanInterestRate, paymentInterval);
 
         auto const overpaymentComponents = computeOverpaymentComponents(
+            env.current()->rules(),
             asset,
             loanScale,
             Number{50, 0},
@@ -1038,6 +1047,7 @@ class LendingHelpers_test : public beast::unit_test::Suite
         auto const periodicRate = loanPeriodicRate(loanInterestRate, paymentInterval);
 
         auto const overpaymentComponents = computeOverpaymentComponents(
+            env.current()->rules(),
             asset,
             loanScale,
             Number{50, 0},
@@ -1139,6 +1149,7 @@ class LendingHelpers_test : public beast::unit_test::Suite
         auto const periodicRate = loanPeriodicRate(loanInterestRate, paymentInterval);
 
         auto const overpaymentComponents = computeOverpaymentComponents(
+            env.current()->rules(),
             asset,
             loanScale,
             Number{50, 0},
@@ -1248,6 +1259,7 @@ class LendingHelpers_test : public beast::unit_test::Suite
         auto const periodicRate = loanPeriodicRate(loanInterestRate, paymentInterval);
 
         auto const overpaymentComponents = computeOverpaymentComponents(
+            env.current()->rules(),
             asset,
             loanScale,
             Number{50, 0},
@@ -1355,7 +1367,9 @@ class LendingHelpers_test : public beast::unit_test::Suite
         std::uint32_t const paymentsRemaining = 10;
         auto const periodicRate = loanPeriodicRate(loanInterestRate, paymentInterval);
 
+        Env const env{*this};
         auto const overpaymentComponents = computeOverpaymentComponents(
+            env.current()->rules(),
             asset,
             loanScale,
             Number{50, 0},

--- a/src/test/app/LendingHelpers_test.cpp
+++ b/src/test/app/LendingHelpers_test.cpp
@@ -1344,7 +1344,6 @@ class LendingHelpers_test : public beast::unit_test::Suite
         using namespace jtx;
         using namespace xrpl::detail;
 
-        Env const env{*this};
         Account const issuer{"issuer"};
         PrettyAsset const asset = issuer["USD"];
         std::int32_t const loanScale = -5;
@@ -1363,87 +1362,93 @@ class LendingHelpers_test : public beast::unit_test::Suite
             TenthBips32(10'000),  // 10% overpayment fee
             managementFeeRate);
 
-        auto const loanProperties = computeLoanProperties(
-            env.current()->rules(),
-            asset,
-            loanPrincipal,
-            loanInterestRate,
-            paymentInterval,
-            paymentsRemaining,
-            managementFeeRate,
-            loanScale);
+        struct Outcome
+        {
+            LoanPaymentParts parts;
+            LoanState oldState;
+            LoanState newState;
+        };
 
-        auto const ret = tryOverpayment(
-            env.current()->rules(),
-            asset,
-            loanScale,
-            overpaymentComponents,
-            loanProperties.loanState,
-            loanProperties.periodicPayment,
-            periodicRate,
-            paymentsRemaining,
-            managementFeeRate,
-            env.journal);
+        // Run tryOverpayment under a given amendment set. At this (non-near-zero)
+        // rate computeLoanProperties is amendment-independent, so the loan state
+        // is identical across the amendment; only tryOverpayment's fixCleanup3_2_0
+        // behaviour (the exact-principal pin and the management-fee re-derivation
+        // from that principal) differs.
+        auto run = [&](FeatureBitset features) -> std::optional<Outcome> {
+            Env const env{*this, features};
+            auto const loanProperties = computeLoanProperties(
+                env.current()->rules(),
+                asset,
+                loanPrincipal,
+                loanInterestRate,
+                paymentInterval,
+                paymentsRemaining,
+                managementFeeRate,
+                loanScale);
+            auto const ret = tryOverpayment(
+                env.current()->rules(),
+                asset,
+                loanScale,
+                overpaymentComponents,
+                loanProperties.loanState,
+                loanProperties.periodicPayment,
+                periodicRate,
+                paymentsRemaining,
+                managementFeeRate,
+                env.journal);
+            if (!BEAST_EXPECT(ret))
+                return std::nullopt;
+            return Outcome{
+                .parts = ret->first,
+                .oldState = loanProperties.loanState,
+                .newState = ret->second.loanState};
+        };
 
-        BEAST_EXPECT(ret);
+        auto const fixedOpt = run(testableAmendments());
+        auto const legacyOpt = run(testableAmendments() - fixCleanup3_2_0);
+        if (!BEAST_EXPECT(fixedOpt && legacyOpt))
+            return;
+        Outcome const& fixed = *fixedOpt;
+        Outcome const& legacy = *legacyOpt;
 
-        auto const& [actualPaymentParts, newLoanProperties] = *ret;
-        auto const& newState = newLoanProperties.loanState;
+        // Components that the amendment does not change. The management fee is
+        // charged against the overpayment interest portion first, so interest
+        // paid stays 4.5 and fee paid 5.5; the principal repaid is 40 in both.
+        auto checkCommon = [&](Outcome const& o, char const* tag) {
+            BEAST_EXPECTS(
+                (o.parts.interestPaid == Number{45, -1}),
+                std::string(tag) + " interestPaid " + to_string(o.parts.interestPaid));
+            BEAST_EXPECTS(
+                (o.parts.feePaid == Number{55, -1}),
+                std::string(tag) + " feePaid " + to_string(o.parts.feePaid));
+            BEAST_EXPECTS(
+                o.parts.principalPaid == 40,
+                std::string(tag) + " principalPaid " + to_string(o.parts.principalPaid));
+            BEAST_EXPECT(
+                o.parts.principalPaid ==
+                o.oldState.principalOutstanding - o.newState.principalOutstanding);
+            // v = p + i + m identity: the non-interest part of valueChange equals
+            // the interest-due change.
+            BEAST_EXPECT(
+                o.parts.valueChange - o.parts.interestPaid ==
+                o.newState.interestDue - o.oldState.interestDue);
+        };
+        checkCommon(fixed, "fixed");
+        checkCommon(legacy, "legacy");
 
-        // =========== VALIDATE PAYMENT PARTS ===========
-
-        // Since there is loan management fee, the fee is charged against
-        // overpayment interest portion first, so interest paid remains 4.5
-        BEAST_EXPECTS(
-            (actualPaymentParts.interestPaid == Number{45, -1}),
-            " interestPaid mismatch: expected 4.5, got " +
-                to_string(actualPaymentParts.interestPaid));
-
-        // With overpayment interest portion, value change should equal the
-        // interest decrease plus overpayment interest portion
-        BEAST_EXPECTS(
-            (actualPaymentParts.valueChange ==
-             Number{-164738, -5} + actualPaymentParts.interestPaid),
-            " valueChange mismatch: expected " +
-                to_string(Number{-164738, -5} + actualPaymentParts.interestPaid) + ", got " +
-                to_string(actualPaymentParts.valueChange));
-
-        // While there is no overpayment fee, fee paid should equal the
-        // management fee charged against the overpayment interest portion
-        BEAST_EXPECTS(
-            (actualPaymentParts.feePaid == Number{55, -1}),
-            " feePaid mismatch: expected 5.5, got " + to_string(actualPaymentParts.feePaid));
-
-        BEAST_EXPECTS(
-            actualPaymentParts.principalPaid == 40,
-            " principalPaid mismatch: expected 40, got `" +
-                to_string(actualPaymentParts.principalPaid));
-
-        // =========== VALIDATE STATE CHANGES ===========
-
-        BEAST_EXPECTS(
-            actualPaymentParts.principalPaid ==
-                loanProperties.loanState.principalOutstanding - newState.principalOutstanding,
-            " principalPaid mismatch: expected " +
-                to_string(
-                    loanProperties.loanState.principalOutstanding - newState.principalOutstanding) +
-                ", got " + to_string(actualPaymentParts.principalPaid));
-
-        // Note that the management fee value change is not captured, as this
-        // value is not needed to correctly update the Vault state.
-        BEAST_EXPECTS(
-            (newState.managementFeeDue - loanProperties.loanState.managementFeeDue ==
-             Number{-18303, -5}),
-            " management fee change mismatch: expected " + to_string(Number{-18303, -5}) +
-                ", got " +
-                to_string(newState.managementFeeDue - loanProperties.loanState.managementFeeDue));
-
-        BEAST_EXPECTS(
-            actualPaymentParts.valueChange - actualPaymentParts.interestPaid ==
-                newState.interestDue - loanProperties.loanState.interestDue,
-            " valueChange mismatch: expected " +
-                to_string(newState.interestDue - loanProperties.loanState.interestDue) + ", got " +
-                to_string(actualPaymentParts.valueChange - actualPaymentParts.interestPaid));
+        // With fixCleanup3_2_0 the management fee is re-derived from the exact
+        // principal; without it, from the one-scale-unit-high round-trip
+        // principal. So the management fee outstanding (and hence the value
+        // change, via v = p + i + m) differ by exactly one scale-unit (1e-5 at
+        // loanScale -5) between the two paths.
+        BEAST_EXPECT((fixed.parts.valueChange == Number{-164738, -5} + fixed.parts.interestPaid));
+        BEAST_EXPECT(
+            (fixed.newState.managementFeeDue - fixed.oldState.managementFeeDue ==
+             Number{-18303, -5}));
+        BEAST_EXPECT((legacy.parts.valueChange == Number{-164737, -5} + legacy.parts.interestPaid));
+        BEAST_EXPECT(
+            (legacy.newState.managementFeeDue - legacy.oldState.managementFeeDue ==
+             Number{-18304, -5}));
     }
 
 public:

--- a/src/test/app/LendingHelpers_test.cpp
+++ b/src/test/app/LendingHelpers_test.cpp
@@ -1403,9 +1403,9 @@ class LendingHelpers_test : public beast::unit_test::Suite
         // interest decrease plus overpayment interest portion
         BEAST_EXPECTS(
             (actualPaymentParts.valueChange ==
-             Number{-164737, -5} + actualPaymentParts.interestPaid),
+             Number{-164738, -5} + actualPaymentParts.interestPaid),
             " valueChange mismatch: expected " +
-                to_string(Number{-164737, -5} + actualPaymentParts.interestPaid) + ", got " +
+                to_string(Number{-164738, -5} + actualPaymentParts.interestPaid) + ", got " +
                 to_string(actualPaymentParts.valueChange));
 
         // While there is no overpayment fee, fee paid should equal the
@@ -1433,8 +1433,8 @@ class LendingHelpers_test : public beast::unit_test::Suite
         // value is not needed to correctly update the Vault state.
         BEAST_EXPECTS(
             (newState.managementFeeDue - loanProperties.loanState.managementFeeDue ==
-             Number{-18304, -5}),
-            " management fee change mismatch: expected " + to_string(Number{-18304, -5}) +
+             Number{-18303, -5}),
+            " management fee change mismatch: expected " + to_string(Number{-18303, -5}) +
                 ", got " +
                 to_string(newState.managementFeeDue - loanProperties.loanState.managementFeeDue));
 

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -8605,8 +8605,6 @@ public:
     void
     run() override
     {
-        testLoanSetNearZeroInterestRateSucceeds();
-        return;
         runAmendmentIndependent();
         for (auto const& features :
              amendmentCombinations({fixCleanup3_1_3, fixCleanup3_2_0, featureMPTokensV2}))

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -7712,6 +7712,7 @@ protected:
             // computed under the same rules as the env so the payment factor
             // matches.
             auto const overpaymentComponents = computeOverpaymentComponents(
+                env.current()->rules(),
                 asset,
                 s.loanScale,
                 p.overpayment,

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -7580,6 +7580,185 @@ protected:
         attemptWithdrawShares(depositorB, sharesLpB, tesSUCCESS);
     }
 
+    // A residual overpayment can reduce the stored principal by one scale-unit
+    // *less* than computeOverpaymentComponents predicts, firing the
+    // "principal change agrees" XRPL_ASSERT_PARTS in doOverpayment:
+    //
+    //   trackedPrincipalDelta == principalOutstanding - newPrincipalOutstanding
+    //
+    // tryOverpayment re-amortizes the loan at the reduced principal, then
+    // re-derives the theoretical principal from the new periodic payment via
+    // (P * paymentFactor) / paymentFactor. That round-trip is not exact in
+    // Number's 19-digit arithmetic; a positive residual pushes the recomputed
+    // principal a hair above the exact grid point `oldPrincipal - delta`, and
+    // the Upward rounding in tryOverpayment then bumps it a full scale-unit
+    // higher. The principal therefore drops by `delta - 1 unit`, not `delta`.
+    //
+    // Concrete case (found by brute-force search over real loans): a 100 USD
+    // loan at the minimum non-zero rate, 3 payments, loanScale -10. After one
+    // regular payment (principalOutstanding 66.6666666674) a residual
+    // overpayment of 0.049999998 yields trackedPrincipalDelta 0.048999998 but
+    // only reduces the principal by 0.0489999979 (newPrincipal 66.6176666695)
+    // — short by 1e-10.
+    //
+    // doOverpayment is only reachable after at least one regular periodic
+    // payment in the same transaction (loanMakePayment returns
+    // tecINSUFFICIENT_PAYMENT when numPayments == 0), so the LoanPay below
+    // pays exactly one period plus the residual overpayment.
+    //
+    // Without fixCleanup3_2_0 this aborts the server at LendingHelpers.cpp
+    // "principal change agrees" in Debug builds. With the amendment (enabled
+    // here via all_), tryOverpayment pins the new principal to the exact,
+    // on-grid reduction (oldPrincipal - trackedPrincipalDelta) instead of the
+    // lossy (P*factor)/factor round-trip, so the assertion holds and the
+    // overpayment applies cleanly.
+    void
+    testBugOverpaymentPrincipalChange()
+    {
+        testcase("bug: doOverpayment asserts 'principal change agrees'");
+
+        using namespace jtx;
+        using namespace loan;
+        using namespace xrpl::detail;
+
+        Env env(*this, all_);
+
+        Account const issuer{"issuer"};
+        Account const lender{"vaultOwner"};
+        Account const borrower{"borrower"};
+
+        env.fund(XRP(1'000'000), issuer, lender, borrower);
+        env(fset(issuer, asfDefaultRipple));
+        env.close();
+
+        PrettyAsset const iouAsset = issuer["USD"];
+        Asset const asset = iouAsset.raw();
+        STAmount const iouLimit{asset, Number{9'999'999'999'999'999LL}};
+        env(trust(lender, iouLimit));
+        env(trust(borrower, iouLimit));
+        env(pay(issuer, lender, iouAsset(1'000'000)));
+        env(pay(issuer, borrower, iouAsset(1'000'000)));
+        env.close();
+
+        auto const broker = createVaultAndBroker(
+            env,
+            iouAsset,
+            lender,
+            {.vaultDeposit = 900'000,
+             .debtMax = 0,
+             .managementFeeRate = TenthBips16{0},
+             .vaultScale = 1});
+
+        auto const brokerSle = env.le(broker.brokerKeylet());
+        if (!BEAST_EXPECT(brokerSle))
+            return;
+        auto const loanSequence = brokerSle->at(sfLoanSequence);
+        auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
+
+        env(set(borrower, broker.brokerID, Number{100}, tfLoanOverpayment),
+            Sig(sfCounterpartySignature, lender),
+            kInterestRate(TenthBips32{1}),
+            kPaymentTotal(3),
+            kPaymentInterval(60),
+            kGracePeriod(60),
+            kOverpaymentFee(TenthBips32{1000}),
+            kOverpaymentInterestRate(TenthBips32{1000}),
+            Fee(env.current()->fees().base * 2),
+            Ter(tesSUCCESS));
+        env.close();
+
+        // Value of exactly one regular period, so the single LoanPay below
+        // makes one regular payment and leaves the residual as an overpayment.
+        auto const s = getCurrentState(env, broker, loanKeylet);
+        auto const periodicRate = loanPeriodicRate(s.interestRate, s.paymentInterval);
+        auto const onePeriod = computePaymentComponents(
+            env.current()->rules(),
+            asset,
+            s.loanScale,
+            s.totalValue,
+            s.principalOutstanding,
+            s.managementFeeOutstanding,
+            s.periodicPayment,
+            periodicRate,
+            s.paymentRemaining,
+            TenthBips16{0});
+
+        // 0.049999998 — smaller than one period, so it stays a residual
+        // overpayment rather than being consumed as a second regular payment.
+        Number const overpayment{49999998, -9};
+        STAmount const payAmount{asset, onePeriod.trackedValueDelta + overpayment};
+
+        env(pay(borrower, loanKeylet.key, payAmount), Txflags(tfLoanOverpayment), Ter(tesSUCCESS));
+        env.close();
+    }
+
+    // POST-FIX (fixCleanup3_2_0): a LoanSet with InterestRate = 1 (0.001%
+    // annualized, the minimum non-zero rate) succeeds. At such a near-zero
+    // rate the closed-form payment factor (1 + r)^n - 1 cancels
+    // catastrophically; the amendment switches to the numerically-stable
+    // series expansion (computePowerMinusOneHybrid), so the periodic payment is
+    // large enough that the scheduled payments cover at least the principal
+    // (no economic underpayment / yield theft).
+    void
+    testLoanSetNearZeroInterestRateSucceeds()
+    {
+        testcase("LoanSet near-zero interest rate covers principal");
+
+        using namespace jtx;
+        using namespace loan;
+
+        Env env(*this, all_);
+
+        Account const issuer{"issuer"};
+        Account const lender{"vaultOwner"};
+        Account const borrower{"borrower"};
+
+        env.fund(XRP(1'000'000), issuer, lender, borrower);
+        env(fset(issuer, asfDefaultRipple));
+        env.close();
+
+        PrettyAsset const iouAsset = issuer["USD"];
+        STAmount const iouLimit{iouAsset.raw(), Number{9'999'999'999'999'999LL}};
+        env(trust(lender, iouLimit));
+        env(trust(borrower, iouLimit));
+        env(pay(issuer, lender, iouAsset(1'000'000)));
+        env(pay(issuer, borrower, iouAsset(1'000'000)));
+        env.close();
+
+        auto const broker = createVaultAndBroker(
+            env,
+            iouAsset,
+            lender,
+            {.vaultDeposit = 100'000, .debtMax = 0, .managementFeeRate = TenthBips16{0}});
+
+        auto const brokerSle = env.le(broker.brokerKeylet());
+        if (!BEAST_EXPECT(brokerSle))
+            return;
+        auto const loanSequence = brokerSle->at(sfLoanSequence);
+        auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
+
+        Number const principalRequested{1000};
+        env(set(borrower, broker.brokerID, principalRequested),
+            Sig(sfCounterpartySignature, lender),
+            kInterestRate(TenthBips32{1}),
+            kPaymentTotal(2),
+            kPaymentInterval(400),
+            Fee(env.current()->fees().base * 2),
+            Ter(tesSUCCESS));
+        env.close();
+
+        auto const loanSle = env.le(loanKeylet);
+        if (!BEAST_EXPECT(loanSle))
+            return;
+        // total scheduled = periodicPayment * paymentTotal must cover principal.
+        Number const periodicPayment = loanSle->at(sfPeriodicPayment);
+        Number const totalScheduled = periodicPayment * 2;
+        BEAST_EXPECTS(
+            totalScheduled >= principalRequested,
+            "near-zero-rate scheduled total " + to_string(totalScheduled) +
+                " for principal 1000; economic underpayment (yield theft)");
+    }
+
     // An overpayment whose residual amount has more precision than loanScale
     // fires the isRounded(asset, overpayment, loanScale) assertion in
     // computeOverpaymentComponents (and a downstream "interest paid agrees"
@@ -8358,12 +8537,14 @@ protected:
         testLimitExceeded();
         testLoanSetBlockedLoanPayAllowedWhenCanTransferCleared();
         testLendingCanTradeClearedNoImpact();
+        testBugOverpaymentPrincipalChange();
         testBugOverpayUnroundedAmount();
 
         for (auto const flags : {0u, tfLoanOverpayment})
             testYieldTheftRounding(flags);
         testBugInterestDueDeltaCrash();
         testFullLifecycleVaultPnLNearZeroRate();
+        testLoanSetNearZeroInterestRateSucceeds();
     }
 
     // Tests run under each entry in amendmentCombinations().
@@ -8424,6 +8605,8 @@ public:
     void
     run() override
     {
+        testLoanSetNearZeroInterestRateSucceeds();
+        return;
         runAmendmentIndependent();
         for (auto const& features :
              amendmentCombinations({fixCleanup3_1_3, fixCleanup3_2_0, featureMPTokensV2}))

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -7594,24 +7594,23 @@ protected:
     // the Upward rounding in tryOverpayment then bumps it a full scale-unit
     // higher. The principal therefore drops by `delta - 1 unit`, not `delta`.
     //
-    // Concrete case (found by brute-force search over real loans): a 100 USD
-    // loan at the minimum non-zero rate, 3 payments, loanScale -10. After one
-    // regular payment (principalOutstanding 66.6666666674) a residual
-    // overpayment of 0.049999998 yields trackedPrincipalDelta 0.048999998 but
-    // only reduces the principal by 0.0489999979 (newPrincipal 66.6176666695)
-    // — short by 1e-10.
+    // Concrete case (isolated, at the tryOverpayment level):
+    // A 100 USD loan at the minimum non-zero rate, 3 payments, loanScale -10.
+    // After one regular payment (principalOutstanding 66.6666666674) a residual overpayment of
+    // 0.049999998 yields trackedPrincipalDelta 0.048999998 but only reduces the principal by
+    // 0.0489999979 (newPrincipal 66.6176666695) — short by 1e-10.
     //
-    // doOverpayment is only reachable after at least one regular periodic
-    // payment in the same transaction (loanMakePayment returns
-    // tecINSUFFICIENT_PAYMENT when numPayments == 0), so the LoanPay below
-    // pays exactly one period plus the residual overpayment.
-    //
-    // Without fixCleanup3_2_0 this aborts the server at LendingHelpers.cpp
-    // "principal change agrees" in Debug builds. With the amendment (enabled
-    // here via all_), tryOverpayment pins the new principal to the exact,
+    // With fixCleanup3_2_0, tryOverpayment pins the new principal to the exact,
     // on-grid reduction (oldPrincipal - trackedPrincipalDelta) instead of the
     // lossy (P*factor)/factor round-trip, so the assertion holds and the
-    // overpayment applies cleanly.
+    // overpayment applies cleanly. The three "principal change agrees" /
+    // "interest paid agrees" / "principal payment matches" assertions are
+    // gated behind the same amendment, so without it they are disabled (the
+    // server does not abort) and the loan keeps the pre-amendment computation.
+    //
+    // The test runs the same scenario under both amendment settings and checks
+    // the stored principal against a ground-truth value derived independently of
+    // the loan-state computation under test.
     void
     testBugOverpaymentPrincipalChange()
     {
@@ -7621,84 +7620,149 @@ protected:
         using namespace loan;
         using namespace xrpl::detail;
 
-        Env env(*this, all_);
+        struct Result
+        {
+            Number principalOutstanding;  // stored principal after the LoanPay
+            Number expectedNewPrincipal;  // ground truth, independent of the fix
+        };
 
-        Account const issuer{"issuer"};
-        Account const lender{"vaultOwner"};
-        Account const borrower{"borrower"};
+        auto runScenario = [this](FeatureBitset features) -> Result {
+            Env env(*this, features);
 
-        env.fund(XRP(1'000'000), issuer, lender, borrower);
-        env(fset(issuer, asfDefaultRipple));
-        env.close();
+            Account const issuer{"issuer"};
+            Account const lender{"vaultOwner"};
+            Account const borrower{"borrower"};
 
-        PrettyAsset const iouAsset = issuer["USD"];
-        Asset const asset = iouAsset.raw();
-        STAmount const iouLimit{asset, Number{9'999'999'999'999'999LL}};
-        env(trust(lender, iouLimit));
-        env(trust(borrower, iouLimit));
-        env(pay(issuer, lender, iouAsset(1'000'000)));
-        env(pay(issuer, borrower, iouAsset(1'000'000)));
-        env.close();
+            env.fund(XRP(1'000'000), issuer, lender, borrower);
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
 
-        auto const broker = createVaultAndBroker(
-            env,
-            iouAsset,
-            lender,
-            {.vaultDeposit = 900'000,
-             .debtMax = 0,
-             .managementFeeRate = TenthBips16{0},
-             .vaultScale = 1});
+            PrettyAsset const iouAsset = issuer["USD"];
+            Asset const asset = iouAsset.raw();
+            STAmount const iouLimit{asset, Number{9'999'999'999'999'999LL}};
+            env(trust(lender, iouLimit));
+            env(trust(borrower, iouLimit));
+            env(pay(issuer, lender, iouAsset(1'000'000)));
+            env(pay(issuer, borrower, iouAsset(1'000'000)));
+            env.close();
 
-        auto const brokerSle = env.le(broker.brokerKeylet());
-        if (!BEAST_EXPECT(brokerSle))
-            return;
-        auto const loanSequence = brokerSle->at(sfLoanSequence);
-        auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
+            auto const broker = createVaultAndBroker(
+                env,
+                iouAsset,
+                lender,
+                {.vaultDeposit = 900'000,
+                 .debtMax = 0,
+                 .managementFeeRate = TenthBips16{0},
+                 .vaultScale = 1});
 
-        env(set(borrower, broker.brokerID, Number{100}, tfLoanOverpayment),
-            Sig(sfCounterpartySignature, lender),
-            kInterestRate(TenthBips32{1}),
-            kPaymentTotal(3),
-            kPaymentInterval(60),
-            kGracePeriod(60),
-            kOverpaymentFee(TenthBips32{1000}),
-            kOverpaymentInterestRate(TenthBips32{1000}),
-            Fee(env.current()->fees().base * 2),
-            Ter(tesSUCCESS));
-        env.close();
+            auto const brokerSle = env.le(broker.brokerKeylet());
+            BEAST_EXPECT(brokerSle);
+            auto const loanSequence = brokerSle ? brokerSle->at(sfLoanSequence) : 0;
+            auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
 
-        // Value of exactly one regular period, so the single LoanPay below
-        // makes one regular payment and leaves the residual as an overpayment.
-        auto const s = getCurrentState(env, broker, loanKeylet);
-        auto const periodicRate = loanPeriodicRate(s.interestRate, s.paymentInterval);
-        auto const onePeriod = computePaymentComponents(
-            env.current()->rules(),
-            asset,
-            s.loanScale,
-            s.totalValue,
-            s.principalOutstanding,
-            s.managementFeeOutstanding,
-            s.periodicPayment,
-            periodicRate,
-            s.paymentRemaining,
-            TenthBips16{0});
+            TenthBips32 const overpaymentInterestRate{1000};
+            TenthBips32 const overpaymentFeeRate{1000};
+            env(set(borrower, broker.brokerID, Number{100}, tfLoanOverpayment),
+                Sig(sfCounterpartySignature, lender),
+                kInterestRate(TenthBips32{1}),
+                kPaymentTotal(3),
+                kPaymentInterval(60),
+                kGracePeriod(60),
+                kOverpaymentFee(overpaymentFeeRate),
+                kOverpaymentInterestRate(overpaymentInterestRate),
+                Fee(env.current()->fees().base * 2),
+                Ter(tesSUCCESS));
+            env.close();
 
-        // 0.049999998 — smaller than one period, so it stays a residual
-        // overpayment rather than being consumed as a second regular payment.
-        Number const overpayment{49999998, -9};
-        STAmount const payAmount{asset, onePeriod.trackedValueDelta + overpayment};
+            // Value of exactly one regular period, so the single LoanPay below
+            // makes one regular payment and leaves the residual as an
+            // overpayment.
+            auto const s = getCurrentState(env, broker, loanKeylet);
+            auto const periodicRate = loanPeriodicRate(s.interestRate, s.paymentInterval);
+            auto const onePeriod = computePaymentComponents(
+                env.current()->rules(),
+                asset,
+                s.loanScale,
+                s.totalValue,
+                s.principalOutstanding,
+                s.managementFeeOutstanding,
+                s.periodicPayment,
+                periodicRate,
+                s.paymentRemaining,
+                TenthBips16{0});
 
-        env(pay(borrower, loanKeylet.key, payAmount), Txflags(tfLoanOverpayment), Ter(tesSUCCESS));
-        env.close();
+            // 0.049999998 — smaller than one period, so it stays a residual
+            // overpayment rather than being consumed as a second regular
+            // payment.
+            Number const overpayment{49999998, -9};
+
+            // Ground truth: the stored principal must drop by exactly the regular
+            // payment's principal portion plus the overpayment's principal
+            // portion. computeOverpaymentComponents depends only on the
+            // overpayment amount and rates (not on the loan-state computation
+            // under test), so it is an independent oracle. Both components are
+            // computed under the same rules as the env so the near-zero-rate
+            // payment factor matches.
+            auto const overpaymentComponents = computeOverpaymentComponents(
+                asset,
+                s.loanScale,
+                overpayment,
+                overpaymentInterestRate,
+                overpaymentFeeRate,
+                TenthBips16{0});
+            Number const expectedNewPrincipal = s.principalOutstanding -
+                onePeriod.trackedPrincipalDelta - overpaymentComponents.trackedPrincipalDelta;
+
+            STAmount const payAmount{asset, onePeriod.trackedValueDelta + overpayment};
+            env(pay(borrower, loanKeylet.key, payAmount),
+                Txflags(tfLoanOverpayment),
+                Ter(tesSUCCESS));
+            env.close();
+
+            auto const loanSle = env.le(loanKeylet);
+            BEAST_EXPECT(loanSle);
+
+            return Result{
+                .principalOutstanding = loanSle ? Number{loanSle->at(sfPrincipalOutstanding)} : 0,
+                .expectedNewPrincipal = expectedNewPrincipal};
+        };
+
+        // With fixCleanup3_2_0 the stored principal lands exactly on the
+        // ground-truth grid point: it is reduced by exactly the overpayment's
+        // principal portion. This is the key correctness check: if the principal
+        // pin were removed (even with the assertions still gated off), the lossy
+        // (P * factor) / factor round-trip would leave the principal one
+        // scale-unit high and this would fail.
+        Result const fixed = runScenario(all_);
+        BEAST_EXPECTS(
+            fixed.principalOutstanding == fixed.expectedNewPrincipal,
+            "fixed principal " + to_string(fixed.principalOutstanding) + " != expected " +
+                to_string(fixed.expectedNewPrincipal));
+
+        // Without the amendment the loan amortizes with the catastrophically
+        // cancelling near-zero payment factor, so its schedule (and ground truth)
+        // differ from the fixed case; the gated assertions keep the server from
+        // aborting and the overpayment still lands exactly on that schedule.
+        Result const legacy = runScenario(all_ - fixCleanup3_2_0);
+        BEAST_EXPECTS(
+            legacy.principalOutstanding == legacy.expectedNewPrincipal,
+            "legacy principal " + to_string(legacy.principalOutstanding) + " != expected " +
+                to_string(legacy.expectedNewPrincipal));
     }
 
-    // POST-FIX (fixCleanup3_2_0): a LoanSet with InterestRate = 1 (0.001%
-    // annualized, the minimum non-zero rate) succeeds. At such a near-zero
-    // rate the closed-form payment factor (1 + r)^n - 1 cancels
-    // catastrophically; the amendment switches to the numerically-stable
-    // series expansion (computePowerMinusOneHybrid), so the periodic payment is
-    // large enough that the scheduled payments cover at least the principal
-    // (no economic underpayment / yield theft).
+    // A LoanSet with InterestRate = 1 (0.001% annualized, the minimum non-zero
+    // rate). At such a near-zero rate the closed-form payment factor
+    // (1 + r)^n - 1 cancels catastrophically.
+    //
+    // Without fixCleanup3_2_0 the resulting amortization is degenerate and the
+    // LoanSet is rejected with tecPRECISION_LOSS (no loan created). With the
+    // amendment, computePowerMinusOneHybrid uses a numerically-stable series
+    // expansion, so the loan is created and the scheduled payments
+    // (2 * periodicPayment) cover the principal — no economic underpayment
+    // (yield theft).
+    //
+    // The test runs the same LoanSet under both amendment settings and pins the
+    // exact outcome for each.
     void
     testLoanSetNearZeroInterestRateSucceeds()
     {
@@ -7707,56 +7771,97 @@ protected:
         using namespace jtx;
         using namespace loan;
 
-        Env env(*this, all_);
-
-        Account const issuer{"issuer"};
-        Account const lender{"vaultOwner"};
-        Account const borrower{"borrower"};
-
-        env.fund(XRP(1'000'000), issuer, lender, borrower);
-        env(fset(issuer, asfDefaultRipple));
-        env.close();
-
-        PrettyAsset const iouAsset = issuer["USD"];
-        STAmount const iouLimit{iouAsset.raw(), Number{9'999'999'999'999'999LL}};
-        env(trust(lender, iouLimit));
-        env(trust(borrower, iouLimit));
-        env(pay(issuer, lender, iouAsset(1'000'000)));
-        env(pay(issuer, borrower, iouAsset(1'000'000)));
-        env.close();
-
-        auto const broker = createVaultAndBroker(
-            env,
-            iouAsset,
-            lender,
-            {.vaultDeposit = 100'000, .debtMax = 0, .managementFeeRate = TenthBips16{0}});
-
-        auto const brokerSle = env.le(broker.brokerKeylet());
-        if (!BEAST_EXPECT(brokerSle))
-            return;
-        auto const loanSequence = brokerSle->at(sfLoanSequence);
-        auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
-
         Number const principalRequested{1000};
-        env(set(borrower, broker.brokerID, principalRequested),
-            Sig(sfCounterpartySignature, lender),
-            kInterestRate(TenthBips32{1}),
-            kPaymentTotal(2),
-            kPaymentInterval(400),
-            Fee(env.current()->fees().base * 2),
-            Ter(tesSUCCESS));
-        env.close();
 
-        auto const loanSle = env.le(loanKeylet);
-        if (!BEAST_EXPECT(loanSle))
-            return;
-        // total scheduled = periodicPayment * paymentTotal must cover principal.
-        Number const periodicPayment = loanSle->at(sfPeriodicPayment);
-        Number const totalScheduled = periodicPayment * 2;
-        BEAST_EXPECTS(
-            totalScheduled >= principalRequested,
-            "near-zero-rate scheduled total " + to_string(totalScheduled) +
-                " for principal 1000; economic underpayment (yield theft)");
+        struct Result
+        {
+            TER ter = tesSUCCESS;
+            bool created = false;
+            std::int32_t loanScale = 0;
+            Number principal;
+            Number totalValue;
+            Number managementFee;
+            Number periodicPayment;
+        };
+
+        auto runScenario = [&](FeatureBitset features, TER expectedTer) -> Result {
+            Env env(*this, features);
+
+            Account const issuer{"issuer"};
+            Account const lender{"vaultOwner"};
+            Account const borrower{"borrower"};
+
+            env.fund(XRP(1'000'000), issuer, lender, borrower);
+            env(fset(issuer, asfDefaultRipple));
+            env.close();
+
+            PrettyAsset const iouAsset = issuer["USD"];
+            STAmount const iouLimit{iouAsset.raw(), Number{9'999'999'999'999'999LL}};
+            env(trust(lender, iouLimit));
+            env(trust(borrower, iouLimit));
+            env(pay(issuer, lender, iouAsset(1'000'000)));
+            env(pay(issuer, borrower, iouAsset(1'000'000)));
+            env.close();
+
+            auto const broker = createVaultAndBroker(
+                env,
+                iouAsset,
+                lender,
+                {.vaultDeposit = 100'000, .debtMax = 0, .managementFeeRate = TenthBips16{0}});
+
+            auto const brokerSle = env.le(broker.brokerKeylet());
+            BEAST_EXPECT(brokerSle);
+            auto const loanSequence = brokerSle ? brokerSle->at(sfLoanSequence) : 0;
+            auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
+
+            env(set(borrower, broker.brokerID, principalRequested),
+                Sig(sfCounterpartySignature, lender),
+                kInterestRate(TenthBips32{1}),
+                kPaymentTotal(2),
+                kPaymentInterval(400),
+                Fee(env.current()->fees().base * 2),
+                Ter(expectedTer));
+            env.close();
+
+            Result r;
+            r.ter = env.ter();
+            if (auto const loanSle = env.le(loanKeylet))
+            {
+                r.created = true;
+                r.loanScale = loanSle->at(sfLoanScale);
+                r.principal = loanSle->at(sfPrincipalOutstanding);
+                r.totalValue = loanSle->at(sfTotalValueOutstanding);
+                r.managementFee = loanSle->at(sfManagementFeeOutstanding);
+                r.periodicPayment = loanSle->at(sfPeriodicPayment);
+            }
+            return r;
+        };
+
+        Result const fixed = runScenario(all_, tesSUCCESS);
+        Result const legacy = runScenario(all_ - fixCleanup3_2_0, tecPRECISION_LOSS);
+
+        // Without the amendment, the catastrophically-cancelling closed-form
+        // payment factor produces a degenerate amortization that fails
+        // checkLoanGuards: the LoanSet is rejected with tecPRECISION_LOSS and no
+        // loan is created.
+        BEAST_EXPECT(legacy.ter == tecPRECISION_LOSS);
+        BEAST_EXPECT(!legacy.created);
+
+        // With the amendment the stable series expansion produces a valid loan
+        // at loanScale -10.
+        BEAST_EXPECT(fixed.ter == tesSUCCESS);
+        BEAST_EXPECT(fixed.created);
+        BEAST_EXPECT(fixed.loanScale == -10);
+        BEAST_EXPECT(fixed.principal == principalRequested);
+        BEAST_EXPECT((fixed.totalValue == Number{10000000001903, -10}));
+        BEAST_EXPECT(fixed.managementFee == beast::kZero);
+
+        // Periodic payment from the numerically-stable series expansion, and the
+        // scheduled total (2 * periodicPayment) which exceeds the 1000 principal
+        // — no economic underpayment / yield theft.
+        BEAST_EXPECT((fixed.periodicPayment == Number{5000000000951293762, -16}));
+        BEAST_EXPECT((fixed.periodicPayment * 2 == Number{1000000000190258752, -15}));
+        BEAST_EXPECT(fixed.periodicPayment * 2 > principalRequested);
     }
 
     // An overpayment whose residual amount has more precision than loanScale

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -7620,13 +7620,28 @@ protected:
         using namespace loan;
         using namespace xrpl::detail;
 
+        struct Params
+        {
+            TenthBips32 interestRate;
+            TenthBips16 managementFeeRate;
+            std::uint32_t paymentTotal;
+            std::uint32_t paymentInterval;
+            std::int64_t principal;
+            Number overpayment;
+            TenthBips32 overpaymentInterestRate;
+            TenthBips32 overpaymentFeeRate;
+            std::optional<int> vaultScale;
+        };
+
         struct Result
         {
             Number principalOutstanding;  // stored principal after the LoanPay
             Number expectedNewPrincipal;  // ground truth, independent of the fix
+            Number managementFeeChange;   // managementFeeOutstanding after - before
+            Number unit;                  // one scale-unit at the loan scale
         };
 
-        auto runScenario = [this](FeatureBitset features) -> Result {
+        auto runScenario = [this](FeatureBitset features, Params const& p) -> Result {
             Env env(*this, features);
 
             Account const issuer{"issuer"};
@@ -7652,30 +7667,28 @@ protected:
                 lender,
                 {.vaultDeposit = 900'000,
                  .debtMax = 0,
-                 .managementFeeRate = TenthBips16{0},
-                 .vaultScale = 1});
+                 .managementFeeRate = p.managementFeeRate,
+                 .vaultScale = p.vaultScale});
 
             auto const brokerSle = env.le(broker.brokerKeylet());
             BEAST_EXPECT(brokerSle);
             auto const loanSequence = brokerSle ? brokerSle->at(sfLoanSequence) : 0;
             auto const loanKeylet = keylet::loan(broker.brokerID, loanSequence);
 
-            TenthBips32 const overpaymentInterestRate{1000};
-            TenthBips32 const overpaymentFeeRate{1000};
-            env(set(borrower, broker.brokerID, Number{100}, tfLoanOverpayment),
+            env(set(borrower, broker.brokerID, Number{p.principal}, tfLoanOverpayment),
                 Sig(sfCounterpartySignature, lender),
-                kInterestRate(TenthBips32{1}),
-                kPaymentTotal(3),
-                kPaymentInterval(60),
-                kGracePeriod(60),
-                kOverpaymentFee(overpaymentFeeRate),
-                kOverpaymentInterestRate(overpaymentInterestRate),
+                kInterestRate(p.interestRate),
+                kPaymentTotal(p.paymentTotal),
+                kPaymentInterval(p.paymentInterval),
+                kGracePeriod(p.paymentInterval),
+                kOverpaymentFee(p.overpaymentFeeRate),
+                kOverpaymentInterestRate(p.overpaymentInterestRate),
                 Fee(env.current()->fees().base * 2),
                 Ter(tesSUCCESS));
             env.close();
 
-            // Value of exactly one regular period, so the single LoanPay below
-            // makes one regular payment and leaves the residual as an
+            // The single LoanPay below makes one regular payment (the overpayment
+            // is smaller than one period) and leaves the residual as an
             // overpayment.
             auto const s = getCurrentState(env, broker, loanKeylet);
             auto const periodicRate = loanPeriodicRate(s.interestRate, s.paymentInterval);
@@ -7689,31 +7702,28 @@ protected:
                 s.periodicPayment,
                 periodicRate,
                 s.paymentRemaining,
-                TenthBips16{0});
-
-            // 0.049999998 — smaller than one period, so it stays a residual
-            // overpayment rather than being consumed as a second regular
-            // payment.
-            Number const overpayment{49999998, -9};
+                p.managementFeeRate);
 
             // Ground truth: the stored principal must drop by exactly the regular
             // payment's principal portion plus the overpayment's principal
             // portion. computeOverpaymentComponents depends only on the
             // overpayment amount and rates (not on the loan-state computation
             // under test), so it is an independent oracle. Both components are
-            // computed under the same rules as the env so the near-zero-rate
-            // payment factor matches.
+            // computed under the same rules as the env so the payment factor
+            // matches.
             auto const overpaymentComponents = computeOverpaymentComponents(
                 asset,
                 s.loanScale,
-                overpayment,
-                overpaymentInterestRate,
-                overpaymentFeeRate,
-                TenthBips16{0});
+                p.overpayment,
+                p.overpaymentInterestRate,
+                p.overpaymentFeeRate,
+                p.managementFeeRate);
             Number const expectedNewPrincipal = s.principalOutstanding -
                 onePeriod.trackedPrincipalDelta - overpaymentComponents.trackedPrincipalDelta;
 
-            STAmount const payAmount{asset, onePeriod.trackedValueDelta + overpayment};
+            Number const managementFeeBefore = s.managementFeeOutstanding;
+
+            STAmount const payAmount{asset, onePeriod.trackedValueDelta + p.overpayment};
             env(pay(borrower, loanKeylet.key, payAmount),
                 Txflags(tfLoanOverpayment),
                 Ter(tesSUCCESS));
@@ -7724,8 +7734,26 @@ protected:
 
             return Result{
                 .principalOutstanding = loanSle ? Number{loanSle->at(sfPrincipalOutstanding)} : 0,
-                .expectedNewPrincipal = expectedNewPrincipal};
+                .expectedNewPrincipal = expectedNewPrincipal,
+                .managementFeeChange =
+                    (loanSle ? Number{loanSle->at(sfManagementFeeOutstanding)} : Number{0}) -
+                    managementFeeBefore,
+                .unit = Number{1, s.loanScale}};
         };
+
+        // Scenario 1: the original near-zero-rate principal reproduction
+        // (loanScale -10, no management fee). 0.049999998 is smaller than one
+        // period, so it stays a residual overpayment.
+        Params const principalCase{
+            .interestRate = TenthBips32{1},
+            .managementFeeRate = TenthBips16{0},
+            .paymentTotal = 3,
+            .paymentInterval = 60,
+            .principal = 100,
+            .overpayment = Number{49999998, -9},
+            .overpaymentInterestRate = TenthBips32{1000},
+            .overpaymentFeeRate = TenthBips32{1000},
+            .vaultScale = 1};
 
         // With fixCleanup3_2_0 the stored principal lands exactly on the
         // ground-truth grid point: it is reduced by exactly the overpayment's
@@ -7733,7 +7761,7 @@ protected:
         // pin were removed (even with the assertions still gated off), the lossy
         // (P * factor) / factor round-trip would leave the principal one
         // scale-unit high and this would fail.
-        Result const fixed = runScenario(all_);
+        Result const fixed = runScenario(all_, principalCase);
         BEAST_EXPECTS(
             fixed.principalOutstanding == fixed.expectedNewPrincipal,
             "fixed principal " + to_string(fixed.principalOutstanding) + " != expected " +
@@ -7743,11 +7771,58 @@ protected:
         // cancelling near-zero payment factor, so its schedule (and ground truth)
         // differ from the fixed case; the gated assertions keep the server from
         // aborting and the overpayment still lands exactly on that schedule.
-        Result const legacy = runScenario(all_ - fixCleanup3_2_0);
+        Result const legacy = runScenario(all_ - fixCleanup3_2_0, principalCase);
         BEAST_EXPECTS(
             legacy.principalOutstanding == legacy.expectedNewPrincipal,
             "legacy principal " + to_string(legacy.principalOutstanding) + " != expected " +
                 to_string(legacy.expectedNewPrincipal));
+
+        // Scenario 2: a normal-rate loan with a 10% management fee. At a normal
+        // rate the payment factor is identical across the amendment, so toggling
+        // fixCleanup3_2_0 isolates the fix. This overpayment (found by search)
+        // lands on a state where both the principal and the management fee differ
+        // by one scale-unit between the fixed and legacy paths.
+        Params const feeCase{
+            .interestRate = TenthBips32{10000},
+            .managementFeeRate = TenthBips16{10000},
+            .paymentTotal = 6,
+            .paymentInterval = 30u * 24 * 60 * 60,
+            .principal = 1000,
+            .overpayment = Number{214367363, -10},
+            .overpaymentInterestRate = TenthBips32{0},
+            .overpaymentFeeRate = TenthBips32{0},
+            .vaultScale = std::nullopt};
+
+        Result const feeFixed = runScenario(all_, feeCase);
+        Result const feeLegacy = runScenario(all_ - fixCleanup3_2_0, feeCase);
+
+        // With the fix the principal is the exact reduction; without it the lossy
+        // (P * factor) / factor round-trip leaves it one scale-unit high.
+        BEAST_EXPECTS(
+            feeFixed.principalOutstanding == feeFixed.expectedNewPrincipal,
+            "fee-case fixed principal " + to_string(feeFixed.principalOutstanding) +
+                " != expected " + to_string(feeFixed.expectedNewPrincipal));
+        BEAST_EXPECTS(
+            feeLegacy.principalOutstanding == feeLegacy.expectedNewPrincipal + feeLegacy.unit,
+            "fee-case legacy principal " + to_string(feeLegacy.principalOutstanding) +
+                " != expected " + to_string(feeLegacy.expectedNewPrincipal + feeLegacy.unit));
+
+        // Management fee: the overpayment re-amortizes a fee-bearing loan, so the management fee
+        // outstanding drops.
+        //
+        // Unlike the principal that is already at the correct precision, the re-amortized
+        // management fee  is tenthBipsOfValue of the new schedule's gross interest, which depends
+        // on the recomputed periodic payment. So the expected change below is a pinned constant
+        // captured from a passing run a magic value only because there is nothing simpler to
+        // compare against.
+        //
+        // At the integration level, toggling the amendment also changes the regular payment's
+        // rounding so a fixed-vs-legacy comparison cannot isolate the overpayment management-fee
+        // fix.
+        BEAST_EXPECT(feeFixed.managementFeeChange == feeLegacy.managementFeeChange);
+        BEAST_EXPECTS(
+            (feeFixed.managementFeeChange == Number{-8219709543, -10}),
+            "fee-case mgmt fee change " + to_string(feeFixed.managementFeeChange));
     }
 
     // A LoanSet with InterestRate = 1 (0.001% annualized, the minimum non-zero


### PR DESCRIPTION
doOverpayment asserted that trackedPrincipalDelta exactly equals the reduction in stored principal after re-amortization. The assertion was failing because tryOverpayment re-derived the new principal from the new periodic payment via a (P * factor) / factor round-trip, which is not exact in Number arithmetic. A positive residual, combined with Upward rounding, pushed the stored principal one scale-unit high, making the principal drop by delta - 1 unit rather than delta.

Under fixCleanup3_2_0, pin the new principal to the exact on-grid reduction (roundedOldState.principalOutstanding - trackedPrincipalDelta) instead. Both operands are already at loan scale, so the subtraction is exact and requires no further rounding. Interest is re-derived via constructLoanState so the V = P + I + M invariant still holds. The three assertions in doOverpayment that encode this invariant are also gated behind the same amendment, since they only hold once the fix ensures the exact reduction.

Adds testBugOverpaymentPrincipalChange to reproduce the core-dump scenario (principal=100, rate=1, n=3, interval=60, one period + residual overpayment of 0.049999998) and
testLoanSetNearZeroInterestRateSucceeds to verify scheduled payments cover principal at InterestRate=1.

<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
