### PR TITLE
fix(mpt): Block delegate mutation in MPTokenIssuanceSet when no granular permission exists

### DIFF
--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceSet.cpp
@@ -168,6 +168,10 @@ MPTokenIssuanceSet::checkPermission(ReadView const& view, STTx const& tx)
     if (tx.isFlag(tfMPTUnlock) && !granularPermissions.contains(MPTokenIssuanceUnlock))
         return terNO_DELEGATE_PERMISSION;
 
+    if (tx.isFieldPresent(sfMutableFlags) || tx.isFieldPresent(sfMPTokenMetadata) ||
+        tx[~sfTransferFee] || tx.isFieldPresent(sfDomainID))
+        return terNO_DELEGATE_PERMISSION;
+
     return tesSUCCESS;
 }
 


### PR DESCRIPTION
## High Level Overview of Change

Fixes a privilege escalation in `MPTokenIssuanceSet::checkPermission()` where any delegate could perform DynamicMPT mutation operations (modify `sfMutableFlags`, `sfMPTokenMetadata`, `sfTransferFee`, `sfDomainID`) without proper authorization.

Closes #7559

### Context of Change

`checkPermission()` only validates granular delegate permissions for `tfMPTLock` and `tfMPTUnlock` flags. When `featureDynamicMPT` is enabled, the transaction can also carry mutation fields, but these are not checked in the granular permission path. A delegate with any permission can submit a mutation-only transaction (no Lock/Unlock flags) and it falls through to `return tesSUCCESS`, bypassing authorization.

**Mitigating factor:** `featureDynamicMPT` is currently `Supported::No` and is not enabled on mainnet.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### The Fix

Before the final `return tesSUCCESS` in `checkPermission()`, reject delegate transactions that carry any mutation field (`sfMutableFlags`, `sfMPTokenMetadata`, `sfTransferFee`, `sfDomainID`) with `terNO_DELEGATE_PERMISSION`. This blocks mutation operations for delegates until dedicated granular permissions are introduced.

The existing `checkTxPermission()` path (full transaction-level permission) is unaffected -- issuers who explicitly grant `ttMPTOKEN_ISSUANCE_SET` to a delegate still allow all operations.

```cpp
if (tx.isFieldPresent(sfMutableFlags) || tx.isFieldPresent(sfMPTokenMetadata) ||
    tx[~sfTransferFee] || tx.isFieldPresent(sfDomainID))
    return terNO_DELEGATE_PERMISSION;
```