### PR TITLE
feat: Remove clear mutable flags for DynamicMPT XLS-94

### DIFF
--- a/include/xrpl/protocol/LedgerFormats.h
+++ b/include/xrpl/protocol/LedgerFormats.h
@@ -180,12 +180,12 @@ enum LedgerEntryType : std::uint16_t {
         LSF_FLAG(lsfMPTCanClawback, 0x00000040))                                                                                   \
                                                                                                                                    \
     LEDGER_OBJECT(MPTokenIssuanceMutable,                                                                                          \
-        LSF_FLAG(lsmfMPTCanMutateCanLock, 0x00000002)                                                                              \
-        LSF_FLAG(lsmfMPTCanMutateRequireAuth, 0x00000004)                                                                          \
-        LSF_FLAG(lsmfMPTCanMutateCanEscrow, 0x00000008)                                                                            \
-        LSF_FLAG(lsmfMPTCanMutateCanTrade, 0x00000010)                                                                             \
-        LSF_FLAG(lsmfMPTCanMutateCanTransfer, 0x00000020)                                                                          \
-        LSF_FLAG(lsmfMPTCanMutateCanClawback, 0x00000040)                                                                          \
+        LSF_FLAG(lsmfMPTCanEnableCanLock, 0x00000002)                                                                              \
+        LSF_FLAG(lsmfMPTCanEnableRequireAuth, 0x00000004)                                                                          \
+        LSF_FLAG(lsmfMPTCanEnableCanEscrow, 0x00000008)                                                                            \
+        LSF_FLAG(lsmfMPTCanEnableCanTrade, 0x00000010)                                                                             \
+        LSF_FLAG(lsmfMPTCanEnableCanTransfer, 0x00000020)                                                                          \
+        LSF_FLAG(lsmfMPTCanEnableCanClawback, 0x00000040)                                                                          \
         LSF_FLAG(lsmfMPTCanMutateMetadata, 0x00010000)                                                                             \
         LSF_FLAG(lsmfMPTCanMutateTransferFee, 0x00020000))                                                                         \
                                                                                                                                    \

--- a/include/xrpl/protocol/TxFlags.h
+++ b/include/xrpl/protocol/TxFlags.h
@@ -355,24 +355,18 @@ inline constexpr FlagValue tmfMPTokenIssuanceCreateMutableMask =
       tmfMPTCanMutateMetadata | tmfMPTCanMutateTransferFee);
 
 // MPTokenIssuanceSet MutableFlags:
-// Set or Clear flags.
+// Enable mutable capability flags. These flags are one-way: once enabled,
+// the corresponding capability cannot be disabled by MPTokenIssuanceSet.
 
 inline constexpr FlagValue tmfMPTSetCanLock = 0x00000001;
-inline constexpr FlagValue tmfMPTClearCanLock = 0x00000002;
-inline constexpr FlagValue tmfMPTSetRequireAuth = 0x00000004;
-inline constexpr FlagValue tmfMPTClearRequireAuth = 0x00000008;
-inline constexpr FlagValue tmfMPTSetCanEscrow = 0x00000010;
-inline constexpr FlagValue tmfMPTClearCanEscrow = 0x00000020;
-inline constexpr FlagValue tmfMPTSetCanTrade = 0x00000040;
-inline constexpr FlagValue tmfMPTClearCanTrade = 0x00000080;
-inline constexpr FlagValue tmfMPTSetCanTransfer = 0x00000100;
-inline constexpr FlagValue tmfMPTClearCanTransfer = 0x00000200;
-inline constexpr FlagValue tmfMPTSetCanClawback = 0x00000400;
-inline constexpr FlagValue tmfMPTClearCanClawback = 0x00000800;
-inline constexpr FlagValue tmfMPTokenIssuanceSetMutableMask = ~(
-    tmfMPTSetCanLock | tmfMPTClearCanLock | tmfMPTSetRequireAuth | tmfMPTClearRequireAuth |
-    tmfMPTSetCanEscrow | tmfMPTClearCanEscrow | tmfMPTSetCanTrade | tmfMPTClearCanTrade |
-    tmfMPTSetCanTransfer | tmfMPTClearCanTransfer | tmfMPTSetCanClawback | tmfMPTClearCanClawback);
+inline constexpr FlagValue tmfMPTSetRequireAuth = 0x00000002;
+inline constexpr FlagValue tmfMPTSetCanEscrow = 0x00000004;
+inline constexpr FlagValue tmfMPTSetCanTrade = 0x00000008;
+inline constexpr FlagValue tmfMPTSetCanTransfer = 0x00000010;
+inline constexpr FlagValue tmfMPTSetCanClawback = 0x00000020;
+inline constexpr FlagValue tmfMPTokenIssuanceSetMutableMask =
+    ~(tmfMPTSetCanLock | tmfMPTSetRequireAuth | tmfMPTSetCanEscrow | tmfMPTSetCanTrade |
+      tmfMPTSetCanTransfer | tmfMPTSetCanClawback);
 
 // Prior to fixRemoveNFTokenAutoTrustLine, transfer of an NFToken between accounts allowed a
 // TrustLine to be added to the issuer of that token without explicit permission from that issuer.

--- a/include/xrpl/protocol/TxFlags.h
+++ b/include/xrpl/protocol/TxFlags.h
@@ -341,17 +341,17 @@ inline constexpr FlagValue tfTrustSetPermissionMask =
 
 // MPTokenIssuanceCreate MutableFlags:
 // Indicating specific fields or flags may be changed after issuance.
-inline constexpr FlagValue tmfMPTCanMutateCanLock = lsmfMPTCanMutateCanLock;
-inline constexpr FlagValue tmfMPTCanMutateRequireAuth = lsmfMPTCanMutateRequireAuth;
-inline constexpr FlagValue tmfMPTCanMutateCanEscrow = lsmfMPTCanMutateCanEscrow;
-inline constexpr FlagValue tmfMPTCanMutateCanTrade = lsmfMPTCanMutateCanTrade;
-inline constexpr FlagValue tmfMPTCanMutateCanTransfer = lsmfMPTCanMutateCanTransfer;
-inline constexpr FlagValue tmfMPTCanMutateCanClawback = lsmfMPTCanMutateCanClawback;
+inline constexpr FlagValue tmfMPTCanEnableCanLock = lsmfMPTCanEnableCanLock;
+inline constexpr FlagValue tmfMPTCanEnableRequireAuth = lsmfMPTCanEnableRequireAuth;
+inline constexpr FlagValue tmfMPTCanEnableCanEscrow = lsmfMPTCanEnableCanEscrow;
+inline constexpr FlagValue tmfMPTCanEnableCanTrade = lsmfMPTCanEnableCanTrade;
+inline constexpr FlagValue tmfMPTCanEnableCanTransfer = lsmfMPTCanEnableCanTransfer;
+inline constexpr FlagValue tmfMPTCanEnableCanClawback = lsmfMPTCanEnableCanClawback;
 inline constexpr FlagValue tmfMPTCanMutateMetadata = lsmfMPTCanMutateMetadata;
 inline constexpr FlagValue tmfMPTCanMutateTransferFee = lsmfMPTCanMutateTransferFee;
 inline constexpr FlagValue tmfMPTokenIssuanceCreateMutableMask =
-    ~(tmfMPTCanMutateCanLock | tmfMPTCanMutateRequireAuth | tmfMPTCanMutateCanEscrow |
-      tmfMPTCanMutateCanTrade | tmfMPTCanMutateCanTransfer | tmfMPTCanMutateCanClawback |
+    ~(tmfMPTCanEnableCanLock | tmfMPTCanEnableRequireAuth | tmfMPTCanEnableCanEscrow |
+      tmfMPTCanEnableCanTrade | tmfMPTCanEnableCanTransfer | tmfMPTCanEnableCanClawback |
       tmfMPTCanMutateMetadata | tmfMPTCanMutateTransferFee);
 
 // MPTokenIssuanceSet MutableFlags:

--- a/include/xrpl/protocol/detail/features.macro
+++ b/include/xrpl/protocol/detail/features.macro
@@ -23,7 +23,7 @@ XRPL_FEATURE(LendingProtocol,             Supported::Yes, VoteBehavior::DefaultN
 XRPL_FEATURE(PermissionDelegationV1_1,    Supported::No,  VoteBehavior::DefaultNo)
 XRPL_FIX    (DirectoryLimit,              Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (IncludeKeyletFields,         Supported::Yes, VoteBehavior::DefaultNo)
-XRPL_FEATURE(DynamicMPT,                  Supported::No,  VoteBehavior::DefaultNo)
+XRPL_FEATURE(DynamicMPT,                  Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (TokenEscrowV1,               Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (PriceOracleOrder,            Supported::Yes, VoteBehavior::DefaultNo)
 XRPL_FIX    (MPTDeliveredAmount,          Supported::Yes, VoteBehavior::DefaultNo)

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
@@ -46,28 +46,28 @@ MPTokenIssuanceSet::getFlagsMask(PreflightContext const& ctx)
 struct MPTMutabilityFlags
 {
     std::uint32_t setFlag;
-    std::uint32_t canMutateFlag;
+    std::uint32_t canEnableFlag;
     std::uint32_t ledgerFlag;
 };
 
 static constexpr std::array<MPTMutabilityFlags, 6> kMptMutabilityFlags = {
     {{.setFlag = tmfMPTSetCanLock,
-      .canMutateFlag = lsmfMPTCanMutateCanLock,
+      .canEnableFlag = lsmfMPTCanEnableCanLock,
       .ledgerFlag = lsfMPTCanLock},
      {.setFlag = tmfMPTSetRequireAuth,
-      .canMutateFlag = lsmfMPTCanMutateRequireAuth,
+      .canEnableFlag = lsmfMPTCanEnableRequireAuth,
       .ledgerFlag = lsfMPTRequireAuth},
      {.setFlag = tmfMPTSetCanEscrow,
-      .canMutateFlag = lsmfMPTCanMutateCanEscrow,
+      .canEnableFlag = lsmfMPTCanEnableCanEscrow,
       .ledgerFlag = lsfMPTCanEscrow},
      {.setFlag = tmfMPTSetCanTrade,
-      .canMutateFlag = lsmfMPTCanMutateCanTrade,
+      .canEnableFlag = lsmfMPTCanEnableCanTrade,
       .ledgerFlag = lsfMPTCanTrade},
      {.setFlag = tmfMPTSetCanTransfer,
-      .canMutateFlag = lsmfMPTCanMutateCanTransfer,
+      .canEnableFlag = lsmfMPTCanEnableCanTransfer,
       .ledgerFlag = lsfMPTCanTransfer},
      {.setFlag = tmfMPTSetCanClawback,
-      .canMutateFlag = lsmfMPTCanMutateCanClawback,
+      .canEnableFlag = lsmfMPTCanEnableCanClawback,
       .ledgerFlag = lsfMPTCanClawback}}};
 
 NotTEC
@@ -220,7 +220,7 @@ MPTokenIssuanceSet::preclaim(PreclaimContext const& ctx)
     if (auto const mutableFlags = ctx.tx[~sfMutableFlags])
     {
         if (std::ranges::any_of(kMptMutabilityFlags, [mutableFlags, &isMutableFlag](auto const& f) {
-                return !isMutableFlag(f.canMutateFlag) && ((*mutableFlags & f.setFlag) != 0u);
+                return !isMutableFlag(f.canEnableFlag) && ((*mutableFlags & f.setFlag) != 0u);
             }))
             return tecNO_PERMISSION;
     }

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
@@ -41,35 +41,34 @@ MPTokenIssuanceSet::getFlagsMask(PreflightContext const& ctx)
     return tfMPTokenIssuanceSetMask;
 }
 
-// Maps set/clear mutable flags in an MPTokenIssuanceSet transaction to the
-// corresponding ledger mutable flags that control whether the change is
-// allowed.
+// Maps each MPTokenIssuanceSet MutableFlags to the corresponding mutable
+// flag and the target ledger flag to mutate.
 struct MPTMutabilityFlags
 {
     std::uint32_t setFlag;
-    std::uint32_t clearFlag;
     std::uint32_t canMutateFlag;
+    std::uint32_t ledgerFlag;
 };
 
 static constexpr std::array<MPTMutabilityFlags, 6> kMptMutabilityFlags = {
     {{.setFlag = tmfMPTSetCanLock,
-      .clearFlag = tmfMPTClearCanLock,
-      .canMutateFlag = lsmfMPTCanMutateCanLock},
+      .canMutateFlag = lsmfMPTCanMutateCanLock,
+      .ledgerFlag = lsfMPTCanLock},
      {.setFlag = tmfMPTSetRequireAuth,
-      .clearFlag = tmfMPTClearRequireAuth,
-      .canMutateFlag = lsmfMPTCanMutateRequireAuth},
+      .canMutateFlag = lsmfMPTCanMutateRequireAuth,
+      .ledgerFlag = lsfMPTRequireAuth},
      {.setFlag = tmfMPTSetCanEscrow,
-      .clearFlag = tmfMPTClearCanEscrow,
-      .canMutateFlag = lsmfMPTCanMutateCanEscrow},
+      .canMutateFlag = lsmfMPTCanMutateCanEscrow,
+      .ledgerFlag = lsfMPTCanEscrow},
      {.setFlag = tmfMPTSetCanTrade,
-      .clearFlag = tmfMPTClearCanTrade,
-      .canMutateFlag = lsmfMPTCanMutateCanTrade},
+      .canMutateFlag = lsmfMPTCanMutateCanTrade,
+      .ledgerFlag = lsfMPTCanTrade},
      {.setFlag = tmfMPTSetCanTransfer,
-      .clearFlag = tmfMPTClearCanTransfer,
-      .canMutateFlag = lsmfMPTCanMutateCanTransfer},
+      .canMutateFlag = lsmfMPTCanMutateCanTransfer,
+      .ledgerFlag = lsfMPTCanTransfer},
      {.setFlag = tmfMPTSetCanClawback,
-      .clearFlag = tmfMPTClearCanClawback,
-      .canMutateFlag = lsmfMPTCanMutateCanClawback}}};
+      .canMutateFlag = lsmfMPTCanMutateCanClawback,
+      .ledgerFlag = lsfMPTCanClawback}}};
 
 NotTEC
 MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
@@ -121,17 +120,6 @@ MPTokenIssuanceSet::preflight(PreflightContext const& ctx)
         {
             if ((*mutableFlags == 0u) || ((*mutableFlags & tmfMPTokenIssuanceSetMutableMask) != 0u))
                 return temINVALID_FLAG;
-
-            // Can not set and clear the same flag
-            if (std::ranges::any_of(kMptMutabilityFlags, [mutableFlags](auto const& f) {
-                    return (*mutableFlags & f.setFlag) && (*mutableFlags & f.clearFlag);
-                }))
-                return temINVALID_FLAG;
-
-            // Trying to set a non-zero TransferFee and clear MPTCanTransfer
-            // in the same transaction is not allowed.
-            if ((transferFee.value_or(0) != 0u) && ((*mutableFlags & tmfMPTClearCanTransfer) != 0u))
-                return temMALFORMED;
         }
     }
 
@@ -232,15 +220,8 @@ MPTokenIssuanceSet::preclaim(PreclaimContext const& ctx)
     if (auto const mutableFlags = ctx.tx[~sfMutableFlags])
     {
         if (std::ranges::any_of(kMptMutabilityFlags, [mutableFlags, &isMutableFlag](auto const& f) {
-                return !isMutableFlag(f.canMutateFlag) &&
-                    ((*mutableFlags & (f.setFlag | f.clearFlag)));
+                return !isMutableFlag(f.canMutateFlag) && ((*mutableFlags & f.setFlag) != 0u);
             }))
-            return tecNO_PERMISSION;
-
-        // Clearing lsfMPTRequireAuth is invalid when the issuance already has
-        // a DomainID set, because a DomainID requires RequireAuth to be active.
-        if ((*mutableFlags & tmfMPTClearRequireAuth) != 0u &&
-            sleMptIssuance->isFieldPresent(sfDomainID))
             return tecNO_PERMISSION;
     }
 
@@ -301,19 +282,8 @@ MPTokenIssuanceSet::doApply()
         {
             if ((mutableFlags & f.setFlag) != 0u)
             {
-                flagsOut |= f.canMutateFlag;
+                flagsOut |= f.ledgerFlag;
             }
-            else if ((mutableFlags & f.clearFlag) != 0u)
-            {
-                flagsOut &= ~f.canMutateFlag;
-            }
-        }
-
-        if ((mutableFlags & tmfMPTClearCanTransfer) != 0u)
-        {
-            // If the lsfMPTCanTransfer flag is being cleared, then also clear
-            // the TransferFee field.
-            sle->makeFieldAbsent(sfTransferFee);
         }
     }
 

--- a/src/test/app/AMMMPT_test.cpp
+++ b/src/test/app/AMMMPT_test.cpp
@@ -2240,7 +2240,9 @@ private:
                     .err = Ter(tecNO_AUTH)});
         }
 
-        // MPTCanTransfer is not set and the account is not the issuer of MPT
+        // MPTCanTransfer is not set and the account is not the issuer of MPT.
+        // The issuer can create the AMM, and an existing LP token holder can
+        // still withdraw.
         {
             Env env{*this};
             env.fund(XRP(30'000), gw_, alice_);
@@ -2250,15 +2252,17 @@ private:
                  .issuer = gw_,
                  .holders = {alice_},
                  .pay = 30'000,
-                 .flags = kMptDexFlags,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer,
+                 .flags = tfMPTCanTrade,
                  .authHolder = true});
 
             AMM amm(env, gw_, XRP(10'000), btc(10'000));
-            amm.deposit(DepositArg{.account = alice_, .asset1In = XRP(200), .asset2In = btc(200)});
 
-            // Allow to withdraw if transfer is disabled
-            btc.set({.mutableFlags = tmfMPTClearCanTransfer});
+            auto const lpIssue = amm.lptIssue();
+            env.trust(STAmount{lpIssue, 20'000'000}, alice_);
+            env.close();
+            env(pay(gw_, alice_, LPToken(1'000'000).tokens(lpIssue)));
+            env.close();
+
             amm.withdraw(
                 WithdrawArg{.account = alice_, .asset1Out = btc(100), .assets = {{XRP, btc}}});
         }

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -5423,110 +5423,12 @@ protected:
     }
 
     void
-    testCoverDepositWithdrawNonTransferableMPT(FeatureBitset feature)
+    testLendingCanTradeDisabledNoImpact()
     {
-        testcase("CoverDeposit blocked, CoverWithdraw allowed when CanTransfer cleared");
-        using namespace jtx;
-        using namespace loanBroker;
-
-        Env env(*this, feature);
-
-        Account const issuer{"issuer"};
-        Account const alice{"alice"};
-
-        env.fund(XRP(100'000), issuer, alice);
-        env.close();
-
-        MPTTester mpt(
-            {.env = env,
-             .issuer = issuer,
-             .holders = {alice},
-             .pay = 100,
-             .flags = tfMPTCanTransfer,
-             .mutableFlags = tmfMPTCanMutateCanTransfer});
-        PrettyAsset const asset = mpt["MPT"];
-
-        Vault const vault{env};
-        auto const [createTx, vaultKeylet] = vault.create({.owner = alice, .asset = asset});
-        env(createTx);
-        env.close();
-
-        auto const brokerKeylet = keylet::loanbroker(alice.id(), env.seq(alice));
-        env(set(alice, vaultKeylet.key));
-        env.close();
-
-        auto const brokerSle = env.le(brokerKeylet);
-        if (!BEAST_EXPECT(brokerSle))
-            return;
-
-        Account const pseudoAccount{"Loan Broker pseudo-account", brokerSle->at(sfAccount)};
-
-        // First, deposit some cover while CanTransfer is set so we have an
-        // existing position to withdraw from after the governance action.
-        auto const depositAmount = asset(1);
-        env(coverDeposit(alice, brokerKeylet.key, depositAmount));
-        env.close();
-
-        if (auto const refreshed = env.le(brokerKeylet); BEAST_EXPECT(refreshed))
-        {
-            BEAST_EXPECT(refreshed->at(sfCoverAvailable) == 1);
-            env.require(Balance(pseudoAccount, depositAmount));
-        }
-
-        // Issuer governance: clear CanTransfer.
-        mpt.set({.mutableFlags = tmfMPTClearCanTransfer});
-        env.close();
-
-        // Standard Payment path still forbids third-party transfers.
-        auto const err = feature[featureMPTokensV2] ? tecNO_PERMISSION : tecNO_AUTH;
-        env(pay(alice, pseudoAccount, asset(1)), Ter(err));
-        env.close();
-
-        // New cover deposits are blocked - this would create new exposure.
-        env(coverDeposit(alice, brokerKeylet.key, depositAmount), Ter{tecNO_AUTH});
-        env.close();
-
-        if (auto const refreshed = env.le(brokerKeylet); BEAST_EXPECT(refreshed))
-        {
-            BEAST_EXPECT(refreshed->at(sfCoverAvailable) == 1);
-            env.require(Balance(pseudoAccount, depositAmount));
-        }
-
-        bool const postAmendment = feature[fixCleanup3_2_0];
-        if (postAmendment)
-        {
-            // Post-fixCleanup3_2_0: existing cover can always be withdrawn
-            // even when CanTransfer is cleared, so the broker is not trapped.
-            env(coverWithdraw(alice, brokerKeylet.key, depositAmount));
-            env.close();
-
-            if (auto const refreshed = env.le(brokerKeylet); BEAST_EXPECT(refreshed))
-            {
-                BEAST_EXPECT(refreshed->at(sfCoverAvailable) == 0);
-                env.require(Balance(pseudoAccount, asset(0)));
-            }
-        }
-        else
-        {
-            // Pre-fixCleanup3_2_0 regression: cover withdraw was blocked,
-            // trapping the broker's first-loss capital.
-            env(coverWithdraw(alice, brokerKeylet.key, depositAmount), Ter{tecNO_AUTH});
-            env.close();
-
-            if (auto const refreshed = env.le(brokerKeylet); BEAST_EXPECT(refreshed))
-            {
-                BEAST_EXPECT(refreshed->at(sfCoverAvailable) == 1);
-                env.require(Balance(pseudoAccount, depositAmount));
-            }
-        }
-    }
-
-    void
-    testLoanSetBlockedLoanPayAllowedWhenCanTransferCleared()
-    {
-        testcase("LoanSet blocked, LoanPay allowed when CanTransfer cleared");
+        testcase("Lending: CanTrade disabled has no impact");
         using namespace jtx;
         using namespace loan;
+        using namespace loanBroker;
 
         Env env(*this, all_);
 
@@ -5542,66 +5444,6 @@ protected:
              .issuer = issuer,
              .holders = {lender, borrower},
              .flags = tfMPTCanTransfer | tfMPTCanLock,
-             .mutableFlags = tmfMPTCanMutateCanTransfer});
-        PrettyAsset const asset = mpt.issuanceID();
-        env(pay(issuer, lender, asset(10'000'000)));
-        // Fund the borrower with enough to cover principal+interest+fees
-        env(pay(issuer, borrower, asset(100'000)));
-        env.close();
-
-        // Create vault and broker while CanTransfer is set.
-        auto const broker = createVaultAndBroker(env, asset, lender);
-
-        auto const loanSetFee = Fee(env.current()->fees().base * 2);
-
-        // Create an existing loan while CanTransfer is set.
-        env(set(borrower, broker.brokerID, 1'000),
-            Sig(sfCounterpartySignature, lender),
-            loanSetFee);
-        env.close();
-        auto const loanKeylet = keylet::loan(broker.brokerID, 1);
-        BEAST_EXPECT(env.le(loanKeylet));
-
-        // Issuer governance: clear CanTransfer.
-        mpt.set({.mutableFlags = tmfMPTClearCanTransfer});
-        env.close();
-
-        // Issuing a NEW loan is blocked - it would create new exposure into
-        // a pool the issuer is restricting.
-        env(set(borrower, broker.brokerID, 1'000),
-            Sig(sfCounterpartySignature, lender),
-            loanSetFee,
-            Ter{tecNO_AUTH});
-        env.close();
-
-        // Repaying an existing loan is always allowed - blocking it would
-        // create irrecoverable bad debt and trap SAV depositor principal.
-        env(pay(borrower, loanKeylet.key, asset(1'000)));
-        env.close();
-    }
-
-    void
-    testLendingCanTradeClearedNoImpact()
-    {
-        testcase("Lending: CanTrade cleared has no impact");
-        using namespace jtx;
-        using namespace loan;
-        using namespace loanBroker;
-
-        Env env(*this, all_);
-
-        Account const issuer{"issuer"};
-        Account const lender{"lender"};
-        Account const borrower{"borrower"};
-
-        env.fund(XRP(1'000'000), issuer, lender, borrower);
-        env.close();
-
-        MPTTester mpt(
-            {.env = env,
-             .issuer = issuer,
-             .holders = {lender, borrower},
-             .flags = tfMPTCanTransfer | tfMPTCanTrade | tfMPTCanLock,
              .mutableFlags = tmfMPTCanMutateCanTrade});
         PrettyAsset const asset = mpt.issuanceID();
         env(pay(issuer, lender, asset(10'000'000)));
@@ -5610,16 +5452,7 @@ protected:
 
         auto const broker = createVaultAndBroker(env, asset, lender);
 
-        // Sanity: while CanTrade is set, the asset can be placed on the DEX.
-        env(offer(lender, XRP(1), asset(10)));
-        env.close();
-
-        // Issuer governance: clear CanTrade. Loan origination and repayment
-        // are not trades: nothing in the Lending Protocol should be impacted.
-        mpt.set({.mutableFlags = tmfMPTClearCanTrade});
-        env.close();
-
-        // Control: clearing CanTrade is observable on the DEX path.
+        // CanTrade is not set
         env(offer(lender, XRP(1), asset(10)), Ter{tecNO_PERMISSION});
         env.close();
 
@@ -5643,6 +5476,13 @@ protected:
 
         // Cover withdrawal still works.
         env(coverWithdraw(lender, broker.brokerID, asset(100)));
+        env.close();
+
+        // Enable CanTrade and verify the DEX path is restored.
+        mpt.set({.mutableFlags = tmfMPTSetCanTrade});
+        env.close();
+
+        env(offer(lender, XRP(1), asset(10)));
         env.close();
     }
 
@@ -8716,8 +8556,7 @@ protected:
         testRIPD3901();
         testBorrowerIsBroker();
         testLimitExceeded();
-        testLoanSetBlockedLoanPayAllowedWhenCanTransferCleared();
-        testLendingCanTradeClearedNoImpact();
+        testLendingCanTradeDisabledNoImpact();
         testBugOverpaymentPrincipalChange();
         testBugOverpayUnroundedAmount();
 
@@ -8747,7 +8586,6 @@ protected:
         testPoCUnsignedUnderflowOnFullPayAfterEarlyPeriodic(features);
         testBatchBypassCounterparty(features);
         testLoanNextPaymentDueDateOverflow(features);
-        testCoverDepositWithdrawNonTransferableMPT(features);
         testSequentialFLCDepletion(features);
 
         // Invariants

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -4,7 +4,6 @@
 #include <test/jtx/Env.h>
 #include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
-#include <test/jtx/balance.h>
 #include <test/jtx/batch.h>
 #include <test/jtx/credentials.h>
 #include <test/jtx/envconfig.h>

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -5443,7 +5443,7 @@ protected:
              .issuer = issuer,
              .holders = {lender, borrower},
              .flags = tfMPTCanTransfer | tfMPTCanLock,
-             .mutableFlags = tmfMPTCanMutateCanTrade});
+             .mutableFlags = tmfMPTCanEnableCanTrade});
         PrettyAsset const asset = mpt.issuanceID();
         env(pay(issuer, lender, asset(10'000'000)));
         env(pay(issuer, borrower, asset(100'000)));

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3533,33 +3533,6 @@ class MPToken_test : public beast::unit_test::Suite
             }
         }
 
-        // Can not set and clear the same mutable flag
-        {
-            Env env{*this, features};
-            MPTTester mptAlice(env, alice, {.holders = {bob}});
-            auto const mptID = makeMptID(env.seq(alice), alice);
-
-            auto const flagCombinations = {
-                tmfMPTSetCanLock | tmfMPTClearCanLock,
-                tmfMPTSetRequireAuth | tmfMPTClearRequireAuth,
-                tmfMPTSetCanEscrow | tmfMPTClearCanEscrow,
-                tmfMPTSetCanTrade | tmfMPTClearCanTrade,
-                tmfMPTSetCanTransfer | tmfMPTClearCanTransfer,
-                tmfMPTSetCanClawback | tmfMPTClearCanClawback,
-                tmfMPTSetCanLock | tmfMPTClearCanLock | tmfMPTClearCanTrade,
-                tmfMPTSetCanTransfer | tmfMPTClearCanTransfer | tmfMPTSetCanEscrow |
-                    tmfMPTClearCanClawback};
-
-            for (auto const& mutableFlags : flagCombinations)
-            {
-                mptAlice.set(
-                    {.account = alice,
-                     .id = mptID,
-                     .mutableFlags = mutableFlags,
-                     .err = temINVALID_FLAG});
-            }
-        }
-
         // Can not mutate flag which is not mutable
         {
             Env env{*this, features};
@@ -3569,17 +3542,11 @@ class MPToken_test : public beast::unit_test::Suite
 
             auto const mutableFlags = {
                 tmfMPTSetCanLock,
-                tmfMPTClearCanLock,
                 tmfMPTSetRequireAuth,
-                tmfMPTClearRequireAuth,
                 tmfMPTSetCanEscrow,
-                tmfMPTClearCanEscrow,
                 tmfMPTSetCanTrade,
-                tmfMPTClearCanTrade,
                 tmfMPTSetCanTransfer,
-                tmfMPTClearCanTransfer,
-                tmfMPTSetCanClawback,
-                tmfMPTClearCanClawback};
+                tmfMPTSetCanClawback};
 
             for (auto const& mutableFlag : mutableFlags)
             {
@@ -3621,34 +3588,6 @@ class MPToken_test : public beast::unit_test::Suite
                  .id = mptID,
                  .transferFee = kMaxTransferFee + 1,
                  .err = temBAD_TRANSFER_FEE});
-        }
-
-        // Test setting non-zero transfer fee and clearing MPTCanTransfer at the
-        // same time
-        {
-            Env env{*this, features};
-            MPTTester mptAlice(env, alice, {.holders = {bob}});
-
-            mptAlice.create(
-                {.transferFee = 100,
-                 .ownerCount = 1,
-                 .flags = tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateTransferFee | tmfMPTCanMutateCanTransfer});
-
-            // Can not set non-zero transfer fee and clear MPTCanTransfer at the
-            // same time
-            mptAlice.set(
-                {.account = alice,
-                 .mutableFlags = tmfMPTClearCanTransfer,
-                 .transferFee = 1,
-                 .err = temMALFORMED});
-
-            // Can set transfer fee to zero and clear MPTCanTransfer at the same
-            // time. tfMPTCanTransfer will be cleared and TransferFee field will
-            // be removed.
-            mptAlice.set(
-                {.account = alice, .mutableFlags = tmfMPTClearCanTransfer, .transferFee = 0});
-            BEAST_EXPECT(!mptAlice.isTransferFeePresent());
         }
 
         // Can not set non-zero transfer fee when MPTCanTransfer is not set
@@ -3698,14 +3637,7 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.set({.account = alice, .transferFee = 100, .err = tecNO_PERMISSION});
 
             auto const invalidFlags = {
-                tmfMPTSetCanLock,
-                tmfMPTClearCanLock,
-                tmfMPTSetRequireAuth,
-                tmfMPTClearRequireAuth,
-                tmfMPTSetCanEscrow,
-                tmfMPTClearCanEscrow,
-                tmfMPTSetCanClawback,
-                tmfMPTClearCanClawback};
+                tmfMPTSetCanLock, tmfMPTSetRequireAuth, tmfMPTSetCanEscrow, tmfMPTSetCanClawback};
 
             // Can not mutate flags which are not mutable
             for (auto const& mutableFlag : invalidFlags)
@@ -3716,11 +3648,9 @@ class MPToken_test : public beast::unit_test::Suite
 
             // Can mutate MPTCanTrade
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanTrade});
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTrade});
 
             // Can mutate MPTCanTransfer
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanTransfer});
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTransfer});
 
             // Can mutate metadata
             mptAlice.set({.account = alice, .metadata = "test"});
@@ -3789,37 +3719,26 @@ class MPToken_test : public beast::unit_test::Suite
             BEAST_EXPECT(mptAlice.checkTransferFee(10));
         }
 
-        // Test flag toggling
+        // Test mutable flag enablement
         {
-            auto testFlagToggle = [&](std::uint32_t createFlags,
-                                      std::uint32_t setFlags,
-                                      std::uint32_t clearFlags) {
+            auto testFlagSet = [&](std::uint32_t createFlags, std::uint32_t setFlags) {
                 Env env{*this, features};
                 MPTTester mptAlice(env, alice);
 
                 // Create the MPT object with the specified initial flags
                 mptAlice.create({.metadata = "test", .ownerCount = 1, .mutableFlags = createFlags});
 
-                // Set and clear the flag multiple times
-                mptAlice.set({.account = alice, .mutableFlags = setFlags});
-                mptAlice.set({.account = alice, .mutableFlags = clearFlags});
-                mptAlice.set({.account = alice, .mutableFlags = clearFlags});
+                // Setting the same mutable capability more than once is harmless.
                 mptAlice.set({.account = alice, .mutableFlags = setFlags});
                 mptAlice.set({.account = alice, .mutableFlags = setFlags});
-                mptAlice.set({.account = alice, .mutableFlags = clearFlags});
-                mptAlice.set({.account = alice, .mutableFlags = setFlags});
-                mptAlice.set({.account = alice, .mutableFlags = clearFlags});
             };
 
-            testFlagToggle(tmfMPTCanMutateCanLock, tfMPTCanLock, tmfMPTClearCanLock);
-            testFlagToggle(
-                tmfMPTCanMutateRequireAuth, tmfMPTSetRequireAuth, tmfMPTClearRequireAuth);
-            testFlagToggle(tmfMPTCanMutateCanEscrow, tmfMPTSetCanEscrow, tmfMPTClearCanEscrow);
-            testFlagToggle(tmfMPTCanMutateCanTrade, tmfMPTSetCanTrade, tmfMPTClearCanTrade);
-            testFlagToggle(
-                tmfMPTCanMutateCanTransfer, tmfMPTSetCanTransfer, tmfMPTClearCanTransfer);
-            testFlagToggle(
-                tmfMPTCanMutateCanClawback, tmfMPTSetCanClawback, tmfMPTClearCanClawback);
+            testFlagSet(tmfMPTCanMutateCanLock, tmfMPTSetCanLock);
+            testFlagSet(tmfMPTCanMutateRequireAuth, tmfMPTSetRequireAuth);
+            testFlagSet(tmfMPTCanMutateCanEscrow, tmfMPTSetCanEscrow);
+            testFlagSet(tmfMPTCanMutateCanTrade, tmfMPTSetCanTrade);
+            testFlagSet(tmfMPTCanMutateCanTransfer, tmfMPTSetCanTransfer);
+            testFlagSet(tmfMPTCanMutateCanClawback, tmfMPTSetCanClawback);
         }
     }
 
@@ -3848,11 +3767,8 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.set({.account = alice, .holder = bob, .flags = tfMPTLock});
 
             // Can mutate the mutable flags and fields
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanLock});
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanLock});
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanLock});
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanTrade});
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTrade});
             mptAlice.set({.account = alice, .transferFee = 200});
         }
 
@@ -3872,36 +3788,23 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.set({.account = alice, .flags = tfMPTLock});
 
             // Can mutate the mutable flags and fields
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanLock});
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanLock});
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanLock});
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanClawback});
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanClawback});
             mptAlice.set({.account = alice, .metadata = "mutate"});
         }
 
-        // Test lock and unlock after mutating MPTCanLock
+        // Test lock and unlock after enabling MPTCanLock
         {
             Env env{*this, features};
             MPTTester mptAlice(env, alice, {.holders = {bob}});
             mptAlice.create(
                 {.ownerCount = 1,
                  .holderCount = 0,
-                 .flags = tfMPTCanLock,
                  .mutableFlags = tmfMPTCanMutateCanLock | tmfMPTCanMutateCanClawback |
                      tmfMPTCanMutateMetadata});
             mptAlice.authorize({.account = bob, .holderCount = 1});
 
-            // Can lock and unlock
-            mptAlice.set({.account = alice, .flags = tfMPTLock});
-            mptAlice.set({.account = alice, .holder = bob, .flags = tfMPTLock});
-            mptAlice.set({.account = alice, .flags = tfMPTUnlock});
-            mptAlice.set({.account = alice, .holder = bob, .flags = tfMPTUnlock});
-
-            // Clear lsfMPTCanLock
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanLock});
-
-            // Can not lock or unlock
+            // Can not lock or unlock before MPTCanLock is enabled
             mptAlice.set({.account = alice, .flags = tfMPTLock, .err = tecNO_PERMISSION});
             mptAlice.set({.account = alice, .flags = tfMPTUnlock, .err = tecNO_PERMISSION});
             mptAlice.set(
@@ -3909,10 +3812,10 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.set(
                 {.account = alice, .holder = bob, .flags = tfMPTUnlock, .err = tecNO_PERMISSION});
 
-            // Set MPTCanLock again
+            // Set MPTCanLock
             mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetCanLock});
 
-            // Can lock and unlock again
+            // Can lock and unlock
             mptAlice.set({.account = alice, .flags = tfMPTLock});
             mptAlice.set({.account = alice, .holder = bob, .flags = tfMPTLock});
             mptAlice.set({.account = alice, .flags = tfMPTUnlock});
@@ -3926,83 +3829,31 @@ class MPToken_test : public beast::unit_test::Suite
         testcase("Mutate MPTRequireAuth");
         using namespace test::jtx;
 
-        // test mutating RequireAuth flag on the issuance and its effect on payment authorization
-        {
-            Env env{*this, features};
-            Account const alice("alice");
-            Account const bob("bob");
+        // test enabling RequireAuth flag on the issuance and its effect on payment
+        // authorization
+        Env env{*this, features};
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const dan("dan");
 
-            MPTTester mptAlice(env, alice, {.holders = {bob}});
-            mptAlice.create(
-                {.ownerCount = 1,
-                 .flags = tfMPTRequireAuth,
-                 .mutableFlags = tmfMPTCanMutateRequireAuth});
+        MPTTester mptAlice(env, alice, {.holders = {bob, dan}});
+        mptAlice.create(
+            {.ownerCount = 1,
+             .flags = tfMPTCanTransfer,
+             .mutableFlags = tmfMPTCanMutateRequireAuth});
 
-            mptAlice.authorize({.account = bob});
-            mptAlice.authorize({.account = alice, .holder = bob});
+        mptAlice.authorize({.account = bob});
+        mptAlice.pay(alice, bob, 1000);
 
-            // Pay to bob
-            mptAlice.pay(alice, bob, 1000);
+        // Set RequireAuth because it is mutable.
+        mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetRequireAuth});
 
-            // Unauthorize bob
-            mptAlice.authorize({.account = alice, .holder = bob, .flags = tfMPTUnauthorize});
+        // This should fail because bob is not authorized yet.
+        mptAlice.pay(alice, bob, 1000, tecNO_AUTH);
 
-            // Can not pay to bob
-            mptAlice.pay(bob, alice, 100, tecNO_AUTH);
-
-            // Clear RequireAuth
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearRequireAuth});
-
-            // Can pay to bob
-            mptAlice.pay(alice, bob, 1000);
-
-            // Set RequireAuth again
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetRequireAuth});
-
-            // Can not pay to bob since he is not authorized
-            mptAlice.pay(bob, alice, 100, tecNO_AUTH);
-
-            // Authorize bob again
-            mptAlice.authorize({.account = alice, .holder = bob});
-
-            // Can pay to bob again
-            mptAlice.pay(alice, bob, 100);
-        }
-
-        // Cannot clear RequireAuth when a DomainID is set on the issuance
-        {
-            Account const alice{"alice"};
-            Account const bob{"bob"};
-            Account const credIssuer{"credIssuer"};
-            pdomain::Credentials const credentials{
-                {.issuer = credIssuer, .credType = "credential"}};
-
-            Env env{*this, features};
-            env.fund(XRP(1000), credIssuer);
-            env.close();
-
-            env(pdomain::setTx(credIssuer, credentials));
-            env.close();
-            auto const domainId = pdomain::getNewDomain(env.meta());
-
-            MPTTester mptAlice(env, alice, {.holders = {bob}});
-            mptAlice.create({
-                .ownerCount = 1,
-                .flags = tfMPTRequireAuth,
-                .mutableFlags = tmfMPTCanMutateRequireAuth,
-                .domainID = domainId,
-            });
-
-            // Clearing RequireAuth while a DomainID is present must be rejected,
-            mptAlice.set({
-                .account = alice,
-                .mutableFlags = tmfMPTClearRequireAuth,
-                .err = tecNO_PERMISSION,
-            });
-
-            // Setting RequireAuth (already set) is still allowed, though it has no effect.
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTSetRequireAuth});
-        }
+        // Issuer authorizes bob and pay should succeed.
+        mptAlice.authorize({.account = alice, .holder = bob});
+        mptAlice.pay(alice, bob, 1000);
     }
 
     void
@@ -4045,14 +3896,6 @@ class MPToken_test : public beast::unit_test::Suite
             escrow::kCondition(escrow::kCb1),
             escrow::kFinishTime(env.now() + 1s),
             Fee(baseFee * 150));
-
-        // Clear MPTCanEscrow
-        mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanEscrow});
-        env(escrow::create(carol, bob, mpt(3)),
-            escrow::kCondition(escrow::kCb1),
-            escrow::kFinishTime(env.now() + 1s),
-            Fee(baseFee * 150),
-            Ter(tecNO_PERMISSION));
     }
 
     void
@@ -4115,19 +3958,9 @@ class MPToken_test : public beast::unit_test::Suite
                 env(pay(bob, carol, mptAlice(50)), Txflags(tfPartialPayment));
                 BEAST_EXPECT(env.balance(carol, mptc) == mptc(49));
             }
-
-            // Alice clears MPTCanTransfer
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTransfer});
-
-            // TransferFee field is removed when MPTCanTransfer is cleared
-            BEAST_EXPECT(!mptAlice.isTransferFeePresent());
-
-            // Bob can not pay
-            mptAlice.pay(bob, carol, 50, tecNO_AUTH);
         }
 
-        // Can set transfer fee to zero when MPTCanTransfer is not set, but
-        // tmfMPTCanMutateTransferFee is set.
+        // Can set transfer fee to zero when tmfMPTCanMutateTransferFee is set.
         {
             Env env{*this, features};
 
@@ -4136,18 +3969,12 @@ class MPToken_test : public beast::unit_test::Suite
                 {.transferFee = 100,
                  .ownerCount = 1,
                  .flags = tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateTransferFee | tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanMutateTransferFee});
 
             BEAST_EXPECT(mptAlice.checkTransferFee(100));
 
-            // Clear MPTCanTransfer and transfer fee is removed
-            mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanTransfer});
-            BEAST_EXPECT(!mptAlice.isTransferFeePresent());
-
-            // Can still set transfer fee to zero, although it is already zero
+            // Setting transfer fee to zero removes the field.
             mptAlice.set({.account = alice, .transferFee = 0});
-
-            // TransferFee field is still not present
             BEAST_EXPECT(!mptAlice.isTransferFeePresent());
         }
     }
@@ -4181,12 +4008,6 @@ class MPToken_test : public beast::unit_test::Suite
 
         // Can clawback now
         mptAlice.claw(alice, bob, 1);
-
-        // Clear MPTCanClawback
-        mptAlice.set({.account = alice, .mutableFlags = tmfMPTClearCanClawback});
-
-        // Can not clawback
-        mptAlice.claw(alice, bob, 1, tecNO_PERMISSION);
     }
 
     void
@@ -4541,22 +4362,17 @@ class MPToken_test : public beast::unit_test::Suite
                  .issuer = gw,
                  .holders = {alice, carol},
                  .pay = 100,
-                 .flags = tfMPTCanTrade,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .flags = tfMPTCanTrade | tfMPTCanTransfer});
             MPTTester eth(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol},
                  .pay = 100,
-                 .flags = tfMPTCanTrade | tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .flags = tfMPTCanTrade});
 
             // Can create
             env(offer(alice, eth(10), btc(10)), Txflags(tfPassive));
-            btc.set({.mutableFlags = tmfMPTSetCanTransfer});
-            eth.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env(offer(alice, eth(10), btc(10)), Txflags(tfPassive));
-            BEAST_EXPECT(getAccountOffers(env, alice)[jss::offers].size() == 2);
+            BEAST_EXPECT(getAccountOffers(env, alice)[jss::offers].size() == 1);
 
             // issuer can create
             env(offer(gw, eth(10), btc(10)), Txflags(tfPassive));
@@ -4896,13 +4712,33 @@ class MPToken_test : public beast::unit_test::Suite
             // BTC is transferred from ed to bob, ed is not authorized
             env(pay(ed, gw, eth(10)), Path(~eth), Sendmax(btc(10)), Ter(tecNO_AUTH));
             env.close();
-            btc.set({.mutableFlags = tmfMPTClearRequireAuth});
+        }
 
-            // MPTCanTransfer is not set
+        // MPTCanTransfer is not set.
+        {
+            auto const ed = Account{"ed"};
+            Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice, carol, bob, ed);
+            MPTTester btc(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob, ed},
+                 .pay = 1'000,
+                 .flags = tfMPTCanTrade});
+            MPTTester eth(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob, ed},
+                 .pay = 1'000,
+                 .flags = kMptDexFlags});
+
+            env(offer(bob, eth(1'000), btc(1'000)), Txflags(tfPassive));
+            env.close();
+            env(offer(bob, btc(1'000), eth(1'000)), Txflags(tfPassive));
+            env.close();
 
             // Fail regardless if source/destination is the issuer or
             // not since the offer is owned by a holder.
-            btc.set({.mutableFlags = tmfMPTClearCanTransfer});
             env(pay(ed, carol, btc(10)), Path(~btc), Sendmax(eth(10)), Ter(tecPATH_PARTIAL));
             env(pay(carol, ed, btc(10)), Path(~btc), Sendmax(eth(10)), Ter(tecPATH_PARTIAL));
             env(pay(ed, carol, eth(10)), Path(~eth), Sendmax(btc(10)), Ter(tecPATH_PARTIAL));
@@ -4926,124 +4762,166 @@ class MPToken_test : public beast::unit_test::Suite
             env(pay(ed, gw, btc(10)), Path(~btc), Sendmax(eth(10)));
             env.close();
         }
-        // Multiple steps: CAD/USD, USD/BTC, BTC/ETH
+
+        // Multiple steps: CAD/USD, USD/BTC, BTC/ETH.
+        // takerGets can transfer if:
+        //  - CanTransfer is set
+        //  - The offer's owner is the issuer
+        //  - BookStep is the last step, which means strand's destination is
+        //    the issuer
+        // takerPays can transfer if
+        //  - BookStep is the first step, which means strand's source is
+        //    the issuer
+        //  - The offer's owner is the issuer
+        //  - Previous step is BookStep, which transfers per above
+        //  - CanTransfer is set
         {
-            auto const ed = Account{"ed"};
-            Env env{*this, features};
-            env.fund(XRP(1'000), gw, alice, carol, bob, ed);
-            env.close();
-            MPTTester btc(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice, carol, bob},
-                 .pay = 1'000,
-                 .flags = tfMPTCanLock | kMptDexFlags,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            MPTTester eth(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice, carol, bob},
-                 .pay = 1'000,
-                 .flags = tfMPTCanLock | kMptDexFlags,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            MPTTester usd(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice, carol, bob},
-                 .pay = 1'000,
-                 .flags = kMptDexFlags | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            MPTTester cad(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice, carol, bob},
-                 .pay = 1'000,
-                 .flags = kMptDexFlags | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            // takerGets can transfer if:
-            //  - CanTransfer is set
-            //  - The offer's owner is the issuer
-            //  - BookStep is the last step, which means strand's destination is
-            //    the issuer
-            // takerPays can transfer if
-            //  - BookStep is the first step, which means strand's source is
-            //    the issuer
-            //  - The offer's owner is the issuer
-            //  - Previous step is BookStep, which transfers per above
-            //  - CanTransfer is set
-            env(offer(bob, cad(100), usd(100)), Txflags(tfPassive));
-            env(offer(bob, usd(100), btc(100)), Txflags(tfPassive));
-            env(offer(bob, btc(100), eth(100)), Txflags(tfPassive));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 3));
-            btc.set({.mutableFlags = tmfMPTSetCanTransfer});
-            usd.set({.mutableFlags = tmfMPTClearCanTransfer});
-            // TakerGets
-            // fail - CAD/USD is owned by bob
-            env(pay(alice, carol, eth(1)),
-                Path(~usd, ~btc, ~eth),
-                Sendmax(cad(1)),
-                Ter(tecPATH_PARTIAL));
-            auto seq(env.seq(gw));
-            env(offer(gw, usd(1), btc(1)), Txflags(tfPassive));
-            env.close();
-            // fail - CAD/USD is owned by bob
-            env(pay(alice, carol, eth(1)),
-                Path(~usd, ~btc, ~eth),
-                Sendmax(cad(1)),
-                Ter(tecPATH_PARTIAL));
-            env.close();
-            env(offerCancel(gw, seq));
-            env(offer(gw, cad(1), usd(1)), Txflags(tfPassive));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 3));
-            // succeed - CAD/USD is owned by issuer
-            env(pay(alice, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
-            env.close();
-            // bob's CAD/USD is deleted
-            BEAST_EXPECT(expectOffers(env, bob, 2));
-            env(offer(bob, cad(100), usd(100)), Txflags(tfPassive));
-            BEAST_EXPECT(expectOffers(env, gw, 0));
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-            eth.set({.mutableFlags = tmfMPTClearCanTransfer});
-            // fail - BTC/ETH is owned by bob, destination is carol
-            env(pay(alice, carol, eth(1)),
-                Path(~usd, ~btc, ~eth),
-                Sendmax(cad(1)),
-                Ter(tecPATH_PARTIAL));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 3));
-            // succeed - destination is an issuer
-            env(pay(alice, gw, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 3));
-            // TakerPays
-            eth.set({.mutableFlags = tmfMPTSetCanTransfer});
-            cad.set({.mutableFlags = tmfMPTClearCanTransfer});
-            // fail - CAD/USD is owned by bob, source is alice
-            env(pay(alice, carol, eth(1)),
-                Path(~usd, ~btc, ~eth),
-                Sendmax(cad(1)),
-                Ter(tecPATH_PARTIAL));
-            // succeed - source is the issuer
-            env(pay(gw, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
-            env.close();
-            env(offer(gw, cad(1), usd(1)), Txflags(tfPassive));
-            env.close();
-            // succeed - CAD/USD is owned by issuer
-            env(pay(alice, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, gw, 0));
-            BEAST_EXPECT(expectOffers(env, bob, 2));
-            cad.set({.mutableFlags = tmfMPTSetCanTransfer});
-            btc.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env(offer(bob, cad(1), usd(1)), Txflags(tfPassive));
-            env(offer(gw, usd(1), btc(1)), Txflags(tfPassive));
-            env.close();
-            // succeed - USD/BTC is owned by issuer
-            env(pay(alice, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, gw, 0));
+            // enum to indicate which MPT doesn't set CanTransfer flag.
+            enum class NoTransferMPT { BTC, ETH, USD, CAD };
+
+            // Lambda to test multi-step payment with one of the MPTs not setting CanTransfer flag.
+            auto const testMultiStepMPTCanTransfer = [&](NoTransferMPT const noTransferMPT,
+                                                         auto const& test) {
+                auto const getFlags = [&](NoTransferMPT const mpt) {
+                    return mpt == noTransferMPT ? tfMPTCanTrade : kMptDexFlags;
+                };
+
+                Env env{*this, features};
+                env.fund(XRP(1'000), gw, alice, carol, bob);
+                env.close();
+                MPTTester const btc(
+                    {.env = env,
+                     .issuer = gw,
+                     .holders = {alice, carol, bob},
+                     .pay = 1'000,
+                     .flags = getFlags(NoTransferMPT::BTC)});
+                MPTTester const eth(
+                    {.env = env,
+                     .issuer = gw,
+                     .holders = {alice, carol, bob},
+                     .pay = 1'000,
+                     .flags = getFlags(NoTransferMPT::ETH)});
+                MPTTester const usd(
+                    {.env = env,
+                     .issuer = gw,
+                     .holders = {alice, carol, bob},
+                     .pay = 1'000,
+                     .flags = getFlags(NoTransferMPT::USD)});
+                MPTTester const cad(
+                    {.env = env,
+                     .issuer = gw,
+                     .holders = {alice, carol, bob},
+                     .pay = 1'000,
+                     .flags = getFlags(NoTransferMPT::CAD)});
+
+                env(offer(bob, cad(100), usd(100)), Txflags(tfPassive));
+                env(offer(bob, usd(100), btc(100)), Txflags(tfPassive));
+                env(offer(bob, btc(100), eth(100)), Txflags(tfPassive));
+                env.close();
+
+                test(env, btc, eth, usd, cad);
+            };
+
+            // USD starts without MPTCanTransfer.
+            testMultiStepMPTCanTransfer(
+                NoTransferMPT::USD,
+                [&](Env& env,
+                    MPTTester const& btc,
+                    MPTTester const& eth,
+                    MPTTester const& usd,
+                    MPTTester const& cad) {
+                    BEAST_EXPECT(expectOffers(env, bob, 3));
+
+                    // fail - CAD/USD is owned by bob
+                    env(pay(alice, carol, eth(1)),
+                        Path(~usd, ~btc, ~eth),
+                        Sendmax(cad(1)),
+                        Ter(tecPATH_PARTIAL));
+
+                    auto seq(env.seq(gw));
+                    env(offer(gw, usd(1), btc(1)), Txflags(tfPassive));
+                    env.close();
+                    // fail - CAD/USD is owned by bob
+                    env(pay(alice, carol, eth(1)),
+                        Path(~usd, ~btc, ~eth),
+                        Sendmax(cad(1)),
+                        Ter(tecPATH_PARTIAL));
+                    env.close();
+                    env(offerCancel(gw, seq));
+                    env(offer(gw, cad(1), usd(1)), Txflags(tfPassive));
+                    env.close();
+                    BEAST_EXPECT(expectOffers(env, bob, 3));
+                    // succeed - CAD/USD is owned by issuer
+                    env(pay(alice, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
+                    env.close();
+                    // bob's CAD/USD is deleted.
+                    BEAST_EXPECT(expectOffers(env, bob, 2));
+                    env(offer(bob, cad(100), usd(100)), Txflags(tfPassive));
+                    BEAST_EXPECT(expectOffers(env, gw, 0));
+                });
+
+            // ETH starts without MPTCanTransfer.
+            testMultiStepMPTCanTransfer(
+                NoTransferMPT::ETH,
+                [&](Env& env,
+                    MPTTester const& btc,
+                    MPTTester const& eth,
+                    MPTTester const& usd,
+                    MPTTester const& cad) {
+                    // fail - BTC/ETH is owned by bob, destination is carol
+                    env(pay(alice, carol, eth(1)),
+                        Path(~usd, ~btc, ~eth),
+                        Sendmax(cad(1)),
+                        Ter(tecPATH_PARTIAL));
+                    env.close();
+                    BEAST_EXPECT(expectOffers(env, bob, 3));
+
+                    // succeed - destination is an issuer
+                    env(pay(alice, gw, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
+                    env.close();
+                    BEAST_EXPECT(expectOffers(env, bob, 3));
+                });
+
+            // CAD starts without MPTCanTransfer.
+            testMultiStepMPTCanTransfer(
+                NoTransferMPT::CAD,
+                [&](Env& env,
+                    MPTTester const& btc,
+                    MPTTester const& eth,
+                    MPTTester const& usd,
+                    MPTTester const& cad) {
+                    // fail - CAD/USD is owned by bob, source is alice
+                    env(pay(alice, carol, eth(1)),
+                        Path(~usd, ~btc, ~eth),
+                        Sendmax(cad(1)),
+                        Ter(tecPATH_PARTIAL));
+                    // succeed - source is the issuer
+                    env(pay(gw, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
+                    env.close();
+                    env(offer(gw, cad(1), usd(1)), Txflags(tfPassive));
+                    env.close();
+                    // succeed - CAD/USD is owned by issuer
+                    env(pay(alice, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
+                    env.close();
+                    BEAST_EXPECT(expectOffers(env, gw, 0));
+                    BEAST_EXPECT(expectOffers(env, bob, 2));
+                });
+
+            // BTC starts without MPTCanTransfer.
+            testMultiStepMPTCanTransfer(
+                NoTransferMPT::BTC,
+                [&](Env& env,
+                    MPTTester const& btc,
+                    MPTTester const& eth,
+                    MPTTester const& usd,
+                    MPTTester const& cad) {
+                    env(offer(gw, usd(1), btc(1)), Txflags(tfPassive));
+                    env.close();
+                    // succeed - USD/BTC is owned by issuer
+                    env(pay(alice, carol, eth(1)), Path(~usd, ~btc, ~eth), Sendmax(cad(1)));
+                    env.close();
+                    BEAST_EXPECT(expectOffers(env, gw, 0));
+                });
         }
 
         // MPTCanTrade is not set
@@ -5063,42 +4941,32 @@ class MPToken_test : public beast::unit_test::Suite
                  .issuer = gw,
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
-                 .flags = tfMPTCanTransfer | tfMPTCanTrade,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .flags = kMptDexFlags});
             MPTTester const usd(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
-                 .flags = tfMPTCanTransfer | tfMPTCanTrade,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .flags = kMptDexFlags});
 
             env(pay(alice, carol, eth(1)), Path(~eth), Sendmax(btc(1)), Ter(tecNO_PERMISSION));
             env(pay(alice, carol, btc(1)), Path(~btc), Sendmax(eth(1)), Ter(tecNO_PERMISSION));
             env.close();
 
+            // Enable MPTCanTrade so BTC can be crossed through offers.
             btc.set({.mutableFlags = tmfMPTSetCanTrade});
             env(offer(bob, XRP(1), btc(1)));
             env(offer(bob, btc(1), eth(1)));
             env(offer(bob, eth(1), usd(1)));
             env.close();
-            btc.set({.mutableFlags = tmfMPTClearCanTrade});
+            BEAST_EXPECT(expectOffers(env, bob, 3));
+
             env(pay(gw, carol, usd(1)),
                 Path(~btc, ~eth, ~usd),
                 Sendmax(XRP(1)),
-                Txflags(tfPartialPayment | tfNoRippleDirect),
-                Ter(tecNO_PERMISSION));
+                Txflags(tfPartialPayment | tfNoRippleDirect));
             env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 3));
-
-            env(pay(carol, bob, btc(10)), Sendmax(XRP(10)), Ter(tecNO_PERMISSION));
-            env(pay(carol, bob, XRP(10)), Sendmax(btc(10)), Ter(tecNO_PERMISSION));
-            env(pay(gw, bob, btc(10)), Sendmax(XRP(10)), Ter(tecNO_PERMISSION));
-            env(pay(gw, bob, XRP(10)), Sendmax(btc(10)), Ter(tecNO_PERMISSION));
-            env(pay(carol, gw, btc(10)), Sendmax(XRP(10)), Ter(tecNO_PERMISSION));
-            env(pay(carol, gw, XRP(10)), Sendmax(btc(10)), Ter(tecNO_PERMISSION));
-            env.close();
-            BEAST_EXPECT(expectOffers(env, bob, 3));
+            BEAST_EXPECT(expectOffers(env, bob, 0));
         }
 
         // Holders are locked
@@ -6933,13 +6801,8 @@ class MPToken_test : public beast::unit_test::Suite
             env.close();
             env(pay(gw, alice, mpt(10)));
             env.close();
-            // can't cash
-            mpt.set({.account = gw, .mutableFlags = tmfMPTClearCanTransfer});
-            env.close();
-            env(check::cash(carol, checkId, mpt(10)), Ter(tecNO_AUTH));
-            env.close();
-            // can cash
-            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTransfer});
+
+            // can cash since MPTCanTransfer is enabled
             env(check::cash(carol, checkId, mpt(10)));
             env.close();
         }
@@ -7358,296 +7221,332 @@ class MPToken_test : public beast::unit_test::Suite
             Env env(*this);
             env.fund(XRP(1'000'000), gw, alice, carol);
 
-            auto usd = MPTTester(
-                {.env = env,
-                 .issuer = gw,
-                 .flags = tfMPTCanLock | kMptDexFlags,
-                 .mutableFlags = tmfMPTCanMutateRequireAuth | tmfMPTCanMutateCanTransfer |
-                     tmfMPTCanMutateCanClawback | tmfMPTCanMutateCanTrade});
-            auto eur = MPTTester({.env = env, .issuer = gw, .holders = {alice}, .pay = 1'000'000});
-
             auto const increment = env.current()->fees().increment;
             auto const txfee = Fee(drops(increment));
             auto const badMPT = MPT(gw, 1'000);
 
-            auto createDeleteAMM = [&](Account const& lp) {
-                AMM amm(
-                    env,
-                    lp,
-                    usd(1'000),
-                    eur(1'000),
-                    CreateArg{.fee = static_cast<std::uint32_t>(increment.value())});
-                amm.withdrawAll(lp);
-                BEAST_EXPECT(!amm.ammExists());
+            auto const makeMPT = [&](std::uint32_t const flags,
+                                     Holders holders = {},
+                                     std::uint64_t const pay = 0,
+                                     std::optional<std::uint32_t> const mutableFlags =
+                                         std::nullopt) {
+                return MPTTester(
+                    {.env = env,
+                     .issuer = gw,
+                     .holders = holders,
+                     .pay = pay ? std::optional<std::uint64_t>{pay} : std::nullopt,
+                     .flags = flags,
+                     .mutableFlags = mutableFlags});
             };
 
-            //
+            auto const makeDexMPT = [&](Holders holders = {}, std::uint64_t const pay = 0) {
+                return makeMPT(
+                    tfMPTCanLock | kMptDexFlags,
+                    holders,
+                    pay,
+                    tmfMPTCanMutateRequireAuth | tmfMPTCanMutateCanTransfer |
+                        tmfMPTCanMutateCanTrade);
+            };
+
+            auto const makeNoTransferMPT = [&](Holders holders = {}, std::uint64_t const pay = 0) {
+                return makeMPT(
+                    tfMPTCanLock | tfMPTCanTrade, holders, pay, tmfMPTCanMutateCanTransfer);
+            };
+
+            auto const makeNoTradeMPT = [&](Holders holders = {}, std::uint64_t const pay = 0) {
+                return makeMPT(
+                    tfMPTCanLock | tfMPTCanTransfer, holders, pay, tmfMPTCanMutateCanTrade);
+            };
+
             // AMMCreate
-            //
-
-            auto createJv = AMM::createJv(alice, badMPT(1'000), eur(1'000), 0);
-
-            auto createFail = [&](Account const& account, auto const& err) {
-                createJv[sfAccount] = account.human();
-                env(createJv, txfee, Ter(err));
-                env.close();
-            };
-
-            // MPTokenIssuance doesn't exist
-
-            createFail(alice, tecOBJECT_NOT_FOUND);
-
-            // MPToken doesn't exist
-
-            createJv[sfAmount] = STAmount{usd(1'000)}.getJson();
-            createFail(alice, tecNO_AUTH);
-
-            // alice authorizes MPToken, can create
-            usd.authorize({.account = alice});
-            env(pay(gw, alice, usd(1'000'000)), txfee);
-            env.close();
-            createDeleteAMM(alice);
-
-            // MPTLock is set
-
-            // alice and issuer can't create
-            usd.set({.flags = tfMPTLock});
-            createFail(alice, tecLOCKED);
-            createFail(gw, tecLOCKED);
-
-            // MPTRequireAuth is set
-
-            // alice is not authorized
-            usd.set({.flags = tfMPTUnlock});
-            usd.set({.mutableFlags = tmfMPTSetRequireAuth});
-            createFail(alice, tecNO_AUTH);
-            // issuer can create
-            createDeleteAMM(gw);
-
-            // alice is authorized, can create
-            usd.authorize({.account = gw, .holder = alice});
-            createDeleteAMM(alice);
-
-            // MPTCanTransfer is not set
-
-            usd.set({.mutableFlags = tmfMPTClearRequireAuth});
-            usd.set({.mutableFlags = tmfMPTClearCanTransfer});
-            // alice can't create
-            createFail(alice, tecNO_AUTH);
-            // issuer can create
-            createDeleteAMM(gw);
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-            // alice can create
-            createDeleteAMM(alice);
-
-            // MPTCanTrade is not set
-
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-            usd.set({.mutableFlags = tmfMPTClearCanTrade});
-            // alice and issuer can't create
-            createFail(alice, tecNO_PERMISSION);
-            createFail(gw, tecNO_PERMISSION);
-            usd.set({.mutableFlags = tmfMPTSetCanTrade});
-
-            //
-            // AMMDeposit
-            //
-
-            AMM amm(env, gw, usd(1'000), eur(1'000));
-
-            // MPTokenIssuance doesn't exist
-
-            amm.deposit(
-                {.account = alice,
-                 .asset1In = badMPT(1),
-                 .asset2In = eur(1),
-                 .assets = std::make_pair(badMPT, eur),
-                 .err = Ter(terNO_AMM)});
-
-            // MPToken doesn't exist
-
-            amm.deposit(
-                {.account = carol, .asset1In = usd(1), .asset2In = eur(1), .err = Ter(tecNO_AUTH)});
-
-            // MPTLock is set
-
-            usd.set({.flags = tfMPTLock});
-            // alice and issuer can't deposit
-            for (auto const& account : {carol, gw})
             {
+                auto usd = makeDexMPT();
+                auto eur = makeDexMPT({alice}, 1'000'000);
+
+                auto createDeleteAMM = [&](auto const& asset, Account const& lp) {
+                    AMM amm(
+                        env,
+                        lp,
+                        asset(1'000),
+                        eur(1'000),
+                        CreateArg{.fee = static_cast<std::uint32_t>(increment.value())});
+                    amm.withdrawAll(lp);
+                    BEAST_EXPECT(!amm.ammExists());
+                };
+
+                auto createFail = [&](auto const& asset, Account const& account, auto const& err) {
+                    auto const createJv = AMM::createJv(account, asset(1'000), eur(1'000), 0);
+                    env(createJv, txfee, Ter(err));
+                    env.close();
+                };
+
+                // MPTokenIssuance doesn't exist
+                createFail(badMPT, alice, tecOBJECT_NOT_FOUND);
+
+                // MPToken doesn't exist
+                createFail(usd, alice, tecNO_AUTH);
+
+                // alice authorizes MPToken, can create
+                usd.authorize({.account = alice});
+                env(pay(gw, alice, usd(1'000'000)), txfee);
+                env.close();
+                createDeleteAMM(usd, alice);
+
+                // MPTLock is set
+                // alice and issuer can't create
+                usd.set({.flags = tfMPTLock});
+                createFail(usd, alice, tecLOCKED);
+                createFail(usd, gw, tecLOCKED);
+
+                // MPTRequireAuth is set
+                // alice is not authorized
+                usd.set({.flags = tfMPTUnlock});
+                usd.set({.mutableFlags = tmfMPTSetRequireAuth});
+                createFail(usd, alice, tecNO_AUTH);
+                // issuer can create
+                createDeleteAMM(usd, gw);
+
+                // alice is authorized, can create
+                usd.authorize({.account = gw, .holder = alice});
+                createDeleteAMM(usd, alice);
+
+                // MPTCanTransfer is not set
+                {
+                    auto usd2 = makeNoTransferMPT({alice}, 1'000'000);
+
+                    // alice can't create
+                    createFail(usd2, alice, tecNO_AUTH);
+                    // issuer can create
+                    createDeleteAMM(usd2, gw);
+                    usd2.set({.mutableFlags = tmfMPTSetCanTransfer});
+                    // alice can create
+                    createDeleteAMM(usd2, alice);
+                }
+
+                // MPTCanTrade is not set
+                {
+                    auto usd3 = makeNoTradeMPT({alice}, 1'000'000);
+
+                    // alice and issuer can't create
+                    createFail(usd3, alice, tecNO_PERMISSION);
+                    createFail(usd3, gw, tecNO_PERMISSION);
+                    usd3.set({.mutableFlags = tmfMPTSetCanTrade});
+                    // alice can create
+                    createDeleteAMM(usd3, alice);
+                }
+            }
+
+            // AMMDeposit
+            {
+                auto usd = makeDexMPT();
+                auto eur = makeDexMPT({alice}, 1'000'000);
+                AMM amm(env, gw, usd(1'000), eur(1'000));
+
+                // MPTokenIssuance doesn't exist
                 amm.deposit(
-                    {.account = account,
+                    {.account = alice,
+                     .asset1In = badMPT(1),
+                     .asset2In = eur(1),
+                     .assets = std::make_pair(badMPT, eur),
+                     .err = Ter(terNO_AMM)});
+
+                // MPToken doesn't exist
+                amm.deposit(
+                    {.account = carol,
                      .asset1In = usd(1),
                      .asset2In = eur(1),
-                     .err = Ter(tecLOCKED)});
+                     .err = Ter(tecNO_AUTH)});
+
+                // Fund carol for the AMMDeposit checks.
+                usd.authorize({.account = carol});
+                env(pay(gw, carol, usd(1'000'000)));
+                eur.authorize({.account = carol});
+                env(pay(gw, carol, eur(1'000'000)));
+                env.close();
+
+                // MPTLock is set
+                usd.set({.flags = tfMPTLock});
+
+                // alice and issuer can't deposit
+                for (auto const& account : {carol, gw})
+                {
+                    amm.deposit(
+                        {.account = account,
+                         .asset1In = usd(1),
+                         .asset2In = eur(1),
+                         .err = Ter(tecLOCKED)});
+                    amm.deposit(
+                        {.account = account,
+                         .asset1In = eur(1),
+                         .assets = std::make_pair(eur, usd),
+                         .err = Ter(tecLOCKED)});
+                }
+                usd.set({.flags = tfMPTUnlock});
+
+                // MPTRequireAuth is set
+                // carol is not authorized by the issuer
+                usd.set({.mutableFlags = tmfMPTSetRequireAuth});
+                env.close();
                 amm.deposit(
-                    {.account = account,
+                    {.account = carol,
+                     .asset1In = usd(1),
+                     .asset2In = eur(1),
+                     .err = Ter(tecNO_AUTH)});
+                amm.deposit(
+                    {.account = carol,
                      .asset1In = eur(1),
                      .assets = std::make_pair(eur, usd),
-                     .err = Ter(tecLOCKED)});
+                     .err = Ter(tecNO_AUTH)});
+                // issuer can deposit
+                amm.deposit({.account = gw, .tokens = 1'000});
+                // carol is authorized, can deposit
+                usd.authorize({.account = gw, .holder = carol});
+                amm.deposit({.account = carol, .tokens = 1'000});
+                // Can't authorize or unauthorize AMM pseudo-account
+                usd.authorize(
+                    {.account = gw,
+                     .holder = Account{"amm", amm.ammAccount()},
+                     .err = tecNO_PERMISSION});
+                usd.authorize(
+                    {.account = gw,
+                     .holder = Account{"amm", amm.ammAccount()},
+                     .flags = tfMPTUnauthorize,
+                     .err = tecNO_PERMISSION});
+
+                // MPTCanTransfer is not set
+                {
+                    auto usd2 = makeNoTransferMPT({carol}, 1'000'000);
+                    AMM amm2(env, gw, usd2(1'000), eur(1'000));
+
+                    // carol can't deposit
+                    amm2.deposit(
+                        {.account = carol,
+                         .asset1In = usd2(1),
+                         .asset2In = eur(1),
+                         .err = Ter(tecNO_AUTH)});
+                    amm2.deposit(
+                        {.account = carol,
+                         .asset1In = eur(1),
+                         .assets = std::make_pair(eur, usd2),
+                         .err = Ter(tecNO_AUTH)});
+                    // issuer can deposit
+                    amm2.deposit({.account = gw, .tokens = 1'000});
+                    usd2.set({.mutableFlags = tmfMPTSetCanTransfer});
+                    // carol can deposit
+                    amm2.deposit({.account = carol, .tokens = 1'000});
+                }
             }
-            usd.set({.flags = tfMPTUnlock});
 
-            // MPTRequireAuth is set
-
-            // carol authorizes MPToken but is not authorized by the issuer
-            usd.authorize({.account = carol});
-            env(pay(gw, carol, usd(1'000'000)));
-            // carol authorizes EUR
-            eur.authorize({.account = carol});
-            env(pay(gw, carol, eur(1'000'000)));
-            usd.set({.mutableFlags = tmfMPTSetRequireAuth});
-            env.close();
-            amm.deposit(
-                {.account = carol, .asset1In = usd(1), .asset2In = eur(1), .err = Ter(tecNO_AUTH)});
-            amm.deposit(
-                {.account = carol,
-                 .asset1In = eur(1),
-                 .assets = std::make_pair(eur, usd),
-                 .err = Ter(tecNO_AUTH)});
-            // issuer can deposit
-            amm.deposit({.account = gw, .tokens = 1'000});
-            // carol is authorized, can deposit
-            usd.authorize({.account = gw, .holder = carol});
-            amm.deposit({.account = carol, .tokens = 1'000});
-            // Can't authorize or unauthorize AMM pseudo-account
-            usd.authorize(
-                {.account = gw,
-                 .holder = Account{"amm", amm.ammAccount()},
-                 .err = tecNO_PERMISSION});
-            usd.authorize(
-                {.account = gw,
-                 .holder = Account{"amm", amm.ammAccount()},
-                 .flags = tfMPTUnauthorize,
-                 .err = tecNO_PERMISSION});
-
-            // MPTCanTransfer is not set
-
-            usd.set({.mutableFlags = tmfMPTClearRequireAuth});
-            usd.set({.mutableFlags = tmfMPTClearCanTransfer});
-            // carol can't deposit
-            amm.deposit(
-                {.account = carol, .asset1In = usd(1), .asset2In = eur(1), .err = Ter(tecNO_AUTH)});
-            amm.deposit(
-                {.account = carol,
-                 .asset1In = eur(1),
-                 .assets = std::make_pair(eur, usd),
-                 .err = Ter(tecNO_AUTH)});
-            // issuer can deposit
-            amm.deposit({.account = gw, .tokens = 1'000});
-            // carol can deposit
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-            amm.deposit({.account = carol, .tokens = 1'000});
-
-            // MPTCanTrade is not set
-
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-            usd.set({.mutableFlags = tmfMPTClearCanTrade});
-            amm.deposit({.account = gw, .tokens = 1'000, .err = Ter(tecNO_PERMISSION)});
-            amm.deposit({.account = carol, .tokens = 1'000, .err = Ter(tecNO_PERMISSION)});
-            usd.set({.mutableFlags = tmfMPTSetCanTrade});
-
-            //
             // AMMWithdraw
-            //
-
-            // MPTokenIssuance doesn't exist
-
-            amm.withdraw(
-                WithdrawArg{
-                    .account = carol,
-                    .asset1Out = badMPT(1),
-                    .asset2Out = eur(1),
-                    .assets = std::make_pair(badMPT, eur),
-                    .err = Ter(terNO_AMM)});
-
-            // MPToken doesn't exist - doesn't apply since MPToken is created
-            // on withdraw in this case
-
-            // MPTLock is set
-
-            usd.set({.flags = tfMPTLock});
-            // carol and issuer can't withdraw
-            for (auto const& account : {carol, gw})
             {
+                auto usd = makeDexMPT();
+                auto eur = makeDexMPT({carol}, 1'000'000);
+                AMM amm(env, gw, usd(1'000), eur(1'000));
+
+                usd.authorize({.account = carol});
+                env(pay(gw, carol, usd(1'000'000)));
+                env.close();
+                amm.deposit({.account = carol, .tokens = 1'000});
+
+                // MPTokenIssuance doesn't exist
                 amm.withdraw(
-                    {.account = account,
+                    WithdrawArg{
+                        .account = carol,
+                        .asset1Out = badMPT(1),
+                        .asset2Out = eur(1),
+                        .assets = std::make_pair(badMPT, eur),
+                        .err = Ter(terNO_AMM)});
+
+                // MPToken doesn't exist - doesn't apply since MPToken is created
+                // on withdraw in this case
+
+                // MPTLock is set
+                usd.set({.flags = tfMPTLock});
+                // carol and issuer can't withdraw
+                for (auto const& account : {carol, gw})
+                {
+                    amm.withdraw(
+                        {.account = account,
+                         .asset1Out = usd(1),
+                         .asset2Out = eur(1),
+                         .err = Ter(tecLOCKED)});
+                    amm.withdraw({.account = account, .tokens = 1'000, .err = Ter(tecLOCKED)});
+                    // can single withdraw another asset
+                    amm.withdraw(
+                        {.account = account,
+                         .asset1Out = eur(1),
+                         .assets = std::make_pair(eur, usd)});
+                }
+                usd.set({.flags = tfMPTUnlock});
+
+                // MPTRequireAuth is set
+                usd.set({.mutableFlags = tmfMPTSetRequireAuth});
+                usd.authorize({.account = gw, .holder = carol, .flags = tfMPTUnauthorize});
+                // carol can't withdraw
+                amm.withdraw(
+                    {.account = carol,
                      .asset1Out = usd(1),
                      .asset2Out = eur(1),
-                     .err = Ter(tecLOCKED)});
-                amm.withdraw({.account = account, .tokens = 1'000, .err = Ter(tecLOCKED)});
-                // can single withdraw another asset
+                     .err = Ter(tecNO_AUTH)});
+                // can withdraw another asset
                 amm.withdraw(
-                    {.account = account, .asset1Out = eur(1), .assets = std::make_pair(eur, usd)});
+                    {.account = carol, .asset1Out = eur(1), .assets = std::make_pair(eur, usd)});
+                // issuer can withdraw
+                amm.withdraw({.account = gw, .asset1Out = usd(1), .asset2Out = eur(1)});
+                // carol is authorized, can withdraw
+                usd.authorize({.account = gw, .holder = carol});
+                amm.withdraw({.account = carol, .asset1Out = usd(1), .asset2Out = eur(1)});
+
+                // MPTCanTransfer is not set, allow to withdraw
+                {
+                    auto usd2 = makeNoTransferMPT({carol}, 1'000'000);
+                    AMM amm2(env, gw, usd2(1'000), eur(1'000));
+
+                    // carol cannot deposit usd2 without MPTCanTransfer, so give her
+                    // LP tokens directly to test the withdraw path.
+                    env.trust(STAmount{amm2.lptIssue(), 1'000}, carol);
+                    env(pay(gw, carol, STAmount{amm2.lptIssue(), 100}));
+                    env.close();
+
+                    // carol can withdraw
+                    amm2.withdraw({.account = carol, .asset1Out = usd2(1), .asset2Out = eur(1)});
+                    // can withdraw another asset
+                    amm2.withdraw(
+                        {.account = carol,
+                         .asset1Out = eur(1),
+                         .assets = std::make_pair(eur, usd2)});
+                    // issuer can withdraw
+                    amm2.withdraw({.account = gw, .asset1Out = usd2(1), .asset2Out = eur(1)});
+                    // Holder can't transfer to another holder
+                    env.fund(XRP(1'000), bob);
+                    usd2.authorize({.account = bob});
+                    env(pay(carol, bob, usd2(1)), Ter(tecNO_AUTH));
+                    usd2.authorize({.account = bob, .flags = tfMPTUnauthorize});
+                    // Can redeem
+                    env(pay(carol, gw, usd2(1)));
+                    usd2.set({.mutableFlags = tmfMPTSetCanTransfer});
+                    // carol can withdraw
+                    amm2.withdraw({.account = carol, .asset1Out = usd2(1), .asset2Out = eur(1)});
+                }
+
+                // MPToken created on withdraw
+                {
+                    auto usd3 = makeDexMPT();
+                    auto eur3 = makeDexMPT({carol}, 1'000'000);
+                    AMM amm3(env, gw, usd3(1'000), eur3(1'000));
+
+                    BEAST_EXPECT(env.le(keylet::mptoken(usd3.issuanceID(), carol)) == nullptr);
+                    // single-deposit EUR
+                    amm3.deposit(
+                        {.account = carol,
+                         .asset1In = eur3(1'000),
+                         .assets = std::make_pair(eur3, usd3)});
+                    BEAST_EXPECT(env.le(keylet::mptoken(usd3.issuanceID(), carol)) == nullptr);
+                    // withdraw in USD to create MPToken
+                    amm3.withdraw({.account = carol, .asset1Out = usd3(100)});
+                    BEAST_EXPECT(env.le(keylet::mptoken(usd3.issuanceID(), carol)));
+                }
             }
-            usd.set({.flags = tfMPTUnlock});
-
-            // MPTRequireAuth is set
-
-            usd.set({.mutableFlags = tmfMPTSetRequireAuth});
-            usd.authorize({.account = gw, .holder = carol, .flags = tfMPTUnauthorize});
-            // carol can't withdraw
-            amm.withdraw(
-                {.account = carol,
-                 .asset1Out = usd(1),
-                 .asset2Out = eur(1),
-                 .err = Ter(tecNO_AUTH)});
-            // can withdraw another asset
-            amm.withdraw(
-                {.account = carol, .asset1Out = eur(1), .assets = std::make_pair(eur, usd)});
-            // issuer can withdraw
-            amm.withdraw({.account = gw, .asset1Out = usd(1), .asset2Out = eur(1)});
-            // carol is authorized, can withdraw
-            usd.authorize({.account = gw, .holder = carol});
-            amm.withdraw({.account = carol, .asset1Out = usd(1), .asset2Out = eur(1)});
-
-            // MPTCanTransfer is not set, allow to withdraw
-
-            usd.set({.mutableFlags = tmfMPTClearRequireAuth});
-            usd.set({.mutableFlags = tmfMPTClearCanTransfer});
-            // carol can withdraw
-            amm.withdraw({.account = carol, .asset1Out = usd(1), .asset2Out = eur(1)});
-            // can withdraw another asset
-            amm.withdraw(
-                {.account = carol, .asset1Out = eur(1), .assets = std::make_pair(eur, usd)});
-            // issuer can withdraw
-            amm.withdraw({.account = gw, .asset1Out = usd(1), .asset2Out = eur(1)});
-            // Holder can't transfer to another holder
-            env.fund(XRP(1'000), bob);
-            usd.authorize({.account = bob});
-            env(pay(carol, bob, usd(1)), Ter(tecNO_AUTH));
-            usd.authorize({.account = bob, .flags = tfMPTUnauthorize});
-            // Can redeem
-            env(pay(carol, gw, usd(1)));
-            // carol can withdraw
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-            amm.withdraw({.account = carol, .asset1Out = usd(1), .asset2Out = eur(1)});
-
-            usd.set({.mutableFlags = tmfMPTSetCanTransfer});
-
-            // MPTCanTrade is not set, allow to withdraw
-
-            usd.set({.mutableFlags = tmfMPTClearCanTrade});
-            amm.withdraw({.account = gw, .tokens = 1'000});
-            amm.withdraw({.account = carol, .tokens = 1'000});
-            // Can't DEX
-            amm.deposit(
-                DepositArg{.account = carol, .asset1In = usd(1), .err = Ter(tecNO_PERMISSION)});
-            usd.set({.mutableFlags = tmfMPTSetCanTrade});
-
-            // MPToken created on withdraw
-
-            // redeem all carol's USD and unauthorize USD
-            amm.withdrawAll(carol);
-            env(pay(carol, gw, env.balance(carol, usd)));
-            usd.authorize({.account = carol, .flags = tfMPTUnauthorize});
-            BEAST_EXPECT(env.le(keylet::mptoken(usd.issuanceID(), carol)) == nullptr);
-            // single-deposit EUR
-            amm.deposit(
-                {.account = carol, .asset1In = eur(1'000), .assets = std::make_pair(eur, usd)});
-            // withdraw in USD to create MPToken
-            amm.withdraw({.account = carol, .asset1Out = usd(100)});
-            BEAST_EXPECT(env.le(keylet::mptoken(usd.issuanceID(), carol)));
         }
     }
 
@@ -7707,41 +7606,37 @@ class MPToken_test : public beast::unit_test::Suite
         Env env(*this);
         env.fund(XRP(1'000), gw, alice, carol);
 
-        MPTTester mpt(
-            {.env = env,
-             .issuer = gw,
-             .holders = {alice, carol},
-             .pay = 100,
-             .flags = kMptDexFlags,
-             .mutableFlags = tmfMPTCanMutateCanTransfer | tmfMPTCanMutateCanTrade});
+        auto const checkCanTradeCanTransfer = [&](std::uint32_t const flags,
+                                                  TER const gwToGw,
+                                                  TER const gwToAlice,
+                                                  TER const aliceToAlice,
+                                                  TER const aliceToCarol) {
+            MPTTester mpt(
+                {.env = env, .issuer = gw, .holders = {alice, carol}, .pay = 100, .flags = flags});
+
+            BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw) == gwToGw);
+            BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice) == gwToAlice);
+            BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == aliceToAlice);
+            BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == aliceToCarol);
+        };
 
         // Both flags are enabled
-        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw)));
-        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice)));
-        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice)));
-        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol)));
+        checkCanTradeCanTransfer(kMptDexFlags, tesSUCCESS, tesSUCCESS, tesSUCCESS, tesSUCCESS);
 
         // MPTCanTrade is disabled
-        mpt.set({.mutableFlags = tmfMPTClearCanTrade});
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw) == tecNO_PERMISSION);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice) == tecNO_PERMISSION);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == tecNO_PERMISSION);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == tecNO_PERMISSION);
+        checkCanTradeCanTransfer(
+            tfMPTCanTransfer,
+            tecNO_PERMISSION,
+            tecNO_PERMISSION,
+            tecNO_PERMISSION,
+            tecNO_PERMISSION);
 
         // MPTCanTransfer is disabled
-        mpt.set({.mutableFlags = tmfMPTSetCanTrade});
-        mpt.set({.mutableFlags = tmfMPTClearCanTransfer});
-        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw)));
-        BEAST_EXPECT(isTesSuccess(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice)));
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == tecNO_AUTH);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == tecNO_AUTH);
+        checkCanTradeCanTransfer(tfMPTCanTrade, tesSUCCESS, tesSUCCESS, tecNO_AUTH, tecNO_AUTH);
 
         // Both flags are disabled
-        mpt.set({.mutableFlags = tmfMPTClearCanTrade});
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw) == tecNO_PERMISSION);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, alice) == tecNO_PERMISSION);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, alice) == tecNO_PERMISSION);
-        BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, alice, carol) == tecNO_PERMISSION);
+        checkCanTradeCanTransfer(
+            0, tecNO_PERMISSION, tecNO_PERMISSION, tecNO_PERMISSION, tecNO_PERMISSION);
     }
 
 public:

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -4357,13 +4357,13 @@ class MPToken_test : public beast::unit_test::Suite
         {
             Env env(*this);
             env.fund(XRP(1'000), gw, alice, carol);
-            MPTTester btc(
+            MPTTester const btc(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol},
                  .pay = 100,
                  .flags = tfMPTCanTrade | tfMPTCanTransfer});
-            MPTTester eth(
+            MPTTester const eth(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol},
@@ -4719,13 +4719,13 @@ class MPToken_test : public beast::unit_test::Suite
             auto const ed = Account{"ed"};
             Env env{*this, features};
             env.fund(XRP(1'000), gw, alice, carol, bob, ed);
-            MPTTester btc(
+            MPTTester const btc(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob, ed},
                  .pay = 1'000,
                  .flags = tfMPTCanTrade});
-            MPTTester eth(
+            MPTTester const eth(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob, ed},
@@ -7611,7 +7611,7 @@ class MPToken_test : public beast::unit_test::Suite
                                                   TER const gwToAlice,
                                                   TER const aliceToAlice,
                                                   TER const aliceToCarol) {
-            MPTTester mpt(
+            MPTTester const mpt(
                 {.env = env, .issuer = gw, .holders = {alice, carol}, .pay = 100, .flags = flags});
 
             BEAST_EXPECT(canMPTTradeAndTransfer(*env.current(), mpt, gw, gw) == gwToGw);

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3485,7 +3485,7 @@ class MPToken_test : public beast::unit_test::Suite
             MPTTester mptAlice(env, alice, {.holders = {bob}});
             mptAlice.create(
                 {.ownerCount = 1,
-                 .mutableFlags = tmfMPTCanMutateMetadata | tmfMPTCanMutateCanLock |
+                 .mutableFlags = tmfMPTCanMutateMetadata | tmfMPTCanEnableCanLock |
                      tmfMPTCanMutateTransferFee});
 
             // Setting flags is not allowed when MutableFlags is present
@@ -3597,7 +3597,7 @@ class MPToken_test : public beast::unit_test::Suite
 
             mptAlice.create(
                 {.ownerCount = 1,
-                 .mutableFlags = tmfMPTCanMutateTransferFee | tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanMutateTransferFee | tmfMPTCanEnableCanTransfer});
 
             mptAlice.set({.account = alice, .transferFee = 100, .err = tecNO_PERMISSION});
 
@@ -3630,7 +3630,7 @@ class MPToken_test : public beast::unit_test::Suite
 
             mptAlice.create(
                 {.ownerCount = 1,
-                 .mutableFlags = tmfMPTCanMutateCanTrade | tmfMPTCanMutateCanTransfer |
+                 .mutableFlags = tmfMPTCanEnableCanTrade | tmfMPTCanEnableCanTransfer |
                      tmfMPTCanMutateMetadata});
 
             // Can not mutate transfer fee
@@ -3733,12 +3733,12 @@ class MPToken_test : public beast::unit_test::Suite
                 mptAlice.set({.account = alice, .mutableFlags = setFlags});
             };
 
-            testFlagSet(tmfMPTCanMutateCanLock, tmfMPTSetCanLock);
-            testFlagSet(tmfMPTCanMutateRequireAuth, tmfMPTSetRequireAuth);
-            testFlagSet(tmfMPTCanMutateCanEscrow, tmfMPTSetCanEscrow);
-            testFlagSet(tmfMPTCanMutateCanTrade, tmfMPTSetCanTrade);
-            testFlagSet(tmfMPTCanMutateCanTransfer, tmfMPTSetCanTransfer);
-            testFlagSet(tmfMPTCanMutateCanClawback, tmfMPTSetCanClawback);
+            testFlagSet(tmfMPTCanEnableCanLock, tmfMPTSetCanLock);
+            testFlagSet(tmfMPTCanEnableRequireAuth, tmfMPTSetRequireAuth);
+            testFlagSet(tmfMPTCanEnableCanEscrow, tmfMPTSetCanEscrow);
+            testFlagSet(tmfMPTCanEnableCanTrade, tmfMPTSetCanTrade);
+            testFlagSet(tmfMPTCanEnableCanTransfer, tmfMPTSetCanTransfer);
+            testFlagSet(tmfMPTCanEnableCanClawback, tmfMPTSetCanClawback);
         }
     }
 
@@ -3759,7 +3759,7 @@ class MPToken_test : public beast::unit_test::Suite
                 {.ownerCount = 1,
                  .holderCount = 0,
                  .flags = tfMPTCanLock | tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateCanLock | tmfMPTCanMutateCanTrade |
+                 .mutableFlags = tmfMPTCanEnableCanLock | tmfMPTCanEnableCanTrade |
                      tmfMPTCanMutateTransferFee});
             mptAlice.authorize({.account = bob, .holderCount = 1});
 
@@ -3780,7 +3780,7 @@ class MPToken_test : public beast::unit_test::Suite
                 {.ownerCount = 1,
                  .holderCount = 0,
                  .flags = tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanLock | tmfMPTCanMutateCanClawback |
+                 .mutableFlags = tmfMPTCanEnableCanLock | tmfMPTCanEnableCanClawback |
                      tmfMPTCanMutateMetadata});
             mptAlice.authorize({.account = bob, .holderCount = 1});
 
@@ -3800,7 +3800,7 @@ class MPToken_test : public beast::unit_test::Suite
             mptAlice.create(
                 {.ownerCount = 1,
                  .holderCount = 0,
-                 .mutableFlags = tmfMPTCanMutateCanLock | tmfMPTCanMutateCanClawback |
+                 .mutableFlags = tmfMPTCanEnableCanLock | tmfMPTCanEnableCanClawback |
                      tmfMPTCanMutateMetadata});
             mptAlice.authorize({.account = bob, .holderCount = 1});
 
@@ -3840,7 +3840,7 @@ class MPToken_test : public beast::unit_test::Suite
         mptAlice.create(
             {.ownerCount = 1,
              .flags = tfMPTCanTransfer,
-             .mutableFlags = tmfMPTCanMutateRequireAuth});
+             .mutableFlags = tmfMPTCanEnableRequireAuth});
 
         mptAlice.authorize({.account = bob});
         mptAlice.pay(alice, bob, 1000);
@@ -3874,7 +3874,7 @@ class MPToken_test : public beast::unit_test::Suite
             {.ownerCount = 1,
              .holderCount = 0,
              .flags = tfMPTCanTransfer,
-             .mutableFlags = tmfMPTCanMutateCanEscrow});
+             .mutableFlags = tmfMPTCanEnableCanEscrow});
         mptAlice.authorize({.account = carol});
         mptAlice.authorize({.account = bob});
 
@@ -3914,7 +3914,7 @@ class MPToken_test : public beast::unit_test::Suite
             MPTTester mptAlice(env, alice, {.holders = {bob, carol}});
             mptAlice.create(
                 {.ownerCount = 1,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer | tmfMPTCanMutateTransferFee});
+                 .mutableFlags = tmfMPTCanEnableCanTransfer | tmfMPTCanMutateTransferFee});
 
             mptAlice.authorize({.account = bob});
             mptAlice.authorize({.account = carol});
@@ -3992,7 +3992,7 @@ class MPToken_test : public beast::unit_test::Suite
         MPTTester mptAlice(env, alice, {.holders = {bob}});
 
         mptAlice.create(
-            {.ownerCount = 1, .holderCount = 0, .mutableFlags = tmfMPTCanMutateCanClawback});
+            {.ownerCount = 1, .holderCount = 0, .mutableFlags = tmfMPTCanEnableCanClawback});
 
         // Bob creates an MPToken
         mptAlice.authorize({.account = bob});
@@ -4400,14 +4400,14 @@ class MPToken_test : public beast::unit_test::Suite
                  .holders = {alice, carol},
                  .pay = 100,
                  .flags = tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .mutableFlags = tmfMPTCanEnableCanTrade});
             MPTTester const eth(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol},
                  .pay = 100,
                  .flags = tfMPTCanTrade,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .mutableFlags = tmfMPTCanEnableCanTrade});
 
             // Can't create
             env(offer(gw, eth(10), btc(10)), Ter(tecNO_PERMISSION));
@@ -4644,29 +4644,29 @@ class MPToken_test : public beast::unit_test::Suite
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
                  .flags = tfMPTCanLock | kMptDexFlags,
-                 .mutableFlags = tmfMPTCanMutateRequireAuth | tmfMPTCanMutateCanTrade |
-                     tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanEnableRequireAuth | tmfMPTCanEnableCanTrade |
+                     tmfMPTCanEnableCanTransfer});
             MPTTester eth(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
                  .flags = tfMPTCanLock | kMptDexFlags,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanEnableCanTransfer});
             MPTTester const usd(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
                  .flags = kMptDexFlags | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanEnableCanTransfer});
             MPTTester const cad(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
                  .flags = kMptDexFlags | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanEnableCanTransfer});
 
             env(offer(bob, eth(1'000), btc(1'000)), Txflags(tfPassive));
             env.close();
@@ -4935,7 +4935,7 @@ class MPToken_test : public beast::unit_test::Suite
                  .holders = {alice, carol, bob},
                  .pay = 1'000,
                  .flags = tfMPTCanTransfer,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .mutableFlags = tmfMPTCanEnableCanTrade});
             MPTTester const eth(
                 {.env = env,
                  .issuer = gw,
@@ -6759,7 +6759,7 @@ class MPToken_test : public beast::unit_test::Suite
                  .issuer = gw,
                  .holders = {alice, carol},
                  .flags = tfMPTCanTrade,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanEnableCanTransfer});
 
             // src is issuer
             uint256 checkId{keylet::check(gw, env.seq(gw)).key};
@@ -7244,18 +7244,18 @@ class MPToken_test : public beast::unit_test::Suite
                     tfMPTCanLock | kMptDexFlags,
                     holders,
                     pay,
-                    tmfMPTCanMutateRequireAuth | tmfMPTCanMutateCanTransfer |
-                        tmfMPTCanMutateCanTrade);
+                    tmfMPTCanEnableRequireAuth | tmfMPTCanEnableCanTransfer |
+                        tmfMPTCanEnableCanTrade);
             };
 
             auto const makeNoTransferMPT = [&](Holders holders = {}, std::uint64_t const pay = 0) {
                 return makeMPT(
-                    tfMPTCanLock | tfMPTCanTrade, holders, pay, tmfMPTCanMutateCanTransfer);
+                    tfMPTCanLock | tfMPTCanTrade, holders, pay, tmfMPTCanEnableCanTransfer);
             };
 
             auto const makeNoTradeMPT = [&](Holders holders = {}, std::uint64_t const pay = 0) {
                 return makeMPT(
-                    tfMPTCanLock | tfMPTCanTransfer, holders, pay, tmfMPTCanMutateCanTrade);
+                    tfMPTCanLock | tfMPTCanTransfer, holders, pay, tmfMPTCanEnableCanTrade);
             };
 
             // AMMCreate

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3834,9 +3834,8 @@ class MPToken_test : public beast::unit_test::Suite
         Env env{*this, features};
         Account const alice("alice");
         Account const bob("bob");
-        Account const dan("dan");
 
-        MPTTester mptAlice(env, alice, {.holders = {bob, dan}});
+        MPTTester mptAlice(env, alice, {.holders = {bob}});
         mptAlice.create(
             {.ownerCount = 1,
              .flags = tfMPTCanTransfer,

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -1599,7 +1599,7 @@ class Vault_test : public beast::unit_test::Suite
                 {.flags = tfMPTCanTransfer | tfMPTCanLock |
                      (args.enableClawback ? tfMPTCanClawback : kNone) |
                      (args.requireAuth ? tfMPTRequireAuth : kNone),
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+                 .mutableFlags = tmfMPTCanEnableCanTransfer});
             PrettyAsset const asset = mptt.issuanceID();
             mptt.authorize({.account = owner});
             mptt.authorize({.account = depositor});
@@ -2330,7 +2330,7 @@ class Vault_test : public beast::unit_test::Suite
             MPTTester mptt{env, issuer, kMptInitNoFund};
             mptt.create(
                 {.flags = tfMPTCanTransfer | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTrade});
+                 .mutableFlags = tmfMPTCanEnableCanTrade});
             PrettyAsset const asset = mptt.issuanceID();
             mptt.authorize({.account = owner});
             mptt.authorize({.account = alice});

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -2238,149 +2238,6 @@ class Vault_test : public beast::unit_test::Suite
             env.close();
         }
 
-        testCase([this](
-                     Env& env,
-                     Account const&,
-                     Account const& owner,
-                     Account const& depositor,
-                     PrettyAsset const& asset,
-                     Vault& vault,
-                     MPTTester& mptt) {
-            testcase("MPT non-transferable: block deposit, allow withdraw");
-
-            auto [tx, keylet] = vault.create({.owner = owner, .asset = asset});
-            env(tx);
-            env.close();
-
-            tx = vault.deposit({.depositor = depositor, .id = keylet.key, .amount = asset(100)});
-            env(tx);
-            env.close();
-
-            // Issuer governance: clear CanTransfer. New exposure must be
-            // blocked, but recovery paths must remain open so existing
-            // depositors are not trapped.
-            mptt.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env.close();
-
-            // New deposit is blocked.
-            env(tx, Ter{tecNO_AUTH});
-            env.close();
-
-            // Existing depositor can always withdraw, even though the asset
-            // is no longer freely transferable.
-            tx = vault.withdraw({.depositor = depositor, .id = keylet.key, .amount = asset(100)});
-            env(tx);
-            env.close();
-
-            // Delete vault with zero balance
-            env(vault.del({.owner = owner, .id = keylet.key}));
-        });
-
-        {
-            testcase("MPT non-transferable: pre-fixCleanup3_2_0 withdraw blocked");
-
-            // Regression: before fixCleanup3_2_0 a depositor was trapped if
-            // the issuer cleared lsfMPTCanTransfer. Verify that the legacy
-            // (broken) behavior is preserved when the amendment is disabled.
-            Env env{*this, testableAmendments() - fixCleanup3_2_0};
-            Account const issuer{"issuer"};
-            Account const owner{"owner"};
-            Account const depositor{"depositor"};
-            env.fund(XRP(10'000), issuer, owner, depositor);
-            env.close();
-            Vault const vault{env};
-
-            MPTTester mptt{env, issuer, kMptInitNoFund};
-            mptt.create(
-                {.flags = tfMPTCanTransfer | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            PrettyAsset const asset = mptt.issuanceID();
-            mptt.authorize({.account = owner});
-            mptt.authorize({.account = depositor});
-            env(pay(issuer, depositor, asset(1'000)));
-            env.close();
-
-            auto [tx, keylet] = vault.create({.owner = owner, .asset = asset});
-            env(tx);
-            env.close();
-
-            env(vault.deposit({.depositor = depositor, .id = keylet.key, .amount = asset(100)}));
-            env.close();
-
-            mptt.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env.close();
-
-            // Pre-amendment: deposit blocked (matches new behavior).
-            env(vault.deposit({.depositor = depositor, .id = keylet.key, .amount = asset(100)}),
-                Ter{tecNO_AUTH});
-            env.close();
-
-            // Pre-amendment: withdraw is also blocked - this is the bug
-            // that fixCleanup3_2_0 fixes.
-            env(vault.withdraw({.depositor = depositor, .id = keylet.key, .amount = asset(100)}),
-                Ter{tecNO_AUTH});
-            env.close();
-        }
-
-        {
-            testcase("MPT non-transferable: vault shares inherit restriction");
-
-            Env env{*this, testableAmendments()};
-            Account const issuer{"issuer"};
-            Account const owner{"owner"};
-            Account const alice{"alice"};
-            Account const bob{"bob"};
-            env.fund(XRP(10'000), issuer, owner, alice, bob);
-            env.close();
-            Vault const vault{env};
-
-            MPTTester mptt{env, issuer, kMptInitNoFund};
-            mptt.create(
-                {.flags = tfMPTCanTransfer | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            PrettyAsset const asset = mptt.issuanceID();
-            mptt.authorize({.account = owner});
-            mptt.authorize({.account = alice});
-            mptt.authorize({.account = bob});
-            env(pay(issuer, alice, asset(1'000)));
-            env(pay(issuer, bob, asset(1'000)));
-            env.close();
-
-            auto [tx, keylet] = vault.create({.owner = owner, .asset = asset});
-            env(tx);
-            env.close();
-
-            env(vault.deposit({.depositor = alice, .id = keylet.key, .amount = asset(500)}));
-            // Bob also deposits so he has a share MPToken to receive into.
-            env(vault.deposit({.depositor = bob, .id = keylet.key, .amount = asset(500)}));
-            env.close();
-
-            auto const shares = [&]() -> PrettyAsset {
-                auto const sle = env.le(keylet);
-                BEAST_EXPECT(sle != nullptr);
-                return MPTIssue(sle->at(sfShareMPTID));
-            }();
-
-            // Sanity: while CanTransfer is set on the underlying, peer-to-peer
-            // share transfers are allowed.
-            env(pay(alice, bob, shares(1)));
-            env.close();
-
-            // Issuer governance: clear CanTransfer on the underlying.
-            mptt.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env.close();
-
-            // Vault shares inherit the restriction: third-party share-to-share
-            // payments are blocked.
-            env(pay(alice, bob, shares(1)), Ter{tecNO_AUTH});
-            env.close();
-
-            // Recovery path: existing share holders can still redeem shares
-            // for the underlying asset via VaultWithdraw.
-            env(vault.withdraw({.depositor = alice, .id = keylet.key, .amount = shares(1)}));
-            env.close();
-        }
-
         {
             testcase("MPT locked: vault shares inherit underlying lock");
 
@@ -2459,56 +2316,6 @@ class Vault_test : public beast::unit_test::Suite
         }
 
         {
-            testcase("MPT non-transferable: pre-fixCleanup3_2_0 share transfer succeeds");
-
-            // Regression: before fixCleanup3_2_0 a peer-to-peer share Payment
-            // succeeded even when the underlying asset's lsfMPTCanTransfer
-            // was cleared. Verify that the legacy (non-inheriting) behavior
-            // is preserved when the amendment is disabled.
-            Env env{*this, testableAmendments() - fixCleanup3_2_0};
-            Account const issuer{"issuer"};
-            Account const owner{"owner"};
-            Account const alice{"alice"};
-            Account const bob{"bob"};
-            env.fund(XRP(10'000), issuer, owner, alice, bob);
-            env.close();
-            Vault const vault{env};
-
-            MPTTester mptt{env, issuer, kMptInitNoFund};
-            mptt.create(
-                {.flags = tfMPTCanTransfer | tfMPTCanLock,
-                 .mutableFlags = tmfMPTCanMutateCanTransfer});
-            PrettyAsset const asset = mptt.issuanceID();
-            mptt.authorize({.account = owner});
-            mptt.authorize({.account = alice});
-            mptt.authorize({.account = bob});
-            env(pay(issuer, alice, asset(1'000)));
-            env(pay(issuer, bob, asset(1'000)));
-            env.close();
-
-            auto [tx, keylet] = vault.create({.owner = owner, .asset = asset});
-            env(tx);
-            env.close();
-
-            env(vault.deposit({.depositor = alice, .id = keylet.key, .amount = asset(500)}));
-            env(vault.deposit({.depositor = bob, .id = keylet.key, .amount = asset(500)}));
-            env.close();
-
-            auto const shares = [&]() -> PrettyAsset {
-                auto const sle = env.le(keylet);
-                BEAST_EXPECT(sle != nullptr);
-                return MPTIssue(sle->at(sfShareMPTID));
-            }();
-
-            mptt.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env.close();
-
-            // Pre-amendment: share transfer leaks past underlying restriction.
-            env(pay(alice, bob, shares(1)));
-            env.close();
-        }
-
-        {
             testcase("MPT CanTrade governance: share inherits underlying on DEX and AMM");
 
             Env env{*this, testableAmendments()};
@@ -2522,7 +2329,7 @@ class Vault_test : public beast::unit_test::Suite
 
             MPTTester mptt{env, issuer, kMptInitNoFund};
             mptt.create(
-                {.flags = tfMPTCanTransfer | tfMPTCanTrade | tfMPTCanLock,
+                {.flags = tfMPTCanTransfer | tfMPTCanLock,
                  .mutableFlags = tmfMPTCanMutateCanTrade});
             PrettyAsset const asset = mptt.issuanceID();
             mptt.authorize({.account = owner});
@@ -2547,38 +2354,18 @@ class Vault_test : public beast::unit_test::Suite
                 return MPTIssue(sle->at(sfShareMPTID));
             }();
 
-            // Sanity: while CanTrade is set on the underlying, both the asset
-            // and the vault share can be placed on the DEX.
-            env(offer(alice, XRP(1), asset(10)));
-            env(offer(alice, XRP(1), shares(1)));
-            env.close();
-
-            // Issuer governance: clear CanTrade on the underlying.
-            mptt.set({.mutableFlags = tmfMPTClearCanTrade});
-            env.close();
-
-            // Control: clearing CanTrade on the underlying is observable on
-            // the DEX path for that asset.
+            // CanTrade is not set on the underlying, both the asset and
+            // the vault share are blocked on the DEX.
             env(offer(alice, XRP(1), asset(10)), Ter{tecNO_PERMISSION});
+            env(offer(alice, XRP(1), shares(1)), Ter{tecNO_PERMISSION});
             env.close();
 
-            // Control: clearing CanTrade on the underlying is also observable
-            // on the AMM path for that asset.
-            AMM const ammUnderlyingFails(
+            // The inherited CanTrade restriction also blocks AMM creation.
+            AMM const ammUnderlyingFail(
                 env, alice, XRP(1'000), asset(1'000), Ter{tecNO_PERMISSION});
-
-            // Post-fixCleanup3_2_0: vault shares inherit the underlying's
-            // CanTrade restriction on the DEX path (canTrade reads the
-            // share's sfReferenceHolding and dispatches to the underlying).
-            env(offer(bob, XRP(1), shares(1)), Ter{tecNO_PERMISSION});
-            env.close();
-
-            // checkMPTAllowed mirrors the inheritance for AMM/Offer-
-            // crossing/Check paths, so a share AMM also cannot be created
-            // when the underlying CanTrade is cleared.
             AMM const ammShares(env, alice, XRP(1'000), shares(100), Ter{tecNO_PERMISSION});
 
-            // Deposit still works (canAddHolding does not consult the field).
+            // Deposit still works before enabling CanTrade.
             env(vault.deposit({.depositor = alice, .id = keylet.key, .amount = asset(100)}));
             env.close();
 
@@ -2587,9 +2374,19 @@ class Vault_test : public beast::unit_test::Suite
             env(pay(alice, bob, shares(1)));
             env.close();
 
-            // Withdraw still works.
+            // Withdraw still works before enabling CanTrade.
             env(vault.withdraw({.depositor = alice, .id = keylet.key, .amount = asset(100)}));
             env.close();
+
+            // Enable CanTrade on the underlying.
+            mptt.set({.mutableFlags = tmfMPTSetCanTrade});
+            env.close();
+
+            env(offer(alice, XRP(1), asset(10)));
+            env(offer(alice, XRP(1), shares(1)));
+            env.close();
+
+            AMM const ammUnderlying(env, alice, XRP(1'000), asset(1'000));
         }
 
         {

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -28,6 +28,7 @@
 #include <xrpl/protocol/jss.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -39,6 +40,21 @@
 #include <vector>
 
 namespace xrpl::test::jtx {
+
+struct MPTSetFlagMapping
+{
+    std::uint32_t setFlag;
+    std::uint32_t ledgerFlag;
+};
+
+static constexpr std::array<MPTSetFlagMapping, 6> mptSetFlagMappings = {{
+    {tmfMPTSetCanLock, lsfMPTCanLock},
+    {tmfMPTSetRequireAuth, lsfMPTRequireAuth},
+    {tmfMPTSetCanEscrow, lsfMPTCanEscrow},
+    {tmfMPTSetCanClawback, lsfMPTCanClawback},
+    {tmfMPTSetCanTrade, lsfMPTCanTrade},
+    {tmfMPTSetCanTransfer, lsfMPTCanTransfer},
+}};
 
 void
 MptFlags::operator()(Env& env) const
@@ -424,59 +440,9 @@ MPTTester::set(MPTSet const& arg)
 
                 if (arg.mutableFlags)
                 {
-                    if (*arg.mutableFlags & tmfMPTSetCanLock)
-                    {
-                        flags |= lsfMPTCanLock;
-                    }
-                    else if (*arg.mutableFlags & tmfMPTClearCanLock)
-                    {
-                        flags &= ~lsfMPTCanLock;
-                    }
-
-                    if (*arg.mutableFlags & tmfMPTSetRequireAuth)
-                    {
-                        flags |= lsfMPTRequireAuth;
-                    }
-                    else if (*arg.mutableFlags & tmfMPTClearRequireAuth)
-                    {
-                        flags &= ~lsfMPTRequireAuth;
-                    }
-
-                    if (*arg.mutableFlags & tmfMPTSetCanEscrow)
-                    {
-                        flags |= lsfMPTCanEscrow;
-                    }
-                    else if (*arg.mutableFlags & tmfMPTClearCanEscrow)
-                    {
-                        flags &= ~lsfMPTCanEscrow;
-                    }
-
-                    if (*arg.mutableFlags & tmfMPTSetCanClawback)
-                    {
-                        flags |= lsfMPTCanClawback;
-                    }
-                    else if (*arg.mutableFlags & tmfMPTClearCanClawback)
-                    {
-                        flags &= ~lsfMPTCanClawback;
-                    }
-
-                    if (*arg.mutableFlags & tmfMPTSetCanTrade)
-                    {
-                        flags |= lsfMPTCanTrade;
-                    }
-                    else if (*arg.mutableFlags & tmfMPTClearCanTrade)
-                    {
-                        flags &= ~lsfMPTCanTrade;
-                    }
-
-                    if (*arg.mutableFlags & tmfMPTSetCanTransfer)
-                    {
-                        flags |= lsfMPTCanTransfer;
-                    }
-                    else if (*arg.mutableFlags & tmfMPTClearCanTransfer)
-                    {
-                        flags &= ~lsfMPTCanTransfer;
-                    }
+                    for (auto const& [setFlag, ledgerFlag] : mptSetFlagMappings)
+                        if ((*arg.mutableFlags & setFlag) != 0u)
+                            flags |= ledgerFlag;
                 }
             }
             env_.require(MptFlags(*this, flags, holder));

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -48,12 +48,12 @@ struct MPTSetFlagMapping
 };
 
 static constexpr std::array<MPTSetFlagMapping, 6> mptSetFlagMappings = {{
-    {tmfMPTSetCanLock, lsfMPTCanLock},
-    {tmfMPTSetRequireAuth, lsfMPTRequireAuth},
-    {tmfMPTSetCanEscrow, lsfMPTCanEscrow},
-    {tmfMPTSetCanClawback, lsfMPTCanClawback},
-    {tmfMPTSetCanTrade, lsfMPTCanTrade},
-    {tmfMPTSetCanTransfer, lsfMPTCanTransfer},
+    {.setFlag = tmfMPTSetCanLock, .ledgerFlag = lsfMPTCanLock},
+    {.setFlag = tmfMPTSetRequireAuth, .ledgerFlag = lsfMPTRequireAuth},
+    {.setFlag = tmfMPTSetCanEscrow, .ledgerFlag = lsfMPTCanEscrow},
+    {.setFlag = tmfMPTSetCanClawback, .ledgerFlag = lsfMPTCanClawback},
+    {.setFlag = tmfMPTSetCanTrade, .ledgerFlag = lsfMPTCanTrade},
+    {.setFlag = tmfMPTSetCanTransfer, .ledgerFlag = lsfMPTCanTransfer},
 }};
 
 void
@@ -441,8 +441,12 @@ MPTTester::set(MPTSet const& arg)
                 if (arg.mutableFlags)
                 {
                     for (auto const& [setFlag, ledgerFlag] : mptSetFlagMappings)
+                    {
                         if ((*arg.mutableFlags & setFlag) != 0u)
+                        {
                             flags |= ledgerFlag;
+                        }
+                    }
                 }
             }
             env_.require(MptFlags(*this, flags, holder));


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

Spec change: https://github.com/XRPLF/XRPL-Standards/pull/562
We're getting rid of the clear flags for dynamic MPTs. Flags that are marked mutable at issuance can still be turned on by the issuer, but they will become immutable immediately after they are set.

### Context of Change

- TxFlags.h: Remove clear mutable flags
- MPTokenIssuanceSet.cpp: Remove clear mutable flags related logic
- Tests:
1.  Affect tests related to dynamic mpt in MPToken_test.cpp
2. Affect existing tests relying on the clear flags.

**The following tests are removed.**
Before: create with mpt transferrable and then `ClearCanTransfer` and then test deposit/withdraw
After: case removed because creation fails when mpt non-transferrable.

`Vault_test`:
- testcase("MPT non-transferable: block deposit, allow withdraw")
- testcase("MPT non-transferable: pre-fixCleanup3_2_0 withdraw blocked")
- testcase("MPT non-transferable: vault shares inherit restriction")
- testcase("MPT non-transferable: pre-fixCleanup3_2_0 share transfer succeeds")

`Loan_test`:
- testcase("CoverDeposit blocked, CoverWithdraw allowed when CanTransfer cleared")
- testcase("Lending: CanTrade disabled has no impact")

`AMMMPT_test`:
- testcase("Invalid AMMWithdraw") // MPTCanTransfer is not set and the account is not the issuer of MPT


**The following tests are modified.**
Before: mpt initialized with CanTransfer/CanTrade, test success first but later cleared to test failure.
After: mpt initialized without CanTransfer/CanTrade, test failure first, and then enabled and test success.

`Vault_test`:
- testcase("MPT CanTrade governance: share inherits underlying on DEX and AMM");

`Loan_test`:
- testcase("Lending: CanTrade cleared has no impact") ->  testcase("Lending: CanTrade disabled has no impact")

`MPToken_test`:
- testOfferCrossing
- testCrossAssetPayment
- testCheckCash
- testAMMClawback
- testBasicAMM
- testTradeAndTransfer

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [x] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
4. What behavior/functionality does the change impact?
5. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
6. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
