### PR TITLE
fix: Fix UBSan issue

### DIFF
--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -26,17 +26,14 @@
 
 namespace xrpl {
 
-namespace {
-
-auto const applyCountDelta = [](std::uint32_t current,
-                                std::int64_t delta) -> std::optional<std::uint32_t> {
+static std::optional<std::uint32_t>
+applyCountDelta(std::uint32_t current, std::int64_t delta)
+{
     std::int64_t const next = static_cast<std::int64_t>(current) + delta;
     if (next < 0 || next > std::numeric_limits<std::uint32_t>::max())
         return std::nullopt;
     return static_cast<std::uint32_t>(next);
-};
-
-}  // namespace
+}
 
 std::uint32_t
 SponsorshipTransfer::getFlagsMask(PreflightContext const& ctx)
@@ -375,7 +372,7 @@ SponsorshipTransfer::preclaim(PreclaimContext const& ctx)
     return tesSUCCESS;
 }
 
-TER
+static TER
 reduceReserveCount(
     ApplyView& view,
     AccountID const& account,

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -20,6 +20,7 @@
 
 #include <bit>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 
@@ -367,7 +368,7 @@ reduceReserveCount(
     ApplyView& view,
     AccountID const& account,
     AccountID const& sponsor,
-    int32_t delta)
+    int64_t delta)
 {
     if (delta == 0)
         return tesSUCCESS;
@@ -379,8 +380,8 @@ reduceReserveCount(
     if (!sponsorSle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    auto const reserveCount = sponsorSle->getFieldU32(sfReserveCount);
-    int32_t const afterReserveCount = reserveCount + delta;
+    int64_t const reserveCount = sponsorSle->getFieldU32(sfReserveCount);
+    int64_t const afterReserveCount = reserveCount + delta;
 
     if (afterReserveCount < 0)
     {
@@ -407,9 +408,9 @@ SponsorshipTransfer::doApply()
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
     auto const setSponsorFieldU32 = [](auto const& sle, auto const& field, auto const& delta) {
-        int32_t const newValue = static_cast<int32_t>(sle->getFieldU32(field)) + delta;
+        int64_t const newValue = sle->getFieldU32(field) + delta;
 
-        if (newValue < 0)
+        if (newValue < 0 || newValue > std::numeric_limits<std::uint32_t>::max())
         {
             UNREACHABLE("xrpl::SponsorshipTransfer::doApply : Invalid sponsor field value");
             return;
@@ -435,7 +436,7 @@ SponsorshipTransfer::doApply()
         if (!ownerSle)
             return tefINTERNAL;  // LCOV_EXCL_LINE
 
-        auto const ownerCountDelta = getLedgerEntryOwnerCount(objSle);
+        std::int64_t const ownerCountDelta = getLedgerEntryOwnerCount(objSle);
 
         auto const& sponsorField = getLedgerEntrySponsorField(objSle, *ownerAccountID);
 

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -408,7 +408,7 @@ SponsorshipTransfer::doApply()
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
     auto const setSponsorFieldU32 = [](auto const& sle, auto const& field, auto const& delta) {
-        int64_t const newValue = sle->getFieldU32(field) + delta;
+        int64_t const newValue = static_cast<int64_t>(sle->getFieldU32(field)) + delta;
 
         if (newValue < 0 || newValue > std::numeric_limits<std::uint32_t>::max())
         {

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -26,6 +26,18 @@
 
 namespace xrpl {
 
+namespace {
+
+auto const applyCountDelta = [](std::uint32_t current,
+                                std::int64_t delta) -> std::optional<std::uint32_t> {
+    std::int64_t const next = static_cast<std::int64_t>(current) + delta;
+    if (next < 0 || next > std::numeric_limits<std::uint32_t>::max())
+        return std::nullopt;
+    return static_cast<std::uint32_t>(next);
+};
+
+}  // namespace
+
 std::uint32_t
 SponsorshipTransfer::getFlagsMask(PreflightContext const& ctx)
 {
@@ -380,16 +392,15 @@ reduceReserveCount(
     if (!sponsorSle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    int64_t const reserveCount = sponsorSle->getFieldU32(sfReserveCount);
-    int64_t const afterReserveCount = reserveCount + delta;
-
-    if (afterReserveCount < 0)
+    auto const afterReserveCount = applyCountDelta(sponsorSle->getFieldU32(sfReserveCount), delta);
+    if (!afterReserveCount)
     {
         // already checked in preclaim()
+        UNREACHABLE("xrpl::reduceReserveCount : invalid reserve count");
         return tefINTERNAL;  // LCOV_EXCL_LINE
     }
 
-    sponsorSle->at(sfReserveCount) = static_cast<unsigned>(afterReserveCount);
+    sponsorSle->at(sfReserveCount) = *afterReserveCount;
     view.update(sponsorSle);
     return tesSUCCESS;
 }
@@ -409,15 +420,14 @@ SponsorshipTransfer::doApply()
 
     auto const setSponsorFieldU32 =
         [] [[nodiscard]] (auto const& sle, auto const& field, auto const& delta) -> TER {
-        int64_t const newValue = static_cast<int64_t>(sle->getFieldU32(field)) + delta;
-
-        if (newValue < 0 || newValue > std::numeric_limits<std::uint32_t>::max())
+        auto const newValue = applyCountDelta(sle->getFieldU32(field), delta);
+        if (!newValue)
         {
             UNREACHABLE("xrpl::SponsorshipTransfer::doApply : Invalid sponsor field value");
             return tecINTERNAL;  // LCOV_EXCL_LINE
         }
 
-        sle->at(field) = static_cast<std::uint32_t>(newValue);
+        sle->at(field) = *newValue;
         return tesSUCCESS;
     };
 

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -407,16 +407,18 @@ SponsorshipTransfer::doApply()
     if (!sponseeSle)
         return tefINTERNAL;  // LCOV_EXCL_LINE
 
-    auto const setSponsorFieldU32 = [](auto const& sle, auto const& field, auto const& delta) {
+    auto const setSponsorFieldU32 =
+        [] [[nodiscard]] (auto const& sle, auto const& field, auto const& delta) -> TER {
         int64_t const newValue = static_cast<int64_t>(sle->getFieldU32(field)) + delta;
 
         if (newValue < 0 || newValue > std::numeric_limits<std::uint32_t>::max())
         {
             UNREACHABLE("xrpl::SponsorshipTransfer::doApply : Invalid sponsor field value");
-            return;
+            return tecINTERNAL;  // LCOV_EXCL_LINE
         }
 
         sle->at(field) = static_cast<std::uint32_t>(newValue);
+        return tesSUCCESS;
     };
 
     if (isObjectSponsor)
@@ -446,14 +448,20 @@ SponsorshipTransfer::doApply()
             XRPL_ASSERT(!!newSponsorAccountID, "New sponsor is required when creating sponsorship");
 
             // update owner's sponsored count
-            setSponsorFieldU32(ownerSle, sfSponsoredOwnerCount, ownerCountDelta);
+            if (auto const ter =
+                    setSponsorFieldU32(ownerSle, sfSponsoredOwnerCount, ownerCountDelta);
+                !isTesSuccess(ter))
+                return ter;
             view().update(ownerSle);
 
             // increment new sponsor's sponsoring count
             auto const newSponsorSle = view().peek(keylet::account(newSponsorAccountID));
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(newSponsorSle, sfSponsoringOwnerCount, ownerCountDelta);
+            if (auto const ter =
+                    setSponsorFieldU32(newSponsorSle, sfSponsoringOwnerCount, ownerCountDelta);
+                !isTesSuccess(ter))
+                return ter;
             view().update(newSponsorSle);
 
             // set new sponsor to object
@@ -483,14 +491,20 @@ SponsorshipTransfer::doApply()
             auto const oldSponsorSle = view().peek(keylet::account(oldSponsorAccountID));
             if (!oldSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(oldSponsorSle, sfSponsoringOwnerCount, -ownerCountDelta);
+            if (auto const ter =
+                    setSponsorFieldU32(oldSponsorSle, sfSponsoringOwnerCount, -ownerCountDelta);
+                !isTesSuccess(ter))
+                return ter;
             view().update(oldSponsorSle);
 
             // increment new sponsor's sponsoring count
             auto const newSponsorSle = view().peek(keylet::account(newSponsorAccountID));
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(newSponsorSle, sfSponsoringOwnerCount, ownerCountDelta);
+            if (auto const ter =
+                    setSponsorFieldU32(newSponsorSle, sfSponsoringOwnerCount, ownerCountDelta);
+                !isTesSuccess(ter))
+                return ter;
             view().update(newSponsorSle);
 
             // set new sponsor to object
@@ -516,11 +530,17 @@ SponsorshipTransfer::doApply()
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
             // decrement sponsored count
-            setSponsorFieldU32(sponseeSle, sfSponsoredOwnerCount, -ownerCountDelta);
+            if (auto const ter =
+                    setSponsorFieldU32(sponseeSle, sfSponsoredOwnerCount, -ownerCountDelta);
+                !isTesSuccess(ter))
+                return ter;
             view().update(sponseeSle);
 
             // decrement old sponsoring count
-            setSponsorFieldU32(oldSponsorSle, sfSponsoringOwnerCount, -ownerCountDelta);
+            if (auto const ter =
+                    setSponsorFieldU32(oldSponsorSle, sfSponsoringOwnerCount, -ownerCountDelta);
+                !isTesSuccess(ter))
+                return ter;
             view().update(oldSponsorSle);
 
             // remove sponsor from object
@@ -538,7 +558,9 @@ SponsorshipTransfer::doApply()
             auto const newSponsorSle = view().peek(keylet::account(newSponsorAccountID));
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(newSponsorSle, sfSponsoringAccountCount, 1);
+            if (auto const ter = setSponsorFieldU32(newSponsorSle, sfSponsoringAccountCount, 1);
+                !isTesSuccess(ter))
+                return ter;
             view().update(newSponsorSle);
 
             // set new sponsor to account
@@ -553,7 +575,9 @@ SponsorshipTransfer::doApply()
             auto const newSponsorSle = view().peek(keylet::account(newSponsorAccountID));
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(newSponsorSle, sfSponsoringAccountCount, 1);
+            if (auto const ter = setSponsorFieldU32(newSponsorSle, sfSponsoringAccountCount, 1);
+                !isTesSuccess(ter))
+                return ter;
             view().update(newSponsorSle);
 
             // decrement old sponsoring count
@@ -561,7 +585,9 @@ SponsorshipTransfer::doApply()
             auto const oldSponsorSle = view().peek(keylet::account(oldSponsor));
             if (!oldSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(oldSponsorSle, sfSponsoringAccountCount, -1);
+            if (auto const ter = setSponsorFieldU32(oldSponsorSle, sfSponsoringAccountCount, -1);
+                !isTesSuccess(ter))
+                return ter;
             view().update(oldSponsorSle);
 
             // set new sponsor to account
@@ -579,7 +605,9 @@ SponsorshipTransfer::doApply()
             auto const oldSponsorSle = view().peek(keylet::account(oldSponsorAccountID));
             if (!oldSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
-            setSponsorFieldU32(oldSponsorSle, sfSponsoringAccountCount, -1);
+            if (auto const ter = setSponsorFieldU32(oldSponsorSle, sfSponsoringAccountCount, -1);
+                !isTesSuccess(ter))
+                return ter;
             view().update(oldSponsorSle);
         }
     }


### PR DESCRIPTION
## High Level Overview of Change

This PR is a quick fix that fixes the UBSan crashes in tests.

### Context of Change

```
/__w/rippled/rippled/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp:485:71: runtime error: negation of 1 cannot be represented in type 'std::uint32_t' (aka 'unsigned int')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /__w/rippled/rippled/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp:485:71
```

### API Impact

N/A