### PR TITLE
refactor: Switch `checkInsufficientReserve` from `ReadView` to `ApplyView`

### DIFF
--- a/include/xrpl/ledger/helpers/AccountRootHelpers.h
+++ b/include/xrpl/ledger/helpers/AccountRootHelpers.h
@@ -63,7 +63,7 @@ baseAccountReserve(ReadView const& view, std::int32_t ownerCount);
 
 [[nodiscard]] TER
 checkInsufficientReserve(
-    ReadView const& view,
+    ApplyView const& view,
     STTx const& tx,
     SLE::const_ref accSle,
     STAmount const& accBalance,

--- a/include/xrpl/ledger/helpers/SponsorHelpers.h
+++ b/include/xrpl/ledger/helpers/SponsorHelpers.h
@@ -168,7 +168,6 @@ getLedgerEntryOwner(ReadView const& view, T const& sle, AccountID const& account
             return std::nullopt;
         }
         default:
-            UNREACHABLE("Object is not supported by sponsorship.");
             return std::nullopt;
     };
 }

--- a/include/xrpl/ledger/helpers/SponsorHelpers.h
+++ b/include/xrpl/ledger/helpers/SponsorHelpers.h
@@ -168,7 +168,30 @@ getLedgerEntryOwner(ReadView const& view, T const& sle, AccountID const& account
             return std::nullopt;
         }
         default:
+            UNREACHABLE("Object is not supported by sponsorship.");
             return std::nullopt;
+    };
+}
+
+template <typename T>
+inline bool
+isLedgerEntrySupportedBySponsorship(T const& sle)
+{
+    switch (sle->getType())
+    {
+        case ltCHECK:
+        case ltESCROW:
+        case ltPAYCHAN:
+        case ltMPTOKEN:
+        case ltDELEGATE:
+        case ltDEPOSIT_PREAUTH:
+        case ltMPTOKEN_ISSUANCE:
+        case ltSIGNER_LIST:
+        case ltCREDENTIAL:
+        case ltRIPPLE_STATE:
+            return true;
+        default:
+            return false;
     };
 }
 

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -332,7 +332,7 @@ baseAccountReserve(ReadView const& view, std::int32_t ownerCount)
 
 TER
 checkInsufficientReserve(
-    ReadView const& view,
+    ApplyView const& view,
     STTx const& tx,
     SLE::const_ref accSle,
     STAmount const& accBalance,

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -10,7 +10,6 @@
 #include <xrpl/ledger/helpers/SponsorHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Indexes.h>
-#include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -400,6 +400,12 @@ SponsorshipTransfer::doApply()
         return tesSUCCESS;
     };
 
+    auto const balanceBeforeFee = [&](SLE::const_ref sle) -> STAmount {
+        if (sle->getAccountID(sfAccount) == accountID_)
+            return STAmount{preFeeBalance_};
+        return sle->getFieldAmount(sfBalance);
+    };
+
     if (isObjectSponsor)
     {
         auto const hasSignature = tx.isFieldPresent(sfSponsorSignature);
@@ -534,6 +540,20 @@ SponsorshipTransfer::doApply()
             if (!oldSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
+            // The owner takes the reserve burden back when the object is
+            // no longer sponsored.
+            if (auto const ter = checkInsufficientReserve(
+                    ctx_.view(),
+                    ctx_.tx,
+                    ownerSle,
+                    balanceBeforeFee(ownerSle),
+                    SLE::pointer(),
+                    ownerCountDelta,
+                    0,
+                    ctx_.journal);
+                !isTesSuccess(ter))
+                return ter;
+
             // decrement sponsored count
             if (auto const ter =
                     setSponsorFieldU32(sponseeSle, sfSponsoredOwnerCount, -ownerCountDelta);
@@ -563,6 +583,19 @@ SponsorshipTransfer::doApply()
             auto const newSponsorSle = view().peek(keylet::account(newSponsorID));
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
+
+            if (auto const ter = checkInsufficientReserve(
+                    ctx_.view(),
+                    ctx_.tx,
+                    sponseeSle,
+                    sponseeSle->getFieldAmount(sfBalance),
+                    newSponsorSle,
+                    0,
+                    1,
+                    ctx_.journal);
+                !isTesSuccess(ter))
+                return ter;
+
             if (auto const ter = setSponsorFieldU32(newSponsorSle, sfSponsoringAccountCount, 1);
                 !isTesSuccess(ter))
                 return ter;
@@ -580,6 +613,19 @@ SponsorshipTransfer::doApply()
             auto const newSponsorSle = view().peek(keylet::account(newSponsorID));
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
+
+            if (auto const ter = checkInsufficientReserve(
+                    ctx_.view(),
+                    ctx_.tx,
+                    sponseeSle,
+                    sponseeSle->getFieldAmount(sfBalance),
+                    newSponsorSle,
+                    0,
+                    1,
+                    ctx_.journal);
+                !isTesSuccess(ter))
+                return ter;
+
             if (auto const ter = setSponsorFieldU32(newSponsorSle, sfSponsoringAccountCount, 1);
                 !isTesSuccess(ter))
                 return ter;
@@ -603,6 +649,21 @@ SponsorshipTransfer::doApply()
         {
             // dissolve account sponsor
             auto const oldSponsorID = sponseeSle->getAccountID(sfSponsor);
+
+            // The sponsee must be able to hold its own account reserve after
+            // the sponsorship is removed.
+            if (auto const ter = checkInsufficientReserve(
+                    ctx_.view(),
+                    ctx_.tx,
+                    sponseeSle,
+                    balanceBeforeFee(sponseeSle),
+                    SLE::pointer(),
+                    0,
+                    1,
+                    ctx_.journal);
+                !isTesSuccess(ter))
+                return ter;
+
             sponseeSle->makeFieldAbsent(sfSponsor);
             view().update(sponseeSle);
 

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -436,10 +436,10 @@ SponsorshipTransfer::doApply()
                     ctx_.tx,
                     sponseeSle,
                     sponseeSle->getFieldAmount(sfBalance),
-                    *newSponsorSle,
+                    newSponsorSle,
                     ownerCountDelta,
                     0,
-                    ctx_.j);
+                    ctx_.journal);
                 !isTesSuccess(ter))
                 return ter;
 
@@ -491,7 +491,7 @@ SponsorshipTransfer::doApply()
                     ctx_.tx,
                     sponseeSle,
                     sponseeSle->getFieldAmount(sfBalance),
-                    *newSponsorSle,
+                    newSponsorSle,
                     ownerCountDelta,
                     0,
                     ctx_.journal);

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -265,8 +265,6 @@ SponsorshipTransfer::preclaim(PreclaimContext const& ctx)
         if (!sle)
             return tecNO_ENTRY;
 
-        auto const ownerCountDelta = getLedgerEntryOwnerCount(sle);
-
         auto const owner = getLedgerEntryOwner(ctx.view, sle, sponseeID);
         if (!owner || owner != sponseeID)
             return tecNO_PERMISSION;
@@ -305,20 +303,6 @@ SponsorshipTransfer::preclaim(PreclaimContext const& ctx)
             if (account != sponsor && account != sponseeID)
                 return tecNO_PERMISSION;
         }
-
-        // check new sponsor have sufficient balance
-        // NOLINTNEXTLINE(readability-suspicious-call-argument)
-        if (auto const ter = checkInsufficientReserve(
-                ctx.view,
-                ctx.tx,
-                sponseeSle,
-                sponseeSle->getFieldAmount(sfBalance),
-                *newSponsorSle,
-                ownerCountDelta,
-                0,
-                ctx.j);
-            !isTesSuccess(ter))
-            return ter;
     }
     else
     {
@@ -354,23 +338,6 @@ SponsorshipTransfer::preclaim(PreclaimContext const& ctx)
             if (account != sponsor && account != sponseeID)
                 return tecNO_PERMISSION;
         }
-
-        // check account have sufficient balance
-        // In the case of removing an account sponsor, accSle should have no sfSponsor set
-        // (AccountReserve = 0). However, by setting accountCountDelta = 1 here, we are able to
-        // calculate the actual required Account Reserve.
-        // NOLINTNEXTLINE(readability-suspicious-call-argument)
-        if (auto const ter = checkInsufficientReserve(
-                ctx.view,
-                ctx.tx,
-                sponseeSle,
-                sponseeSle->getFieldAmount(sfBalance),
-                *newSponsorSle,
-                0,
-                1,
-                ctx.j);
-            !isTesSuccess(ter))
-            return ter;
     }
 
     return tesSUCCESS;
@@ -458,6 +425,23 @@ SponsorshipTransfer::doApply()
         {
             auto const newSponsorID = tx.getAccountID(sfSponsor);
             XRPL_ASSERT(!!newSponsorID, "New sponsor is required when creating sponsorship");
+            auto const newSponsorSle = view().peek(keylet::account(newSponsorID));
+            if (!newSponsorSle)
+                return tefINTERNAL;  // LCOV_EXCL_LINE
+
+            // check new sponsor have sufficient balance
+            // NOLINTNEXTLINE(readability-suspicious-call-argument)
+            if (auto const ter = checkInsufficientReserve(
+                    ctx_.view(),
+                    ctx_.tx,
+                    sponseeSle,
+                    sponseeSle->getFieldAmount(sfBalance),
+                    *newSponsorSle,
+                    ownerCountDelta,
+                    0,
+                    ctx_.j);
+                !isTesSuccess(ter))
+                return ter;
 
             // update owner's sponsored count
             if (auto const ter =
@@ -467,9 +451,6 @@ SponsorshipTransfer::doApply()
             view().update(ownerSle);
 
             // increment new sponsor's sponsoring count
-            auto const newSponsorSle = view().peek(keylet::account(newSponsorID));
-            if (!newSponsorSle)
-                return tefINTERNAL;  // LCOV_EXCL_LINE
             if (auto const ter =
                     setSponsorFieldU32(newSponsorSle, sfSponsoringOwnerCount, ownerCountDelta);
                 !isTesSuccess(ter))
@@ -493,14 +474,31 @@ SponsorshipTransfer::doApply()
         {
             auto const newSponsorID = tx.getAccountID(sfSponsor);
             XRPL_ASSERT(!!newSponsorID, "New sponsor is required when reassigning sponsorship");
+            auto const newSponsorSle = view().peek(keylet::account(newSponsorID));
+            if (!newSponsorSle)
+                return tefINTERNAL;  // LCOV_EXCL_LINE
 
             auto const oldSponsorID = objSle->getAccountID(sponsorField);
             XRPL_ASSERT(!!oldSponsorID, "Old sponsor is required when reassigning sponsorship");
-
-            // decrement old sponsor's sponsoring count
             auto const oldSponsorSle = view().peek(keylet::account(oldSponsorID));
             if (!oldSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
+
+            // check new sponsor have sufficient balance
+            // NOLINTNEXTLINE(readability-suspicious-call-argument)
+            if (auto const ter = checkInsufficientReserve(
+                    ctx_.view(),
+                    ctx_.tx,
+                    sponseeSle,
+                    sponseeSle->getFieldAmount(sfBalance),
+                    *newSponsorSle,
+                    ownerCountDelta,
+                    0,
+                    ctx_.journal);
+                !isTesSuccess(ter))
+                return ter;
+
+            // decrement old sponsor's sponsoring count
             if (auto const ter =
                     setSponsorFieldU32(oldSponsorSle, sfSponsoringOwnerCount, -ownerCountDelta);
                 !isTesSuccess(ter))
@@ -508,9 +506,6 @@ SponsorshipTransfer::doApply()
             view().update(oldSponsorSle);
 
             // increment new sponsor's sponsoring count
-            auto const newSponsorSle = view().peek(keylet::account(newSponsorID));
-            if (!newSponsorSle)
-                return tefINTERNAL;  // LCOV_EXCL_LINE
             if (auto const ter =
                     setSponsorFieldU32(newSponsorSle, sfSponsoringOwnerCount, ownerCountDelta);
                 !isTesSuccess(ter))

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -147,6 +147,9 @@ SponsorshipTransfer::preclaim(PreclaimContext const& ctx)
         if (!sle)
             return tecNO_ENTRY;
 
+        if (!isLedgerEntrySupportedBySponsorship(sle))
+            return tecNO_PERMISSION;
+
         auto const owner = getLedgerEntryOwner(ctx.view, sle, sponseeID);
         if (!owner.has_value() || owner.value() != sponseeID)
             return tecNO_PERMISSION;


### PR DESCRIPTION
## High Level Overview of Change

`checkInsufficientReserve` takes `ReadView` but the norm is for that check to happen in `doApply`. This PR makes that change and fixes any downstream changes.

### Context of Change

#7618 and #7661

### API Impact

N/A

`libxrpl` doesn't count since it hasn't been released