### PR TITLE
refactor: Move `baseAccountReserve` back to `Fees.h`

### DIFF
--- a/include/xrpl/ledger/helpers/AccountRootHelpers.h
+++ b/include/xrpl/ledger/helpers/AccountRootHelpers.h
@@ -82,19 +82,6 @@ accountReserve(
     return accountReserve(view, view.read(keylet::account(id)), j, ownerCountAdj, accountCountAdj);
 }
 
-/** @brief Return the hypothetical reserve required by an account with the provided counters.
- *
- *  @param view The ledger view to read from
- *  @param ownerCount Number of objects for which the account will be responsible.
- *  @param accountCount Number of accounts for which the account will be responsible.
- *                      Defaults to 1, as normally every account is responsible for its own reserve.
- *                      Can be 0 if the account is sponsored.
- *                      Can be greater than 1 if the account is sponsoring other accounts.
- *  @return The hypothetical reserve amount
- */
-XRPAmount
-baseAccountReserve(ReadView const& view, std::int32_t ownerCount, std::int32_t accountCount = 1);
-
 /** Check if an account has insufficient reserve.
  *
  *  @param view The ledger view to read from

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -33,6 +33,17 @@ struct Fees
         : base(base), reserve(reserve), increment(increment)
     {
     }
+
+    /** Returns the account reserve given the owner count, in drops.
+
+        The reserve is calculated as the reserve base times the number of owners plus the reserve
+       increment times the number of increments.
+    */
+    [[nodiscard]] XRPAmount
+    accountReserve(std::uint32_t ownerCount, std::uint32_t accountCount) const
+    {
+        return (reserve * accountCount) + (increment * ownerCount);
+    }
 };
 
 }  // namespace xrpl

--- a/include/xrpl/protocol/Fees.h
+++ b/include/xrpl/protocol/Fees.h
@@ -36,8 +36,8 @@ struct Fees
 
     /** Returns the account reserve given the owner count, in drops.
 
-        The reserve is calculated as the reserve base times the number of owners plus the reserve
-       increment times the number of increments.
+        The reserve is calculated as the reserve base times the number of accounts plus the reserve
+        increment times the number of increments.
     */
     [[nodiscard]] XRPAmount
     accountReserve(std::uint32_t ownerCount, std::uint32_t accountCount) const

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -165,7 +165,7 @@ xrpLiquid(ReadView const& view, AccountID const& id, std::int32_t ownerCountAdj,
     // Pseudo-accounts have no reserve requirement
     auto const reserve = isPseudoAccount(sle)
         ? XRPAmount{0}
-        : baseAccountReserve(view, currentOwnerCount, currentAccountCount);
+        : view.fees().accountReserve(currentOwnerCount, currentAccountCount);
 
     auto const fullBalance = sle->getFieldAmount(sfBalance);
 
@@ -290,14 +290,7 @@ accountReserve(
     std::uint32_t const currentOwnerCount = ownerCount(sle, j, ownerCountAdj);
     std::uint32_t const currentAccountCount = accountCountImpl(sle, accountCountAdj, j);
 
-    return baseAccountReserve(view, currentOwnerCount, currentAccountCount);
-}
-
-XRPAmount
-baseAccountReserve(ReadView const& view, std::int32_t ownerCount, std::int32_t accountCount)
-{
-    auto const& fees = view.fees();
-    return (fees.reserve * accountCount) + (fees.increment * ownerCount);
+    return view.fees().accountReserve(currentOwnerCount, currentAccountCount);
 }
 
 TER

--- a/src/test/app/AMMExtendedMPT_test.cpp
+++ b/src/test/app/AMMExtendedMPT_test.cpp
@@ -31,7 +31,6 @@
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/Sandbox.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/OfferHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/AMMExtendedMPT_test.cpp
+++ b/src/test/app/AMMExtendedMPT_test.cpp
@@ -464,7 +464,7 @@ private:
         // Provide micro amounts to compensate for fees to make results round
         // nice.
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 2) + env.current()->fees().base * 3;
+            XRP(100) + env.current()->fees().accountReserve(2, 1) + env.current()->fees().base * 3;
 
         env.fund(startingXrp, gw_, alice_);
         env.fund(XRP(2'000), bob_);

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -35,7 +35,6 @@
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/Sandbox.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/OfferHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/AMMExtended_test.cpp
+++ b/src/test/app/AMMExtended_test.cpp
@@ -547,7 +547,7 @@ private:
         //  1 for each trust limit == 3 (alice_ < mtgox/amazon/bitstamp) +
         //  1 for payment          == 4
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 3) + env.current()->fees().base * 4;
+            XRP(100) + env.current()->fees().accountReserve(3, 1) + env.current()->fees().base * 4;
 
         env.fund(startingXrp, gw1, gw2, gw3, localAlice);
         env.fund(XRP(2'000), localBob);

--- a/src/test/app/CheckMPT_test.cpp
+++ b/src/test/app/CheckMPT_test.cpp
@@ -410,7 +410,7 @@ class CheckMPT_test : public beast::unit_test::Suite
 
         // Insufficient reserve.
         Account const cheri{"cheri"};
-        env.fund(baseAccountReserve(*env.current(), 1) - drops(1), cheri);
+        env.fund(env.current()->fees().accountReserve(1, 1) - drops(1), cheri);
 
         env(check::create(cheri, bob, usd(50)),
             Fee(drops(env.current()->fees().base)),

--- a/src/test/app/CheckMPT_test.cpp
+++ b/src/test/app/CheckMPT_test.cpp
@@ -24,7 +24,6 @@
 #include <xrpl/basics/contract.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/core/ServiceRegistry.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -471,7 +471,7 @@ class Check_test : public beast::unit_test::Suite
 
         // Insufficient reserve.
         Account const cheri{"cheri"};
-        env.fund(baseAccountReserve(*env.current(), 1) - drops(1), cheri);
+        env.fund(env.current()->fees().accountReserve(1, 1) - drops(1), cheri);
         env.close();
 
         env(check::create(cheri, bob, usd(50)),

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -26,7 +26,6 @@
 #include <xrpl/basics/chrono.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/core/ServiceRegistry.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -20,7 +20,6 @@
 #include <xrpl/json/to_string.h>
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/ApplyViewImpl.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/CredentialHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Credentials_test.cpp
+++ b/src/test/app/Credentials_test.cpp
@@ -639,8 +639,8 @@ struct Credentials_test : public beast::unit_test::Suite
         {
             Env env{*this, features};
 
-            env.fund(drops(baseAccountReserve(*env.current(), 1)), issuer);
-            env.fund(drops(baseAccountReserve(*env.current(), 0)), subject);
+            env.fund(drops(env.current()->fees().accountReserve(1, 1)), issuer);
+            env.fund(drops(env.current()->fees().accountReserve(0, 1)), subject);
             env.close();
 
             {

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -35,7 +35,6 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
 #include <xrpl/ledger/Dir.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DelegateHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>

--- a/src/test/app/Delegate_test.cpp
+++ b/src/test/app/Delegate_test.cpp
@@ -262,7 +262,7 @@ class Delegate_test : public beast::unit_test::Suite
             Account const bob{"bob"};
 
             auto const txFee = env.current()->fees().base;
-            env.fund(baseAccountReserve(*env.current(), 0) + txFee, alice);
+            env.fund(env.current()->fees().accountReserve(0, 1) + txFee, alice);
             env.fund(XRP(100000), bob);
             env.close();
 
@@ -279,7 +279,7 @@ class Delegate_test : public beast::unit_test::Suite
 
             auto const txFee = env.current()->fees().base;
 
-            env.fund(baseAccountReserve(*env.current(), 1) + (txFee * 4), alice);
+            env.fund(env.current()->fees().accountReserve(1, 1) + (txFee * 4), alice);
             env.fund(XRP(100000), bob, carol);
             env.close();
 
@@ -305,8 +305,8 @@ class Delegate_test : public beast::unit_test::Suite
             Account const alice{"alice"};
             Account const bob{"bob"};
 
-            env.fund(drops(baseAccountReserve(*env.current(), 1)), alice);
-            env.fund(drops(baseAccountReserve(*env.current(), 2)), bob);
+            env.fund(drops(env.current()->fees().accountReserve(1, 1)), alice);
+            env.fund(drops(env.current()->fees().accountReserve(2, 1)), bob);
             env.close();
 
             // alice gives bob permission
@@ -409,7 +409,7 @@ class Delegate_test : public beast::unit_test::Suite
                 Account const carol{"carol"};
 
                 auto const baseFee = env.current()->fees().base;
-                auto const reserve = baseAccountReserve(*env.current(), 1);
+                auto const reserve = env.current()->fees().accountReserve(1, 1);
                 auto const paymentAmount = XRP(1);
                 auto const highFee = reserve + baseFee;
                 BEAST_EXPECT(highFee > reserve);
@@ -475,9 +475,9 @@ class Delegate_test : public beast::unit_test::Suite
             Account const carol{"carol"};
 
             auto const baseFee = env.current()->fees().base;
-            auto const baseReserve = baseAccountReserve(*env.current(), 0);
+            auto const baseReserve = env.current()->fees().accountReserve(0, 1);
 
-            env.fund(baseAccountReserve(*env.current(), 1) + baseFee + XRP(1), alice);
+            env.fund(env.current()->fees().accountReserve(1, 1) + baseFee + XRP(1), alice);
             env.fund(baseReserve, bob);
             env.fund(XRP(1000), carol);
             env.close();
@@ -510,7 +510,7 @@ class Delegate_test : public beast::unit_test::Suite
             Account const carol{"carol"};
 
             auto const baseFee = env.current()->fees().base;
-            auto const reserve = baseAccountReserve(*env.current(), 1);
+            auto const reserve = env.current()->fees().accountReserve(1, 1);
 
             // Alice is funded with (reserve + baseFee): after DelegateSet she has
             // exactly 'reserve', which is insufficient to send XRP(10) while keeping

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -26,7 +26,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/LedgerFormats.h>

--- a/src/test/app/DepositAuth_test.cpp
+++ b/src/test/app/DepositAuth_test.cpp
@@ -52,7 +52,7 @@ namespace xrpl::test {
 static XRPAmount
 reserve(jtx::Env& env, std::uint32_t count)
 {
-    return baseAccountReserve(*env.current(), count);
+    return env.current()->fees().accountReserve(count, 1);
 }
 
 // Helper function that returns true if acct has the lsfDepositAuth flag set.
@@ -1026,7 +1026,7 @@ struct DepositPreauth_test : public beast::unit_test::Suite
             {
                 // not enough reserve
                 Account const john{"john"};
-                env.fund(baseAccountReserve(*env.current(), 0), john);
+                env.fund(env.current()->fees().accountReserve(0, 1), john);
                 env.close();
                 auto jv =
                     deposit::authCredentials(john, {{.issuer = issuer, .credType = credType}});

--- a/src/test/app/FlowMPT_test.cpp
+++ b/src/test/app/FlowMPT_test.cpp
@@ -726,7 +726,7 @@ struct FlowMPT_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return env.current()->fees().accountReserve(count, 1);
     }
 
     // Helper function that returns the Offers on an account.

--- a/src/test/app/FlowMPT_test.cpp
+++ b/src/test/app/FlowMPT_test.cpp
@@ -20,7 +20,6 @@
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/Sandbox.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/ledger/helpers/OfferHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -707,7 +707,7 @@ struct Flow_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return env.current()->fees().accountReserve(count, 1);
     }
 
     // Helper function that returns the Offers on an account.

--- a/src/test/app/Flow_test.cpp
+++ b/src/test/app/Flow_test.cpp
@@ -24,7 +24,6 @@
 #include <xrpl/ledger/OpenView.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/Sandbox.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/ledger/helpers/OfferHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/test/app/Loan_test.cpp
+++ b/src/test/app/Loan_test.cpp
@@ -690,11 +690,17 @@ protected:
             case AssetType::MPT: {
                 // Enough to cover initial fees
                 if (!env.le(keylet::account(issuer)))
-                    env.fund(baseAccountReserve(*env.current(), 10) * 10, issuer);
+                {
+                    env.fund(env.current()->fees().accountReserve(10, 1) * 10, issuer);
+                }
                 if (!env.le(keylet::account(lender)))
-                    env.fund(baseAccountReserve(*env.current(), 10) * 10, noripple(lender));
+                {
+                    env.fund(env.current()->fees().accountReserve(10, 1) * 10, noripple(lender));
+                }
                 if (!env.le(keylet::account(borrower)))
-                    env.fund(baseAccountReserve(*env.current(), 10) * 10, noripple(borrower));
+                {
+                    env.fund(env.current()->fees().accountReserve(10, 1) * 10, noripple(borrower));
+                }
 
                 MPTTester mptt{env, issuer, kMptInitNoFund};
                 mptt.create({.flags = tfMPTCanClawback | tfMPTCanTransfer | tfMPTCanLock});
@@ -779,11 +785,15 @@ protected:
         using namespace jtx;
 
         // Enough to cover initial fees
-        env.fund(baseAccountReserve(*env.current(), 10) * 10, issuer);
+        env.fund(env.current()->fees().accountReserve(10, 1) * 10, issuer);
         if (lender != issuer)
-            env.fund(baseAccountReserve(*env.current(), 10) * 10, noripple(lender));
+        {
+            env.fund(env.current()->fees().accountReserve(10, 1) * 10, noripple(lender));
+        }
         if (borrower != issuer && borrower != lender)
-            env.fund(baseAccountReserve(*env.current(), 10) * 10, noripple(borrower));
+        {
+            env.fund(env.current()->fees().accountReserve(10, 1) * 10, noripple(borrower));
+        }
 
         describeLoan(env, brokerParams, loanParams, assetType, issuer, lender, borrower);
 
@@ -3089,7 +3099,7 @@ protected:
         auto const [acctReserve, incReserve] = [this]() -> std::pair<int, int> {
             Env const env{*this, testableAmendments()};
             return {
-                baseAccountReserve(*env.current(), 0).drops() / kDropsPerXrp.drops(),
+                env.current()->fees().accountReserve(0, 1).drops() / kDropsPerXrp.drops(),
                 env.current()->fees().increment.drops() / kDropsPerXrp.drops()};
         }();
 

--- a/src/test/app/OfferMPT_test.cpp
+++ b/src/test/app/OfferMPT_test.cpp
@@ -22,7 +22,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/json/json_value.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/OfferMPT_test.cpp
+++ b/src/test/app/OfferMPT_test.cpp
@@ -58,7 +58,7 @@ class OfferMPT_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return env.current()->fees().accountReserve(count, 1);
     }
 
     static std::uint32_t
@@ -1793,7 +1793,8 @@ public:
             //  1 for each trust limit == 3 (alice < mtgox/amazon/bitstamp) +
             //  1 for payment          == 4
             auto const base = env.current()->fees().base;
-            auto const startingXrp = XRP(100) + baseAccountReserve(*env.current(), 3) + base * 4;
+            auto const startingXrp =
+                XRP(100) + env.current()->fees().accountReserve(3, 1) + base * 4;
 
             env.fund(startingXrp, gw1, gw2, gw3, alice, bob);
             env.close();
@@ -1813,7 +1814,8 @@ public:
             env(offer(alice, usD1(200), XRP(200)));
 
             BEAST_EXPECT(env.balance(alice, usD1) == usD1(100));
-            BEAST_EXPECT(env.balance(alice) == STAmount(baseAccountReserve(*env.current(), 3)));
+            BEAST_EXPECT(
+                env.balance(alice) == STAmount(env.current()->fees().accountReserve(3, 1)));
 
             BEAST_EXPECT(env.balance(bob, usD1) == usD1(400));
         };
@@ -1864,7 +1866,7 @@ public:
         auto const bob = Account{"bob"};
 
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2;
+            XRP(100) + env.current()->fees().accountReserve(1, 1) + env.current()->fees().base * 2;
 
         env.fund(startingXrp, gw, alice, bob);
 
@@ -1883,7 +1885,7 @@ public:
         jrr = ledgerEntryRoot(env, alice);
         BEAST_EXPECT(
             jrr[jss::node][sfBalance.fieldName] ==
-            STAmount(baseAccountReserve(*env.current(), 1)).getText());
+            STAmount(env.current()->fees().accountReserve(1, 1)).getText());
 
         jrr = ledgerEntryMPT(env, bob, usd);
         BEAST_EXPECT(jrr[jss::node][sfMPTAmount.fieldName] == "400");
@@ -1903,7 +1905,7 @@ public:
         auto const bob = Account{"bob"};
 
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2;
+            XRP(100) + env.current()->fees().accountReserve(1, 1) + env.current()->fees().base * 2;
 
         env.fund(startingXrp, gw, alice, bob);
 
@@ -1924,7 +1926,7 @@ public:
         jrr = ledgerEntryRoot(env, alice);
         BEAST_EXPECT(
             jrr[jss::node][sfBalance.fieldName] ==
-            STAmount(baseAccountReserve(*env.current(), 1)).getText());
+            STAmount(env.current()->fees().accountReserve(1, 1)).getText());
 
         jrr = ledgerEntryMPT(env, bob, usd);
         BEAST_EXPECT(jrr[jss::node][sfMPTAmount.fieldName] == "300");
@@ -1944,7 +1946,8 @@ public:
             Env env{*this, features};
 
             auto const base = env.current()->fees().base;
-            auto const startingXrp = XRP(100.1) + baseAccountReserve(*env.current(), 1) + base * 2;
+            auto const startingXrp =
+                XRP(100.1) + env.current()->fees().accountReserve(1, 1) + base * 2;
 
             env.fund(startingXrp, gw, alice, bob);
             env.close();

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -28,7 +28,6 @@
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/DirectoryHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Offer_test.cpp
+++ b/src/test/app/Offer_test.cpp
@@ -61,7 +61,7 @@ class OfferBaseUtil_test : public beast::unit_test::Suite
     static XRPAmount
     reserve(jtx::Env& env, std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return env.current()->fees().accountReserve(count, 1);
     }
 
     static std::uint32_t
@@ -1963,7 +1963,7 @@ public:
         //  1 for each trust limit == 3 (alice < mtgox/amazon/bitstamp) +
         //  1 for payment          == 4
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 3) + env.current()->fees().base * 4;
+            XRP(100) + env.current()->fees().accountReserve(3, 1) + env.current()->fees().base * 4;
 
         env.fund(startingXrp, gw1, gw2, gw3, alice, bob);
         env.close();
@@ -1986,7 +1986,7 @@ public:
         jrr = ledgerEntryRoot(env, alice);
         BEAST_EXPECT(
             jrr[jss::node][sfBalance.fieldName] ==
-            STAmount(baseAccountReserve(*env.current(), 3)).getText());
+            STAmount(env.current()->fees().accountReserve(3, 1)).getText());
 
         jrr = ledgerEntryState(env, bob, gw1, "USD");
         BEAST_EXPECT(jrr[jss::node][sfBalance.fieldName][jss::value] == "-400");
@@ -2046,7 +2046,7 @@ public:
         auto const usd = gw["USD"];
 
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2;
+            XRP(100) + env.current()->fees().accountReserve(1, 1) + env.current()->fees().base * 2;
 
         env.fund(startingXrp, gw, alice, bob);
         env.close();
@@ -2067,7 +2067,7 @@ public:
         jrr = ledgerEntryRoot(env, alice);
         BEAST_EXPECT(
             jrr[jss::node][sfBalance.fieldName] ==
-            STAmount(baseAccountReserve(*env.current(), 1)).getText());
+            STAmount(env.current()->fees().accountReserve(1, 1)).getText());
 
         jrr = ledgerEntryState(env, bob, gw, "USD");
         BEAST_EXPECT(jrr[jss::node][sfBalance.fieldName][jss::value] == "-400");
@@ -2088,7 +2088,7 @@ public:
         auto const usd = gw["USD"];
 
         auto const startingXrp =
-            XRP(100) + baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2;
+            XRP(100) + env.current()->fees().accountReserve(1, 1) + env.current()->fees().base * 2;
 
         env.fund(startingXrp, gw, alice, bob);
         env.close();
@@ -2111,7 +2111,7 @@ public:
         jrr = ledgerEntryRoot(env, alice);
         BEAST_EXPECT(
             jrr[jss::node][sfBalance.fieldName] ==
-            STAmount(baseAccountReserve(*env.current(), 1)).getText());
+            STAmount(env.current()->fees().accountReserve(1, 1)).getText());
 
         jrr = ledgerEntryState(env, bob, gw, "USD");
         BEAST_EXPECT(jrr[jss::node][sfBalance.fieldName][jss::value] == "-300");
@@ -2132,8 +2132,8 @@ public:
         auto const xts = gw["XTS"];
         auto const xxx = gw["XXX"];
 
-        auto const startingXrp =
-            XRP(100.1) + baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2;
+        auto const startingXrp = XRP(100.1) + env.current()->fees().accountReserve(1, 1) +
+            env.current()->fees().base * 2;
 
         env.fund(startingXrp, gw, alice, bob);
         env.close();

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -18,7 +18,6 @@
 #include <xrpl/basics/chrono.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/KeyType.h>

--- a/src/test/app/Oracle_test.cpp
+++ b/src/test/app/Oracle_test.cpp
@@ -61,7 +61,7 @@ private:
         // Insufficient reserve
         {
             Env env(*this);
-            env.fund(baseAccountReserve(*env.current(), 0), owner);
+            env.fund(env.current()->fees().accountReserve(0, 1), owner);
             Oracle const oracle(
                 env,
                 {.owner = owner,
@@ -71,7 +71,8 @@ private:
         // Insufficient reserve if the data series extends to greater than 5
         {
             Env env(*this);
-            env.fund(baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2, owner);
+            env.fund(
+                env.current()->fees().accountReserve(1, 1) + env.current()->fees().base * 2, owner);
             Oracle oracle(
                 env, {.owner = owner, .fee = static_cast<int>(env.current()->fees().base.drops())});
             BEAST_EXPECT(oracle.exists());
@@ -639,7 +640,8 @@ private:
         {
             Env env(*this);
             auto const baseFee = static_cast<int>(env.current()->fees().base.drops());
-            env.fund(baseAccountReserve(*env.current(), 1) + env.current()->fees().base * 2, owner);
+            env.fund(
+                env.current()->fees().accountReserve(1, 1) + env.current()->fees().base * 2, owner);
             Oracle oracle(env, {.owner = owner, .fee = baseFee});
             oracle.set(UpdateArg{.series = {{"XRP", "USD", 742, 2}}, .fee = baseFee});
         }

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -76,7 +76,7 @@ accountReserve(jtx::Env& env, std::uint32_t count = 1)
 static STAmount
 reserve(jtx::Env& env, std::uint32_t count)
 {
-    return baseAccountReserve(*env.current(), count);
+    return env.current()->fees().accountReserve(count, 1);
 }
 
 static void
@@ -2031,7 +2031,7 @@ public:
 
         // Account is not sponsored by normal Sponsor specification
         {
-            env(pay(alice, bob, drops(baseAccountReserve(*env.current(), 0))),
+            env(pay(alice, bob, drops(env.current()->fees().accountReserve(0, 1))),
                 sponsor::As(sponsor, spfSponsorReserve),
                 Sig(sfSponsorSignature, sponsor));
             env.close();

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -40,7 +40,6 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/ledger/ApplyView.h>
 #include <xrpl/ledger/OpenView.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Asset.h>
 #include <xrpl/protocol/Feature.h>

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -22,7 +22,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/STTx.h>

--- a/src/test/app/Ticket_test.cpp
+++ b/src/test/app/Ticket_test.cpp
@@ -504,7 +504,7 @@ class Ticket_test : public beast::unit_test::Suite
         Account const alice{"alice"};
 
         // Fund alice not quite enough to make the reserve for a Ticket.
-        env.fund(baseAccountReserve(*env.current(), 1) - drops(1), alice);
+        env.fund(env.current()->fees().accountReserve(1, 1) - drops(1), alice);
         env.close();
 
         env(ticket::create(alice, 1), Ter(tecINSUFFICIENT_RESERVE));
@@ -512,7 +512,8 @@ class Ticket_test : public beast::unit_test::Suite
         env.require(Owners(alice, 0), tickets(alice, 0));
 
         // Give alice enough to exactly meet the reserve for one Ticket.
-        env(pay(env.master, alice, baseAccountReserve(*env.current(), 1) - env.balance(alice)));
+        env(pay(
+            env.master, alice, env.current()->fees().accountReserve(1, 1) - env.balance(alice)));
         env.close();
 
         env(ticket::create(alice, 1));
@@ -525,7 +526,7 @@ class Ticket_test : public beast::unit_test::Suite
         env(
             pay(env.master,
                 alice,
-                baseAccountReserve(*env.current(), 250) - drops(1) - env.balance(alice)));
+                env.current()->fees().accountReserve(250, 1) - drops(1) - env.balance(alice)));
         env.close();
 
         // alice doesn't quite have the reserve for a total of 250
@@ -536,7 +537,8 @@ class Ticket_test : public beast::unit_test::Suite
 
         // Give alice enough so she can make the reserve for all 250
         // Tickets.
-        env(pay(env.master, alice, baseAccountReserve(*env.current(), 250) - env.balance(alice)));
+        env(pay(
+            env.master, alice, env.current()->fees().accountReserve(250, 1) - env.balance(alice)));
         env.close();
 
         std::uint32_t const ticketSeq{env.seq(alice) + 1};

--- a/src/test/app/TrustSet_test.cpp
+++ b/src/test/app/TrustSet_test.cpp
@@ -14,7 +14,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/AccountID.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/TER.h>

--- a/src/test/app/TrustSet_test.cpp
+++ b/src/test/app/TrustSet_test.cpp
@@ -192,7 +192,7 @@ public:
 
         auto const txFee = env.current()->fees().base;
         auto const baseReserve = env.current()->fees().reserve;
-        auto const threelineReserve = baseAccountReserve(*env.current(), 3);
+        auto const threelineReserve = env.current()->fees().accountReserve(3, 1);
 
         env.fund(XRP(10000), gwA, gwB, assistor);
 

--- a/src/test/app/Vault_test.cpp
+++ b/src/test/app/Vault_test.cpp
@@ -1877,7 +1877,7 @@ class Vault_test : public beast::unit_test::Suite
         auto const [acctReserve, incReserve] = [this]() -> std::pair<int, int> {
             Env const env{*this, testableAmendments()};
             return {
-                baseAccountReserve(*env.current(), 0).drops() / kDropsPerXrp.drops(),
+                env.current()->fees().accountReserve(0, 1).drops() / kDropsPerXrp.drops(),
                 env.current()->fees().increment.drops() / kDropsPerXrp.drops()};
         }();
 
@@ -2950,7 +2950,7 @@ class Vault_test : public beast::unit_test::Suite
         auto const [acctReserve, incReserve] = [this]() -> std::pair<int, int> {
             Env const env{*this, testableAmendments()};
             return {
-                baseAccountReserve(*env.current(), 0).drops() / kDropsPerXrp.drops(),
+                env.current()->fees().accountReserve(0, 1).drops() / kDropsPerXrp.drops(),
                 env.current()->fees().increment.drops() / kDropsPerXrp.drops()};
         }();
 

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -22,7 +22,6 @@
 #include <xrpl/beast/utility/Journal.h>
 #include <xrpl/core/ServiceRegistry.h>
 #include <xrpl/json/json_value.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/Issue.h>

--- a/src/test/app/XChain_test.cpp
+++ b/src/test/app/XChain_test.cpp
@@ -142,7 +142,7 @@ struct SEnv
     XRPAmount
     reserve(std::uint32_t count)
     {
-        return baseAccountReserve(*env.current(), count);
+        return env.current()->fees().accountReserve(count, 1);
     }
 
     XRPAmount
@@ -372,7 +372,7 @@ struct XChain_test : public beast::unit_test::Suite, public jtx::XChainBridgeObj
     XRPAmount
     reserve(std::uint32_t count)
     {
-        return baseAccountReserve(*XEnv(*this).env.current(), count);
+        return XEnv(*this).env.current()->fees().accountReserve(count, 1);
     }
 
     XRPAmount

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -14,7 +14,6 @@
 
 #include <xrpl/basics/Number.h>
 #include <xrpl/beast/unit_test/suite.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/Issue.h>
 #include <xrpl/protocol/MPTIssue.h>

--- a/src/test/jtx/impl/AMMTest.cpp
+++ b/src/test/jtx/impl/AMMTest.cpp
@@ -198,7 +198,7 @@ AMMTestBase::testAMM(std::function<void(jtx::AMM&, jtx::Env&)> const& cb, TestAM
 XRPAmount
 AMMTest::reserve(jtx::Env& env, std::uint32_t count)
 {
-    return baseAccountReserve(*env.current(), count);
+    return env.current()->fees().accountReserve(count, 1);
 }
 
 XRPAmount

--- a/src/test/ledger/PaymentSandbox_test.cpp
+++ b/src/test/ledger/PaymentSandbox_test.cpp
@@ -331,7 +331,7 @@ class PaymentSandbox_test : public beast::unit_test::Suite
         };
 
         auto reserve = [](jtx::Env& env, std::uint32_t count) -> XRPAmount {
-            return baseAccountReserve(*env.current(), count);
+            return env.current()->fees().accountReserve(count, 1);
         };
 
         Env env(*this, features);

--- a/src/test/ledger/PaymentSandbox_test.cpp
+++ b/src/test/ledger/PaymentSandbox_test.cpp
@@ -14,7 +14,6 @@
 #include <xrpl/ledger/ApplyViewImpl.h>
 #include <xrpl/ledger/PaymentSandbox.h>
 #include <xrpl/ledger/ReadView.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/ledger/helpers/RippleStateHelpers.h>
 #include <xrpl/ledger/helpers/TokenHelpers.h>
 #include <xrpl/protocol/AccountID.h>

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -28,7 +28,6 @@
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/to_string.h>
-#include <xrpl/ledger/helpers/AccountRootHelpers.h>
 #include <xrpl/protocol/ApiVersion.h>
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/Indexes.h>

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -776,7 +776,7 @@ class AccountTx_test : public beast::unit_test::Suite
 
         // All it takes is a large enough XRP payment to resurrect
         // becky's account.  Try too small a payment.
-        env(pay(alice, becky, drops(baseAccountReserve(*env.current(), 0)) - drops(1)),
+        env(pay(alice, becky, drops(env.current()->fees().accountReserve(0, 1)) - drops(1)),
             Ter(tecNO_DST_INSUF_XRP));
         env.close();
 


### PR DESCRIPTION
## High Level Overview of Change

This PR moves `baseAccountReserve` from `AccountRootHelpers` to `Fees.h` and renames it to `accountReserve` (like it is in `develop`).

### Context of Change

Decreasing the diff with develop

### API Impact

N/A