### PR TITLE
fix: Add [[maybe_unused]] to fix320Enabled for assert=OFF builds

### DIFF
--- a/src/libxrpl/ledger/helpers/LendingHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/LendingHelpers.cpp
@@ -813,7 +813,7 @@ doOverpayment(
     //   3. The overpayment's penalty interest part (= untrackedInterest
     //      for the overpayment path; see computeOverpaymentComponents):
     //        trackedInterestPart()
-    bool const fix320Enabled = rules.enabled(fixCleanup3_2_0);
+    [[maybe_unused]] bool const fix320Enabled = rules.enabled(fixCleanup3_2_0);
     XRPL_ASSERT_IF(
         fix320Enabled,
         overpaymentComponents.trackedPrincipalDelta ==


### PR DESCRIPTION
## Summary

- `fix320Enabled` in `LendingHelpers.cpp:816` is used only as the condition in `XRPL_ASSERT_IF`
- With `assert=OFF`, `XRPL_ASSERT_IF` expands to nothing → `fix320Enabled` is unused → `-Werror=unused-variable` fails the build
- With `assert=ON` (GitHub Actions default), the macro expands normally → no warning
- Fix: add `[[maybe_unused]]` to suppress the warning when `assert=OFF`

## Root cause

Introduced by #7378 ("refactor: Introduce XRPL_ASSERT_IF for amendment-gated assertions"). GitHub Actions hardcodes `-Dassert=ON` in `generate.py`, so the bug was not caught before merge. Any build system that compiles Release with `assert=OFF` will hit this failure.

## Test plan

- [x] Verified fix compiles cleanly in a Release build with `assert=OFF`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)