### PR TITLE
fix: sponsorshipSet self-inflicted reserve lock fix

### DIFF
--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp
@@ -220,6 +220,18 @@ deleteSponsorship(ApplyView& view, SLE::ref sle, beast::Journal j)
     return tesSUCCESS;
 }
 
+static TER
+checkOwnReserveFloor(ReadView const& view, SLE::const_ref accountSle, beast::Journal j)
+{
+    STAmount const balance = accountSle->getFieldAmount(sfBalance);
+    STAmount const reserve = accountReserve(view, accountSle, j);
+
+    if (balance < reserve)
+        return tecINSUFFICIENT_RESERVE;
+
+    return tesSUCCESS;
+}
+
 TER
 SponsorshipSet::doApply()
 {
@@ -270,6 +282,10 @@ SponsorshipSet::doApply()
         {
             (*sponsorAccSle)[sfBalance] -= *feeAmount;
             (*newSle)[sfFeeAmount] = *feeAmount;
+
+            if (auto const ret = checkOwnReserveFloor(ctx_.view(), sponsorAccSle, ctx_.journal);
+                !isTesSuccess(ret))
+                return tecUNFUNDED;
         }
 
         if (auto const ret = checkInsufficientReserve(
@@ -339,6 +355,13 @@ SponsorshipSet::doApply()
             else
             {
                 (*sponsorObjSle).setFieldAmount(sfFeeAmount, *feeAmount);
+            }
+
+            if (feeAmountDelta > beast::kZero)
+            {
+                if (auto const ret = checkOwnReserveFloor(ctx_.view(), sponsorAccSle, ctx_.journal);
+                    !isTesSuccess(ret))
+                    return tecUNFUNDED;
             }
 
             if (auto const ret = checkInsufficientReserve(

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -336,6 +336,37 @@ public:
     }
 
     void
+    testSponsorshipSetFeeAmountReserveFloor()
+    {
+        testcase("SponsorshipSet FeeAmount keeps grantor reserve floor");
+        using namespace test::jtx;
+
+        Env env{*this, testableAmendments()};
+        Account const outer("outer");
+        Account const grantor("grantor");
+        Account const sponsee("sponsee");
+        env.fund(XRP(10000), outer, grantor, sponsee);
+        env.close();
+
+        env(sponsor::set(outer, 0, 1, XRP(1)), sponsor::SponseeAcc(grantor));
+        env.close();
+
+        auto const feeAmount = XRP(5);
+        auto const grantorBalance = accountReserve(env, 1) + feeAmount - drops(1);
+        adjustAccountXRPBalance(env, grantor, grantorBalance);
+
+        env(sponsor::set_fee(grantor, 0, feeAmount),
+            sponsor::SponseeAcc(sponsee),
+            sponsor::As(outer, spfSponsorReserve | spfSponsorFee),
+            Sig(sfSponsorSignature, outer),
+            Ter(tecUNFUNDED));
+        env.close();
+
+        BEAST_EXPECT(!env.le(keylet::sponsorship(grantor, sponsee)));
+        BEAST_EXPECT(env.balance(grantor) == grantorBalance);
+    }
+
+    void
     testPseudoAccountSponsorship()
     {
         testcase("Pseudo account sponsorship");
@@ -5043,10 +5074,10 @@ public:
                     sponsor::As(sponsor, spfSponsorReserve));
                 env.close();
 
-                auto const sponsorshipSle = env.le(keylet::sponsor(sponsor, alice));
+                auto const sponsorshipSle = env.le(keylet::sponsorship(sponsor, alice));
                 if (!BEAST_EXPECT(sponsorshipSle))
                     return;
-                BEAST_EXPECT(sponsorshipSle->getFieldU32(sfReserveCount) == 0);
+                BEAST_EXPECT(sponsorshipSle->getFieldU32(sfRemainingOwnerCount) == 0);
             }
 
             BEAST_EXPECT(env.le(vaultKeylet)->getAccountID(sfSponsor) == sponsor.id());
@@ -6080,6 +6111,7 @@ protected:
     {
         testDisabled();
         testInvalidSponsorshipSet();
+        testSponsorshipSetFeeAmountReserveFloor();
         testPseudoAccountSponsorship();
 
         testSingleSigning();


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
The missing post-deduction reserve-floor validation for the grantor in SponsorshipSet::doApply will cause a reserve-lock for the grantor as a transaction that uses an outer reserve sponsor will successfully create a sponsorship object after deducting sfFeeAmount from the grantor even when that deduction leaves the grantor strictly below their own required reserve.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
