### PR TITLE
build: Add protobuf dependencies to Nix

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -32,6 +32,15 @@ in
     perl # needed for openssl
     pkg-config
     pre-commit
+    # protoc generates the Go gRPC bindings and embeds its own version string into every committed
+    # .pb.go file. To allow CI to verify those files with a plain `git diff`, we pin the version to
+    # `protobuf_34` rather than the rolling `protobuf` to keep regeneration reproducible across the
+    # Nix frequently changing unstable channel. The protoc-gen-go* plugins have no versioned
+    # attributes in nixpkgs; protoc-gen-go's version is in turn constrained by the go.mod require
+    # on google.golang.org/protobuf.
+    protobuf_34 # provides protoc
+    protoc-gen-go # protoc plugin for the Go message bindings
+    protoc-gen-go-grpc # protoc plugin for the Go gRPC service stubs
     python3
     runClangTidy
     vim


### PR DESCRIPTION
## High Level Overview of Change

This change adds protocol buffer related dependencies to Nix.

### Context of Change

To allow Golang applications to use the protos in the repository, we will need to generate .pb.go files and then make them accessible. To ensure any modification to a proto file results in recompilation of those generated files, our CI workflows will need these dependencies so it can perform the check.

See https://github.com/XRPLF/rippled/pull/5281 for the initial attempt to add Golang support for the protos. However, more changes are needed to actually make this work, which will be done in a new PR.