### PR TITLE
ci: Disable assertions on Release builds

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -20,8 +20,6 @@ _SANITIZER_SUFFIX: dict[str, str] = {
 def get_cmake_args(build_type: str, extra_args: str) -> str:
     """Get the full list of CMake arguments for a config."""
     args = _BASE_CMAKE_ARGS.copy()
-    if build_type == "Release":
-        args.append("-Dassert=OFF")
     if extra_args:
         args.extend(extra_args.split())
     return " ".join(args)

--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -21,7 +21,7 @@ def get_cmake_args(build_type: str, extra_args: str) -> str:
     """Get the full list of CMake arguments for a config."""
     args = _BASE_CMAKE_ARGS.copy()
     if build_type == "Release":
-        args.append("-Dassert=ON")
+        args.append("-Dassert=OFF")
     if extra_args:
         args.extend(extra_args.split())
     return " ".join(args)


### PR DESCRIPTION
This probably shouldn't just be blanket `assert=ON` if `Release`. Not sure why this was ever set here like this. We should probably make assertion builds its own config as with the sanitizer builds.
 