### PR TITLE
fix: Better handling of txs that send XRP + charge reserve

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -319,6 +319,7 @@ words:
   - unserviced
   - unshareable
   - unshares
+  - unsponsored
   - unsquelch
   - unsquelched
   - unsquelching

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -33,6 +33,7 @@
 #include <xrpl/tx/Transactor.h>
 #include <xrpl/tx/applySteps.h>
 
+#include <cstdint>
 #include <memory>
 #include <system_error>
 #include <variant>

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -436,7 +436,9 @@ EscrowCreate::doApply()
     // Check reserve and funds availability
     STAmount const amount{ctx_.tx[sfAmount]};
 
-    auto const balance = sle->getFieldAmount(sfBalance).xrp();
+    auto const balance = view().rules().enabled(featureSponsor)
+        ? preFeeBalance_
+        : sle->getFieldAmount(sfBalance).xrp();
     auto const sponsorSle = getTxReserveSponsor(view(), ctx_.tx);
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -436,9 +436,7 @@ EscrowCreate::doApply()
     // Check reserve and funds availability
     STAmount const amount{ctx_.tx[sfAmount]};
 
-    auto const balance = view().rules().enabled(featureSponsor)
-        ? preFeeBalance_
-        : sle->getFieldAmount(sfBalance).xrp();
+    auto const balance = sle->getFieldAmount(sfBalance).xrp();
     auto const sponsorSle = getTxReserveSponsor(view(), ctx_.tx);
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -439,8 +439,11 @@ EscrowCreate::doApply()
     auto const sponsorSle = getTxReserveSponsor(view(), ctx_.tx);
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE
-    // Whoever is on the hook for the new owner increment (sponsor if
-    // sponsored, source otherwise) must cover it.
+    // First check: whoever is on the hook for the new owner increment
+    // can cover it. When sponsored this hits the sponsor branch and
+    // validates the sponsor's reserve + remaining credit. When
+    // unsponsored this hits the source branch and validates the
+    // source's pre-lock balance against base + (currentOC+1)*increment.
     if (auto const ret =
             checkInsufficientReserve(ctx_.view(), ctx_.tx, sle, balance, *sponsorSle, 1, 0, j_);
         !isTesSuccess(ret))
@@ -448,13 +451,26 @@ EscrowCreate::doApply()
 
     if (isXRP(amount))
     {
-        // After locking the escrowed amount, the source must still meet
-        // its own reserve floor. When sponsored, the sponsor covers the
-        // new object's increment (validated above), so the source only
-        // needs its base reserve. When unsponsored, the source covers
-        // everything.
-        auto const sourceReserve = accountReserve(view(), sle, j_, *sponsorSle ? 0 : 1, 0);
-        if (balance - STAmount(amount).xrp() < sourceReserve)
+        // Second check (XRP escrow only): after locking the escrowed
+        // amount, the source must still meet its own reserve floor.
+        // Always passes `{}` so the source branch runs (the sponsor's
+        // reserve was already validated above; here we're verifying the
+        // source can fund the lock without dipping below its own
+        // reserve). ownerCountAdj differs by case:
+        // - sponsored:   adj=0  — sponsor covers the new owner increment,
+        //                so the source only owes its base reserve.
+        // - unsponsored: adj=1  — source owes base + the new increment.
+        std::int32_t const ownerCountAdj = *sponsorSle ? 0 : 1;
+        if (auto const ret = checkInsufficientReserve(
+                ctx_.view(),
+                ctx_.tx,
+                sle,
+                balance - STAmount(amount).xrp(),
+                {},
+                ownerCountAdj,
+                0,
+                j_);
+            !isTesSuccess(ret))
             return tecUNFUNDED;
     }
 

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -439,17 +439,22 @@ EscrowCreate::doApply()
     auto const sponsorSle = getTxReserveSponsor(view(), ctx_.tx);
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE
+    // Whoever is on the hook for the new owner increment (sponsor if
+    // sponsored, source otherwise) must cover it.
     if (auto const ret =
             checkInsufficientReserve(ctx_.view(), ctx_.tx, sle, balance, *sponsorSle, 1, 0, j_);
         !isTesSuccess(ret))
         return ret;
 
-    // Check reserve and funds availability
     if (isXRP(amount))
     {
-        if (auto const ret = checkInsufficientReserve(
-                ctx_.view(), ctx_.tx, sle, balance - STAmount(amount).xrp(), {}, 1, 0, j_);
-            !isTesSuccess(ret))
+        // After locking the escrowed amount, the source must still meet
+        // its own reserve floor. When sponsored, the sponsor covers the
+        // new object's increment (validated above), so the source only
+        // needs its base reserve. When unsponsored, the source covers
+        // everything.
+        auto const sourceReserve = accountReserve(view(), sle, j_, *sponsorSle ? 0 : 1, 0);
+        if (balance - STAmount(amount).xrp() < sourceReserve)
             return tecUNFUNDED;
     }
 

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
@@ -140,24 +140,35 @@ PaymentChannelCreate::doApply()
 
     if (ctx_.view().rules().enabled(featureSponsor))
     {
-        // When sponsored, the sponsor must cover the new owner increment.
-        // When unsponsored, this check is redundant with the post-lock
-        // check below (which is strictly stricter since sfAmount > 0).
-        if (*sponsorSle)
-        {
-            if (auto const ret = checkInsufficientReserve(
-                    ctx_.view(), ctx_.tx, sle, preFeeBalance_, *sponsorSle, 1, 0, j_);
-                !isTesSuccess(ret))
-                return ret;
-        }
+        // First check: whoever is on the hook for the new owner increment
+        // can cover it. When sponsored this hits the sponsor branch and
+        // validates the sponsor's reserve + remaining credit. When
+        // unsponsored this hits the source branch and validates the
+        // source's pre-lock balance against base + (currentOC+1)*increment.
+        if (auto const ret = checkInsufficientReserve(
+                ctx_.view(), ctx_.tx, sle, preFeeBalance_, *sponsorSle, 1, 0, j_);
+            !isTesSuccess(ret))
+            return ret;
 
-        // The source must cover its own reserve floor after locking
-        // sfAmount. When sponsored, the sponsor covers the new owner
-        // increment (validated above), so the source only needs its base
-        // reserve (ownerCountAdj=0). When unsponsored, the source covers
-        // everything (ownerCountAdj=1).
-        auto const sourceReserve = accountReserve(view(), sle, j_, *sponsorSle ? 0 : 1, 0);
-        if (preFeeBalance_ - ctx_.tx[sfAmount].xrp() < sourceReserve)
+        // Second check: after locking sfAmount in the channel, the source
+        // must still meet its own reserve floor. Always passes `{}` so the
+        // source branch runs (the sponsor's reserve was already validated
+        // above; here we're verifying the source can fund the lock without
+        // dipping below its own reserve). ownerCountAdj differs by case:
+        // - sponsored:   adj=0  — sponsor covers the new owner increment,
+        //                so the source only owes its base reserve.
+        // - unsponsored: adj=1  — source owes base + the new increment.
+        std::int32_t const ownerCountAdj = *sponsorSle ? 0 : 1;
+        if (auto const ret = checkInsufficientReserve(
+                ctx_.view(),
+                ctx_.tx,
+                sle,
+                preFeeBalance_ - ctx_.tx[sfAmount].xrp(),
+                {},
+                ownerCountAdj,
+                0,
+                j_);
+            !isTesSuccess(ret))
             return tecUNFUNDED;
     }
 

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
@@ -22,6 +22,7 @@
 #include <xrpl/tx/Transactor.h>
 #include <xrpl/tx/applySteps.h>
 
+#include <cstdint>
 #include <memory>
 
 namespace xrpl {

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
@@ -134,25 +134,30 @@ PaymentChannelCreate::doApply()
             return tecEXPIRED;
     }
 
+    auto const sponsorSle = getTxReserveSponsor(view(), ctx_.tx);
+    if (!sponsorSle)
+        return sponsorSle.error();  // LCOV_EXCL_LINE
+
     if (ctx_.view().rules().enabled(featureSponsor))
     {
-        auto const sponsorSle = getTxReserveSponsor(ctx_.view(), ctx_.tx);
-        if (!sponsorSle)
-            return sponsorSle.error();
-        if (auto const ret = checkInsufficientReserve(
-                ctx_.view(), ctx_.tx, sle, STAmount{preFeeBalance_}, *sponsorSle, 1, 0, j_);
-            !isTesSuccess(ret))
-            return ret;
-        if (auto const ret = checkInsufficientReserve(
-                ctx_.view(),
-                ctx_.tx,
-                sle,
-                STAmount{preFeeBalance_ - ctx_.tx[sfAmount].xrp()},
-                {},
-                1,
-                0,
-                j_);
-            !isTesSuccess(ret))
+        // When sponsored, the sponsor must cover the new owner increment.
+        // When unsponsored, this check is redundant with the post-lock
+        // check below (which is strictly stricter since sfAmount > 0).
+        if (*sponsorSle)
+        {
+            if (auto const ret = checkInsufficientReserve(
+                    ctx_.view(), ctx_.tx, sle, preFeeBalance_, *sponsorSle, 1, 0, j_);
+                !isTesSuccess(ret))
+                return ret;
+        }
+
+        // The source must cover its own reserve floor after locking
+        // sfAmount. When sponsored, the sponsor covers the new owner
+        // increment (validated above), so the source only needs its base
+        // reserve (ownerCountAdj=0). When unsponsored, the source covers
+        // everything (ownerCountAdj=1).
+        auto const sourceReserve = accountReserve(view(), sle, j_, *sponsorSle ? 0 : 1, 0);
+        if (preFeeBalance_ - ctx_.tx[sfAmount].xrp() < sourceReserve)
             return tecUNFUNDED;
     }
 
@@ -203,9 +208,6 @@ PaymentChannelCreate::doApply()
 
     // Deduct owner's balance, increment owner count
     (*sle)[sfBalance] = (*sle)[sfBalance] - ctx_.tx[sfAmount];
-    auto const sponsorSle = getTxReserveSponsor(view(), ctx_.tx);
-    if (!sponsorSle)
-        return sponsorSle.error();  // LCOV_EXCL_LINE
     adjustOwnerCount(ctx_.view(), sle, *sponsorSle, 1, ctx_.journal);
     addSponsorToLedgerEntry(slep, *sponsorSle);
     ctx_.view().update(sle);

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -2677,6 +2677,50 @@ public:
             BEAST_EXPECT(sponsoredOwnerCount(env, bob) == 1);
             BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 1);
         }
+
+        // A sponsored EscrowCreate must still verify that the source
+        // can fund the escrow amount and stay above its own base
+        // reserve. The sponsor covers the new object's owner
+        // increment, but cannot cover the source's base reserve.
+        {
+            Env env{*this, testableAmendments()};
+            env.fund(XRP(10000), alice, bob, sponsor);
+            env.close();
+
+            // alice's balance is just above the base reserve. After
+            // locking escrowAmount she would dip below it.
+            adjustAccountXRPBalance(env, alice, accountReserve(env, 1) + XRP(1));
+
+            auto const escrowAmount = XRP(2);
+            auto const seq = env.seq(alice);
+
+            if (cosigning)
+            {
+                env(escrow::create(alice, bob, escrowAmount),
+                    escrow::kCondition(escrow::kCb1),
+                    escrow::kCancelTime(env.now() + 100s),
+                    sponsor::As(sponsor, spfSponsorReserve),
+                    Sig(sfSponsorSignature, sponsor),
+                    Ter(tecUNFUNDED));
+            }
+            else
+            {
+                env(sponsor::set(sponsor, 0, 1, XRP(1)), sponsor::SponseeAcc(alice));
+                env.close();
+
+                env(escrow::create(alice, bob, escrowAmount),
+                    escrow::kCondition(escrow::kCb1),
+                    escrow::kCancelTime(env.now() + 100s),
+                    sponsor::As(sponsor, spfSponsorReserve),
+                    Ter(tecUNFUNDED));
+            }
+            env.close();
+
+            BEAST_EXPECT(!env.le(keylet::escrow(alice, seq)));
+            BEAST_EXPECT(ownerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
+        }
     }
 
     void
@@ -2942,6 +2986,48 @@ public:
             BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
             BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
             BEAST_EXPECT(sponsoringOwnerCount(env, sponsor2) == 0);
+        }
+
+        // A sponsored PaymentChannelCreate must still verify that the
+        // source can fund the channel amount and stay above its own
+        // base reserve. The sponsor covers the new object's owner
+        // increment, but cannot cover the source's base reserve.
+        {
+            Env env{*this, testableAmendments()};
+            env.fund(XRP(10000), alice, bob, sponsor);
+            env.close();
+
+            // alice's balance is just above the base reserve. After
+            // locking channelAmount she would dip below it.
+            adjustAccountXRPBalance(env, alice, accountReserve(env, 1) + XRP(1));
+
+            auto const pk = alice.pk();
+            auto const settleDelay = 10s;
+            auto const channelAmount = XRP(2);
+            auto const chan = paychan::channel(alice, bob, env.seq(alice));
+
+            if (cosigning)
+            {
+                env(paychan::create(alice, bob, channelAmount, settleDelay, pk),
+                    sponsor::As(sponsor, spfSponsorReserve),
+                    Sig(sfSponsorSignature, sponsor),
+                    Ter(tecUNFUNDED));
+            }
+            else
+            {
+                env(sponsor::set(sponsor, 0, 1, XRP(1)), sponsor::SponseeAcc(alice));
+                env.close();
+
+                env(paychan::create(alice, bob, channelAmount, settleDelay, pk),
+                    sponsor::As(sponsor, spfSponsorReserve),
+                    Ter(tecUNFUNDED));
+            }
+            env.close();
+
+            BEAST_EXPECT(!paychan::channelExists(*env.current(), chan));
+            BEAST_EXPECT(ownerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
+            BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
         }
     }
 


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes `PaymentChannelCreate` and `EscrowCreate` to properly handle sponsorship and reserves. They're a bit of a special case since they also can send XRP, which always comes from the `Account` (never the `Sponsor`).

### Context of Change

Sherlock 1680, issues found in the process of fixing that

See also: #6599 

### API Impact

N/A