### PR TITLE
fix: Adjust xrpld systemd service and update timer

### DIFF
--- a/package/debian/rules
+++ b/package/debian/rules
@@ -10,7 +10,7 @@ override_dh_auto_configure override_dh_auto_build override_dh_auto_test:
 
 override_dh_installsystemd:
 	dh_installsystemd --no-stop-on-upgrade xrpld.service
-	dh_installsystemd --name=update-xrpld --no-start update-xrpld.service update-xrpld.timer
+	dh_installsystemd --name=update-xrpld --no-enable --no-start update-xrpld.service update-xrpld.timer
 
 execute_before_dh_installtmpfiles:
 	dh_installsysusers

--- a/package/shared/update-xrpld.timer
+++ b/package/shared/update-xrpld.timer
@@ -3,7 +3,7 @@ Description=Daily xrpld update check
 
 [Timer]
 OnCalendar=*-*-* 00:00:00
-RandomizedDelaySec=24h
+RandomizedDelaySec=4h
 Persistent=true
 
 [Install]

--- a/package/shared/xrpld.service
+++ b/package/shared/xrpld.service
@@ -8,8 +8,9 @@ StartLimitBurst=5
 [Service]
 Type=simple
 ExecStart=/usr/bin/xrpld --net --silent --conf /etc/xrpld/xrpld.cfg
-Restart=always
+Restart=on-failure
 RestartSec=5s
+TimeoutStopSec=300
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=true

--- a/package/shared/xrpld.service
+++ b/package/shared/xrpld.service
@@ -2,7 +2,7 @@
 Description=XRP Ledger Daemon
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=300
+StartLimitIntervalSec=5min
 StartLimitBurst=5
 
 [Service]
@@ -10,7 +10,7 @@ Type=simple
 ExecStart=/usr/bin/xrpld --net --silent --conf /etc/xrpld/xrpld.cfg
 Restart=on-failure
 RestartSec=5s
-TimeoutStopSec=300
+TimeoutStopSec=5min
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=true


### PR DESCRIPTION
xrpld can take longer than the default time systemd allots for a service to stop so we'll extend that time so it can stop gracefully.

- Allow 5 minutes for xrpld to gracefully shut down before systemd SIGKILLs it (TimeoutStopSec=300)
- Restart only on failure, not on clean exit
- Reduce the auto-update randomized delay from 24h to 4h
- Don't auto-enable the update timer on Debian installs matches the RPM preset, which already disables it
