### PR TITLE
Fix legacy SignerList sponsorship reserve mismatch

### DIFF
--- a/include/xrpl/ledger/helpers/SponsorHelpers.h
+++ b/include/xrpl/ledger/helpers/SponsorHelpers.h
@@ -213,6 +213,15 @@ getLedgerEntryOwnerCount(T const& sle)
         // Vaults require 2 owner counts (the vault and a pseudo-account)
         case ltVAULT:
             return 2;
+        case ltSIGNER_LIST: {
+            // Mirror SignerListSet's owner-count accounting so that create and
+            // delete agree. Modern lists (post-MultiSignReserve) carry the
+            // lsfOneOwnerCount flag and cost a single owner count. Legacy
+            // pre-MultiSignReserve lists cost 2 + signer_count owner counts
+            if (sle->isFlag(lsfOneOwnerCount))
+                return 1;
+            return 2 + static_cast<std::uint32_t>(sle->getFieldArray(sfSignerEntries).size());
+        }
         default:
             return 1;
     }

--- a/src/libxrpl/tx/invariants/SponsorshipInvariant.cpp
+++ b/src/libxrpl/tx/invariants/SponsorshipInvariant.cpp
@@ -69,6 +69,15 @@ SponsorshipOwnerCountsMatch::visitEntry(
                     return 0;
                 return 2;
             }
+            case ltSIGNER_LIST: {
+                if (!sle->isFieldPresent(sfSponsor))
+                    return 0;
+                // Modern lists carry lsfOneOwnerCount and cost 1.
+                // Legacy (pre-MultiSignReserve) lists cost 2 + signer_count.
+                if (sle->isFlag(lsfOneOwnerCount))
+                    return 1;
+                return 2 + static_cast<std::uint32_t>(sle->getFieldArray(sfSignerEntries).size());
+            }
             default: {
                 if (sle->isFieldPresent(sfSponsor))
                     return 1;

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -307,7 +307,7 @@ SponsorshipTransfer::doApply()
         if (!ownerSle)
             return tefINTERNAL;  // LCOV_EXCL_LINE
 
-        std::int64_t const ownerCountDelta = 1;
+        auto const ownerCountDelta = static_cast<std::int32_t>(getLedgerEntryOwnerCount(objSle));
 
         auto const& sponsorField = getLedgerEntrySponsorField(objSle, *ownerID);
 

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -3409,6 +3409,77 @@ public:
         BEAST_EXPECT(sponsoringOwnerCount(env, sponsor2) == 0);
     }
 
+    // Legacy (pre-MultiSignReserve) SignerLists lack lsfOneOwnerCount and cost
+    // 2 + signer_count owner units, whereas modern lists cost 1.
+    void
+    testLegacySignerListReserve()
+    {
+        testcase("Legacy SignerList sponsorship reserve");
+        using namespace test::jtx;
+
+        Account const alice("alice");
+        Account const bob("bob");
+        Account const carol("carol");
+        Account const dave("dave");
+        Account const sponsor("sponsor");
+
+        Env env{*this, testableAmendments()};
+        env.fund(XRP(1000000), alice, bob, carol, dave, sponsor);
+        env.close();
+
+        // Modern 3-signer list: weight 1, lsfOneOwnerCount set.
+        env(signers(alice, 1, {{bob, 1}, {carol, 1}, {dave, 1}}));
+        env.close();
+
+        auto const signerListKeylet = keylet::signerList(alice.id());
+        auto const sponsorKeylet = keylet::sponsorship(sponsor.id(), alice.id());
+        std::uint32_t const legacyWeight = 5;  // 2 + 3 signers
+        BEAST_EXPECT(ownerCount(env, alice) == 1);
+
+        // Pre-fund exactly the legacy weight
+        env(sponsor::set_reserve(sponsor, 0, legacyWeight), sponsor::SponseeAcc(alice));
+        env.close();
+        if (auto const sle = env.le(sponsorKeylet); BEAST_EXPECT(sle))
+            BEAST_EXPECT(sle->getFieldU32(sfRemainingOwnerCount) == legacyWeight);
+
+        // Synthesize a pre-MultiSignReserve list: clear lsfOneOwnerCount and
+        // restore the owner's OwnerCount to the legacy weight.
+        env.app().getOpenLedger().modify([&](OpenView& view, beast::Journal) -> bool {
+            auto signerList = std::make_shared<SLE>(*view.read(signerListKeylet));
+            auto account = std::make_shared<SLE>(*view.read(keylet::account(alice.id())));
+            signerList->clearFlag(lsfOneOwnerCount);
+            account->setFieldU32(sfOwnerCount, legacyWeight);
+            view.rawReplace(signerList);
+            view.rawReplace(account);
+            return true;
+        });
+        if (auto const sle = env.le(signerListKeylet); BEAST_EXPECT(sle))
+            BEAST_EXPECT((sle->getFlags() & lsfOneOwnerCount) == 0);
+        BEAST_EXPECT(ownerCount(env, alice) == legacyWeight);
+
+        // Create must charge the full legacy weight (5), not 1: the bug bumped
+        // the counters by 1 and left 4 pre-funded units unspent.
+        env(sponsor::transfer(alice, tfSponsorshipCreate, signerListKeylet.key),
+            sponsor::As(sponsor, spfSponsorReserve));
+
+        BEAST_EXPECT(sponsoredOwnerCount(env, alice) == legacyWeight);
+        BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == legacyWeight);
+        // All pre-funded units consumed (drained to absent).
+        if (auto const sle = env.le(sponsorKeylet); BEAST_EXPECT(sle))
+            BEAST_EXPECT(!sle->isFieldPresent(sfRemainingOwnerCount));
+
+        // Delete unwinds the legacy weight; create bumped by the same amount, so
+        // the counters return to 0 (the bug bumped by 1 -> underflow on delete).
+        env(signers(alice, NoneT()));
+
+        BEAST_EXPECT(!env.le(signerListKeylet));
+        BEAST_EXPECT(ownerCount(env, alice) == 0);
+        BEAST_EXPECT(sponsoredOwnerCount(env, alice) == 0);
+        BEAST_EXPECT(sponsoringOwnerCount(env, sponsor) == 0);
+        if (auto const sle = env.le(sponsorKeylet); BEAST_EXPECT(sle))
+            BEAST_EXPECT(!sle->isFieldPresent(sfRemainingOwnerCount));
+    }
+
     void
     testSponsoredTrustLineNoFreeReserve()
     {
@@ -4306,6 +4377,7 @@ protected:
         testSponsoredFreeTierReserve();
 
         testTransferSponsor();
+        testLegacySignerListReserve();
         testSponsorFee();
         testSponsorAccount();
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
getLedgerEntryOwnerCount now charges 2 + signer_count for pre-MultiSignReserve (no lsfOneOwnerCount) . 
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
