### PR TITLE
fix: Ensure xrpld service directories exist at startup

### DIFF
--- a/package/shared/xrpld.service
+++ b/package/shared/xrpld.service
@@ -18,7 +18,10 @@ PrivateTmp=true
 User=xrpld
 Group=xrpld
 StateDirectory=xrpld
+StateDirectoryMode=0750
 LogsDirectory=xrpld
+LogsDirectoryMode=0750
+UMask=0027
 LimitNOFILE=65536
 
 [Install]

--- a/package/shared/xrpld.service
+++ b/package/shared/xrpld.service
@@ -21,7 +21,6 @@ StateDirectory=xrpld
 StateDirectoryMode=0750
 LogsDirectory=xrpld
 LogsDirectoryMode=0750
-UMask=0027
 LimitNOFILE=65536
 
 [Install]

--- a/package/shared/xrpld.service
+++ b/package/shared/xrpld.service
@@ -17,6 +17,8 @@ ProtectHome=true
 PrivateTmp=true
 User=xrpld
 Group=xrpld
+StateDirectory=xrpld
+LogsDirectory=xrpld
 LimitNOFILE=65536
 
 [Install]


### PR DESCRIPTION
The package tmpfiles config creates `/var/lib/xrpld` and `/var/log/xrpld` during install, but those directories can still be removed or damaged afterward. When that happens, xrpld fails later with less helpful path creation errors, such as permission denied while opening the log path.

Have systemd create the default state and log directories whenever the service starts. This keeps the packaged defaults self-healing. Operators who configure custom paths are unaffected and the default directories will be unused and is harmless.
