### PR TITLE
feat: Add inner object formats to server_definitions

### DIFF
--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -343,6 +343,7 @@ JSS(LEDGER_ENTRY_TYPES);          // out: RPC server_definitions
                                   // matches definitions.json format
 JSS(LEDGER_ENTRY_FLAGS);          // out: RPC server_definitions
 JSS(LEDGER_ENTRY_FORMATS);        // out: RPC server_definitions
+JSS(INNER_OBJECT_FORMATS);        // out: RPC server_definitions
 JSS(levels);                      // LogLevels
 JSS(limit);                       // in/out: AccountTx*, AccountOffers, AccountLines, AccountObjects
                                   // in: LedgerData, BookOffers

--- a/src/libxrpl/protocol/InnerObjectFormats.cpp
+++ b/src/libxrpl/protocol/InnerObjectFormats.cpp
@@ -202,18 +202,6 @@ InnerObjectFormats::InnerObjectFormats()
             {sfHookParameters, SoeOptional},
             {sfHookGrants, SoeOptional},
         });
-
-    add(sfRawTransaction.jsonName,
-        sfRawTransaction.getCode(),
-        {
-            {sfTransactionType, SoeRequired},
-            {sfAccount, SoeRequired},
-            {sfAmount, SoeOptional},
-            {sfDestination, SoeOptional},
-            {sfSequence, SoeRequired},
-            {sfSigningPubKey, SoeRequired},
-            {sfTxnSignature, SoeOptional},
-        });
 }
 
 InnerObjectFormats const&

--- a/src/libxrpl/protocol/InnerObjectFormats.cpp
+++ b/src/libxrpl/protocol/InnerObjectFormats.cpp
@@ -160,6 +160,60 @@ InnerObjectFormats::InnerObjectFormats()
             {sfTxnSignature, SoeOptional},
             {sfSigners, SoeOptional},
         });
+
+    add(sfMemo.jsonName,
+        sfMemo.getCode(),
+        {
+            {sfMemoType, SoeOptional},
+            {sfMemoData, SoeOptional},
+            {sfMemoFormat, SoeOptional},
+        });
+
+    add(sfHookParameter.jsonName,
+        sfHookParameter.getCode(),
+        {
+            {sfHookParameterName, SoeRequired},
+            {sfHookParameterValue, SoeRequired},
+        });
+
+    add(sfHookGrant.jsonName,
+        sfHookGrant.getCode(),
+        {
+            {sfHookHash, SoeOptional},
+            {sfAuthorize, SoeOptional},
+        });
+
+    add(sfHook.jsonName,
+        sfHook.getCode(),
+        {
+            {sfHookGrants, SoeOptional},
+            {sfHookParameters, SoeOptional},
+            {sfHookDefinition, SoeOptional},
+        });
+
+    add(sfHookDefinition.jsonName,
+        sfHookDefinition.getCode(),
+        {
+            {sfHookOn, SoeOptional},
+            {sfHookNamespace, SoeOptional},
+            {sfHookApiVersion, SoeOptional},
+            {sfCreateCode, SoeOptional},
+            {sfFee, SoeOptional},
+            {sfHookParameters, SoeOptional},
+            {sfHookGrants, SoeOptional},
+        });
+
+    add(sfRawTransaction.jsonName,
+        sfRawTransaction.getCode(),
+        {
+            {sfTransactionType, SoeRequired},
+            {sfAccount, SoeRequired},
+            {sfAmount, SoeOptional},
+            {sfDestination, SoeOptional},
+            {sfSequence, SoeRequired},
+            {sfSigningPubKey, SoeRequired},
+            {sfTxnSignature, SoeOptional},
+        });
 }
 
 InnerObjectFormats const&

--- a/src/libxrpl/protocol/InnerObjectFormats.cpp
+++ b/src/libxrpl/protocol/InnerObjectFormats.cpp
@@ -161,14 +161,6 @@ InnerObjectFormats::InnerObjectFormats()
             {sfSigners, SoeOptional},
         });
 
-    add(sfMemo.jsonName,
-        sfMemo.getCode(),
-        {
-            {sfMemoType, SoeOptional},
-            {sfMemoData, SoeOptional},
-            {sfMemoFormat, SoeOptional},
-        });
-
     add(sfHookParameter.jsonName,
         sfHookParameter.getCode(),
         {

--- a/src/test/rpc/ServerDefinitions_test.cpp
+++ b/src/test/rpc/ServerDefinitions_test.cpp
@@ -375,21 +375,6 @@ public:
                 BEAST_EXPECT(result[jss::result].isMember(jss::INNER_OBJECT_FORMATS));
                 json::Value const& innerFormats = result[jss::result][jss::INNER_OBJECT_FORMATS];
 
-                // test the fields of the Memo inner object
-                {
-                    BEAST_EXPECT(innerFormats.isMember("Memo"));
-                    json::Value const& section = innerFormats["Memo"];
-
-                    BEAST_EXPECT(section[0u][jss::name] == "MemoType");
-                    BEAST_EXPECT(section[0u][jss::optionality] == SoeOptional);
-
-                    BEAST_EXPECT(section[1u][jss::name] == "MemoData");
-                    BEAST_EXPECT(section[1u][jss::optionality] == SoeOptional);
-
-                    BEAST_EXPECT(section[2u][jss::name] == "MemoFormat");
-                    BEAST_EXPECT(section[2u][jss::optionality] == SoeOptional);
-                }
-
                 // test the fields of the SignerEntry inner object
                 {
                     BEAST_EXPECT(innerFormats.isMember("SignerEntry"));

--- a/src/test/rpc/ServerDefinitions_test.cpp
+++ b/src/test/rpc/ServerDefinitions_test.cpp
@@ -33,6 +33,7 @@ public:
             BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_RESULTS));
             BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_TYPES));
             BEAST_EXPECT(result[jss::result].isMember(jss::TYPES));
+            BEAST_EXPECT(result[jss::result].isMember(jss::INNER_OBJECT_FORMATS));
             BEAST_EXPECT(result[jss::result].isMember(jss::hash));
 
             // test a random element of each result
@@ -369,6 +370,54 @@ public:
                 }
             }
 
+            // test the properties of the INNER_OBJECT_FORMATS section
+            {
+                BEAST_EXPECT(result[jss::result].isMember(jss::INNER_OBJECT_FORMATS));
+                json::Value const& innerFormats = result[jss::result][jss::INNER_OBJECT_FORMATS];
+
+                // test the fields of the Memo inner object
+                {
+                    BEAST_EXPECT(innerFormats.isMember("Memo"));
+                    json::Value const& section = innerFormats["Memo"];
+
+                    BEAST_EXPECT(section[0u][jss::name] == "MemoType");
+                    BEAST_EXPECT(section[0u][jss::optionality] == SoeOptional);
+
+                    BEAST_EXPECT(section[1u][jss::name] == "MemoData");
+                    BEAST_EXPECT(section[1u][jss::optionality] == SoeOptional);
+
+                    BEAST_EXPECT(section[2u][jss::name] == "MemoFormat");
+                    BEAST_EXPECT(section[2u][jss::optionality] == SoeOptional);
+                }
+
+                // test the fields of the SignerEntry inner object
+                {
+                    BEAST_EXPECT(innerFormats.isMember("SignerEntry"));
+                    json::Value const& section = innerFormats["SignerEntry"];
+
+                    BEAST_EXPECT(section[0u][jss::name] == "Account");
+                    BEAST_EXPECT(section[0u][jss::optionality] == SoeRequired);
+
+                    BEAST_EXPECT(section[1u][jss::name] == "SignerWeight");
+                    BEAST_EXPECT(section[1u][jss::optionality] == SoeRequired);
+
+                    BEAST_EXPECT(section[2u][jss::name] == "WalletLocator");
+                    BEAST_EXPECT(section[2u][jss::optionality] == SoeOptional);
+                }
+
+                // test the fields of the HookParameter inner object
+                {
+                    BEAST_EXPECT(innerFormats.isMember("HookParameter"));
+                    json::Value const& section = innerFormats["HookParameter"];
+
+                    BEAST_EXPECT(section[0u][jss::name] == "HookParameterName");
+                    BEAST_EXPECT(section[0u][jss::optionality] == SoeRequired);
+
+                    BEAST_EXPECT(section[1u][jss::name] == "HookParameterValue");
+                    BEAST_EXPECT(section[1u][jss::optionality] == SoeRequired);
+                }
+            }
+
             // Exhaustive test: verify all transaction flags from getAllTxFlags() appear in the
             // output
             {
@@ -442,6 +491,7 @@ public:
                 BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_ENTRY_TYPES));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_ENTRY_FLAGS));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_ENTRY_FORMATS));
+                BEAST_EXPECT(!result[jss::result].isMember(jss::INNER_OBJECT_FORMATS));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::TRANSACTION_RESULTS));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::TRANSACTION_TYPES));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::TRANSACTION_FLAGS));
@@ -465,6 +515,7 @@ public:
                 BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_TYPES));
                 BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_FLAGS));
                 BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_FORMATS));
+                BEAST_EXPECT(result[jss::result].isMember(jss::INNER_OBJECT_FORMATS));
                 BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_RESULTS));
                 BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_TYPES));
                 BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_FLAGS));
@@ -484,6 +535,7 @@ public:
         for (auto const& field :
              {jss::ACCOUNT_SET_FLAGS,
               jss::FIELDS,
+              jss::INNER_OBJECT_FORMATS,
               jss::LEDGER_ENTRY_FLAGS,
               jss::LEDGER_ENTRY_FORMATS,
               jss::LEDGER_ENTRY_TYPES,

--- a/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp
+++ b/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp
@@ -6,6 +6,7 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/json_writer.h>
 #include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/InnerObjectFormats.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/TER.h>
@@ -256,7 +257,6 @@ ServerDefinitions::ServerDefinitions() : defs_{json::ValueType::Object}
         defs_[jss::FIELDS][i++] = innerArray;
     }
 
-    // populate TER code names and values
     defs_[jss::TRANSACTION_RESULTS] = json::ValueType::Object;
 
     for (auto const& [code, terInfo] : transResults())
@@ -264,7 +264,6 @@ ServerDefinitions::ServerDefinitions() : defs_{json::ValueType::Object}
         defs_[jss::TRANSACTION_RESULTS][terInfo.first] = code;
     }
 
-    // populate TxType names and values
     defs_[jss::TRANSACTION_TYPES] = json::ValueType::Object;
     defs_[jss::TRANSACTION_TYPES][jss::Invalid] = -1;
     for (auto const& f : TxFormats::getInstance())
@@ -272,7 +271,6 @@ ServerDefinitions::ServerDefinitions() : defs_{json::ValueType::Object}
         defs_[jss::TRANSACTION_TYPES][f.getName()] = f.getType();
     }
 
-    // populate TxFormats
     defs_[jss::TRANSACTION_FORMATS] = json::ValueType::Object;
 
     defs_[jss::TRANSACTION_FORMATS][jss::common] = json::ValueType::Array;
@@ -302,7 +300,6 @@ ServerDefinitions::ServerDefinitions() : defs_{json::ValueType::Object}
         defs_[jss::TRANSACTION_FORMATS][format.getName()] = templateArray;
     }
 
-    // populate LedgerFormats
     defs_[jss::LEDGER_ENTRY_FORMATS] = json::ValueType::Object;
     defs_[jss::LEDGER_ENTRY_FORMATS][jss::common] = json::ValueType::Array;
     auto ledgerCommonFields = std::set<std::string>();
@@ -328,6 +325,21 @@ ServerDefinitions::ServerDefinitions() : defs_{json::ValueType::Object}
             templateArray.append(elementObj);
         }
         defs_[jss::LEDGER_ENTRY_FORMATS][format.getName()] = templateArray;
+    }
+
+    defs_[jss::INNER_OBJECT_FORMATS] = json::ValueType::Object;
+    for (auto const& format : InnerObjectFormats::getInstance())
+    {
+        auto const& soTemplate = format.getSOTemplate();
+        json::Value templateArray = json::ValueType::Array;
+        for (auto const& element : soTemplate)
+        {
+            json::Value elementObj = json::ValueType::Object;
+            elementObj[jss::name] = element.sField().getName();
+            elementObj[jss::optionality] = element.style();
+            templateArray.append(elementObj);
+        }
+        defs_[jss::INNER_OBJECT_FORMATS][format.getName()] = templateArray;
     }
 
     defs_[jss::TRANSACTION_FLAGS] = json::ValueType::Object;


### PR DESCRIPTION
## High Level Overview of Change

This PR adds most of what is requested in https://github.com/XRPLF/rippled/pull/6321#issuecomment-4561620695

Hi @donovanhide , here are some details about the changes:

Not implementable in this codebase - SFields don't exist:**
- `ActiveValidator`
- `CredentialSubject`
- `CredentialAttestation`

**XChain objects - key name mismatch:**
The list in the comment uses `XChainClaimAttestation` and `XChainCreateAccountAttestation`, but in rippled these SFields are named `XChainClaimAttestationCollectionElement` and `XChainCreateAccountAttestationCollectionElement` - so that's what appears as the key in the output. Their field lists also differ slightly: `XChainBridge` is not part of the inner object template, and what was called `OtherChainSource` maps to the `Account` SField in the C++ code. 
Pleas let me know if a different SField was intended.

**`HookGrant` - one field name mismatch:**
The list has `HookAuthorize`, but the SField in the codebase is `Authorize` (`sfAuthorize`). There is no `sfHookAuthorize`. The output will show `Authorize`. Let me know if that's ok.

**`Memo` - can't be easily restricted because of the legacy `Flags` field**

**`RawTransaction` - should not be restricted in general and so should not appear as part of inner objects**

Also, all hook stuff is not actually supported by `xrpld` so i'm not sure it should be in `server_definitions` either.

### API Impact

Changes are additive so it should not be breaking anyone's code. Having that said:

- [x] Public API: New feature (new methods and/or new fields)
