### PR TITLE
fix: backward compatibility for legacy NoRipple flag positions in TrustSet

### DIFF
--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -468,6 +468,9 @@ TrustSet::doApply()
             if ((bHigh ? saHighBalance : saLowBalance) >= beast::kZero)
             {
                 uFlagsOut |= (bHigh ? lsfHighNoRipple : lsfLowNoRipple);
+                // Also set legacy flag positions for backward compatibility
+                // with trust lines created before the DeepFreeze flag shift
+                uFlagsOut |= (bHigh ? 0x00020000u : 0x00010000u);
             }
             else
             {
@@ -478,6 +481,9 @@ TrustSet::doApply()
         else if (bClearNoRipple && !bSetNoRipple)
         {
             uFlagsOut &= ~(bHigh ? lsfHighNoRipple : lsfLowNoRipple);
+            // Also clear legacy flag positions for backward compatibility
+            // with trust lines created before the DeepFreeze flag shift
+            uFlagsOut &= ~(bHigh ? 0x00020000u : 0x00010000u);
         }
 
         // Have to use lsfNoFreeze to maintain pre-deep freeze behavior


### PR DESCRIPTION
## Summary

The DeepFreeze amendment shifted the RippleState flag bit positions for `lsfHighNoRipple` (0x00020000 → 0x00200000) and `lsfLowNoRipple` (0x00010000 → 0x00100000). The TrustSet `tfSetNoRipple`/`tfClearNoRipple` handlers only operate on the **new** flag positions, leaving trust lines created before the flag shift with unmigratable flag values.

This means existing trust lines (with the old flag positions) cannot have NoRipple cleared via `tfClearNoRipple`, which prevents:
- Third-party DEX trades on custom tokens
- Trust line cleanup for legacy holders
- Account deletion for accounts with legacy trust lines

## Fix

When setting or clearing NoRipple, also set/clear the legacy flag positions (0x00020000 for high, 0x00010000 for low). This ensures backward compatibility with all trust lines regardless of when they were created.

## Changes

`src/libxrpl/tx/transactors/token/TrustSet.cpp` — 6 lines added (3 for set, 3 for clear)

## Testing

Manual verification: trust line with flags=0x00020000 (legacy lsfHighNoRipple) was not cleared by `tfClearNoRipple` before the fix. After the fix, both the legacy (0x00020000) and current (0x00200000) flag positions are cleared.

Automated tests in the CI pipeline should verify no regressions for TrustSet flag handling.