### PR TITLE
refactor: Clean up reserve calculation functions in `AccountRootHelpers`

### DIFF
--- a/include/xrpl/ledger/helpers/AccountRootHelpers.h
+++ b/include/xrpl/ledger/helpers/AccountRootHelpers.h
@@ -33,33 +33,56 @@ isGlobalFrozen(ReadView const& view, AccountID const& issuer);
 [[nodiscard]] XRPAmount
 xrpLiquid(ReadView const& view, AccountID const& id, std::int32_t ownerCountAdj, beast::Journal j);
 
-/** Returns the account reserve, in drops.
-    Actual owner count can be adjusted by delta in ownerCountAdj
-    The reserve is calculated as
-       (ownerCount + "sponsoring object count" - "sponsored object count" + additionalOwnerCount) *
-   increment + (1 if not sponsored account + sponsoringAccountCount) * "reserve base"
+/*  Calculates the number of objects that the account is responsible for reserve-wise
+    sfOwnerCount - sfSponsoredOwnerCount + sfSponsoringOwnerCount
 */
-[[nodiscard]] XRPAmount
-accountReserve(
-    ReadView const& view,
-    SLE::const_ref sle,
-    beast::Journal j,
-    std::int32_t ownerCountAdj = 0,
-    std::int32_t reserveCountAdj = 0);
-
-[[nodiscard]] inline XRPAmount
-accountReserve(
-    ReadView const& view,
-    AccountID const& id,
-    beast::Journal j,
-    std::int32_t ownerCountAdj = 0,
-    std::int32_t reserveCountAdj = 0)
+inline std::uint32_t
+objectOwnerCount(SLE::const_pointer accountSle, std::int32_t delta = 0)
 {
-    return accountReserve(view, view.read(keylet::account(id)), j, ownerCountAdj, reserveCountAdj);
+    XRPL_ASSERT(
+        accountSle && accountSle->getType() == ltACCOUNT_ROOT,
+        "xrpl::objectOwnerCount : valid account sle");
+    return accountSle->at(sfOwnerCount) - accountSle->at(sfSponsoredOwnerCount) +
+        accountSle->at(sfSponsoringOwnerCount) + delta;
 }
 
-XRPAmount
-baseAccountReserve(ReadView const& view, std::int32_t ownerCount);
+/*  Calculates the number of accounts that the account is responsible for reserve-wise
+    (accountIsSponsored ? 0 : 1) + sfSponsoringAccountCount
+*/
+inline std::uint32_t
+accountOwnerCount(SLE::const_pointer accountSle, std::int32_t delta = 0)
+{
+    XRPL_ASSERT(
+        accountSle && accountSle->getType() == ltACCOUNT_ROOT,
+        "xrpl::accountOwnerCount : valid account sle");
+    return (accountSle->isFieldPresent(sfSponsor) ? 0 : 1) +
+        accountSle->getFieldU32(sfSponsoringAccountCount) + delta;
+}
+
+/*  Calculates the total reserve, in XRP, that the account is currently responsible for
+ */
+inline XRPAmount
+totalAccountReserve(
+    ReadView const& view,
+    SLE::const_pointer accountSle,
+    std::int32_t objectDelta = 0,
+    std::int32_t accountDelta = 0)
+{
+    auto const& fees = view.fees();
+    return (fees.reserve * accountOwnerCount(accountSle, accountDelta)) +
+        (fees.increment * objectOwnerCount(accountSle, objectDelta));
+}
+
+[[nodiscard]] inline XRPAmount
+totalAccountReserve(
+    ReadView const& view,
+    AccountID const& id,
+    std::int32_t ownerCountDelta = 0,
+    std::int32_t accountCountDelta = 0)
+{
+    return totalAccountReserve(
+        view, view.read(keylet::account(id)), ownerCountDelta, accountCountDelta);
+}
 
 [[nodiscard]] TER
 checkInsufficientReserve(
@@ -72,19 +95,12 @@ checkInsufficientReserve(
     std::int32_t reserveCountDelta = 0,
     beast::Journal j = beast::Journal{beast::Journal::getNullSink()});
 
-std::uint32_t
-ownerCount(
-    ReadView const& view,
-    SLE::const_ref sle,
-    beast::Journal j,
-    std::int32_t ownerCountAdj = 0);
-
 /** Adjust the owner count up or down. */
 void
 adjustOwnerCount(
     ApplyView& view,
-    SLE::ref accountSle,
-    SLE::ref sponsorSle,
+    SLE::pointer accountSle,
+    SLE::pointer sponsorSle,
     std::int32_t amount,
     beast::Journal j = beast::Journal{beast::Journal::getNullSink()});
 
@@ -107,8 +123,8 @@ adjustOwnerCount(
 void
 adjustOwnerCountObj(
     ApplyView& view,
-    SLE::ref accountSle,
-    SLE::ref objectSle,
+    SLE::pointer accountSle,
+    SLE::pointer objectSle,
     std::int32_t amount,
     beast::Journal j = beast::Journal{beast::Journal::getNullSink()});
 
@@ -116,11 +132,11 @@ inline void
 adjustOwnerCountObj(
     ApplyView& view,
     AccountID const& account,
-    SLE::ref objectSle,
+    SLE::pointer objectSle,
     std::int32_t amount,
     beast::Journal j = beast::Journal{beast::Journal::getNullSink()})
 {
-    SLE::ref accountSle = view.peek(keylet::account(account));
+    SLE::pointer accountSle = view.peek(keylet::account(account));
     adjustOwnerCountObj(view, accountSle, objectSle, amount, j);
 }
 
@@ -158,7 +174,7 @@ getPseudoAccountFields();
     - null pointer
 */
 [[nodiscard]] bool
-isPseudoAccount(SLE::const_ref sleAcct, std::set<SField const*> const& pseudoFieldFilter = {});
+isPseudoAccount(SLE::const_pointer sleAcct, std::set<SField const*> const& pseudoFieldFilter = {});
 
 /** Convenience overload that reads the account from the view. */
 [[nodiscard]] inline bool

--- a/include/xrpl/ledger/helpers/AccountRootHelpers.h
+++ b/include/xrpl/ledger/helpers/AccountRootHelpers.h
@@ -136,7 +136,7 @@ adjustOwnerCountObj(
     std::int32_t amount,
     beast::Journal j = beast::Journal{beast::Journal::getNullSink()})
 {
-    SLE::pointer accountSle = view.peek(keylet::account(account));
+    SLE::pointer const accountSle = view.peek(keylet::account(account));
     adjustOwnerCountObj(view, accountSle, objectSle, amount, j);
 }
 

--- a/include/xrpl/ledger/helpers/EscrowHelpers.h
+++ b/include/xrpl/ledger/helpers/EscrowHelpers.h
@@ -193,7 +193,7 @@ escrowUnlockApplyHelper<MPTIssue>(
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
 
-        if (sle->getType() != ltACCOUNT_ROOT)  // only possible without fixCleanup3_2_0
+        if (sleDest->getType() != ltACCOUNT_ROOT)  // only possible without fixCleanup3_2_0
         {
             return tefEXCEPTION;
         }
@@ -202,7 +202,7 @@ escrowUnlockApplyHelper<MPTIssue>(
             !isTesSuccess(ret))
             return ret;
 
-        if (sle->getType() != ltACCOUNT_ROOT)  // only possible without fixCleanup3_2_0
+        if (sleDest->getType() != ltACCOUNT_ROOT)  // only possible without fixCleanup3_2_0
         {
             return tefEXCEPTION;
         }

--- a/include/xrpl/ledger/helpers/EscrowHelpers.h
+++ b/include/xrpl/ledger/helpers/EscrowHelpers.h
@@ -193,11 +193,19 @@ escrowUnlockApplyHelper<MPTIssue>(
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
 
+        if (sle->getType() != ltACCOUNT_ROOT)  // only possible without fixCleanup3_2_0
+        {
+            return tefEXCEPTION;
+        }
         if (auto const ret =
                 checkInsufficientReserve(view, tx, sleDest, xrpBalance, *sponsorSle, 1, 0, journal);
             !isTesSuccess(ret))
             return ret;
 
+        if (sle->getType() != ltACCOUNT_ROOT)  // only possible without fixCleanup3_2_0
+        {
+            return tefEXCEPTION;
+        }
         if (auto const ter = createMPToken(view, mptID, receiver, *sponsorSle, 0);
             !isTesSuccess(ter))
         {

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -92,10 +92,14 @@ xrpLiquid(ReadView const& view, AccountID const& id, std::int32_t ownerCountAdj,
     if (sle == nullptr)
         return beast::kZero;
 
-    std::uint32_t const ownerCount = view.ownerCountHook(id, sle->at(sfOwnerCount)) -
-        sle->at(sfSponsoredOwnerCount) + sle->at(sfSponsoringOwnerCount) + ownerCountAdj;
+    std::uint32_t const ownerCount = confineOwnerCount(
+        view.ownerCountHook(id, sle->at(sfOwnerCount)) - sle->at(sfSponsoredOwnerCount) +
+            sle->at(sfSponsoringOwnerCount),
+        ownerCountAdj);
     auto const& fees = view.fees();
-    auto const reserve = (fees.reserve * accountOwnerCount(sle)) + (fees.increment * ownerCount);
+    auto const reserve = isPseudoAccount(sle)
+        ? XRPAmount{0}
+        : ((fees.reserve * accountOwnerCount(sle)) + (fees.increment * ownerCount));
 
     auto const fullBalance = sle->getFieldAmount(sfBalance);
 

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -90,7 +90,7 @@ ownerCountHlp(
     ReadView const& view,
     SLE::const_ref sle,
     std::int32_t adjustment,
-    bool reportConfine,
+    std::optional<AccountID> reportId,
     beast::Journal j)
 {
     AccountID const id = sle->getAccountID(sfAccount);
@@ -124,40 +124,16 @@ ownerCountHlp(
                         << ", sponsoringCount: " << sponsoringCount;
     }
 
-    std::uint32_t const confinedCount = reportConfine
-        ? confineOwnerCount(hookedCount, deltaCount, id, j)
-        : confineOwnerCount(hookedCount, deltaCount);
-
-    return confinedCount;
+    return confineOwnerCount(hookedCount, static_cast<std::int32_t>(deltaCount), reportId, j);
 }
 
 static std::uint32_t
-reserveCountHlp(SLE::const_ref sle, std::int32_t adjustment, beast::Journal j)
+reserveCountHlp(SLE::const_ref sle, std::int32_t adjustment)
 {
     bool const isSponsored = sle->isFieldPresent(sfSponsor);
     std::uint32_t const sponsoringCount = sle->getFieldU32(sfSponsoringAccountCount);
     std::uint32_t const reserveCount = (isSponsored ? 0 : 1) + sponsoringCount;
-
-    std::uint32_t adjusted{reserveCount + adjustment};
-    if (adjustment > 0)
-    {
-        // Overflow is well defined on unsigned
-        if (adjusted < reserveCount)
-        {
-            JLOG(j.fatal()) << "Reserve count exceeds max!";
-            adjusted = std::numeric_limits<std::uint32_t>::max();
-        }
-    }
-    else
-    {
-        // Underflow is well defined on unsigned
-        if (adjusted > reserveCount)
-        {
-            JLOG(j.fatal()) << "Reserve count set below 0!";
-            adjusted = 0;
-        }
-    }
-    return adjusted;
+    return confineOwnerCount(reserveCount, adjustment);
 }
 
 static inline XRPAmount
@@ -185,7 +161,7 @@ reserveHlp(
 std::uint32_t
 ownerCount(ReadView const& view, SLE::const_ref sle, beast::Journal j, std::int32_t adjustment)
 {
-    return ownerCountHlp(view, sle, adjustment, true, j);
+    return ownerCountHlp(view, sle, adjustment, sle->getAccountID(sfAccount), j);
 }
 
 XRPAmount
@@ -195,8 +171,8 @@ xrpLiquid(ReadView const& view, AccountID const& id, std::int32_t ownerCountAdj,
     if (sle == nullptr)
         return beast::kZero;
 
-    std::uint32_t const ownerCount = ownerCountHlp(view, sle, ownerCountAdj, false, j);
-    std::uint32_t const reserveCount = reserveCountHlp(sle, 0, j);
+    std::uint32_t const ownerCount = ownerCountHlp(view, sle, ownerCountAdj, std::nullopt, j);
+    std::uint32_t const reserveCount = reserveCountHlp(sle, 0);
     auto const reserve = reserveHlp(view, sle, ownerCount, reserveCount);
 
     auto const fullBalance = sle->getFieldAmount(sfBalance);
@@ -232,12 +208,11 @@ adjustOwnerCountHlp(
     SF_UINT32 const& sfield,
     AccountID const& accID,
     std::int32_t adjustment,
-    beast::Journal j,
-    bool callHook = true)
+    beast::Journal j)
 {
     std::uint32_t const current = sle->at(sfield);
     std::uint32_t const adjusted = confineOwnerCount(current, adjustment, accID, j);
-    if (callHook)
+    if (sle->getType() == ltACCOUNT_ROOT)
         view.adjustOwnerCountHook(accID, current, adjusted);
     sle->at(sfield) = adjusted;
     view.update(sle);
@@ -281,7 +256,7 @@ adjustOwnerCount(
             // Remaining owner count moves opposite to adjustment:
             // +adjustment => consume reserve (-),
             adjustOwnerCountHlp(
-                view, sponsorshipSle, sfRemainingOwnerCount, sponsorID, -adjustment, j, false);
+                view, sponsorshipSle, sfRemainingOwnerCount, sponsorID, -adjustment, j);
         }
     }
     adjustOwnerCountHlp(view, accountSle, sfOwnerCount, accountID, adjustment, j);
@@ -317,8 +292,9 @@ accountReserve(
     if (sle->getType() != ltACCOUNT_ROOT)
         Throw<std::logic_error>("xrpl::accountReserve : valid sle type");
 
-    std::uint32_t const ownerCount = ownerCountHlp(view, sle, ownerCountAdj, true, j);
-    std::uint32_t const reserveCount = reserveCountHlp(sle, reserveCountAdj, j);
+    std::uint32_t const ownerCount =
+        ownerCountHlp(view, sle, ownerCountAdj, sle->getAccountID(sfAccount), j);
+    std::uint32_t const reserveCount = reserveCountHlp(sle, reserveCountAdj);
 
     return reserveHlp(view, sle, ownerCount, reserveCount);
 }

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -201,7 +201,7 @@ adjustOwnerCountObj(
     if (objectSle->getType() == ltACCOUNT_ROOT)
         Throw<std::logic_error>("xrpl::adjustOwnerCount : valid object sle type");
 
-    SLE::pointer sponsorSle = getLedgerEntryReserveSponsor(view, objectSle);
+    SLE::pointer const sponsorSle = getLedgerEntryReserveSponsor(view, objectSle);
     adjustOwnerCount(view, accountSle, sponsorSle, amount, j);
 }
 

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -85,85 +85,6 @@ confineOwnerCount(
     return adjusted;
 }
 
-static std::uint32_t
-ownerCountHlp(
-    ReadView const& view,
-    SLE::const_ref sle,
-    std::int32_t adjustment,
-    std::optional<AccountID> reportId,
-    beast::Journal j)
-{
-    AccountID const id = sle->getAccountID(sfAccount);
-    std::uint32_t const savedCount = sle->at(sfOwnerCount);
-    std::uint32_t const hookedCount = view.ownerCountHook(id, savedCount);
-
-    std::uint32_t const sponsoredCount = sle->at(sfSponsoredOwnerCount);
-    std::uint32_t const sponsoringCount = sle->at(sfSponsoringOwnerCount);
-
-    if (hookedCount < sponsoredCount)
-    {
-        Throw<std::logic_error>(
-            "xrpl::ownerCountHlp : OwnerCount must be greater than or equal to "
-            "SponsoredOwnerCount");
-    }
-
-    std::int64_t deltaCount =
-        static_cast<std::int64_t>(adjustment) - sponsoredCount + sponsoringCount;
-    if (deltaCount > std::numeric_limits<std::int32_t>::max())
-    {
-        deltaCount = std::numeric_limits<std::int32_t>::max();
-        JLOG(j.fatal()) << "Account " << id << " delta count exceeds max, "
-                        << "adjustment: " << adjustment << ", sponsoredCount: " << sponsoredCount
-                        << ", sponsoringOwnerCount: " << sponsoringCount;
-    }
-    else if (deltaCount < std::numeric_limits<std::int32_t>::min())
-    {
-        deltaCount = std::numeric_limits<std::int32_t>::min();
-        JLOG(j.fatal()) << "Account " << id << " delta count exceeds min, "
-                        << "adjustment: " << adjustment << ", sponsoredCount: " << sponsoredCount
-                        << ", sponsoringCount: " << sponsoringCount;
-    }
-
-    return confineOwnerCount(hookedCount, static_cast<std::int32_t>(deltaCount), reportId, j);
-}
-
-static std::uint32_t
-reserveCountHlp(SLE::const_ref sle, std::int32_t adjustment)
-{
-    bool const isSponsored = sle->isFieldPresent(sfSponsor);
-    std::uint32_t const sponsoringCount = sle->getFieldU32(sfSponsoringAccountCount);
-    std::uint32_t const reserveCount = (isSponsored ? 0 : 1) + sponsoringCount;
-    return confineOwnerCount(reserveCount, adjustment);
-}
-
-static inline XRPAmount
-baseReserveHlp(ReadView const& view, std::uint32_t ownerCount, std::uint32_t reserveCount)
-{
-    auto const& fees = view.fees();
-    return (fees.reserve * reserveCount) + (fees.increment * ownerCount);
-}
-
-static XRPAmount
-reserveHlp(
-    ReadView const& view,
-    SLE::const_ref sle,
-    std::uint32_t ownerCount,
-    std::uint32_t reserveCount)
-{
-    // Pseudo-accounts have no reserve requirement
-    if (isPseudoAccount(sle))
-        return XRPAmount(0);
-
-    auto const reserve = baseReserveHlp(view, ownerCount, reserveCount);
-    return reserve;
-}
-
-std::uint32_t
-ownerCount(ReadView const& view, SLE::const_ref sle, beast::Journal j, std::int32_t adjustment)
-{
-    return ownerCountHlp(view, sle, adjustment, sle->getAccountID(sfAccount), j);
-}
-
 XRPAmount
 xrpLiquid(ReadView const& view, AccountID const& id, std::int32_t ownerCountAdj, beast::Journal j)
 {
@@ -171,9 +92,10 @@ xrpLiquid(ReadView const& view, AccountID const& id, std::int32_t ownerCountAdj,
     if (sle == nullptr)
         return beast::kZero;
 
-    std::uint32_t const ownerCount = ownerCountHlp(view, sle, ownerCountAdj, std::nullopt, j);
-    std::uint32_t const reserveCount = reserveCountHlp(sle, 0);
-    auto const reserve = reserveHlp(view, sle, ownerCount, reserveCount);
+    std::uint32_t const ownerCount = view.ownerCountHook(id, sle->at(sfOwnerCount)) -
+        sle->at(sfSponsoredOwnerCount) + sle->at(sfSponsoringOwnerCount) + ownerCountAdj;
+    auto const& fees = view.fees();
+    auto const reserve = (fees.reserve * accountOwnerCount(sle)) + (fees.increment * ownerCount);
 
     auto const fullBalance = sle->getFieldAmount(sfBalance);
 
@@ -221,8 +143,8 @@ adjustOwnerCountHlp(
 void
 adjustOwnerCount(
     ApplyView& view,
-    SLE::ref accountSle,
-    SLE::ref sponsorSle,
+    SLE::pointer accountSle,
+    SLE::pointer sponsorSle,
     std::int32_t adjustment,
     beast::Journal j)
 {
@@ -265,8 +187,8 @@ adjustOwnerCount(
 void
 adjustOwnerCountObj(
     ApplyView& view,
-    SLE::ref accountSle,
-    SLE::ref objectSle,
+    SLE::pointer accountSle,
+    SLE::pointer objectSle,
     std::int32_t amount,
     beast::Journal j)
 {
@@ -275,35 +197,8 @@ adjustOwnerCountObj(
     if (objectSle->getType() == ltACCOUNT_ROOT)
         Throw<std::logic_error>("xrpl::adjustOwnerCount : valid object sle type");
 
-    SLE::ref sponsorSle = getLedgerEntryReserveSponsor(view, objectSle);
+    SLE::pointer sponsorSle = getLedgerEntryReserveSponsor(view, objectSle);
     adjustOwnerCount(view, accountSle, sponsorSle, amount, j);
-}
-
-XRPAmount
-accountReserve(
-    ReadView const& view,
-    SLE::const_ref sle,
-    beast::Journal j,
-    std::int32_t ownerCountAdj,
-    std::int32_t reserveCountAdj)
-{
-    if (!sle)
-        Throw<std::runtime_error>("xrpl::accountReserve : valid sle");
-    if (sle->getType() != ltACCOUNT_ROOT)
-        Throw<std::logic_error>("xrpl::accountReserve : valid sle type");
-
-    std::uint32_t const ownerCount =
-        ownerCountHlp(view, sle, ownerCountAdj, sle->getAccountID(sfAccount), j);
-    std::uint32_t const reserveCount = reserveCountHlp(sle, reserveCountAdj);
-
-    return reserveHlp(view, sle, ownerCount, reserveCount);
-}
-
-XRPAmount
-baseAccountReserve(ReadView const& view, std::int32_t ownerCount)
-{
-    auto const reserve = baseReserveHlp(view, ownerCount, 1);
-    return reserve;
 }
 
 TER
@@ -338,7 +233,7 @@ checkInsufficientReserve(
 
         auto const sponsorBalance = sponsorSle->getFieldAmount(sfBalance);
         STAmount const sponsorReserve =
-            accountReserve(view, sponsorSle, j, ownerCountDelta, reserveCountDelta);
+            totalAccountReserve(view, sponsorSle, ownerCountDelta, reserveCountDelta);
 
         if (sponsorBalance < sponsorReserve)
             return tecINSUFFICIENT_RESERVE;
@@ -346,7 +241,7 @@ checkInsufficientReserve(
     else
     {
         STAmount const reserve =
-            accountReserve(view, accSle, j, ownerCountDelta, reserveCountDelta);
+            totalAccountReserve(view, accSle, ownerCountDelta, reserveCountDelta);
         if (accBalance < reserve)
             return tecINSUFFICIENT_RESERVE;
     }
@@ -405,7 +300,7 @@ getPseudoAccountFields()
 }
 
 [[nodiscard]] bool
-isPseudoAccount(SLE::const_ref sleAcct, std::set<SField const*> const& pseudoFieldFilter)
+isPseudoAccount(SLE::const_pointer sleAcct, std::set<SField const*> const& pseudoFieldFilter)
 {
     auto const& fields = getPseudoAccountFields();
 

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -206,8 +206,7 @@ authorizeMPToken(
         // items. This is similar to the reserve requirements of trust lines.
         // If PreFunded Sponsor, it must be checked whether sufficient
         // ReserveCount exists.
-        if (ownerCount(view, *sponsorSle ? *sponsorSle : sleAcct, journal) >= 2 ||
-            isSponsoredAndPreFunded)
+        if (objectOwnerCount(*sponsorSle ? *sponsorSle : sleAcct) >= 2 || isSponsoredAndPreFunded)
         {
             if (auto const ret = checkInsufficientReserve(
                     view, tx, sleAcct, priorBalance, *sponsorSle, 1, 0, journal);

--- a/src/libxrpl/tx/Transactor.cpp
+++ b/src/libxrpl/tx/Transactor.cpp
@@ -553,8 +553,8 @@ Transactor::checkFee(PreclaimContext const& ctx, XRPAmount baseFee)
 
         if (feePayer.type == FeePayerType::SponsorCoSigned)
         {
-            STAmount const sponsorReserve = accountReserve(ctx.view, payerSle, ctx.j);
-            maxSpendable = payerSle->getFieldAmount(sfBalance).xrp() - sponsorReserve.xrp();
+            auto const sponsorReserve = totalAccountReserve(ctx.view, payerSle);
+            maxSpendable = payerSle->getFieldAmount(sfBalance).xrp() - sponsorReserve;
         }
         else
         {

--- a/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
+++ b/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
@@ -437,7 +437,7 @@ transferHelper(
             return tecINTERNAL;  // LCOV_EXCL_LINE
 
         {
-            auto const reserve = accountReserve(psb, sleSrc, j, 0, 0);
+            auto const reserve = totalAccountReserve(psb, sleSrc);
 
             auto const availableBalance = [&]() -> STAmount {
                 STAmount curBal = (*sleSrc)[sfBalance];

--- a/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
+++ b/src/libxrpl/tx/transactors/dex/AMMWithdraw.cpp
@@ -657,8 +657,7 @@ AMMWithdraw::withdraw(
                 return tecINTERNAL;  // LCOV_EXCL_LINE
 
             auto const balance = (*sleAccount)[sfBalance]->xrp();
-            std::uint32_t const count =
-                ownerCount(view, sponsorSle ? sponsorSle : sleAccount, journal);
+            std::uint32_t const count = objectOwnerCount(sponsorSle ? sponsorSle : sleAccount);
             // See also TrustSet::doApply() and MPTokenAuthorize::authorize()
             if (count >= 2)
             {

--- a/src/libxrpl/tx/transactors/payment/Payment.cpp
+++ b/src/libxrpl/tx/transactors/payment/Payment.cpp
@@ -636,7 +636,7 @@ Payment::doApply()
 
     // the number of reserves in this ledger for this account that require a
     // reserve.
-    auto const reserve = accountReserve(view(), sleSrc, j_);
+    auto const reserve = totalAccountReserve(view(), sleSrc);
 
     // In a delegated payment, the fee payer is the delegated account,
     // not the source account (accountID_).

--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -332,7 +332,7 @@ TrustSet::doApply()
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE
 
-    std::uint32_t const uOwnerCount = ownerCount(view(), *sponsorSle ? *sponsorSle : sle, j_);
+    std::uint32_t const uOwnerCount = objectOwnerCount(*sponsorSle ? *sponsorSle : sle);
 
     bool const isSponsoredAndPreFunded = *sponsorSle && !isSponsorReserveCoSigning(ctx_.tx);
     // If PreFunded Sponsor, it must be checked whether sufficient

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -35,7 +35,6 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
 #include <xrpl/ledger/Dir.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DelegateHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -26,7 +26,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/LedgerFormats.h>

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -52,7 +52,7 @@ namespace xrpl::test {
 static XRPAmount
 reserve(jtx::Env& env, std::uint32_t count)
 {
-    return baseAccountReserve(*env.current(), count);
+    return jtx::baseAccountReserve(*env.current(), count);
 }
 
 // Helper function that returns true if acct has the lsfDepositAuth flag set.

--- a/src/test/app/FlowMPT_test.cpp
+++ b/src/test/app/FlowMPT_test.cpp
@@ -726,7 +726,7 @@ struct FlowMPT_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return jtx::baseAccountReserve(*env.current(), count);
     }
 
     // Helper function that returns the Offers on an account.

--- a/src/test/app/FlowMPT_test.cpp
+++ b/src/test/app/FlowMPT_test.cpp
@@ -20,7 +20,6 @@
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/Sandbox.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/ledger/helpers/OfferHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -24,7 +24,6 @@
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/Sandbox.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/ledger/helpers/OfferHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -707,7 +707,7 @@ struct Flow_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return jtx::baseAccountReserve(*env.current(), count);
     }
 
     // Helper function that returns the Offers on an account.

--- a/src/test/app/LoanBroker_test.cpp
+++ b/src/test/app/LoanBroker_test.cpp
@@ -29,7 +29,6 @@
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/OpenView.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>

--- a/src/test/app/LoanBroker_test.cpp
+++ b/src/test/app/LoanBroker_test.cpp
@@ -1094,8 +1094,7 @@ class LoanBroker_test : public beast::unit_test::Suite
                 env.close();
             }
 
-            auto const amt =
-                env.balance(alice) - accountReserve(*env.current(), alice.id(), env.journal);
+            auto const amt = env.balance(alice) - accountReserve(*env.current(), alice.id());
             env(pay(alice, issuer, amt));
 
             // preclaim:: tecINSUFFICIENT_RESERVE

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -36,7 +36,6 @@
 #include <xrpl/beast/xor_shift_engine.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/LendingHelpers.h>
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -861,7 +861,7 @@ protected:
         auto const totalNeeded = state.totalValue + (serviceFee * state.paymentRemaining) +
             (broker.asset.native() ? Number(
                                          baseFee * state.paymentRemaining +
-                                         accountReserve(*env.current(), borrower.id(), env.journal))
+                                         accountReserve(*env.current(), borrower.id()))
                                    : broker.asset(15).number());
 
         auto const shortage = totalNeeded - borrowerBalance.number();
@@ -4545,8 +4545,7 @@ protected:
                         BrokerInfo const& brokerInfo,
                         jtx::Fee const& loanSetFee,
                         Number const& debtMaximumRequest) {
-            auto const amt =
-                env.balance(borrower) - accountReserve(*env.current(), borrower.id(), env.journal);
+            auto const amt = env.balance(borrower) - accountReserve(*env.current(), borrower.id());
             env(pay(borrower, issuer, amt));
 
             // tecINSUFFICIENT_RESERVE

--- a/src/test/app/OfferMPT_test.cpp
+++ b/src/test/app/OfferMPT_test.cpp
@@ -58,7 +58,7 @@ class OfferMPT_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return jtx::baseAccountReserve(*env.current(), count);
     }
 
     static std::uint32_t

--- a/src/test/app/OfferMPT_test.cpp
+++ b/src/test/app/OfferMPT_test.cpp
@@ -22,7 +22,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/json/json_value.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -28,7 +28,6 @@
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -61,7 +61,7 @@ class OfferBaseUtil_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return jtx::baseAccountReserve(*env.current(), count);
     }
 
     static std::uint32_t

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -85,7 +85,7 @@ accountReserve(jtx::Env& env, std::uint32_t count = 1)
 static STAmount
 reserve(jtx::Env& env, std::uint32_t count)
 {
-    return baseAccountReserve(*env.current(), count);
+    return jtx::baseAccountReserve(*env.current(), count);
 }
 
 static void

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -48,7 +48,6 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/OpenView.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -1,6 +1,7 @@
 
 #include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
+#include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
 #include <test/jtx/deposit.h>

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -23,7 +23,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STTx.h>

--- a/src/test/app/TrustSet_test.cpp
+++ b/src/test/app/TrustSet_test.cpp
@@ -15,7 +15,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/TER.h>

--- a/src/test/app/TrustSet_test.cpp
+++ b/src/test/app/TrustSet_test.cpp
@@ -1,6 +1,7 @@
 
 #include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
+#include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/balance.h>  // IWYU pragma: keep
 #include <test/jtx/flags.h>

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -143,7 +143,7 @@ struct SEnv
     XRPAmount
     reserve(std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return jtx::baseAccountReserve(*env.current(), count);
     }
 
     XRPAmount

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -1,5 +1,6 @@
 #include <test/jtx/Account.h>
 #include <test/jtx/Env.h>
+#include <test/jtx/TestHelpers.h>
 #include <test/jtx/acctdelete.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/attester.h>
@@ -372,7 +373,7 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
     XRPAmount
     reserve(std::uint32_t count)
     {
-        return baseAccountReserve(*XEnv(*this).env.current(), count);
+        return jtx::baseAccountReserve(*XEnv(*this).env.current(), count);
     }
 
     XRPAmount

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -23,7 +23,6 @@
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/json/json_value.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>

--- a/src/test/jtx/TestHelpers.h
+++ b/src/test/jtx/TestHelpers.h
@@ -6,7 +6,10 @@
 
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/json/json_value.h>
+#include <xrpl/ledger/ReadView.h>
+#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Quality.h>
 #include <xrpl/protocol/STNumber.h>
 #include <xrpl/protocol/Units.h>
@@ -515,6 +518,21 @@ txFee(Env const& env, std::uint16_t n);
 
 PrettyAmount
 xrpMinusFee(Env const& env, std::int64_t xrpAmount);
+
+/** Returns the base reserve for a non-sponsored account with `count` owned objects. */
+inline XRPAmount
+baseAccountReserve(ReadView const& view, std::uint32_t count = 0)
+{
+    auto const& fees = view.fees();
+    return fees.reserve + fees.increment * count;
+}
+
+/** Returns the total reserve for an account, read from the ledger. */
+inline XRPAmount
+accountReserve(ReadView const& view, AccountID const& id)
+{
+    return totalAccountReserve(view, view.read(keylet::account(id)));
+}
 
 bool
 expectHolding(

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -4,6 +4,7 @@
 #include <test/jtx/Account.h>
 #include <test/jtx/CaptureLogs.h>
 #include <test/jtx/Env.h>
+#include <test/jtx/TestHelpers.h>
 #include <test/jtx/amount.h>
 #include <test/jtx/envconfig.h>
 #include <test/jtx/mpt.h>

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -15,7 +15,6 @@
 
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/unit_test/suite.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/MPTIssue.h>


### PR DESCRIPTION
## High Level Overview of Change

This PR does a bunch of cleanup in `AccountRootHelpers` to make the helper functions more readable/maintainable, and make the diff with develop more readable for review as well.

While there are many checks removed here, if we wanted to re-add them they would need to be amendment-gated (those checks aren't in develop). I don't think that's necessary here.

Note to reviewers: I recommend also examining the AccountRootHelpers.h/.cpp diffs with develop.

I left `adjustOwnerCount`/`checkInsufficientReserve` out of scope for now to keep this PR smaller.

### Context of Change

Cleanup

### API Impact

N/A