### PR TITLE
ci: Make sanitizer flags lists in the profile, not a string

### DIFF
--- a/conan/profiles/sanitizers
+++ b/conan/profiles/sanitizers
@@ -52,52 +52,50 @@ include(default)
 {% endif %}
 
 {# Frame pointer required for meaningful stack traces; -O1 for reasonable performance #}
-{% set compile_flags = ["-fno-omit-frame-pointer", "-O1"] %}
+{% set sanitizer_compiler_flags = ["-fno-omit-frame-pointer", "-O1"] %}
 
 {% if compiler == "gcc" %}
     {# Suppress false positive warnings with GCC #}
-    {% set _ = compile_flags.append("-Wno-stringop-overflow") %}
+    {% set _ = sanitizer_compiler_flags.append("-Wno-stringop-overflow") %}
 
     {% set relocation_flags = [] %}
 
     {% if arch == "x86_64" and enable_asan %}
         {# Large code model prevents relocation errors in instrumented ASAN binaries #}
-        {% set _ = compile_flags.append("-mcmodel=large") %}
+        {% set _ = sanitizer_compiler_flags.append("-mcmodel=large") %}
         {% set _ = relocation_flags.append("-mcmodel=large") %}
     {% elif enable_tsan %}
         {# GCC doesn't support atomic_thread_fence with TSAN; suppress warnings #}
-        {% set _ = compile_flags.append("-Wno-tsan") %}
+        {% set _ = sanitizer_compiler_flags.append("-Wno-tsan") %}
         {% if arch == "x86_64" %}
             {# Medium code model for TSAN; large is incompatible #}
-            {% set _ = compile_flags.append("-mcmodel=medium") %}
+            {% set _ = sanitizer_compiler_flags.append("-mcmodel=medium") %}
             {% set _ = relocation_flags.append("-mcmodel=medium") %}
         {% endif %}
     {% endif %}
 
     {% set fsanitize = "-fsanitize=" ~ ",".join(sanitizer_types) %}
-    {% set _ = compile_flags.append(fsanitize) %}
+    {% set _ = sanitizer_compiler_flags.append(fsanitize) %}
     {% set _ = relocation_flags.append(fsanitize) %}
 
-    {% set sanitizer_compiler_flags = " ".join(compile_flags) %}
-    {% set sanitizer_linker_flags = " ".join(relocation_flags) %}
+    {% set sanitizer_linker_flags = relocation_flags %}
 {% elif compiler == "clang" or compiler == "apple-clang" %}
     {% set fsanitize = "-fsanitize=" ~ ",".join(sanitizer_types) %}
-    {% set _ = compile_flags.append(fsanitize) %}
+    {% set _ = sanitizer_compiler_flags.append(fsanitize) %}
 
-    {% set sanitizer_compiler_flags = " ".join(compile_flags) %}
-    {% set sanitizer_linker_flags = fsanitize %}
+    {% set sanitizer_linker_flags = [fsanitize] %}
 {% endif %}
 
 [conf]
 tools.build:defines+={{defines}}
-tools.build:cxxflags+=['{{sanitizer_compiler_flags}}']
-tools.build:sharedlinkflags+=['{{sanitizer_linker_flags}}']
-tools.build:exelinkflags+=['{{sanitizer_linker_flags}}']
+tools.build:cxxflags+={{sanitizer_compiler_flags}}
+tools.build:sharedlinkflags+={{sanitizer_linker_flags}}
+tools.build:exelinkflags+={{sanitizer_linker_flags}}
 
 tools.info.package_id:confs+=["tools.build:cxxflags", "tools.build:exelinkflags", "tools.build:sharedlinkflags", "tools.build:defines"]
 
 # &: means "apply only to the consumer/root package"
-&:tools.cmake.cmaketoolchain:extra_variables={"SANITIZERS": "{{sanitizers}}", "SANITIZERS_COMPILER_FLAGS": "{{sanitizer_compiler_flags}}", "SANITIZERS_LINKER_FLAGS": "{{sanitizer_linker_flags}}"}
+&:tools.cmake.cmaketoolchain:extra_variables={"SANITIZERS": "{{sanitizers}}", "SANITIZERS_COMPILER_FLAGS": "{{sanitizer_compiler_flags | join(' ')}}", "SANITIZERS_LINKER_FLAGS": "{{sanitizer_linker_flags | join(' ')}}"}
 
 [options]
 {% if enable_asan %}


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

`tools.build:cxxflags` (and so on) is a list of separate flags, so there shouldn't be a huge space-separated string of all flags, but individual flags separately.
This might have worked before, because some toolchains might treat it ok, but in general it's a bug.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
