### PR TITLE
fix: Add zero domainID check for permissionedDomain

### DIFF
--- a/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
@@ -3,6 +3,7 @@
 #include <xrpl/basics/Log.h>
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Journal.h>
+#include <xrpl/beast/utility/Zero.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/CredentialHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
@@ -4,6 +4,7 @@
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/beast/utility/Zero.h>
+#include <xrpl/beast/utility/instrumentation.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/CredentialHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
@@ -23,7 +23,7 @@ accountInDomain(ReadView const& view, AccountID const& account, Domain const& do
     // Avoid constructing a zero-key PermissionedDomain keylet.
     // keylet::permissionedDomain(uint256) uses the DomainID as the ledger key.
     if (view.rules().enabled(fixCleanup3_2_0) && domainID == beast::kZero)
-        return false;
+        return false;  // LCOV_EXCL_LINE
 
     auto const sleDomain = view.read(keylet::permissionedDomain(domainID));
     if (!sleDomain)

--- a/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
@@ -23,7 +23,12 @@ accountInDomain(ReadView const& view, AccountID const& account, Domain const& do
     // Avoid constructing a zero-key PermissionedDomain keylet.
     // keylet::permissionedDomain(uint256) uses the DomainID as the ledger key.
     if (view.rules().enabled(fixCleanup3_2_0) && domainID == beast::kZero)
-        return false;  // LCOV_EXCL_LINE
+    {
+        // LCOV_EXCL_START
+        UNREACHABLE("xrpl::permissioned_dex::accountInDomain : domainID is zero");
+        return false;
+        // LCOV_EXCL_STOP
+    }
 
     auto const sleDomain = view.read(keylet::permissionedDomain(domainID));
     if (!sleDomain)

--- a/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/PermissionedDEXHelpers.cpp
@@ -19,6 +19,11 @@ namespace xrpl::permissioned_dex {
 bool
 accountInDomain(ReadView const& view, AccountID const& account, Domain const& domainID)
 {
+    // Avoid constructing a zero-key PermissionedDomain keylet.
+    // keylet::permissionedDomain(uint256) uses the DomainID as the ledger key.
+    if (view.rules().enabled(fixCleanup3_2_0) && domainID == beast::kZero)
+        return false;
+
     auto const sleDomain = view.read(keylet::permissionedDomain(domainID));
     if (!sleDomain)
         return false;

--- a/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
+++ b/src/libxrpl/tx/transactors/dex/OfferCreate.cpp
@@ -94,6 +94,12 @@ OfferCreate::preflight(PreflightContext const& ctx)
     if (tx.isFlag(tfHybrid) && !tx.isFieldPresent(sfDomainID))
         return temINVALID_FLAG;
 
+    // A zero DomainID is invalid for a PermissionedDomain ledger entry because
+    // keylet::permissionedDomain(uint256) uses the DomainID as the ledger key.
+    if (auto const domainID = tx[~sfDomainID];
+        ctx.rules.enabled(fixCleanup3_2_0) && domainID && *domainID == beast::kZero)
+        return temMALFORMED;
+
     bool const bImmediateOrCancel(tx.isFlag(tfImmediateOrCancel));
     bool const bFillOrKill(tx.isFlag(tfFillOrKill));
 

--- a/src/libxrpl/tx/transactors/payment/Payment.cpp
+++ b/src/libxrpl/tx/transactors/payment/Payment.cpp
@@ -125,6 +125,12 @@ Payment::preflight(PreflightContext const& ctx)
     if (!mpTokensV2 && isDstMPT && ctx.tx.isFieldPresent(sfPaths))
         return temMALFORMED;
 
+    // A zero DomainID is invalid for a PermissionedDomain ledger entry because
+    // keylet::permissionedDomain(uint256) uses the DomainID as the ledger key.
+    if (auto const domainID = tx[~sfDomainID];
+        ctx.rules.enabled(fixCleanup3_2_0) && domainID && *domainID == beast::kZero)
+        return temMALFORMED;
+
     bool const partialPaymentAllowed = tx.isFlag(tfPartialPayment);
     bool const limitQuality = tx.isFlag(tfLimitQuality);
     bool const defaultPathsAllowed = !tx.isFlag(tfNoRippleDirect);

--- a/src/test/app/PermissionedDEX_test.cpp
+++ b/src/test/app/PermissionedDEX_test.cpp
@@ -197,6 +197,20 @@ class PermissionedDEX_test : public beast::unit_test::Suite
             env.close();
         }
 
+        // test preflight - malformed DomainID being zero
+        // Only test this with fixCleanup3_2_0 enabled. Without the fix,
+        // an assert-enabled build can crash when Ledger::read() receives
+        // a zero-key PermissionedDomain keylet.
+        if (features[fixCleanup3_2_0])
+        {
+            Env env(*this, features);
+            auto const& [gw_, domainOwner, alice_, bob_, carol_, USD, domainID, credType] =
+                PermissionedDEX(env);
+
+            env(offer(bob_, XRP(10), USD(10)), Domain(uint256{}), Ter(temMALFORMED));
+            env.close();
+        }
+
         // preclaim - someone outside of the domain cannot create domain offer
         {
             Env env(*this, features);
@@ -393,6 +407,24 @@ class PermissionedDEX_test : public beast::unit_test::Suite
             env.close();
 
             env(pay(bob_, alice_, USD(10)), Path(~USD), Sendmax(XRP(10)), Domain(domainID));
+            env.close();
+        }
+
+        // test preflight - malformed DomainID being zero
+        // Only test this with fixCleanup3_2_0 enabled. Without the fix,
+        // an assert-enabled build can crash when Ledger::read() receives
+        // a zero-key PermissionedDomain keylet.
+        if (features[fixCleanup3_2_0])
+        {
+            Env env(*this, features);
+            auto const& [gw_, domainOwner, alice_, bob_, carol_, USD, domainID, credType] =
+                PermissionedDEX(env);
+
+            env(pay(bob_, alice_, USD(10)),
+                Path(~USD),
+                Sendmax(XRP(10)),
+                Domain(uint256{}),
+                Ter(temMALFORMED));
             env.close();
         }
 
@@ -1772,7 +1804,9 @@ public:
 
         // Test domain offer (w/o hybrid)
         testOfferCreate(all);
+        testOfferCreate(all - fixCleanup3_2_0);
         testPayment(all);
+        testPayment(all - fixCleanup3_2_0);
         testBookStep(all);
         testRippling(all);
         testOfferTokenIssuerInDomain(all);


### PR DESCRIPTION
Because `Ledger::read()` asserts on zero keys, `view.read(keylet::permissionedDomain(domainID))` must only be called with a non-zero `domainID`. This PR adds guarded validation for zero `DomainID` in `OfferCreate` and `Payment`, plus a defensive check in `permissioned_dex::accountInDomain()`.
Although the asserts are only triggered in debug build, it is still worth adding the defensive check.

- Add preflight checks for `OfferCreate` and `Payment` so a zero `DomainID` returns `temMALFORMED`.
- Add check in `permissioned_dex::accountInDomain()` to avoid constructing a zero-key `PermissionedDomain` keylet.
- The changes are guarded by `fixCleanup3_2_0`


<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
