### PR TITLE
fix: TxQ of sponsor-created-account without reserving future sponsor fee

### DIFF
--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -33,6 +33,7 @@
 #include <test/jtx/vault.h>
 #include <test/jtx/xchain_bridge.h>
 
+#include <xrpld/app/misc/TxQ.h>
 #include <xrpld/core/Config.h>
 
 #include <xrpl/basics/Number.h>
@@ -5968,6 +5969,84 @@ public:
     }
 
     void
+    testTxQueueSponsorReserve()
+    {
+        /* Each queued tfSponsorCreatedAccount payment that creates a new
+           destination raises the source's own future reserve (via
+           sfSponsoringAccountCount). TxQ admission must account for that
+           liability across all of an account's queued creations. Otherwise a
+           source could queue several sequential sponsored creations that are
+           not collectively reserve-safe and would all be admitted as terQUEUED,
+           even though once the earlier ones drain and raise the reserve the
+           later ones can no longer be queue-safe and would fail at execution
+           with tecUNFUNDED_PAYMENT, burning their fee. */
+        testcase("TxQ accounts for sponsor-created-account reserve");
+
+        using namespace jtx;
+
+        // Sponsor is funded for its own reserve, both sponsored accounts, and
+        // `feeUnits` fees. Two creations need two fees, so feeUnits == 1 rejects
+        // the second creation; feeUnits == 2 queues both.
+        auto const runScenario = [this](int feeUnits, TER secondResult) {
+            Env env(
+                *this,
+                makeConfig({{"minimum_txn_in_ledger_standalone", "1"}}),
+                testableAmendments());
+
+            Account const filler("filler");
+            Account const sponsor("sponsor");
+            Account const bob("bob");
+            Account const carol("carol");
+
+            for (auto const& account : {filler, sponsor})
+            {
+                env.fund(XRP(1000), account);
+                env.close();
+            }
+
+            auto const feeDrops = env.current()->fees().base.drops() * 100;
+            auto const feeAmt = drops(feeDrops);
+            adjustAccountXRPBalance(
+                env, sponsor, accountReserve(env, 3) + drops(feeDrops * feeUnits) + drops(2));
+
+            auto& txq = env.app().getTxQ();
+
+            // Fill the open ledger so the sponsor's payments are held in the
+            // queue rather than applied directly.
+            auto const metrics = txq.getMetrics(*env.current());
+            for (std::size_t i = metrics.txInLedger; i <= metrics.txPerLedger; ++i)
+                env(noop(filler));
+
+            auto const sponsorSeq = env.seq(sponsor);
+
+            // The first sponsored creation is reserve-safe on its own.
+            env(pay(sponsor, bob, drops(1)),
+                Seq(sponsorSeq),
+                Txflags(tfSponsorCreatedAccount),
+                Fee(feeAmt),
+                Ter(terQUEUED));
+
+            // The second only queues if the sponsor can cover both creations'
+            // future reserve together.
+            env(pay(sponsor, carol, drops(1)),
+                Seq(sponsorSeq + 1),
+                Txflags(tfSponsorCreatedAccount),
+                Fee(feeAmt),
+                Ter(secondResult));
+
+            std::size_t const expectedQueued = secondResult == terQUEUED ? 2 : 1;
+            BEAST_EXPECT(txq.getAccountTxs(sponsor.id()).size() == expectedQueued);
+        };
+
+        // Not collectively reserve-safe: the second creation is rejected.
+        runScenario(1, telCAN_NOT_QUEUE_BALANCE);
+
+        // Enough headroom for both creations: the second is admitted, proving
+        // the accounting does not over-reject.
+        runScenario(2, terQUEUED);
+    }
+
+    void
     testSponsorReserve(bool cosigning)
     {
         testRequireFlag();
@@ -5992,6 +6071,11 @@ public:
         testVault(cosigning);
         testXChain(cosigning);
         testLending(cosigning);
+
+        // The source is its own sponsor and pays its own fee here, so there is
+        // no co-signer involved; run this case once rather than in both passes.
+        if (!cosigning)
+            testTxQueueSponsorReserve();
     }
 
 protected:

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -64,6 +64,7 @@
 #include <xrpl/tx/apply.h>
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -5985,9 +5985,11 @@ public:
 
         using namespace jtx;
 
-        // Sponsor is funded for its own reserve, both sponsored accounts, and
-        // `feeUnits` fees. Two creations need two fees, so feeUnits == 1 rejects
-        // the second creation; feeUnits == 2 queues both.
+        // The sponsor is always funded for 3 reserves (itself + the two accounts it
+        // will sponsor) and the two 1-drop deliveries; `feeUnits` tunes how many tx
+        // fees it can also cover. Two creations need two fees in flight, so
+        // feeUnits == 1 is one fee short and the second creation is rejected, while
+        // feeUnits == 2 covers both and both queue.
         auto const runScenario = [this](int feeUnits, TER secondResult) {
             Env env(
                 *this,
@@ -6039,11 +6041,9 @@ public:
             BEAST_EXPECT(txq.getAccountTxs(sponsor.id()).size() == expectedQueued);
         };
 
-        // Not collectively reserve-safe: the second creation is rejected.
         runScenario(1, telCAN_NOT_QUEUE_BALANCE);
 
-        // Enough headroom for both creations: the second is admitted, proving
-        // the accounting does not over-reject.
+        // Enough funds for both: the second is admitted
         runScenario(2, terQUEUED);
     }
 

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -1127,8 +1127,8 @@ TxQ::apply(
             std::uint32_t sponsorReserveUnits = locksSponsorReserve(pfResult.tx) ? 1 : 0;
             XRPAmount sponsorFeesAndSpend =
                 pfResult.consequences.fee() + pfResult.consequences.potentialSpend();
-            // NOLINTBEGIN(bugprone-unchecked-optional-access) requiresMultiTxn
-            // implies txIter is set
+            // NOLINTBEGIN(bugprone-unchecked-optional-access)
+            // requiresMultiTxn implies txIter is set
             for (auto iter = txIter->first; iter != txIter->end; ++iter)
             {
                 // Skip the queued entry the candidate is replacing

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -1127,6 +1127,8 @@ TxQ::apply(
             std::uint32_t sponsorReserveUnits = locksSponsorReserve(pfResult.tx) ? 1 : 0;
             XRPAmount sponsorFeesAndSpend =
                 pfResult.consequences.fee() + pfResult.consequences.potentialSpend();
+            // NOLINTBEGIN(bugprone-unchecked-optional-access) requiresMultiTxn
+            // implies txIter is set
             for (auto iter = txIter->first; iter != txIter->end; ++iter)
             {
                 // Skip the queued entry the candidate is replacing
@@ -1137,6 +1139,7 @@ TxQ::apply(
                 sponsorFeesAndSpend += iter->second.consequences().fee() +
                     iter->second.consequences().potentialSpend();
             }
+            // NOLINTEND(bugprone-unchecked-optional-access)
 
             if (sponsorReserveUnits > 0)
             {

--- a/src/xrpld/app/misc/detail/TxQ.cpp
+++ b/src/xrpld/app/misc/detail/TxQ.cpp
@@ -15,6 +15,7 @@
 #include <xrpl/ledger/ApplyViewImpl.h>
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/ReadView.h>
+#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Keylet.h>
@@ -25,6 +26,8 @@
 #include <xrpl/protocol/STTx.h>
 #include <xrpl/protocol/SeqProxy.h>
 #include <xrpl/protocol/TER.h>
+#include <xrpl/protocol/TxFlags.h>
+#include <xrpl/protocol/TxFormats.h>
 #include <xrpl/protocol/Units.h>
 #include <xrpl/protocol/XRPAmount.h>
 #include <xrpl/protocol/jss.h>
@@ -1104,6 +1107,50 @@ TxQ::apply(
                 JLOG(j_.trace()) << "Ignoring transaction " << transactionID
                                  << ". Total fees in flight too high.";
                 return {telCAN_NOT_QUEUE_BALANCE, false};
+            }
+
+            /* Account for the future reserve liability of queued sponsored
+               account creations.
+
+               A Payment with tfSponsorCreatedAccount that creates a new
+               destination permanently raises the *source* account's own
+               reserve by one base reserve unit (via sfSponsoringAccountCount)
+               once it executes. Only fresh destinations matter, because doApply()
+               only increments sfSponsoringAccountCount when it actually creates
+               the account. */
+            auto const locksSponsorReserve = [&view](STTx const& candidate) {
+                return candidate.getTxnType() == ttPAYMENT &&
+                    candidate.isFlag(tfSponsorCreatedAccount) &&
+                    !view.exists(keylet::account(candidate.getAccountID(sfDestination)));
+            };
+
+            std::uint32_t sponsorReserveUnits = locksSponsorReserve(pfResult.tx) ? 1 : 0;
+            XRPAmount sponsorFeesAndSpend =
+                pfResult.consequences.fee() + pfResult.consequences.potentialSpend();
+            for (auto iter = txIter->first; iter != txIter->end; ++iter)
+            {
+                // Skip the queued entry the candidate is replacing
+                if (iter->first == txSeqProx)
+                    continue;
+                if (locksSponsorReserve(*iter->second.txn))
+                    ++sponsorReserveUnits;
+                sponsorFeesAndSpend += iter->second.consequences().fee() +
+                    iter->second.consequences().potentialSpend();
+            }
+
+            if (sponsorReserveUnits > 0)
+            {
+                // After paying every queued fee and explicit XRP spend, the
+                // source must still hold its full reserve floor, including the
+                // reserve units added by the queued sponsored account creations.
+                XRPAmount const requiredBalance = accountReserve(view, sleAccount, j) +
+                    (reserve * sponsorReserveUnits) + sponsorFeesAndSpend;
+                if (balance < requiredBalance)
+                {
+                    JLOG(j_.trace()) << "Ignoring transaction " << transactionID
+                                     << ". Insufficient balance to cover future sponsor reserve.";
+                    return {telCAN_NOT_QUEUE_BALANCE, false};
+                }
             }
 
             // Create the test view from the current view.


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
`Payment::makeTxConsequences()` models only a queued payment's fee and explicit
XRP spend. It does not model the future reserve liability a
`tfSponsorCreatedAccount` payment adds to the *source* account: creating a new
sponsored destination increments the sponsor's `sfSponsoringAccountCount`,
raising its own reserve floor by one base reserve.

As a result, a sponsor could queue several sequential sponsored account
creations that are each individually affordable but not collectively
reserve-safe. All were admitted as `terQUEUED`; once the earlier ones drained
and raised the reserve, the later ones failed at execution with
`tecUNFUNDED_PAYMENT`, burning their fee.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
