### PR TITLE
Sponsorship should be non-obligated for sponsee

### DIFF
--- a/include/xrpl/tx/transactors/sponsor/SponsorshipSet.h
+++ b/include/xrpl/tx/transactors/sponsor/SponsorshipSet.h
@@ -25,6 +25,9 @@ public:
     static TER
     preclaim(PreclaimContext const& ctx);
 
+    static TER
+    deleteSponsorship(ApplyView& view, SLE::ref sle, beast::Journal j);
+
     TER
     doApply() override;
 

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp
@@ -1,7 +1,10 @@
 #include <xrpl/tx/transactors/sponsor/SponsorshipSet.h>
 
+#include <xrpl/basics/Log.h>
+#include <xrpl/beast/utility/Journal.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/core/ServiceRegistry.h>
+#include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/ReadView.h>
 #include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DelegateHelpers.h>
@@ -176,6 +179,47 @@ SponsorshipSet::preclaim(PreclaimContext const& ctx)
 }
 
 TER
+SponsorshipSet::deleteSponsorship(ApplyView& view, SLE::ref sle, beast::Journal j)
+{
+    if (!sle)
+        return tecINTERNAL;  // LCOV_EXCL_LINE
+
+    auto const sponsorAccountID = (*sle)[sfOwner];
+    auto const sponseeAccountID = (*sle)[sfSponsee];
+
+    // The reserve for the Sponsorship object is held by the sponsor (Owner).
+    auto sponsorAccSle = view.peek(keylet::account(sponsorAccountID));
+    if (!sponsorAccSle)
+        return tecINTERNAL;  // LCOV_EXCL_LINE
+
+    if (!view.dirRemove(keylet::ownerDir(sponsorAccountID), (*sle)[sfOwnerNode], sle->key(), false))
+    {
+        // LCOV_EXCL_START
+        JLOG(j.fatal()) << "Unable to delete Sponsorship from sponsor.";
+        return tefBAD_LEDGER;
+        // LCOV_EXCL_STOP
+    }
+    if (!view.dirRemove(
+            keylet::ownerDir(sponseeAccountID), (*sle)[sfSponseeNode], sle->key(), false))
+    {
+        // LCOV_EXCL_START
+        JLOG(j.fatal()) << "Unable to delete Sponsorship from sponsee.";
+        return tefBAD_LEDGER;
+        // LCOV_EXCL_STOP
+    }
+
+    adjustOwnerCountObj(view, sponsorAccSle, sle, -1, j);
+
+    // transfer feeAmount back to the sponsor
+    if (sle->isFieldPresent(sfFeeAmount))
+        (*sponsorAccSle)[sfBalance] += sle->getFieldAmount(sfFeeAmount);
+
+    view.erase(sle);
+
+    return tesSUCCESS;
+}
+
+TER
 SponsorshipSet::doApply()
 {
     auto const sponsorAccountID = ctx_.tx[~sfCounterpartySponsor].value_or(accountID_);
@@ -200,29 +244,7 @@ SponsorshipSet::doApply()
         if (!sponsorObjSle)
             return tecINTERNAL;  // LCOV_EXCL_LINE
 
-        adjustOwnerCountObj(ctx_.view(), sponsorAccSle, sponsorObjSle, -1, ctx_.journal);
-
-        ctx_.view().dirRemove(
-            keylet::ownerDir(sponsorAccountID),
-            (*sponsorObjSle)[sfOwnerNode],
-            sponsorObjSle->key(),
-            false);
-        ctx_.view().dirRemove(
-            keylet::ownerDir(sponseeAccountID),
-            (*sponsorObjSle)[sfSponseeNode],
-            sponsorObjSle->key(),
-            false);
-
-        // transfer feeAmount from ledger entry
-        if (sponsorObjSle->isFieldPresent(sfFeeAmount))
-        {
-            auto const feeAmount = sponsorObjSle->getFieldAmount(sfFeeAmount);
-            (*sponsorAccSle)[sfBalance] += feeAmount;
-        }
-
-        ctx_.view().erase(sponsorObjSle);
-
-        return tesSUCCESS;
+        return deleteSponsorship(ctx_.view(), sponsorObjSle, ctx_.journal);
     }
 
     auto const feeAmount = ctx_.tx[~sfFeeAmount];

--- a/src/libxrpl/tx/transactors/account/AccountDelete.cpp
+++ b/src/libxrpl/tx/transactors/account/AccountDelete.cpp
@@ -30,6 +30,7 @@
 #include <xrpl/tx/transactors/did/DIDDelete.h>
 #include <xrpl/tx/transactors/oracle/OracleDelete.h>
 #include <xrpl/tx/transactors/payment/DepositPreauth.h>
+#include <xrpl/tx/transactors/sponsor/SponsorshipSet.h>
 
 #include <cstdint>
 #include <utility>
@@ -185,11 +186,23 @@ removeDelegateFromLedger(
     return DelegateSet::deleteDelegate(view, sleDel, j);
 }
 
-// Return nullptr if the LedgerEntryType represents an obligation that can't
-// be deleted.  Otherwise return the pointer to the function that can delete
-// the non-obligation
+TER
+removeSponsorshipFromLedger(
+    ServiceRegistry&,
+    ApplyView& view,
+    AccountID const&,
+    uint256 const&,
+    SLE::ref sleDel,
+    beast::Journal j)
+{
+    return SponsorshipSet::deleteSponsorship(view, sleDel, j);
+}
+
+// Return nullptr if the object represents an obligation that can't be deleted
+// during deletion of account.  Otherwise return the pointer to the function
+// that can delete the non-obligation.
 DeleterFuncPtr
-nonObligationDeleter(LedgerEntryType t)
+nonObligationDeleter(LedgerEntryType t, SLE::const_ref sleItem, AccountID const& account)
 {
     switch (t)
     {
@@ -211,6 +224,12 @@ nonObligationDeleter(LedgerEntryType t)
             return removeCredentialFromLedger;
         case ltDELEGATE:
             return removeDelegateFromLedger;
+        case ltSPONSORSHIP:
+            // A Sponsorship lives in both the sponsor's (Owner) and the
+            // sponsee's owner directories, but it is an obligation only for the
+            // sponsor, who holds its reserve. The sponsee must remain free to
+            // delete its account.
+            return (*sleItem)[sfOwner] == account ? nullptr : removeSponsorshipFromLedger;
         default:
             return nullptr;
     }
@@ -335,7 +354,7 @@ AccountDelete::preclaim(PreclaimContext const& ctx)
 
         LedgerEntryType const nodeType{safeCast<LedgerEntryType>((*sleItem)[sfLedgerEntryType])};
 
-        if (nonObligationDeleter(nodeType) == nullptr)
+        if (nonObligationDeleter(nodeType, sleItem, account) == nullptr)
             return tecHAS_OBLIGATIONS;
 
         // We found a deletable directory entry.  Count it.  If we find too
@@ -376,7 +395,7 @@ AccountDelete::doApply()
         [&](LedgerEntryType nodeType,
             uint256 const& dirEntry,
             SLE::pointer& sleItem) -> std::pair<TER, SkipEntry> {
-            if (auto deleter = nonObligationDeleter(nodeType))
+            if (auto deleter = nonObligationDeleter(nodeType, sleItem, accountID_))
             {
                 TER const result{deleter(ctx_.registry, view(), accountID_, dirEntry, sleItem, j_)};
 

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -5456,7 +5456,8 @@ public:
         Account const sponsor("sponsor");
 
         {
-            // Delete Sponsor/Sponsee Account with ltSponsorship (tecHAS_OBLIGATIONS)
+            // A Sponsorship object blocks deletion of the sponsor,
+            // but NOT of the sponsee.
             Env env{*this, testableAmendments()};
             env.fund(XRP(1000000), alice, bob, sponsor);
             env.close();
@@ -5467,20 +5468,35 @@ public:
                 Ter(tesSUCCESS));
             env.close();
 
-            incLgrSeqForAccDel(env, sponsor);
-
             auto const keylet = keylet::sponsor(sponsor, alice);
-            auto const sponsorObj = env.le(keylet);
-            BEAST_EXPECT(sponsorObj);
+            BEAST_EXPECT(env.le(keylet));
+            BEAST_EXPECT(ownerCount(env, sponsor) == 1);
+            BEAST_EXPECT(ownerCount(env, alice) == 0);
 
-            // AccountDelete
+            // sponsor's sequence is the higher one, so a single call readies
+            // both accounts for deletion
+            incLgrSeqForAccDel(env, sponsor);
             auto const requiredFee = drops(env.current()->fees().increment);
-            env(acctdelete(alice, bob), Fee(requiredFee), Ter(tecHAS_OBLIGATIONS));
+
+            // sponsor cannot be deleted while the Sponsorship exists
             env(acctdelete(sponsor, bob), Fee(requiredFee), Ter(tecHAS_OBLIGATIONS));
+            env.close();
+
+            // sponsee can be deleted
+            auto const sponsorBalBefore = env.balance(sponsor);
+            env(acctdelete(alice, bob), Fee(requiredFee), Ter(tesSUCCESS));
+            env.close();
+
+            BEAST_EXPECT(!env.le(keylet));
+            BEAST_EXPECT(!env.le(keylet::account(alice)));
+            BEAST_EXPECT(ownerCount(env, sponsor) == 0);
+
+            // FeeAmount is returned to the sponsor
+            BEAST_EXPECT(env.balance(sponsor) == sponsorBalBefore + XRP(100));
         }
 
         {
-            // Delete SponsoredAccount
+            // Deleting SponsoredAccount, whose account reserve is paid by a sponsor.
             Env env{*this, testableAmendments()};
             env.memoize(alice);
             env.fund(XRP(1000000), bob, sponsor);

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -5470,8 +5470,11 @@ public:
 
             auto const keylet = keylet::sponsor(sponsor, alice);
             BEAST_EXPECT(env.le(keylet));
+            // sponsor pays its own reserve here, so there is no SponsoredOwnerCount.
             BEAST_EXPECT(ownerCount(env, sponsor) == 1);
             BEAST_EXPECT(ownerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
 
             // sponsor's sequence is the higher one, so a single call readies
             // both accounts for deletion
@@ -5489,9 +5492,54 @@ public:
 
             BEAST_EXPECT(!env.le(keylet));
             BEAST_EXPECT(!env.le(keylet::account(alice)));
+            // deleting sponsee makes those counts zero.
             BEAST_EXPECT(ownerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
 
             // FeeAmount is returned to the sponsor
+            BEAST_EXPECT(env.balance(sponsor) == sponsorBalBefore + XRP(100));
+        }
+
+        {
+            // The SponsorshipSet transaction itself
+            // is sponsored by a 3rd counterparty. Test deleting sponsee.
+            Env env{*this, testableAmendments()};
+            Account const counterparty("counterparty");
+            env.fund(XRP(1000000), alice, bob, sponsor, counterparty);
+            env.close();
+
+            // sponsor creates a Sponsorship for alice; the SponsorshipSet tx is
+            // itself reserve-sponsored by counterparty, so the object's reserve is counterparty's.
+            env(sponsor::set(sponsor, 0, 100, XRP(100)),
+                sponsor::SponseeAcc(alice),
+                sponsor::As(counterparty, spfSponsorReserve),
+                Sig(sfSponsorSignature, counterparty),
+                Ter(tesSUCCESS));
+            env.close();
+
+            auto const keylet = keylet::sponsor(sponsor, alice);
+            auto const obj = env.le(keylet);
+            BEAST_EXPECT(obj);
+            BEAST_EXPECT(
+                obj->isFieldPresent(sfSponsor) &&
+                obj->getAccountID(sfSponsor) == counterparty.id());
+            // sponsor owns the object; its reserve is sponsored by counterparty.
+            BEAST_EXPECT(ownerCount(env, sponsor) == 1);
+            BEAST_EXPECT(sponsoredOwnerCount(env, sponsor) == 1);
+            BEAST_EXPECT(sponsoringOwnerCount(env, counterparty) == 1);
+
+            auto const sponsorBalBefore = env.balance(sponsor);
+            incLgrSeqForAccDel(env, alice);
+            auto const requiredFee = drops(env.current()->fees().increment);
+            env(acctdelete(alice, bob), Fee(requiredFee), Ter(tesSUCCESS));
+            env.close();
+
+            BEAST_EXPECT(!env.le(keylet));
+            // deleting sponsee makes those counts zero.
+            BEAST_EXPECT(ownerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, sponsor) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, counterparty) == 0);
             BEAST_EXPECT(env.balance(sponsor) == sponsorBalBefore + XRP(100));
         }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

A Sponsorship object lives in both the sponsor's (Owner) and the
sponsee's owner directories, but AccountDelete treated it as a deletion
blocker for both. It should be an obligation only for the sponsor, who
holds its reserve; for the sponsee it must be a non-obligation.
Otherwise anyone could block a sponsee's account deletion simply by
creating a Sponsorship.

related issue: https://github.com/XRPLF/rippled/issues/6892

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
