### PR TITLE
ci: Make configurations launch on certain event types

### DIFF
--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -27,6 +27,18 @@ def get_cmake_args(build_type: str, extra_args: str) -> str:
     return " ".join(args)
 
 
+def runs_on_event(event_type: str | list[str], event: str | None) -> bool:
+    """Whether a config with this event_type should run for the current event.
+
+    'event_type' is either the string "all" (run on every event) or a list of
+    GitHub event names (e.g. ["push", "pull_request"]) to restrict the config
+    to. When no event is given (event is None), no filtering is applied.
+    """
+    if event is None or event_type == "all":
+        return True
+    return event in event_type
+
+
 # ---------------------------------------------------------------------------
 # Input types — shapes of the JSON config files
 # ---------------------------------------------------------------------------
@@ -43,6 +55,9 @@ class LinuxConfig:
     suffix: str = ""
     extra_cmake_args: str = ""
     image: str = ""  # only used by package_configs entries
+    # Either the string "all" or a list of GitHub event names (e.g. "push",
+    # "pull_request") on which this config should run.
+    event_type: str | list[str] = "all"
 
 
 @dataclasses.dataclass
@@ -77,6 +92,9 @@ class PlatformConfig:
     build_type: list[str]
     build_only: bool = False  # if true, skip tests (e.g. macos/Windows Debug)
     extra_cmake_args: str = ""
+    # Either the string "all" or a list of GitHub event names (e.g. "push",
+    # "pull_request") on which this config should run.
+    event_type: str | list[str] = "all"
 
     def __post_init__(self) -> None:
         if isinstance(self.build_type, str):
@@ -151,16 +169,21 @@ _ARCHS: dict[str, Architecture] = {
 }
 
 
-def expand_linux_matrix(linux: LinuxFile) -> list[MatrixEntry]:
+def expand_linux_matrix(
+    linux: LinuxFile, event: str | None = None
+) -> list[MatrixEntry]:
     """Expand a LinuxFile into a flat list of matrix entries.
 
     Each config entry is expanded over the cross-product of its
-    compiler, build_type, sanitizers, and architecture lists.
+    compiler, build_type, sanitizers, and architecture lists. Configs whose
+    'event_type' does not match the current event are skipped.
     """
     entries: list[MatrixEntry] = []
 
     for distro, configs in linux.configs.items():
         for cfg in configs:
+            if not runs_on_event(cfg.event_type, event):
+                continue
             # An empty sanitizers list means "one entry with no sanitizer".
             effective_sanitizers = cfg.sanitizers or [""]
             effective_archs = {arch: _ARCHS[arch] for arch in cfg.arch}
@@ -218,13 +241,20 @@ def expand_linux_packaging(linux: LinuxFile) -> list[PackagingEntry]:
     return entries
 
 
-def expand_platform_matrix(pf: PlatformFile) -> list[MatrixEntry]:
-    """Expand a PlatformFile (macOS or Windows) into matrix entries."""
+def expand_platform_matrix(
+    pf: PlatformFile, event: str | None = None
+) -> list[MatrixEntry]:
+    """Expand a PlatformFile (macOS or Windows) into matrix entries.
+
+    Configs whose 'event_type' does not match the current event are skipped.
+    """
     platform_name, arch = pf.platform.split("/")
     is_windows = platform_name == "windows"
 
     entries: list[MatrixEntry] = []
     for cfg in pf.configs:
+        if not runs_on_event(cfg.event_type, event):
+            continue
         for build_type in cfg.build_type:
             entries.append(
                 MatrixEntry(
@@ -262,6 +292,14 @@ if __name__ == "__main__":
         help="Emit the Linux packaging matrix instead of the build/test matrix.",
         action="store_true",
     )
+    parser.add_argument(
+        "-e",
+        "--event",
+        help="The GitHub event name that triggered the workflow (e.g. 'push', "
+        "'pull_request'). Configs are filtered by their 'event_type'. If "
+        "omitted, no filtering is applied.",
+        default=None,
+    )
     args = parser.parse_args()
 
     matrix: list[MatrixEntry] | list[PackagingEntry] = []
@@ -270,12 +308,16 @@ if __name__ == "__main__":
         matrix = expand_linux_packaging(LinuxFile.load(THIS_DIR / "linux.json"))
     else:
         if args.config in ("linux", None):
-            matrix += expand_linux_matrix(LinuxFile.load(THIS_DIR / "linux.json"))
+            matrix += expand_linux_matrix(
+                LinuxFile.load(THIS_DIR / "linux.json"), args.event
+            )
         if args.config in ("macos", None):
-            matrix += expand_platform_matrix(PlatformFile.load(THIS_DIR / "macos.json"))
+            matrix += expand_platform_matrix(
+                PlatformFile.load(THIS_DIR / "macos.json"), args.event
+            )
         if args.config in ("windows", None):
             matrix += expand_platform_matrix(
-                PlatformFile.load(THIS_DIR / "windows.json")
+                PlatformFile.load(THIS_DIR / "windows.json"), args.event
             )
 
     print(f"matrix={json.dumps({'include': [dataclasses.asdict(e) for e in matrix]})}")

--- a/.github/scripts/strategy-matrix/generate.py
+++ b/.github/scripts/strategy-matrix/generate.py
@@ -27,16 +27,17 @@ def get_cmake_args(build_type: str, extra_args: str) -> str:
     return " ".join(args)
 
 
-def runs_on_event(event_type: str | list[str], event: str | None) -> bool:
-    """Whether a config with this event_type should run for the current event.
+def runs_on_event(exclude_event_types: list[str], event: str | None) -> bool:
+    """Whether a config should run for the current event.
 
-    'event_type' is either the string "all" (run on every event) or a list of
-    GitHub event names (e.g. ["push", "pull_request"]) to restrict the config
-    to. When no event is given (event is None), no filtering is applied.
+    'exclude_event_types' is a list of GitHub event names (e.g.
+    ["pull_request"]) on which the config should NOT run; an empty list means
+    the config runs on every event. When no event is given (event is None), no
+    filtering is applied.
     """
-    if event is None or event_type == "all":
+    if event is None:
         return True
-    return event in event_type
+    return event not in exclude_event_types
 
 
 # ---------------------------------------------------------------------------
@@ -55,9 +56,9 @@ class LinuxConfig:
     suffix: str = ""
     extra_cmake_args: str = ""
     image: str = ""  # only used by package_configs entries
-    # Either the string "all" or a list of GitHub event names (e.g. "push",
-    # "pull_request") on which this config should run.
-    event_type: str | list[str] = "all"
+    # List of GitHub event names (e.g. "pull_request") on which this config
+    # should NOT run. Empty means it runs on every event.
+    exclude_event_types: list[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -92,9 +93,9 @@ class PlatformConfig:
     build_type: list[str]
     build_only: bool = False  # if true, skip tests (e.g. macos/Windows Debug)
     extra_cmake_args: str = ""
-    # Either the string "all" or a list of GitHub event names (e.g. "push",
-    # "pull_request") on which this config should run.
-    event_type: str | list[str] = "all"
+    # List of GitHub event names (e.g. "pull_request") on which this config
+    # should NOT run. Empty means it runs on every event.
+    exclude_event_types: list[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self) -> None:
         if isinstance(self.build_type, str):
@@ -175,14 +176,14 @@ def expand_linux_matrix(
     """Expand a LinuxFile into a flat list of matrix entries.
 
     Each config entry is expanded over the cross-product of its
-    compiler, build_type, sanitizers, and architecture lists. Configs whose
-    'event_type' does not match the current event are skipped.
+    compiler, build_type, sanitizers, and architecture lists. Configs that
+    exclude the current event are skipped.
     """
     entries: list[MatrixEntry] = []
 
     for distro, configs in linux.configs.items():
         for cfg in configs:
-            if not runs_on_event(cfg.event_type, event):
+            if not runs_on_event(cfg.exclude_event_types, event):
                 continue
             # An empty sanitizers list means "one entry with no sanitizer".
             effective_sanitizers = cfg.sanitizers or [""]
@@ -246,14 +247,14 @@ def expand_platform_matrix(
 ) -> list[MatrixEntry]:
     """Expand a PlatformFile (macOS or Windows) into matrix entries.
 
-    Configs whose 'event_type' does not match the current event are skipped.
+    Configs that exclude the current event are skipped.
     """
     platform_name, arch = pf.platform.split("/")
     is_windows = platform_name == "windows"
 
     entries: list[MatrixEntry] = []
     for cfg in pf.configs:
-        if not runs_on_event(cfg.event_type, event):
+        if not runs_on_event(cfg.exclude_event_types, event):
             continue
         for build_type in cfg.build_type:
             entries.append(

--- a/.github/scripts/strategy-matrix/linux.json
+++ b/.github/scripts/strategy-matrix/linux.json
@@ -41,7 +41,8 @@
         "build_type": ["Debug"],
         "arch": ["amd64"],
         "suffix": "unity",
-        "extra_cmake_args": "-Dunity=ON"
+        "extra_cmake_args": "-Dunity=ON",
+        "event_type": ["push", "merge_group", "schedule", "workflow_dispatch"]
       }
     ],
 

--- a/.github/scripts/strategy-matrix/linux.json
+++ b/.github/scripts/strategy-matrix/linux.json
@@ -42,7 +42,7 @@
         "arch": ["amd64"],
         "suffix": "unity",
         "extra_cmake_args": "-Dunity=ON",
-        "event_type": ["push", "merge_group", "schedule", "workflow_dispatch"]
+        "exclude_event_types": ["pull_request"]
       }
     ],
 

--- a/.github/scripts/strategy-matrix/macos.json
+++ b/.github/scripts/strategy-matrix/macos.json
@@ -10,7 +10,7 @@
       "build_type": "Debug",
       "extra_cmake_args": "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
       "build_only": true,
-      "event_type": ["push", "merge_group", "schedule", "workflow_dispatch"]
+      "exclude_event_types": ["pull_request"]
     }
   ]
 }

--- a/.github/scripts/strategy-matrix/macos.json
+++ b/.github/scripts/strategy-matrix/macos.json
@@ -9,7 +9,8 @@
     {
       "build_type": "Debug",
       "extra_cmake_args": "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-      "build_only": true
+      "build_only": true,
+      "event_type": ["push", "merge_group", "schedule", "workflow_dispatch"]
     }
   ]
 }

--- a/.github/scripts/strategy-matrix/windows.json
+++ b/.github/scripts/strategy-matrix/windows.json
@@ -6,7 +6,7 @@
     {
       "build_type": "Debug",
       "build_only": true,
-      "event_type": ["push", "merge_group", "schedule", "workflow_dispatch"]
+      "exclude_event_types": ["pull_request"]
     }
   ]
 }

--- a/.github/scripts/strategy-matrix/windows.json
+++ b/.github/scripts/strategy-matrix/windows.json
@@ -3,6 +3,10 @@
   "runner": ["self-hosted", "Windows", "devbox"],
   "configs": [
     { "build_type": "Release" },
-    { "build_type": "Debug", "build_only": true }
+    {
+      "build_type": "Debug",
+      "build_only": true,
+      "event_type": ["push", "merge_group", "schedule", "workflow_dispatch"]
+    }
   ]
 }

--- a/.github/workflows/reusable-strategy-matrix.yml
+++ b/.github/workflows/reusable-strategy-matrix.yml
@@ -35,4 +35,5 @@ jobs:
         id: generate
         env:
           GENERATE_CONFIG: ${{ inputs.os != '' && format('--config={0}', inputs.os) || '' }}
-        run: ./generate.py ${GENERATE_CONFIG} >>"${GITHUB_OUTPUT}"
+          GENERATE_EVENT: ${{ github.event_name }}
+        run: ./generate.py ${GENERATE_CONFIG} --event="${GENERATE_EVENT}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

We have limited number of Windows / macOS runners, so let's only launch when not in PR.
Default is to launch on any event type, this allows to keep the config simple, and it's reasonable default.

If needed, we can reduce it even further in the future, by removing more configurations from pull_request mode, but keeping them for merge_group - this would mean everything gets tested before actually landing in develop, but not on every commit.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
